### PR TITLE
Add FXIOS-2997 [v108] Single scene setup

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -663,6 +663,7 @@
 		964FA97528A1A8F20024BB3B /* ContextualHintEligibilityUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964FA97428A1A8F20024BB3B /* ContextualHintEligibilityUtility.swift */; };
 		964FA97728A2A55C0024BB3B /* ContextualHintPrefsKeysProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964FA97628A2A55C0024BB3B /* ContextualHintPrefsKeysProvider.swift */; };
 		966206CD2698DE1E005C0A55 /* RecentlySavedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966206CC2698DE1E005C0A55 /* RecentlySavedViewModel.swift */; };
+		967A028E28FA026F003C35E3 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967A028D28FA026F003C35E3 /* SceneDelegate.swift */; };
 		968BD7EB27DFF0F8003148B3 /* ASGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 968BD7EA27DFF0F8003148B3 /* ASGroup.swift */; };
 		9699F77326F39E5100C5FA47 /* SiteImageHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9699F77226F39E5100C5FA47 /* SiteImageHelper.swift */; };
 		96A562A027D6D0E80045144A /* ContileProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A5629F27D6D0E80045144A /* ContileProvider.swift */; };
@@ -3496,6 +3497,7 @@
 		964FA97428A1A8F20024BB3B /* ContextualHintEligibilityUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualHintEligibilityUtility.swift; sourceTree = "<group>"; };
 		964FA97628A2A55C0024BB3B /* ContextualHintPrefsKeysProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualHintPrefsKeysProvider.swift; sourceTree = "<group>"; };
 		966206CC2698DE1E005C0A55 /* RecentlySavedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentlySavedViewModel.swift; sourceTree = "<group>"; };
+		967A028D28FA026F003C35E3 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		967AF157275FF4C60099E161 /* tt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tt; path = tt.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		967AF158275FF4C60099E161 /* tt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tt; path = tt.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
 		967AF159275FF4C60099E161 /* tt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tt; path = tt.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
@@ -7841,6 +7843,7 @@
 				EB9854FD2422686F0040F24B /* AppDelegate+PushNotifications.swift */,
 				EB98550024226EF60040F24B /* AppDelegate+SyncSentTabs.swift */,
 				D3BE7B451B054F8600641031 /* UITestAppDelegate.swift */,
+				967A028D28FA026F003C35E3 /* SceneDelegate.swift */,
 			);
 			name = Delegates;
 			sourceTree = "<group>";
@@ -10465,6 +10468,7 @@
 				E127313D28B6AD99006F39D2 /* WallpaperSettingsViewModel.swift in Sources */,
 				048B4C8624A53F3E001B56E8 /* TodayUX.swift in Sources */,
 				8A07910F278F62F2005529CB /* AdjustHelper.swift in Sources */,
+				967A028E28FA026F003C35E3 /* SceneDelegate.swift in Sources */,
 				1DF4266E251BC46D0086386A /* FaviconFetcher+Non-Bundled.swift in Sources */,
 				C8B07A4128199500000AFCE7 /* NimbusFlaggableFeature.swift in Sources */,
 				0B62EFD21AD63CD100ACB9CD /* Clearables.swift in Sources */,

