### PR TITLE
Refactor FXIOS-4883 [v108] Update tab tray to use ThemeApplicable

### DIFF
--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -64,7 +64,9 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate, Themeable {
     }()
 
     fileprivate lazy var tabLayoutDelegate: TabLayoutDelegate = {
-        let delegate = TabLayoutDelegate(tabDisplayManager: self.tabDisplayManager, traitCollection: self.traitCollection, scrollView: self.collectionView)
+        let delegate = TabLayoutDelegate(tabDisplayManager: self.tabDisplayManager,
+                                         traitCollection: self.traitCollection,
+                                         scrollView: self.collectionView)
         delegate.tabSelectionDelegate = self
         delegate.tabPeekDelegate = self
         return delegate
@@ -143,6 +145,7 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate, Themeable {
 
         emptyPrivateTabsView.isHidden = !privateTabsAreEmpty()
 
+        listenForThemeChange()
         applyTheme()
 
         setupNotifications(forObserver: self, observing: [

--- a/Client/Frontend/Browser/TabCell.swift
+++ b/Client/Frontend/Browser/TabCell.swift
@@ -16,7 +16,10 @@ protocol TabTrayCell where Self: UICollectionViewCell {
 }
 
 // MARK: - Tab Cell
-class TabCell: UICollectionViewCell, TabTrayCell, ReusableCell {
+class TabCell: UICollectionViewCell,
+               TabTrayCell,
+               ReusableCell,
+               ThemeApplicable {
     // MARK: - Constants
     enum Style {
         case light
@@ -164,7 +167,7 @@ class TabCell: UICollectionViewCell, TabTrayCell, ReusableCell {
     func configureWith(tab: Tab, isSelected selected: Bool, theme: Theme) {
         isSelectedTab = selected
 
-        applyColors(theme)
+        applyTheme(theme: theme)
 
         titleText.text = tab.getTabTrayTitle()
         accessibilityLabel = getA11yTitleLabel(tab: tab)
@@ -211,7 +214,7 @@ class TabCell: UICollectionViewCell, TabTrayCell, ReusableCell {
         }
     }
 
-    private func applyColors(_ theme: Theme) {
+    func applyTheme(theme: Theme) {
         backgroundHolder.backgroundColor = theme.colors.layer1
         closeButton.tintColor = theme.colors.indicatorActive
         titleText.textColor = theme.colors.textPrimary

--- a/Client/Frontend/Browser/Tabs/GroupedTabCell.swift
+++ b/Client/Frontend/Browser/Tabs/GroupedTabCell.swift
@@ -32,7 +32,12 @@ protocol GroupedTabDelegate: AnyObject {
     func newSearchFromGroup(searchTerm: String)
 }
 
-class GroupedTabCell: UICollectionViewCell, NotificationThemeable, UITableViewDataSource, UITableViewDelegate, GroupedTabsDelegate, ReusableCell {
+class GroupedTabCell: UICollectionViewCell,
+                      UITableViewDataSource,
+                      UITableViewDelegate,
+                      GroupedTabsDelegate,
+                      ReusableCell,
+                      ThemeApplicable {
 
     var tabDisplayManagerDelegate: GroupedTabDelegate?
     var tabGroups: [ASGroup<Tab>]?
@@ -59,7 +64,7 @@ class GroupedTabCell: UICollectionViewCell, NotificationThemeable, UITableViewDa
         super.init(frame: frame)
         addSubviews(tableView)
         setupConstraints()
-        applyTheme()
+        applyTheme(theme: theme)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -137,7 +142,7 @@ class GroupedTabCell: UICollectionViewCell, NotificationThemeable, UITableViewDa
         }
     }
 
-    func applyTheme() {
+    func applyTheme(theme: Theme) {
         self.backgroundColor = .clear
         self.tableView.backgroundColor = .clear
         tableView.reloadData()
@@ -166,7 +171,8 @@ class GroupedTabContainerCell: UITableViewCell,
                                UICollectionViewDelegateFlowLayout,
                                UICollectionViewDataSource,
                                TabCellDelegate,
-                               ReusableCell {
+                               ReusableCell,
+                               ThemeApplicable {
 
     // Delegate
     var delegate: GroupedTabsDelegate?
@@ -265,7 +271,7 @@ class GroupedTabContainerCell: UITableViewCell,
             make.bottom.equalToSuperview()
         }
 
-        applyTheme()
+        applyTheme(theme: theme)
     }
 
     func focusTab(tab: Tab) {
@@ -275,7 +281,7 @@ class GroupedTabContainerCell: UITableViewCell,
         }
     }
 
-    private func applyTheme() {
+    func applyTheme(theme: Theme) {
         selectedView.backgroundColor = theme.colors.layer3
         collectionView.backgroundColor = theme.colors.layer5
     }
@@ -284,7 +290,7 @@ class GroupedTabContainerCell: UITableViewCell,
         super.prepareForReuse()
         self.selectionStyle = .none
         self.titleLabel.text = searchGroupName
-        applyTheme()
+        applyTheme(theme: theme)
     }
 
     // UICollectionViewDelegateFlowLayout

--- a/Client/Frontend/Browser/Tabs/RemoteTabsPanel.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabsPanel.swift
@@ -68,7 +68,7 @@ class RemoteTabsPanel: UIViewController, Themeable, Loggable {
     func applyTheme() {
         view.backgroundColor = themeManager.currentTheme.colors.layer4
         tableViewController.tableView.backgroundColor =  themeManager.currentTheme.colors.layer3
-        tableViewController.tableView.separatorColor = themeManager.currentTheme.colors.layerLightGrey30
+        tableViewController.tableView.separatorColor = themeManager.currentTheme.colors.borderPrimary
         tableViewController.tableView.reloadData()
         tableViewController.refreshTabs()
     }
@@ -170,8 +170,6 @@ class RemoteTabsPanelClientAndTabsDataSource: NSObject, RemoteTabsPanelDataSourc
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard let headerView = tableView.dequeueReusableHeaderFooterView(
             withIdentifier: SiteTableViewHeader.cellIdentifier) as? SiteTableViewHeader else { return nil }
-        headerView.theme = theme
-        headerView.setupLayout()
         let clientTabs = self.clientAndTabs[section]
         let client = clientTabs.client
 
@@ -188,7 +186,7 @@ class RemoteTabsPanelClientAndTabsDataSource: NSObject, RemoteTabsPanelDataSourc
         headerView.tag = section
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(sectionHeaderTapped(sender:)))
         headerView.addGestureRecognizer(tapGesture)
-
+        headerView.applyTheme(theme: theme)
         /*
         * A note on timestamps.
         * We have access to two timestamps here: the timestamp of the remote client record,
@@ -253,7 +251,7 @@ class RemoteTabsPanelErrorDataSource: NSObject, RemoteTabsPanelDataSource, Theme
     weak var remoteTabsPanel: RemoteTabsPanel?
     var error: RemoteTabsError
     var notLoggedCell: UITableViewCell?
-    var theme: Theme
+    private var theme: Theme
 
     init(remoteTabsPanel: RemoteTabsPanel,
          error: RemoteTabsError,
@@ -622,7 +620,7 @@ class RemoteTabsTableViewController: UITableViewController, Themeable {
     func applyTheme() {
         tableView.separatorColor = themeManager.currentTheme.colors.layerLightGrey30
         if let delegate = tableViewDelegate as? RemoteTabsPanelErrorDataSource {
-            delegate.theme = themeManager.currentTheme
+            delegate.applyTheme(theme: themeManager.currentTheme)
         }
     }
 

--- a/Client/Frontend/Browser/Tabs/RemoteTabsPanel.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabsPanel.swift
@@ -18,23 +18,31 @@ protocol RemotePanelDelegate: AnyObject {
 }
 
 // MARK: - RemoteTabsPanel
-class RemoteTabsPanel: UIViewController, NotificationThemeable, Loggable {
+class RemoteTabsPanel: UIViewController, Themeable, Loggable {
 
+    var themeManager: ThemeManager
+    var themeObserver: NSObjectProtocol?
+    var notificationCenter: NotificationProtocol
     var remotePanelDelegate: RemotePanelDelegate?
     var profile: Profile
     lazy var tableViewController = RemoteTabsTableViewController()
 
-    init(profile: Profile) {
+    init(profile: Profile,
+         themeManager: ThemeManager = AppContainer.shared.resolve(),
+         notificationCenter: NotificationProtocol = NotificationCenter.default) {
         self.profile = profile
+        self.themeManager = themeManager
+        self.notificationCenter = notificationCenter
+
         super.init(nibName: nil, bundle: nil)
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(notificationReceived),
-                                               name: .FirefoxAccountChanged,
-                                               object: nil)
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(notificationReceived),
-                                               name: .ProfileDidFinishSyncing,
-                                               object: nil)
+        notificationCenter.addObserver(self,
+                                       selector: #selector(notificationReceived),
+                                       name: .FirefoxAccountChanged,
+                                       object: nil)
+        notificationCenter.addObserver(self,
+                                       selector: #selector(notificationReceived),
+                                       name: .ProfileDidFinishSyncing,
+                                       object: nil)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -53,14 +61,14 @@ class RemoteTabsPanel: UIViewController, NotificationThemeable, Loggable {
         }
 
         tableViewController.didMove(toParent: self)
-
+        listenForThemeChange()
         applyTheme()
     }
 
     func applyTheme() {
-        view.backgroundColor = UIColor.theme.tabTray.background
-        tableViewController.tableView.backgroundColor =  UIColor.theme.homePanel.panelBackground
-        tableViewController.tableView.separatorColor = UIColor.theme.tableView.separator
+        view.backgroundColor = themeManager.currentTheme.colors.layer4
+        tableViewController.tableView.backgroundColor =  themeManager.currentTheme.colors.layer3
+        tableViewController.tableView.separatorColor = themeManager.currentTheme.colors.layerLightGrey30
         tableViewController.tableView.reloadData()
         tableViewController.refreshTabs()
     }
@@ -122,11 +130,16 @@ class RemoteTabsPanelClientAndTabsDataSource: NSObject, RemoteTabsPanelDataSourc
     var clientAndTabs: [ClientAndTabs]
     var hiddenSections = Set<Int>()
     private let siteImageHelper: SiteImageHelper
+    private var theme: Theme
 
-    init(remoteTabPanel: RemoteTabsPanel, clientAndTabs: [ClientAndTabs], profile: Profile) {
+    init(remoteTabPanel: RemoteTabsPanel,
+         clientAndTabs: [ClientAndTabs],
+         profile: Profile,
+         theme: Theme) {
         self.remoteTabPanel = remoteTabPanel
         self.clientAndTabs = clientAndTabs
         self.siteImageHelper = SiteImageHelper(profile: profile)
+        self.theme = theme
     }
 
     @objc private func sectionHeaderTapped(sender: UIGestureRecognizer) {
@@ -157,6 +170,8 @@ class RemoteTabsPanelClientAndTabsDataSource: NSObject, RemoteTabsPanelDataSourc
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard let headerView = tableView.dequeueReusableHeaderFooterView(
             withIdentifier: SiteTableViewHeader.cellIdentifier) as? SiteTableViewHeader else { return nil }
+        headerView.theme = theme
+        headerView.setupLayout()
         let clientTabs = self.clientAndTabs[section]
         let client = clientTabs.client
 
@@ -210,7 +225,7 @@ class RemoteTabsPanelClientAndTabsDataSource: NSObject, RemoteTabsPanelDataSourc
 
         getFavicon(for: tab) { [weak cell] image in
             cell?.leftImageView.image = image
-            cell?.leftImageView.backgroundColor = UIColor.theme.general.faviconBackground
+            cell?.leftImageView.backgroundColor = .clear
         }
 
         return cell
@@ -234,15 +249,19 @@ class RemoteTabsPanelClientAndTabsDataSource: NSObject, RemoteTabsPanelDataSourc
 
 // MARK: - RemoteTabsPanelErrorDataSource
 
-class RemoteTabsPanelErrorDataSource: NSObject, RemoteTabsPanelDataSource {
+class RemoteTabsPanelErrorDataSource: NSObject, RemoteTabsPanelDataSource, ThemeApplicable {
     weak var remoteTabsPanel: RemoteTabsPanel?
     var error: RemoteTabsError
     var notLoggedCell: UITableViewCell?
+    var theme: Theme
 
-    init(remoteTabsPanel: RemoteTabsPanel, error: RemoteTabsError) {
+    init(remoteTabsPanel: RemoteTabsPanel,
+         error: RemoteTabsError,
+         theme: Theme) {
         self.remoteTabsPanel = remoteTabsPanel
         self.error = error
         self.notLoggedCell = nil
+        self.theme = theme
     }
 
     func numberOfSections(in tableView: UITableView) -> Int {
@@ -272,21 +291,26 @@ class RemoteTabsPanelErrorDataSource: NSObject, RemoteTabsPanelDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         switch error {
         case .notLoggedIn:
-            let cell = RemoteTabsNotLoggedInCell(remoteTabsPanel: remoteTabsPanel)
+            let cell = RemoteTabsNotLoggedInCell(remoteTabsPanel: remoteTabsPanel,
+                                                 theme: theme)
             self.notLoggedCell = cell
             return cell
         default:
-            let cell = RemoteTabsErrorCell(error: self.error)
+            let cell = RemoteTabsErrorCell(error: self.error,
+                                           theme: theme)
             self.notLoggedCell = nil
             return cell
         }
     }
 
+    func applyTheme(theme: Theme) {
+        self.theme = theme
+    }
 }
 
 // MARK: - RemoteTabsErrorCell
 
-class RemoteTabsErrorCell: UITableViewCell, ReusableCell {
+class RemoteTabsErrorCell: UITableViewCell, ReusableCell, ThemeApplicable {
 
     struct UX {
         static let EmptyStateInstructionsWidth = 170
@@ -297,8 +321,11 @@ class RemoteTabsErrorCell: UITableViewCell, ReusableCell {
     let titleLabel = UILabel()
     let emptyStateImageView = UIImageView()
     let instructionsLabel = UILabel()
+    var theme: Theme
 
-    init(error: RemoteTabsError) {
+    init(error: RemoteTabsError,
+         theme: Theme) {
+        self.theme = theme
         super.init(style: .default, reuseIdentifier: RemoteTabsErrorCell.cellIdentifier)
         selectionStyle = .none
 
@@ -352,28 +379,26 @@ class RemoteTabsErrorCell: UITableViewCell, ReusableCell {
 
         containerView.backgroundColor =  .clear
 
-        applyTheme()
+        applyTheme(theme: theme)
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func applyTheme() {
-        emptyStateImageView.tintColor = UIColor.theme.tableView.rowText
-        titleLabel.textColor = UIColor.theme.tableView.headerTextDark
-        instructionsLabel.textColor = UIColor.theme.tableView.headerTextDark
-        backgroundColor = UIColor.theme.tabTray.background
-
+    func applyTheme(theme: Theme) {
+        emptyStateImageView.tintColor = theme.colors.textPrimary
+        titleLabel.textColor = theme.colors.textPrimary
+        instructionsLabel.textColor = theme.colors.textPrimary
+        backgroundColor = theme.colors.layer3
     }
 }
 
 // MARK: - RemoteTabsNotLoggedInCell
 
-class RemoteTabsNotLoggedInCell: UITableViewCell, ReusableCell {
+class RemoteTabsNotLoggedInCell: UITableViewCell, ReusableCell, ThemeApplicable {
 
     struct UX {
-        static let EmptyStateSignInButtonColor = UIColor.Photon.Blue40
         static let EmptyStateSignInButtonCornerRadius: CGFloat = 4
         static let EmptyStateSignInButtonHeight = 44
         static let EmptyStateSignInButtonWidth = 200
@@ -385,8 +410,11 @@ class RemoteTabsNotLoggedInCell: UITableViewCell, ReusableCell {
     let signInButton = UIButton()
     let titleLabel = UILabel()
     let emptyStateImageView = UIImageView()
+    var theme: Theme
 
-    init(remoteTabsPanel: RemoteTabsPanel?) {
+    init(remoteTabsPanel: RemoteTabsPanel?,
+         theme: Theme) {
+        self.theme = theme
         super.init(style: .default, reuseIdentifier: RemoteTabsErrorCell.cellIdentifier)
         selectionStyle = .none
 
@@ -441,19 +469,19 @@ class RemoteTabsNotLoggedInCell: UITableViewCell, ReusableCell {
             make.top.equalTo(signInButton.snp.bottom).offset(RemoteTabsErrorCell.UX.EmptyStateTopPaddingInBetweenItems)
         }
 
-        applyTheme()
+        applyTheme(theme: theme)
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func applyTheme() {
-        emptyStateImageView.tintColor = UIColor.theme.tableView.rowText
-        titleLabel.textColor = UIColor.theme.tableView.headerTextDark
-        instructionsLabel.textColor = UIColor.theme.tableView.headerTextDark
-        signInButton.backgroundColor = UX.EmptyStateSignInButtonColor
-        backgroundColor = UIColor.theme.tabTray.background
+    func applyTheme(theme: Theme) {
+        emptyStateImageView.tintColor = theme.colors.textPrimary
+        titleLabel.textColor = theme.colors.textPrimary
+        instructionsLabel.textColor = theme.colors.textPrimary
+        signInButton.backgroundColor = theme.colors.textAccent
+        backgroundColor = theme.colors.layer4
     }
 
     @objc fileprivate func signIn() {
@@ -517,7 +545,7 @@ class RemoteTabsNotLoggedInCell: UITableViewCell, ReusableCell {
 }
 
 // MARK: - RemoteTabsTableViewController
-class RemoteTabsTableViewController: UITableViewController {
+class RemoteTabsTableViewController: UITableViewController, Themeable {
 
     struct UX {
         static let RowHeight = SiteTableViewControllerUX.RowHeight
@@ -526,6 +554,9 @@ class RemoteTabsTableViewController: UITableViewController {
 
     weak var remoteTabsPanel: RemoteTabsPanel?
     var profile: Profile!
+    var themeManager: ThemeManager
+    var themeObserver: NSObjectProtocol?
+    var notificationCenter: NotificationProtocol
     var tableViewDelegate: RemoteTabsPanelDataSource? {
         didSet {
             tableView.dataSource = tableViewDelegate
@@ -536,6 +567,17 @@ class RemoteTabsTableViewController: UITableViewController {
     fileprivate lazy var longPressRecognizer: UILongPressGestureRecognizer = {
         return UILongPressGestureRecognizer(target: self, action: #selector(longPress))
     }()
+
+    init(themeManager: ThemeManager = AppContainer.shared.resolve(),
+         notificationCenter: NotificationProtocol = NotificationCenter.default) {
+        self.themeManager = themeManager
+        self.notificationCenter = notificationCenter
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -552,8 +594,9 @@ class RemoteTabsTableViewController: UITableViewController {
         tableView.delegate = nil
         tableView.dataSource = nil
 
-        tableView.separatorColor = UIColor.theme.tableView.separator
         tableView.accessibilityIdentifier = AccessibilityIdentifiers.TabTray.syncedTabs
+        listenForThemeChange()
+        applyTheme()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -573,6 +616,13 @@ class RemoteTabsTableViewController: UITableViewController {
         super.viewWillDisappear(animated)
         if refreshControl != nil {
             removeRefreshControl()
+        }
+    }
+
+    func applyTheme() {
+        tableView.separatorColor = themeManager.currentTheme.colors.layerLightGrey30
+        if let delegate = tableViewDelegate as? RemoteTabsPanelErrorDataSource {
+            delegate.theme = themeManager.currentTheme
         }
     }
 
@@ -609,16 +659,19 @@ class RemoteTabsTableViewController: UITableViewController {
         guard let remoteTabsPanel = remoteTabsPanel else { return }
         if clientAndTabs.isEmpty {
             self.tableViewDelegate = RemoteTabsPanelErrorDataSource(remoteTabsPanel: remoteTabsPanel,
-                                                                    error: .noClients)
+                                                                    error: .noClients,
+                                                                    theme: themeManager.currentTheme)
         } else {
             let nonEmptyClientAndTabs = clientAndTabs.filter { !$0.tabs.isEmpty }
             if nonEmptyClientAndTabs.isEmpty {
                 self.tableViewDelegate = RemoteTabsPanelErrorDataSource(remoteTabsPanel: remoteTabsPanel,
-                                                                        error: .noTabs)
+                                                                        error: .noTabs,
+                                                                        theme: themeManager.currentTheme)
             } else {
                 let tabsPanelDataSource = RemoteTabsPanelClientAndTabsDataSource(remoteTabPanel: remoteTabsPanel,
                                                                                  clientAndTabs: nonEmptyClientAndTabs,
-                                                                                 profile: profile)
+                                                                                 profile: profile,
+                                                                                 theme: themeManager.currentTheme)
                 tabsPanelDataSource.collapsibleSectionDelegate = self
                 self.tableViewDelegate = tabsPanelDataSource
             }
@@ -635,7 +688,8 @@ class RemoteTabsTableViewController: UITableViewController {
         guard profile.hasSyncableAccount() else {
             self.endRefreshing()
             self.tableViewDelegate = RemoteTabsPanelErrorDataSource(remoteTabsPanel: remoteTabsPanel,
-                                                                    error: .notLoggedIn)
+                                                                    error: .notLoggedIn,
+                                                                    theme: themeManager.currentTheme)
             return
         }
 
@@ -644,7 +698,8 @@ class RemoteTabsTableViewController: UITableViewController {
             guard let clientAndTabs = result.successValue else {
                 self.endRefreshing()
                 self.tableViewDelegate = RemoteTabsPanelErrorDataSource(remoteTabsPanel: remoteTabsPanel,
-                                                                        error: .failedToSync)
+                                                                        error: .failedToSync,
+                                                                        theme: self.themeManager.currentTheme)
                 return
             }
 

--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -202,6 +202,7 @@ class TabTrayViewController: UIViewController, Themeable {
         super.viewDidLoad()
 
         viewSetup()
+        listenForThemeChange()
         applyTheme()
         updatePrivateUIState()
         panelChanged()
@@ -383,7 +384,6 @@ class TabTrayViewController: UIViewController, Themeable {
     func applyTheme() {
         view.backgroundColor = themeManager.currentTheme.colors.layer4
         navigationToolbar.barTintColor = themeManager.currentTheme.colors.layer1
-        viewModel.syncedTabsController.applyTheme()
     }
 }
 

--- a/Client/Frontend/Browser/Tabs/TabTrayViewModel.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewModel.swift
@@ -67,7 +67,10 @@ class TabTrayViewModel {
         self.profile = profile
         self.tabManager = tabManager
 
-        self.tabTrayView = GridTabViewController(tabManager: self.tabManager, profile: profile, tabTrayDelegate: tabTrayDelegate, tabToFocus: tabToFocus)
+        self.tabTrayView = GridTabViewController(tabManager: self.tabManager,
+                                                 profile: profile,
+                                                 tabTrayDelegate: tabTrayDelegate,
+                                                 tabToFocus: tabToFocus)
         self.syncedTabsController = RemoteTabsPanel(profile: self.profile)
         self.segmentToFocus = segmentToFocus
     }

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -140,6 +140,7 @@ class TopTabsViewController: UIViewController, Themeable {
         collectionView.dragDelegate = topTabDisplayManager
         collectionView.dropDelegate = topTabDisplayManager
 
+        listenForThemeChange()
         setupLayout()
 
         // Setup UIDropInteraction to handle dragging and dropping

--- a/Client/Frontend/Theme/LegacyThemeManager/LegacyTheme.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/LegacyTheme.swift
@@ -24,7 +24,7 @@ enum BuiltinThemeName: String {
 
 // Convenience reference to these normal mode colors which are used in a few color classes.
 private let defaultBackground = UIColor.Photon.Grey10 // layer1 in new system
-private let defaultSeparator = UIColor.Photon.Grey30
+private let defaultSeparator = UIColor.Photon.Grey30 // layerLightGray30
 private let defaultTextAndTint = UIColor.Photon.Grey80 // textPrimary in new system
 
 class TableViewColor {

--- a/Client/Frontend/Theme/Themable.swift
+++ b/Client/Frontend/Theme/Themable.swift
@@ -18,6 +18,7 @@ extension Themeable {
         themeObserver = notificationCenter.addObserver(name: .ThemeDidChange,
                                                        queue: mainQueue) { [weak self] _ in
             self?.applyTheme()
+            self?.updateThemeApplicableSubviews()
         }
     }
 

--- a/Client/Frontend/Widgets/SiteTableViewHeader.swift
+++ b/Client/Frontend/Widgets/SiteTableViewHeader.swift
@@ -40,18 +40,25 @@ class SiteTableViewHeader: UITableViewHeaderFooterView, ThemeApplicable, Reusabl
 
     private var titleTrailingConstraint: NSLayoutConstraint!
     private var imageViewLeadingConstraint: NSLayoutConstraint!
-    var theme: Theme = LightTheme()
-
     fileprivate let bordersHelper = ThemedHeaderFooterViewBordersHelper()
 
     override var textLabel: UILabel? {
         return titleLabel
     }
 
+    override init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+
+        setupLayout()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     override func prepareForReuse() {
         super.prepareForReuse()
         setDefaultBordersValues()
-        applyTheme(theme: theme)
     }
 
     func configure(_ model: SiteTableViewHeaderModel) {
@@ -61,7 +68,7 @@ class SiteTableViewHeader: UITableViewHeaderFooterView, ThemeApplicable, Reusabl
         collapsibleState = model.collapsibleState
     }
 
-    func setupLayout() {
+    private func setupLayout() {
         translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubviews(titleLabel, collapsibleImageView)
 
@@ -95,7 +102,6 @@ class SiteTableViewHeader: UITableViewHeaderFooterView, ThemeApplicable, Reusabl
         ])
 
         showImage(false)
-        applyTheme(theme: theme)
     }
 
     func applyTheme(theme: Theme) {

--- a/Client/Frontend/Widgets/SiteTableViewHeader.swift
+++ b/Client/Frontend/Widgets/SiteTableViewHeader.swift
@@ -11,7 +11,7 @@ struct SiteTableViewHeaderModel {
     let collapsibleState: ExpandButtonState?
 }
 
-class SiteTableViewHeader: UITableViewHeaderFooterView, NotificationThemeable, ReusableCell {
+class SiteTableViewHeader: UITableViewHeaderFooterView, ThemeApplicable, ReusableCell {
 
     struct UX {
         static let titleTrailingLeadingMargin: CGFloat = 16
@@ -40,6 +40,7 @@ class SiteTableViewHeader: UITableViewHeaderFooterView, NotificationThemeable, R
 
     private var titleTrailingConstraint: NSLayoutConstraint!
     private var imageViewLeadingConstraint: NSLayoutConstraint!
+    var theme: Theme = LightTheme()
 
     fileprivate let bordersHelper = ThemedHeaderFooterViewBordersHelper()
 
@@ -47,20 +48,10 @@ class SiteTableViewHeader: UITableViewHeaderFooterView, NotificationThemeable, R
         return titleLabel
     }
 
-    override init(reuseIdentifier: String?) {
-        super.init(reuseIdentifier: reuseIdentifier)
-
-        setupLayout()
-    }
-
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
     override func prepareForReuse() {
         super.prepareForReuse()
         setDefaultBordersValues()
-        applyTheme()
+        applyTheme(theme: theme)
     }
 
     func configure(_ model: SiteTableViewHeaderModel) {
@@ -104,12 +95,12 @@ class SiteTableViewHeader: UITableViewHeaderFooterView, NotificationThemeable, R
         ])
 
         showImage(false)
-        applyTheme()
+        applyTheme(theme: theme)
     }
 
-    func applyTheme() {
-        titleLabel.textColor = UIColor.theme.tableView.headerTextDark
-        backgroundView?.backgroundColor = UIColor.theme.tableView.selectedBackground
+    func applyTheme(theme: Theme) {
+        titleLabel.textColor = theme.colors.textPrimary
+        backgroundView?.backgroundColor = theme.colors.layer4
         bordersHelper.applyTheme()
     }
 


### PR DESCRIPTION
Update the views on the tab tray to use the ThemeApplicable protocol
Call listenForThemeChange (this was missed in the last PR)
Update the colors on the remote panel (also missed in the last PR)