### PR TITLE
Bugfix FXIOS-5074 [v110] iPad The synced tab is displayed only after closing a tab

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -119,6 +119,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         TelemetryWrapper.recordEvent(category: .action, method: .background, object: .app)
         TabsQuantityTelemetry.trackTabsQuantity(tabManager: tabManager)
 
+        profile.syncManager.applicationDidEnterBackground()
+
         let singleShotTimer = DispatchSource.makeTimerSource(queue: DispatchQueue.main)
         // 2 seconds is ample for a localhost request to be completed by GCDWebServer. <500ms is expected on newer devices.
         singleShotTimer.schedule(deadline: .now() + 2.0, repeating: .never)

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -32,6 +32,7 @@ public protocol SyncManager {
 
     func endTimedSyncs()
     func applicationDidBecomeActive()
+    func applicationDidEnterBackground()
 
     @discardableResult func onRemovedAccount() -> Success
     @discardableResult func onAddedAccount() -> Success
@@ -777,7 +778,7 @@ open class BrowserProfile: Profile {
         }
 
         public func applicationDidBecomeActive() {
-            self.backgrounded = false
+            backgrounded = false
 
             guard self.profile.hasSyncableAccount() else { return }
 
@@ -796,6 +797,10 @@ open class BrowserProfile: Profile {
             if since > SyncConstants.SyncOnForegroundMinimumDelayMillis {
                 self.syncEverythingSoon()
             }
+        }
+
+        public func applicationDidEnterBackground() {
+            backgrounded = true
         }
 
         public var isSyncing: Bool {
@@ -834,7 +839,7 @@ open class BrowserProfile: Profile {
                 }
             #endif
 
-            // Dont notify if we are performing a sync in the background. This prevents more db access from happening
+            // Don't notify if we are performing a sync in the background. This prevents more db access from happening
             if !self.backgrounded {
                 notifySyncing(notification: .ProfileDidFinishSyncing)
             }


### PR DESCRIPTION
### [FXIOS-5074](https://mozilla-hub.atlassian.net/browse/FXIOS-5074)
#12118

The issue was related to the request to get the Sync Tab data failing because the app was on the background. The request was failing because the database is closed when the app goes in background. We already had a mechanism to avoid sending the `ProfileDidFinishSyncing` notification if the app was back grounded but it was not working. Fixing this we will not receive the notification anymore which makes us to loose SyncTabCell temporarily until another successful request is done 