### PR TITLE
Bugfix FXIOS-4950 [v106] Fix wallpaper onboarding apparition

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -919,26 +919,18 @@ class BrowserViewController: UIViewController {
         guard homepageViewController?.view.alpha != 1 else { return }
 
         homepageViewController?.applyTheme()
-        homepageViewController?.recordHomepageAppeared(isZeroSearch: !inline)
+        homepageViewController?.homepageWillAppear(isZeroSearch: !inline)
         homepageViewController?.reloadView()
         NotificationCenter.default.post(name: .ShowHomepage, object: nil)
-
-        let wallpaperOnboardingClosure = {
-            // Display wallpaper onboarding if needed when homepage appears
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) { [weak self] in
-                self?.homepageViewController?.displayWallpaperSelector()
-            }
-        }
 
         UIView.animate(
             withDuration: 0.2,
             animations: { () -> Void in
                 self.homepageViewController?.view.alpha = 1
             }, completion: { finished in
-                guard finished else { return }
                 self.webViewContainer.accessibilityElementsHidden = true
                 UIAccessibility.post(notification: UIAccessibility.Notification.screenChanged, argument: nil)
-                wallpaperOnboardingClosure()
+                self.homepageViewController?.homepageDidAppear()
             })
 
         // Make sure reload button is hidden on homepage
@@ -959,6 +951,8 @@ class BrowserViewController: UIViewController {
         addChild(homepageViewController)
         view.addSubview(homepageViewController.view)
         homepageViewController.didMove(toParent: self)
+        // When we first create the homepage, set it's alpha to 0 to ensure we trigger the custom homepage view cycles
+        homepageViewController.view.alpha = 0
         view.bringSubviewToFront(overKeyboardContainer)
     }
 
@@ -970,7 +964,7 @@ class BrowserViewController: UIViewController {
         // Return early if the home page is already hidden
         guard self.homepageViewController?.view.alpha != 0 else { return }
 
-        homepageViewController.recordHomepageDisappeared()
+        homepageViewController.homepageWillDisappear()
         UIView.animate(
             withDuration: 0.2,
             delay: 0,

--- a/Client/Frontend/Components/LabelButtonHeaderView.swift
+++ b/Client/Frontend/Components/LabelButtonHeaderView.swift
@@ -80,7 +80,7 @@ class LabelButtonHeaderView: UICollectionReusableView, ReusableCell {
 
     func setConstraints(viewModel: LabelButtonHeaderViewModel) {
         NSLayoutConstraint.activate([
-            stackView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor),
+            stackView.topAnchor.constraint(equalTo: topAnchor),
             stackView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor,
                                                constant: viewModel.leadingInset),
             stackView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor,


### PR DESCRIPTION
# [FXIOS-4950](https://mozilla-hub.atlassian.net/browse/FXIOS-4950) https://github.com/mozilla-mobile/firefox-ios/issues/11941
- Fix wallpaper onboarding apparition. 
    - Making sure wallpaper method is called at the right time 
    - Checking alpha is proper before showing so modal isn't shown on top of a the webview
    - When creating the homepage we set the homepage alpha to 0 so custom homepage view cycles can be triggered
- Fix constraint on label for header