### PR TITLE
Refactor FXIOS-4099 [v106] OpenQLPreviewHelper changes

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -516,10 +516,10 @@
 		8A11C8132731E54800AC7318 /* DictionaryExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A11C8122731E54800AC7318 /* DictionaryExtensionsTests.swift */; };
 		8A161411282C035D00DDBB02 /* CustomizeHomepageSectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A161410282C035D00DDBB02 /* CustomizeHomepageSectionViewModel.swift */; };
 		8A161413282C2F8F00DDBB02 /* NimbusSponsoredTileLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A161412282C2F8F00DDBB02 /* NimbusSponsoredTileLayer.swift */; };
-		8A1E3BE628CBBF44003388C4 /* OpenSearchEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1E3BE528CBBF44003388C4 /* OpenSearchEngine.swift */; };
-		8A1E3BE728CBC204003388C4 /* OpenSearchEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1E3BE528CBBF44003388C4 /* OpenSearchEngine.swift */; };
 		8A1E3BDF28CBA81E003388C4 /* SponsoredContentFilterUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1E3BDE28CBA81E003388C4 /* SponsoredContentFilterUtility.swift */; };
 		8A1E3BE328CBACDD003388C4 /* SponsoredContentFilterUtilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1E3BE128CBACD7003388C4 /* SponsoredContentFilterUtilityTests.swift */; };
+		8A1E3BE628CBBF44003388C4 /* OpenSearchEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1E3BE528CBBF44003388C4 /* OpenSearchEngine.swift */; };
+		8A1E3BE728CBC204003388C4 /* OpenSearchEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1E3BE528CBBF44003388C4 /* OpenSearchEngine.swift */; };
 		8A2366FA28A302E500846D1B /* MockSponsoredPocketAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2366F928A302E500846D1B /* MockSponsoredPocketAPI.swift */; };
 		8A2783F1275FFDC50080D29D /* KeyboardPressesHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2783F0275FFDC50080D29D /* KeyboardPressesHandler.swift */; };
 		8A2825352760399B00395E66 /* KeyboardPressesHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2825342760399B00395E66 /* KeyboardPressesHandlerTests.swift */; };
@@ -602,6 +602,7 @@
 		8ABA9C8D28931223002C0077 /* MockDispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABA9C8C28931223002C0077 /* MockDispatchQueue.swift */; };
 		8ABA9C8E28931288002C0077 /* JumpBackInDataAdaptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABA9C8A28931207002C0077 /* JumpBackInDataAdaptorTests.swift */; };
 		8ABC5AEE284532C900FEA552 /* PocketDiscoverCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABC5AED284532C900FEA552 /* PocketDiscoverCell.swift */; };
+		8AC1065F28D0CD700013263A /* OpenQLPreviewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC1065E28D0CD700013263A /* OpenQLPreviewHelper.swift */; };
 		8AC5D55F28BFE6C8001F6F7F /* Presenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC5D55E28BFE6C8001F6F7F /* Presenter.swift */; };
 		8AD08D1527E9198E00B8E907 /* TabsQuantityTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD08D1427E9198E00B8E907 /* TabsQuantityTelemetry.swift */; };
 		8AD08D1727E91AC800B8E907 /* TabsQuantityTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD08D1627E91AC800B8E907 /* TabsQuantityTelemetryTests.swift */; };
@@ -3319,6 +3320,7 @@
 		8ABA9C8A28931207002C0077 /* JumpBackInDataAdaptorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JumpBackInDataAdaptorTests.swift; sourceTree = "<group>"; };
 		8ABA9C8C28931223002C0077 /* MockDispatchQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDispatchQueue.swift; sourceTree = "<group>"; };
 		8ABC5AED284532C900FEA552 /* PocketDiscoverCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketDiscoverCell.swift; sourceTree = "<group>"; };
+		8AC1065E28D0CD700013263A /* OpenQLPreviewHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenQLPreviewHelper.swift; sourceTree = "<group>"; };
 		8AC5D55E28BFE6C8001F6F7F /* Presenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Presenter.swift; sourceTree = "<group>"; };
 		8AD08D1427E9198E00B8E907 /* TabsQuantityTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsQuantityTelemetry.swift; sourceTree = "<group>"; };
 		8AD08D1627E91AC800B8E907 /* TabsQuantityTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsQuantityTelemetryTests.swift; sourceTree = "<group>"; };
@@ -6347,6 +6349,7 @@
 			children = (
 				7BA8D1C61BA037F500C8AE9E /* OpenInHelper.swift */,
 				8A590C6028C123100032F1AA /* OpenPassBookHelper.swift */,
+				8AC1065E28D0CD700013263A /* OpenQLPreviewHelper.swift */,
 			);
 			path = OpenInHelper;
 			sourceTree = "<group>";
