### PR TITLE
Refactor MTE-231 [v110] Update SnapshotHelper file

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1408,7 +1408,6 @@ trigger_map:
 - push_branch: release/v108.0
   workflow: SPM_Deploy_Prod_Beta
 - pull_request_target_branch: main
-  #pipeline: pipeline_multiple_shards
-  workflow: L10nBuild
+  pipeline: pipeline_multiple_shards
 - pull_request_target_branch: epic-branch/*
   pipeline: pipeline_multiple_shards

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1408,6 +1408,7 @@ trigger_map:
 - push_branch: release/v108.0
   workflow: SPM_Deploy_Prod_Beta
 - pull_request_target_branch: main
-  pipeline: pipeline_multiple_shards
+  #pipeline: pipeline_multiple_shards
+  workflow: L10nBuild
 - pull_request_target_branch: epic-branch/*
   pipeline: pipeline_multiple_shards

--- a/fastlane/SnapshotHelper.swift
+++ b/fastlane/SnapshotHelper.swift
@@ -181,7 +181,7 @@ open class Snapshot: NSObject {
 
                 let path = screenshotsDir.appendingPathComponent("\(simulator)-\(name).png")
                 #if swift(<5.0)
-                    UIImagePNGRepresentation(image)?.write(to: path, options: .atomic)
+                    try UIImagePNGRepresentation(image)?.write(to: path, options: .atomic)
                 #else
                     try image.pngData()?.write(to: path, options: .atomic)
                 #endif
@@ -306,4 +306,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.28]
+// SnapshotHelperVersion [1.29]


### PR DESCRIPTION
So that we can run the screenshots tests, the SnapshotHelper file has to be updated. The new version is needed because the fastlane version is also a new one.