### PR TITLE
Refactor [v109] Remove unused import XCGLogger + `let log =` declarations

### DIFF
--- a/Account/FxAPushMessageHandler.swift
+++ b/Account/FxAPushMessageHandler.swift
@@ -8,8 +8,6 @@ import Account
 import os.log
 import MozillaAppServices
 
-private let log = Logger.syncLogger
-
 let PendingAccountDisconnectedKey = "PendingAccountDisconnect"
 
 /// This class provides handles push messages from FxA.

--- a/Account/SyncAuthState.swift
+++ b/Account/SyncAuthState.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import Shared
-import XCGLogger
 import SwiftyJSON
 import MozillaAppServices
 

--- a/Client/Application/AppDelegate+PushNotifications.swift
+++ b/Client/Application/AppDelegate+PushNotifications.swift
@@ -6,12 +6,9 @@ import UIKit
 import Shared
 import Storage
 import Sync
-import XCGLogger
 import UserNotifications
 import Account
 import MozillaAppServices
-
-private let log = Logger.browserLogger
 
 /**
  * This exists because the Sync code is extension-safe, and thus doesn't get

--- a/Client/Application/AppDelegate+SyncSentTabs.swift
+++ b/Client/Application/AppDelegate+SyncSentTabs.swift
@@ -5,7 +5,6 @@
 import Shared
 import Storage
 import Sync
-import XCGLogger
 import UserNotifications
 import Account
 

--- a/Client/Application/QuickActions.swift
+++ b/Client/Application/QuickActions.swift
@@ -108,7 +108,7 @@ struct QuickActionsImplementation: QuickActions, Loggable {
                 dynamicShortcutItems.append(openLastBookmarkShortcut)
             }
         default:
-            Logger.browserLogger.warning("Cannot add static shortcut item of type \(type)")
+            browserLog.warning("Cannot add static shortcut item of type \(type)")
         }
         application.shortcutItems = dynamicShortcutItems
     }

--- a/Client/Application/UITestAppDelegate.swift
+++ b/Client/Application/UITestAppDelegate.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import Shared
-import XCGLogger
 import Kingfisher
 
 private let log = Logger.browserLogger

--- a/Client/Experiments/Experiments.swift
+++ b/Client/Experiments/Experiments.swift
@@ -5,7 +5,6 @@
 import Foundation
 import MozillaAppServices
 import Shared
-import XCGLogger
 
 private let log = Logger.browserLogger
 private let nimbusAppName = "firefox_ios"

--- a/Client/Frontend/Accessors/HomePageAccessors.swift
+++ b/Client/Frontend/Accessors/HomePageAccessors.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import Shared
-import XCGLogger
 
 /// Accessors for homepage details from the app state.
 /// These are pure functions, so it's quite ok to have them

--- a/Client/Frontend/Accessors/NewTabAccessors.swift
+++ b/Client/Frontend/Accessors/NewTabAccessors.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import Shared
-import XCGLogger
 
 /// Accessors to find what a new tab should do when created without a URL.
 struct NewTabAccessors {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -9,7 +9,6 @@ import WebKit
 import Shared
 import Storage
 import SnapKit
-import XCGLogger
 import Account
 import MobileCoreServices
 import Telemetry

--- a/Client/Frontend/Browser/HomePageHelper.swift
+++ b/Client/Frontend/Browser/HomePageHelper.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import Shared
-import XCGLogger
 
 private let log = Logger.browserLogger
 

--- a/Client/Frontend/Browser/MetadataParserHelper.swift
+++ b/Client/Frontend/Browser/MetadataParserHelper.swift
@@ -5,7 +5,6 @@
 import Foundation
 import Shared
 import Storage
-import XCGLogger
 import WebKit
 
 private let log = Logger.browserLogger

--- a/Client/Frontend/Browser/SearchLoader.swift
+++ b/Client/Frontend/Browser/SearchLoader.swift
@@ -5,10 +5,7 @@
 import Foundation
 import Shared
 import Storage
-import XCGLogger
 import Glean
-
-private let log = Logger.browserLogger
 
 private let URLBeforePathRegex = try! NSRegularExpression(pattern: "^https?://([^/]+)/", options: [])
 

--- a/Client/Frontend/Browser/Tab Management/Tab.swift
+++ b/Client/Frontend/Browser/Tab Management/Tab.swift
@@ -6,7 +6,6 @@ import Foundation
 import WebKit
 import Storage
 import Shared
-import XCGLogger
 
 private var debugTabCount = 0
 

--- a/Client/Frontend/Browser/Tabs/RemoteTabsPanel.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabsPanel.swift
@@ -8,7 +8,6 @@ import Shared
 import SnapKit
 import Storage
 import Sync
-import XCGLogger
 
 protocol RemotePanelDelegate: AnyObject {
     func remotePanelDidRequestToSignIn()

--- a/Client/Frontend/Home/TopSites/DataManagement/TopSiteHistoryManager.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/TopSiteHistoryManager.swift
@@ -7,7 +7,7 @@ import Shared
 import Storage
 
 // Manages the top site
-class TopSiteHistoryManager: DataObserver, Loggable {
+class TopSiteHistoryManager: DataObserver {
 
     private let profile: Profile
 

--- a/Client/Frontend/Home/Wallpapers/Legacy/Utilities/LegacyWallpaperStorageUtility.swift
+++ b/Client/Frontend/Home/Wallpapers/Legacy/Utilities/LegacyWallpaperStorageUtility.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import Shared
-import XCGLogger
 
 class LegacyWallpaperStorageUtility: LegacyWallpaperFilePathProtocol, Loggable {
 

--- a/Client/Frontend/Home/Wallpapers/v1/Models/Wallpaper.swift
+++ b/Client/Frontend/Home/Wallpapers/v1/Models/Wallpaper.swift
@@ -18,7 +18,7 @@ struct WallpaperFilenameIdentifiers {
 }
 
 /// A single wallpaper instance.
-struct Wallpaper: Equatable, Loggable {
+struct Wallpaper: Equatable {
     typealias fileId = WallpaperFilenameIdentifiers
 
     static func == (lhs: Wallpaper, rhs: Wallpaper) -> Bool {

--- a/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperSelectorViewController.swift
+++ b/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperSelectorViewController.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-class WallpaperSelectorViewController: WallpaperBaseViewController, Loggable, Themeable {
+class WallpaperSelectorViewController: WallpaperBaseViewController, Themeable {
 
     private struct UX {
         static let cardWidth: CGFloat = UIDevice().isTinyFormFactor ? 88 : 97

--- a/Client/Frontend/Library/Bookmarks/BookmarkDetailPanel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarkDetailPanel.swift
@@ -5,7 +5,6 @@
 import UIKit
 import Storage
 import Shared
-import XCGLogger
 
 private let log = Logger.browserLogger
 

--- a/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
@@ -5,7 +5,6 @@
 import UIKit
 import Storage
 import Shared
-import XCGLogger
 
 let LocalizedRootBookmarkFolderStrings = [
     BookmarkRoots.MenuFolderGUID: String.BookmarksFolderTitleMenu,

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -5,7 +5,6 @@
 import UIKit
 import Shared
 import Storage
-import XCGLogger
 import WebKit
 import os.log
 

--- a/Client/Frontend/Library/ReaderPanel.swift
+++ b/Client/Frontend/Library/ReaderPanel.swift
@@ -5,7 +5,6 @@
 import UIKit
 import Storage
 import Shared
-import XCGLogger
 
 private let log = Logger.browserLogger
 

--- a/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
+++ b/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
@@ -6,7 +6,6 @@ import UIKit
 import Shared
 import Storage
 
-
 private struct RecentlyClosedPanelUX {
     static let IconSize = CGSize(width: 23, height: 23)
     static let IconBorderColor = UIColor.Photon.Grey30

--- a/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
+++ b/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
@@ -3,12 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0
 
 import UIKit
-
 import Shared
 import Storage
-import XCGLogger
 
-private let log = Logger.browserLogger
 
 private struct RecentlyClosedPanelUX {
     static let IconSize = CGSize(width: 23, height: 23)

--- a/Client/Frontend/Reader/ReaderModeBarView.swift
+++ b/Client/Frontend/Reader/ReaderModeBarView.swift
@@ -4,9 +4,6 @@
 
 import UIKit
 import Shared
-import XCGLogger
-
-private let log = Logger.browserLogger
 
 enum ReaderModeBarButtonType {
     case markAsRead

--- a/Client/Frontend/Settings/CustomSearchViewController.swift
+++ b/Client/Frontend/Settings/CustomSearchViewController.swift
@@ -7,8 +7,6 @@ import Shared
 import SnapKit
 import Storage
 
-private let log = Logger.browserLogger
-
 class CustomSearchError: MaybeErrorType {
 
     enum Reason {

--- a/Client/Frontend/Share/ShareExtensionHelper.swift
+++ b/Client/Frontend/Share/ShareExtensionHelper.swift
@@ -6,8 +6,6 @@ import Foundation
 import Shared
 import MobileCoreServices
 
-private let log = Logger.browserLogger
-
 class ShareExtensionHelper: NSObject {
     fileprivate weak var selectedTab: Tab?
 

--- a/Client/Frontend/TabContentsScripts/LoginsHelper.swift
+++ b/Client/Frontend/TabContentsScripts/LoginsHelper.swift
@@ -5,7 +5,6 @@
 import Foundation
 import Shared
 import Storage
-import XCGLogger
 import WebKit
 
 private let log = Logger.browserLogger

--- a/Client/Utils/FaviconFetcher+Non-Bundled.swift
+++ b/Client/Utils/FaviconFetcher+Non-Bundled.swift
@@ -4,7 +4,6 @@
 
 import Storage
 import Shared
-import XCGLogger
 import Fuzi
 
 // Extension of FaviconFetcher that handles fetching non-bundled, non-letter favicons

--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -6,7 +6,6 @@ import UIKit
 import NotificationCenter
 import Shared
 import SnapKit
-import XCGLogger
 
 private let log = Logger.browserLogger
 

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -11,7 +11,6 @@ import Account
 import Shared
 import Storage
 import Sync
-import XCGLogger
 import SyncTelemetry
 import AuthenticationServices
 import MozillaAppServices

--- a/Shared/Extensions/KeychainWrapperExtensions.swift
+++ b/Shared/Extensions/KeychainWrapperExtensions.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0
 
 import Foundation
-import XCGLogger
 import MozillaAppServices
 
 private let log = Logger.keychainLogger

--- a/Shared/KeychainCache.swift
+++ b/Shared/KeychainCache.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0
 
 import Foundation
-import XCGLogger
 import SwiftyJSON
 import MozillaAppServices
 
@@ -54,7 +53,6 @@ open class KeychainCache<T: JSONLiteralConvertible> {
 
     open func checkpoint() {
         log.info("Storing \(self.branch) in Keychain with label \(self.branch).\(self.label).")
-        // TODO: PII logging.
         if let value = value,
             let jsonString = value.asJSON().stringify() {
             MZKeychainWrapper.sharedClientAppContainerKeychain.set(jsonString, forKey: "\(branch).\(label)", withAccessibility: .afterFirstUnlock)

--- a/Shared/KeychainStore.swift
+++ b/Shared/KeychainStore.swift
@@ -3,11 +3,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0
 
 import Foundation
-import XCGLogger
 import SwiftyJSON
 import MozillaAppServices
-
-private let log = Logger.keychainLogger
 
 public class KeychainStore {
     public static let shared = KeychainStore()

--- a/Storage/Rust/RustLogins.swift
+++ b/Storage/Rust/RustLogins.swift
@@ -7,8 +7,6 @@ import Shared
 import Glean
 @_exported import MozillaAppServices
 
-private let log = Logger.syncLogger
-
 typealias LoginsStoreError = LoginsApiError
 public typealias LoginRecord = EncryptedLogin
 

--- a/Storage/SQL/BrowserDB.swift
+++ b/Storage/SQL/BrowserDB.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0
 
 import Foundation
-import XCGLogger
 import Shared
 
 private let log = Logger.syncLogger

--- a/Storage/SQL/BrowserSchema.swift
+++ b/Storage/SQL/BrowserSchema.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import Shared
-import XCGLogger
 
 let _TableBookmarks = "bookmarks"                                      // Removed in v12. Kept for migration.
 let TableBookmarksMirror = "bookmarksMirror"                           // Added in v9.

--- a/Storage/SQL/ReadingListSchema.swift
+++ b/Storage/SQL/ReadingListSchema.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import Shared
-import XCGLogger
 
 private let AllTables: [String] = ["items"]
 

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import Shared
-import XCGLogger
 import Glean
 
 private let log = Logger.syncLogger

--- a/Storage/SQL/SQLiteHistoryFavicons.swift
+++ b/Storage/SQL/SQLiteHistoryFavicons.swift
@@ -7,7 +7,6 @@ import UIKit
 import Fuzi
 import SwiftyJSON
 import Shared
-import XCGLogger
 
 private let log = Logger.syncLogger
 

--- a/Storage/SQL/SQLiteHistoryRecommendations.swift
+++ b/Storage/SQL/SQLiteHistoryRecommendations.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import Shared
-import XCGLogger
 
 private let log = Logger.syncLogger
 

--- a/Storage/SQL/SQLiteQueue.swift
+++ b/Storage/SQL/SQLiteQueue.swift
@@ -4,9 +4,6 @@
 
 import Foundation
 import Shared
-import XCGLogger
-
-private let log = Logger.syncLogger
 
 open class SQLiteQueue: TabQueue {
     let db: BrowserDB

--- a/Storage/SQL/SQLiteReadingList.swift
+++ b/Storage/SQL/SQLiteReadingList.swift
@@ -4,9 +4,6 @@
 
 import Foundation
 import Shared
-import XCGLogger
-
-private let log = Logger.syncLogger
 
 public class ReadingListStorageError: MaybeErrorType {
     var message: String

--- a/Storage/SQL/SQLiteRemoteClientsAndTabs.swift
+++ b/Storage/SQL/SQLiteRemoteClientsAndTabs.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import Shared
-import XCGLogger
 import SwiftyJSON
 
 private let log = Logger.syncLogger

--- a/Sync/BatchingClient.swift
+++ b/Sync/BatchingClient.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import Shared
-import XCGLogger
 
 open class SerializeRecordFailure<T: CleartextPayloadJSON>: MaybeErrorType, SyncPingFailureFormattable {
     public let record: Record<T>
@@ -21,8 +20,6 @@ open class SerializeRecordFailure<T: CleartextPayloadJSON>: MaybeErrorType, Sync
         self.record = record
     }
 }
-
-private let log = Logger.syncLogger
 
 private typealias UploadRecord = (guid: GUID, payload: String, sizeBytes: Int)
 public typealias DeferredResponse = Deferred<Maybe<StorageResponse<POSTResult>>>

--- a/Sync/EncryptedJSON.swift
+++ b/Sync/EncryptedJSON.swift
@@ -5,8 +5,6 @@
 import Foundation
 import Account
 import Shared
-
-import XCGLogger
 import SwiftyJSON
 
 private let log = Logger.syncLogger

--- a/Sync/LoginPayload.swift
+++ b/Sync/LoginPayload.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import Shared
-import XCGLogger
 import SwiftyJSON
 
 private let log = Logger.syncLogger

--- a/Sync/Record.swift
+++ b/Sync/Record.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import Shared
-import XCGLogger
 
 private let log = Logger.syncLogger
 

--- a/Sync/State.swift
+++ b/Sync/State.swift
@@ -5,7 +5,6 @@
 import Foundation
 import Account
 import Shared
-import XCGLogger
 import MozillaAppServices
 import SwiftyJSON
 

--- a/Sync/StorageClient.swift
+++ b/Sync/StorageClient.swift
@@ -5,7 +5,6 @@
 import Foundation
 import Shared
 import Account
-import XCGLogger
 import SwiftyJSON
 
 private let log = Logger.syncLogger
@@ -373,7 +372,6 @@ open class Sync15StorageClient {
     func getFailureInfo(_ response: URLResponse?, _ error: Error?) -> MaybeErrorType? {
         func failFromResponse(_ httpResponse: HTTPURLResponse?) -> MaybeErrorType? {
             guard let httpResponse = httpResponse else {
-                // TODO: better error.
                 log.error("No response")
                 return RecordParseError()
             }

--- a/Sync/SyncStateMachine.swift
+++ b/Sync/SyncStateMachine.swift
@@ -5,7 +5,6 @@
 import Foundation
 import Shared
 import Account
-import XCGLogger
 
 private let log = Logger.syncLogger
 

--- a/Sync/Synchronizers/ClientsSynchronizer.swift
+++ b/Sync/Synchronizers/ClientsSynchronizer.swift
@@ -5,7 +5,6 @@
 import UIKit
 import Shared
 import Storage
-import XCGLogger
 import SwiftyJSON
 
 private let log = Logger.syncLogger

--- a/Sync/Synchronizers/Downloader.swift
+++ b/Sync/Synchronizers/Downloader.swift
@@ -5,7 +5,6 @@
 import Foundation
 import Shared
 import Storage
-import XCGLogger
 
 private let log = Logger.syncLogger
 

--- a/Sync/Synchronizers/HistorySynchronizer.swift
+++ b/Sync/Synchronizers/HistorySynchronizer.swift
@@ -5,11 +5,10 @@
 import Foundation
 import Shared
 import Storage
-import XCGLogger
 import SwiftyJSON
 
 private let log = Logger.syncLogger
-private let HistoryTTLInSeconds = 5184000                   // 60 days.
+private let HistoryTTLInSeconds = 5184000 // 60 days.
 let HistoryStorageVersion = 1
 
 func makeDeletedHistoryRecord(_ guid: GUID) -> Record<HistoryPayload> {

--- a/Sync/Synchronizers/IndependentRecordSynchronizer.swift
+++ b/Sync/Synchronizers/IndependentRecordSynchronizer.swift
@@ -5,7 +5,6 @@
 import Foundation
 import Shared
 import Storage
-import XCGLogger
 
 private let log = Logger.syncLogger
 

--- a/Sync/Synchronizers/Synchronizer.swift
+++ b/Sync/Synchronizers/Synchronizer.swift
@@ -5,7 +5,6 @@
 import Foundation
 import Shared
 import Storage
-import XCGLogger
 
 private let log = Logger.syncLogger
 

--- a/Sync/TabsPayload.swift
+++ b/Sync/TabsPayload.swift
@@ -5,7 +5,6 @@
 import Foundation
 import Shared
 import Storage
-import XCGLogger
 import SwiftyJSON
 
 // Int64.max / 1000.

--- a/SyncTelemetry/SyncTelemetry.swift
+++ b/SyncTelemetry/SyncTelemetry.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0
 
 import Foundation
-import XCGLogger
 import SwiftyJSON
 import Shared
 

--- a/SyncTelemetry/SyncTelemetryEvents.swift
+++ b/SyncTelemetry/SyncTelemetryEvents.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0
 
 import Shared
-import XCGLogger
 
 private let log = Logger.browserLogger
 

--- a/Tests/StorageTests/TestBrowserDB.swift
+++ b/Tests/StorageTests/TestBrowserDB.swift
@@ -6,11 +6,8 @@ import Foundation
 import Shared
 @testable import Storage
 @testable import Client
-import XCGLogger
 
 import XCTest
-
-private let log = XCGLogger.default
 
 class TestBrowserDB: XCTestCase {
     let files = MockFiles()

--- a/Tests/SyncTests/HistorySynchronizerTests.swift
+++ b/Tests/SyncTests/HistorySynchronizerTests.swift
@@ -6,7 +6,6 @@ import Shared
 import Account
 import Storage
 @testable import Sync
-import XCGLogger
 
 import XCTest
 import SwiftyJSON

--- a/Tests/SyncTests/MetaGlobalTests.swift
+++ b/Tests/SyncTests/MetaGlobalTests.swift
@@ -7,12 +7,9 @@ import Foundation
 import Shared
 import Storage
 @testable import Sync
-import XCGLogger
 
 import XCTest
 import SwiftyJSON
-
-private let log = Logger.syncLogger
 
 class MockSyncAuthState: SyncAuthState {
     var clientName: String?


### PR DESCRIPTION
Had a quick look at some logs and took the opportunity to do some clean up in there. 
- Remove unused `import XCGLogger`
- Remove unused `let log = ...` declarations
- Make sure we use `Loggable` protocol when it was supposed to be used (but not changing code that doesn't use it yet)
- Remove unused `Loggable` protocol conformance 