### PR TITLE
Refactor 11772 [v?] Sending normal_and_private_uri_count in baseline ping

### DIFF
--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -2209,6 +2209,11 @@ tabs:
     type: counter
     description: |
       Record the number of URI's visited by the user.
+    send_in_pings:
+      - baseline
+      - metrics
+    no_lint:
+      - BASELINE_PING
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/9158
     data_reviews:


### PR DESCRIPTION
Sends URI counts in Baseline ping for DS to being evaluating using baseline for QCDOU calculations.

Includes lint bypass for adding metrics to baseline. Typically, adding to the baseline ping is undesirable, except for the case where data is used for things like QCDOU (which is being evaluated as a KPI), so including it here.

Not sure about version number, would appreciate it someone could help me out on that front
