### PR TITLE
Refactor FXIOS-4837 [v106] Update hint text for email field

### DIFF
--- a/Client/Application/AccessibilityIdentifiers.swift
+++ b/Client/Application/AccessibilityIdentifiers.swift
@@ -182,6 +182,7 @@ public struct AccessibilityIdentifiers {
         struct FirefoxAccount {
             static let qrButton = "QRCodeSignIn.button"
             static let continueButton = "Sign up or sign in"
+            static let emailTextFieldChinaFxA = "Email"
             static let emailTextField = "Enter your email"
             static let fxaNavigationBar = "Sync and Save Data"
             static let fxaSettingsButton = "Sync and Save Data"

--- a/Tests/Fennec_Enterprise_XCUITests.xctestplan
+++ b/Tests/Fennec_Enterprise_XCUITests.xctestplan
@@ -65,7 +65,6 @@
         "HomePageSettingsUITests\/testCustomizeHomepage()",
         "HomePageSettingsUITests\/testJumpBackIn()",
         "HomePageUITest",
-        "IntegrationTests",
         "IntegrationTests\/testFxASyncBookmark()",
         "NavigationTest\/testLongPressLinkOptions()",
         "NavigationTest\/testNavigationPreservesDesktopSiteOnSameHost()",

--- a/Tests/Fennec_Enterprise_XCUITests.xctestplan
+++ b/Tests/Fennec_Enterprise_XCUITests.xctestplan
@@ -65,6 +65,7 @@
         "HomePageSettingsUITests\/testCustomizeHomepage()",
         "HomePageSettingsUITests\/testJumpBackIn()",
         "HomePageUITest",
+        "IntegrationTests",
         "IntegrationTests\/testFxASyncBookmark()",
         "NavigationTest\/testLongPressLinkOptions()",
         "NavigationTest\/testNavigationPreservesDesktopSiteOnSameHost()",

--- a/Tests/XCUITests/IntegrationTests.swift
+++ b/Tests/XCUITests/IntegrationTests.swift
@@ -92,7 +92,7 @@ class IntegrationTests: BaseTestCase {
         navigator.goto(Intro_FxASignin)
         navigator.performAction(Action.OpenEmailToSignIn)
         waitForExistence(app.navigationBars[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaNavigationBar], timeout: 20)
-        waitForExistence(app.webViews.textFields[AccessibilityIdentifiers.Settings.FirefoxAccount.emailTextField], timeout: 20)
+        waitForExistence(app.webViews.textFields[AccessibilityIdentifiers.Settings.FirefoxAccount.emailTextFieldChinaFxA], timeout: 20)
 
         // Wait for element not present on FxA sign in page China FxA server
         waitForNoExistence(app.webViews.otherElements.staticTexts["Firefox Monitor"])


### PR DESCRIPTION
The hint text for the email field is "Email" instead of "Enter your email" on the Chinese language login page. 

Since the `emailTextField` identifier is used in other places, I created a new identifier just for this page.