### PR TITLE
Add FXIOS-5388 [v110] Add site image fetcher in SiteImageView package

### DIFF
--- a/BrowserKit/Sources/SiteImageView/Entities/SiteImageModel.swift
+++ b/BrowserKit/Sources/SiteImageView/Entities/SiteImageModel.swift
@@ -4,11 +4,12 @@
 
 import UIKit
 
+/// Used to fill in information throughout the lifetime of an image request inside SiteImageView
 struct SiteImageModel {
     let expectedImageType: SiteImageType
     let siteURL: URL
     let domain: String
     let faviconURL: URL?
-    let faviconImage: UIImage?
-    let heroImage: UIImage?
+    var faviconImage: UIImage?
+    var heroImage: UIImage?
 }

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/ImageHandler.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/ImageHandler.swift
@@ -18,7 +18,7 @@ protocol ImageHandler {
     ///   - domain: The domain this favicon will be associated with
     /// - Returns: The favicon image
     func fetchFavicon(imageURL: URL?,
-                      domain: String) async throws -> UIImage
+                      domain: String) async -> UIImage
 
     /// The ImageHandler will fetch the hero image with the following precedence
     ///     1. Tries to fetch from the cache.
@@ -54,11 +54,11 @@ class DefaultImageHandler: ImageHandler {
     }
 
     func fetchFavicon(imageURL: URL?,
-                      domain: String) async throws -> UIImage {
+                      domain: String) async -> UIImage {
         do {
             return try bundleImageFetcher.getImageFromBundle(domain: domain)
         } catch {
-            return try await fetchFaviconFromCache(imageURL: imageURL, domain: domain)
+            return await fetchFaviconFromCache(imageURL: imageURL, domain: domain)
         }
     }
 
