### PR TITLE
Refactor MTE-183 [v109] M1 specific test failures in DownloadFilesTests, HomePageSettingsUITests and ReaderViewTest

### DIFF
--- a/Tests/XCUITests/DownloadFilesTests.swift
+++ b/Tests/XCUITests/DownloadFilesTests.swift
@@ -12,30 +12,40 @@ class DownloadFilesTests: BaseTestCase {
     override func tearDown() {
         // The downloaded file has to be removed between tests
         waitForExistence(app.tables["DownloadsTable"])
-
-        let list = app.tables["DownloadsTable"].cells.count
-        if list != 0 {
-            for _ in 0...list-1 {
-                waitForExistence(app.tables["DownloadsTable"].cells.element(boundBy: 0))
-                app.tables["DownloadsTable"].cells.element(boundBy: 0).swipeLeft()
-                waitForExistence(app.tables.cells.buttons["Delete"])
-                app.tables.cells.buttons["Delete"].tap()
+        if processIsTranslatedStr() == m1Rosetta {
+            navigator.nowAt(LibraryPanel_Downloads)
+            navigator.goto(NewTabScreen)
+            navigator.performAction(Action.CloseURLBarOpen)
+            navigator.nowAt(NewTabScreen)
+            navigator.goto(ClearPrivateDataSettings)
+            app.cells.switches["Downloaded Files"].tap()
+            app.tables.cells["ClearPrivateData"].tap()
+            app.alerts.buttons["OK"].tap()
+        } else {
+            let list = app.tables["DownloadsTable"].cells.count
+            if list != 0 {
+                for _ in 0...list-1 {
+                    waitForExistence(app.tables["DownloadsTable"].cells.element(boundBy: 0))
+                    app.tables["DownloadsTable"].cells.element(boundBy: 0).swipeLeft()
+                    waitForExistence(app.tables.cells.buttons["Delete"])
+                    app.tables.cells.buttons["Delete"].tap()
+                }
             }
         }
     }
 
     private func deleteItem(itemName: String) {
         app.tables.cells.staticTexts[itemName].swipeLeft()
-        waitForExistence(app.tables.cells.buttons["Delete"], timeout: 3)
+        waitForExistence(app.tables.cells.buttons["Delete"], timeout: TIMEOUT)
         app.tables.cells.buttons["Delete"].tap()
     }
 
     func testDownloadFilesAppMenuFirstTime() {
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: 5)
+        waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         navigator.goto(LibraryPanel_Downloads)
-        waitForExistence(app.tables["DownloadsTable"], timeout: 5)
+        waitForExistence(app.tables["DownloadsTable"], timeout: TIMEOUT)
         XCTAssertTrue(app.tables["DownloadsTable"].exists)
         // Check that there is not any items and the default text shown is correct
         checkTheNumberOfDownloadedItems(items: 0)
@@ -46,9 +56,13 @@ class DownloadFilesTests: BaseTestCase {
         navigator.openURL(testURL)
         waitUntilPageLoad()
         // Verify that the context menu prior to download a file is correct
+        if !iPad() {
+            app.webViews.links.firstMatch.swipeLeft(velocity: 1000)
+            app.webViews.links.firstMatch.swipeLeft(velocity: 1000)
+        }
         app.webViews.links[testFileName].firstMatch.tap()
 
-        waitForExistence(app.tables["Context Menu"], timeout: 5)
+        waitForExistence(app.tables["Context Menu"], timeout: TIMEOUT)
         XCTAssertTrue(app.tables["Context Menu"].staticTexts[testFileNameDownloadPanel].exists)
         XCTAssertTrue(app.tables["Context Menu"].otherElements["download"].exists)
         app.buttons["Cancel"].tap()
@@ -63,7 +77,7 @@ class DownloadFilesTests: BaseTestCase {
         navigator.goto(BrowserTabMenu)
         navigator.goto(LibraryPanel_Downloads)
 
-        waitForExistence(app.tables["DownloadsTable"], timeout: 5)
+        waitForExistence(app.tables["DownloadsTable"], timeout: TIMEOUT)
         // There should be one item downloaded. It's name and size should be shown
         checkTheNumberOfDownloadedItems(items: 1)
         XCTAssertTrue(app.tables.cells.staticTexts[testFileNameDownloadPanel].exists)
@@ -83,26 +97,32 @@ class DownloadFilesTests: BaseTestCase {
         XCTAssertTrue(app.tables.cells.staticTexts[testBLOBFileSize].exists)
     }
 
-    func testDeleteDownloadedFile() {
+    func testDeleteDownloadedFile() throws {
         downloadFile(fileName: testFileName, numberOfDownlowds: 1)
         navigator.goto(BrowserTabMenu)
         navigator.goto(LibraryPanel_Downloads)
         waitForExistence(app.tables["DownloadsTable"])
-
-        deleteItem(itemName: testFileNameDownloadPanel)
-        waitForNoExistence(app.tables.cells.staticTexts[testFileNameDownloadPanel])
-
-        // After removing the number of items should be 0
-        checkTheNumberOfDownloadedItems(items: 0)
+        if processIsTranslatedStr() == m1Rosetta {
+            throw XCTSkip("swipeLeft() does not work on M1")
+        } else {
+            deleteItem(itemName: testFileNameDownloadPanel)
+            waitForNoExistence(app.tables.cells.staticTexts[testFileNameDownloadPanel])
+            // After removing the number of items should be 0
+            checkTheNumberOfDownloadedItems(items: 0)
+        }
     }
 
-    func testShareDownloadedFile() {
+    func testShareDownloadedFile() throws {
         downloadFile(fileName: testFileName, numberOfDownlowds: 1)
         navigator.goto(BrowserTabMenu)
         navigator.goto(LibraryPanel_Downloads)
-        app.tables.cells.staticTexts[testFileNameDownloadPanel].swipeLeft()
-        XCTAssertTrue(app.tables.buttons.staticTexts["Share"].exists)
-        XCTAssertTrue(app.tables.buttons.staticTexts["Delete"].exists)
+        if processIsTranslatedStr() == m1Rosetta {
+            throw XCTSkip("swipeLeft() does not work on M1")
+        } else {
+            app.tables.cells.staticTexts[testFileNameDownloadPanel].swipeLeft()
+            XCTAssertTrue(app.tables.buttons.staticTexts["Share"].exists)
+            XCTAssertTrue(app.tables.buttons.staticTexts["Delete"].exists)
+        }
     }
 
     func testLongPressOnDownloadedFile() {
@@ -113,9 +133,16 @@ class DownloadFilesTests: BaseTestCase {
         waitForExistence(app.tables["DownloadsTable"])
         // Commenting out until share sheet can be managed with automated tests issue #5477
         app.tables.cells.staticTexts[testFileNameDownloadPanel].press(forDuration: 2)
-        waitForExistence(app.otherElements["ActivityListView"], timeout: 10)
+        waitForExistence(app.otherElements["ActivityListView"], timeout: TIMEOUT)
         if !iPad() {
             app.buttons["Close"].tap()
+        } else {
+            // Workaround to close the context menu.
+            // XCUITest does not allow me to click the greyed out portion of the app.
+            app.otherElements["ActivityListView"].cells["XCElementSnapshotPrivilegedValuePlaceholder"].firstMatch.tap()
+            print(app.debugDescription)
+            waitForExistence(app.alerts["Unable to Import Clinical Documents"], timeout: TIMEOUT)
+            app.buttons["OK"].tap()
         }
      }
 
@@ -124,18 +151,18 @@ class DownloadFilesTests: BaseTestCase {
         waitUntilPageLoad()
         app.webViews.firstMatch.swipeLeft()
         for _ in 0..<numberOfDownlowds {
-            waitForExistence(app.webViews.links[testFileName], timeout: 5)
+            waitForExistence(app.webViews.links[testFileName], timeout: TIMEOUT)
 
             app.webViews.links[testFileName].firstMatch.tap()
 
-            waitForExistence(app.tables["Context Menu"].otherElements["download"], timeout: 5)
+            waitForExistence(app.tables["Context Menu"].otherElements["download"], timeout: TIMEOUT)
             app.tables["Context Menu"].otherElements["download"].tap()
         }
     }
 
     private func downloadBLOBFile() {
         navigator.openURL(testBLOBURL)
-        waitForExistence(app.webViews.links["Download Text"], timeout: 5)
+        waitForExistence(app.webViews.links["Download Text"], timeout: TIMEOUT)
         app.webViews.links["Download Text"].press(forDuration: 1)
         app.buttons["Download Link"].tap()
     }
@@ -168,7 +195,7 @@ class DownloadFilesTests: BaseTestCase {
 
         // Remove private data once the switch to remove downloaded files is enabled
         navigator.goto(NewTabScreen)
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: 5)
+        waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         navigator.goto(ClearPrivateDataSettings)
@@ -176,7 +203,7 @@ class DownloadFilesTests: BaseTestCase {
         navigator.performAction(Action.AcceptClearPrivateData)
 
         navigator.goto(HomePanelsScreen)
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: 5)
+        waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         navigator.goto(LibraryPanel_Downloads)
@@ -185,7 +212,7 @@ class DownloadFilesTests: BaseTestCase {
     }
 
     private func checkTheNumberOfDownloadedItems(items: Int) {
-        waitForExistence(app.tables["DownloadsTable"], timeout: 10)
+        waitForExistence(app.tables["DownloadsTable"], timeout: TIMEOUT)
         let list = app.tables["DownloadsTable"].cells.count
         XCTAssertEqual(list, items, "The number of items in the downloads table is not correct")
     }
@@ -194,7 +221,7 @@ class DownloadFilesTests: BaseTestCase {
         downloadFile(fileName: testFileName, numberOfDownlowds: 1)
         waitForExistence(app.buttons["Downloads"])
         app.buttons["Downloads"].tap()
-        waitForExistence(app.tables["DownloadsTable"], timeout: 3)
+        waitForExistence(app.tables["DownloadsTable"], timeout: TIMEOUT)
         checkTheNumberOfDownloadedItems(items: 1)
     }
 }

--- a/Tests/XCUITests/DownloadFilesTests.swift
+++ b/Tests/XCUITests/DownloadFilesTests.swift
@@ -140,7 +140,6 @@ class DownloadFilesTests: BaseTestCase {
             // Workaround to close the context menu.
             // XCUITest does not allow me to click the greyed out portion of the app.
             app.otherElements["ActivityListView"].cells["XCElementSnapshotPrivilegedValuePlaceholder"].firstMatch.tap()
-            print(app.debugDescription)
             waitForExistence(app.alerts["Unable to Import Clinical Documents"], timeout: TIMEOUT)
             app.buttons["OK"].tap()
         }

--- a/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -93,21 +93,24 @@ class HomePageSettingsUITests: BaseTestCase {
         waitForValueContains(app.textFields["url"], value: "example")
     }
 
-    func testClipboard() {
-        navigator.performAction(Action.CloseURLBarOpen)
-        navigator.nowAt(NewTabScreen)
-        // Check that what's in clipboard is copied
-        UIPasteboard.general.string = websiteUrl1
-        navigator.goto(HomeSettings)
-        app.textFields["HomeAsCustomURLTextField"].tap()
-        app.textFields["HomeAsCustomURLTextField"].press(forDuration: 3)
-        waitForExistence(app.menuItems["Paste"])
-        app.menuItems["Paste"].tap()
-        waitForNoExistence(app.menuItems["Paste"])
-        waitForValueContains(app.textFields["HomeAsCustomURLTextField"], value: "mozilla")
-        // Check that the webpage has been correctly copied into the correct field
-        let value = app.textFields["HomeAsCustomURLTextField"].value as! String
-        XCTAssertEqual(value, websiteUrl1)
+    func testClipboard() throws {
+        if processIsTranslatedStr() == m1Rosetta {
+            throw XCTSkip("Copy & paste may not work on M1")
+        } else {
+            navigator.performAction(Action.CloseURLBarOpen)
+            navigator.nowAt(NewTabScreen)
+            // Check that what's in clipboard is copied
+            UIPasteboard.general.string = websiteUrl1
+            navigator.goto(HomeSettings)
+            app.textFields["HomeAsCustomURLTextField"].tap()
+            app.textFields["HomeAsCustomURLTextField"].press(forDuration: 3)
+            waitForExistence(app.menuItems["Paste"])
+            app.menuItems["Paste"].tap()
+            waitForValueContains(app.textFields["HomeAsCustomURLTextField"], value: "mozilla")
+            // Check that the webpage has been correctly copied into the correct field
+            let value = app.textFields["HomeAsCustomURLTextField"].value as! String
+            XCTAssertEqual(value, websiteUrl1)
+        }
     }
 
     func testSetFirefoxHomeAsHome() {

--- a/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -103,7 +103,8 @@ class HomePageSettingsUITests: BaseTestCase {
         app.textFields["HomeAsCustomURLTextField"].press(forDuration: 3)
         waitForExistence(app.menuItems["Paste"])
         app.menuItems["Paste"].tap()
-        waitForValueContains(app.textFields["HomeAsCustomURLTextField"], value: "mozilla", timeout: TIMEOUT)
+        waitForNoExistence(app.menuItems["Paste"])
+        waitForValueContains(app.textFields["HomeAsCustomURLTextField"], value: "mozilla")
         // Check that the webpage has been correctly copied into the correct field
         let value = app.textFields["HomeAsCustomURLTextField"].value as! String
         XCTAssertEqual(value, websiteUrl1)

--- a/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -103,7 +103,7 @@ class HomePageSettingsUITests: BaseTestCase {
         app.textFields["HomeAsCustomURLTextField"].press(forDuration: 3)
         waitForExistence(app.menuItems["Paste"])
         app.menuItems["Paste"].tap()
-        waitForValueContains(app.textFields["HomeAsCustomURLTextField"], value: "mozilla")
+        waitForValueContains(app.textFields["HomeAsCustomURLTextField"], value: "mozilla", timeout: TIMEOUT)
         // Check that the webpage has been correctly copied into the correct field
         let value = app.textFields["HomeAsCustomURLTextField"].value as! String
         XCTAssertEqual(value, websiteUrl1)

--- a/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -38,7 +38,32 @@ class HomePageSettingsUITests: BaseTestCase {
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         navigator.goto(HomeSettings)
-        XCTAssertTrue(app.tables.cells["Firefox Home"].exists)
+
+        waitForExistence(app.navigationBars["Homepage"])
+        waitForExistence(app.tables.otherElements["OPENING SCREEN"])
+        waitForExistence(app.tables.otherElements["INCLUDE ON HOMEPAGE"])
+        waitForExistence(app.tables.otherElements["CURRENT HOMEPAGE"])
+
+        // Opening Screen
+        XCTAssertFalse(app.tables.cells["StartAtHomeAlways"].isSelected)
+        XCTAssertFalse(app.tables.cells["StartAtHomeDisabled"].isSelected)
+        XCTAssertTrue(app.tables.cells["StartAtHomeAfterFourHours"].isSelected)
+
+        // Include on Homepage
+        XCTAssertTrue(app.tables.cells["TopSitesSettings"].staticTexts["On"].exists)
+        let jumpBackIn = app.tables.cells.switches["Jump Back In"].value
+        XCTAssertEqual("1", jumpBackIn as? String)
+        let recentlySaved = app.tables.cells.switches["Recently Saved"].value
+        XCTAssertEqual("1", recentlySaved as? String)
+        let recentlyVisited = app.tables.cells.switches["Recently Visited"].value
+        XCTAssertEqual("1", recentlyVisited as? String)
+        let recommendedByPocket = app.tables.cells.switches["Recommended by Pocket"].value
+        XCTAssertEqual("1", recommendedByPocket as? String)
+        let sponsoredStories = app.tables.cells.switches["Sponsored stories"].value
+        XCTAssertEqual("1", sponsoredStories as? String)
+
+        // Current Homepage
+        XCTAssertTrue(app.tables.cells["Firefox Home"].isSelected)
         XCTAssertTrue(app.tables.cells["HomeAsCustomURL"].exists)
     }
 

--- a/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -40,8 +40,6 @@ class HomePageSettingsUITests: BaseTestCase {
         navigator.goto(HomeSettings)
         XCTAssertTrue(app.tables.cells["Firefox Home"].exists)
         XCTAssertTrue(app.tables.cells["HomeAsCustomURL"].exists)
-        XCTAssert(app.tables.cells["WallpaperSettings"].exists)
-        XCTAssertTrue(app.cells.switches["Recommended by Pocket"].exists)
     }
 
     func testTyping() {
@@ -64,7 +62,7 @@ class HomePageSettingsUITests: BaseTestCase {
 
         // Now check open home page should load the previously saved home page
         let homePageMenuItem = app.buttons[AccessibilityIdentifiers.Toolbar.homeButton]
-        waitForExistence(homePageMenuItem, timeout: 5)
+        waitForExistence(homePageMenuItem, timeout: TIMEOUT)
         homePageMenuItem.tap()
         waitUntilPageLoad()
         waitForValueContains(app.textFields["url"], value: "example")
@@ -98,7 +96,7 @@ class HomePageSettingsUITests: BaseTestCase {
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
         waitUntilPageLoad()
         navigator.performAction(Action.GoToHomePage)
-        waitForExistence(app.textFields["url"], timeout: 3)
+        waitForExistence(app.textFields["url"], timeout: TIMEOUT)
 
         // Now after setting History, make sure FF home is set
         navigator.goto(SettingsScreen)
@@ -125,14 +123,14 @@ class HomePageSettingsUITests: BaseTestCase {
 
         // Workaroud needed after xcode 11.3 update Issue 5937
         // Lets check only that website is open
-        waitForExistence(app.textFields["url"], timeout: 5)
+        waitForExistence(app.textFields["url"], timeout: TIMEOUT)
         waitForValueContains(app.textFields["url"], value: "mozilla")
     }
 
     func testDisableTopSitesSettingsRemovesSection() {
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: 15)
+        waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
         navigator.performAction(Action.CloseURLBarOpen)
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 5)
+        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: TIMEOUT)
         navigator.nowAt(NewTabScreen)
         navigator.goto(HomeSettings)
         app.staticTexts["Shortcuts"].tap()
@@ -196,13 +194,13 @@ class HomePageSettingsUITests: BaseTestCase {
     func testCustomizeHomepage() {
         if !iPad() {
             navigator.performAction(Action.CloseURLBarOpen)
-            waitForExistence(app.collectionViews.firstMatch, timeout: 5)
+            waitForExistence(app.collectionViews.firstMatch, timeout: TIMEOUT)
             app.collectionViews.firstMatch.swipeUp()
-            waitForExistence(app.cells.otherElements.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.customizeHomePage], timeout: 5)
+            waitForExistence(app.cells.otherElements.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.customizeHomePage], timeout: TIMEOUT)
         }
         app.cells.otherElements.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.customizeHomePage].tap()
         // Verify default settings
-        waitForExistence(app.navigationBars[AccessibilityIdentifiers.Settings.Homepage.homePageNavigationBar], timeout: 20)
+        waitForExistence(app.navigationBars[AccessibilityIdentifiers.Settings.Homepage.homePageNavigationBar], timeout: TIMEOUT_LONG)
         XCTAssertTrue(app.tables.cells[AccessibilityIdentifiers.Settings.Homepage.StartAtHome.always].exists)
         XCTAssertTrue(app.tables.cells[AccessibilityIdentifiers.Settings.Homepage.StartAtHome.disabled].exists)
         XCTAssertTrue(app.tables.cells[AccessibilityIdentifiers.Settings.Homepage.StartAtHome.afterFourHours].exists)

--- a/Tests/XCUITests/ReaderViewUITest.swift
+++ b/Tests/XCUITests/ReaderViewUITest.swift
@@ -10,10 +10,10 @@ class ReaderViewTest: BaseTestCase {
         navigator.openURL(path(forTestPage: "test-mozilla-book.html"))
         navigator.goto(BrowserTab)
         waitForNoExistence(app.staticTexts["Fennec pasted from XCUITests-Runner"])
-        waitForExistence(app.buttons["Reader View"], timeout: 5)
+        waitForExistence(app.buttons["Reader View"], timeout: TIMEOUT)
         app.buttons["Reader View"].tap()
         // The settings of reader view are shown as well as the content of the web site
-        waitForExistence(app.buttons["Display Settings"], timeout: 5)
+        waitForExistence(app.buttons["Display Settings"], timeout: TIMEOUT)
         XCTAssertTrue(app.webViews.staticTexts["The Book of Mozilla"].exists)
     }
 
@@ -28,7 +28,7 @@ class ReaderViewTest: BaseTestCase {
         userState.url = path(forTestPage: "test-mozilla-book.html")
         navigator.openURL(path(forTestPage: "test-mozilla-book.html"))
         waitUntilPageLoad()
-        waitForExistence(app.buttons["Reader View"], timeout: 5)
+        waitForExistence(app.buttons["Reader View"], timeout: TIMEOUT)
         app.buttons["Reader View"].tap()
         waitUntilPageLoad()
         waitForExistence(app.buttons["Add to Reading List"])
@@ -44,7 +44,7 @@ class ReaderViewTest: BaseTestCase {
     // Smoketest
     func testAddToReadingList() {
         XCTExpectFailure("The app was not launched", strict: false) {
-            waitForExistence(app.buttons["urlBar-cancel"], timeout: 25)
+            waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT_LONG)
         }
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
@@ -129,10 +129,9 @@ class ReaderViewTest: BaseTestCase {
         checkReadingListNumberOfItems(items: 0)
     }
 
-    func testMarkAsReadAndUnreadFromReadingList() {
+    func testMarkAsReadAndUnreadFromReadingList() throws {
         addContentToReaderView()
         navigator.goto(BrowserTabMenu)
-        navigator.goto(LibraryPanel_ReadingList)
         navigator.goto(LibraryPanel_ReadingList)
 
         waitForExistence(app.tables["ReadingTable"])
@@ -141,11 +140,15 @@ class ReaderViewTest: BaseTestCase {
         XCTAssertTrue(savedToReadingList.exists)
 
         // Mark it as read/unread
-        savedToReadingList.swipeLeft()
-        waitForExistence(app.tables.cells.buttons.staticTexts["Mark as  Read"], timeout: 3)
-        app.tables["ReadingTable"].cells.buttons.element(boundBy: 1).tap()
-        savedToReadingList.swipeLeft()
-        waitForExistence(app.tables.cells.buttons.staticTexts["Mark as  Unread"])
+        if processIsTranslatedStr() == m1Rosetta {
+            throw XCTSkip("swipeLeft() does not work on M1")
+        } else {
+            savedToReadingList.swipeLeft()
+            waitForExistence(app.tables.cells.buttons.staticTexts["Mark as  Read"], timeout: TIMEOUT)
+            app.tables["ReadingTable"].cells.buttons.element(boundBy: 1).tap()
+            savedToReadingList.swipeLeft()
+            waitForExistence(app.tables.cells.buttons.staticTexts["Mark as  Unread"])
+        }
     }
 
     func testRemoveFromReadingList() {
@@ -155,11 +158,17 @@ class ReaderViewTest: BaseTestCase {
 
         let savedToReadingList = app.tables["ReadingTable"].cells.staticTexts["The Book of Mozilla"]
         waitForExistence(savedToReadingList)
-        savedToReadingList.swipeLeft()
-        waitForExistence(app.buttons["Remove"])
 
         // Remove the item from reading list
-        app.buttons["Remove"].tap()
+        if processIsTranslatedStr() == m1Rosetta {
+            savedToReadingList.press(forDuration: 2)
+            waitForExistence(app.otherElements["Remove"])
+            app.otherElements["Remove"].tap()
+        } else {
+            savedToReadingList.swipeLeft()
+            waitForExistence(app.buttons["Remove"])
+            app.buttons["Remove"].tap()
+        }
         XCTAssertFalse(savedToReadingList.exists)
 
         // Reader list view should be empty
@@ -228,11 +237,11 @@ class ReaderViewTest: BaseTestCase {
     // Smoketest
     func testAddToReaderListOptions() throws {
         XCTExpectFailure("The app was not launched", strict: false) {
-            waitForExistence(app.buttons["urlBar-cancel"], timeout: 45)
+            waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT_LONG)
         }
         addContentToReaderView()
         // Check that Settings layouts options are shown
-        waitForExistence(app.buttons["ReaderModeBarView.settingsButton"], timeout: 10)
+        waitForExistence(app.buttons["ReaderModeBarView.settingsButton"], timeout: TIMEOUT)
         app.buttons["ReaderModeBarView.settingsButton"].tap()
         XCTAssertTrue(app.buttons["Light"].exists)
     }


### PR DESCRIPTION
M1 cannot handle `swipeLeft()`. For DownloadFilesTests, HomePageSettingsUITests and ReaderViewTest, the swipe operations are replaced by a workaround or the rest of the test is skipped. The workarounds are performing the identical operation using a different menu.

I have also use `TIMEOUT` and `TIMEOUT_LONG` constants in places that require a non-default, longer `timeout` values.

https://mozilla-hub.atlassian.net/browse/MTE-183