### PR TITLE
Bugfix FXIOS-5391 [v109] hero image request spam

### DIFF
--- a/Tests/ClientTests/Helpers/SiteImageHelperTests.swift
+++ b/Tests/ClientTests/Helpers/SiteImageHelperTests.swift
@@ -223,10 +223,21 @@ class MetadataProviderFake: LPMetadataProvider {
 }
 
 class ItemProviderFake: NSItemProvider {
-    var imageResult: UIImage? = UIImage()
+    var imageResult: UIImage?
     var errorResult: Error?
     override func loadObject(ofClass aClass: NSItemProviderReading.Type, completionHandler: @escaping (NSItemProviderReading?, Error?) -> Void) -> Progress {
+        imageResult = generateFakeImage()
         completionHandler(imageResult, errorResult)
         return Progress()
+    }
+
+    private func generateFakeImage() -> UIImage? {
+        //let rect = CGRectMake(0, 0, 50, 50)
+
+        UIGraphicsBeginImageContextWithOptions(CGSize(width: 50, height: 50), true, 0)
+        //UIRectFill(rect)
+        let image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return image
     }
 }

--- a/Tests/ClientTests/Helpers/SiteImageHelperTests.swift
+++ b/Tests/ClientTests/Helpers/SiteImageHelperTests.swift
@@ -232,10 +232,7 @@ class ItemProviderFake: NSItemProvider {
     }
 
     private func generateFakeImage() -> UIImage? {
-        //let rect = CGRectMake(0, 0, 50, 50)
-
         UIGraphicsBeginImageContextWithOptions(CGSize(width: 50, height: 50), true, 0)
-        //UIRectFill(rect)
         let image = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
         return image


### PR DESCRIPTION
[FXIOS-5391](https://mozilla-hub.atlassian.net/browse/FXIOS-5391)
#12617 

The issue was that when a site has no hero image the SiteImageHelper will first try to get the hero image using LPMetadataProvider and then fall back to using the favicon. Since no hero image was fetched, no hero image was cached. This means on a home page refresh it will attempted to use LPMetadataProvider again to check for a hero image we should already know is not there. When there are many home page refreshes this can get quite spammy as LPMetadataProvider is heavy.

This solution is a hacky work around until the SiteImageView package is ready for use in v110.

This issue has been around for a long time but I believe the homepage changes that caused the homepage to refresh up to 100 times in quick succession made it much more visible. That issue was introduced in 105 and was addressed in 107.3, now the home page only refreshes a handful of times. Even with that this issue is still pretty spammy so I'm adding this quick fix in the short term because it will be a while before the SiteImageView project is finished. 

I also removed the throttle functionality because I don't think this is an appropriate use case and it was making it difficult to debug. Instead opting to fallback when needed as soon as the hero image fetching is finished.