### PR TITLE
Refactor MTE-98 [v107] ⚰️ Remove potentially unneeded state in FxScreenGraph

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -16340,7 +16340,7 @@
 			repositoryURL = "https://github.com/mozilla/glean-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 51.2.0;
+				version = 51.4.0;
 			};
 		};
 		4368F811279611AC0013419B /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -40,8 +40,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla/glean-swift",
       "state" : {
-        "revision" : "5b810598dbe39579703af99af4afe4de92811d0c",
-        "version" : "51.2.0"
+        "revision" : "5aedaf3001cb6c0174179ad97c1d91d2bef4b91d",
+        "version" : "51.4.0"
       }
     },
     {

--- a/Client/Assets/CC_Script/LoginManagerChild.jsm
+++ b/Client/Assets/CC_Script/LoginManagerChild.jsm
@@ -36,15 +36,18 @@ const { AppConstants } = ChromeUtils.import(
 const { PrivateBrowsingUtils } = ChromeUtils.import(
   "resource://gre/modules/PrivateBrowsingUtils.jsm"
 );
-const { CreditCard } = ChromeUtils.import(
-  "resource://gre/modules/CreditCard.jsm"
+const { CreditCard } = ChromeUtils.importESModule(
+  "resource://gre/modules/CreditCard.sys.mjs"
 );
 
 const lazy = {};
 
+ChromeUtils.defineESModuleGetters(lazy, {
+  FormLikeFactory: "resource://gre/modules/FormLikeFactory.sys.mjs",
+});
+
 XPCOMUtils.defineLazyModuleGetters(lazy, {
   DeferredTask: "resource://gre/modules/DeferredTask.jsm",
-  FormLikeFactory: "resource://gre/modules/FormLikeFactory.jsm",
   LoginFormFactory: "resource://gre/modules/LoginFormFactory.jsm",
   LoginRecipesContent: "resource://gre/modules/LoginRecipes.jsm",
   LoginHelper: "resource://gre/modules/LoginHelper.jsm",

--- a/Client/Experiments/initial_experiments.json
+++ b/Client/Experiments/initial_experiments.json
@@ -2,29 +2,34 @@
   "data": [
     {
       "schemaVersion": "1.9.0",
-      "slug": "firefox-ios-mr-new-user-onboarding",
-      "id": "firefox-ios-mr-new-user-onboarding",
+      "slug": "release-firefox-ios-mr-new-user-onboarding",
+      "id": "release-firefox-ios-mr-new-user-onboarding",
       "arguments": {},
       "application": "org.mozilla.ios.Firefox",
       "appName": "firefox_ios",
       "appId": "org.mozilla.ios.Firefox",
       "channel": "release",
-      "userFacingName": "[QA] Firefox iOS MR New User Onboarding",
-      "userFacingDescription": "This is for testing.",
+      "userFacingName": "[Release] Firefox iOS MR New User Onboarding",
+      "userFacingDescription": "New onboarding for v106.",
       "isEnrollmentPaused": false,
       "isRollout": false,
       "bucketConfig": {
         "randomizationUnit": "nimbus_id",
-        "namespace": "ios-mr2022-release-1",
+        "namespace": "ios-mr2022-release-2",
         "start": 0,
-        "count": 10000,
+        "count": 1500,
         "total": 10000
       },
       "featureIds": [
         "mr2022"
       ],
       "probeSets": [],
-      "outcomes": [],
+      "outcomes": [
+        {
+          "slug": "mr_2022",
+          "priority": "primary"
+        }
+      ],
       "branches": [
         {
           "slug": "control",
@@ -64,11 +69,11 @@
         }
       ],
       "targeting": "((is_already_enrolled) || ((days_since_install < 7) && (app_version|versionCompare('106.!') >= 0)))",
-      "startDate": "2022-09-21",
-      "enrollmentEndDate": "2022-09-28",
+      "startDate": "2022-10-05",
+      "enrollmentEndDate": "2022-10-29",
       "endDate": null,
-      "proposedDuration": 28,
-      "proposedEnrollment": 7,
+      "proposedDuration": 73,
+      "proposedEnrollment": 24,
       "referenceBranch": "control"
     }
   ]

--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -187,12 +187,16 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate {
         flowlayout.invalidateLayout()
     }
 
-    deinit {
+    private func tabManagerTeardown() {
         tabManager.removeDelegate(self.tabDisplayManager)
         tabManager.removeDelegate(self)
         tabDisplayManager = nil
         contextualHintViewController.stopTimer()
         notificationCenter.removeObserver(self)
+    }
+
+    deinit {
+        tabManagerTeardown()
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsCell.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsCell.swift
@@ -33,7 +33,7 @@ class HistoryHighlightsCell: BlurrableCollectionViewCell, ReusableCell {
 
     let itemDescription: UILabel = .build { label in
         label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption1,
-                                                                   size: 13)
+                                                                   size: 12)
         label.adjustsFontForContentSizeCategory = true
     }
 
@@ -126,20 +126,12 @@ class HistoryHighlightsCell: BlurrableCollectionViewCell, ReusableCell {
             heroImage.heightAnchor.constraint(equalToConstant: UX.heroImageDimension),
             heroImage.widthAnchor.constraint(equalToConstant: UX.heroImageDimension),
             heroImage.centerYAnchor.constraint(equalTo: textStack.centerYAnchor),
-            heroImage.topAnchor.constraint(greaterThanOrEqualTo: contentView.topAnchor,
-                                           constant: UX.verticalSpacing),
-            heroImage.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor,
-                                              constant: -UX.verticalSpacing),
 
             textStack.leadingAnchor.constraint(equalTo: heroImage.trailingAnchor,
                                                constant: UX.horizontalSpacing),
             textStack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor,
                                                 constant: -UX.horizontalSpacing),
             textStack.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            textStack.topAnchor.constraint(greaterThanOrEqualTo: contentView.topAnchor,
-                                           constant: UX.verticalSpacing),
-            textStack.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor,
-                                              constant: -UX.verticalSpacing),
 
             bottomLine.heightAnchor.constraint(equalToConstant: 0.5),
             bottomLine.leadingAnchor.constraint(equalTo: itemTitle.leadingAnchor),

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -328,9 +328,9 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable {
 
     func displayWallpaperSelector() {
         let wallpaperManager = WallpaperManager(userDefaults: userDefaults)
-        guard wallpaperManager.canOnboardingBeShown, canModalBePresented else {
-            return
-        }
+        guard wallpaperManager.canOnboardingBeShown(using: viewModel.profile),
+              canModalBePresented
+        else { return }
 
         self.dismissKeyboard()
 

--- a/Tests/ClientTests/Wallpaper/Mocks/WallpaperManagerMock.swift
+++ b/Tests/ClientTests/Wallpaper/Mocks/WallpaperManagerMock.swift
@@ -18,11 +18,12 @@ class WallpaperManagerMock: WallpaperManagerInterface {
         return mockAvailableCollections
     }
 
-    var canOnboardingBeShown: Bool = true
     var canSettingsBeShown: Bool = true
 
     var setCurrentWallpaperCallCount = 0
     var setCurrentWallpaperResult: Result<Void, Error> = .success(())
+
+    func canOnboardingBeShown(using: Profile) -> Bool { return true }
 
     func setCurrentWallpaper(
         to wallpaper: Wallpaper,

--- a/Tests/XCUITests/FxScreenGraph.swift
+++ b/Tests/XCUITests/FxScreenGraph.swift
@@ -320,26 +320,6 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     map.addScreenState(URLBarLongPressMenu) { screenState in
         let menu = app.tables["Context Menu"].firstMatch
 
-        if !(processIsTranslatedStr() == m1Rosetta) {
-            if #unavailable(iOS 16) {
-                // Remove Action.LoadURLByPasting
-                /*
-                screenState.gesture(forAction: Action.LoadURLByPasting, Action.LoadURL) { userState in
-                    UIPasteboard.general.string = userState.url ?? defaultURL
-                    menu.otherElements[ImageIdentifiers.pasteAndGo].firstMatch.tap()
-                }
-                */
-            }
-        }
-
-        // Remove Action.SetURLByPasting
-        /*
-        screenState.gesture(forAction: Action.SetURLByPasting) { userState in
-            UIPasteboard.general.string = userState.url ?? defaultURL
-            menu.cells[ImageIdentifiers.paste].firstMatch.tap()
-        }
-        */
-
         screenState.backAction = {
             if isTablet {
                 // There is no Cancel option in iPad.
@@ -356,25 +336,6 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
             app.tables.cells["tp.add-to-safelist"].tap()
             userState.trackingProtectionPerTabEnabled = !userState.trackingProtectionPerTabEnabled
         }
-
-        // Remove Action.OpenSettingsFromTPMenu
-        /*
-        screenState.gesture(forAction: Action.OpenSettingsFromTPMenu, transitionTo: TrackingProtectionSettings) { userState in
-            app.cells["settings"].tap()
-        }
-        */
-
-        // Remove Action.CloseTPContextMenu
-        /*
-        screenState.gesture(forAction: Action.CloseTPContextMenu) { userState in
-            if isTablet {
-                // There is no Cancel option in iPad.
-                app.otherElements["PopoverDismissRegion"].tap()
-            } else {
-                app.buttons["PhotonMenu.close"].tap()
-            }
-        }
-        */
     }
 
     // URLBarOpen is dismissOnUse, which ScreenGraph interprets as "now we've done this action, then go back to the one before it"
@@ -476,14 +437,6 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     }
 
     map.addScreenState(MobileBookmarks) { screenState in
-        let bookmarksMenuNavigationBar = app.navigationBars["Mobile Bookmarks"]
-        let bookmarksButton = bookmarksMenuNavigationBar.buttons["Bookmarks"]
-        // Remove Action.ExitMobileBookmarksFolder
-        /*
-        screenState.gesture(forAction: Action.ExitMobileBookmarksFolder, transitionTo: LibraryPanel_Bookmarks) { userState in
-                bookmarksButton.tap()
-        }
-        */
         screenState.tap(app.buttons["Edit"], to: MobileBookmarksEdit)
     }
 
@@ -531,32 +484,14 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
                 .element(boundBy: 0)
                 .tap()
         }
-        // Remove Action.CloseHistoryListPanel
-        /*
-        screenState.gesture(forAction: Action.CloseHistoryListPanel, transitionTo: HomePanelsScreen) { userState in
-                app.buttons["Done"].tap()
-        }
-        */
     }
 
     map.addScreenState(LibraryPanel_ReadingList) { screenState in
         screenState.dismissOnUse = true
-        // Remove Action.CloseReadingListPanel
-        /*
-        screenState.gesture(forAction: Action.CloseReadingListPanel, transitionTo: HomePanelsScreen) { userState in
-                app.buttons["Done"].tap()
-        }
-        */
     }
 
     map.addScreenState(LibraryPanel_Downloads) { screenState in
         screenState.dismissOnUse = true
-        // Remove Action.CloseDownloadsPanel
-        /*
-        screenState.gesture(forAction: Action.CloseDownloadsPanel, transitionTo: HomePanelsScreen) { userState in
-            app.buttons["Done"].tap()
-        }
-        */
     }
 
     map.addScreenState(HistoryRecentlyClosed) { screenState in
@@ -723,15 +658,6 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
             userState.pocketInNewTab = !userState.pocketInNewTab
             app.switches["ASPocketStoriesVisible"].tap()
         }
-
-        // Remove Action.SelectTopSitesRows
-        /*
-        screenState.gesture(forAction: Action.SelectTopSitesRows) { userState in
-            app.tables.cells["TopSitesRows"].tap()
-            select(rows: userState.numTopSitesRows)
-            app.navigationBars.element(boundBy: 0).buttons.element(boundBy: 0).tap()
-        }
-        */
 
         screenState.backAction = navigationControllerBackAction
     }

--- a/Tests/XCUITests/FxScreenGraph.swift
+++ b/Tests/XCUITests/FxScreenGraph.swift
@@ -405,7 +405,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
                 userState.isPrivate = !userState.isPrivate
             }
         }
- 
+
         // Workaround to bug Bug 1417522
         if isTablet {
             screenState.tap(app.buttons["TopTabsViewController.tabsButton"], to: TabTray)

--- a/Tests/XCUITests/FxScreenGraph.swift
+++ b/Tests/XCUITests/FxScreenGraph.swift
@@ -451,9 +451,6 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
             app.buttons["urlBar-cancel"].tap()
         }
 
-        screenState.gesture(forAction: Action.OpenSearchBarFromSearchButton, transitionTo: URLBarOpen) {
-            userState in app.buttons["TabToolbar.stopReloadButton"].tap()
-        }
     }
 
     map.addScreenState(LibraryPanel_Bookmarks) { screenState in

--- a/Tests/XCUITests/FxScreenGraph.swift
+++ b/Tests/XCUITests/FxScreenGraph.swift
@@ -320,6 +320,26 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     map.addScreenState(URLBarLongPressMenu) { screenState in
         let menu = app.tables["Context Menu"].firstMatch
 
+        if !(processIsTranslatedStr() == m1Rosetta) {
+            if #unavailable(iOS 16) {
+                // Remove Action.LoadURLByPasting
+                /*
+                screenState.gesture(forAction: Action.LoadURLByPasting, Action.LoadURL) { userState in
+                    UIPasteboard.general.string = userState.url ?? defaultURL
+                    menu.otherElements[ImageIdentifiers.pasteAndGo].firstMatch.tap()
+                }
+                */
+            }
+        }
+
+        // Remove Action.SetURLByPasting
+        /*
+        screenState.gesture(forAction: Action.SetURLByPasting) { userState in
+            UIPasteboard.general.string = userState.url ?? defaultURL
+            menu.cells[ImageIdentifiers.paste].firstMatch.tap()
+        }
+        */
+
         screenState.backAction = {
             if isTablet {
                 // There is no Cancel option in iPad.
@@ -336,6 +356,25 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
             app.tables.cells["tp.add-to-safelist"].tap()
             userState.trackingProtectionPerTabEnabled = !userState.trackingProtectionPerTabEnabled
         }
+
+        // Remove Action.OpenSettingsFromTPMenu
+        /*
+        screenState.gesture(forAction: Action.OpenSettingsFromTPMenu, transitionTo: TrackingProtectionSettings) { userState in
+            app.cells["settings"].tap()
+        }
+        */
+
+        // Remove Action.CloseTPContextMenu
+        /*
+        screenState.gesture(forAction: Action.CloseTPContextMenu) { userState in
+            if isTablet {
+                // There is no Cancel option in iPad.
+                app.otherElements["PopoverDismissRegion"].tap()
+            } else {
+                app.buttons["PhotonMenu.close"].tap()
+            }
+        }
+        */
     }
 
     // URLBarOpen is dismissOnUse, which ScreenGraph interprets as "now we've done this action, then go back to the one before it"
@@ -405,7 +444,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
                 userState.isPrivate = !userState.isPrivate
             }
         }
