### PR TITLE
Bugfix [v107.1] Only send fatal errors to sentry

### DIFF
--- a/Shared/SentryIntegration.swift
+++ b/Shared/SentryIntegration.swift
@@ -195,8 +195,8 @@ public class SentryIntegration: SentryProtocol {
          Release    n      n       y
      */
     private func shouldSendEventFor(_ severity: SentryLevel) -> Bool {
-        let shouldSendRelease = AppConstants.BuildChannel == .release && severity.rawValue >= SentryLevel.warning.rawValue
-        let shouldSendBeta = AppConstants.BuildChannel == .beta && severity.rawValue >= SentryLevel.info.rawValue
+        let shouldSendRelease = AppConstants.BuildChannel == .release && severity.rawValue >= SentryLevel.fatal.rawValue
+        let shouldSendBeta = AppConstants.BuildChannel == .beta && severity.rawValue >= SentryLevel.fatal.rawValue
 
         return shouldSendBeta || shouldSendRelease
     }


### PR DESCRIPTION
With the increase in events being sent to Sentry we are being rate limited which is hurting our ability to track the worse crashes.
Rolling back to only send fatal errors and making the same change for the beta app. We were being rated limited before but at a much lower rate and these info logs that are being spammed provide little value at the moment. 
