### PR TITLE
Bugfix FXIOS-4291 [v107] Should leave from overlay mode on the first run while onboarding is displayed on iPad

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1020,6 +1020,9 @@ class BrowserViewController: UIViewController {
                     self?.urlBar.enterOverlayMode(nil, pasted: false, search: false)
                 }
             }
+        } else if presentedViewController is IntroViewController {
+            // leave from overlay mode while in onboarding is displayed on iPad
+            self.urlBar.leaveOverlayMode()
         } else {
             self.urlBar.enterOverlayMode(nil, pasted: false, search: false)
         }


### PR DESCRIPTION
Reference Issues : #10850 , #11812

We should leave from overlay mode on the first run while onboarding is displayed on the iPad.

As we presented `IntroViewController` as `.formSheet` in `BrowserViewController`, we can make sure the presentedController is presenting as `IntroViewController` in `enterOverlayMode` method. And then I called `self.urlBar.leaveOverlayMode()` to dismiss the keyboard on iPad. I attached the video in the comment. Please kindly review my changes.

https://github.com/mozilla-mobile/firefox-ios/issues/10850#issuecomment-1242654870