### PR TITLE
Refactor FXIOS-4884 [v107] Implement settings theming, first pass

### DIFF
--- a/Client/Application/NavigationRouter.swift
+++ b/Client/Application/NavigationRouter.swift
@@ -331,7 +331,9 @@ enum NavigationPath {
         case .wallpaper:
             let wallpaperManager = WallpaperManager()
             if wallpaperManager.canSettingsBeShown {
-                let viewModel = WallpaperSettingsViewModel(wallpaperManager: wallpaperManager, tabManager: tabManager)
+                let viewModel = WallpaperSettingsViewModel(wallpaperManager: wallpaperManager,
+                                                           tabManager: tabManager,
+                                                           theme: baseSettingsVC.themeManager.currentTheme)
                 let wallpaperVC = WallpaperSettingsViewController(viewModel: viewModel)
                 controller.pushViewController(wallpaperVC, animated: true)
             }

--- a/Client/Frontend/Browser/OpenWithSettingsViewController.swift
+++ b/Client/Frontend/Browser/OpenWithSettingsViewController.swift
@@ -94,6 +94,7 @@ class OpenWithSettingsViewController: ThemedTableViewController {
         cell.textLabel?.attributedText = NSAttributedString.tableRowTitle(option.name, enabled: option.enabled)
         cell.accessoryType = (currentChoice == option.scheme && option.enabled) ? .checkmark : .none
         cell.isUserInteractionEnabled = option.enabled
+        cell.applyTheme(theme: themeManager.currentTheme)
 
         return cell
     }

--- a/Client/Frontend/Login Management/LoginDataSource.swift
+++ b/Client/Frontend/Login Management/LoginDataSource.swift
@@ -52,7 +52,7 @@ class LoginDataSource: NSObject, UITableViewDataSource {
 
             let hideSettings = viewModel.searchController?.isActive ?? false || tableView.isEditing
             let setting = indexPath.row == 0 ? boolSettings.0 : boolSettings.1
-            setting.onConfigureCell(cell)
+            setting.onConfigureCell(cell, theme: viewModel.theme)
             if hideSettings {
                 cell.isHidden = true
             } else if viewModel.isDuringSearchControllerDismiss {

--- a/Client/Frontend/Login Management/LoginDetailTableViewCell.swift
+++ b/Client/Frontend/Login Management/LoginDetailTableViewCell.swift
@@ -27,6 +27,7 @@ enum LoginTableViewCellStyle {
     case iconAndDescriptionLabel
 }
 
+// TODO: Next task for FXIOS-4884 - apply ThemedTableViewCell theme
 class LoginDetailTableViewCell: ThemedTableViewCell {
 
     fileprivate lazy var labelContainer: UIView = .build { _ in }
@@ -162,9 +163,9 @@ class LoginDetailTableViewCell: ThemedTableViewCell {
         setNeedsUpdateConstraints()
     }
 
-    override func applyTheme() {
-        super.applyTheme()
-        descriptionLabel.textColor = UIColor.theme.tableView.rowText
+    override func applyTheme(theme: Theme) {
+        super.applyTheme(theme: theme)
+        descriptionLabel.textColor = theme.colors.textPrimary
     }
 }
 

--- a/Client/Frontend/Login Management/LoginListTableViewCell.swift
+++ b/Client/Frontend/Login Management/LoginListTableViewCell.swift
@@ -4,6 +4,7 @@
 
 import UIKit
 
+// TODO: Next task for FXIOS-4884 - apply ThemedTableViewCell theme
 class LoginListTableViewSettingsCell: ThemedTableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -14,6 +15,7 @@ class LoginListTableViewSettingsCell: ThemedTableViewCell {
     }
 }
 
+// TODO: Next task for FXIOS-4884 - apply ThemedTableViewCell theme
 class LoginListTableViewCell: ThemedTableViewCell {
     private let breachAlertSize: CGFloat = 24
     lazy var breachAlertImageView: UIImageView = .build { imageView in
@@ -75,7 +77,6 @@ class LoginListTableViewCell: ThemedTableViewCell {
         contentView.addSubview(contentStack)
         // Need to override the default background multi-select color to support theming
         multipleSelectionBackgroundView = UIView()
-        applyTheme()
         setConstraints()
     }
 

--- a/Client/Frontend/Login Management/LoginListViewModel.swift
+++ b/Client/Frontend/Login Management/LoginListViewModel.swift
@@ -40,9 +40,12 @@ final class LoginListViewModel {
         }
     }
     var hasLoadedBreaches: Bool = false
-    init(profile: Profile, searchController: UISearchController) {
+    var theme: Theme
+
+    init(profile: Profile, searchController: UISearchController, theme: Theme) {
         self.profile = profile
         self.searchController = searchController
+        self.theme = theme
     }
 
     func loadLogins(_ query: String? = nil, loginDataSource: LoginDataSource) {

--- a/Client/Frontend/Settings/AdvancedAccountSettingViewController.swift
+++ b/Client/Frontend/Settings/AdvancedAccountSettingViewController.swift
@@ -71,6 +71,7 @@ class AdvancedAccountSettingViewController: SettingsTableViewController {
     override func generateSettings() -> [SettingSection] {
         let prefs = profile.prefs
 
+        // TODO: Laurie - textPrimary
         let useStage = BoolSetting(
             prefs: prefs,
             prefKey: PrefsKeys.UseStageServer,

--- a/Client/Frontend/Settings/AdvancedAccountSettingViewController.swift
+++ b/Client/Frontend/Settings/AdvancedAccountSettingViewController.swift
@@ -71,14 +71,14 @@ class AdvancedAccountSettingViewController: SettingsTableViewController {
     override func generateSettings() -> [SettingSection] {
         let prefs = profile.prefs
 
-        // TODO: Laurie - textPrimary
+        let attributes = [NSAttributedString.Key.foregroundColor: themeManager.currentTheme.colors.textPrimary]
         let useStage = BoolSetting(
             prefs: prefs,
             prefKey: PrefsKeys.UseStageServer,
             defaultValue: false,
             attributedTitleText: NSAttributedString(
                 string: .AdvancedAccountUseStageServer,
-                attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])) { isOn in
+                attributes: attributes)) { isOn in
             self.settings = self.generateSettings()
             self.tableView.reloadData()
         }

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -23,7 +23,6 @@ struct SettingDisclosureUtility {
     }
 }
 
-
 // MARK: - ConnectSetting
 // Sync setting for connecting a Firefox Account. Shown when we don't have an account.
 class ConnectSetting: WithoutAccountSetting {

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -13,23 +13,24 @@ import Glean
 private var ShowDebugSettings: Bool = false
 private var DebugSettingsClickCount: Int = 0
 
-private var disclosureIndicator: UIImageView {
-    let disclosureIndicator = UIImageView()
-    disclosureIndicator.image = UIImage(named: "menu-Disclosure")?.withRenderingMode(.alwaysTemplate).imageFlippedForRightToLeftLayoutDirection()
-    // TODO: Laurie - actionSecondary
-    disclosureIndicator.tintColor = UIColor.theme.tableView.accessoryViewTint
-    disclosureIndicator.sizeToFit()
-    return disclosureIndicator
+struct SettingDisclosureUtility {
+    static func buildDisclosureIndicator(theme: Theme) -> UIImageView {
+        let disclosureIndicator = UIImageView()
+        disclosureIndicator.image = UIImage(named: ImageIdentifiers.menuChevron)?.withRenderingMode(.alwaysTemplate).imageFlippedForRightToLeftLayoutDirection()
+        disclosureIndicator.tintColor = theme.colors.actionSecondary
+        disclosureIndicator.sizeToFit()
+        return disclosureIndicator
+    }
 }
+
 
 // MARK: - ConnectSetting
 // Sync setting for connecting a Firefox Account. Shown when we don't have an account.
 class ConnectSetting: WithoutAccountSetting {
-    override var accessoryView: UIImageView? { return disclosureIndicator }
+    override var accessoryView: UIImageView? { return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme) }
 
     override var title: NSAttributedString? {
-        // TODO: Laurie - textPrimary
-        return NSAttributedString(string: .Settings.Sync.ButtonTitle, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        return NSAttributedString(string: .Settings.Sync.ButtonTitle, attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }
 
     override var accessibilityIdentifier: String? { return "SignInToSync" }
@@ -40,11 +41,10 @@ class ConnectSetting: WithoutAccountSetting {
         navigationController?.pushViewController(viewController, animated: true)
     }
 
-    override func onConfigureCell(_ cell: UITableViewCell) {
-        super.onConfigureCell(cell)
+    override func onConfigureCell(_ cell: UITableViewCell, theme: Theme) {
+        super.onConfigureCell(cell, theme: theme)
         cell.imageView?.image = UIImage.templateImageNamed("FxA-Default")
-        // TODO: Laurie - textDisabled
-        cell.imageView?.tintColor = UIColor.theme.tableView.disabledRowText
+        cell.imageView?.tintColor = theme.colors.textDisabled
         cell.imageView?.layer.cornerRadius = (cell.imageView?.frame.size.width)! / 2
         cell.imageView?.layer.masksToBounds = true
     }
@@ -55,11 +55,6 @@ class SyncNowSetting: WithAccountSetting {
     let imageView = UIImageView(frame: CGRect(width: 30, height: 30))
     let syncIconWrapper = UIImage.createWithColor(CGSize(width: 30, height: 30), color: UIColor.clear)
     let syncBlueIcon = UIImage(named: "FxA-Sync-Blue")
-    let syncIcon: UIImage? = {
-        let image = UIImage(named: "FxA-Sync")
-        // TODO: Laurie - iconPrimary
-        return LegacyThemeManager.instance.currentName == .dark ? image?.tinted(withColor: .white) : image
-    }()
 
     // Animation used to rotate the Sync icon 360 degrees while syncing is in progress.
     let continuousRotateAnimation = CABasicAnimation(keyPath: "transform.rotation")
@@ -80,17 +75,14 @@ class SyncNowSetting: WithAccountSetting {
             return NSAttributedString(
                 string: .FxANoInternetConnection,
                 attributes: [
-                    // TODO: Laurie - textWarning
-                    NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.errorText,
+                    NSAttributedString.Key.foregroundColor: theme.colors.textWarning,
                     NSAttributedString.Key.font: DynamicFontHelper.defaultHelper.DefaultMediumFont
                 ]
             )
         }
 
-        // TODO: Laurie - textPrimary
-        let syncText = UIColor.theme.tableView.syncText
-        // TODO: Laurie - textSecondary
-        let headerLightText = UIColor.theme.tableView.headerTextLight
+        let syncText = theme.colors.textPrimary
+        let headerLightText = theme.colors.textSecondary
         return NSAttributedString(
             string: .FxASyncNow,
             attributes: [
@@ -99,14 +91,6 @@ class SyncNowSetting: WithAccountSetting {
             ]
         )
     }
-
-    fileprivate let syncingTitle = NSAttributedString(
-        string: .SyncingMessageWithEllipsis,
-        // TODO: Laurie - textPrimary
-        attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.syncText,
-                     NSAttributedString.Key.font: UIFont.systemFont(
-                        ofSize: DynamicFontHelper.defaultHelper.DefaultStandardFontSize,
-                        weight: UIFont.Weight.regular)])
 
     func startRotateSyncIcon() {
         DispatchQueue.main.async {
@@ -123,6 +107,8 @@ class SyncNowSetting: WithAccountSetting {
     override var accessoryType: UITableViewCell.AccessoryType { return .none }
 
     override var image: UIImage? {
+        let syncIcon = UIImage(named: "FxA-Sync")?.tinted(withColor: theme.colors.iconPrimary)
+
         guard let syncStatus = profile.syncManager.syncDisplayState else {
             return syncIcon
         }
@@ -146,18 +132,21 @@ class SyncNowSetting: WithAccountSetting {
             return NSAttributedString(
                 string: message,
                 attributes: [
-                    // TODO: Laurie - textWarning
-                    NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.errorText,
+                    NSAttributedString.Key.foregroundColor: theme.colors.textWarning,
                     NSAttributedString.Key.font: DynamicFontHelper.defaultHelper.DefaultStandardFont])
         case .warning(let message):
             return  NSAttributedString(
                 string: message,
                 attributes: [
-                    // TODO: Laurie - textWarning
-                    NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.warningText,
+                    NSAttributedString.Key.foregroundColor: theme.colors.textWarning,
                     NSAttributedString.Key.font: DynamicFontHelper.defaultHelper.DefaultStandardFont])
         case .inProgress:
-            return syncingTitle
+            return NSAttributedString(
+                string: .SyncingMessageWithEllipsis,
+                attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary,
+                             NSAttributedString.Key.font: UIFont.systemFont(
+                                ofSize: DynamicFontHelper.defaultHelper.DefaultStandardFontSize,
+                                weight: UIFont.Weight.regular)])
         default:
             return syncNowTitle
         }
@@ -168,8 +157,7 @@ class SyncNowSetting: WithAccountSetting {
 
         let formattedLabel = timestampFormatter.string(from: Date.fromTimestamp(timestamp))
         let attributedString = NSMutableAttributedString(string: formattedLabel)
-        // TODO: Laurie - textSecondary
-        let attributes = [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.headerTextLight, NSAttributedString.Key.font: UIFont.systemFont(ofSize: 12, weight: UIFont.Weight.regular)]
+        let attributes = [NSAttributedString.Key.foregroundColor: theme.colors.textSecondary, NSAttributedString.Key.font: UIFont.systemFont(ofSize: 12, weight: UIFont.Weight.regular)]
         let range = NSRange(location: 0, length: attributedString.length)
         attributedString.setAttributes(attributes, range: range)
         return attributedString
@@ -193,8 +181,7 @@ class SyncNowSetting: WithAccountSetting {
         let troubleshootButton = UIButton(type: .roundedRect)
         troubleshootButton.setTitle(.FirefoxSyncTroubleshootTitle, for: .normal)
         troubleshootButton.addTarget(self, action: #selector(self.troubleshoot), for: .touchUpInside)
-        // TODO: Laurie - actionPrimary
-        troubleshootButton.tintColor = UIColor.theme.tableView.rowActionAccessory
+        troubleshootButton.tintColor = theme.colors.actionPrimary
         troubleshootButton.titleLabel?.font = DynamicFontHelper.defaultHelper.DefaultSmallFont
         troubleshootButton.sizeToFit()
         return troubleshootButton
@@ -220,7 +207,8 @@ class SyncNowSetting: WithAccountSetting {
         settings.navigationController?.pushViewController(viewController, animated: true)
     }
 
-    override func onConfigureCell(_ cell: UITableViewCell) {
+    override func onConfigureCell(_ cell: UITableViewCell, theme: Theme) {
+        super.onConfigureCell(cell, theme: theme)
         cell.textLabel?.attributedText = title
         cell.textLabel?.numberOfLines = 0
         cell.textLabel?.lineBreakMode = .byWordWrapping
@@ -322,7 +310,7 @@ class AccountStatusSetting: WithAccountSetting {
     }
 
     override var accessoryView: UIImageView? {
-        return disclosureIndicator
+        return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme)
     }
 
     override var title: NSAttributedString? {
@@ -331,8 +319,7 @@ class AccountStatusSetting: WithAccountSetting {
                 string: displayName,
                 attributes: [
                     NSAttributedString.Key.font: DynamicFontHelper.defaultHelper.DefaultStandardFontBold,
-                    // TODO: Laurie - textPrimary
-                    NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.syncText])
+                    NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
         }
 
         if let email = RustFirefoxAccounts.shared.userProfile?.email {
@@ -340,8 +327,7 @@ class AccountStatusSetting: WithAccountSetting {
                 string: email,
                 attributes: [
                     NSAttributedString.Key.font: DynamicFontHelper.defaultHelper.DefaultStandardFontBold,
-                    // TODO: Laurie - textPrimary
-                    NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.syncText])
+                    NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
         }
 
         return nil
@@ -350,8 +336,7 @@ class AccountStatusSetting: WithAccountSetting {
     override var status: NSAttributedString? {
         if RustFirefoxAccounts.shared.isActionNeeded {
             let string: String = .FxAAccountVerifyPassword
-            // TODO: Laurie - textWarning
-            let color = UIColor.theme.tableView.warningText
+            let color = theme.colors.textWarning
             let range = NSRange(location: 0, length: string.count)
             let attrs = [NSAttributedString.Key.foregroundColor: color]
             let res = NSMutableAttributedString(string: string)
@@ -374,8 +359,8 @@ class AccountStatusSetting: WithAccountSetting {
         navigationController?.pushViewController(viewController, animated: true)
     }
 
-    override func onConfigureCell(_ cell: UITableViewCell) {
-        super.onConfigureCell(cell)
+    override func onConfigureCell(_ cell: UITableViewCell, theme: Theme) {
+        super.onConfigureCell(cell, theme: theme)
         if let imageView = cell.imageView {
             imageView.subviews.forEach({ $0.removeFromSuperview() })
             imageView.frame = CGRect(width: 30, height: 30)
@@ -416,8 +401,7 @@ class HiddenSetting: Setting {
 class DeleteExportedDataSetting: HiddenSetting {
     override var title: NSAttributedString? {
         // Not localized for now.
-        // TODO: Laurie - textPrimary
-        return NSAttributedString(string: "Debug: delete exported databases", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        return NSAttributedString(string: "Debug: delete exported databases", attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -439,8 +423,7 @@ class DeleteExportedDataSetting: HiddenSetting {
 class ExportBrowserDataSetting: HiddenSetting {
     override var title: NSAttributedString? {
         // Not localized for now.
-        // TODO: Laurie - textPrimary
-        return NSAttributedString(string: "Debug: copy databases to app container", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        return NSAttributedString(string: "Debug: copy databases to app container", attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -460,8 +443,7 @@ class ExportBrowserDataSetting: HiddenSetting {
 class ExportLogDataSetting: HiddenSetting {
     override var title: NSAttributedString? {
         // Not localized for now.
-        // TODO: Laurie - textPrimary
-        return NSAttributedString(string: "Debug: copy log files to app container", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        return NSAttributedString(string: "Debug: copy log files to app container", attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -499,8 +481,7 @@ class FeatureSwitchSetting: BoolSetting {
 
 class ForceCrashSetting: HiddenSetting {
     override var title: NSAttributedString? {
-        // TODO: Laurie - textPrimary
-        return NSAttributedString(string: "💥 Debug: Force Crash", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        return NSAttributedString(string: "💥 Debug: Force Crash", attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -510,8 +491,7 @@ class ForceCrashSetting: HiddenSetting {
 
 class ChangeToChinaSetting: HiddenSetting {
     override var title: NSAttributedString? {
-        // TODO: Laurie - textPrimary
-        return NSAttributedString(string: "Debug: toggle China version (needs restart)", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        return NSAttributedString(string: "Debug: toggle China version (needs restart)", attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -524,9 +504,8 @@ class ChangeToChinaSetting: HiddenSetting {
 }
 
 class SlowTheDatabase: HiddenSetting {
-    // TODO: Laurie - textPrimary
     override var title: NSAttributedString? {
-        return NSAttributedString(string: "Debug: simulate slow database operations", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        return NSAttributedString(string: "Debug: simulate slow database operations", attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -536,10 +515,9 @@ class SlowTheDatabase: HiddenSetting {
 
 class ForgetSyncAuthStateDebugSetting: HiddenSetting {
     override var title: NSAttributedString? {
-        // TODO: Laurie - textPrimary
         return NSAttributedString(
             string: "Debug: forget Sync auth state",
-            attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+            attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -551,11 +529,10 @@ class ForgetSyncAuthStateDebugSetting: HiddenSetting {
 class SentryIDSetting: HiddenSetting {
     let deviceAppHash = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)?.string(forKey: "SentryDeviceAppHash") ?? "0000000000000000000000000000000000000000"
     override var title: NSAttributedString? {
-        // TODO: Laurie - textPrimary
         return NSAttributedString(
             string: "Sentry ID: \(deviceAppHash)",
             attributes: [
-                NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText,
+                NSAttributedString.Key.foregroundColor: theme.colors.textPrimary,
                 NSAttributedString.Key.font: UIFont.systemFont(ofSize: 10)])
     }
 
@@ -586,9 +563,8 @@ class SentryIDSetting: HiddenSetting {
 class ShowEtpCoverSheet: HiddenSetting {
     let profile: Profile
 
-    // TODO: Laurie - textPrimary
     override var title: NSAttributedString? {
-        return NSAttributedString(string: "Debug: ETP Cover Sheet On", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        return NSAttributedString(string: "Debug: ETP Cover Sheet On", attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }
 
     override init(settings: SettingsTableViewController) {
@@ -615,10 +591,9 @@ class ExperimentsSettings: HiddenSetting {
 
 class TogglePullToRefresh: HiddenSetting, FeatureFlaggable {
     override var title: NSAttributedString? {
-        // TODO: Laurie - textPrimary
         let toNewStatus = featureFlags.isFeatureEnabled(.pullToRefresh, checking: .userOnly) ? "OFF" : "ON"
         return NSAttributedString(string: "Toggle Pull to Refresh \(toNewStatus)",
-                                  attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+                                  attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -630,10 +605,9 @@ class TogglePullToRefresh: HiddenSetting, FeatureFlaggable {
 
 class ResetWallpaperOnboardingPage: HiddenSetting, FeatureFlaggable {
     override var title: NSAttributedString? {
-        // TODO: Laurie - textPrimary
         let seenStatus = UserDefaults.standard.bool(forKey: PrefsKeys.Wallpapers.OnboardingSeenKey) ? "SEEN" : "UNSEEN"
         return NSAttributedString(string: "Reset wallpaper onboarding sheet (\(seenStatus))",
-                                  attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+                                  attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -644,10 +618,9 @@ class ResetWallpaperOnboardingPage: HiddenSetting, FeatureFlaggable {
 
 class ToggleInactiveTabs: HiddenSetting, FeatureFlaggable {
     override var title: NSAttributedString? {
-        // TODO: Laurie - textPrimary
         let toNewStatus = featureFlags.isFeatureEnabled(.inactiveTabs, checking: .userOnly) ? "OFF" : "ON"
         return NSAttributedString(string: "Toggle inactive tabs \(toNewStatus)",
-                                  attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+                                  attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -660,11 +633,10 @@ class ToggleInactiveTabs: HiddenSetting, FeatureFlaggable {
 
 class ToggleHistoryGroups: HiddenSetting, FeatureFlaggable {
     override var title: NSAttributedString? {
-        // TODO: Laurie - textPrimary
         let toNewStatus = featureFlags.isFeatureEnabled(.historyGroups, checking: .userOnly) ? "OFF" : "ON"
         return NSAttributedString(
             string: "Toggle history groups \(toNewStatus)",
-            attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+            attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -680,10 +652,9 @@ class ResetContextualHints: HiddenSetting {
     override var accessibilityIdentifier: String? { return "ResetContextualHints.Setting" }
 
     override var title: NSAttributedString? {
-        // TODO: Laurie - textPrimary
         return NSAttributedString(
             string: "Reset all contextual hints",
-            attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+            attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }
 
     override init(settings: SettingsTableViewController) {
@@ -703,8 +674,7 @@ class OpenFiftyTabsDebugOption: HiddenSetting {
     override var accessibilityIdentifier: String? { return "OpenFiftyTabsOption.Setting" }
 
     override var title: NSAttributedString? {
-        // TODO: Laurie - textPrimary
-        return NSAttributedString(string: "⚠️ Open 50 `mozilla.org` tabs ⚠️", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        return NSAttributedString(string: "⚠️ Open 50 `mozilla.org` tabs ⚠️", attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -725,12 +695,11 @@ class VersionSetting: Setting {
     }
 
     override var title: NSAttributedString? {
-        // TODO: Laurie - textPrimary
-        return NSAttributedString(string: "\(AppName.shortName) \(AppInfo.appVersion) (\(AppInfo.buildNumber))", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        return NSAttributedString(string: "\(AppName.shortName) \(AppInfo.appVersion) (\(AppInfo.buildNumber))", attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }
 
-    override func onConfigureCell(_ cell: UITableViewCell) {
-        super.onConfigureCell(cell)
+    override func onConfigureCell(_ cell: UITableViewCell, theme: Theme) {
+        super.onConfigureCell(cell, theme: theme)
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -769,8 +738,7 @@ class VersionSetting: Setting {
 // Opens the license page in a new tab
 class LicenseAndAcknowledgementsSetting: Setting {
     override var title: NSAttributedString? {
-        // TODO: Laurie - textPrimary
-        return NSAttributedString(string: .AppSettingsLicenses, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        return NSAttributedString(string: .AppSettingsLicenses, attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }
 
     override var url: URL? {
@@ -786,8 +754,7 @@ class LicenseAndAcknowledgementsSetting: Setting {
 class AppStoreReviewSetting: Setting {
 
     override var title: NSAttributedString? {
-        // TODO: Laurie - textPrimary
-        return NSAttributedString(string: .Settings.About.RateOnAppStore, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        return NSAttributedString(string: .Settings.About.RateOnAppStore, attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -798,9 +765,8 @@ class AppStoreReviewSetting: Setting {
 // Opens about:rights page in the content view controller
 class YourRightsSetting: Setting {
     override var title: NSAttributedString? {
-        // TODO: Laurie - textPrimary
-        return NSAttributedString(string: .AppSettingsYourRights, attributes:
-            [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        return NSAttributedString(string: .AppSettingsYourRights,
+                                  attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }
 
     override var url: URL? {
@@ -820,8 +786,7 @@ class ShowIntroductionSetting: Setting {
 
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
-        // TODO: Laurie - textPrimary
-        super.init(title: NSAttributedString(string: .AppSettingsShowTour, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+        super.init(title: NSAttributedString(string: .AppSettingsShowTour, attributes: [NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -833,8 +798,7 @@ class ShowIntroductionSetting: Setting {
 
 class SendFeedbackSetting: Setting {
     override var title: NSAttributedString? {
-        // TODO: Laurie - textPrimary
-        return NSAttributedString(string: .AppSettingsSendFeedback, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        return NSAttributedString(string: .AppSettingsSendFeedback, attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }
 
     override var url: URL? {
@@ -847,13 +811,11 @@ class SendFeedbackSetting: Setting {
 }
 
 class SendAnonymousUsageDataSetting: BoolSetting {
-    init(prefs: Prefs, delegate: SettingsDelegate?) {
+    init(prefs: Prefs, delegate: SettingsDelegate?, theme: Theme) {
         let statusText = NSMutableAttributedString()
-        // TODO: Laurie - textSecondary
-        statusText.append(NSAttributedString(string: .SendUsageSettingMessage, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.headerTextLight]))
+        statusText.append(NSAttributedString(string: .SendUsageSettingMessage, attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textSecondary]))
         statusText.append(NSAttributedString(string: " "))
-        // TODO: Laurie - actionPrimary
-        statusText.append(NSAttributedString(string: .SendUsageSettingLink, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.general.highlightBlue]))
+        statusText.append(NSAttributedString(string: .SendUsageSettingLink, attributes: [NSAttributedString.Key.foregroundColor: theme.colors.actionPrimary]))
 
         super.init(
             prefs: prefs,
@@ -884,13 +846,11 @@ class SendAnonymousUsageDataSetting: BoolSetting {
 }
 
 class StudiesToggleSetting: BoolSetting {
-    init(prefs: Prefs, delegate: SettingsDelegate?) {
+    init(prefs: Prefs, delegate: SettingsDelegate?, theme: Theme) {
         let statusText = NSMutableAttributedString()
-        // TODO: Laurie - textSecondary
-        statusText.append(NSAttributedString(string: .SettingsStudiesToggleMessage, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.headerTextLight]))
+        statusText.append(NSAttributedString(string: .SettingsStudiesToggleMessage, attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textSecondary]))
         statusText.append(NSAttributedString(string: " "))
-        // TODO: Laurie - actionPrimary
-        statusText.append(NSAttributedString(string: .SettingsStudiesToggleLink, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.general.highlightBlue]))
+        statusText.append(NSAttributedString(string: .SettingsStudiesToggleLink, attributes: [NSAttributedString.Key.foregroundColor: theme.colors.actionPrimary]))
 
         super.init(
             prefs: prefs,
@@ -920,9 +880,8 @@ class StudiesToggleSetting: BoolSetting {
 
 // Opens the SUMO page in a new tab
 class OpenSupportPageSetting: Setting {
-    init(delegate: SettingsDelegate?) {
-        // TODO: Laurie - textPrimary
-        super.init(title: NSAttributedString(string: .AppSettingsHelp, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]),
+    init(delegate: SettingsDelegate?, theme: Theme) {
+        super.init(title: NSAttributedString(string: .AppSettingsHelp, attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary]),
             delegate: delegate)
     }
 
@@ -939,7 +898,7 @@ class OpenSupportPageSetting: Setting {
 class SearchSetting: Setting {
     let profile: Profile
 
-    override var accessoryView: UIImageView? { return disclosureIndicator }
+    override var accessoryView: UIImageView? { return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme) }
 
     override var style: UITableViewCell.CellStyle { return .value1 }
 
@@ -949,8 +908,7 @@ class SearchSetting: Setting {
 
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
-        // TODO: Laurie - textPrimary
-        super.init(title: NSAttributedString(string: .AppSettingsSearch, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+        super.init(title: NSAttributedString(string: .AppSettingsSearch, attributes: [NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -967,7 +925,7 @@ class LoginsSetting: Setting {
     weak var navigationController: UINavigationController?
     weak var settings: AppSettingsTableViewController?
 
-    override var accessoryView: UIImageView? { return disclosureIndicator }
+    override var accessoryView: UIImageView? { return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme) }
 
     override var accessibilityIdentifier: String? { return "Logins" }
 
@@ -978,10 +936,9 @@ class LoginsSetting: Setting {
         self.settings = settings as? AppSettingsTableViewController
 
         super.init(
-            // TODO: Laurie - textPrimary
             title: NSAttributedString(
                 string: .Settings.Passwords.Title,
-                attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]
+                attributes: [NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary]
             ),
             delegate: delegate
         )
@@ -1051,14 +1008,13 @@ class LoginsSetting: Setting {
 class ContentBlockerSetting: Setting {
     let profile: Profile
     var tabManager: TabManager!
-    override var accessoryView: UIImageView? { return disclosureIndicator }
+    override var accessoryView: UIImageView? { return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme) }
     override var accessibilityIdentifier: String? { return "TrackingProtection" }
 
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
         self.tabManager = settings.tabManager
-        // TODO: Laurie - textPrimary
-        super.init(title: NSAttributedString(string: .SettingsTrackingProtectionSectionName, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+        super.init(title: NSAttributedString(string: .SettingsTrackingProtectionSectionName, attributes: [NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -1073,7 +1029,7 @@ class ClearPrivateDataSetting: Setting {
     let profile: Profile
     var tabManager: TabManager!
 
-    override var accessoryView: UIImageView? { return disclosureIndicator }
+    override var accessoryView: UIImageView? { return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme) }
 
     override var accessibilityIdentifier: String? { return "ClearPrivateData" }
 
@@ -1081,9 +1037,8 @@ class ClearPrivateDataSetting: Setting {
         self.profile = settings.profile
         self.tabManager = settings.tabManager
 
-        // TODO: Laurie - textPrimary
         let clearTitle: String = .SettingsDataManagementSectionName
-        super.init(title: NSAttributedString(string: clearTitle, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+        super.init(title: NSAttributedString(string: clearTitle, attributes: [NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -1096,8 +1051,7 @@ class ClearPrivateDataSetting: Setting {
 
 class PrivacyPolicySetting: Setting {
     override var title: NSAttributedString? {
-        // TODO: Laurie - textPrimary
-        return NSAttributedString(string: .AppSettingsPrivacyPolicy, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        return NSAttributedString(string: .AppSettingsPrivacyPolicy, attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }
 
     override var url: URL? {
@@ -1119,13 +1073,13 @@ class ChinaSyncServiceSetting: Setting {
     override var hidden: Bool { return !AppInfo.isChinaEdition }
 
     override var title: NSAttributedString? {
-        // TODO: Laurie - textPrimary
-        return NSAttributedString(string: "本地同步服务", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        return NSAttributedString(string: "本地同步服务",
+                                  attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }
 
     override var status: NSAttributedString? {
-        // TODO: Laurie - textSecondary
-        return NSAttributedString(string: "禁用后使用全球服务同步数据", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.headerTextLight])
+        return NSAttributedString(string: "禁用后使用全球服务同步数据",
+                                  attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textSecondary])
     }
 
     init(settings: SettingsTableViewController) {
@@ -1133,11 +1087,10 @@ class ChinaSyncServiceSetting: Setting {
         self.settings = settings
     }
 
-    override func onConfigureCell(_ cell: UITableViewCell) {
-        super.onConfigureCell(cell)
+    override func onConfigureCell(_ cell: UITableViewCell, theme: Theme) {
+        super.onConfigureCell(cell, theme: theme)
         let control = UISwitchThemed()
-        // TODO: Laurie - actionPrimary
-        control.onTintColor = UIColor.theme.tableView.controlTint
+        control.onTintColor = theme.colors.actionPrimary
         control.addTarget(self, action: #selector(switchValueChanged), for: .valueChanged)
         control.isOn = prefs.boolForKey(prefKey) ?? AppInfo.isChinaEdition
         cell.accessoryView = control
@@ -1173,7 +1126,7 @@ class ChinaSyncServiceSetting: Setting {
 class NewTabPageSetting: Setting {
     let profile: Profile
 
-    override var accessoryView: UIImageView? { return disclosureIndicator }
+    override var accessoryView: UIImageView? { return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme) }
 
     override var accessibilityIdentifier: String? { return "NewTab" }
 
@@ -1185,8 +1138,8 @@ class NewTabPageSetting: Setting {
 
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
-        // TODO: Laurie - textPrimary
-        super.init(title: NSAttributedString(string: .SettingsNewTabSectionName, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+        super.init(title: NSAttributedString(string: .SettingsNewTabSectionName,
+                                             attributes: [NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -1199,7 +1152,7 @@ class NewTabPageSetting: Setting {
 class HomeSetting: Setting {
     let profile: Profile
 
-    override var accessoryView: UIImageView? { return disclosureIndicator }
+    override var accessoryView: UIImageView? { return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme) }
 
     override var accessibilityIdentifier: String? { return "Home" }
 
@@ -1211,8 +1164,8 @@ class HomeSetting: Setting {
 
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
-        // TODO: Laurie - textPrimary
-        super.init(title: NSAttributedString(string: .SettingsHomePageSectionName, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+        super.init(title: NSAttributedString(string: .SettingsHomePageSectionName,
+                                             attributes: [NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -1224,13 +1177,13 @@ class HomeSetting: Setting {
 
 class TabsSetting: Setting {
 
-    override var accessoryView: UIImageView? { return disclosureIndicator }
+    override var accessoryView: UIImageView? { return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme) }
 
     override var accessibilityIdentifier: String? { return "TabsSetting" }
 
-    init() {
-        // TODO: Laurie - textPrimary
-        super.init(title: NSAttributedString(string: .Settings.SectionTitles.TabsTitle, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+    init(theme: Theme) {
+        super.init(title: NSAttributedString(string: .Settings.SectionTitles.TabsTitle,
+                                             attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -1242,15 +1195,15 @@ class TabsSetting: Setting {
 class SiriPageSetting: Setting {
     let profile: Profile
 
-    override var accessoryView: UIImageView? { return disclosureIndicator }
+    override var accessoryView: UIImageView? { return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme) }
 
     override var accessibilityIdentifier: String? { return "SiriSettings" }
 
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
 
-        // TODO: Laurie - textPrimary
-        super.init(title: NSAttributedString(string: .SettingsSiriSectionName, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+        super.init(title: NSAttributedString(string: .SettingsSiriSectionName,
+                                             attributes: [NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -1289,9 +1242,9 @@ class NoImageModeSetting: BoolSetting {
 class DefaultBrowserSetting: Setting {
     override var accessibilityIdentifier: String? { return "DefaultBrowserSettings" }
 
-    init() {
-        // TODO: Laurie - actionPrimary
-        super.init(title: NSAttributedString(string: String.DefaultBrowserMenuItem, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowActionAccessory]))
+    init(theme: Theme) {
+        super.init(title: NSAttributedString(string: String.DefaultBrowserMenuItem,
+                                             attributes: [NSAttributedString.Key.foregroundColor: theme.colors.actionPrimary]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -1303,7 +1256,7 @@ class DefaultBrowserSetting: Setting {
 class OpenWithSetting: Setting {
     let profile: Profile
 
-    override var accessoryView: UIImageView? { return disclosureIndicator }
+    override var accessoryView: UIImageView? { return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme) }
 
     override var accessibilityIdentifier: String? { return "OpenWith.Setting" }
 
@@ -1325,8 +1278,8 @@ class OpenWithSetting: Setting {
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
 
-        // TODO: Laurie - textPrimary
-        super.init(title: NSAttributedString(string: .SettingsOpenWithSectionName, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+        super.init(title: NSAttributedString(string: .SettingsOpenWithSectionName,
+                                             attributes: [NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -1338,13 +1291,12 @@ class OpenWithSetting: Setting {
 class AdvancedAccountSetting: HiddenSetting {
     let profile: Profile
 
-    override var accessoryView: UIImageView? { return disclosureIndicator }
+    override var accessoryView: UIImageView? { return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme) }
 
     override var accessibilityIdentifier: String? { return "AdvancedAccount.Setting" }
 
-    // TODO: Laurie - textPrimary
     override var title: NSAttributedString? {
-        return NSAttributedString(string: .SettingsAdvancedAccountTitle, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        return NSAttributedString(string: .SettingsAdvancedAccountTitle, attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }
 
     override init(settings: SettingsTableViewController) {
@@ -1365,7 +1317,7 @@ class AdvancedAccountSetting: HiddenSetting {
 
 class ThemeSetting: Setting {
     let profile: Profile
-    override var accessoryView: UIImageView? { return disclosureIndicator }
+    override var accessoryView: UIImageView? { return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme) }
     override var style: UITableViewCell.CellStyle { return .value1 }
     override var accessibilityIdentifier: String? { return "DisplayThemeOption" }
 
@@ -1382,8 +1334,8 @@ class ThemeSetting: Setting {
 
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
-        // TODO: Laurie - textPrimary
-        super.init(title: NSAttributedString(string: .SettingsDisplayThemeTitle, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+        super.init(title: NSAttributedString(string: .SettingsDisplayThemeTitle,
+                                             attributes: [NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -1394,7 +1346,7 @@ class ThemeSetting: Setting {
 class SearchBarSetting: Setting {
     let viewModel: SearchBarSettingsViewModel
 
-    override var accessoryView: UIImageView? { return disclosureIndicator }
+    override var accessoryView: UIImageView? { return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme) }
 
     override var accessibilityIdentifier: String? { return AccessibilityIdentifiers.Settings.SearchBar.searchBarSetting }
 
@@ -1406,9 +1358,8 @@ class SearchBarSetting: Setting {
 
     init(settings: SettingsTableViewController) {
         self.viewModel = SearchBarSettingsViewModel(prefs: settings.profile.prefs)
-        // TODO: Laurie - textPrimary
         super.init(title: NSAttributedString(string: viewModel.title,
-                                             attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+                                             attributes: [NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -16,6 +16,7 @@ private var DebugSettingsClickCount: Int = 0
 private var disclosureIndicator: UIImageView {
     let disclosureIndicator = UIImageView()
     disclosureIndicator.image = UIImage(named: "menu-Disclosure")?.withRenderingMode(.alwaysTemplate).imageFlippedForRightToLeftLayoutDirection()
+    // TODO: Laurie - actionSecondary
     disclosureIndicator.tintColor = UIColor.theme.tableView.accessoryViewTint
     disclosureIndicator.sizeToFit()
     return disclosureIndicator
@@ -27,6 +28,7 @@ class ConnectSetting: WithoutAccountSetting {
     override var accessoryView: UIImageView? { return disclosureIndicator }
 
     override var title: NSAttributedString? {
+        // TODO: Laurie - textPrimary
         return NSAttributedString(string: .Settings.Sync.ButtonTitle, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
@@ -41,6 +43,7 @@ class ConnectSetting: WithoutAccountSetting {
     override func onConfigureCell(_ cell: UITableViewCell) {
         super.onConfigureCell(cell)
         cell.imageView?.image = UIImage.templateImageNamed("FxA-Default")
+        // TODO: Laurie - textDisabled
         cell.imageView?.tintColor = UIColor.theme.tableView.disabledRowText
         cell.imageView?.layer.cornerRadius = (cell.imageView?.frame.size.width)! / 2
         cell.imageView?.layer.masksToBounds = true
@@ -54,6 +57,7 @@ class SyncNowSetting: WithAccountSetting {
     let syncBlueIcon = UIImage(named: "FxA-Sync-Blue")
     let syncIcon: UIImage? = {
         let image = UIImage(named: "FxA-Sync")
+        // TODO: Laurie - iconPrimary
         return LegacyThemeManager.instance.currentName == .dark ? image?.tinted(withColor: .white) : image
     }()
 
@@ -76,13 +80,16 @@ class SyncNowSetting: WithAccountSetting {
             return NSAttributedString(
                 string: .FxANoInternetConnection,
                 attributes: [
+                    // TODO: Laurie - textWarning
                     NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.errorText,
                     NSAttributedString.Key.font: DynamicFontHelper.defaultHelper.DefaultMediumFont
                 ]
             )
         }
 
+        // TODO: Laurie - textPrimary
         let syncText = UIColor.theme.tableView.syncText
+        // TODO: Laurie - textSecondary
         let headerLightText = UIColor.theme.tableView.headerTextLight
         return NSAttributedString(
             string: .FxASyncNow,
@@ -95,6 +102,7 @@ class SyncNowSetting: WithAccountSetting {
 
     fileprivate let syncingTitle = NSAttributedString(
         string: .SyncingMessageWithEllipsis,
+        // TODO: Laurie - textPrimary
         attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.syncText,
                      NSAttributedString.Key.font: UIFont.systemFont(
                         ofSize: DynamicFontHelper.defaultHelper.DefaultStandardFontSize,
@@ -138,12 +146,14 @@ class SyncNowSetting: WithAccountSetting {
             return NSAttributedString(
                 string: message,
                 attributes: [
+                    // TODO: Laurie - textWarning
                     NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.errorText,
                     NSAttributedString.Key.font: DynamicFontHelper.defaultHelper.DefaultStandardFont])
         case .warning(let message):
             return  NSAttributedString(
                 string: message,
                 attributes: [
+                    // TODO: Laurie - textWarning
                     NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.warningText,
                     NSAttributedString.Key.font: DynamicFontHelper.defaultHelper.DefaultStandardFont])
         case .inProgress:
@@ -158,6 +168,7 @@ class SyncNowSetting: WithAccountSetting {
 
         let formattedLabel = timestampFormatter.string(from: Date.fromTimestamp(timestamp))
         let attributedString = NSMutableAttributedString(string: formattedLabel)
+        // TODO: Laurie - textSecondary
         let attributes = [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.headerTextLight, NSAttributedString.Key.font: UIFont.systemFont(ofSize: 12, weight: UIFont.Weight.regular)]
         let range = NSRange(location: 0, length: attributedString.length)
         attributedString.setAttributes(attributes, range: range)
@@ -182,6 +193,7 @@ class SyncNowSetting: WithAccountSetting {
         let troubleshootButton = UIButton(type: .roundedRect)
         troubleshootButton.setTitle(.FirefoxSyncTroubleshootTitle, for: .normal)
         troubleshootButton.addTarget(self, action: #selector(self.troubleshoot), for: .touchUpInside)
+        // TODO: Laurie - actionPrimary
         troubleshootButton.tintColor = UIColor.theme.tableView.rowActionAccessory
         troubleshootButton.titleLabel?.font = DynamicFontHelper.defaultHelper.DefaultSmallFont
         troubleshootButton.sizeToFit()
@@ -319,6 +331,7 @@ class AccountStatusSetting: WithAccountSetting {
                 string: displayName,
                 attributes: [
                     NSAttributedString.Key.font: DynamicFontHelper.defaultHelper.DefaultStandardFontBold,
+                    // TODO: Laurie - textPrimary
                     NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.syncText])
         }
 
@@ -327,6 +340,7 @@ class AccountStatusSetting: WithAccountSetting {
                 string: email,
                 attributes: [
                     NSAttributedString.Key.font: DynamicFontHelper.defaultHelper.DefaultStandardFontBold,
+                    // TODO: Laurie - textPrimary
                     NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.syncText])
         }
 
@@ -336,9 +350,10 @@ class AccountStatusSetting: WithAccountSetting {
     override var status: NSAttributedString? {
         if RustFirefoxAccounts.shared.isActionNeeded {
             let string: String = .FxAAccountVerifyPassword
-            let orange = UIColor.theme.tableView.warningText
+            // TODO: Laurie - textWarning
+            let color = UIColor.theme.tableView.warningText
             let range = NSRange(location: 0, length: string.count)
-            let attrs = [NSAttributedString.Key.foregroundColor: orange]
+            let attrs = [NSAttributedString.Key.foregroundColor: color]
             let res = NSMutableAttributedString(string: string)
             res.setAttributes(attrs, range: range)
             return res
@@ -401,6 +416,7 @@ class HiddenSetting: Setting {
 class DeleteExportedDataSetting: HiddenSetting {
     override var title: NSAttributedString? {
         // Not localized for now.
+        // TODO: Laurie - textPrimary
         return NSAttributedString(string: "Debug: delete exported databases", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
@@ -423,6 +439,7 @@ class DeleteExportedDataSetting: HiddenSetting {
 class ExportBrowserDataSetting: HiddenSetting {
     override var title: NSAttributedString? {
         // Not localized for now.
+        // TODO: Laurie - textPrimary
         return NSAttributedString(string: "Debug: copy databases to app container", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
@@ -443,6 +460,7 @@ class ExportBrowserDataSetting: HiddenSetting {
 class ExportLogDataSetting: HiddenSetting {
     override var title: NSAttributedString? {
         // Not localized for now.
+        // TODO: Laurie - textPrimary
         return NSAttributedString(string: "Debug: copy log files to app container", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
@@ -481,6 +499,7 @@ class FeatureSwitchSetting: BoolSetting {
 
 class ForceCrashSetting: HiddenSetting {
     override var title: NSAttributedString? {
+        // TODO: Laurie - textPrimary
         return NSAttributedString(string: "💥 Debug: Force Crash", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
@@ -491,6 +510,7 @@ class ForceCrashSetting: HiddenSetting {
 
 class ChangeToChinaSetting: HiddenSetting {
     override var title: NSAttributedString? {
+        // TODO: Laurie - textPrimary
         return NSAttributedString(string: "Debug: toggle China version (needs restart)", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
@@ -504,6 +524,7 @@ class ChangeToChinaSetting: HiddenSetting {
 }
 
 class SlowTheDatabase: HiddenSetting {
+    // TODO: Laurie - textPrimary
     override var title: NSAttributedString? {
         return NSAttributedString(string: "Debug: simulate slow database operations", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
@@ -515,6 +536,7 @@ class SlowTheDatabase: HiddenSetting {
 
 class ForgetSyncAuthStateDebugSetting: HiddenSetting {
     override var title: NSAttributedString? {
+        // TODO: Laurie - textPrimary
         return NSAttributedString(
             string: "Debug: forget Sync auth state",
             attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
@@ -529,6 +551,7 @@ class ForgetSyncAuthStateDebugSetting: HiddenSetting {
 class SentryIDSetting: HiddenSetting {
     let deviceAppHash = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)?.string(forKey: "SentryDeviceAppHash") ?? "0000000000000000000000000000000000000000"
     override var title: NSAttributedString? {
+        // TODO: Laurie - textPrimary
         return NSAttributedString(
             string: "Sentry ID: \(deviceAppHash)",
             attributes: [
@@ -563,6 +586,7 @@ class SentryIDSetting: HiddenSetting {
 class ShowEtpCoverSheet: HiddenSetting {
     let profile: Profile
 
+    // TODO: Laurie - textPrimary
     override var title: NSAttributedString? {
         return NSAttributedString(string: "Debug: ETP Cover Sheet On", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
@@ -591,6 +615,7 @@ class ExperimentsSettings: HiddenSetting {
 
 class TogglePullToRefresh: HiddenSetting, FeatureFlaggable {
     override var title: NSAttributedString? {
+        // TODO: Laurie - textPrimary
         let toNewStatus = featureFlags.isFeatureEnabled(.pullToRefresh, checking: .userOnly) ? "OFF" : "ON"
         return NSAttributedString(string: "Toggle Pull to Refresh \(toNewStatus)",
                                   attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
@@ -605,6 +630,7 @@ class TogglePullToRefresh: HiddenSetting, FeatureFlaggable {
 
 class ResetWallpaperOnboardingPage: HiddenSetting, FeatureFlaggable {
     override var title: NSAttributedString? {
+        // TODO: Laurie - textPrimary
         let seenStatus = UserDefaults.standard.bool(forKey: PrefsKeys.Wallpapers.OnboardingSeenKey) ? "SEEN" : "UNSEEN"
         return NSAttributedString(string: "Reset wallpaper onboarding sheet (\(seenStatus))",
                                   attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
@@ -618,6 +644,7 @@ class ResetWallpaperOnboardingPage: HiddenSetting, FeatureFlaggable {
 
 class ToggleInactiveTabs: HiddenSetting, FeatureFlaggable {
     override var title: NSAttributedString? {
+        // TODO: Laurie - textPrimary
         let toNewStatus = featureFlags.isFeatureEnabled(.inactiveTabs, checking: .userOnly) ? "OFF" : "ON"
         return NSAttributedString(string: "Toggle inactive tabs \(toNewStatus)",
                                   attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
@@ -633,6 +660,7 @@ class ToggleInactiveTabs: HiddenSetting, FeatureFlaggable {
 
 class ToggleHistoryGroups: HiddenSetting, FeatureFlaggable {
     override var title: NSAttributedString? {
+        // TODO: Laurie - textPrimary
         let toNewStatus = featureFlags.isFeatureEnabled(.historyGroups, checking: .userOnly) ? "OFF" : "ON"
         return NSAttributedString(
             string: "Toggle history groups \(toNewStatus)",
@@ -652,6 +680,7 @@ class ResetContextualHints: HiddenSetting {
     override var accessibilityIdentifier: String? { return "ResetContextualHints.Setting" }
 
     override var title: NSAttributedString? {
+        // TODO: Laurie - textPrimary
         return NSAttributedString(
             string: "Reset all contextual hints",
             attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
@@ -674,6 +703,7 @@ class OpenFiftyTabsDebugOption: HiddenSetting {
     override var accessibilityIdentifier: String? { return "OpenFiftyTabsOption.Setting" }
 
     override var title: NSAttributedString? {
+        // TODO: Laurie - textPrimary
         return NSAttributedString(string: "⚠️ Open 50 `mozilla.org` tabs ⚠️", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
@@ -695,6 +725,7 @@ class VersionSetting: Setting {
     }
 
     override var title: NSAttributedString? {
+        // TODO: Laurie - textPrimary
         return NSAttributedString(string: "\(AppName.shortName) \(AppInfo.appVersion) (\(AppInfo.buildNumber))", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
@@ -738,6 +769,7 @@ class VersionSetting: Setting {
 // Opens the license page in a new tab
 class LicenseAndAcknowledgementsSetting: Setting {
     override var title: NSAttributedString? {
+        // TODO: Laurie - textPrimary
         return NSAttributedString(string: .AppSettingsLicenses, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
@@ -754,6 +786,7 @@ class LicenseAndAcknowledgementsSetting: Setting {
 class AppStoreReviewSetting: Setting {
 
     override var title: NSAttributedString? {
+        // TODO: Laurie - textPrimary
         return NSAttributedString(string: .Settings.About.RateOnAppStore, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
@@ -765,6 +798,7 @@ class AppStoreReviewSetting: Setting {
 // Opens about:rights page in the content view controller
 class YourRightsSetting: Setting {
     override var title: NSAttributedString? {
+        // TODO: Laurie - textPrimary
         return NSAttributedString(string: .AppSettingsYourRights, attributes:
             [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
@@ -786,6 +820,7 @@ class ShowIntroductionSetting: Setting {
 
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
+        // TODO: Laurie - textPrimary
         super.init(title: NSAttributedString(string: .AppSettingsShowTour, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
     }
 
@@ -798,6 +833,7 @@ class ShowIntroductionSetting: Setting {
 
 class SendFeedbackSetting: Setting {
     override var title: NSAttributedString? {
+        // TODO: Laurie - textPrimary
         return NSAttributedString(string: .AppSettingsSendFeedback, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
@@ -813,8 +849,10 @@ class SendFeedbackSetting: Setting {
 class SendAnonymousUsageDataSetting: BoolSetting {
     init(prefs: Prefs, delegate: SettingsDelegate?) {
         let statusText = NSMutableAttributedString()
+        // TODO: Laurie - textSecondary
         statusText.append(NSAttributedString(string: .SendUsageSettingMessage, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.headerTextLight]))
         statusText.append(NSAttributedString(string: " "))
+        // TODO: Laurie - actionPrimary
         statusText.append(NSAttributedString(string: .SendUsageSettingLink, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.general.highlightBlue]))
 
         super.init(
@@ -848,8 +886,10 @@ class SendAnonymousUsageDataSetting: BoolSetting {
 class StudiesToggleSetting: BoolSetting {
     init(prefs: Prefs, delegate: SettingsDelegate?) {
         let statusText = NSMutableAttributedString()
+        // TODO: Laurie - textSecondary
         statusText.append(NSAttributedString(string: .SettingsStudiesToggleMessage, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.headerTextLight]))
         statusText.append(NSAttributedString(string: " "))
+        // TODO: Laurie - actionPrimary
         statusText.append(NSAttributedString(string: .SettingsStudiesToggleLink, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.general.highlightBlue]))
 
         super.init(
@@ -881,6 +921,7 @@ class StudiesToggleSetting: BoolSetting {
 // Opens the SUMO page in a new tab
 class OpenSupportPageSetting: Setting {
     init(delegate: SettingsDelegate?) {
+        // TODO: Laurie - textPrimary
         super.init(title: NSAttributedString(string: .AppSettingsHelp, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]),
             delegate: delegate)
     }
@@ -908,6 +949,7 @@ class SearchSetting: Setting {
 
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
+        // TODO: Laurie - textPrimary
         super.init(title: NSAttributedString(string: .AppSettingsSearch, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
     }
 
@@ -936,6 +978,7 @@ class LoginsSetting: Setting {
         self.settings = settings as? AppSettingsTableViewController
 
         super.init(
+            // TODO: Laurie - textPrimary
             title: NSAttributedString(
                 string: .Settings.Passwords.Title,
                 attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]
@@ -1014,6 +1057,7 @@ class ContentBlockerSetting: Setting {
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
         self.tabManager = settings.tabManager
+        // TODO: Laurie - textPrimary
         super.init(title: NSAttributedString(string: .SettingsTrackingProtectionSectionName, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
     }
 
@@ -1037,6 +1081,7 @@ class ClearPrivateDataSetting: Setting {
         self.profile = settings.profile
         self.tabManager = settings.tabManager
 
+        // TODO: Laurie - textPrimary
         let clearTitle: String = .SettingsDataManagementSectionName
         super.init(title: NSAttributedString(string: clearTitle, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
     }
@@ -1051,6 +1096,7 @@ class ClearPrivateDataSetting: Setting {
 
 class PrivacyPolicySetting: Setting {
     override var title: NSAttributedString? {
+        // TODO: Laurie - textPrimary
         return NSAttributedString(string: .AppSettingsPrivacyPolicy, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
@@ -1073,10 +1119,12 @@ class ChinaSyncServiceSetting: Setting {
     override var hidden: Bool { return !AppInfo.isChinaEdition }
 
     override var title: NSAttributedString? {
+        // TODO: Laurie - textPrimary
         return NSAttributedString(string: "本地同步服务", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
     override var status: NSAttributedString? {
+        // TODO: Laurie - textSecondary
         return NSAttributedString(string: "禁用后使用全球服务同步数据", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.headerTextLight])
     }
 
@@ -1088,6 +1136,7 @@ class ChinaSyncServiceSetting: Setting {
     override func onConfigureCell(_ cell: UITableViewCell) {
         super.onConfigureCell(cell)
         let control = UISwitchThemed()
+        // TODO: Laurie - actionPrimary
         control.onTintColor = UIColor.theme.tableView.controlTint
         control.addTarget(self, action: #selector(switchValueChanged), for: .valueChanged)
         control.isOn = prefs.boolForKey(prefKey) ?? AppInfo.isChinaEdition
@@ -1136,6 +1185,7 @@ class NewTabPageSetting: Setting {
 
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
+        // TODO: Laurie - textPrimary
         super.init(title: NSAttributedString(string: .SettingsNewTabSectionName, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
     }
 
@@ -1161,7 +1211,7 @@ class HomeSetting: Setting {
 
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
-
+        // TODO: Laurie - textPrimary
         super.init(title: NSAttributedString(string: .SettingsHomePageSectionName, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
     }
 
@@ -1179,6 +1229,7 @@ class TabsSetting: Setting {
     override var accessibilityIdentifier: String? { return "TabsSetting" }
 
     init() {
+        // TODO: Laurie - textPrimary
         super.init(title: NSAttributedString(string: .Settings.SectionTitles.TabsTitle, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
     }
 
@@ -1198,6 +1249,7 @@ class SiriPageSetting: Setting {
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
 
+        // TODO: Laurie - textPrimary
         super.init(title: NSAttributedString(string: .SettingsSiriSectionName, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
     }
 
@@ -1238,6 +1290,7 @@ class DefaultBrowserSetting: Setting {
     override var accessibilityIdentifier: String? { return "DefaultBrowserSettings" }
 
     init() {
+        // TODO: Laurie - actionPrimary
         super.init(title: NSAttributedString(string: String.DefaultBrowserMenuItem, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowActionAccessory]))
     }
 
@@ -1272,6 +1325,7 @@ class OpenWithSetting: Setting {
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
 
+        // TODO: Laurie - textPrimary
         super.init(title: NSAttributedString(string: .SettingsOpenWithSectionName, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
     }
 
@@ -1288,6 +1342,7 @@ class AdvancedAccountSetting: HiddenSetting {
 
     override var accessibilityIdentifier: String? { return "AdvancedAccount.Setting" }
 
+    // TODO: Laurie - textPrimary
     override var title: NSAttributedString? {
         return NSAttributedString(string: .SettingsAdvancedAccountTitle, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
@@ -1327,6 +1382,7 @@ class ThemeSetting: Setting {
 
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
+        // TODO: Laurie - textPrimary
         super.init(title: NSAttributedString(string: .SettingsDisplayThemeTitle, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
     }
 
@@ -1350,6 +1406,7 @@ class SearchBarSetting: Setting {
 
     init(settings: SettingsTableViewController) {
         self.viewModel = SearchBarSettingsViewModel(prefs: settings.profile.prefs)
+        // TODO: Laurie - textPrimary
         super.init(title: NSAttributedString(string: viewModel.title,
                                              attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
     }

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -80,7 +80,9 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
         case .wallpaper:
             let wallpaperManager = WallpaperManager()
             if wallpaperManager.canSettingsBeShown {
-                let viewModel = WallpaperSettingsViewModel(wallpaperManager: wallpaperManager, tabManager: tabManager)
+                let viewModel = WallpaperSettingsViewModel(wallpaperManager: wallpaperManager,
+                                                           tabManager: tabManager,
+                                                           theme: themeManager.currentTheme)
                 let wallpaperVC = WallpaperSettingsViewController(viewModel: viewModel)
                 navigationController?.pushViewController(wallpaperVC, animated: true)
             }
@@ -109,6 +111,7 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
             SiriPageSetting(settings: self),
             BoolSetting(
                 prefs: prefs,
+                theme: themeManager.currentTheme,
                 prefKey: PrefsKeys.KeyBlockPopups,
                 defaultValue: true,
                 titleText: .AppSettingsBlockPopups),
@@ -122,7 +125,7 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
         let tabTrayGroupsAreBuildActive = featureFlags.isFeatureEnabled(.tabTrayGroups, checking: .buildOnly)
         let inactiveTabsAreBuildActive = featureFlags.isFeatureEnabled(.inactiveTabs, checking: .buildOnly)
         if tabTrayGroupsAreBuildActive || inactiveTabsAreBuildActive {
-            generalSettings.insert(TabsSetting(), at: 3)
+            generalSettings.insert(TabsSetting(theme: themeManager.currentTheme), at: 3)
         }
 
         let accountChinaSyncSetting: [Setting]
@@ -141,12 +144,14 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
         generalSettings += [
             BoolSetting(
                 prefs: prefs,
+                theme: themeManager.currentTheme,
                 prefKey: "showClipboardBar",
                 defaultValue: false,
                 titleText: .SettingsOfferClipboardBarTitle,
                 statusText: .SettingsOfferClipboardBarStatus),
             BoolSetting(
                 prefs: prefs,
+                theme: themeManager.currentTheme,
                 prefKey: PrefsKeys.ContextMenuShowLinkPreviews,
                 defaultValue: true,
                 titleText: .SettingsShowLinkPreviewsTitle,
@@ -156,7 +161,7 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
         if #available(iOS 14.0, *) {
             settings += [
                 SettingSection(footerTitle: NSAttributedString(string: String.FirefoxHomepage.HomeTabBanner.EvergreenMessage.HomeTabBannerDescription),
-                               children: [DefaultBrowserSetting()])
+                               children: [DefaultBrowserSetting(theme: themeManager.currentTheme)])
             ]
         }
 
@@ -182,10 +187,11 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
 
         privacySettings += [
             BoolSetting(prefs: prefs,
-                prefKey: "settings.closePrivateTabs",
-                defaultValue: false,
-                titleText: .AppSettingsClosePrivateTabsTitle,
-                statusText: .AppSettingsClosePrivateTabsDescription)
+                        theme: themeManager.currentTheme,
+                        prefKey: "settings.closePrivateTabs",
+                        defaultValue: false,
+                        titleText: .AppSettingsClosePrivateTabsTitle,
+                        statusText: .AppSettingsClosePrivateTabsDescription)
         ]
 
         privacySettings.append(ContentBlockerSetting(settings: self))
@@ -199,9 +205,9 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
             SettingSection(title: NSAttributedString(string: .AppSettingsSupport), children: [
                 ShowIntroductionSetting(settings: self),
                 SendFeedbackSetting(),
-                SendAnonymousUsageDataSetting(prefs: prefs, delegate: settingsDelegate),
-                StudiesToggleSetting(prefs: prefs, delegate: settingsDelegate),
-                OpenSupportPageSetting(delegate: settingsDelegate),
+                SendAnonymousUsageDataSetting(prefs: prefs, delegate: settingsDelegate, theme: themeManager.currentTheme),
+                StudiesToggleSetting(prefs: prefs, delegate: settingsDelegate, theme: themeManager.currentTheme),
+                OpenSupportPageSetting(delegate: settingsDelegate, theme: themeManager.currentTheme),
             ]),
             SettingSection(title: NSAttributedString(string: .AppSettingsAbout), children: [
                 AppStoreReviewSetting(),

--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -74,6 +74,7 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        // TODO: Next task for FXIOS-4884 - apply ThemedTableViewCell theme
         let cell = ThemedTableViewCell()
 
         if indexPath.section == SectionArrow {

--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -57,6 +57,7 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
 
     fileprivate var clearButtonEnabled = true {
         didSet {
+            // TODO: Laurie - textWarning && textDisabled
             clearButton?.textLabel?.textColor = clearButtonEnabled ? UIColor.theme.general.destructiveRed : UIColor.theme.tableView.disabledRowText
         }
     }
@@ -84,6 +85,7 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
         } else if indexPath.section == SectionToggles {
             cell.textLabel?.text = clearables[indexPath.item].clearable.label
             let control = UISwitchThemed()
+            // TODO: Laurie - actionPrimary
             control.onTintColor = UIColor.theme.tableView.controlTint
             control.addTarget(self, action: #selector(switchValueChanged), for: .valueChanged)
             control.isOn = toggles[indexPath.item]
@@ -94,6 +96,7 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
             assert(indexPath.section == SectionButton)
             cell.textLabel?.text = .SettingsClearPrivateDataClearButton
             cell.textLabel?.textAlignment = .center
+            // TODO: Laurie - textWarning
             cell.textLabel?.textColor = UIColor.theme.general.destructiveRed
             cell.accessibilityTraits = UIAccessibilityTraits.button
             cell.accessibilityIdentifier = "ClearPrivateData"

--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -57,8 +57,7 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
 
     fileprivate var clearButtonEnabled = true {
         didSet {
-            // TODO: Laurie - textWarning && textDisabled
-            clearButton?.textLabel?.textColor = clearButtonEnabled ? UIColor.theme.general.destructiveRed : UIColor.theme.tableView.disabledRowText
+            clearButton?.textLabel?.textColor = clearButtonEnabled ? themeManager.currentTheme.colors.textWarning : themeManager.currentTheme.colors.textDisabled
         }
     }
 
@@ -85,8 +84,7 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
         } else if indexPath.section == SectionToggles {
             cell.textLabel?.text = clearables[indexPath.item].clearable.label
             let control = UISwitchThemed()
-            // TODO: Laurie - actionPrimary
-            control.onTintColor = UIColor.theme.tableView.controlTint
+            control.onTintColor = themeManager.currentTheme.colors.actionPrimary
             control.addTarget(self, action: #selector(switchValueChanged), for: .valueChanged)
             control.isOn = toggles[indexPath.item]
             cell.accessoryView = control
@@ -96,8 +94,7 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
             assert(indexPath.section == SectionButton)
             cell.textLabel?.text = .SettingsClearPrivateDataClearButton
             cell.textLabel?.textAlignment = .center
-            // TODO: Laurie - textWarning
-            cell.textLabel?.textColor = UIColor.theme.general.destructiveRed
+            cell.textLabel?.textColor = themeManager.currentTheme.colors.textWarning
             cell.accessibilityTraits = UIAccessibilityTraits.button
             cell.accessibilityIdentifier = "ClearPrivateData"
             clearButton = cell

--- a/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -58,6 +58,7 @@ class TPAccessoryInfo: ThemedTableViewController {
         let header = UILabel()
         header.text = .TPAccessoryInfoBlocksTitle
         header.font = DynamicFontHelper.defaultHelper.DefaultMediumBoldFont
+        // TODO: Laurie - textSecondary
         header.textColor = UIColor.theme.tableView.headerTextLight
 
         stack.addArrangedSubview(UIView())
@@ -76,6 +77,7 @@ class TPAccessoryInfo: ThemedTableViewController {
         topStack.layoutMargins = UIEdgeInsets(top: 8, left: 0, bottom: 0, right: 0)
         topStack.isLayoutMarginsRelativeArrangement = true
 
+        // TODO: Laurie - layer4
         sep.backgroundColor = UIColor.theme.tableView.separator
         sep.snp.makeConstraints { make in
             make.height.equalTo(0.5)
@@ -125,6 +127,7 @@ class TPAccessoryInfo: ThemedTableViewController {
                 cell.textLabel?.text = .TPCategoryDescriptionContentTrackers
             }
         }
+        // TODO: Laurie - iconPrimary
         cell.imageView?.tintColor = UIColor.theme.tableView.rowText
         if indexPath.row == 1 {
             cell.textLabel?.font = DynamicFontHelper.defaultHelper.DefaultMediumFont
@@ -132,6 +135,7 @@ class TPAccessoryInfo: ThemedTableViewController {
         cell.textLabel?.numberOfLines = 0
         cell.detailTextLabel?.numberOfLines = 0
         cell.backgroundColor = .clear
+        // TODO: Laurie - textPrimary
         cell.textLabel?.textColor = UIColor.theme.tableView.rowDetailText
         cell.selectionStyle = .none
         return cell
@@ -240,6 +244,7 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
         let font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline, size: 12.0)
         var attributes = [NSAttributedString.Key: AnyObject]()
         attributes[NSAttributedString.Key.font] = font
+        // TODO: Laurie - actionPrimary
         attributes[NSAttributedString.Key.foregroundColor] = UIColor.theme.general.highlightBlue
 
         let button = UIButton()

--- a/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -93,6 +93,7 @@ class TPAccessoryInfo: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        // TODO: Next task for FXIOS-4884 - apply ThemedTableViewCell theme
         let cell = ThemedTableViewCell(style: .subtitle, reuseIdentifier: nil)
         if indexPath.section == 0 {
             if indexPath.row == 0 {

--- a/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -58,8 +58,7 @@ class TPAccessoryInfo: ThemedTableViewController {
         let header = UILabel()
         header.text = .TPAccessoryInfoBlocksTitle
         header.font = DynamicFontHelper.defaultHelper.DefaultMediumBoldFont
-        // TODO: Laurie - textSecondary
-        header.textColor = UIColor.theme.tableView.headerTextLight
+        header.textColor = themeManager.currentTheme.colors.textSecondary
 
         stack.addArrangedSubview(UIView())
         stack.addArrangedSubview(header)
@@ -77,8 +76,7 @@ class TPAccessoryInfo: ThemedTableViewController {
         topStack.layoutMargins = UIEdgeInsets(top: 8, left: 0, bottom: 0, right: 0)
         topStack.isLayoutMarginsRelativeArrangement = true
 
-        // TODO: Laurie - layer4
-        sep.backgroundColor = UIColor.theme.tableView.separator
+        sep.backgroundColor = themeManager.currentTheme.colors.layer4
         sep.snp.makeConstraints { make in
             make.height.equalTo(0.5)
             make.width.equalToSuperview()
@@ -127,16 +125,14 @@ class TPAccessoryInfo: ThemedTableViewController {
                 cell.textLabel?.text = .TPCategoryDescriptionContentTrackers
             }
         }
-        // TODO: Laurie - iconPrimary
-        cell.imageView?.tintColor = UIColor.theme.tableView.rowText
+        cell.imageView?.tintColor = themeManager.currentTheme.colors.iconPrimary
         if indexPath.row == 1 {
             cell.textLabel?.font = DynamicFontHelper.defaultHelper.DefaultMediumFont
         }
         cell.textLabel?.numberOfLines = 0
         cell.detailTextLabel?.numberOfLines = 0
         cell.backgroundColor = .clear
-        // TODO: Laurie - textPrimary
-        cell.textLabel?.textColor = UIColor.theme.tableView.rowDetailText
+        cell.textLabel?.textColor = themeManager.currentTheme.colors.textPrimary
         cell.selectionStyle = .none
         return cell
     }
@@ -244,8 +240,7 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
         let font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline, size: 12.0)
         var attributes = [NSAttributedString.Key: AnyObject]()
         attributes[NSAttributedString.Key.font] = font
-        // TODO: Laurie - actionPrimary
-        attributes[NSAttributedString.Key.foregroundColor] = UIColor.theme.general.highlightBlue
+        attributes[NSAttributedString.Key.foregroundColor] = themeManager.currentTheme.colors.actionPrimary
 
         let button = UIButton()
         button.setAttributedTitle(NSAttributedString(string: title, attributes: attributes), for: .normal)

--- a/Client/Frontend/Settings/CustomSearchViewController.swift
+++ b/Client/Frontend/Settings/CustomSearchViewController.swift
@@ -32,8 +32,7 @@ class CustomSearchViewController: SettingsTableViewController {
     fileprivate var engineTitle = ""
     fileprivate lazy var spinnerView: UIActivityIndicatorView = {
         let spinner = UIActivityIndicatorView(style: .medium)
-        // TODO: Laurie - Crystal - Spinner color
-        spinner.color = themeManager.currentTheme.colors.textPrimary
+        spinner.color = themeManager.currentTheme.colors.iconSpinnerDefault
         spinner.hidesWhenStopped = true
         return spinner
     }()
@@ -226,8 +225,7 @@ class CustomSearchEngineTextView: Setting, UITextViewDelegate {
         }
 
         placeholderLabel.adjustsFontSizeToFitWidth = true
-        // TODO: Laurie - Crystal - Placeholder color
-        placeholderLabel.textColor = theme.colors.textDisabled
+        placeholderLabel.textColor = theme.colors.textSecondary
         placeholderLabel.text = placeholder
         placeholderLabel.isHidden = !textField.text.isEmpty
         placeholderLabel.frame = CGRect(width: TextLabelWidth, height: TextLabelHeight)

--- a/Client/Frontend/Settings/CustomSearchViewController.swift
+++ b/Client/Frontend/Settings/CustomSearchViewController.swift
@@ -32,8 +32,8 @@ class CustomSearchViewController: SettingsTableViewController {
     fileprivate var engineTitle = ""
     fileprivate lazy var spinnerView: UIActivityIndicatorView = {
         let spinner = UIActivityIndicatorView(style: .medium)
-        // TODO: Laurie - spinner color? Asked Crystal
-        spinner.color = .systemGray
+        // TODO: Laurie - Crystal - Spinner color
+        spinner.color = themeManager.currentTheme.colors.textPrimary
         spinner.hidesWhenStopped = true
         return spinner
     }()
@@ -219,15 +219,15 @@ class CustomSearchEngineTextView: Setting, UITextViewDelegate {
         super.init(cellHeight: TextFieldHeight)
     }
 
-    override func onConfigureCell(_ cell: UITableViewCell) {
-        super.onConfigureCell(cell)
+    override func onConfigureCell(_ cell: UITableViewCell, theme: Theme) {
+        super.onConfigureCell(cell, theme: theme)
         if let id = accessibilityIdentifier {
             textField.accessibilityIdentifier = id + "TextField"
         }
 
         placeholderLabel.adjustsFontSizeToFitWidth = true
-        // TODO: Laurie - textDisabled? asked Crystal
-        placeholderLabel.textColor = UIColor.theme.general.settingsTextPlaceholder
+        // TODO: Laurie - Crystal - Placeholder color
+        placeholderLabel.textColor = theme.colors.textDisabled
         placeholderLabel.text = placeholder
         placeholderLabel.isHidden = !textField.text.isEmpty
         placeholderLabel.frame = CGRect(width: TextLabelWidth, height: TextLabelHeight)
@@ -240,10 +240,8 @@ class CustomSearchEngineTextView: Setting, UITextViewDelegate {
         }
         textField.autocorrectionType = .no
         textField.delegate = self
-        // TODO: Laurie - layer2
-        textField.backgroundColor = UIColor.theme.tableView.rowBackground
-        // TODO: Laurie - textPrimary
-        textField.textColor = UIColor.theme.tableView.rowText
+        textField.backgroundColor = theme.colors.layer2
+        textField.textColor = theme.colors.textPrimary
         cell.isUserInteractionEnabled = true
         cell.accessibilityTraits = UIAccessibilityTraits.none
         cell.contentView.addSubview(textField)
@@ -277,8 +275,7 @@ class CustomSearchEngineTextView: Setting, UITextViewDelegate {
     func textViewDidChange(_ textView: UITextView) {
         placeholderLabel.isHidden = !textField.text.isEmpty
         settingDidChange?(textView.text)
-        // TODO: Laurie - textPrimary && textWarning
-        let color = isValid(textField.text) ? UIColor.theme.tableView.rowText : UIColor.theme.general.destructiveRed
+        let color = isValid(textField.text) ? theme.colors.textPrimary : theme.colors.textWarning
         textField.textColor = color
     }
 

--- a/Client/Frontend/Settings/CustomSearchViewController.swift
+++ b/Client/Frontend/Settings/CustomSearchViewController.swift
@@ -32,6 +32,7 @@ class CustomSearchViewController: SettingsTableViewController {
     fileprivate var engineTitle = ""
     fileprivate lazy var spinnerView: UIActivityIndicatorView = {
         let spinner = UIActivityIndicatorView(style: .medium)
+        // TODO: Laurie - spinner color? Asked Crystal
         spinner.color = .systemGray
         spinner.hidesWhenStopped = true
         return spinner
@@ -225,6 +226,7 @@ class CustomSearchEngineTextView: Setting, UITextViewDelegate {
         }
 
         placeholderLabel.adjustsFontSizeToFitWidth = true
+        // TODO: Laurie - textDisabled? asked Crystal
         placeholderLabel.textColor = UIColor.theme.general.settingsTextPlaceholder
         placeholderLabel.text = placeholder
         placeholderLabel.isHidden = !textField.text.isEmpty
@@ -238,7 +240,9 @@ class CustomSearchEngineTextView: Setting, UITextViewDelegate {
         }
         textField.autocorrectionType = .no
         textField.delegate = self
+        // TODO: Laurie - layer2
         textField.backgroundColor = UIColor.theme.tableView.rowBackground
+        // TODO: Laurie - textPrimary
         textField.textColor = UIColor.theme.tableView.rowText
         cell.isUserInteractionEnabled = true
         cell.accessibilityTraits = UIAccessibilityTraits.none
@@ -273,6 +277,7 @@ class CustomSearchEngineTextView: Setting, UITextViewDelegate {
     func textViewDidChange(_ textView: UITextView) {
         placeholderLabel.isHidden = !textField.text.isEmpty
         settingDidChange?(textView.text)
+        // TODO: Laurie - textPrimary && textWarning
         let color = isValid(textField.text) ? UIColor.theme.tableView.rowText : UIColor.theme.general.destructiveRed
         textField.textColor = color
     }

--- a/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -266,7 +266,7 @@ extension HomePageSettingViewController {
 extension HomePageSettingViewController {
     class WallpaperSettings: Setting, FeatureFlaggable {
 
-        var profile: Profile
+        var settings: SettingsTableViewController
         var tabManager: TabManager
         var wallpaperManager: WallpaperManagerInterface
 
@@ -278,7 +278,7 @@ extension HomePageSettingViewController {
              and tabManager: TabManager = BrowserViewController.foregroundBVC().tabManager,
              wallpaperManager: WallpaperManagerInterface = WallpaperManager()
         ) {
-            self.profile = settings.profile
+            self.settings = settings
             self.tabManager = tabManager
             self.wallpaperManager = wallpaperManager
             super.init(title: NSAttributedString(string: .Settings.Homepage.CustomizeFirefoxHome.Wallpaper))
@@ -286,7 +286,9 @@ extension HomePageSettingViewController {
 
         override func onClick(_ navigationController: UINavigationController?) {
             if wallpaperManager.canSettingsBeShown {
-                let viewModel = WallpaperSettingsViewModel(wallpaperManager: wallpaperManager, tabManager: tabManager)
+                let viewModel = WallpaperSettingsViewModel(wallpaperManager: wallpaperManager,
+                                                           tabManager: tabManager,
+                                                           theme: settings.themeManager.currentTheme)
                 let wallpaperVC = WallpaperSettingsViewController(viewModel: viewModel)
                 navigationController?.pushViewController(wallpaperVC, animated: true)
             }

--- a/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
+++ b/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
@@ -64,6 +64,7 @@ extension TopSitesSettingsViewController {
 
         init(settings: SettingsTableViewController) {
             self.profile = settings.profile
+            // TODO: Laurie - textPrimary
             super.init(title: NSAttributedString(string: .Settings.Homepage.Shortcuts.Rows,
                                                  attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
         }

--- a/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
+++ b/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
@@ -64,9 +64,8 @@ extension TopSitesSettingsViewController {
 
         init(settings: SettingsTableViewController) {
             self.profile = settings.profile
-            // TODO: Laurie - textPrimary
             super.init(title: NSAttributedString(string: .Settings.Homepage.Shortcuts.Rows,
-                                                 attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+                                                 attributes: [NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary]))
         }
 
         override func onClick(_ navigationController: UINavigationController?) {

--- a/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsHeaderView.swift
+++ b/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsHeaderView.swift
@@ -145,6 +145,10 @@ extension WallpaperSettingsHeaderView: NotificationThemeable, Notifiable {
     func applyTheme() {
         let theme = BuiltinThemeName(rawValue: LegacyThemeManager.instance.current.name) ?? .normal
 
+        // TODO: Laurie
+        // contentStackView.backgroundColor = layer5
+        // titleLabel.textColor = textSecondary
+        // descriptionLabel.textColor = textSecondary
         if theme == .dark {
             contentStackView.backgroundColor = UIColor.Photon.DarkGrey40
             titleLabel.textColor = UIColor.Photon.Grey10

--- a/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsHeaderView.swift
+++ b/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsHeaderView.swift
@@ -5,6 +5,7 @@
 import Foundation
 
 struct WallpaperSettingsHeaderViewModel {
+    var theme: Theme
     var title: String
     var titleA11yIdentifier: String
 
@@ -24,7 +25,6 @@ class WallpaperSettingsHeaderView: UICollectionReusableView, ReusableCell {
     }
 
     private var viewModel: WallpaperSettingsHeaderViewModel?
-    var notificationCenter: NotificationProtocol = NotificationCenter.default
 
     // Views
     private lazy var contentStackView: UIStackView = .build { stackView in
@@ -54,17 +54,10 @@ class WallpaperSettingsHeaderView: UICollectionReusableView, ReusableCell {
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupView()
-        applyTheme()
-        setupNotifications(forObserver: self,
-                           observing: [.DisplayThemeChanged])
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    deinit {
-        notificationCenter.removeObserver(self)
     }
 
     // MARK: - Helper functions
@@ -95,7 +88,6 @@ class WallpaperSettingsHeaderView: UICollectionReusableView, ReusableCell {
         if let _ = viewModel.buttonTitle,
            let buttonA11y = viewModel.buttonA11yIdentifier,
            let _ = viewModel.buttonAction {
-            setButtonStyle()
             learnMoreButton.addTarget(
                 self,
                 action: #selector((buttonTapped(_:))),
@@ -108,6 +100,8 @@ class WallpaperSettingsHeaderView: UICollectionReusableView, ReusableCell {
             setNeedsLayout()
             layoutIfNeeded()
         }
+
+        applyTheme(theme: viewModel.theme)
     }
 
     @objc func buttonTapped(_ sender: Any) {
@@ -131,41 +125,18 @@ private extension WallpaperSettingsHeaderView {
     }
 }
 
-// MARK: - Themable & Notifiable
-extension WallpaperSettingsHeaderView: NotificationThemeable, Notifiable {
+// MARK: - Themable
+extension WallpaperSettingsHeaderView {
 
-    func handleNotifications(_ notification: Notification) {
-        switch notification.name {
-        case .DisplayThemeChanged:
-            applyTheme()
-        default: break
-        }
+    private func applyTheme(theme: Theme) {
+        contentStackView.backgroundColor = theme.colors.layer5
+        titleLabel.textColor = theme.colors.textSecondary
+        descriptionLabel.textColor = theme.colors.textSecondary
+        setButtonStyle(theme: theme)
     }
 
-    func applyTheme() {
-        let theme = BuiltinThemeName(rawValue: LegacyThemeManager.instance.current.name) ?? .normal
-
-        // TODO: Laurie
-        // contentStackView.backgroundColor = layer5
-        // titleLabel.textColor = textSecondary
-        // descriptionLabel.textColor = textSecondary
-        if theme == .dark {
-            contentStackView.backgroundColor = UIColor.Photon.DarkGrey40
-            titleLabel.textColor = UIColor.Photon.Grey10
-            descriptionLabel.textColor = UIColor.Photon.Grey10
-        } else {
-            contentStackView.backgroundColor = UIColor.Photon.LightGrey10
-            titleLabel.textColor = UIColor.Photon.Grey75A60
-            descriptionLabel.textColor = UIColor.Photon.Grey75A60
-        }
-        setButtonStyle()
-    }
-
-    func setButtonStyle() {
-        let theme = BuiltinThemeName(rawValue: LegacyThemeManager.instance.current.name) ?? .normal
-
-        let color = theme == .dark ? UIColor.Photon.Grey10 : UIColor.Photon.Grey75A60
-
+    private func setButtonStyle(theme: Theme) {
+        let color = theme.colors.actionSecondary
         learnMoreButton.setTitleColor(color, for: .normal)
 
         // in iOS 13 the title color set is not used for the attributed text color so we have to set it via attributes

--- a/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewController.swift
+++ b/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewController.swift
@@ -282,6 +282,7 @@ extension WallpaperSettingsViewController: NotificationThemeable, Notifiable {
 
     func applyTheme() {
         let theme = BuiltinThemeName(rawValue: LegacyThemeManager.instance.current.name) ?? .normal
+        // TODO: Laurie - layer5
         if theme == .dark {
             contentView.backgroundColor = UIColor.Photon.DarkGrey40
         } else {

--- a/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewController.swift
+++ b/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewController.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-class WallpaperSettingsViewController: WallpaperBaseViewController, Loggable {
+class WallpaperSettingsViewController: WallpaperBaseViewController, Loggable, Themeable {
 
     private struct UX {
         static let cardWidth: CGFloat = UIDevice().isTinyFormFactor ? 88 : 97
@@ -16,6 +16,8 @@ class WallpaperSettingsViewController: WallpaperBaseViewController, Loggable {
 
     private var viewModel: WallpaperSettingsViewModel
     var notificationCenter: NotificationProtocol
+    var themeManager: ThemeManager
+    var themeObserver: NSObjectProtocol?
 
     // Views
     private lazy var contentView: UIView = .build { _ in }
@@ -45,9 +47,11 @@ class WallpaperSettingsViewController: WallpaperBaseViewController, Loggable {
 
     // MARK: - Initializers
     init(viewModel: WallpaperSettingsViewModel,
-         notificationCenter: NotificationProtocol = NotificationCenter.default) {
+         notificationCenter: NotificationProtocol = NotificationCenter.default,
+         themeManager: ThemeManager = AppContainer.shared.resolve()) {
         self.viewModel = viewModel
         self.notificationCenter = notificationCenter
+        self.themeManager = themeManager
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -61,7 +65,8 @@ class WallpaperSettingsViewController: WallpaperBaseViewController, Loggable {
         setupView()
         applyTheme()
         setupNotifications(forObserver: self,
-                           observing: [.DisplayThemeChanged, UIContentSizeCategory.didChangeNotification])
+                           observing: [UIContentSizeCategory.didChangeNotification])
+        listenForThemeChange()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -85,6 +90,10 @@ class WallpaperSettingsViewController: WallpaperBaseViewController, Loggable {
 
     override func updateOnRotation() {
         configureCollectionView()
+    }
+
+    func applyTheme() {
+        contentView.backgroundColor = themeManager.currentTheme.colors.layer5
     }
 }
 
@@ -267,26 +276,14 @@ private extension WallpaperSettingsViewController {
     }
 }
 
-// MARK: - Themable & Notifiable
-extension WallpaperSettingsViewController: NotificationThemeable, Notifiable {
+// MARK: - Notifiable
+extension WallpaperSettingsViewController: Notifiable {
 
     func handleNotifications(_ notification: Notification) {
         switch notification.name {
-        case .DisplayThemeChanged:
-            applyTheme()
         case UIContentSizeCategory.didChangeNotification:
             preferredContentSizeChanged(notification)
         default: break
-        }
-    }
-
-    func applyTheme() {
-        let theme = BuiltinThemeName(rawValue: LegacyThemeManager.instance.current.name) ?? .normal
-        // TODO: Laurie - layer5
-        if theme == .dark {
-            contentView.backgroundColor = UIColor.Photon.DarkGrey40
-        } else {
-            contentView.backgroundColor = UIColor.Photon.LightGrey10
         }
     }
 }

--- a/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewModel.swift
+++ b/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewModel.swift
@@ -35,6 +35,7 @@ class WallpaperSettingsViewModel {
         }
     }
 
+    private var theme: Theme
     private var wallpaperManager: WallpaperManagerInterface
     private var wallpaperCollections = [WallpaperCollection]()
     var tabManager: TabManagerProtocol
@@ -45,9 +46,12 @@ class WallpaperSettingsViewModel {
         return wallpaperCollections.count
     }
 
-    init(wallpaperManager: WallpaperManagerInterface = WallpaperManager(), tabManager: TabManagerProtocol) {
+    init(wallpaperManager: WallpaperManagerInterface = WallpaperManager(),
+         tabManager: TabManagerProtocol,
+         theme: Theme) {
         self.wallpaperManager = wallpaperManager
         self.tabManager = tabManager
+        self.theme = theme
         setupWallpapers()
     }
 
@@ -82,6 +86,7 @@ class WallpaperSettingsViewModel {
         }
 
         return WallpaperSettingsHeaderViewModel(
+            theme: theme,
             title: title,
             titleA11yIdentifier: "\(a11yIds.collectionTitle)_\(sectionIndex)",
             description: description,

--- a/Client/Frontend/Settings/LoginDetailViewController.swift
+++ b/Client/Frontend/Settings/LoginDetailViewController.swift
@@ -25,6 +25,7 @@ struct LoginDetailUX {
     static let SeparatorHeight: CGFloat = 84
 }
 
+// TODO: Next task for FXIOS-4884 - apply ThemedTableViewCell theme
 private class CenteredDetailCell: ThemedTableViewCell {
     override func layoutSubviews() {
         super.layoutSubviews()

--- a/Client/Frontend/Settings/SearchEnginePicker.swift
+++ b/Client/Frontend/Settings/SearchEnginePicker.swift
@@ -21,6 +21,7 @@ class SearchEnginePicker: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        // TODO: Next task for FXIOS-4884 - apply ThemedTableViewCell theme
         let engine = engines[indexPath.item]
         let cell = ThemedTableViewCell()
         cell.textLabel?.text = engine.shortName

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -91,6 +91,7 @@ class SearchSettingsTableViewController: ThemedTableViewController {
             case ItemDefaultSuggestions:
                 cell.textLabel?.text = .SearchSettingsShowSearchSuggestions
                 let toggle = UISwitchThemed()
+                // TODO: Laurie - actionPrimary
                 toggle.onTintColor = UIColor.theme.tableView.controlTint
                 toggle.addTarget(self, action: #selector(didToggleSearchSuggestions), for: .valueChanged)
                 toggle.isOn = model.shouldShowSearchSuggestions
@@ -108,6 +109,7 @@ class SearchSettingsTableViewController: ThemedTableViewController {
                 cell.showsReorderControl = true
 
                 let toggle = UISwitchThemed()
+                // TODO: Laurie - actionPrimary
                 toggle.onTintColor = UIColor.theme.tableView.controlTint
                 // This is an easy way to get from the toggle control to the corresponding index.
                 toggle.tag = index
@@ -200,6 +202,7 @@ class SearchSettingsTableViewController: ThemedTableViewController {
             for subViewB in subViewA.subviews {
                 if let imageView = subViewB as? UIImageView {
                     imageView.image = imageView.image?.withRenderingMode(.alwaysTemplate)
+                    // TODO: Laurie - iconSecondary
                     imageView.tintColor = UIColor.theme.tableView.accessoryViewTint
                 }
             }

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -74,6 +74,7 @@ class SearchSettingsTableViewController: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        // TODO: Next task for FXIOS-4884 - apply ThemedTableViewCell theme
         let cell = ThemedTableViewCell()
         var engine: OpenSearchEngine!
 

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -91,8 +91,7 @@ class SearchSettingsTableViewController: ThemedTableViewController {
             case ItemDefaultSuggestions:
                 cell.textLabel?.text = .SearchSettingsShowSearchSuggestions
                 let toggle = UISwitchThemed()
-                // TODO: Laurie - actionPrimary
-                toggle.onTintColor = UIColor.theme.tableView.controlTint
+                toggle.onTintColor = themeManager.currentTheme.colors.actionPrimary
                 toggle.addTarget(self, action: #selector(didToggleSearchSuggestions), for: .valueChanged)
                 toggle.isOn = model.shouldShowSearchSuggestions
                 cell.editingAccessoryView = toggle
@@ -109,8 +108,7 @@ class SearchSettingsTableViewController: ThemedTableViewController {
                 cell.showsReorderControl = true
 
                 let toggle = UISwitchThemed()
-                // TODO: Laurie - actionPrimary
-                toggle.onTintColor = UIColor.theme.tableView.controlTint
+                toggle.onTintColor = themeManager.currentTheme.colors.actionPrimary
                 // This is an easy way to get from the toggle control to the corresponding index.
                 toggle.tag = index
                 toggle.addTarget(self, action: #selector(didToggleEngine), for: .valueChanged)
@@ -202,8 +200,7 @@ class SearchSettingsTableViewController: ThemedTableViewController {
             for subViewB in subViewA.subviews {
                 if let imageView = subViewB as? UIImageView {
                     imageView.image = imageView.image?.withRenderingMode(.alwaysTemplate)
-                    // TODO: Laurie - iconSecondary
-                    imageView.tintColor = UIColor.theme.tableView.accessoryViewTint
+                    imageView.tintColor = themeManager.currentTheme.colors.iconSecondary
                 }
             }
         }

--- a/Client/Frontend/Settings/SettingsContentViewController.swift
+++ b/Client/Frontend/Settings/SettingsContentViewController.swift
@@ -141,8 +141,7 @@ class SettingsContentViewController: UIViewController, WKNavigationDelegate, The
     fileprivate func makeInterstitialViews() -> InterstitialViews {
         let view = UIView()
         let spinner = UIActivityIndicatorView(style: .medium)
-        // TODO: Laurie - Crystal - Spinner color
-        spinner.color = themeManager.currentTheme.colors.textPrimary
+        spinner.color = themeManager.currentTheme.colors.iconSpinnerDefault
         view.addSubview(spinner)
 
         let error = UILabel()

--- a/Client/Frontend/Settings/SettingsContentViewController.swift
+++ b/Client/Frontend/Settings/SettingsContentViewController.swift
@@ -73,6 +73,7 @@ class SettingsContentViewController: UIViewController, WKNavigationDelegate {
         self.interstitialSpinnerView.startAnimating()
     }
 
+    // TODO: Laurie - White
     init(backgroundColor: UIColor = UIColor.Photon.White100, title: NSAttributedString? = nil) {
         interstitialBackgroundColor = backgroundColor
         settingsTitle = title
@@ -139,12 +140,14 @@ class SettingsContentViewController: UIViewController, WKNavigationDelegate {
         view.backgroundColor = interstitialBackgroundColor
 
         let spinner = UIActivityIndicatorView(style: .medium)
+        // TODO: Laurie - spinner color? Asked Crystal
         spinner.color = .systemGray
         view.addSubview(spinner)
 
         let error = UILabel()
         if let _ = settingsTitle {
             error.text = .SettingsContentPageLoadError
+            // TODO: Laurie - textWarning
             error.textColor = UIColor.theme.tableView.errorText
             error.textAlignment = .center
         }

--- a/Client/Frontend/Settings/SettingsLoadingView.swift
+++ b/Client/Frontend/Settings/SettingsLoadingView.swift
@@ -15,6 +15,7 @@ class SettingsLoadingView: UIView {
     lazy var indicator: UIActivityIndicatorView = {
         let isDarkTheme = LegacyThemeManager.instance.currentName == .dark
         let indicator = UIActivityIndicatorView(style: .medium)
+        // TODO: Laurie - spinner color? Asked Crystal
         indicator.color = isDarkTheme ? .white : .systemGray
         indicator.hidesWhenStopped = false
         return indicator
@@ -27,6 +28,7 @@ class SettingsLoadingView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         addSubview(indicator)
+        // TODO: Laurie - layer1
         backgroundColor = UIColor.theme.tableView.headerBackground
         indicator.startAnimating()
     }

--- a/Client/Frontend/Settings/SettingsLoadingView.swift
+++ b/Client/Frontend/Settings/SettingsLoadingView.swift
@@ -13,10 +13,7 @@ class SettingsLoadingView: UIView {
     }
 
     lazy var indicator: UIActivityIndicatorView = {
-        let isDarkTheme = LegacyThemeManager.instance.currentName == .dark
         let indicator = UIActivityIndicatorView(style: .medium)
-        // TODO: Laurie - spinner color? Asked Crystal
-        indicator.color = isDarkTheme ? .white : .systemGray
         indicator.hidesWhenStopped = false
         return indicator
     }()
@@ -28,9 +25,13 @@ class SettingsLoadingView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         addSubview(indicator)
-        // TODO: Laurie - layer1
-        backgroundColor = UIColor.theme.tableView.headerBackground
         indicator.startAnimating()
+    }
+
+    func configure(theme: Theme) {
+        // TODO: Laurie - Crystal - Spinner color
+        indicator.color = theme.colors.textPrimary
+        backgroundColor = theme.colors.layer1
     }
 
     internal override func updateConstraints() {

--- a/Client/Frontend/Settings/SettingsLoadingView.swift
+++ b/Client/Frontend/Settings/SettingsLoadingView.swift
@@ -29,8 +29,7 @@ class SettingsLoadingView: UIView {
     }
 
     func configure(theme: Theme) {
-        // TODO: Laurie - Crystal - Spinner color
-        indicator.color = theme.colors.textPrimary
+        indicator.color = theme.colors.iconSpinnerDefault
         backgroundColor = theme.colors.layer1
     }
 

--- a/Client/Frontend/Settings/SettingsNavigationController.swift
+++ b/Client/Frontend/Settings/SettingsNavigationController.swift
@@ -31,7 +31,9 @@ extension ThemedNavigationController: NotificationThemeable {
     private func setupNavigationBarAppearance() {
         let standardAppearance = UINavigationBarAppearance()
         standardAppearance.configureWithDefaultBackground()
+        // TODO: Laurie - layer1
         standardAppearance.backgroundColor = UIColor.theme.tableView.headerBackground
+        // TODO: Laurie - layer4. not sure
         standardAppearance.titleTextAttributes = [.foregroundColor: UIColor.theme.tableView.headerTextDark]
 
         navigationBar.standardAppearance = standardAppearance
@@ -40,6 +42,7 @@ extension ThemedNavigationController: NotificationThemeable {
         if #available(iOS 15.0, *) {
             navigationBar.compactScrollEdgeAppearance = standardAppearance
         }
+        // TODO: Laurie - actionPrimary
         navigationBar.tintColor = UIColor.theme.general.controlTint
     }
     func applyTheme() {

--- a/Client/Frontend/Settings/SettingsNavigationController.swift
+++ b/Client/Frontend/Settings/SettingsNavigationController.swift
@@ -38,8 +38,7 @@ extension ThemedNavigationController {
         let standardAppearance = UINavigationBarAppearance()
         standardAppearance.configureWithDefaultBackground()
         standardAppearance.backgroundColor = theme.colors.layer1
-        // TODO: Laurie - Not sure - UIColor.theme.tableView.headerTextDark
-        standardAppearance.titleTextAttributes = [.foregroundColor: theme.colors.layer4]
+        standardAppearance.titleTextAttributes = [.foregroundColor: theme.colors.textPrimary]
 
         navigationBar.standardAppearance = standardAppearance
         navigationBar.compactAppearance = standardAppearance

--- a/Client/Frontend/Settings/SettingsNavigationController.swift
+++ b/Client/Frontend/Settings/SettingsNavigationController.swift
@@ -4,7 +4,12 @@
 
 import UIKit
 
-class ThemedNavigationController: DismissableNavigationViewController {
+class ThemedNavigationController: DismissableNavigationViewController, Themeable {
+
+    var themeManager: ThemeManager = AppContainer.shared.resolve()
+    var themeObserver: NSObjectProtocol?
+    var notificationCenter: NotificationProtocol = NotificationCenter.default
+
     var presentingModalViewControllerDelegate: PresentingModalViewControllerDelegate?
 
     @objc func done() {
@@ -24,17 +29,17 @@ class ThemedNavigationController: DismissableNavigationViewController {
         modalPresentationStyle = .overFullScreen
         modalPresentationCapturesStatusBarAppearance = true
         applyTheme()
+        listenForThemeChange()
     }
 }
 
-extension ThemedNavigationController: NotificationThemeable {
-    private func setupNavigationBarAppearance() {
+extension ThemedNavigationController {
+    private func setupNavigationBarAppearance(theme: Theme) {
         let standardAppearance = UINavigationBarAppearance()
         standardAppearance.configureWithDefaultBackground()
-        // TODO: Laurie - layer1
-        standardAppearance.backgroundColor = UIColor.theme.tableView.headerBackground
-        // TODO: Laurie - layer4. not sure
-        standardAppearance.titleTextAttributes = [.foregroundColor: UIColor.theme.tableView.headerTextDark]
+        standardAppearance.backgroundColor = theme.colors.layer1
+        // TODO: Laurie - Not sure - UIColor.theme.tableView.headerTextDark
+        standardAppearance.titleTextAttributes = [.foregroundColor: theme.colors.layer4]
 
         navigationBar.standardAppearance = standardAppearance
         navigationBar.compactAppearance = standardAppearance
@@ -42,12 +47,14 @@ extension ThemedNavigationController: NotificationThemeable {
         if #available(iOS 15.0, *) {
             navigationBar.compactScrollEdgeAppearance = standardAppearance
         }
-        // TODO: Laurie - actionPrimary
-        navigationBar.tintColor = UIColor.theme.general.controlTint
+        navigationBar.tintColor = theme.colors.actionPrimary
     }
+
     func applyTheme() {
-        setupNavigationBarAppearance()
+        setupNavigationBarAppearance(theme: themeManager.currentTheme)
         setNeedsStatusBarAppearanceUpdate()
+
+        // TODO: Remove with legacy theme clean up FXIOS-3960
         viewControllers.forEach {
             ($0 as? NotificationThemeable)?.applyTheme()
         }

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -107,7 +107,7 @@ class Setting: NSObject {
         cell.layoutMargins = .zero
 
         let backgroundView = UIView()
-        backgroundView.backgroundColor = theme.colors.actionSecondaryHover
+        backgroundView.backgroundColor = theme.colors.layer3
         backgroundView.bounds = cell.bounds
         cell.selectedBackgroundView = backgroundView
 

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -114,7 +114,7 @@ class Setting: NSObject {
         // So that the separator line goes all the way to the left edge.
         cell.separatorInset = .zero
         if let cell = cell as? ThemedTableViewCell {
-            cell.applyTheme()
+            cell.applyTheme(theme: theme)
         }
     }
 
@@ -229,7 +229,7 @@ class BoolSetting: Setting, FeatureFlaggable {
     ) {
         var statusTextAttributedString: NSAttributedString?
         if let statusTextString = statusText {
-            let attributes = [NSAttributedString.Key.foregroundColor:  theme.colors.textSecondary]
+            let attributes = [NSAttributedString.Key.foregroundColor: theme.colors.textSecondary]
             statusTextAttributedString = NSAttributedString(string: statusTextString,
                                                             attributes: attributes)
         }
@@ -782,6 +782,7 @@ class SettingsTableViewController: ThemedTableViewController {
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let section = settings[indexPath.section]
         if let setting = section[indexPath.row] {
+            // TODO: Next task for FXIOS-4884 - apply ThemedTableViewCell theme
             let cell = ThemedTableViewCell(style: setting.style, reuseIdentifier: nil)
             setting.onConfigureCell(cell, theme: themeManager.currentTheme)
             cell.backgroundColor = themeManager.currentTheme.colors.layer2

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -454,8 +454,7 @@ class StringSetting: Setting, UITextFieldDelegate {
         if let id = accessibilityIdentifier {
             textField.accessibilityIdentifier = id + "TextField"
         }
-        // TODO: Laurie - Crystal - Placeholder color
-        let placeholderColor = theme.colors.textDisabled
+        let placeholderColor = theme.colors.textSecondary
         textField.attributedPlaceholder = NSAttributedString(string: placeholder, attributes: [NSAttributedString.Key.foregroundColor: placeholderColor])
 
         cell.tintColor = self.persister.readPersistedValue() != nil ? theme.colors.actionPrimary : UIColor.clear

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -17,6 +17,7 @@ extension UILabel {
         let attribs = attributed.attributes(at: 0, effectiveRange: nil)
         if attribs[NSAttributedString.Key.foregroundColor] == nil {
             // If the text color attribute isn't set, use the table view row text color.
+            // TODO: Laurie - textPrimary
             textColor = UIColor.theme.tableView.rowText
         } else {
             textColor = nil
@@ -105,6 +106,7 @@ class Setting: NSObject {
         cell.layoutMargins = .zero
 
         let backgroundView = UIView()
+        // TODO: Laurie - actionSecondaryHover
         backgroundView.backgroundColor = UIColor.theme.tableView.selectedBackground
         backgroundView.bounds = cell.bounds
         cell.selectedBackgroundView = backgroundView
@@ -226,8 +228,10 @@ class BoolSetting: Setting, FeatureFlaggable {
     ) {
         var statusTextAttributedString: NSAttributedString?
         if let statusTextString = statusText {
+            // TODO: Laurie - textSecondary
             statusTextAttributedString = NSAttributedString(string: statusTextString, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.headerTextLight])
         }
+        // TODO: Laurie - textPrimary
         self.init(
             prefs: prefs,
             prefKey: prefKey,
@@ -260,6 +264,7 @@ class BoolSetting: Setting, FeatureFlaggable {
         super.onConfigureCell(cell)
 
         let control = UISwitchThemed()
+        // TODO: Laurie - actionPrimary
         control.onTintColor = UIConstants.SystemBlueColor
         control.addTarget(self, action: #selector(switchValueChanged), for: .valueChanged)
         control.accessibilityIdentifier = prefKey
@@ -449,12 +454,15 @@ class StringSetting: Setting, UITextFieldDelegate {
         if let id = accessibilityIdentifier {
             textField.accessibilityIdentifier = id + "TextField"
         }
+        // TODO: Laurie - textDisabled?
         let placeholderColor = UIColor.theme.general.settingsTextPlaceholder
         textField.attributedPlaceholder = NSAttributedString(string: placeholder, attributes: [NSAttributedString.Key.foregroundColor: placeholderColor])
 
+        // TODO: Laurie - actionPrimary
         cell.tintColor = self.persister.readPersistedValue() != nil ? UIColor.theme.tableView.rowActionAccessory : UIColor.clear
         textField.textAlignment = .center
         textField.delegate = self
+        // TODO: Laurie - actionPrimary
         textField.tintColor = UIColor.theme.tableView.rowActionAccessory
         textField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
         cell.isUserInteractionEnabled = true
@@ -493,6 +501,7 @@ class StringSetting: Setting, UITextFieldDelegate {
     }
 
     @objc func textFieldDidChange(_ textField: UITextField) {
+        // TODO: Laurie - textPrimary && textWarning
         let color = isValid(textField.text) ? UIColor.theme.tableView.rowText : UIColor.theme.general.destructiveRed
         textField.textColor = color
     }
@@ -549,6 +558,7 @@ class CheckmarkSetting: Setting {
 
         if checkmarkStyle == .rightSide {
             cell.accessoryType = .checkmark
+            // TODO: Laurie - actionPrimary
             cell.tintColor = isChecked() ? UIColor.theme.tableView.rowActionAccessory : UIColor.clear
         } else {
             let window = UIWindow.keyWindow
@@ -557,8 +567,10 @@ class CheckmarkSetting: Setting {
             cell.indentationLevel = 1
 
             cell.accessoryType = .detailButton
+            // TODO: Laurie - actionPrimary
             cell.tintColor = UIColor.theme.tableView.rowActionAccessory // Sets accessory color only
 
+            // TODO: Laurie - actionPrimary
             let checkColor = isChecked() ? UIColor.theme.tableView.rowActionAccessory : UIColor.clear
             let check = UILabel()
             cell.contentView.addSubview(check)
@@ -573,6 +585,7 @@ class CheckmarkSetting: Setting {
             check.textColor = checkColor
 
             let result = NSMutableAttributedString()
+            // TODO: Laurie - textPrimary
             if let str = title?.string {
                 result.append(NSAttributedString(string: str, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
             }
@@ -616,8 +629,10 @@ class ButtonSetting: Setting {
         super.onConfigureCell(cell)
 
         if isEnabled?() ?? true {
+            // TODO: Laurie - textWarning && actionPrimary
             cell.textLabel?.textColor = destructive ? UIColor.theme.general.destructiveRed : UIColor.theme.general.highlightBlue
         } else {
+            // TODO: Laurie - textDisabled
             cell.textLabel?.textColor = UIColor.theme.tableView.disabledRowText
         }
         cell.textLabel?.snp.makeConstraints({ make in
@@ -777,6 +792,7 @@ class SettingsTableViewController: ThemedTableViewController {
         if let setting = section[indexPath.row] {
             let cell = ThemedTableViewCell(style: setting.style, reuseIdentifier: nil)
             setting.onConfigureCell(cell)
+            // TODO: Laurie - white
             cell.backgroundColor = UIColor.theme.tableView.rowBackground
             return cell
         }

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -29,6 +29,7 @@ class SettingsViewController: UIViewController {
     }
 
     @objc func updateTheme() {
+        // TODO: Laurie - layer1
         view.backgroundColor = theme.current.tableView.headerBackground
     }
 

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -4,15 +4,23 @@
 
 import UIKit
 
-class SettingsViewController: UIViewController {
+class SettingsViewController: UIViewController, Themeable {
+
+    var themeManager: ThemeManager
+    var themeObserver: NSObjectProtocol?
+    var notificationCenter: NotificationProtocol
+
     weak var settingsDelegate: SettingsDelegate?
 
     var profile: Profile!
     var tabManager: TabManager!
 
-    let theme = LegacyThemeManager.instance
-
-    init(profile: Profile? = nil, tabManager: TabManager? = nil) {
+    init(profile: Profile? = nil,
+         tabManager: TabManager? = nil,
+         themeManager: ThemeManager = AppContainer.shared.resolve(),
+         notificationCenter: NotificationCenter = NotificationCenter.default) {
+        self.themeManager = themeManager
+        self.notificationCenter = notificationCenter
         super.init(nibName: nil, bundle: nil)
         self.profile = profile
         self.tabManager = tabManager
@@ -24,16 +32,11 @@ class SettingsViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        updateTheme()
-        NotificationCenter.default.addObserver(self, selector: #selector(updateTheme), name: .DisplayThemeChanged, object: nil)
+        listenForThemeChange()
+        applyTheme()
     }
 
-    @objc func updateTheme() {
-        // TODO: Laurie - layer1
-        view.backgroundColor = theme.current.tableView.headerBackground
-    }
-
-    deinit {
-        NotificationCenter.default.removeObserver(self)
+    func applyTheme() {
+        view.backgroundColor = themeManager.currentTheme.colors.layer1
     }
 }

--- a/Client/Frontend/Settings/SiriSettingsViewController.swift
+++ b/Client/Frontend/Settings/SiriSettingsViewController.swift
@@ -34,6 +34,7 @@ class SiriOpenURLSetting: Setting {
     override var accessibilityIdentifier: String? { return "SiriSettings" }
 
     init(settings: SettingsTableViewController) {
+        // TODO: Laurie - textPrimary
         super.init(title: NSAttributedString(string: .SettingsSiriOpenURL, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
     }
 

--- a/Client/Frontend/Settings/SiriSettingsViewController.swift
+++ b/Client/Frontend/Settings/SiriSettingsViewController.swift
@@ -34,8 +34,7 @@ class SiriOpenURLSetting: Setting {
     override var accessibilityIdentifier: String? { return "SiriSettings" }
 
     init(settings: SettingsTableViewController) {
-        // TODO: Laurie - textPrimary
-        super.init(title: NSAttributedString(string: .SettingsSiriOpenURL, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+        super.init(title: NSAttributedString(string: .SettingsSiriOpenURL, attributes: [NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {

--- a/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -17,6 +17,7 @@ class ManageFxAccountSetting: Setting {
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
 
+        // TODO: Laurie - textPrimary
         super.init(title: NSAttributedString(string: .FxAManageAccount, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
     }
 
@@ -33,6 +34,7 @@ class DisconnectSetting: Setting {
     override var textAlignment: NSTextAlignment { return .center }
 
     override var title: NSAttributedString? {
+        // TODO: Laurie - textWarning
         return NSAttributedString(string: .SettingsDisconnectSyncButton, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.general.destructiveRed])
     }
 

--- a/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -17,8 +17,7 @@ class ManageFxAccountSetting: Setting {
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
 
-        // TODO: Laurie - textPrimary
-        super.init(title: NSAttributedString(string: .FxAManageAccount, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
+        super.init(title: NSAttributedString(string: .FxAManageAccount, attributes: [NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -34,8 +33,7 @@ class DisconnectSetting: Setting {
     override var textAlignment: NSTextAlignment { return .center }
 
     override var title: NSAttributedString? {
-        // TODO: Laurie - textWarning
-        return NSAttributedString(string: .SettingsDisconnectSyncButton, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.general.destructiveRed])
+        return NSAttributedString(string: .SettingsDisconnectSyncButton, attributes: [NSAttributedString.Key.foregroundColor: settingsVC.themeManager.currentTheme.colors.textWarning])
     }
 
     init(settings: SettingsTableViewController) {
@@ -107,8 +105,8 @@ class DeviceNameSetting: StringSetting {
         }
     }
 
-    override func onConfigureCell(_ cell: UITableViewCell) {
-        super.onConfigureCell(cell)
+    override func onConfigureCell(_ cell: UITableViewCell, theme: Theme) {
+        super.onConfigureCell(cell, theme: theme)
         textField.textAlignment = .natural
     }
 

--- a/Client/Frontend/Settings/ThemeSettingsController.swift
+++ b/Client/Frontend/Settings/ThemeSettingsController.swift
@@ -24,6 +24,7 @@ class ThemeSettingsController: ThemedTableViewController {
     private var slider: (control: UISlider, deviceBrightnessIndicator: UISlider)?
 
     // TODO decide if this is themeable, or if it is being replaced by a different style of slider
+    // TODO: Laurie - formKnob
     private let deviceBrightnessIndicatorColor = UIColor(white: 182/255, alpha: 1.0)
 
     var isAutoBrightnessOn: Bool {
@@ -50,6 +51,7 @@ class ThemeSettingsController: ThemedTableViewController {
         super.viewDidLoad()
         title = .SettingsDisplayThemeTitle
         tableView.accessibilityIdentifier = "DisplayTheme.Setting.Options"
+        // TODO: Laurie - layer1
         tableView.backgroundColor = UIColor.theme.tableView.headerBackground
 
         tableView.register(ThemedTableSectionHeaderFooterView.self,
@@ -92,6 +94,7 @@ class ThemeSettingsController: ThemedTableViewController {
             label.text = .DisplayThemeSectionFooter
             label.numberOfLines = 0
             label.font = UIFont.systemFont(ofSize: UX.footerFontSize)
+            // TODO: Laurie - textSecondary
             label.textColor = UIColor.theme.tableView.headerTextLight
         }
         footer.addSubview(label)
@@ -156,6 +159,7 @@ class ThemeSettingsController: ThemedTableViewController {
     private func makeSlider(parent: UIView) -> UISlider {
         let size = CGSize(width: UX.moonSunIconSize, height: UX.moonSunIconSize)
         let images = [ImageIdentifiers.nightMode, "themeBrightness"].map { name in
+            // TODO: Laurie - layerLightGrey30??
             UIImage(imageLiteralResourceName: name).createScaled(size).tinted(withColor: UIColor.theme.browser.tint)
         }
 
@@ -187,6 +191,7 @@ class ThemeSettingsController: ThemedTableViewController {
             let control = UISwitchThemed()
 
             control.accessibilityIdentifier = "SystemThemeSwitchValue"
+            // TODO: Laurie - actionPrimary
             control.onTintColor = UIColor.theme.tableView.controlTint
             control.addTarget(self, action: #selector(systemThemeSwitchValueChanged), for: .valueChanged)
             control.isOn = LegacyThemeManager.instance.systemThemeIsOn

--- a/Client/Frontend/Settings/ThemeSettingsController.swift
+++ b/Client/Frontend/Settings/ThemeSettingsController.swift
@@ -23,10 +23,6 @@ class ThemeSettingsController: ThemedTableViewController {
     // A non-interactable slider is underlaid to show the current screen brightness indicator
     private var slider: (control: UISlider, deviceBrightnessIndicator: UISlider)?
 
-    // TODO decide if this is themeable, or if it is being replaced by a different style of slider
-    // TODO: Laurie - formKnob
-    private let deviceBrightnessIndicatorColor = UIColor(white: 182/255, alpha: 1.0)
-
     var isAutoBrightnessOn: Bool {
         return LegacyThemeManager.instance.automaticBrightnessIsOn
     }
@@ -36,10 +32,8 @@ class ThemeSettingsController: ThemedTableViewController {
     }
 
     private var shouldHideSystemThemeSection = false
-    private let themeManager: ThemeManager
 
-    init(themeManager: ThemeManager = AppContainer.shared.resolve()) {
-        self.themeManager = themeManager
+    init() {
         super.init(style: .grouped)
     }
 
@@ -51,8 +45,6 @@ class ThemeSettingsController: ThemedTableViewController {
         super.viewDidLoad()
         title = .SettingsDisplayThemeTitle
         tableView.accessibilityIdentifier = "DisplayTheme.Setting.Options"
-        // TODO: Laurie - layer1
-        tableView.backgroundColor = UIColor.theme.tableView.headerBackground
 
         tableView.register(ThemedTableSectionHeaderFooterView.self,
                            forHeaderFooterViewReuseIdentifier: ThemedTableSectionHeaderFooterView.cellIdentifier)
@@ -64,6 +56,11 @@ class ThemeSettingsController: ThemedTableViewController {
         guard LegacyThemeManager.instance.automaticBrightnessIsOn else { return }
         LegacyThemeManager.instance.updateCurrentThemeBasedOnScreenBrightness()
         applyTheme()
+    }
+
+    override func applyTheme() {
+        super.applyTheme()
+
     }
 
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
@@ -94,8 +91,7 @@ class ThemeSettingsController: ThemedTableViewController {
             label.text = .DisplayThemeSectionFooter
             label.numberOfLines = 0
             label.font = UIFont.systemFont(ofSize: UX.footerFontSize)
-            // TODO: Laurie - textSecondary
-            label.textColor = UIColor.theme.tableView.headerTextLight
+            label.textColor = self.themeManager.currentTheme.colors.textSecondary
         }
         footer.addSubview(label)
         NSLayoutConstraint.activate([
@@ -159,8 +155,7 @@ class ThemeSettingsController: ThemedTableViewController {
     private func makeSlider(parent: UIView) -> UISlider {
         let size = CGSize(width: UX.moonSunIconSize, height: UX.moonSunIconSize)
         let images = [ImageIdentifiers.nightMode, "themeBrightness"].map { name in
-            // TODO: Laurie - layerLightGrey30??
-            UIImage(imageLiteralResourceName: name).createScaled(size).tinted(withColor: UIColor.theme.browser.tint)
+            UIImage(imageLiteralResourceName: name).createScaled(size).tinted(withColor: themeManager.currentTheme.colors.layerLightGrey30)
         }
 
         let slider: UISlider = .build { slider in
@@ -191,8 +186,7 @@ class ThemeSettingsController: ThemedTableViewController {
             let control = UISwitchThemed()
 
             control.accessibilityIdentifier = "SystemThemeSwitchValue"
-            // TODO: Laurie - actionPrimary
-            control.onTintColor = UIColor.theme.tableView.controlTint
+            control.onTintColor = themeManager.currentTheme.colors.actionPrimary
             control.addTarget(self, action: #selector(systemThemeSwitchValueChanged), for: .valueChanged)
             control.isOn = LegacyThemeManager.instance.systemThemeIsOn
             cell.accessoryView = control
@@ -225,7 +219,7 @@ class ThemeSettingsController: ThemedTableViewController {
                 deviceBrightnessIndicator.isUserInteractionEnabled = false
                 deviceBrightnessIndicator.minimumTrackTintColor = .clear
                 deviceBrightnessIndicator.maximumTrackTintColor = .clear
-                deviceBrightnessIndicator.thumbTintColor = deviceBrightnessIndicatorColor
+                deviceBrightnessIndicator.thumbTintColor = themeManager.currentTheme.colors.formKnob
                 self.slider = (slider, deviceBrightnessIndicator)
             } else {
                 if indexPath.row == 0 {

--- a/Client/Frontend/Settings/ThemeSettingsController.swift
+++ b/Client/Frontend/Settings/ThemeSettingsController.swift
@@ -174,7 +174,6 @@ class ThemeSettingsController: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        // TODO: Next task for FXIOS-4884 - apply ThemedTableViewCell theme
         let cell = ThemedTableViewCell(style: .subtitle, reuseIdentifier: nil)
         cell.selectionStyle = .none
         let section = Section(rawValue: indexPath.section) ?? .automaticBrightness
@@ -239,6 +238,7 @@ class ThemeSettingsController: ThemedTableViewController {
                 }
             }
         }
+        cell.applyTheme(theme: themeManager.currentTheme)
 
         return cell
     }

--- a/Client/Frontend/Settings/ThemeSettingsController.swift
+++ b/Client/Frontend/Settings/ThemeSettingsController.swift
@@ -174,6 +174,7 @@ class ThemeSettingsController: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        // TODO: Next task for FXIOS-4884 - apply ThemedTableViewCell theme
         let cell = ThemedTableViewCell(style: .subtitle, reuseIdentifier: nil)
         cell.selectionStyle = .none
         let section = Section(rawValue: indexPath.section) ?? .automaticBrightness

--- a/Client/Frontend/Settings/WebsiteDataManagementViewController.swift
+++ b/Client/Frontend/Settings/WebsiteDataManagementViewController.swift
@@ -102,6 +102,7 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
 
     fileprivate let loadingView = SettingsLoadingView()
 
+    // TODO: Next task for FXIOS-4884 - apply ThemedTableViewCell theme
     fileprivate var showMoreButton: ThemedTableViewCell?
 
     private let viewModel = WebsiteDataManagementViewModel()
@@ -168,11 +169,8 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
         searchController.obscuresBackgroundDuringPresentation = false
         searchController.searchBar.placeholder = .SettingsFilterSitesSearchLabel
         searchController.searchBar.delegate = self
+        searchController.searchBar.barStyle = themeManager.currentTheme.type.getBarStyle()
 
-        // Laurie - Orla - Bar style 
-//        if theme == .dark {
-//            searchController.searchBar.barStyle = .black
-//        }
         navigationItem.searchController = searchController
         self.searchController = searchController
 
@@ -188,6 +186,7 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        // TODO: Next task for FXIOS-4884 - apply ThemedTableViewCell theme
         let cell = ThemedTableViewCell(style: .default, reuseIdentifier: nil)
         let section = Section(rawValue: indexPath.section)!
         switch section {

--- a/Client/Frontend/Settings/WebsiteDataManagementViewController.swift
+++ b/Client/Frontend/Settings/WebsiteDataManagementViewController.swift
@@ -115,7 +115,9 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
         tableView = UITableView()
         tableView.dataSource = self
         tableView.delegate = self
+        // TODO: Laurie - layer4
         tableView.separatorColor = UIColor.theme.tableView.separator
+        // TODO: Laurie - layer1
         tableView.backgroundColor = UIColor.theme.tableView.headerBackground
         tableView.isEditing = true
         tableView.allowsMultipleSelectionDuringEditing = true
@@ -192,6 +194,7 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
             }
         case .showMore:
             cell.textLabel?.text = .SettingsWebsiteDataShowMoreButton
+            // TODO: Laurie - actionPrimary && textDisabled
             cell.textLabel?.textColor = showMoreButtonEnabled ? UIColor.theme.general.highlightBlue : UIColor.gray
             cell.accessibilityTraits = UIAccessibilityTraits.button
             cell.accessibilityIdentifier = "ShowMoreWebsiteData"
@@ -199,6 +202,7 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
         case .clearButton:
             cell.textLabel?.text = viewModel.clearButtonTitle
             cell.textLabel?.textAlignment = .center
+            // TODO: Laurie - textWarning
             cell.textLabel?.textColor = UIColor.theme.general.destructiveRed
             cell.accessibilityTraits = UIAccessibilityTraits.button
             cell.accessibilityIdentifier = "ClearAllWebsiteData"

--- a/Client/Frontend/Settings/WebsiteDataSearchResultsViewController.swift
+++ b/Client/Frontend/Settings/WebsiteDataSearchResultsViewController.swift
@@ -7,7 +7,12 @@ import SnapKit
 import Shared
 import WebKit
 
-class WebsiteDataSearchResultsViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
+class WebsiteDataSearchResultsViewController: UIViewController, UITableViewDataSource, UITableViewDelegate, Themeable {
+
+    var themeManager: ThemeManager = AppContainer.shared.resolve()
+    var themeObserver: NSObjectProtocol?
+    var notificationCenter: NotificationProtocol = NotificationCenter.default
+
     private enum Section: Int {
         case sites = 0
         case clearButton = 1
@@ -36,10 +41,7 @@ class WebsiteDataSearchResultsViewController: UIViewController, UITableViewDataS
         tableView = UITableView()
         tableView.dataSource = self
         tableView.delegate = self
-        // TODO: Laurie - layer4
-        tableView.separatorColor = UIColor.theme.tableView.separator
-        // TODO: Laurie - layer1
-        tableView.backgroundColor = UIColor.theme.tableView.headerBackground
+
         tableView.isEditing = true
         tableView.allowsMultipleSelectionDuringEditing = true
         tableView.register(ThemedTableViewCell.self, forCellReuseIdentifier: "Cell")
@@ -55,6 +57,9 @@ class WebsiteDataSearchResultsViewController: UIViewController, UITableViewDataS
             make.edges.equalTo(view)
         }
         KeyboardHelper.defaultHelper.addDelegate(self)
+
+        listenForThemeChange()
+        applyTheme()
     }
 
     func reloadData() {
@@ -91,8 +96,7 @@ class WebsiteDataSearchResultsViewController: UIViewController, UITableViewDataS
         case .clearButton:
             cell.textLabel?.text = viewModel.clearButtonTitle
             cell.textLabel?.textAlignment = .center
-            // TODO: Laurie - textWarning
-            cell.textLabel?.textColor = UIColor.theme.general.destructiveRed
+            cell.textLabel?.textColor = themeManager.currentTheme.colors.textWarning
             cell.accessibilityTraits = UIAccessibilityTraits.button
             cell.accessibilityIdentifier = "ClearAllWebsiteData"
         }
@@ -171,6 +175,11 @@ class WebsiteDataSearchResultsViewController: UIViewController, UITableViewDataS
         })
 
         tableView.reloadData()
+    }
+
+    func applyTheme() {
+        tableView.separatorColor = themeManager.currentTheme.colors.layer4
+        tableView.backgroundColor = themeManager.currentTheme.colors.layer1
     }
 }
 

--- a/Client/Frontend/Settings/WebsiteDataSearchResultsViewController.swift
+++ b/Client/Frontend/Settings/WebsiteDataSearchResultsViewController.swift
@@ -81,6 +81,7 @@ class WebsiteDataSearchResultsViewController: UIViewController, UITableViewDataS
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        // TODO: Next task for FXIOS-4884 - apply ThemedTableViewCell theme
         let cell = ThemedTableViewCell(style: .default, reuseIdentifier: nil)
         let section = Section(rawValue: indexPath.section)!
         switch section {

--- a/Client/Frontend/Settings/WebsiteDataSearchResultsViewController.swift
+++ b/Client/Frontend/Settings/WebsiteDataSearchResultsViewController.swift
@@ -36,7 +36,9 @@ class WebsiteDataSearchResultsViewController: UIViewController, UITableViewDataS
         tableView = UITableView()
         tableView.dataSource = self
         tableView.delegate = self
+        // TODO: Laurie - layer4
         tableView.separatorColor = UIColor.theme.tableView.separator
+        // TODO: Laurie - layer1
         tableView.backgroundColor = UIColor.theme.tableView.headerBackground
         tableView.isEditing = true
         tableView.allowsMultipleSelectionDuringEditing = true
@@ -89,6 +91,7 @@ class WebsiteDataSearchResultsViewController: UIViewController, UITableViewDataS
         case .clearButton:
             cell.textLabel?.text = viewModel.clearButtonTitle
             cell.textLabel?.textAlignment = .center
+            // TODO: Laurie - textWarning
             cell.textLabel?.textColor = UIColor.theme.general.destructiveRed
             cell.accessibilityTraits = UIAccessibilityTraits.button
             cell.accessibilityIdentifier = "ClearAllWebsiteData"

--- a/Client/Frontend/Theme/DarkTheme.swift
+++ b/Client/Frontend/Theme/DarkTheme.swift
@@ -60,5 +60,8 @@ private struct DarkColourPalette: ThemeColourPalette {
     var borderAccentPrivate: UIColor = FXColors.Purple60
 
     // MARK: - Shadow
-    var shadow: UIColor = FXColors.DarkGrey90.withAlphaComponent(0.16)
+    var shadowDefault: UIColor = FXColors.DarkGrey90.withAlphaComponent(0.16)
+
+    // MARK: - Icon Spinner
+    var iconSpinnerDefault: UIColor = FXColors.White
 }

--- a/Client/Frontend/Theme/LegacyThemeManager/LegacyDarkTheme.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/LegacyDarkTheme.swift
@@ -10,16 +10,16 @@ private let defaultSeparator = UIColor.Photon.Grey60
 private let defaultTextAndTint = UIColor.Photon.Grey10
 
 private class DarkTableViewColor: TableViewColor {
-    override var rowBackground: UIColor { return UIColor.Photon.Grey70 }
-    override var rowText: UIColor { return defaultTextAndTint }
+    override var rowBackground: UIColor { return UIColor.Photon.Grey70 } // layer2
+    override var rowText: UIColor { return defaultTextAndTint } // textPrimary
     override var rowDetailText: UIColor { return UIColor.Photon.Grey30 }
-    override var disabledRowText: UIColor { return UIColor.Photon.Grey40 }
+    override var disabledRowText: UIColor { return UIColor.Photon.Grey40 } // textDisabled
     override var separator: UIColor { return UIColor.Photon.Grey60 }
     override var headerBackground: UIColor { return UIColor.Photon.Grey80 }
-    override var headerTextLight: UIColor { return UIColor.Photon.Grey30 }
+    override var headerTextLight: UIColor { return UIColor.Photon.Grey30 } // textSecondary
     override var headerTextDark: UIColor { return UIColor.Photon.Grey30 }
     override var syncText: UIColor { return defaultTextAndTint }
-    override var accessoryViewTint: UIColor { return UIColor.Photon.Grey40 }
+    override var accessoryViewTint: UIColor { return UIColor.Photon.Grey40 } // actionSecondary
     override var selectedBackground: UIColor { return UIColor.Custom.selectedHighlightDark }
 }
 

--- a/Client/Frontend/Theme/LegacyThemeManager/LegacyTheme.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/LegacyTheme.swift
@@ -28,7 +28,7 @@ private let defaultSeparator = UIColor.Photon.Grey30
 private let defaultTextAndTint = UIColor.Photon.Grey80 // textPrimary in new system
 
 class TableViewColor {
-    var rowBackground: UIColor { return UIColor.Photon.White100 } // white
+    var rowBackground: UIColor { return UIColor.Photon.White100 } // layer2
     var rowText: UIColor { return UIColor.Photon.Grey90 } // textPrimary
     var rowDetailText: UIColor { return UIColor.Photon.Grey60 }
     var disabledRowText: UIColor { return UIColor.Photon.Grey40 } // textDisabled

--- a/Client/Frontend/Theme/LegacyThemeManager/LegacyTheme.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/LegacyTheme.swift
@@ -37,14 +37,14 @@ class TableViewColor {
     // Used for table headers in Settings and Photon menus
     var headerTextLight: UIColor { return UIColor.Photon.Grey50 } // textSecondary
     // Used for table headers in home panel tables
-    var headerTextDark: UIColor { return UIColor.Photon.Grey90 } // layer4. not sure
+    var headerTextDark: UIColor { return UIColor.Photon.Grey90 }
     var rowActionAccessory: UIColor { return UIColor.Photon.Blue40 } // actionPrimary
     var controlTint: UIColor { return rowActionAccessory } // actionPrimary
     var syncText: UIColor { return defaultTextAndTint } // textPrimary
     var errorText: UIColor { return UIColor.Photon.Red50 } // textWarning
     var warningText: UIColor { return UIColor.Photon.Orange50 } // textWarning
     var accessoryViewTint: UIColor { return UIColor.Photon.Grey40 } // iconSecondary
-    var selectedBackground: UIColor { return UIColor.Custom.selectedHighlightLight } // actionSecondaryHover
+    var selectedBackground: UIColor { return UIColor.Custom.selectedHighlightLight } // layer3
 }
 
 class ActionMenuColor {

--- a/Client/Frontend/Theme/LegacyThemeManager/LegacyTheme.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/LegacyTheme.swift
@@ -28,23 +28,23 @@ private let defaultSeparator = UIColor.Photon.Grey30
 private let defaultTextAndTint = UIColor.Photon.Grey80 // textPrimary in new system
 
 class TableViewColor {
-    var rowBackground: UIColor { return UIColor.Photon.White100 }
-    var rowText: UIColor { return UIColor.Photon.Grey90 }
+    var rowBackground: UIColor { return UIColor.Photon.White100 } // white
+    var rowText: UIColor { return UIColor.Photon.Grey90 } // textPrimary
     var rowDetailText: UIColor { return UIColor.Photon.Grey60 }
-    var disabledRowText: UIColor { return UIColor.Photon.Grey40 }
-    var separator: UIColor { return defaultSeparator }
-    var headerBackground: UIColor { return defaultBackground }
+    var disabledRowText: UIColor { return UIColor.Photon.Grey40 } // textDisabled
+    var separator: UIColor { return defaultSeparator } // layer4
+    var headerBackground: UIColor { return defaultBackground } // layer1
     // Used for table headers in Settings and Photon menus
-    var headerTextLight: UIColor { return UIColor.Photon.Grey50 }
+    var headerTextLight: UIColor { return UIColor.Photon.Grey50 } // textSecondary
     // Used for table headers in home panel tables
-    var headerTextDark: UIColor { return UIColor.Photon.Grey90 }
-    var rowActionAccessory: UIColor { return UIColor.Photon.Blue40 }
-    var controlTint: UIColor { return rowActionAccessory }
-    var syncText: UIColor { return defaultTextAndTint }
-    var errorText: UIColor { return UIColor.Photon.Red50 }
-    var warningText: UIColor { return UIColor.Photon.Orange50 }
-    var accessoryViewTint: UIColor { return UIColor.Photon.Grey40 }
-    var selectedBackground: UIColor { return UIColor.Custom.selectedHighlightLight }
+    var headerTextDark: UIColor { return UIColor.Photon.Grey90 } // layer4. not sure
+    var rowActionAccessory: UIColor { return UIColor.Photon.Blue40 } // actionPrimary
+    var controlTint: UIColor { return rowActionAccessory } // actionPrimary
+    var syncText: UIColor { return defaultTextAndTint } // textPrimary
+    var errorText: UIColor { return UIColor.Photon.Red50 } // textWarning
+    var warningText: UIColor { return UIColor.Photon.Orange50 } // textWarning
+    var accessoryViewTint: UIColor { return UIColor.Photon.Grey40 } // iconSecondary
+    var selectedBackground: UIColor { return UIColor.Custom.selectedHighlightLight } // actionSecondaryHover
 }
 
 class ActionMenuColor {
@@ -230,11 +230,11 @@ class SnackBarColor {
 class GeneralColor {
     var faviconBackground: UIColor { return UIColor.clear }
     var passcodeDot: UIColor { return UIColor.Photon.Grey60 }
-    var highlightBlue: UIColor { return UIColor.Photon.Blue40 }
-    var destructiveRed: UIColor { return UIColor.Photon.Red50 }
+    var highlightBlue: UIColor { return UIColor.Photon.Blue40 } // actionPrimary
+    var destructiveRed: UIColor { return UIColor.Photon.Red50 } // textWarning
     var separator: UIColor { return defaultSeparator }
-    var settingsTextPlaceholder: UIColor { return UIColor.Photon.Grey40 }
-    var controlTint: UIColor { return UIColor.Photon.Blue40 }
+    var settingsTextPlaceholder: UIColor { return UIColor.Photon.Grey40 } // textDisabled? asked Crystal
+    var controlTint: UIColor { return UIColor.Photon.Blue40 } // actionPrimary
     var switchToggle: UIColor { return UIColor.Photon.Grey90A40 }
 }
 

--- a/Client/Frontend/Theme/LegacyThemeManager/ThemedWidgets.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/ThemedWidgets.swift
@@ -3,23 +3,21 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0
 import UIKit
 
-class ThemedTableViewCell: UITableViewCell, NotificationThemeable {
-    var detailTextColor = UIColor.theme.tableView.disabledRowText
+class ThemedTableViewCell: UITableViewCell {
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        applyTheme()
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func applyTheme() {
-        textLabel?.textColor = UIColor.theme.tableView.rowText
-        detailTextLabel?.textColor = detailTextColor
-        backgroundColor = UIColor.theme.tableView.rowBackground
-        tintColor = UIColor.theme.general.controlTint
+    func applyTheme(theme: Theme) {
+        textLabel?.textColor = theme.colors.textPrimary
+        detailTextLabel?.textColor = theme.colors.textSecondary
+        backgroundColor = theme.colors.layer2
+        tintColor = theme.colors.actionPrimary
     }
 }
 
@@ -38,8 +36,7 @@ class ThemedTableViewController: UITableViewController, Themeable {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = ThemedTableViewCell(style: .subtitle, reuseIdentifier: nil)
-        return cell
+        return ThemedTableViewCell(style: .subtitle, reuseIdentifier: nil)
     }
 
     override func viewDidLoad() {

--- a/Client/Frontend/Theme/LegacyThemeManager/ThemedWidgets.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/ThemedWidgets.swift
@@ -23,7 +23,12 @@ class ThemedTableViewCell: UITableViewCell, NotificationThemeable {
     }
 }
 
-class ThemedTableViewController: UITableViewController, NotificationThemeable {
+class ThemedTableViewController: UITableViewController, Themeable {
+
+    var themeManager: ThemeManager = AppContainer.shared.resolve()
+    var notificationCenter: NotificationProtocol = NotificationCenter.default
+    var themeObserver: NSObjectProtocol?
+
     override init(style: UITableView.Style = .grouped) {
         super.init(style: style)
     }
@@ -40,13 +45,15 @@ class ThemedTableViewController: UITableViewController, NotificationThemeable {
     override func viewDidLoad() {
         super.viewDidLoad()
         applyTheme()
+        listenForThemeChange()
     }
 
     func applyTheme() {
-        tableView.separatorColor = UIColor.theme.tableView.separator
-        tableView.backgroundColor = UIColor.theme.tableView.headerBackground
+        tableView.separatorColor = themeManager.currentTheme.colors.layer4
+        tableView.backgroundColor = themeManager.currentTheme.colors.layer1
         tableView.reloadData()
 
+        // TODO: Remove with legacy theme clean up FXIOS-3960
         (tableView.tableHeaderView as? NotificationThemeable)?.applyTheme()
     }
 }

--- a/Client/Frontend/Theme/LightTheme.swift
+++ b/Client/Frontend/Theme/LightTheme.swift
@@ -62,5 +62,8 @@ private struct LightColourPalette: ThemeColourPalette {
     var borderAccentPrivate: UIColor = FXColors.Purple60
 
     // MARK: - Shadow
-    var shadow: UIColor = FXColors.DarkGrey80.withAlphaComponent(0.16)
+    var shadowDefault: UIColor = FXColors.DarkGrey80.withAlphaComponent(0.16)
+
+    // MARK: - Icon Spinner
+    var iconSpinnerDefault: UIColor = FXColors.LightGrey80
 }

--- a/Client/Frontend/Theme/Theme.swift
+++ b/Client/Frontend/Theme/Theme.swift
@@ -70,5 +70,8 @@ protocol ThemeColourPalette {
     var borderAccentPrivate: UIColor { get }
 
     // MARK: - Shadow
-    var shadow: UIColor { get }
+    var shadowDefault: UIColor { get }
+
+    // MARK: - Icon Spinner
+    var iconSpinnerDefault: UIColor { get }
 }

--- a/Client/Frontend/Theme/ThemeManager.swift
+++ b/Client/Frontend/Theme/ThemeManager.swift
@@ -17,6 +17,15 @@ enum ThemeType: String {
             return .dark
         }
     }
+
+    func getBarStyle() -> UIBarStyle {
+        switch self {
+        case .light:
+            return .default
+        case .dark:
+            return .black
+        }
+    }
 }
 
 protocol ThemeManager {

--- a/Tests/ClientTests/LoginsListViewModelTests.swift
+++ b/Tests/ClientTests/LoginsListViewModelTests.swift
@@ -15,7 +15,9 @@ class LoginsListViewModelTests: XCTestCase {
         super.setUp()
         let mockProfile = MockProfile()
         let searchController = UISearchController()
-        self.viewModel = LoginListViewModel(profile: mockProfile, searchController: searchController)
+        self.viewModel = LoginListViewModel(profile: mockProfile,
+                                            searchController: searchController,
+                                            theme: LightTheme())
         self.dataSource = LoginDataSource(viewModel: self.viewModel)
         self.viewModel.setBreachAlertsManager(MockBreachAlertsClient())
         self.addLogins()

--- a/Tests/ClientTests/Wallpaper/WallpaperSettingsViewModelTests.swift
+++ b/Tests/ClientTests/Wallpaper/WallpaperSettingsViewModelTests.swift
@@ -105,7 +105,9 @@ class WallpaperSettingsViewModelTests: XCTestCase {
 //    }
 
     func createSubject() -> WallpaperSettingsViewModel {
-        let subject = WallpaperSettingsViewModel(wallpaperManager: wallpaperManager, tabManager: MockTabManager())
+        let subject = WallpaperSettingsViewModel(wallpaperManager: wallpaperManager,
+                                                 tabManager: MockTabManager(),
+                                                 theme: LightTheme())
         trackForMemoryLeaks(subject)
         return subject
     }


### PR DESCRIPTION
# [FXIOS-4884](https://mozilla-hub.atlassian.net/browse/FXIOS-4884) https://github.com/mozilla-mobile/firefox-ios/issues/11825
- First step towards implementing settings pages with the new theming system, before the PR gets any bigger.
- Wrote a bunch of ToDos in there for me as the PR was getting big (example: `// TODO: Next task for FXIOS-4884 - apply ThemedTableViewCell theme`). Those needs to be fixed as my next steps, and will absolutely need to be done before v107 is soft frozen as theme change in settings will be a bit broken for now.
- Design review still needs to happen for those colors, but want to finish a first pass and fix any theme change hickups before showing this to design peeps.
- Mainly the changes in this PR is to add a bunch of VC to be `Themable`, then pass down the theme in the different cells whenever they are configured.
- Removed listening to theme change for example in WallpaperSettingsHeaderViewModel, since the VC is the one listening to theme changes
- Next PRs: Still need to make sure on theme changes the cells will adapt properly (currently they are set and unless the view is killed, the theme is not changed again)