### PR TITLE
Bugfix FXIOS-4990 [v106] Ignore http data for sentry breadcrumbs

### DIFF
--- a/Shared/SentryIntegration.swift
+++ b/Shared/SentryIntegration.swift
@@ -90,6 +90,12 @@ public class SentryIntegration: SentryProtocol {
 
                 return event
             }
+            options.beforeBreadcrumb = { crumb in
+                if crumb.type == "http" || crumb.category == "http" {
+                    return nil
+                }
+                return crumb
+            }
         }
         enabled = true
 


### PR DESCRIPTION
Blocking breadcrumbs from being sent when they contain http request info.