### PR TITLE
Bump FXIOS-11867 Pulling in MappaMundi Update for Test Support

### DIFF
--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -77,7 +77,7 @@
       "location" : "https://github.com/nbhasin2/MappaMundi.git",
       "state" : {
         "branch" : "master",
-        "revision" : "7fcd2b7910550227088480490ac19ea66044b3d1"
+        "revision" : "a125309d71dffbeae2efe1df24b0ee9fa0a771a4"
       }
     },
     {


### PR DESCRIPTION
The MappaMundi built-in wrapping the `wait` api is being updated from a 5 second wait to 10 seconds to accommodate the variable app launch times within Bitrise for tests.

This is to keep the tests from trying to run before the test `setup()` method can complete, which is causing intermittent `Fennec app not launched` failures.
