### PR TITLE
Refactor FXIOS-5463 [v110] Update colors to use new theming

### DIFF
--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsClientAndTabsDataSource.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsClientAndTabsDataSource.swift
@@ -8,8 +8,6 @@ import Storage
 class RemoteTabsClientAndTabsDataSource: NSObject, RemoteTabsPanelDataSource {
     struct UX {
         static let headerHeight = SiteTableViewControllerUX.RowHeight
-        static let iconBorderColor = UIColor.Photon.Grey30
-        static let iconBorderWidth: CGFloat = 0.5
     }
 
     weak var collapsibleSectionDelegate: CollapsibleTableViewSection?
@@ -105,13 +103,10 @@ class RemoteTabsClientAndTabsDataSource: NSObject, RemoteTabsPanelDataSource {
         cell.titleLabel.text = tab.title
         cell.descriptionLabel.text = tab.URL.absoluteString
 
-        cell.leftImageView.layer.borderColor = UX.iconBorderColor.cgColor
-        cell.leftImageView.layer.borderWidth = UX.iconBorderWidth
         cell.accessoryView = nil
 
         getFavicon(for: tab) { [weak cell] image in
             cell?.leftImageView.image = image
-            cell?.leftImageView.backgroundColor = .clear
         }
 
         cell.applyTheme(theme: theme)

--- a/Client/Frontend/Widgets/TwoLineImageOverlayCell.swift
+++ b/Client/Frontend/Widgets/TwoLineImageOverlayCell.swift
@@ -10,6 +10,7 @@ class TwoLineImageOverlayCell: UITableViewCell,
     struct UX {
         static let ImageSize: CGFloat = 29
         static let BorderViewMargin: CGFloat = 16
+        static let iconBorderWidth: CGFloat = 0.5
     }
 
     /// Cell reuse causes the chevron to appear where it shouldn't. So, we use a different reuseIdentifier to prevent that.
@@ -25,8 +26,10 @@ class TwoLineImageOverlayCell: UITableViewCell,
 
     lazy var leftImageView: UIImageView = .build { imageView in
         imageView.contentMode = .scaleAspectFit
+        imageView.layer.borderWidth = UX.iconBorderWidth
         imageView.layer.cornerRadius = 5.0
         imageView.clipsToBounds = true
+        imageView.backgroundColor = .clear
     }
 
     lazy var leftOverlayImageView: UIImageView = .build { imageView in
@@ -113,6 +116,7 @@ class TwoLineImageOverlayCell: UITableViewCell,
         selectedView.backgroundColor = theme.colors.layer5Hover
         titleLabel.textColor = theme.colors.textPrimary
         descriptionLabel.textColor = theme.colors.textSecondary
+        leftImageView.layer.borderColor = theme.colors.layer4.cgColor
     }
 
     override func prepareForReuse() {


### PR DESCRIPTION
# [FXIOS-5463](https://mozilla-hub.atlassian.net/browse/FXIOS-5463) | #12733

TLDR: TwoLineImageOverlayCell has been updated to follow the new theming standards. Some cell customization stuff has been moved out of `RemoteTabsClientAndTabsDataSource` and into the `TwoLineImageOverlayCell`.