### PR TITLE
Refactor FXIOS-5286 [v109] Remove BVC dependence in TabManager

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -652,6 +652,9 @@
 		964FA97528A1A8F20024BB3B /* ContextualHintEligibilityUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964FA97428A1A8F20024BB3B /* ContextualHintEligibilityUtility.swift */; };
 		964FA97728A2A55C0024BB3B /* ContextualHintPrefsKeysProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964FA97628A2A55C0024BB3B /* ContextualHintPrefsKeysProvider.swift */; };
 		965C3C8F29313A1B006499ED /* AppSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 965C3C8E29313A1B006499ED /* AppSessionManager.swift */; };
+		965C3C942933A860006499ED /* LaunchSessionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 965C3C932933A860006499ED /* LaunchSessionProvider.swift */; };
+		965C3C96293431FC006499ED /* MockLaunchSessionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 965C3C95293431FC006499ED /* MockLaunchSessionProvider.swift */; };
+		965C3C9829343445006499ED /* MockAppSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 965C3C9729343445006499ED /* MockAppSessionManager.swift */; };
 		966206CD2698DE1E005C0A55 /* RecentlySavedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966206CC2698DE1E005C0A55 /* RecentlySavedViewModel.swift */; };
 		966B0DC82926F60500A85A7E /* UIResponder+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966B0DC72926F60500A85A7E /* UIResponder+Extensions.swift */; };
 		966B0DC92926F68000A85A7E /* UIView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1390FA628B032AD00C9EF3E /* UIView+Extension.swift */; };
@@ -3506,6 +3509,9 @@
 		964FA97428A1A8F20024BB3B /* ContextualHintEligibilityUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualHintEligibilityUtility.swift; sourceTree = "<group>"; };
 		964FA97628A2A55C0024BB3B /* ContextualHintPrefsKeysProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualHintPrefsKeysProvider.swift; sourceTree = "<group>"; };
 		965C3C8E29313A1B006499ED /* AppSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSessionManager.swift; sourceTree = "<group>"; };
+		965C3C932933A860006499ED /* LaunchSessionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchSessionProvider.swift; sourceTree = "<group>"; };
+		965C3C95293431FC006499ED /* MockLaunchSessionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLaunchSessionProvider.swift; sourceTree = "<group>"; };
+		965C3C9729343445006499ED /* MockAppSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAppSessionManager.swift; sourceTree = "<group>"; };
 		966206CC2698DE1E005C0A55 /* RecentlySavedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentlySavedViewModel.swift; sourceTree = "<group>"; };
 		966B0DC72926F60500A85A7E /* UIResponder+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIResponder+Extensions.swift"; sourceTree = "<group>"; };
 		967A028D28FA026F003C35E3 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -6654,6 +6660,7 @@
 			children = (
 				965C3C8E29313A1B006499ED /* AppSessionManager.swift */,
 				96EA9453293655BF00123345 /* AppSession+Enums.swift */,
+				965C3C932933A860006499ED /* LaunchSessionProvider.swift */,
 			);
 			name = AppSession;
 			sourceTree = "<group>";
@@ -7099,6 +7106,8 @@
 				C80C11EF28B3C9150062922A /* MockUserDefaults.swift */,
 				5A9A09D528B01FD500B6F51E /* MockURLBarView.swift */,
 				8AE80BB02891A39F00BC12EA /* SpyNotificationCenter.swift */,
+				965C3C9729343445006499ED /* MockAppSessionManager.swift */,
+				965C3C95293431FC006499ED /* MockLaunchSessionProvider.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -10520,6 +10529,7 @@
 				964FA97528A1A8F20024BB3B /* ContextualHintEligibilityUtility.swift in Sources */,
 				CA7FC7D324A6A9B70012F347 /* LoginListDataSourceHelper.swift in Sources */,
 				43AB6FA425DC53D30016B015 /* LabelButtonHeaderView.swift in Sources */,
