### PR TITLE
Bugfix FXIOS-5090 [v108] Quick action recent bookmarks not updated properly on some deletion cases

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -522,6 +522,7 @@
 		8A2366FA28A302E500846D1B /* MockSponsoredPocketAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2366F928A302E500846D1B /* MockSponsoredPocketAPI.swift */; };
 		8A2783F1275FFDC50080D29D /* KeyboardPressesHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2783F0275FFDC50080D29D /* KeyboardPressesHandler.swift */; };
 		8A2825352760399B00395E66 /* KeyboardPressesHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2825342760399B00395E66 /* KeyboardPressesHandlerTests.swift */; };
+		8A28C628291028870078A81A /* CanRemoveQuickActionBookmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A28C627291028870078A81A /* CanRemoveQuickActionBookmarkTests.swift */; };
 		8A2B1A5D28216C4D0061216B /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 8A2B1A5A28216C4C0061216B /* Debug.xcconfig */; };
 		8A2B1A5E28216C4D0061216B /* Common.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 8A2B1A5B28216C4C0061216B /* Common.xcconfig */; };
 		8A2B1A5F28216C4D0061216B /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 8A2B1A5C28216C4D0061216B /* Release.xcconfig */; };
@@ -3250,6 +3251,7 @@
 		8A2366F928A302E500846D1B /* MockSponsoredPocketAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSponsoredPocketAPI.swift; sourceTree = "<group>"; };
 		8A2783F0275FFDC50080D29D /* KeyboardPressesHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardPressesHandler.swift; sourceTree = "<group>"; };
 		8A2825342760399B00395E66 /* KeyboardPressesHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardPressesHandlerTests.swift; sourceTree = "<group>"; };
+		8A28C627291028870078A81A /* CanRemoveQuickActionBookmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanRemoveQuickActionBookmarkTests.swift; sourceTree = "<group>"; };
 		8A2B1A5A28216C4C0061216B /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Configuration/Debug.xcconfig; sourceTree = "<group>"; };
 		8A2B1A5B28216C4C0061216B /* Common.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Common.xcconfig; path = Configuration/Common.xcconfig; sourceTree = "<group>"; };
 		8A2B1A5C28216C4D0061216B /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Configuration/Release.xcconfig; sourceTree = "<group>"; };
@@ -8177,6 +8179,7 @@
 				2FDB10921A9FBEC5006CF312 /* PrefsTests.swift */,
 				0BA896491A250E6500C1010C /* ProfileTest.swift */,
 				8AF0CFF427A0B0ED00C1A4A2 /* QuickActionsTests.swift */,
+				8A28C627291028870078A81A /* CanRemoveQuickActionBookmarkTests.swift */,
 				8AEE284A276A973400C7104D /* RatingPromptManagerTests.swift */,
 				8A11C8102731CFD700AC7318 /* ReaderModeStyleTests.swift */,
 				8A355E5D27D267A400B9AF34 /* RecentItemsHelperTests.swift */,
@@ -10855,6 +10858,7 @@
 				2165B2C42860CB34004C0786 /* MockAdjustTelemetryData.swift in Sources */,
 				0BA8964B1A250E6500C1010C /* ProfileTest.swift in Sources */,
 				8AE80BAF2891960300BC12EA /* MockTraitCollection.swift in Sources */,
