### PR TITLE
Refactor MTE-379 [v110] Update testClosePrivateTabsOptionClosesPrivateTabs to specify the acceptable behaviour

### DIFF
--- a/Tests/XCUITests/PrivateBrowsingTest.swift
+++ b/Tests/XCUITests/PrivateBrowsingTest.swift
@@ -101,6 +101,10 @@ class PrivateBrowsingTest: BaseTestCase {
 
         // Go back to regular browser
         navigator.toggleOff(userState.isPrivate, withAction: Action.ToggleRegularMode)
+        app.cells.staticTexts["Homepage"].tap()
+        navigator.nowAt(NewTabScreen)
+        waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
+        navigator.performAction(Action.CloseURLBarOpen)
 
         // Go back to private browsing and check that the tab has not been closed
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
@@ -123,6 +127,10 @@ class PrivateBrowsingTest: BaseTestCase {
 
         // Go back to regular browsing and check that the private tab has been closed and that the initial Private Browsing message appears when going back to Private Browsing
         navigator.toggleOff(userState.isPrivate, withAction: Action.ToggleRegularMode)
+        app.cells.staticTexts["Homepage"].tap()
+        navigator.nowAt(NewTabScreen)
+        waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
+        navigator.performAction(Action.CloseURLBarOpen)
 
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         waitForNoExistence(app.cells.staticTexts["Internet for people, not profit — Mozilla. Currently selected tab."])


### PR DESCRIPTION
When the “Close Private Tabs” setting is on, the tabs under private mode are closed automatically only if we switch back to regular mode *and* maximize a browser tab. The existing test does not maximize a browser tab.

We decided that it's ok to not clear the tabs under private mode if a browser tab from the regular mode has not been maximize yet: https://mozilla-hub.atlassian.net/browse/FXIOS-5349.