### PR TITLE
Add FXIOS-5207 [v108] Telemetry for logins component key regeneration logic

### DIFF
--- a/Storage/Rust/RustLogins.swift
+++ b/Storage/Rust/RustLogins.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Shared
+import Glean
 @_exported import MozillaAppServices
 
 private let log = Logger.syncLogger
@@ -908,6 +909,7 @@ public class RustLogins {
                         return key!
                     } else {
                         SentryIntegration.shared.sendWithStacktrace(message: "Logins key was corrupted, new one generated", tag: SentryTag.rustLogins, severity: .warning)
+                        GleanMetrics.LoginsStoreKeyRegeneration.corrupt.record()
                         _ = self.wipeLocalEngine()
                         return try rustKeys.createAndStoreKey()
                     }
@@ -918,6 +920,7 @@ public class RustLogins {
                 // The key is present, but we didn't expect it to be there.
                 do {
                     SentryIntegration.shared.sendWithStacktrace(message: "Logins key lost due to storage malfunction, new one generated", tag: SentryTag.rustLogins, severity: .warning)
+                    GleanMetrics.LoginsStoreKeyRegeneration.other.record()
                     _ = self.wipeLocalEngine()
                     return try rustKeys.createAndStoreKey()
                 } catch let err as NSError {
@@ -927,6 +930,7 @@ public class RustLogins {
                 // We expected the key to be present, but it's gone missing on us.
                 do {
                     SentryIntegration.shared.sendWithStacktrace(message: "Logins key lost, new one generated", tag: SentryTag.rustLogins, severity: .warning)
+                    GleanMetrics.LoginsStoreKeyRegeneration.lost.record()
                     _ = self.wipeLocalEngine()
                     return try rustKeys.createAndStoreKey()
                 } catch let err as NSError {

--- a/Storage/metrics.yaml
+++ b/Storage/metrics.yaml
@@ -20,3 +20,52 @@ history:
       - sync-core@mozilla.com
       - teshaq@mozilla.com
     expires: never
+
+logins_store_key_regeneration:
+  # These track when we need to regenerate the encryption key which causes all
+  # local data to be lost
+  lost:
+    type: event
+    description: >
+      The encryption key was regenerated because it was lost
+    bugs:
+      - https://github.com/mozilla/application-services/issues/5221
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/12306
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - synced-client-integrations@mozilla.com
+      - lougenia@mozilla.com
+    expires: never
+
+  corrupt:
+    type: event
+    description: >
+      The encryption key was regenerated because it didn't match the encrypted
+      data
+    bugs:
+      - https://github.com/mozilla/application-services/issues/5221
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/12306
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - synced-client-integrations@mozilla.com
+      - lougenia@mozilla.com
+    expires: never
+
+  other:
+    type: event
+    description: >
+      The encryption key was regenerated for an unknown reason
+    bugs:
+      - https://github.com/mozilla/application-services/issues/5221
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/12306
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - synced-client-integrations@mozilla.com
+      - lougenia@mozilla.com
+    expires: never


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5207)
https://github.com/mozilla-mobile/firefox-ios/issues/12308
Adding telemetry to the key regeneration logic in the logins component in order to monitor the rates in which we recreate the encryption key. This will help us surface any spikes in encryption key errors similar to [the ones we previously noticed](https://github.com/mozilla-mobile/firefox-ios/issues/11480).

With the exception of some naming changes suggested by Glean, this is identical to what we have implemented for Android (see [here](https://github.com/mozilla/application-services/pull/4613/files)).
