### PR TITLE
Refactor FXIOS-5405 [v108] Remove foregroundBVC dependence in HistoryPanel

### DIFF
--- a/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -40,8 +40,7 @@ enum MenuButtonToastAction {
 ///     - The home page menu, determined with isHomePage variable
 ///     - The file URL menu, shown when the user is on a url of type `file://`
 ///     - The site menu, determined by the absence of isHomePage and isFileURL
-class MainMenuActionHelper:
-    PhotonActionSheetProtocol,
+class MainMenuActionHelper: PhotonActionSheetProtocol,
     FeatureFlaggable,
     CanRemoveQuickActionBookmark,
     AppVersionUpdateCheckerProtocol {

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -754,7 +754,6 @@ extension HistoryPanel {
         let nextController = RecentlyClosedTabsPanel(profile: profile)
         nextController.title = .RecentlyClosedTabsPanelTitle
         nextController.libraryPanelDelegate = libraryPanelDelegate
-        nextController.recentlyClosedTabsDelegate = BrowserViewController.foregroundBVC()
         refreshControl?.endRefreshing()
         navigationController?.pushViewController(nextController, animated: true)
     }

--- a/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
+++ b/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
@@ -56,6 +56,14 @@ class RecentlyClosedTabsPanel: UIViewController, LibraryPanel {
             tableViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
     }
+
+    override func viewDidAppear(_ animated: Bool) {
+        guard recentlyClosedTabsDelegate != nil else {
+            recentlyClosedTabsDelegate = sceneForVC?.browserViewController
+
+            return
+        }
+    }
 }
 
 class RecentlyClosedTabsPanelSiteTableViewController: SiteTableViewController {

--- a/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
+++ b/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
@@ -58,6 +58,11 @@ class RecentlyClosedTabsPanel: UIViewController, LibraryPanel {
     }
 
     override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        /// BVC is assigned as `RecentlyClosedTabsPanel` delegate, to support opening tabs from within it.
+        /// Previously, BVC was assigned it on panel creation via a foregroundBVC call. But it can be done this way, to
+        /// avoid that call. `sceneForVC` will use the focused, active and foregrounded scene's BVC.
         guard recentlyClosedTabsDelegate != nil else {
             recentlyClosedTabsDelegate = sceneForVC?.browserViewController
 

--- a/Client/Frontend/Login Management/LoginListViewController.swift
+++ b/Client/Frontend/Login Management/LoginListViewController.swift
@@ -169,6 +169,8 @@ class LoginListViewController: SensitiveViewController, Themeable {
     }
 
     override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
         guard settingsDelegate != nil else {
             settingsDelegate = sceneForVC?.browserViewController
 

--- a/Client/Frontend/Login Management/LoginListViewController.swift
+++ b/Client/Frontend/Login Management/LoginListViewController.swift
@@ -170,7 +170,7 @@ class LoginListViewController: SensitiveViewController, Themeable {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
+
         guard settingsDelegate != nil else {
             settingsDelegate = sceneForVC?.browserViewController
 


### PR DESCRIPTION
# [FXIOS-5405](https://mozilla-hub.atlassian.net/browse/FXIOS-5405) | #12637 

TLDR: BrowserVC was assigned as the delegate for RecentlyClosedTabsPanel by foregroundingBVC prior. Now, we walk the chain and assign BVC as the delegate.