### PR TITLE
Add SYNC-3478 [v109] Poll for missing send tabs when syncing clients

### DIFF
--- a/Client/Application/AppDelegate+SyncSentTabs.swift
+++ b/Client/Application/AppDelegate+SyncSentTabs.swift
@@ -31,8 +31,8 @@ class AppSyncDelegate: SyncDelegate {
     }
 
     func displaySentTab(for url: URL, title: String, from deviceName: String?) {
-        DispatchQueue.main.sync {
-            if app.applicationState == .active {
+        DispatchQueue.main.async {
+            if self.app.applicationState == .active {
                 BrowserViewController.foregroundBVC().switchToTabForURLOrOpen(url)
                 return
             }
@@ -63,7 +63,9 @@ class AppSyncDelegate: SyncDelegate {
                 let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 0.1, repeats: false)
 
                 // The identifier for each notification request must be unique in order to be created
-                let requestIdentifier = "\(SentTabAction.TabSendCategory).\(url.absoluteString)"
+                // we attach a unique identifier in case the user sends the tab multiple times.
+                let uuidString = UUID()
+                let requestIdentifier = "\(uuidString).\(SentTabAction.TabSendCategory).\(url.absoluteString)"
                 let request = UNNotificationRequest(identifier: requestIdentifier, content: notificationContent, trigger: trigger)
 
                 UNUserNotificationCenter.current().add(request) { error in


### PR DESCRIPTION
On desktop and android, we poll for missed send tabs occasionally. For iOS, we only poll for send tabs when we receive a notification (and even then, we only poll for exactly one tab). This PR changes it so we poll for missing commands whenever we sync the clients collection.


Happy to take any feedback here. Creating the PR as a starting point. Keeping as a draft as I do more testing on a physical device

## Questions:
### What's the user experience:
   - I'll upload a small gif recording, but its:
       - Once the browser detects that there are missing tabs, it would open and switch to them

### Would this increase load to the FxA servers
   - Yes, but shouldn't be a large problem, the number of sync-enabled iOS devices in the wild is dwarfed by other desktop traffic. TODO(@tarikeshaq): provide the actual numbers here
   - I can also move this around so it's happening in less-often intervals, or add some throttling so it's only every X minuts/hours/days

### Now that we poll, what happens to users who didn't get their tabs in the past?
- Each send tab has a TTL of 30 days. Users will get all the tabs they sent and lost in past 30 days, but they won't get anymore.
- That said, I'm happy to make the first poll a noop, so we silently drop tabs that could have been sent before this so that we don't surprise users.
  