### PR TITLE
Add FXIOS-5360 [v109] Adds entrypoints for all flows into firefox accounts

### DIFF
--- a/Client/Application/NavigationRouter.swift
+++ b/Client/Application/NavigationRouter.swift
@@ -7,7 +7,38 @@ import Shared
 import Glean
 
 struct FxALaunchParams {
+    let entrypoint: FxAEntrypoint
     var query: [String: String]
+}
+
+/// FxAEntrypoint represents all the possible reasons for the application
+/// could launch firefox accounts.
+/// Those entrypoints will be reflected in the authentication URL and will be tracked
+/// in telemetry to allow us to differentiate between flows
+///
+/// If you are introducing a new path to the firefox accounts sign in/settings flow
+/// please add a new entrypoint here
+enum FxAEntrypoint: String {
+    /// Tapping `Sync and Save Data` in the synced tabs menu when signed out
+    case homepanel = "homepanel"
+    /// Navigating to fxa through a deep-link
+    case fxaDeepLinkNavigation = "fxa-deep-link-navigation"
+    /// Using a deeplink, navigate to the fxa setting
+    case fxaDeepLinkSetting = "fxa-deep-link-setting"
+    /// Tapping on the `Sync and Save Data` in the hamburger main menu
+    case browserMenu = "browser-menu"
+    /// Sign in while undergoing update onboarding
+    case updateOnboarding = "update-onboarding"
+    /// Sign in while undergoing introduction onboarding
+    case introOnboarding = "intro-onboarding"
+    /// Tapping on the `Sync and Save Data` in the setting menu when not signed in
+    case connectSetting = "connect-setting"
+    /// Tapping on the FxA setting in the settings menu, when signed in, but need to be re-authenticated
+    case accountStatusSettingReauth = "account-status-setting-reauth"
+    /// When signed in, going through the settings menu to manage fxa settings
+    case manageFxASetting = "manage-fxa-setting"
+    /// Sign in/create account from the library panel
+    case libraryPanel = "library-panel"
 }
 
 // An enum to route to HomePanels
