### PR TITLE
Bugfix FXIOS-5221 [v108] Contile provider no data has caching

### DIFF
--- a/Client/Frontend/Home/TopSites/DataManagement/ContileProvider.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/ContileProvider.swift
@@ -68,9 +68,8 @@ class ContileProvider: ContileProviderInterface, Loggable, URLCaching, FeatureFl
             }
 
             guard let response = validatedHTTPResponse(response, statusCode: 200..<300),
-                  let data = data, !data.isEmpty
-            else {
-                self.browserLog.debug("Response isn't proper: \(response.debugDescription), with data \(String(describing: data))")
+                  let data = data else {
+                self.browserLog.debug("Response isn't valid: \(response.debugDescription)")
                 completion(.failure(Error.failure))
                 return
             }

--- a/Client/Frontend/Home/TopSites/DataManagement/ContileProvider.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/ContileProvider.swift
@@ -68,7 +68,8 @@ class ContileProvider: ContileProviderInterface, Loggable, URLCaching, FeatureFl
             }
 
             guard let response = validatedHTTPResponse(response, statusCode: 200..<300),
-                  let data = data else {
+                  let data = data
+            else {
                 self.browserLog.debug("Response isn't valid: \(response.debugDescription)")
                 completion(.failure(Error.failure))
                 return

--- a/Client/Frontend/Home/TopSites/DataManagement/TopSitesDataAdaptor.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/TopSitesDataAdaptor.swift
@@ -153,6 +153,8 @@ class TopSitesDataAdaptorImplementation: TopSitesDataAdaptor, FeatureFlaggable, 
         contileProvider.fetchContiles { [weak self] result in
             if case .success(let contiles) = result {
                 self?.contiles = contiles
+            } else {
+                self?.contiles = []
             }
             self?.dispatchGroup.leave()
         }

--- a/Client/Protocols/URLCaching.swift
+++ b/Client/Protocols/URLCaching.swift
@@ -43,7 +43,7 @@ extension URLCaching {
     }
 
     func cache(response: HTTPURLResponse?, for request: URLRequest, with data: Data?) {
-        guard let response = response, let data  = data else { return }
+        guard let response = response, let data = data else { return }
 
         let metadata = [cacheAgeKey: Date.now()]
         let cachedResp = CachedURLResponse(response: response, data: data, userInfo: metadata, storagePolicy: .allowed)


### PR DESCRIPTION
# [FXIOS-5221](https://mozilla-hub.atlassian.net/browse/FXIOS-5221) https://github.com/mozilla-mobile/firefox-ios/issues/12335
Realized the following by investigating logs:
- If we receive a valid response without data, we don't cache. This means on time we layout the collection view we make a _lot_ of calls to contile provider API.
- Added that on failure of contile provider we set the contiles to `[]` in prod code. 