### PR TITLE
Update FXIOS-4902 [v108] default search suggestion header for engine search results

### DIFF
--- a/Client/Frontend/Browser/SearchEngines/OpenSearchEngine.swift
+++ b/Client/Frontend/Browser/SearchEngines/OpenSearchEngine.swift
@@ -20,13 +20,14 @@ class OpenSearchEngine: NSObject, NSCoding {
     private let searchTermComponent = "{searchTerms}"
     private let localeTermComponent = "{moz:locale}"
     private lazy var searchQueryComponentKey: String? = self.getQueryArgFromTemplate()
+    private let googleEngineID = "google-b-1-m"
 
     var headerSearchTitle: String {
-        if shortName == "Google" {
-            return "\(shortName) Search"
-        } else {
-            return"\(shortName) search"
+        guard engineID != googleEngineID else {
+            return .Search.GoogleEngineSectionTitle
         }
+
+        return String(format: .Search.EngineSectionTitle, shortName)
     }
 
     enum CodingKeys: String, CodingKey {

--- a/Client/Frontend/Browser/SearchEngines/OpenSearchEngine.swift
+++ b/Client/Frontend/Browser/SearchEngines/OpenSearchEngine.swift
@@ -21,6 +21,14 @@ class OpenSearchEngine: NSObject, NSCoding {
     private let localeTermComponent = "{moz:locale}"
     private lazy var searchQueryComponentKey: String? = self.getQueryArgFromTemplate()
 
+    var headerSearchTitle: String {
+        if shortName == "Google" {
+            return "\(shortName) Search"
+        } else {
+            return"\(shortName) search"
+        }
+    }
+
     enum CodingKeys: String, CodingKey {
         case isCustomEngine
         case searchTemplate

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -557,20 +557,40 @@ class SearchViewController: SiteTableViewController,
     }
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        guard section == SearchListSection.remoteTabs.rawValue,
-              hasFirefoxSuggestions else { return 0 }
+//        guard section == SearchListSection.remoteTabs.rawValue,
+//              hasFirefoxSuggestions else { return 0 }
 
         return UITableView.automaticDimension
     }
 
+    private func shouldShowHeader(viewForHeaderInSection section: Int) -> Bool {
+        switch section {
+        case SearchListSection.remoteTabs.rawValue:
+            return hasFirefoxSuggestions
+        case SearchListSection.searchSuggestions.rawValue:
+            return true
+        default:
+            return false
+        }
+
+    }
+
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        guard section == SearchListSection.remoteTabs.rawValue,
-              hasFirefoxSuggestions,
+        guard shouldShowHeader(viewForHeaderInSection: section),
               let headerView = tableView.dequeueReusableHeaderFooterView(
                 withIdentifier: SiteTableViewHeader.cellIdentifier) as? SiteTableViewHeader
         else { return nil }
 
-        let viewModel = SiteTableViewHeaderModel(title: .Search.SuggestSectionTitle,
+        var title: String
+        switch section {
+        case SearchListSection.remoteTabs.rawValue:
+            title = .Search.SuggestSectionTitle
+        case SearchListSection.searchSuggestions.rawValue:
+            title = searchEngines.defaultEngine.headerSearchTitle
+        default:  title = ""
+        }
+
+        let viewModel = SiteTableViewHeaderModel(title: title,
                                                  isCollapsible: false,
                                                  collapsibleState: nil)
         headerView.configure(viewModel)

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -557,26 +557,13 @@ class SearchViewController: SiteTableViewController,
     }
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-//        guard section == SearchListSection.remoteTabs.rawValue,
-//              hasFirefoxSuggestions else { return 0 }
+        guard shouldShowHeader(for: section) else { return 0 }
 
         return UITableView.automaticDimension
     }
 
-    private func shouldShowHeader(viewForHeaderInSection section: Int) -> Bool {
-        switch section {
-        case SearchListSection.remoteTabs.rawValue:
-            return hasFirefoxSuggestions
-        case SearchListSection.searchSuggestions.rawValue:
-            return true
-        default:
-            return false
-        }
-
-    }
-
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        guard shouldShowHeader(viewForHeaderInSection: section),
+        guard shouldShowHeader(for: section),
               let headerView = tableView.dequeueReusableHeaderFooterView(
                 withIdentifier: SiteTableViewHeader.cellIdentifier) as? SiteTableViewHeader
         else { return nil }
@@ -758,6 +745,18 @@ class SearchViewController: SiteTableViewController,
         return cell
     }
 
+    private func shouldShowHeader(for section: Int) -> Bool {
+        switch section {
+        case SearchListSection.remoteTabs.rawValue:
+            return hasFirefoxSuggestions
+        case SearchListSection.searchSuggestions.rawValue:
+            return true
+        default:
+            return false
+        }
+
+    }
+
     func append(_ sender: UIButton) {
         let buttonPosition = sender.convert(CGPoint(), to: tableView)
         if let indexPath = tableView.indexPathForRow(at: buttonPosition), let newQuery = suggestions?[indexPath.row] {
@@ -779,7 +778,7 @@ class SearchViewController: SiteTableViewController,
         return searchAppendImage
     }
 
-    // MARK: - Notifable
+    // MARK: - Notifiable
 
     func handleNotifications(_ notification: Notification) {
         switch notification.name {

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -746,6 +746,16 @@ extension String {
             value: "Firefox Suggest",
             comment: "When making a new search from the awesome bar, suggestions appear to the user as they write new letters in their search. Different types of suggestions can appear. This string will be used as a header to separate Firefox suggestions from normal suggestions.",
             lastUpdated: .v102)
+        public static let EngineSectionTitle = MZLocalizedString(
+            "Search.EngineSection.Title.v108",
+            value: "%@ search",
+            comment: "When making a new search from the awesome bar, search results appear as the user write new letters in their search. Different sections with results from the selected search engine will appear. This string will be used as a header to separate the selected engine search results from current search query.",
+            lastUpdated: .v102)
+        public static let GoogleEngineSectionTitle = MZLocalizedString(
+            "Search.Google.Title.v108",
+            value: "Google Search",
+            comment: "When making a new search from the awesome bar, search results appear as the user write new letters in their search. This string will be used as a header for Google search results listed as suggestions.",
+            lastUpdated: .v102)
     }
 }
 

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -748,14 +748,16 @@ extension String {
             lastUpdated: .v102)
         public static let EngineSectionTitle = MZLocalizedString(
             "Search.EngineSection.Title.v108",
+            tableName: "SearchHeaderTitle",
             value: "%@ search",
             comment: "When making a new search from the awesome bar, search results appear as the user write new letters in their search. Different sections with results from the selected search engine will appear. This string will be used as a header to separate the selected engine search results from current search query.",
-            lastUpdated: .v102)
+            lastUpdated: .v108)
         public static let GoogleEngineSectionTitle = MZLocalizedString(
             "Search.Google.Title.v108",
+            tableName: "SearchHeaderTitle",
             value: "Google Search",
             comment: "When making a new search from the awesome bar, search results appear as the user write new letters in their search. This string will be used as a header for Google search results listed as suggestions.",
-            lastUpdated: .v102)
+            lastUpdated: .v108)
     }
 }
 


### PR DESCRIPTION

### [FXIOS-4902](https://mozilla-hub.atlassian.net/browse/FXIOS-4902)

- Add strings for header
- Add logic to show header title based on search engine