### PR TITLE
Bugfix FXIOS-4957 [v106] Add CFR checks for wallpaper onboarding

### DIFF
--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -328,9 +328,9 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable {
 
     func displayWallpaperSelector() {
         let wallpaperManager = WallpaperManager(userDefaults: userDefaults)
-        guard wallpaperManager.canOnboardingBeShown, canModalBePresented else {
-            return
-        }
+        guard wallpaperManager.canOnboardingBeShown(using: viewModel.profile),
+              canModalBePresented
+        else { return }
 
         self.dismissKeyboard()
 

--- a/Tests/ClientTests/Wallpaper/Mocks/WallpaperManagerMock.swift
+++ b/Tests/ClientTests/Wallpaper/Mocks/WallpaperManagerMock.swift
@@ -18,11 +18,12 @@ class WallpaperManagerMock: WallpaperManagerInterface {
         return mockAvailableCollections
     }
 
-    var canOnboardingBeShown: Bool = true
     var canSettingsBeShown: Bool = true
 
     var setCurrentWallpaperCallCount = 0
     var setCurrentWallpaperResult: Result<Void, Error> = .success(())
+
+    func canOnboardingBeShown(using: Profile) -> Bool { return true }
 
     func setCurrentWallpaper(
         to wallpaper: Wallpaper,


### PR DESCRIPTION
[JIRA Reference](https://mozilla-hub.atlassian.net/browse/FXIOS-4957)

Note: Because the synced tab has multiple conditions that are checked in multiple places and cannot be fixed without moving a lot of things around that's too dangerous to do at this late stage, we're ok with this bug remaining for that CFR and can be addressed at a later time.