### PR TITLE
Bugfix FXIOS-4965 [v106] Sync tab CFR incorrectly displayed on visited page

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -535,6 +535,7 @@
 		8A35497227BD672700534A65 /* ToggleSwitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A35497127BD672700534A65 /* ToggleSwitch.swift */; };
 		8A355E5E27D267A400B9AF34 /* RecentItemsHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A355E5D27D267A400B9AF34 /* RecentItemsHelperTests.swift */; };
 		8A36AC2C2886F27F00CDC0AD /* MockTabManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A36AC2B2886F27F00CDC0AD /* MockTabManager.swift */; };
+		8A37C79F28DA4BA600B1FAD4 /* ContextualHintViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A37C79E28DA4BA600B1FAD4 /* ContextualHintViewModelTests.swift */; };
 		8A471183287F6D9C00F5A6EA /* BookmarksPanelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A471182287F6D9C00F5A6EA /* BookmarksPanelViewModel.swift */; };
 		8A471185287F6E4800F5A6EA /* SeparatorTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A471184287F6E4800F5A6EA /* SeparatorTableViewCell.swift */; };
 		8A4AC0EB28C929D700439F83 /* URLSessionDataTaskProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4AC0E928C929D700439F83 /* URLSessionDataTaskProtocol.swift */; };
@@ -3256,6 +3257,7 @@
 		8A35497127BD672700534A65 /* ToggleSwitch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleSwitch.swift; sourceTree = "<group>"; };
 		8A355E5D27D267A400B9AF34 /* RecentItemsHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentItemsHelperTests.swift; sourceTree = "<group>"; };
 		8A36AC2B2886F27F00CDC0AD /* MockTabManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTabManager.swift; sourceTree = "<group>"; };
+		8A37C79E28DA4BA600B1FAD4 /* ContextualHintViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualHintViewModelTests.swift; sourceTree = "<group>"; };
 		8A471182287F6D9C00F5A6EA /* BookmarksPanelViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksPanelViewModel.swift; sourceTree = "<group>"; };
 		8A471184287F6E4800F5A6EA /* SeparatorTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeparatorTableViewCell.swift; sourceTree = "<group>"; };
 		8A4AC0E928C929D700439F83 /* URLSessionDataTaskProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionDataTaskProtocol.swift; sourceTree = "<group>"; };
@@ -6581,6 +6583,7 @@
 			isa = PBXGroup;
 			children = (
 				9614BF4028A53F7C00D3F7EA /* ContextualHintEligibilityUtilityTests.swift */,
+				8A37C79E28DA4BA600B1FAD4 /* ContextualHintViewModelTests.swift */,
 			);
 			path = ContextualHints;
 			sourceTree = "<group>";
@@ -10963,6 +10966,7 @@
 				8A635ECD289437A8006378BA /* SyncedTabCellTests.swift in Sources */,
 				8AE80BB12891A39F00BC12EA /* SpyNotificationCenter.swift in Sources */,
 				5AB4237C28A1947A003BC40C /* MockNotificationCenter.swift in Sources */,
