### PR TITLE
Refactor [v109] Adjust warnings threshold

### DIFF
--- a/test-fixtures/generate-metrics.sh
+++ b/test-fixtures/generate-metrics.sh
@@ -4,8 +4,8 @@ set -e
 
 BUILD_LOG_FILE="$1"
 TYPE_LOG_FILE="$2"
-THREESHOLD_UNIT_TEST=100
-THREESHOLD_XCUITEST=100
+THREESHOLD_UNIT_TEST=60
+THREESHOLD_XCUITEST=59
 
  
 WARNING_COUNT=`egrep '^(\/.+:[0-9+:[0-9]+:.|warning:|⚠️|ld: warning:|<unknown>:0: warning:|fatal|===)' "$BUILD_LOG_FILE" | uniq | wc -l`


### PR DESCRIPTION
Fixed warnings from Mappa Mundi, which decreased the warnings count. Let's decrease the threshold a bit so there's not too much space for new warnings in CI check.