### PR TITLE
Added FXIOS-5466 [v110] expire url cache on start up

### DIFF
--- a/BrowserKit/.swiftpm/xcode/xcshareddata/xcschemes/Common.xcscheme
+++ b/BrowserKit/.swiftpm/xcode/xcshareddata/xcschemes/Common.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "SiteImageView"
-               BuildableName = "SiteImageView"
-               BlueprintName = "SiteImageView"
+               BlueprintIdentifier = "Common"
+               BuildableName = "Common"
+               BlueprintName = "Common"
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
@@ -32,9 +32,9 @@
       <CodeCoverageTargets>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "SiteImageView"
-            BuildableName = "SiteImageView"
-            BlueprintName = "SiteImageView"
+            BlueprintIdentifier = "Common"
+            BuildableName = "Common"
+            BlueprintName = "Common"
             ReferencedContainer = "container:">
          </BuildableReference>
       </CodeCoverageTargets>
@@ -43,9 +43,9 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "SiteImageViewTests"
-               BuildableName = "SiteImageViewTests"
-               BlueprintName = "SiteImageViewTests"
+               BlueprintIdentifier = "CommonTests"
+               BuildableName = "CommonTests"
+               BlueprintName = "CommonTests"
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>
@@ -71,9 +71,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "SiteImageView"
-            BuildableName = "SiteImageView"
-            BlueprintName = "SiteImageView"
+            BlueprintIdentifier = "Common"
+            BuildableName = "Common"
+            BlueprintName = "Common"
             ReferencedContainer = "container:">
          </BuildableReference>
       </MacroExpansion>

--- a/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/Cache/FaviconURL.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/Cache/FaviconURL.swift
@@ -7,5 +7,5 @@ import Foundation
 struct FaviconURL: Codable {
     let domain: ImageDomain
     let faviconURL: String
-    let createdAt: Date
+    var createdAt: Date
 }

--- a/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/Cache/FaviconURLCache.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/Cache/FaviconURLCache.swift
@@ -12,6 +12,7 @@ protocol FaviconURLCache {
 actor DefaultFaviconURLCache: FaviconURLCache {
     private enum CacheConstants {
         static let cacheKey = "favicon-url-cache"
+        static let daysToExpiration = 30
     }
 
     static let shared = DefaultFaviconURLCache()
@@ -32,6 +33,10 @@ actor DefaultFaviconURLCache: FaviconURLCache {
         guard let favicon = urlCache[domain.baseDomain],
               let url = URL(string: favicon.faviconURL)
         else { throw SiteImageError.noURLInCache }
+
+        // Update the element in the cache so it's time to expire is rest
+        await cacheURL(domain: domain, faviconURL: url)
+
         return url
     }
 
@@ -75,8 +80,22 @@ actor DefaultFaviconURLCache: FaviconURLCache {
             // is not catastrophic and the cache can always be rebuilt
             return
         }
+
+        // Ignore elements that are past the expiration time
+        let today = Date()
         urlCache = cacheList.reduce(into: [String: FaviconURL]()) {
+            if numberOfDaysBetween(start: $1.createdAt, end: today) >= CacheConstants.daysToExpiration {
+                return
+            }
             $0[$1.domain.baseDomain] = $1
         }
+    }
+
+    private func numberOfDaysBetween(start: Date, end: Date) -> Int {
+        let calendar = NSCalendar.current
+        let startDate = calendar.startOfDay(for: start)
+        let endDate = calendar.startOfDay(for: end)
+        let numberOfDays = calendar.dateComponents([.day], from: startDate, to: endDate)
+        return numberOfDays.day ?? 0
     }
 }