-
+ 
         // Workaround to bug Bug 1417522
         if isTablet {
             screenState.tap(app.buttons["TopTabsViewController.tabsButton"], to: TabTray)
@@ -437,6 +476,14 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     }
 
     map.addScreenState(MobileBookmarks) { screenState in
+        let bookmarksMenuNavigationBar = app.navigationBars["Mobile Bookmarks"]
+        let bookmarksButton = bookmarksMenuNavigationBar.buttons["Bookmarks"]
+        // Remove Action.ExitMobileBookmarksFolder
+        /*
+        screenState.gesture(forAction: Action.ExitMobileBookmarksFolder, transitionTo: LibraryPanel_Bookmarks) { userState in
+                bookmarksButton.tap()
+        }
+        */
         screenState.tap(app.buttons["Edit"], to: MobileBookmarksEdit)
     }
 
@@ -484,14 +531,32 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
                 .element(boundBy: 0)
                 .tap()
         }
+        // Remove Action.CloseHistoryListPanel
+        /*
+        screenState.gesture(forAction: Action.CloseHistoryListPanel, transitionTo: HomePanelsScreen) { userState in
+                app.buttons["Done"].tap()
+        }
+        */
     }
 
     map.addScreenState(LibraryPanel_ReadingList) { screenState in
         screenState.dismissOnUse = true
+        // Remove Action.CloseReadingListPanel
+        /*
+        screenState.gesture(forAction: Action.CloseReadingListPanel, transitionTo: HomePanelsScreen) { userState in
+                app.buttons["Done"].tap()
+        }
+        */
     }
 
     map.addScreenState(LibraryPanel_Downloads) { screenState in
         screenState.dismissOnUse = true
+        // Remove Action.CloseDownloadsPanel
+        /*
+        screenState.gesture(forAction: Action.CloseDownloadsPanel, transitionTo: HomePanelsScreen) { userState in
+            app.buttons["Done"].tap()
+        }
+        */
     }
 
     map.addScreenState(HistoryRecentlyClosed) { screenState in
@@ -658,6 +723,15 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
             userState.pocketInNewTab = !userState.pocketInNewTab
             app.switches["ASPocketStoriesVisible"].tap()
         }
