### PR TITLE
Bugfix FXIOS-4842 [v106] Mobile bookmark order

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1121,7 +1121,11 @@ class BrowserViewController: UIViewController {
         }
 
         let shareItem = ShareItem(url: url, title: title, favicon: favicon)
-        profile.places.createBookmark(parentGUID: "mobile______", url: shareItem.url, title: shareItem.title)
+        // Add new mobile bookmark at the top of the list
+        profile.places.createBookmark(parentGUID: BookmarkRoots.MobileFolderGUID,
+                                      url: shareItem.url,
+                                      title: shareItem.title,
+                                      position: 0)
 
         var userData = [QuickActions.TabURLKey: shareItem.url]
         if let title = shareItem.title {
@@ -1158,7 +1162,7 @@ class BrowserViewController: UIViewController {
         profile.places.getBookmarksTree(rootGUID: BookmarkRoots.MobileFolderGUID, recursive: false).uponQueue(.main) { result in
 
             guard let bookmarkFolder = result.successValue as? BookmarkFolderData,
-                  let bookmarkNode = bookmarkFolder.children?.last as? FxBookmarkNode
+                  let bookmarkNode = bookmarkFolder.children?.first as? FxBookmarkNode
             else { return }
 
             let detailController = BookmarkDetailPanel(profile: self.profile,

--- a/Client/Frontend/Home/HomepageContextMenuHelper.swift
+++ b/Client/Frontend/Home/HomepageContextMenuHelper.swift
@@ -146,7 +146,11 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
     private func getAddBookmarkAction(site: Site) -> SingleActionViewModel {
         return SingleActionViewModel(title: .BookmarkContextMenuTitle, iconString: ImageIdentifiers.actionAddBookmark, tapHandler: { _ in
             let shareItem = ShareItem(url: site.url, title: site.title, favicon: site.icon)
-            _ = self.viewModel.profile.places.createBookmark(parentGUID: BookmarkRoots.MobileFolderGUID, url: shareItem.url, title: shareItem.title)
+            // Add new mobile bookmark at the top of the list
+            _ = self.viewModel.profile.places.createBookmark(parentGUID: BookmarkRoots.MobileFolderGUID,
+                                                             url: shareItem.url,
+                                                             title: shareItem.title,
+                                                             position: 0)
 
             var userData = [QuickActions.TabURLKey: shareItem.url]
             if let title = shareItem.title {

--- a/Client/Frontend/Library/Bookmarks/BookmarkDetailPanel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarkDetailPanel.swift
@@ -245,12 +245,18 @@ class BookmarkDetailPanel: SiteTableViewController {
     // MARK: - Save Functionality
     func save() -> Success {
         if isNew {
+            // Add new mobile node at the top of the list
+            let position: UInt32? = parentBookmarkFolder.guid == BookmarkRoots.MobileFolderGUID ? 0 : nil
+
             if bookmarkNodeType == .bookmark {
                 guard let bookmarkItemURL = self.bookmarkItemURL else {
                     return deferMaybe(BookmarkDetailPanelError())
                 }
 
-                return profile.places.createBookmark(parentGUID: parentBookmarkFolder.guid, url: bookmarkItemURL, title: bookmarkItemOrFolderTitle).bind({ result in
+                return profile.places.createBookmark(parentGUID: parentBookmarkFolder.guid,
+                                                     url: bookmarkItemURL,
+                                                     title: bookmarkItemOrFolderTitle,
+                                                     position: position).bind({ result in
                     return result.isFailure ? deferMaybe(BookmarkDetailPanelError()) : succeed()
                 })
             } else if bookmarkNodeType == .folder {
@@ -258,7 +264,9 @@ class BookmarkDetailPanel: SiteTableViewController {
                     return deferMaybe(BookmarkDetailPanelError())
                 }
 
-                return profile.places.createFolder(parentGUID: parentBookmarkFolder.guid, title: bookmarkItemOrFolderTitle).bind({ result in
+                return profile.places.createFolder(parentGUID: parentBookmarkFolder.guid,
+                                                   title: bookmarkItemOrFolderTitle,
+                                                   position: position).bind({ result in
                     return result.isFailure ? deferMaybe(BookmarkDetailPanelError()) : succeed()
                 })
             }

--- a/Client/Frontend/Library/Bookmarks/BookmarksPanelViewModel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarksPanelViewModel.swift
@@ -63,31 +63,13 @@ class BookmarksPanelViewModel {
             return
         }
 
-        let newIndex = getNewIndex(from: destinationIndexPath.row)
-        _ = profile.places.updateBookmarkNode(guid: bookmarkNode.guid, position: UInt32(newIndex))
+        _ = profile.places.updateBookmarkNode(guid: bookmarkNode.guid, position: UInt32(destinationIndexPath.row))
 
         bookmarkNodes.remove(at: sourceIndexPath.row)
         bookmarkNodes.insert(bookmarkNode, at: destinationIndexPath.row)
     }
 
     // MARK: - Private
-
-    /// Since we have a Local Desktop folder that isn't referenced in A-S under the mobile folder, we need to account for this when saving bookmark index in A-S.
-    /// Index is calculated by inverting it inside the mobile folder. We also need to account for the local desktop folder spot it takes.
-    func getNewIndex(from index: Int) -> Int {
-        if bookmarkFolderGUID == BookmarkRoots.MobileFolderGUID {
-            let mobileFolderIndex = bookmarkNodes.count - index - LocalDesktopFolder.numberOfRowsTaken
-            if mobileFolderIndex < 0 {
-                return 0
-            } else if mobileFolderIndex > bookmarkNodes.count {
-                return bookmarkNodes.count - LocalDesktopFolder.numberOfRowsTaken
-            }
-
-            return mobileFolderIndex
-        } else {
-            return index
-        }
-    }
 
     private func setupMobileFolderData(completion: @escaping () -> Void) {
         profile.places

--- a/Client/Frontend/Library/Bookmarks/BookmarksPanelViewModel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarksPanelViewModel.swift
@@ -82,8 +82,7 @@ class BookmarksPanelViewModel {
                 }
 
                 self.bookmarkFolder = mobileFolder
-                // Reversed since we want the newest mobile bookmarks at the top
-                self.bookmarkNodes = mobileFolder.fxChildren?.reversed() ?? []
+                self.bookmarkNodes = mobileFolder.fxChildren ?? []
 
                 let desktopFolder = LocalDesktopFolder()
                 self.bookmarkNodes.insert(desktopFolder, at: 0)

--- a/Extensions/ShareTo/ShareViewController.swift
+++ b/Extensions/ShareTo/ShareViewController.swift
@@ -343,7 +343,12 @@ extension ShareViewController {
         if let shareItem = shareItem, case .shareItem(let item) = shareItem {
             let profile = BrowserProfile(localName: "profile")
             profile.reopen()
-            _ = profile.places.createBookmark(parentGUID: BookmarkRoots.MobileFolderGUID, url: item.url, title: item.title).value // Intentionally block thread with database call.
+            // Intentionally block thread with database call.
+            // Add new mobile bookmark at the top of the list
+            _ = profile.places.createBookmark(parentGUID: BookmarkRoots.MobileFolderGUID,
+                                              url: item.url,
+                                              title: item.title,
+                                              position: 0).value
             profile.shutdown()
 
             addAppExtensionTelemetryEvent(forMethod: "bookmark-this-page")

--- a/Storage/Rust/RustPlaces.swift
+++ b/Storage/Rust/RustPlaces.swift
@@ -255,20 +255,25 @@ public class RustPlaces: BookmarksHandler {
         }
     }
 
-    public func createFolder(parentGUID: GUID, title: String, position: UInt32? = nil) -> Deferred<Maybe<GUID>> {
+    public func createFolder(parentGUID: GUID, title: String,
+                             position: UInt32?) -> Deferred<Maybe<GUID>> {
         return withWriter { connection in
             return try connection.createFolder(parentGUID: parentGUID, title: title, position: position)
         }
     }
 
-    public func createSeparator(parentGUID: GUID, position: UInt32? = nil) -> Deferred<Maybe<GUID>> {
+    public func createSeparator(parentGUID: GUID,
+                                position: UInt32?) -> Deferred<Maybe<GUID>> {
         return withWriter { connection in
             return try connection.createSeparator(parentGUID: parentGUID, position: position)
         }
     }
 
     @discardableResult
-    public func createBookmark(parentGUID: GUID, url: String, title: String?, position: UInt32? = nil) -> Deferred<Maybe<GUID>> {
+    public func createBookmark(parentGUID: GUID,
+                               url: String,
+                               title: String?,
+                               position: UInt32?) -> Deferred<Maybe<GUID>> {
         return withWriter { connection in
             let response = try connection.createBookmark(parentGUID: parentGUID, url: url, title: title, position: position)
             self.notificationCenter.post(name: .BookmarksUpdated, object: self)

--- a/Tests/ClientTests/Library/BookmarkPanelViewModelTests.swift
+++ b/Tests/ClientTests/Library/BookmarkPanelViewModelTests.swift
@@ -91,68 +91,6 @@ class BookmarksPanelViewModelTests: XCTestCase {
         }
         waitForExpectations(timeout: 1)
     }
-
-    // MARK: - Move row at index
-
-    func testMoveRowAtGetNewIndex_NotMobileStaysSame_atZero() {
-        let subject = createSubject(guid: BookmarkRoots.MenuFolderGUID)
-        let expectedIndex = 0
-        let index = subject.getNewIndex(from: expectedIndex)
-        XCTAssertEqual(index, expectedIndex)
-    }
-
-    func testMoveRowAtGetNewIndex_NotMobileStaysSame_atFive() {
-        let subject = createSubject(guid: BookmarkRoots.MenuFolderGUID)
-        let expectedIndex = 5
-        let index = subject.getNewIndex(from: expectedIndex)
-        XCTAssertEqual(index, expectedIndex)
-    }
-
-    func testMoveRowAtGetNewIndex_MobileWithZeroBookmarks_zeroIndex() {
-        let subject = createSubject(guid: BookmarkRoots.MobileFolderGUID)
-        let index = subject.getNewIndex(from: 0)
-        XCTAssertEqual(index, 0)
-    }
-
-    func testMoveRowAtGetNewIndex_MobileWithZeroBookmarks_minusIndex() {
-        let subject = createSubject(guid: BookmarkRoots.MobileFolderGUID)
-        let index = subject.getNewIndex(from: -1)
-        XCTAssertEqual(index, 0)
-    }
-
-    func testMoveRowAtGetNewIndex_MobileWithZeroBookmarks_greaterThanCount() {
-        let subject = createSubject(guid: BookmarkRoots.MobileFolderGUID)
-        let index = subject.getNewIndex(from: 5)
-        XCTAssertEqual(index, 0)
-    }
-
-    func testMoveRowAtGetNewIndex_MobileWithBookmarks_zeroIndex() {
-        let subject = createSubject(guid: BookmarkRoots.MobileFolderGUID)
-        subject.bookmarkNodes = createBookmarksNode(count: 5)
-        let index = subject.getNewIndex(from: 5)
-        XCTAssertEqual(index, 0)
-    }
-
-    func testMoveRowAtGetNewIndex_MobileWithBookmarks_greaterThanCount() {
-        let subject = createSubject(guid: BookmarkRoots.MobileFolderGUID)
-        subject.bookmarkNodes = createBookmarksNode(count: 5)
-        let index = subject.getNewIndex(from: 10)
-        XCTAssertEqual(index, 0)
-    }
-
-    func testMoveRowAtGetNewIndex_MobileWithBookmarks_smallerThanCount() {
-        let subject = createSubject(guid: BookmarkRoots.MobileFolderGUID)
-        subject.bookmarkNodes = createBookmarksNode(count: 5)
-        let index = subject.getNewIndex(from: -1)
-        XCTAssertEqual(index, 5)
-    }
-
-    func testMoveRowAtGetNewIndex_MobileWithBookmarks_inMiddleOfCount() {
-        let subject = createSubject(guid: BookmarkRoots.MobileFolderGUID)
-        subject.bookmarkNodes = createBookmarksNode(count: 5)
-        let index = subject.getNewIndex(from: 3)
-        XCTAssertEqual(index, 1)
-    }
 }
 
 extension BookmarksPanelViewModelTests {

--- a/Tests/ClientTests/RatingPromptManagerTests.swift
+++ b/Tests/ClientTests/RatingPromptManagerTests.swift
@@ -204,7 +204,10 @@ private extension RatingPromptManagerTests {
     func createBookmarks(bookmarkCount: Int, withRoot root: String) {
         (1...bookmarkCount).forEach { index in
             let bookmark = ShareItem(url: "http://www.example.com/\(index)", title: "Example \(index)", favicon: nil)
-            _ = mockProfile.places.createBookmark(parentGUID: root, url: bookmark.url, title: bookmark.title).value
+            _ = mockProfile.places.createBookmark(parentGUID: root,
+                                                  url: bookmark.url,
+                                                  title: bookmark.title,
+                                                  position: nil).value
         }
 
         // Make sure the bookmarks we create are deleted at the end of the test


### PR DESCRIPTION
# [FXIOS-4842](https://mozilla-hub.atlassian.net/browse/FXIOS-4842) https://github.com/mozilla-mobile/firefox-ios/issues/11753
- New bookmarks and folders created in the mobile folder get placed at the top
- New separator keeps existing logic of `centerVisibleRow()`
- Keep user order, not changing order of appearance by inverting so recent is placed at the top
- Revert code that was put in place to fix moving inside mobile folder after inverting of order of appearance (in PR https://github.com/mozilla-mobile/firefox-ios/pull/11831)
- Removed default param in RustPlaces for position. We always need to specify the position when saving to A-S