### PR TITLE
Bugfix FXIOS-5257 [v109] Fix ImageError -> SiteImageError, update hero image fetcher interface

### DIFF
--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/HeroImageFetcher/HeroImageFetcher.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/HeroImageFetcher/HeroImageFetcher.swift
@@ -6,7 +6,7 @@ import LinkPresentation
 import UIKit
 
 protocol HeroImageFetcher {
-    func fetchHeroImage(from imageURL: URL) async throws -> UIImage
+    func fetchHeroImage(from siteURL: URL) async throws -> UIImage
 }
 
 class DefaultHeroImageFetcher: HeroImageFetcher {
@@ -17,11 +17,11 @@ class DefaultHeroImageFetcher: HeroImageFetcher {
         self.metadataProvider = metadataProvider
     }
 
-    func fetchHeroImage(from imageURL: URL) async throws -> UIImage {
+    func fetchHeroImage(from siteURL: URL) async throws -> UIImage {
         do {
-            let metadata = try await metadataProvider.startFetchingMetadata(for: imageURL)
+            let metadata = try await metadataProvider.startFetchingMetadata(for: siteURL)
             guard let imageProvider = metadata.imageProvider else {
-                throw ImageError.unableToDownloadImage("Metadata image provider could not be retrieved.")
+                throw SiteImageError.unableToDownloadImage("Metadata image provider could not be retrieved.")
             }
 
             return try await imageProvider.loadObject(ofClass: UIImage.self)

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/HeroImageFetcher/ImageProvider.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/HeroImageFetcher/ImageProvider.swift
@@ -17,12 +17,12 @@ extension NSItemProvider: ImageProvider {
         return try await withCheckedThrowingContinuation { continuation in
             loadObject(ofClass: aClass) { image, error in
                 guard error == nil else {
-                    continuation.resume(throwing: ImageError.unableToDownloadImage(error.debugDescription.description))
+                    continuation.resume(throwing: SiteImageError.unableToDownloadImage(error.debugDescription.description))
                     return
                 }
 
                 guard let image = image as? UIImage else {
-                    continuation.resume(throwing: ImageError.unableToDownloadImage("NSItemProviderReading not an image"))
+                    continuation.resume(throwing: SiteImageError.unableToDownloadImage("NSItemProviderReading not an image"))
                     return
                 }
 

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/ImageHandler.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/ImageHandler.swift
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0
+
+import UIKit
+
+protocol ImageHandler {
+    func fetchFavicon(imageURL: URL, domain: String) async throws -> UIImage
+    func fetchHeroImage(siteURL: URL, domain: String) async throws -> UIImage
+}
+
+class DefaultImageHandler: ImageHandler {
+
+    init() {}
+
+    func fetchFavicon(imageURL: URL, domain: String) async throws -> UIImage {
+        return UIImage()
+    }
+
+    func fetchHeroImage(siteURL: URL, domain: String) async throws -> UIImage {
+        return UIImage()
+    }
+}

--- a/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/HeroImageFetcherTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/HeroImageFetcherTests.swift
@@ -41,11 +41,11 @@ final class HeroImageFetcherTests: XCTestCase {
             _ = try await subject.fetchHeroImage(from: URL(string: "www.example.com")!)
             XCTFail("Should have failed")
 
-        } catch let error as ImageError {
+        } catch let error as SiteImageError {
             XCTAssertEqual("Unable to download image with reason: Metadata image provider could not be retrieved.",
                            error.description)
         } catch {
-            XCTFail("Should have failed with ImageError type")
+            XCTFail("Should have failed with SiteImageError type")
         }
     }
 
@@ -59,11 +59,11 @@ final class HeroImageFetcherTests: XCTestCase {
             _ = try await subject.fetchHeroImage(from: URL(string: "www.example.com")!)
             XCTFail("Should have failed")
 
-        } catch let error as ImageError {
+        } catch let error as SiteImageError {
             XCTAssertEqual("Unable to download image with reason: Optional(A test error)",
                            error.description)
         } catch {
-            XCTFail("Should have failed with ImageError type")
+            XCTFail("Should have failed with SiteImageError type")
         }
     }
 

--- a/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/SiteImageCacheTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/SiteImageCacheTests.swift
@@ -34,7 +34,7 @@ final class SiteImageCacheTests: XCTestCase {
             XCTAssertEqual("Unable to retrieve image from cache with reason: The request is empty or `nil`.",
                            error.description)
         } catch {
-            XCTFail("Should have failed with ImageError type")
+            XCTFail("Should have failed with SiteImageError type")
         }
     }
 
@@ -49,7 +49,7 @@ final class SiteImageCacheTests: XCTestCase {
             XCTAssertEqual("Unable to retrieve image from cache with reason: Image was nil",
                            error.description)
         } catch {
-            XCTFail("Should have failed with ImageError type")
+            XCTFail("Should have failed with SiteImageError type")
         }
     }
 
@@ -84,7 +84,7 @@ final class SiteImageCacheTests: XCTestCase {
             XCTAssertEqual("Unable to cache image with reason: The request is empty or `nil`.",
                            error.description)
         } catch {
-            XCTFail("Should have failed with ImageError type")
+            XCTFail("Should have failed with SiteImageError type")
         }
     }
 

--- a/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/SiteImageFetcherTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/SiteImageFetcherTests.swift
@@ -32,7 +32,7 @@ final class SiteImageFetcherTests: XCTestCase {
             XCTAssertEqual("Unable to download image with reason: The request is empty or `nil`.",
                            error.description)
         } catch {
-            XCTFail("Should have failed with ImageError type")
+            XCTFail("Should have failed with SiteImageError type")
         }
     }
 


### PR DESCRIPTION
# [FXIOS-5257](https://mozilla-hub.atlassian.net/browse/FXIOS-5257)
- Fix ImageError -> SiteImageError
- Update hero image fetcher interface
- Ran swiftlint locally, as well as unit tests for BrowserKit

This fixes:
![Screen Shot 2022-12-06 at 2 34 34 PM](https://user-images.githubusercontent.com/11338480/206006246-c956031e-c022-4114-bbf1-6b95ab38a4d0.png)
