### PR TITLE
Bugfix FXIOS-4981 [v109] The `Jump back in` pop-up text jump to `Recently Visited` or `Thought-Provoking Stories` when multitasking with `Voice over` On

### DIFF
--- a/Client/Frontend/Contextual Hint/ContextualHintViewController.swift
+++ b/Client/Frontend/Contextual Hint/ContextualHintViewController.swift
@@ -267,19 +267,21 @@ class ContextualHintViewController: UIViewController, OnViewDismissable {
         withArrowDirection arrowDirection: UIPopoverArrowDirection,
         andDelegate delegate: UIPopoverPresentationControllerDelegate,
         presentedUsing presentation: (() -> Void)?,
+        sourceRect: CGRect = CGRect.null,
         withActionBeforeAppearing preAction: (() -> Void)? = nil,
         actionOnDismiss postAction: (() -> Void)? = nil,
         andActionForButton buttonAction: (() -> Void)? = nil,
         andShouldStartTimerRightAway shouldStartTimer: Bool = true
     ) {
         stopTimer()
-        self.modalPresentationStyle = .popover
-        self.popoverPresentationController?.sourceView = anchor
-        self.popoverPresentationController?.permittedArrowDirections = arrowDirection
-        self.popoverPresentationController?.delegate = delegate
-        self.onViewSummoned = preAction
-        self.onViewDismissed = postAction
-        self.onActionTapped = buttonAction
+        modalPresentationStyle = .popover
+        popoverPresentationController?.sourceRect = sourceRect
+        popoverPresentationController?.sourceView = anchor
+        popoverPresentationController?.permittedArrowDirections = arrowDirection
+        popoverPresentationController?.delegate = delegate
+        onViewSummoned = preAction
+        onViewDismissed = postAction
+        onActionTapped = buttonAction
         viewModel.presentFromTimer = presentation
         viewModel.arrowDirection = arrowDirection
 

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -203,7 +203,7 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
             contentStackView.topAnchor.constraint(equalTo: view.topAnchor),
             contentStackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             contentStackView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            contentStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            contentStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
     }
 
@@ -458,8 +458,8 @@ extension HomepageViewController: UICollectionViewDelegate, UICollectionViewData
         // Jump back in header specific setup
         if sectionViewModel.sectionType == .jumpBackIn {
             self.viewModel.jumpBackInViewModel.sendImpressionTelemetry()
-            // Delaying CFR presentation because to wait for header view
-            // layout readjust
+            // Moving called after header view gets configured
+            // and delaying to wait for header view layout readjust
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 self.prepareJumpBackInContextualHint(onView: headerView)
             }

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -460,8 +460,8 @@ extension HomepageViewController: UICollectionViewDelegate, UICollectionViewData
             self.viewModel.jumpBackInViewModel.sendImpressionTelemetry()
             // Moving called after header view gets configured
             // and delaying to wait for header view layout readjust
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                self.prepareJumpBackInContextualHint(onView: headerView)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                self?.prepareJumpBackInContextualHint(onView: headerView)
             }
         }
         return headerView

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -203,7 +203,7 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
             contentStackView.topAnchor.constraint(equalTo: view.topAnchor),
             contentStackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             contentStackView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            contentStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+            contentStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
         ])
     }
 
@@ -392,14 +392,20 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
 
     private func prepareJumpBackInContextualHint(onView headerView: LabelButtonHeaderView) {
         guard jumpBackInContextualHintViewController.shouldPresentHint(),
-              !viewModel.shouldDisplayHomeTabBanner
+              !viewModel.shouldDisplayHomeTabBanner,
+              !headerView.frame.isEmpty
         else { return }
 
+        // Calculate label header view frame to add as source rect for CFR
+        var rect = headerView.convert(headerView.titleLabel.frame, to: collectionView)
+        rect = collectionView.convert(rect, to: view)
+
         jumpBackInContextualHintViewController.configure(
-            anchor: headerView.titleLabel,
+            anchor: view,
             withArrowDirection: .down,
             andDelegate: self,
             presentedUsing: { self.presentContextualHint(contextualHintViewController: self.jumpBackInContextualHintViewController) },
+            sourceRect: rect,
             withActionBeforeAppearing: { self.contextualHintPresented(type: .jumpBackIn) },
             andActionForButton: { self.openTabsSettings() })
     }
@@ -445,15 +451,19 @@ extension HomepageViewController: UICollectionViewDelegate, UICollectionViewData
               let sectionViewModel = viewModel.getSectionViewModel(shownSection: indexPath.section)
         else { return UICollectionReusableView() }
 
-        // Jump back in header specific setup
-        if sectionViewModel.sectionType == .jumpBackIn {
-            viewModel.jumpBackInViewModel.sendImpressionTelemetry()
-            prepareJumpBackInContextualHint(onView: headerView)
-        }
-
         // Configure header only if section is shown
         let headerViewModel = sectionViewModel.shouldShow ? sectionViewModel.headerViewModel : LabelButtonHeaderViewModel.emptyHeader
         headerView.configure(viewModel: headerViewModel, theme: themeManager.currentTheme)
+
+        // Jump back in header specific setup
+        if sectionViewModel.sectionType == .jumpBackIn {
+            self.viewModel.jumpBackInViewModel.sendImpressionTelemetry()
+            // Delaying CFR presentation because to wait for header view
+            // layout readjust
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                self.prepareJumpBackInContextualHint(onView: headerView)
+            }
+        }
         return headerView
     }
 


### PR DESCRIPTION
### [FXIOS-4981](https://mozilla-hub.atlassian.net/browse/FXIOS-4981)
Issue #11996

The bug is related to presenting the CFR from a collection view header or cell (LabelButtonHeaderView in this case)  so the solution is to get the CGRect from the original view we wanted to present it from and use view as `sourceView` and the calculated rect as `sourceRect`. Added a delay because the HeaderView adjust his layout which causes the calculated rect to be wrong and show the CFR in a weird position

Delay CFR presentation and present on view using source rect