--- a/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/Cache/FaviconURLCache.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/Cache/FaviconURLCache.swift
@@ -19,7 +19,7 @@ actor DefaultFaviconURLCache: FaviconURLCache {
     private let fileManager: URLCacheFileManager
     private var urlCache = [String: FaviconURL]()
     private var preserveTask: Task<Void, Never>?
-    private let preserveDebounceTime: UInt64 = 5_000_000_000 // 5 seconds
+    private let preserveDebounceTime: UInt64 = 10_000_000_000 // 10 seconds
 
     init(fileManager: URLCacheFileManager = DefaultURLCacheFileManager()) {
         self.fileManager = fileManager
@@ -34,7 +34,7 @@ actor DefaultFaviconURLCache: FaviconURLCache {
               let url = URL(string: favicon.faviconURL)
         else { throw SiteImageError.noURLInCache }
 
-        // Update the element in the cache so it's time to expire is rest
+        // Update the element in the cache so it's time to expire is reset
         await cacheURL(domain: domain, faviconURL: url)
 
         return url

--- a/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/URLFetcher/HTMLDataRequest.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/URLFetcher/HTMLDataRequest.swift
@@ -24,7 +24,7 @@ struct DefaultHTMLDataRequest: HTMLDataRequest {
         return try await withCheckedThrowingContinuation { continuation in
             urlSession.dataTask(with: url) { data, _, error in
                 guard let data = data,
-                      error != nil
+                      error == nil
                 else {
                     continuation.resume(throwing: SiteImageError.invalidHTML)
                     return

--- a/BrowserKit/Tests/SiteImageViewTests/FaviconURLProcessing/FaviconURLCacheTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/FaviconURLProcessing/FaviconURLCacheTests.swift
@@ -36,14 +36,15 @@ class FaviconURLCacheTests: XCTestCase {
 
     func testRetrieveCacheNotExpired() async throws {
         let fileManager = DefaultURLCacheFileManager()
-        let testFavicons = [FaviconURL(domain: "google", faviconURL: "www.google.com", createdAt: Date())]
+        let googleDomain = ImageDomain(baseDomain: "google", bundleDomains: [])
+        let testFavicons = [FaviconURL(domain: googleDomain, faviconURL: "www.google.com", createdAt: Date())]
         await fileManager.saveURLCache(data: getTestData(items: testFavicons))
 
         subject = DefaultFaviconURLCache(fileManager: fileManager)
 
         try await Task.sleep(nanoseconds: 1_000_000_000)
 
-        let result = try? await subject.getURLFromCache(domain: "google")
+        let result = try? await subject.getURLFromCache(domain: googleDomain)
         XCTAssertEqual(result?.absoluteString, "www.google.com")
     }
 
@@ -53,18 +54,20 @@ class FaviconURLCacheTests: XCTestCase {
             XCTFail("Something went wrong generating a date in the past")
             return
         }
-        let testFavicons = [FaviconURL(domain: "amazon", faviconURL: "www.amazon.com", createdAt: Date()),
-                            FaviconURL(domain: "firefox", faviconURL: "www.firefox.com", createdAt: expiredDate)]
+        let amazonDomain = ImageDomain(baseDomain: "amazon", bundleDomains: [])
+        let firefoxDomain = ImageDomain(baseDomain: "firefox", bundleDomains: [])
+        let testFavicons = [FaviconURL(domain: amazonDomain, faviconURL: "www.amazon.com", createdAt: Date()),
+                            FaviconURL(domain: firefoxDomain, faviconURL: "www.firefox.com", createdAt: expiredDate)]
         await fileManager.saveURLCache(data: getTestData(items: testFavicons))
 
         subject = DefaultFaviconURLCache(fileManager: fileManager)
 
         try await Task.sleep(nanoseconds: 1_000_000_000)
 
-        let result1 = try? await subject.getURLFromCache(domain: "amazon")
+        let result1 = try? await subject.getURLFromCache(domain: amazonDomain)
         XCTAssertEqual(result1?.absoluteString, "www.amazon.com")
 
-        let result2 = try? await subject.getURLFromCache(domain: "firefox")
+        let result2 = try? await subject.getURLFromCache(domain: firefoxDomain)
         XCTAssertNil(result2)
     }
 

--- a/BrowserKit/Tests/SiteImageViewTests/FaviconURLProcessing/FaviconURLCacheTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/FaviconURLProcessing/FaviconURLCacheTests.swift
@@ -71,12 +71,12 @@ class FaviconURLCacheTests: XCTestCase {
         XCTAssertNil(result2)
     }
 
-    private func getTestData(items: [FaviconURL]) -> Data {
+    private func getTestData(items: [FaviconURL], file: String = #file, line: UInt = #line) -> Data {
         let archiver = NSKeyedArchiver(requiringSecureCoding: false)
         do {
             try archiver.encodeEncodable(items, forKey: "favicon-url-cache")
         } catch {
-            XCTFail("Something went wrong generating mock favicon data")
+            XCTFail("Something went wrong generating mock favicon data, file: \(file), line: \(line)")
         }
         return archiver.encodedData
     }


### PR DESCRIPTION
[FXIOS-5466](https://mozilla-hub.atlassian.net/browse/FXIOS-5466)
#12738 

Expires elements in the cache after 30 days when the cache is initially loaded from file.
Updated the cache retrieval code to update the stored date so we don't expire elements that were created 30 days ago but are still in regular use. 

I couldn't think of a better way to test this other than adding a sleep :(

Tests and swiftlint pass locally