@@ -112,7 +143,7 @@ enum NavigationPath {
             if host == "deep-link", let deepURL = components.valueForQuery("url"), let link = DeepLink(urlString: deepURL.lowercased()) {
                 self = .deepLink(link)
             } else if host == "fxa-signin", components.valueForQuery("signin") != nil {
-                self = .fxa(params: FxALaunchParams(query: url.getQuery()))
+                self = .fxa(params: FxALaunchParams(entrypoint: .fxaDeepLinkNavigation, query: url.getQuery()))
             } else if host == "open-url" {
                 self = .openUrlFromComponents(components: components)
             } else if let widgetKitNavPath = NavigationPath.handleWidgetKitQuery(components: components) {
@@ -329,7 +360,13 @@ enum NavigationPath {
             viewController.tabManager = tabManager
             controller.pushViewController(viewController, animated: true)
         case .fxa:
-            let viewController = FirefoxAccountSignInViewController.getSignInOrFxASettingsVC(flowType: .emailLoginFlow, referringPage: .settings, profile: bvc.profile)
+            let fxaParams = FxALaunchParams(entrypoint: .fxaDeepLinkSetting, query: [:])
+            let viewController = FirefoxAccountSignInViewController.getSignInOrFxASettingsVC(
+                fxaParams,
+                flowType: .emailLoginFlow,
+                referringPage: .settings,
+                profile: bvc.profile
+            )
             controller.pushViewController(viewController, animated: true)
         case .theme:
             controller.pushViewController(ThemeSettingsController(), animated: true)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1807,12 +1807,12 @@ extension BrowserViewController: TabDelegate {
 // MARK: - LibraryPanelDelegate
 extension BrowserViewController: LibraryPanelDelegate {
     func libraryPanelDidRequestToSignIn() {
-        let fxaParams = FxALaunchParams(query: ["entrypoint": "homepanel"])
+        let fxaParams = FxALaunchParams(entrypoint: .libraryPanel, query: [:])
         presentSignInViewController(fxaParams) // TODO UX Right now the flow for sign in and create account is the same
     }
 
     func libraryPanelDidRequestToCreateAccount() {
-        let fxaParams = FxALaunchParams(query: ["entrypoint": "homepanel"])
+        let fxaParams = FxALaunchParams(entrypoint: .libraryPanel, query: [:])
         presentSignInViewController(fxaParams) // TODO UX Right now the flow for sign in and create account is the same
     }
 
@@ -2280,7 +2280,7 @@ extension BrowserViewController {
         }
     }
 
-    func presentSignInViewController(_ fxaOptions: FxALaunchParams? = nil, flowType: FxAPageType = .emailLoginFlow, referringPage: ReferringPage = .none) {
+    func presentSignInViewController(_ fxaOptions: FxALaunchParams, flowType: FxAPageType = .emailLoginFlow, referringPage: ReferringPage = .none) {
         let vcToPresent = FirefoxAccountSignInViewController.getSignInOrFxASettingsVC(fxaOptions, flowType: flowType, referringPage: referringPage, profile: profile)
         presentThemedViewController(navItemLocation: .Left, navItemText: .Close, vcBeingPresented: vcToPresent, topTabsVisible: UIDevice.current.userInterfaceIdiom == .pad)
     }

--- a/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -44,7 +44,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
 
     // TODO: https://mozilla-hub.atlassian.net/browse/FXIOS-5323
     // swiftlint: disable large_tuple
-    typealias FXASyncClosure = (params: FxALaunchParams?, flowType: FxAPageType, referringPage: ReferringPage)
+    typealias FXASyncClosure = (params: FxALaunchParams, flowType: FxAPageType, referringPage: ReferringPage)
     // swiftlint: enable large_tuple
     typealias SendToDeviceDelegate = InstructionsViewDelegate & DevicePickerViewControllerDelegate
 
@@ -485,7 +485,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
 
     private func syncMenuButton(showFxA: @escaping (FXASyncClosure) -> Void) -> PhotonRowActions? {
         let action: (SingleActionViewModel) -> Void = { action in
-            let fxaParams = FxALaunchParams(query: ["entrypoint": "browsermenu"])
+            let fxaParams = FxALaunchParams(entrypoint: .browserMenu, query: [:])
             let params = FXASyncClosure(fxaParams, .emailLoginFlow, .appMenu)
             showFxA(params)
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .signIntoSync)

--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -578,7 +578,7 @@ extension TabTrayViewController: RemotePanelDelegate {
 
     // Sign In and Create Account Helper
     func fxaSignInOrCreateAccountHelper() {
-        let fxaParams = FxALaunchParams(query: ["entrypoint": "homepanel"])
+        let fxaParams = FxALaunchParams(entrypoint: .homepanel, query: [:])
         let controller = FirefoxAccountSignInViewController.getSignInOrFxASettingsVC(fxaParams,
                                                                                      flowType: .emailLoginFlow,
                                                                                      referringPage: .tabTray,

--- a/Client/Frontend/Intro/IntroViewController.swift
+++ b/Client/Frontend/Intro/IntroViewController.swift
@@ -185,7 +185,8 @@ extension IntroViewController: OnboardingCardDelegate {
         case .welcome:
             moveToNextPage(cardType: cardType)
         case .signSync:
-            presentSignToSync()
+            let fxaPrams = FxALaunchParams(entrypoint: .introOnboarding, query: [:])
+            presentSignToSync(fxaPrams)
         default:
             break
         }
@@ -200,7 +201,7 @@ extension IntroViewController: OnboardingCardDelegate {
         }
     }
 
-    private func presentSignToSync(_ fxaOptions: FxALaunchParams? = nil,
+    private func presentSignToSync(_ fxaOptions: FxALaunchParams,
                                   flowType: FxAPageType = .emailLoginFlow,
                                   referringPage: ReferringPage = .onboarding) {
         let singInSyncVC = FirefoxAccountSignInViewController.getSignInOrFxASettingsVC(fxaOptions,

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -35,7 +35,8 @@ class ConnectSetting: WithoutAccountSetting {
     override var accessibilityIdentifier: String? { return "SignInToSync" }
 
     override func onClick(_ navigationController: UINavigationController?) {
-        let viewController = FirefoxAccountSignInViewController(profile: profile, parentType: .settings, deepLinkParams: nil)
+        let fxaParams = FxALaunchParams(entrypoint: .connectSetting, query: [:])
+        let viewController = FirefoxAccountSignInViewController(profile: profile, parentType: .settings, deepLinkParams: fxaParams)
         TelemetryWrapper.recordEvent(category: .firefoxAccount, method: .view, object: .settings)
         navigationController?.pushViewController(viewController, animated: true)
     }
@@ -349,7 +350,8 @@ class AccountStatusSetting: WithAccountSetting {
 
     override func onClick(_ navigationController: UINavigationController?) {
         guard !profile.rustFxA.accountNeedsReauth() else {
-            let controller = FirefoxAccountSignInViewController(profile: profile, parentType: .settings, deepLinkParams: nil)
+            let fxaParams = FxALaunchParams(entrypoint: .accountStatusSettingReauth, query: [:])
+            let controller = FirefoxAccountSignInViewController(profile: profile, parentType: .settings, deepLinkParams: fxaParams)
             TelemetryWrapper.recordEvent(category: .firefoxAccount, method: .view, object: .settings)
             navigationController?.pushViewController(controller, animated: true)
             return

--- a/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -21,7 +21,8 @@ class ManageFxAccountSetting: Setting {
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
-        let viewController = FxAWebViewController(pageType: .settingsPage, profile: profile, dismissalStyle: .popToRootVC, deepLinkParams: nil)
+        let fxaParams = FxALaunchParams(entrypoint: .manageFxASetting, query: [:])
+        let viewController = FxAWebViewController(pageType: .settingsPage, profile: profile, dismissalStyle: .popToRootVC, deepLinkParams: fxaParams)
         navigationController?.pushViewController(viewController, animated: true)
     }
 }

--- a/Client/Frontend/Update/UpdateViewController.swift
+++ b/Client/Frontend/Update/UpdateViewController.swift
@@ -167,7 +167,7 @@ class UpdateViewController: UIViewController, OnboardingViewControllerProtocol {
         return index
     }
 
-    private func presentSignToSync(_ fxaOptions: FxALaunchParams? = nil,
+    private func presentSignToSync(_ fxaOptions: FxALaunchParams,
                                    flowType: FxAPageType = .emailLoginFlow,
                                    referringPage: ReferringPage = .onboarding) {
 
@@ -237,7 +237,8 @@ extension UpdateViewController: OnboardingCardDelegate {
         case .updateWelcome:
             showNextPage(cardType)
         case .updateSignSync:
-            presentSignToSync()
+            let fxaParams = FxALaunchParams(entrypoint: .updateOnboarding, query: [:])
+            presentSignToSync(fxaParams)
         default:
             break
         }

--- a/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/RustFxA/FirefoxAccountSignInViewController.swift
@@ -31,7 +31,7 @@ class FirefoxAccountSignInViewController: UIViewController {
     var shouldReload: (() -> Void)?
 
     private let profile: Profile
-    private var deepLinkParams: FxALaunchParams?
+    private let deepLinkParams: FxALaunchParams
     var notificationCenter: NotificationProtocol = NotificationCenter.default
 
     /// This variable is used to track parent page that launched this sign in VC.
@@ -136,7 +136,7 @@ class FirefoxAccountSignInViewController: UIViewController {
     ///   - profile: User Profile info
     ///   - parentType: FxASignInParentType is an enum parent page that presented this VC. Parameter used in telemetry button events.
     ///   - deepLinkParams: URL args passed in from deep link that propagate to FxA web view
-    init(profile: Profile, parentType: FxASignInParentType, deepLinkParams: FxALaunchParams?) {
+    init(profile: Profile, parentType: FxASignInParentType, deepLinkParams: FxALaunchParams) {
         self.deepLinkParams = deepLinkParams
         self.profile = profile
         switch parentType {
@@ -290,7 +290,12 @@ extension FirefoxAccountSignInViewController {
     ///     - flowType: FxAPageType is used to determine if email login, qr code login, or user settings page should be presented
     ///     - referringPage: ReferringPage enum is used to handle telemetry events correctly for the view event and the FxA sign in tap events, need to know which route we took to get to them
     ///     - profile:
-    static func getSignInOrFxASettingsVC(_ deepLinkParams: FxALaunchParams? = nil, flowType: FxAPageType, referringPage: ReferringPage, profile: Profile) -> UIViewController {
+    static func getSignInOrFxASettingsVC(
+        _ deepLinkParams: FxALaunchParams,
+        flowType: FxAPageType,
+        referringPage: ReferringPage,
+        profile: Profile
+    ) -> UIViewController {
         // Show the settings page if we have already signed in. If we haven't then show the signin page
         let parentType: FxASignInParentType
         let object: TelemetryWrapper.EventObject

--- a/RustFxA/FxAWebViewController.swift
+++ b/RustFxA/FxAWebViewController.swift
@@ -33,7 +33,7 @@ class FxAWebViewController: UIViewController {
      - parameter dismissalStyle: depending on how this was presented, it uses modal dismissal, or if part of a UINavigationController stack it will pop to the root.
      - parameter deepLinkParams: URL args passed in from deep link that propagate to FxA web view
      */
-    init(pageType: FxAPageType, profile: Profile, dismissalStyle: DismissType, deepLinkParams: FxALaunchParams?) {
+    init(pageType: FxAPageType, profile: Profile, dismissalStyle: DismissType, deepLinkParams: FxALaunchParams) {
         self.viewModel = FxAWebViewModel(pageType: pageType, profile: profile, deepLinkParams: deepLinkParams)
 
         self.dismissType = dismissalStyle

--- a/Tests/ClientTests/NavigationRouterTests.swift
+++ b/Tests/ClientTests/NavigationRouterTests.swift
@@ -94,7 +94,7 @@ class NavigationRouterTests: XCTestCase {
     func testFxALinks() {
         XCTAssertEqual(
             NavigationPath(url: URL(string: "\(appScheme)://fxa-signin?signin=coolcodes&user=foo&email=bar")!),
-            NavigationPath.fxa(params: FxALaunchParams(query: ["user": "foo", "email": "bar", "signin": "coolcodes"])))
+            NavigationPath.fxa(params: FxALaunchParams(entrypoint: .fxaDeepLinkNavigation, query: ["user": "foo", "email": "bar", "signin": "coolcodes"])))
         XCTAssertEqual(NavigationPath(url: URL(string: "\(appScheme)://fxa-signin?user=foo&email=bar")!), nil)
     }
 


### PR DESCRIPTION
fixes #12542 

The context in the bug above

## What's in the change:
- Makes the `FxALaunchParams` required for the view controllers that manage FxA
- Modifies `FxALaunchParams` to include a new entrypoint enum...
- Creates an enum that represents all the possible flows to launch FxA
- Passes the entry point into the authentication flow, so it can be recorded in telemetry


cc @dnarcese I think I covered all the authentication paths here!
