### PR TITLE
Bugfix FXIOS-5281 [v109] Device orientation change would put the check over the text

### DIFF
--- a/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -163,6 +163,10 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func didRotate(from fromInterfaceOrientation: UIInterfaceOrientation) {
+        tableView.reloadData()
+    }
+
     override func generateSettings() -> [SettingSection] {
         let strengthSetting: [CheckmarkSetting] = BlockingStrength.allOptions.map { option in
             let id = BlockingStrength.accessibilityId(for: option)


### PR DESCRIPTION
Issue #12415 

I added an override func of didRotate to know when the Interface Orientation would change to reload data from the tableview.
How I got to this solution: I noticed when rotate and tap the non-selected cell, it would fix the check over the text and it was because of reloadData. It wasn't the first try however, I tried a few other things like multiply the Padding on the left anchor of the label when orientation changed but wasn't a good approach, in my opinion.