### PR TITLE
Refactor FXIOS-5289 [v109] Remove loadQueuedTabs BVC foreground call with notification

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -478,6 +478,7 @@
 		8A04136928258DF600D20B10 /* SponsoredTileTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A04136828258DF600D20B10 /* SponsoredTileTelemetry.swift */; };
 		8A04136B2825ABEA00D20B10 /* SponsoredTileTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A04136A2825ABEA00D20B10 /* SponsoredTileTelemetryTests.swift */; };
 		8A05123927D17EC3009930CC /* LegacyWallpaperStorageUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A05123827D17EC3009930CC /* LegacyWallpaperStorageUtility.swift */; };
+		8A0621B829428FBD005D1EFD /* OpenTabNotificationObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0621B729428FBD005D1EFD /* OpenTabNotificationObject.swift */; };
 		8A07910F278F62F2005529CB /* AdjustHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A07910E278F62F2005529CB /* AdjustHelper.swift */; };
 		8A08EC6227EBDCA400E119C7 /* iAd.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E4B334871BBF23F3004E2BFF /* iAd.framework */; };
 		8A08EC6427EBDCAD00E119C7 /* AdServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A08EC6327EBDCAC00E119C7 /* AdServices.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
@@ -3273,6 +3274,7 @@
 		8A05816B28B56DD700FD8D46 /* hi-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "hi-IN"; path = "hi-IN.lproj/WidgetIntents.strings"; sourceTree = "<group>"; };
 		8A05817B28B56DD700FD8D46 /* ast */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ast; path = ast.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
 		8A05818B28B56DD700FD8D46 /* te */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = te; path = te.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
+		8A0621B729428FBD005D1EFD /* OpenTabNotificationObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenTabNotificationObject.swift; sourceTree = "<group>"; };
 		8A07910E278F62F2005529CB /* AdjustHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdjustHelper.swift; sourceTree = "<group>"; };
 		8A08EC6327EBDCAC00E119C7 /* AdServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdServices.framework; path = System/Library/Frameworks/AdServices.framework; sourceTree = SDKROOT; };
 		8A0F2A7D286DFCC800D84CC6 /* PushRemoteError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushRemoteError.swift; sourceTree = "<group>"; };
@@ -7427,6 +7429,7 @@
 				744ED5601DBFEB8D00A2B5BE /* MailtoLinkHandler.swift */,
 				D0C95E35200FDC5400E4E51C /* MetadataParserHelper.swift */,
 				74821FC41DB56A2500EEEA72 /* OpenWithSettingsViewController.swift */,
+				8A0621B729428FBD005D1EFD /* OpenTabNotificationObject.swift */,
 				D31CF65B1CC1959A001D0BD0 /* PrivilegedRequest.swift */,
 				FA6B2AC11D41F02D00429414 /* String+Punycode.swift */,
 				FA9294001D6584A200AC8D33 /* QRCode.xcassets */,
@@ -10246,6 +10249,7 @@
 				8A93080B27C01AD60052167D /* SingleActionViewModel.swift in Sources */,
 				8A7368AD27924AAF005D7704 /* CanRemoveQuickActionBookmark.swift in Sources */,
 				EBA3B2CD2268F27500728BDB /* PhotonActionSheetWidgets.swift in Sources */,
+				8A0621B829428FBD005D1EFD /* OpenTabNotificationObject.swift in Sources */,
 				C8D0D6F2281C182D00AFAED9 /* FeatureFlagUserPrefsMigrationUtility.swift in Sources */,
 				D3C3696E1CC6B78800348A61 /* LocalRequestHelper.swift in Sources */,
 				C87DC85C27B2C94D006EFCE2 /* LegacyWallpaperResourceManager.swift in Sources */,

--- a/Client/Application/AppDelegate+PushNotifications.swift
+++ b/Client/Application/AppDelegate+PushNotifications.swift
@@ -82,13 +82,10 @@ extension AppDelegate {
             }
         }
 
-        // Check if the app is foregrounded, _also_ verify the BVC is initialized. Most BVC functions depend on viewDidLoad() having run –if not, they will crash.
+        // Check if the app is foregrounded
         if UIApplication.shared.applicationState == .active {
-            let browserViewController = BrowserViewController.foregroundBVC()
-
-            // TODO: Temporary. foregrounding BVC to open tabs is going to be addressed soon.
-            // See https://mozilla-hub.atlassian.net/browse/FXIOS-5289
-            browserViewController?.loadQueuedTabs(receivedURLs: receivedUrlsQueue)
+            let object = OpenTabNotificationObject(type: .loadQueuedTabs(receivedUrlsQueue))
+            NotificationCenter.default.post(name: .OpenTabNotification, object: object)
         }
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -219,6 +219,17 @@ class BrowserViewController: UIViewController {
         leaveOverlayMode(didCancel: true)
     }
 
+    @objc func openTabNotification(notification: Notification) {
+        guard let openTabObject = notification.object as? OpenTabNotificationObject else {
+            return
+        }
+
+        switch openTabObject.type {
+        case .loadQueuedTabs(let urls):
+            loadQueuedTabs(receivedURLs: urls)
+        }
+    }
+
     @objc func searchBarPositionDidChange(notification: Notification) {
         guard let dict = notification.object as? NSDictionary,
               let newSearchBarPosition = dict[PrefsKeys.FeatureFlags.SearchBarPosition] as? SearchBarPosition,
@@ -488,6 +499,11 @@ class BrowserViewController: UIViewController {
             self,
             selector: #selector(didTapUndoCloseAllTabToast),
             name: .DidTapUndoCloseAllTabToast,
+            object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(openTabNotification),
+            name: .OpenTabNotification,
             object: nil)
     }
 

--- a/Client/Frontend/Browser/OpenTabNotificationObject.swift
+++ b/Client/Frontend/Browser/OpenTabNotificationObject.swift
@@ -8,7 +8,6 @@ import Foundation
 // a singleton. This is an intermediary step to move towards multiple windows
 // as part of the multitasking epic.
 struct OpenTabNotificationObject {
-
     enum ObjectType {
         case loadQueuedTabs([URL])
     }

--- a/Client/Frontend/Browser/OpenTabNotificationObject.swift
+++ b/Client/Frontend/Browser/OpenTabNotificationObject.swift
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+// This notification is to help us move away from using BrowserViewController as
+// a singleton. This is an intermediary step to move towards multiple windows
+// as part of the multitasking epic.
+struct OpenTabNotificationObject {
+
+    enum ObjectType {
+        case loadQueuedTabs([URL])
+    }
+
+    var type: ObjectType
+}

--- a/Shared/NotificationConstants.swift
+++ b/Shared/NotificationConstants.swift
@@ -89,6 +89,9 @@ extension Notification.Name {
     // fired when user taps on undo button on Toast
     public static let DidTapUndoCloseAllTabToast = Notification.Name("DidTapUndoCloseAllTabToast")
 
+    // Has to be used in combination of OpenTabNotificationObject
+    public static let OpenTabNotification = Notification.Name("OpenTabNotification")
+
     // MARK: Settings
 
     public static let BookmarksUpdated = Notification.Name("BookmarksUpdated")


### PR DESCRIPTION
# [FXIOS-5289](https://mozilla-hub.atlassian.net/browse/FXIOS-5289) https://github.com/mozilla-mobile/firefox-ios/issues/12635
- Removing BVC loadQueuedTabs in AppDelegate+PushNotification.swift
- Creating OpenTabNotificationObject to handle different tab management inside BVC with the same notification. Having different types in it to send different payload.
