### PR TITLE
Refactor FXIOS-4994 [v107] Remove unused code UIView extension, remove deprecations

### DIFF
--- a/Client/Extensions/UIView+Extension.swift
+++ b/Client/Extensions/UIView+Extension.swift
@@ -87,12 +87,6 @@ extension UIView {
         clipsToBounds = false
     }
 
-    /// Performs a deep copy of the view. Does not copy constraints.
-    @objc func clone() -> UIView {
-        let data = NSKeyedArchiver.archivedData(withRootObject: self)
-        return NSKeyedUnarchiver.unarchiveObject(with: data) as! UIView
-    }
-
     /// Rounds the requested corners of a view with the provided radius.
     func addRoundedCorners(_ cornersToRound: UIRectCorner, radius: CGFloat) {
         let maskPath = UIBezierPath(roundedRect: bounds,

--- a/Client/Frontend/Widgets/TabsButton.swift
+++ b/Client/Frontend/Widgets/TabsButton.swift
@@ -103,7 +103,7 @@ class TabsButton: UIButton {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func clone() -> UIView {
+    func createTabsButton() -> TabsButton {
         let button = TabsButton()
 
         button.accessibilityLabel = accessibilityLabel
@@ -145,8 +145,7 @@ class TabsButton: UIButton {
             insideButton.layer.removeAllAnimations()
         }
 
-        // make a 'clone' of the tabs button
-        let newTabsButton = clone() as! TabsButton
+        let newTabsButton = createTabsButton()
 
         self.clonedTabsButton = newTabsButton
         newTabsButton.frame = self.bounds


### PR DESCRIPTION
# [FXIOS-4994](https://mozilla-hub.atlassian.net/browse/FXIOS-4994) https://github.com/mozilla-mobile/firefox-ios/issues/12017
- Remove unused code, also cleaning up deprecations
- The method was overridden but super was never called.