### PR TITLE
Refactor FXIOS-5383 [v108] ForegroundBVC made optional and sentry logs

### DIFF
--- a/Client/Application/AppDelegate+PushNotifications.swift
+++ b/Client/Application/AppDelegate+PushNotifications.swift
@@ -86,7 +86,9 @@ extension AppDelegate {
         if UIApplication.shared.applicationState == .active {
             let browserViewController = BrowserViewController.foregroundBVC()
 
-            browserViewController.loadQueuedTabs(receivedURLs: receivedUrlsQueue)
+            // TODO: Temporary. foregrounding BVC to open tabs is going to be addressed soon.
+            // See https://mozilla-hub.atlassian.net/browse/FXIOS-5289
+            browserViewController?.loadQueuedTabs(receivedURLs: receivedUrlsQueue)
         }
     }
 }

--- a/Client/Application/AppDelegate+SyncSentTabs.swift
+++ b/Client/Application/AppDelegate+SyncSentTabs.swift
@@ -32,7 +32,9 @@ class AppSyncDelegate: SyncDelegate {
     func displaySentTab(for url: URL, title: String, from deviceName: String?) {
         DispatchQueue.main.async {
             if self.app.applicationState == .active {
-                BrowserViewController.foregroundBVC().switchToTabForURLOrOpen(url)
+                // TODO: Temporary. foregrounding BVC to open tabs is going to be addressed soon.
+                // See https://mozilla-hub.atlassian.net/browse/FXIOS-5289
+                BrowserViewController.foregroundBVC()?.switchToTabForURLOrOpen(url)
                 return
             }
 

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -108,7 +108,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) { [weak self] in
             self?.profile.cleanupHistoryIfNeeded()
             self?.ratingPromptManager.updateData()
-            BrowserViewController.foregroundBVC().loadQueuedTabs()
+
+            // TODO: Temporary.
+            // Although `sceneDidBecomeActive` doesn't result in the same behavior as applicationDidBecomeActive,
+            // we can possibly observe UIApplication.didBecomeActiveNotification inside SceneDelegate and invoke
+            // loadQueuedTabs there. That can cut a foregroundBVC call.
+            BrowserViewController.foregroundBVC()?.loadQueuedTabs()
         }
     }
 

--- a/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
+++ b/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
@@ -134,7 +134,7 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
         /// With our well-formed URL, we can handle the action here.
         if url.isWebPage() {
             let bvc = BrowserViewController.foregroundBVC()
-            
+
             // TODO: Temporary. foregrounding BVC to open tabs is going to be addressed soon.
             // See https://mozilla-hub.atlassian.net/browse/FXIOS-5289
             bvc?.openURLInNewTab(url)

--- a/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
+++ b/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
@@ -134,7 +134,10 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
         /// With our well-formed URL, we can handle the action here.
         if url.isWebPage() {
             let bvc = BrowserViewController.foregroundBVC()
-            bvc.openURLInNewTab(url)
+            
+            // TODO: Temporary. foregrounding BVC to open tabs is going to be addressed soon.
+            // See https://mozilla-hub.atlassian.net/browse/FXIOS-5289
+            bvc?.openURLInNewTab(url)
         } else {
             UIApplication.shared.open(url, options: [:])
         }

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -606,7 +606,10 @@ extension TabDisplayManager: GroupedTabDelegate {
 
     func newSearchFromGroup(searchTerm: String) {
         let bvc = BrowserViewController.foregroundBVC()
-        bvc.openSearchNewTab(searchTerm)
+
+        // TODO: Temporary. foregrounding BVC to open tabs is going to be addressed soon.
+        // See https://mozilla-hub.atlassian.net/browse/FXIOS-5289
+        bvc?.openSearchNewTab(searchTerm)
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .groupedTabPerformSearch)
     }
 

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -427,7 +427,10 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
     }
 
     @objc private func presentContextualHint(contextualHintViewController: ContextualHintViewController) {
-        guard BrowserViewController.foregroundBVC().searchController == nil, canModalBePresented else {
+        // TODO: Temporary
+        // This is one case where foregroundBVC is accessed to check the existance of a property.
+        // See https://mozilla-hub.atlassian.net/browse/FXIOS-5286
+        guard BrowserViewController.foregroundBVC()?.searchController == nil, canModalBePresented else {
             contextualHintViewController.stopTimer()
             return
         }

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -659,7 +659,10 @@ class OpenFiftyTabsDebugOption: HiddenSetting {
 
     override func onClick(_ navigationController: UINavigationController?) {
         guard let url = URL(string: "https://www.mozilla.org") else { return }
-        BrowserViewController.foregroundBVC().debugOpen(numberOfNewTabs: 50, at: url)
+
+        // TODO: Temporary. foregrounding BVC to open tabs is going to be addressed soon.
+        // See https://mozilla-hub.atlassian.net/browse/FXIOS-5289
+        BrowserViewController.foregroundBVC()?.debugOpen(numberOfNewTabs: 50, at: url)
     }
 }
 
@@ -820,7 +823,9 @@ class ShowIntroductionSetting: Setting {
 
     override func onClick(_ navigationController: UINavigationController?) {
         navigationController?.dismiss(animated: true, completion: {
-            BrowserViewController.foregroundBVC().presentIntroViewController(true)
+            // TODO: Temporary.
+            // This instance of foregroundBVC is going to be revisited after having enough telemetry of ShowTour.
+            BrowserViewController.foregroundBVC()?.presentIntroViewController(true)
 
             TelemetryWrapper.recordEvent(
                 category: .action,

--- a/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -275,7 +275,7 @@ extension HomePageSettingViewController {
         override var style: UITableViewCell.CellStyle { return .value1 }
 
         init(settings: SettingsTableViewController,
-             and tabManager: TabManager = BrowserViewController.foregroundBVC().tabManager,
+             and tabManager: TabManager = AppContainer.shared.resolve(),
              wallpaperManager: WallpaperManagerInterface = WallpaperManager()
         ) {
             self.settings = settings

--- a/Client/Frontend/TabContentsScripts/DownloadContentScript.swift
+++ b/Client/Frontend/TabContentsScripts/DownloadContentScript.swift
@@ -57,7 +57,7 @@ class DownloadContentScript: TabContentScript {
         let browserViewController = BrowserViewController.foregroundBVC()
 
         defer {
-            browserViewController.pendingDownloadWebView = nil
+            browserViewController?.pendingDownloadWebView = nil
             DownloadContentScript.blobUrlForDownload = nil
         }
 
@@ -84,6 +84,9 @@ class DownloadContentScript: TabContentScript {
         }
 
         let download = BlobDownload(filename: filename, mimeType: mimeType, size: size, data: data)
-        browserViewController.downloadQueue.enqueue(download)
+
+        // TODO: Temporary - DownloadQueue access will be moved out of BVC soon.
+        // See https://mozilla-hub.atlassian.net/browse/FXIOS-5290
+        browserViewController?.downloadQueue.enqueue(download)
     }
 }


### PR DESCRIPTION
# [FXIOS-5383](https://mozilla-hub.atlassian.net/browse/FXIOS-5383) | #12601 

TLDR: ForegroundBVC made optional & sentry logging added. 

## Details
With the transition to [a single scened app](https://github.com/mozilla-mobile/firefox-ios/pull/12241), we've, surprisingly, started seeing crashes caused by times where a scene doesn't exist, [even five seconds](https://github.com/mozilla-mobile/firefox-ios/blob/63fead9be61920f5a724f2e8ac9d3d4f29e73ecb/Client/Application/AppDelegate.swift#L108) into the app session. 

Until we can investigate how and why this happens, we're going to temporarily make foregroundBVC return an optional. We are aware that this will break functionality where BVC is expected to be non-nil. However, these cases should be very rare, and we'll have some logs for it by then. 