### PR TITLE
Add FXIOS-4878 [v106] Add Shadow color

### DIFF
--- a/Client/Frontend/Theme/DarkTheme.swift
+++ b/Client/Frontend/Theme/DarkTheme.swift
@@ -58,4 +58,7 @@ private struct DarkColourPalette: ThemeColourPalette {
     var borderAccent: UIColor = FXColors.Blue20
     var borderAccentNonOpaque: UIColor = FXColors.Blue20.withAlphaComponent(0.2)
     var borderAccentPrivate: UIColor = FXColors.Purple60
+
+    // MARK: - Shadow
+    var shadow: UIColor = FXColors.DarkGrey90.withAlphaComponent(0.16)
 }

--- a/Client/Frontend/Theme/LightTheme.swift
+++ b/Client/Frontend/Theme/LightTheme.swift
@@ -60,4 +60,7 @@ private struct LightColourPalette: ThemeColourPalette {
     var borderAccent: UIColor = FXColors.Blue50
     var borderAccentNonOpaque: UIColor = FXColors.Blue50.withAlphaComponent(0.1)
     var borderAccentPrivate: UIColor = FXColors.Purple60
+
+    // MARK: - Shadow
+    var shadow: UIColor = FXColors.DarkGrey80.withAlphaComponent(0.16)
 }

--- a/Client/Frontend/Theme/Theme.swift
+++ b/Client/Frontend/Theme/Theme.swift
@@ -68,4 +68,7 @@ protocol ThemeColourPalette {
     var borderAccent: UIColor { get }
     var borderAccentNonOpaque: UIColor { get }
     var borderAccentPrivate: UIColor { get }
+
+    // MARK: - Shadow
+    var shadow: UIColor { get }
 }


### PR DESCRIPTION
# [FXIOS-4878](https://mozilla-hub.atlassian.net/browse/FXIOS-4878) https://github.com/mozilla-mobile/firefox-ios/issues/11817
Add missing shadow color in mobile color pallet