### PR TITLE
Remove [v108] Remove memory warning sentry error

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -82,12 +82,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 
-    func applicationDidReceiveMemoryWarning(_ application: UIApplication) {
-        // This is not fatal but sentry only sends fatal events
-        SentryIntegration.shared.sendWithStacktrace(message: "Memory warning received",
-                                                    severity: .fatal)
-    }
-
     // We sync in the foreground only, to avoid the possibility of runaway resource usage.
     // Eventually we'll sync in response to notifications.
     func applicationDidBecomeActive(_ application: UIApplication) {


### PR DESCRIPTION
I think this is worth uplifitng to 108, the volume of this error is already causing us to drop an increasing number of other errors on Sentry.