### PR TITLE
Refactor MTE-346 [v110] SaveLoginsTests failing on iPad

### DIFF
--- a/Tests/XCUITests/SaveLoginsTests.swift
+++ b/Tests/XCUITests/SaveLoginsTests.swift
@@ -21,12 +21,6 @@ let defaultNumRowsEmptyFilterList = 0
 
 class SaveLoginTest: BaseTestCase {
     private func saveLogin(givenUrl: String) {
-        if iPad() {
-            waitForTabsButton()
-            navigator.goto(TabTray)
-            navigator.performAction(Action.OpenNewTabFromTabTray)
-            navigator.nowAt(URLBarOpen)
-        }
         navigator.openURL(givenUrl)
         waitUntilPageLoad()
         waitForExistence(app.buttons["submit"], timeout: 10)
@@ -105,10 +99,6 @@ class SaveLoginTest: BaseTestCase {
     }
 
     func testDoNotSaveLogin() {
-        if iPad() {
-            navigator.performAction(Action.CloseURLBarOpen)
-            navigator.nowAt(NewTabScreen)
-        }
         navigator.openURL(testLoginPage)
         waitUntilPageLoad()
         app.buttons["submit"].tap()


### PR DESCRIPTION
Some tests from the full functional tests have been failing only on iPad.

For the failures from `SaveLoginsTests`, we should remove the code specifically for the previous versions of iOS/iPad. Those snippets of code are no longer needed as the browser opens to the same screen on both iPhone and iPad.

I've tested the solution on the command line using these commands:
```
xcodebuild test -target Client -scheme Fennec_Enterprise_XCUITests -destination 'platform=iOS Simulator,name=iPhone 14' -only-testing:XCUITests/SaveLoginTest
xcodebuild test -target Client -scheme Fennec_Enterprise_XCUITests -destination 'platform=iOS Simulator,name=iPad Pro (12.9-inch) (5th generation)' -only-testing:XCUITests/SaveLoginTest
```

Epic on JIRA: https://mozilla-hub.atlassian.net/browse/MTE-345

Test report: https://storage.googleapis.com/mobile-reports/public/firefox-ios-M1/FullFunctionalTests-iPad/result_33/build/reports/tests.html