### PR TITLE
Bugfix FXIOS-4949 [v106] Tab pickup tile not showing after onboarding

### DIFF
--- a/Client/Frontend/Home/JumpBackIn/Data/JumpBackInDataAdaptor.swift
+++ b/Client/Frontend/Home/JumpBackIn/Data/JumpBackInDataAdaptor.swift
@@ -72,9 +72,10 @@ class JumpBackInDataAdaptorImplementation: JumpBackInDataAdaptor, FeatureFlaggab
         setupNotifications(forObserver: self, observing: [.ShowHomepage,
                                                           .TabsTrayDidClose,
                                                           .TabsTrayDidSelectHomeTab,
-                                                          .TopTabsTabClosed])
-        getHasSyncAccount()
-        updateData()
+                                                          .TopTabsTabClosed,
+                                                          .ProfileDidFinishSyncing,
+                                                          .FirefoxAccountChanged])
+        updateTabsAndAccountData()
     }
 
     deinit {
@@ -84,8 +85,7 @@ class JumpBackInDataAdaptorImplementation: JumpBackInDataAdaptor, FeatureFlaggab
     // MARK: Public interface
 
     var hasSyncedTabFeatureEnabled: Bool {
-        return featureFlags.isFeatureEnabled(.jumpBackInSyncedTab, checking: .buildOnly) &&
-            hasSyncAccount ?? false
+        return featureFlags.isFeatureEnabled(.jumpBackInSyncedTab, checking: .buildOnly) && hasSyncAccount ?? false
     }
 
     func getJumpBackInData() -> JumpBackInList {
@@ -133,26 +133,30 @@ class JumpBackInDataAdaptorImplementation: JumpBackInDataAdaptor, FeatureFlaggab
 
     // MARK: Jump back in data
 
-    private func updateData() {
-        // Has to be on main due to tab manager needing main tread
-        // This can be fixed when tab manager has been revisited
-        mainQueue.async { [weak self] in
-            guard let self = self else { return }
-
-            self.dispatchGroup.enter()
-            self.updateJumpBackInData {
-                self.dispatchGroup.leave()
+    private func updateTabsAndAccountData() {
+        getHasSyncAccount { [weak self] in
+            // Has to be on main due to tab manager needing main tread
+            // This can be fixed when tab manager has been revisited
+            self?.mainQueue.async { [weak self] in
+                self?.updateTabsData()
             }
+        }
+    }
 
-            self.dispatchGroup.enter()
-            self.updateRemoteTabs {
-                self.dispatchGroup.leave()
-            }
+    private func updateTabsData() {
+        dispatchGroup.enter()
+        updateJumpBackInData { [weak self] in
+            self?.dispatchGroup.leave()
+        }
 
-            self.dispatchGroup.notify(queue: .main) {
-                self.refreshData()
-                self.delegate?.didLoadNewData()
-            }
+        dispatchGroup.enter()
+        updateRemoteTabs { [weak self] in
+            self?.dispatchGroup.leave()
+        }
+
+        dispatchGroup.notify(queue: .main) { [weak self] in
+            self?.refreshData()
+            self?.delegate?.didLoadNewData()
         }
     }
 
@@ -216,14 +220,15 @@ class JumpBackInDataAdaptorImplementation: JumpBackInDataAdaptor, FeatureFlaggab
 
     // MARK: Synced tab data
 
-    private func getHasSyncAccount() {
-        guard featureFlags.isFeatureEnabled(.jumpBackInSyncedTab, checking: .buildOnly) else { return }
+    private func getHasSyncAccount(completion: @escaping () -> Void) {
+        guard featureFlags.isFeatureEnabled(.jumpBackInSyncedTab, checking: .buildOnly) else {
+            completion()
+            return
+        }
 
         profile.hasSyncAccount { hasSync in
             self.hasSyncAccount = hasSync
-            self.updateRemoteTabs {
-                self.delegate?.didLoadNewData()
-            }
+            completion()
         }
     }
 
@@ -258,7 +263,9 @@ class JumpBackInDataAdaptorImplementation: JumpBackInDataAdaptor, FeatureFlaggab
         var mostRecentTab: (client: RemoteClient, tab: RemoteTab)?
 
         desktopClientAndTabs.forEach { remoteClient in
-            guard let firstClient = remoteClient.tabs.first else { return }
+            guard let firstClient = remoteClient.tabs.first else {
+                return
+            }
             let mostRecentClientTab = remoteClient.tabs.reduce(firstClient, {
                                                                 $0.lastUsed > $1.lastUsed ? $0 : $1 })
 
@@ -289,7 +296,10 @@ extension JumpBackInDataAdaptorImplementation: Notifiable {
                 .TabsTrayDidClose,
                 .TabsTrayDidSelectHomeTab,
                 .TopTabsTabClosed:
-            updateData()
+            updateTabsData()
+        case .ProfileDidFinishSyncing,
+                .FirefoxAccountChanged:
+            updateTabsAndAccountData()
         default: break
         }
     }

--- a/Client/Frontend/Home/JumpBackIn/Data/JumpBackInDataAdaptor.swift
+++ b/Client/Frontend/Home/JumpBackIn/Data/JumpBackInDataAdaptor.swift
@@ -263,9 +263,7 @@ class JumpBackInDataAdaptorImplementation: JumpBackInDataAdaptor, FeatureFlaggab
         var mostRecentTab: (client: RemoteClient, tab: RemoteTab)?
 
         desktopClientAndTabs.forEach { remoteClient in
-            guard let firstClient = remoteClient.tabs.first else {
-                return
-            }
+            guard let firstClient = remoteClient.tabs.first else { return }
             let mostRecentClientTab = remoteClient.tabs.reduce(firstClient, {
                                                                 $0.lastUsed > $1.lastUsed ? $0 : $1 })
 


### PR DESCRIPTION
# [FXIOS-4949](https://mozilla-hub.atlassian.net/browse/FXIOS-4949) https://github.com/mozilla-mobile/firefox-ios/issues/11940
Update sync account variable from jump back in data adaptor when sync account changes
