### PR TITLE
Refactor [MTE-338] Intermittent test failures from performance tests

### DIFF
--- a/Tests/XCUITests/TabsPerformanceTests.swift
+++ b/Tests/XCUITests/TabsPerformanceTests.swift
@@ -62,7 +62,7 @@ class TabsPerformanceTest: BaseTestCase {
     func testPerfTabs_3_20tabTray() {
         if #available(iOS 13.0, *) {
             app.launch()
-            waitForExistence(app.buttons["urlBar-cancel"], timeout: 10)
+            waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
             navigator.performAction(Action.CloseURLBarOpen)
             waitForTabsButton()
             measure(metrics: [
@@ -82,6 +82,7 @@ class TabsPerformanceTest: BaseTestCase {
     func testPerfTabs_4_1280tabTray() {
         if #available(iOS 13.0, *) {
             app.launch()
+            waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
             navigator.performAction(Action.CloseURLBarOpen)
             waitForTabsButton()
             measure(metrics: [


### PR DESCRIPTION
On Dec 3 and Dec 5, `testPerfTabs_3_20tabTray` and `testPerfTabs_4_1280tabTray` failed to launch. My preliminary investigation indicates that the app was still getting ready when the commands `navigator.performAction(Action.CloseURLBarOpen)` or `waitForExistence(app.buttons["urlBar-cancel"]` timed out.

Let's wait longer for the `urlBar-cancel` to be ready before the performance tests start.

I have tested this change using the following command on both my computer and MacStadium.
```
xcodebuild test -target Client -scheme Fennec_Enterprise_XCUITests -destination 'platform=iOS Simulator,name=iPhone 14' -testPlan PerformanceTestPlan -only-testing:XCUITests/TabsPerformanceTest -test-iterations 10
```