### PR TITLE
Bugfix FXIOS-4938 [v106] The user should be directed to a marketing link after tapping on "Learn more"

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -923,6 +923,13 @@ class BrowserViewController: UIViewController {
         homepageViewController?.reloadView()
         NotificationCenter.default.post(name: .ShowHomepage, object: nil)
 
+        let wallpaperOnboardingClosure = {
+            // Display wallpaper onboarding if needed when homepage appears
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) { [weak self] in
+                self?.homepageViewController?.displayWallpaperSelector()
+            }
+        }
+
         UIView.animate(
             withDuration: 0.2,
             animations: { () -> Void in
@@ -931,6 +938,7 @@ class BrowserViewController: UIViewController {
                 guard finished else { return }
                 self.webViewContainer.accessibilityElementsHidden = true
                 UIAccessibility.post(notification: UIAccessibility.Notification.screenChanged, argument: nil)
+                wallpaperOnboardingClosure()
             })
 
         // Make sure reload button is hidden on homepage

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -313,7 +313,7 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable {
     private func displayWallpaperSelector() {
         let wallpaperManager = WallpaperManager(userDefaults: userDefaults)
         guard wallpaperManager.canOnboardingBeShown,
-              !(presentedViewController is ContextualHintViewController)
+              presentedViewController == nil
         else { return }
 
         self.dismissKeyboard()

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -104,14 +104,6 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable {
         reloadView()
     }
 
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) { [weak self] in
-            self?.displayWallpaperSelector()
-        }
-    }
-
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         contextualHintViewController.stopTimer()
@@ -310,7 +302,7 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable {
         }
     }
 
-    private func displayWallpaperSelector() {
+    func displayWallpaperSelector() {
         let wallpaperManager = WallpaperManager(userDefaults: userDefaults)
         guard wallpaperManager.canOnboardingBeShown,
               presentedViewController == nil

--- a/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewModel.swift
+++ b/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewModel.swift
@@ -86,7 +86,7 @@ class WallpaperSettingsViewModel {
             descriptionA11yIdentifier: "\(a11yIds.collectionDescription)_\(sectionIndex)",
             buttonTitle: buttonTitle,
             buttonA11yIdentifier: "\(a11yIds.collectionButton)_\(sectionIndex)",
-            buttonAction: buttonAction)
+            buttonAction: collection.learnMoreUrl != nil ? buttonAction : nil)
     }
 
     func updateSectionLayout(for traitCollection: UITraitCollection) {


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-4938)
#11919

This also includes the wallpaper onboarding not showing up correctly.