### PR TITLE
Add FXIOS-5291 [v109] Add telemetry for Show Tour in AppSettingsMenu

### DIFF
--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -841,6 +841,12 @@ class ShowIntroductionSetting: Setting {
     override func onClick(_ navigationController: UINavigationController?) {
         navigationController?.dismiss(animated: true, completion: {
             BrowserViewController.foregroundBVC().presentIntroViewController(true)
+
+            TelemetryWrapper.recordEvent(
+                category: .action,
+                method: .tap,
+                object: .settingsMenuShowTour
+            )
         })
     }
 }

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -402,6 +402,7 @@ extension TelemetryWrapper {
         case appMenu = "app_menu"
         case settings = "settings"
         case settingsMenuSetAsDefaultBrowser = "set-as-default-browser-menu-go-to-settings"
+        case settingsMenuShowTour = "show-tour"
         // MARK: New Onboarding
         case onboardingClose = "onboarding-close"
         case onboardingCardView = "onboarding-card-view"
@@ -760,6 +761,8 @@ extension TelemetryWrapper {
         // MARK: Settings Menu
         case (.action, .open, .settingsMenuSetAsDefaultBrowser, _, _):
             GleanMetrics.SettingsMenu.setAsDefaultBrowserPressed.add()
+        case(.action, .tap, .settingsMenuShowTour, _, _):
+            GleanMetrics.SettingsMenu.showTourPressed.record()
 
         // MARK: Start Search Button
         case (.action, .tap, .startSearchButton, _, _):

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -1984,7 +1984,7 @@ settings_menu:
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/12433
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/12433
+      - https://github.com/mozilla-mobile/firefox-ios/pull/12462
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2023-06-01"

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -1976,6 +1976,18 @@ settings_menu:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2023-06-01"
+  show_tour_pressed:
+    type: event
+    description: |
+      Metric recorded when a user taps an on the Show Tour option
+      from the app settings menu.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/12433
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/12433
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2023-06-01"
 
 # Search and search releated metrics
 search:

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -1979,7 +1979,7 @@ settings_menu:
   show_tour_pressed:
     type: event
     description: |
-      Metric recorded when a user taps an on the Show Tour option
+      Metric recorded when a user taps on the Show Tour option
       from the app settings menu.
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/12433

--- a/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -403,6 +403,18 @@ class TelemetryWrapperTests: XCTestCase {
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Accessibility.dynamicText)
     }
+
+    // MARK: - App Settings Menu
+
+    func test_showTour_GleanIsCalled() {
+        TelemetryWrapper.recordEvent(
+            category: .action,
+            method: .tap,
+            object: .settingsMenuShowTour
+        )
+
+        testEventMetricRecordingSuccess(metric: GleanMetrics.SettingsMenu.showTourPressed)
+    }
 }
 
 // MARK: - Helper functions to test telemetry


### PR DESCRIPTION
# [FXIOS-5291](https://mozilla-hub.atlassian.net/browse/FXIOS-5291) | #12433 

Added telemetry for Show Tour option in AppSettingsMenu. We want to know if this option is valuable for users. 

PS: Show Tour adds complexity b/c it calls foregoundBVC for navigation purposes, not an easy one to work around. 