### PR TITLE
Bugfix FXIOS-3538 [v108] Top tabs / URL bar should be revealed when scrolling to top using a mouse or trackpad

### DIFF
--- a/Client/Frontend/Browser/TabScrollController.swift
+++ b/Client/Frontend/Browser/TabScrollController.swift
@@ -74,6 +74,11 @@ class TabScrollingController: NSObject, FeatureFlaggable {
     private lazy var panGesture: UIPanGestureRecognizer = {
         let panGesture = UIPanGestureRecognizer(target: self, action: #selector(handlePan))
         panGesture.maximumNumberOfTouches = 1
+        // Note: Setting this mask enables the pan gesture to recognize scroll events,
+        // like a mouse scroll movement or a two-finger scroll on a track pad.
+        if #available(iOS 13.4, *) {
+            panGesture.allowedScrollTypesMask = .continuous
+        }
         panGesture.delegate = self
         return panGesture
     }()


### PR DESCRIPTION
[Jira](https://mozilla-hub.atlassian.net/browse/FXIOS-3538)
[Github](https://github.com/mozilla-mobile/firefox-ios/issues/9657)

https://user-images.githubusercontent.com/8919439/196828480-493cc054-4d3a-4637-ac52-5dfd5c2d63af.mov



