### PR TITLE
Bugfix FXIOS-5123 [v107.1] Fix jump back in crash

### DIFF
--- a/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -177,7 +177,7 @@ class JumpBackInViewModel: FeatureFlaggable {
 // MARK: - Private: Prepare UI data
 private extension JumpBackInViewModel {
 
-    func refreshData(maxItemsToDisplay: JumpBackInDisplayGroupCount) {
+    private func refreshData(maxItemsToDisplay: JumpBackInDisplayGroupCount) {
         jumpBackInList = createJumpBackInList(
             from: recentTabs,
             withMaxTabsCount: maxItemsToDisplay.tabsCount,
@@ -415,22 +415,14 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
     func refreshData(for traitCollection: UITraitCollection,
                      isPortrait: Bool = UIWindow.isPortrait,
                      device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
-        getLatestData()
         updateSectionLayout(for: traitCollection,
                             isPortrait: isPortrait,
                             device: device)
-
         let maxItemsToDisplay = sectionLayout.maxItemsToDisplay(
             hasAccount: jumpBackInDataAdaptor.hasSyncedTabFeatureEnabled,
             device: device
         )
         refreshData(maxItemsToDisplay: maxItemsToDisplay)
-    }
-
-    private func getLatestData() {
-        recentTabs = jumpBackInDataAdaptor.getRecentTabData()
-        recentGroups = jumpBackInDataAdaptor.getGroupsData()
-        recentSyncedTab = jumpBackInDataAdaptor.getSyncedTabData()
     }
 
     func updatePrivacyConcernedSection(isPrivate: Bool) {
@@ -509,7 +501,9 @@ extension JumpBackInViewModel: HomepageSectionHandler {
 extension JumpBackInViewModel: JumpBackInDelegate {
     func didLoadNewData() {
         ensureMainThread {
-            self.getLatestData()
+            self.recentTabs = self.jumpBackInDataAdaptor.getRecentTabData()
+            self.recentGroups = self.jumpBackInDataAdaptor.getGroupsData()
+            self.recentSyncedTab = self.jumpBackInDataAdaptor.getSyncedTabData()
             guard self.isEnabled else { return }
             self.delegate?.reloadView()
         }

--- a/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
@@ -169,6 +169,7 @@ class JumpBackInViewModelTests: XCTestCase {
         trait.overridenHorizontalSizeClass = .compact
         trait.overridenVerticalSizeClass = .regular
 
+        subject.didLoadNewData()
         subject.refreshData(for: trait, isPortrait: true, device: .phone)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: false,
                                                                device: .phone)
@@ -186,6 +187,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .compact
         trait.overridenVerticalSizeClass = .regular
+        subject.didLoadNewData()
         subject.refreshData(for: trait, isPortrait: true, device: .phone)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .phone)
@@ -206,6 +208,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .compact
         trait.overridenVerticalSizeClass = .regular
+        subject.didLoadNewData()
         subject.refreshData(for: trait, isPortrait: true, device: .phone)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .phone)
@@ -225,6 +228,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
         trait.overridenVerticalSizeClass = .compact
+        subject.didLoadNewData()
         subject.refreshData(for: trait, isPortrait: false, device: .phone)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .phone)
@@ -244,6 +248,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
         trait.overridenVerticalSizeClass = .compact
+        subject.didLoadNewData()
         subject.refreshData(for: trait, isPortrait: false, device: .phone)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .phone)
@@ -263,6 +268,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
         trait.overridenVerticalSizeClass = .regular
+        subject.didLoadNewData()
         subject.refreshData(for: trait, isPortrait: true, device: .pad)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .pad)
@@ -282,6 +288,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
         trait.overridenVerticalSizeClass = .regular
+        subject.didLoadNewData()
         subject.refreshData(for: trait, isPortrait: true, device: .pad)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .pad)
@@ -301,6 +308,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
         trait.overridenVerticalSizeClass = .regular
+        subject.didLoadNewData()
         subject.refreshData(for: trait, isPortrait: false, device: .pad)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .pad)
@@ -321,6 +329,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
         trait.overridenVerticalSizeClass = .compact
+        subject.didLoadNewData()
         subject.refreshData(for: trait, isPortrait: true, device: .phone)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .phone)
@@ -340,6 +349,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
         trait.overridenVerticalSizeClass = .regular
+        subject.didLoadNewData()
         subject.refreshData(for: trait, isPortrait: false, device: .pad)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .pad)
