### PR TITLE
Bugfix FXIOS-5049 [v107]  Moving rows inside the mobile folder places the bookmarks one position lower

### DIFF
--- a/Client/Frontend/Library/Bookmarks/BookmarksPanelViewModel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarksPanelViewModel.swift
@@ -63,13 +63,25 @@ class BookmarksPanelViewModel {
             return
         }
 
-        _ = profile.places.updateBookmarkNode(guid: bookmarkNode.guid, position: UInt32(destinationIndexPath.row))
+        let newIndex = getNewIndex(from: destinationIndexPath.row)
+        _ = profile.places.updateBookmarkNode(guid: bookmarkNode.guid, position: UInt32(newIndex))
 
         bookmarkNodes.remove(at: sourceIndexPath.row)
         bookmarkNodes.insert(bookmarkNode, at: destinationIndexPath.row)
     }
 
     // MARK: - Private
+
+    /// Since we have a Local Desktop folder that isn't referenced in A-S under the mobile folder, we need to account for this when saving bookmark index in A-S.
+    /// This is done by substracting the Local Desktop Folder number of rows it takes to the actual index.
+    func getNewIndex(from index: Int) -> Int {
+        guard bookmarkFolderGUID == BookmarkRoots.MobileFolderGUID else {
+            return index
+        }
+
+        // Ensure we don't return lower than 0
+        return max(index - LocalDesktopFolder.numberOfRowsTaken, 0)
+    }
 
     private func setupMobileFolderData(completion: @escaping () -> Void) {
         profile.places

--- a/Tests/ClientTests/Library/BookmarkPanelViewModelTests.swift
+++ b/Tests/ClientTests/Library/BookmarkPanelViewModelTests.swift
@@ -91,6 +91,47 @@ class BookmarksPanelViewModelTests: XCTestCase {
         }
         waitForExpectations(timeout: 1)
     }
+
+    // MARK: - Move row at index
+
+    func testMoveRowAtGetNewIndex_NotMobileGuid_atZero() {
+        let subject = createSubject(guid: BookmarkRoots.MenuFolderGUID)
+        let expectedIndex = 0
+        let index = subject.getNewIndex(from: expectedIndex)
+        XCTAssertEqual(index, expectedIndex)
+    }
+
+    func testMoveRowAtGetNewIndex_NotMobileGuid_minusIndex() {
+        let subject = createSubject(guid: BookmarkRoots.MenuFolderGUID)
+        let expectedIndex = -1
+        let index = subject.getNewIndex(from: expectedIndex)
+        XCTAssertEqual(index, expectedIndex)
+    }
+
+    func testMoveRowAtGetNewIndex_NotMobileGuid_atFive() {
+        let subject = createSubject(guid: BookmarkRoots.MenuFolderGUID)
+        let expectedIndex = 5
+        let index = subject.getNewIndex(from: expectedIndex)
+        XCTAssertEqual(index, expectedIndex)
+    }
+
+    func testMoveRowAtGetNewIndex_MobileGuid_zeroIndex() {
+        let subject = createSubject(guid: BookmarkRoots.MobileFolderGUID)
+        let index = subject.getNewIndex(from: 0)
+        XCTAssertEqual(index, 0)
+    }
+
+    func testMoveRowAtGetNewIndex_MobileGuid_minusIndex() {
+        let subject = createSubject(guid: BookmarkRoots.MobileFolderGUID)
+        let index = subject.getNewIndex(from: -1)
+        XCTAssertEqual(index, 0)
+    }
+
+    func testMoveRowAtGetNewIndex_MobileGuid_atFive() {
+        let subject = createSubject(guid: BookmarkRoots.MobileFolderGUID)
+        let index = subject.getNewIndex(from: 5)
+        XCTAssertEqual(index, 4)
+    }
 }
 
 extension BookmarksPanelViewModelTests {


### PR DESCRIPTION
# [FXIOS-5049](https://mozilla-hub.atlassian.net/browse/FXIOS-5049) https://github.com/mozilla-mobile/firefox-ios/issues/12082
- Fix moving rows inside the mobile folder places the bookmarks one position lower
- Add unit tests