+
+        // Remove Action.SelectTopSitesRows
+        /*
+        screenState.gesture(forAction: Action.SelectTopSitesRows) { userState in
+            app.tables.cells["TopSitesRows"].tap()
+            select(rows: userState.numTopSitesRows)
+            app.navigationBars.element(boundBy: 0).buttons.element(boundBy: 0).tap()
+        }
+        */
 
         screenState.backAction = navigationControllerBackAction
     }

--- a/Tests/XCUITests/FxScreenGraph.swift
+++ b/Tests/XCUITests/FxScreenGraph.swift
@@ -322,17 +322,23 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
         if !(processIsTranslatedStr() == m1Rosetta) {
             if #unavailable(iOS 16) {
+                // Remove Action.LoadURLByPasting
+                /*
                 screenState.gesture(forAction: Action.LoadURLByPasting, Action.LoadURL) { userState in
                     UIPasteboard.general.string = userState.url ?? defaultURL
                     menu.otherElements[ImageIdentifiers.pasteAndGo].firstMatch.tap()
                 }
+                */
             }
         }
 
+        // Remove Action.SetURLByPasting
+        /*
         screenState.gesture(forAction: Action.SetURLByPasting) { userState in
             UIPasteboard.general.string = userState.url ?? defaultURL
             menu.cells[ImageIdentifiers.paste].firstMatch.tap()
         }
+        */
 
         screenState.backAction = {
             if isTablet {
@@ -351,10 +357,15 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
             userState.trackingProtectionPerTabEnabled = !userState.trackingProtectionPerTabEnabled
         }
 
+        // Remove Action.OpenSettingsFromTPMenu
+        /*
         screenState.gesture(forAction: Action.OpenSettingsFromTPMenu, transitionTo: TrackingProtectionSettings) { userState in
             app.cells["settings"].tap()
         }
+        */
 
+        // Remove Action.CloseTPContextMenu
+        /*
         screenState.gesture(forAction: Action.CloseTPContextMenu) { userState in
             if isTablet {
                 // There is no Cancel option in iPad.
@@ -363,6 +374,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
                 app.buttons["PhotonMenu.close"].tap()
             }
         }
+        */
     }
 
     // URLBarOpen is dismissOnUse, which ScreenGraph interprets as "now we've done this action, then go back to the one before it"
