### PR TITLE
Refactor FXIOS-5404 [v109] Use delegate for glean plumb to remove foreground call

### DIFF
--- a/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
+++ b/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
@@ -8,6 +8,10 @@ import MozillaAppServices
 import Shared
 
 protocol GleanPlumbMessageManagerProtocol {
+
+    /// Delegate protocol to open Glean message when pressed
+    var pressedDelegate: GleanPlumbMessagePressedDelegate? { get set }
+
     /// Performs the bookkeeping and preparation of messages for their respective surfaces.
     /// We can build our collection of eligible messages for a surface in here.
     func onStartup()
@@ -34,6 +38,10 @@ protocol GleanPlumbMessageManagerProtocol {
     func onMalformedMessage(messageKey: String)
 }
 
+protocol GleanPlumbMessagePressedDelegate: AnyObject {
+    func openURLInNewTab(url: URL)
+}
+
 /// To the surface that requests messages, it provides valid and triggered messages in priority order.
 ///
 /// Note: The term "valid" in `GleanPlumbMessage` context means a well-formed, non-expired, priority ordered message.
@@ -54,6 +62,8 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
     private let messagingUtility: GleanPlumbMessageUtility
     private let messagingStore: GleanPlumbMessageStoreProtocol
     private let feature = FxNimbus.shared.features.messaging.value()
+
+    weak var pressedDelegate: GleanPlumbMessagePressedDelegate?
 
     // MARK: - Inits
 
@@ -131,11 +141,7 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
 
         /// With our well-formed URL, we can handle the action here.
         if url.isWebPage() {
-            let bvc = BrowserViewController.foregroundBVC()
-
-            // TODO: Temporary. foregrounding BVC to open tabs is going to be addressed soon.
-            // See https://mozilla-hub.atlassian.net/browse/FXIOS-5289
-            bvc?.openURLInNewTab(url)
+            pressedDelegate?.openURLInNewTab(url: url)
         } else {
             UIApplication.shared.open(url, options: [:])
         }

--- a/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
+++ b/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
@@ -8,7 +8,6 @@ import MozillaAppServices
 import Shared
 
 protocol GleanPlumbMessageManagerProtocol {
-
     /// Delegate protocol to open Glean message when pressed
     var pressedDelegate: GleanPlumbMessagePressedDelegate? { get set }
 

--- a/Client/Experiments/Messaging/GleanPlumbMessageStore.swift
+++ b/Client/Experiments/Messaging/GleanPlumbMessageStore.swift
@@ -54,7 +54,7 @@ class GleanPlumbMessageStore: GleanPlumbMessageStoreProtocol {
 
     /// For the MVP, we always expire the message.
     func onMessagePressed(_ message: GleanPlumbMessage) {
-       onMessageExpired(message.metadata, shouldReport: false)
+        onMessageExpired(message.metadata, shouldReport: false)
 
         set(key: message.id, metadata: message.metadata)
     }

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -14,7 +14,11 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
     typealias SendToDeviceDelegate = InstructionsViewDelegate & DevicePickerViewControllerDelegate
 
     // MARK: - Operational Variables
-    weak var homePanelDelegate: HomePanelDelegate?
+    weak var homePanelDelegate: HomePanelDelegate? {
+        didSet {
+            viewModel.messageCardViewModel.homepanelDelegate = homePanelDelegate
+        }
+    }
     weak var libraryPanelDelegate: LibraryPanelDelegate?
     weak var browserBarViewDelegate: BrowserBarViewDelegate? {
         didSet {

--- a/Client/Frontend/Home/MessageCard/HomepageMessageCardViewModel.swift
+++ b/Client/Frontend/Home/MessageCard/HomepageMessageCardViewModel.swift
@@ -13,9 +13,10 @@ protocol MessageSurfaceProtocol {
 
 class HomepageMessageCardViewModel: MessageSurfaceProtocol {
     private let dataAdaptor: MessageCardDataAdaptor
-    private let messagingManager: GleanPlumbMessageManagerProtocol
+    private var messagingManager: GleanPlumbMessageManagerProtocol
 
     weak var delegate: HomepageDataModelDelegate?
+    weak var homepanelDelegate: HomePanelDelegate?
     var message: GleanPlumbMessage?
     var dismissClosure: (() -> Void)?
     var theme: Theme
@@ -27,6 +28,7 @@ class HomepageMessageCardViewModel: MessageSurfaceProtocol {
         self.dataAdaptor = dataAdaptor
         self.theme = theme
         self.messagingManager = messagingManager
+        self.messagingManager.pressedDelegate = self
     }
 
     func getMessage(for surface: MessageSurfaceId) -> GleanPlumbMessage? {
@@ -122,5 +124,12 @@ extension HomepageMessageCardViewModel: MessageCardDelegate {
             self.delegate?.reloadView()
             self.handleMessageDisplayed()
         }
+    }
+}
+
+// MARK: - GleanPlumbMessagePressedDelegate
+extension HomepageMessageCardViewModel: GleanPlumbMessagePressedDelegate {
+    func openURLInNewTab(url: URL) {
+        homepanelDelegate?.homePanelDidRequestToOpenInNewTab(url, isPrivate: false, selectNewTab: true)
     }
 }

--- a/Tests/ClientTests/Frontend/Home/MessageCard/HomepageMessageCardViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/MessageCard/HomepageMessageCardViewModelTests.swift
@@ -175,6 +175,8 @@ class MockStyleDataProtocol: StyleDataProtocol {
 
 // MARK: - MockGleanPlumbMessageManagerProtocol
 class MockGleanPlumbMessageManagerProtocol: GleanPlumbMessageManagerProtocol {
+    weak var pressedDelegate: GleanPlumbMessagePressedDelegate?
+
     func onStartup() {}
 
     var message: GleanPlumbMessage?


### PR DESCRIPTION
# [FXIOS-5404](https://mozilla-hub.atlassian.net/browse/FXIOS-5404) https://github.com/mozilla-mobile/firefox-ios/issues/12636
Went with a delegate call to remove BVC foreground call in GleanPlumbMessager. My reasoning behind this is that we already have the homepanel actions to support this from homepage. This will already future proof this call (since the homepage is tied to a particular BVC already, so if there's multiple BVC the right one will be used to open the glean message).