### PR TITLE
Refactor FXIOS-4831 [v106] Update L10n intro test

### DIFF
--- a/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
@@ -35,16 +35,18 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
         sleep(3)
         waitForExistence(app.scrollViews.staticTexts["WelcomeCardTitleLabel"], timeout: 15)
         snapshot("Onboarding-1")
+        
         // Swipe to the second screen
         app.buttons["\(rootA11yId)PrimaryButton"].tap()
         currentScreen += 1
+        waitForExistence(app.buttons["SignSyncCardPrimaryButton"])
         waitForExistence(app.buttons["SignSyncCardSecondaryButton"])
         snapshot("Onboarding-2")
 
-        // Swipe to the third screen
+        // Swipe to the Homescreen
         app.buttons["SignSyncCardSecondaryButton"].tap()
         currentScreen += 1
-        snapshot("Onboarding-3")
+        snapshot("Homescreen-first-visit")
     }
 
     func testWebViewContextMenu () throws {

--- a/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
@@ -35,7 +35,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
         sleep(3)
         waitForExistence(app.scrollViews.staticTexts["WelcomeCardTitleLabel"], timeout: 15)
         snapshot("Onboarding-1")
-        
+
         // Swipe to the second screen
         app.buttons["\(rootA11yId)PrimaryButton"].tap()
         currentScreen += 1

--- a/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
@@ -38,11 +38,11 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
         // Swipe to the second screen
         app.buttons["\(rootA11yId)PrimaryButton"].tap()
         currentScreen += 1
-        waitForExistence(app.buttons["\(rootA11yId)PrimaryButton"])
+        waitForExistence(app.buttons["SignSyncCardSecondaryButton"])
         snapshot("Onboarding-2")
 
         // Swipe to the third screen
-        app.buttons["\(rootA11yId)SecondaryButton"].tap()
+        app.buttons["SignSyncCardSecondaryButton"].tap()
         currentScreen += 1
         snapshot("Onboarding-3")
     }


### PR DESCRIPTION
The L10n intro test is failing because the design has been updated (see #11733). In particular the button to swipe to the next screen is changed. The test has been updated to reflect the update.