### PR TITLE
Bugfix FXIOS-4618 [v107] Fixes cannot access property in deinitializer warning

### DIFF
--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -187,12 +187,16 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate {
         flowlayout.invalidateLayout()
     }
 
-    deinit {
+    private func tabManagerTeardown() {
         tabManager.removeDelegate(self.tabDisplayManager)
         tabManager.removeDelegate(self)
         tabDisplayManager = nil
         contextualHintViewController.stopTimer()
         notificationCenter.removeObserver(self)
+    }
+
+    deinit {
+        tabManagerTeardown()
     }
 
     required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
This PR Fixes the warning by using a private function to avoid using the reference properties directly