### PR TITLE
Refactor FXIOS-4905 [v106] Update nimbus experiments job step inputs and control flow

### DIFF
--- a/.github/workflows/update-nimbus-experiments.yml
+++ b/.github/workflows/update-nimbus-experiments.yml
@@ -15,17 +15,20 @@ jobs:
         with:
           path: firefox-ios
           ref: main
+          fetch-depth: 0
       - name: "Update Experiments JSON"
         id: update-experiments-json
-        uses: mozilla-mobile/update-experiments@v1
+        uses: mozilla-mobile/update-experiments@v2
         with:
           repo-path: firefox-ios
           output-path: Client/Experiments/initial_experiments.json
-          experimenter-url: https://experimenter.services.mozilla.com/api/v6/experiments/?is_first_run=true
+          experimenter-url: https://experimenter.services.mozilla.com/api/v6/experiments-first-run/
           app-name: firefox_ios
+          branch: automation/update-nimbus-experiments
       - name: Create Pull Request
+        id: create-pull-request
         uses: peter-evans/create-pull-request@v3
-        if: steps.update-experiments-json.outputs.changed == 1
+        if: steps.update-experiments-json.outputs.changed == 1 && steps.update-experiments-json.outputs.changed-branch == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           path: firefox-ios
@@ -35,3 +38,10 @@ jobs:
           body: "This (automated) PR updates the initial_experiments.json on the `main` branch"
           delete-branch: true
           labels: Needs Code Review
+      - name: Enable Pull Request Automerge
+        if: steps.create-pull-request.outputs.pull-request-operation == 'created'
+        uses: peter-evans/enable-pull-request-automerge@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ steps.create-pull-request.outputs.pull-request-number }}
+          merge-method: squash


### PR DESCRIPTION
A few changes are happening here:
* update the fetch depth to be 0 so it will fetch branches when cloning the repository
* update the version and inputs for the update experiments step
* update the create pull request step to make sure there are changes for the branch
* add the enable pull request automerge step
  * the automerge will only happen after all other branch protection points are met, such as an approving review

#11864