### PR TITLE
Refactor FXIOS-5488 [v110] Remove deferred from SQLiteHistoryFavicons

### DIFF
--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -727,13 +727,17 @@ class SearchViewController: SiteTableViewController,
             twoLineCell.leftImageView.layer.borderColor = SearchViewControllerUX.IconBorderColor.cgColor
             twoLineCell.leftImageView.layer.borderWidth = SearchViewControllerUX.IconBorderWidth
             twoLineCell.leftImageView.contentMode = .center
-            profile.favicons.getFaviconImage(forSite: site).uponQueue(.main) {
-                [weak twoLineCell] result in
+            profile.favicons.getFaviconImage(forSite: site) { [weak twoLineCell] result in
                 // Check that we successfully retrieved an image (should always happen)
                 // and ensure that the cell we were fetching for is still on-screen.
-                guard let image = result.successValue else { return }
-                twoLineCell?.leftImageView.image = image
-                twoLineCell?.leftImageView.image = twoLineCell?.leftImageView.image?.createScaled(CGSize(width: SearchViewControllerUX.IconSize, height: SearchViewControllerUX.IconSize))
+                guard let image = result else { return }
+
+                DispatchQueue.main.async {
+                    twoLineCell?.leftImageView.image = image
+                    twoLineCell?.leftImageView.image = twoLineCell?.leftImageView.image?
+                        .createScaled(CGSize(width: SearchViewControllerUX.IconSize,
+                                             height: SearchViewControllerUX.IconSize))
+                }
             }
             twoLineCell.accessoryView = nil
             cell = twoLineCell

--- a/Client/Frontend/Library/Bookmarks/BookmarksFolderCell.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarksFolderCell.swift
@@ -71,15 +71,17 @@ extension BookmarkItemData: BookmarksFolderCell {
                                                       accessoryType: .disclosureIndicator)
 
         if let site = site {
-            profile?.favicons.getFaviconImage(forSite: site).uponQueue(.main) { result in
+            profile?.favicons.getFaviconImage(forSite: site) { result in
                 // Check that we successfully retrieved an image (should always happen)
                 // and ensure that the cell we were fetching for is still on-screen.
-                guard let image = result.successValue else { return }
+                guard let image = result else { return }
 
-                viewModel.leftImageView = image
-                viewModel.leftImageViewContentView = .scaleAspectFill
+                DispatchQueue.main.async {
+                    viewModel.leftImageView = image
+                    viewModel.leftImageViewContentView = .scaleAspectFill
 
-                completion?(viewModel)
+                    completion?(viewModel)
+                }
             }
         }
 

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetSiteHeaderView.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetSiteHeaderView.swift
@@ -57,11 +57,13 @@ class PhotonActionSheetSiteHeaderView: UITableViewHeaderFooterView, ReusableCell
             }
         } else if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
             let profile = appDelegate.profile
-            profile.favicons.getFaviconImage(forSite: site).uponQueue(.main) { result in
-                guard let image = result.successValue else { return }
+            profile.favicons.getFaviconImage(forSite: site) { result in
+                guard let image = result else { return }
 
-                self.siteImageView.backgroundColor = .clear
-                self.siteImageView.image = image.createScaled(PhotonActionSheet.UX.iconSize)
+                DispatchQueue.main.async {
+                    self.siteImageView.backgroundColor = .clear
+                    self.siteImageView.image = image.createScaled(PhotonActionSheet.UX.iconSize)
+                }
             }
         }
 

--- a/Client/SiteImageHelper.swift
+++ b/Client/SiteImageHelper.swift
@@ -159,11 +159,14 @@ class SiteImageHelper: SiteImageHelperProtocol {
         if let cachedImage = SiteImageHelper.cache.object(forKey: faviconCacheKey) {
             completion(cachedImage, true)
         } else {
-            faviconFetcher.getFaviconImage(forSite: site).uponQueue(.main, block: { result in
-                guard let image = result.successValue else { return }
-                SiteImageHelper.cache.setObject(image, forKey: faviconCacheKey)
-                completion(image, true)
-            })
+            faviconFetcher.getFaviconImage(forSite: site) { result in
+                guard let image = result else { return }
+
+                DispatchQueue.main.async {
+                    SiteImageHelper.cache.setObject(image, forKey: faviconCacheKey)
+                    completion(image, true)
+                }
+            }
         }
     }
 }

--- a/Storage/Favicons.swift
+++ b/Storage/Favicons.swift
@@ -7,5 +7,5 @@ import UIKit
 
 /// The base favicons protocol. To be deprecated soon, do not use for new code
 public protocol Favicons {
-    func getFaviconImage(forSite site: Site) -> Deferred<Maybe<UIImage>>
+    func getFaviconImage(forSite site: Site, completionHandler: @escaping (UIImage?) -> Void)
 }

--- a/Tests/ClientTests/Helpers/SiteImageHelperTests.swift
+++ b/Tests/ClientTests/Helpers/SiteImageHelperTests.swift
@@ -200,17 +200,9 @@ extension SiteImageHelperTests {
 }
 
 class FaviconFetcherMock: Favicons {
-    func addFavicon(_ icon: Favicon) -> Deferred<Maybe<Int>> {
-        return deferMaybe(0)
-    }
-
-    func addFavicon(_ icon: Favicon, forSite site: Site) -> Deferred<Maybe<Int>> {
-        return deferMaybe(0)
-    }
-
     var shouldSucceed = true
-    func getFaviconImage(forSite site: Site) -> Deferred<Maybe<UIImage>> {
-        return shouldSucceed ? deferMaybe(UIImage()) : Deferred(value: Maybe(failure: SiteImageHelperTests.TestError.invalidResult))
+    func getFaviconImage(forSite site: Storage.Site, completionHandler: @escaping (UIImage?) -> Void) {
+        completionHandler(shouldSucceed ? UIImage() : nil)
     }
 }
 


### PR DESCRIPTION
# [FXIOS-5488](https://mozilla-hub.atlassian.net/browse/FXIOS-5488) https://github.com/mozilla-mobile/firefox-ios/issues/12773
Looking at https://github.com/mozilla-mobile/firefox-ios/issues/12771, we can't rule out that deferred isn't linked into this crash. Seeing https://github.com/mozilla-mobile/firefox-ios/issues/12527 this also becomes suspicious. 

One easy change is to remove deferred from that code in 109. This module is enclosed and so this shouldn't make things worst. Made sure that we call UI code from the main thread. This is a patch in the meantime that we're working on the long term favicon solution.