### PR TITLE
Bump [v108] Update Sentry to 7.30.0

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -16406,7 +16406,7 @@
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa.git";
 			requirement = {
 				kind = exactVersion;
-				version = 7.29.0;
+				version = 7.30.0;
 			};
 		};
 		4368F83B279669690013419B /* XCRemoteSwiftPackageReference "SnapKit" */ = {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -103,8 +103,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "7521e07ce9a73f23ca9f028d6b0f8917c3e72c1b",
-        "version" : "7.29.0"
+        "revision" : "3e56a8dd14f4adc4b7de7ce6517f91543bf2046c",
+        "version" : "7.30.0"
       }
     },
     {


### PR DESCRIPTION
Changelog link:
https://github.com/getsentry/sentry-cocoa/releases/tag/7.30.0