### PR TITLE
Bugfix FXIOS-3746 [v107] tapping on view from the toast will open a new tab

### DIFF
--- a/Client/Frontend/Browser/Tab Management/TabManager.swift
+++ b/Client/Frontend/Browser/Tab Management/TabManager.swift
@@ -42,6 +42,7 @@ protocol TabManagerProtocol {
 
     func selectTab(_ tab: Tab?, previous: Tab?)
     func addTab(_ request: URLRequest?, afterTab: Tab?, isPrivate: Bool) -> Tab
+    func getMostRecentHomepageTab() -> Tab?
 }
 
 // TabManager must extend NSObjectProtocol in order to implement WKNavigationDelegate
@@ -267,6 +268,13 @@ class TabManager: NSObject, FeatureFlaggable, TabManagerProtocol {
             tab.applyTheme()
         }
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .tab)
+    }
+
+    func getMostRecentHomepageTab() -> Tab? {
+        let tabsToFilter = selectedTab?.isPrivate ?? false ? privateTabs : normalTabs
+        let homePageTabs = tabsToFilter.filter { $0.isFxHomeTab }
+
+        return mostRecentTab(inTabs: homePageTabs)
     }
 
     // MARK: - Clear and store

--- a/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewController.swift
+++ b/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewController.swift
@@ -235,11 +235,7 @@ private extension WallpaperSettingsViewController {
     func dismissView() {
         guard let navigationController = self.navigationController as? ThemedNavigationController else { return }
 
-        if let isFxHomeTab = viewModel.tabManager.selectedTab?.isFxHomeTab, !isFxHomeTab {
-            viewModel.tabManager.selectTab(viewModel.tabManager.addTab(nil, afterTab: nil, isPrivate: false),
-                                           previous: nil)
-        }
-
+        viewModel.selectHomepageTab()
         navigationController.done()
     }
 

--- a/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewModel.swift
+++ b/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewModel.swift
@@ -147,6 +147,22 @@ class WallpaperSettingsViewModel {
     func removeAssetsOnDismiss() {
         wallpaperManager.removeUnusedAssets()
     }
+
+    func selectHomepageTab() {
+        let homepageTab = getHomepageTab(isPrivate: tabManager.selectedTab?.isPrivate ?? false)
+
+        tabManager.selectTab(homepageTab, previous: nil)
+    }
+
+    /// Get mostRecentHomePage used if none is available we add and select a new homepage Tab
+    /// - Parameter isPrivate: If private mode is selected
+    private func getHomepageTab(isPrivate: Bool) -> Tab {
+        guard let homepageTab = tabManager.getMostRecentHomepageTab() else {
+            return tabManager.addTab(nil, afterTab: nil, isPrivate: isPrivate)
+        }
+
+        return homepageTab
+    }
 }
 
 private extension WallpaperSettingsViewModel {

--- a/Tests/ClientTests/Frontend/Browser/Tab Management/TabManagerTests.swift
+++ b/Tests/ClientTests/Frontend/Browser/Tab Management/TabManagerTests.swift
@@ -603,6 +603,62 @@ class TabManagerTests: XCTestCase {
             self.delegate.verify("Not all delegate methods were called")
         }
     }
+
+    func testGetMostRecentHomePageTab_NilHomepage() {
+        let urlTab = manager.addTab(URLRequest(url: URL(string: "https://test.com")!))
+        manager.selectTab(urlTab)
+
+        XCTAssertNil(manager.getMostRecentHomepageTab())
+    }
+
+    func testGetMostRecentHomePageTab_ExistingHomepage() {
+        let homepageTab = manager.addTab()
+        let urlTab = manager.addTab(URLRequest(url: URL(string: "https://test.com")!))
+        manager.selectTab(homepageTab)
+        manager.selectTab(urlTab)
+
+        XCTAssertEqual(manager.getMostRecentHomepageTab(), homepageTab)
+    }
+
+    func testGetMostRecentHomePageTab_LastCreated() {
+        let firstHomepageTab = manager.addTab()
+        let secondHomepageTab = manager.addTab()
+        manager.selectTab(firstHomepageTab)
+        manager.selectTab(secondHomepageTab)
+
+        XCTAssertEqual(manager.getMostRecentHomepageTab(), secondHomepageTab)
+    }
+
+    func testGetMostRecentHomePageTab_SelectingFirst() {
+        let firstHomepageTab = manager.addTab()
+        let secondHomepageTab = manager.addTab()
+        manager.selectTab(firstHomepageTab)
+        manager.selectTab(secondHomepageTab)
+        manager.selectTab(firstHomepageTab)
+
+        XCTAssertEqual(manager.getMostRecentHomepageTab(), firstHomepageTab)
+    }
+
+    func testGetMostRecentHomePageTab_LastPrivateCreated() {
+        let firstHomepageTab = manager.addTab(nil, afterTab: nil, isPrivate: true)
+        let secondHomepageTab = manager.addTab(nil, afterTab: nil, isPrivate: true)
+        manager.selectTab(firstHomepageTab)
+        manager.selectTab(secondHomepageTab)
+
+        XCTAssertEqual(manager.getMostRecentHomepageTab(), secondHomepageTab)
+    }
+
+    func testGetMostRecentHomePageTab_FirstPrivateCreated() {
+        let privateHomepageTab = manager.addTab(nil, afterTab: nil, isPrivate: true)
+        let normalHomepageTab = manager.addTab()
+        let privateUrlTab = manager.addTab(URLRequest(url: URL(string: "https://test.com")!), afterTab: nil, isPrivate: true)
+        manager.selectTab(privateHomepageTab)
+        manager.selectTab(normalHomepageTab)
+        manager.selectTab(privateUrlTab)
+
+        // Expected private homepage because last selected tab is private
+        XCTAssertEqual(manager.getMostRecentHomepageTab(), privateHomepageTab)
+    }
 }
 
 // MARK: - Helper methods

--- a/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -39,4 +39,8 @@ class MockTabManager: TabManagerProtocol {
         tabs.append(tab)
         return tab
     }
+
+    func getMostRecentHomepageTab() -> Tab? {
+        return addTab(nil, afterTab: nil, isPrivate: false)
+    }
 }


### PR DESCRIPTION
[Jira 3746](https://mozilla-hub.atlassian.net/browse/FXIOS-3746)

Notes:
- Gets more recent active homepage (from private or normal mode) if there is no homepage creates a new one
- Add func to `TabManager` to return most recent active Homepage (not necessarily last HomePage created)
- Add unit test