### PR TITLE
Bugfix FXIOS-5391 [v109] Request Flooding

### DIFF
--- a/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/Cache/FaviconURLCache.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/Cache/FaviconURLCache.swift
@@ -4,23 +4,23 @@
 
 import Foundation
 
-protocol FaviconURLCache {
+public protocol FaviconURLCache {
     func getURLFromCache(domain: String) async throws -> URL
     func cacheURL(domain: String, faviconURL: URL) async
 }
 
-actor DefaultFaviconURLCache: FaviconURLCache {
+public actor DefaultFaviconURLCache: FaviconURLCache {
     private enum CacheConstants {
         static let cacheKey = "favicon-url-cache"
     }
 
-    static let shared = DefaultFaviconURLCache()
+    public static let shared = DefaultFaviconURLCache()
     private let fileManager: URLCacheFileManager
     private var urlCache = [String: FaviconURL]()
     private var preserveTask: Task<Void, Never>?
     private let preserveDebounceTime: UInt64 = 5_000_000_000 // 5 seconds
 
-    init(fileManager: URLCacheFileManager = DefaultURLCacheFileManager()) {
+    public init(fileManager: URLCacheFileManager = DefaultURLCacheFileManager()) {
         self.fileManager = fileManager
 
         Task {
@@ -28,14 +28,14 @@ actor DefaultFaviconURLCache: FaviconURLCache {
         }
     }
 
-    func getURLFromCache(domain: String) async throws -> URL {
+    public func getURLFromCache(domain: String) async throws -> URL {
         guard let favicon = urlCache[domain],
               let url = URL(string: favicon.faviconURL)
         else { throw SiteImageError.noURLInCache }
         return url
     }
 
-    func cacheURL(domain: String, faviconURL: URL) async {
+    public func cacheURL(domain: String, faviconURL: URL) async {
         let favicon = FaviconURL(domain: domain,
                                  faviconURL: faviconURL.absoluteString,
                                  createdAt: Date())

--- a/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/Cache/FileManagerProtocol.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/Cache/FileManagerProtocol.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-protocol FileManagerProtocol {
+public protocol FileManagerProtocol {
     func fileExists(atPath path: String) -> Bool
     func urls(for directory: FileManager.SearchPathDirectory, in domainMask: FileManager.SearchPathDomainMask) -> [URL]
 }

--- a/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/Cache/URLCacheFileManager.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/Cache/URLCacheFileManager.swift
@@ -4,26 +4,26 @@
 
 import Foundation
 
-protocol URLCacheFileManager: Actor {
+public protocol URLCacheFileManager: Actor {
     func getURLCache() async -> Data?
     func saveURLCache(data: Data)
 }
 
-actor DefaultURLCacheFileManager: URLCacheFileManager {
+public actor DefaultURLCacheFileManager: URLCacheFileManager {
     let fileName = "favicon-url-cache"
     private let fileManager: FileManagerProtocol
 
-    init(fileManager: FileManagerProtocol = FileManager.default) {
+    public init(fileManager: FileManagerProtocol = FileManager.default) {
         self.fileManager = fileManager
     }
 
-    func getURLCache() async -> Data? {
+    public func getURLCache() async -> Data? {
         let directory = getCacheDirectory()
         guard fileManager.fileExists(atPath: directory.path) else { return nil }
         return try? Data(contentsOf: directory)
     }
 
-    func saveURLCache(data: Data) {
+    public func saveURLCache(data: Data) {
         let path = getCacheDirectory()
         do {
             try data.write(to: path, options: [])

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -510,6 +510,8 @@
 		8A355E5E27D267A400B9AF34 /* RecentItemsHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A355E5D27D267A400B9AF34 /* RecentItemsHelperTests.swift */; };
 		8A36AC2C2886F27F00CDC0AD /* MockTabManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A36AC2B2886F27F00CDC0AD /* MockTabManager.swift */; };
 		8A37C79F28DA4BA600B1FAD4 /* ContextualHintViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A37C79E28DA4BA600B1FAD4 /* ContextualHintViewModelTests.swift */; };
+		8A3A3F73294D1F6200EF5F65 /* SiteImageView in Frameworks */ = {isa = PBXBuildFile; productRef = 8A3A3F72294D1F6200EF5F65 /* SiteImageView */; };
+		8A3A3F75294D1F7300EF5F65 /* SiteImageView in Frameworks */ = {isa = PBXBuildFile; productRef = 8A3A3F74294D1F7300EF5F65 /* SiteImageView */; };
 		8A471183287F6D9C00F5A6EA /* BookmarksPanelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A471182287F6D9C00F5A6EA /* BookmarksPanelViewModel.swift */; };
 		8A471185287F6E4800F5A6EA /* SeparatorTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A471184287F6E4800F5A6EA /* SeparatorTableViewCell.swift */; };
 		8A48CE33292FCC0800B32289 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 8A48CE32292FCC0800B32289 /* Kingfisher */; };
@@ -5282,6 +5284,7 @@
 			files = (
 				8A48CE3D292FCE1A00B32289 /* Kingfisher in Frameworks */,
 				43BE581B278BE5AE00491291 /* RustMozillaAppServices.framework in Frameworks */,
+				8A3A3F75294D1F7300EF5F65 /* SiteImageView in Frameworks */,
 				5A87148C292EA1640039A5BD /* Fuzi in Frameworks */,
 				C820439A2523DC4500740B71 /* libStorage.a in Frameworks */,
 				D09A0CDC1FAA24CC009A0273 /* libAccount.a in Frameworks */,
@@ -5367,6 +5370,7 @@
 				5A8FD0F8293A7ECD00333AA7 /* Sentry in Frameworks */,
 				8A48CE37292FCC2700B32289 /* Kingfisher in Frameworks */,
 				43BE5809278BA9D700491291 /* RustMozillaAppServices.framework in Frameworks */,
+				8A3A3F73294D1F6200EF5F65 /* SiteImageView in Frameworks */,
 				5A8FD0E4293A7B4600333AA7 /* XCGLogger in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -8490,6 +8494,7 @@
 				5A87148B292EA1640039A5BD /* Fuzi */,
 				8A48CE3C292FCE1A00B32289 /* Kingfisher */,
 				5A8FD0E9293A7D0C00333AA7 /* XCGLogger */,
+				8A3A3F74294D1F7300EF5F65 /* SiteImageView */,
 			);
 			productName = Sync;
 			productReference = 2827315E1ABC9BE600AA1954 /* Sync.framework */;
@@ -8596,6 +8601,7 @@
 				8A48CE36292FCC2700B32289 /* Kingfisher */,
 				5A8FD0E3293A7B4600333AA7 /* XCGLogger */,
 				5A8FD0F7293A7ECD00333AA7 /* Sentry */,
+				8A3A3F72294D1F6200EF5F65 /* SiteImageView */,
 			);
 			productName = Storage;
 			productReference = 2FCAE21A1ABB51F800877008 /* libStorage.a */;
@@ -15867,6 +15873,14 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 435C85EE2788F4D00072B526 /* XCRemoteSwiftPackageReference "glean-swift" */;
 			productName = Glean;
+		};
+		8A3A3F72294D1F6200EF5F65 /* SiteImageView */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SiteImageView;
+		};
+		8A3A3F74294D1F7300EF5F65 /* SiteImageView */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SiteImageView;
 		};
 		8A48CE32292FCC0800B32289 /* Kingfisher */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -724,13 +724,17 @@ class SearchViewController: SiteTableViewController,
             twoLineCell.leftImageView.layer.borderColor = SearchViewControllerUX.IconBorderColor.cgColor
             twoLineCell.leftImageView.layer.borderWidth = SearchViewControllerUX.IconBorderWidth
             twoLineCell.leftImageView.contentMode = .center
-            profile.favicons.getFaviconImage(forSite: site).uponQueue(.main) {
-                [weak twoLineCell] result in
+            profile.favicons.getFaviconImage(forSite: site) { [weak twoLineCell] result in
                 // Check that we successfully retrieved an image (should always happen)
                 // and ensure that the cell we were fetching for is still on-screen.
-                guard let image = result.successValue else { return }
-                twoLineCell?.leftImageView.image = image
-                twoLineCell?.leftImageView.image = twoLineCell?.leftImageView.image?.createScaled(CGSize(width: SearchViewControllerUX.IconSize, height: SearchViewControllerUX.IconSize))
+                guard let image = result else { return }
+
+                DispatchQueue.main.async {
+                    twoLineCell?.leftImageView.image = image
+                    twoLineCell?.leftImageView.image = twoLineCell?.leftImageView.image?
+                        .createScaled(CGSize(width: SearchViewControllerUX.IconSize,
+                                             height: SearchViewControllerUX.IconSize))
+                }
             }
             twoLineCell.accessoryView = nil
             cell = twoLineCell

--- a/Client/Frontend/Library/Bookmarks/BookmarksFolderCell.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarksFolderCell.swift
@@ -71,15 +71,17 @@ extension BookmarkItemData: BookmarksFolderCell {
                                                       accessoryType: .disclosureIndicator)
 
         if let site = site {
-            profile?.favicons.getFaviconImage(forSite: site).uponQueue(.main) { result in
+            profile?.favicons.getFaviconImage(forSite: site) { result in
                 // Check that we successfully retrieved an image (should always happen)
                 // and ensure that the cell we were fetching for is still on-screen.
-                guard let image = result.successValue else { return }
+                guard let image = result else { return }
 
-                viewModel.leftImageView = image
-                viewModel.leftImageViewContentView = .scaleAspectFill
+                DispatchQueue.main.async {
+                    viewModel.leftImageView = image
+                    viewModel.leftImageViewContentView = .scaleAspectFill
 
-                completion?(viewModel)
+                    completion?(viewModel)
+                }
             }
         }
 

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetSiteHeaderView.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetSiteHeaderView.swift
@@ -57,11 +57,13 @@ class PhotonActionSheetSiteHeaderView: UITableViewHeaderFooterView, ReusableCell
             }
         } else if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
             let profile = appDelegate.profile
-            profile.favicons.getFaviconImage(forSite: site).uponQueue(.main) { result in
-                guard let image = result.successValue else { return }
+            profile.favicons.getFaviconImage(forSite: site) { result in
+                guard let image = result else { return }
 
-                self.siteImageView.backgroundColor = .clear
-                self.siteImageView.image = image.createScaled(PhotonActionSheet.UX.iconSize)
+                DispatchQueue.main.async {
+                    self.siteImageView.backgroundColor = .clear
+                    self.siteImageView.image = image.createScaled(PhotonActionSheet.UX.iconSize)
+                }
             }
         }
 

--- a/Client/SiteImageHelper.swift
+++ b/Client/SiteImageHelper.swift
@@ -163,11 +163,14 @@ class SiteImageHelper: SiteImageHelperProtocol {
         if let cachedImage = SiteImageHelper.cache.object(forKey: faviconCacheKey) {
             completion(cachedImage, true)
         } else {
-            faviconFetcher.getFaviconImage(forSite: site).uponQueue(.main, block: { result in
-                guard let image = result.successValue else { return }
-                SiteImageHelper.cache.setObject(image, forKey: faviconCacheKey)
-                completion(image, true)
-            })
+            faviconFetcher.getFaviconImage(forSite: site) { result in
+                guard let image = result else { return }
+
+                DispatchQueue.main.async {
+                    SiteImageHelper.cache.setObject(image, forKey: faviconCacheKey)
+                    completion(image, true)
+                }
+            }
         }
     }
 }

--- a/Storage/Favicons.swift
+++ b/Storage/Favicons.swift
@@ -7,5 +7,5 @@ import UIKit
 
 /// The base favicons protocol. To be deprecated soon, do not use for new code
 public protocol Favicons {
-    func getFaviconImage(forSite site: Site) -> Deferred<Maybe<UIImage>>
+    func getFaviconImage(forSite site: Site, completionHandler: @escaping (UIImage?) -> Void)
 }

--- a/Storage/SQL/SQLiteHistoryFavicons.swift
+++ b/Storage/SQL/SQLiteHistoryFavicons.swift
@@ -7,6 +7,7 @@ import UIKit
 import Fuzi
 import SwiftyJSON
 import Shared
+import SiteImageView
 
 private let log = Logger.syncLogger
 
@@ -72,60 +73,83 @@ class FaviconDownloadError: MaybeErrorType {
 }
 
 extension SQLiteHistory: Favicons {
-    public func getFaviconImage(forSite site: Site) -> Deferred<Maybe<UIImage>> {
+    public func getFaviconImage(forSite site: Site, completionHandler: @escaping (UIImage?) -> Void) {
         // First, attempt to lookup the favicon from our bundled top sites.
-        return getTopSitesFaviconImage(forSite: site).bind { result in
-            guard let image = result.successValue else {
-                // Note: "Attempt to lookup the favicon URL from the database" was removed as part of FXIOS-5164 and
-                // FXIOS-5294. This means at the moment we don't save nor retrieve favicon URLs from the database.
+        return getTopSitesFaviconImage(forSite: site) { result in
+            guard let image = result else {
+                self.test(forSite: site, completionHandler: completionHandler)
+                return
+            }
 
+            completionHandler(image)
+        }
+    }
+
+    // Note: "Attempt to lookup the favicon URL from the database" was removed as part of FXIOS-5164 and
+    // FXIOS-5294. This DefaultFaviconURLCache is an attempt to mitigate problems caused by this removal,
+    // which is documented in issue FXIOS-5391
+    private func test(forSite site: Site, completionHandler: @escaping (UIImage) -> Void) {
+        Task {
+            do {
+                let faviconURL = try await DefaultFaviconURLCache.shared.getURLFromCache(domain: site.url)
+                // Try to get the favicon from the URL scraped from the web page.
+                return self.retrieveTopSiteSQLiteHistoryFaviconImage(faviconURL: faviconURL) { result in
+                    // If the favicon could not be downloaded, use the generated "default" favicon.
+                    guard let image = result else {
+                        self.generateDefaultFaviconImage(forSite: site, completionHandler: completionHandler)
+                        return
+                    }
+
+                    completionHandler(image)
+                }
+            } catch {
                 // Attempt to scrape its URL from the web page.
-                return self.lookupFaviconURLFromWebPage(forSite: site).bind { result in
-                    guard let faviconURL = result.successValue else {
+                return self.lookupFaviconURLFromWebPage(forSite: site) { result in
+                    guard let faviconURL = result else {
                         // Otherwise, get the default favicon image.
-                        return self.generateDefaultFaviconImage(forSite: site)
+                        self.generateDefaultFaviconImage(forSite: site, completionHandler: completionHandler)
+                        return
                     }
                     // Try to get the favicon from the URL scraped from the web page.
-                    return self.retrieveTopSiteSQLiteHistoryFaviconImage(faviconURL: faviconURL).bind { result in
+                    return self.retrieveTopSiteSQLiteHistoryFaviconImage(faviconURL: faviconURL) { result in
                         // If the favicon could not be downloaded, use the generated "default" favicon.
-                        guard let image = result.successValue else {
-                            return self.generateDefaultFaviconImage(forSite: site)
+                        guard let image = result else {
+                            self.generateDefaultFaviconImage(forSite: site, completionHandler: completionHandler)
+                            return
                         }
 
-                        return deferMaybe(image)
+                        completionHandler(image)
+                        return
                     }
                 }
             }
-
-            return deferMaybe(image)
         }
     }
 
     // Downloads a favicon image from the web or retrieves it from the cache.
-    fileprivate func retrieveTopSiteSQLiteHistoryFaviconImage(faviconURL: URL) -> Deferred<Maybe<UIImage>> {
-        let deferred = CancellableDeferred<Maybe<UIImage>>()
-
+    fileprivate func retrieveTopSiteSQLiteHistoryFaviconImage(faviconURL: URL,
+                                                              completionHandler: @escaping (UIImage?) -> Void) {
         ImageLoadingHandler.shared.getImageFromCacheOrDownload(with: faviconURL,
                                                                limit: ImageLoadingConstants.MaximumFaviconSize) { image, error in
             guard error == nil, let image = image else {
-                deferred.fill(Maybe(failure: FaviconDownloadError(faviconURL: faviconURL.absoluteString)))
+                completionHandler(nil)
                 return
             }
 
-            deferred.fill(Maybe(success: image))
+            completionHandler(image)
         }
-
-        return deferred
     }
 
-    fileprivate func getTopSitesFaviconImage(forSite site: Site) -> Deferred<Maybe<UIImage>> {
+    fileprivate func getTopSitesFaviconImage(forSite site: Site, completionHandler: (UIImage?) -> Void) {
         guard let url = URL(string: site.url) else {
-            return deferMaybe(FaviconLookupError(siteURL: site.url))
+            completionHandler(nil)
+            return
         }
 
-        func imageFor(icon: (color: UIColor, fileURL: URL)) -> Deferred<Maybe<UIImage>> {
+        func imageFor(icon: (color: UIColor, fileURL: URL), completionHandler: (UIImage?) -> Void) {
             guard let image = UIImage(contentsOfFile: icon.fileURL.path) else {
-                return deferMaybe(FaviconLookupError(siteURL: site.url))
+                completionHandler(nil)
+                return
             }
 
             UIGraphicsBeginImageContextWithOptions(image.size, false, image.scale)
@@ -133,7 +157,8 @@ extension SQLiteHistory: Favicons {
 
             guard let context = UIGraphicsGetCurrentContext(),
                 let cgImage = image.cgImage else {
-                return deferMaybe(image)
+                completionHandler(image)
+                return
             }
 
             let rect = CGRect(origin: .zero, size: image.size)
@@ -143,70 +168,70 @@ extension SQLiteHistory: Favicons {
             context.draw(cgImage, in: rect)
 
             guard let imageWithBackground = UIGraphicsGetImageFromCurrentImageContext() else {
-                return deferMaybe(image)
+                completionHandler(image)
+                return
             }
 
-            return deferMaybe(imageWithBackground)
+            completionHandler(imageWithBackground)
         }
 
         let domain = url.shortDisplayString
         if multiRegionTopSitesDomains.contains(domain), let icon = topSitesIcons[domain] {
-            return imageFor(icon: icon)
+            imageFor(icon: icon, completionHandler: completionHandler)
+            return
         }
 
         let urlWithoutScheme = url.absoluteDisplayString.remove("\(url.scheme ?? "")://")
         if let baseDomain = url.baseDomain, let icon = topSitesIcons[baseDomain] ?? topSitesIcons[urlWithoutScheme] {
-            return imageFor(icon: icon)
+            imageFor(icon: icon, completionHandler: completionHandler)
+            return
         }
 
-        return deferMaybe(FaviconLookupError(siteURL: site.url))
+        completionHandler(nil)
     }
 
     // Retrieve's a site's favicon URL from the web.
-    fileprivate func lookupFaviconURLFromWebPage(forSite site: Site) -> Deferred<Maybe<URL>> {
+    fileprivate func lookupFaviconURLFromWebPage(forSite site: Site, completionHandler: @escaping (URL?) -> Void) {
         guard let url = URL(string: site.url) else {
-            return deferMaybe(FaviconLookupError(siteURL: site.url))
+            completionHandler(nil)
+            return
         }
 
-        let deferred = CancellableDeferred<Maybe<URL>>()
-        getFaviconURLsFromWebPage(url: url).upon { result in
-            guard let faviconURLs = result.successValue,
+        getFaviconURLsFromWebPage(url: url) { result in
+            guard let faviconURLs = result,
                 let faviconURL = faviconURLs.first else {
-                deferred.fill(Maybe(failure: FaviconLookupError(siteURL: site.url)))
+                completionHandler(nil)
                 return
             }
-
-            deferred.fill(Maybe(success: faviconURL))
+            Task {
+                await DefaultFaviconURLCache.shared.cacheURL(domain: site.url, faviconURL: faviconURL)
+            }
+            completionHandler(faviconURL)
         }
-
-        return deferred
     }
 
     // Scrapes an HTMLDocument DOM from a web page URL.
-    fileprivate func getHTMLDocumentFromWebPage(url: URL) -> Deferred<Maybe<HTMLDocument>> {
-        let deferred = CancellableDeferred<Maybe<HTMLDocument>>()
-
-        // getHTMLDocumentFromWebPage can be called from getFaviconURLsFromWebPage, and that function is off-main. 
+    fileprivate func getHTMLDocumentFromWebPage(url: URL, completionHandler: @escaping (HTMLDocument?) -> Void) {
+        // getHTMLDocumentFromWebPage can be called from getFaviconURLsFromWebPage, and that function is off-main.
         DispatchQueue.main.async {
             urlSession.dataTask(with: url) { (data, response, error) in
                 guard error == nil,
-                    let data = data,
-                    let document = try? HTMLDocument(data: data) else {
-                        deferred.fill(Maybe(failure: FaviconLookupError(siteURL: url.absoluteString)))
-                        return
+                      let data = data,
+                      let document = try? HTMLDocument(data: data) else {
+                    completionHandler(nil)
+                    return
                 }
-                deferred.fill(Maybe(success: document))
+                completionHandler(document)
             }.resume()
         }
-
-        return deferred
     }
 
     // Scrapes the web page at the specified URL for its favicon URLs.
-    fileprivate func getFaviconURLsFromWebPage(url: URL) -> Deferred<Maybe<[URL]>> {
-        return getHTMLDocumentFromWebPage(url: url).bind { result in
-            guard let document = result.successValue else {
-                return deferMaybe(FaviconLookupError(siteURL: url.absoluteString))
+    fileprivate func getFaviconURLsFromWebPage(url: URL, completionHandler: @escaping ([URL]?) -> Void) {
+        return getHTMLDocumentFromWebPage(url: url) { result in
+            guard let document = result else {
+                completionHandler(nil)
+                return
             }
 
             // If we were redirected via a <meta> tag on the page to a different
@@ -217,7 +242,8 @@ extension SQLiteHistory: Favicons {
                     let index = content.range(of: "URL="),
                     let reloadURL = URL(string: String(content[index.upperBound...])),
                     reloadURL != url {
-                    return self.getFaviconURLsFromWebPage(url: reloadURL)
+                    self.getFaviconURLsFromWebPage(url: reloadURL, completionHandler: completionHandler)
+                    return
                 }
             }
 
@@ -236,25 +262,23 @@ extension SQLiteHistory: Favicons {
                 icons.append(faviconURL)
             }
 
-            return deferMaybe(icons)
+            completionHandler(icons)
         }
     }
 
     // Generates a "default" favicon based on the first character in the
     // site's domain name or gets an already-generated icon from the cache.
-    fileprivate func generateDefaultFaviconImage(forSite site: Site) -> Deferred<Maybe<UIImage>> {
-        let deferred = Deferred<Maybe<UIImage>>()
-
+    fileprivate func generateDefaultFaviconImage(forSite site: Site, completionHandler: @escaping (UIImage) -> Void) {
         DispatchQueue.main.async {
             guard let url = URL(string: site.url), let character = url.baseDomain?.first else {
-                deferred.fill(Maybe(success: defaultFavicon))
+                completionHandler(defaultFavicon)
                 return
             }
 
             let faviconLetter = String(character).uppercased()
 
             if let cachedFavicon = defaultFaviconImageCache[faviconLetter] {
-                deferred.fill(Maybe(success: cachedFavicon))
+                completionHandler(cachedFavicon)
                 return
             }
 
@@ -283,8 +307,7 @@ extension SQLiteHistory: Favicons {
             UIGraphicsEndImageContext()
 
             defaultFaviconImageCache[faviconLetter] = image
-            deferred.fill(Maybe(success: image))
+            completionHandler(image)
         }
-        return deferred
     }
 }

--- a/Storage/SQL/SQLiteHistoryFavicons.swift
+++ b/Storage/SQL/SQLiteHistoryFavicons.swift
@@ -77,7 +77,7 @@ extension SQLiteHistory: Favicons {
         // First, attempt to lookup the favicon from our bundled top sites.
         return getTopSitesFaviconImage(forSite: site) { result in
             guard let image = result else {
-                self.test(forSite: site, completionHandler: completionHandler)
+                self.retrieveFavicon(forSite: site, completionHandler: completionHandler)
                 return
             }
 
@@ -88,7 +88,7 @@ extension SQLiteHistory: Favicons {
     // Note: "Attempt to lookup the favicon URL from the database" was removed as part of FXIOS-5164 and
     // FXIOS-5294. This DefaultFaviconURLCache is an attempt to mitigate problems caused by this removal,
     // which is documented in issue FXIOS-5391
-    private func test(forSite site: Site, completionHandler: @escaping (UIImage) -> Void) {
+    private func retrieveFavicon(forSite site: Site, completionHandler: @escaping (UIImage) -> Void) {
         Task {
             do {
                 let faviconURL = try await DefaultFaviconURLCache.shared.getURLFromCache(domain: site.url)

--- a/Tests/ClientTests/Helpers/SiteImageHelperTests.swift
+++ b/Tests/ClientTests/Helpers/SiteImageHelperTests.swift
@@ -200,17 +200,9 @@ extension SiteImageHelperTests {
 }
 
 class FaviconFetcherMock: Favicons {
-    func addFavicon(_ icon: Favicon) -> Deferred<Maybe<Int>> {
-        return deferMaybe(0)
-    }
-
-    func addFavicon(_ icon: Favicon, forSite site: Site) -> Deferred<Maybe<Int>> {
-        return deferMaybe(0)
-    }
-
     var shouldSucceed = true
-    func getFaviconImage(forSite site: Site) -> Deferred<Maybe<UIImage>> {
-        return shouldSucceed ? deferMaybe(UIImage()) : Deferred(value: Maybe(failure: SiteImageHelperTests.TestError.invalidResult))
+    func getFaviconImage(forSite site: Storage.Site, completionHandler: @escaping (UIImage?) -> Void) {
+        completionHandler(shouldSucceed ? UIImage() : nil)
     }
 }
 


### PR DESCRIPTION
# [FXIOS-5391](https://mozilla-hub.atlassian.net/browse/FXIOS-5391) https://github.com/mozilla-mobile/firefox-ios/issues/12617
This is a proposal for a an idea to have a short term fix for the flooding of requests described in the issue. This is short term since we want to remove all of that code and replace it with SiteImageView package. The things is that the replacement/long term solution is still a WIP. The idea here is to put back the caching of the faviconURL but using our new module from SiteImageView (which doesn't use the problematic bit of SQL that was causing crashes initially).

## Description
- Make FaviconURLCache from SiteImageView public (for this temp for fix only)
- Use it in SQLHistoryFavicons
- This will cache/retrieve the faviconURL to avoid flooding requests
- Removed deferred since with `Task` from `async` `await` I had trouble to make deferred work. Removing it entirely isn't too risky there as this code is enclosed in SQLHistoryFavicons entirely. 