### PR TITLE
Add [v106] Adjust first session and metrics ping for attribution

### DIFF
--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -2919,6 +2919,7 @@ adjust:
         type: string
     send_in_pings:
       - first-session
+      - metrics
       - events
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/pull/11089
@@ -2937,6 +2938,7 @@ adjust:
       Firefox-iOS.
     send_in_pings:
       - first-session
+      - metrics
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/pull/11089
     data_reviews:
@@ -2954,6 +2956,7 @@ adjust:
       Firefox-iOS.
     send_in_pings:
       - first-session
+      - metrics
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/pull/11089
     data_reviews:
@@ -2971,6 +2974,7 @@ adjust:
       Firefox-iOS.
     send_in_pings:
       - first-session
+      - metrics
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/pull/11089
     data_reviews:
@@ -2988,6 +2992,7 @@ adjust:
       Firefox-iOS.
     send_in_pings:
       - first-session
+      - metrics
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/pull/11089
     data_reviews:


### PR DESCRIPTION
# Request for Data Collection Changes in Ping

** This form is for the renewal of an existing, reviewed data collection.**

** All questions are mandatory.
You must receive Data Review from a
[Data Steward](https://wiki.mozilla.org/Data_Collection)
on a filled-out Request before Changes in Ping data collection.**

1) Provide a link to the initial Data Collection Review Request for this collection.
[Adjust](https://github.com/mozilla-mobile/firefox-ios/pull/11089)

2) When will this collection now expire?
It will expire on 2023-01-01

3) Why was the change required for ping?
- consistency with Android implementation
- we want to look at recent behaviour according to marketing attribution we would need to query just recent data instead of having to look at all-time data to find the attribution information