### PR TITLE
Bugfix FXIOS-4963 [v107] Remove copy item at output since test-fixtures data wasn't encoded with new methods

### DIFF
--- a/Client/Application/UITestAppDelegate.swift
+++ b/Client/Application/UITestAppDelegate.swift
@@ -77,7 +77,6 @@ class UITestAppDelegate: AppDelegate, FeatureFlaggable {
                                                                                           inDirectory: "test-fixtures")!)
                 try? FileManager.default.createDirectory(atPath: dirForTestProfile, withIntermediateDirectories: false, attributes: nil)
                 let deprecatedOutput = URL(fileURLWithPath: "\(dirForTestProfile)/\(TabManagerStoreImplementation.deprecatedStorePath)")
-                let output = URL(fileURLWithPath: "\(dirForTestProfile)/\(TabManagerStoreImplementation.storePath)")
 
                 let enumerator = FileManager.default.enumerator(atPath: dirForTestProfile)
                 let filePaths = enumerator?.allObjects as! [String]
@@ -85,8 +84,10 @@ class UITestAppDelegate: AppDelegate, FeatureFlaggable {
                     try! FileManager.default.removeItem(at: URL(fileURLWithPath: "\(dirForTestProfile)/\(item)"))
                 }
 
+                // When we remove migration code for tabs, make sure we migrate the archive test-fixtures data.
+                // See FXIOS-4913 for more details. Correct output will be:
+                // let output = URL(fileURLWithPath: "\(dirForTestProfile)/\(TabManagerStoreImplementation.storePath)")
                 try! FileManager.default.copyItem(at: input, to: deprecatedOutput)
-                try! FileManager.default.copyItem(at: input, to: output)
             }
 
         }


### PR DESCRIPTION
# [FXIOS-4963](https://mozilla-hub.atlassian.net/browse/FXIOS-4963) https://github.com/mozilla-mobile/firefox-ios/issues/11963
Remove copy item at output since test-fixtures data wasn't encoded with new methods. When we remove the migration tabs code, we'll need to make sure the test-fixtures tabs data is properly encoded with the new archiving methods, so it can be properly decoded during UITests. 