### PR TITLE
Bugfix FXIOS-5062 [v107] Recently Visited header view alignment

### DIFF
--- a/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
@@ -220,7 +220,7 @@ extension HistoryHighlightsViewModel: HomepageViewModelProtocol, FeatureFlaggabl
             top: 0,
             leading: horizontalInset,
             bottom: HomepageViewModel.UX.spacingBetweenSections,
-            trailing: horizontalInset)
+            trailing: 0)
         section.orthogonalScrollingBehavior = .continuous
 
         return section


### PR DESCRIPTION
**Referenced Issue**: #12103

I have changed to `zero` for the trailing inset when setting the `contentInsets` for the `HistoryHighlights` section view, on L223. I think it looks good now. Please review my PR bro, @lmarceau.

https://github.com/mozilla-mobile/firefox-ios/blob/ccd24af4484b94acc6c27c6d4d9bcbb55cc156c3/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift#L218-L227

![IMG_4624](https://user-images.githubusercontent.com/6712795/195316654-59f095ed-63ad-492b-a83a-343f335bd13f.jpg)

![Simulator Screen Shot - iPhone 8 - 2022-10-12 at 16 21 06](https://user-images.githubusercontent.com/6712795/195316725-34c1cf53-2327-45e3-b2ca-6d711b600525.png)


