### PR TITLE
Fixed FXIOS-5128, FXIOS-5274 [v109] close all tabs from trash will get propagatedto recently closed tabs list

### DIFF
--- a/Client/Frontend/Browser/Tab Management/TabManager.swift
+++ b/Client/Frontend/Browser/Tab Management/TabManager.swift
@@ -305,6 +305,18 @@ class TabManager: NSObject, FeatureFlaggable, TabManagerProtocol {
             }
         }
 
+        // Add last 10 tab(s) to recently closed list
+        // Note: The recently closed tab list is only updated when the undo
+        // snackbar disappears and does not update if someone taps on undo button
+        closedTabs.suffix(10).forEach { tab in
+            if let url = tab.lastKnownUrl, !(InternalURL(url)?.isAboutURL ?? false), !tab.isPrivate {
+                profile.recentlyClosedTabs.addTab(url as URL,
+                                                  title: tab.lastTitle,
+                                                  faviconURL: tab.displayFavicon?.url,
+                                                  lastExecutedTime: tab.lastExecutedTime)
+            }
+        }
+
         // perform remaining tab cleanup related to removing wkwebview
         // observers which can only happen on main thread in close() call
         closedTabs.forEach { tab in

--- a/Client/Frontend/Browser/Tab Management/TabManager.swift
+++ b/Client/Frontend/Browser/Tab Management/TabManager.swift
@@ -305,18 +305,6 @@ class TabManager: NSObject, FeatureFlaggable, TabManagerProtocol {
             }
         }
 
-        // Add last 10 tab(s) to recently closed list
-        // Note: The recently closed tab list is only updated when the undo
-        // snackbar disappears and does not update if someone taps on undo button
-        closedTabs.suffix(10).forEach { tab in
-            if let url = tab.lastKnownUrl, !(InternalURL(url)?.isAboutURL ?? false), !tab.isPrivate {
-                profile.recentlyClosedTabs.addTab(url as URL,
-                                                  title: tab.lastTitle,
-                                                  faviconURL: tab.displayFavicon?.url,
-                                                  lastExecutedTime: tab.lastExecutedTime)
-            }
-        }
-
         // perform remaining tab cleanup related to removing wkwebview
         // observers which can only happen on main thread in close() call
         closedTabs.forEach { tab in
@@ -726,6 +714,20 @@ class TabManager: NSObject, FeatureFlaggable, TabManagerProtocol {
         var toast: ButtonToast?
         let numberOfTabs = recentlyClosedTabs.count
         if numberOfTabs > 0 {
+
+            // Add last 10 tab(s) to recently closed list
+            // Note: The recently closed tab list is only updated when the undo
+            // snackbar disappears and does not update if someone taps on undo button
+            recentlyClosedTabs.suffix(10).forEach { tab in
+                if let url = tab.lastKnownUrl, !(InternalURL(url)?.isAboutURL ?? false), !tab.isPrivate {
+                    profile.recentlyClosedTabs.addTab(url as URL,
+                                                      title: tab.lastTitle,
+                                                      faviconURL: tab.displayFavicon?.url,
+                                                      lastExecutedTime: tab.lastExecutedTime)
+                }
+            }
+
+            // Toast
             var didPressButton = false
             toast = ButtonToast(
                 labelText: String.localizedStringWithFormat(.TabsDeleteAllUndoTitle, numberOfTabs),

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -187,6 +187,9 @@ class HistoryPanel: UIViewController,
 
         bottomStackView.isHidden = !viewModel.isSearchInProgress
         fetchDataAndUpdateLayout()
+        DispatchQueue.main.async {
+            self.refreshRecentlyClosedCell()
+        }
     }
 
     // MARK: - Private helpers


### PR DESCRIPTION
[FXIOS-5128](https://mozilla-hub.atlassian.net/browse/FXIOS-5128)
[FXIOS-5274](https://mozilla-hub.atlassian.net/browse/FXIOS-5274) 
[#12197](https://github.com/mozilla-mobile/firefox-ios/issues/12197)
