### PR TITLE
Fixes SYNC-3493 [v108] Adds handling if user quickly goes to background in history panel

### DIFF
--- a/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
@@ -303,11 +303,22 @@ class HistoryPanelViewModel: Loggable, FeatureFlaggable {
                 return deferMaybe(result)
             }
         case .new:
-            return profile.places.getVisitPageWithBound(
+            let deferred = profile.places.getVisitPageWithBound(
                 limit: queryFetchLimit,
                 offset: currentFetchOffset,
                 excludedTypes: VisitTransitionSet(0)
-            ) >>== { result in
+            )
+            let ret = Deferred<Maybe<Cursor<Site>>>()
+            deferred.upon { result in
+                guard let result = result.successValue else {
+                    // It's possible for our query to be interrupted
+                    // either by triggering the interrupt or by the user leaving putting the application
+                    // in tha background
+                    // we should make sure we re-set the fetching flag
+                    self.isFetchInProgress = false
+                    ret.fill(Maybe(failure: result.failureValue ?? "Unknown Error"))
+                    return
+                }
                 DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) {
                     self.isFetchInProgress = false
                     self.browserLog.debug("currentFetchOffset is: \(self.currentFetchOffset)")
@@ -325,8 +336,9 @@ class HistoryPanelViewModel: Loggable, FeatureFlaggable {
                     site.latestVisit = Visit(date: UInt64(info.timestamp) * 1000)
                     return site
                 }.uniqued()
-                return deferMaybe(ArrayCursor(data: sites))
+                ret.fill(Maybe(success: ArrayCursor(data: sites)))
             }
+            return ret
         }
     }
 

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
@@ -313,7 +313,7 @@ class HistoryPanelViewModel: Loggable, FeatureFlaggable {
                 guard let result = result.successValue else {
                     // It's possible for our query to be interrupted
                     // either by triggering the interrupt or by the user leaving putting the application
-                    // in tha background
+                    // in the background
                     // we should make sure we re-set the fetching flag
                     self.isFetchInProgress = false
                     ret.fill(Maybe(failure: result.failureValue ?? "Unknown Error"))


### PR DESCRIPTION
Doing some more testing on the new history implementation, I caught an edge case which can be reproduced by:

- First, enable "Migrate and Use Places API" from the secret debug menu
- Now go to your history panel and click on a history item
- Quickly go back to the history panel and put the app in the background
- Keep repeating and notice that we'll be stuck in a state where the history panel doesn't update


The issue is that it is possible that the query to the places DB can get interrupted (on in this case, when we go to the background, we close the database connection) and in that case the function returns an error.
 
We add handling for that error to make sure that we reset the `isFetchInProgress` flag so new searches can go through


cc @lmarceau since you've been kind enough to review the bigger PR! 🙏