### PR TITLE
Bugfix FXIOS-4692 [v108] Fix crash when selecting search engine

### DIFF
--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -56,7 +56,8 @@ struct SearchViewModel {
 class SearchViewController: SiteTableViewController,
                             KeyboardHelperDelegate,
                             LoaderListener,
-                            FeatureFlaggable {
+                            FeatureFlaggable,
+                            Notifiable {
 
     var searchDelegate: SearchViewControllerDelegate?
     private let viewModel: SearchViewModel
@@ -142,10 +143,8 @@ class SearchViewController: SiteTableViewController,
             make.leading.trailing.bottom.equalToSuperview()
         }
 
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(dynamicFontChanged),
-                                               name: .DynamicFontChanged,
-                                               object: nil)
+        setupNotifications(forObserver: self, observing: [.DynamicFontChanged,
+                                                          .SearchSettingsChanged])
     }
 
     private func loadSearchHighlights() {
@@ -758,6 +757,19 @@ class SearchViewController: SiteTableViewController,
             )
         }
         return searchAppendImage
+    }
+
+    // MARK: - Notifable
+
+    func handleNotifications(_ notification: Notification) {
+        switch notification.name {
+        case .DynamicFontChanged:
+            dynamicFontChanged(notification)
+        case .SearchSettingsChanged:
+            reloadSearchEngines()
+        default:
+            break
+        }
     }
 }
 

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -328,7 +328,8 @@ extension SearchSettingsTableViewController {
     }
 
     @objc func dismissAnimated() {
-        self.dismiss(animated: true, completion: nil)
+        notificationCenter.post(name: .SearchSettingsChanged)
+        dismiss(animated: true, completion: nil)
     }
 
     @objc func beginEditing() {

--- a/Shared/NotificationConstants.swift
+++ b/Shared/NotificationConstants.swift
@@ -82,6 +82,8 @@ extension Notification.Name {
 
     public static let LibraryPanelStateDidChange = Notification.Name("LibraryPanelStateDidChange")
 
+    public static let SearchSettingsChanged = Notification.Name("SearchSettingsChanged")
+    
     // MARK: Tab manager
 
     // Tab manager creates a toast for undo recently closed tabs and a notification is


### PR DESCRIPTION
[#11499](https://github.com/mozilla-mobile/firefox-ios/issues/11499)
[Jira Issue](https://mozilla-hub.atlassian.net/browse/FXIOS-4692)

I don't love using notifications in this way but with how all of the navigation is set up to go through the BVC it's actually kind of difficult to get a message back to the search view controller to tell it that it should refresh it's data, so not sure there is a better way without major refactoring. 