### PR TITLE
Refactor FXIOS-5400 [v108] Remove foregroundBVC in AppDelegate

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -106,12 +106,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) { [weak self] in
             self?.profile.cleanupHistoryIfNeeded()
             self?.ratingPromptManager.updateData()
-
-            // TODO: Temporary.
-            // Although `sceneDidBecomeActive` doesn't result in the same behavior as applicationDidBecomeActive,
-            // we can possibly observe UIApplication.didBecomeActiveNotification inside SceneDelegate and invoke
-            // loadQueuedTabs there. That can cut a foregroundBVC call.
-            BrowserViewController.foregroundBVC()?.loadQueuedTabs()
         }
     }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -392,6 +392,12 @@ class BrowserViewController: UIViewController {
 
         tabManager.startAtHomeCheck()
         updateWallpaperMetadata()
+
+        /// When, for example, you "Load in Background" via the share sheet, the tab is added to `Profile`'s `TabQueue`.
+        /// So, we delay five seconds because we need to wait for `Profile` to be initialized and setup for use.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) { [weak self] in
+            self?.loadQueuedTabs()
+        }
     }
 
     // MARK: - Lifecycle


### PR DESCRIPTION
# [FXIOS-5400](https://mozilla-hub.atlassian.net/browse/FXIOS-5400) | #12629 

TLDR: Moved this loadQueuedTabs call out of AppDelegate's `applicationDidBecomeActive` and into BVC's `appDidBecomeActiveNotification`.

BVC was already observing `UIApplication.didBecomeActiveNotification`, so we get the same behavior by moving that method call into here. 