### PR TITLE
Add FXIOS-5389 [v109] Add logs in bookmarks panel and add success one in tabmanager store

### DIFF
--- a/Client/Frontend/Browser/Tab Management/TabManagerStore.swift
+++ b/Client/Frontend/Browser/Tab Management/TabManagerStore.swift
@@ -242,9 +242,10 @@ class TabManagerStoreImplementation: TabManagerStore, FeatureFlaggable, Loggable
         guard let data = tabStateData, let path = path else { return }
         do {
             try data.write(to: path, options: [])
+            browserLog.debug("PreserveTabs write succeeded with bytes count: \(data.count)")
         } catch {
             // Failure could happen when restoring
-            self.browserLog.debug("PreserveTabs write failed with bytes count: \(data.count)")
+            browserLog.debug("PreserveTabs write failed with bytes count: \(data.count)")
         }
     }
 

--- a/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
@@ -287,13 +287,16 @@ class BookmarksPanel: SiteTableViewController,
 
     private func flashRow(at indexPath: IndexPath) {
         guard indexPathIsValid(indexPath) else {
+            browserLog.debug("Flash row indexPath invalid")
             return
         }
 
+        browserLog.debug("Flash row by selecting at \(indexPath)")
         tableView.selectRow(at: indexPath, animated: true, scrollPosition: .middle)
 
         DispatchQueue.main.asyncAfter(deadline: .now() + UX.RowFlashDelay) {
             if self.indexPathIsValid(indexPath) {
+                self.browserLog.debug("Flash row by deselecting row at \(indexPath)")
                 self.tableView.deselectRow(at: indexPath, animated: true)
             }
         }
@@ -476,6 +479,7 @@ extension BookmarksPanel: LibraryPanelContextMenu {
         guard let bookmarkNode = viewModel.bookmarkNodes[safe: indexPath.row],
               let bookmarkItem = bookmarkNode as? BookmarkItemData
         else {
+            self.browserLog.debug("Could not get site details for indexPath \(indexPath)")
             return nil
         }
 
@@ -494,6 +498,8 @@ extension BookmarksPanel: LibraryPanelContextMenu {
                 if result.isSuccess {
                     SimpleToast().showAlertWithText(.AppMenu.AddPinToShortcutsConfirmMessage,
                                                     bottomContainer: self.view)
+                } else {
+                    self.browserLog.debug("Could not add pinned top site")
                 }
             }
         }).items

--- a/Client/Frontend/Library/Bookmarks/BookmarksPanelViewModel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarksPanelViewModel.swift
@@ -6,7 +6,7 @@ import Foundation
 import Storage
 import Shared
 
-class BookmarksPanelViewModel {
+class BookmarksPanelViewModel: Loggable {
     enum BookmarksSection: Int, CaseIterable {
         case bookmarks
     }
@@ -38,6 +38,7 @@ class BookmarksPanelViewModel {
     func reloadData(completion: @escaping () -> Void) {
         // Can be called while app backgrounded and the db closed, don't try to reload the data source in this case
         if profile.isShutdown {
+            browserLog.debug("Profile was shutdown")
             completion()
             return
         }
@@ -57,6 +58,7 @@ class BookmarksPanelViewModel {
 
     func moveRow(at sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
         guard let bookmarkNode = bookmarkNodes[safe: sourceIndexPath.row] else {
+            browserLog.debug("Could not move row from \(sourceIndexPath) to \(destinationIndexPath)")
             return
         }
 
@@ -85,6 +87,7 @@ class BookmarksPanelViewModel {
             .getBookmarksTree(rootGUID: BookmarkRoots.MobileFolderGUID, recursive: false)
             .uponQueue(.main) { result in
                 guard let mobileFolder = result.successValue as? BookmarkFolderData else {
+                    self.browserLog.debug("Mobile folder data setup failed \(String(describing: result.failureValue))")
                     self.setErrorCase()
                     completion()
                     return
@@ -117,6 +120,7 @@ class BookmarksPanelViewModel {
         profile.places.getBookmarksTree(rootGUID: bookmarkFolderGUID,
                                         recursive: false).uponQueue(.main) { result in
             guard let folder = result.successValue as? BookmarkFolderData else {
+                self.browserLog.debug("Sublfolder data setup failed \(String(describing: result.failureValue))")
                 self.setErrorCase()
                 completion()
                 return


### PR DESCRIPTION
# [FXIOS-5389](https://mozilla-hub.atlassian.net/browse/FXIOS-5389) https://github.com/mozilla-mobile/firefox-ios/issues/12615
Add logs in bookmarks panel and add back success one in TabManager store