### PR TITLE
Add SYNC-3309 [v108] Configures history to use application services places

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -9,6 +9,7 @@ import SDWebImage
 import UIKit
 
 let LatestAppVersionProfileKey = "latestAppVersion"
+let NewPlacesAPIDefaultKey = "NewPlacesAPI"
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
@@ -17,10 +18,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     private let log = Logger.browserLogger
 
-    lazy var profile: Profile = BrowserProfile(
-        localName: "profile",
-        syncDelegate: UIApplication.shared.syncDelegate
-    )
+    lazy var profile: Profile = BrowserProfile(localName: "profile",
+                                               syncDelegate: UIApplication.shared.syncDelegate,
+                                               isNewHistoryPlacesAPI: UserDefaults.standard.bool(forKey: NewPlacesAPIDefaultKey))
 
     lazy var tabManager: TabManager = TabManager(
         profile: profile,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -9,7 +9,6 @@ import SDWebImage
 import UIKit
 
 let LatestAppVersionProfileKey = "latestAppVersion"
-let NewPlacesAPIDefaultKey = "NewPlacesAPI"
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
@@ -18,9 +17,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     private let log = Logger.browserLogger
 
-    lazy var profile: Profile = BrowserProfile(localName: "profile",
-                                               syncDelegate: UIApplication.shared.syncDelegate,
-                                               isNewHistoryPlacesAPI: UserDefaults.standard.bool(forKey: NewPlacesAPIDefaultKey))
+    lazy var profile: Profile = BrowserProfile(
+        localName: "profile",
+        syncDelegate: UIApplication.shared.syncDelegate,
+        isNewHistoryPlacesAPI: UserDefaults.standard.bool(forKey: PrefsKeys.NewPlacesAPIDefaultKey)
+    )
 
     lazy var tabManager: TabManager = TabManager(
         profile: profile,

--- a/Client/Application/AppLaunchUtil.swift
+++ b/Client/Application/AppLaunchUtil.swift
@@ -206,8 +206,6 @@ class AppLaunchUtil {
     // MARK: - Application Services History Migration
 
     private func runAppServicesHistoryMigration() {
-        let browserProfile = self.profile as? BrowserProfile
-
         let placesHistory = FxNimbus.shared.features.placesHistory.value()
         FxNimbus.shared.features.placesHistory.recordExposure()
 
@@ -216,6 +214,8 @@ class AppLaunchUtil {
             return
         }
 
+        let browserProfile = self.profile as? BrowserProfile
+
         let migrationRanKey = "PlacesHistoryMigrationRan" + placesHistory.migration.rawValue
         let migrationRan = UserDefaults.standard.bool(forKey: migrationRanKey)
         UserDefaults.standard.setValue(true, forKey: migrationRanKey)
@@ -223,7 +223,7 @@ class AppLaunchUtil {
             if placesHistory.api == .new {
                 browserProfile?.historyApiConfiguration = .new
                 // We set a user default so users with new configuration never go back
-                UserDefaults.standard.setValue(true, forKey: NewPlacesAPIDefaultKey)
+                UserDefaults.standard.setValue(true, forKey: PrefsKeys.NewPlacesAPIDefaultKey)
             }
 
             log.info("Migrating Application services history")

--- a/Client/Frontend/Browser/SearchLoader.swift
+++ b/Client/Frontend/Browser/SearchLoader.swift
@@ -27,7 +27,6 @@ class SearchLoader: Loader<Cursor<Site>, SearchViewController>, FeatureFlaggable
         self.profile = profile
         self.urlBar = urlBar
         self.frecentHistory = profile.history.getFrecentHistory()
-
         self.skipNextAutocomplete = false
 
         super.init()
@@ -53,6 +52,43 @@ class SearchLoader: Loader<Cursor<Site>, SearchViewController>, FeatureFlaggable
         }
     }
 
+    fileprivate func getHistoryAsSites(matchingSearchQuery query: String, limit: Int) -> Deferred<Maybe<Cursor<Site>>> {
+
+        switch self.profile.historyApiConfiguration {
+           case .old:
+            currentDeferredHistoryQuery?.cancel()
+
+            guard let deferredHistory = frecentHistory.getSites(
+                matchingSearchQuery: query,
+                limit: 100
+            ) as? CancellableDeferred else {
+                assertionFailure("FrecentHistory query should be cancellable")
+                return deferMaybe(ArrayCursor(data: []))
+            }
+            currentDeferredHistoryQuery = deferredHistory
+            return deferredHistory
+        case .new:
+            return self.profile.places.queryAutocomplete(matchingSearchQuery: query, limit: limit).bind { result in
+                guard let historyItems = result.successValue else {
+                    SentryIntegration.shared.sendWithStacktrace(
+                        message: "Error searching history",
+                        tag: .rustPlaces,
+                        severity: .error,
+                        description: result.failureValue?.localizedDescription ?? "Unknown error searching history"
+                    )
+                    return deferMaybe(ArrayCursor(data: []))
+                }
+                let sites = historyItems.sorted {
+                    // Sort decending by frecency score
+                    $0.frecency > $1.frecency
+                }.map({
+                    return Site(url: $0.url, title: $0.title )
+                }).uniqued()
+                return deferMaybe(ArrayCursor(data: sites))
+            }
+        }
+    }
+
     var query: String = "" {
         didSet {
             let timerid = GleanMetrics.Awesomebar.queryTime.start()
@@ -62,21 +98,14 @@ class SearchLoader: Loader<Cursor<Site>, SearchViewController>, FeatureFlaggable
                 return
             }
 
-            currentDeferredHistoryQuery?.cancel()
-
+            profile.places.interruptReader()
             if query.isEmpty {
                 load(Cursor(status: .success, msg: "Empty query"))
                 GleanMetrics.Awesomebar.queryTime.cancel(timerid)
                 return
             }
 
-            guard let deferredHistory = frecentHistory.getSites(matchingSearchQuery: query, limit: 100) as? CancellableDeferred else {
-                assertionFailure("FrecentHistory query should be cancellable")
-                GleanMetrics.Awesomebar.queryTime.cancel(timerid)
-                return
-            }
-
-            currentDeferredHistoryQuery = deferredHistory
+            let deferredHistory = getHistoryAsSites(matchingSearchQuery: query, limit: 100)
 
             let deferredBookmarks = getBookmarksAsSites(matchingSearchQuery: query, limit: 5)
 
@@ -86,7 +115,12 @@ class SearchLoader: Loader<Cursor<Site>, SearchViewController>, FeatureFlaggable
                     GleanMetrics.Awesomebar.queryTime.stopAndAccumulate(timerid)
                 }
 
-                guard !deferredHistory.cancelled else { return }
+                let cancellableHistory = deferredHistory as? CancellableDeferred
+                if let cancellableHistory = cancellableHistory {
+                    if cancellableHistory.cancelled {
+                        return
+                    }
+                }
 
                 let deferredHistorySites = results[0].successValue?.asArray() ?? []
                 let deferredBookmarksSites = results[1].successValue?.asArray() ?? []

--- a/Client/Frontend/Browser/SearchLoader.swift
+++ b/Client/Frontend/Browser/SearchLoader.swift
@@ -52,10 +52,11 @@ class SearchLoader: Loader<Cursor<Site>, SearchViewController>, FeatureFlaggable
         }
     }
 
-    fileprivate func getHistoryAsSites(matchingSearchQuery query: String, limit: Int) -> Deferred<Maybe<Cursor<Site>>> {
+    private func getHistoryAsSites(matchingSearchQuery query: String, limit: Int) ->
+    Deferred<Maybe<Cursor<Site>>> {
 
         switch self.profile.historyApiConfiguration {
-           case .old:
+        case .old:
             currentDeferredHistoryQuery?.cancel()
 
             guard let deferredHistory = frecentHistory.getSites(
@@ -116,10 +117,8 @@ class SearchLoader: Loader<Cursor<Site>, SearchViewController>, FeatureFlaggable
                 }
 
                 let cancellableHistory = deferredHistory as? CancellableDeferred
-                if let cancellableHistory = cancellableHistory {
-                    if cancellableHistory.cancelled {
-                        return
-                    }
+                if let cancellableHistory = cancellableHistory, cancellableHistory.cancelled {
+                    return
                 }
 
                 let deferredHistorySites = results[0].successValue?.asArray() ?? []

--- a/Client/Frontend/Browser/SearchLoader.swift
+++ b/Client/Frontend/Browser/SearchLoader.swift
@@ -52,8 +52,7 @@ class SearchLoader: Loader<Cursor<Site>, SearchViewController>, FeatureFlaggable
         }
     }
 
-    private func getHistoryAsSites(matchingSearchQuery query: String, limit: Int) ->
-    Deferred<Maybe<Cursor<Site>>> {
+    private func getHistoryAsSites(matchingSearchQuery query: String, limit: Int) -> Deferred<Maybe<Cursor<Site>>> {
 
         switch self.profile.historyApiConfiguration {
         case .old:

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
@@ -142,12 +142,35 @@ class HistoryPanelViewModel: Loggable, FeatureFlaggable {
     func performSearch(term: String, completion: @escaping (Bool) -> Void) {
         isFetchInProgress = true
 
-        profile.history.getHistory(matching: term,
-                                   limit: searchQueryFetchLimit,
-                                   offset: searchCurrentFetchOffset) { results in
-            self.isFetchInProgress = false
-            self.searchResultSites = results
-            completion(!results.isEmpty)
+        switch self.profile.historyApiConfiguration {
+        case .old:
+            profile.history.getHistory(matching: term,
+                                       limit: searchQueryFetchLimit,
+                                       offset: searchCurrentFetchOffset) { results in
+                self.isFetchInProgress = false
+                self.searchResultSites = results
+                completion(!results.isEmpty)
+            }
+        case .new:
+            profile.places.interruptReader()
+            profile.places.queryAutocomplete(matchingSearchQuery: term, limit: searchQueryFetchLimit).uponQueue(.main) { result in
+                self.isFetchInProgress = false
+
+                guard result.isSuccess else {
+                    SentryIntegration.shared.sendWithStacktrace(
+                        message: "Error searching history panel",
+                        tag: .rustPlaces,
+                        severity: .error,
+                        description: result.failureValue?.localizedDescription ?? "Unkown error searching history"
+                    )
+                    completion(false)
+                    return
+                }
+                if let result = result.successValue {
+                    self.searchResultSites = result.map { Site(url: $0.url, title: $0.title) }
+                    completion(!result.isEmpty)
+                }
+            }
         }
     }
 
@@ -266,16 +289,35 @@ class HistoryPanelViewModel: Loggable, FeatureFlaggable {
 
         isFetchInProgress = true
 
-        return profile.history.getSitesByLastVisit(limit: queryFetchLimit, offset: currentFetchOffset) >>== { result in
-            // Force 100ms delay between resolution of the last batch of results
-            // and the next time `fetchData()` can be called.
-            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) {
-                self.isFetchInProgress = false
-
-                self.browserLog.debug("currentFetchOffset is: \(self.currentFetchOffset)")
+        switch profile.historyApiConfiguration {
+            case .old:
+            return profile.history.getSitesByLastVisit(limit: queryFetchLimit, offset: currentFetchOffset) >>== { result in
+                // Force 100ms delay between resolution of the last batch of results
+                // and the next time `fetchData()` can be called.
+                DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) {
+                    self.isFetchInProgress = false
+                    self.browserLog.debug("currentFetchOffset is: \(self.currentFetchOffset)")
+                }
+                return deferMaybe(result)
             }
-
-            return deferMaybe(result)
+            case .new:
+            return profile.places.getVisitPageWithBound(
+                limit: queryFetchLimit,
+                offset: currentFetchOffset,
+                excludedTypes: VisitTransitionSet(0)
+            ) >>== { result in
+                DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) {
+                    self.isFetchInProgress = false
+                    self.browserLog.debug("currentFetchOffset is: \(self.currentFetchOffset)")
+                }
+                let sites = result.infos.map { info in
+                    let title = (info.title ?? "").isEmpty ? info.url : info.title!
+                    let site = Site(url: info.url, title: title)
+                    site.latestVisit = Visit(date: UInt64(info.timestamp) * 1000)
+                    return site
+                }.uniqued()
+                return deferMaybe(ArrayCursor(data: sites))
+            }
         }
     }
 
@@ -319,6 +361,9 @@ class HistoryPanelViewModel: Loggable, FeatureFlaggable {
     private func deleteSingle(site: Site) {
         groupedSites.remove(site)
         profile.history.removeHistoryForURL(site.url)
+        if profile.historyApiConfiguration == .new {
+            _ = profile.places.deleteVisitsFor(site.url)
+        }
 
         if isSearchInProgress, let indexToRemove = searchResultSites.firstIndex(of: site) {
             searchResultSites.remove(at: indexToRemove)

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
@@ -144,9 +144,11 @@ class HistoryPanelViewModel: Loggable, FeatureFlaggable {
 
         switch self.profile.historyApiConfiguration {
         case .old:
-            profile.history.getHistory(matching: term,
-                                       limit: searchQueryFetchLimit,
-                                       offset: searchCurrentFetchOffset) { results in
+            profile.history.getHistory(
+                matching: term,
+                limit: searchQueryFetchLimit,
+                offset: searchCurrentFetchOffset
+            ) { results in
                 self.isFetchInProgress = false
                 self.searchResultSites = results
                 completion(!results.isEmpty)
@@ -290,7 +292,7 @@ class HistoryPanelViewModel: Loggable, FeatureFlaggable {
         isFetchInProgress = true
 
         switch profile.historyApiConfiguration {
-            case .old:
+        case .old:
             return profile.history.getSitesByLastVisit(limit: queryFetchLimit, offset: currentFetchOffset) >>== { result in
                 // Force 100ms delay between resolution of the last batch of results
                 // and the next time `fetchData()` can be called.
@@ -300,7 +302,7 @@ class HistoryPanelViewModel: Loggable, FeatureFlaggable {
                 }
                 return deferMaybe(result)
             }
-            case .new:
+        case .new:
             return profile.places.getVisitPageWithBound(
                 limit: queryFetchLimit,
                 offset: currentFetchOffset,
@@ -311,7 +313,14 @@ class HistoryPanelViewModel: Loggable, FeatureFlaggable {
                     self.browserLog.debug("currentFetchOffset is: \(self.currentFetchOffset)")
                 }
                 let sites = result.infos.map { info in
-                    let title = (info.title ?? "").isEmpty ? info.url : info.title!
+                    var title: String
+                    if let actualTitle = info.title, !actualTitle.isEmpty {
+                        title = actualTitle
+                    } else {
+                        // In case there is no title, we use the url
+                        // as the title
+                        title = info.url
+                    }
                     let site = Site(url: info.url, title: title)
                     site.latestVisit = Visit(date: UInt64(info.timestamp) * 1000)
                     return site

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -714,7 +714,7 @@ class UseNewHistoryApiOption: HiddenSetting {
                         Logger.browserLogger.info("Successful Migration took \(result.totalDuration / 1000) seconds")
 
                     }, errCallback: { _ in
-                        // noop
+                        Logger.browserLogger.debug("Failed migration of history")
                     }
                 )
                 browserProfile?.historyApiConfiguration = .new
@@ -724,7 +724,7 @@ class UseNewHistoryApiOption: HiddenSetting {
         case .new:
             Logger.browserLogger.info("Setting the history configuration to old")
             browserProfile?.historyApiConfiguration = .old
-            // We set a user default so users with new configuration never go back
+            // We set a user default so users will use the old configuration
             UserDefaults.standard.setValue(false, forKey: PrefsKeys.NewPlacesAPIDefaultKey)
         }
     }

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -683,6 +683,52 @@ class OpenFiftyTabsDebugOption: HiddenSetting {
     }
 }
 
+class UseNewHistoryApiOption: HiddenSetting {
+    let profile: Profile
+
+    override init(settings: SettingsTableViewController) {
+        self.profile = settings.profile
+        super.init(settings: settings)
+    }
+
+    override var title: NSAttributedString? { switch self.profile.historyApiConfiguration {
+        case .old:
+            return NSAttributedString(string: "Migrate and Use Places History Apis")
+        case .new:
+            return NSAttributedString(string: "Use Legacy History Apis")
+        }}
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        let browserProfile = self.profile as? BrowserProfile
+        switch self.profile.historyApiConfiguration {
+        case .old:
+            Logger.browserLogger.info("Setting the history configuration to new")
+            // We run the migration, then we override the profile to use the new apis
+            Logger.browserLogger.info("Deleting history to prepare for migration")
+            let deferred = browserProfile?.places.deleteEverythingHistory()
+            deferred?.upon { _ in
+                Logger.browserLogger.info("History deleted, about to migrate")
+                browserProfile?.migrateHistoryToPlaces(
+                    migrationConfig: .real,
+                    callback: { result in
+                        Logger.browserLogger.info("Successful Migration took \(result.totalDuration / 1000) seconds")
+
+                    }, errCallback: { _ in
+                        // noop
+                    }
+                )
+                browserProfile?.historyApiConfiguration = .new
+                // We set a user default so users with new configuration never go back
+                UserDefaults.standard.setValue(true, forKey: NewPlacesAPIDefaultKey)
+            }
+        case .new:
+            browserProfile?.historyApiConfiguration = .old
+            // We set a user default so users with new configuration never go back
+            UserDefaults.standard.setValue(false, forKey: NewPlacesAPIDefaultKey)
+        }
+    }
+}
+
 // Show the current version of Firefox
 class VersionSetting: Setting {
     unowned let settings: SettingsTableViewController

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -687,20 +687,20 @@ class UseNewHistoryApiOption: HiddenSetting {
     let profile: Profile
 
     override init(settings: SettingsTableViewController) {
-        self.profile = settings.profile
+        profile = settings.profile
         super.init(settings: settings)
     }
 
-    override var title: NSAttributedString? { switch self.profile.historyApiConfiguration {
-        case .old:
-            return NSAttributedString(string: "Migrate and Use Places History Apis")
-        case .new:
-            return NSAttributedString(string: "Use Legacy History Apis")
-        }}
+    override var title: NSAttributedString? { switch profile.historyApiConfiguration {
+    case .old:
+        return NSAttributedString(string: "Migrate and Use Places History Apis")
+    case .new:
+        return NSAttributedString(string: "Use Legacy History Apis")
+    }}
 
     override func onClick(_ navigationController: UINavigationController?) {
-        let browserProfile = self.profile as? BrowserProfile
-        switch self.profile.historyApiConfiguration {
+        let browserProfile = profile as? BrowserProfile
+        switch profile.historyApiConfiguration {
         case .old:
             Logger.browserLogger.info("Setting the history configuration to new")
             // We run the migration, then we override the profile to use the new apis
@@ -719,12 +719,13 @@ class UseNewHistoryApiOption: HiddenSetting {
                 )
                 browserProfile?.historyApiConfiguration = .new
                 // We set a user default so users with new configuration never go back
-                UserDefaults.standard.setValue(true, forKey: NewPlacesAPIDefaultKey)
+                UserDefaults.standard.setValue(true, forKey: PrefsKeys.NewPlacesAPIDefaultKey)
             }
         case .new:
+            Logger.browserLogger.info("Setting the history configuration to old")
             browserProfile?.historyApiConfiguration = .old
             // We set a user default so users with new configuration never go back
-            UserDefaults.standard.setValue(false, forKey: NewPlacesAPIDefaultKey)
+            UserDefaults.standard.setValue(false, forKey: PrefsKeys.NewPlacesAPIDefaultKey)
         }
     }
 }

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -229,6 +229,7 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
                 ToggleHistoryGroups(settings: self),
                 ResetContextualHints(settings: self),
                 OpenFiftyTabsDebugOption(settings: self),
+                UseNewHistoryApiOption(settings: self),
                 ExperimentsSettings(settings: self)
             ])]
 

--- a/Client/Frontend/Settings/Clearables.swift
+++ b/Client/Frontend/Settings/Clearables.swift
@@ -46,11 +46,11 @@ class HistoryClearable: Clearable {
         case .old:
             return profile.history.clearHistory().bindQueue(.main) { success in
                 return self.clearAfterHistory(success: success)
-        }
-        case.new:
-                _ = profile.history.clearHistory()
-                return profile.places.deleteEverythingHistory().bindQueue(.main) { success in
-                    return self.clearAfterHistory(success: success)
+            }
+        case .new:
+            _ = profile.history.clearHistory()
+            return profile.places.deleteEverythingHistory().bindQueue(.main) { success in
+                return self.clearAfterHistory(success: success)
             }
         }
     }

--- a/Client/Frontend/Settings/Clearables.swift
+++ b/Client/Frontend/Settings/Clearables.swift
@@ -42,27 +42,38 @@ class HistoryClearable: Clearable {
 
         // Treat desktop sites as part of browsing history.
         Tab.ChangeUserAgent.clear()
-
-        return profile.history.clearHistory().bindQueue(.main) { success in
-            // TODO: Remove clear cache for SDWebImage when we are ready to remove library
-            // Clear image cache - SDWebImage
-            SDImageCache.shared.clearDisk()
-            SDImageCache.shared.clearMemory()
-
-            // Clear image cache - Kingfisher
-            KingfisherManager.shared.cache.clearMemoryCache()
-            KingfisherManager.shared.cache.clearDiskCache()
-
-            self.profile.recentlyClosedTabs.clearTabs()
-            self.profile.places.deleteHistoryMetadataOlderThan(olderThan: INT64_MAX).uponQueue(.global(qos: .userInteractive)) { _ in }
-            CSSearchableIndex.default().deleteAllSearchableItems()
-            NotificationCenter.default.post(name: .PrivateDataClearedHistory, object: nil)
-            log.debug("HistoryClearable succeeded: \(success).")
-
-            self.tabManager.clearAllTabsHistory()
-
-            return Deferred(value: success)
+        switch profile.historyApiConfiguration {
+        case .old:
+            return profile.history.clearHistory().bindQueue(.main) { success in
+                return self.clearAfterHistory(success: success)
         }
+        case.new:
+                _ = profile.history.clearHistory()
+                return profile.places.deleteEverythingHistory().bindQueue(.main) { success in
+                    return self.clearAfterHistory(success: success)
+            }
+        }
+    }
+
+    func clearAfterHistory(success: Maybe<Void>) -> Success {
+        // TODO: Remove clear cache for SDWebImage when we are ready to remove library
+        // Clear image cache - SDWebImage
+        SDImageCache.shared.clearDisk()
+        SDImageCache.shared.clearMemory()
+
+        // Clear image cache - Kingfisher
+        KingfisherManager.shared.cache.clearMemoryCache()
+        KingfisherManager.shared.cache.clearDiskCache()
+
+        self.profile.recentlyClosedTabs.clearTabs()
+        self.profile.places.deleteHistoryMetadataOlderThan(olderThan: INT64_MAX).uponQueue(.global(qos: .userInteractive)) { _ in }
+        CSSearchableIndex.default().deleteAllSearchableItems()
+        NotificationCenter.default.post(name: .PrivateDataClearedHistory, object: nil)
+        log.debug("HistoryClearable succeeded: \(success).")
+
+        self.tabManager.clearAllTabsHistory()
+
+        return Deferred(value: success)
     }
 }
 

--- a/Client/Utils/HistoryDeletionUtility.swift
+++ b/Client/Utils/HistoryDeletionUtility.swift
@@ -5,6 +5,7 @@
 import Foundation
 import MozillaAppServices
 import WebKit
+import Shared
 
 enum HistoryDeletionUtilityDateOptions {
     case lastHour
@@ -56,6 +57,9 @@ class HistoryDeletionUtility: HistoryDeletionProtocol {
     // MARK: URL based deletion functions
     private func deleteFromHistory(_ sites: [String]) {
         sites.forEach { profile.history.removeHistoryForURL($0) }
+        if profile.historyApiConfiguration == .new {
+            sites.forEach { _ = profile.places.deleteVisitsFor($0) }
+        }
     }
 
     private func deleteMetadata(
@@ -98,20 +102,39 @@ class HistoryDeletionUtility: HistoryDeletionProtocol {
 
         switch dateOption {
         case .allTime:
-            profile.history
-                .clearHistory()
-                .uponQueue(.global(qos: .userInteractive)) { result in
+            switch profile.historyApiConfiguration {
+                case .old:
+                    profile.history
+                        .clearHistory()
+                        .uponQueue(.global(qos: .userInteractive)) { result in
+                            completion(result.isSuccess)
+                        }
+            case .new:
+                // for now we also delete the old history to keep
+                _ = profile.history
+                    .clearHistory()
+                profile.places.deleteEverythingHistory().uponQueue(.global(qos: .userInteractive)) { result in
                     completion(result.isSuccess)
                 }
-
+            }
         default:
             guard let date = dateFor(dateOption) else { return }
-
-            profile.history
-                .removeHistoryFromDate(date)
-                .uponQueue(.global(qos: .userInteractive)) { result in
+            switch profile.historyApiConfiguration {
+                case .old:
+                profile.history
+                    .removeHistoryFromDate(date)
+                    .uponQueue(.global(qos: .userInteractive)) { result in
+                        completion(result.isSuccess)
+                    }
+            case .new:
+                // for now we also delete the old history to keep the browser.db up to date
+                _ = profile.history
+                    .removeHistoryFromDate(date)
+                profile.places.deleteVisitsBetween(date).uponQueue(.global(qos: .userInteractive)) { result in
                     completion(result.isSuccess)
                 }
+            }
+
         }
     }
 

--- a/Client/Utils/HistoryDeletionUtility.swift
+++ b/Client/Utils/HistoryDeletionUtility.swift
@@ -103,14 +103,13 @@ class HistoryDeletionUtility: HistoryDeletionProtocol {
         switch dateOption {
         case .allTime:
             switch profile.historyApiConfiguration {
-                case .old:
-                    profile.history
-                        .clearHistory()
-                        .uponQueue(.global(qos: .userInteractive)) { result in
-                            completion(result.isSuccess)
-                        }
+            case .old:
+                profile.history
+                    .clearHistory()
+                    .uponQueue(.global(qos: .userInteractive)) { result in
+                        completion(result.isSuccess)
+                    }
             case .new:
-                // for now we also delete the old history to keep
                 _ = profile.history
                     .clearHistory()
                 profile.places.deleteEverythingHistory().uponQueue(.global(qos: .userInteractive)) { result in
@@ -120,7 +119,7 @@ class HistoryDeletionUtility: HistoryDeletionProtocol {
         default:
             guard let date = dateFor(dateOption) else { return }
             switch profile.historyApiConfiguration {
-                case .old:
+            case .old:
                 profile.history
                     .removeHistoryFromDate(date)
                     .uponQueue(.global(qos: .userInteractive)) { result in
@@ -134,7 +133,6 @@ class HistoryDeletionUtility: HistoryDeletionProtocol {
                     completion(result.isSuccess)
                 }
             }
-
         }
     }
 

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -45,6 +45,12 @@ public enum HistoryMigrationConfiguration {
     case dryRun
     case real
 }
+
+public enum HistoryAPIConfiguration {
+    case old
+    case new
+}
+
 class ProfileFileAccessor: FileAccessor {
     convenience init(profile: Profile) {
         self.init(localName: profile.localName())
@@ -98,6 +104,7 @@ protocol Profile: AnyObject {
     var logins: RustLogins { get }
     var certStore: CertStore { get }
     var recentlyClosedTabs: ClosedTabsStore { get }
+    var historyApiConfiguration: HistoryAPIConfiguration { get }
 
     #if !MOZ_TARGET_NOTIFICATIONSERVICE
         var readingList: ReadingList { get }
@@ -212,6 +219,7 @@ extension Profile {
 }
 
 open class BrowserProfile: Profile {
+
     fileprivate let name: String
     fileprivate let keychain: MZKeychainWrapper
     var isShutdown = false
@@ -223,6 +231,8 @@ open class BrowserProfile: Profile {
     var syncManager: SyncManager!
 
     var syncDelegate: SyncDelegate?
+
+    var historyApiConfiguration: HistoryAPIConfiguration
 
     /**
      * N.B., BrowserProfile is used from our extensions, often via a pattern like
@@ -236,12 +246,17 @@ open class BrowserProfile: Profile {
      * A SyncDelegate can be provided in this initializer, or once the profile is initialized.
      * However, if we provide it here, it's assumed that we're initializing it from the application.
      */
-    init(localName: String, syncDelegate: SyncDelegate? = nil, clear: Bool = false) {
+    init(localName: String, syncDelegate: SyncDelegate? = nil, clear: Bool = false, isNewHistoryPlacesAPI: Bool = false) {
         log.debug("Initing profile \(localName) on thread \(Thread.current).")
         self.name = localName
         self.files = ProfileFileAccessor(localName: localName)
         self.keychain = MZKeychainWrapper.sharedClientAppContainerKeychain
         self.syncDelegate = syncDelegate
+        if isNewHistoryPlacesAPI {
+            self.historyApiConfiguration = .new
+        } else {
+            self.historyApiConfiguration = .old
+        }
 
         if clear {
             do {
@@ -374,6 +389,15 @@ open class BrowserProfile: Profile {
                                       date: Date().toMicrosecondsSince1970(),
                                       type: visitType)
                 history.addLocalVisit(visit)
+                if self.historyApiConfiguration == .new {
+                    let result = self.places.applyObservation(visitObservation: VisitObservation(url: url.description, title: title as String, visitType: VisitTransition.fromVisitType(visitType: visitType)))
+                    result.upon { result in
+                        guard result.isSuccess else {
+                            SentryIntegration.shared.sendWithStacktrace(message: result.failureValue?.localizedDescription ?? "Unknown error adding history visit", tag: .rustPlaces, severity: .error)
+                            return
+                        }
+                    }
+                }
             }
 
             history.setTopSitesNeedsInvalidation()
@@ -903,7 +927,12 @@ open class BrowserProfile: Profile {
                 return self.profile.tabs.resetSync() >>> { ClientsSynchronizer.resetClientsWithStorage(self.profile.remoteClientsAndTabs, basePrefs: self.prefsForSync) }
 
             case "history":
-                return HistorySynchronizer.resetSynchronizerWithStorage(self.profile.history, basePrefs: self.prefsForSync, collection: "history")
+                switch self.profile.historyApiConfiguration {
+                case .old:
+                    return HistorySynchronizer.resetSynchronizerWithStorage(self.profile.history, basePrefs: self.prefsForSync, collection: "history")
+                case .new:
+                    return self.profile.places.resetHistoryMetadata()
+                }
             case "passwords":
                 return self.profile.logins.resetSync()
             case "forms":
@@ -925,12 +954,18 @@ open class BrowserProfile: Profile {
             let profile = self.profile
 
             // Run these in order, because they might write to the same DB!
-            let remove = [
-                profile.history.onRemovedAccount,
+
+            var remove = [
                 profile.remoteClientsAndTabs.onRemovedAccount,
                 profile.logins.resetSync,
                 profile.places.resetBookmarksMetadata,
             ]
+            switch profile.historyApiConfiguration {
+            case .old:
+                remove.append(profile.history.onRemovedAccount)
+            case .new:
+                remove.append(profile.places.resetHistoryMetadata)
+            }
 
             let clearPrefs: () -> Success = {
                 withExtendedLifetime(self) {
@@ -1004,7 +1039,7 @@ open class BrowserProfile: Profile {
             }
         }
 
-        fileprivate func syncHistoryWithDelegate(_ delegate: SyncDelegate, prefs: Prefs, ready: Ready, why: SyncReason) -> SyncResult {
+        fileprivate func syncLegacyHistoryWithDelegate(_ delegate: SyncDelegate, prefs: Prefs, ready: Ready, why: SyncReason) -> SyncResult {
             log.debug("Syncing history to storage.")
             let historySynchronizer = ready.synchronizer(HistorySynchronizer.self, delegate: delegate, prefs: prefs, why: why)
             return historySynchronizer.synchronizeLocalHistory(self.profile.history, withServer: ready.client, info: ready.info, greenLight: self.greenLight())
@@ -1100,6 +1135,24 @@ open class BrowserProfile: Profile {
                     }
 
                     let syncEngineStatsSession = SyncEngineStatsSession(collection: "bookmarks")
+                    return deferMaybe(SyncStatus.completed(syncEngineStatsSession))
+                })
+            })
+        }
+
+        fileprivate func syncHistoryWithDelegate(_ delegate: SyncDelegate, prefs: Prefs, ready: Ready, why: SyncReason) -> SyncResult {
+            log.debug("Syncing History to storage.")
+            return syncUnlockInfo().bind({ result in
+                guard let syncUnlockInfo = result.successValue else {
+                    return deferMaybe(SyncStatus.notStarted(.unknown))
+                }
+
+                return self.profile.places.syncHistory(unlockInfo: syncUnlockInfo).bind({ result in
+                    guard result.isSuccess else {
+                        return deferMaybe(SyncStatus.notStarted(.unknown))
+                    }
+
+                    let syncEngineStatsSession = SyncEngineStatsSession(collection: "history")
                     return deferMaybe(SyncStatus.completed(syncEngineStatsSession))
                 })
             })
@@ -1321,11 +1374,16 @@ open class BrowserProfile: Profile {
                 return Success()
             }
 
+            var historySynchronizer = self.syncLegacyHistoryWithDelegate
+            if self.profile.historyApiConfiguration == .new {
+                historySynchronizer = self.syncHistoryWithDelegate
+            }
+
             let synchronizers = [
                 ("clients", self.syncClientsWithDelegate),
                 ("tabs", self.syncTabsWithDelegate),
                 ("bookmarks", self.syncBookmarksWithDelegate),
-                ("history", self.syncHistoryWithDelegate),
+                ("history", historySynchronizer),
                 ("logins", self.syncLoginsWithDelegate)
             ]
 
@@ -1366,7 +1424,13 @@ open class BrowserProfile: Profile {
                 case "tabs": return ("tabs", self.syncTabsWithDelegate)
                 case "logins": return ("logins", self.syncLoginsWithDelegate)
                 case "bookmarks": return ("bookmarks", self.syncBookmarksWithDelegate)
-                case "history": return ("history", self.syncHistoryWithDelegate)
+                case "history":
+                    switch self.profile.historyApiConfiguration {
+                    case .old:
+                        return ("history", self.syncLegacyHistoryWithDelegate)
+                    case .new:
+                        return ("history", self.syncHistoryWithDelegate)
+                    }
                 default: return nil
                 }
             }
@@ -1406,8 +1470,12 @@ open class BrowserProfile: Profile {
         }
 
         public func syncHistory() -> SyncResult {
-            // TODO: recognize .NotStarted.
-            return self.sync("history", function: syncHistoryWithDelegate)
+            switch self.profile.historyApiConfiguration {
+            case .old:
+                return self.sync("history", function: syncLegacyHistoryWithDelegate)
+            case .new:
+                return self.sync("history", function: syncHistoryWithDelegate)
+            }
         }
 
         /**

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -390,7 +390,13 @@ open class BrowserProfile: Profile {
                                       type: visitType)
                 history.addLocalVisit(visit)
                 if self.historyApiConfiguration == .new {
-                    let result = self.places.applyObservation(visitObservation: VisitObservation(url: url.description, title: title as String, visitType: VisitTransition.fromVisitType(visitType: visitType)))
+                    let result = self.places.applyObservation(
+                        visitObservation: VisitObservation(
+                            url: url.description,
+                            title: title as String,
+                            visitType: VisitTransition.fromVisitType(visitType: visitType)
+                        )
+                    )
                     result.upon { result in
                         guard result.isSuccess else {
                             SentryIntegration.shared.sendWithStacktrace(message: result.failureValue?.localizedDescription ?? "Unknown error adding history visit", tag: .rustPlaces, severity: .error)
@@ -489,7 +495,12 @@ open class BrowserProfile: Profile {
                 },
                 errCallback: errCallback)
         case .real:
-            self.places.migrateHistory(dbPath: self.browserDbPath, lastSyncTimestamp: lastSyncTimestamp, completion: callback, errCallback: errCallback)
+            self.places.migrateHistory(
+                dbPath: self.browserDbPath,
+                lastSyncTimestamp: lastSyncTimestamp,
+                completion: callback,
+                errCallback: errCallback
+            )
         }
     }
 

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -126,6 +126,10 @@ public struct PrefsKeys {
     public static let WallpaperManagerCurrentWallpaperImage = "WallpaperManagerCurrentWallpaperImage"
     public static let WallpaperManagerCurrentWallpaperImageLandscape = "WallpaperManagerCurrentWallpaperImageLandscape"
     public static let WallpaperManagerLogoSwitchPreference = "WallpaperManagerLogoSwitchPreference"
+
+    // Application Services Migration to Places DB
+    public static let NewPlacesAPIDefaultKey = "NewPlacesAPI"
+
 }
 
 public struct PrefsDefaults {

--- a/Tests/ClientTests/Library/HistoryPanelViewModelTests.swift
+++ b/Tests/ClientTests/Library/HistoryPanelViewModelTests.swift
@@ -24,7 +24,7 @@ class HistoryPanelViewModelTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
 
-        clear(profile.history)
+        clear(profile: profile)
         profile.shutdown()
         profile = nil
         subject = nil
@@ -230,19 +230,34 @@ class HistoryPanelViewModelTests: XCTestCase {
 
     // MARK: -
     private func setupSiteVisits() {
-        addSiteVisit(profile.history, url: "http://mozilla.org/", title: "Mozilla internet")
-        addSiteVisit(profile.history, url: "http://mozilla.dev.org/", title: "Internet dev")
-        addSiteVisit(profile.history, url: "https://apple.com/", title: "Apple")
+        addSiteVisit(profile, url: "http://mozilla.org/", title: "Mozilla internet")
+        addSiteVisit(profile, url: "http://mozilla.dev.org/", title: "Internet dev")
+        addSiteVisit(profile, url: "https://apple.com/", title: "Apple")
     }
 
-    private func addSiteVisit(_ history: BrowserHistory, url: String, title: String, siteAdded: Bool = true) {
+    private func addSiteVisit(_ profile: MockProfile, url: String, title: String) {
         let site = Site(url: url, title: title)
         let visit = SiteVisit(site: site, date: Date().toMicrosecondsSince1970())
-        XCTAssertEqual(siteAdded, history.addLocalVisit(visit).value.isSuccess, "Site added: \(url).")
+        let result: Success
+        switch profile.historyApiConfiguration {
+            case .old:
+            result = profile.history.addLocalVisit(visit)
+        case .new:
+            result = profile.places.applyObservation(visitObservation: VisitObservation(url: url, title: title, visitType: VisitTransition.link))
+        }
+
+        XCTAssertEqual(true, result.value.isSuccess, "Site added: \(url).")
     }
 
-    private func clear(_ history: BrowserHistory) {
-        XCTAssertTrue(history.clearHistory().value.isSuccess, "History cleared.")
+    private func clear(profile: MockProfile) {
+        let result: Success
+        switch profile.historyApiConfiguration {
+        case .old:
+            result = profile.history.clearHistory()
+        case .new:
+            result = profile.places.deleteEverythingHistory()
+        }
+        XCTAssertTrue(result.value.isSuccess, "History cleared.")
     }
 
     private func fetchHistory(completion: @escaping (Bool) -> Void) {

--- a/Tests/ClientTests/Library/HistoryPanelViewModelTests.swift
+++ b/Tests/ClientTests/Library/HistoryPanelViewModelTests.swift
@@ -240,7 +240,7 @@ class HistoryPanelViewModelTests: XCTestCase {
         let visit = SiteVisit(site: site, date: Date().toMicrosecondsSince1970())
         let result: Success
         switch profile.historyApiConfiguration {
-            case .old:
+        case .old:
             result = profile.history.addLocalVisit(visit)
         case .new:
             result = profile.places.applyObservation(visitObservation: VisitObservation(url: url, title: title, visitType: VisitTransition.link))

--- a/Tests/ClientTests/Mocks/MockProfile.swift
+++ b/Tests/ClientTests/Mocks/MockProfile.swift
@@ -83,6 +83,7 @@ open class MockProfile: Client.Profile {
     public var history: BrowserHistory & SyncableHistory & ResettableSyncStorage
     public var logins: RustLogins
     public var syncManager: SyncManager!
+    public var historyApiConfiguration: HistoryAPIConfiguration
 
     fileprivate var legacyPlaces: BrowserHistory & Favicons & SyncableHistory & ResettableSyncStorage & HistoryRecommendations
 
@@ -115,6 +116,11 @@ open class MockProfile: Client.Profile {
         legacyPlaces = SQLiteHistory(database: self.database, prefs: MockProfilePrefs())
         recommendations = legacyPlaces
         history = legacyPlaces
+        // We run the tests using the old configuration
+        // the new APIs have extensive tests in the application services repository
+        // For now, to test the new configuration
+        // change the following to `.new`
+        historyApiConfiguration = .old
     }
 
     public func localName() -> String {


### PR DESCRIPTION
This a draft until we create a new release in application services

But this is ready for the first round of review as I clean a few things up (long lines, lints etc)

cc @nbhasin2 (Mark and Lougenia are out, but I'll tag them next week)

## What's in this PR:
- Using the nimbus configuration to decide which API to use for history
- Using the new APIs where appropriate
- A secret menu item to switch to the new implementation so it's easier to test

### Using the nimbus configuration
The nimbus configuration decides which API to use, it's either `.new` or `.old.

- `.old`: We use the old apis and the old apis alone for all **writes**, **reads** and **sync**. In other words, nothing changes.
- `.new`: We use the  new apis for reads, we use both apis for writes (in other words, we keep the other database up to date), but we only use the new APIs for sync.

**NOTE**: Once we set the APIs to `.new`, they cannot be reverted back (even if the remote configuration changes). This is to ensure that users can't go back and forth. We will do a gradual rollout to reduce risk.

#### Why do writes to both APIs when the configuration is set to new?
- It's a risk management decision in case we are forced to revert this patch. This also allows us to revert releases in case a different patch caused crashes and we want to pull the whole release without losing any user data.
- in 109, assuming the rollout goes OK, we will delete that code.


### The new APIs:
There are <X> number of new apis used here:
- Sync:
  - `syncHistory`: This syncs history using the Rust implementation
  - `resetHistoryMetadata`: Resets History's sync metadata (the last sync timestamp) so the next sync does a full sync
- Writes:
  - `applyObservation`: This adds a new visit to the visits database, used whenever a user initiates a visit
  - `deleteHistoryFor`: Deletes all visits to a single URL
  - `deleteVisitsBetween`: Deletes all visits between two timestamps
  - `deleteEverythingHistory`: Deletes all history
- Reads:
  - `queryAutocomplete`: Retrieves search results from history based on query term, used in awesombar and history panel search
  - `getVisitPageWithBound`: Retrieves visits with a given bound, this is used in the history panel
  
  ### The secret menu:
  There is a new secret menu item, it'll be called `Migrate and use new Places API` if you're using the old configuration. and `Use Legacy History Api` if you're using the new configuration. This makes it easier to test:
  <img width="394" alt="Screen Shot 2022-10-27 at 1 52 39 PM" src="https://user-images.githubusercontent.com/5303520/198395706-7d16d456-f12c-40b6-9c5f-a7d331132932.png">
