### PR TITLE
Bugfix MTE-266 [v109] Bump the iOS simulator version from iPhone 11 to iPhone 14

### DIFF
--- a/SyncIntegrationTests/xcodebuild.py
+++ b/SyncIntegrationTests/xcodebuild.py
@@ -10,7 +10,7 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 class XCodeBuild(object):
     binary = 'xcodebuild'
-    destination = 'platform=iOS Simulator,name=iPhone 11'
+    destination = 'platform=iOS Simulator,name=iPhone 14 Pro Max'
     logger = logging.getLogger()
     scheme = 'Fennec_Enterprise_XCUITests'
     testPlan = 'SyncIntegrationTestPlan'

--- a/SyncIntegrationTests/xcodebuild.py
+++ b/SyncIntegrationTests/xcodebuild.py
@@ -10,7 +10,7 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 class XCodeBuild(object):
     binary = 'xcodebuild'
-    destination = 'platform=iOS Simulator,name=iPhone 14 Pro Max'
+    destination = 'platform=iOS Simulator,name=iPhone 14'
     logger = logging.getLogger()
     scheme = 'Fennec_Enterprise_XCUITests'
     testPlan = 'SyncIntegrationTestPlan'


### PR DESCRIPTION
The SyncIntegration tests are failing after the XCode upgrade because the new XCode's default iOS simulator version is 14 instead of 11. Let us bump the version of the simulator to `iPhone 14 Pro Max`.

I've run `pipenv run pytest` with the change locally to ensure that there's no syntax errors.

https://mozilla-hub.atlassian.net/browse/MTE-266