### PR TITLE
Bugfix FXIOS-5280 [v108] Loading URLs in the background from the share sheet restored

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -115,6 +115,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) { [weak self] in
             self?.profile.cleanupHistoryIfNeeded()
             self?.ratingPromptManager.updateData()
+            BrowserViewController.foregroundBVC().loadQueuedTabs()
         }
     }
 


### PR DESCRIPTION
# [FXIOS-5280](https://mozilla-hub.atlassian.net/browse/FXIOS-5280) | #12414

When using the sharing extension (ShareTo) via the ShareVC, loading tabs in the background didn't work because that method was removed in AppDelegate's `applicationDidBecomeActive`. 

Although the fix utilizes foregroundBVC, in this case it might be okay. iPhones will always have a single scene, and that's what the current foregrouncBVC gives back. 

When iPad supports multiple windows, we can adjust it to find the last actively engaged with scene. 