+				8A37C79F28DA4BA600B1FAD4 /* ContextualHintViewModelTests.swift in Sources */,
 				8A355E5E27D267A400B9AF34 /* RecentItemsHelperTests.swift in Sources */,
 				C8699153289177FB007ACC5C /* WallpaperDataServiceTests.swift in Sources */,
 				8AFE4C2127480D0C00B97C65 /* TabTrayViewControllerTests.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -495,11 +495,6 @@ class BrowserViewController: UIViewController {
             selector: #selector(didTapUndoCloseAllTabToast),
             name: .DidTapUndoCloseAllTabToast,
             object: nil)
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(homePanelDidPresentContextualHintWith),
-            name: .DidPresentContextualHint,
-            object: nil)
     }
 
     func addSubviews() {
@@ -1877,20 +1872,6 @@ extension BrowserViewController: HomePanelDelegate {
                 .toolbarLocation:
             self.urlBar.leaveOverlayMode()
         default: break
-        }
-    }
-
-    /// We leave overlay mode this way when a contextual hint is too far out of reach from
-    /// accessing `homePanelDidPresentContextualHintOf(type: ContextualHintType)`
-    @objc func homePanelDidPresentContextualHintWith(notification: NSNotification) {
-        guard let userInfo = notification.userInfo,
-              let hint = userInfo["contextualHint"] as? ContextualHintType
-        else { return }
-
-        switch hint {
-        case .jumpBackIn, .jumpBackInSyncedTab, .toolbarLocation:
-            self.urlBar.leaveOverlayMode()
-        case .inactiveTabs: break
         }
     }
 

--- a/Client/Frontend/Contextual Hint/ContextualHintViewController.swift
+++ b/Client/Frontend/Contextual Hint/ContextualHintViewController.swift
@@ -258,11 +258,11 @@ class ContextualHintViewController: UIViewController, OnViewDismissable {
     }
 
     // MARK: - Interface
-    public func shouldPresentHint() -> Bool {
+    func shouldPresentHint() -> Bool {
         return viewModel.shouldPresentContextualHint()
     }
 
-    public func configure(
+    func configure(
         anchor: UIView,
         withArrowDirection arrowDirection: UIPopoverArrowDirection,
         andDelegate delegate: UIPopoverPresentationControllerDelegate,
@@ -270,8 +270,7 @@ class ContextualHintViewController: UIViewController, OnViewDismissable {
         withActionBeforeAppearing preAction: (() -> Void)? = nil,
         actionOnDismiss postAction: (() -> Void)? = nil,
         andActionForButton buttonAction: (() -> Void)? = nil,
-        andShouldStartTimerRightAway shouldStartTimer: Bool = true,
-        onHintConfigured completion: (() -> Void)? = nil
+        andShouldStartTimerRightAway shouldStartTimer: Bool = true
     ) {
         stopTimer()
         self.modalPresentationStyle = .popover
@@ -290,14 +289,18 @@ class ContextualHintViewController: UIViewController, OnViewDismissable {
             viewModel.startTimer()
         }
 
-        completion?()
+        viewModel.markContextualHintConfiguration(configured: true)
     }
 
-    public func stopTimer() {
+    func unconfigure() {
+        viewModel.markContextualHintConfiguration(configured: false)
+    }
+
+    func stopTimer() {
         viewModel.stopTimer()
     }
 
-    public func startTimer() {
+    func startTimer() {
         viewModel.startTimer()
     }
 }

--- a/Client/Frontend/Contextual Hint/ContextualHintViewModel.swift
+++ b/Client/Frontend/Contextual Hint/ContextualHintViewModel.swift
@@ -57,12 +57,13 @@ class ContextualHintViewModel: ContextualHintPrefsKeysProvider {
         }
     }
 
+    // Utility for this method explained in ContextualHintEligibilityUtility with hasHintBeenConfigured function
     func markContextualHintConfiguration(configured: Bool) {
         switch hintType {
         case .jumpBackIn:
-            profile.prefs.setBool(configured, forKey: PrefsKeys.ContextualHints.jumpBackInConfiguredKey.rawValue)
+            profile.prefs.setBool(configured, forKey: CFRPrefsKeys.jumpBackInConfiguredKey.rawValue)
         case .jumpBackInSyncedTab:
-            profile.prefs.setBool(configured, forKey: PrefsKeys.ContextualHints.jumpBackInSyncedTabConfiguredKey.rawValue)
+            profile.prefs.setBool(configured, forKey: CFRPrefsKeys.jumpBackInSyncedTabConfiguredKey.rawValue)
         default:
             break
         }

--- a/Client/Frontend/Contextual Hint/ContextualHintViewModel.swift
+++ b/Client/Frontend/Contextual Hint/ContextualHintViewModel.swift
@@ -57,6 +57,17 @@ class ContextualHintViewModel: ContextualHintPrefsKeysProvider {
         }
     }
 
+    func markContextualHintConfiguration(configured: Bool) {
+        switch hintType {
+        case .jumpBackIn:
+            profile.prefs.setBool(configured, forKey: PrefsKeys.ContextualHints.jumpBackInConfiguredKey.rawValue)
+        case .jumpBackInSyncedTab:
+            profile.prefs.setBool(configured, forKey: PrefsKeys.ContextualHints.jumpBackInSyncedTabConfiguredKey.rawValue)
+        default:
+            break
+        }
+    }
+
     func startTimer() {
         var timeInterval: TimeInterval = 0
 

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -30,7 +30,8 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable {
     private var urlBar: URLBarViewProtocol
     private var userDefaults: UserDefaultsInterface
     private lazy var wallpaperView: WallpaperBackgroundView = .build { _ in }
-    private var contextualHintViewController: ContextualHintViewController
+    private var jumpBackInContextualHintViewController: ContextualHintViewController
+    private var syncTabContextualHintViewController: ContextualHintViewController
     private var collectionView: UICollectionView! = nil
 
     // Content stack views contains collection view.
@@ -58,9 +59,12 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable {
                                            tabManager: tabManager,
                                            urlBar: urlBar)
 
-        let contextualViewModel = ContextualHintViewModel(forHintType: .jumpBackIn,
-                                                          with: viewModel.profile)
-        self.contextualHintViewController = ContextualHintViewController(with: contextualViewModel)
+        let jumpBackInContextualViewModel = ContextualHintViewModel(forHintType: .jumpBackIn,
+                                                                    with: viewModel.profile)
+        self.jumpBackInContextualHintViewController = ContextualHintViewController(with: jumpBackInContextualViewModel)
+        let syncTabContextualViewModel = ContextualHintViewModel(forHintType: .jumpBackInSyncedTab,
+                                                                 with: viewModel.profile)
+        self.syncTabContextualHintViewController = ContextualHintViewController(with: syncTabContextualViewModel)
         self.contextMenuHelper = HomepageContextMenuHelper(viewModel: viewModel)
         super.init(nibName: nil, bundle: nil)
 
@@ -81,7 +85,8 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable {
     }
 
     deinit {
-        contextualHintViewController.stopTimer()
+        jumpBackInContextualHintViewController.stopTimer()
+        syncTabContextualHintViewController.stopTimer()
         notificationCenter.removeObserver(self)
     }
 
@@ -107,7 +112,8 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable {
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        contextualHintViewController.stopTimer()
+        jumpBackInContextualHintViewController.stopTimer()
+        syncTabContextualHintViewController.stopTimer()
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -233,7 +239,8 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable {
     }
 
     func homepageWillDisappear() {
-        contextualHintViewController.stopTimer()
+        jumpBackInContextualHintViewController.stopTimer()
+        syncTabContextualHintViewController.stopTimer()
         viewModel.recordViewDisappeared()
     }
 
@@ -341,30 +348,63 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable {
         return presentedViewController == nil && view.alpha == 1
     }
 
-    // MARK: - Contextual hint
+    // MARK: - Jump back in contextual hint
+
     private func prepareJumpBackInContextualHint(onView headerView: LabelButtonHeaderView) {
-        guard contextualHintViewController.shouldPresentHint(),
+        guard jumpBackInContextualHintViewController.shouldPresentHint(),
               !viewModel.shouldDisplayHomeTabBanner
         else { return }
 
-        contextualHintViewController.configure(
+        jumpBackInContextualHintViewController.configure(
             anchor: headerView.titleLabel,
             withArrowDirection: .down,
             andDelegate: self,
-            presentedUsing: { self.presentContextualHint() },
-            withActionBeforeAppearing: { self.contextualHintPresented() },
+            presentedUsing: presentJumpBackInContextualHint,
+            withActionBeforeAppearing: { self.contextualHintPresented(type: .jumpBackIn) },
             andActionForButton: { self.openTabsSettings() })
     }
 
-    @objc private func presentContextualHint() {
+    @objc private func presentJumpBackInContextualHint() {
         guard BrowserViewController.foregroundBVC().searchController == nil, canModalBePresented else {
-            contextualHintViewController.stopTimer()
+            jumpBackInContextualHintViewController.stopTimer()
             return
         }
 
-        present(contextualHintViewController, animated: true, completion: nil)
+        present(jumpBackInContextualHintViewController, animated: true, completion: nil)
 
-        UIAccessibility.post(notification: .layoutChanged, argument: contextualHintViewController)
+        UIAccessibility.post(notification: .layoutChanged, argument: jumpBackInContextualHintViewController)
+    }
+
+    // MARK: - Sync tab contextual hint
+
+    private func prepareSyncedTabOnJumpBackInContextualHint(onView headerView: LabelButtonHeaderView) {
+        guard syncTabContextualHintViewController.shouldPresentHint(),
+              featureFlags.isFeatureEnabled(.contextualHintForJumpBackInSyncedTab, checking: .buildOnly)
+        else {
+            viewModel.profile.prefs.setBool(false, forKey: PrefsKeys.ContextualHints.jumpBackInSyncedTabConfiguredKey.rawValue)
+            return
+        }
+
+        syncTabContextualHintViewController.configure(
+            anchor: headerView.titleLabel,
+            withArrowDirection: .down,
+            andDelegate: self,
+            presentedUsing: presentSyncTabContextualHint,
+            withActionBeforeAppearing: { self.contextualHintPresented(type: .jumpBackInSyncedTab) },
+            onHintConfigured: {
+                self.viewModel.profile.prefs.setBool(true, forKey: PrefsKeys.ContextualHints.jumpBackInSyncedTabConfiguredKey.rawValue)
+            })
+    }
+
+    private func presentSyncTabContextualHint() {
+        guard BrowserViewController.foregroundBVC().searchController == nil, canModalBePresented else {
+            syncTabContextualHintViewController.stopTimer()
+            return
+        }
+
+        present(syncTabContextualHintViewController, animated: true, completion: nil)
+
+        UIAccessibility.post(notification: .layoutChanged, argument: syncTabContextualHintViewController)
     }
 }
 
@@ -602,8 +642,8 @@ private extension HomepageViewController {
                                      value: .customizeHomepageButton)
     }
 
-    func contextualHintPresented() {
-        homePanelDelegate?.homePanelDidPresentContextualHintOf(type: .jumpBackIn)
+    func contextualHintPresented(type: ContextualHintType) {
+        homePanelDelegate?.homePanelDidPresentContextualHintOf(type: type)
     }
 
     func openTabsSettings() {
@@ -643,7 +683,7 @@ extension HomepageViewController: UIPopoverPresentationControllerDelegate {
         in view: AutoreleasingUnsafeMutablePointer<UIView>
     ) {
         // Do not dismiss if the popover is a CFR
-        if contextualHintViewController.isPresenting { return }
+        if jumpBackInContextualHintViewController.isPresenting { return }
         popoverPresentationController.presentedViewController.dismiss(animated: false, completion: nil)
     }
 

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -143,7 +143,6 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable {
         // Can be removed once underlying problem is solved (FXIOS-4904)
         if let presentedViewController = presentedViewController,
            presentedViewController.isKind(of: BottomSheetViewController.self) {
-            print("Laurie - Homepage - Dismiss keyboard viewDidLayoutSubviews")
             self.dismissKeyboard()
         }
     }
@@ -252,7 +251,6 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable {
     /// since it's `.regular` on both. We reloadOnRotation from viewWillTransition in that case.
     private func reloadOnRotation() {
         if let _ = presentedViewController as? PhotonActionSheet {
-            print("Laurie - Homepage - Dismiss presentedViewController reloadOnRotation")
             presentedViewController?.dismiss(animated: false, completion: nil)
         }
 
@@ -673,8 +671,8 @@ extension HomepageViewController: UIPopoverPresentationControllerDelegate {
         in view: AutoreleasingUnsafeMutablePointer<UIView>
     ) {
         // Do not dismiss if the popover is a CFR
-        if jumpBackInContextualHintViewController.isPresenting,
-            syncTabContextualHintViewController.isPresenting { return }
+        guard !jumpBackInContextualHintViewController.isPresenting &&
+                !syncTabContextualHintViewController.isPresenting else { return }
         popoverPresentationController.presentedViewController.dismiss(animated: false, completion: nil)
     }
 

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -143,6 +143,7 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable {
         // Can be removed once underlying problem is solved (FXIOS-4904)
         if let presentedViewController = presentedViewController,
            presentedViewController.isKind(of: BottomSheetViewController.self) {
+            print("Laurie - Homepage - Dismiss keyboard viewDidLayoutSubviews")
             self.dismissKeyboard()
         }
     }
@@ -251,6 +252,7 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable {
     /// since it's `.regular` on both. We reloadOnRotation from viewWillTransition in that case.
     private func reloadOnRotation() {
         if let _ = presentedViewController as? PhotonActionSheet {
+            print("Laurie - Homepage - Dismiss presentedViewController reloadOnRotation")
             presentedViewController?.dismiss(animated: false, completion: nil)
         }
 
@@ -671,7 +673,8 @@ extension HomepageViewController: UIPopoverPresentationControllerDelegate {
         in view: AutoreleasingUnsafeMutablePointer<UIView>
     ) {
         // Do not dismiss if the popover is a CFR
-        if jumpBackInContextualHintViewController.isPresenting { return }
+        if jumpBackInContextualHintViewController.isPresenting,
+            syncTabContextualHintViewController.isPresenting { return }
         popoverPresentationController.presentedViewController.dismiss(animated: false, completion: nil)
     }
 

--- a/Client/Frontend/Home/JumpBackIn/Cell/SyncedTabCell.swift
+++ b/Client/Frontend/Home/JumpBackIn/Cell/SyncedTabCell.swift
@@ -198,6 +198,10 @@ class SyncedTabCell: BlurrableCollectionViewCell, ReusableCell {
         accessibilityCustomActions = [showAllSyncedTabsA11yAction, openSyncedTabA11yAction]
     }
 
+    func getContextualHintAnchor() -> UIView {
+        return cardTitle
+    }
+
     @objc func showAllSyncedTabs(_ sender: Any) {
         showAllSyncedTabsAction?()
     }

--- a/Client/Frontend/Home/JumpBackIn/Cell/SyncedTabCell.swift
+++ b/Client/Frontend/Home/JumpBackIn/Cell/SyncedTabCell.swift
@@ -42,7 +42,6 @@ class SyncedTabCell: BlurrableCollectionViewCell, ReusableCell {
     }
 
     private var syncedDeviceIconFirstBaselineConstraint: NSLayoutConstraint?
-    private var contextualHintViewController: ContextualHintViewController!
     private var syncedDeviceIconCenterConstraint: NSLayoutConstraint?
     private var showAllSyncedTabsAction: (() -> Void)?
     private var itemTitleTopConstraint: NSLayoutConstraint!
@@ -146,7 +145,6 @@ class SyncedTabCell: BlurrableCollectionViewCell, ReusableCell {
     }
 
     deinit {
-        contextualHintViewController?.stopTimer()
         notificationCenter.removeObserver(self)
     }
 
@@ -174,13 +172,6 @@ class SyncedTabCell: BlurrableCollectionViewCell, ReusableCell {
         accessibilityLabel = viewModel.accessibilityLabel
         cardTitle.text = viewModel.cardTitleText
         configureImages(viewModel: viewModel)
-
-        let contextualHintViewModel = ContextualHintViewModel(
-            forHintType: .jumpBackInSyncedTab,
-            with: viewModel.profile
-        )
-        contextualHintViewController = ContextualHintViewController(with: contextualHintViewModel)
-        prepareSyncedTabOnJumpBackInContextualHint(with: viewModel.profile)
 
         let textAttributes: [NSAttributedString.Key: Any] = [ .underlineStyle: NSUnderlineStyle.single.rawValue ]
         let attributeString = NSMutableAttributedString(
@@ -390,52 +381,4 @@ extension SyncedTabCell: Notifiable {
             }
         }
     }
-}
-
-// MARK: - Contextual Hints related
-extension SyncedTabCell: FeatureFlaggable {
-    typealias CFRPrefsKeys = PrefsKeys.ContextualHints
-
-    private func prepareSyncedTabOnJumpBackInContextualHint(with profile: Profile) {
-        guard contextualHintViewController.shouldPresentHint(),
-              featureFlags.isFeatureEnabled(.contextualHintForJumpBackInSyncedTab, checking: .buildOnly)
-        else {
-            profile.prefs.setBool(false, forKey: CFRPrefsKeys.jumpBackInSyncedTabConfiguredKey.rawValue)
-            return
-        }
-
-        contextualHintViewController.configure(
-            anchor: cardTitle,
-            withArrowDirection: .down,
-            andDelegate: BrowserViewController.foregroundBVC(),
-            presentedUsing: presentContextualHint,
-            withActionBeforeAppearing: prepareToPresentHint,
-            actionOnDismiss: nil,
-            andActionForButton: nil,
-            andShouldStartTimerRightAway: true) {
-                profile.prefs.setBool(true, forKey: CFRPrefsKeys.jumpBackInSyncedTabConfiguredKey.rawValue)
-            }
-    }
-
-    private func presentContextualHint() {
-        let bvc = BrowserViewController.foregroundBVC()
-
-        guard bvc.searchController == nil,
-              bvc.presentedViewController == nil
-        else {
-            contextualHintViewController.stopTimer()
-            return
-        }
-
-        bvc.present(contextualHintViewController, animated: true, completion: nil)
-
-        UIAccessibility.post(notification: .layoutChanged, argument: contextualHintViewController)
-    }
-
-    /// We need to leave overlay mode before the hint can show.
-    private func prepareToPresentHint() {
-        let info: [AnyHashable: Any] = ["contextualHint": ContextualHintType.jumpBackInSyncedTab]
-        NotificationCenter.default.post(name: .DidPresentContextualHint, object: self, userInfo: info)
-    }
-
 }

--- a/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -21,6 +21,7 @@ class JumpBackInViewModel: FeatureFlaggable {
     var onTapGroup: ((Tab) -> Void)?
     var syncedTabsShowAllAction: (() -> Void)?
     var openSyncedTabAction: ((URL) -> Void)?
+    var prepareContextualHint: ((SyncedTabCell) -> Void)?
 
     weak var browserBarViewDelegate: BrowserBarViewDelegate?
     weak var delegate: HomepageDataModelDelegate?
@@ -381,9 +382,11 @@ extension JumpBackInViewModel: HomepageSectionHandler {
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SyncedTabCell.cellIdentifier,
                                                           for: indexPath)
             guard let syncedTabCell = cell as? SyncedTabCell,
-                    let mostRecentSyncedTab = mostRecentSyncedTab
+                  let mostRecentSyncedTab = mostRecentSyncedTab,
+                  let prepareContextualHint = prepareContextualHint
             else { return UICollectionViewCell() }
             configureSyncedTabCellForTab(item: mostRecentSyncedTab, cell: syncedTabCell, indexPath: indexPath)
+            prepareContextualHint(syncedTabCell)
             return syncedTabCell
         }
 

--- a/Shared/NotificationConstants.swift
+++ b/Shared/NotificationConstants.swift
@@ -82,8 +82,6 @@ extension Notification.Name {
 
     public static let LibraryPanelStateDidChange = Notification.Name("LibraryPanelStateDidChange")
 
-    public static let DidPresentContextualHint = Notification.Name("DidPresentContextualHint")
-
     // MARK: Tab manager
 
     // Tab manager creates a toast for undo recently closed tabs and a notification is

--- a/Tests/ClientTests/Frontend/ContextualHints/ContextualHintViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/ContextualHints/ContextualHintViewModelTests.swift
@@ -1,0 +1,51 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Shared
+import XCTest
+
+@testable import Client
+
+class ContextualHintViewModelTests: XCTestCase {
+
+    typealias CFRPrefsKeys = PrefsKeys.ContextualHints
+
+    private var profile: MockProfile!
+
+    override func setUp() {
+        super.setUp()
+        profile = MockProfile()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        profile = nil
+    }
+
+    // MARK: Mark Contextual Hint Configuration
+
+    func testJumpBackInSyncTabConfiguredTrue() {
+        let subject = ContextualHintViewModel(forHintType: .jumpBackInSyncedTab, with: profile)
+        subject.markContextualHintConfiguration(configured: true)
+        XCTAssertTrue(profile.prefs.boolForKey(CFRPrefsKeys.jumpBackInSyncedTabConfiguredKey.rawValue)!)
+    }
+
+    func testJumpBackInSyncTabConfiguredFalse() {
+        let subject = ContextualHintViewModel(forHintType: .jumpBackInSyncedTab, with: profile)
+        subject.markContextualHintConfiguration(configured: false)
+        XCTAssertFalse(profile.prefs.boolForKey(CFRPrefsKeys.jumpBackInSyncedTabConfiguredKey.rawValue)!)
+    }
+
+    func testJumpBackInConfiguredTrue() {
+        let subject = ContextualHintViewModel(forHintType: .jumpBackIn, with: profile)
+        subject.markContextualHintConfiguration(configured: true)
+        XCTAssertTrue(profile.prefs.boolForKey(CFRPrefsKeys.jumpBackInConfiguredKey.rawValue)!)
+    }
+
+    func testJumpBackInConfiguredFalse() {
+        let subject = ContextualHintViewModel(forHintType: .jumpBackIn, with: profile)
+        subject.markContextualHintConfiguration(configured: false)
+        XCTAssertFalse(profile.prefs.boolForKey(CFRPrefsKeys.jumpBackInConfiguredKey.rawValue)!)
+    }
+}


### PR DESCRIPTION
# [FXIOS-4965 ](https://mozilla-hub.atlassian.net/browse/FXIOS-4965) https://github.com/mozilla-mobile/firefox-ios/issues/11967
- Sync tab CFR was owned by the synced tab cell and presented from BVC foreground. Sync tab CFR which is shown only on the homepage should be owned by the homepage view controller, has the other CFR shown in there. This enables us to reuse same logic to ensure CFRs are only showed when they need, aka when homepage is presented.
- The sync tab CFR is still showing from the sync tab title. No UI or logic changes in this PR. Same order of precedence between CFRs.
- Removed homePanelDidPresentContextualHintWith since not needed anymore
- Add markContextualHintConfiguration method on viewModel to encapsulate configuration saving logic, add tests for that as well