--- a/Client/Application/AppContainer.swift
+++ b/Client/Application/AppContainer.swift
@@ -43,26 +43,37 @@ class AppContainer: ServiceProvider {
             do {
                 unowned let container = container
 
-                container.register(.eagerSingleton) {
-                    return BrowserProfile(
-                        localName: "profile",
-                        syncDelegate: UIApplication.shared.syncDelegate
-                    ) as Profile
+                container.register(.eagerSingleton) { () -> Profile in
+                    if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
+                        return appDelegate.profile
+                    } else {
+                        return BrowserProfile(
+                            localName: "profile",
+                            syncDelegate: UIApplication.shared.syncDelegate
+                        ) as Profile
+                    }
                 }
 
-                /// TabManager access should be through the container, since we'll support multiple scenes.
-                container.register(.singleton) {
-                    return TabManager(
-                        profile: try container.resolve(),
-                        imageStore: DiskImageStore(
-                            files: (try container.resolve() as Profile).files,
-                            namespace: "TabManagerScreenshots",
-                            quality: UIConstants.ScreenshotQuality)
-                    )
+                container.register(.singleton) { () -> TabManager in
+                    if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
+                        return appDelegate.tabManager
+                    } else {
+                        return TabManager(
+                            profile: try container.resolve(),
+                            imageStore: DiskImageStore(
+                                files: (try container.resolve() as Profile).files,
+                                namespace: "TabManagerScreenshots",
+                                quality: UIConstants.ScreenshotQuality)
+                        )
+                    }
                 }
 
-                container.register(.singleton) {
-                    return DefaultThemeManager(appDelegate: UIApplication.shared.delegate) as ThemeManager
+                container.register(.singleton) { () -> ThemeManager in
+                    if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
+                        return appDelegate.themeManager
+                    } else {
+                        return DefaultThemeManager(appDelegate: UIApplication.shared.delegate)
+                    }
                 }
 
                 container.register(.singleton) {

--- a/Client/Application/AppContainer.swift
+++ b/Client/Application/AppContainer.swift
@@ -37,12 +37,15 @@ class AppContainer: ServiceProvider {
     // MARK: - Misc helpers
 
     /// Prepares the container by registering all services for the app session.
+    /// Insert a dependency when needed, otherwise it floats in memory.
     /// - Returns: A bootstrapped `DependencyContainer`.
     private func bootstrapContainer() -> DependencyContainer {
         return DependencyContainer { container in
             do {
                 unowned let container = container
 
+                /// Since Profile's usage is at the very beginning (and is a dependency for others in this container)
+                /// we give this an `eagerSingleton` scope, forcing the instance to exist ON container boostrap.
                 container.register(.eagerSingleton) { () -> Profile in
                     if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
                         return appDelegate.profile

--- a/Client/Application/AppDelegate+PushNotifications.swift
+++ b/Client/Application/AppDelegate+PushNotifications.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0
 
+import UIKit
 import Shared
 import Storage
 import Sync
@@ -73,17 +74,20 @@ extension AppDelegate {
     }
 
     private func openURLsInNewTabs(_ notification: UNNotification) {
+        var sentUrlsToQueue: [URL] = []
+
         guard let urls = notification.request.content.userInfo["sentTabs"] as? [NSDictionary]  else { return }
         for sentURL in urls {
             if let urlString = sentURL.value(forKey: "url") as? String, let url = URL(string: urlString) {
-                receivedURLs.append(url)
+                sentUrlsToQueue.append(url)
             }
         }
 
         // Check if the app is foregrounded, _also_ verify the BVC is initialized. Most BVC functions depend on viewDidLoad() having run –if not, they will crash.
-        if UIApplication.shared.applicationState == .active && browserViewController.isViewLoaded {
-            browserViewController.loadQueuedTabs(receivedURLs: receivedURLs)
-            receivedURLs.removeAll()
+        if UIApplication.shared.applicationState == .active {
+            let browserViewController = BrowserViewController.foregroundBVC()
+
+            browserViewController.loadQueuedTabs(receivedURLs: sentUrlsToQueue)
         }
     }
 }

--- a/Client/Application/AppDelegate+PushNotifications.swift
+++ b/Client/Application/AppDelegate+PushNotifications.swift
@@ -74,12 +74,12 @@ extension AppDelegate {
     }
 
     private func openURLsInNewTabs(_ notification: UNNotification) {
-        var sentUrlsToQueue: [URL] = []
+        var receivedUrlsQueue: [URL] = []
 
         guard let urls = notification.request.content.userInfo["sentTabs"] as? [NSDictionary]  else { return }
         for sentURL in urls {
             if let urlString = sentURL.value(forKey: "url") as? String, let url = URL(string: urlString) {
-                sentUrlsToQueue.append(url)
+                receivedUrlsQueue.append(url)
             }
         }
 
@@ -87,7 +87,7 @@ extension AppDelegate {
         if UIApplication.shared.applicationState == .active {
             let browserViewController = BrowserViewController.foregroundBVC()
 
-            browserViewController.loadQueuedTabs(receivedURLs: sentUrlsToQueue)
+            browserViewController.loadQueuedTabs(receivedURLs: receivedUrlsQueue)
         }
     }
 }

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -176,24 +176,6 @@ extension AppDelegate: Notifiable {
         default: break
         }
     }
-
-<<<<<<< HEAD
-    /// When a user presses and holds the app icon from the Home Screen, we present quick actions / shortcut items (see QuickActions).
-    ///
-    /// This method can handle a quick action from both app launch and when the app becomes active. However, the system calls launch methods first if the app `launches`
-    /// and gives you a chance to handle the shortcut there. If it's not handled there, this method is called in the activation process with the shortcut item.
-    ///
-    /// Quick actions / shortcut items are handled here as long as our two launch methods return `true`. If either of them return `false`, this method
-    /// won't be called to handle shortcut items.
-    func application(_ application: UIApplication, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void) {
-        let handledShortCutItem = QuickActionsImplementation().handleShortCutItem(
-            shortcutItem,
-            withBrowserViewController: browserViewController)
-
-        completionHandler(handledShortCutItem)
-    }
-=======
->>>>>>> e96f57a28 (Add FXIOS-2997 [v107] Single scene setup)
 }
 
 // This functionality will need to be moved to the SceneDelegate when the time comes

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -226,16 +226,4 @@ extension AppDelegate {
         return configuration
     }
 
-    /// Invoked by the system when an open scene session is discarded. It can be discarded by a user interaction,
-    /// or by the system itself (in the background as well).
-    ///
-    /// Use this method to release resources specific to that discarded scene.
-    /// Clean anything that holds memory or can deadlock resources for other scenes.
-    func application(
-        _ application: UIApplication,
-        didDiscardSceneSessions sceneSessions: Set<UISceneSession>
-    ) {
-        // no-op
-    }
-
 }

--- a/Client/Application/QuickActions.swift
+++ b/Client/Application/QuickActions.swift
@@ -53,8 +53,9 @@ protocol QuickActions {
 
     func handleShortCutItem(
         _ shortcutItem: UIApplicationShortcutItem,
-        withBrowserViewController bvc: BrowserViewController
-    ) -> Bool
+        withBrowserViewController bvc: BrowserViewController,
+        completionHandler: @escaping (Bool) -> Void
+    )
 }
 
 extension QuickActions {
@@ -67,7 +68,7 @@ extension QuickActions {
     }
 }
 
-class QuickActionsImplementation: NSObject, QuickActions, Loggable {
+struct QuickActionsImplementation: QuickActions, Loggable {
 
     // MARK: Administering Quick Actions
     func addDynamicApplicationShortcutItemOfType(_ type: ShortcutType,
@@ -125,16 +126,21 @@ class QuickActionsImplementation: NSObject, QuickActions, Loggable {
     // MARK: - Handling Quick Actions
 
     func handleShortCutItem(_ shortcutItem: UIApplicationShortcutItem,
-                            withBrowserViewController bvc: BrowserViewController) -> Bool {
+                            withBrowserViewController bvc: BrowserViewController,
+                            completionHandler: @escaping (Bool) -> Void) {
 
         // Verify that the provided `shortcutItem`'s `type` is one handled by the application.
-        guard let shortCutType = ShortcutType(fullType: shortcutItem.type) else { return false }
-
-        DispatchQueue.main.async {
-            self.handleShortCutItemOfType(shortCutType, userData: shortcutItem.userInfo, browserViewController: bvc)
+        guard let shortCutType = ShortcutType(fullType: shortcutItem.type) else {
+            completionHandler(false)
+            return
         }
 
-        return true
+        DispatchQueue.main.async {
+            self.handleShortCutItemOfType(shortCutType,
+                                          userData: shortcutItem.userInfo,
+                                          browserViewController: bvc)
+            completionHandler(true)
+        }
     }
 
     // MARK: - Private

--- a/Client/Application/SceneDelegate.swift
+++ b/Client/Application/SceneDelegate.swift
@@ -102,7 +102,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let url = URLContexts.first?.url,
               let routerPath = NavigationPath(url: url) else { return }
 
-        if let _ = profile.prefs.boolForKey(PrefsKeys.AppExtensionTelemetryOpenUrl) {
+        if profile.prefs.boolForKey(PrefsKeys.AppExtensionTelemetryOpenUrl) != nil {
             profile.prefs.removeObjectForKey(PrefsKeys.AppExtensionTelemetryOpenUrl)
 
             var object = TelemetryWrapper.EventObject.url

--- a/Client/Application/SceneDelegate.swift
+++ b/Client/Application/SceneDelegate.swift
@@ -1,0 +1,308 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import CoreSpotlight
+import Storage
+import Shared
+import Sync
+import UserNotifications
+import Account
+import MozillaAppServices
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+    /// This is temporary. We don't want to continue treating App / Scene delegates as containers for certain session specific properties.
+    /// TODO: When we begin to support multiple scenes, this is risky to keep. If we foregroundBVC, we should have a more specific
+    /// way to foreground the BVC FOR the scene being actively interacted with.
+    var browserViewController: BrowserViewController!
+
+    let profile: Profile = AppContainer.shared.resolve()
+    let tabManager: TabManager = AppContainer.shared.resolve()
+
+    // MARK: - Connecting / Disconnecting Scenes
+
+    /// Invoked when the app creates OR restores an instance of the UI.
+    ///
+    /// Use this method to respond to the addition of a new scene, and begin loading data that needs to display.
+    /// Take advantage of what's given in `options`.
+    func scene(
+        _ scene: UIScene,
+        willConnectTo session: UISceneSession,
+        options connectionOptions: UIScene.ConnectionOptions
+    ) {
+        let window = configureWindowFor(scene)
+        let rootVC = configureRootViewController()
+
+        window.rootViewController = rootVC
+        window.makeKeyAndVisible()
+
+        self.window = window
+    }
+
+    /// Invoked as the scene is being released by the system. A scene is released when its backgrounded or when its session is discarded.
+    /// The scene can reconnect later if it's session wasn't discarded.
+    ///
+    /// Use this method to do any final clean up before the scene is purged from memory. Release resources and shutdown things gracefully.
+    /// Note: Removal of a scene occurs before it's discarded.
+    func sceneDidDisconnect(_ scene: UIScene) {
+        print("sceneDidDisconnect")
+    }
+
+    // MARK: - Transitioning to Foreground
+
+    /// Invoked before a scene enters the foreground and becomes visible to the user.
+    ///
+    /// Use this method to undo changes made on the scene entering the background.
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        print("sceneWillEnterForeground")
+    }
+
+    /// Invoked when the interface is finished loading for your screen, but before that interface appears on screen.
+    ///
+    /// Use this method to refresh the contents of your scene's view (especially if it's a restored scene), or other activities that need
+    /// to begin.
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        /// Resume previously stopped downloads for, and on, THIS scene only.
+        browserViewController.downloadQueue.resumeAll()
+
+        /// Sent Tabs are now handled when the app is notified of them. Having that handling in lifecycle methods is redundant.
+    }
+
+    // MARK: - Transitioning to Background
+
+    /// Invoked before transitioning the app to the background, OR for temporary interruptions like system alerts.
+    ///
+    /// Use this method to prepare to be backgrounded cleanly. Any data that needs to persist can be done in here AS A LAST RESORT.
+    /// In general, data management should be done outside of this method.
+    func sceneWillResignActive(_ scene: UIScene) {
+        // no-op
+    }
+
+    /// The scene's running in the background and not visible on screen.
+    ///
+    /// Use this method to reduce the scene's memory usage, clear claims to resources & dependencies / services.
+    /// UIKit takes a snapshot of the scene for the app switcher after this method returns.
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        browserViewController.downloadQueue.pauseAll()
+    }
+
+    // MARK: - Opening URLs
+
+    /// Asks the delegate to open one or more URLs.
+    ///
+    /// This method is equialent to AppDelegate's openURL method. We implement deeplinks this way.
+    func scene(
+        _ scene: UIScene,
+        openURLContexts URLContexts: Set<UIOpenURLContext>
+    ) {
+        guard let url = URLContexts.first?.url,
+              let routerPath = NavigationPath(url: url) else { return }
+
+        if let _ = profile.prefs.boolForKey(PrefsKeys.AppExtensionTelemetryOpenUrl) {
+            profile.prefs.removeObjectForKey(PrefsKeys.AppExtensionTelemetryOpenUrl)
+
+            var object = TelemetryWrapper.EventObject.url
+            if case .text = routerPath {
+                object = .searchText
+            }
+
+            TelemetryWrapper.recordEvent(category: .appExtensionAction, method: .applicationOpenUrl, object: object)
+        }
+
+        DispatchQueue.main.async {
+            NavigationPath.handle(nav: routerPath, with: self.browserViewController)
+        }
+
+    }
+
+    // MARK: - Continuing User Activities
+
+    /// Tells the delegate it's about to recieve Handoff-related data.
+    func scene(
+        _ scene: UIScene,
+        willContinueUserActivityWithType userActivityType: String
+    ) {
+        // no-op
+    }
+
+    /// Use this method to handle Handoff-related data or other activities.
+    func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+        if userActivity.activityType == SiriShortcuts.activityType.openURL.rawValue {
+            browserViewController.openBlankNewTab(focusLocationField: false)
+        }
+
+        // If the `NSUserActivity` has a `webpageURL`, it is either a deep link or an old history item
+        // reached via a "Spotlight" search before we began indexing visited pages via CoreSpotlight.
+        if let url = userActivity.webpageURL {
+            let query = url.getQuery()
+
+            // Check for fxa sign-in code and launch the login screen directly
+            if query["signin"] != nil {
+                // bvc.launchFxAFromDeeplinkURL(url) // Was using Adjust. Consider hooking up again when replacement system in-place.
+            }
+
+            // Per Adjust documentation, https://docs.adjust.com/en/universal-links/#running-campaigns-through-universal-links,
+            // it is recommended that links contain the `deep_link` query parameter. This link will also
+            // be url encoded.
+            if let deepLink = query["deep_link"]?.removingPercentEncoding, let url = URL(string: deepLink) {
+                browserViewController.switchToTabForURLOrOpen(url)
+            }
+
+            browserViewController.switchToTabForURLOrOpen(url)
+        }
+
+        // Otherwise, check if the `NSUserActivity` is a CoreSpotlight item and switch to its tab or
+        // open a new one.
+        if userActivity.activityType == CSSearchableItemActionType {
+            if let userInfo = userActivity.userInfo,
+                let urlString = userInfo[CSSearchableItemActivityIdentifier] as? String,
+                let url = URL(string: urlString) {
+                browserViewController.switchToTabForURLOrOpen(url)
+            }
+        }
+
+    }
+
+    /// Use this method to notify the user that the specified activity couldn't be completed.
+    ///
+    /// We need to think about the right ways to notifiy users
+    func scene(
+        _ scene: UIScene,
+        didFailToContinueUserActivityWithType userActivityType: String, error: Error
+    ) {
+        // no-op
+    }
+
+    // MARK: - Responding to Scene (environment) Changes
+
+    /// Use this method to handle certain environment changes and adjust your scene accordingly.
+    ///
+    /// See how / what needs to be done here so that we can lock orientation on modal presentation as well.
+    func windowScene(
+        _ windowScene: UIWindowScene,
+        didUpdate previousCoordinateSpace: UICoordinateSpace,
+        interfaceOrientation previousInterfaceOrientation: UIInterfaceOrientation,
+        traitCollection previousTraitCollection: UITraitCollection
+    ) {
+        // no-op
+        // return self.orientationLock
+    }
+
+    // MARK: - Performing Tasks
+
+    /// Use this method to handle a selected shortcut action.
+    ///
+    /// Invoked when:
+    /// - a user activates the application by selecting a shortcut item on the home screen AND
+    /// - the window scene is already connected.
+    func windowScene(
+        _ windowScene: UIWindowScene,
+        performActionFor shortcutItem: UIApplicationShortcutItem,
+        completionHandler: @escaping (Bool) -> Void
+    ) {
+        let handledShortCutItem = QuickActions.sharedInstance.handleShortCutItem(shortcutItem,
+                                                                                 withBrowserViewController: self.browserViewController)
+
+        completionHandler(handledShortCutItem)
+    }
+
+    // MARK: - Misc. Helpers
+
+    private func configureWindowFor(_ scene: UIScene) -> UIWindow {
+        guard let windowScene = (scene as? UIWindowScene) else {
+            return UIWindow(frame: UIScreen.main.bounds)
+        }
+
+        let window = UIWindow(windowScene: windowScene)
+
+        if !LegacyThemeManager.instance.systemThemeIsOn {
+            window.overrideUserInterfaceStyle = LegacyThemeManager.instance.userInterfaceStyle
+        }
+
+        return window
+    }
+
+    private func configureRootViewController() -> UINavigationController {
+        let browserViewController = BrowserViewController(profile: profile, tabManager: tabManager)
+
+        // TODO: When we begin to support multiple scenes, remove this line and the reference to BVC in SceneDelegate.
+        self.browserViewController = browserViewController
+
+        let navigationController = UINavigationController(rootViewController: browserViewController)
+        navigationController.isNavigationBarHidden = true
+        navigationController.edgesForExtendedLayout = UIRectEdge(rawValue: 0)
+
+        return navigationController
+    }
+
+}
+
+/**
+    TODO: We need to figure out what the best approach to addressing `foregroundBVC` is.
+    The extensions below are one possible solution, but we'll discuss with the team.
+
+extension UIWindowScene {
+
+    /// Typically, we'll have one BVC per scene. But in the off chance where we have multiple windows per scene,
+    /// and each has a BVC, we can find them all.
+    var browserViewControllers: [BrowserViewController] {
+        let bvcs = windows.compactMap({ window in
+            window.rootViewController as? UINavigationController
+        }).flatMap({ navigationController in
+            navigationController.viewControllers.compactMap({ viewController in
+                viewController as? BrowserViewController
+            })
+        })
+
+        return bvcs
+    }
+
+    var bvcForScene: BrowserViewController? {
+        browserViewControllers.first
+    }
+
+}
+
+extension UIView {
+
+    /// Return the scene the view belongs to.
+    var sceneForView: UIWindowScene? {
+        guard let scene = window?.windowScene else { return nil }
+
+        return scene
+    }
+
+}
+
+extension UIViewController {
+
+    /// Return the scene this VC belongs to.
+    var sceneForViewController: UIWindowScene? {
+        guard let scene = view.window?.windowScene else { return nil }
+
+        return scene
+    }
+
+}
+
+ extension AppDelegate {
+ /// In cases where you need a `Scene`, but don't have access to a view or viewController (and therefore a window), we can retrieve a scene this way.
+ /// It'll attempt to return a scene with activation states in this order: foregroundActive, foregroundInactive, background.
+ func getNextScene() -> UIScene? {
+     guard let foregroundedScene = UIApplication.shared.connectedScenes.first(where: { scene in
+         return scene.activationState == .foregroundActive
+     }) else {
+         /// The best case is returning a foregrounded scene. But if there's none, return the next options.
+         return UIApplication.shared.connectedScenes.first(where: { scene in
+             scene.activationState == .foregroundInactive || scene.activationState == .background
+         })
+     }
+
+     return foregroundedScene
+ }
+ }
+*/

--- a/Client/Application/SceneDelegate.swift
+++ b/Client/Application/SceneDelegate.swift
@@ -203,7 +203,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         performActionFor shortcutItem: UIApplicationShortcutItem,
         completionHandler: @escaping (Bool) -> Void
     ) {
-        QuickActions.sharedInstance.handleShortCutItem(
+        QuickActionsImplementation().handleShortCutItem(
             shortcutItem,
             withBrowserViewController: browserViewController
         )
@@ -250,7 +250,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         /// At launch, shortcut items can be handled this way.
         if let shortcutItem = connectionOptions.shortcutItem {
-            QuickActions.sharedInstance.handleShortCutItem(
+            QuickActionsImplementation().handleShortCutItem(
                 shortcutItem,
                 withBrowserViewController: browserViewController
             )

--- a/Client/Application/SceneDelegate.swift
+++ b/Client/Application/SceneDelegate.swift
@@ -34,6 +34,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         willConnectTo session: UISceneSession,
         options connectionOptions: UIScene.ConnectionOptions
     ) {
+        guard !AppConstants.isRunningUnitTest else { return }
+
         let window = configureWindowFor(scene)
         let rootVC = configureRootViewController()
 
@@ -68,6 +70,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     /// Use this method to refresh the contents of your scene's view (especially if it's a restored scene), or other activities that need
     /// to begin.
     func sceneDidBecomeActive(_ scene: UIScene) {
+        guard !AppConstants.isRunningUnitTest else { return }
+
         /// Resume previously stopped downloads for, and on, THIS scene only.
         browserViewController.downloadQueue.resumeAll()
     }
@@ -205,7 +209,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     ) {
         QuickActionsImplementation().handleShortCutItem(
             shortcutItem,
-            withBrowserViewController: browserViewController
+            withBrowserViewController: browserViewController,
+            completionHandler: completionHandler
         )
     }
 
@@ -252,7 +257,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         if let shortcutItem = connectionOptions.shortcutItem {
             QuickActionsImplementation().handleShortCutItem(
                 shortcutItem,
-                withBrowserViewController: browserViewController
+                withBrowserViewController: browserViewController,
+                completionHandler: { _ in }
             )
         }
     }

--- a/Client/Application/SceneDelegate.swift
+++ b/Client/Application/SceneDelegate.swift
@@ -47,23 +47,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         handleDeeplinkOrShortcutsAtLaunch(with: connectionOptions, on: scene)
     }
 
-    /// Invoked as the scene is being released by the system. A scene is released when its backgrounded or when its session is discarded.
-    /// The scene can reconnect later if it's session wasn't discarded.
-    ///
-    /// Use this method to do any final clean up before the scene is purged from memory. Release resources and shutdown things gracefully.
-    /// Note: Removal of a scene occurs before it's discarded.
-    func sceneDidDisconnect(_ scene: UIScene) {
-        // no-op
-    }
-
     // MARK: - Transitioning to Foreground
-
-    /// Invoked before a scene enters the foreground and becomes visible to the user.
-    ///
-    /// Use this method to undo changes made on the scene entering the background.
-    func sceneWillEnterForeground(_ scene: UIScene) {
-        // no-op
-    }
 
     /// Invoked when the interface is finished loading for your screen, but before that interface appears on screen.
     ///
@@ -77,14 +61,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     // MARK: - Transitioning to Background
-
-    /// Invoked before transitioning the app to the background, OR for temporary interruptions like system alerts.
-    ///
-    /// Use this method to prepare to be backgrounded cleanly. Any data that needs to persist can be done in here AS A LAST RESORT.
-    /// In general, data management should be done outside of this method.
-    func sceneWillResignActive(_ scene: UIScene) {
-        // no-op
-    }
 
     /// The scene's running in the background and not visible on screen.
     ///
@@ -125,14 +101,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     // MARK: - Continuing User Activities
 
-    /// Tells the delegate it's about to recieve Handoff-related data.
-    func scene(
-        _ scene: UIScene,
-        willContinueUserActivityWithType userActivityType: String
-    ) {
-        // no-op
-    }
-
     /// Use this method to handle Handoff-related data or other activities.
     func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
         if userActivity.activityType == SiriShortcuts.activityType.openURL.rawValue {
@@ -169,30 +137,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             }
         }
 
-    }
-
-    /// Use this method to notify the user that the specified activity couldn't be completed.
-    ///
-    /// We need to think about the right ways to notifiy users
-    func scene(
-        _ scene: UIScene,
-        didFailToContinueUserActivityWithType userActivityType: String, error: Error
-    ) {
-        // no-op
-    }
-
-    // MARK: - Responding to Scene (environment) Changes
-
-    /// Use this method to handle certain environment changes and adjust your scene accordingly.
-    ///
-    /// See how / what needs to be done here so that we can lock orientation on modal presentation as well.
-    func windowScene(
-        _ windowScene: UIWindowScene,
-        didUpdate previousCoordinateSpace: UICoordinateSpace,
-        interfaceOrientation previousInterfaceOrientation: UIInterfaceOrientation,
-        traitCollection previousTraitCollection: UITraitCollection
-    ) {
-        // no-op
     }
 
     // MARK: - Performing Tasks

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -169,14 +169,17 @@ class BrowserViewController: UIViewController {
 
     fileprivate var shouldShowIntroScreen: Bool { profile.prefs.intForKey(PrefsKeys.IntroSeen) == nil }
 
-    init(profile: Profile,
-         tabManager: TabManager,
-         themeManager: ThemeManager = AppContainer.shared.resolve()) {
+    init(
+        profile: Profile,
+        tabManager: TabManager,
+        themeManager: ThemeManager = AppContainer.shared.resolve(),
+        ratingPromptManager: RatingPromptManager = AppContainer.shared.resolve()
+    ) {
         self.profile = profile
         self.tabManager = tabManager
         self.themeManager = themeManager
+        self.ratingPromptManager = ratingPromptManager
         self.readerModeCache = DiskReaderModeCache.sharedInstance
-        self.ratingPromptManager = RatingPromptManager(profile: profile)
 
         let contextViewModel = ContextualHintViewModel(forHintType: .toolbarLocation,
                                                        with: profile)
@@ -2683,13 +2686,16 @@ extension BrowserViewController: FeatureFlaggable {
 }
 
 extension BrowserViewController {
+    /// This method now returns the BrowserViewController associated with the scene.
+    /// We currently have a single scene app setup, so this will change as we introduce support for multiple scenes.
     public static func foregroundBVC() -> BrowserViewController {
-        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate,
-              let browserViewController = appDelegate.browserViewController else {
-            fatalError("Unable unwrap BrowserViewController")
+        guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate else {
+            /// Currently, we have a single scene app. If we're here, there's no scene or window.
+            /// This should be impossible, and fatal.
+            fatalError("Unable to fetch the Scene.")
         }
 
-        return browserViewController
+        return sceneDelegate.browserViewController
     }
 }
 

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
@@ -249,8 +249,8 @@ class PhotonActionSheet: UIViewController {
     }
 
     private func applyBackgroundBlur() {
-        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate,
-              let screenshot = appDelegate.window?.screenshot() else { return }
+        guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate,
+              let screenshot = sceneDelegate.window?.screenshot() else { return }
 
         let blurredImage = screenshot.applyBlur(withRadius: 5,
                                                 blurType: BOXFILTER,

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>AdjustAppToken</key>
+	<string>$(ADJUST_APP_TOKEN)</string>
 	<key>AppIdentifierPrefix</key>
 	<string>$(APP_IDENTIFIER_PREFIX)</string>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
@@ -99,12 +101,10 @@
 		<string>QuickActionIntent</string>
 		<string>org.mozilla.ios.firefox.browsing</string>
 	</array>
-	<key>PocketEnvironmentAPIKey</key>
-	<string>$(POCKET_API_KEY)</string>
-	<key>AdjustAppToken</key>
-	<string>$(ADJUST_APP_TOKEN)</string>
 	<key>NimbusURL</key>
 	<string>$(NIMBUS_URL)</string>
+	<key>PocketEnvironmentAPIKey</key>
+	<string>$(POCKET_API_KEY)</string>
 	<key>SentryCloudDSN</key>
 	<string>$(SENTRY_CLOUD_DSN)</string>
 	<key>UIAppFonts</key>
@@ -114,6 +114,25 @@
 		<string>NewYorkMedium-Regular.otf</string>
 		<string>NewYorkMedium-RegularItalic.otf</string>
 	</array>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UIApplicationShortcutItems</key>
 	<array>
 		<dict>
@@ -141,6 +160,8 @@
 			<string>$(PRODUCT_BUNDLE_IDENTIFIER).QRCode</string>
 		</dict>
 	</array>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>processing</string>
@@ -171,8 +192,6 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UTImportedTypeDeclarations</key>
 	<array>

--- a/Shared/AppConstants.swift
+++ b/Shared/AppConstants.swift
@@ -37,12 +37,20 @@ public struct KeychainKey {
 }
 
 public struct AppConstants {
+    // Any type of tests (UI and Unit)
     public static let isRunningTest = NSClassFromString("XCTestCase") != nil
     || AppConstants.isRunningUITests
     || AppConstants.isRunningPerfTests
 
+    // Unit tests only
+    public static let isRunningUnitTest = NSClassFromString("XCTestCase") != nil
+    && !AppConstants.isRunningUITests
+    && !AppConstants.isRunningPerfTests
+
+    // Only UI tests
     public static let isRunningUITests = ProcessInfo.processInfo.arguments.contains(LaunchArguments.Test)
 
+    // Only performance tests
     public static let isRunningPerfTests = ProcessInfo.processInfo.arguments.contains(LaunchArguments.PerformanceTest)
 
     public static let FxAiOSClientId = "1b1a3e44c54fbb58"

--- a/Tests/ClientTests/CanRemoveQuickActionBookmarkTests.swift
+++ b/Tests/ClientTests/CanRemoveQuickActionBookmarkTests.swift
@@ -95,9 +95,12 @@ class MockQuickActions: QuickActions {
     }
 
     var handleShortCutItemCalled = 0
-    func handleShortCutItem(_ shortcutItem: UIApplicationShortcutItem,
-                            withBrowserViewController bvc: BrowserViewController) -> Bool {
+    func handleShortCutItem(
+        _ shortcutItem: UIApplicationShortcutItem,
+        withBrowserViewController bvc: BrowserViewController,
+        completionHandler: @escaping (Bool) -> Void
+    ) {
         handleShortCutItemCalled += 1
-        return true
+        completionHandler(true)
     }
 }

--- a/Tests/ClientTests/Frontend/Theme/ThemableTests.swift
+++ b/Tests/ClientTests/Frontend/Theme/ThemableTests.swift
@@ -53,14 +53,12 @@ class ThemableTests: XCTestCaseRootViewController {
     }
 
     func testGetAllSubviews_withTableView() {
-        loadViewForTesting()
-
         let tableView = UITableView(frame: CGRect(width: 200, height: 300))
         tableView.dataSource = tableViewDelegate
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: TestsTableView.testCellId)
         rootViewController.view.addSubview(tableView)
-        tableView.reloadData()
-        wait(0.5)
+
+        loadViewForTesting()
 
         let result = testThemable.getAllSubviews(for: tableView, ofType: UITableViewCell.self)
         XCTAssertEqual(result.count, 3, "Retrieving three UITableViewCell in tableview")

--- a/Tests/ClientTests/QuickActionsTests.swift
+++ b/Tests/ClientTests/QuickActionsTests.swift
@@ -62,7 +62,8 @@ private extension QuickActionsTest {
         }
 
         _ = quickActions.handleShortCutItem(shortcutItem,
-                                            withBrowserViewController: browserViewController)
+                                            withBrowserViewController: browserViewController,
+                                            completionHandler: { _ in })
         waitForExpectations(timeout: 5, handler: nil)
     }
 }

--- a/Tests/ClientTests/XCTestCaseRootViewController.swift
+++ b/Tests/ClientTests/XCTestCaseRootViewController.swift
@@ -22,8 +22,8 @@ class XCTestCaseRootViewController: XCTestCase {
     }
 
     func loadViewForTesting() {
-        _ = rootViewController.view
         window.rootViewController = rootViewController
         window.makeKeyAndVisible()
+        rootViewController.view.layoutIfNeeded()
     }
 }


### PR DESCRIPTION
# [FXIOS-2997](https://mozilla-hub.atlassian.net/browse/FXIOS-2997) | https://github.com/mozilla-mobile/firefox-ios/issues/8897 : Move to a Single Scene App

This PR transitions our app to a single scened app. 

The big picture behind this is: 
- any window or view setup logic from AppDelegate must be moved to SceneDelegate
- anywhere AppDelegate references a window / viewController to do a task needs a workaround

Note the following:
- This PR is hopefully as small as it can get, solely to do the work of supporting a single scened app. 
- This PR is also overcommented! That's intentional - we'll remove those after it has gone through an initial round of reviews.  After the initial round, this PR will go from draft to actual PR.
- This PR also has many no-op methods. We can keep them for now because there will be a use for them soon - whether it's to report telemetry or handle resource management in ways we couldn't before. 

There are a lot of steps before we could get to the point of making this PR. See [this document](https://docs.google.com/document/d/16CkeBm5Y-g95tF-BVqi_b38KV5JfC8yQJVlOawhTKjk/edit?usp=sharing) to understand what went into it. 

What's next? This is a risky ticket, with a potential to impact lots of existing features. We'll test thoroughly. At the same time, we'll think about how to handle multiple scenes. 

~// TODO: A message to contributors.~ 