### PR TITLE
Add FXIOS-5198 [v107] Track memory warning

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -82,6 +82,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 
+    func applicationDidReceiveMemoryWarning(_ application: UIApplication) {
+        // This is not fatal but sentry only sends fatal events
+        SentryIntegration.shared.sendWithStacktrace(message: "Memory warning received",
+                                                    severity: .fatal)
+    }
+
     // We sync in the foreground only, to avoid the possibility of runaway resource usage.
     // Eventually we'll sync in response to notifications.
     func applicationDidBecomeActive(_ application: UIApplication) {


### PR DESCRIPTION
We are getting a lot of OOM events fired in Sentry but all other evidence suggests this is not a real issue. Sentry have had a lot of issues with this event misfiring in the past so I would like to gather more data to see if this is a real issue or just noise from Sentry. 