### PR TITLE
Refactor FXIOS-5269 [v110] Use HeroImageView from BrowserKit in Recently saved

### DIFF
--- a/BrowserKit/Sources/SiteImageView/Entities/SiteImageModel.swift
+++ b/BrowserKit/Sources/SiteImageView/Entities/SiteImageModel.swift
@@ -16,10 +16,10 @@ struct SiteImageModel {
     let urlStringRequest: String
 
     /// URL can be nil in case the urlStringRequest cannot be used to build a URL
-    let siteURL: URL?
+    var siteURL: URL?
 
     /// Domain can be nil in case we don't have a siteURL to get the domain from
-    let domain: String?
+    var domain: String?
 
     /// The favicon URL scrapped from the webpage, high resolution found at preference
     var faviconURL: URL?

--- a/BrowserKit/Sources/SiteImageView/Entities/SiteImageModel.swift
+++ b/BrowserKit/Sources/SiteImageView/Entities/SiteImageModel.swift
@@ -6,11 +6,27 @@ import UIKit
 
 /// Used to fill in information throughout the lifetime of an image request inside SiteImageView
 struct SiteImageModel {
+    /// A unique ID to tie the request to a certain image view
     let id: UUID
+
+    /// The image type expected when making a request
     let expectedImageType: SiteImageType
-    let siteURL: URL
-    let domain: String
-    let faviconURL: URL?
+
+    /// Always present, used to make the initial request
+    let urlStringRequest: String
+
+    /// URL can be nil in case the urlStringRequest cannot be used to build a URL
+    let siteURL: URL?
+
+    /// Domain can be nil in case we don't have a siteURL to get the domain from
+    let domain: String?
+
+    /// The favicon URL scrapped from the webpage, high resolution found at preference
+    var faviconURL: URL?
+
+    /// The fetched or generated favicon image
     var faviconImage: UIImage?
+
+    /// The fetched hero image
     var heroImage: UIImage?
 }

--- a/BrowserKit/Sources/SiteImageView/FaviconImageView.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconImageView.swift
@@ -15,6 +15,7 @@ public class FaviconImageView: UIImageView, SiteImageView {
     // MARK: - Properties
     var uniqueID: UUID?
     var imageFetcher: SiteImageFetcher
+    var requestStartedWith: String?
     private var completionHandler: (() -> Void)?
 
     // MARK: - Init
@@ -46,10 +47,12 @@ public class FaviconImageView: UIImageView, SiteImageView {
 
     // MARK: - SiteImageView
 
-    func setURL(_ siteURL: URL, type: SiteImageType) {
+    func setURL(_ urlStringRequest: String, type: SiteImageType) {
+        guard canMakeRequest(with: urlStringRequest) else { return }
+
         let id = UUID()
         uniqueID = id
-        updateImage(url: siteURL, type: type, id: id)
+        updateImage(url: urlStringRequest, type: type, id: id)
     }
 
     func setImage(imageModel: SiteImageModel) {

--- a/BrowserKit/Sources/SiteImageView/FaviconImageView.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconImageView.swift
@@ -42,7 +42,7 @@ public class FaviconImageView: UIImageView, SiteImageView {
 
     public func setFavicon(_ viewModel: FaviconImageViewModel) {
         setupFaviconLayout(viewModel: viewModel)
-        setURL(viewModel.siteURL, type: viewModel.type)
+        setURL(viewModel.urlStringRequest, type: viewModel.type)
     }
 
     // MARK: - SiteImageView

--- a/BrowserKit/Sources/SiteImageView/FaviconImageViewModel.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconImageViewModel.swift
@@ -5,11 +5,11 @@
 import UIKit
 
 public struct FaviconImageViewModel {
-    let siteURL: URL
+    let siteURL: String
     let type: SiteImageType
     let faviconCornerRadius: CGFloat
 
-    public init(siteURL: URL, faviconCornerRadius: CGFloat) {
+    public init(siteURL: String, faviconCornerRadius: CGFloat) {
         self.type = .favicon
         self.siteURL = siteURL
         self.faviconCornerRadius = faviconCornerRadius

--- a/BrowserKit/Sources/SiteImageView/FaviconImageViewModel.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconImageViewModel.swift
@@ -5,13 +5,13 @@
 import UIKit
 
 public struct FaviconImageViewModel {
-    let siteURL: String
+    let urlStringRequest: String
     let type: SiteImageType
     let faviconCornerRadius: CGFloat
 
-    public init(siteURL: String, faviconCornerRadius: CGFloat) {
+    public init(urlStringRequest: String, faviconCornerRadius: CGFloat) {
         self.type = .favicon
-        self.siteURL = siteURL
+        self.urlStringRequest = urlStringRequest
         self.faviconCornerRadius = faviconCornerRadius
     }
 }

--- a/BrowserKit/Sources/SiteImageView/HeroImageView.swift
+++ b/BrowserKit/Sources/SiteImageView/HeroImageView.swift
@@ -16,6 +16,7 @@ public class HeroImageView: UIView, SiteImageView {
     // MARK: - Properties
     var uniqueID: UUID?
     var imageFetcher: SiteImageFetcher
+    var requestStartedWith: String?
     private var completionHandler: (() -> Void)?
 
     private lazy var heroImageView: UIImageView = .build { imageView in
@@ -70,10 +71,12 @@ public class HeroImageView: UIView, SiteImageView {
 
     // MARK: - SiteImageView
 
-    func setURL(_ siteURL: URL, type: SiteImageType) {
+    func setURL(_ urlStringRequest: String, type: SiteImageType) {
+        guard canMakeRequest(with: urlStringRequest) else { return }
+
         let id = UUID()
         uniqueID = id
-        updateImage(url: siteURL, type: type, id: id)
+        updateImage(url: urlStringRequest, type: type, id: id)
     }
 
     func setImage(imageModel: SiteImageModel) {

--- a/BrowserKit/Sources/SiteImageView/HeroImageView.swift
+++ b/BrowserKit/Sources/SiteImageView/HeroImageView.swift
@@ -60,7 +60,7 @@ public class HeroImageView: UIView, SiteImageView {
 
     public func setHeroImage(_ viewModel: HeroImageViewModel) {
         setupHeroImageLayout(viewModel: viewModel)
-        setURL(viewModel.siteURL, type: viewModel.type)
+        setURL(viewModel.urlStringRequest, type: viewModel.type)
     }
 
     public func updateHeroImageTheme(with colors: HeroImageViewColor) {

--- a/BrowserKit/Sources/SiteImageView/HeroImageView.swift
+++ b/BrowserKit/Sources/SiteImageView/HeroImageView.swift
@@ -69,6 +69,11 @@ public class HeroImageView: UIView, SiteImageView {
         fallbackFaviconBackground.layer.borderColor = colors.faviconBorderColor.cgColor
     }
 
+    public func prepareForReuse() {
+        heroImageView.image = nil
+        setFallBackFaviconVisibility(isHidden: false)
+    }
+
     // MARK: - SiteImageView
 
     func setURL(_ urlStringRequest: String, type: SiteImageType) {

--- a/BrowserKit/Sources/SiteImageView/HeroImageViewColor.swift
+++ b/BrowserKit/Sources/SiteImageView/HeroImageViewColor.swift
@@ -8,4 +8,12 @@ public struct HeroImageViewColor {
     let faviconTintColor: UIColor
     let faviconBackgroundColor: UIColor
     let faviconBorderColor: UIColor
+
+    public init(faviconTintColor: UIColor,
+                faviconBackgroundColor: UIColor,
+                faviconBorderColor: UIColor) {
+        self.faviconTintColor = faviconTintColor
+        self.faviconBackgroundColor = faviconBackgroundColor
+        self.faviconBorderColor = faviconBorderColor
+    }
 }

--- a/BrowserKit/Sources/SiteImageView/HeroImageViewModel.swift
+++ b/BrowserKit/Sources/SiteImageView/HeroImageViewModel.swift
@@ -5,7 +5,7 @@
 import UIKit
 
 public struct HeroImageViewModel {
-    let siteURL: URL
+    let siteURL: String
     let type: SiteImageType
     let generalCornerRadius: CGFloat
     let faviconCornerRadius: CGFloat
@@ -13,7 +13,7 @@ public struct HeroImageViewModel {
     let heroImageSize: CGSize
     let fallbackFaviconSize: CGSize
 
-    public init(siteURL: URL,
+    public init(siteURL: String,
                 generalCornerRadius: CGFloat,
                 faviconCornerRadius: CGFloat,
                 faviconBorderWidth: CGFloat,

--- a/BrowserKit/Sources/SiteImageView/HeroImageViewModel.swift
+++ b/BrowserKit/Sources/SiteImageView/HeroImageViewModel.swift
@@ -4,14 +4,24 @@
 
 import UIKit
 
-public struct HeroImageViewModel {
-    let urlStringRequest: String
-    let type: SiteImageType
-    let generalCornerRadius: CGFloat
-    let faviconCornerRadius: CGFloat
-    let faviconBorderWidth: CGFloat
-    let heroImageSize: CGSize
-    let fallbackFaviconSize: CGSize
+public protocol HeroImageViewModel {
+    var urlStringRequest: String { get }
+    var type: SiteImageType { get }
+    var generalCornerRadius: CGFloat { get }
+    var faviconCornerRadius: CGFloat { get }
+    var faviconBorderWidth: CGFloat { get }
+    var heroImageSize: CGSize { get }
+    var fallbackFaviconSize: CGSize { get }
+}
+
+public struct DefaultHeroImageViewModel {
+    var urlStringRequest: String
+    var type: SiteImageType
+    var generalCornerRadius: CGFloat
+    var faviconCornerRadius: CGFloat
+    var faviconBorderWidth: CGFloat
+    var heroImageSize: CGSize
+    var fallbackFaviconSize: CGSize
 
     public init(urlStringRequest: String,
                 generalCornerRadius: CGFloat,

--- a/BrowserKit/Sources/SiteImageView/HeroImageViewModel.swift
+++ b/BrowserKit/Sources/SiteImageView/HeroImageViewModel.swift
@@ -14,14 +14,14 @@ public protocol HeroImageViewModel {
     var fallbackFaviconSize: CGSize { get }
 }
 
-public struct DefaultHeroImageViewModel {
-    var urlStringRequest: String
-    var type: SiteImageType
-    var generalCornerRadius: CGFloat
-    var faviconCornerRadius: CGFloat
-    var faviconBorderWidth: CGFloat
-    var heroImageSize: CGSize
-    var fallbackFaviconSize: CGSize
+public struct DefaultHeroImageViewModel: HeroImageViewModel {
+    public var urlStringRequest: String
+    public var type: SiteImageType
+    public var generalCornerRadius: CGFloat
+    public var faviconCornerRadius: CGFloat
+    public var faviconBorderWidth: CGFloat
+    public var heroImageSize: CGSize
+    public var fallbackFaviconSize: CGSize
 
     public init(urlStringRequest: String,
                 generalCornerRadius: CGFloat,

--- a/BrowserKit/Sources/SiteImageView/HeroImageViewModel.swift
+++ b/BrowserKit/Sources/SiteImageView/HeroImageViewModel.swift
@@ -5,7 +5,7 @@
 import UIKit
 
 public struct HeroImageViewModel {
-    let siteURL: String
+    let urlStringRequest: String
     let type: SiteImageType
     let generalCornerRadius: CGFloat
     let faviconCornerRadius: CGFloat
@@ -13,14 +13,14 @@ public struct HeroImageViewModel {
     let heroImageSize: CGSize
     let fallbackFaviconSize: CGSize
 
-    public init(siteURL: String,
+    public init(urlStringRequest: String,
                 generalCornerRadius: CGFloat,
                 faviconCornerRadius: CGFloat,
                 faviconBorderWidth: CGFloat,
                 heroImageSize: CGSize,
                 fallbackFaviconSize: CGSize) {
         self.type = .heroImage
-        self.siteURL = siteURL
+        self.urlStringRequest = urlStringRequest
         self.generalCornerRadius = generalCornerRadius
         self.faviconCornerRadius = faviconCornerRadius
         self.faviconBorderWidth = faviconBorderWidth

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/HeroImageFetcher/HeroImageFetcher.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/HeroImageFetcher/HeroImageFetcher.swift
@@ -6,17 +6,27 @@ import LinkPresentation
 import UIKit
 
 protocol HeroImageFetcher {
-    func fetchHeroImage(from siteURL: URL) async throws -> UIImage
+    /// FetchHeroImage using metadataProvider needs the main thread, hence using @MainActor for it.
+    /// LPMetadataProvider is also a one shot object that we need to throw away once used.
+    /// - Parameters:
+    ///   - siteURL: the url to fetch the hero image with
+    ///   - metadataProvider: LPMetadataProvider
+    /// - Returns: the hero image
+    @MainActor func fetchHeroImage(from siteURL: URL, metadataProvider: LPMetadataProvider) async throws -> UIImage
+}
+
+extension HeroImageFetcher {
+    @MainActor func fetchHeroImage(from siteURL: URL,
+                                   metadataProvider: LPMetadataProvider = LPMetadataProvider()
+    ) async throws -> UIImage {
+        try await fetchHeroImage(from: siteURL, metadataProvider: metadataProvider)
+    }
 }
 
 class DefaultHeroImageFetcher: HeroImageFetcher {
-    private let metadataProvider: LPMetadataProvider
-
-    init(metadataProvider: LPMetadataProvider = LPMetadataProvider()) {
-        self.metadataProvider = metadataProvider
-    }
-
-    func fetchHeroImage(from siteURL: URL) async throws -> UIImage {
+    @MainActor func fetchHeroImage(from siteURL: URL,
+                                   metadataProvider: LPMetadataProvider = LPMetadataProvider()
+    ) async throws -> UIImage {
         do {
             let metadata = try await metadataProvider.startFetchingMetadata(for: siteURL)
             guard let imageProvider = metadata.imageProvider else {

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/ImageHandler.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/ImageHandler.swift
@@ -18,7 +18,8 @@ protocol ImageHandler {
     ///   - domain: The domain this favicon will be associated with
     /// - Returns: The favicon image
     func fetchFavicon(imageURL: URL?,
-                      domain: String) async -> UIImage
+                      domain: String,
+                      expectedType: SiteImageType) async -> UIImage
 
     /// The ImageHandler will fetch the hero image with the following precedence
     ///     1. Tries to fetch from the cache.
@@ -54,11 +55,12 @@ class DefaultImageHandler: ImageHandler {
     }
 
     func fetchFavicon(imageURL: URL?,
-                      domain: String) async -> UIImage {
+                      domain: String,
+                      expectedType type: SiteImageType) async -> UIImage {
         do {
             return try bundleImageFetcher.getImageFromBundle(domain: domain)
         } catch {
-            return await fetchFaviconFromCache(imageURL: imageURL, domain: domain)
+            return await fetchFaviconFromCache(imageURL: imageURL, domain: domain, expectedType: type)
         }
     }
 
@@ -74,26 +76,28 @@ class DefaultImageHandler: ImageHandler {
     // MARK: Private
 
     private func fetchFaviconFromCache(imageURL: URL?,
-                                       domain: String) async -> UIImage {
+                                       domain: String,
+                                       expectedType type: SiteImageType) async -> UIImage {
         do {
-            return try await imageCache.getImageFromCache(domain: domain, type: .favicon)
+            return try await imageCache.getImageFromCache(domain: domain, type: type)
         } catch {
-            return await fetchFaviconFromFetcher(imageURL: imageURL, domain: domain)
+            return await fetchFaviconFromFetcher(imageURL: imageURL, domain: domain, expectedType: type)
         }
     }
 
     private func fetchFaviconFromFetcher(imageURL: URL?,
-                                         domain: String) async -> UIImage {
+                                         domain: String,
+                                         expectedType type: SiteImageType) async -> UIImage {
         do {
             guard let url = imageURL else {
-                return await fallbackToLetterFavicon(domain: domain)
+                return await fallbackToLetterFavicon(domain: domain, expectedType: type)
             }
 
             let image = try await faviconFetcher.fetchFavicon(from: url)
-            await imageCache.cacheImage(image: image, domain: domain, type: .favicon)
+            await imageCache.cacheImage(image: image, domain: domain, type: type)
             return image
         } catch {
-            return await fallbackToLetterFavicon(domain: domain)
+            return await fallbackToLetterFavicon(domain: domain, expectedType: type)
         }
     }
 
@@ -108,9 +112,9 @@ class DefaultImageHandler: ImageHandler {
         }
     }
 
-    private func fallbackToLetterFavicon(domain: String) async -> UIImage {
+    private func fallbackToLetterFavicon(domain: String, expectedType type: SiteImageType) async -> UIImage {
         let image = await letterImageGenerator.generateLetterImage(domain: domain)
-        await imageCache.cacheImage(image: image, domain: domain, type: .favicon)
+        await imageCache.cacheImage(image: image, domain: domain, type: type)
         return image
     }
 }

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/ImageHandler.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/ImageHandler.swift
@@ -109,7 +109,7 @@ class DefaultImageHandler: ImageHandler {
     }
 
     private func fallbackToLetterFavicon(domain: String) async -> UIImage {
-        let image = letterImageGenerator.generateLetterImage(domain: domain)
+        let image = await letterImageGenerator.generateLetterImage(domain: domain)
         await imageCache.cacheImage(image: image, domain: domain, type: .favicon)
         return image
     }

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/LetterImageGenerator.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/LetterImageGenerator.swift
@@ -7,15 +7,16 @@ import UIKit
 /// Generate a default letter image from the domain name
 protocol LetterImageGenerator {
     /// Generates a letter image based on the first character in the domain name
+    /// Runs main thread due to UILabel.initWithFrame(:)
     /// - Parameter domain: The string domain name
     /// - Returns: The generated letter image
-    func generateLetterImage(domain: String) -> UIImage
+    @MainActor func generateLetterImage(domain: String) async -> UIImage
 }
 
 class DefaultLetterImageGenerator: LetterImageGenerator {
     private let defaultLetter: Character = "#"
 
-    func generateLetterImage(domain: String) -> UIImage {
+    @MainActor func generateLetterImage(domain: String) async -> UIImage {
         let letter: Character = domain.first ?? defaultLetter
         let capitalizedLetter = letter.uppercased()
 

--- a/BrowserKit/Sources/SiteImageView/SiteImageFetcher.swift
+++ b/BrowserKit/Sources/SiteImageView/SiteImageFetcher.swift
@@ -69,18 +69,21 @@ class DefaultSiteImageFetcher: SiteImageFetcher {
         guard let domain = imageModel.domain else {
             // If no domain, we generate the favicon from the urlStringRequest
             return await imageHandler.fetchFavicon(imageURL: imageModel.faviconURL,
-                                                   domain: imageModel.urlStringRequest)
+                                                   domain: imageModel.urlStringRequest,
+                                                   expectedType: imageModel.expectedImageType)
         }
 
         do {
             // Try to fetch the favicon URL
             let faviconURLImageModel = try await urlHandler.getFaviconURL(site: imageModel)
             return await imageHandler.fetchFavicon(imageURL: faviconURLImageModel.faviconURL,
-                                                   domain: domain)
+                                                   domain: domain,
+                                                   expectedType: imageModel.expectedImageType)
         } catch {
             // If no favicon URL, generate favicon without it
             return await imageHandler.fetchFavicon(imageURL: imageModel.faviconURL,
-                                                   domain: domain)
+                                                   domain: domain,
+                                                   expectedType: imageModel.expectedImageType)
         }
     }
 

--- a/BrowserKit/Tests/SiteImageViewTests/FaviconURLProcessing/FaviconURLHandlerTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/FaviconURLProcessing/FaviconURLHandlerTests.swift
@@ -36,7 +36,7 @@ class FaviconURLHandlerTests: XCTestCase {
             XCTAssertEqual(cacheURLCount, 0, "cache url should not have been called")
             XCTAssertEqual(mockFetcher.fetchFaviconURLCalledCount, 0, "fetch favicon url should not have been called")
             XCTAssertEqual(site.faviconURL?.absoluteString, "www.firefox.com/image")
-            XCTAssertEqual(site.siteURL.absoluteString, "www.firefox.com")
+            XCTAssertEqual(site.siteURL?.absoluteString, "www.firefox.com")
         } catch {
             XCTFail("failed to get favicon url from cache")
         }
@@ -55,7 +55,7 @@ class FaviconURLHandlerTests: XCTestCase {
             XCTAssertEqual(cacheURLCount, 1, "cache url should have been called")
             XCTAssertEqual(mockFetcher.fetchFaviconURLCalledCount, 1, "fetch favicon url should have been called")
             XCTAssertEqual(site.faviconURL?.absoluteString, "www.firefox.com/image")
-            XCTAssertEqual(site.siteURL.absoluteString, "www.firefox.com")
+            XCTAssertEqual(site.siteURL?.absoluteString, "www.firefox.com")
         } catch {
             XCTFail("failed to get fetch favicon")
         }
@@ -78,6 +78,7 @@ class FaviconURLHandlerTests: XCTestCase {
     private func createSiteImageModel(siteURL: String) -> SiteImageModel {
         return SiteImageModel(id: UUID(),
                               expectedImageType: .favicon,
+                              urlStringRequest: siteURL,
                               siteURL: URL(string: siteURL)!,
                               domain: "domain",
                               faviconURL: nil,

--- a/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/HeroImageFetcherTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/HeroImageFetcherTests.swift
@@ -21,9 +21,10 @@ final class HeroImageFetcherTests: XCTestCase {
 
     func testHeroImageLoading_whenError_throwsError() async {
         metadataProvider.errorResult = TestError.invalidResult
-        let subject = DefaultHeroImageFetcher(metadataProvider: metadataProvider)
+        let subject = DefaultHeroImageFetcher()
         do {
-            _ = try await subject.fetchHeroImage(from: URL(string: "www.example.com")!)
+            _ = try await subject.fetchHeroImage(from: URL(string: "www.example.com")!,
+                                                 metadataProvider: metadataProvider)
             XCTFail("Should have failed")
         } catch let error as TestError {
             XCTAssertEqual("A test error",
@@ -34,9 +35,10 @@ final class HeroImageFetcherTests: XCTestCase {
     }
 
     func testHeroImageLoads_whenEmptyMetadata_throwsError() async {
-        let subject = DefaultHeroImageFetcher(metadataProvider: metadataProvider)
+        let subject = DefaultHeroImageFetcher()
         do {
-            _ = try await subject.fetchHeroImage(from: URL(string: "www.example.com")!)
+            _ = try await subject.fetchHeroImage(from: URL(string: "www.example.com")!,
+                                                 metadataProvider: metadataProvider)
             XCTFail("Should have failed")
         } catch let error as SiteImageError {
             XCTAssertEqual("Unable to download image with reason: Metadata image provider could not be retrieved.",
@@ -51,9 +53,10 @@ final class HeroImageFetcherTests: XCTestCase {
         providerFake.errorResult = TestError.invalidResult
         providerFake.imageResult = nil
         metadataProvider.metadataResult.imageProvider = providerFake
-        let subject = DefaultHeroImageFetcher(metadataProvider: metadataProvider)
+        let subject = DefaultHeroImageFetcher()
         do {
-            _ = try await subject.fetchHeroImage(from: URL(string: "www.example.com")!)
+            _ = try await subject.fetchHeroImage(from: URL(string: "www.example.com")!,
+                                                 metadataProvider: metadataProvider)
             XCTFail("Should have failed")
         } catch let error as SiteImageError {
             XCTAssertEqual("Unable to download image with reason: Optional(A test error)",
@@ -65,9 +68,10 @@ final class HeroImageFetcherTests: XCTestCase {
 
     func testHeroImageLoads_whenImage_returnsImage() async {
         metadataProvider.metadataResult.imageProvider = ItemProviderFake()
-        let subject = DefaultHeroImageFetcher(metadataProvider: metadataProvider)
+        let subject = DefaultHeroImageFetcher()
         do {
-            let image = try await subject.fetchHeroImage(from: URL(string: "www.example.com")!)
+            let image = try await subject.fetchHeroImage(from: URL(string: "www.example.com")!,
+                                                         metadataProvider: metadataProvider)
             XCTAssertNotNil(image)
         } catch {
             XCTFail("Should have succeed with image")

--- a/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/ImageHandlerTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/ImageHandlerTests.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0
 
 import XCTest
+import LinkPresentation
 @testable import SiteImageView
 
 final class ImageHandlerTests: XCTestCase {
@@ -235,7 +236,9 @@ private class MockHeroImageFetcher: HeroImageFetcher {
     var fetchHeroImageSucceedCalled = 0
     var fetchHeroImageFailedCalled = 0
 
-    func fetchHeroImage(from siteURL: URL) async throws -> UIImage {
+    func fetchHeroImage(from siteURL: URL,
+                        metadataProvider: LPMetadataProvider = LPMetadataProvider()
+    ) async throws -> UIImage {
         if let image = image {
             fetchHeroImageSucceedCalled += 1
             return image

--- a/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/ImageHandlerTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/ImageHandlerTests.swift
@@ -39,7 +39,8 @@ final class ImageHandlerTests: XCTestCase {
         let subject = createSubject()
 
         let result = await subject.fetchFavicon(imageURL: URL(string: "www.mozilla.com")!,
-                                                domain: "Mozilla")
+                                                domain: "Mozilla",
+                                                expectedType: .favicon)
         XCTAssertEqual(expectedResult, result)
         XCTAssertEqual(bundleImageFetcher.getImageFromBundleSucceedCalled, 1)
         XCTAssertEqual(bundleImageFetcher.getImageFromBundleFailedCalled, 0)
@@ -60,7 +61,8 @@ final class ImageHandlerTests: XCTestCase {
         let subject = createSubject()
 
         let result = await subject.fetchFavicon(imageURL: URL(string: "www.mozilla.com")!,
-                                                domain: "Mozilla")
+                                                domain: "Mozilla",
+                                                expectedType: .favicon)
         XCTAssertEqual(expectedResult, result)
         XCTAssertEqual(bundleImageFetcher.getImageFromBundleSucceedCalled, 0)
         XCTAssertEqual(bundleImageFetcher.getImageFromBundleFailedCalled, 1)
@@ -80,7 +82,8 @@ final class ImageHandlerTests: XCTestCase {
         let subject = createSubject()
 
         let result = await subject.fetchFavicon(imageURL: nil,
-                                                domain: "Mozilla")
+                                                domain: "Mozilla",
+                                                expectedType: .favicon)
         XCTAssertEqual(letterImageGenerator.image, result)
         XCTAssertEqual(bundleImageFetcher.getImageFromBundleSucceedCalled, 0)
         XCTAssertEqual(bundleImageFetcher.getImageFromBundleFailedCalled, 1)
@@ -102,7 +105,8 @@ final class ImageHandlerTests: XCTestCase {
         let subject = createSubject()
 
         let result = await subject.fetchFavicon(imageURL: URL(string: "www.mozilla.com")!,
-                                                domain: "Mozilla")
+                                                domain: "Mozilla",
+                                                expectedType: .favicon)
         XCTAssertEqual(expectedResult, result)
         XCTAssertEqual(bundleImageFetcher.getImageFromBundleSucceedCalled, 0)
         XCTAssertEqual(bundleImageFetcher.getImageFromBundleFailedCalled, 1)
@@ -122,7 +126,8 @@ final class ImageHandlerTests: XCTestCase {
         let subject = createSubject()
 
         let result = await subject.fetchFavicon(imageURL: URL(string: "www.mozilla.com")!,
-                                                domain: "Mozilla")
+                                                domain: "Mozilla",
+                                                expectedType: .favicon)
         XCTAssertEqual(letterImageGenerator.image, result)
         XCTAssertEqual(bundleImageFetcher.getImageFromBundleSucceedCalled, 0)
         XCTAssertEqual(bundleImageFetcher.getImageFromBundleFailedCalled, 1)
@@ -200,6 +205,53 @@ final class ImageHandlerTests: XCTestCase {
         } catch {
             XCTFail("Should have failed with SiteImageError.noHeroImage")
         }
+    }
+
+    // MARK: - Hero image fallback
+
+    func testHeroImageFallback_retrievesFromHeroImageCache() async {
+        let expectedResult = UIImage()
+        let subject = createSubject()
+        siteImageCache.image = expectedResult
+
+        let result = await subject.fetchFavicon(imageURL: URL(string: "www.mozilla.com")!,
+                                                domain: "Mozilla",
+                                                expectedType: .heroImage)
+        XCTAssertEqual(letterImageGenerator.image, result)
+        XCTAssertEqual(bundleImageFetcher.getImageFromBundleSucceedCalled, 0)
+        XCTAssertEqual(bundleImageFetcher.getImageFromBundleFailedCalled, 1)
+
+        XCTAssertEqual(siteImageCache.getImageFromCacheSucceedCalled, 1)
+        XCTAssertEqual(siteImageCache.getImageFromCacheFailedCalled, 0)
+
+        XCTAssertEqual(faviconFetcher.fetchImageSucceedCalled, 0)
+        XCTAssertEqual(faviconFetcher.fetchImageFailedCalled, 0)
+
+        XCTAssertEqual(siteImageCache.cacheImageCalled, 0)
+        XCTAssertEqual(letterImageGenerator.generateLetterImageCalled, 0)
+    }
+
+    func testHeroImageFallback_savesInHeroImageCache() async {
+        let expectedResult = UIImage()
+        let subject = createSubject()
+        faviconFetcher.image = expectedResult
+
+        let result = await subject.fetchFavicon(imageURL: URL(string: "www.mozilla.com")!,
+                                                domain: "Mozilla",
+                                                expectedType: .heroImage)
+        XCTAssertEqual(letterImageGenerator.image, result)
+        XCTAssertEqual(bundleImageFetcher.getImageFromBundleSucceedCalled, 0)
+        XCTAssertEqual(bundleImageFetcher.getImageFromBundleFailedCalled, 1)
+
+        XCTAssertEqual(siteImageCache.getImageFromCacheSucceedCalled, 0)
+        XCTAssertEqual(siteImageCache.getImageFromCacheFailedCalled, 1)
+
+        XCTAssertEqual(faviconFetcher.fetchImageSucceedCalled, 1)
+        XCTAssertEqual(faviconFetcher.fetchImageFailedCalled, 0)
+
+        XCTAssertEqual(siteImageCache.cachedWithType, .heroImage)
+        XCTAssertEqual(siteImageCache.cacheImageCalled, 1)
+        XCTAssertEqual(letterImageGenerator.generateLetterImageCalled, 0)
     }
 }
 

--- a/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/LetterImageGeneratorTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/LetterImageGeneratorTests.swift
@@ -6,36 +6,36 @@ import XCTest
 @testable import SiteImageView
 
 final class LetterImageGeneratorTests: XCTestCase {
-    func testEmptyDomain_doesntReturnEmptyImage() {
+    func testEmptyDomain_doesntReturnEmptyImage() async {
         let subject = DefaultLetterImageGeneratorSpy()
-        let result = subject.generateLetterImage(domain: "")
+        let result = await subject.generateLetterImage(domain: "")
 
         XCTAssertEqual(subject.capturedLetter, "#")
         XCTAssertNotEqual(result, UIImage())
         testColor(subject: subject, red: 0.850, green: 0.133, blue: 0.082, alpha: 1.0)
     }
 
-    func testDomain1_returnsExpectedLetterAndColor() {
+    func testDomain1_returnsExpectedLetterAndColor() async {
         let subject = DefaultLetterImageGeneratorSpy()
-        let result = subject.generateLetterImage(domain: "mozilla.com")
+        let result = await subject.generateLetterImage(domain: "mozilla.com")
 
         XCTAssertEqual(subject.capturedLetter, "M")
         XCTAssertNotEqual(result, UIImage())
         testColor(subject: subject, red: 0.223, green: 0.576, blue: 0.125, alpha: 1.0)
     }
 
-    func testDomain2_returnsExpectedLetterAndColor() {
+    func testDomain2_returnsExpectedLetterAndColor() async {
         let subject = DefaultLetterImageGeneratorSpy()
-        let result = subject.generateLetterImage(domain: "firefox.com")
+        let result = await subject.generateLetterImage(domain: "firefox.com")
 
         XCTAssertEqual(subject.capturedLetter, "F")
         XCTAssertNotEqual(result, UIImage())
         testColor(subject: subject, red: 0.584, green: 0.803, blue: 1.0, alpha: 1.0)
     }
 
-    func testFakeDomain_returnsExpectedLetterAndColor() {
+    func testFakeDomain_returnsExpectedLetterAndColor() async {
         let subject = DefaultLetterImageGeneratorSpy()
-        let result = subject.generateLetterImage(domain: "?$%^")
+        let result = await subject.generateLetterImage(domain: "?$%^")
 
         XCTAssertEqual(subject.capturedLetter, "?")
         XCTAssertNotEqual(result, UIImage())

--- a/BrowserKit/Tests/SiteImageViewTests/SiteImageFetcherTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/SiteImageFetcherTests.swift
@@ -24,15 +24,15 @@ final class SiteImageFetcherTests: XCTestCase {
     // MARK: - Favicon
 
     func testFavicon_noFaviconURLFound_generatesFavicon() async {
-        let siteURL = URL(string: "https://www.example.hello.com")!
+        let siteURL = "https://www.example.hello.com"
         let subject = DefaultSiteImageFetcher(urlHandler: urlHandler,
                                               imageHandler: imageHandler)
-        let result = await subject.getImage(siteURL: siteURL,
+        let result = await subject.getImage(urlStringRequest: siteURL,
                                             type: .favicon,
                                             id: UUID())
 
         XCTAssertEqual(result.domain, "example.hello")
-        XCTAssertEqual(result.siteURL, siteURL)
+        XCTAssertEqual(result.siteURL, URL(string: siteURL))
         XCTAssertEqual(result.faviconURL, nil)
         XCTAssertEqual(result.expectedImageType, .favicon)
         XCTAssertNil(result.heroImage)
@@ -45,10 +45,10 @@ final class SiteImageFetcherTests: XCTestCase {
 
     func testFavicon_wrongURL_useFallbackDomain() async {
         // URL without https://
-        let siteURL = URL(string: "www.example.hello.com")!
+        let siteURL = "www.example.hello.com"
         let subject = DefaultSiteImageFetcher(urlHandler: urlHandler,
                                               imageHandler: imageHandler)
-        let result = await subject.getImage(siteURL: siteURL,
+        let result = await subject.getImage(urlStringRequest: siteURL,
                                             type: .favicon,
                                             id: UUID())
 
@@ -58,16 +58,16 @@ final class SiteImageFetcherTests: XCTestCase {
 
     func testFavicon_faviconURLFound_generateFavicon() async {
         let faviconURL = URL(string: "www.mozilla.com/resource")!
-        let siteURL = URL(string: "https://www.mozilla.com")!
+        let siteURL = "https://www.mozilla.com"
         urlHandler.faviconURL = faviconURL
         let subject = DefaultSiteImageFetcher(urlHandler: urlHandler,
                                               imageHandler: imageHandler)
-        let result = await subject.getImage(siteURL: siteURL,
+        let result = await subject.getImage(urlStringRequest: siteURL,
                                             type: .favicon,
                                             id: UUID())
 
         XCTAssertEqual(result.domain, "mozilla")
-        XCTAssertEqual(result.siteURL, siteURL)
+        XCTAssertEqual(result.siteURL, URL(string: siteURL))
         XCTAssertEqual(result.faviconURL, nil)
         XCTAssertEqual(result.expectedImageType, .favicon)
         XCTAssertNil(result.heroImage)
@@ -83,13 +83,13 @@ final class SiteImageFetcherTests: XCTestCase {
     func testHeroImage_heroImageNotFound_returnsFavicon() async {
         let subject = DefaultSiteImageFetcher(urlHandler: urlHandler,
                                               imageHandler: imageHandler)
-        let siteURL = URL(string: "https://www.firefox.com")!
-        let result = await subject.getImage(siteURL: siteURL,
+        let siteURL = "https://www.firefox.com"
+        let result = await subject.getImage(urlStringRequest: siteURL,
                                             type: .heroImage,
                                             id: UUID())
 
         XCTAssertEqual(result.domain, "firefox")
-        XCTAssertEqual(result.siteURL, siteURL)
+        XCTAssertEqual(result.siteURL, URL(string: siteURL))
         XCTAssertEqual(result.faviconURL, nil)
         XCTAssertEqual(result.expectedImageType, .heroImage)
         XCTAssertNil(result.heroImage)
@@ -97,20 +97,20 @@ final class SiteImageFetcherTests: XCTestCase {
 
         XCTAssertNil(imageHandler.capturedFaviconURL)
         XCTAssertEqual(imageHandler.capturedDomain, "firefox")
-        XCTAssertEqual(imageHandler.capturedSiteURL, siteURL)
+        XCTAssertEqual(imageHandler.capturedSiteURL, URL(string: siteURL))
     }
 
     func testHeroImage_heroImageFound_returnsHeroImage() async {
         imageHandler.heroImage = UIImage()
         let subject = DefaultSiteImageFetcher(urlHandler: urlHandler,
                                               imageHandler: imageHandler)
-        let siteURL = URL(string: "https://www.focus.com")!
-        let result = await subject.getImage(siteURL: siteURL,
+        let siteURL = "https://www.focus.com"
+        let result = await subject.getImage(urlStringRequest: siteURL,
                                             type: .heroImage,
                                             id: UUID())
 
         XCTAssertEqual(result.domain, "focus")
-        XCTAssertEqual(result.siteURL, siteURL)
+        XCTAssertEqual(result.siteURL, URL(string: siteURL))
         XCTAssertEqual(result.faviconURL, nil)
         XCTAssertEqual(result.expectedImageType, .heroImage)
         XCTAssertNotNil(result.heroImage)
@@ -118,7 +118,7 @@ final class SiteImageFetcherTests: XCTestCase {
 
         XCTAssertNil(imageHandler.capturedFaviconURL)
         XCTAssertEqual(imageHandler.capturedDomain, "focus")
-        XCTAssertEqual(imageHandler.capturedSiteURL, siteURL)
+        XCTAssertEqual(imageHandler.capturedSiteURL, URL(string: siteURL))
     }
 }
 
@@ -131,6 +131,7 @@ private class MockFaviconURLHandler: FaviconURLHandler {
         capturedImageModel = site
         return SiteImageModel(id: site.id,
                               expectedImageType: site.expectedImageType,
+                              urlStringRequest: site.urlStringRequest,
                               siteURL: site.siteURL,
                               domain: site.domain,
                               faviconURL: faviconURL)

--- a/BrowserKit/Tests/SiteImageViewTests/SiteImageFetcherTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/SiteImageFetcherTests.swift
@@ -144,7 +144,7 @@ private class MockImageHandler: ImageHandler {
     var capturedFaviconURL: URL?
     var capturedDomain: String?
 
-    func fetchFavicon(imageURL: URL?, domain: String) async -> UIImage {
+    func fetchFavicon(imageURL: URL?, domain: String, expectedType: SiteImageType) async -> UIImage {
         capturedFaviconURL = imageURL
         capturedDomain = domain
         return faviconImage

--- a/BrowserKit/Tests/SiteImageViewTests/SiteImageViewTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/SiteImageViewTests.swift
@@ -21,7 +21,7 @@ final class SiteImageViewTests: XCTestCase {
     func testFaviconSetup() {
         let expectation = expectation(description: "Completed image setup")
         let url = "https://www.firefox.com"
-        let viewModel = FaviconImageViewModel(siteURL: url,
+        let viewModel = FaviconImageViewModel(urlStringRequest: url,
                                               faviconCornerRadius: 8)
         let subject = FaviconImageView(frame: .zero, imageFetcher: imageFetcher) {
             expectation.fulfill()
@@ -36,7 +36,7 @@ final class SiteImageViewTests: XCTestCase {
     func testHeroImageSetup() {
         let expectation = expectation(description: "Completed image setup")
         let url = "https://www.firefox.com"
-        let viewModel = HeroImageViewModel(siteURL: url,
+        let viewModel = HeroImageViewModel(urlStringRequest: url,
                                            generalCornerRadius: 8,
                                            faviconCornerRadius: 4,
                                            faviconBorderWidth: 0.5,

--- a/BrowserKit/Tests/SiteImageViewTests/SiteImageViewTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/SiteImageViewTests.swift
@@ -20,7 +20,7 @@ final class SiteImageViewTests: XCTestCase {
 
     func testFaviconSetup() {
         let expectation = expectation(description: "Completed image setup")
-        let url = URL(string: "https://www.firefox.com")!
+        let url = "https://www.firefox.com"
         let viewModel = FaviconImageViewModel(siteURL: url,
                                               faviconCornerRadius: 8)
         let subject = FaviconImageView(frame: .zero, imageFetcher: imageFetcher) {
@@ -29,13 +29,13 @@ final class SiteImageViewTests: XCTestCase {
         subject.setFavicon(viewModel)
 
         waitForExpectations(timeout: 0.1)
-        XCTAssertEqual(imageFetcher.capturedSiteURL, url)
+        XCTAssertEqual(imageFetcher.capturedStringRequest, url)
         XCTAssertEqual(imageFetcher.capturedType, .favicon)
     }
 
     func testHeroImageSetup() {
         let expectation = expectation(description: "Completed image setup")
-        let url = URL(string: "https://www.firefox.com")!
+        let url = "https://www.firefox.com"
         let viewModel = HeroImageViewModel(siteURL: url,
                                            generalCornerRadius: 8,
                                            faviconCornerRadius: 4,
@@ -48,7 +48,7 @@ final class SiteImageViewTests: XCTestCase {
         subject.setHeroImage(viewModel)
 
         waitForExpectations(timeout: 0.1)
-        XCTAssertEqual(imageFetcher.capturedSiteURL, url)
+        XCTAssertEqual(imageFetcher.capturedStringRequest, url)
         XCTAssertEqual(imageFetcher.capturedType, .heroImage)
     }
 }
@@ -56,15 +56,16 @@ final class SiteImageViewTests: XCTestCase {
 class MockSiteImageFetcher: SiteImageFetcher {
     var image = UIImage()
     var capturedType: SiteImageType?
-    var capturedSiteURL: URL?
-    func getImage(siteURL: URL,
+    var capturedStringRequest: String?
+    func getImage(urlStringRequest: String,
                   type: SiteImageType,
                   id: UUID) async -> SiteImageModel {
-        capturedSiteURL = siteURL
+        capturedStringRequest = urlStringRequest
         capturedType = type
         return SiteImageModel(id: id,
                               expectedImageType: type,
-                              siteURL: siteURL,
+                              urlStringRequest: urlStringRequest,
+                              siteURL: URL(string: urlStringRequest)!,
                               domain: "",
                               faviconURL: nil,
                               faviconImage: image,

--- a/BrowserKit/Tests/SiteImageViewTests/SiteImageViewTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/SiteImageViewTests.swift
@@ -36,12 +36,12 @@ final class SiteImageViewTests: XCTestCase {
     func testHeroImageSetup() {
         let expectation = expectation(description: "Completed image setup")
         let url = "https://www.firefox.com"
-        let viewModel = HeroImageViewModel(urlStringRequest: url,
-                                           generalCornerRadius: 8,
-                                           faviconCornerRadius: 4,
-                                           faviconBorderWidth: 0.5,
-                                           heroImageSize: CGSize(),
-                                           fallbackFaviconSize: CGSize())
+        let viewModel = DefaultHeroImageViewModel(urlStringRequest: url,
+                                                  generalCornerRadius: 8,
+                                                  faviconCornerRadius: 4,
+                                                  faviconBorderWidth: 0.5,
+                                                  heroImageSize: CGSize(),
+                                                  fallbackFaviconSize: CGSize())
         let subject = HeroImageView(frame: .zero, imageFetcher: imageFetcher) {
             expectation.fulfill()
         }

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -496,6 +496,7 @@
 		8A2366FA28A302E500846D1B /* MockSponsoredPocketAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2366F928A302E500846D1B /* MockSponsoredPocketAPI.swift */; };
 		8A2783F1275FFDC50080D29D /* KeyboardPressesHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2783F0275FFDC50080D29D /* KeyboardPressesHandler.swift */; };
 		8A2825352760399B00395E66 /* KeyboardPressesHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2825342760399B00395E66 /* KeyboardPressesHandlerTests.swift */; };
+		8A285B08294A5D4C00149B0F /* HomepageHeroImageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A285B07294A5D4C00149B0F /* HomepageHeroImageViewModel.swift */; };
 		8A28C628291028870078A81A /* CanRemoveQuickActionBookmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A28C627291028870078A81A /* CanRemoveQuickActionBookmarkTests.swift */; };
 		8A2B1A5D28216C4D0061216B /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 8A2B1A5A28216C4C0061216B /* Debug.xcconfig */; };
 		8A2B1A5E28216C4D0061216B /* Common.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 8A2B1A5B28216C4C0061216B /* Common.xcconfig */; };
@@ -3309,6 +3310,7 @@
 		8A2366F928A302E500846D1B /* MockSponsoredPocketAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSponsoredPocketAPI.swift; sourceTree = "<group>"; };
 		8A2783F0275FFDC50080D29D /* KeyboardPressesHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardPressesHandler.swift; sourceTree = "<group>"; };
 		8A2825342760399B00395E66 /* KeyboardPressesHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardPressesHandlerTests.swift; sourceTree = "<group>"; };
+		8A285B07294A5D4C00149B0F /* HomepageHeroImageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageHeroImageViewModel.swift; sourceTree = "<group>"; };
 		8A28C627291028870078A81A /* CanRemoveQuickActionBookmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanRemoveQuickActionBookmarkTests.swift; sourceTree = "<group>"; };
 		8A2B1A5A28216C4C0061216B /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Configuration/Debug.xcconfig; sourceTree = "<group>"; };
 		8A2B1A5B28216C4C0061216B /* Common.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Common.xcconfig; path = Configuration/Common.xcconfig; sourceTree = "<group>"; };
@@ -8382,6 +8384,7 @@
 				DF036E41274FD3FC002E834E /* HistoryHighlights */,
 				8A6A796C27F773550022D6C6 /* HomepageContextMenuHelper.swift */,
 				8AB8574527D97CB00075C173 /* HomepageContextMenuProtocol.swift */,
+				8A285B07294A5D4C00149B0F /* HomepageHeroImageViewModel.swift */,
 				8AB59589284145B30090F4AE /* HomepageSectionHandler.swift */,
 				1DFE57FE27BAE3150025DE58 /* HomepageSectionType.swift */,
 				3BB50E1F1D627539004B33DF /* HomepageViewController.swift */,
@@ -10420,6 +10423,7 @@
 				C4EFEECF1CEBB6F2009762A4 /* BackForwardTableViewCell.swift in Sources */,
 				E1442FD3294782D9003680B0 /* UIView+Constraints.swift in Sources */,
 				2C49854E206173C800893DAE /* photon-colors.swift in Sources */,
+				8A285B08294A5D4C00149B0F /* HomepageHeroImageViewModel.swift in Sources */,
 				8AC1065F28D0CD700013263A /* OpenQLPreviewHelper.swift in Sources */,
 				EBA3B2C32268F16300728BDB /* PhotonActionSheetView.swift in Sources */,
 				E18EA56F28AD3279003F97FC /* UIDevice+Extension.swift in Sources */,

--- a/Client/Frontend/Home/HomepageHeroImageViewModel.swift
+++ b/Client/Frontend/Home/HomepageHeroImageViewModel.swift
@@ -13,10 +13,4 @@ struct HomepageHeroImageViewModel: HeroImageViewModel {
     let faviconBorderWidth: CGFloat = HomepageViewModel.UX.generalBorderWidth
     let heroImageSize: CGSize
     let fallbackFaviconSize: CGSize = HomepageViewModel.UX.fallbackFaviconSize
-
-    init(urlStringRequest: String,
-         heroImageSize: CGSize) {
-        self.urlStringRequest = urlStringRequest
-        self.heroImageSize = heroImageSize
-    }
 }

--- a/Client/Frontend/Home/HomepageHeroImageViewModel.swift
+++ b/Client/Frontend/Home/HomepageHeroImageViewModel.swift
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import SiteImageView
+
+struct HomepageHeroImageViewModel: HeroImageViewModel {
+    let urlStringRequest: String
+    let type: SiteImageView.SiteImageType = .heroImage
+    let generalCornerRadius: CGFloat = HomepageViewModel.UX.generalCornerRadius
+    let faviconCornerRadius: CGFloat = HomepageViewModel.UX.generalCornerRadius
+    let faviconBorderWidth: CGFloat = HomepageViewModel.UX.generalBorderWidth
+    let heroImageSize: CGSize
+    let fallbackFaviconSize: CGSize = HomepageViewModel.UX.fallbackFaviconSize
+
+    init(urlStringRequest: String,
+         heroImageSize: CGSize) {
+        self.urlStringRequest = urlStringRequest
+        self.heroImageSize = heroImageSize
+    }
+}

--- a/Client/Frontend/Home/HomepageViewModel.swift
+++ b/Client/Frontend/Home/HomepageViewModel.swift
@@ -28,6 +28,7 @@ class HomepageViewModel: FeatureFlaggable {
         static let generalCornerRadius: CGFloat = 8
         static let generalBorderWidth: CGFloat = 0.5
         static let generalIconCornerRadius: CGFloat = 4
+        static let fallbackFaviconSize = CGSize(width: 36, height: 36)
 
         static func leadingInset(traitCollection: UITraitCollection,
                                  interfaceIdiom: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) -> CGFloat {

--- a/Client/Frontend/Home/RecentlySaved/RecentlySavedCell.swift
+++ b/Client/Frontend/Home/RecentlySaved/RecentlySavedCell.swift
@@ -53,12 +53,8 @@ class RecentlySavedCell: UICollectionViewCell, ReusableCell {
     }
 
     func configure(viewModel: RecentlySavedCellViewModel, theme: Theme) {
-        let heroImageViewModel = HeroImageViewModel(urlStringRequest: viewModel.site.url,
-                                                    generalCornerRadius: HomepageViewModel.UX.generalCornerRadius,
-                                                    faviconCornerRadius: HomepageViewModel.UX.generalCornerRadius,
-                                                    faviconBorderWidth: HomepageViewModel.UX.generalBorderWidth,
-                                                    heroImageSize: UX.heroImageSize,
-                                                    fallbackFaviconSize: HomepageViewModel.UX.fallbackFaviconSize)
+        let heroImageViewModel = HomepageHeroImageViewModel(urlStringRequest: viewModel.site.url,
+                                                            heroImageSize: UX.heroImageSize)
         heroImageView.setHeroImage(heroImageViewModel)
         itemTitle.text = viewModel.site.title
         applyTheme(theme: theme)

--- a/Client/Frontend/Home/RecentlySaved/RecentlySavedCell.swift
+++ b/Client/Frontend/Home/RecentlySaved/RecentlySavedCell.swift
@@ -53,7 +53,7 @@ class RecentlySavedCell: UICollectionViewCell, ReusableCell {
     }
 
     func configure(viewModel: RecentlySavedCellViewModel, theme: Theme) {
-        let heroImageViewModel = HeroImageViewModel(siteURL: viewModel.site.url,
+        let heroImageViewModel = HeroImageViewModel(urlStringRequest: viewModel.site.url,
                                                     generalCornerRadius: HomepageViewModel.UX.generalCornerRadius,
                                                     faviconCornerRadius: HomepageViewModel.UX.generalCornerRadius,
                                                     faviconBorderWidth: HomepageViewModel.UX.generalBorderWidth,

--- a/Client/Frontend/Home/RecentlySaved/RecentlySavedCell.swift
+++ b/Client/Frontend/Home/RecentlySaved/RecentlySavedCell.swift
@@ -44,6 +44,7 @@ class RecentlySavedCell: UICollectionViewCell, ReusableCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         itemTitle.text = nil
+        heroImageView.prepareForReuse()
     }
 
     override func layoutSubviews() {

--- a/Client/Frontend/Home/RecentlySaved/RecentlySavedCell.swift
+++ b/Client/Frontend/Home/RecentlySaved/RecentlySavedCell.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Storage
+import SiteImageView
 
 /// A cell used in FxHomeScreen's Recently Saved section. It holds bookmarks and reading list items.
 class RecentlySavedCell: UICollectionViewCell, ReusableCell {
@@ -11,7 +12,6 @@ class RecentlySavedCell: UICollectionViewCell, ReusableCell {
         static let bookmarkTitleFontSize: CGFloat = 12
         static let containerSpacing: CGFloat = 16
         static let heroImageSize: CGSize = CGSize(width: 126, height: 82)
-        static let fallbackFaviconSize = CGSize(width: 36, height: 36)
         static let generalSpacing: CGFloat = 8
     }
 
@@ -21,31 +21,7 @@ class RecentlySavedCell: UICollectionViewCell, ReusableCell {
         view.layer.cornerRadius = HomepageViewModel.UX.generalCornerRadius
     }
 
-    // Contains the hero image and fallback favicons
-    private var imageContainer: UIView = .build { view in
-        view.backgroundColor = .clear
-    }
-
-    let heroImageView: UIImageView = .build { imageView in
-        imageView.contentMode = .scaleAspectFill
-        imageView.clipsToBounds = true
-        imageView.layer.masksToBounds = true
-        imageView.layer.cornerRadius = HomepageViewModel.UX.generalCornerRadius
-    }
-
-    // Used as a fallback if hero image isn't set
-    private let fallbackFaviconImage: UIImageView = .build { imageView in
-        imageView.contentMode = .scaleAspectFit
-        imageView.clipsToBounds = true
-        imageView.backgroundColor = .clear
-        imageView.layer.cornerRadius = HomepageViewModel.UX.generalIconCornerRadius
-        imageView.layer.masksToBounds = true
-    }
-
-    private var fallbackFaviconBackground: UIView = .build { view in
-        view.layer.cornerRadius = HomepageViewModel.UX.generalCornerRadius
-        view.layer.borderWidth = HomepageViewModel.UX.generalBorderWidth
-    }
+    private var heroImageView: HeroImageView = .build { _ in }
 
     let itemTitle: UILabel = .build { label in
         label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
@@ -67,11 +43,7 @@ class RecentlySavedCell: UICollectionViewCell, ReusableCell {
 
     override func prepareForReuse() {
         super.prepareForReuse()
-
-        heroImageView.image = nil
-        fallbackFaviconImage.image = nil
         itemTitle.text = nil
-        setFallBackFaviconVisibility(isHidden: false)
     }
 
     override func layoutSubviews() {
@@ -81,40 +53,22 @@ class RecentlySavedCell: UICollectionViewCell, ReusableCell {
     }
 
     func configure(viewModel: RecentlySavedCellViewModel, theme: Theme) {
-        configureImages(heroImage: viewModel.heroImage, favIconImage: viewModel.favIconImage)
-
+        let heroImageViewModel = HeroImageViewModel(siteURL: viewModel.site.url,
+                                                    generalCornerRadius: HomepageViewModel.UX.generalCornerRadius,
+                                                    faviconCornerRadius: HomepageViewModel.UX.generalCornerRadius,
+                                                    faviconBorderWidth: HomepageViewModel.UX.generalBorderWidth,
+                                                    heroImageSize: UX.heroImageSize,
+                                                    fallbackFaviconSize: HomepageViewModel.UX.fallbackFaviconSize)
+        heroImageView.setHeroImage(heroImageViewModel)
         itemTitle.text = viewModel.site.title
         applyTheme(theme: theme)
-    }
-
-    private func configureImages(heroImage: UIImage?, favIconImage: UIImage?) {
-        if heroImage == nil {
-            // Sets a small favicon in place of the hero image in case there's no hero image
-            fallbackFaviconImage.image = favIconImage
-        } else if heroImage?.size.width == heroImage?.size.height {
-            // If hero image is a square use it as a favicon
-            fallbackFaviconImage.image = heroImage
-        } else {
-            setFallBackFaviconVisibility(isHidden: true)
-            heroImageView.image = heroImage
-        }
-    }
-
-    private func setFallBackFaviconVisibility(isHidden: Bool) {
-        fallbackFaviconBackground.isHidden = isHidden
-        fallbackFaviconImage.isHidden = isHidden
-
-        heroImageView.isHidden = !isHidden
     }
 
     // MARK: - Helpers
 
     private func setupLayout() {
         contentView.backgroundColor = .clear
-
-        fallbackFaviconBackground.addSubviews(fallbackFaviconImage)
-        imageContainer.addSubviews(heroImageView, fallbackFaviconBackground)
-        rootContainer.addSubviews(imageContainer, itemTitle)
+        rootContainer.addSubviews(heroImageView, itemTitle)
         contentView.addSubview(rootContainer)
 
         NSLayoutConstraint.activate([
@@ -123,21 +77,14 @@ class RecentlySavedCell: UICollectionViewCell, ReusableCell {
             rootContainer.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
             rootContainer.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
 
-            // Image container, hero image and fallback
-
-            imageContainer.topAnchor.constraint(equalTo: rootContainer.topAnchor,
-                                                constant: UX.containerSpacing),
-            imageContainer.leadingAnchor.constraint(equalTo: rootContainer.leadingAnchor,
-                                                    constant: UX.containerSpacing),
-            imageContainer.trailingAnchor.constraint(equalTo: rootContainer.trailingAnchor,
-                                                     constant: -UX.containerSpacing),
-            imageContainer.heightAnchor.constraint(equalToConstant: UX.heroImageSize.height),
-            imageContainer.widthAnchor.constraint(equalToConstant: UX.heroImageSize.width),
-
-            heroImageView.topAnchor.constraint(equalTo: imageContainer.topAnchor),
-            heroImageView.leadingAnchor.constraint(equalTo: imageContainer.leadingAnchor),
-            heroImageView.trailingAnchor.constraint(equalTo: imageContainer.trailingAnchor),
-            heroImageView.bottomAnchor.constraint(equalTo: imageContainer.bottomAnchor),
+            heroImageView.topAnchor.constraint(equalTo: rootContainer.topAnchor,
+                                               constant: UX.containerSpacing),
+            heroImageView.leadingAnchor.constraint(equalTo: rootContainer.leadingAnchor,
+                                                   constant: UX.containerSpacing),
+            heroImageView.trailingAnchor.constraint(equalTo: rootContainer.trailingAnchor,
+                                                    constant: -UX.containerSpacing),
+            heroImageView.heightAnchor.constraint(equalToConstant: UX.heroImageSize.height),
+            heroImageView.widthAnchor.constraint(equalToConstant: UX.heroImageSize.width),
 
             itemTitle.topAnchor.constraint(equalTo: heroImageView.bottomAnchor,
                                            constant: UX.generalSpacing),
@@ -145,23 +92,6 @@ class RecentlySavedCell: UICollectionViewCell, ReusableCell {
             itemTitle.trailingAnchor.constraint(equalTo: heroImageView.trailingAnchor),
             itemTitle.bottomAnchor.constraint(equalTo: rootContainer.bottomAnchor,
                                               constant: -UX.generalSpacing),
-
-            fallbackFaviconBackground.centerXAnchor.constraint(equalTo: imageContainer.centerXAnchor),
-            fallbackFaviconBackground.centerYAnchor.constraint(equalTo: imageContainer.centerYAnchor),
-            fallbackFaviconBackground.heightAnchor.constraint(equalToConstant: UX.heroImageSize.height),
-            fallbackFaviconBackground.widthAnchor.constraint(equalToConstant: UX.heroImageSize.width),
-
-            fallbackFaviconImage.heightAnchor.constraint(equalToConstant: UX.fallbackFaviconSize.height),
-            fallbackFaviconImage.widthAnchor.constraint(equalToConstant: UX.fallbackFaviconSize.width),
-            fallbackFaviconImage.centerXAnchor.constraint(equalTo: fallbackFaviconBackground.centerXAnchor),
-            fallbackFaviconImage.centerYAnchor.constraint(equalTo: fallbackFaviconBackground.centerYAnchor),
-
-            itemTitle.topAnchor.constraint(equalTo: heroImageView.bottomAnchor,
-                                           constant: UX.generalSpacing),
-            itemTitle.leadingAnchor.constraint(equalTo: heroImageView.leadingAnchor),
-            itemTitle.trailingAnchor.constraint(equalTo: heroImageView.trailingAnchor),
-            itemTitle.bottomAnchor.constraint(equalTo: rootContainer.bottomAnchor,
-                                              constant: -UX.generalSpacing)
         ])
     }
 
@@ -180,8 +110,10 @@ class RecentlySavedCell: UICollectionViewCell, ReusableCell {
 extension RecentlySavedCell: ThemeApplicable {
     func applyTheme(theme: Theme) {
         itemTitle.textColor = theme.colors.textPrimary
-        fallbackFaviconBackground.backgroundColor = theme.colors.layer1
-        fallbackFaviconBackground.layer.borderColor = theme.colors.layer1.cgColor
+        let heroImageColors = HeroImageViewColor(faviconTintColor: theme.colors.iconPrimary,
+                                                 faviconBackgroundColor: theme.colors.layer1,
+                                                 faviconBorderColor: theme.colors.layer1)
+        heroImageView.updateHeroImageTheme(with: heroImageColors)
 
         adjustBlur(theme: theme)
     }

--- a/Client/Frontend/Home/RecentlySaved/RecentlySavedViewModel.swift
+++ b/Client/Frontend/Home/RecentlySaved/RecentlySavedViewModel.swift
@@ -7,8 +7,6 @@ import Storage
 
 struct RecentlySavedCellViewModel {
     let site: Site
-    var heroImage: UIImage?
-    var favIconImage: UIImage?
 }
 
 class RecentlySavedViewModel {
@@ -131,36 +129,7 @@ extension RecentlySavedViewModel: HomepageSectionHandler {
 
         if let item = recentItems[safe: indexPath.row] {
             let site = Site(url: item.url, title: item.title, bookmarked: true)
-
-            let id = Int(arc4random())
-            cell.tag = id
-            var heroImage: UIImage?
-            var favicon: UIImage?
-            let viewModel = RecentlySavedCellViewModel(site: site,
-                                                       heroImage: heroImage,
-                                                       favIconImage: favicon)
-            siteImageHelper.fetchImageFor(site: site,
-                                          imageType: .heroImage,
-                                          shouldFallback: true) { image in
-                guard cell.tag == id else { return }
-                heroImage = image
-                let viewModel = RecentlySavedCellViewModel(site: site,
-                                                           heroImage: heroImage,
-                                                           favIconImage: favicon)
-                recentlySavedCell.configure(viewModel: viewModel, theme: self.theme)
-            }
-
-            siteImageHelper.fetchImageFor(site: site,
-                                          imageType: .favicon,
-                                          shouldFallback: true) { image in
-                guard cell.tag == id else { return }
-                favicon = image
-                let viewModel = RecentlySavedCellViewModel(site: site,
-                                                           heroImage: heroImage,
-                                                           favIconImage: favicon)
-                recentlySavedCell.configure(viewModel: viewModel, theme: self.theme)
-            }
-
+            let viewModel = RecentlySavedCellViewModel(site: site)
             recentlySavedCell.configure(viewModel: viewModel, theme: theme)
         }
 


### PR DESCRIPTION
# [FXIOS-5269](https://mozilla-hub.atlassian.net/browse/FXIOS-5269) https://github.com/mozilla-mobile/firefox-ios/issues/12400
Needed to do some bugfixes and improvements to use HeroImageView in Recently Saved:
- MetadataProvider in HeroImageFetcher needs to be called from the main thread. Put it as a @MainActor for this.
- MetadataProvider in HeroImageFetcher threw me an error that it needs to be discarded since it's a one time use object, changed that to be the case (it's a param injection instead of injected in the class).
- Only request one time, even if we configure the cell again (and we do that often..) using `requestStartedWith`. Reason is that we can only request one time on a metadata provider object. We'll make a new request if the URL is different.
- We use the `Site` object in most places to configure our views. This object doesn't necessarily have a proper URL since we keep the URL as a string. This means I had to change SiteImageView to be setup with a URL of type string (called now `urlStringRequest`). We gracefully handle URL failure by falling back to the letter favicon (if what we have isn't a real URL somehow).
- Also found out that using the fallback to favicon in the HeroImageView, setting the favicon would always take longer thanb expected since we tried to fetch the hero image everytime (even when we had a cached favicon waiting for us for that particular domain). I fixed that by caching the found favicon inside the heroimage cache, hence saving the fallback and avoiding us to retrieve the heroimage each time.
- Make HeroImageViewColor init public

### All in all
- Bugfixes and adjustements to make HeroImageView usable 
- Added some documentation
- After all those changes I could use HeroImageView in RecentlySavedCell which enabled a bunch of code to be removed and cleaned up.