### PR TITLE
Build mergify: tighten conditions for auto-approval and merge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -13,7 +13,9 @@ pull_request_rules:
   - name: github-actions
     conditions:
       - author=github-actions[bot]
-      - files~=(bitrise.yml)
+      - files=bitrise.yml
+      - -files~=^(?!bitrise.yml).+$
+      - head=update-br-new-xcode-version
     actions:
       review:
         type: APPROVE


### PR DESCRIPTION
Require that the PR only modify bitrise.yml, and that its branch is the expected one, to avoid automatically approving and merging arbitrary PRs.