### PR TITLE
Add FXIOS-5364 [v109] instrument nimbus events for application opening and sync login

### DIFF
--- a/Client/Experiments/Experiments.swift
+++ b/Client/Experiments/Experiments.swift
@@ -106,17 +106,16 @@ enum Experiments {
     static var dbPath: String? {
         let profilePath: String?
         if AppConstants.isRunningUITests || AppConstants.isRunningPerfTests {
-            let delegate = UIApplication.shared.delegate as? UITestAppDelegate
-            profilePath = delegate?.dirForTestProfile
-            log.info("Nimbus::Test:: Delegate: \(delegate); path: \(profilePath)")
+            profilePath = (UIApplication.shared.delegate as? UITestAppDelegate)?.dirForTestProfile
+        } else if AppConstants.isRunningUnitTest {
+            let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            profilePath = dir.path
         } else {
-            let containerUrl = FileManager.default.containerURL(
+            profilePath = FileManager.default.containerURL(
                 forSecurityApplicationGroupIdentifier: AppInfo.sharedContainerIdentifier
-            )
-            profilePath = containerUrl?
+            )?
                 .appendingPathComponent("profile.profile")
                 .path
-            log.info("Nimbus::Live:: ContainerUrl: \(containerUrl); path: \(profilePath)")
         }
         let dbPath = profilePath.flatMap {
             URL(fileURLWithPath: $0).appendingPathComponent("nimbus.db").path

--- a/Client/Experiments/Experiments.swift
+++ b/Client/Experiments/Experiments.swift
@@ -106,13 +106,17 @@ enum Experiments {
     static var dbPath: String? {
         let profilePath: String?
         if AppConstants.isRunningUITests || AppConstants.isRunningPerfTests {
-            profilePath = (UIApplication.shared.delegate as? UITestAppDelegate)?.dirForTestProfile
+            let delegate = UIApplication.shared.delegate as? UITestAppDelegate
+            profilePath = delegate?.dirForTestProfile
+            log.info("Nimbus::Test:: Delegate: \(delegate); path: \(profilePath)")
         } else {
-            profilePath = FileManager.default.containerURL(
+            let containerUrl = FileManager.default.containerURL(
                 forSecurityApplicationGroupIdentifier: AppInfo.sharedContainerIdentifier
-            )?
+            )
+            profilePath = containerUrl?
                 .appendingPathComponent("profile.profile")
                 .path
+            log.info("Nimbus::Live:: ContainerUrl: \(containerUrl); path: \(profilePath)")
         }
         let dbPath = profilePath.flatMap {
             URL(fileURLWithPath: $0).appendingPathComponent("nimbus.db").path

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -950,6 +950,8 @@ extension TelemetryWrapper {
             GleanMetrics.Sync.loginView.record()
         case (.firefoxAccount, .view, .fxaLoginCompleteWebpage, _, _):
             GleanMetrics.Sync.loginCompletedView.record()
+            // record the same event for Nimbus' internal event store
+            Experiments.shared.recordEvent("sync.login_completed_view")
         case (.firefoxAccount, .view, .fxaConfirmSignUpCode, _, _):
             GleanMetrics.Sync.registrationCodeView.record()
         case (.firefoxAccount, .view, .fxaConfirmSignInToken, _, _):
@@ -957,6 +959,8 @@ extension TelemetryWrapper {
         // MARK: App cycle
         case(.action, .foreground, .app, _, _):
             GleanMetrics.AppCycle.foreground.record()
+            // record the same event for Nimbus' internal event store
+            Experiments.shared.recordEvent("app_cycle.foreground")
         case(.action, .background, .app, _, _):
             GleanMetrics.AppCycle.background.record()
         // MARK: Accessibility

--- a/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -415,6 +415,18 @@ class TelemetryWrapperTests: XCTestCase {
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.SettingsMenu.showTourPressed)
     }
+
+    // MARK: - Nimbus Calls
+
+    func test_appForeground_NimbusIsCalled() {
+        TelemetryWrapper.recordEvent(category: .action, method: .foreground, object: .app, value: nil)
+        XCTAssertTrue(try Experiments.shared.createMessageHelper().evalJexl(expression: "'app_cycle.foreground'|eventSum('Minutes', 1, 0) > 0"))
+    }
+
+    func test_syncLogin_NimbusIsCalled() {
+        TelemetryWrapper.recordEvent(category: .firefoxAccount, method: .view, object: .fxaLoginCompleteWebpage, value: nil)
+        XCTAssertTrue(try Experiments.shared.createMessageHelper().evalJexl(expression: "'sync.login_completed_view'|eventSum('Minutes', 1, 0) > 0"))
+    }
 }
 
 // MARK: - Helper functions to test telemetry

--- a/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -420,12 +420,12 @@ class TelemetryWrapperTests: XCTestCase {
 
     func test_appForeground_NimbusIsCalled() {
         TelemetryWrapper.recordEvent(category: .action, method: .foreground, object: .app, value: nil)
-        XCTAssertTrue(try Experiments.shared.createMessageHelper().evalJexl(expression: "'app_cycle.foreground'|eventSum('Minutes', 1, 0) > 0"))
+        XCTAssertTrue(try Experiments.shared.createMessageHelper().evalJexl(expression: "'app_cycle.foreground'|eventSum('Days', 1, 0) > 0"))
     }
 
     func test_syncLogin_NimbusIsCalled() {
         TelemetryWrapper.recordEvent(category: .firefoxAccount, method: .view, object: .fxaLoginCompleteWebpage, value: nil)
-        XCTAssertTrue(try Experiments.shared.createMessageHelper().evalJexl(expression: "'sync.login_completed_view'|eventSum('Minutes', 1, 0) > 0"))
+        XCTAssertTrue(try Experiments.shared.createMessageHelper().evalJexl(expression: "'sync.login_completed_view'|eventSum('Days', 1, 0) > 0"))
     }
 }
 


### PR DESCRIPTION
This adds calls to Nimbus to record events as they are recorded in Glean. At the moment, we only plan to instrument the application being opened and successful sync logins. 

This also adds some tests to validate they are recorded as intended. We still need to add a cleanup method for the nimbus event store, so for now the tests simply check that the events have been recorded more than once in the last minute.

#12556 
Experimentation ticket: [EXP-2917](https://mozilla-hub.atlassian.net/browse/EXP-2917)