@@ -432,7 +444,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
                 userState.isPrivate = !userState.isPrivate
             }
         }
-
+ 
         // Workaround to bug Bug 1417522
         if isTablet {
             screenState.tap(app.buttons["TopTabsViewController.tabsButton"], to: TabTray)
@@ -466,9 +478,12 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     map.addScreenState(MobileBookmarks) { screenState in
         let bookmarksMenuNavigationBar = app.navigationBars["Mobile Bookmarks"]
         let bookmarksButton = bookmarksMenuNavigationBar.buttons["Bookmarks"]
+        // Remove Action.ExitMobileBookmarksFolder
+        /*
         screenState.gesture(forAction: Action.ExitMobileBookmarksFolder, transitionTo: LibraryPanel_Bookmarks) { userState in
                 bookmarksButton.tap()
         }
+        */
         screenState.tap(app.buttons["Edit"], to: MobileBookmarksEdit)
     }
 
@@ -516,23 +531,32 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
                 .element(boundBy: 0)
                 .tap()
         }
+        // Remove Action.CloseHistoryListPanel
+        /*
         screenState.gesture(forAction: Action.CloseHistoryListPanel, transitionTo: HomePanelsScreen) { userState in
                 app.buttons["Done"].tap()
         }
+        */
     }
 
     map.addScreenState(LibraryPanel_ReadingList) { screenState in
         screenState.dismissOnUse = true
+        // Remove Action.CloseReadingListPanel
+        /*
         screenState.gesture(forAction: Action.CloseReadingListPanel, transitionTo: HomePanelsScreen) { userState in
                 app.buttons["Done"].tap()
         }
+        */
     }
 
     map.addScreenState(LibraryPanel_Downloads) { screenState in
         screenState.dismissOnUse = true
+        // Remove Action.CloseDownloadsPanel
+        /*
         screenState.gesture(forAction: Action.CloseDownloadsPanel, transitionTo: HomePanelsScreen) { userState in
             app.buttons["Done"].tap()
         }
+        */
     }
 
     map.addScreenState(HistoryRecentlyClosed) { screenState in
@@ -700,11 +724,14 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
             app.switches["ASPocketStoriesVisible"].tap()
         }
 
+        // Remove Action.SelectTopSitesRows
+        /*
         screenState.gesture(forAction: Action.SelectTopSitesRows) { userState in
             app.tables.cells["TopSitesRows"].tap()
             select(rows: userState.numTopSitesRows)
             app.navigationBars.element(boundBy: 0).buttons.element(boundBy: 0).tap()
         }
+        */
 
         screenState.backAction = navigationControllerBackAction
     }
@@ -767,7 +794,6 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
                         forAction: Action.OpenNewTabFromTabTray,
                         transitionTo: NewTabScreen)
         screenState.tap(app.toolbars.buttons["closeAllTabsButtonTabTray"], to: CloseTabMenu)
-//        screenState.tap(app.buttons["syncNowButtonTabsButtonTabTray"], to: CloseTabMenu)
 
         var regularModeSelector: XCUIElement
         var privateModeSelector: XCUIElement


### PR DESCRIPTION
Through the work on refactoring the history tests, I discovered that `Action.OpenSearchBarFromSearchButton` should not have the `stopReloadButton` available. Removing such a state may result in workaround not required in the history tests.

https://mozilla-hub.atlassian.net/browse/MTE-98