### PR TITLE
Refactor FXIOS-5149 [v108] Put back recent tabs on main thread

### DIFF
--- a/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInDataAdaptorTests.swift
+++ b/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInDataAdaptorTests.swift
@@ -143,6 +143,7 @@ extension JumpBackInDataAdaptorTests {
         let subject = JumpBackInDataAdaptorImplementation(profile: mockProfile,
                                                           tabManager: mockTabManager,
                                                           siteImageHelper: siteImageHelper,
+                                                          mainQueue: dispatchQueue,
                                                           userInitiatedQueue: dispatchQueue,
                                                           notificationCenter: notificationCenter)
 


### PR DESCRIPTION
# [FXIOS-5149](https://mozilla-hub.atlassian.net/browse/FXIOS-5149) https://github.com/mozilla-mobile/firefox-ios/issues/12218
Following PR #12290, we need to put back recent tabs on main thread for the following case:
- On Ipad, have a tab open and be on homepage
- Close the tab from top tabs
- There was a delay before the tab would disappear from the jump back in section
If we don't pick the recent tabs from main thread, we don't have the right value to update that section

I also separated updating groups into a different function in the adaptor.