### PR TITLE
Refactor FXIOS-5270 [v110] FaviconImageView integration in History Highlights

### DIFF
--- a/BrowserKit/Sources/SiteImageView/FaviconImageView.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconImageView.swift
@@ -23,6 +23,7 @@ public class FaviconImageView: UIImageView, SiteImageView {
     public override init(frame: CGRect) {
         self.imageFetcher = DefaultSiteImageFetcher()
         super.init(frame: frame)
+        setupUI()
     }
 
     // Internal init used in unit tests only
@@ -32,6 +33,7 @@ public class FaviconImageView: UIImageView, SiteImageView {
         self.imageFetcher = imageFetcher
         self.completionHandler = completionHandler
         super.init(frame: frame)
+        setupUI()
     }
 
     required init?(coder: NSCoder) {
@@ -67,10 +69,15 @@ public class FaviconImageView: UIImageView, SiteImageView {
 
     private func setupFaviconImage(_ viewModel: SiteImageModel) {
         image = viewModel.faviconImage
-        layer.masksToBounds = true
     }
 
     private func setupFaviconLayout(viewModel: FaviconImageViewModel) {
         layer.cornerRadius = viewModel.faviconCornerRadius
+    }
+
+    private func setupUI() {
+        layer.masksToBounds = true
+        contentMode = .scaleAspectFit
+        clipsToBounds = true
     }
 }

--- a/BrowserKit/Sources/SiteImageView/FaviconImageViewModel.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconImageViewModel.swift
@@ -4,14 +4,16 @@
 
 import UIKit
 
-public struct FaviconImageViewModel {
-    let urlStringRequest: String
-    let faviconCornerRadius: CGFloat
-    let usesIndirectDomain: Bool
+public protocol FaviconImageViewModel {
+    var urlStringRequest: String { get }
+    var faviconCornerRadius: CGFloat { get }
+}
 
-    public init(urlStringRequest: String,
-                faviconCornerRadius: CGFloat,
-                usesIndirectDomain: Bool = false) {
+public struct DefaultFaviconImageViewModel: FaviconImageViewModel {
+    public let urlStringRequest: String
+    public let faviconCornerRadius: CGFloat
+
+    public init(urlStringRequest: String, faviconCornerRadius: CGFloat) {
         self.urlStringRequest = urlStringRequest
         self.faviconCornerRadius = faviconCornerRadius
         self.usesIndirectDomain = usesIndirectDomain

--- a/BrowserKit/Sources/SiteImageView/FaviconImageViewModel.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconImageViewModel.swift
@@ -7,13 +7,17 @@ import UIKit
 public protocol FaviconImageViewModel {
     var urlStringRequest: String { get }
     var faviconCornerRadius: CGFloat { get }
+    var usesIndirectDomain: Bool { get }
 }
 
 public struct DefaultFaviconImageViewModel: FaviconImageViewModel {
     public let urlStringRequest: String
     public let faviconCornerRadius: CGFloat
+    public let usesIndirectDomain: Bool
 
-    public init(urlStringRequest: String, faviconCornerRadius: CGFloat) {
+    public init(urlStringRequest: String,
+                faviconCornerRadius: CGFloat,
+                usesIndirectDomain: Bool = false) {
         self.urlStringRequest = urlStringRequest
         self.faviconCornerRadius = faviconCornerRadius
         self.usesIndirectDomain = usesIndirectDomain

--- a/BrowserKit/Tests/SiteImageViewTests/SiteImageViewTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/SiteImageViewTests.swift
@@ -21,8 +21,8 @@ final class SiteImageViewTests: XCTestCase {
     func testFaviconSetup() {
         let expectation = expectation(description: "Completed image setup")
         let url = "https://www.firefox.com"
-        let viewModel = FaviconImageViewModel(urlStringRequest: url,
-                                              faviconCornerRadius: 8)
+        let viewModel = DefaultFaviconImageViewModel(urlStringRequest: url,
+                                                     faviconCornerRadius: 8)
         let subject = FaviconImageView(frame: .zero, imageFetcher: imageFetcher) {
             expectation.fulfill()
         }

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -564,6 +564,7 @@
 		8AB5958828413F6C0090F4AE /* RecentlySavedCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB5958728413F6C0090F4AE /* RecentlySavedCell.swift */; };
 		8AB5958A284145B30090F4AE /* HomepageSectionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB59589284145B30090F4AE /* HomepageSectionHandler.swift */; };
 		8AB5958C28414DF60090F4AE /* ActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB5958B28414DF60090F4AE /* ActionButton.swift */; };
+		8AB6962F29536F4F003F1E48 /* HomepageFaviconImageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB6962E29536F4F003F1E48 /* HomepageFaviconImageViewModel.swift */; };
 		8AB8571D27D929350075C173 /* TopSitesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB8571C27D929350075C173 /* TopSitesViewModel.swift */; };
 		8AB8571F27D931B40075C173 /* EmptyTopSiteCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB8571E27D931B40075C173 /* EmptyTopSiteCell.swift */; };
 		8AB8572727D93AEC0075C173 /* TopSiteHistoryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43AB6FA125DC53D30016B015 /* TopSiteHistoryManager.swift */; };
@@ -3392,6 +3393,7 @@
 		8AB5958728413F6C0090F4AE /* RecentlySavedCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentlySavedCell.swift; sourceTree = "<group>"; };
 		8AB59589284145B30090F4AE /* HomepageSectionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageSectionHandler.swift; sourceTree = "<group>"; };
 		8AB5958B28414DF60090F4AE /* ActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionButton.swift; sourceTree = "<group>"; };
+		8AB6962E29536F4F003F1E48 /* HomepageFaviconImageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageFaviconImageViewModel.swift; sourceTree = "<group>"; };
 		8AB8571C27D929350075C173 /* TopSitesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSitesViewModel.swift; sourceTree = "<group>"; };
 		8AB8571E27D931B40075C173 /* EmptyTopSiteCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyTopSiteCell.swift; sourceTree = "<group>"; };
 		8AB8572827D9411A0075C173 /* DataObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataObserver.swift; sourceTree = "<group>"; };
@@ -8391,6 +8393,7 @@
 				DF036E41274FD3FC002E834E /* HistoryHighlights */,
 				8A6A796C27F773550022D6C6 /* HomepageContextMenuHelper.swift */,
 				8AB8574527D97CB00075C173 /* HomepageContextMenuProtocol.swift */,
+				8AB6962E29536F4F003F1E48 /* HomepageFaviconImageViewModel.swift */,
 				8A285B07294A5D4C00149B0F /* HomepageHeroImageViewModel.swift */,
 				8AB59589284145B30090F4AE /* HomepageSectionHandler.swift */,
 				1DFE57FE27BAE3150025DE58 /* HomepageSectionType.swift */,
@@ -10737,6 +10740,7 @@
 				966B0DC82926F60500A85A7E /* UIResponder+Extensions.swift in Sources */,
 				4390F7FF246DAFBE00570811 /* FirefoxColors.swift in Sources */,
 				E16E1C9828C25F1D00EE2EF5 /* SiteTableViewHeader.swift in Sources */,
+				8AB6962F29536F4F003F1E48 /* HomepageFaviconImageViewModel.swift in Sources */,
 				8AC5D55F28BFE6C8001F6F7F /* Presenter.swift in Sources */,
 				C8501F4F2850FB72003B09AB /* LegacyWallpaperMigrationUtility.swift in Sources */,
 				C8741FE928C4D30F00030029 /* FileManagerInterface.swift in Sources */,

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -543,7 +543,8 @@ class SearchViewController: SiteTableViewController,
                 }
             }
         case .searchHighlights:
-            if let url = searchHighlights[indexPath.row].siteUrl {
+            if let urlString = searchHighlights[indexPath.row].urlString,
+                let url = URL(string: urlString) {
                 recordSearchListSelectionTelemetry(type: .searchHighlights)
                 searchDelegate?.searchViewController(self, didSelectURL: url, searchTerm: nil)
             }
@@ -718,7 +719,7 @@ class SearchViewController: SiteTableViewController,
             }
         case .searchHighlights:
             let highlightItem = searchHighlights[indexPath.row]
-            let urlString = highlightItem.siteUrl?.absoluteString ?? ""
+            let urlString = highlightItem.urlString ?? ""
             let site = Site(url: urlString, title: highlightItem.displayTitle)
             cell = twoLineCell
             twoLineCell.descriptionLabel.isHidden = false

--- a/Client/Frontend/Browser/Tabs/ASGroup.swift
+++ b/Client/Frontend/Browser/Tabs/ASGroup.swift
@@ -40,4 +40,8 @@ extension ASGroup: HighlightItem {
     var siteUrl: URL? {
         return nil
     }
+
+    var urlString: String? {
+        return nil
+    }
 }

--- a/Client/Frontend/Home/HistoryHighlights/HighlightItem.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HighlightItem.swift
@@ -13,6 +13,7 @@ protocol HighlightItem {
     var displayTitle: String { get }
     var description: String? { get }
     var siteUrl: URL? { get }
+    var urlString: String? { get }
     var type: HighlightItemType { get }
     var group: [HighlightItem]? { get }
 }
@@ -36,5 +37,9 @@ extension HistoryHighlight: HighlightItem {
 
     var siteUrl: URL? {
         return URL(string: url)
+    }
+
+    var urlString: String? {
+        return url
     }
 }

--- a/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsCell.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsCell.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import UIKit
+import SiteImageView
 
 /// A cell used in FxHomeScreen's History Highlights section.
 class HistoryHighlightsCell: UICollectionViewCell, ReusableCell {
@@ -13,13 +14,7 @@ class HistoryHighlightsCell: UICollectionViewCell, ReusableCell {
     }
 
     // MARK: - UI Elements
-    let heroImage: UIImageView = .build { imageView in
-        imageView.contentMode = .scaleAspectFit
-        imageView.clipsToBounds = true
-        imageView.layer.masksToBounds = true
-        imageView.layer.cornerRadius = HomepageViewModel.UX.generalCornerRadius
-        imageView.image = UIImage.templateImageNamed(ImageIdentifiers.stackedTabsIcon)
-    }
+    let imageView: FaviconImageView = .build { imageView in }
 
     let itemTitle: UILabel = .build { label in
         label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
@@ -50,7 +45,7 @@ class HistoryHighlightsCell: UICollectionViewCell, ReusableCell {
     var isFillerCell: Bool = false {
         didSet {
             itemTitle.isHidden = isFillerCell
-            heroImage.isHidden = isFillerCell
+            imageView.isHidden = isFillerCell
             bottomLine.isHidden = isFillerCell
         }
     }
@@ -87,7 +82,12 @@ class HistoryHighlightsCell: UICollectionViewCell, ReusableCell {
         isFillerCell = options.isFillerCell
         accessibilityLabel = options.accessibilityLabel
 
-        heroImage.image = UIImage.templateImageNamed(ImageIdentifiers.stackedTabsIcon)
+        if let url = options.urlString {
+            let faviconViewModel = HomepageFaviconImageViewModel(urlStringRequest: url)
+            imageView.setFavicon(faviconViewModel)
+        } else {
+            imageView.image = UIImage.templateImageNamed(ImageIdentifiers.stackedTabsIcon)
+        }
 
         applyTheme(theme: theme)
     }
@@ -95,7 +95,7 @@ class HistoryHighlightsCell: UICollectionViewCell, ReusableCell {
     override func prepareForReuse() {
         super.prepareForReuse()
 
-        heroImage.image = nil
+        imageView.image = nil
         itemDescription.isHidden = true
 
         contentView.layer.shadowRadius = 0.0
@@ -105,18 +105,18 @@ class HistoryHighlightsCell: UICollectionViewCell, ReusableCell {
 
     // MARK: - Setup Helper methods
     private func setupLayout() {
-        contentView.addSubview(heroImage)
+        contentView.addSubview(imageView)
         contentView.addSubview(textStack)
         contentView.addSubview(bottomLine)
 
         NSLayoutConstraint.activate([
-            heroImage.leadingAnchor.constraint(equalTo: contentView.leadingAnchor,
+            imageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor,
                                                constant: UX.horizontalSpacing),
-            heroImage.heightAnchor.constraint(equalToConstant: UX.heroImageDimension),
-            heroImage.widthAnchor.constraint(equalToConstant: UX.heroImageDimension),
-            heroImage.centerYAnchor.constraint(equalTo: textStack.centerYAnchor),
+            imageView.heightAnchor.constraint(equalToConstant: UX.heroImageDimension),
+            imageView.widthAnchor.constraint(equalToConstant: UX.heroImageDimension),
+            imageView.centerYAnchor.constraint(equalTo: textStack.centerYAnchor),
 
-            textStack.leadingAnchor.constraint(equalTo: heroImage.trailingAnchor,
+            textStack.leadingAnchor.constraint(equalTo: imageView.trailingAnchor,
                                                constant: UX.horizontalSpacing),
             textStack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor,
                                                 constant: -UX.horizontalSpacing),
@@ -165,7 +165,7 @@ class HistoryHighlightsCell: UICollectionViewCell, ReusableCell {
 // MARK: - ThemeApplicable
 extension HistoryHighlightsCell: ThemeApplicable {
     func applyTheme(theme: Theme) {
-        heroImage.tintColor = theme.colors.iconPrimary
+        imageView.tintColor = theme.colors.iconPrimary
         bottomLine.backgroundColor = theme.colors.borderPrimary
         itemTitle.textColor = theme.colors.textPrimary
         itemDescription.textColor = theme.colors.textSecondary

--- a/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsDataAdaptor.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsDataAdaptor.swift
@@ -67,11 +67,11 @@ class HistoryHighlightsDataAdaptorImplementation: HistoryHighlightsDataAdaptor {
 
     private func extractDeletableURLs(from item: HighlightItem) -> [String] {
         var urls = [String]()
-        if item.type == .item, let url = item.siteUrl?.absoluteString {
+        if item.type == .item, let url = item.urlString {
             urls = [url]
         } else if item.type == .group, let items = item.group {
             items.forEach { groupedItem in
-                if let url = groupedItem.siteUrl?.absoluteString { urls.append(url) }
+                if let url = groupedItem.urlString { urls.append(url) }
             }
         }
 

--- a/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsManager.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsManager.swift
@@ -73,7 +73,7 @@ class HistoryHighlightsManager: HistoryHighlightsManagerProtocol {
                 return
             }
             for site in results {
-                let urlString = site.siteUrl?.absoluteString ?? ""
+                let urlString = site.urlString ?? ""
                 if site.displayTitle.lowercased().contains(searchQuery) ||
                     urlString.lowercased().contains(searchQuery) {
                     searchResults.append(site)

--- a/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
@@ -9,7 +9,7 @@ import UIKit
 struct HistoryHighlightsModel {
     let title: String
     let description: String?
-    let favIconImage: UIImage?
+    let urlString: String?
     let corners: CACornerMask?
     let hideBottomLine: Bool
     let isFillerCell: Bool
@@ -24,16 +24,16 @@ struct HistoryHighlightsModel {
 
     init(title: String,
          description: String?,
+         urlString: String? = nil,
          shouldHideBottomLine: Bool,
          with corners: CACornerMask? = nil,
-         and heroImage: UIImage? = nil,
          andIsFillerCell: Bool = false,
          shouldAddShadow: Bool = false) {
         self.title = title
         self.description = description
+        self.urlString = urlString
         self.hideBottomLine = shouldHideBottomLine
         self.corners = corners
-        self.favIconImage = heroImage
         self.isFillerCell = andIsFillerCell
         self.shouldAddShadow = shouldAddShadow
     }
@@ -46,7 +46,6 @@ struct HistoryHighlightsModel {
                   description: "",
                   shouldHideBottomLine: shouldHideBottomLine,
                   with: corners,
-                  and: nil,
                   andIsFillerCell: true,
                   shouldAddShadow: shouldAddShadow)
     }
@@ -67,7 +66,6 @@ class HistoryHighlightsViewModel {
     private var profile: Profile
     private var isPrivate: Bool
     private var urlBar: URLBarViewProtocol
-    private lazy var siteImageHelper = SiteImageHelper(profile: profile)
     private var hasSentSectionEvent = false
     private var historyHighlightsDataAdaptor: HistoryHighlightsDataAdaptor
     private let dispatchQueue: DispatchQueueInterface
@@ -147,12 +145,6 @@ class HistoryHighlightsViewModel {
                               method: .tap,
                               object: .firefoxHomepage,
                               value: .historyHighlightsItemOpened)
-    }
-
-    func getFavIcon(for site: Site, completion: @escaping (UIImage?) -> Void) {
-        siteImageHelper.fetchImageFor(site: site, imageType: .favicon, shouldFallback: false) { image in
-            completion(image)
-        }
     }
 
     func getItemDetailsAt(index: Int) -> HighlightItem? {
@@ -404,23 +396,14 @@ extension HistoryHighlightsViewModel: HomepageSectionHandler {
                                                   item: HighlightItem) -> UICollectionViewCell {
         guard let cell = cell as? HistoryHighlightsCell else { return UICollectionViewCell() }
 
-        let itemURL = item.siteUrl?.absoluteString ?? ""
-        let site = Site(url: itemURL, title: item.displayTitle)
-
         let cellOptions = HistoryHighlightsModel(title: item.displayTitle,
                                                  description: nil,
+                                                 urlString: item.urlString,
                                                  shouldHideBottomLine: hideBottomLine,
                                                  with: cornersToRound,
                                                  shouldAddShadow: shouldAddShadow)
 
         cell.configureCell(with: cellOptions, theme: theme)
-
-        let id = Int(arc4random())
-        cell.tag = id
-        getFavIcon(for: site) { image in
-            guard cell.tag == id else { return }
-            cell.heroImage.image = image
-        }
 
         return cell
     }

--- a/Client/Frontend/Home/HomepageContextMenuProtocol.swift
+++ b/Client/Frontend/Home/HomepageContextMenuProtocol.swift
@@ -59,8 +59,8 @@ extension HomepageContextMenuProtocol {
 
         switch highlightItem.type {
         case .item:
-            guard let url = highlightItem.siteUrl?.absoluteString else { return nil }
-            let site = Site(url: url, title: highlightItem.displayTitle)
+            guard let urlString = highlightItem.urlString else { return nil }
+            let site = Site(url: urlString, title: highlightItem.displayTitle)
 
             viewModel = PhotonActionSheetViewModel(actions: [actions],
                                                    site: site,

--- a/Client/Frontend/Home/HomepageFaviconImageViewModel.swift
+++ b/Client/Frontend/Home/HomepageFaviconImageViewModel.swift
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import SiteImageView
+
+struct HomepageFaviconImageViewModel: FaviconImageViewModel {
+    var urlStringRequest: String
+    var type: SiteImageView.SiteImageType = .favicon
+    var faviconCornerRadius: CGFloat = HomepageViewModel.UX.generalIconCornerRadius
+}

--- a/Client/Frontend/Home/HomepageFaviconImageViewModel.swift
+++ b/Client/Frontend/Home/HomepageFaviconImageViewModel.swift
@@ -9,4 +9,5 @@ struct HomepageFaviconImageViewModel: FaviconImageViewModel {
     var urlStringRequest: String
     var type: SiteImageView.SiteImageType = .favicon
     var faviconCornerRadius: CGFloat = HomepageViewModel.UX.generalIconCornerRadius
+    var usesIndirectDomain = false
 }

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -634,7 +634,7 @@ private extension HomepageViewController {
     }
 
     private func buildSite(from highlight: HighlightItem) -> Site {
-        let itemURL = highlight.siteUrl?.absoluteString ?? ""
+        let itemURL = highlight.urlString ?? ""
         return Site(url: itemURL, title: highlight.displayTitle)
     }
 


### PR DESCRIPTION
# [FXIOS-5270](https://mozilla-hub.atlassian.net/browse/FXIOS-5270) https://github.com/mozilla-mobile/firefox-ios/issues/12401
This work will need [FXIOS-5486](https://mozilla-hub.atlassian.net/browse/FXIOS-5486) to be mergeable, so opening as a draft PR for now.

- Added a urlString on the HighlightItem object (only URL? was available, which was itself gotten from a string. I made sure we use the urlString when we would get the absoluteString from the url (so we're not converting to an optional URL for nothing).
- Use FaviconImageView in History highlights
- Rename heroImage from History highlights to imageView since this image can be a favicon or the stackedTabsIcon. It's not a heroImage.
- Create HomepageFaviconImageViewModel so we have a consistent way of creating favicons on homepage