### PR TITLE
Refactor FXIOS-4928 [v107] Bitrise: change to available simulator on …

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -696,7 +696,7 @@ workflows:
         run_if: '{{getenv "NEW_XCODE_VERSION" | eq "New_Version_Found" | or (getenv "RUN_ALL_STEPS" | eq "Run_All_Steps")}}'
         inputs:
         - scheme: Fennec
-        - simulator_device: iPhone 14
+        - destination: platform=iOS Simulator,name=iPhone 14,OS=latest
     - deploy-to-bitrise-io@1.9: {}
     - cache-push@2.4: {}
     - slack@3.1:


### PR DESCRIPTION
…xcode14 Follow Up

My bad :/ for the build-for-testing step we use `-simulator_device`, but for the test-step it is `-destination` so that we can update the current device