### PR TITLE
Bugfix FXIOS-4836 [v106]: Synced tab title fix

### DIFF
--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -379,11 +379,13 @@ class Tab: NSObject {
             return nil
         }
 
+        guard let title = tab.title, !title.isEmpty else { return nil }
+
         if let displayURL = tab.url?.displayURL, RemoteTab.shouldIncludeURL(displayURL) {
             let history = Array(tab.historyList.filter(RemoteTab.shouldIncludeURL).reversed())
             return RemoteTab(clientGUID: nil,
                 URL: displayURL,
-                title: tab.displayTitle,
+                title: title,
                 history: history,
                 lastUsed: tab.lastExecutedTime ?? 0,
                 icon: nil)
@@ -392,7 +394,7 @@ class Tab: NSObject {
             if let displayURL = history.first {
                 return RemoteTab(clientGUID: nil,
                     URL: displayURL,
-                    title: tab.displayTitle,
+                    title: title,
                     history: history,
                     lastUsed: sessionData.lastUsedTime,
                     icon: nil)
@@ -729,6 +731,7 @@ class Tab: NSObject {
         if let title = self.webView?.title, !title.isEmpty,
            path == KVOConstants.title.rawValue {
             metadataManager?.updateObservationTitle(title)
+            _ = Tab.toRemoteTab(self)
         }
     }
 

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -178,6 +178,8 @@ class Tab: NSObject {
         return nil
     }
 
+    /// This property returns, ideally, the web page's title. Otherwise, based on the page being internal or not, it will
+    /// resort to other displayable titles.
     var displayTitle: String {
         /// First, check if the webView can give us a title.
         if let title = webView?.title, !title.isEmpty {
@@ -205,7 +207,7 @@ class Tab: NSObject {
         /// Finally, somehow lastTitle is persisted (and webView's title isn't).
         guard let lastTitle = lastTitle, !lastTitle.isEmpty else {
             /// And if `lastTitle` fails, we'll take the URL itself (somewhat treated) as the last resort.
-            return self.url?.displayURL?.absoluteString ??  ""
+            return self.url?.displayURL?.baseDomain ??  ""
         }
 
         return lastTitle

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -171,30 +171,40 @@ class Tab: NSObject {
     }
 
     var title: String? {
-        return webView?.title
+        if let title = webView?.title, !title.isEmpty {
+            return webView?.title
+        }
+
+        return nil
     }
 
     var displayTitle: String {
+        /// First, check if the webView can give us a title.
         if let title = webView?.title, !title.isEmpty {
             return title
         }
 
+        /// If the webView doesn't give a title. check the URL to see if it's our Home URL, with no sessionData on this tab.
         // When picking a display title. Tabs with sessionData are pending a restore so show their old title.
         // To prevent flickering of the display title. If a tab is restoring make sure to use its lastTitle.
         if let url = self.url, InternalURL(url)?.isAboutHomeURL ?? false, sessionData == nil, !isRestoring {
             return .AppMenu.AppMenuOpenHomePageTitleString
         }
 
+        /// Here's another check to see if we're at the Home URL, using sessionData.
         // lets double check the sessionData in case this is a non-restored new tab
         if let firstURL = sessionData?.urls.first, sessionData?.urls.count == 1, InternalURL(firstURL)?.isAboutHomeURL ?? false {
             return .AppMenu.AppMenuOpenHomePageTitleString
         }
 
+        /// Then, if it's not Home, and it's also not a complete and valid URL, display what was "entered" as the title.
         if let url = self.url, !InternalURL.isValid(url: url), let shownUrl = url.displayURL?.absoluteString {
             return shownUrl
         }
 
+        /// Finally, somehow lastTitle is persisted (and webView's title isn't).
         guard let lastTitle = lastTitle, !lastTitle.isEmpty else {
+            /// And if `lastTitle` fails, we'll take the URL itself (somewhat treated) as the last resort.
             return self.url?.displayURL?.absoluteString ??  ""
         }
 
@@ -379,25 +389,27 @@ class Tab: NSObject {
             return nil
         }
 
-        guard let title = tab.title, !title.isEmpty else { return nil }
-
         if let displayURL = tab.url?.displayURL, RemoteTab.shouldIncludeURL(displayURL) {
             let history = Array(tab.historyList.filter(RemoteTab.shouldIncludeURL).reversed())
-            return RemoteTab(clientGUID: nil,
+            return RemoteTab(
+                clientGUID: nil,
                 URL: displayURL,
-                title: title,
+                title: tab.title ?? tab.displayTitle,
                 history: history,
                 lastUsed: tab.lastExecutedTime ?? 0,
-                icon: nil)
+                icon: nil
+            )
         } else if let sessionData = tab.sessionData, !sessionData.urls.isEmpty {
             let history = Array(sessionData.urls.filter(RemoteTab.shouldIncludeURL).reversed())
             if let displayURL = history.first {
-                return RemoteTab(clientGUID: nil,
+                return RemoteTab(
+                    clientGUID: nil,
                     URL: displayURL,
-                    title: title,
+                    title: tab.title ?? tab.displayTitle,
                     history: history,
                     lastUsed: sessionData.lastUsedTime,
-                    icon: nil)
+                    icon: nil
+                )
             }
         }
 


### PR DESCRIPTION
# #11742 | [FXIOS-4836](https://mozilla-hub.atlassian.net/browse/FXIOS-4836)

## Overview

For synced tabs, the title would sometimes becomes the URL of the page. Now, if the title isn't available at the time, it'll show the URL's base domain. When a title becomes available (KVO on webView's title), it'll update to use it.

This handles edge cases where a title may never be available. 

## Testing
To test, use Fx Nightly (Desktop) and check the "Firefox View" screen. It should display the web page's title. 

Open a page, wait 5 seconds for the sync to happen. Then click into the Firefox View screen.

Note - depending on the site, you may see the site name synced before you see the actual web page's title. This issue occurs with Twitter for us. 