### PR TITLE
Refactor FXIOS-5403 [v109] Replace foreground BVC with open tab notification

### DIFF
--- a/Client/Application/AppDelegate+SyncSentTabs.swift
+++ b/Client/Application/AppDelegate+SyncSentTabs.swift
@@ -32,9 +32,8 @@ class AppSyncDelegate: SyncDelegate {
     func displaySentTab(for url: URL, title: String, from deviceName: String?) {
         DispatchQueue.main.async {
             if self.app.applicationState == .active {
-                // TODO: Temporary. foregrounding BVC to open tabs is going to be addressed soon.
-                // See https://mozilla-hub.atlassian.net/browse/FXIOS-5289
-                BrowserViewController.foregroundBVC()?.switchToTabForURLOrOpen(url)
+                let object = OpenTabNotificationObject(type: .switchToTabForURLOrOpen(url))
+                NotificationCenter.default.post(name: .OpenTabNotification, object: object)
                 return
             }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -227,6 +227,8 @@ class BrowserViewController: UIViewController {
         switch openTabObject.type {
         case .loadQueuedTabs(let urls):
             loadQueuedTabs(receivedURLs: urls)
+        case .switchToTabForURLOrOpen(let url):
+            switchToTabForURLOrOpen(url)
         }
     }
 

--- a/Client/Frontend/Browser/OpenTabNotificationObject.swift
+++ b/Client/Frontend/Browser/OpenTabNotificationObject.swift
@@ -10,6 +10,7 @@ import Foundation
 struct OpenTabNotificationObject {
     enum ObjectType {
         case loadQueuedTabs([URL])
+        case switchToTabForURLOrOpen(URL)
     }
 
     var type: ObjectType


### PR DESCRIPTION
# [FXIOS-5403](https://mozilla-hub.atlassian.net/browse/FXIOS-5403) https://github.com/mozilla-mobile/firefox-ios/issues/12635
Replace foreground BVC with open tab notification in AppDelegate+SyncSentTabs