### PR TITLE
Bugfix FXIOS-5037 [v106] The "Jump Back In" CFR message is not displayed on iPad Air 2

### DIFF
--- a/Client/Frontend/Contextual Hint/ContextualHintEligibilityUtility.swift
+++ b/Client/Frontend/Contextual Hint/ContextualHintEligibilityUtility.swift
@@ -44,16 +44,22 @@ struct ContextualHintEligibilityUtility: ContextualHintEligibilityUtilityProtoco
         !UIWindow.isLandscape || UIDevice.current.userInterfaceIdiom == .pad
     }
 
+    /// If device is iPhone we present JumpBackIn and SyncTab CFRs only after Toolbar CFR has been presented
+    /// The toolbar CFR is not presented on iPad so we bypass it
+    var shouldCheckToolbarHasShown: Bool {
+        guard UIDevice.current.userInterfaceIdiom != .pad else { return true }
+
+        return profile.prefs.boolForKey(CFRPrefsKeys.toolbarOnboardingKey.rawValue) ?? false
+    }
+
     /// Determine if the CFR for Jump Back In is presentable.
     ///
     /// It's presentable on these conditions:
-    /// - this CFR should not be presented on iPad
     /// - the Toolbar CFR has already been presented
     /// - the JumpBackInSyncedTab CFR has NOT been presented already
     /// - the JumpBackIn CFR has NOT been presented yet
     private var canJumpBackInBePresented: Bool {
-        guard let hasPresentedToolbarCFR = profile.prefs.boolForKey(CFRPrefsKeys.toolbarOnboardingKey.rawValue),
-              hasPresentedToolbarCFR,
+        guard shouldCheckToolbarHasShown,
               !hasHintBeenConfigured(.jumpBackInSyncedTab),
               !hasAlreadyBeenPresented(.jumpBackInSyncedTab)
         else { return false }
@@ -69,10 +75,7 @@ struct ContextualHintEligibilityUtility: ContextualHintEligibilityUtilityProtoco
     /// - This CFR hasn't already been presented
     /// - The Home Tab Banner isn't being displayed (not specified by Product, but the CFR might show when the anchor point isn't on screen)
     private var canPresentJumpBackInSyncedTab: Bool {
-        guard let hasPresentedToolbarCFR = profile.prefs.boolForKey(CFRPrefsKeys.toolbarOnboardingKey.rawValue),
-              hasPresentedToolbarCFR else { return false }
-
-        return true
+        return shouldCheckToolbarHasShown
     }
 
     private func hasAlreadyBeenPresented(_ hintType: ContextualHintType) -> Bool {

--- a/Client/Frontend/Contextual Hint/ContextualHintEligibilityUtility.swift
+++ b/Client/Frontend/Contextual Hint/ContextualHintEligibilityUtility.swift
@@ -46,7 +46,7 @@ struct ContextualHintEligibilityUtility: ContextualHintEligibilityUtilityProtoco
 
     /// If device is iPhone we present JumpBackIn and SyncTab CFRs only after Toolbar CFR has been presented
     /// The toolbar CFR is not presented on iPad so we bypass it
-    var shouldCheckToolbarHasShown: Bool {
+    private var shouldCheckToolbarHasShown: Bool {
         guard UIDevice.current.userInterfaceIdiom != .pad else { return true }
 
         return profile.prefs.boolForKey(CFRPrefsKeys.toolbarOnboardingKey.rawValue) ?? false


### PR DESCRIPTION
[Jira 5037](https://mozilla-hub.atlassian.net/browse/FXIOS-5037)
Issue #12071 

Update `canJumpBackInBePresented` to check Toolbar CFR has been shown only for iPhone. Toolbar CFR is not shown on iPad which was preventing JumpBackIn CFR and SyncTab CFR to be shown