### PR TITLE
Bugfix FXIOS-3077 [v106] Wallet pass changes

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -532,6 +532,7 @@
 		8A471185287F6E4800F5A6EA /* SeparatorTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A471184287F6E4800F5A6EA /* SeparatorTableViewCell.swift */; };
 		8A56955227C68AE00077A89E /* UILabel+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A56955127C68AE00077A89E /* UILabel+Extension.swift */; };
 		8A57519927AD80B800A84DBF /* ReaderModeStyleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A57519827AD80B800A84DBF /* ReaderModeStyleViewModel.swift */; };
+		8A590C6128C123100032F1AA /* OpenPassBookHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A590C6028C123100032F1AA /* OpenPassBookHelper.swift */; };
 		8A5BD95A28788A3D000FE773 /* TopSitesHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5BD9582878871B000FE773 /* TopSitesHelperTests.swift */; };
 		8A5BD95C2878AA74000FE773 /* PinnedSite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5BD95B2878AA74000FE773 /* PinnedSite.swift */; };
 		8A5BD95F2878B7B6000FE773 /* TopSitesWidgetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5BD95E2878B7B6000FE773 /* TopSitesWidgetManager.swift */; };
@@ -588,6 +589,7 @@
 		8ABA9C8D28931223002C0077 /* MockDispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABA9C8C28931223002C0077 /* MockDispatchQueue.swift */; };
 		8ABA9C8E28931288002C0077 /* JumpBackInDataAdaptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABA9C8A28931207002C0077 /* JumpBackInDataAdaptorTests.swift */; };
 		8ABC5AEE284532C900FEA552 /* PocketDiscoverCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABC5AED284532C900FEA552 /* PocketDiscoverCell.swift */; };
+		8AC5D55F28BFE6C8001F6F7F /* Presenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC5D55E28BFE6C8001F6F7F /* Presenter.swift */; };
 		8AD08D1527E9198E00B8E907 /* TabsQuantityTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD08D1427E9198E00B8E907 /* TabsQuantityTelemetry.swift */; };
 		8AD08D1727E91AC800B8E907 /* TabsQuantityTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD08D1627E91AC800B8E907 /* TabsQuantityTelemetryTests.swift */; };
 		8AD1980F27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD1980E27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift */; };
