### PR TITLE
Bump [v109] Update Sentry to 7.31.3

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -16053,7 +16053,7 @@
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa.git";
 			requirement = {
 				kind = exactVersion;
-				version = 7.30.0;
+				version = 7.31.3;
 			};
 		};
 		4368F83B279669690013419B /* XCRemoteSwiftPackageReference "SnapKit" */ = {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -94,8 +94,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "3e56a8dd14f4adc4b7de7ce6517f91543bf2046c",
-        "version" : "7.30.0"
+        "revision" : "c3c19e29f775ee95b77aa3168f3e2fd6c20deba6",
+        "version" : "7.31.3"
       }
     },
     {


### PR DESCRIPTION
Changelog links since 7.30.0:
https://github.com/getsentry/sentry-cocoa/releases/tag/7.30.1
https://github.com/getsentry/sentry-cocoa/releases/tag/7.30.2
https://github.com/getsentry/sentry-cocoa/releases/tag/7.31.0
https://github.com/getsentry/sentry-cocoa/releases/tag/7.31.1
https://github.com/getsentry/sentry-cocoa/releases/tag/7.31.2
https://github.com/getsentry/sentry-cocoa/releases/tag/7.31.3