@@ -74,16 +74,16 @@ class DefaultImageHandler: ImageHandler {
     // MARK: Private
 
     private func fetchFaviconFromCache(imageURL: URL?,
-                                       domain: String) async throws -> UIImage {
+                                       domain: String) async -> UIImage {
         do {
             return try await imageCache.getImageFromCache(domain: domain, type: .favicon)
         } catch {
-            return try await fetchFaviconFromFetcher(imageURL: imageURL, domain: domain)
+            return await fetchFaviconFromFetcher(imageURL: imageURL, domain: domain)
         }
     }
 
     private func fetchFaviconFromFetcher(imageURL: URL?,
-                                         domain: String) async throws -> UIImage {
+                                         domain: String) async -> UIImage {
         do {
             guard let url = imageURL else {
                 return await fallbackToLetterFavicon(domain: domain)

--- a/BrowserKit/Sources/SiteImageView/SiteImageFetcher.swift
+++ b/BrowserKit/Sources/SiteImageView/SiteImageFetcher.swift
@@ -1,0 +1,73 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0
+
+import UIKit
+import Common
+
+protocol SiteImageFetcher {
+    func getImage(siteURL: URL, type: SiteImageType, id: UUID) async -> SiteImageModel
+}
+
+class DefaultSiteImageFetcher: SiteImageFetcher {
+    private let urlHandler: FaviconURLHandler
+    private let imageHandler: ImageHandler
+
+    init(urlHandler: FaviconURLHandler = DefaultFaviconURLHandler(),
+         imageHandler: ImageHandler = DefaultImageHandler()) {
+        self.urlHandler = urlHandler
+        self.imageHandler = imageHandler
+    }
+
+    func getImage(siteURL: URL, type: SiteImageType, id: UUID) async -> SiteImageModel {
+        let domain = generateDomainURL(siteURL: siteURL)
+        var imageModel = SiteImageModel(expectedImageType: type,
+                                        siteURL: siteURL,
+                                        domain: domain,
+                                        faviconURL: nil,
+                                        faviconImage: nil,
+                                        heroImage: nil)
+
+        do {
+            switch type {
+            case .heroImage:
+                imageModel.heroImage = try await getHeroImage(imageModel: imageModel)
+            case .favicon:
+                imageModel.faviconImage = await getFaviconImage(imageModel: imageModel)
+            }
+        } catch {
+            // If hero image fails, we return a favicon image
+            imageModel.faviconImage = await getFaviconImage(imageModel: imageModel)
+        }
+
+        return imageModel
+    }
+
+    // MARK: - Private
+
+    private func getHeroImage(imageModel: SiteImageModel) async throws -> UIImage {
+        do {
+            return try await imageHandler.fetchHeroImage(siteURL: imageModel.siteURL,
+                                                         domain: imageModel.domain)
+        } catch {
+            throw error
+        }
+    }
+
+    private func getFaviconImage(imageModel: SiteImageModel) async -> UIImage {
+        do {
+            // Try to fetch the favicon URL
+            let faviconURLImageModel = try await urlHandler.getFaviconURL(site: imageModel)
+            return await imageHandler.fetchFavicon(imageURL: faviconURLImageModel.faviconURL,
+                                                   domain: faviconURLImageModel.domain)
+        } catch {
+            // If no favicon URL, generate favicon without it
+            return await imageHandler.fetchFavicon(imageURL: imageModel.faviconURL,
+                                                   domain: imageModel.domain)
+        }
+    }
+
+    private func generateDomainURL(siteURL: URL) -> String {
+        return siteURL.shortDomain ?? siteURL.shortDisplayString
+    }
+}

--- a/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/ImageHandlerTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/ImageHandlerTests.swift
@@ -37,24 +37,20 @@ final class ImageHandlerTests: XCTestCase {
         bundleImageFetcher.image = expectedResult
         let subject = createSubject()
 
-        do {
-            let result = try await subject.fetchFavicon(imageURL: URL(string: "www.mozilla.com")!,
-                                                        domain: "Mozilla")
-            XCTAssertEqual(expectedResult, result)
-            XCTAssertEqual(bundleImageFetcher.getImageFromBundleSucceedCalled, 1)
-            XCTAssertEqual(bundleImageFetcher.getImageFromBundleFailedCalled, 0)
+        let result = await subject.fetchFavicon(imageURL: URL(string: "www.mozilla.com")!,
+                                                domain: "Mozilla")
+        XCTAssertEqual(expectedResult, result)
+        XCTAssertEqual(bundleImageFetcher.getImageFromBundleSucceedCalled, 1)
+        XCTAssertEqual(bundleImageFetcher.getImageFromBundleFailedCalled, 0)
 
-            XCTAssertEqual(siteImageCache.getImageFromCacheSucceedCalled, 0)
-            XCTAssertEqual(siteImageCache.getImageFromCacheFailedCalled, 0)
+        XCTAssertEqual(siteImageCache.getImageFromCacheSucceedCalled, 0)
+        XCTAssertEqual(siteImageCache.getImageFromCacheFailedCalled, 0)
 
-            XCTAssertEqual(faviconFetcher.fetchImageSucceedCalled, 0)
-            XCTAssertEqual(faviconFetcher.fetchImageFailedCalled, 0)
+        XCTAssertEqual(faviconFetcher.fetchImageSucceedCalled, 0)
+        XCTAssertEqual(faviconFetcher.fetchImageFailedCalled, 0)
 
-            XCTAssertEqual(siteImageCache.cacheImageCalled, 0)
-            XCTAssertEqual(letterImageGenerator.generateLetterImageCalled, 0)
-        } catch {
-            XCTFail("Should have succeeded with bundle image")
-        }
+        XCTAssertEqual(siteImageCache.cacheImageCalled, 0)
+        XCTAssertEqual(letterImageGenerator.generateLetterImageCalled, 0)
     }
 
     func testFavicon_whenImageInCache_returnsCacheImage() async {
@@ -62,49 +58,41 @@ final class ImageHandlerTests: XCTestCase {
         siteImageCache.image = expectedResult
         let subject = createSubject()
 
-        do {
-            let result = try await subject.fetchFavicon(imageURL: URL(string: "www.mozilla.com")!,
-                                                        domain: "Mozilla")
-            XCTAssertEqual(expectedResult, result)
-            XCTAssertEqual(bundleImageFetcher.getImageFromBundleSucceedCalled, 0)
-            XCTAssertEqual(bundleImageFetcher.getImageFromBundleFailedCalled, 1)
+        let result = await subject.fetchFavicon(imageURL: URL(string: "www.mozilla.com")!,
+                                                domain: "Mozilla")
+        XCTAssertEqual(expectedResult, result)
+        XCTAssertEqual(bundleImageFetcher.getImageFromBundleSucceedCalled, 0)
+        XCTAssertEqual(bundleImageFetcher.getImageFromBundleFailedCalled, 1)
 
-            XCTAssertEqual(siteImageCache.getImageFromCacheSucceedCalled, 1)
-            XCTAssertEqual(siteImageCache.getImageFromCacheFailedCalled, 0)
-            XCTAssertEqual(siteImageCache.getFromCacheWithType, .favicon)
+        XCTAssertEqual(siteImageCache.getImageFromCacheSucceedCalled, 1)
+        XCTAssertEqual(siteImageCache.getImageFromCacheFailedCalled, 0)
+        XCTAssertEqual(siteImageCache.getFromCacheWithType, .favicon)
 
-            XCTAssertEqual(faviconFetcher.fetchImageSucceedCalled, 0)
-            XCTAssertEqual(faviconFetcher.fetchImageFailedCalled, 0)
+        XCTAssertEqual(faviconFetcher.fetchImageSucceedCalled, 0)
+        XCTAssertEqual(faviconFetcher.fetchImageFailedCalled, 0)
 
-            XCTAssertEqual(siteImageCache.cacheImageCalled, 0)
-            XCTAssertEqual(letterImageGenerator.generateLetterImageCalled, 0)
-        } catch {
-            XCTFail("Should have succeeded with cache image")
-        }
+        XCTAssertEqual(siteImageCache.cacheImageCalled, 0)
+        XCTAssertEqual(letterImageGenerator.generateLetterImageCalled, 0)
     }
 
     func testFavicon_whenNoUrl_returnsFallbackLetterFavicon() async {
         let subject = createSubject()
 
-        do {
-            let result = try await subject.fetchFavicon(imageURL: nil,
-                                                        domain: "Mozilla")
-            XCTAssertEqual(letterImageGenerator.image, result)
-            XCTAssertEqual(bundleImageFetcher.getImageFromBundleSucceedCalled, 0)
-            XCTAssertEqual(bundleImageFetcher.getImageFromBundleFailedCalled, 1)
+        let result = await subject.fetchFavicon(imageURL: nil,
+                                                domain: "Mozilla")
+        XCTAssertEqual(letterImageGenerator.image, result)
+        XCTAssertEqual(bundleImageFetcher.getImageFromBundleSucceedCalled, 0)
+        XCTAssertEqual(bundleImageFetcher.getImageFromBundleFailedCalled, 1)
 
-            XCTAssertEqual(siteImageCache.getImageFromCacheSucceedCalled, 0)
-            XCTAssertEqual(siteImageCache.getImageFromCacheFailedCalled, 1)
+        XCTAssertEqual(siteImageCache.getImageFromCacheSucceedCalled, 0)
+        XCTAssertEqual(siteImageCache.getImageFromCacheFailedCalled, 1)
 
-            XCTAssertEqual(faviconFetcher.fetchImageSucceedCalled, 0)
-            XCTAssertEqual(faviconFetcher.fetchImageFailedCalled, 0)
+        XCTAssertEqual(faviconFetcher.fetchImageSucceedCalled, 0)
+        XCTAssertEqual(faviconFetcher.fetchImageFailedCalled, 0)
 
-            XCTAssertEqual(siteImageCache.cachedWithType, .favicon)
-            XCTAssertEqual(siteImageCache.cacheImageCalled, 1)
-            XCTAssertEqual(letterImageGenerator.generateLetterImageCalled, 1)
-        } catch {
-            XCTFail("Should have succeeded with fallback letter image")
-        }
+        XCTAssertEqual(siteImageCache.cachedWithType, .favicon)
+        XCTAssertEqual(siteImageCache.cacheImageCalled, 1)
+        XCTAssertEqual(letterImageGenerator.generateLetterImageCalled, 1)
     }
 
     func testFavicon_whenImageFetcher_returnsImageFetcherFavicon() async {
@@ -112,49 +100,41 @@ final class ImageHandlerTests: XCTestCase {
         faviconFetcher.image = expectedResult
         let subject = createSubject()
 
-        do {
-            let result = try await subject.fetchFavicon(imageURL: URL(string: "www.mozilla.com")!,
-                                                        domain: "Mozilla")
-            XCTAssertEqual(expectedResult, result)
-            XCTAssertEqual(bundleImageFetcher.getImageFromBundleSucceedCalled, 0)
-            XCTAssertEqual(bundleImageFetcher.getImageFromBundleFailedCalled, 1)
+        let result = await subject.fetchFavicon(imageURL: URL(string: "www.mozilla.com")!,
+                                                domain: "Mozilla")
+        XCTAssertEqual(expectedResult, result)
+        XCTAssertEqual(bundleImageFetcher.getImageFromBundleSucceedCalled, 0)
+        XCTAssertEqual(bundleImageFetcher.getImageFromBundleFailedCalled, 1)
 
-            XCTAssertEqual(siteImageCache.getImageFromCacheSucceedCalled, 0)
-            XCTAssertEqual(siteImageCache.getImageFromCacheFailedCalled, 1)
+        XCTAssertEqual(siteImageCache.getImageFromCacheSucceedCalled, 0)
+        XCTAssertEqual(siteImageCache.getImageFromCacheFailedCalled, 1)
 
-            XCTAssertEqual(faviconFetcher.fetchImageSucceedCalled, 1)
-            XCTAssertEqual(faviconFetcher.fetchImageFailedCalled, 0)
+        XCTAssertEqual(faviconFetcher.fetchImageSucceedCalled, 1)
+        XCTAssertEqual(faviconFetcher.fetchImageFailedCalled, 0)
 
-            XCTAssertEqual(siteImageCache.cachedWithType, .favicon)
-            XCTAssertEqual(siteImageCache.cacheImageCalled, 1)
-            XCTAssertEqual(letterImageGenerator.generateLetterImageCalled, 0)
-        } catch {
-            XCTFail("Should have succeeded with fallback letter image")
-        }
+        XCTAssertEqual(siteImageCache.cachedWithType, .favicon)
+        XCTAssertEqual(siteImageCache.cacheImageCalled, 1)
+        XCTAssertEqual(letterImageGenerator.generateLetterImageCalled, 0)
     }
 
     func testFavicon_whenNoImages_returnsFallbackLetterFavicon() async {
         let subject = createSubject()
 
-        do {
-            let result = try await subject.fetchFavicon(imageURL: URL(string: "www.mozilla.com")!,
-                                                        domain: "Mozilla")
-            XCTAssertEqual(letterImageGenerator.image, result)
-            XCTAssertEqual(bundleImageFetcher.getImageFromBundleSucceedCalled, 0)
-            XCTAssertEqual(bundleImageFetcher.getImageFromBundleFailedCalled, 1)
+        let result = await subject.fetchFavicon(imageURL: URL(string: "www.mozilla.com")!,
+                                                domain: "Mozilla")
+        XCTAssertEqual(letterImageGenerator.image, result)
+        XCTAssertEqual(bundleImageFetcher.getImageFromBundleSucceedCalled, 0)
+        XCTAssertEqual(bundleImageFetcher.getImageFromBundleFailedCalled, 1)
 
-            XCTAssertEqual(siteImageCache.getImageFromCacheSucceedCalled, 0)
-            XCTAssertEqual(siteImageCache.getImageFromCacheFailedCalled, 1)
+        XCTAssertEqual(siteImageCache.getImageFromCacheSucceedCalled, 0)
+        XCTAssertEqual(siteImageCache.getImageFromCacheFailedCalled, 1)
 
-            XCTAssertEqual(faviconFetcher.fetchImageSucceedCalled, 0)
-            XCTAssertEqual(faviconFetcher.fetchImageFailedCalled, 1)
+        XCTAssertEqual(faviconFetcher.fetchImageSucceedCalled, 0)
+        XCTAssertEqual(faviconFetcher.fetchImageFailedCalled, 1)
 
-            XCTAssertEqual(siteImageCache.cachedWithType, .favicon)
-            XCTAssertEqual(siteImageCache.cacheImageCalled, 1)
-            XCTAssertEqual(letterImageGenerator.generateLetterImageCalled, 1)
-        } catch {
-            XCTFail("Should have succeeded with fallback letter image")
-        }
+        XCTAssertEqual(siteImageCache.cachedWithType, .favicon)
+        XCTAssertEqual(siteImageCache.cacheImageCalled, 1)
+        XCTAssertEqual(letterImageGenerator.generateLetterImageCalled, 1)
     }
 
     // MARK: - Hero image

--- a/BrowserKit/Tests/SiteImageViewTests/SiteImageFetcherTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/SiteImageFetcherTests.swift
@@ -1,0 +1,163 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0
+
+import XCTest
+@testable import SiteImageView
+
+final class SiteImageFetcherTests: XCTestCase {
+    private var urlHandler: MockFaviconURLHandler!
+    private var imageHandler: MockImageHandler!
+
+    override func setUp() {
+        super.setUp()
+        self.urlHandler = MockFaviconURLHandler()
+        self.imageHandler = MockImageHandler()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        self.urlHandler = nil
+        self.imageHandler = nil
+    }
+
+    // MARK: - Favicon
+
+    func testFavicon_noFaviconURLFound_generatesFavicon() async {
+        let siteURL = URL(string: "https://www.example.hello.com")!
+        let subject = DefaultSiteImageFetcher(urlHandler: urlHandler,
+                                              imageHandler: imageHandler)
+        let result = await subject.getImage(siteURL: siteURL,
+                                            type: .favicon,
+                                            id: UUID())
+
+        XCTAssertEqual(result.domain, "example.hello")
+        XCTAssertEqual(result.siteURL, siteURL)
+        XCTAssertEqual(result.faviconURL, nil)
+        XCTAssertEqual(result.expectedImageType, .favicon)
+        XCTAssertNil(result.heroImage)
+        XCTAssertNotNil(result.faviconImage)
+
+        XCTAssertNil(imageHandler.capturedFaviconURL)
+        XCTAssertEqual(imageHandler.capturedDomain, "example.hello")
+        XCTAssertNil(imageHandler.capturedSiteURL)
+    }
+
+    func testFavicon_wrongURL_useFallbackDomain() async {
+        // URL without https://
+        let siteURL = URL(string: "www.example.hello.com")!
+        let subject = DefaultSiteImageFetcher(urlHandler: urlHandler,
+                                              imageHandler: imageHandler)
+        let result = await subject.getImage(siteURL: siteURL,
+                                            type: .favicon,
+                                            id: UUID())
+
+        XCTAssertEqual(result.domain, "www.example.hello.com")
+        XCTAssertEqual(imageHandler.capturedDomain, "www.example.hello.com")
+    }
+
+    func testFavicon_faviconURLFound_generateFavicon() async {
+        let faviconURL = URL(string: "www.mozilla.com/resource")!
+        let siteURL = URL(string: "https://www.mozilla.com")!
+        urlHandler.faviconURL = faviconURL
+        let subject = DefaultSiteImageFetcher(urlHandler: urlHandler,
+                                              imageHandler: imageHandler)
+        let result = await subject.getImage(siteURL: siteURL,
+                                            type: .favicon,
+                                            id: UUID())
+
+        XCTAssertEqual(result.domain, "mozilla")
+        XCTAssertEqual(result.siteURL, siteURL)
+        XCTAssertEqual(result.faviconURL, nil)
+        XCTAssertEqual(result.expectedImageType, .favicon)
+        XCTAssertNil(result.heroImage)
+        XCTAssertNotNil(result.faviconImage)
+
+        XCTAssertEqual(imageHandler.capturedFaviconURL, faviconURL)
+        XCTAssertEqual(imageHandler.capturedDomain, "mozilla")
+        XCTAssertNil(imageHandler.capturedSiteURL)
+    }
+
+    // MARK: - Hero image
+
+    func testHeroImage_heroImageNotFound_returnsFavicon() async {
+        let subject = DefaultSiteImageFetcher(urlHandler: urlHandler,
+                                              imageHandler: imageHandler)
+        let siteURL = URL(string: "https://www.firefox.com")!
+        let result = await subject.getImage(siteURL: siteURL,
+                                            type: .heroImage,
+                                            id: UUID())
+
+        XCTAssertEqual(result.domain, "firefox")
+        XCTAssertEqual(result.siteURL, siteURL)
+        XCTAssertEqual(result.faviconURL, nil)
+        XCTAssertEqual(result.expectedImageType, .heroImage)
+        XCTAssertNil(result.heroImage)
+        XCTAssertNotNil(result.faviconImage)
+
+        XCTAssertNil(imageHandler.capturedFaviconURL)
+        XCTAssertEqual(imageHandler.capturedDomain, "firefox")
+        XCTAssertEqual(imageHandler.capturedSiteURL, siteURL)
+    }
+
+    func testHeroImage_heroImageFound_returnsHeroImage() async {
+        imageHandler.heroImage = UIImage()
+        let subject = DefaultSiteImageFetcher(urlHandler: urlHandler,
+                                              imageHandler: imageHandler)
+        let siteURL = URL(string: "https://www.focus.com")!
+        let result = await subject.getImage(siteURL: siteURL,
+                                            type: .heroImage,
+                                            id: UUID())
+
+        XCTAssertEqual(result.domain, "focus")
+        XCTAssertEqual(result.siteURL, siteURL)
+        XCTAssertEqual(result.faviconURL, nil)
+        XCTAssertEqual(result.expectedImageType, .heroImage)
+        XCTAssertNotNil(result.heroImage)
+        XCTAssertNil(result.faviconImage)
+
+        XCTAssertNil(imageHandler.capturedFaviconURL)
+        XCTAssertEqual(imageHandler.capturedDomain, "focus")
+        XCTAssertEqual(imageHandler.capturedSiteURL, siteURL)
+    }
+}
+
+// MARK: - MockFaviconURLHandler
+private class MockFaviconURLHandler: FaviconURLHandler {
+    var faviconURL: URL?
+    var capturedImageModel: SiteImageModel?
+
+    func getFaviconURL(site: SiteImageModel) async throws -> SiteImageModel {
+        capturedImageModel = site
+        return SiteImageModel(expectedImageType: site.expectedImageType,
+                              siteURL: site.siteURL,
+                              domain: site.domain,
+                              faviconURL: faviconURL)
+    }
+}
+
+// MARK: - MockImageHandler
+private class MockImageHandler: ImageHandler {
+    var faviconImage = UIImage()
+    var capturedFaviconURL: URL?
+    var capturedDomain: String?
+
+    func fetchFavicon(imageURL: URL?, domain: String) async -> UIImage {
+        capturedFaviconURL = imageURL
+        capturedDomain = domain
+        return faviconImage
+    }
+
+    var capturedSiteURL: URL?
+    var heroImage: UIImage?
+
+    func fetchHeroImage(siteURL: URL, domain: String) async throws -> UIImage {
+        capturedSiteURL = siteURL
+        capturedDomain = domain
+        if let image = heroImage {
+            return image
+        } else {
+            throw SiteImageError.noHeroImage
+        }
+    }
+}


### PR DESCRIPTION
# [FXIOS-5388](https://mozilla-hub.atlassian.net/browse/FXIOS-5388) https://github.com/mozilla-mobile/firefox-ios/issues/12610
- Site image fetcher is the class that given a certain image type request (favicon or hero image), will fetch the right image. 
- I removed throwing when fetching favicons in `ImageHandler.swift` since when all fails we default to letter favicons. This will never fail. 
- Added unit tests

### Fetching favicons
We're given a certain site URL that we use to try to fetch the `faviconURL` with (through the FaviconURLHandler). If there's no `faviconURL` we still try to fetch the favicon (worst case we default to the letter favicon. This is all handled in ImageHandler).

### Fetching hero image
In case no hero image can be fetched, we fallback to a favicon. Getting a favicon can never fails since we default to a letter favicon. This is all handled in ImageHandler.

-----
I won't run BR since BrowserKit doesn't affect Fennec. I ran the unit tests locally + swiftlint.