@@ -360,6 +370,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
         trait.overridenVerticalSizeClass = .compact
+        subject.didLoadNewData()
         subject.refreshData(for: trait, isPortrait: true, device: .phone)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .phone)
@@ -378,6 +389,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
         trait.overridenVerticalSizeClass = .compact
+        subject.didLoadNewData()
         subject.refreshData(for: trait, isPortrait: false, device: .phone)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .phone)
@@ -396,6 +408,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
         trait.overridenVerticalSizeClass = .regular
+        subject.didLoadNewData()
         subject.refreshData(for: trait, isPortrait: false, device: .pad)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .pad)
@@ -411,6 +424,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let tab2 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
         let tab3 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
         adaptor.recentTabs = [tab1, tab2, tab3]
+        subject.didLoadNewData()
 
         // Start in portrait
         let portraitTrait = MockTraitCollection()
@@ -455,6 +469,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
     func testRefreshData_noData() {
         let subject = createSubject()
+        subject.didLoadNewData()
         subject.refreshData(for: MockTraitCollection())
 
         XCTAssertEqual(subject.jumpBackInList.tabs.count, 0)
@@ -465,6 +480,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let subject = createSubject()
         let tab1 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
         adaptor.recentTabs = [tab1]
+        subject.didLoadNewData()
         subject.refreshData(for: MockTraitCollection())
 
         XCTAssertEqual(subject.jumpBackInList.tabs.count, 1)
@@ -474,6 +490,7 @@ class JumpBackInViewModelTests: XCTestCase {
     func testRefreshData_syncedTab() {
         let subject = createSubject()
         adaptor.syncedTab = JumpBackInSyncedTab(client: remoteClient, tab: remoteTab)
+        subject.didLoadNewData()
         subject.refreshData(for: MockTraitCollection())
 
         XCTAssertEqual(subject.jumpBackInList.tabs.count, 0)
@@ -493,6 +510,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .compact
         trait.overridenVerticalSizeClass = .regular
+        subject.didLoadNewData()
         subject.refreshData(for: trait, isPortrait: true, device: .phone)
 
         XCTAssertEqual(subject.sectionLayout, .compactJumpBackIn)
@@ -512,6 +530,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .compact
         trait.overridenVerticalSizeClass = .regular
+        subject.didLoadNewData()
         subject.refreshData(for: trait, isPortrait: true, device: .phone)
 
         XCTAssertEqual(subject.sectionLayout, .compactJumpBackIn)
@@ -532,6 +551,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .compact
         trait.overridenVerticalSizeClass = .regular
+        subject.didLoadNewData()
         subject.refreshData(for: trait, isPortrait: true, device: .phone)
 
         let jumpBackIn = subject.jumpBackInList
@@ -556,6 +576,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
         trait.overridenVerticalSizeClass = .compact
+        subject.didLoadNewData()
         subject.refreshData(for: trait, isPortrait: false, device: .phone)
 
         let jumpBackIn = subject.jumpBackInList
@@ -581,6 +602,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let trait = MockTraitCollection()
         trait.overridenHorizontalSizeClass = .regular
         trait.overridenVerticalSizeClass = .compact
+        subject.didLoadNewData()
         subject.refreshData(for: trait, isPortrait: false, device: .phone)
 
         let jumpBackIn = subject.jumpBackInList


### PR DESCRIPTION
#12188 
[FXIOS-5123](https://mozilla-hub.atlassian.net/browse/FXIOS-5123)

I'm still not sure why this is crashing but this PR entirely removes the code path of the crash so hopefully it won't just pop up elsewhere. 
The call to getLatestData that I removed is redundant in this instance because the data would have been set when the update was initially triggered. Ideally this is the only place where the data is updated so I have removed the convenience method to remove the temptation to call it mid update cycle in future.