### PR TITLE
Refactor FXIOS-5357 [v109] Move to async await for site image fetcher

### DIFF
--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/SiteImageDownloader.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/SiteImageDownloader.swift
@@ -15,13 +15,25 @@ protocol SiteImageDownloader {
         with url: URL,
         completionHandler: ((Result<SiteImageLoadingResult, KingfisherError>) -> Void)?
     ) -> DownloadTask?
+
+    func downloadImage(with url: URL) async -> Result<SiteImageLoadingResult, KingfisherError>
+}
+
+extension SiteImageDownloader {
+    func downloadImage(with url: URL) async -> Result<SiteImageLoadingResult, KingfisherError> {
+        await withCheckedContinuation { continuation in
+            _ = downloadImage(with: url) { result in
+                continuation.resume(returning: result)
+            }
+        }
+    }
 }
 
 extension ImageDownloader: SiteImageDownloader {
     func downloadImage(with url: URL,
                        completionHandler: ((Result<SiteImageLoadingResult, KingfisherError>) -> Void)?
     ) -> DownloadTask? {
-        self.downloadImage(with: url, options: nil, completionHandler: { result in
+        downloadImage(with: url, options: nil, completionHandler: { result in
             switch result {
             case .success(let value):
                 completionHandler?(.success(value))

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/SiteImageFetcher.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/SiteImageFetcher.swift
@@ -7,11 +7,9 @@ import Kingfisher
 
 protocol SiteImageFetcher {
     /// Fetches an image from a specific URL
-    /// - Parameters:
-    ///   - imageURL: Given a certain image URL
-    ///   - completion: The return will be an image or an image error following Result type
-    func fetchImage(imageURL: URL,
-                    completion: @escaping ((Result<UIImage, ImageError>) -> Void))
+    /// - Parameter imageURL: Given a certain image URL
+    /// - Returns: An image or an image error following Result type
+    func fetchImage(from imageURL: URL) async -> Result<UIImage, ImageError>
 }
 
 struct DefaultSiteImageFetcher: SiteImageFetcher {
@@ -22,16 +20,14 @@ struct DefaultSiteImageFetcher: SiteImageFetcher {
         self.imageDownloader = imageDownloader
     }
 
-    func fetchImage(imageURL: URL,
-                    completion: @escaping ((Result<UIImage, ImageError>) -> Void)) {
-        imageDownloader.downloadImage(with: imageURL,
-                                      completionHandler: { result in
-            switch result {
-            case .success(let value):
-                completion(.success(value.image))
-            case .failure(let error):
-                completion(.failure(ImageError.unableToDownloadImage(error.errorDescription ?? "No description")))
-            }
-        })
+    func fetchImage(from imageURL: URL) async -> Result<UIImage, ImageError> {
+        let result = await imageDownloader.downloadImage(with: imageURL)
+
+        switch result {
+        case .success(let value):
+            return .success(value.image)
+        case .failure(let error):
+            return .failure(ImageError.unableToDownloadImage(error.errorDescription ?? "No description"))
+        }
     }
 }

--- a/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/SiteImageFetcherTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/SiteImageFetcherTests.swift
@@ -20,36 +20,33 @@ final class SiteImageFetcherTests: XCTestCase {
         self.mockImageDownloader = nil
     }
 
-    func testReturnsFailure_onAnyError() {
+    func testReturnsFailure_onAnyError() async {
         mockImageDownloader.error = KingfisherError.requestError(reason: .emptyRequest)
         let subject = DefaultSiteImageFetcher(imageDownloader: mockImageDownloader)
 
-        subject.fetchImage(imageURL: URL(string: "www.mozilla.com")!,
-                           completion: { result in
-            switch result {
-            case .success:
-                XCTFail("Should have failed with error")
-            case .failure(let error):
-                XCTAssertEqual("Unable to download image with reason: The request is empty or `nil`.",
-                               error.description)
-            }
-        })
+        let result = await subject.fetchImage(from: URL(string: "www.mozilla.com")!)
+
+        switch result {
+        case .success:
+            XCTFail("Should have failed with error")
+        case .failure(let error):
+            XCTAssertEqual("Unable to download image with reason: The request is empty or `nil`.",
+                           error.description)
+        }
     }
 
-    func testReturnsSuccess_onImage() {
+    func testReturnsSuccess_onImage() async {
         let resultImage = UIImage()
         mockImageDownloader.image = resultImage
         let subject = DefaultSiteImageFetcher(imageDownloader: mockImageDownloader)
 
-        subject.fetchImage(imageURL: URL(string: "www.mozilla.com")!,
-                           completion: { result in
-            switch result {
-            case .success(let value):
-                XCTAssertEqual(resultImage, value)
-            case .failure:
-                XCTFail("Should have succeeded with image")
-            }
-        })
+        let result = await subject.fetchImage(from: URL(string: "www.mozilla.com")!)
+        switch result {
+        case .success(let value):
+            XCTAssertEqual(resultImage, value)
+        case .failure:
+            XCTFail("Should have succeeded with image")
+        }
     }
 }
 


### PR DESCRIPTION
# [FXIOS-5357](https://mozilla-hub.atlassian.net/browse/FXIOS-5357) https://github.com/mozilla-mobile/firefox-ios/issues/12536
- Move to async await for site image fetcher
- Won't run BR for this PR as this is in a different package. Ran the tests locally for it.