### PR TITLE
Refactor FXIOS-5286 [v109] BVC dependence removed from ReadabilityService

### DIFF
--- a/Client/Frontend/Reader/ReaderModeHandlers.swift
+++ b/Client/Frontend/Reader/ReaderModeHandlers.swift
@@ -70,7 +70,7 @@ struct ReaderModeHandlers: ReaderModeHandlersProtocol {
                         // What we do is simply queue the page in the ReadabilityService and then show our loading
                         // screen, which will periodically call page-exists to see if the readerized content has
                         // become available.
-                        ReadabilityService.sharedInstance.process(url, cache: readerModeCache)
+                        ReadabilityService().process(url, cache: readerModeCache, with: profile)
                         if let readerViewLoadingPath = Bundle.main.path(forResource: "ReaderViewLoading", ofType: "html") {
                             do {
                                 let readerViewLoading = try NSMutableString(contentsOfFile: readerViewLoadingPath, encoding: String.Encoding.utf8.rawValue)


### PR DESCRIPTION
# [FXIOS-5286](https://mozilla-hub.atlassian.net/browse/FXIOS-5286)

TLDR: Remove BVC dependence in ReadabilityService

## Details
ReadabilityService, ReadabilityOperation and ReaderModeHandlers struct are a bit weird. The registration is called once in WebServerUtil, and it calls into a `static register` func. I think that portion of the codebase might need a thorough refactor later. For now, this PR removes that BVC call, and we can keep moving forward. 

Also, I saw no point in keeping ReadabilityService's shared access pattern. It doesn't look like the queue it maintains needs to live through an appSession. I only found one call to it.