### PR TITLE
Refactor FXIOS-5469 [v111] Disables search highlights in dev and beta builds

### DIFF
--- a/Tests/ClientTests/FeatureFlagManagerTests.swift
+++ b/Tests/ClientTests/FeatureFlagManagerTests.swift
@@ -54,8 +54,6 @@ class FeatureFlagManagerTests: XCTestCase, FeatureFlaggable {
         XCTAssertTrue(featureFlags.isFeatureEnabled(.recentlySaved, checking: .userOnly))
         XCTAssertTrue(featureFlags.isFeatureEnabled(.reportSiteIssue, checking: .buildOnly))
         XCTAssertTrue(featureFlags.isFeatureEnabled(.reportSiteIssue, checking: .userOnly))
-        XCTAssertTrue(featureFlags.isFeatureEnabled(.searchHighlights, checking: .buildOnly))
-        XCTAssertTrue(featureFlags.isFeatureEnabled(.searchHighlights, checking: .userOnly))
         XCTAssertTrue(featureFlags.isFeatureEnabled(.shakeToRestore, checking: .buildOnly))
         XCTAssertTrue(featureFlags.isFeatureEnabled(.shakeToRestore, checking: .userOnly))
         XCTAssertTrue(featureFlags.isFeatureEnabled(.sponsoredTiles, checking: .buildOnly))

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -152,7 +152,7 @@ features:
       - channel: developer
         value:
           awesome-bar:
-            search-highlights: true
+            search-highlights: false
             position:
               is-position-feature-enabled: true
               is-bottom: false
@@ -160,7 +160,7 @@ features:
       - channel: beta
         value:
           awesome-bar:
-            search-highlights: true
+            search-highlights: false
             position:
               is-position-feature-enabled: true
               is-bottom: false


### PR DESCRIPTION
Fixes [FXIOS-5469](https://mozilla-hub.atlassian.net/browse/FXIOS-5469)
Fixes #12749 

The context in the bug, but search highlights are enabled for beta and dev builds but not for release - meaning our experience with the search bar in beta builds isn't representative of our release population.

cc @dnarcese 
