### PR TITLE
Bugfix FXIOS-4828 [v108] The bookmark is not immediately deleted from the Recently saved after deleting it from the bookmark panel

### DIFF
--- a/Storage/Rust/RustPlaces.swift
+++ b/Storage/Rust/RustPlaces.swift
@@ -235,9 +235,12 @@ public class RustPlaces: BookmarksHandler {
     public func deleteBookmarkNode(guid: GUID) -> Success {
         return withWriter { connection in
             let result = try connection.deleteBookmarkNode(guid: guid)
-            if !result {
+            guard result  else {
                 log.debug("Bookmark with GUID \(guid) does not exist.")
+                return
             }
+
+            self.notificationCenter.post(name: .BookmarksUpdated, object: self)
         }
     }
 

--- a/Storage/Rust/RustPlaces.swift
+++ b/Storage/Rust/RustPlaces.swift
@@ -235,7 +235,7 @@ public class RustPlaces: BookmarksHandler {
     public func deleteBookmarkNode(guid: GUID) -> Success {
         return withWriter { connection in
             let result = try connection.deleteBookmarkNode(guid: guid)
-            guard result  else {
+            guard result else {
                 log.debug("Bookmark with GUID \(guid) does not exist.")
                 return
             }


### PR DESCRIPTION
### [FXIOS-4828](https://mozilla-hub.atlassian.net/browse/FXIOS-4828)   #11724

- Post `.BookmarksUpdated` notification from deleteBookmarkNode