### PR TITLE
Bugfix FXIOS-5027 [v105.1] Reset telemetry for home page sections on screen view

### DIFF
--- a/Client/Frontend/Home/HomepageViewModel.swift
+++ b/Client/Frontend/Home/HomepageViewModel.swift
@@ -173,6 +173,7 @@ class HomepageViewModel: FeatureFlaggable {
                                      object: .firefoxHomepage,
                                      value: trackingValue,
                                      extras: nil)
+        childViewModels.forEach { $0.screenWasShown() }
     }
 
     func recordViewDisappeared() {

--- a/Client/Frontend/Home/HomepageViewModelProtocol.swift
+++ b/Client/Frontend/Home/HomepageViewModelProtocol.swift
@@ -33,6 +33,9 @@ protocol HomepageViewModelProtocol {
 
     // Update section that are privacy sensitive, only implement when needed
     func updatePrivacyConcernedSection(isPrivate: Bool)
+
+    // Called anytime the screen is shown
+    func screenWasShown()
 }
 
 extension HomepageViewModelProtocol {
@@ -49,4 +52,6 @@ extension HomepageViewModelProtocol {
                      device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
         refreshData(for: traitCollection, isPortrait: isPortrait, device: device)
     }
+
+    func screenWasShown() {}
 }

--- a/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -357,6 +357,10 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
     func updatePrivacyConcernedSection(isPrivate: Bool) {
         self.isPrivate = isPrivate
     }
+
+    func screenWasShown() {
+        hasSentJumpBackInTileEvent = false
+    }
 }
 
 // MARK: FxHomeSectionHandler

--- a/Client/Frontend/Home/Pocket/PocketViewModel.swift
+++ b/Client/Frontend/Home/Pocket/PocketViewModel.swift
@@ -195,6 +195,10 @@ extension PocketViewModel: HomepageViewModelProtocol, FeatureFlaggable {
     func refreshData(for traitCollection: UITraitCollection,
                      isPortrait: Bool = UIWindow.isPortrait,
                      device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {}
+
+    func screenWasShown() {
+        hasSentPocketSectionEvent = false
+    }
 }
 
 // MARK: FxHomeSectionHandler

--- a/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -196,6 +196,10 @@ extension TopSitesViewModel: HomepageViewModelProtocol, FeatureFlaggable {
         topSites = topSitesDataAdaptor.getTopSitesData()
         numberOfItems = sectionDimension.numberOfRows * sectionDimension.numberOfTilesPerRow
     }
+
+    func screenWasShown() {
+        sentImpressionTelemetry = [String: Bool]()
+    }
 }
 
 // MARK: - FxHomeTopSitesManagerDelegate


### PR DESCRIPTION
Reset the telemetry on the home page sections every time the screen is shown.
