### PR TITLE
Refactor FXIOS-4992 [v107] XCUITests and build on Xcode14

### DIFF
--- a/Tests/XCUITests/ClipBoardTests.swift
+++ b/Tests/XCUITests/ClipBoardTests.swift
@@ -26,13 +26,23 @@ class ClipBoardTests: BaseTestCase {
 
     // Check copied url is same as in browser
     func checkCopiedUrl() {
-        if let myString = UIPasteboard.general.string {
-            var value = app.textFields["url"].value as! String
-            if value.hasPrefix("http") == false {
-                value = "http://\(value)"
+        if #available(iOS 16.0, *){
+            // Skipping this check as per Allow/Deny pop up issue
+        } else {
+            if let myString = UIPasteboard.general.string {
+                let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+                let allowBtn = springboard.buttons["Allow Paste"]
+                if allowBtn.waitForExistence(timeout: 10) {
+                    allowBtn.tap()
+                }
+
+                var value = app.textFields["url"].value as! String
+                if value.hasPrefix("http") == false {
+                    value = "http://\(value)"
+                }
+                XCTAssertNotNil(myString)
+                XCTAssertEqual(myString, value, "Url matches with the UIPasteboard")
             }
-            XCTAssertNotNil(myString)
-            XCTAssertEqual(myString, value, "Url matches with the UIPasteboard")
         }
     }
 

--- a/Tests/XCUITests/ClipBoardTests.swift
+++ b/Tests/XCUITests/ClipBoardTests.swift
@@ -26,9 +26,7 @@ class ClipBoardTests: BaseTestCase {
 
     // Check copied url is same as in browser
     func checkCopiedUrl() {
-        if #available(iOS 16.0, *){
-            // Skipping this check as per Allow/Deny pop up issue
-        } else {
+        if #unavailable(iOS 16.0) {
             if let myString = UIPasteboard.general.string {
                 let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
                 let allowBtn = springboard.buttons["Allow Paste"]

--- a/Tests/XCUITests/DownloadFilesTests.swift
+++ b/Tests/XCUITests/DownloadFilesTests.swift
@@ -122,8 +122,10 @@ class DownloadFilesTests: BaseTestCase {
     private func downloadFile(fileName: String, numberOfDownlowds: Int) {
         navigator.openURL(testURL)
         waitUntilPageLoad()
+        app.webViews.firstMatch.swipeLeft()
         for _ in 0..<numberOfDownlowds {
             waitForExistence(app.webViews.links[testFileName], timeout: 5)
+
             app.webViews.links[testFileName].firstMatch.tap()
 
             waitForExistence(app.tables["Context Menu"].otherElements["download"], timeout: 5)

--- a/Tests/XCUITests/FxScreenGraph.swift
+++ b/Tests/XCUITests/FxScreenGraph.swift
@@ -321,9 +321,13 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         let menu = app.tables["Context Menu"].firstMatch
 
         if !(processIsTranslatedStr() == m1Rosetta) {
-            screenState.gesture(forAction: Action.LoadURLByPasting, Action.LoadURL) { userState in
-                UIPasteboard.general.string = userState.url ?? defaultURL
-                menu.otherElements[ImageIdentifiers.pasteAndGo].firstMatch.tap()
+            if #available(iOS 16, *) {
+                // Skip
+            } else {
+                screenState.gesture(forAction: Action.LoadURLByPasting, Action.LoadURL) { userState in
+                    UIPasteboard.general.string = userState.url ?? defaultURL
+                    menu.otherElements[ImageIdentifiers.pasteAndGo].firstMatch.tap()
+                }
             }
         }
 
@@ -989,7 +993,10 @@ extension MMNavigator where T == FxUserState {
         UIPasteboard.general.string = urlString
         userState.url = urlString
         userState.waitForLoading = waitForLoading
+        // Using LoadURLByTyping for Intel too on Xcode14
         if processIsTranslatedStr() == m1Rosetta {
+            performAction(Action.LoadURLByTyping)
+        } else if #available (iOS 16, *) {
             performAction(Action.LoadURLByTyping)
         } else {
             performAction(Action.LoadURL)

--- a/Tests/XCUITests/FxScreenGraph.swift
+++ b/Tests/XCUITests/FxScreenGraph.swift
@@ -767,7 +767,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         screenState.tap(app.buttons["newTabButtonTabTray"],
                         forAction: Action.OpenNewTabFromTabTray,
                         transitionTo: NewTabScreen)
-        screenState.tap(app.buttons["closeAllTabsButtonTabTray"], to: CloseTabMenu)
+        screenState.tap(app.toolbars.buttons["closeAllTabsButtonTabTray"], to: CloseTabMenu)
 //        screenState.tap(app.buttons["syncNowButtonTabsButtonTabTray"], to: CloseTabMenu)
 
         var regularModeSelector: XCUIElement
@@ -814,7 +814,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     }
 
     map.addScreenState(CloseTabMenu) { screenState in
-        screenState.tap(app.sheets.buttons[AccessibilityIdentifiers.TabTray.deleteCloseAllButton], forAction: Action.AcceptRemovingAllTabs, transitionTo: HomePanelsScreen)
+        screenState.tap(app.scrollViews.buttons[AccessibilityIdentifiers.TabTray.deleteCloseAllButton], forAction: Action.AcceptRemovingAllTabs, transitionTo: HomePanelsScreen)
         screenState.backAction = cancelBackAction
     }
 

--- a/Tests/XCUITests/FxScreenGraph.swift
+++ b/Tests/XCUITests/FxScreenGraph.swift
@@ -321,9 +321,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         let menu = app.tables["Context Menu"].firstMatch
 
         if !(processIsTranslatedStr() == m1Rosetta) {
-            if #available(iOS 16, *) {
-                // Skip
-            } else {
+            if #unavailable(iOS 16) {
                 screenState.gesture(forAction: Action.LoadURLByPasting, Action.LoadURL) { userState in
                     UIPasteboard.general.string = userState.url ?? defaultURL
                     menu.otherElements[ImageIdentifiers.pasteAndGo].firstMatch.tap()

--- a/Tests/XCUITests/NavigationTest.swift
+++ b/Tests/XCUITests/NavigationTest.swift
@@ -353,9 +353,10 @@ class NavigationTest: BaseTestCase {
     }
 
     // Smoketest
-     func testSSL() {
-         waitForExistence(app.buttons["urlBar-cancel"], timeout: 15)
-         navigator.performAction(Action.CloseURLBarOpen)
+    func testSSL() {
+        waitForExistence(app.buttons["urlBar-cancel"], timeout: 15)
+        navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
 
         navigator.openURL("https://expired.badssl.com/")
         waitForExistence(app.buttons["Advanced"], timeout: 10)

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -46,7 +46,7 @@ workflows:
             echo "-- build-for-testing --"
             mkdir DerivedData
 
-            xcodebuild "-project" "/Users/vagrant/git/Client.xcodeproj" "-scheme" "Fennec_Enterprise_XCUITests" -configuration "Fennec" "CODE_SIGNING_ALLOWED=NO" -sdk "iphonesimulator" "-destination" "platform=iOS Simulator,name=iPhone 11,OS=latest" "COMPILER_INDEX_STORE_ENABLE=NO" "build-for-testing" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" -derivedDataPath "/Users/vagrant/git/DerivedData" | xcpretty | tee xcodebuild_test.log
+            xcodebuild "-project" "/Users/vagrant/git/Client.xcodeproj" "-scheme" "Fennec_Enterprise_XCUITests" -configuration "Fennec" "CODE_SIGNING_ALLOWED=NO" -sdk "iphonesimulator" "-destination" "platform=iOS Simulator,name=iPhone 14,OS=latest" "COMPILER_INDEX_STORE_ENABLE=NO" "build-for-testing" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" -derivedDataPath "/Users/vagrant/git/DerivedData" | xcpretty | tee xcodebuild_test.log
     - script@1.1:
         title: Detect number of warnings
         is_always_run: true
@@ -141,7 +141,7 @@ workflows:
             ls -la
             echo "-- test-without-building --"
 
-            xcodebuild -project "Client.xcodeproj" -scheme "Fennec_Enterprise_XCUITests" -resultBundlePath "xcodebuild.xcresult" -derivedDataPath "/Users/vagrant/git/DerivedData" -testPlan "Smoketest2" -destination "platform=iOS Simulator,name=iPhone 11,OS=latest" test-without-building
+            xcodebuild -project "Client.xcodeproj" -scheme "Fennec_Enterprise_XCUITests" -resultBundlePath "xcodebuild.xcresult" -derivedDataPath "/Users/vagrant/git/DerivedData" -testPlan "Smoketest2" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" test-without-building
     - custom-test-results-export@0:
         inputs:
         - search_pattern: "$BITRISE_SOURCE_DIR/xcodebuild.xcresult"
@@ -179,7 +179,7 @@ workflows:
             ls -la
 
             echo "-- test-without-building --"
-            xcodebuild -project "Client.xcodeproj" -scheme "Fennec_Enterprise_XCUITests" -resultBundlePath "xcodebuild.xcresult" -derivedDataPath "/Users/vagrant/git/DerivedData" -destination "platform=iOS Simulator,name=iPhone 11,OS=latest" -testPlan "SmokeXCUITests" "test-without-building"
+            xcodebuild -project "Client.xcodeproj" -scheme "Fennec_Enterprise_XCUITests" -resultBundlePath "xcodebuild.xcresult" -derivedDataPath "/Users/vagrant/git/DerivedData" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" -testPlan "SmokeXCUITests" "test-without-building"
     - custom-test-results-export@0:
         inputs:
         - search_pattern: "$BITRISE_SOURCE_DIR/xcodebuild.xcresult"
@@ -216,7 +216,7 @@ workflows:
             ls -la
 
             echo "-- test-without-building --"
-            xcodebuild -project "Client.xcodeproj" -scheme "Fennec_Enterprise_XCUITests" -resultBundlePath "xcodebuild.xcresult" -derivedDataPath "/Users/vagrant/git/DerivedData" -destination "platform=iOS Simulator,name=iPhone 11,OS=latest" -testPlan "Smoketest3" "test-without-building"
+            xcodebuild -project "Client.xcodeproj" -scheme "Fennec_Enterprise_XCUITests" -resultBundlePath "xcodebuild.xcresult" -derivedDataPath "/Users/vagrant/git/DerivedData" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" -testPlan "Smoketest3" "test-without-building"
     - custom-test-results-export@0:
         inputs:
         - search_pattern: "$BITRISE_SOURCE_DIR/xcodebuild.xcresult"
@@ -254,7 +254,7 @@ workflows:
             ls -la
 
             echo "-- test-without-building --"
-            xcodebuild -project "Client.xcodeproj" -scheme "Fennec_Enterprise_XCUITests" -resultBundlePath "xcodebuild.xcresult" -derivedDataPath "/Users/vagrant/git/DerivedData" -destination "platform=iOS Simulator,name=iPhone 11,OS=latest" -testPlan "Smoketest4" "test-without-building"
+            xcodebuild -project "Client.xcodeproj" -scheme "Fennec_Enterprise_XCUITests" -resultBundlePath "xcodebuild.xcresult" -derivedDataPath "/Users/vagrant/git/DerivedData" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" -testPlan "Smoketest4" "test-without-building"
     - custom-test-results-export@0:
         inputs:
         - search_pattern: "$BITRISE_SOURCE_DIR/xcodebuild.xcresult"
@@ -295,7 +295,7 @@ workflows:
             pwd
             echo "-- test-without-building --"
 
-            xcodebuild -project "Client.xcodeproj" -scheme "Fennec_Enterprise_XCUITests" -resultBundlePath "xcodebuild.xcresult" -destination "platform=iOS Simulator,name=iPhone 11,OS=latest" -derivedDataPath "/Users/vagrant/git/DerivedData" -testPlan "UnitTest" "test-without-building"
+            xcodebuild -project "Client.xcodeproj" -scheme "Fennec_Enterprise_XCUITests" -resultBundlePath "xcodebuild.xcresult" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" -derivedDataPath "/Users/vagrant/git/DerivedData" -testPlan "UnitTest" "test-without-building"
     - script@1.1:
         title: Compress Result Bundle
         is_always_run: true
@@ -316,7 +316,7 @@ workflows:
     - deploy-to-bitrise-io@2.0: {}
     meta:
       bitrise.io:
-        stack: osx-xcode-13.4.x
+        stack: osx-xcode-14.0.x
         machine_type_id: g2.8core
   just_build_fennec_to_get_warnings:
     before_run:
@@ -334,7 +334,7 @@ workflows:
             echo "-- build-for-testing --"
             mkdir DerivedData2
 
-            xcodebuild "-project" "/Users/vagrant/git/Client.xcodeproj" "-scheme" "Fennec" -configuration "Fennec" "CODE_SIGNING_ALLOWED=NO" -sdk "iphonesimulator" "-destination" "platform=iOS Simulator,name=iPhone 11,OS=latest" "COMPILER_INDEX_STORE_ENABLE=NO" "build" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" | xcpretty | tee xcodebuild_fennec.log
+            xcodebuild "-project" "/Users/vagrant/git/Client.xcodeproj" "-scheme" "Fennec" -configuration "Fennec" "CODE_SIGNING_ALLOWED=NO" -sdk "iphonesimulator" "-destination" "platform=iOS Simulator,name=iPhone 14,OS=latest" "COMPILER_INDEX_STORE_ENABLE=NO" "build" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" | xcpretty | tee xcodebuild_fennec.log
             echo "show files"
             ls
     - script@1.1:
@@ -380,7 +380,7 @@ workflows:
             Mana|https://mana.mozilla.org/wiki/display/MTE/Mobile+Test+Engineering
     meta:
       bitrise.io:
-        stack: osx-xcode-13.4.x
+        stack: osx-xcode-14.0.x
         machine_type_id: g2.4core
   send_slack_notification:
     steps:
@@ -1016,7 +1016,7 @@ workflows:
       in master
     meta:
       bitrise.io:
-        stack: osx-xcode-13.4.x
+        stack: osx-xcode-14.0.x
         machine_type_id: g2.8core
     before_run:
     - 1_git_clone_and_post_clone
@@ -1397,7 +1397,7 @@ app:
 
 meta:
   bitrise.io:
-    stack: osx-xcode-13.4.x
+    stack: osx-xcode-14.0.x
     machine_type_id: g2.4core
 
 trigger_map:


### PR DESCRIPTION
With this PR the idea is to move the build and testing on Bitrise to Xcode14/iOS16
A few changes:
- Use LoadURLByTapping instead of copying to not deal with [issue](https://github.com/mozilla-mobile/firefox-ios/issues/11160) with the Allow/Deny pop up
- Use iPhone 14 since the iPhone 11 used so far is no longer available on Xcode 14 by default
- On Download tests, with this new device, we need to swipe on the website to tap on the desired content
- To close all tabs we need to modify the element hierarchy for that button

This applies only for the SmokeTest for now, the tests that run as part of checkins in main and PRs.
In a different PR we will fix/update the Full Functional tests