### PR TITLE
Refactor FXIOS-4912 [v108] Remove reverse migration code

### DIFF
--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -40,8 +40,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla/glean-swift",
       "state" : {
-        "revision" : "35a894ffdc3af8d34150562ea4bf634a437e4694",
-        "version" : "51.7.0"
+        "revision" : "9c6d307e503d33bf71f46e3263d0907acfa50cc2",
+        "version" : "51.8.0"
       }
     },
     {

--- a/Tests/ClientTests/Frontend/Browser/Tab Management/TabManagerStoreTests.swift
+++ b/Tests/ClientTests/Frontend/Browser/Tab Management/TabManagerStoreTests.swift
@@ -230,7 +230,7 @@ class TabManagerStoreTests: XCTestCase {
         let manager = createManager()
         let tabs = createTabs(tabNumber: 2)
         // Save tabs only with deprecated method, as if we're in v105
-        manager.preserveTabs(tabs, selectedTab: nil, useNewArchivingMethod: false)
+        manager.preserveTabs(tabs, selectedTab: nil)
 
         // Retrieve tabs as if we're in v106
         let tabToSelect = manager.restoreStartupTabs(clearPrivateTabs: false,
@@ -241,26 +241,6 @@ class TabManagerStoreTests: XCTestCase {
 
         XCTAssertNil(tabToSelect, "No tab was selected in restore, tab manager is expected to select one")
         let retrievedTabs = manager.testTabOnDisk()
-        XCTAssertEqual(retrievedTabs.count, 2, "Expected 2 tabs on disk")
-        XCTAssertTrue(manager.hasTabsToRestoreAtStartup)
-    }
-
-    func testMigrationBackWards_retrievingOnlyWithDeprecatedMethod() {
-        let manager = createManager()
-        let tabs = createTabs(tabNumber: 2)
-        // Save tabs as if we're in v106, with both methods old and new
-        manager.preserveTabs(tabs, selectedTab: nil, useNewArchivingMethod: true)
-
-        // Retrieve tabs as if we're in v105
-        let tabToSelect = manager.restoreTabs(savedTabs: manager.getDeprecatedTabsToMigrate(),
-                                              clearPrivateTabs: false,
-                                              addTabClosure: { isPrivate in
-            XCTAssertFalse(isPrivate)
-            return createTab(isPrivate: isPrivate)
-        })
-
-        XCTAssertNil(tabToSelect, "No tab was selected in restore, tab manager is expected to select one")
-        let retrievedTabs = manager.testTabOnDisk(useNewArchivingMethod: false)
         XCTAssertEqual(retrievedTabs.count, 2, "Expected 2 tabs on disk")
         XCTAssertTrue(manager.hasTabsToRestoreAtStartup)
     }


### PR DESCRIPTION
# [FXIOS-4912](https://mozilla-hub.atlassian.net/browse/FXIOS-4912) https://github.com/mozilla-mobile/firefox-ios/issues/11874
Tab migration was introduced in v106. It was asked to support reverse migration in case that's something we needed to do, to mitigate risk of this migration. In v108 this code can be remove as we won't reverse this anymore. Forward migration is still kept until it's considered ready to be removed (that will be in a while).