@@ -3205,6 +3207,7 @@
 		8A5143D6BF179870414566ED /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Search.strings; sourceTree = "<group>"; };
 		8A56955127C68AE00077A89E /* UILabel+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Extension.swift"; sourceTree = "<group>"; };
 		8A57519827AD80B800A84DBF /* ReaderModeStyleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeStyleViewModel.swift; sourceTree = "<group>"; };
+		8A590C6028C123100032F1AA /* OpenPassBookHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenPassBookHelper.swift; sourceTree = "<group>"; };
 		8A5BD9582878871B000FE773 /* TopSitesHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSitesHelperTests.swift; sourceTree = "<group>"; };
 		8A5BD95B2878AA74000FE773 /* PinnedSite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedSite.swift; sourceTree = "<group>"; };
 		8A5BD95E2878B7B6000FE773 /* TopSitesWidgetManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSitesWidgetManager.swift; sourceTree = "<group>"; };
@@ -3269,6 +3272,7 @@
 		8ABA9C8A28931207002C0077 /* JumpBackInDataAdaptorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JumpBackInDataAdaptorTests.swift; sourceTree = "<group>"; };
 		8ABA9C8C28931223002C0077 /* MockDispatchQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDispatchQueue.swift; sourceTree = "<group>"; };
 		8ABC5AED284532C900FEA552 /* PocketDiscoverCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketDiscoverCell.swift; sourceTree = "<group>"; };
+		8AC5D55E28BFE6C8001F6F7F /* Presenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Presenter.swift; sourceTree = "<group>"; };
 		8AD08D1427E9198E00B8E907 /* TabsQuantityTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsQuantityTelemetry.swift; sourceTree = "<group>"; };
 		8AD08D1627E91AC800B8E907 /* TabsQuantityTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsQuantityTelemetryTests.swift; sourceTree = "<group>"; };
 		8AD1980E27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotonActionSheetViewModel.swift; sourceTree = "<group>"; };
@@ -6248,6 +6252,15 @@
 			path = TestingHelperClasses;
 			sourceTree = "<group>";
 		};
+		8A590C5F28C122FF0032F1AA /* OpenInHelper */ = {
+			isa = PBXGroup;
+			children = (
+				7BA8D1C61BA037F500C8AE9E /* OpenInHelper.swift */,
+				8A590C6028C123100032F1AA /* OpenPassBookHelper.swift */,
+			);
+			path = OpenInHelper;
+			sourceTree = "<group>";
+		};
 		8A7653C028A2E54800924ABF /* Pocket */ = {
 			isa = PBXGroup;
 			children = (
@@ -7183,6 +7196,7 @@
 		D3A994941A368691008AD1AC /* Browser */ = {
 			isa = PBXGroup;
 			children = (
+				8A590C5F28C122FF0032F1AA /* OpenInHelper */,
 				C849E45F26B9C36600260F0B /* EnhancedTrackingProtection */,
 				23F2C365244E44FA00FA4496 /* Tabs */,
 				D38F02D01C05127100175932 /* Authenticator.swift */,
@@ -7205,7 +7219,6 @@
 				7482205B1DBAB56300EEEA72 /* MailProviders.swift */,
 				744ED5601DBFEB8D00A2B5BE /* MailtoLinkHandler.swift */,
 				D0C95E35200FDC5400E4E51C /* MetadataParserHelper.swift */,
-				7BA8D1C61BA037F500C8AE9E /* OpenInHelper.swift */,
 				D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */,
 				74821FC41DB56A2500EEEA72 /* OpenWithSettingsViewController.swift */,
 				D31CF65B1CC1959A001D0BD0 /* PrivilegedRequest.swift */,
@@ -7321,6 +7334,7 @@
 				8ABA9C8828931197002C0077 /* DispatchQueueInterface.swift */,
 				C87DC85D27B2CA49006EFCE2 /* Loggable.swift */,
 				C8044BD527B96A4E00CEE7AD /* Notifiable.swift */,
+				8AC5D55E28BFE6C8001F6F7F /* Presenter.swift */,
 				DFACDFAE274D4D6D00A94EEC /* ReusableCell.swift */,
 				8AE1E1D127B1ADC40024C45E /* TopBottomInterchangeable.swift */,
 				8A6B77CD2811CD11001110D2 /* URLCaching.swift */,
@@ -10193,6 +10207,7 @@
 				D029A04920A62DB0001DB72F /* TemporaryDocument.swift in Sources */,
 				C8BA0E7627F20B8E00DD8214 /* HistoryDeletionUtility.swift in Sources */,
 				5AB4237E28A2BA9C003BC40C /* HistoryHighlightsDataAdaptor.swift in Sources */,
+				8A590C6128C123100032F1AA /* OpenPassBookHelper.swift in Sources */,
 				EBB895332193FFF400EB91A0 /* ContentBlockerSettingViewController.swift in Sources */,
 				E692E3371C46E86A009D1240 /* AppSettingsOptions.swift in Sources */,
 				D38F02D11C05127100175932 /* Authenticator.swift in Sources */,
@@ -10668,6 +10683,7 @@
 				D04CD718215EBD85004FF5B0 /* SettingsLoadingView.swift in Sources */,
 				4390F7FF246DAFBE00570811 /* FirefoxColors.swift in Sources */,
 				D04CD74C216CF86B004FF5B0 /* InstructionsViewController.swift in Sources */,
+				8AC5D55F28BFE6C8001F6F7F /* Presenter.swift in Sources */,
 				C8501F4F2850FB72003B09AB /* WallpaperMigrationUtility.swift in Sources */,
 				8A3233FE28627446003E1C33 /* LocalDesktopFolder.swift in Sources */,
 				C8954A532729AD9D001C7283 /* ThemeManager.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -74,6 +74,7 @@ class BrowserViewController: UIViewController {
     fileprivate var customSearchBarButton: UIBarButtonItem?
     var updateState: TabUpdateState = .coldStart
     var openedUrlFromExternalSource = false
+    var passBookHelper: OpenPassBookHelper?
 
     var contextHintVC: ContextualHintViewController
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -616,16 +616,17 @@ extension BrowserViewController: WKNavigationDelegate {
         let forceDownload = webView == pendingDownloadWebView
         let cookieStore = webView.configuration.websiteDataStore.httpCookieStore
 
-        // Check if this response should be handed off to Passbook.
-        if let passbookHelper = OpenPassBookHelper(
-            request: request,
-            response: response,
-            cookieStore: cookieStore,
-            canShowInWebView: canShowInWebView,
-            forceDownload: forceDownload,
-            browserViewController: self) {
-            // Open our helper and cancel this response from the webview.
-            passbookHelper.open()
+        if OpenPassBookHelper.shouldOpenWithPassBook(response: response,
+                                                     forceDownload: forceDownload) {
+            self.passBookHelper = OpenPassBookHelper(response: response,
+                                                     cookieStore: cookieStore,
+                                                     presenter: self)
+            // Open our helper and nullifies the helper when done with it
+            self.passBookHelper?.open {
+                self.passBookHelper = nil
+            }
+
+            // Cancel this response from the webview.
             decisionHandler(.cancel)
             return
         }

--- a/Client/Frontend/Browser/OpenInHelper/OpenPassBookHelper.swift
+++ b/Client/Frontend/Browser/OpenInHelper/OpenPassBookHelper.swift
@@ -1,0 +1,148 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import PassKit
+import Shared
+import WebKit
+
+class OpenPassBookHelper {
+
+    private enum InvalidPassError: Error {
+        case contentsOfURL
+        case dataTaskURL
+        case openError
+    }
+
+    private var response: URLResponse
+    private var url: URL?
+    private let presenter: Presenter
+    private let cookieStore: WKHTTPCookieStore
+    private lazy var session = makeURLSession(userAgent: UserAgent.fxaUserAgent,
+                                              configuration: .ephemeral)
+
+    init(response: URLResponse,
+         cookieStore: WKHTTPCookieStore,
+         presenter: Presenter) {
+        self.response = response
+        self.url  = response.url
+        self.cookieStore = cookieStore
+        self.presenter = presenter
+    }
+
+    static func shouldOpenWithPassBook(response: URLResponse,
+                                       forceDownload: Bool) -> Bool {
+        guard let mimeType = response.mimeType, response.url != nil else { return false }
+        return mimeType == MIMEType.Passbook && PKAddPassesViewController.canAddPasses() && !forceDownload
+    }
+
+    func open(completion: @escaping () -> Void) {
+        do {
+            try openPassWithContentsOfURL()
+            completion()
+
+        } catch InvalidPassError.contentsOfURL {
+            openPassWithCookies { error in
+                if error != nil {
+                    self.presentErrorAlert(completion: completion)
+                } else {
+                    completion()
+                }
+            }
+
+        } catch {
+            presentErrorAlert(completion: completion)
+        }
+    }
+
+    private func openPassWithCookies(completion: @escaping (InvalidPassError?) -> Void) {
+        configureCookies { [weak self] in
+            self?.openPassfromDataTask(completion: completion)
+        }
+    }
+
+    private func openPassfromDataTask(completion: @escaping (InvalidPassError?) -> Void) {
+        getData(completion: { data in
+            guard let data = data else {
+                completion(InvalidPassError.dataTaskURL)
+                return
+            }
+
+            do {
+                try self.open(passData: data)
+            } catch {
+                completion(InvalidPassError.dataTaskURL)
+            }
+        })
+    }
+
+    private func getData(completion: @escaping (Data?) -> Void) {
+        guard let url = url else {
+            completion(nil)
+            return
+        }
+
+        session.dataTask(with: url) { (data, response, error) in
+            guard let _ = validatedHTTPResponse(response, statusCode: 200..<300),
+                  let data = data
+            else {
+                completion(nil)
+                return
+            }
+
+            completion(data)
+        }.resume()
+    }
+
+    /// Get webview cookies to add onto download session
+    private func configureCookies(completion: @escaping () -> Void) {
+        cookieStore.getAllCookies { [weak self] cookies in
+            for cookie in cookies {
+                self?.session.configuration.httpCookieStorage?.setCookie(cookie)
+            }
+
+            completion()
+        }
+    }
+
+    private func openPassWithContentsOfURL() throws {
+        guard let url = url, let passData = try? Data(contentsOf: url) else {
+            throw InvalidPassError.contentsOfURL
+        }
+
+        do {
+            try open(passData: passData)
+        } catch {
+            throw InvalidPassError.contentsOfURL
+        }
+    }
+
+    private func open(passData: Data) throws {
+        do {
+            let pass = try PKPass(data: passData)
+            let passLibrary = PKPassLibrary()
+            if passLibrary.containsPass(pass) {
+                UIApplication.shared.open(pass.passURL!, options: [:])
+            } else {
+                guard let addController = PKAddPassesViewController(pass: pass) else {
+                    throw InvalidPassError.openError
+                }
+                presenter.present(addController, animated: true, completion: nil)
+            }
+        } catch {
+            throw InvalidPassError.openError
+        }
+    }
+
+    private func presentErrorAlert(completion: @escaping () -> Void) {
+        let alertController = UIAlertController(title: .UnableToAddPassErrorTitle,
+                                                message: .UnableToAddPassErrorMessage,
+                                                preferredStyle: .alert)
+
+        alertController.addAction(UIAlertAction(title: .UnableToAddPassErrorDismiss,
+                                                style: .cancel) { (action) in })
+        presenter.present(alertController, animated: true, completion: {
+            completion()
+        })
+    }
+}

--- a/Client/Protocols/Presenter.swift
+++ b/Client/Protocols/Presenter.swift
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// Protocol to present a view controller
+protocol Presenter {
+    func present(_ viewControllerToPresent: UIViewController,
+                 animated flag: Bool,
+                 completion: (() -> Void)?)
+}
+
+extension Presenter {
+    func present(_ viewControllerToPresent: UIViewController,
+                 animated flag: Bool,
+                 completion: (() -> Void)? = nil) {
+        present(viewControllerToPresent, animated: flag, completion: completion)
+    }
+}
+
+extension UIViewController: Presenter {}


### PR DESCRIPTION
# [FXIOS-3077](https://mozilla-hub.atlassian.net/browse/FXIOS-3077) https://github.com/mozilla-mobile/firefox-ios/issues/8994
- Keep reference to OpenPassBookHelper so it's not deinit (was one of the issues why nothing was happening when a user was trying to open a pass)
- Add back way to download PKpass without cookies, and fallback to cookies if that didn't work
- Put OpenPassBookHelper in it's own file

This probably won't fix all issues with adding passes to wallet, but at least it will show an error as it should when it's not able to add to it. 