### PR TITLE
Refactor FXIOS-4883 [v107] More tabs tray theming

### DIFF
--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -291,6 +291,7 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate, Themeable {
 
     func applyTheme() {
         tabDisplayManager.theme = themeManager.currentTheme
+        emptyPrivateTabsView.applyTheme(themeManager.currentTheme)
         backgroundPrivacyOverlay.backgroundColor = themeManager.currentTheme.colors.layerScrim
         collectionView.backgroundColor = themeManager.currentTheme.colors.layer3
         collectionView.reloadData()

--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -31,7 +31,7 @@ protocol TabTrayDelegate: AnyObject {
     func tabTrayDidRequestTabsSettings()
 }
 
-class GridTabViewController: UIViewController, TabTrayViewDelegate {
+class GridTabViewController: UIViewController, TabTrayViewDelegate, Themeable {
     let tabManager: TabManager
     let profile: Profile
     weak var delegate: TabTrayDelegate?
@@ -40,11 +40,13 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate {
     static let independentTabsHeaderIdentifier = "IndependentTabs"
     var otherBrowsingModeOffset = CGPoint.zero
     // Backdrop used for displaying greyed background for private tabs
-    var webViewContainerBackdrop = UIView()
+    var backgroundPrivacyOverlay = UIView()
     var collectionView: UICollectionView!
     var recentlyClosedTabsPanel: RecentlyClosedTabsPanel?
     var notificationCenter: NotificationProtocol
     var contextualHintViewController: ContextualHintViewController
+    var themeManager: ThemeManager
+    var themeObserver: NSObjectProtocol?
 
     // This is an optional variable used if we wish to focus a tab that is not the
     // currently selected tab. This allows us to force the scroll behaviour to move
@@ -77,7 +79,8 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate {
          profile: Profile,
          tabTrayDelegate: TabTrayDelegate? = nil,
          tabToFocus: Tab? = nil,
-         notificationCenter: NotificationProtocol = NotificationCenter.default
+         notificationCenter: NotificationProtocol = NotificationCenter.default,
+         themeManager: ThemeManager = AppContainer.shared.resolve()
     ) {
         self.tabManager = tabManager
         self.profile = profile
@@ -88,6 +91,7 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate {
         let contextualViewModel = ContextualHintViewModel(forHintType: .inactiveTabs,
                                                           with: profile)
         self.contextualHintViewController = ContextualHintViewController(with: contextualViewModel)
+        self.themeManager = themeManager
 
         super.init(nibName: nil, bundle: nil)
         collectionViewSetup()
@@ -109,7 +113,8 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate {
                                               reuseID: TabCell.cellIdentifier,
                                               tabDisplayType: .TabGrid,
                                               profile: profile,
-                                              cfrDelegate: self)
+                                              cfrDelegate: self,
+                                              theme: themeManager.currentTheme)
         collectionView.dataSource = tabDisplayManager
         collectionView.delegate = tabLayoutDelegate
 
@@ -121,7 +126,7 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate {
         tabManager.addDelegate(self)
         view.accessibilityLabel = .TabTrayViewAccessibilityLabel
 
-        webViewContainerBackdrop.alpha = 0
+        backgroundPrivacyOverlay.alpha = 0
 
         collectionView.alwaysBounceVertical = true
         collectionView.keyboardDismissMode = .onDrag
@@ -142,8 +147,7 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate {
 
         setupNotifications(forObserver: self, observing: [
             UIApplication.willResignActiveNotification,
-            UIApplication.didBecomeActiveNotification,
-            .DisplayThemeChanged
+            UIApplication.didBecomeActiveNotification
         ])
     }
 
@@ -151,7 +155,7 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate {
         // TODO: Remove SNAPKIT - this will require some work as the layouts
         // are using other snapkit constraints and this will require modification
         // in several places.
-        [webViewContainerBackdrop, collectionView].forEach { view.addSubview($0) }
+        [backgroundPrivacyOverlay, collectionView].forEach { view.addSubview($0) }
         setupConstraints()
 
         view.insertSubview(emptyPrivateTabsView, aboveSubview: collectionView)
@@ -161,7 +165,7 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate {
     }
 
     private func setupConstraints() {
-        webViewContainerBackdrop.snp.makeConstraints { make in
+        backgroundPrivacyOverlay.snp.makeConstraints { make in
             make.edges.equalTo(self.view)
         }
 
@@ -284,6 +288,13 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate {
 
         tabManager.selectTab(tabManager.addTab(request, isPrivate: isPrivate))
     }
+
+    func applyTheme() {
+        tabDisplayManager.theme = themeManager.currentTheme
+        backgroundPrivacyOverlay.backgroundColor = themeManager.currentTheme.colors.layerScrim
+        collectionView.backgroundColor = themeManager.currentTheme.colors.layer3
+        collectionView.reloadData()
+    }
 }
 
 extension GridTabViewController: TabManagerDelegate {
@@ -316,7 +327,7 @@ extension GridTabViewController: TabDisplayer {
         tabCell.animator?.delegate = self
         tabCell.delegate = self
         let selected = tab == tabManager.selectedTab
-        tabCell.configureWith(tab: tab, isSelected: selected)
+        tabCell.configureWith(tab: tab, isSelected: selected, theme: themeManager.currentTheme)
         return tabCell
     }
 }
@@ -389,8 +400,8 @@ extension GridTabViewController {
 extension GridTabViewController {
     @objc func appWillResignActiveNotification() {
         if tabDisplayManager.isPrivate {
-            webViewContainerBackdrop.alpha = 1
-            view.bringSubviewToFront(webViewContainerBackdrop)
+            backgroundPrivacyOverlay.alpha = 1
+            view.bringSubviewToFront(backgroundPrivacyOverlay)
             collectionView.alpha = 0
             emptyPrivateTabsView.alpha = 0
         }
@@ -405,8 +416,8 @@ extension GridTabViewController {
                 self.collectionView.alpha = 1
                 self.emptyPrivateTabsView.alpha = 1
             }) { _ in
-                self.webViewContainerBackdrop.alpha = 0
-                self.view.sendSubviewToBack(self.webViewContainerBackdrop)
+                self.backgroundPrivacyOverlay.alpha = 0
+                self.view.sendSubviewToBack(self.backgroundPrivacyOverlay)
             }
     }
 }
@@ -795,14 +806,6 @@ protocol TabCellDelegate: AnyObject {
     func tabCellDidClose(_ cell: TabCell)
 }
 
-// MARK: - NotificationThemable
-extension GridTabViewController: NotificationThemeable {
-    @objc func applyTheme() {
-        webViewContainerBackdrop.backgroundColor = UIColor.Photon.Ink90
-        collectionView.backgroundColor = UIColor.theme.tabTray.background
-    }
-}
-
 // MARK: - Notifiable
 extension GridTabViewController: Notifiable {
     func handleNotifications(_ notification: Notification) {
@@ -811,8 +814,6 @@ extension GridTabViewController: Notifiable {
             appWillResignActiveNotification()
         case UIApplication.didBecomeActiveNotification:
             appDidBecomeActiveNotification()
-        case .DisplayThemeChanged:
-            applyTheme()
         default: break
         }
     }

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -81,6 +81,7 @@ class TabDisplayManager: NSObject, FeatureFlaggable {
     var cfrDelegate: InactiveTabsCFRProtocol?
     private var nimbus: FxNimbus?
     var notificationCenter: NotificationProtocol
+    var theme: Theme
 
     lazy var filteredTabs = [Tab]()
     var tabDisplayOrder: TabDisplayOrder = TabDisplayOrder()
@@ -179,7 +180,8 @@ class TabDisplayManager: NSObject, FeatureFlaggable {
          tabDisplayType: TabDisplayType,
          profile: Profile,
          cfrDelegate: InactiveTabsCFRProtocol? = nil,
-         nimbus: FxNimbus = FxNimbus.shared
+         nimbus: FxNimbus = FxNimbus.shared,
+         theme: Theme
     ) {
         self.collectionView = collectionView
         self.tabDisplayer = tabDisplayer
@@ -191,7 +193,8 @@ class TabDisplayManager: NSObject, FeatureFlaggable {
         self.cfrDelegate = cfrDelegate
         self.nimbus = nimbus
         self.notificationCenter = NotificationCenter.default
-
+        self.theme = theme
+        
         super.init()
         setupNotifications(forObserver: self, observing: [.DidTapUndoCloseAllTabToast])
         self.inactiveViewModel = InactiveTabViewModel()
@@ -569,6 +572,7 @@ extension TabDisplayManager: UICollectionViewDataSource {
 
         case .groupedTabs:
             if let groupedCell = collectionView.dequeueReusableCell(withReuseIdentifier: GroupedTabCell.cellIdentifier, for: indexPath) as? GroupedTabCell {
+                groupedCell.theme = theme
                 groupedCell.tabDisplayManagerDelegate = self
                 groupedCell.tabGroups = self.tabGroups
                 groupedCell.hasExpanded = true
@@ -903,7 +907,9 @@ extension TabDisplayManager: TabEventHandler {
         guard forceUpdate || cell.isSelectedTab else { return }
 
         let isSelected = tab == tabManager.selectedTab
-        cell.configureWith(tab: tab, isSelected: isSelected)
+        cell.configureWith(tab: tab,
+                           isSelected: isSelected,
+                           theme: theme)
     }
 
     func removeAllTabsFromView() {

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -194,7 +194,7 @@ class TabDisplayManager: NSObject, FeatureFlaggable {
         self.nimbus = nimbus
         self.notificationCenter = NotificationCenter.default
         self.theme = theme
-        
+
         super.init()
         setupNotifications(forObserver: self, observing: [.DidTapUndoCloseAllTabToast])
         self.inactiveViewModel = InactiveTabViewModel()

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -559,6 +559,7 @@ extension TabDisplayManager: UICollectionViewDataSource {
         switch TabDisplaySection(rawValue: indexPath.section) {
         case .inactiveTabs:
             if let inactiveCell = collectionView.dequeueReusableCell(withReuseIdentifier: InactiveTabCell.cellIdentifier, for: indexPath) as? InactiveTabCell {
+                inactiveCell.applyTheme(theme)
                 inactiveCell.inactiveTabsViewModel = inactiveViewModel
                 inactiveCell.hasExpanded = isInactiveViewExpanded
                 inactiveCell.delegate = self

--- a/Client/Frontend/Browser/TabTrayButtonExtensions.swift
+++ b/Client/Frontend/Browser/TabTrayButtonExtensions.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-class PrivateModeButton: ToggleButton, NotificationThemeable, PrivateModeUI {
+class PrivateModeButton: ToggleButton, PrivateModeUI {
     var offTint = UIColor.black
     var onTint = UIColor.black
 
@@ -29,7 +29,9 @@ class PrivateModeButton: ToggleButton, NotificationThemeable, PrivateModeUI {
         accessibilityValue = isSelected ? .TabTrayToggleAccessibilityValueOn : .TabTrayToggleAccessibilityValueOff
     }
 
-    func applyTheme() {
+    func applyTheme(theme: Theme) {
+        onTint = theme.colors.iconOnColor
+        offTint = theme.colors.iconDisabled
         tintColor = isSelected ? onTint : offTint
         imageView?.tintColor = tintColor
     }

--- a/Client/Frontend/Browser/TabTrayButtonExtensions.swift
+++ b/Client/Frontend/Browser/TabTrayButtonExtensions.swift
@@ -31,7 +31,7 @@ class PrivateModeButton: ToggleButton, PrivateModeUI {
 
     func applyTheme(theme: Theme) {
         onTint = theme.colors.iconOnColor
-        offTint = theme.colors.iconDisabled
+        offTint = theme.colors.iconPrimary
         tintColor = isSelected ? onTint : offTint
         imageView?.tintColor = tintColor
     }

--- a/Client/Frontend/Browser/Tabs/EmptyPrivateTabsView.swift
+++ b/Client/Frontend/Browser/Tabs/EmptyPrivateTabsView.swift
@@ -34,12 +34,10 @@ class EmptyPrivateTabsView: UIView {
     }
     let learnMoreButton: UIButton = .build { button in
         button.setTitle( .PrivateBrowsingLearnMore, for: [])
-        button.setTitleColor(UIColor.theme.tabTray.privateModeLearnMore, for: [])
         button.titleLabel?.font = EmptyPrivateTabsViewUX.LearnMoreFont
     }
     let iconImageView: UIImageView = .build { imageView in
         imageView.image = UIImage.templateImageNamed("largePrivateMask")
-        imageView.tintColor = UIColor.Photon.Grey60
     }
 
     // MARK: - Inits
@@ -64,24 +62,16 @@ class EmptyPrivateTabsView: UIView {
             learnMoreButton.topAnchor.constraint(equalTo: descriptionLabel.bottomAnchor, constant: CGFloat(EmptyPrivateTabsViewUX.LearnMoreMargin)),
             learnMoreButton.centerXAnchor.constraint(equalTo: centerXAnchor),
         ])
-
-        applyTheme()
-
-        NotificationCenter.default.addObserver(self, selector: #selector(applyTheme), name: .DisplayThemeChanged, object: nil)
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-}
-
-extension EmptyPrivateTabsView: NotificationThemeable {
-    @objc func applyTheme() {
-        titleLabel.textColor = UIColor.theme.tabTray.tabTitleText
-        descriptionLabel.textColor = UIColor.theme.tabTray.tabTitleText
+    func applyTheme(_ theme: Theme) {
+        titleLabel.textColor = theme.colors.textPrimary
+        descriptionLabel.textColor = theme.colors.textPrimary
+        learnMoreButton.setTitleColor(theme.colors.borderAccentPrivate, for: [])
+        iconImageView.tintColor = theme.colors.indicatorActive
     }
 }

--- a/Client/Frontend/Browser/Tabs/EmptyPrivateTabsView.swift
+++ b/Client/Frontend/Browser/Tabs/EmptyPrivateTabsView.swift
@@ -71,7 +71,7 @@ class EmptyPrivateTabsView: UIView {
     func applyTheme(_ theme: Theme) {
         titleLabel.textColor = theme.colors.textPrimary
         descriptionLabel.textColor = theme.colors.textPrimary
-        learnMoreButton.setTitleColor(theme.colors.borderAccentPrivate, for: [])
+        learnMoreButton.setTitleColor(theme.colors.textAccent, for: [])
         iconImageView.tintColor = theme.colors.indicatorActive
     }
 }

--- a/Client/Frontend/Browser/Tabs/EmptyPrivateTabsView.swift
+++ b/Client/Frontend/Browser/Tabs/EmptyPrivateTabsView.swift
@@ -71,7 +71,7 @@ class EmptyPrivateTabsView: UIView {
     func applyTheme(_ theme: Theme) {
         titleLabel.textColor = theme.colors.textPrimary
         descriptionLabel.textColor = theme.colors.textPrimary
-        learnMoreButton.setTitleColor(theme.colors.textAccent, for: [])
+        learnMoreButton.setTitleColor(theme.colors.borderAccentPrivate, for: [])
         iconImageView.tintColor = theme.colors.indicatorActive
     }
 }

--- a/Client/Frontend/Browser/Tabs/GroupedTabCell.swift
+++ b/Client/Frontend/Browser/Tabs/GroupedTabCell.swift
@@ -41,6 +41,7 @@ class GroupedTabCell: UICollectionViewCell, NotificationThemeable, UITableViewDa
     let GroupedTabsHeaderIdentifier = "GroupedTabsHeaderIdentifier"
     let GroupedTabCellIdentifier = "GroupedTabCellIdentifier"
     var hasExpanded = true
+    var theme: Theme = LightTheme()
 
     // Views
     lazy var tableView: UITableView = {
@@ -92,6 +93,7 @@ class GroupedTabCell: UICollectionViewCell, NotificationThemeable, UITableViewDa
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: GroupedTabCellIdentifier, for: indexPath) as! GroupedTabContainerCell
         cell.delegate = self
+        cell.theme = theme
         cell.tabs = tabGroups?.map { $0.groupedItems }[indexPath.item]
         cell.titleLabel.text = tabGroups?.map { $0.searchTerm }[indexPath.item] ?? ""
         cell.collectionView.reloadData()
@@ -200,8 +202,8 @@ class GroupedTabContainerCell: UITableViewCell, UICollectionViewDelegateFlowLayo
     var tabs: [Tab]?
     var selectedTab: Tab?
     var searchGroupName: String = ""
-    var notificationCenter: NotificationProtocol = NotificationCenter.default
-
+    var theme: Theme = LightTheme()
+    
     lazy var collectionView: UICollectionView = {
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.scrollDirection = .horizontal
@@ -224,7 +226,6 @@ class GroupedTabContainerCell: UITableViewCell, UICollectionViewDelegateFlowLayo
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         initialViewSetup()
-        setupNotifications(forObserver: self, observing: [.DisplayThemeChanged])
     }
 
     required init?(coder: NSCoder) {
@@ -349,7 +350,9 @@ class GroupedTabContainerCell: UITableViewCell, UICollectionViewDelegateFlowLayo
         else { return cell }
 
         tabCell.delegate = self
-        tabCell.configureWith(tab: tab, isSelected: selectedTab == tab)
+        tabCell.configureWith(tab: tab,
+                              isSelected: selectedTab == tab,
+                              theme: theme)
         tabCell.animator = nil
         return tabCell
     }
@@ -357,17 +360,6 @@ class GroupedTabContainerCell: UITableViewCell, UICollectionViewDelegateFlowLayo
     func tabCellDidClose(_ cell: TabCell) {
         if let indexPath = collectionView.indexPath(for: cell), let tab = tabs?[indexPath.item] {
             delegate?.closeTab(tab: tab)
-        }
-    }
-}
-
-// MARK: - Notifiable
-extension GroupedTabContainerCell: Notifiable {
-    func handleNotifications(_ notification: Notification) {
-        switch notification.name {
-        case .DisplayThemeChanged:
-            applyTheme()
-        default: break
         }
     }
 }

--- a/Client/Frontend/Browser/Tabs/GroupedTabCell.swift
+++ b/Client/Frontend/Browser/Tabs/GroupedTabCell.swift
@@ -163,10 +163,10 @@ class GroupedTabCell: UICollectionViewCell, NotificationThemeable, UITableViewDa
 }
 
 class GroupedTabContainerCell: UITableViewCell,
-                                UICollectionViewDelegateFlowLayout,
-                                UICollectionViewDataSource,
-                                TabCellDelegate,
-                                ReusableCell {
+                               UICollectionViewDelegateFlowLayout,
+                               UICollectionViewDataSource,
+                               TabCellDelegate,
+                               ReusableCell {
 
     // Delegate
     var delegate: GroupedTabsDelegate?

--- a/Client/Frontend/Browser/Tabs/GroupedTabCell.swift
+++ b/Client/Frontend/Browser/Tabs/GroupedTabCell.swift
@@ -37,18 +37,13 @@ class GroupedTabCell: UICollectionViewCell, NotificationThemeable, UITableViewDa
     var tabDisplayManagerDelegate: GroupedTabDelegate?
     var tabGroups: [ASGroup<Tab>]?
     var selectedTab: Tab?
-    let GroupedTabsTableIdentifier = "GroupedTabsTableIdentifier"
-    let GroupedTabsHeaderIdentifier = "GroupedTabsHeaderIdentifier"
-    let GroupedTabCellIdentifier = "GroupedTabCellIdentifier"
     var hasExpanded = true
     var theme: Theme = LightTheme()
 
     // Views
     lazy var tableView: UITableView = {
         let tableView = UITableView(frame: .zero, style: .grouped)
-        tableView.register(OneLineTableViewCell.self, forCellReuseIdentifier: GroupedTabsTableIdentifier)
-        tableView.register(GroupedTabContainerCell.self, forCellReuseIdentifier: GroupedTabCellIdentifier)
-        tableView.register(InactiveTabHeader.self, forHeaderFooterViewReuseIdentifier: GroupedTabsHeaderIdentifier)
+        tableView.register(GroupedTabContainerCell.self, forCellReuseIdentifier: GroupedTabContainerCell.cellIdentifier)
         tableView.allowsMultipleSelectionDuringEditing = false
         tableView.sectionHeaderHeight = 0
         tableView.sectionFooterHeight = 0
@@ -91,7 +86,8 @@ class GroupedTabCell: UICollectionViewCell, NotificationThemeable, UITableViewDa
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: GroupedTabCellIdentifier, for: indexPath) as! GroupedTabContainerCell
+        let cell = tableView.dequeueReusableCell(withIdentifier: GroupedTabContainerCell.cellIdentifier,
+                                                 for: indexPath) as! GroupedTabContainerCell
         cell.delegate = self
         cell.theme = theme
         cell.tabs = tabGroups?.map { $0.groupedItems }[indexPath.item]
@@ -166,17 +162,17 @@ class GroupedTabCell: UICollectionViewCell, NotificationThemeable, UITableViewDa
     }
 }
 
-class GroupedTabContainerCell: UITableViewCell, UICollectionViewDelegateFlowLayout, UICollectionViewDataSource, TabCellDelegate {
+class GroupedTabContainerCell: UITableViewCell,
+                                UICollectionViewDelegateFlowLayout,
+                                UICollectionViewDataSource,
+                                TabCellDelegate,
+                                ReusableCell {
 
     // Delegate
     var delegate: GroupedTabsDelegate?
 
     // Views
-    var selectedView: UIView = {
-        let view = UIView()
-        view.backgroundColor = UIColor.theme.tableView.selectedBackground
-        return view
-    }()
+    var selectedView = UIView()
 
     lazy var searchButton: UIButton = .build { button in
         button.setImage(UIImage(named: "search")?.withTintColor(.label), for: [.normal])
@@ -197,18 +193,16 @@ class GroupedTabContainerCell: UITableViewCell, UICollectionViewDelegateFlowLayo
 
     let containerView = UIView()
     let midView = UIView()
-
-    let singleTabCellIdentifier = "singleTabCellIdentifier"
     var tabs: [Tab]?
     var selectedTab: Tab?
     var searchGroupName: String = ""
     var theme: Theme = LightTheme()
-    
+
     lazy var collectionView: UICollectionView = {
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.scrollDirection = .horizontal
         let collectionView = UICollectionView(frame: CGRect.zero, collectionViewLayout: flowLayout)
-        collectionView.register(TabCell.self, forCellWithReuseIdentifier: singleTabCellIdentifier)
+        collectionView.register(TabCell.self, forCellWithReuseIdentifier: TabCell.cellIdentifier)
         collectionView.showsVerticalScrollIndicator = false
         collectionView.showsHorizontalScrollIndicator = false
         collectionView.bounces = false
@@ -282,12 +276,8 @@ class GroupedTabContainerCell: UITableViewCell, UICollectionViewDelegateFlowLayo
     }
 
     private func applyTheme() {
-        if LegacyThemeManager.instance.currentName == .normal {
-            collectionView.backgroundColor = UIColor.Photon.White100
-        } else {
-            collectionView.backgroundColor = UIColor.Photon.DarkGrey50
-        }
-
+        selectedView.backgroundColor = theme.colors.layer3
+        collectionView.backgroundColor = theme.colors.layer5
     }
 
     override func prepareForReuse() {
@@ -344,7 +334,7 @@ class GroupedTabContainerCell: UITableViewCell, UICollectionViewDelegateFlowLayo
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: singleTabCellIdentifier, for: indexPath)
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TabCell.cellIdentifier, for: indexPath)
         guard let tabCell = cell as? TabCell,
               let tab = tabs?[indexPath.item]
         else { return cell }

--- a/Client/Frontend/Browser/Tabs/InactiveTabCell.swift
+++ b/Client/Frontend/Browser/Tabs/InactiveTabCell.swift
@@ -32,7 +32,6 @@ class InactiveTabCell: UICollectionViewCell, ReusableCell {
     }
 
     // MARK: - Properties
-    var notificationCenter: NotificationProtocol = NotificationCenter.default
     var inactiveTabsViewModel: InactiveTabViewModel?
     var hasExpanded = false
     weak var delegate: InactiveTabsDelegate?
@@ -73,9 +72,6 @@ class InactiveTabCell: UICollectionViewCell, ReusableCell {
         containerView.addSubviews(tableView)
         addSubviews(containerView)
         setupConstraints()
-        applyTheme()
-
-        setupNotifications(forObserver: self, observing: [.DisplayThemeChanged])
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -271,23 +267,11 @@ extension InactiveTabCell: UITableViewDataSource, UITableViewDelegate {
 
         return tab.url?.domainURL
     }
-}
 
-extension InactiveTabCell: NotificationThemeable {
-    @objc func applyTheme() {
-        self.backgroundColor = .clear
-        self.tableView.backgroundColor = .clear
+    func applyTheme(_ theme: Theme) {
+        backgroundColor = .clear
+        tableView.backgroundColor = .clear
+        containerView.backgroundColor = theme.colors.layer5
         tableView.reloadData()
-        let theme = BuiltinThemeName(rawValue: LegacyThemeManager.instance.current.name) ?? .normal
-        containerView.backgroundColor = theme == .normal ? .white : .Photon.DarkGrey50
-    }
-}
-
-extension InactiveTabCell: Notifiable {
-    func handleNotifications(_ notification: Notification) {
-        switch notification.name {
-        case .DisplayThemeChanged: applyTheme()
-        default: break
-        }
     }
 }

--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -184,8 +184,7 @@ class TabTrayViewController: UIViewController, Themeable {
         super.init(nibName: nil, bundle: nil)
 
         setupNotifications(forObserver: self,
-                           observing: [.DisplayThemeChanged,
-                                       .ProfileDidStartSyncing,
+                           observing: [.ProfileDidStartSyncing,
                                        .ProfileDidFinishSyncing,
                                        .UpdateLabelOnTabClosed])
     }

--- a/Client/Frontend/Browser/TopTabCell.swift
+++ b/Client/Frontend/Browser/TopTabCell.swift
@@ -77,7 +77,7 @@ class TopTabCell: UICollectionViewCell, NotificationThemeable, TabTrayCell, Reus
         setupLayout()
     }
 
-    func configureWith(tab: Tab, isSelected selected: Bool) {
+    func configureWith(tab: Tab, isSelected selected: Bool, theme: Theme) {
         isSelectedTab = selected
 
         titleText.text = tab.getTabTrayTitle()

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -94,12 +94,14 @@ class TopTabsViewController: UIViewController {
         self.profile = profile
         super.init(nibName: nil, bundle: nil)
 
+        // TODO: Update to use real theme
         topTabDisplayManager = TabDisplayManager(collectionView: self.collectionView,
                                                  tabManager: self.tabManager,
                                                  tabDisplayer: self,
                                                  reuseID: TopTabCell.cellIdentifier,
                                                  tabDisplayType: .TopTabTray,
-                                                 profile: profile)
+                                                 profile: profile,
+                                                 theme: LightTheme())
         tabManager.tabDisplayType = .TopTabTray
         collectionView.dataSource = topTabDisplayManager
         collectionView.delegate = tabLayoutDelegate
@@ -273,7 +275,8 @@ extension TopTabsViewController: TabDisplayer {
         guard let tabCell = cell as? TopTabCell else { return UICollectionViewCell() }
         tabCell.delegate = self
         let isSelected = (tab == tabManager.selectedTab)
-        tabCell.configureWith(tab: tab, isSelected: isSelected)
+        // TODO: Update to pass in the theme
+        tabCell.configureWith(tab: tab, isSelected: isSelected, theme: LightTheme())
         // Not all cells are visible when the appearance changes. Let's make sure
         // the cell has the proper theme when recycled.
         tabCell.applyTheme()

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -27,7 +27,7 @@ protocol TopTabsDelegate: AnyObject {
     func topTabsDidChangeTab()
 }
 
-class TopTabsViewController: UIViewController {
+class TopTabsViewController: UIViewController, Themeable {
 
     // MARK: - Properties
     let tabManager: TabManager
@@ -35,6 +35,9 @@ class TopTabsViewController: UIViewController {
     private var topTabDisplayManager: TabDisplayManager!
     var tabCellIdentifer: TabDisplayer.TabCellIdentifer = TopTabCell.cellIdentifier
     var profile: Profile
+    var themeManager: ThemeManager
+    var themeObserver: NSObjectProtocol?
+    var notificationCenter: NotificationProtocol
 
     // MARK: - UI Elements
     lazy var collectionView: UICollectionView = {
@@ -89,19 +92,23 @@ class TopTabsViewController: UIViewController {
     }()
 
     // MARK: - Inits
-    init(tabManager: TabManager, profile: Profile) {
+    init(tabManager: TabManager,
+         profile: Profile,
+         themeManager: ThemeManager = AppContainer.shared.resolve(),
+         notificationCenter: NotificationProtocol = NotificationCenter.default) {
         self.tabManager = tabManager
         self.profile = profile
+        self.themeManager = themeManager
+        self.notificationCenter = notificationCenter
         super.init(nibName: nil, bundle: nil)
 
-        // TODO: Update to use real theme
         topTabDisplayManager = TabDisplayManager(collectionView: self.collectionView,
                                                  tabManager: self.tabManager,
                                                  tabDisplayer: self,
                                                  reuseID: TopTabCell.cellIdentifier,
                                                  tabDisplayType: .TopTabTray,
                                                  profile: profile,
-                                                 theme: LightTheme())
+                                                 theme: themeManager.currentTheme)
         tabManager.tabDisplayType = .TopTabTray
         collectionView.dataSource = topTabDisplayManager
         collectionView.delegate = tabLayoutDelegate
@@ -275,8 +282,9 @@ extension TopTabsViewController: TabDisplayer {
         guard let tabCell = cell as? TopTabCell else { return UICollectionViewCell() }
         tabCell.delegate = self
         let isSelected = (tab == tabManager.selectedTab)
-        // TODO: Update to pass in the theme
-        tabCell.configureWith(tab: tab, isSelected: isSelected, theme: LightTheme())
+        tabCell.configureWith(tab: tab,
+                              isSelected: isSelected,
+                              theme: themeManager.currentTheme)
         // Not all cells are visible when the appearance changes. Let's make sure
         // the cell has the proper theme when recycled.
         tabCell.applyTheme()
@@ -295,20 +303,17 @@ extension TopTabsViewController: NotificationThemeable, PrivateModeUI {
     func applyUIMode(isPrivate: Bool) {
         topTabDisplayManager.togglePrivateMode(isOn: isPrivate, createTabOnEmptyPrivateMode: true)
 
-        privateModeButton.onTint = UIColor.theme.topTabs.privateModeButtonOnTint
-        privateModeButton.offTint = UIColor.theme.topTabs.privateModeButtonOffTint
+        privateModeButton.applyTheme(theme: themeManager.currentTheme)
         privateModeButton.applyUIMode(isPrivate: topTabDisplayManager.isPrivate)
     }
 
     func applyTheme() {
-        view.backgroundColor = UIColor.theme.topTabs.background
+        view.backgroundColor = themeManager.currentTheme.colors.layer3
         tabsButton.applyTheme()
-        privateModeButton.onTint = UIColor.theme.topTabs.privateModeButtonOnTint
-        privateModeButton.offTint = UIColor.theme.topTabs.privateModeButtonOffTint
-        privateModeButton.applyTheme()
-        newTab.tintColor = UIColor.theme.topTabs.buttonTint
+
+        newTab.tintColor = themeManager.currentTheme.colors.textSecondary
         collectionView.backgroundColor = view.backgroundColor
-        (collectionView.visibleCells as? [TopTabCell])?.forEach { $0.applyTheme() }
+        collectionView.reloadData()
         topTabDisplayManager.refreshStore()
     }
 }

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -310,8 +310,8 @@ extension TopTabsViewController: NotificationThemeable, PrivateModeUI {
     func applyTheme() {
         view.backgroundColor = themeManager.currentTheme.colors.layer3
         tabsButton.applyTheme()
-
-        newTab.tintColor = themeManager.currentTheme.colors.textSecondary
+        privateModeButton.applyTheme(theme: themeManager.currentTheme)
+        newTab.tintColor = themeManager.currentTheme.colors.iconPrimary
         collectionView.backgroundColor = view.backgroundColor
         collectionView.reloadData()
         topTabDisplayManager.refreshStore()

--- a/Tests/ClientTests/TabDisplayManagerTests.swift
+++ b/Tests/ClientTests/TabDisplayManagerTests.swift
@@ -256,7 +256,8 @@ extension TabDisplayManagerTests {
                                                   tabDisplayer: self,
                                                   reuseID: TopTabCell.cellIdentifier,
                                                   tabDisplayType: .TopTabTray,
-                                                  profile: profile)
+                                                  profile: profile,
+                                                  theme: LightTheme())
         collectionView.dataSource = tabDisplayManager
         tabDisplayManager.dataStore = useMockDataStore ? mockDataStore : dataStore
         return tabDisplayManager
@@ -282,7 +283,7 @@ extension TabDisplayManagerTests: TabDisplayer {
     func cellFactory(for cell: UICollectionViewCell, using tab: Tab) -> UICollectionViewCell {
         guard let tabCell = cell as? TabTrayCell else { return UICollectionViewCell() }
         let isSelected = (tab == manager.selectedTab)
-        tabCell.configureWith(tab: tab, isSelected: isSelected)
+        tabCell.configureWith(tab: tab, isSelected: isSelected, theme: LightTheme())
         return tabCell
     }
 }


### PR DESCRIPTION
Here are some screenshots of the tabs tray for design review.

![1](https://user-images.githubusercontent.com/3929954/195363026-a8e763e0-0405-482a-9d45-fd16ccc6ea7b.PNG)
![2](https://user-images.githubusercontent.com/3929954/195363030-f4a50490-ebb0-4892-bbee-36b1d2dea308.PNG)
![3](https://user-images.githubusercontent.com/3929954/195363034-4a8e86c0-b11b-4836-a902-e35daa86b570.PNG)
![4](https://user-images.githubusercontent.com/3929954/195363039-e8ef5906-cf4c-4ae1-a81f-50b01d57ceb9.PNG)
![5](https://user-images.githubusercontent.com/3929954/195363043-880e7164-c5d5-4e76-924b-8a971c7d591f.PNG)
![6](https://user-images.githubusercontent.com/3929954/195363045-12bcbee9-820f-446c-9cc7-3074851f736d.PNG)
![7](https://user-images.githubusercontent.com/3929954/195363046-aff13cca-d0c7-4712-9d6a-3af61249b4d3.PNG)
![8](h
![Screen Shot 2022-10-12 at 9 45 00 AM](https://user-images.githubusercontent.com/3929954/195363087-84799556-2fd0-4e8d-8ce5-dc37ea252fc5.png)
![Screen Shot 2022-10-12 at 9 48 54 AM](https://user-images.githubusercontent.com/3929954/195363092-0219219a-2583-44ac-9654-c27207cd46f4.png)
![Screen Shot 2022-10-12 at 9 48 59 AM](https://user-images.githubusercontent.com/3929954/195363097-2d8517de-6842-46e5-abb2-e22c7f606642.png)
![Screen Shot 2022-10-12 at 9 49 17 AM](https://user-images.githubusercontent.com/3929954/195363098-dca8a19c-f4c0-4196-8abf-d8dc30528a82.png)
ttps://user-images.githubusercontent.com/3929954/195363048-8c9db618-83c2-4dc1-8c03-a0e71105557b.PNG)
