### PR TITLE
Refactor FXIOS-4891 [v107] Bitrise follow up Smoketest iPad

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1406,7 +1406,6 @@ trigger_map:
 - push_branch: v105.0
   workflow: SPM_Deploy_Prod_Beta
 - pull_request_target_branch: main
-  #pipeline: pipeline_multiple_shards
-  workflow: RunSmokeXCUITestsiPad
+  pipeline: pipeline_multiple_shards
 - pull_request_target_branch: epic-branch/*
   pipeline: pipeline_multiple_shards

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -730,31 +730,31 @@ workflows:
         - scheme: Fennec_Enterprise_XCUITests
     - xcode-test@4.5:
         inputs:
+        is_always_run: true
         - scheme: Fennec_Enterprise_XCUITests
         - test_plan: "SmokeXCUITests"
-        - simulator_os_version: latest
-        - simulator_device: iPad Pro (12.9-inch) (5th generation)
+        - destination: platform=iOS Simulator,name=iPad Pro (12.9-inch) (5th generation),OS=latest
         description: This Workflow is to run SmokeTest on iPad simulator device
     - xcode-test@4.5:
         inputs:
+        is_always_run: true
         - scheme: Fennec_Enterprise_XCUITests
         - test_plan: "Smoketest2"
-        - simulator_os_version: latest
-        - simulator_device: iPad Pro (12.9-inch) (5th generation)
+        - destination: platform=iOS Simulator,name=iPad Pro (12.9-inch) (5th generation),OS=latest
         description: This Workflow is to run SmokeTest on iPad simulator device Smoketest2
     - xcode-test@4.5:
         inputs:
+        is_always_run: true
         - scheme: Fennec_Enterprise_XCUITests
         - test_plan: "Smoketest3"
-        - simulator_os_version: latest
-        - simulator_device: iPad Pro (12.9-inch) (5th generation)
+        - destination: platform=iOS Simulator,name=iPad Pro (12.9-inch) (5th generation),OS=latest
         description: This Workflow is to run SmokeTest on iPad simulator device Smoketest3
     - xcode-test@4.5:
+        is_always_run: true
         inputs:
         - scheme: Fennec_Enterprise_XCUITests
         - test_plan: "Smoketest4"
-        - simulator_os_version: latest
-        - simulator_device: iPad Pro (12.9-inch) (5th generation)
+        - destination: platform=iOS Simulator,name=iPad Pro (12.9-inch) (5th generation),OS=latest
         description: This Workflow is to run SmokeTest on iPad simulator device Smoketest4
     meta:
       bitrise.io:
@@ -1406,6 +1406,7 @@ trigger_map:
 - push_branch: v105.0
   workflow: SPM_Deploy_Prod_Beta
 - pull_request_target_branch: main
-  pipeline: pipeline_multiple_shards
+  #pipeline: pipeline_multiple_shards
+  workflow: RunSmokeXCUITestsiPad
 - pull_request_target_branch: epic-branch/*
   pipeline: pipeline_multiple_shards

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -729,22 +729,22 @@ workflows:
         - xcodebuild_options: CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
         - scheme: Fennec_Enterprise_XCUITests
     - xcode-test@4.5:
-        inputs:
         is_always_run: true
+        inputs:
         - scheme: Fennec_Enterprise_XCUITests
         - test_plan: "SmokeXCUITests"
         - destination: platform=iOS Simulator,name=iPad Pro (12.9-inch) (5th generation),OS=latest
         description: This Workflow is to run SmokeTest on iPad simulator device
     - xcode-test@4.5:
-        inputs:
         is_always_run: true
+        inputs:
         - scheme: Fennec_Enterprise_XCUITests
         - test_plan: "Smoketest2"
         - destination: platform=iOS Simulator,name=iPad Pro (12.9-inch) (5th generation),OS=latest
         description: This Workflow is to run SmokeTest on iPad simulator device Smoketest2
     - xcode-test@4.5:
-        inputs:
         is_always_run: true
+        inputs:
         - scheme: Fennec_Enterprise_XCUITests
         - test_plan: "Smoketest3"
         - destination: platform=iOS Simulator,name=iPad Pro (12.9-inch) (5th generation),OS=latest


### PR DESCRIPTION
Fixes #11838 
With the new test step's version its options have changed, now we have to use `destination` and we are adding also the `run: always true` so that all the test steps run 