### PR TITLE
Refactor FXIOS-5265 [v110] FaviconImageView integration in TopSites

### DIFF
--- a/Client/Frontend/Home/TopSites/Cell/TopSiteItemCell.swift
+++ b/Client/Frontend/Home/TopSites/Cell/TopSiteItemCell.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Shared
+import SiteImageView
 import Storage
 import UIKit
 
@@ -33,10 +34,7 @@ class TopSiteItemCell: UICollectionViewCell, ReusableCell {
         view.layer.cornerRadius = HomepageViewModel.UX.generalCornerRadius
     }
 
-    lazy var imageView: UIImageView = .build { imageView in
-        imageView.layer.cornerRadius = HomepageViewModel.UX.generalIconCornerRadius
-        imageView.layer.masksToBounds = true
-    }
+    lazy var imageView: FaviconImageView = .build { _ in }
 
     // Holds the title and the pin image of the top site
     private lazy var titlePinWrapper: UIStackView = .build { stackView in
@@ -142,7 +140,6 @@ class TopSiteItemCell: UICollectionViewCell, ReusableCell {
     // MARK: - Public methods
 
     func configure(_ topSite: TopSite,
-                   favicon: UIImage?,
                    position: Int,
                    theme: Theme,
                    textColor: UIColor?) {
@@ -150,7 +147,8 @@ class TopSiteItemCell: UICollectionViewCell, ReusableCell {
         titleLabel.text = topSite.title
         accessibilityLabel = topSite.accessibilityLabel
 
-        imageView.image = favicon
+        let viewModel = HomepageFaviconImageViewModel(urlStringRequest: topSite.site.url)
+        imageView.setFavicon(viewModel)
         self.textColor = textColor
 
         configurePinnedSite(topSite)

--- a/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -29,7 +29,6 @@ class TopSitesViewModel {
     private let topSiteHistoryManager: TopSiteHistoryManager
     private let googleTopSiteManager: GoogleTopSiteManager
     private var wallpaperManager: WallpaperManager
-    private var siteImageHelper: SiteImageHelper
 
     init(profile: Profile,
          isZeroSearch: Bool = false,
@@ -42,7 +41,6 @@ class TopSitesViewModel {
 
         self.topSiteHistoryManager = TopSiteHistoryManager(profile: profile)
         self.googleTopSiteManager = GoogleTopSiteManager(prefs: profile.prefs)
-        self.siteImageHelper = SiteImageHelper(profile: profile)
         let adaptor = TopSitesDataAdaptorImplementation(profile: profile,
                                                         topSiteHistoryManager: topSiteHistoryManager,
                                                         googleTopSiteManager: googleTopSiteManager)
@@ -227,23 +225,12 @@ extension TopSitesViewModel: HomepageSectionHandler {
                    at indexPath: IndexPath) -> UICollectionViewCell {
         if let cell = collectionView.dequeueReusableCell(cellType: TopSiteItemCell.self, for: indexPath),
            let contentItem = topSites[safe: indexPath.row] {
-            let id = Int(arc4random())
-            cell.tag = id
-            siteImageHelper.fetchImageFor(site: contentItem.site,
-                                          imageType: .favicon,
-                                          shouldFallback: false) { image in
-                guard cell.tag == id else { return }
-                cell.imageView.image = image
-            }
-
             var textColor: UIColor?
-
             if wallpaperManager.featureAvailable {
                 textColor = wallpaperManager.currentWallpaper.textColor
             }
 
             cell.configure(contentItem,
-                           favicon: nil,
                            position: indexPath.row,
                            theme: theme,
                            textColor: textColor)


### PR DESCRIPTION
# [FXIOS-5265](https://mozilla-hub.atlassian.net/browse/FXIOS-5265) https://github.com/mozilla-mobile/firefox-ios/issues/12396
This work will need [FXIOS-5486](https://mozilla-hub.atlassian.net/browse/FXIOS-5486) to be mergeable, so opening as a draft PR for now. There might also be some trouble around Sponsored Tiles favicons, but maybe the issue will be fixed with 5486 as well. If not, this means we'll need a way to pass an imageURL to the FaviconImageView instead of us retrieving the imageURL for the sponsored tile. The ContileAPI returns the imageURL already.

- Use FaviconImageView in TopSites
- Create HomepageFaviconImageViewModel so we have a consistent way of creating favicons on homepage (same commit as https://github.com/mozilla-mobile/firefox-ios/pull/12781 to avoid conflicts).