### PR TITLE
Refactor FXIOS-5408 [v108] Remove BVC dependence in homepageVC

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1105,6 +1105,7 @@ class BrowserViewController: UIViewController {
         }
 
         homepageViewController?.view?.isHidden = true
+        homepageViewController?.homepageWillDisappear()
 
         searchController.didMove(toParent: self)
     }
@@ -1114,7 +1115,9 @@ class BrowserViewController: UIViewController {
         searchController.willMove(toParent: nil)
         searchController.view.removeFromSuperview()
         searchController.removeFromParent()
+
         homepageViewController?.view?.isHidden = false
+        homepageViewController?.homepageWillAppear(isZeroSearch: false)
 
         keyboardBackdrop?.removeFromSuperview()
         keyboardBackdrop = nil

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -428,7 +428,7 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
         // TODO: Temporary
         // This is one case where foregroundBVC is accessed to check the existance of a property.
         // See https://mozilla-hub.atlassian.net/browse/FXIOS-5286
-        guard BrowserViewController.foregroundBVC()?.searchController == nil, canModalBePresented else {
+        guard viewModel.viewAppeared, canModalBePresented else {
             contextualHintViewController.stopTimer()
             return
         }

--- a/Client/Frontend/Home/HomepageViewModel.swift
+++ b/Client/Frontend/Home/HomepageViewModel.swift
@@ -75,7 +75,7 @@ class HomepageViewModel: FeatureFlaggable {
     }
 
     /// Record view appeared is sent multiple times, this avoids recording telemetry multiple times for one appearance
-    private var viewAppeared: Bool = false
+    var viewAppeared: Bool = false
 
     var shownSections = [HomepageSectionType]()
     weak var delegate: HomepageViewModelDelegate?


### PR DESCRIPTION
# [FXIOS-5408](https://mozilla-hub.atlassian.net/browse/FXIOS-5408) | #12640 

TLDR: Instead of checking if SearchViewController exists FROM HomePageViewController, we'll transition to check if HomePageViewController is visible at all. If SearchVC is visible, HomePage's alpha makes it hidden. 

When searchVC is removed, homePage is unhidden (this happens inside BVC). So we can take advantage of these points.