### PR TITLE
Bugfix FXIOS-5294 [v107.2] Removing further database favicons calls

### DIFF
--- a/Client/Frontend/Browser/FaviconHandler.swift
+++ b/Client/Frontend/Browser/FaviconHandler.swift
@@ -71,21 +71,10 @@ class FaviconHandler {
         }
 
         let domainLevelIconUrl = currentUrl.domainURL.appendingPathComponent("favicon.ico")
-        let site = Site(url: currentUrl.absoluteString, title: "")
 
         let onSuccess: (Favicon) -> Void = { [weak tab] (favicon) -> Void in
             tab?.favicons.append(favicon)
-
-            guard !(tab?.isPrivate ?? true),
-                  let appDelegate = UIApplication.shared.delegate as? AppDelegate else {
-                completion(favicon, nil)
-                return
-            }
-
-            let profile = appDelegate.profile
-            profile.favicons.addFavicon(favicon, forSite: site) >>> {
-                completion(favicon, nil)
-            }
+            completion(favicon, nil)
         }
 
         getFaviconIconFrom(url: faviconUrl,
@@ -107,12 +96,13 @@ extension FaviconHandler: TabEventHandler {
         tab.favicons.removeAll(keepingCapacity: false)
         guard let faviconURL = metadata.faviconURL else { return }
 
+        // This is necessary for tab favicons. Tab tray tabs favicon doesn't get updated without it
         loadFaviconURL(faviconURL, forTab: tab) { favicon, error in
             guard error == nil else { return }
             TabEvent.post(.didLoadFavicon(favicon), for: tab)
         }
-
     }
+
     func tabMetadataNotAvailable(_ tab: Tab) {
         tab.favicons.removeAll(keepingCapacity: false)
     }

--- a/Client/Utils/FaviconFetcher+Non-Bundled.swift
+++ b/Client/Utils/FaviconFetcher+Non-Bundled.swift
@@ -113,7 +113,6 @@ extension FaviconFetcher {
     func getFavicon(_ siteUrl: URL, icon: Favicon, profile: Profile) -> Deferred<Maybe<Favicon>> {
         let deferred = Deferred<Maybe<Favicon>>()
         let url = icon.url
-        let site = Site(url: siteUrl.absoluteString, title: "")
 
         var fav = Favicon(url: url)
 
@@ -137,7 +136,6 @@ extension FaviconFetcher {
 
                 fav.width = Int(image.size.width)
                 fav.height = Int(image.size.height)
-                profile.favicons.addFavicon(fav, forSite: site)
 
                 deferred.fill(Maybe(success: fav))
             }

--- a/Storage/Favicons.swift
+++ b/Storage/Favicons.swift
@@ -5,17 +5,7 @@
 import Shared
 import UIKit
 
-/* The base favicons protocol */
+/// The base favicons protocol. To be deprecated soon, do not use for new code
 public protocol Favicons {
-    /**
-     * Returns the ID of the added favicon.
-     */
-    func addFavicon(_ icon: Favicon) -> Deferred<Maybe<Int>>
-
-    /**
-     * Returns the ID of the added favicon.
-     */
-    @discardableResult func addFavicon(_ icon: Favicon, forSite site: Site) -> Deferred<Maybe<Int>>
-
     func getFaviconImage(forSite site: Site) -> Deferred<Maybe<UIImage>>
 }

--- a/Storage/SQL/SQLiteFavicons.swift
+++ b/Storage/SQL/SQLiteFavicons.swift
@@ -59,14 +59,4 @@ open class SQLiteFavicons {
 
         return (sql: sql, args: nil)
     }
-
-    public func insertOrUpdateFavicon(_ favicon: Favicon) -> Deferred<Maybe<Int>> {
-        return db.withConnection { conn -> Int in
-            self.insertOrUpdateFaviconInTransaction(favicon, conn: conn) ?? 0
-        }
-    }
-
-    func insertOrUpdateFaviconInTransaction(_ favicon: Favicon, conn: SQLiteDBConnection) -> Int? {
-        return nil
-    }
 }

--- a/Storage/SQL/SQLiteHistoryFavicons.swift
+++ b/Storage/SQL/SQLiteHistoryFavicons.swift
@@ -72,78 +72,6 @@ class FaviconDownloadError: MaybeErrorType {
 }
 
 extension SQLiteHistory: Favicons {
-    func getFaviconsForURL(_ url: String) -> Deferred<Maybe<Cursor<Favicon?>>> {
-        let sql = """
-            SELECT iconID, iconURL, iconDate
-            FROM (
-                SELECT iconID, iconURL, iconDate
-                FROM view_favicons_widest, history
-                WHERE history.id = siteID AND history.url = ?
-                UNION ALL
-                SELECT favicons.id AS iconID, url as iconURL, date as iconDate
-                FROM favicons, favicon_site_urls
-                WHERE favicons.id = favicon_site_urls.faviconID AND favicon_site_urls.site_url = ?
-            ) LIMIT 1
-            """
-
-        let args: Args = [url, url]
-        return database.runQueryConcurrently(sql, args: args, factory: SQLiteHistory.iconColumnFactory)
-    }
-
-    public func addFavicon(_ icon: Favicon) -> Deferred<Maybe<Int>> {
-        return self.favicons.insertOrUpdateFavicon(icon)
-    }
-
-    /**
-     * This method assumes that the site has already been recorded
-     * in the history table.
-     */
-    public func addFavicon(_ icon: Favicon, forSite site: Site) -> Deferred<Maybe<Int>> {
-        func doChange(_ query: String, args: Args?) -> Deferred<Maybe<Int>> {
-            return database.withConnection { conn -> Int in
-                // Blind! We don't see failure here.
-                let id = self.favicons.insertOrUpdateFaviconInTransaction(icon, conn: conn)
-
-                // Now set up the mapping.
-                try conn.executeChange(query, withArgs: args)
-
-                guard let faviconID = id else {
-                    let err = DatabaseError(description: "Error adding favicon. ID = 0")
-                    log.error("addFavicon(_:, forSite:) encountered an error: \(err.localizedDescription)")
-                    throw err
-                }
-
-                return faviconID
-            }
-        }
-
-        let siteSubselect = "(SELECT id FROM history WHERE url = ?)"
-        let iconSubselect = "(SELECT id FROM favicons WHERE url = ?)"
-        let insertOrIgnore = "INSERT OR IGNORE INTO favicon_sites (siteID, faviconID) VALUES "
-        if let iconID = icon.id {
-            // Easy!
-            if let siteID = site.id {
-                // So easy!
-                let args: Args? = [siteID, iconID]
-                return doChange("\(insertOrIgnore) (?, ?)", args: args)
-            }
-
-            // Nearly easy.
-            let args: Args? = [site.url, iconID]
-            return doChange("\(insertOrIgnore) (\(siteSubselect), ?)", args: args)
-
-        }
-
-        // Sigh.
-        if let siteID = site.id {
-            let args: Args? = [siteID, icon.url]
-            return doChange("\(insertOrIgnore) (?, \(iconSubselect))", args: args)
-        }
-
-        // The worst.
-        let args: Args? = [site.url, icon.url]
-        return doChange("\(insertOrIgnore) (\(siteSubselect), \(iconSubselect))", args: args)
-    }
 
     public func getFaviconImage(forSite site: Site) -> Deferred<Maybe<UIImage>> {
         // First, attempt to lookup the favicon from our bundled top sites.
@@ -261,25 +189,11 @@ extension SQLiteHistory: Favicons {
         }
 
         let deferred = CancellableDeferred<Maybe<URL>>()
-
         getFaviconURLsFromWebPage(url: url).upon { result in
             guard let faviconURLs = result.successValue,
                 let faviconURL = faviconURLs.first else {
                 deferred.fill(Maybe(failure: FaviconLookupError(siteURL: site.url)))
                 return
-            }
-
-            // Since we were able to scrape a favicon URL off the web page,
-            // insert it into the DB to avoid having to scrape again later.
-            let favicon = Favicon(url: faviconURL.absoluteString)
-            self.favicons.insertOrUpdateFavicon(favicon).upon { result in
-                if let faviconID = result.successValue {
-
-                    // Also, insert a row in `favicon_site_urls` so we can
-                    // look up this favicon later without requiring history.
-                    // This is primarily needed for bookmarks.
-                    _ = self.database.run("INSERT OR IGNORE INTO favicon_site_urls(site_url, faviconID) VALUES (?, ?)", withArgs: [site.url, faviconID])
-                }
             }
 
             deferred.fill(Maybe(success: faviconURL))

--- a/Tests/ClientTests/Utils/TestFavicons.swift
+++ b/Tests/ClientTests/Utils/TestFavicons.swift
@@ -10,17 +10,6 @@ import Shared
 
 class TestFavicons: ProfileTest {
 
-    fileprivate func addSite(_ favicons: Favicons, url: String, isSuccessful: Bool = true) {
-        let expectation = self.expectation(description: "Wait for history")
-        let site = Site(url: url, title: "")
-        let icon = Favicon(url: url + "/icon.png")
-        favicons.addFavicon(icon, forSite: site).upon {
-            XCTAssertEqual($0.isSuccess, isSuccessful, "Icon added \(url)")
-            expectation.fulfill()
-        }
-        self.waitForExpectations(timeout: 100, handler: nil)
-    }
-
     func testFaviconFetcherParse() {
         let expectation = self.expectation(description: "Wait for Favicons to be fetched")
 


### PR DESCRIPTION
# [FXIOS-5294](https://mozilla-hub.atlassian.net/browse/FXIOS-5294) https://github.com/mozilla-mobile/firefox-ios/issues/12443
Removing further database favicons calls since this is possibly causing db locks and hangs in production. This is a follow up on PR https://github.com/mozilla-mobile/firefox-ios/pull/12353 that removed reading from that particular db to get favicons URLs. This PR now also remove saving into it. Caching of favicons is handled in Kingfisher. 

This is a short term band-aid, the plan is to follow this up with a more robust system for managing favicons as described with epic [FXIOS-5249](https://mozilla-hub.atlassian.net/browse/FXIOS-5249).

## Details
- Removing `addFavicon` to SQL db querys that were not queried anymore. This was causing errors in production as described in the ticket. As a result of this, `Favicons` protocol got a small clean up which resulted in the following changes:
    - `addFavicon` in `FaviconHandler.loadFaviconURL` removed on success. We get the favicon from `getFaviconIconFrom` which retrieves the favicon from KingFisher with `ImageLoadingHandler.shared`. Removing this should have no impact.
    - `addFavicon` in `FaviconFetcher+Non-Bundled.getFavicon` removed. We get the favicon from KingFisher with `ImageLoadingHandler.shared`. Removing this should have no impact.
-  Removing saving the favicon URL with `insertOrUpdateFavicon` after a webpage URL scrapping. This URL was at the moment never queried since https://github.com/mozilla-mobile/firefox-ios/pull/12353 made `lookupFaviconURLFromDatabase` return an error only. This doesn't make the favicons loading worst than what it is already since we weren't retrieving from that db. Now we also don't save in it. 