### PR TITLE
BugFix FXIOS-5233 [v108] Fix synced tabs after signout/signin

### DIFF
--- a/RustFxA/RustFirefoxAccounts.swift
+++ b/RustFxA/RustFirefoxAccounts.swift
@@ -285,6 +285,7 @@ open class RustFirefoxAccounts {
         prefs?.removeObjectForKey(RustFirefoxAccounts.prefKeySyncAuthStateUniqueID)
         prefs?.removeObjectForKey(prefKeyCachedUserProfile)
         prefs?.removeObjectForKey(PendingAccountDisconnectedKey)
+        self.syncAuthState.invalidate()
         cachedUserProfile = nil
         pushNotifications.unregister()
         MZKeychainWrapper.sharedClientAppContainerKeychain.removeObject(forKey: KeychainKey.apnsToken, withAccessibility: .afterFirstUnlock)


### PR DESCRIPTION
This fixes a preexisting bug in which the sync auth state isn't invalidated during signout. This causes issues if the user chooses to sign in again with a different account. See the [Bugzilla bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1799077) for more details.


