### PR TITLE
Refactor MTE-347 [v110] ToolbarTests and TopTabsTests for iPad

### DIFF
--- a/Tests/XCUITests/ToolbarTest.swift
+++ b/Tests/XCUITests/ToolbarTest.swift
@@ -43,7 +43,11 @@ class ToolbarTests: BaseTestCase {
         XCTAssertEqual(valueMozilla, urlValueLong)
         XCTAssertTrue(app.buttons["URLBarView.backButton"].isEnabled)
         XCTAssertFalse(app.buttons["Forward"].isEnabled)
-        XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.reloadButton].isEnabled)
+        if iPad() {
+            XCTAssertTrue(app.buttons["Reload"].isEnabled)
+        } else {
+            XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.reloadButton].isEnabled)
+        }
 
         navigator.openURL(website2)
         waitUntilPageLoad()

--- a/Tests/XCUITests/TopTabsTest.swift
+++ b/Tests/XCUITests/TopTabsTest.swift
@@ -240,7 +240,7 @@ class TopTabsTest: BaseTestCase {
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
         // Close all tabs and check that the number of tabs is correct
         navigator.performAction(Action.AcceptRemovingAllTabs)
-        XCTAssertTrue(app.staticTexts["Private Browsing"].exists, "Private welcome screen is not shown")
+        waitForExistence(app.staticTexts["Private Browsing"], timeout: TIMEOUT)
     }
 
     // Smoketest


### PR DESCRIPTION
Some tests from the full functional tests have been failing only on iPad.

For the failure from ToolBarTests, the `Reload` button has a different identifier on iPad than on iPhone. For the (intermittent) failure from TopTabsTests, I added a timeout to see if doing so alleviate the test from failing. (Without this change, the test is passing locally on my end. 😕 )

I've tested the change on both `iPhone 14` and `iPad Pro (12.9-inch) (5th generation)` iOS simulators on the command line.

Epic on JIRA: https://mozilla-hub.atlassian.net/browse/MTE-345

Test report: https://storage.googleapis.com/mobile-reports/public/firefox-ios-M1/FullFunctionalTests-iPad/result_33/build/reports/tests.html
