### PR TITLE
Bugfix FXIOS-5247 [v109] out of memory issues

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -147,6 +147,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             widgetManager?.writeWidgetKitTopSites()
         }
     }
+
+    func applicationDidReceiveMemoryWarning(_ application: UIApplication) {
+        tabManager.relieveMemoryPressure()
+    }
 }
 
 extension AppDelegate: Notifiable {

--- a/Client/Frontend/Browser/Tab Management/TabManager.swift
+++ b/Client/Frontend/Browser/Tab Management/TabManager.swift
@@ -882,6 +882,13 @@ class TabManager: NSObject, FeatureFlaggable, TabManagerProtocol {
 
         return selectedTab ?? addTab()
     }
+
+    func relieveMemoryPressure() {
+        for tab in tabs {
+            if tab.isCurrentTab { continue }
+            tab.webView = nil
+        }
+    }
 }
 
 // MARK: - WKNavigationDelegate


### PR DESCRIPTION
[FXIOS-5247](https://mozilla-hub.atlassian.net/browse/FXIOS-5247)
#12375 

This is an experimental change to see what kind of impact this has on out of memory issues.

The hypothesis is that one of the biggest contributors to memory pressure are the webviews, which are notoriously greedy with memory, hanging around longer than they probably ought to.

This change is a bit of a hack in that it will just kill all of the webviews except the current one if a memory pressure event is fired. There are more sophisticated approaches we can take to solve this issue if this experiment results in a significant drop in out of memory crashes.

Marking as 109 for now but if there are new builds going anyway I'd like to see this in 108, will consult Daniela and update if needed.