### PR TITLE
Bugfix FXIOS-12179 [v108] Fix bug where 'Learn more' is printed in various places on the ETP settings screen

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -14112,6 +14112,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 43AQ936H96;
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = "";
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				INFOPLIST_FILE = "KingfisherDynamic-Info.plist";
 				LOCALIZED_STRING_MACRO_NAMES = (
@@ -14136,6 +14137,7 @@
 				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 43AQ936H96;
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = "";
 				INFOPLIST_FILE = "KingfisherDynamic-Info.plist";
 				LOCALIZED_STRING_MACRO_NAMES = (
 					MZLocalizedString,

--- a/Client/Application/LaunchScreen.xib
+++ b/Client/Application/LaunchScreen.xib
@@ -1,7 +1,11 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14E26a" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -18,7 +22,7 @@
                     </constraints>
                 </imageView>
             </subviews>
-            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstItem="8jg-1f-0sB" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="ITK-hU-DwR"/>
                 <constraint firstItem="8jg-1f-0sB" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="grm-jt-xY2"/>
@@ -29,6 +33,9 @@
         </view>
     </objects>
     <resources>
-        <image name="splash" width="400" height="390"/>
+        <image name="splash" width="134" height="134"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -210,8 +210,21 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
                 }
                 self?.tableView.reloadData()
         }
+		
+		// The first section header gets a More Info link
+		let title: String = .TrackerProtectionLearnMore
 
-        let firstSection = SettingSection(title: nil, footerTitle: NSAttributedString(string: .TrackingProtectionCellFooter), children: [enabledSetting])
+		let font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline, size: 12.0)
+		var attributes = [NSAttributedString.Key: AnyObject]()
+		attributes[NSAttributedString.Key.font] = font
+		attributes[NSAttributedString.Key.foregroundColor] = UIColor.theme.general.highlightBlue
+
+		let button = UIButton()
+		button.setAttributedTitle(NSAttributedString(string: title, attributes: attributes), for: .normal)
+		button.addTarget(self, action: #selector(moreInfoTapped), for: .touchUpInside)
+
+        let firstSection = SettingSection(title: nil, footerTitle: NSAttributedString(string: .TrackingProtectionCellFooter), footerButton: button, children: [enabledSetting])
+		
 
         let optionalFooterTitle = NSAttributedString(string: .TrackingProtectionLevelFooter)
 
@@ -222,47 +235,32 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
         return [firstSection, secondSection]
     }
 
-    // The first section header gets a More Info link
     override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         let _defaultFooter = super.tableView(tableView, viewForFooterInSection: section) as? ThemedTableSectionHeaderFooterView
 
-        guard let defaultFooter = _defaultFooter, section > 0 else {
-            return _defaultFooter
-        }
-
-        if currentBlockingStrength == .basic {
-            return nil
-        }
-
-        // TODO: Get a dedicated string for this.
-        let title: String = .TrackerProtectionLearnMore
-
-        let font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline, size: 12.0)
-        var attributes = [NSAttributedString.Key: AnyObject]()
-        attributes[NSAttributedString.Key.font] = font
-        attributes[NSAttributedString.Key.foregroundColor] = UIColor.theme.general.highlightBlue
-
-        let button = UIButton()
-        button.setAttributedTitle(NSAttributedString(string: title, attributes: attributes), for: .normal)
-        button.addTarget(self, action: #selector(moreInfoTapped), for: .touchUpInside)
-
-        defaultFooter.addSubview(button)
-
-        button.snp.makeConstraints { (make) in
-            make.top.equalTo(defaultFooter.titleLabel.snp.bottom)
-            make.leading.equalTo(defaultFooter.titleLabel)
-        }
+		guard let defaultFooter = _defaultFooter, section == 1 else {
+			return _defaultFooter
+		}
+		
+		if currentBlockingStrength == .basic {
+			return nil
+		}
 
         return defaultFooter
     }
 
     override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return UITableView.automaticDimension
