### PR TITLE
Bugfix FXIOS-4960 [v106] shortcut doesnt have a background after changing the wallpaper

### DIFF
--- a/Client/Extensions/UIView+Extension.swift
+++ b/Client/Extensions/UIView+Extension.swift
@@ -83,6 +83,8 @@ extension UIView {
         for subview in self.subviews {
             if subview is UIVisualEffectView { subview.removeFromSuperview() }
         }
+        // Set clipsToBounds to false to make sure shadows will be visible
+        clipsToBounds = false
     }
 
     /// Performs a deep copy of the view. Does not copy constraints.

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -266,6 +266,8 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable {
 
     func applyTheme() {
         view.backgroundColor = UIColor.theme.homePanel.topSitesBackground
+        // TODO: Remove this once the new theme system is implemented on the homepage FXIOS-4882
+        reloadView()
     }
 
     func scrollToTop(animated: Bool = false) {

--- a/Client/Frontend/Home/RecentlySaved/RecentlySavedCell.swift
+++ b/Client/Frontend/Home/RecentlySaved/RecentlySavedCell.swift
@@ -92,7 +92,7 @@ class RecentlySavedCell: BlurrableCollectionViewCell, ReusableCell, Notification
         fallbackFaviconImage.image = nil
         itemTitle.text = nil
         setFallBackFaviconVisibility(isHidden: false)
-        applyTheme()
+
     }
 
     override func layoutSubviews() {
@@ -105,7 +105,7 @@ class RecentlySavedCell: BlurrableCollectionViewCell, ReusableCell, Notification
         configureImages(heroImage: viewModel.heroImage, favIconImage: viewModel.favIconImage)
 
         itemTitle.text = viewModel.site.title
-        adjustLayout()
+        applyTheme()
     }
 
     private func configureImages(heroImage: UIImage?, favIconImage: UIImage?) {
@@ -189,26 +189,20 @@ class RecentlySavedCell: BlurrableCollectionViewCell, ReusableCell, Notification
     func adjustLayout() {
         // If blur is disabled set background color
         if shouldApplyWallpaperBlur {
-
             rootContainer.addBlurEffectWithClearBackgroundAndClipping(using: .systemThickMaterial)
         } else {
             rootContainer.removeVisualEffectView()
-            let isDarkMode = LegacyThemeManager.instance.currentName == .dark
-                rootContainer.backgroundColor = isDarkMode ? UIColor.Photon.DarkGrey40 : .white
+            rootContainer.backgroundColor = LegacyThemeManager.instance.current.homePanel.recentlySavedBookmarkCellBackground
             setupShadow()
         }
     }
 
     func applyTheme() {
-        if LegacyThemeManager.instance.currentName == .dark {
-            itemTitle.textColor = UIColor.Photon.LightGrey10
-            fallbackFaviconBackground.backgroundColor = UIColor.Photon.DarkGrey60
-        } else {
-            itemTitle.textColor = UIColor.Photon.DarkGrey90
-            fallbackFaviconBackground.backgroundColor = UIColor.Photon.LightGrey10
-        }
+        itemTitle.textColor = LegacyThemeManager.instance.current.homePanel.recentlySavedBookmarkTitle
+        fallbackFaviconBackground.backgroundColor = LegacyThemeManager.instance.current.homePanel.recentlySavedBookmarkImageBackground
+        fallbackFaviconBackground.layer.borderColor = LegacyThemeManager.instance.current.homePanel.topSitesBackground.cgColor
 
-        fallbackFaviconBackground.layer.borderColor = UIColor.theme.homePanel.topSitesBackground.cgColor
+        adjustLayout()
     }
 
     private func setupShadow() {
@@ -227,10 +221,9 @@ extension RecentlySavedCell: Notifiable {
     func handleNotifications(_ notification: Notification) {
         ensureMainThread { [weak self] in
             switch notification.name {
-            case .DisplayThemeChanged:
+            case .DisplayThemeChanged,
+                    .WallpaperDidChange:
                 self?.applyTheme()
-            case .WallpaperDidChange:
-                self?.adjustLayout()
             default:
                 break
             }

--- a/Client/Frontend/Home/RecentlySaved/RecentlySavedCell.swift
+++ b/Client/Frontend/Home/RecentlySaved/RecentlySavedCell.swift
@@ -97,7 +97,7 @@ class RecentlySavedCell: BlurrableCollectionViewCell, ReusableCell, Notification
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        rootContainer.layer.shadowPath = UIBezierPath(roundedRect: contentView.bounds,
+        rootContainer.layer.shadowPath = UIBezierPath(roundedRect: rootContainer.bounds,
                                                       cornerRadius: UX.generalCornerRadius).cgPath
     }
 
@@ -207,7 +207,7 @@ class RecentlySavedCell: BlurrableCollectionViewCell, ReusableCell, Notification
 
     private func setupShadow() {
         rootContainer.layer.cornerRadius = UX.generalCornerRadius
-        rootContainer.layer.shadowPath = UIBezierPath(roundedRect: contentView.bounds,
+        rootContainer.layer.shadowPath = UIBezierPath(roundedRect: rootContainer.bounds,
                                                       cornerRadius: UX.generalCornerRadius).cgPath
         rootContainer.layer.shadowColor = UIColor.theme.homePanel.shortcutShadowColor
         rootContainer.layer.shadowOpacity = UIColor.theme.homePanel.shortcutShadowOpacity

--- a/Client/Frontend/Home/TopSites/Cell/TopSiteItemCell.swift
+++ b/Client/Frontend/Home/TopSites/Cell/TopSiteItemCell.swift
@@ -115,10 +115,9 @@ class TopSiteItemCell: BlurrableCollectionViewCell, ReusableCell {
         accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell
 
         setupLayout()
-        applyTheme()
-
         setupNotifications(forObserver: self, observing: [.DisplayThemeChanged,
                                                           .WallpaperDidChange])
+        applyTheme()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -131,8 +130,8 @@ class TopSiteItemCell: BlurrableCollectionViewCell, ReusableCell {
 
     override func prepareForReuse() {
         super.prepareForReuse()
+
         imageView.image = nil
-        rootContainer.backgroundColor = .clear
         titleLabel.text = nil
         sponsoredLabel.text = nil
         pinViewHolder.isHidden = true
@@ -169,6 +168,8 @@ class TopSiteItemCell: BlurrableCollectionViewCell, ReusableCell {
     // MARK: - Setup Helper methods
 
     private func setupLayout() {
+        rootContainer.backgroundColor = .clear
+
         titlePinWrapper.addArrangedSubview(pinViewHolder)
         titlePinWrapper.addArrangedSubview(titleLabel)
         pinViewHolder.addSubview(pinImageView)
@@ -238,7 +239,7 @@ class TopSiteItemCell: BlurrableCollectionViewCell, ReusableCell {
             rootContainer.addBlurEffectWithClearBackgroundAndClipping(using: .systemThickMaterial)
         } else {
             rootContainer.removeVisualEffectView()
-            rootContainer.backgroundColor = LegacyThemeManager.instance.current.homePanel.topSitesContainerView
+            rootContainer.backgroundColor = UIColor.theme.homePanel.topSitesContainerView
             setupShadow()
         }
     }
@@ -270,10 +271,9 @@ extension TopSiteItemCell: Notifiable {
     func handleNotifications(_ notification: Notification) {
         ensureMainThread { [weak self] in
             switch notification.name {
-            case .DisplayThemeChanged:
+            case .DisplayThemeChanged,
+                    .WallpaperDidChange:
                 self?.applyTheme()
-            case .WallpaperDidChange:
-                self?.adjustLayout()
             default: break
             }
         }

--- a/Client/Frontend/Home/TopSites/Cell/TopSiteItemCell.swift
+++ b/Client/Frontend/Home/TopSites/Cell/TopSiteItemCell.swift
@@ -246,7 +246,7 @@ class TopSiteItemCell: BlurrableCollectionViewCell, ReusableCell {
 
     private func setupShadow() {
         rootContainer.layer.cornerRadius = UX.cellCornerRadius
-        rootContainer.layer.shadowPath = UIBezierPath(roundedRect: contentView.bounds,
+        rootContainer.layer.shadowPath = UIBezierPath(roundedRect: rootContainer.bounds,
                                                       cornerRadius: UX.cellCornerRadius).cgPath
         rootContainer.layer.shadowColor = UIColor.theme.homePanel.shortcutShadowColor
         rootContainer.layer.shadowOpacity = UIColor.theme.homePanel.shortcutShadowOpacity

--- a/Client/Frontend/Theme/LegacyThemeManager/LegacyDarkTheme.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/LegacyDarkTheme.swift
@@ -127,7 +127,9 @@ private class DarkHomePanelColor: HomePanelColor {
     override var shortcutShadowColor: CGColor { return UIColor(red: 0.11, green: 0.11, blue: 0.13, alpha: 1.0).cgColor }
     override var shortcutShadowOpacity: Float { return 0.5 }
 
-    override var recentlySavedBookmarkCellBackground: UIColor { return UIColor.Photon.DarkGrey30 }
+    override var recentlySavedBookmarkCellBackground: UIColor { return UIColor.Photon.DarkGrey40 }
+    override var recentlySavedBookmarkImageBackground: UIColor { return UIColor.Photon.DarkGrey60 }
+    override var recentlySavedBookmarkTitle: UIColor { return UIColor.Photon.LightGrey10 }
 
     override var recentlyVisitedCellGroupImage: UIColor { return .white }
 

--- a/Client/Frontend/Theme/LegacyThemeManager/LegacyTheme.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/LegacyTheme.swift
@@ -192,7 +192,9 @@ class HomePanelColor {
     var shortcutShadowColor: CGColor { return UIColor(red: 0.23, green: 0.22, blue: 0.27, alpha: 1.0).cgColor }
     var shortcutShadowOpacity: Float { return 0.2 }
 
-    var recentlySavedBookmarkCellBackground: UIColor { return .white}
+    var recentlySavedBookmarkCellBackground: UIColor { return .white }
+    var recentlySavedBookmarkImageBackground: UIColor { return UIColor.Photon.LightGrey10 }
+    var recentlySavedBookmarkTitle: UIColor { return UIColor.Photon.DarkGrey90 }
 
     var recentlyVisitedCellGroupImage: UIColor { return UIColor.Photon.DarkGrey90 }
     var recentlyVisitedCellBottomLine: UIColor { return UIColor.Photon.LightGrey40 }


### PR DESCRIPTION
Jira [4960](https://mozilla-hub.atlassian.net/browse/FXIOS-4960)
Issue #11960 

- Use LegacyTheme colors for TopSites and Recently saved cells
- Call adjustLayout on `configure` and `applyTheme` to fix not setting the blur or shadow if the cell bounds are not correctly set yet

Includes https://github.com/mozilla-mobile/firefox-ios/pull/11986