### PR TITLE
Bugfix FXIOS-4619 [v108] Fixed Xcode 14 Warning for the Run script build phase

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -9749,6 +9749,7 @@
 		};
 		C874A4E327F62C5B006F54E5 /* Swiftlint */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -9767,6 +9768,7 @@
 		};
 		E6639F191BF11E3A002D0853 /* Conditionally Add Settings Bundle */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);


### PR DESCRIPTION
# [FXIOS-4619](https://mozilla-hub.atlassian.net/browse/FXIOS-4619) https://github.com/mozilla-mobile/firefox-ios/issues/11381
This PR fixes the Xcode 14 warning for the Run script build phase for the "Swiftlint" and "Conditionally Add Settings Bundle" scripts
By unchecking "Based on dependency analysis" in the script phase thus they are now configured to run in every build.