+		return UITableView.automaticDimension
     }
 
     @objc func moreInfoTapped() {
         let viewController = SettingsContentViewController()
         viewController.url = SupportUtils.URLForTopic("tracking-protection-ios")
-        navigationController?.pushViewController(viewController, animated: true)
+		let navBarOnModal: UINavigationController = UINavigationController(rootViewController: viewController)
+		navBarOnModal.navigationBar.topItem?.rightBarButtonItem = UIBarButtonItem(title: "Done", style: .done, closure: { _ in
+			navBarOnModal.dismiss(animated: true)
+		})
+		self.present(navBarOnModal, animated: true, completion: nil)
+		
     }
 }

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -42,6 +42,7 @@ extension UILabel {
 class Setting: NSObject {
     fileprivate var _title: NSAttributedString?
     fileprivate var _footerTitle: NSAttributedString?
+	fileprivate var _footerButton: UIButton?
     fileprivate var _cellHeight: CGFloat?
     fileprivate var _image: UIImage?
 
@@ -53,6 +54,7 @@ class Setting: NSObject {
     // The title shown on the pref.
     var title: NSAttributedString? { return _title }
     var footerTitle: NSAttributedString? { return _footerTitle }
+	var footerButton: UIButton? { return _footerButton }
     var cellHeight: CGFloat? { return _cellHeight}
     fileprivate(set) var accessibilityIdentifier: String?
 
@@ -132,9 +134,10 @@ class Setting: NSObject {
         }
     }
 
-    init(title: NSAttributedString? = nil, footerTitle: NSAttributedString? = nil, cellHeight: CGFloat? = nil, delegate: SettingsDelegate? = nil, enabled: Bool? = nil) {
+	init(title: NSAttributedString? = nil, footerTitle: NSAttributedString? = nil, footerButton: UIButton? = nil, cellHeight: CGFloat? = nil, delegate: SettingsDelegate? = nil, enabled: Bool? = nil) {
         self._title = title
         self._footerTitle = footerTitle
+		self._footerButton = footerButton
         self._cellHeight = cellHeight
         self.delegate = delegate
         self.enabled = enabled ?? true
@@ -145,9 +148,9 @@ class Setting: NSObject {
 class SettingSection: Setting {
     fileprivate let children: [Setting]
 
-    init(title: NSAttributedString? = nil, footerTitle: NSAttributedString? = nil, cellHeight: CGFloat? = nil, children: [Setting]) {
+	init(title: NSAttributedString? = nil, footerTitle: NSAttributedString? = nil, footerButton: UIButton? = nil, cellHeight: CGFloat? = nil, children: [Setting]) {
         self.children = children
-        super.init(title: title, footerTitle: footerTitle, cellHeight: cellHeight)
+        super.init(title: title, footerTitle: footerTitle, footerButton: footerButton, cellHeight: cellHeight)
     }
 
     var count: Int {
@@ -805,9 +808,20 @@ class SettingsTableViewController: ThemedTableViewController {
 
     override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         let sectionSetting = settings[section]
-
+		
         guard let footerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: ThemedTableSectionHeaderFooterView.cellIdentifier) as? ThemedTableSectionHeaderFooterView,
-                let sectionFooter = sectionSetting.footerTitle?.string else { return nil }
+		
+		let sectionFooter = sectionSetting.footerTitle?.string else { return nil }
+		
+		if let sectionFooterButton = sectionSetting.footerButton {
+			// Add button subview
+			footerView.addSubview(sectionFooterButton)
+
+			sectionFooterButton.snp.makeConstraints { (make) in
+				make.top.equalTo(footerView.titleLabel.snp.bottom)
+				make.leading.equalTo(footerView.titleLabel)
+			}
+		}
 
         footerView.titleLabel.text = sectionFooter
         footerView.titleAlignment = .top


### PR DESCRIPTION
This commit will fixes #12179 where the 'Learn More' link is printed in various places in the UI when making changes to the ETP settings. The 'Learn more' button now remains in a single location as intended. The fix was to allow the button to be configured as part of the `SettingSection` instead of adding it on the override function for `viewForFooterInSection`. This also makes this reusable in future when other section footers need a button to be added.  