### PR TITLE
Add FXIOS-5257 [v109] Add image handler in BrowserKit

### DIFF
--- a/BrowserKit/Sources/SiteImageView/Entities/SiteImageError.swift
+++ b/BrowserKit/Sources/SiteImageView/Entities/SiteImageError.swift
@@ -11,6 +11,7 @@ enum SiteImageError: Error, CustomStringConvertible {
     case unableToCacheImage(String)
     case unableToRetrieveFromCache(String)
     case noURLInCache
+    case noHeroImage
 
     var description: String {
         switch self {
@@ -26,6 +27,8 @@ enum SiteImageError: Error, CustomStringConvertible {
             return "Unable to retrieve image from cache with reason: \(error)"
         case .noURLInCache:
             return "The URL was not found in the cache"
+        case .noHeroImage:
+            return "No hero image was found"
         }
     }
 }

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/BundleImageFetcher/BundleImageFetcher.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/BundleImageFetcher/BundleImageFetcher.swift
@@ -36,7 +36,7 @@ class DefaultBundleImageFetcher: BundleImageFetcher {
     // In case no bundled images could be retrieved, this will be set
     private var generalBundleError: BundleError?
 
-    init(bundleDataProvider: BundleDataProvider) {
+    init(bundleDataProvider: BundleDataProvider = DefaultBundleDataProvider()) {
         self.bundleDataProvider = bundleDataProvider
         bundledImages = retrieveBundledImages()
     }

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/ImageHandler.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/ImageHandler.swift
@@ -5,8 +5,34 @@
 import UIKit
 
 protocol ImageHandler {
-    func fetchFavicon(imageURL: URL?, domain: String) async throws -> UIImage
-    func fetchHeroImage(siteURL: URL, domain: String) async throws -> UIImage
+
+    /// The ImageHandler will fetch the favicon with the following precedence:
+    ///     1. Tries to fetch from the bundle.
+    ///     2. Tries to fetch from the cache.
+    ///     3. Tries to fetch from the image fetcher (from the web) if there's a URL. If there's no URL it fallbacks to the letter favicon.
+    ///     4. When all fails it returns the letter favicon.
+    ///
+    /// Any time the favicon is fetched, it will be cache for future usage.
+    ///
+    /// - Parameters:
+    ///   - imageURL: The image URL, can be nil if it could not be retrieved from the site
+    ///   - domain: The domain this favicon will be associated with
+    /// - Returns: The favicon image
+    func fetchFavicon(imageURL: URL?,
+                      domain: String) async throws -> UIImage
+
+    /// The ImageHandler will fetch the hero image with the following precedence
+    ///     1. Tries to fetch from the cache.
+    ///     2. Tries to fetch from the hero image fetcher (from the web).
+    ///     3. If all fails it throws an error
+    ///
+    /// Any time the hero image  is fetched, it will be cache for future usage.
+    /// - Parameters:
+    ///   - siteURL: The site URL to fetch the hero image from
+    ///   - domain: The domain this hero image will be associated with
+    /// - Returns: The hero image
+    func fetchHeroImage(siteURL: URL,
+                        domain: String) async throws -> UIImage
 }
 
 class DefaultImageHandler: ImageHandler {
@@ -29,16 +55,40 @@ class DefaultImageHandler: ImageHandler {
         self.heroImageFetcher = heroImageFetcher
     }
 
-    func fetchFavicon(imageURL: URL?, domain: String) async throws -> UIImage {
+    func fetchFavicon(imageURL: URL?,
+                      domain: String) async throws -> UIImage {
         do {
             return try bundleImageFetcher.getImageFromBundle(domain: domain)
+        } catch {
+            return try await fetchFaviconFromCache(imageURL: imageURL, domain: domain)
+        }
+    }
 
-        } catch is BundleError {
+    func fetchHeroImage(siteURL: URL,
+                        domain: String) async throws -> UIImage {
+        do {
+            return try await imageCache.getImageFromCache(domain: domain, type: .heroImage)
+        } catch {
+            return try await fetchHeroImageFromFetcher(siteURL: siteURL, domain: domain)
+        }
+    }
+
+    // MARK: Private
+
+    private func fetchFaviconFromCache(imageURL: URL?,
+                                       domain: String) async throws -> UIImage {
+        do {
             return try await imageCache.getImageFromCache(domain: domain, type: .favicon)
+        } catch {
+            return try await fetchFaviconFromFetcher(imageURL: imageURL, domain: domain)
+        }
+    }
 
-        } catch SiteImageError.unableToRetrieveFromCache {
+    private func fetchFaviconFromFetcher(imageURL: URL?,
+                                         domain: String) async throws -> UIImage {
+        do {
             guard let url = imageURL else {
-                return await fallbackLetterFavicon(domain: domain)
+                return await fallbackToLetterFavicon(domain: domain)
             }
 
             let image = try await imageFetcher.fetchImage(from: url)
@@ -46,22 +96,13 @@ class DefaultImageHandler: ImageHandler {
             return image
 
         } catch {
-            return await fallbackLetterFavicon(domain: domain)
+            return await fallbackToLetterFavicon(domain: domain)
         }
     }
 
-    // If we have no image URL or all other method fails, then use the letter favicon
-    private func fallbackLetterFavicon(domain: String) async -> UIImage {
-        let image = letterImageGenerator.generateLetterImage(domain: domain)
-        await imageCache.cacheImage(image: image, domain: domain, type: .favicon)
-        return image
-    }
-
-    func fetchHeroImage(siteURL: URL, domain: String) async throws -> UIImage {
+    private func fetchHeroImageFromFetcher(siteURL: URL,
+                                           domain: String) async throws -> UIImage {
         do {
-            return try await imageCache.getImageFromCache(domain: domain, type: .heroImage)
-
-        } catch SiteImageError.unableToRetrieveFromCache {
             let image = try await heroImageFetcher.fetchHeroImage(from: siteURL)
             await imageCache.cacheImage(image: image, domain: domain, type: .heroImage)
             return image
@@ -69,5 +110,11 @@ class DefaultImageHandler: ImageHandler {
         } catch {
             throw SiteImageError.noHeroImage
         }
+    }
+
+    private func fallbackToLetterFavicon(domain: String) async -> UIImage {
+        let image = letterImageGenerator.generateLetterImage(domain: domain)
+        await imageCache.cacheImage(image: image, domain: domain, type: .favicon)
+        return image
     }
 }

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/ImageHandler.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/ImageHandler.swift
@@ -11,13 +11,54 @@ protocol ImageHandler {
 
 class DefaultImageHandler: ImageHandler {
 
-    init() {}
+    private let bundleImageFetcher: BundleImageFetcher
+    private let imageCache: SiteImageCache
+    private let imageFetcher: SiteImageFetcher
+    private let letterImageGenerator: LetterImageGenerator
+    private let heroImageFetcher: HeroImageFetcher
+
+    init(bundleImageFetcher: BundleImageFetcher = DefaultBundleImageFetcher(),
+         imageCache: SiteImageCache = DefaultSiteImageCache(),
+         imageFetcher: SiteImageFetcher = DefaultSiteImageFetcher(),
+         letterImageGenerator: LetterImageGenerator = DefaultLetterImageGenerator(),
+         heroImageFetcher: HeroImageFetcher = DefaultHeroImageFetcher()) {
+        self.bundleImageFetcher = bundleImageFetcher
+        self.imageCache = imageCache
+        self.imageFetcher = imageFetcher
+        self.letterImageGenerator = letterImageGenerator
+        self.heroImageFetcher = heroImageFetcher
+    }
 
     func fetchFavicon(imageURL: URL, domain: String) async throws -> UIImage {
-        return UIImage()
+        do {
+            return try bundleImageFetcher.getImageFromBundle(domain: domain)
+
+        } catch is BundleError {
+            return try await imageCache.getImageFromCache(domain: domain, type: .favicon)
+
+        } catch SiteImageError.unableToRetrieveFromCache {
+            let image = try await imageFetcher.fetchImage(from: imageURL)
+            await imageCache.cacheImage(image: image, domain: domain, type: .favicon)
+            return image
+
+        } catch {
+            let image = letterImageGenerator.generateLetterImage(domain: domain)
+            await imageCache.cacheImage(image: image, domain: domain, type: .favicon)
+            return image
+        }
     }
 
     func fetchHeroImage(siteURL: URL, domain: String) async throws -> UIImage {
-        return UIImage()
+        do {
+            return try await imageCache.getImageFromCache(domain: domain, type: .heroImage)
+
+        } catch SiteImageError.unableToRetrieveFromCache {
+            let image = try await heroImageFetcher.fetchHeroImage(from: siteURL)
+            await imageCache.cacheImage(image: image, domain: domain, type: .heroImage)
+            return image
+
+        } catch {
+            throw SiteImageError.noHeroImage
+        }
     }
 }

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/ImageHandler.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/ImageHandler.swift
@@ -9,7 +9,7 @@ protocol ImageHandler {
     /// The ImageHandler will fetch the favicon with the following precedence:
     ///     1. Tries to fetch from the bundle.
     ///     2. Tries to fetch from the cache.
-    ///     3. Tries to fetch from the image fetcher (from the web) if there's a URL. If there's no URL it fallbacks to the letter favicon.
+    ///     3. Tries to fetch from the favicon fetcher (from the web) if there's a URL. If there's no URL it fallbacks to the letter favicon.
     ///     4. When all fails it returns the letter favicon.
     ///
     /// Any time the favicon is fetched, it will be cache for future usage.
@@ -39,18 +39,18 @@ class DefaultImageHandler: ImageHandler {
 
     private let bundleImageFetcher: BundleImageFetcher
     private let imageCache: SiteImageCache
-    private let imageFetcher: SiteImageFetcher
+    private let faviconFetcher: FaviconFetcher
     private let letterImageGenerator: LetterImageGenerator
     private let heroImageFetcher: HeroImageFetcher
 
     init(bundleImageFetcher: BundleImageFetcher = DefaultBundleImageFetcher(),
          imageCache: SiteImageCache = DefaultSiteImageCache(),
-         imageFetcher: SiteImageFetcher = DefaultSiteImageFetcher(),
+         faviconFetcher: FaviconFetcher = DefaultFaviconFetcher(),
          letterImageGenerator: LetterImageGenerator = DefaultLetterImageGenerator(),
          heroImageFetcher: HeroImageFetcher = DefaultHeroImageFetcher()) {
         self.bundleImageFetcher = bundleImageFetcher
         self.imageCache = imageCache
-        self.imageFetcher = imageFetcher
+        self.faviconFetcher = faviconFetcher
         self.letterImageGenerator = letterImageGenerator
         self.heroImageFetcher = heroImageFetcher
     }
@@ -91,7 +91,7 @@ class DefaultImageHandler: ImageHandler {
                 return await fallbackToLetterFavicon(domain: domain)
             }
 
-            let image = try await imageFetcher.fetchImage(from: url)
+            let image = try await faviconFetcher.fetchFavicon(from: url)
             await imageCache.cacheImage(image: image, domain: domain, type: .favicon)
             return image
 

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageCache/DefaultImageCache.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageCache/DefaultImageCache.swift
@@ -12,7 +12,7 @@ import UIKit
 protocol DefaultImageCache {
     func retrieveImage(forKey key: String) async throws -> UIImage?
 
-    func store(image: UIImage, forKey key: String) async throws
+    func store(image: UIImage, forKey key: String)
 }
 
 extension ImageCache: DefaultImageCache {
@@ -30,17 +30,7 @@ extension ImageCache: DefaultImageCache {
         }
     }
 
-    func store(image: UIImage, forKey key: String) async throws {
-        return try await withCheckedThrowingContinuation { continuation in
-            store(image, forKey: key) { result in
-                // memoryCacheResult never fails
-                switch result.diskCacheResult {
-                case .success:
-                    continuation.resume()
-                case .failure(let error):
-                    continuation.resume(throwing: error)
-                }
-            }
-        }
+    func store(image: UIImage, forKey key: String) {
+        self.store(image, forKey: key)
     }
 }

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageCache/SiteImageCache.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageCache/SiteImageCache.swift
@@ -21,10 +21,9 @@ protocol SiteImageCache {
     ///   - image: The image to cache
     ///   - domain: The image domain
     ///   - type: The image type
-    ///   Returns:  Calls completes with success or throws an error why the caching failed
     func cacheImage(image: UIImage,
                     domain: String,
-                    type: SiteImageType) async throws
+                    type: SiteImageType) async
 }
 
 actor DefaultSiteImageCache: SiteImageCache {
@@ -49,17 +48,9 @@ actor DefaultSiteImageCache: SiteImageCache {
         }
     }
 
-    func cacheImage(image: UIImage, domain: String, type: SiteImageType) async throws {
+    func cacheImage(image: UIImage, domain: String, type: SiteImageType) async {
         let key = cacheKey(from: domain, type: type)
-
-        do {
-            try await imageCache.store(image: image, forKey: key)
-
-        } catch let error as KingfisherError {
-            throw SiteImageError.unableToCacheImage(error.errorDescription ?? "No description")
-        } catch {
-            throw SiteImageError.unableToCacheImage("No description")
-        }
+        imageCache.store(image: image, forKey: key)
     }
 
     private func cacheKey(from domain: String, type: SiteImageType) -> String {

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/FaviconFetcher.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/FaviconFetcher.swift
@@ -5,14 +5,14 @@
 import UIKit
 import Kingfisher
 
-protocol SiteImageFetcher {
-    /// Fetches an image from a specific URL
+protocol FaviconFetcher {
+    /// Fetches a favicon image from a specific URL
     /// - Parameter imageURL: Given a certain image URL
     /// - Returns: An image or an image error following Result type
-    func fetchImage(from imageURL: URL) async throws -> UIImage
+    func fetchFavicon(from imageURL: URL) async throws -> UIImage
 }
 
-struct DefaultSiteImageFetcher: SiteImageFetcher {
+struct DefaultFaviconFetcher: FaviconFetcher {
 
     private let imageDownloader: SiteImageDownloader
 
@@ -20,7 +20,7 @@ struct DefaultSiteImageFetcher: SiteImageFetcher {
         self.imageDownloader = imageDownloader
     }
 
-    func fetchImage(from imageURL: URL) async throws -> UIImage {
+    func fetchFavicon(from imageURL: URL) async throws -> UIImage {
         do {
             let result = try await imageDownloader.downloadImage(with: imageURL)
             return result.image

--- a/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/FaviconFetcherTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/FaviconFetcherTests.swift
@@ -6,7 +6,7 @@ import XCTest
 import Kingfisher
 @testable import SiteImageView
 
-final class SiteImageFetcherTests: XCTestCase {
+final class FaviconFetcherTests: XCTestCase {
 
     private var mockImageDownloader: MockSiteImageDownloader!
 
@@ -22,10 +22,10 @@ final class SiteImageFetcherTests: XCTestCase {
 
     func testReturnsFailure_onAnyError() async {
         mockImageDownloader.error = KingfisherError.requestError(reason: .emptyRequest)
-        let subject = DefaultSiteImageFetcher(imageDownloader: mockImageDownloader)
+        let subject = DefaultFaviconFetcher(imageDownloader: mockImageDownloader)
 
         do {
-            _ = try await subject.fetchImage(from: URL(string: "www.mozilla.com")!)
+            _ = try await subject.fetchFavicon(from: URL(string: "www.mozilla.com")!)
             XCTFail("Should have failed with error")
 
         } catch let error as SiteImageError {
@@ -39,10 +39,10 @@ final class SiteImageFetcherTests: XCTestCase {
     func testReturnsSuccess_onImage() async {
         let resultImage = UIImage()
         mockImageDownloader.image = resultImage
-        let subject = DefaultSiteImageFetcher(imageDownloader: mockImageDownloader)
+        let subject = DefaultFaviconFetcher(imageDownloader: mockImageDownloader)
 
         do {
-            let result = try await subject.fetchImage(from: URL(string: "www.mozilla.com")!)
+            let result = try await subject.fetchFavicon(from: URL(string: "www.mozilla.com")!)
             XCTAssertEqual(resultImage, result)
 
         } catch {

--- a/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/ImageHandlerTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/ImageHandlerTests.swift
@@ -1,0 +1,335 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0
+
+import XCTest
+@testable import SiteImageView
+
+final class ImageHandlerTests: XCTestCase {
+
+    private var bundleImageFetcher: MockBundleImageFetcher!
+    private var heroImageFetcher: MockHeroImageFetcher!
+    private var siteImageCache: MockSiteImageCache!
+    private var siteImageFetcher: MockSiteImageFetcher!
+    private var letterImageGenerator: MockLetterImageGenerator!
+
+    override func setUp() {
+        super.setUp()
+        self.bundleImageFetcher = MockBundleImageFetcher()
+        self.heroImageFetcher = MockHeroImageFetcher()
+        self.siteImageCache = MockSiteImageCache()
+        self.siteImageFetcher = MockSiteImageFetcher()
+        self.letterImageGenerator = MockLetterImageGenerator()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        self.bundleImageFetcher = nil
+        self.heroImageFetcher = nil
+        self.siteImageCache = nil
+        self.siteImageFetcher = nil
+        self.letterImageGenerator = nil
+    }
+
+    // MARK: - Favicon
+
+    func testFavicon_whenImageInBundle_returnsBundleImage() async {
+        let expectedResult = UIImage()
+        bundleImageFetcher.image = expectedResult
+        let subject = createSubject()
+
+        do {
+            let result = try await subject.fetchFavicon(imageURL: URL(string: "www.mozilla.com")!,
+                                                        domain: "Mozilla")
+            XCTAssertEqual(expectedResult, result)
+            XCTAssertEqual(bundleImageFetcher.getImageFromBundleSucceedCalled, 1)
+            XCTAssertEqual(bundleImageFetcher.getImageFromBundleFailedCalled, 0)
+
+            XCTAssertEqual(siteImageCache.getImageFromCacheSucceedCalled, 0)
+            XCTAssertEqual(siteImageCache.getImageFromCacheFailedCalled, 0)
+
+            XCTAssertEqual(siteImageFetcher.fetchImageSucceedCalled, 0)
+            XCTAssertEqual(siteImageFetcher.fetchImageFailedCalled, 0)
+
+            XCTAssertEqual(siteImageCache.cacheImageCalled, 0)
+            XCTAssertEqual(letterImageGenerator.generateLetterImageCalled, 0)
+        } catch {
+            XCTFail("Should have succeeded with bundle image")
+        }
+    }
+
+    func testFavicon_whenImageInCache_returnsCacheImage() async {
+        let expectedResult = UIImage()
+        siteImageCache.image = expectedResult
+        let subject = createSubject()
+
+        do {
+            let result = try await subject.fetchFavicon(imageURL: URL(string: "www.mozilla.com")!,
+                                                        domain: "Mozilla")
+            XCTAssertEqual(expectedResult, result)
+            XCTAssertEqual(bundleImageFetcher.getImageFromBundleSucceedCalled, 0)
+            XCTAssertEqual(bundleImageFetcher.getImageFromBundleFailedCalled, 1)
+
+            XCTAssertEqual(siteImageCache.getImageFromCacheSucceedCalled, 1)
+            XCTAssertEqual(siteImageCache.getImageFromCacheFailedCalled, 0)
+            XCTAssertEqual(siteImageCache.getFromCacheWithType, .favicon)
+
+            XCTAssertEqual(siteImageFetcher.fetchImageSucceedCalled, 0)
+            XCTAssertEqual(siteImageFetcher.fetchImageFailedCalled, 0)
+
+            XCTAssertEqual(siteImageCache.cacheImageCalled, 0)
+            XCTAssertEqual(letterImageGenerator.generateLetterImageCalled, 0)
+
+        } catch {
+            XCTFail("Should have succeeded with cache image")
+        }
+    }
+
+    func testFavicon_whenNoUrl_returnsFallbackLetterFavicon() async {
+        let subject = createSubject()
+
+        do {
+            let result = try await subject.fetchFavicon(imageURL: nil,
+                                                        domain: "Mozilla")
+            XCTAssertEqual(letterImageGenerator.image, result)
+            XCTAssertEqual(bundleImageFetcher.getImageFromBundleSucceedCalled, 0)
+            XCTAssertEqual(bundleImageFetcher.getImageFromBundleFailedCalled, 1)
+
+            XCTAssertEqual(siteImageCache.getImageFromCacheSucceedCalled, 0)
+            XCTAssertEqual(siteImageCache.getImageFromCacheFailedCalled, 1)
+
+            XCTAssertEqual(siteImageFetcher.fetchImageSucceedCalled, 0)
+            XCTAssertEqual(siteImageFetcher.fetchImageFailedCalled, 0)
+
+            XCTAssertEqual(siteImageCache.cachedWithType, .favicon)
+            XCTAssertEqual(siteImageCache.cacheImageCalled, 1)
+            XCTAssertEqual(letterImageGenerator.generateLetterImageCalled, 1)
+
+        } catch {
+            XCTFail("Should have succeeded with fallback letter image")
+        }
+    }
+
+    func testFavicon_whenImageFetcher_returnsImageFetcherFavicon() async {
+        let expectedResult = UIImage()
+        siteImageFetcher.image = expectedResult
+        let subject = createSubject()
+
+        do {
+            let result = try await subject.fetchFavicon(imageURL: URL(string: "www.mozilla.com")!,
+                                                        domain: "Mozilla")
+            XCTAssertEqual(expectedResult, result)
+            XCTAssertEqual(bundleImageFetcher.getImageFromBundleSucceedCalled, 0)
+            XCTAssertEqual(bundleImageFetcher.getImageFromBundleFailedCalled, 1)
+
+            XCTAssertEqual(siteImageCache.getImageFromCacheSucceedCalled, 0)
+            XCTAssertEqual(siteImageCache.getImageFromCacheFailedCalled, 1)
+
+            XCTAssertEqual(siteImageFetcher.fetchImageSucceedCalled, 1)
+            XCTAssertEqual(siteImageFetcher.fetchImageFailedCalled, 0)
+
+            XCTAssertEqual(siteImageCache.cachedWithType, .favicon)
+            XCTAssertEqual(siteImageCache.cacheImageCalled, 1)
+            XCTAssertEqual(letterImageGenerator.generateLetterImageCalled, 0)
+
+        } catch {
+            XCTFail("Should have succeeded with fallback letter image")
+        }
+    }
+
+    func testFavicon_whenNoImages_returnsFallbackLetterFavicon() async {
+        let subject = createSubject()
+
+        do {
+            let result = try await subject.fetchFavicon(imageURL: URL(string: "www.mozilla.com")!,
+                                                        domain: "Mozilla")
+            XCTAssertEqual(letterImageGenerator.image, result)
+            XCTAssertEqual(bundleImageFetcher.getImageFromBundleSucceedCalled, 0)
+            XCTAssertEqual(bundleImageFetcher.getImageFromBundleFailedCalled, 1)
+
+            XCTAssertEqual(siteImageCache.getImageFromCacheSucceedCalled, 0)
+            XCTAssertEqual(siteImageCache.getImageFromCacheFailedCalled, 1)
+
+            XCTAssertEqual(siteImageFetcher.fetchImageSucceedCalled, 0)
+            XCTAssertEqual(siteImageFetcher.fetchImageFailedCalled, 1)
+
+            XCTAssertEqual(siteImageCache.cachedWithType, .favicon)
+            XCTAssertEqual(siteImageCache.cacheImageCalled, 1)
+            XCTAssertEqual(letterImageGenerator.generateLetterImageCalled, 1)
+
+        } catch {
+            XCTFail("Should have succeeded with fallback letter image")
+        }
+    }
+
+    // MARK: - Hero image
+
+    func testHeroImage_whenImageCached_returnsFromCache() async {
+        let expectedResult = UIImage()
+        siteImageCache.image = expectedResult
+        let subject = createSubject()
+
+        do {
+            let result = try await subject.fetchHeroImage(siteURL: URL(string: "www.mozilla.com")!,
+                                                          domain: "Mozilla")
+            XCTAssertEqual(expectedResult, result)
+            XCTAssertEqual(siteImageCache.getImageFromCacheSucceedCalled, 1)
+            XCTAssertEqual(siteImageCache.getImageFromCacheFailedCalled, 0)
+            XCTAssertEqual(siteImageCache.getFromCacheWithType, .heroImage)
+            XCTAssertEqual(siteImageCache.cacheImageCalled, 0)
+
+            XCTAssertEqual(heroImageFetcher.fetchHeroImageSucceedCalled, 0)
+            XCTAssertEqual(heroImageFetcher.fetchHeroImageFailedCalled, 0)
+
+        } catch {
+            XCTFail("Should have succeeded with fallback letter image")
+        }
+    }
+
+    func testHeroImage_whenImageFetcherHasImage_returnsFromImageFetcher() async {
+        let expectedResult = UIImage()
+        heroImageFetcher.image = expectedResult
+        let subject = createSubject()
+
+        do {
+            let result = try await subject.fetchHeroImage(siteURL: URL(string: "www.mozilla.com")!,
+                                                          domain: "Mozilla")
+            XCTAssertEqual(expectedResult, result)
+            XCTAssertEqual(siteImageCache.getImageFromCacheSucceedCalled, 0)
+            XCTAssertEqual(siteImageCache.getImageFromCacheFailedCalled, 1)
+            XCTAssertEqual(siteImageCache.cacheImageCalled, 1)
+
+            XCTAssertEqual(heroImageFetcher.fetchHeroImageSucceedCalled, 1)
+            XCTAssertEqual(heroImageFetcher.fetchHeroImageFailedCalled, 0)
+
+        } catch {
+            XCTFail("Should have succeeded with fallback letter image")
+        }
+    }
+
+    func testHeroImage_whenNoHeroImage_throwsNoHeroImageError() async {
+        let subject = createSubject()
+
+        do {
+            _ = try await subject.fetchHeroImage(siteURL: URL(string: "www.mozilla.com")!,
+                                                 domain: "Mozilla")
+
+            XCTFail("Should have failed with SiteImageError.noHeroImage")
+
+        } catch let error as SiteImageError {
+            XCTAssertEqual(error.description, "No hero image was found")
+            XCTAssertEqual(siteImageCache.getImageFromCacheSucceedCalled, 0)
+            XCTAssertEqual(siteImageCache.getImageFromCacheFailedCalled, 1)
+            XCTAssertEqual(siteImageCache.cacheImageCalled, 0)
+
+            XCTAssertEqual(heroImageFetcher.fetchHeroImageSucceedCalled, 0)
+            XCTAssertEqual(heroImageFetcher.fetchHeroImageFailedCalled, 1)
+
+        } catch {
+            XCTFail("Should have failed with SiteImageError.noHeroImage")
+        }
+    }
+}
+
+private extension ImageHandlerTests {
+    func createSubject() -> ImageHandler {
+        return DefaultImageHandler(bundleImageFetcher: bundleImageFetcher,
+                                   imageCache: siteImageCache,
+                                   imageFetcher: siteImageFetcher,
+                                   letterImageGenerator: letterImageGenerator,
+                                   heroImageFetcher: heroImageFetcher)
+    }
+}
+
+// MARK: - MockBundleImageFetcher
+private class MockBundleImageFetcher: BundleImageFetcher {
+
+    var image: UIImage?
+    var getImageFromBundleSucceedCalled = 0
+    var getImageFromBundleFailedCalled = 0
+
+    func getImageFromBundle(domain: String) throws -> UIImage {
+        if let image = image {
+            getImageFromBundleSucceedCalled += 1
+            return image
+        } else {
+            getImageFromBundleFailedCalled += 1
+            throw BundleError.noImage("")
+        }
+    }
+}
+
+// MARK: - MockHeroImageFetcher
+private class MockHeroImageFetcher: HeroImageFetcher {
+
+    var image: UIImage?
+    var fetchHeroImageSucceedCalled = 0
+    var fetchHeroImageFailedCalled = 0
+
+    func fetchHeroImage(from siteURL: URL) async throws -> UIImage {
+        if let image = image {
+            fetchHeroImageSucceedCalled += 1
+            return image
+        } else {
+            fetchHeroImageFailedCalled += 1
+            throw SiteImageError.noHeroImage
+        }
+    }
+}
+
+// MARK: - MockSiteImageCache
+private class MockSiteImageCache: SiteImageCache {
+
+    var image: UIImage?
+    var getImageFromCacheSucceedCalled = 0
+    var getImageFromCacheFailedCalled = 0
+    var getFromCacheWithType: SiteImageType?
+
+    func getImageFromCache(domain: String, type: SiteImageType) async throws -> UIImage {
+        getFromCacheWithType = type
+        if let image = image {
+            getImageFromCacheSucceedCalled += 1
+            return image
+        } else {
+            getImageFromCacheFailedCalled += 1
+            throw SiteImageError.unableToRetrieveFromCache("")
+        }
+    }
+
+    var cacheImageCalled = 0
+    var cachedWithType: SiteImageType?
+    func cacheImage(image: UIImage, domain: String, type: SiteImageType) async {
+        cacheImageCalled += 1
+        cachedWithType = type
+    }
+}
+
+// MARK: - MockSiteImageFetcher
+private class MockSiteImageFetcher: SiteImageFetcher {
+
+    var image: UIImage?
+    var fetchImageSucceedCalled = 0
+    var fetchImageFailedCalled = 0
+
+    func fetchImage(from imageURL: URL) async throws -> UIImage {
+        if let image = image {
+            fetchImageSucceedCalled += 1
+            return image
+        } else {
+            fetchImageFailedCalled += 1
+            throw SiteImageError.unableToDownloadImage("")
+        }
+    }
+}
+
+// MARK: - MockLetterImageGenerator
+private class MockLetterImageGenerator: LetterImageGenerator {
+
+    var image: UIImage = UIImage()
+    var generateLetterImageCalled = 0
+
+    func generateLetterImage(domain: String) -> UIImage {
+        generateLetterImageCalled += 1
+        return image
+    }
+}

--- a/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/ImageHandlerTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/ImageHandlerTests.swift
@@ -10,7 +10,7 @@ final class ImageHandlerTests: XCTestCase {
     private var bundleImageFetcher: MockBundleImageFetcher!
     private var heroImageFetcher: MockHeroImageFetcher!
     private var siteImageCache: MockSiteImageCache!
-    private var siteImageFetcher: MockSiteImageFetcher!
+    private var faviconFetcher: MockFaviconFetcher!
     private var letterImageGenerator: MockLetterImageGenerator!
 
     override func setUp() {
@@ -18,7 +18,7 @@ final class ImageHandlerTests: XCTestCase {
         self.bundleImageFetcher = MockBundleImageFetcher()
         self.heroImageFetcher = MockHeroImageFetcher()
         self.siteImageCache = MockSiteImageCache()
-        self.siteImageFetcher = MockSiteImageFetcher()
+        self.faviconFetcher = MockFaviconFetcher()
         self.letterImageGenerator = MockLetterImageGenerator()
     }
 
@@ -27,7 +27,7 @@ final class ImageHandlerTests: XCTestCase {
         self.bundleImageFetcher = nil
         self.heroImageFetcher = nil
         self.siteImageCache = nil
-        self.siteImageFetcher = nil
+        self.faviconFetcher = nil
         self.letterImageGenerator = nil
     }
 
@@ -48,8 +48,8 @@ final class ImageHandlerTests: XCTestCase {
             XCTAssertEqual(siteImageCache.getImageFromCacheSucceedCalled, 0)
             XCTAssertEqual(siteImageCache.getImageFromCacheFailedCalled, 0)
 
-            XCTAssertEqual(siteImageFetcher.fetchImageSucceedCalled, 0)
-            XCTAssertEqual(siteImageFetcher.fetchImageFailedCalled, 0)
+            XCTAssertEqual(faviconFetcher.fetchImageSucceedCalled, 0)
+            XCTAssertEqual(faviconFetcher.fetchImageFailedCalled, 0)
 
             XCTAssertEqual(siteImageCache.cacheImageCalled, 0)
             XCTAssertEqual(letterImageGenerator.generateLetterImageCalled, 0)
@@ -74,8 +74,8 @@ final class ImageHandlerTests: XCTestCase {
             XCTAssertEqual(siteImageCache.getImageFromCacheFailedCalled, 0)
             XCTAssertEqual(siteImageCache.getFromCacheWithType, .favicon)
 
-            XCTAssertEqual(siteImageFetcher.fetchImageSucceedCalled, 0)
-            XCTAssertEqual(siteImageFetcher.fetchImageFailedCalled, 0)
+            XCTAssertEqual(faviconFetcher.fetchImageSucceedCalled, 0)
+            XCTAssertEqual(faviconFetcher.fetchImageFailedCalled, 0)
 
             XCTAssertEqual(siteImageCache.cacheImageCalled, 0)
             XCTAssertEqual(letterImageGenerator.generateLetterImageCalled, 0)
@@ -98,8 +98,8 @@ final class ImageHandlerTests: XCTestCase {
             XCTAssertEqual(siteImageCache.getImageFromCacheSucceedCalled, 0)
             XCTAssertEqual(siteImageCache.getImageFromCacheFailedCalled, 1)
 
-            XCTAssertEqual(siteImageFetcher.fetchImageSucceedCalled, 0)
-            XCTAssertEqual(siteImageFetcher.fetchImageFailedCalled, 0)
+            XCTAssertEqual(faviconFetcher.fetchImageSucceedCalled, 0)
+            XCTAssertEqual(faviconFetcher.fetchImageFailedCalled, 0)
 
             XCTAssertEqual(siteImageCache.cachedWithType, .favicon)
             XCTAssertEqual(siteImageCache.cacheImageCalled, 1)
@@ -112,7 +112,7 @@ final class ImageHandlerTests: XCTestCase {
 
     func testFavicon_whenImageFetcher_returnsImageFetcherFavicon() async {
         let expectedResult = UIImage()
-        siteImageFetcher.image = expectedResult
+        faviconFetcher.image = expectedResult
         let subject = createSubject()
 
         do {
@@ -125,8 +125,8 @@ final class ImageHandlerTests: XCTestCase {
             XCTAssertEqual(siteImageCache.getImageFromCacheSucceedCalled, 0)
             XCTAssertEqual(siteImageCache.getImageFromCacheFailedCalled, 1)
 
-            XCTAssertEqual(siteImageFetcher.fetchImageSucceedCalled, 1)
-            XCTAssertEqual(siteImageFetcher.fetchImageFailedCalled, 0)
+            XCTAssertEqual(faviconFetcher.fetchImageSucceedCalled, 1)
+            XCTAssertEqual(faviconFetcher.fetchImageFailedCalled, 0)
 
             XCTAssertEqual(siteImageCache.cachedWithType, .favicon)
             XCTAssertEqual(siteImageCache.cacheImageCalled, 1)
@@ -150,8 +150,8 @@ final class ImageHandlerTests: XCTestCase {
             XCTAssertEqual(siteImageCache.getImageFromCacheSucceedCalled, 0)
             XCTAssertEqual(siteImageCache.getImageFromCacheFailedCalled, 1)
 
-            XCTAssertEqual(siteImageFetcher.fetchImageSucceedCalled, 0)
-            XCTAssertEqual(siteImageFetcher.fetchImageFailedCalled, 1)
+            XCTAssertEqual(faviconFetcher.fetchImageSucceedCalled, 0)
+            XCTAssertEqual(faviconFetcher.fetchImageFailedCalled, 1)
 
             XCTAssertEqual(siteImageCache.cachedWithType, .favicon)
             XCTAssertEqual(siteImageCache.cacheImageCalled, 1)
@@ -235,7 +235,7 @@ private extension ImageHandlerTests {
     func createSubject() -> ImageHandler {
         return DefaultImageHandler(bundleImageFetcher: bundleImageFetcher,
                                    imageCache: siteImageCache,
-                                   imageFetcher: siteImageFetcher,
+                                   faviconFetcher: faviconFetcher,
                                    letterImageGenerator: letterImageGenerator,
                                    heroImageFetcher: heroImageFetcher)
     }
@@ -304,14 +304,14 @@ private class MockSiteImageCache: SiteImageCache {
     }
 }
 
-// MARK: - MockSiteImageFetcher
-private class MockSiteImageFetcher: SiteImageFetcher {
+// MARK: - MockFaviconFetcher
+private class MockFaviconFetcher: FaviconFetcher {
 
     var image: UIImage?
     var fetchImageSucceedCalled = 0
     var fetchImageFailedCalled = 0
 
-    func fetchImage(from imageURL: URL) async throws -> UIImage {
+    func fetchFavicon(from imageURL: URL) async throws -> UIImage {
         if let image = image {
             fetchImageSucceedCalled += 1
             return image

--- a/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/SiteImageCacheTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/SiteImageCacheTests.swift
@@ -70,36 +70,13 @@ final class SiteImageCacheTests: XCTestCase {
 
     // MARK: - Cache image
 
-    func testCacheImage_whenError_returnsError() async {
-        let expectedImage = UIImage()
-        imageCache.storageError = KingfisherError.requestError(reason: .emptyRequest)
-        let subject = DefaultSiteImageCache(imageCache: imageCache)
-
-        do {
-            _ = try await subject.cacheImage(image: expectedImage, domain: "www.firefox.com", type: .favicon)
-
-        } catch let error as SiteImageError {
-            XCTAssertEqual(imageCache.capturedStorageKey, "www.firefox.com-favicon")
-            XCTAssertEqual(imageCache.capturedImage, expectedImage)
-            XCTAssertEqual("Unable to cache image with reason: The request is empty or `nil`.",
-                           error.description)
-        } catch {
-            XCTFail("Should have failed with SiteImageError type")
-        }
-    }
-
     func testCacheImage_whenSuccess_returnsSuccess() async {
         let expectedImage = UIImage()
         let subject = DefaultSiteImageCache(imageCache: imageCache)
 
-        do {
-            _ = try await subject.cacheImage(image: expectedImage, domain: "www.firefox.com", type: .favicon)
-            XCTAssertEqual(imageCache.capturedStorageKey, "www.firefox.com-favicon")
-            XCTAssertEqual(imageCache.capturedImage, expectedImage)
-
-        } catch {
-            XCTFail("Should have succeeded")
-        }
+        _ = await subject.cacheImage(image: expectedImage, domain: "www.firefox.com", type: .favicon)
+        XCTAssertEqual(imageCache.capturedStorageKey, "www.firefox.com-favicon")
+        XCTAssertEqual(imageCache.capturedImage, expectedImage)
     }
 }
 
@@ -117,14 +94,10 @@ private class MockDefaultImageCache: DefaultImageCache {
         }
     }
 
-    var storageError: KingfisherError?
     var capturedImage: UIImage?
     var capturedStorageKey: String?
-    func store(image: UIImage, forKey key: String) async throws {
+    func store(image: UIImage, forKey key: String) {
         capturedImage = image
         capturedStorageKey = key
-        if let error = storageError {
-            throw error
-        }
     }
 }


### PR DESCRIPTION
# [FXIOS-5257](https://mozilla-hub.atlassian.net/browse/FXIOS-5257) https://github.com/mozilla-mobile/firefox-ios/issues/12388
- The last piece of the Image Processing, adding a bit more documentation for it since this is overvieweing all of the other parts of the Image Processing of the SiteImageView.
- Removed throwing error for ImageCache. It was introducing the case where if there's a saving to disk error while saving with Kingfisher, we would not return an image even if we had one (since ImageHandler would throw an error before returning the image, and fall into the next catch block). Kingfisher states that we should for sure at least cache to memory. I rather return an image that is only cached in memory and not to disk than return no image at all. 
- Rename SiteImageFetcher to FaviconFetcher since SiteImageFetcher will be another class
- Won't run BR for this PR as this is in a different package. Ran the tests and swiftlint locally for it