### PR TITLE
Refactor [v108] metrics yml documentation rendering

### DIFF
--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -2689,7 +2689,7 @@ browser_search:
     type: labeled_counter
     description: |
       Records counts of SERP pages with adverts displayed.
-      The key format is ‘<provider-name>’.
+      The key format is `<provider-name>`.
     send_in_pings:
       - metrics
     bugs:
@@ -2704,7 +2704,7 @@ browser_search:
     type: labeled_counter
     description: |
       Records clicks of adverts on SERP pages.
-      The key format is ‘<provider-name>’.
+      The key format is `<provider-name>`.
     send_in_pings:
       - metrics
     bugs:


### PR DESCRIPTION
This uses backticks to wrap the provider name. This will fix rendering the text in the metrics docs in the Glean Dictionary, which is otherwise broken for these metrics (part of the text is cropped).
