### PR TITLE
Bugfix FXIOS-5112 [v108] Fix Learn More button in ETP settings showing up in wrong places

### DIFF
--- a/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -139,6 +139,7 @@ class TPAccessoryInfo: ThemedTableViewController {
 }
 
 class ContentBlockerSettingViewController: SettingsTableViewController {
+    private let button = UIButton()
     let prefs: Prefs
     var currentBlockingStrength: BlockingStrength
 
@@ -180,6 +181,7 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
                                                  extras: extras)
 
                     if option == .strict {
+                        self.button.isHidden = false
                         let alert = UIAlertController(title: .TrackerProtectionAlertTitle,
                                                       message: .TrackerProtectionAlertDescription,
                                                       preferredStyle: .alert)
@@ -187,6 +189,8 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
                                                       style: .default,
                                                       handler: nil))
                         self.present(alert, animated: true)
+                    } else {
+                        self.button.isHidden = true
                     }
             })
 
@@ -242,7 +246,6 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
         attributes[NSAttributedString.Key.font] = font
         attributes[NSAttributedString.Key.foregroundColor] = UIColor.theme.general.highlightBlue
 
-        let button = UIButton()
         button.setAttributedTitle(NSAttributedString(string: title, attributes: attributes), for: .normal)
         button.addTarget(self, action: #selector(moreInfoTapped), for: .touchUpInside)
 


### PR DESCRIPTION
Issue #12179

This bug was happening because when you tapped Standard option it would lose the label constraint reference for the button and it would still shows up. The only way that I thought that would be a quick and effective solution would take the creation of the UIButton out of the footer function and let it be private inside of the class so I could hide and show the button when check the Standard and Strict button inside of the generateSettings function. 
A few other things that I tried was doing some rules to just create the button based on the currentBlockingStrength and/or section but would still happen.