+				965C3C942933A860006499ED /* LaunchSessionProvider.swift in Sources */,
 				C8163851268A0899004C7160 /* AddCredentialViewController.swift in Sources */,
 				CA520E7A24913C1B00CCAB48 /* LoginListViewModel.swift in Sources */,
 				8AB8574327D963920075C173 /* Loggable.swift in Sources */,
@@ -10903,7 +10913,9 @@
 				D8BA1790206D47830023AC00 /* DeferredTestUtils.swift in Sources */,
 				2F13E79B1AC0C02700D75081 /* StringExtensionsTests.swift in Sources */,
 				CA24B52224ABD7D40093848C /* LoginsListViewModelTests.swift in Sources */,
+				965C3C96293431FC006499ED /* MockLaunchSessionProvider.swift in Sources */,
 				C869915628917803007ACC5C /* WallpaperJSONTestProvider.swift in Sources */,
+				965C3C9829343445006499ED /* MockAppSessionManager.swift in Sources */,
 				8AE1E1DB27B1C1320024C45E /* SearchBarSettingsViewModelTests.swift in Sources */,
 				CA24B53924ABFE250093848C /* LoginsListSelectionHelperTests.swift in Sources */,
 				2FDB10931A9FBEC5006CF312 /* PrefsTests.swift in Sources */,