+				8A28C628291028870078A81A /* CanRemoveQuickActionBookmarkTests.swift in Sources */,
 				03CCC9181AF05E7300DBF30D /* RelativeDatesTests.swift in Sources */,
 				F84B21DA1A090F8100AAB793 /* ClientTests.swift in Sources */,
 				E1AEC179286E0CF500062E29 /* FirefoxHomeViewModelTests.swift in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -175,7 +175,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     /// Quick actions / shortcut items are handled here as long as our two launch methods return `true`. If either of them return `false`, this method
     /// won't be called to handle shortcut items.
     func application(_ application: UIApplication, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void) {
-        let handledShortCutItem = QuickActions.sharedInstance.handleShortCutItem(shortcutItem, withBrowserViewController: browserViewController)
+        let handledShortCutItem = QuickActionsImplementation().handleShortCutItem(
+            shortcutItem,
+            withBrowserViewController: browserViewController)
 
         completionHandler(handledShortCutItem)
     }

--- a/Client/Application/QuickActions.swift
+++ b/Client/Application/QuickActions.swift
@@ -4,10 +4,9 @@
 
 import Foundation
 import Storage
-
 import Shared
-import XCGLogger
 
+// MARK: - ShortcutType
 enum ShortcutType: String {
     case newTab = "NewTab"
     case newPrivateTab = "NewPrivateTab"
@@ -25,60 +24,96 @@ enum ShortcutType: String {
     }
 }
 
-class QuickActions: NSObject {
+// MARK: - QuickActionInfos
+struct QuickActionInfos {
+    static let version = "1.0"
+    static let versionKey = "dynamicQuickActionsVersion"
+    static let tabURLKey = "url"
+    static let tabTitleKey = "title"
+}
 
-    fileprivate let log = Logger.browserLogger
+// MARK: - QuickActions
+protocol QuickActions {
+    func addDynamicApplicationShortcutItemOfType(
+        _ type: ShortcutType,
+        fromShareItem shareItem: ShareItem,
+        toApplication application: UIApplication
+    )
 
-    static let QuickActionsVersion = "1.0"
-    static let QuickActionsVersionKey = "dynamicQuickActionsVersion"
+    func addDynamicApplicationShortcutItemOfType(
+        _ type: ShortcutType,
+        withUserData userData: [String: String],
+        toApplication application: UIApplication
+    )
 
-    static let TabURLKey = "url"
-    static let TabTitleKey = "title"
+    func removeDynamicApplicationShortcutItemOfType(
+        _ type: ShortcutType,
+        fromApplication application: UIApplication
+    )
 
-    static var sharedInstance = QuickActions()
+    func handleShortCutItem(
+        _ shortcutItem: UIApplicationShortcutItem,
+        withBrowserViewController bvc: BrowserViewController
+    ) -> Bool
+}
 
-    var launchedShortcutItem: UIApplicationShortcutItem?
-
-    // MARK: Administering Quick Actions
-    func addDynamicApplicationShortcutItemOfType(_ type: ShortcutType, fromShareItem shareItem: ShareItem, toApplication application: UIApplication) {
-            var userData = [QuickActions.TabURLKey: shareItem.url]
-            if let title = shareItem.title {
-                userData[QuickActions.TabTitleKey] = title
-            }
-        QuickActions.sharedInstance.addDynamicApplicationShortcutItemOfType(type, withUserData: userData, toApplication: application)
-    }
-
-    @discardableResult func addDynamicApplicationShortcutItemOfType(
+extension QuickActions {
+    func addDynamicApplicationShortcutItemOfType(
         _ type: ShortcutType,
         withUserData userData: [String: String] = [String: String](),
         toApplication application: UIApplication
-    ) -> Bool {
+    ) {
+        self.addDynamicApplicationShortcutItemOfType(type, withUserData: userData, toApplication: application)
+    }
+}
+
+class QuickActionsImplementation: NSObject, QuickActions, Loggable {
+
+    // MARK: Administering Quick Actions
+    func addDynamicApplicationShortcutItemOfType(_ type: ShortcutType,
+                                                 fromShareItem shareItem: ShareItem,
+                                                 toApplication application: UIApplication) {
+        var userData = [QuickActionInfos.tabURLKey: shareItem.url]
+        if let title = shareItem.title {
+            userData[QuickActionInfos.tabTitleKey] = title
+        }
+        addDynamicApplicationShortcutItemOfType(type,
+                                                withUserData: userData,
+                                                toApplication: application)
+    }
+
+    func addDynamicApplicationShortcutItemOfType(
+        _ type: ShortcutType,
+        withUserData userData: [String: String] = [String: String](),
+        toApplication application: UIApplication
+    ) {
         // add the quick actions version so that it is always in the user info
         var userData: [String: String] = userData
-        userData[QuickActions.QuickActionsVersionKey] = QuickActions.QuickActionsVersion
+        userData[QuickActionInfos.versionKey] = QuickActionInfos.version
         var dynamicShortcutItems = application.shortcutItems ?? [UIApplicationShortcutItem]()
         switch type {
         case .openLastBookmark:
-            let openLastBookmarkShortcut = UIMutableApplicationShortcutItem(type: ShortcutType.openLastBookmark.type,
+            let openLastBookmarkShortcut = UIMutableApplicationShortcutItem(
+                type: ShortcutType.openLastBookmark.type,
                 localizedTitle: .QuickActionsLastBookmarkTitle,
-                localizedSubtitle: userData[QuickActions.TabTitleKey],
+                localizedSubtitle: userData[QuickActionInfos.tabTitleKey],
                 icon: UIApplicationShortcutIcon(templateImageName: "quick_action_last_bookmark"),
                 userInfo: userData as [String: NSSecureCoding]
             )
+
             if let index = (dynamicShortcutItems.firstIndex { $0.type == ShortcutType.openLastBookmark.type }) {
                 dynamicShortcutItems[index] = openLastBookmarkShortcut
             } else {
                 dynamicShortcutItems.append(openLastBookmarkShortcut)
             }
         default:
-            log.warning("Cannot add static shortcut item of type \(type)")
-            return false
+            Logger.browserLogger.warning("Cannot add static shortcut item of type \(type)")
         }
         application.shortcutItems = dynamicShortcutItems
-        return true
     }
 
-    func removeDynamicApplicationShortcutItemOfType(_ type: ShortcutType, fromApplication application: UIApplication) {
+    func removeDynamicApplicationShortcutItemOfType(_ type: ShortcutType,
+                                                    fromApplication application: UIApplication) {
         guard var dynamicShortcutItems = application.shortcutItems,
               let index = (dynamicShortcutItems.firstIndex { $0.type == type.type })
         else { return }
@@ -87,8 +122,10 @@ class QuickActions: NSObject {
         application.shortcutItems = dynamicShortcutItems
     }
 
-    // MARK: Handling Quick Actions
-    @discardableResult func handleShortCutItem(_ shortcutItem: UIApplicationShortcutItem, withBrowserViewController bvc: BrowserViewController ) -> Bool {
+    // MARK: - Handling Quick Actions
+
+    func handleShortCutItem(_ shortcutItem: UIApplicationShortcutItem,
+                            withBrowserViewController bvc: BrowserViewController) -> Bool {
 
         // Verify that the provided `shortcutItem`'s `type` is one handled by the application.
         guard let shortCutType = ShortcutType(fullType: shortcutItem.type) else { return false }
@@ -100,14 +137,17 @@ class QuickActions: NSObject {
         return true
     }
 
-    fileprivate func handleShortCutItemOfType(_ type: ShortcutType, userData: [String: NSSecureCoding]?, browserViewController: BrowserViewController) {
+    // MARK: - Private
+
+    private func handleShortCutItemOfType(_ type: ShortcutType, userData: [String: NSSecureCoding]?,
+                                          browserViewController: BrowserViewController) {
         switch type {
         case .newTab:
             handleOpenNewTab(withBrowserViewController: browserViewController, isPrivate: false)
         case .newPrivateTab:
             handleOpenNewTab(withBrowserViewController: browserViewController, isPrivate: true)
         case .openLastBookmark:
-            if let urlToOpen = (userData?[QuickActions.TabURLKey] as? String)?.asURL {
+            if let urlToOpen = (userData?[QuickActionInfos.tabURLKey] as? String)?.asURL {
                 handleOpenURL(withBrowserViewController: browserViewController, urlToOpen: urlToOpen)
             }
         case .qrCode:
@@ -115,11 +155,13 @@ class QuickActions: NSObject {
         }
     }
 
-    fileprivate func handleOpenNewTab(withBrowserViewController bvc: BrowserViewController, isPrivate: Bool) {
+    private func handleOpenNewTab(withBrowserViewController bvc: BrowserViewController,
+                                  isPrivate: Bool) {
         bvc.openBlankNewTab(focusLocationField: true, isPrivate: isPrivate)
     }
 
-    fileprivate func handleOpenURL(withBrowserViewController bvc: BrowserViewController, urlToOpen: URL) {
+    private func handleOpenURL(withBrowserViewController bvc: BrowserViewController,
+                               urlToOpen: URL) {
         // open bookmark in a non-private browsing tab
         bvc.switchToPrivacyMode(isPrivate: false)
 
@@ -129,7 +171,7 @@ class QuickActions: NSObject {
         bvc.switchToTabForURLOrOpen(urlToOpen)
     }
 
-    fileprivate func handleQRCode(with vc: QRCodeViewControllerDelegate & UIViewController) {
+    private func handleQRCode(with vc: QRCodeViewControllerDelegate & UIViewController) {
         let qrCodeViewController = QRCodeViewController()
         qrCodeViewController.qrCodeDelegate = vc
         let controller = UINavigationController(rootViewController: qrCodeViewController)

--- a/Client/Application/QuickActions.swift
+++ b/Client/Application/QuickActions.swift
@@ -63,7 +63,7 @@ extension QuickActions {
         withUserData userData: [String: String] = [String: String](),
         toApplication application: UIApplication
     ) {
-        self.addDynamicApplicationShortcutItemOfType(type, withUserData: userData, toApplication: application)
+        addDynamicApplicationShortcutItemOfType(type, withUserData: userData, toApplication: application)
     }
 }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1136,11 +1136,13 @@ class BrowserViewController: UIViewController {
                                       title: shareItem.title,
                                       position: 0)
 
-        var userData = [QuickActions.TabURLKey: shareItem.url]
+        var userData = [QuickActionInfos.tabURLKey: shareItem.url]
         if let title = shareItem.title {
-            userData[QuickActions.TabTitleKey] = title
+            userData[QuickActionInfos.tabTitleKey] = title
         }
-        QuickActions.sharedInstance.addDynamicApplicationShortcutItemOfType(.openLastBookmark, withUserData: userData, toApplication: .shared)
+        QuickActionsImplementation().addDynamicApplicationShortcutItemOfType(.openLastBookmark,
+                                                                             withUserData: userData,
+                                                                             toApplication: .shared)
 
         showBookmarksToast()
     }

--- a/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -51,6 +51,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
     private let showFXASyncAction: (FXASyncClosure) -> Void
     private let themeManager: ThemeManager
 
+    var bookmarksHandler: BookmarksHandler
     let profile: Profile
     let tabManager: TabManager
 
@@ -70,6 +71,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
          themeManager: ThemeManager = AppContainer.shared.resolve()) {
 
         self.profile = profile
+        self.bookmarksHandler = profile.places
         self.tabManager = tabManager
         self.buttonView = buttonView
         self.showFXASyncAction = showFXASyncAction

--- a/Client/Frontend/Home/HomepageContextMenuHelper.swift
+++ b/Client/Frontend/Home/HomepageContextMenuHelper.swift
@@ -152,13 +152,13 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
                                                              title: shareItem.title,
                                                              position: 0)
 
-            var userData = [QuickActions.TabURLKey: shareItem.url]
+            var userData = [QuickActionInfos.tabURLKey: shareItem.url]
             if let title = shareItem.title {
-                userData[QuickActions.TabTitleKey] = title
+                userData[QuickActionInfos.tabTitleKey] = title
             }
-            QuickActions.sharedInstance.addDynamicApplicationShortcutItemOfType(.openLastBookmark,
-                                                                                withUserData: userData,
-                                                                                toApplication: .shared)
+            QuickActionsImplementation().addDynamicApplicationShortcutItemOfType(.openLastBookmark,
+                                                                                 withUserData: userData,
+                                                                                 toApplication: .shared)
             site.setBookmarked(true)
             TelemetryWrapper.recordEvent(category: .action, method: .add, object: .bookmark, value: .activityStream)
         })

--- a/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
@@ -23,6 +23,7 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel, CanRemoveQuickActio
     }
 
     // MARK: - Properties
+    var bookmarksHandler: BookmarksHandler
     var libraryPanelDelegate: LibraryPanelDelegate?
     var notificationCenter: NotificationProtocol
     var state: LibraryPanelMainState
@@ -77,6 +78,7 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel, CanRemoveQuickActio
         self.viewModel = viewModel
         self.notificationCenter = notificationCenter
         self.state = viewModel.bookmarkFolderGUID == BookmarkRoots.MobileFolderGUID ? .bookmarks(state: .mainView) : .bookmarks(state: .inFolder)
+        self.bookmarksHandler = viewModel.profile.places
         super.init(profile: viewModel.profile)
 
         setupNotifications(forObserver: self, observing: [.FirefoxAccountChanged])

--- a/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
@@ -241,13 +241,14 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel, CanRemoveQuickActio
     /// Performs the delete asynchronously even though we update the
     /// table view data source immediately for responsiveness.
     private func deleteBookmarkNode(_ indexPath: IndexPath, bookmarkNode: FxBookmarkNode) {
-        _ = profile.places.deleteBookmarkNode(guid: bookmarkNode.guid)
+        profile.places.deleteBookmarkNode(guid: bookmarkNode.guid).uponQueue(.main) { _ in
+            self.removeBookmarkShortcut()
+        }
 
         tableView.beginUpdates()
         viewModel.bookmarkNodes.remove(at: indexPath.row)
         tableView.deleteRows(at: [indexPath], with: .left)
         tableView.endUpdates()
-        removeBookmarkShortcut()
     }
 
     // MARK: Button Actions helpers

--- a/Client/Protocols/CanRemoveQuickActionBookmark.swift
+++ b/Client/Protocols/CanRemoveQuickActionBookmark.swift
@@ -3,36 +3,30 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import Storage
 
 protocol CanRemoveQuickActionBookmark {
-    var profile: Profile { get }
-    func removeBookmarkShortcut()
+    var bookmarksHandler: BookmarksHandler { get }
+    func removeBookmarkShortcut(quickAction: QuickActions)
 }
 
 // Extension to easily remove a bookmark from the quick actions
 extension CanRemoveQuickActionBookmark {
 
-    func removeBookmarkShortcut() {
+    func removeBookmarkShortcut(quickAction: QuickActions = QuickActionsImplementation()) {
         // Get most recent bookmark
-        profile.places.getRecentBookmarks(limit: 1).uponQueue(.main) { result in
-            guard let bookmarkItems = result.successValue else {
-                // Remove openLastBookmark shortcut on failure
-                QuickActions.sharedInstance.removeDynamicApplicationShortcutItemOfType(.openLastBookmark,
-                                                                                       fromApplication: .shared)
-                return
-            }
-
+        bookmarksHandler.getRecentBookmarks(limit: 1) { bookmarkItems in
             if bookmarkItems.isEmpty {
                 // Remove the openLastBookmark shortcut
-                QuickActions.sharedInstance.removeDynamicApplicationShortcutItemOfType(.openLastBookmark,
-                                                                                       fromApplication: .shared)
+                quickAction.removeDynamicApplicationShortcutItemOfType(.openLastBookmark,
+                                                                       fromApplication: .shared)
             } else {
                 // Update the last bookmark shortcut
-                let userData = [QuickActions.TabURLKey: bookmarkItems[0].url,
-                                QuickActions.TabTitleKey: bookmarkItems[0].title]
-                QuickActions.sharedInstance.addDynamicApplicationShortcutItemOfType(.openLastBookmark,
-                                                                                    withUserData: userData,
-                                                                                    toApplication: .shared)
+                let userData = [QuickActionInfos.tabURLKey: bookmarkItems[0].url,
+                                QuickActionInfos.tabTitleKey: bookmarkItems[0].title]
+                quickAction.addDynamicApplicationShortcutItemOfType(.openLastBookmark,
+                                                                    withUserData: userData,
+                                                                    toApplication: .shared)
             }
         }
     }

--- a/Client/Protocols/CanRemoveQuickActionBookmark.swift
+++ b/Client/Protocols/CanRemoveQuickActionBookmark.swift
@@ -16,18 +16,25 @@ extension CanRemoveQuickActionBookmark {
     func removeBookmarkShortcut(quickAction: QuickActions = QuickActionsImplementation()) {
         // Get most recent bookmark
         bookmarksHandler.getRecentBookmarks(limit: 1) { bookmarkItems in
-            if bookmarkItems.isEmpty {
-                // Remove the openLastBookmark shortcut
-                quickAction.removeDynamicApplicationShortcutItemOfType(.openLastBookmark,
-                                                                       fromApplication: .shared)
-            } else {
-                // Update the last bookmark shortcut
-                let userData = [QuickActionInfos.tabURLKey: bookmarkItems[0].url,
-                                QuickActionInfos.tabTitleKey: bookmarkItems[0].title]
-                quickAction.addDynamicApplicationShortcutItemOfType(.openLastBookmark,
-                                                                    withUserData: userData,
-                                                                    toApplication: .shared)
+            ensureMainThread {
+                self.removeBookmarks(quickAction: quickAction,
+                                     bookmarkItems: bookmarkItems)
             }
+        }
+    }
+
+    private func removeBookmarks(quickAction: QuickActions, bookmarkItems: [BookmarkItemData]) {
+        if bookmarkItems.isEmpty {
+            // Remove the openLastBookmark shortcut
+            quickAction.removeDynamicApplicationShortcutItemOfType(.openLastBookmark,
+                                                                   fromApplication: .shared)
+        } else {
+            // Update the last bookmark shortcut
+            let userData = [QuickActionInfos.tabURLKey: bookmarkItems[0].url,
+                            QuickActionInfos.tabTitleKey: bookmarkItems[0].title]
+            quickAction.addDynamicApplicationShortcutItemOfType(.openLastBookmark,
+                                                                withUserData: userData,
+                                                                toApplication: .shared)
         }
     }
 }

--- a/Client/Protocols/CanRemoveQuickActionBookmark.swift
+++ b/Client/Protocols/CanRemoveQuickActionBookmark.swift
@@ -15,14 +15,24 @@ extension CanRemoveQuickActionBookmark {
     func removeBookmarkShortcut() {
         // Get most recent bookmark
         profile.places.getRecentBookmarks(limit: 1).uponQueue(.main) { result in
-            guard let bookmarkItems = result.successValue else { return }
+            guard let bookmarkItems = result.successValue else {
+                // Remove openLastBookmark shortcut on failure
+                QuickActions.sharedInstance.removeDynamicApplicationShortcutItemOfType(.openLastBookmark,
+                                                                                       fromApplication: .shared)
+                return
+            }
+
             if bookmarkItems.isEmpty {
                 // Remove the openLastBookmark shortcut
-                QuickActions.sharedInstance.removeDynamicApplicationShortcutItemOfType(.openLastBookmark, fromApplication: .shared)
+                QuickActions.sharedInstance.removeDynamicApplicationShortcutItemOfType(.openLastBookmark,
+                                                                                       fromApplication: .shared)
             } else {
                 // Update the last bookmark shortcut
-                let userData = [QuickActions.TabURLKey: bookmarkItems[0].url, QuickActions.TabTitleKey: bookmarkItems[0].title]
-                QuickActions.sharedInstance.addDynamicApplicationShortcutItemOfType(.openLastBookmark, withUserData: userData, toApplication: .shared)
+                let userData = [QuickActions.TabURLKey: bookmarkItems[0].url,
+                                QuickActions.TabTitleKey: bookmarkItems[0].title]
+                QuickActions.sharedInstance.addDynamicApplicationShortcutItemOfType(.openLastBookmark,
+                                                                                    withUserData: userData,
+                                                                                    toApplication: .shared)
             }
         }
     }

--- a/Tests/ClientTests/CanRemoveQuickActionBookmarkTests.swift
+++ b/Tests/ClientTests/CanRemoveQuickActionBookmarkTests.swift
@@ -1,0 +1,103 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import Storage
+
+@testable import Client
+
+class CanRemoveQuickActionBookmarkTests: XCTestCase {
+
+    private var subject: MockCanRemoveQuickActionBookmark!
+    private var mockBookmarksHandler: BookmarksHandlerMock!
+    private var mockQuickActions: MockQuickActions!
+
+    override func setUp() {
+        super.setUp()
+        mockQuickActions = MockQuickActions()
+        mockBookmarksHandler = BookmarksHandlerMock()
+        subject = MockCanRemoveQuickActionBookmark(bookmarksHandler: mockBookmarksHandler)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        mockQuickActions = nil
+        mockBookmarksHandler = nil
+        subject = nil
+    }
+
+    func testWithoutBookmarks() {
+        subject.removeBookmarkShortcut(quickAction: mockQuickActions)
+        mockBookmarksHandler.callGetRecentBookmarksCompletion(with: [])
+
+        XCTAssertEqual(mockBookmarksHandler.getRecentBookmarksCallCount, 1)
+        XCTAssertEqual(mockQuickActions.removeWasCalled, 1)
+        XCTAssertEqual(mockQuickActions.addWithUserDataCalled, 0)
+        XCTAssertEqual(mockQuickActions.addFromShareItemCalled, 0)
+    }
+
+    func testWithBookmarks() {
+        subject.removeBookmarkShortcut(quickAction: mockQuickActions)
+        mockBookmarksHandler.callGetRecentBookmarksCompletion(with: getMockBookmarks())
+
+        XCTAssertEqual(mockBookmarksHandler.getRecentBookmarksCallCount, 1)
+        XCTAssertEqual(mockQuickActions.removeWasCalled, 0)
+        XCTAssertEqual(mockQuickActions.addWithUserDataCalled, 1)
+        XCTAssertEqual(mockQuickActions.addFromShareItemCalled, 0)
+    }
+}
+
+// MARK: - Helper methods
+private extension CanRemoveQuickActionBookmarkTests {
+    func getMockBookmarks() -> [BookmarkItemData] {
+        let one = BookmarkItemData(guid: "abc",
+                                   dateAdded: Int64(Date().toTimestamp()),
+                                   lastModified: Int64(Date().toTimestamp()),
+                                   parentGUID: "123",
+                                   position: 0,
+                                   url: "www.firefox.com",
+                                   title: "bookmark1")
+        return [one]
+    }
+}
+
+// MARK: - CanRemoveQuickActionBookmarkMock
+private class MockCanRemoveQuickActionBookmark: CanRemoveQuickActionBookmark {
+    var bookmarksHandler: BookmarksHandler
+
+    init(bookmarksHandler: BookmarksHandler) {
+        self.bookmarksHandler = bookmarksHandler
+    }
+}
+
+// MARK: - MockQuickActions
+class MockQuickActions: QuickActions {
+
+    var addFromShareItemCalled = 0
+    func addDynamicApplicationShortcutItemOfType(_ type: ShortcutType,
+                                                 fromShareItem shareItem: ShareItem,
+                                                 toApplication application: UIApplication) {
+        addFromShareItemCalled += 1
+    }
+
+    var addWithUserDataCalled = 0
+    func addDynamicApplicationShortcutItemOfType(_ type: ShortcutType,
+                                                 withUserData userData: [String: String],
+                                                 toApplication application: UIApplication) {
+        addWithUserDataCalled += 1
+    }
+
+    var removeWasCalled = 0
+    func removeDynamicApplicationShortcutItemOfType(_ type: ShortcutType,
+                                                    fromApplication application: UIApplication) {
+        removeWasCalled += 1
+    }
+
+    var handleShortCutItemCalled = 0
+    func handleShortCutItem(_ shortcutItem: UIApplicationShortcutItem,
+                            withBrowserViewController bvc: BrowserViewController) -> Bool {
+        handleShortCutItemCalled += 1
+        return true
+    }
+}

--- a/Tests/ClientTests/QuickActionsTests.swift
+++ b/Tests/ClientTests/QuickActionsTests.swift
@@ -20,7 +20,7 @@ class QuickActionsTest: XCTestCase {
         tabManager = TabManager(profile: profile, imageStore: nil)
         browserViewController = SpyBrowserViewController(profile: profile, tabManager: tabManager)
         browserViewController.addSubviews()
-        quickActions = QuickActions.sharedInstance
+        quickActions = QuickActionsImplementation()
     }
 
     override func tearDown() {
@@ -61,7 +61,8 @@ private extension QuickActionsTest {
             expectation.fulfill()
         }
 
-        quickActions.handleShortCutItem(shortcutItem, withBrowserViewController: browserViewController)
+        _ = quickActions.handleShortCutItem(shortcutItem,
+                                            withBrowserViewController: browserViewController)
         waitForExpectations(timeout: 5, handler: nil)
     }
 }
@@ -72,7 +73,7 @@ private class BookmarkShortcutItem: UIApplicationShortcutItem {
     }
 
     override var userInfo: [String: NSSecureCoding]? {
-        return [QuickActions.TabURLKey: "https://www.mozilla.org/en-CA/" as NSSecureCoding]
+        return [QuickActionInfos.tabURLKey: "https://www.mozilla.org/en-CA/" as NSSecureCoding]
     }
 }
 


### PR DESCRIPTION
# [FXIOS-5090](https://mozilla-hub.atlassian.net/browse/FXIOS-5090) https://github.com/mozilla-mobile/firefox-ios/issues/12148
- When deleting a bookmark we weren't waiting for the deletion to be done before fetching the most recent bookmarks for the quick action. This resulted in the quick action showing a bookmark that was deleted.
- In case of error, we make sure to remove the quick action since something went wrong.