### PR TITLE
Bump FXIOS-4843 [v106] Bitrise - Update xcode-build-for-simulator and xcode-test

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -491,11 +491,11 @@ workflows:
             npm run build
   4_A_xcode_build_and_test_Fennec:
     steps:
-    - xcode-build-for-simulator@0.11:
+    - xcode-build-for-simulator@0.12:
         inputs:
         - scheme: Fennec
         - xcodebuild_options: CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
-    - xcode-test@3.1:
+    - xcode-test@4.5:
         inputs:
         - scheme: Fennec
         - simulator_device: iPhone 8
@@ -550,11 +550,11 @@ workflows:
             Mana|https://mana.mozilla.org/wiki/display/MTE/Mobile+Test+Engineering
   4_B_xcode_build_and_test_Fennec_Enterprise_XCUITests:
     steps:
-    - xcode-build-for-simulator@0.11:
+    - xcode-build-for-simulator@0.12:
         inputs:
         - xcodebuild_options: CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
         - scheme: Fennec_Enterprise_XCUITests
-    - xcode-test@3.1:
+    - xcode-test@4.5:
         inputs:
         - scheme: Fennec_Enterprise_XCUITests
         - xcodebuild_test_options: "-testPlan Fennec_Enterprise_XCUITests"
@@ -686,12 +686,12 @@ workflows:
 
             npm install
             npm run build
-    - xcode-build-for-simulator@0.11:
+    - xcode-build-for-simulator@0.12:
         run_if: '{{getenv "NEW_XCODE_VERSION" | eq "New_Version_Found" | or (getenv "RUN_ALL_STEPS" | eq "Run_All_Steps")}}'
         inputs:
         - xcodebuild_options: CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
         - scheme: Fennec
-    - xcode-test@2:
+    - xcode-test@4.5:
         run_if: '{{getenv "NEW_XCODE_VERSION" | eq "New_Version_Found" | or (getenv "RUN_ALL_STEPS" | eq "Run_All_Steps")}}'
         inputs:
         - scheme: Fennec
@@ -724,32 +724,32 @@ workflows:
         machine_type_id: g2.4core
   RunSmokeXCUITestsiPad:
     steps:
-    - xcode-build-for-simulator@0.11:
+    - xcode-build-for-simulator@0.12:
         inputs:
         - xcodebuild_options: CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
         - scheme: Fennec_Enterprise_XCUITests
-    - xcode-test@2.4:
+    - xcode-test@4.5:
         inputs:
         - scheme: Fennec_Enterprise_XCUITests
         - xcodebuild_test_options: "-testPlan SmokeXCUITests"
         - simulator_os_version: latest
         - simulator_device: iPad Pro (12.9-inch) (5th generation)
         description: This Workflow is to run SmokeTest on iPad simulator device
-    - xcode-test@2.4:
+    - xcode-test@4.5:
         inputs:
         - scheme: Fennec_Enterprise_XCUITests
         - xcodebuild_test_options: "-testPlan Smoketest2"
         - simulator_os_version: latest
         - simulator_device: iPad Pro (12.9-inch) (5th generation)
         description: This Workflow is to run SmokeTest on iPad simulator device Smoketest2
-    - xcode-test@2.4:
+    - xcode-test@4.5:
         inputs:
         - scheme: Fennec_Enterprise_XCUITests
         - xcodebuild_test_options: "-testPlan Smoketest3"
         - simulator_os_version: latest
         - simulator_device: iPad Pro (12.9-inch) (5th generation)
         description: This Workflow is to run SmokeTest on iPad simulator device Smoketest3
-    - xcode-test@2.4:
+    - xcode-test@4.5:
         inputs:
         - scheme: Fennec_Enterprise_XCUITests
         - xcodebuild_test_options: "-testPlan Smoketest4"
@@ -768,13 +768,13 @@ workflows:
     - 5_deploy_and_slack
   RunUITests:
     steps:
-    - xcode-build-for-simulator@0.11:
+    - xcode-build-for-simulator@0.12:
         inputs:
         - configuration: Release
         - xcodebuild_options: CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -testPlan SmokeXCUITests
         - scheme: Fennec_Enterprise_XCUITests
         - xcodebuild_test_options: "-testPlan SmokeXCUITests"
-    - xcode-test@2:
+    - xcode-test@4.5:
         inputs:
         - scheme: Fennec_Enterprise_UITests
         - simulator_device: iPhone 8
@@ -1029,7 +1029,7 @@ workflows:
     steps:
     - cache-pull@2.1:
         is_always_run: true
-    - xcode-test@2:
+    - xcode-test@4.5:
         inputs:
         - scheme: Fennec_Enterprise_XCUITests
         - xcodebuild_test_options: "-testPlan SmokeXCUITests"


### PR DESCRIPTION
`xcode-test` has been updated to 4.5.
`xcode-build-for-simulator` has been updated to 0.12.

This PR will fix #11755.