@@ -10519,6 +10522,7 @@
 				742A56391D80B54A00BDB803 /* PhotonActionSheet.swift in Sources */,
 				C4EFEECF1CEBB6F2009762A4 /* BackForwardTableViewCell.swift in Sources */,
 				2C49854E206173C800893DAE /* photon-colors.swift in Sources */,
+				8AC1065F28D0CD700013263A /* OpenQLPreviewHelper.swift in Sources */,
 				EBA3B2C32268F16300728BDB /* PhotonActionSheetView.swift in Sources */,
 				E18EA56F28AD3279003F97FC /* UIDevice+Extension.swift in Sources */,
 				CDB3BE8724746787009320EE /* FirefoxAccountSignInViewController.swift in Sources */,

--- a/Client/Frontend/Browser/OpenInHelper/OpenInHelper.swift
+++ b/Client/Frontend/Browser/OpenInHelper/OpenInHelper.swift
@@ -5,7 +5,6 @@
 import Foundation
 import MobileCoreServices
 import WebKit
-import QuickLook
 import Shared
 
 struct MIMEType {
@@ -131,40 +130,5 @@ class DownloadHelper: NSObject {
                                                    modalStyle: .overCurrentContext)
 
         return viewModel
-    }
-}
-
-class OpenQLPreviewHelper: NSObject, QLPreviewControllerDataSource {
-    var url: NSURL
-
-    fileprivate let browserViewController: BrowserViewController
-
-    fileprivate let previewController: QLPreviewController
-
-    required init?(request: URLRequest?, response: URLResponse, canShowInWebView: Bool, forceDownload: Bool, browserViewController: BrowserViewController) {
-        guard let mimeType = response.mimeType,
-              (mimeType == MIMEType.USDZ || mimeType == MIMEType.Reality),
-              let responseURL = response.url as NSURL?,
-              !forceDownload,
-              !canShowInWebView else { return nil }
-        self.url = responseURL
-        self.browserViewController = browserViewController
-        self.previewController = QLPreviewController()
-        super.init()
-    }
-
-    func open() {
-        self.previewController.dataSource = self
-        ensureMainThread {
-            self.browserViewController.present(self.previewController, animated: true, completion: nil)
-        }
-    }
-
-    func numberOfPreviewItems(in controller: QLPreviewController) -> Int {
-        return 1
-    }
-
-    func previewController(_ controller: QLPreviewController, previewItemAt index: Int) -> QLPreviewItem {
-        return self.url
     }
 }

--- a/Client/Frontend/Browser/OpenInHelper/OpenPassBookHelper.swift
+++ b/Client/Frontend/Browser/OpenInHelper/OpenPassBookHelper.swift
@@ -25,7 +25,7 @@ class OpenPassBookHelper {
          cookieStore: WKHTTPCookieStore,
          presenter: Presenter) {
         self.response = response
-        self.url  = response.url
+        self.url = response.url
         self.cookieStore = cookieStore
         self.presenter = presenter
     }

--- a/Client/Frontend/Browser/OpenInHelper/OpenQLPreviewHelper.swift
+++ b/Client/Frontend/Browser/OpenInHelper/OpenQLPreviewHelper.swift
@@ -1,0 +1,52 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import QuickLook
+
+class OpenQLPreviewHelper: NSObject, QLPreviewControllerDataSource {
+
+    private var previewItem = NSURL()
+    private let presenter: Presenter
+    private let previewController: QLPreviewController
+
+    init(presenter: Presenter) {
+        self.presenter = presenter
+        self.previewController = QLPreviewController()
+        super.init()
+    }
+
+    static func shouldOpenPreviewHelper(response: URLResponse,
+                                        forceDownload: Bool) -> Bool {
+        guard let mimeType = response.mimeType else { return false }
+        return (mimeType == MIMEType.USDZ || mimeType == MIMEType.Reality) && !forceDownload
+    }
+
+    func canOpen(url: URL?) -> Bool {
+        guard let url = url as? NSURL else {
+            return false
+        }
+
+        previewItem = url
+        return QLPreviewController.canPreview(url)
+    }
+
+    func open() {
+        previewController.dataSource = self
+        ensureMainThread {
+            self.presenter.present(self.previewController,
+                                   animated: true,
+                                   completion: nil)
+        }
+    }
+
+    func numberOfPreviewItems(in controller: QLPreviewController) -> Int {
+        return 1
+    }
+
+    func previewController(_ controller: QLPreviewController,
+                           previewItemAt index: Int) -> QLPreviewItem {
+        return previewItem
+    }
+}


### PR DESCRIPTION
# [FXIOS-4099](https://mozilla-hub.atlassian.net/browse/FXIOS-4099) https://github.com/mozilla-mobile/firefox-ios/issues/10500
- Put OpenQLPreviewHelper in it's own file
- Add QLPreviewController.canPreview check before opening QLPreview
- Clean up QLPreviewController so we check if it can open before creating it
- Fix that couldn't open a QLPreview on iPad