### PR TITLE
Add FXIOS-5253 [v109] Favicon project

### DIFF
--- a/BrowserKit/.gitignore
+++ b/BrowserKit/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/config/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/BrowserKit/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/BrowserKit/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version: 5.6
+
+import PackageDescription
+
+let package = Package(
+    name: "BrowserKit",
+    platforms: [
+        .iOS(.v13)
+    ],
+    products: [
+        .library(
+            name: "SiteImageView",
+            targets: ["SiteImageView"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "SiteImageView",
+            dependencies: []),
+        .testTarget(
+            name: "SiteImageViewTests",
+            dependencies: ["SiteImageView"]),
+    ]
+)

--- a/BrowserKit/README.md
+++ b/BrowserKit/README.md
@@ -1,0 +1,3 @@
+# BrowserKit
+
+A collection of projects that are useful for building a browser

--- a/BrowserKit/Sources/SiteImageView/SiteImageType.swift
+++ b/BrowserKit/Sources/SiteImageView/SiteImageType.swift
@@ -1,0 +1,5 @@
+
+public enum SiteImageType {
+    case favicon
+    case heroImage
+}

--- a/BrowserKit/Sources/SiteImageView/SiteImageType.swift
+++ b/BrowserKit/Sources/SiteImageView/SiteImageType.swift
@@ -1,3 +1,6 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0
 
 public enum SiteImageType {
     case favicon

--- a/BrowserKit/Sources/SiteImageView/SiteImageView.swift
+++ b/BrowserKit/Sources/SiteImageView/SiteImageView.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0
+
 import UIKit
 
 public class SiteImageView: UIImageView {

--- a/BrowserKit/Sources/SiteImageView/SiteImageView.swift
+++ b/BrowserKit/Sources/SiteImageView/SiteImageView.swift
@@ -1,0 +1,10 @@
+import UIKit
+
+public class SiteImageView: UIImageView {
+    private var uniqueID: UUID?
+
+    public func setURL(siteURL: String, type: SiteImageType = .favicon) {
+        uniqueID = UUID()
+        backgroundColor = .magenta
+    }
+}

--- a/BrowserKit/Tests/SiteImageViewTests/SiteImageViewTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/SiteImageViewTests.swift
@@ -1,0 +1,4 @@
+import XCTest
+@testable import SiteImageView
+
+final class SiteImageViewTests: XCTestCase {}

--- a/BrowserKit/Tests/SiteImageViewTests/SiteImageViewTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/SiteImageViewTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0
+
 import XCTest
 @testable import SiteImageView
 

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -415,6 +415,7 @@
 		5A430D792853DFDD00782BFF /* OrientationLockUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A430D782853DFDD00782BFF /* OrientationLockUtility.swift */; };
 		5A43EC9328CBC25F003155A3 /* Themable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A43EC9228CBC25F003155A3 /* Themable.swift */; };
 		5A47CFF52860FB8900B2B7BF /* AppLaunchUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A47CFF42860FB8900B2B7BF /* AppLaunchUtil.swift */; };
+		5A65BE19292861C900E841A7 /* SiteImageView in Frameworks */ = {isa = PBXBuildFile; productRef = 5A65BE18292861C900E841A7 /* SiteImageView */; };
 		5A9A09D228AFD51900B6F51E /* MockHomepageDataModelDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A9A09D128AFD51900B6F51E /* MockHomepageDataModelDelegate.swift */; };
 		5A9A09D428B01D8700B6F51E /* MockTelemetryWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A9A09D328B01D8700B6F51E /* MockTelemetryWrapper.swift */; };
 		5A9A09D628B01FD500B6F51E /* MockURLBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A9A09D528B01FD500B6F51E /* MockURLBarView.swift */; };
@@ -2857,6 +2858,7 @@
 		5A430D782853DFDD00782BFF /* OrientationLockUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrientationLockUtility.swift; sourceTree = "<group>"; };
 		5A43EC9228CBC25F003155A3 /* Themable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Themable.swift; sourceTree = "<group>"; };
 		5A47CFF42860FB8900B2B7BF /* AppLaunchUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLaunchUtil.swift; sourceTree = "<group>"; };
+		5A65BE172928619E00E841A7 /* BrowserKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = BrowserKit; sourceTree = "<group>"; };
 		5A9A09D128AFD51900B6F51E /* MockHomepageDataModelDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHomepageDataModelDelegate.swift; sourceTree = "<group>"; };
 		5A9A09D328B01D8700B6F51E /* MockTelemetryWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTelemetryWrapper.swift; sourceTree = "<group>"; };
 		5A9A09D528B01FD500B6F51E /* MockURLBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLBarView.swift; sourceTree = "<group>"; };
@@ -5283,6 +5285,7 @@
 				8A08EC6427EBDCAD00E119C7 /* AdServices.framework in Frameworks */,
 				8A08EC6227EBDCA400E119C7 /* iAd.framework in Frameworks */,
 				43BE580E278BABCF00491291 /* RustMozillaAppServices.framework in Frameworks */,
+				5A65BE19292861C900E841A7 /* SiteImageView in Frameworks */,
 				C82043852523DBF600740B71 /* Sync.framework in Frameworks */,
 				C877037A25222F30006E38EB /* Shared.framework in Frameworks */,
 				C8E18F20222EDED000E30E52 /* SafariServices.framework in Frameworks */,
@@ -8082,6 +8085,7 @@
 		F84B21B51A090F8100AAB793 = {
 			isa = PBXGroup;
 			children = (
+				5A65BE172928619E00E841A7 /* BrowserKit */,
 				C8E2E80623D20FB3005AACE6 /* RustFxA */,
 				2FA435FC1ABB83B4008031D1 /* Account */,
 				F84B21C01A090F8100AAB793 /* Client */,
@@ -8983,6 +8987,7 @@
 				435C85EF2788F4D00072B526 /* Glean */,
 				432BD0232790EBD000A0F3C3 /* Adjust */,
 				96C11E952863985E00840E7C /* Dip */,
+				5A65BE18292861C900E841A7 /* SiteImageView */,
 			);
 			productName = Client;
 			productReference = F84B21BE1A090F8100AAB793 /* Client.app */;
@@ -16452,6 +16457,10 @@
 		43EFA63D2786562600400DF0 /* Places */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Places;
+		};
+		5A65BE18292861C900E841A7 /* SiteImageView */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SiteImageView;
 		};
 		5FA2233B27F74071005B3D87 /* Glean */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
This PR adds a new local package to the project using SPM called BrowserKit. This is intended to be the home of several future projects that make sense to be self contained frameworks and can potentially be shared with the Focus project in the future. 
The package is embedded in the FIrefox XCode project so local development can happen from within the project and tests can be run from there.
Also included is the first package called SiteImageView, this will be built out into a solution to better manage favicons, it is just a skeleton at present.

Not included in this PR:
A solution for CI. Test for this project currently will not run automatically.
Any sort of linting for the new project.

These will be tackled at separate tasks in the future.