### PR TITLE
Bugfix FXIOS-5273 [v109] Extra spacing in the download panel

### DIFF
--- a/Client/Frontend/Library/DownloadsPanel.swift
+++ b/Client/Frontend/Library/DownloadsPanel.swift
@@ -68,7 +68,9 @@ class DownloadsPanel: UIViewController,
         tableView.keyboardDismissMode = .onDrag
         tableView.accessibilityIdentifier = "DownloadsTable"
         tableView.cellLayoutMarginsFollowReadableWidth = false
-
+        if #available(iOS 15.0, *) {
+            tableView.sectionHeaderTopPadding = 0.0
+        }
         // Set an empty footer to prevent empty cells from appearing in the list.
         tableView.tableFooterView = UIView()
     }


### PR DESCRIPTION
Issue #12404 

On iOS 15 they've changed the tableviews appearance and now for extra space problems on the header it should set sectionHeaderTopPadding to zero to fix that.

iPhone 14 Pro - iOS 16.1 with the fix
![simulator_screenshot_AF0C8B29-8A1D-49FD-9FE8-CD0C4B9497F0](https://user-images.githubusercontent.com/69827434/203457173-54a2a209-557f-4ef6-9ed3-239cf1ad65c9.png)
