### PR TITLE
Bugfix FXIOS-4987 [v107] Classic wallpapers in settings are having the wrong accessibility label

### DIFF
--- a/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewModel.swift
+++ b/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewModel.swift
@@ -169,7 +169,7 @@ private extension WallpaperSettingsViewModel {
 
         switch collectionType {
         case .classic:
-            a11yLabel = "\(stringIds.ClassicWallpaper) \(indexPath.row + 1)"
+            a11yLabel = "\(String(format: stringIds.ClassicWallpaper, AppName.shortName.rawValue)) \(indexPath.row + 1)"
         case .limitedEdition:
             a11yLabel = "\(stringIds.LimitedEditionWallpaper) \(indexPath.row + 1)"
         }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-4987)
#12005