--- a/Client/Application/AppContainer.swift
+++ b/Client/Application/AppContainer.swift
@@ -37,7 +37,13 @@ class AppContainer: ServiceProvider {
     // MARK: - Misc helpers
 
     /// Prepares the container by registering all services for the app session.
+    ///
+    /// Dependencies that are app-wide (scene independent) are towards the top. Generally, these
+    /// dependencies are initialized in `AppDelegate`. The container searches for dependencies there before
+    /// creating an instance.
+    ///
     /// Insert a dependency when needed, otherwise it floats in memory.
+    ///
     /// - Returns: A bootstrapped `DependencyContainer`.
     private func bootstrapContainer() -> DependencyContainer {
         return DependencyContainer { container in
@@ -45,7 +51,7 @@ class AppContainer: ServiceProvider {
                 unowned let container = container
 
                 /// Since Profile's usage is at the very beginning (and is a dependency for others in this container)
-                /// we give this an `eagerSingleton` scope, forcing the instance to exist ON container boostrap.
+                /// we give this an `eagerSingleton` scope, forcing the instance to exist ON container bootstrap.
                 container.register(.eagerSingleton) { () -> Profile in
                     if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
                         return appDelegate.profile
@@ -71,14 +77,6 @@ class AppContainer: ServiceProvider {
                     }
                 }
 
-                container.register(.singleton) { () -> ThemeManager in
-                    if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
-                        return appDelegate.themeManager
-                    } else {
-                        return DefaultThemeManager(appDelegate: UIApplication.shared.delegate)
-                    }
-                }
-
                 container.register(.singleton) { () -> AppSessionProvider in
                     if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
                         return appDelegate.appSessionManager
@@ -87,8 +85,20 @@ class AppContainer: ServiceProvider {
                     }
                 }
 
-                container.register(.singleton) {
-                    return RatingPromptManager(profile: try container.resolve())
+                container.register(.singleton) { () -> ThemeManager in
+                    if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
+                        return appDelegate.themeManager
+                    } else {
+                        return DefaultThemeManager(appDelegate: UIApplication.shared.delegate)
+                    }
+                }
+                
+                container.register(.singleton) { () -> RatingPromptManager in
+                    if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
+                        return appDelegate.ratingPromptManager
+                    } else {
+                        return RatingPromptManager(profile: try container.resolve())
+                    }
                 }
 
                 try container.bootstrap()

--- a/Client/Application/AppContainer.swift
+++ b/Client/Application/AppContainer.swift
@@ -92,7 +92,7 @@ class AppContainer: ServiceProvider {
                         return DefaultThemeManager(appDelegate: UIApplication.shared.delegate)
                     }
                 }
-                
+
                 container.register(.singleton) { () -> RatingPromptManager in
                     if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
                         return appDelegate.ratingPromptManager

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -10,11 +10,10 @@ import UIKit
 let LatestAppVersionProfileKey = "latestAppVersion"
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
+    private let log = Logger.browserLogger
 
     var notificationCenter: NotificationProtocol = NotificationCenter.default
     var orientationLock = UIInterfaceOrientationMask.all
-
-    private let log = Logger.browserLogger
 
     lazy var profile: Profile = BrowserProfile(
         localName: "profile",
@@ -28,9 +27,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             namespace: "TabManagerScreenshots",
             quality: UIConstants.ScreenshotQuality)
     )
-    var appSessionManager: AppSessionProvider = AppSessionManager()
     lazy var themeManager: ThemeManager = DefaultThemeManager(appDelegate: self)
-    lazy private var ratingPromptManager: RatingPromptManager = AppContainer.shared.resolve()
+    lazy var ratingPromptManager = RatingPromptManager(profile: profile)
+    var appSessionManager: AppSessionProvider = AppSessionManager()
 
     private var shutdownWebServer: DispatchSourceTimer?
     private var webServerUtil: WebServerUtil?

--- a/Client/Application/AppSessionManager.swift
+++ b/Client/Application/AppSessionManager.swift
@@ -6,6 +6,7 @@ import Foundation
 
 protocol AppSessionProvider {
     var tabUpdateState: TabUpdateState { get set }
+    var launchSessionProvider: LaunchSessionProviderProtocol { get set }
 }
 
 /// `AppSessionManager` exists to track, mutate and (sometimes) persist session related properties. Each category of
@@ -16,5 +17,11 @@ protocol AppSessionProvider {
 struct AppSessionManager: AppSessionProvider {
 
     var tabUpdateState: TabUpdateState = .coldStart
+    var launchSessionProvider: LaunchSessionProviderProtocol
 
+    init(
+        launchSessionProvider: LaunchSessionProvider = LaunchSessionProvider()
+    ) {
+        self.launchSessionProvider = launchSessionProvider
+    }
 }

--- a/Client/Application/LaunchSessionProvider.swift
+++ b/Client/Application/LaunchSessionProvider.swift
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// An `activation` occurs when a user taps on the icon, or otherwise goes to the app in some way.
+///
+/// A launch is when the process needs to start, and a resume is when your app already had a process alive, even if suspended.
+enum ActivationState {
+    case launch, resume
+}
+
+protocol LaunchSessionProviderProtocol {
+    var activationState: ActivationState { get set }
+    var openedFromExternalSource: Bool { get set }
+}
+
+class LaunchSessionProvider: LaunchSessionProviderProtocol {
+
+    init() {
+        addObservers()
+    }
+
+    var notificationCenter: NotificationProtocol = NotificationCenter.default
+    var activationState: ActivationState = .launch
+    var openedFromExternalSource = false
+
+}
+
+extension LaunchSessionProvider: Notifiable {
+    func addObservers() {
+        setupNotifications(forObserver: self, observing: [UIApplication.willResignActiveNotification,
+                                                          UIScene.willDeactivateNotification])
+    }
+
+    func handleNotifications(_ notification: Notification) {
+        switch notification.name {
+        case UIApplication.willResignActiveNotification,
+            UIScene.willDeactivateNotification:
+            activationState = .resume
+            openedFromExternalSource = false
+
+        default: break
+        }
+    }
+
+}

--- a/Client/Application/LaunchSessionProvider.swift
+++ b/Client/Application/LaunchSessionProvider.swift
@@ -4,15 +4,7 @@
 
 import Foundation
 
-/// An `activation` occurs when a user taps on the icon, or otherwise goes to the app in some way.
-///
-/// A launch is when the process needs to start, and a resume is when your app already had a process alive, even if suspended.
-enum ActivationState {
-    case launch, resume
-}
-
 protocol LaunchSessionProviderProtocol {
-    var activationState: ActivationState { get set }
     var openedFromExternalSource: Bool { get set }
 }
 
@@ -23,7 +15,6 @@ class LaunchSessionProvider: LaunchSessionProviderProtocol {
     }
 
     var notificationCenter: NotificationProtocol = NotificationCenter.default
-    var activationState: ActivationState = .launch
     var openedFromExternalSource = false
 
 }
@@ -38,7 +29,6 @@ extension LaunchSessionProvider: Notifiable {
         switch notification.name {
         case UIApplication.willResignActiveNotification,
             UIScene.willDeactivateNotification:
-            activationState = .resume
             openedFromExternalSource = false
 
         default: break

--- a/Client/Application/SceneDelegate.swift
+++ b/Client/Application/SceneDelegate.swift
@@ -22,6 +22,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     let profile: Profile = AppContainer.shared.resolve()
     let tabManager: TabManager = AppContainer.shared.resolve()
+    var sessionManager: AppSessionProvider = AppContainer.shared.resolve()
 
     // MARK: - Connecting / Disconnecting Scenes
 
@@ -97,6 +98,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             NavigationPath.handle(nav: routerPath, with: self.browserViewController)
         }
 
+        sessionManager.launchSessionProvider.openedFromExternalSource = true
     }
 
     // MARK: - Continuing User Activities
@@ -196,12 +198,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         with connectionOptions: UIScene.ConnectionOptions,
         on scene: UIScene
     ) {
-        /// Handling deeplinks at launch can be handled this way.
         if !connectionOptions.urlContexts.isEmpty {
             self.scene(scene, openURLContexts: connectionOptions.urlContexts)
         }
 
-        /// At launch, shortcut items can be handled this way.
         if let shortcutItem = connectionOptions.shortcutItem {
             QuickActionsImplementation().handleShortCutItem(
                 shortcutItem,

--- a/Client/Frontend/Browser/StartAtHomeHelper.swift
+++ b/Client/Frontend/Browser/StartAtHomeHelper.swift
@@ -9,17 +9,23 @@ class StartAtHomeHelper: FeatureFlaggable {
     // Override only for UI tests to test `shouldSkipStartHome` logic
     private var isRunningUITest: Bool
     lazy var startAtHomeSetting: StartAtHomeSetting? = featureFlags.getCustomState(for: .startAtHome)
+    var launchSessionProvider: LaunchSessionProviderProtocol
 
-    init(isRestoringTabs: Bool,
-         isRunningUITest: Bool = AppConstants.isRunningUITests) {
+    init(appSessionManager: AppSessionProvider = AppContainer.shared.resolve(),
+         isRestoringTabs: Bool,
+         isRunningUITest: Bool = AppConstants.isRunningUITests
+    ) {
+        self.launchSessionProvider = appSessionManager.launchSessionProvider
         self.isRestoringTabs = isRestoringTabs
         self.isRunningUITest = isRunningUITest
     }
 
     var shouldSkipStartHome: Bool {
         return isRunningUITest ||
-              DebugSettingsBundleOptions.skipSessionRestore ||
-              isRestoringTabs
+        DebugSettingsBundleOptions.skipSessionRestore ||
+        isRestoringTabs ||
+        launchSessionProvider.openedFromExternalSource ||
+        launchSessionProvider.activationState == .launch
     }
 
     /// Determines whether the Start at Home feature is enabled, how long it has been since

--- a/Client/Frontend/Browser/StartAtHomeHelper.swift
+++ b/Client/Frontend/Browser/StartAtHomeHelper.swift
@@ -24,8 +24,7 @@ class StartAtHomeHelper: FeatureFlaggable {
         return isRunningUITest ||
         DebugSettingsBundleOptions.skipSessionRestore ||
         isRestoringTabs ||
-        launchSessionProvider.openedFromExternalSource ||
-        launchSessionProvider.activationState == .launch
+        launchSessionProvider.openedFromExternalSource
     }
 
     /// Determines whether the Start at Home feature is enabled, how long it has been since

--- a/Client/Frontend/Browser/Tab Management/TabManager.swift
+++ b/Client/Frontend/Browser/Tab Management/TabManager.swift
@@ -136,7 +136,10 @@ class TabManager: NSObject, FeatureFlaggable, TabManagerProtocol {
     }
 
     // MARK: - Initializer
-    init(profile: Profile, imageStore: DiskImageStore?) {
+
+    init(profile: Profile,
+         imageStore: DiskImageStore?
+    ) {
         self.profile = profile
         self.navDelegate = TabManagerNavDelegate()
         self.tabEventHandlers = TabEventHandlers.create(with: profile)
@@ -834,15 +837,8 @@ class TabManager: NSObject, FeatureFlaggable, TabManagerProtocol {
 
     /// Public interface for checking whether the StartAtHome Feature should run.
     func startAtHomeCheck() {
-        // Do not open a new home page if we come from an external url source
-        guard !BrowserViewController.foregroundBVC().openedUrlFromExternalSource else {
-            // Reset the value for external url source so that
-            // after inactivity we can start at home again
-            BrowserViewController.foregroundBVC().openedUrlFromExternalSource = false
-            return
-        }
-
         let startAtHomeManager = StartAtHomeHelper(isRestoringTabs: isRestoringTabs)
+
         guard !startAtHomeManager.shouldSkipStartHome else { return }
 
         if startAtHomeManager.shouldStartAtHome() {

--- a/Tests/ClientTests/Mocks/MockAppSessionManager.swift
+++ b/Tests/ClientTests/Mocks/MockAppSessionManager.swift
@@ -5,7 +5,7 @@
 import Foundation
 @testable import Client
 
-class MockAppSessionManager: Client.AppSessionProvider {
+class MockAppSessionManager: AppSessionProvider {
 
     var tabUpdateState: TabUpdateState = .coldStart
     var launchSessionProvider: LaunchSessionProviderProtocol

--- a/Tests/ClientTests/Mocks/MockAppSessionManager.swift
+++ b/Tests/ClientTests/Mocks/MockAppSessionManager.swift
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+@testable import Client
+
+class MockAppSessionManager: Client.AppSessionProvider {
+
+    var tabUpdateState: TabUpdateState = .coldStart
+    var launchSessionProvider: LaunchSessionProviderProtocol
+
+    init(
+        launchSessionProvider: LaunchSessionProviderProtocol = MockLaunchSessionProvider()
+    ) {
+        self.launchSessionProvider = launchSessionProvider
+    }
+}

--- a/Tests/ClientTests/Mocks/MockLaunchSessionProvider.swift
+++ b/Tests/ClientTests/Mocks/MockLaunchSessionProvider.swift
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+import Foundation
+
+
+class MockLaunchSessionProvider: Client.LaunchSessionProviderProtocol {
+
+    var activationState: ActivationState = .launch
+
+    var openedFromExternalSource: Bool = false
+
+}

--- a/Tests/ClientTests/Mocks/MockLaunchSessionProvider.swift
+++ b/Tests/ClientTests/Mocks/MockLaunchSessionProvider.swift
@@ -5,10 +5,7 @@
 @testable import Client
 import Foundation
 
-
 class MockLaunchSessionProvider: Client.LaunchSessionProviderProtocol {
-
-    var activationState: ActivationState = .launch
 
     var openedFromExternalSource: Bool = false
 

--- a/Tests/ClientTests/StartAtHomeHelperTests.swift
+++ b/Tests/ClientTests/StartAtHomeHelperTests.swift
@@ -32,8 +32,12 @@ class StartAtHomeHelperTests: XCTestCase {
     }
 
     func testShouldNotSkipStartAtHome() throws {
-        setupHelper()
+        let mockAppSessionManager = MockAppSessionManager()
+        mockAppSessionManager.launchSessionProvider.activationState = .resume
+
+        setupHelper(appSessionManager: mockAppSessionManager)
         let shouldSkip = helper.shouldSkipStartHome
+        
         XCTAssertFalse(shouldSkip, "Should not skip StartAtHome")
     }
 
@@ -41,6 +45,26 @@ class StartAtHomeHelperTests: XCTestCase {
         setupHelper(isRestoringTabs: true)
         let shouldSkip = helper.shouldSkipStartHome
         XCTAssertTrue(shouldSkip, "Expected to skip because is restoring tabs")
+    }
+
+    func test_shouldSkipStartAtHome_openedFromExternalSource() {
+        let mockAppSessionManager = MockAppSessionManager()
+        mockAppSessionManager.launchSessionProvider.openedFromExternalSource = true
+
+        setupHelper(appSessionManager: mockAppSessionManager)
+        let shouldSkip = helper.shouldSkipStartHome
+
+        XCTAssert(shouldSkip, "Expected to skip because the app was opened from an external source.")
+    }
+
+    func test_shouldSkipStartAtHome_appActivationStateIsLaunch() {
+        let mockAppSessionManager = MockAppSessionManager()
+        mockAppSessionManager.launchSessionProvider.activationState = .launch
+
+        setupHelper(appSessionManager: mockAppSessionManager)
+        let shouldSkip = helper.shouldSkipStartHome
+
+        XCTAssert(shouldSkip, "Expected to skip because the activationState is launch.")
     }
 
     func testNotShouldStartAtHome_AfterFourHours() {
@@ -106,9 +130,16 @@ class StartAtHomeHelperTests: XCTestCase {
     }
 
     // MARK: - Private
-    private func setupHelper(isRestoringTabs: Bool = false) {
-        helper = StartAtHomeHelper(isRestoringTabs: isRestoringTabs,
-                                   isRunningUITest: false)
+    private func setupHelper(
+        appSessionManager: MockAppSessionManager = MockAppSessionManager(),
+        isRestoringTabs: Bool = false
+    ) {
+        helper = StartAtHomeHelper(
+            appSessionManager: appSessionManager,
+            isRestoringTabs: isRestoringTabs,
+            isRunningUITest: false
+        )
+
         helper.startAtHomeSetting = .afterFourHours
     }
 

--- a/Tests/ClientTests/StartAtHomeHelperTests.swift
+++ b/Tests/ClientTests/StartAtHomeHelperTests.swift
@@ -32,12 +32,9 @@ class StartAtHomeHelperTests: XCTestCase {
     }
 
     func testShouldNotSkipStartAtHome() throws {
-        let mockAppSessionManager = MockAppSessionManager()
-        mockAppSessionManager.launchSessionProvider.activationState = .resume
-
-        setupHelper(appSessionManager: mockAppSessionManager)
+        setupHelper()
         let shouldSkip = helper.shouldSkipStartHome
-        
+
         XCTAssertFalse(shouldSkip, "Should not skip StartAtHome")
     }
 
@@ -55,16 +52,6 @@ class StartAtHomeHelperTests: XCTestCase {
         let shouldSkip = helper.shouldSkipStartHome
 
         XCTAssert(shouldSkip, "Expected to skip because the app was opened from an external source.")
-    }
-
-    func test_shouldSkipStartAtHome_appActivationStateIsLaunch() {
-        let mockAppSessionManager = MockAppSessionManager()
-        mockAppSessionManager.launchSessionProvider.activationState = .launch
-
-        setupHelper(appSessionManager: mockAppSessionManager)
-        let shouldSkip = helper.shouldSkipStartHome
-
-        XCTAssert(shouldSkip, "Expected to skip because the activationState is launch.")
     }
 
     func testNotShouldStartAtHome_AfterFourHours() {


### PR DESCRIPTION
# [FXIOS-5286](https://mozilla-hub.atlassian.net/browse/FXIOS-5286)

TLDR: Remove BVC dependence in TabManager using AppSessionManager. It was used to provide the startAtHome func with information about whether the app was opened from an external source.

## Related
See https://github.com/mozilla-mobile/firefox-ios/pull/12518 for more context. That PR introduced AppSessionManager.