### PR TITLE
Revert FXIOS-4884 [v107] Implement settings theming, first pass (#12007)

### DIFF
--- a/Client/Application/NavigationRouter.swift
+++ b/Client/Application/NavigationRouter.swift
@@ -331,9 +331,7 @@ enum NavigationPath {
         case .wallpaper:
             let wallpaperManager = WallpaperManager()
             if wallpaperManager.canSettingsBeShown {
-                let viewModel = WallpaperSettingsViewModel(wallpaperManager: wallpaperManager,
-                                                           tabManager: tabManager,
-                                                           theme: baseSettingsVC.themeManager.currentTheme)
+                let viewModel = WallpaperSettingsViewModel(wallpaperManager: wallpaperManager, tabManager: tabManager)
                 let wallpaperVC = WallpaperSettingsViewController(viewModel: viewModel)
                 controller.pushViewController(wallpaperVC, animated: true)
             }

--- a/Client/Frontend/Browser/OpenWithSettingsViewController.swift
+++ b/Client/Frontend/Browser/OpenWithSettingsViewController.swift
@@ -94,7 +94,6 @@ class OpenWithSettingsViewController: ThemedTableViewController {
         cell.textLabel?.attributedText = NSAttributedString.tableRowTitle(option.name, enabled: option.enabled)
         cell.accessoryType = (currentChoice == option.scheme && option.enabled) ? .checkmark : .none
         cell.isUserInteractionEnabled = option.enabled
-        cell.applyTheme(theme: themeManager.currentTheme)
 
         return cell
     }

--- a/Client/Frontend/Login Management/LoginDataSource.swift
+++ b/Client/Frontend/Login Management/LoginDataSource.swift
@@ -52,7 +52,7 @@ class LoginDataSource: NSObject, UITableViewDataSource {
 
             let hideSettings = viewModel.searchController?.isActive ?? false || tableView.isEditing
             let setting = indexPath.row == 0 ? boolSettings.0 : boolSettings.1
-            setting.onConfigureCell(cell, theme: viewModel.theme)
+            setting.onConfigureCell(cell)
             if hideSettings {
                 cell.isHidden = true
             } else if viewModel.isDuringSearchControllerDismiss {

--- a/Client/Frontend/Login Management/LoginDetailTableViewCell.swift
+++ b/Client/Frontend/Login Management/LoginDetailTableViewCell.swift
@@ -27,7 +27,6 @@ enum LoginTableViewCellStyle {
     case iconAndDescriptionLabel
 }
 
-// TODO: Next task for FXIOS-4884 - apply ThemedTableViewCell theme
 class LoginDetailTableViewCell: ThemedTableViewCell {
 
     fileprivate lazy var labelContainer: UIView = .build { _ in }
@@ -163,9 +162,9 @@ class LoginDetailTableViewCell: ThemedTableViewCell {
         setNeedsUpdateConstraints()
     }
 
-    override func applyTheme(theme: Theme) {
-        super.applyTheme(theme: theme)
-        descriptionLabel.textColor = theme.colors.textPrimary
+    override func applyTheme() {
+        super.applyTheme()
+        descriptionLabel.textColor = UIColor.theme.tableView.rowText
     }
 }
 

--- a/Client/Frontend/Login Management/LoginListTableViewCell.swift
+++ b/Client/Frontend/Login Management/LoginListTableViewCell.swift
@@ -4,7 +4,6 @@
 
 import UIKit
 
-// TODO: Next task for FXIOS-4884 - apply ThemedTableViewCell theme
 class LoginListTableViewSettingsCell: ThemedTableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -15,7 +14,6 @@ class LoginListTableViewSettingsCell: ThemedTableViewCell {
     }
 }
 
-// TODO: Next task for FXIOS-4884 - apply ThemedTableViewCell theme
 class LoginListTableViewCell: ThemedTableViewCell {
     private let breachAlertSize: CGFloat = 24
     lazy var breachAlertImageView: UIImageView = .build { imageView in
@@ -77,6 +75,7 @@ class LoginListTableViewCell: ThemedTableViewCell {
         contentView.addSubview(contentStack)
         // Need to override the default background multi-select color to support theming
         multipleSelectionBackgroundView = UIView()
+        applyTheme()
         setConstraints()
     }
 

--- a/Client/Frontend/Login Management/LoginListViewController.swift
+++ b/Client/Frontend/Login Management/LoginListViewController.swift
@@ -19,11 +19,7 @@ private extension UITableView {
 let CellReuseIdentifier = "cell-reuse-id"
 let LoginsSettingsSection = 0
 
-class LoginListViewController: SensitiveViewController, Themeable {
-
-    var themeManager: ThemeManager
-    var themeObserver: NSObjectProtocol?
-    var notificationCenter: NotificationProtocol
+class LoginListViewController: SensitiveViewController {
 
     private let viewModel: LoginListViewModel
 
@@ -84,19 +80,11 @@ class LoginListViewController: SensitiveViewController, Themeable {
         return deferred
     }
 
-    private init(profile: Profile,
-                 webpageNavigationHandler: ((_ url: URL?) -> Void)?,
-                 themeManager: ThemeManager = AppContainer.shared.resolve(),
-                 notificationCenter: NotificationCenter = NotificationCenter.default) {
-        self.viewModel = LoginListViewModel(profile: profile,
-                                            searchController: searchController,
-                                            theme: themeManager.currentTheme)
+    private init(profile: Profile, webpageNavigationHandler: ((_ url: URL?) -> Void)?) {
+        self.viewModel = LoginListViewModel(profile: profile, searchController: searchController)
         self.loginDataSource = LoginDataSource(viewModel: self.viewModel)
         self.webpageNavigationHandler = webpageNavigationHandler
-        self.themeManager = themeManager
-        self.notificationCenter = notificationCenter
         super.init(nibName: nil, bundle: nil)
-        listenForThemeChange()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -118,8 +106,8 @@ class LoginListViewController: SensitiveViewController, Themeable {
         tableView.tableFooterView = UIView()
 
         if #available(iOS 15.0, *) {
-            tableView.sectionHeaderTopPadding = 0
-        }
+             tableView.sectionHeaderTopPadding = 0
+         }
 
         // Setup the Search Controller
         searchController.searchBar.autocapitalizationType = .none
@@ -188,7 +176,6 @@ class LoginListViewController: SensitiveViewController, Themeable {
         tableView.backgroundColor = UIColor.theme.tableView.headerBackground
         tableView.reloadData()
 
-        // TODO: Remove with legacy theme clean up FXIOS-3960
         (tableView.tableHeaderView as? NotificationThemeable)?.applyTheme()
 
         selectionButton.setTitleColor(UIColor.theme.tableView.rowBackground, for: [])
@@ -209,8 +196,6 @@ class LoginListViewController: SensitiveViewController, Themeable {
             glassIconView.image = glassIconView.image?.withRenderingMode(.alwaysTemplate)
             glassIconView.tintColor = UIColor.theme.tableView.headerTextLight
         }
-
-        loadingView.configure(theme: themeManager.currentTheme)
     }
 
     @objc func dismissLogins() {
@@ -284,7 +269,6 @@ private extension LoginListViewController {
 
     func loadLogins(_ query: String? = nil) {
         loadingView.isHidden = false
-        loadingView.configure(theme: themeManager.currentTheme)
         viewModel.loadLogins(query, loginDataSource: self.loginDataSource)
     }
 

--- a/Client/Frontend/Login Management/LoginListViewModel.swift
+++ b/Client/Frontend/Login Management/LoginListViewModel.swift
@@ -40,12 +40,9 @@ final class LoginListViewModel {
         }
     }
     var hasLoadedBreaches: Bool = false
-    var theme: Theme
-
-    init(profile: Profile, searchController: UISearchController, theme: Theme) {
+    init(profile: Profile, searchController: UISearchController) {
         self.profile = profile
         self.searchController = searchController
-        self.theme = theme
     }
 
     func loadLogins(_ query: String? = nil, loginDataSource: LoginDataSource) {

--- a/Client/Frontend/Settings/AdvancedAccountSettingViewController.swift
+++ b/Client/Frontend/Settings/AdvancedAccountSettingViewController.swift
@@ -71,14 +71,13 @@ class AdvancedAccountSettingViewController: SettingsTableViewController {
     override func generateSettings() -> [SettingSection] {
         let prefs = profile.prefs
 
-        let attributes = [NSAttributedString.Key.foregroundColor: themeManager.currentTheme.colors.textPrimary]
         let useStage = BoolSetting(
             prefs: prefs,
             prefKey: PrefsKeys.UseStageServer,
             defaultValue: false,
             attributedTitleText: NSAttributedString(
                 string: .AdvancedAccountUseStageServer,
-                attributes: attributes)) { isOn in
+                attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])) { isOn in
             self.settings = self.generateSettings()
             self.tableView.reloadData()
         }

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -80,9 +80,7 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
         case .wallpaper:
             let wallpaperManager = WallpaperManager()
             if wallpaperManager.canSettingsBeShown {
-                let viewModel = WallpaperSettingsViewModel(wallpaperManager: wallpaperManager,
-                                                           tabManager: tabManager,
-                                                           theme: themeManager.currentTheme)
+                let viewModel = WallpaperSettingsViewModel(wallpaperManager: wallpaperManager, tabManager: tabManager)
                 let wallpaperVC = WallpaperSettingsViewController(viewModel: viewModel)
                 navigationController?.pushViewController(wallpaperVC, animated: true)
             }
@@ -111,7 +109,6 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
             SiriPageSetting(settings: self),
             BoolSetting(
                 prefs: prefs,
-                theme: themeManager.currentTheme,
                 prefKey: PrefsKeys.KeyBlockPopups,
                 defaultValue: true,
                 titleText: .AppSettingsBlockPopups),
@@ -125,7 +122,7 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
         let tabTrayGroupsAreBuildActive = featureFlags.isFeatureEnabled(.tabTrayGroups, checking: .buildOnly)
         let inactiveTabsAreBuildActive = featureFlags.isFeatureEnabled(.inactiveTabs, checking: .buildOnly)
         if tabTrayGroupsAreBuildActive || inactiveTabsAreBuildActive {
-            generalSettings.insert(TabsSetting(theme: themeManager.currentTheme), at: 3)
+            generalSettings.insert(TabsSetting(), at: 3)
         }
 
         let accountChinaSyncSetting: [Setting]
@@ -144,14 +141,12 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
         generalSettings += [
             BoolSetting(
                 prefs: prefs,
-                theme: themeManager.currentTheme,
                 prefKey: "showClipboardBar",
                 defaultValue: false,
                 titleText: .SettingsOfferClipboardBarTitle,
                 statusText: .SettingsOfferClipboardBarStatus),
             BoolSetting(
                 prefs: prefs,
-                theme: themeManager.currentTheme,
                 prefKey: PrefsKeys.ContextMenuShowLinkPreviews,
                 defaultValue: true,
                 titleText: .SettingsShowLinkPreviewsTitle,
@@ -161,7 +156,7 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
         if #available(iOS 14.0, *) {
             settings += [
                 SettingSection(footerTitle: NSAttributedString(string: String.FirefoxHomepage.HomeTabBanner.EvergreenMessage.HomeTabBannerDescription),
-                               children: [DefaultBrowserSetting(theme: themeManager.currentTheme)])
+                               children: [DefaultBrowserSetting()])
             ]
         }
 
@@ -187,11 +182,10 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
 
         privacySettings += [
             BoolSetting(prefs: prefs,
-                        theme: themeManager.currentTheme,
-                        prefKey: "settings.closePrivateTabs",
-                        defaultValue: false,
-                        titleText: .AppSettingsClosePrivateTabsTitle,
-                        statusText: .AppSettingsClosePrivateTabsDescription)
+                prefKey: "settings.closePrivateTabs",
+                defaultValue: false,
+                titleText: .AppSettingsClosePrivateTabsTitle,
+                statusText: .AppSettingsClosePrivateTabsDescription)
         ]
 
         privacySettings.append(ContentBlockerSetting(settings: self))
@@ -205,9 +199,9 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
             SettingSection(title: NSAttributedString(string: .AppSettingsSupport), children: [
                 ShowIntroductionSetting(settings: self),
                 SendFeedbackSetting(),
-                SendAnonymousUsageDataSetting(prefs: prefs, delegate: settingsDelegate, theme: themeManager.currentTheme),
-                StudiesToggleSetting(prefs: prefs, delegate: settingsDelegate, theme: themeManager.currentTheme),
-                OpenSupportPageSetting(delegate: settingsDelegate, theme: themeManager.currentTheme),
+                SendAnonymousUsageDataSetting(prefs: prefs, delegate: settingsDelegate),
+                StudiesToggleSetting(prefs: prefs, delegate: settingsDelegate),
+                OpenSupportPageSetting(delegate: settingsDelegate),
             ]),
             SettingSection(title: NSAttributedString(string: .AppSettingsAbout), children: [
                 AppStoreReviewSetting(),

--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -57,7 +57,7 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
 
     fileprivate var clearButtonEnabled = true {
         didSet {
-            clearButton?.textLabel?.textColor = clearButtonEnabled ? themeManager.currentTheme.colors.textWarning : themeManager.currentTheme.colors.textDisabled
+            clearButton?.textLabel?.textColor = clearButtonEnabled ? UIColor.theme.general.destructiveRed : UIColor.theme.tableView.disabledRowText
         }
     }
 
@@ -74,7 +74,6 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        // TODO: Next task for FXIOS-4884 - apply ThemedTableViewCell theme
         let cell = ThemedTableViewCell()
 
         if indexPath.section == SectionArrow {
@@ -85,7 +84,7 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
         } else if indexPath.section == SectionToggles {
             cell.textLabel?.text = clearables[indexPath.item].clearable.label
             let control = UISwitchThemed()
-            control.onTintColor = themeManager.currentTheme.colors.actionPrimary
+            control.onTintColor = UIColor.theme.tableView.controlTint
             control.addTarget(self, action: #selector(switchValueChanged), for: .valueChanged)
             control.isOn = toggles[indexPath.item]
             cell.accessoryView = control
@@ -95,7 +94,7 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
             assert(indexPath.section == SectionButton)
             cell.textLabel?.text = .SettingsClearPrivateDataClearButton
             cell.textLabel?.textAlignment = .center
-            cell.textLabel?.textColor = themeManager.currentTheme.colors.textWarning
+            cell.textLabel?.textColor = UIColor.theme.general.destructiveRed
             cell.accessibilityTraits = UIAccessibilityTraits.button
             cell.accessibilityIdentifier = "ClearPrivateData"
             clearButton = cell

--- a/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -58,7 +58,7 @@ class TPAccessoryInfo: ThemedTableViewController {
         let header = UILabel()
         header.text = .TPAccessoryInfoBlocksTitle
         header.font = DynamicFontHelper.defaultHelper.DefaultMediumBoldFont
-        header.textColor = themeManager.currentTheme.colors.textSecondary
+        header.textColor = UIColor.theme.tableView.headerTextLight
 
         stack.addArrangedSubview(UIView())
         stack.addArrangedSubview(header)
@@ -76,7 +76,7 @@ class TPAccessoryInfo: ThemedTableViewController {
         topStack.layoutMargins = UIEdgeInsets(top: 8, left: 0, bottom: 0, right: 0)
         topStack.isLayoutMarginsRelativeArrangement = true
 
-        sep.backgroundColor = themeManager.currentTheme.colors.layer4
+        sep.backgroundColor = UIColor.theme.tableView.separator
         sep.snp.makeConstraints { make in
             make.height.equalTo(0.5)
             make.width.equalToSuperview()
@@ -93,7 +93,6 @@ class TPAccessoryInfo: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        // TODO: Next task for FXIOS-4884 - apply ThemedTableViewCell theme
         let cell = ThemedTableViewCell(style: .subtitle, reuseIdentifier: nil)
         if indexPath.section == 0 {
             if indexPath.row == 0 {
@@ -126,14 +125,14 @@ class TPAccessoryInfo: ThemedTableViewController {
                 cell.textLabel?.text = .TPCategoryDescriptionContentTrackers
             }
         }
-        cell.imageView?.tintColor = themeManager.currentTheme.colors.iconPrimary
+        cell.imageView?.tintColor = UIColor.theme.tableView.rowText
         if indexPath.row == 1 {
             cell.textLabel?.font = DynamicFontHelper.defaultHelper.DefaultMediumFont
         }
         cell.textLabel?.numberOfLines = 0
         cell.detailTextLabel?.numberOfLines = 0
         cell.backgroundColor = .clear
-        cell.textLabel?.textColor = themeManager.currentTheme.colors.textPrimary
+        cell.textLabel?.textColor = UIColor.theme.tableView.rowDetailText
         cell.selectionStyle = .none
         return cell
     }
@@ -241,7 +240,7 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
         let font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline, size: 12.0)
         var attributes = [NSAttributedString.Key: AnyObject]()
         attributes[NSAttributedString.Key.font] = font
-        attributes[NSAttributedString.Key.foregroundColor] = themeManager.currentTheme.colors.actionPrimary
+        attributes[NSAttributedString.Key.foregroundColor] = UIColor.theme.general.highlightBlue
 
         let button = UIButton()
         button.setAttributedTitle(NSAttributedString(string: title, attributes: attributes), for: .normal)

--- a/Client/Frontend/Settings/CustomSearchViewController.swift
+++ b/Client/Frontend/Settings/CustomSearchViewController.swift
@@ -32,7 +32,7 @@ class CustomSearchViewController: SettingsTableViewController {
     fileprivate var engineTitle = ""
     fileprivate lazy var spinnerView: UIActivityIndicatorView = {
         let spinner = UIActivityIndicatorView(style: .medium)
-        spinner.color = themeManager.currentTheme.colors.iconSpinnerDefault
+        spinner.color = .systemGray
         spinner.hidesWhenStopped = true
         return spinner
     }()
@@ -218,14 +218,14 @@ class CustomSearchEngineTextView: Setting, UITextViewDelegate {
         super.init(cellHeight: TextFieldHeight)
     }
 
-    override func onConfigureCell(_ cell: UITableViewCell, theme: Theme) {
-        super.onConfigureCell(cell, theme: theme)
+    override func onConfigureCell(_ cell: UITableViewCell) {
+        super.onConfigureCell(cell)
         if let id = accessibilityIdentifier {
             textField.accessibilityIdentifier = id + "TextField"
         }
 
         placeholderLabel.adjustsFontSizeToFitWidth = true
-        placeholderLabel.textColor = theme.colors.textSecondary
+        placeholderLabel.textColor = UIColor.theme.general.settingsTextPlaceholder
         placeholderLabel.text = placeholder
         placeholderLabel.isHidden = !textField.text.isEmpty
         placeholderLabel.frame = CGRect(width: TextLabelWidth, height: TextLabelHeight)
@@ -238,8 +238,8 @@ class CustomSearchEngineTextView: Setting, UITextViewDelegate {
         }
         textField.autocorrectionType = .no
         textField.delegate = self
-        textField.backgroundColor = theme.colors.layer2
-        textField.textColor = theme.colors.textPrimary
+        textField.backgroundColor = UIColor.theme.tableView.rowBackground
+        textField.textColor = UIColor.theme.tableView.rowText
         cell.isUserInteractionEnabled = true
         cell.accessibilityTraits = UIAccessibilityTraits.none
         cell.contentView.addSubview(textField)
@@ -273,7 +273,7 @@ class CustomSearchEngineTextView: Setting, UITextViewDelegate {
     func textViewDidChange(_ textView: UITextView) {
         placeholderLabel.isHidden = !textField.text.isEmpty
         settingDidChange?(textView.text)
-        let color = isValid(textField.text) ? theme.colors.textPrimary : theme.colors.textWarning
+        let color = isValid(textField.text) ? UIColor.theme.tableView.rowText : UIColor.theme.general.destructiveRed
         textField.textColor = color
     }
 

--- a/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -266,7 +266,7 @@ extension HomePageSettingViewController {
 extension HomePageSettingViewController {
     class WallpaperSettings: Setting, FeatureFlaggable {
 
-        var settings: SettingsTableViewController
+        var profile: Profile
         var tabManager: TabManager
         var wallpaperManager: WallpaperManagerInterface
 
@@ -278,7 +278,7 @@ extension HomePageSettingViewController {
              and tabManager: TabManager = BrowserViewController.foregroundBVC().tabManager,
              wallpaperManager: WallpaperManagerInterface = WallpaperManager()
         ) {
-            self.settings = settings
+            self.profile = settings.profile
             self.tabManager = tabManager
             self.wallpaperManager = wallpaperManager
             super.init(title: NSAttributedString(string: .Settings.Homepage.CustomizeFirefoxHome.Wallpaper))
@@ -286,9 +286,7 @@ extension HomePageSettingViewController {
 
         override func onClick(_ navigationController: UINavigationController?) {
             if wallpaperManager.canSettingsBeShown {
-                let viewModel = WallpaperSettingsViewModel(wallpaperManager: wallpaperManager,
-                                                           tabManager: tabManager,
-                                                           theme: settings.themeManager.currentTheme)
+                let viewModel = WallpaperSettingsViewModel(wallpaperManager: wallpaperManager, tabManager: tabManager)
                 let wallpaperVC = WallpaperSettingsViewController(viewModel: viewModel)
                 navigationController?.pushViewController(wallpaperVC, animated: true)
             }

--- a/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
+++ b/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
@@ -65,7 +65,7 @@ extension TopSitesSettingsViewController {
         init(settings: SettingsTableViewController) {
             self.profile = settings.profile
             super.init(title: NSAttributedString(string: .Settings.Homepage.Shortcuts.Rows,
-                                                 attributes: [NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary]))
+                                                 attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
         }
 
         override func onClick(_ navigationController: UINavigationController?) {

--- a/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewModel.swift
+++ b/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewModel.swift
@@ -35,7 +35,6 @@ class WallpaperSettingsViewModel {
         }
     }
 
-    private var theme: Theme
     private var wallpaperManager: WallpaperManagerInterface
     private var wallpaperCollections = [WallpaperCollection]()
     var tabManager: TabManagerProtocol
@@ -46,12 +45,9 @@ class WallpaperSettingsViewModel {
         return wallpaperCollections.count
     }
 
-    init(wallpaperManager: WallpaperManagerInterface = WallpaperManager(),
-         tabManager: TabManagerProtocol,
-         theme: Theme) {
+    init(wallpaperManager: WallpaperManagerInterface = WallpaperManager(), tabManager: TabManagerProtocol) {
         self.wallpaperManager = wallpaperManager
         self.tabManager = tabManager
-        self.theme = theme
         setupWallpapers()
     }
 
@@ -86,7 +82,6 @@ class WallpaperSettingsViewModel {
         }
 
         return WallpaperSettingsHeaderViewModel(
-            theme: theme,
             title: title,
             titleA11yIdentifier: "\(a11yIds.collectionTitle)_\(sectionIndex)",
             description: description,

--- a/Client/Frontend/Settings/LoginDetailViewController.swift
+++ b/Client/Frontend/Settings/LoginDetailViewController.swift
@@ -25,7 +25,6 @@ struct LoginDetailUX {
     static let SeparatorHeight: CGFloat = 84
 }
 
-// TODO: Next task for FXIOS-4884 - apply ThemedTableViewCell theme
 private class CenteredDetailCell: ThemedTableViewCell {
     override func layoutSubviews() {
         super.layoutSubviews()

--- a/Client/Frontend/Settings/SearchEnginePicker.swift
+++ b/Client/Frontend/Settings/SearchEnginePicker.swift
@@ -21,7 +21,6 @@ class SearchEnginePicker: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        // TODO: Next task for FXIOS-4884 - apply ThemedTableViewCell theme
         let engine = engines[indexPath.item]
         let cell = ThemedTableViewCell()
         cell.textLabel?.text = engine.shortName

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -74,7 +74,6 @@ class SearchSettingsTableViewController: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        // TODO: Next task for FXIOS-4884 - apply ThemedTableViewCell theme
         let cell = ThemedTableViewCell()
         var engine: OpenSearchEngine!
 
@@ -92,7 +91,7 @@ class SearchSettingsTableViewController: ThemedTableViewController {
             case ItemDefaultSuggestions:
                 cell.textLabel?.text = .SearchSettingsShowSearchSuggestions
                 let toggle = UISwitchThemed()
-                toggle.onTintColor = themeManager.currentTheme.colors.actionPrimary
+                toggle.onTintColor = UIColor.theme.tableView.controlTint
                 toggle.addTarget(self, action: #selector(didToggleSearchSuggestions), for: .valueChanged)
                 toggle.isOn = model.shouldShowSearchSuggestions
                 cell.editingAccessoryView = toggle
@@ -109,7 +108,7 @@ class SearchSettingsTableViewController: ThemedTableViewController {
                 cell.showsReorderControl = true
 
                 let toggle = UISwitchThemed()
-                toggle.onTintColor = themeManager.currentTheme.colors.actionPrimary
+                toggle.onTintColor = UIColor.theme.tableView.controlTint
                 // This is an easy way to get from the toggle control to the corresponding index.
                 toggle.tag = index
                 toggle.addTarget(self, action: #selector(didToggleEngine), for: .valueChanged)
@@ -201,7 +200,7 @@ class SearchSettingsTableViewController: ThemedTableViewController {
             for subViewB in subViewA.subviews {
                 if let imageView = subViewB as? UIImageView {
                     imageView.image = imageView.image?.withRenderingMode(.alwaysTemplate)
-                    imageView.tintColor = themeManager.currentTheme.colors.iconSecondary
+                    imageView.tintColor = UIColor.theme.tableView.accessoryViewTint
                 }
             }
         }

--- a/Client/Frontend/Settings/SettingsContentViewController.swift
+++ b/Client/Frontend/Settings/SettingsContentViewController.swift
@@ -13,12 +13,8 @@ let DefaultTimeoutTimeInterval = 10.0 // Seconds.  We'll want some telemetry on 
  * A controller that manages a single web view and provides a way for
  * the user to navigate back to Settings.
  */
-class SettingsContentViewController: UIViewController, WKNavigationDelegate, Themeable {
-
-    var themeManager: ThemeManager
-    var themeObserver: NSObjectProtocol?
-    var notificationCenter: NotificationProtocol
-
+class SettingsContentViewController: UIViewController, WKNavigationDelegate {
+    let interstitialBackgroundColor: UIColor
     var settingsTitle: NSAttributedString?
     var url: URL!
     var timer: Timer?
@@ -77,12 +73,9 @@ class SettingsContentViewController: UIViewController, WKNavigationDelegate, The
         self.interstitialSpinnerView.startAnimating()
     }
 
-    init(title: NSAttributedString? = nil,
-         themeManager: ThemeManager = AppContainer.shared.resolve(),
-         notificationCenter: NotificationCenter = NotificationCenter.default) {
-        self.settingsTitle = title
-        self.themeManager = themeManager
-        self.notificationCenter = notificationCenter
+    init(backgroundColor: UIColor = UIColor.Photon.White100, title: NSAttributedString? = nil) {
+        interstitialBackgroundColor = backgroundColor
+        settingsTitle = title
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -92,6 +85,10 @@ class SettingsContentViewController: UIViewController, WKNavigationDelegate, The
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        // This background agrees with the web page background.
+        // Keeping the background constant prevents a pop of mismatched color.
+        view.backgroundColor = interstitialBackgroundColor
 
         self.settingsWebView = makeWebView()
         view.addSubview(settingsWebView)
@@ -110,9 +107,6 @@ class SettingsContentViewController: UIViewController, WKNavigationDelegate, The
         }
 
         startLoading()
-
-        applyTheme()
-        listenForThemeChange()
     }
 
     func makeWebView() -> WKWebView {
@@ -140,14 +134,18 @@ class SettingsContentViewController: UIViewController, WKNavigationDelegate, The
 
     fileprivate func makeInterstitialViews() -> InterstitialViews {
         let view = UIView()
+
+        // Keeping the background constant prevents a pop of mismatched color.
+        view.backgroundColor = interstitialBackgroundColor
+
         let spinner = UIActivityIndicatorView(style: .medium)
-        spinner.color = themeManager.currentTheme.colors.iconSpinnerDefault
+        spinner.color = .systemGray
         view.addSubview(spinner)
 
         let error = UILabel()
         if let _ = settingsTitle {
             error.text = .SettingsContentPageLoadError
-            error.textColor = themeManager.currentTheme.colors.textWarning
+            error.textColor = UIColor.theme.tableView.errorText
             error.textAlignment = .center
         }
         error.isHidden = true
@@ -186,9 +184,5 @@ class SettingsContentViewController: UIViewController, WKNavigationDelegate, The
         self.timer?.invalidate()
         self.timer = nil
         self.isLoaded = true
-    }
-
-    func applyTheme() {
-        view.backgroundColor = themeManager.currentTheme.colors.layer2
     }
 }

--- a/Client/Frontend/Settings/SettingsLoadingView.swift
+++ b/Client/Frontend/Settings/SettingsLoadingView.swift
@@ -13,7 +13,9 @@ class SettingsLoadingView: UIView {
     }
 
     lazy var indicator: UIActivityIndicatorView = {
+        let isDarkTheme = LegacyThemeManager.instance.currentName == .dark
         let indicator = UIActivityIndicatorView(style: .medium)
+        indicator.color = isDarkTheme ? .white : .systemGray
         indicator.hidesWhenStopped = false
         return indicator
     }()
@@ -25,12 +27,8 @@ class SettingsLoadingView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         addSubview(indicator)
+        backgroundColor = UIColor.theme.tableView.headerBackground
         indicator.startAnimating()
-    }
-
-    func configure(theme: Theme) {
-        indicator.color = theme.colors.iconSpinnerDefault
-        backgroundColor = theme.colors.layer1
     }
 
     internal override func updateConstraints() {

--- a/Client/Frontend/Settings/SettingsNavigationController.swift
+++ b/Client/Frontend/Settings/SettingsNavigationController.swift
@@ -4,12 +4,7 @@
 
 import UIKit
 
-class ThemedNavigationController: DismissableNavigationViewController, Themeable {
-
-    var themeManager: ThemeManager = AppContainer.shared.resolve()
-    var themeObserver: NSObjectProtocol?
-    var notificationCenter: NotificationProtocol = NotificationCenter.default
-
+class ThemedNavigationController: DismissableNavigationViewController {
     var presentingModalViewControllerDelegate: PresentingModalViewControllerDelegate?
 
     @objc func done() {
@@ -29,16 +24,15 @@ class ThemedNavigationController: DismissableNavigationViewController, Themeable
         modalPresentationStyle = .overFullScreen
         modalPresentationCapturesStatusBarAppearance = true
         applyTheme()
-        listenForThemeChange()
     }
 }
 
-extension ThemedNavigationController {
-    private func setupNavigationBarAppearance(theme: Theme) {
+extension ThemedNavigationController: NotificationThemeable {
+    private func setupNavigationBarAppearance() {
         let standardAppearance = UINavigationBarAppearance()
         standardAppearance.configureWithDefaultBackground()
-        standardAppearance.backgroundColor = theme.colors.layer1
-        standardAppearance.titleTextAttributes = [.foregroundColor: theme.colors.textPrimary]
+        standardAppearance.backgroundColor = UIColor.theme.tableView.headerBackground
+        standardAppearance.titleTextAttributes = [.foregroundColor: UIColor.theme.tableView.headerTextDark]
 
         navigationBar.standardAppearance = standardAppearance
         navigationBar.compactAppearance = standardAppearance
@@ -46,14 +40,11 @@ extension ThemedNavigationController {
         if #available(iOS 15.0, *) {
             navigationBar.compactScrollEdgeAppearance = standardAppearance
         }
-        navigationBar.tintColor = theme.colors.actionPrimary
+        navigationBar.tintColor = UIColor.theme.general.controlTint
     }
-
     func applyTheme() {
-        setupNavigationBarAppearance(theme: themeManager.currentTheme)
+        setupNavigationBarAppearance()
         setNeedsStatusBarAppearanceUpdate()
-
-        // TODO: Remove with legacy theme clean up FXIOS-3960
         viewControllers.forEach {
             ($0 as? NotificationThemeable)?.applyTheme()
         }

--- a/Client/Frontend/Settings/SettingsViewController.swift
+++ b/Client/Frontend/Settings/SettingsViewController.swift
@@ -4,23 +4,15 @@
 
 import UIKit
 
-class SettingsViewController: UIViewController, Themeable {
-
-    var themeManager: ThemeManager
-    var themeObserver: NSObjectProtocol?
-    var notificationCenter: NotificationProtocol
-
+class SettingsViewController: UIViewController {
     weak var settingsDelegate: SettingsDelegate?
 
     var profile: Profile!
     var tabManager: TabManager!
 
-    init(profile: Profile? = nil,
-         tabManager: TabManager? = nil,
-         themeManager: ThemeManager = AppContainer.shared.resolve(),
-         notificationCenter: NotificationCenter = NotificationCenter.default) {
-        self.themeManager = themeManager
-        self.notificationCenter = notificationCenter
+    let theme = LegacyThemeManager.instance
+
+    init(profile: Profile? = nil, tabManager: TabManager? = nil) {
         super.init(nibName: nil, bundle: nil)
         self.profile = profile
         self.tabManager = tabManager
@@ -32,11 +24,15 @@ class SettingsViewController: UIViewController, Themeable {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        listenForThemeChange()
-        applyTheme()
+        updateTheme()
+        NotificationCenter.default.addObserver(self, selector: #selector(updateTheme), name: .DisplayThemeChanged, object: nil)
     }
 
-    func applyTheme() {
-        view.backgroundColor = themeManager.currentTheme.colors.layer1
+    @objc func updateTheme() {
+        view.backgroundColor = theme.current.tableView.headerBackground
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 }

--- a/Client/Frontend/Settings/SiriSettingsViewController.swift
+++ b/Client/Frontend/Settings/SiriSettingsViewController.swift
@@ -34,7 +34,7 @@ class SiriOpenURLSetting: Setting {
     override var accessibilityIdentifier: String? { return "SiriSettings" }
 
     init(settings: SettingsTableViewController) {
-        super.init(title: NSAttributedString(string: .SettingsSiriOpenURL, attributes: [NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary]))
+        super.init(title: NSAttributedString(string: .SettingsSiriOpenURL, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {

--- a/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -17,7 +17,7 @@ class ManageFxAccountSetting: Setting {
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
 
-        super.init(title: NSAttributedString(string: .FxAManageAccount, attributes: [NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary]))
+        super.init(title: NSAttributedString(string: .FxAManageAccount, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -33,7 +33,7 @@ class DisconnectSetting: Setting {
     override var textAlignment: NSTextAlignment { return .center }
 
     override var title: NSAttributedString? {
-        return NSAttributedString(string: .SettingsDisconnectSyncButton, attributes: [NSAttributedString.Key.foregroundColor: settingsVC.themeManager.currentTheme.colors.textWarning])
+        return NSAttributedString(string: .SettingsDisconnectSyncButton, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.general.destructiveRed])
     }
 
     init(settings: SettingsTableViewController) {
@@ -105,8 +105,8 @@ class DeviceNameSetting: StringSetting {
         }
     }
 
-    override func onConfigureCell(_ cell: UITableViewCell, theme: Theme) {
-        super.onConfigureCell(cell, theme: theme)
+    override func onConfigureCell(_ cell: UITableViewCell) {
+        super.onConfigureCell(cell)
         textField.textAlignment = .natural
     }
 

--- a/Client/Frontend/Settings/ThemeSettingsController.swift
+++ b/Client/Frontend/Settings/ThemeSettingsController.swift
@@ -23,6 +23,9 @@ class ThemeSettingsController: ThemedTableViewController {
     // A non-interactable slider is underlaid to show the current screen brightness indicator
     private var slider: (control: UISlider, deviceBrightnessIndicator: UISlider)?
 
+    // TODO decide if this is themeable, or if it is being replaced by a different style of slider
+    private let deviceBrightnessIndicatorColor = UIColor(white: 182/255, alpha: 1.0)
+
     var isAutoBrightnessOn: Bool {
         return LegacyThemeManager.instance.automaticBrightnessIsOn
     }
@@ -32,8 +35,10 @@ class ThemeSettingsController: ThemedTableViewController {
     }
 
     private var shouldHideSystemThemeSection = false
+    private let themeManager: ThemeManager
 
-    init() {
+    init(themeManager: ThemeManager = AppContainer.shared.resolve()) {
+        self.themeManager = themeManager
         super.init(style: .grouped)
     }
 
@@ -45,6 +50,7 @@ class ThemeSettingsController: ThemedTableViewController {
         super.viewDidLoad()
         title = .SettingsDisplayThemeTitle
         tableView.accessibilityIdentifier = "DisplayTheme.Setting.Options"
+        tableView.backgroundColor = UIColor.theme.tableView.headerBackground
 
         tableView.register(ThemedTableSectionHeaderFooterView.self,
                            forHeaderFooterViewReuseIdentifier: ThemedTableSectionHeaderFooterView.cellIdentifier)
@@ -56,11 +62,6 @@ class ThemeSettingsController: ThemedTableViewController {
         guard LegacyThemeManager.instance.automaticBrightnessIsOn else { return }
         LegacyThemeManager.instance.updateCurrentThemeBasedOnScreenBrightness()
         applyTheme()
-    }
-
-    override func applyTheme() {
-        super.applyTheme()
-
     }
 
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
@@ -91,7 +92,7 @@ class ThemeSettingsController: ThemedTableViewController {
             label.text = .DisplayThemeSectionFooter
             label.numberOfLines = 0
             label.font = UIFont.systemFont(ofSize: UX.footerFontSize)
-            label.textColor = self.themeManager.currentTheme.colors.textSecondary
+            label.textColor = UIColor.theme.tableView.headerTextLight
         }
         footer.addSubview(label)
         NSLayoutConstraint.activate([
@@ -155,7 +156,7 @@ class ThemeSettingsController: ThemedTableViewController {
     private func makeSlider(parent: UIView) -> UISlider {
         let size = CGSize(width: UX.moonSunIconSize, height: UX.moonSunIconSize)
         let images = [ImageIdentifiers.nightMode, "themeBrightness"].map { name in
-            UIImage(imageLiteralResourceName: name).createScaled(size).tinted(withColor: themeManager.currentTheme.colors.layerLightGrey30)
+            UIImage(imageLiteralResourceName: name).createScaled(size).tinted(withColor: UIColor.theme.browser.tint)
         }
 
         let slider: UISlider = .build { slider in
@@ -186,7 +187,7 @@ class ThemeSettingsController: ThemedTableViewController {
             let control = UISwitchThemed()
 
             control.accessibilityIdentifier = "SystemThemeSwitchValue"
-            control.onTintColor = themeManager.currentTheme.colors.actionPrimary
+            control.onTintColor = UIColor.theme.tableView.controlTint
             control.addTarget(self, action: #selector(systemThemeSwitchValueChanged), for: .valueChanged)
             control.isOn = LegacyThemeManager.instance.systemThemeIsOn
             cell.accessoryView = control
@@ -219,7 +220,7 @@ class ThemeSettingsController: ThemedTableViewController {
                 deviceBrightnessIndicator.isUserInteractionEnabled = false
                 deviceBrightnessIndicator.minimumTrackTintColor = .clear
                 deviceBrightnessIndicator.maximumTrackTintColor = .clear
-                deviceBrightnessIndicator.thumbTintColor = themeManager.currentTheme.colors.formKnob
+                deviceBrightnessIndicator.thumbTintColor = deviceBrightnessIndicatorColor
                 self.slider = (slider, deviceBrightnessIndicator)
             } else {
                 if indexPath.row == 0 {
@@ -238,7 +239,6 @@ class ThemeSettingsController: ThemedTableViewController {
                 }
             }
         }
-        cell.applyTheme(theme: themeManager.currentTheme)
 
         return cell
     }

--- a/Client/Frontend/Settings/WebsiteDataManagementViewController.swift
+++ b/Client/Frontend/Settings/WebsiteDataManagementViewController.swift
@@ -85,13 +85,7 @@ class WebsiteDataManagementViewModel {
     }
 }
 
-class WebsiteDataManagementViewController: UIViewController, UITableViewDataSource,
-                                           UITableViewDelegate, UISearchBarDelegate, Themeable {
-
-    var themeManager: ThemeManager = AppContainer.shared.resolve()
-    var themeObserver: NSObjectProtocol?
-    var notificationCenter: NotificationProtocol = NotificationCenter.default
-
+class WebsiteDataManagementViewController: UIViewController, UITableViewDataSource, UITableViewDelegate, UISearchBarDelegate {
     private enum Section: Int {
         case sites = 0
         case showMore = 1
@@ -102,7 +96,6 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
 
     fileprivate let loadingView = SettingsLoadingView()
 
-    // TODO: Next task for FXIOS-4884 - apply ThemedTableViewCell theme
     fileprivate var showMoreButton: ThemedTableViewCell?
 
     private let viewModel = WebsiteDataManagementViewModel()
@@ -110,6 +103,7 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
     var tableView: UITableView!
     var searchController: UISearchController?
     var showMoreButtonEnabled = true
+    let theme = BuiltinThemeName(rawValue: LegacyThemeManager.instance.current.name) ?? .normal
 
     private lazy var searchResultsViewController = WebsiteDataSearchResultsViewController(viewModel: viewModel)
 
@@ -121,8 +115,8 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
         tableView = UITableView()
         tableView.dataSource = self
         tableView.delegate = self
-        tableView.separatorColor = themeManager.currentTheme.colors.layer4
-        tableView.backgroundColor = themeManager.currentTheme.colors.layer1
+        tableView.separatorColor = UIColor.theme.tableView.separator
+        tableView.backgroundColor = UIColor.theme.tableView.headerBackground
         tableView.isEditing = true
         tableView.allowsMultipleSelectionDuringEditing = true
         tableView.allowsSelectionDuringEditing = true
@@ -135,7 +129,6 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
 
         view.addSubview(tableView)
         view.addSubview(loadingView)
-        loadingView.configure(theme: themeManager.currentTheme)
 
         tableView.snp.makeConstraints { make in
             make.edges.equalTo(view)
@@ -169,15 +162,14 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
         searchController.obscuresBackgroundDuringPresentation = false
         searchController.searchBar.placeholder = .SettingsFilterSitesSearchLabel
         searchController.searchBar.delegate = self
-        searchController.searchBar.barStyle = themeManager.currentTheme.type.getBarStyle()
 
+        if theme == .dark {
+            searchController.searchBar.barStyle = .black
+        }
         navigationItem.searchController = searchController
         self.searchController = searchController
 
         definesPresentationContext = true
-
-        listenForThemeChange()
-        applyTheme()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -186,7 +178,6 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        // TODO: Next task for FXIOS-4884 - apply ThemedTableViewCell theme
         let cell = ThemedTableViewCell(style: .default, reuseIdentifier: nil)
         let section = Section(rawValue: indexPath.section)!
         switch section {
@@ -201,14 +192,14 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
             }
         case .showMore:
             cell.textLabel?.text = .SettingsWebsiteDataShowMoreButton
-            cell.textLabel?.textColor = showMoreButtonEnabled ? themeManager.currentTheme.colors.actionPrimary : themeManager.currentTheme.colors.textDisabled
+            cell.textLabel?.textColor = showMoreButtonEnabled ? UIColor.theme.general.highlightBlue : UIColor.gray
             cell.accessibilityTraits = UIAccessibilityTraits.button
             cell.accessibilityIdentifier = "ShowMoreWebsiteData"
             showMoreButton = cell
         case .clearButton:
             cell.textLabel?.text = viewModel.clearButtonTitle
             cell.textLabel?.textAlignment = .center
-            cell.textLabel?.textColor = themeManager.currentTheme.colors.textWarning
+            cell.textLabel?.textColor = UIColor.theme.general.destructiveRed
             cell.accessibilityTraits = UIAccessibilityTraits.button
             cell.accessibilityIdentifier = "ClearAllWebsiteData"
         }
@@ -329,9 +320,5 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
     private func unfoldSearchbar() {
         guard let searchBarHeight = navigationItem.searchController?.searchBar.intrinsicContentSize.height else { return }
         tableView.setContentOffset(CGPoint(x: 0, y: -searchBarHeight + tableView.contentOffset.y), animated: true)
-    }
-
-    func applyTheme() {
-        loadingView.configure(theme: themeManager.currentTheme)
     }
 }

--- a/Client/Frontend/Settings/WebsiteDataSearchResultsViewController.swift
+++ b/Client/Frontend/Settings/WebsiteDataSearchResultsViewController.swift
@@ -7,12 +7,7 @@ import SnapKit
 import Shared
 import WebKit
 
-class WebsiteDataSearchResultsViewController: UIViewController, UITableViewDataSource, UITableViewDelegate, Themeable {
-
-    var themeManager: ThemeManager = AppContainer.shared.resolve()
-    var themeObserver: NSObjectProtocol?
-    var notificationCenter: NotificationProtocol = NotificationCenter.default
-
+class WebsiteDataSearchResultsViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
     private enum Section: Int {
         case sites = 0
         case clearButton = 1
@@ -41,7 +36,8 @@ class WebsiteDataSearchResultsViewController: UIViewController, UITableViewDataS
         tableView = UITableView()
         tableView.dataSource = self
         tableView.delegate = self
-
+        tableView.separatorColor = UIColor.theme.tableView.separator
+        tableView.backgroundColor = UIColor.theme.tableView.headerBackground
         tableView.isEditing = true
         tableView.allowsMultipleSelectionDuringEditing = true
         tableView.register(ThemedTableViewCell.self, forCellReuseIdentifier: "Cell")
@@ -57,9 +53,6 @@ class WebsiteDataSearchResultsViewController: UIViewController, UITableViewDataS
             make.edges.equalTo(view)
         }
         KeyboardHelper.defaultHelper.addDelegate(self)
-
-        listenForThemeChange()
-        applyTheme()
     }
 
     func reloadData() {
@@ -81,7 +74,6 @@ class WebsiteDataSearchResultsViewController: UIViewController, UITableViewDataS
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        // TODO: Next task for FXIOS-4884 - apply ThemedTableViewCell theme
         let cell = ThemedTableViewCell(style: .default, reuseIdentifier: nil)
         let section = Section(rawValue: indexPath.section)!
         switch section {
@@ -97,7 +89,7 @@ class WebsiteDataSearchResultsViewController: UIViewController, UITableViewDataS
         case .clearButton:
             cell.textLabel?.text = viewModel.clearButtonTitle
             cell.textLabel?.textAlignment = .center
-            cell.textLabel?.textColor = themeManager.currentTheme.colors.textWarning
+            cell.textLabel?.textColor = UIColor.theme.general.destructiveRed
             cell.accessibilityTraits = UIAccessibilityTraits.button
             cell.accessibilityIdentifier = "ClearAllWebsiteData"
         }
@@ -176,11 +168,6 @@ class WebsiteDataSearchResultsViewController: UIViewController, UITableViewDataS
         })
 
         tableView.reloadData()
-    }
-
-    func applyTheme() {
-        tableView.separatorColor = themeManager.currentTheme.colors.layer4
-        tableView.backgroundColor = themeManager.currentTheme.colors.layer1
     }
 }
 

--- a/Client/Frontend/Theme/DarkTheme.swift
+++ b/Client/Frontend/Theme/DarkTheme.swift
@@ -60,8 +60,5 @@ private struct DarkColourPalette: ThemeColourPalette {
     var borderAccentPrivate: UIColor = FXColors.Purple60
 
     // MARK: - Shadow
-    var shadowDefault: UIColor = FXColors.DarkGrey90.withAlphaComponent(0.16)
-
-    // MARK: - Icon Spinner
-    var iconSpinnerDefault: UIColor = FXColors.White
+    var shadow: UIColor = FXColors.DarkGrey90.withAlphaComponent(0.16)
 }

--- a/Client/Frontend/Theme/LegacyThemeManager/LegacyDarkTheme.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/LegacyDarkTheme.swift
@@ -10,16 +10,16 @@ private let defaultSeparator = UIColor.Photon.Grey60
 private let defaultTextAndTint = UIColor.Photon.Grey10
 
 private class DarkTableViewColor: TableViewColor {
-    override var rowBackground: UIColor { return UIColor.Photon.Grey70 } // layer2
-    override var rowText: UIColor { return defaultTextAndTint } // textPrimary
+    override var rowBackground: UIColor { return UIColor.Photon.Grey70 }
+    override var rowText: UIColor { return defaultTextAndTint }
     override var rowDetailText: UIColor { return UIColor.Photon.Grey30 }
-    override var disabledRowText: UIColor { return UIColor.Photon.Grey40 } // textDisabled
+    override var disabledRowText: UIColor { return UIColor.Photon.Grey40 }
     override var separator: UIColor { return UIColor.Photon.Grey60 }
     override var headerBackground: UIColor { return UIColor.Photon.Grey80 }
-    override var headerTextLight: UIColor { return UIColor.Photon.Grey30 } // textSecondary
+    override var headerTextLight: UIColor { return UIColor.Photon.Grey30 }
     override var headerTextDark: UIColor { return UIColor.Photon.Grey30 }
     override var syncText: UIColor { return defaultTextAndTint }
-    override var accessoryViewTint: UIColor { return UIColor.Photon.Grey40 } // actionSecondary
+    override var accessoryViewTint: UIColor { return UIColor.Photon.Grey40 }
     override var selectedBackground: UIColor { return UIColor.Custom.selectedHighlightDark }
 }
 

--- a/Client/Frontend/Theme/LegacyThemeManager/LegacyTheme.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/LegacyTheme.swift
@@ -28,23 +28,23 @@ private let defaultSeparator = UIColor.Photon.Grey30
 private let defaultTextAndTint = UIColor.Photon.Grey80 // textPrimary in new system
 
 class TableViewColor {
-    var rowBackground: UIColor { return UIColor.Photon.White100 } // layer2
-    var rowText: UIColor { return UIColor.Photon.Grey90 } // textPrimary
+    var rowBackground: UIColor { return UIColor.Photon.White100 }
+    var rowText: UIColor { return UIColor.Photon.Grey90 }
     var rowDetailText: UIColor { return UIColor.Photon.Grey60 }
-    var disabledRowText: UIColor { return UIColor.Photon.Grey40 } // textDisabled
-    var separator: UIColor { return defaultSeparator } // layer4
-    var headerBackground: UIColor { return defaultBackground } // layer1
+    var disabledRowText: UIColor { return UIColor.Photon.Grey40 }
+    var separator: UIColor { return defaultSeparator }
+    var headerBackground: UIColor { return defaultBackground }
     // Used for table headers in Settings and Photon menus
-    var headerTextLight: UIColor { return UIColor.Photon.Grey50 } // textSecondary
+    var headerTextLight: UIColor { return UIColor.Photon.Grey50 }
     // Used for table headers in home panel tables
     var headerTextDark: UIColor { return UIColor.Photon.Grey90 }
-    var rowActionAccessory: UIColor { return UIColor.Photon.Blue40 } // actionPrimary
-    var controlTint: UIColor { return rowActionAccessory } // actionPrimary
-    var syncText: UIColor { return defaultTextAndTint } // textPrimary
-    var errorText: UIColor { return UIColor.Photon.Red50 } // textWarning
-    var warningText: UIColor { return UIColor.Photon.Orange50 } // textWarning
-    var accessoryViewTint: UIColor { return UIColor.Photon.Grey40 } // iconSecondary
-    var selectedBackground: UIColor { return UIColor.Custom.selectedHighlightLight } // layer3
+    var rowActionAccessory: UIColor { return UIColor.Photon.Blue40 }
+    var controlTint: UIColor { return rowActionAccessory }
+    var syncText: UIColor { return defaultTextAndTint }
+    var errorText: UIColor { return UIColor.Photon.Red50 }
+    var warningText: UIColor { return UIColor.Photon.Orange50 }
+    var accessoryViewTint: UIColor { return UIColor.Photon.Grey40 }
+    var selectedBackground: UIColor { return UIColor.Custom.selectedHighlightLight }
 }
 
 class ActionMenuColor {
@@ -230,11 +230,11 @@ class SnackBarColor {
 class GeneralColor {
     var faviconBackground: UIColor { return UIColor.clear }
     var passcodeDot: UIColor { return UIColor.Photon.Grey60 }
-    var highlightBlue: UIColor { return UIColor.Photon.Blue40 } // actionPrimary
-    var destructiveRed: UIColor { return UIColor.Photon.Red50 } // textWarning
+    var highlightBlue: UIColor { return UIColor.Photon.Blue40 }
+    var destructiveRed: UIColor { return UIColor.Photon.Red50 }
     var separator: UIColor { return defaultSeparator }
-    var settingsTextPlaceholder: UIColor { return UIColor.Photon.Grey40 } // textDisabled? asked Crystal
-    var controlTint: UIColor { return UIColor.Photon.Blue40 } // actionPrimary
+    var settingsTextPlaceholder: UIColor { return UIColor.Photon.Grey40 }
+    var controlTint: UIColor { return UIColor.Photon.Blue40 }
     var switchToggle: UIColor { return UIColor.Photon.Grey90A40 }
 }
 

--- a/Client/Frontend/Theme/LegacyThemeManager/ThemedWidgets.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/ThemedWidgets.swift
@@ -3,30 +3,27 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0
 import UIKit
 
-class ThemedTableViewCell: UITableViewCell {
+class ThemedTableViewCell: UITableViewCell, NotificationThemeable {
+    var detailTextColor = UIColor.theme.tableView.disabledRowText
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
+        applyTheme()
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func applyTheme(theme: Theme) {
-        textLabel?.textColor = theme.colors.textPrimary
-        detailTextLabel?.textColor = theme.colors.textSecondary
-        backgroundColor = theme.colors.layer2
-        tintColor = theme.colors.actionPrimary
+    func applyTheme() {
+        textLabel?.textColor = UIColor.theme.tableView.rowText
+        detailTextLabel?.textColor = detailTextColor
+        backgroundColor = UIColor.theme.tableView.rowBackground
+        tintColor = UIColor.theme.general.controlTint
     }
 }
 
-class ThemedTableViewController: UITableViewController, Themeable {
-
-    var themeManager: ThemeManager = AppContainer.shared.resolve()
-    var notificationCenter: NotificationProtocol = NotificationCenter.default
-    var themeObserver: NSObjectProtocol?
-
+class ThemedTableViewController: UITableViewController, NotificationThemeable {
     override init(style: UITableView.Style = .grouped) {
         super.init(style: style)
     }
@@ -36,21 +33,20 @@ class ThemedTableViewController: UITableViewController, Themeable {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        return ThemedTableViewCell(style: .subtitle, reuseIdentifier: nil)
+        let cell = ThemedTableViewCell(style: .subtitle, reuseIdentifier: nil)
+        return cell
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
         applyTheme()
-        listenForThemeChange()
     }
 
     func applyTheme() {
-        tableView.separatorColor = themeManager.currentTheme.colors.layer4
-        tableView.backgroundColor = themeManager.currentTheme.colors.layer1
+        tableView.separatorColor = UIColor.theme.tableView.separator
+        tableView.backgroundColor = UIColor.theme.tableView.headerBackground
         tableView.reloadData()
 
-        // TODO: Remove with legacy theme clean up FXIOS-3960
         (tableView.tableHeaderView as? NotificationThemeable)?.applyTheme()
     }
 }

--- a/Client/Frontend/Theme/LightTheme.swift
+++ b/Client/Frontend/Theme/LightTheme.swift
@@ -62,8 +62,5 @@ private struct LightColourPalette: ThemeColourPalette {
     var borderAccentPrivate: UIColor = FXColors.Purple60
 
     // MARK: - Shadow
-    var shadowDefault: UIColor = FXColors.DarkGrey80.withAlphaComponent(0.16)
-
-    // MARK: - Icon Spinner
-    var iconSpinnerDefault: UIColor = FXColors.LightGrey80
+    var shadow: UIColor = FXColors.DarkGrey80.withAlphaComponent(0.16)
 }

--- a/Client/Frontend/Theme/Theme.swift
+++ b/Client/Frontend/Theme/Theme.swift
@@ -70,8 +70,5 @@ protocol ThemeColourPalette {
     var borderAccentPrivate: UIColor { get }
 
     // MARK: - Shadow
-    var shadowDefault: UIColor { get }
-
-    // MARK: - Icon Spinner
-    var iconSpinnerDefault: UIColor { get }
+    var shadow: UIColor { get }
 }

--- a/Client/Frontend/Theme/ThemeManager.swift
+++ b/Client/Frontend/Theme/ThemeManager.swift
@@ -17,15 +17,6 @@ enum ThemeType: String {
             return .dark
         }
     }
-
-    func getBarStyle() -> UIBarStyle {
-        switch self {
-        case .light:
-            return .default
-        case .dark:
-            return .black
-        }
-    }
 }
 
 protocol ThemeManager {

--- a/Tests/ClientTests/LoginsListViewModelTests.swift
+++ b/Tests/ClientTests/LoginsListViewModelTests.swift
@@ -15,9 +15,7 @@ class LoginsListViewModelTests: XCTestCase {
         super.setUp()
         let mockProfile = MockProfile()
         let searchController = UISearchController()
-        self.viewModel = LoginListViewModel(profile: mockProfile,
-                                            searchController: searchController,
-                                            theme: LightTheme())
+        self.viewModel = LoginListViewModel(profile: mockProfile, searchController: searchController)
         self.dataSource = LoginDataSource(viewModel: self.viewModel)
         self.viewModel.setBreachAlertsManager(MockBreachAlertsClient())
         self.addLogins()

--- a/Tests/ClientTests/Wallpaper/WallpaperSettingsViewModelTests.swift
+++ b/Tests/ClientTests/Wallpaper/WallpaperSettingsViewModelTests.swift
@@ -105,9 +105,7 @@ class WallpaperSettingsViewModelTests: XCTestCase {
 //    }
 
     func createSubject() -> WallpaperSettingsViewModel {
-        let subject = WallpaperSettingsViewModel(wallpaperManager: wallpaperManager,
-                                                 tabManager: MockTabManager(),
-                                                 theme: LightTheme())
+        let subject = WallpaperSettingsViewModel(wallpaperManager: wallpaperManager, tabManager: MockTabManager())
         trackForMemoryLeaks(subject)
         return subject
     }


### PR DESCRIPTION
# [FXIOS-4884](https://mozilla-hub.atlassian.net/browse/FXIOS-4884) https://github.com/mozilla-mobile/firefox-ios/issues/11825
This reverts commit 9ac46386afa7636a37daf78d8f4ab3b2517bdeed (with PR https://github.com/mozilla-mobile/firefox-ios/pull/12007). Reason is that the settings theme changes won't be done entirely for v107, and soft freeze is on Monday. To avoid rushing let's revert this 1 commit and continue work for settings theme changes for v108 instead.
