### PR TITLE
Refactor FXIOS-4805 [v106] Remove tab manager usage where it's not used

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -88,7 +88,7 @@ extension BrowserViewController: URLBarDelegate {
 
     func urlBarDidTapShield(_ urlBar: URLBarView) {
         if let tab = self.tabManager.selectedTab {
-            let etpViewModel = EnhancedTrackingProtectionMenuVM(tab: tab, profile: profile, tabManager: tabManager)
+            let etpViewModel = EnhancedTrackingProtectionMenuVM(tab: tab, profile: profile)
             etpViewModel.onOpenSettingsTapped = {
                 let settingsTableViewController = AppSettingsTableViewController(
                     with: self.profile,

--- a/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVM.swift
+++ b/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVM.swift
@@ -9,7 +9,6 @@ class EnhancedTrackingProtectionMenuVM {
 
     // MARK: - Variables
     var tab: Tab
-    var tabManager: TabManager
     var profile: Profile
     var onOpenSettingsTapped: (() -> Void)?
 
@@ -51,11 +50,9 @@ class EnhancedTrackingProtectionMenuVM {
 
     // MARK: - Initializers
 
-    init(tab: Tab, profile: Profile, tabManager: TabManager) {
+    init(tab: Tab, profile: Profile) {
         self.tab = tab
         self.profile = profile
-        self.tabManager = tabManager
-
     }
 
     // MARK: - Functions

--- a/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
@@ -68,7 +68,6 @@ class HistoryHighlightsViewModel {
     var historyItems = [HighlightItem]()
     private var profile: Profile
     private var isPrivate: Bool
-    private var tabManager: TabManagerProtocol
     private var urlBar: URLBarViewProtocol
     private lazy var siteImageHelper = SiteImageHelper(profile: profile)
     private var hasSentSectionEvent = false
@@ -110,14 +109,12 @@ class HistoryHighlightsViewModel {
     // MARK: - Inits
     init(with profile: Profile,
          isPrivate: Bool,
-         tabManager: TabManagerProtocol,
          urlBar: URLBarViewProtocol,
          historyHighlightsDataAdaptor: HistoryHighlightsDataAdaptor,
          dispatchQueue: DispatchQueueInterface = DispatchQueue.main,
          telemetry: TelemetryWrapperProtocol = TelemetryWrapper.shared) {
         self.profile = profile
         self.isPrivate = isPrivate
-        self.tabManager = tabManager
         self.urlBar = urlBar
         self.dispatchQueue = dispatchQueue
         self.telemetry = telemetry

--- a/Client/Frontend/Home/HomepageViewModel.swift
+++ b/Client/Frontend/Home/HomepageViewModel.swift
@@ -116,7 +116,6 @@ class HomepageViewModel: FeatureFlaggable {
         self.historyHighlightsViewModel = HistoryHighlightsViewModel(
             with: profile,
             isPrivate: isPrivate,
-            tabManager: tabManager,
             urlBar: urlBar,
             historyHighlightsDataAdaptor: historyDataAdaptor)
 

--- a/Client/Frontend/Login Management/DevicePasscodeRequiredViewController.swift
+++ b/Client/Frontend/Login Management/DevicePasscodeRequiredViewController.swift
@@ -27,8 +27,8 @@ class DevicePasscodeRequiredViewController: SettingsViewController {
         return button
     }()
 
-    init(profile: Profile? = nil, tabManager: TabManager? = nil, shownFromAppMenu: Bool = false) {
-        super.init(profile: profile, tabManager: tabManager)
+    init(shownFromAppMenu: Bool = false) {
+        super.init()
         self.shownFromAppMenu = shownFromAppMenu
     }
 

--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -29,10 +29,10 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
     // Bug 1445687 -- https://bugzilla.mozilla.org/show_bug.cgi?id=1445687
     fileprivate lazy var clearables: [(clearable: Clearable, checked: DefaultCheckedState)] = {
         var items: [(clearable: Clearable, checked: DefaultCheckedState)] = [
-            (HistoryClearable(profile: self.profile, tabManager: tabManager), true),
-            (CacheClearable(tabManager: self.tabManager), true),
-            (CookiesClearable(tabManager: self.tabManager), true),
-            (SiteDataClearable(tabManager: self.tabManager), true),
+            (HistoryClearable(profile: profile, tabManager: tabManager), true),
+            (CacheClearable(), true),
+            (CookiesClearable(), true),
+            (SiteDataClearable(), true),
             (TrackingProtectionClearable(), true),
             (DownloadedFilesClearable(), false), // Don't clear downloaded files by default
         ]

--- a/Client/Frontend/Settings/Clearables.swift
+++ b/Client/Frontend/Settings/Clearables.swift
@@ -81,11 +81,6 @@ struct ClearableErrorType: MaybeErrorType {
 // Clear the web cache. Note, this has to close all open tabs in order to ensure the data
 // cached in them isn't flushed to disk.
 class CacheClearable: Clearable {
-    let tabManager: TabManager
-    init(tabManager: TabManager) {
-        self.tabManager = tabManager
-    }
-
     var label: String { .ClearableCache }
 
     func clear() -> Success {
@@ -136,10 +131,6 @@ private func deleteLibraryFolder(_ folder: String) throws {
 
 // Removes all app cache storage.
 class SiteDataClearable: Clearable {
-    let tabManager: TabManager
-    init(tabManager: TabManager) {
-        self.tabManager = tabManager
-    }
 
     var label: String { .ClearableOfflineData }
 
@@ -154,10 +145,6 @@ class SiteDataClearable: Clearable {
 
 // Remove all cookies stored by the site. This includes localStorage, sessionStorage, and WebSQL/IndexedDB.
 class CookiesClearable: Clearable {
-    let tabManager: TabManager
-    init(tabManager: TabManager) {
-        self.tabManager = tabManager
-    }
 
     var label: String { .ClearableCookies }
 

--- a/Tests/ClientTests/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModelTests.swift
@@ -10,7 +10,6 @@ class HistoryHighlightsViewModelTests: XCTestCase {
 
     private var subject: HistoryHighlightsViewModel!
     private var profile: MockProfile!
-    private var tabManager: MockTabManager!
     private var dataAdaptor: MockHistoryHighlightsDataAdaptor!
     private var delegate: MockHomepageDataModelDelegate!
     private var telemetry: MockTelemetryWrapper!
@@ -21,7 +20,6 @@ class HistoryHighlightsViewModelTests: XCTestCase {
 
         profile = MockProfile()
         FeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
-        tabManager = MockTabManager()
         dataAdaptor = MockHistoryHighlightsDataAdaptor()
         delegate = MockHomepageDataModelDelegate()
         telemetry = MockTelemetryWrapper()
@@ -32,7 +30,6 @@ class HistoryHighlightsViewModelTests: XCTestCase {
         super.tearDown()
 
         profile = nil
-        tabManager = nil
         dataAdaptor = nil
         subject = nil
         delegate = nil
@@ -237,7 +234,6 @@ class HistoryHighlightsViewModelTests: XCTestCase {
         subject = HistoryHighlightsViewModel(
             with: profile,
             isPrivate: isPrivate,
-            tabManager: tabManager,
             urlBar: urlBar,
             historyHighlightsDataAdaptor: dataAdaptor,
             dispatchQueue: MockDispatchQueue(),


### PR DESCRIPTION
## [FXIOS-4805](https://mozilla-hub.atlassian.net/browse/FXIOS-4805) https://github.com/mozilla-mobile/firefox-ios/issues/11681
Remove tab manager usage where it's not used