### PR TITLE
Refactor MTE-183 [v109] Timing related test failures from ReaderViewUITest and TabCounterTests

### DIFF
--- a/Tests/XCUITests/ReaderViewUITest.swift
+++ b/Tests/XCUITests/ReaderViewUITest.swift
@@ -68,12 +68,15 @@ class ReaderViewTest: BaseTestCase {
     }
 
     func testAddToReadingListPrivateMode() {
+        waitForExistence(app.buttons["urlBar-cancel"])
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         navigator.performAction(Action.OpenNewTabFromTabTray)
+        waitForExistence(app.buttons["urlBar-cancel"])
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
+        waitForTabsButton()
         navigator.goto(BrowserTabMenu)
         navigator.goto(LibraryPanel_ReadingList)
 
@@ -95,8 +98,10 @@ class ReaderViewTest: BaseTestCase {
         // Check that it appears on regular mode
         navigator.toggleOff(userState.isPrivate, withAction: Action.ToggleRegularMode)
         navigator.performAction(Action.OpenNewTabFromTabTray)
+        waitForExistence(app.buttons["urlBar-cancel"])
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
+        waitForTabsButton()
         navigator.goto(LibraryPanel_ReadingList)
         checkReadingListNumberOfItems(items: 1)
     }

--- a/Tests/XCUITests/TabCounterTests.swift
+++ b/Tests/XCUITests/TabCounterTests.swift
@@ -70,8 +70,6 @@ class TabCounterTests: BaseTestCase {
         tabsOpen = app.buttons["Show Tabs"].value
         XCTAssertEqual("1", tabsOpen as? String)
 
-        waitForExistence(app.buttons["urlBar-cancel"])
-        navigator.performAction(Action.CloseURLBarOpen)
         navigator.goto(TabTray)
         tabsOpen = app.segmentedControls.buttons.element(boundBy: 0).label
         XCTAssertTrue(app.segmentedControls.buttons.element(boundBy: 0).isSelected)

--- a/Tests/XCUITests/TabCounterTests.swift
+++ b/Tests/XCUITests/TabCounterTests.swift
@@ -71,6 +71,7 @@ class TabCounterTests: BaseTestCase {
         XCTAssertEqual("1", tabsOpen as? String)
 
         navigator.goto(TabTray)
+        waitForExistence(app.navigationBars["Open Tabs"])
         tabsOpen = app.segmentedControls.buttons.element(boundBy: 0).label
         XCTAssertTrue(app.segmentedControls.buttons.element(boundBy: 0).isSelected)
         if !isTablet {

--- a/Tests/XCUITests/TabCounterTests.swift
+++ b/Tests/XCUITests/TabCounterTests.swift
@@ -32,6 +32,7 @@ class TabCounterTests: BaseTestCase {
 
     func testTabDecrement() throws {
         navigator.nowAt(NewTabScreen)
+        waitForExistence(app.buttons["urlBar-cancel"])
         navigator.performAction(Action.CloseURLBarOpen)
         waitForTabsButton()
 
@@ -41,6 +42,7 @@ class TabCounterTests: BaseTestCase {
         navigator.createNewTab()
         navigator.nowAt(NewTabScreen)
 
+        waitForExistence(app.buttons["urlBar-cancel"])
         navigator.performAction(Action.CloseURLBarOpen)
         waitForTabsButton()
 
@@ -61,12 +63,15 @@ class TabCounterTests: BaseTestCase {
 
         app.otherElements["Tabs Tray"].cells.element(boundBy: 0).tap()
         navigator.nowAt(NewTabScreen)
+        waitForExistence(app.buttons["urlBar-cancel"])
         navigator.performAction(Action.CloseURLBarOpen)
         waitForTabsButton()
 
         tabsOpen = app.buttons["Show Tabs"].value
         XCTAssertEqual("1", tabsOpen as? String)
 
+        waitForExistence(app.buttons["urlBar-cancel"])
+        navigator.performAction(Action.CloseURLBarOpen)
         navigator.goto(TabTray)
         tabsOpen = app.segmentedControls.buttons.element(boundBy: 0).label
         XCTAssertTrue(app.segmentedControls.buttons.element(boundBy: 0).isSelected)


### PR DESCRIPTION
The tests `ReaderViewUITest/testAddToReadingListPrivateMode()` and ` TabCounterTests/testTabDecrement()` fail in severals places intermittently due to the intended UI element has not appear or not available.  We've added

* `waitForExistence(app.buttons["urlBar-cancel"])` before `navigator.performAction(Action.CloseURLBarOpen)` to ensure that the "<" button appears and becomes available before clicking.
* `waitForTabsButton()` before clicking the tabs button.
* `waitForExistence(app.navigationBars["Open Tabs"])` after open `tabTray`

I've tested the changes on my M1 computer as well as on the MacStadium. 