### PR TITLE
Bugfix FXIOS-5304 [v109] Fixes pinned sites no longer work from add to shortcuts

### DIFF
--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -156,9 +156,9 @@ open class SQLiteHistory {
     public func getSites(forURLs urls: [String]) -> Deferred<Maybe<Cursor<Site?>>> {
         let inExpression = urls.joined(separator: "\",\"")
         let sql = """
-        SELECT history.id AS historyID, history.url AS url, title, guid, iconID, iconURL, iconDate, iconType, iconWidth
-        FROM view_favicons_widest, history
-        WHERE history.id = siteID AND history.url IN (\"\(inExpression)\")
+        SELECT history.id AS historyID, history.url AS url, title, guid
+        FROM history
+        WHERE history.url IN (\"\(inExpression)\")
         """
 
         let args: Args = []
@@ -457,8 +457,7 @@ extension SQLiteHistory: BrowserHistory {
 
     public func getPinnedTopSites() -> Deferred<Maybe<Cursor<Site>>> {
         let sql = """
-            SELECT * FROM pinned_top_sites LEFT OUTER JOIN view_favicons_widest ON
-                historyID = view_favicons_widest.siteID
+            SELECT * FROM pinned_top_sites
             ORDER BY pinDate DESC
             """
         return database.runQueryConcurrently(sql, args: [], factory: SQLiteHistory.iconHistoryMetadataColumnFactory)


### PR DESCRIPTION
Bugfix for #12461 

Removes the extra query to the `browser.db` when adding a pinned site through the `Add to Shortcuts` button.
- In 107 we removed favicons from the SQL layer
- The query joins with the favicons table, which there is a really good chance doesn't have the site
- The query returns an empty site, then the actual add to pinned sites won't run

This PR removes that extra query and instead writes directly to the pinned sites. Note that since we no longer run the query, we now don't have the site's guid. but that's okay, it's nullable and pinned sites don't really need to have site's history guid.


I put this as 108 since it was a regression in 107. But please feel free to change it up to whatever the team sees fit!
