### PR TITLE
Bugfix FXIOS-5196 [v107] Remove extra instances from app container

### DIFF
--- a/Client/Application/AppContainer.swift
+++ b/Client/Application/AppContainer.swift
@@ -46,22 +46,6 @@ class AppContainer: ServiceProvider {
             do {
                 unowned let container = container
 
-                container.register(.eagerSingleton) {
-                    return BrowserProfile(
-                            localName: "profile",
-                            syncDelegate: UIApplication.shared.syncDelegate) as Profile
-                }
-
-                /// TabManager can remain a singleton until we support multiple scenes.
-                container.register(.singleton) {
-                    return TabManager(
-                            profile: try container.resolve(),
-                            imageStore: DiskImageStore(
-                            files: (try container.resolve() as Profile).files,
-                            namespace: "TabManagerScreenshots",
-                            quality: UIConstants.ScreenshotQuality))
-                }
-
                 container.register(.singleton) { () -> ThemeManager in
                     if let delegate = UIApplication.shared.delegate as? AppDelegate {
                         return delegate.themeManager


### PR DESCRIPTION
These unused dependencies registered by the container were causing there to be multiple instances of the objects floating around in memory. This could have all sorts of weird knock on effects and could even be responsible for some of the performance issues we have been seeing.
This is fixed in Nishant's scenes PR but I think it would be good to get this change in isolation included in 107 without the baggage of the scene stuff.