### PR TITLE
 Add ProtonMail Option to MailApp Settings

### DIFF
--- a/Client/Frontend/Browser/MailProviders.swift
+++ b/Client/Frontend/Browser/MailProviders.swift
@@ -154,3 +154,18 @@ class FastmailIntegration: MailProvider {
         return constructEmailURLString(beginningScheme, metadata: metadata, supportedHeaders: supportedHeaders).asURL
     }
 }
+
+class ProtonMailIntegration: MailProvider {
+    var beginningScheme = "protonmail://"
+    var supportedHeaders = [
+        "to",
+        "cc",
+        "bcc",
+        "subject",
+        "body"
+    ]
+
+    func newEmailURLFromMetadata(_ metadata: MailToMetadata) -> URL? {
+        return constructEmailURLString(beginningScheme, metadata: metadata, supportedHeaders: supportedHeaders).asURL
+    }
+}

--- a/Client/Frontend/Browser/MailtoLinkHandler.swift
+++ b/Client/Frontend/Browser/MailtoLinkHandler.swift
@@ -29,7 +29,9 @@ open class MailtoLinkHandler {
                         providerDict[scheme] = ReaddleSparkIntegration()
                     } else if scheme == "mymail-mailto://" {
                         providerDict[scheme] = MyMailIntegration()
-                    } else if scheme == "mailru-mailto://" {
+                    } else if scheme == "protonmail://" {
+                        providerDict[scheme] = ProtonMailIntegration()
+                    }else if scheme == "mailru-mailto://" {
                         providerDict[scheme] = MailRuIntegration()
                     } else if scheme == "airmail://" {
                         providerDict[scheme] = AirmailIntegration()

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -67,6 +67,7 @@
 		<string>org-appextension-feature-password-management</string>
 		<string>googlegmail</string>
 		<string>fastmail</string>
+		<string>protonmail</string>
 		<string>whatsapp</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>

--- a/Client/MailSchemes.plist
+++ b/Client/MailSchemes.plist
@@ -9,6 +9,12 @@
 		<string>mailto:</string>
 	</dict>
 	<dict>
+		<key>name</key>
+		<string>ProtonMail</string>
+		<key>scheme</key>
+		<string>protonmail://</string>
+	</dict>
+	<dict>
 		<key>scheme</key>
 		<string>ms-outlook://</string>
 		<key>name</key>

--- a/Tests/XCUITests/MailAppSettingsTests.swift
+++ b/Tests/XCUITests/MailAppSettingsTests.swift
@@ -19,11 +19,13 @@ class MailAppSettingsTests: BaseTestCase {
         XCTAssertTrue(app.tables.staticTexts["OPEN MAIL LINKS WITH"].exists)
         XCTAssertFalse(app.tables.cells.staticTexts["Mail"].isSelected)
         XCTAssertFalse(app.tables.cells.staticTexts["Outlook"].isSelected)
+        XCTAssertFalse(app.tables.cells.staticTexts["ProtonMail"].isSelected)
         XCTAssertFalse(app.tables.cells.staticTexts["Airmail"].isSelected)
         XCTAssertFalse(app.tables.cells.staticTexts["myMail"].isSelected)
         XCTAssertFalse(app.tables.cells.staticTexts["Spark"].isSelected)
         XCTAssertFalse(app.tables.cells.staticTexts["YMail!"].isSelected)
         XCTAssertFalse(app.tables.cells.staticTexts["Gmail"].isSelected)
+        XCTAssertFalse(app.tables.cells.staticTexts["Fastmail"].isSelected)
 
         // Check that tapping on an element does nothing
         waitForExistence(app.tables["OpenWithPage.Setting.Options"])


### PR DESCRIPTION
ProtonMail is a trusted mail application and has a similar ethos to the Mozilla foundation surrounding end user privacy. Many Firefox users likely use the ProtonMail app and thus I added the support for it. 