### PR TITLE
Fixes SYNC-3506 [v109] Resets FxA manager state after push notifications arrive

### DIFF
--- a/Account/FxAPushMessageHandler.swift
+++ b/Account/FxAPushMessageHandler.swift
@@ -29,7 +29,9 @@ extension FxAPushMessageHandler {
     /// and then effects changes on the logged in account.
     @discardableResult func handle(userInfo: [AnyHashable: Any]) -> PushMessageResults {
         let keychain = MZKeychainWrapper.sharedClientAppContainerKeychain
-        guard let pushReg = keychain.object(forKey: KeychainKey.fxaPushRegistration) as? PushRegistration else {
+        guard let pushReg = keychain.object(forKey: KeychainKey.fxaPushRegistration, ofClass: PushRegistration.self) else {
+            // We've somehow lost our push registration, lets also reset our apnsToken so we trigger push registration
+            keychain.removeObject(forKey: KeychainKey.apnsToken, withAccessibility: MZKeychainItemAccessibility.afterFirstUnlock)
             return deferMaybe(PushMessageError.accountError)
         }
 

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -16033,7 +16033,7 @@
 			repositoryURL = "https://github.com/mozilla/rust-components-swift.git";
 			requirement = {
 				kind = exactVersion;
-				version = 96.0.1;
+				version = 96.1.0;
 			};
 		};
 		435C85EE2788F4D00072B526 /* XCRemoteSwiftPackageReference "glean-swift" */ = {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -85,8 +85,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla/rust-components-swift.git",
       "state" : {
-        "revision" : "0fef395b67096deef09f51ca1223568686178837",
-        "version" : "96.0.1"
+        "revision" : "7ca10ec39fb0b78c82cbc31635c886dbdc96ae5d",
+        "version" : "96.1.0"
       }
     },
     {

--- a/Client/Application/AppDelegate+PushNotifications.swift
+++ b/Client/Application/AppDelegate+PushNotifications.swift
@@ -66,7 +66,7 @@ extension AppDelegate {
         // The notification service extension can clear this token if there is an error, and the main app can detect this and re-register.
         NotificationCenter.default.addObserver(forName: .ProfileDidStartSyncing, object: nil, queue: .main) { _ in
             let kc = MZKeychainWrapper.sharedClientAppContainerKeychain
-            if kc.object(forKey: KeychainKey.apnsToken, withAccessibility: MZKeychainItemAccessibility.afterFirstUnlock) == nil {
+            if kc.string(forKey: KeychainKey.apnsToken, withAccessibility: MZKeychainItemAccessibility.afterFirstUnlock) == nil {
                 NotificationCenter.default.post(name: .RegisterForPushNotifications, object: nil)
             }
         }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -839,6 +839,14 @@ class BrowserViewController: UIViewController {
                     self.tabManager.addTabsForURLs(receivedURLs, zombie: false)
                 }
             }
+
+            if !receivedURLs.isEmpty || cursorCount > 0 {
+                // Because the notification service runs as a seperate process
+                // we need to make sure that our account manager picks up any persisted state
+                // the notification services persisted.
+                self.profile.rustFxA.accountManager.peek()?.resetPersistedAccount()
+                self.profile.rustFxA.accountManager.peek()?.deviceConstellation()?.refreshState()
+            }
         }
     }
 

--- a/Push/PushRegistration.swift
+++ b/Push/PushRegistration.swift
@@ -7,7 +7,9 @@ import Foundation
 import Shared
 import SwiftyJSON
 
-public class PushRegistration: NSObject, NSCoding {
+public class PushRegistration: NSObject, NSSecureCoding {
+    public static var supportsSecureCoding: Bool = true
+
     let uaid: String
     let secret: String
     // We don't need to have more than one subscription until WebPush is exposed to content Javascript
@@ -30,11 +32,15 @@ public class PushRegistration: NSObject, NSCoding {
     }
 
     @objc public convenience required init?(coder aDecoder: NSCoder) {
-        guard let uaid = aDecoder.decodeObject(forKey: "uaid") as? String,
-            let secret = aDecoder.decodeObject(forKey: "secret") as? String,
-            let subscriptions = aDecoder.decodeObject(forKey: "subscriptions") as? [String: PushSubscription] else {
-                fatalError("Cannot decode registration")
+        guard let uaid = aDecoder.decodeObject(of: NSString.self, forKey: "uaid") as? String,
+              let secret = aDecoder.decodeObject(of: NSString.self, forKey: "secret") as? String,
+              let subscriptions = aDecoder.decodeObject(
+                of: [NSDictionary.self, NSString.self, PushSubscription.self],
+                forKey: "subscriptions"
+              ) as? [String: PushSubscription] else {
+            fatalError("Cannot decode registration")
         }
+
         self.init(uaid: uaid, secret: secret, subscriptions: subscriptions)
     }
 
@@ -60,7 +66,9 @@ public class PushRegistration: NSObject, NSCoding {
 private let defaultSubscriptionID = "defaultSubscription"
 /// Small NSCodable class for persisting a channel subscription.
 /// We use NSCoder because we expect it to be stored in the profile.
-public class PushSubscription: NSObject, NSCoding {
+public class PushSubscription: NSObject, NSSecureCoding {
+    public static var supportsSecureCoding: Bool = true
+
     public let channelID: String
     public let endpoint: URL
 
@@ -90,12 +98,12 @@ public class PushSubscription: NSObject, NSCoding {
     }
 
     @objc public convenience required init?(coder aDecoder: NSCoder) {
-        guard let channelID = aDecoder.decodeObject(forKey: "channelID") as? String,
-            let urlString = aDecoder.decodeObject(forKey: "endpoint") as? String,
+        guard let channelID = aDecoder.decodeObject(of: NSString.self, forKey: "channelID") as? String,
+            let urlString = aDecoder.decodeObject(of: NSString.self, forKey: "endpoint") as? String,
             let endpoint = URL(string: urlString),
-            let p256dhPrivateKey = aDecoder.decodeObject(forKey: "p256dhPrivateKey") as? String,
-            let p256dhPublicKey = aDecoder.decodeObject(forKey: "p256dhPublicKey") as? String,
-            let authKey = aDecoder.decodeObject(forKey: "authKey") as? String else {
+            let p256dhPrivateKey = aDecoder.decodeObject(of: NSString.self, forKey: "p256dhPrivateKey") as? String,
+            let p256dhPublicKey = aDecoder.decodeObject(of: NSString.self, forKey: "p256dhPublicKey") as? String,
+            let authKey = aDecoder.decodeObject(of: NSString.self, forKey: "authKey") as? String else {
             return nil
         }
 

--- a/RustFxA/PushNotificationSetup.swift
+++ b/RustFxA/PushNotificationSetup.swift
@@ -32,7 +32,7 @@ open class PushNotificationSetup {
                 // We set our apnsToken **after** the call to set the push subscription completes
                 // This helps ensure that if that call fails, we will try again with a new token next time
                 keychain.set(apnsToken, forKey: KeychainKey.apnsToken, withAccessibility: .afterFirstUnlock)
-                keychain.set(pushRegistration as NSCoding,
+                keychain.set(pushRegistration,
                              forKey: KeychainKey.fxaPushRegistration,
                              withAccessibility: .afterFirstUnlock)
             }

--- a/RustFxA/RustFirefoxAccounts.swift
+++ b/RustFxA/RustFirefoxAccounts.swift
@@ -200,17 +200,17 @@ open class RustFirefoxAccounts {
         // that returns JSON string.
         let keychain = MZKeychainWrapper.sharedClientAppContainerKeychain
         let key = "profile.account"
-        keychain.ensureObjectItemAccessibility(.afterFirstUnlock, forKey: key)
+        keychain.ensureDictonaryItemAccessibility(.afterFirstUnlock, forKey: key)
 
         // Ignore this class when de-archiving, it isn't needed.
         NSKeyedUnarchiver.setClass(Unknown.self, forClassName: "Account.FxADeviceRegistration")
 
-        guard let dict = keychain.object(forKey: key) as? [String: AnyObject],
+        guard let dict = keychain.object(forKey: key, ofClass: NSDictionary.self) as? [String: AnyObject],
               let guid = dict["stateKeyLabel"]
         else { return nil }
 
         let key2 = "account.state.\(guid)"
-        keychain.ensureObjectItemAccessibility(.afterFirstUnlock, forKey: key2)
+        keychain.ensureDictonaryItemAccessibility(.afterFirstUnlock, forKey: key2)
         guard let jsonData = keychain.data(forKey: key2) else { return nil }
 
         guard let json = try? JSONSerialization.jsonObject(with: jsonData, options: .allowFragments) as? [String: Any] else { return nil }

--- a/Shared/Extensions/KeychainWrapperExtensions.swift
+++ b/Shared/Extensions/KeychainWrapperExtensions.swift
@@ -38,12 +38,12 @@ public extension MZKeychainWrapper {
         }
     }
 
-    func ensureObjectItemAccessibility(_ accessibility: MZKeychainItemAccessibility, forKey key: String) {
+    func ensureDictonaryItemAccessibility(_ accessibility: MZKeychainItemAccessibility, forKey key: String) {
         if self.hasValue(forKey: key) {
             if self.accessibilityOfKey(key) != .afterFirstUnlock {
                 log.debug("updating item \(key) with \(accessibility)")
 
-                guard let value = self.object(forKey: key) else {
+                guard let value = self.object(forKey: key, ofClass: NSDictionary.self) else {
                     log.error("failed to get item \(key)")
                     return
                 }


### PR DESCRIPTION
Because the notification service runs as a separate process, we need to make sure that our account manager picks up any persisted state the notification services persisted. This fixes a bug where sometimes the tabs polled from FxA duplicate tabs the user received as a push notification cc @OrlaM (this is the change I mentioned last week)

Also, as I was building this with 96.1.0, realized that a few breaking changes made their way with the keychain refactor - I tested to make sure push registrations are handled OK, and fixed anything else that broke, cc @lmarceau 