### PR TITLE
Bugfix [v108] Unused setter value warnings in main

### DIFF
--- a/Client/Frontend/Login Management/LoginDetailTableViewCell.swift
+++ b/Client/Frontend/Login Management/LoginDetailTableViewCell.swift
@@ -80,9 +80,9 @@ class LoginDetailTableViewCell: ThemedTableViewCell, ReusableCell {
                 return "\(highlightedLabel.text ?? ""), \(descriptionLabel.text ?? "")"
             }
         }
-        set {
-            // Ignore sets
-        }
+        // swiftlint:disable unused_setter_value
+        set { }
+        // swiftlint:enable unused_setter_value
     }
 
     var descriptionTextSize: CGSize? {

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -172,8 +172,9 @@ class SyncNowSetting: WithAccountSetting {
 
             return profile.hasSyncableAccount()
         }
-        set {
-        }
+        // swiftlint:disable unused_setter_value
+        set { }
+        // swiftlint:enable unused_setter_value
     }
 
     fileprivate lazy var troubleshootButton: UIButton = {


### PR DESCRIPTION
Unused setter value warnings in main on some overriden variables. 
<img width="1291" alt="Screen Shot 2022-10-31 at 11 24 03 AM" src="https://user-images.githubusercontent.com/11338480/199045801-e0f2b7ef-0965-42c6-9f12-dfd1d407daf9.png">

We can't remove the empty `set` on those otherwise it raises another error like this one:
<img width="1406" alt="Screen Shot 2022-10-31 at 11 26 32 AM" src="https://user-images.githubusercontent.com/11338480/199045751-816d2354-d2d0-48ff-a84b-c12867733b48.png">
