### PR TITLE
Bugfix FXIOS-5113 [v108] Session restore url in recently visited

### DIFF
--- a/Client/Frontend/Browser/Tab Management/Tab.swift
+++ b/Client/Frontend/Browser/Tab Management/Tab.swift
@@ -380,7 +380,7 @@ class Tab: NSObject {
         self.nightMode = false
         self.noImageMode = false
         self.profile = profile
-        self.metadataManager = TabMetadataManager(profile: profile)
+        self.metadataManager = TabMetadataManager(metadataObserver: profile.places)
         super.init()
         self.isPrivate = isPrivate
         debugTabCount += 1

--- a/Client/Frontend/Browser/Tab Management/TabMetadataManager.swift
+++ b/Client/Frontend/Browser/Tab Management/TabMetadataManager.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import MozillaAppServices
+import Shared
 
 class TabMetadataManager {
 
@@ -98,7 +99,9 @@ class TabMetadataManager {
                                          completion: (() -> Void)?) {
         guard let profile = profile else { return }
 
-        guard !key.url.isEmpty else { return }
+        // If URL is empty or a session restore URL, do not record in metadata observation
+        let sessionRestoreURL = "\(InternalURL.baseUrl)/\(SessionRestoreHandler.path)"
+        guard !key.url.isEmpty, !key.url.contains(sessionRestoreURL) else { return }
 
         profile.places.noteHistoryMetadataObservation(key: key, observation: observation).uponQueue(.main) { _ in
             completion?()

--- a/Client/Frontend/Browser/Tab Management/TabMetadataManager.swift
+++ b/Client/Frontend/Browser/Tab Management/TabMetadataManager.swift
@@ -4,10 +4,11 @@
 
 import MozillaAppServices
 import Shared
+import Storage
 
 class TabMetadataManager {
 
-    let profile: Profile?
+    let metadataObserver: HistoryMetadataObserver
 
     // Tab Groups
     var tabGroupData = TabGroupData()
@@ -21,8 +22,8 @@ class TabMetadataManager {
         tabGroupData.tabHistoryCurrentState == TabGroupTimerState.openURLOnly.rawValue
     }
 
-    init(profile: Profile) {
-        self.profile = profile
+    init(metadataObserver: HistoryMetadataObserver) {
+        self.metadataObserver = metadataObserver
     }
 
     // Only update search term data with valid search term data
@@ -97,13 +98,14 @@ class TabMetadataManager {
     private func updateObservationForKey(key: HistoryMetadataKey,
                                          observation: HistoryMetadataObservation,
                                          completion: (() -> Void)?) {
-        guard let profile = profile else { return }
-
         // If URL is empty or a session restore URL, do not record in metadata observation
         let sessionRestoreURL = "\(InternalURL.baseUrl)/\(SessionRestoreHandler.path)"
-        guard !key.url.isEmpty, !key.url.contains(sessionRestoreURL) else { return }
+        guard !key.url.isEmpty, !key.url.contains(sessionRestoreURL) else {
+            completion?()
+            return
+        }
 
-        profile.places.noteHistoryMetadataObservation(key: key, observation: observation).uponQueue(.main) { _ in
+        metadataObserver.noteHistoryMetadataObservation(key: key, observation: observation) {
             completion?()
         }
     }

--- a/Client/Utils/SponsoredContentFilterUtility.swift
+++ b/Client/Utils/SponsoredContentFilterUtility.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Storage
+import Shared
 
 // Utility to filter sponsored content out of certain data type
 struct SponsoredContentFilterUtility {
@@ -23,6 +24,13 @@ struct SponsoredContentFilterUtility {
     }
 
     func filterSponsoredHighlights(from items: [HistoryHighlight]) -> [HistoryHighlight] {
-        return items.filter { !$0.url.contains(hideWithSearchParam) }
+        return items.filter {
+            // As part of bug TODO, session restore URLs have been saved in metadata for a while
+            // This means that to abstain already recorded restore session URLs to appear in recently visited we
+            // need to manually filter them out for now. In a couple of release (greater than v115) this can be removed
+            // with task TODO
+            let sessionRestoreURL = "\(InternalURL.baseUrl)/\(SessionRestoreHandler.path)"
+            return !$0.url.contains(hideWithSearchParam) && !$0.url.contains(sessionRestoreURL)
+        }
     }
 }

--- a/Client/Utils/SponsoredContentFilterUtility.swift
+++ b/Client/Utils/SponsoredContentFilterUtility.swift
@@ -25,10 +25,10 @@ struct SponsoredContentFilterUtility {
 
     func filterSponsoredHighlights(from items: [HistoryHighlight]) -> [HistoryHighlight] {
         return items.filter {
-            // As part of bug TODO, session restore URLs have been saved in metadata for a while
+            // As part of bug FXIOS-5113, session restore URLs have been saved in metadata for a while
             // This means that to abstain already recorded restore session URLs to appear in recently visited we
-            // need to manually filter them out for now. In a couple of release (greater than v115) this can be removed
-            // with task TODO
+            // need to manually filter them out for now. In a couple of release (greater than v110) this can be removed
+            // with task FXIOS-5212
             let sessionRestoreURL = "\(InternalURL.baseUrl)/\(SessionRestoreHandler.path)"
             return !$0.url.contains(hideWithSearchParam) && !$0.url.contains(sessionRestoreURL)
         }

--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -432,6 +432,10 @@ extension URL {
         return scheme == "http" && host == "localhost" && path == "/reader-mode/page"
     }
 
+    public var isSessionRestoreURL: Bool {
+        return absoluteString.hasPrefix("internal://local/sessionrestore?url=https")
+    }
+
     public var isSyncedReaderModeURL: Bool {
         return self.absoluteString.hasPrefix("about:reader?url=")
     }

--- a/Storage/Rust/RustPlaces.swift
+++ b/Storage/Rust/RustPlaces.swift
@@ -12,7 +12,13 @@ public protocol BookmarksHandler {
     func getRecentBookmarks(limit: UInt, completion: @escaping ([BookmarkItemData]) -> Void)
 }
 
-public class RustPlaces: BookmarksHandler {
+public protocol HistoryMetadataObserver {
+    func noteHistoryMetadataObservation(key: HistoryMetadataKey,
+                                        observation: HistoryMetadataObservation,
+                                        completion: @escaping () -> Void)
+}
+
+public class RustPlaces: BookmarksHandler, HistoryMetadataObserver {
     let databasePath: String
 
     let writerQueue: DispatchQueue
@@ -435,6 +441,18 @@ public class RustPlaces: BookmarksHandler {
     public func queryHistoryMetadata(query: String, limit: Int32) -> Deferred<Maybe<[HistoryMetadata]>> {
         return withReader { connection in
             return try connection.queryHistoryMetadata(query: query, limit: limit)
+        }
+    }
+
+    public func noteHistoryMetadataObservation(key: HistoryMetadataKey,
+                                               observation: HistoryMetadataObservation,
+                                               completion: @escaping () -> Void) {
+        let deferredResponse = withReader { connection in
+            return self.noteHistoryMetadataObservation(key: key, observation: observation)
+        }
+
+        deferredResponse.upon { result in
+            completion()
         }
     }
 

--- a/Tests/ClientTests/Frontend/Browser/Tab Management/TabMetadataManagerTests.swift
+++ b/Tests/ClientTests/Frontend/Browser/Tab Management/TabMetadataManagerTests.swift
@@ -10,24 +10,24 @@ import Shared
 
 class TabMetadataManagerTests: XCTestCase {
 
-    private var profile: MockProfile!
+    private var metadataObserver: HistoryMetadataObserverMock!
     private var manager: TabMetadataManager!
 
     override func setUp() {
         super.setUp()
 
-        profile = MockProfile(databasePrefix: "historyHighlights_tests")
-        profile.reopen()
-        manager = TabMetadataManager(profile: profile)
+        metadataObserver = HistoryMetadataObserverMock()
+        manager = TabMetadataManager(metadataObserver: metadataObserver)
     }
 
     override func tearDown() {
         super.tearDown()
 
-        profile.shutdown()
-        profile = nil
+        metadataObserver = nil
         manager = nil
     }
+
+    // MARK: - Should Update Search Term Data
 
     func testShouldUpdateSearchTermData() throws {
         let stringUrl = "www.mozilla.org"
@@ -67,64 +67,46 @@ class TabMetadataManagerTests: XCTestCase {
         XCTAssertFalse(shouldUpdate)
     }
 
+    // MARK: - Update Observation Title
+
     func testUpdateObservationTitle_ForOpenURLOnly() throws {
-        emptyDB()
         let stringUrl = "https://www.developer.org/"
         let title = "updated title"
 
-        let expectation = expectation(description: "historyRecording")
         manager.tabGroupData = TabGroupData(searchTerm: "",
                                             searchUrl: stringUrl,
                                             nextReferralUrl: "",
                                             tabHistoryCurrentState: TabGroupTimerState.openURLOnly.rawValue)
 
         manager.updateObservationTitle(title) {
-            let result = self.profile.places.getHistoryMetadataSince(since: 0).value
-
-            XCTAssertTrue(result.isSuccess)
-            XCTAssertNotNil(result.successValue)
-            XCTAssertEqual(result.successValue!.count, 1)
-            XCTAssertEqual(result.successValue![0].url, stringUrl)
-            XCTAssertEqual(result.successValue![0].title?.lowercased(), title)
-            XCTAssertNil(result.successValue![0].referrerUrl)
-            expectation.fulfill()
+            XCTAssertEqual(self.metadataObserver.observation?.url, stringUrl)
+            XCTAssertEqual(self.metadataObserver.observation?.title?.lowercased(), title)
+            XCTAssertEqual(self.metadataObserver.observation?.referrerUrl, "")
         }
-        waitForExpectations(timeout: 5, handler: nil)
     }
 
     func testUpdateObservationTitle_ForNavigatedToDifferentURL() throws {
-        emptyDB()
         let stringUrl = "https://www.developer.org/"
         let referralURL = "https://www.developer.org/ref"
         let title = "updated title"
 
-        let expectation = expectation(description: "historyRecording")
         manager.tabGroupData = TabGroupData(searchTerm: "",
                                             searchUrl: stringUrl,
                                             nextReferralUrl: referralURL,
                                             tabHistoryCurrentState: TabGroupTimerState.tabNavigatedToDifferentUrl.rawValue)
 
         manager.updateObservationTitle(title) {
-            let result = self.profile.places.getHistoryMetadataSince(since: 0).value
-
-            XCTAssertTrue(result.isSuccess)
-            XCTAssertNotNil(result.successValue)
-            XCTAssertEqual(result.successValue!.count, 1)
-            XCTAssertEqual(result.successValue![0].url, stringUrl)
-            XCTAssertEqual(result.successValue![0].title?.lowercased(), title)
-            XCTAssertEqual(result.successValue![0].referrerUrl?.lowercased(), referralURL)
-            expectation.fulfill()
+            XCTAssertEqual(self.metadataObserver.observation?.url, stringUrl)
+            XCTAssertEqual(self.metadataObserver.observation?.title?.lowercased(), title)
+            XCTAssertEqual(self.metadataObserver.observation?.referrerUrl?.lowercased(), referralURL)
         }
-        waitForExpectations(timeout: 5, handler: nil)
     }
 
     func testNotUpdateObservationTitle_ForOpenInNewTab() throws {
-        emptyDB()
         let stringUrl = "https://www.developer.org/"
         let referralURL = "https://www.developer.org/ref"
         let title = "updated title"
 
-        let expectation = expectation(description: "historyRecording")
         manager.tabGroupData = TabGroupData(searchTerm: "",
                                             searchUrl: stringUrl,
                                             nextReferralUrl: referralURL,
@@ -132,42 +114,56 @@ class TabMetadataManagerTests: XCTestCase {
 
         // Title should not be updated for this state
         manager.updateObservationTitle(title) {
-            let result = self.profile.places.getHistoryMetadataSince(since: 0).value
-
-            XCTAssertTrue(result.isSuccess)
-            XCTAssertNotNil(result.successValue)
-            XCTAssertEqual(result.successValue!.count, 0)
-            expectation.fulfill()
+            XCTAssertNil(self.metadataObserver.observation)
+            XCTAssertNil(self.metadataObserver.key)
         }
-        waitForExpectations(timeout: 5, handler: nil)
     }
 
     func testNotUpdateObservationTitle_ForTabSwitched() throws {
-        emptyDB()
         let stringUrl = "https://www.developer.org/"
         let referralURL = "https://www.developer.org/ref"
         let title = "updated title"
 
-        let expectation = expectation(description: "historyRecording")
         manager.tabGroupData = TabGroupData(searchTerm: "",
                                             searchUrl: stringUrl,
                                             nextReferralUrl: referralURL,
                                             tabHistoryCurrentState: TabGroupTimerState.tabSwitched.rawValue)
+
         // Title should not be updated for this state
         manager.updateObservationTitle(title) {
-            let result = self.profile.places.getHistoryMetadataSince(since: 0).value
-
-            XCTAssertTrue(result.isSuccess)
-            XCTAssertNotNil(result.successValue)
-            XCTAssertEqual(result.successValue!.count, 0)
-            expectation.fulfill()
+            XCTAssertNil(self.metadataObserver.observation)
+            XCTAssertNil(self.metadataObserver.key)
         }
-        waitForExpectations(timeout: 5, handler: nil)
     }
 
-    private func emptyDB() {
-        XCTAssertTrue(profile.places.deleteHistoryMetadataOlderThan(olderThan: 0).value.isSuccess)
-        XCTAssertTrue(profile.places.deleteHistoryMetadataOlderThan(olderThan: INT64_MAX).value.isSuccess)
-        XCTAssertTrue(profile.places.deleteHistoryMetadataOlderThan(olderThan: -1).value.isSuccess)
+    func testNotUpdateObservationTitle_ForSessionRestoreUrl() throws {
+        let stringUrl = "\(InternalURL.baseUrl)/\(SessionRestoreHandler.path)?url=https://www.mozilla.org/"
+        let referralURL = "\(InternalURL.baseUrl)/\(SessionRestoreHandler.path)?url=https://www.mozilla.org/"
+        let title = "Session restore title"
+
+        manager.tabGroupData = TabGroupData(searchTerm: "",
+                                            searchUrl: stringUrl,
+                                            nextReferralUrl: referralURL,
+                                            tabHistoryCurrentState: TabGroupTimerState.tabSwitched.rawValue)
+
+        // Title should not be updated for this state
+        manager.updateObservationTitle(title) {
+            XCTAssertNil(self.metadataObserver.observation)
+            XCTAssertNil(self.metadataObserver.key)
+        }
+    }
+}
+
+class HistoryMetadataObserverMock: HistoryMetadataObserver {
+
+    var key: HistoryMetadataKey?
+    var observation: HistoryMetadataObservation?
+
+    func noteHistoryMetadataObservation(key: HistoryMetadataKey,
+                                        observation: HistoryMetadataObservation,
+                                        completion: @escaping () -> Void) {
+        self.key = key
+        self.observation = observation
+        completion()
     }
 }


### PR DESCRIPTION
# Issue [FXIOS-5113](https://mozilla-hub.atlassian.net/browse/FXIOS-5113)
- Prevent session restore URLs from being recorded in metadata observer (so it doesn't appear in History highlights)
- Make sure we filter out existing records so session restore URLs won't appear anymore in History Highlights (through `SponsoredContentFilterUtility`)
- Add tests for those changes (while making those tests I removed the async part of `TabMetaDataManagerTests` by introducing the `HistoryMetadataObserver` which doesn't use `Deferred`)