### PR TITLE
Added FXIOS-5464 [v110] update cache key

### DIFF
--- a/BrowserKit/Sources/SiteImageView/Entities/SiteImageModel.swift
+++ b/BrowserKit/Sources/SiteImageView/Entities/SiteImageModel.swift
@@ -18,6 +18,9 @@ struct SiteImageModel {
     /// URL can be nil in case the urlStringRequest cannot be used to build a URL
     var siteURL: URL?
 
+    /// Used to cache any resources related to this request
+    var cacheKey: String
+
     /// Domain can be nil in case we don't have a siteURL to get the domain from
     var domain: ImageDomain?
 

--- a/BrowserKit/Sources/SiteImageView/FaviconImageView.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconImageView.swift
@@ -42,17 +42,20 @@ public class FaviconImageView: UIImageView, SiteImageView {
 
     public func setFavicon(_ viewModel: FaviconImageViewModel) {
         setupFaviconLayout(viewModel: viewModel)
-        setURL(viewModel.urlStringRequest, type: viewModel.type)
+        setURL(viewModel)
     }
 
     // MARK: - SiteImageView
 
-    func setURL(_ urlStringRequest: String, type: SiteImageType) {
-        guard canMakeRequest(with: urlStringRequest) else { return }
+    func setURL(_ viewModel: FaviconImageViewModel) {
+        guard canMakeRequest(with: viewModel.urlStringRequest) else { return }
 
         let id = UUID()
         uniqueID = id
-        updateImage(url: urlStringRequest, type: type, id: id)
+        updateImage(url: viewModel.urlStringRequest,
+                    type: .favicon,
+                    id: id,
+                    usesIndirectDomain: viewModel.usesIndirectDomain)
     }
 
     func setImage(imageModel: SiteImageModel) {

--- a/BrowserKit/Sources/SiteImageView/FaviconImageViewModel.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconImageViewModel.swift
@@ -6,12 +6,14 @@ import UIKit
 
 public struct FaviconImageViewModel {
     let urlStringRequest: String
-    let type: SiteImageType
     let faviconCornerRadius: CGFloat
+    let usesIndirectDomain: Bool
 
-    public init(urlStringRequest: String, faviconCornerRadius: CGFloat) {
-        self.type = .favicon
+    public init(urlStringRequest: String,
+                faviconCornerRadius: CGFloat,
+                usesIndirectDomain: Bool = false) {
         self.urlStringRequest = urlStringRequest
         self.faviconCornerRadius = faviconCornerRadius
+        self.usesIndirectDomain = usesIndirectDomain
     }
 }

--- a/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/Cache/FaviconURL.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/Cache/FaviconURL.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 struct FaviconURL: Codable {
-    let domain: ImageDomain
+    let cacheKey: String
     let faviconURL: String
     var createdAt: Date
 }

--- a/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/FaviconURLHandler.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/FaviconURLHandler.swift
@@ -20,19 +20,19 @@ struct DefaultFaviconURLHandler: FaviconURLHandler {
 
     func getFaviconURL(site: SiteImageModel) async throws -> SiteImageModel {
         // Don't fetch favicon URL if we don't have a URL or domain for it
-        guard let siteURL = site.siteURL, let domain = site.domain else {
+        guard let siteURL = site.siteURL else {
             throw SiteImageError.noFaviconURLFound
         }
 
         var imageModel = site
         do {
-            let url = try await urlCache.getURLFromCache(domain: domain)
+            let url = try await urlCache.getURLFromCache(cacheKey: imageModel.cacheKey)
             imageModel.faviconURL = url
             return imageModel
         } catch {
             do {
                 let url = try await urlFetcher.fetchFaviconURL(siteURL: siteURL)
-                await urlCache.cacheURL(domain: domain, faviconURL: url)
+                await urlCache.cacheURL(cacheKey: imageModel.cacheKey, faviconURL: url)
                 imageModel.faviconURL = url
                 return imageModel
             } catch {

--- a/BrowserKit/Sources/SiteImageView/HeroImageView.swift
+++ b/BrowserKit/Sources/SiteImageView/HeroImageView.swift
@@ -81,7 +81,10 @@ public class HeroImageView: UIView, SiteImageView {
 
         let id = UUID()
         uniqueID = id
-        updateImage(url: urlStringRequest, type: type, id: id)
+        updateImage(url: urlStringRequest,
+                    type: type,
+                    id: id,
+                    usesIndirectDomain: true)
     }
 
     func setImage(imageModel: SiteImageModel) {

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/BundleImageFetcher/BundleImageFetcher.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/BundleImageFetcher/BundleImageFetcher.swift
@@ -8,7 +8,7 @@ protocol BundleImageFetcher {
     /// Fetches from the bundle
     /// - Parameter domain: The domain to fetch the image with from the bundle
     /// - Returns: The image or throw an error if it fails
-    func getImageFromBundle(domain: ImageDomain) throws -> UIImage
+    func getImageFromBundle(domain: ImageDomain?) throws -> UIImage
 }
 
 class DefaultBundleImageFetcher: BundleImageFetcher {
@@ -34,8 +34,9 @@ class DefaultBundleImageFetcher: BundleImageFetcher {
         bundledImages = retrieveBundledImages()
     }
 
-    func getImageFromBundle(domain: ImageDomain) throws -> UIImage {
-        guard let bundleDomain = getBundleDomain(domain: domain) else {
+    func getImageFromBundle(domain: ImageDomain?) throws -> UIImage {
+        guard let domain = domain,
+              let bundleDomain = getBundleDomain(domain: domain) else {
             throw SiteImageError.noImageInBundle
         }
 

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/BundleImageFetcher/BundleImageFetcher.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/BundleImageFetcher/BundleImageFetcher.swift
@@ -36,9 +36,8 @@ class DefaultBundleImageFetcher: BundleImageFetcher {
 
     func getImageFromBundle(domain: ImageDomain?) throws -> UIImage {
         guard let domain = domain,
-              let bundleDomain = getBundleDomain(domain: domain) else {
-            throw SiteImageError.noImageInBundle
-        }
+              let bundleDomain = getBundleDomain(domain: domain)
+        else { throw SiteImageError.noImageInBundle }
 
         guard let bundledImage = bundledImages[bundleDomain],
               let image = bundleDataProvider.getBundleImage(from: bundledImage.filePath) else {

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/ImageDomain.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/ImageDomain.swift
@@ -6,9 +6,6 @@ import Foundation
 
 /// The domains associated with the image
 struct ImageDomain: Codable {
-    /// Used to cache and retrieve from cache
-    var baseDomain: String
-
     /// Used to retrieve from the bundle, more than one domain can be used to retrieve. See `BundleDomainBuilder`
     var bundleDomains: [String]
 }

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/LetterImageGenerator.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/LetterImageGenerator.swift
@@ -10,17 +10,17 @@ protocol LetterImageGenerator {
     /// Runs main thread due to UILabel.initWithFrame(:)
     /// - Parameter domain: The string domain name
     /// - Returns: The generated letter image
-    @MainActor func generateLetterImage(domain: ImageDomain) async -> UIImage
+    @MainActor func generateLetterImage(siteString: String) async -> UIImage
 }
 
 class DefaultLetterImageGenerator: LetterImageGenerator {
     private let defaultLetter: Character = "#"
 
-    @MainActor func generateLetterImage(domain: ImageDomain) async -> UIImage {
-        let letter: Character = domain.baseDomain.first ?? defaultLetter
+    @MainActor func generateLetterImage(siteString: String) async -> UIImage {
+        let letter: Character = siteString.first ?? defaultLetter
         let capitalizedLetter = letter.uppercased()
 
-        let color = generateBackgroundColor(forDomain: domain)
+        let color = generateBackgroundColor(forSite: siteString)
         let image = generateImage(fromLetter: capitalizedLetter,
                                   color: color)
         return image
@@ -44,8 +44,8 @@ class DefaultLetterImageGenerator: LetterImageGenerator {
         return image
     }
 
-    private func generateBackgroundColor(forDomain domain: ImageDomain) -> UIColor {
-        let index = abs(stableHash(domain.baseDomain)) % (defaultBackgroundColors.count - 1)
+    private func generateBackgroundColor(forSite siteString: String) -> UIColor {
+        let index = abs(stableHash(siteString)) % (defaultBackgroundColors.count - 1)
         let colorHex = defaultBackgroundColors[index]
         return UIColor(colorString: colorHex)
     }

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageCache/SiteImageCache.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageCache/SiteImageCache.swift
@@ -12,7 +12,7 @@ protocol SiteImageCache {
     ///   - domain: The domain to retrieve the image from
     ///   - type: The image type to retrieve the image from the cache
     /// - Returns: The image from the cache or throws an error if it could not retrieve it
-    func getImageFromCache(domain: ImageDomain,
+    func getImageFromCache(cacheKey: String,
                            type: SiteImageType) async throws -> UIImage
 
     /// Cache an image into the right cache depending on it's type
@@ -21,7 +21,7 @@ protocol SiteImageCache {
     ///   - domain: The image domain
     ///   - type: The image type
     func cacheImage(image: UIImage,
-                    domain: ImageDomain,
+                    cacheKey: String,
                     type: SiteImageType) async
 }
 
@@ -32,8 +32,9 @@ actor DefaultSiteImageCache: SiteImageCache {
         self.imageCache = imageCache
     }
 
-    func getImageFromCache(domain: ImageDomain, type: SiteImageType) async throws -> UIImage {
-        let key = cacheKey(from: domain, type: type)
+    func getImageFromCache(cacheKey: String,
+                           type: SiteImageType) async throws -> UIImage {
+        let key = self.cacheKey(cacheKey, type: type)
         do {
             let result = try await imageCache.retrieveImage(forKey: key)
             guard let image = result else {
@@ -45,12 +46,12 @@ actor DefaultSiteImageCache: SiteImageCache {
         }
     }
 
-    func cacheImage(image: UIImage, domain: ImageDomain, type: SiteImageType) async {
-        let key = cacheKey(from: domain, type: type)
+    func cacheImage(image: UIImage, cacheKey: String, type: SiteImageType) async {
+        let key = self.cacheKey(cacheKey, type: type)
         imageCache.store(image: image, forKey: key)
     }
 
-    private func cacheKey(from domain: ImageDomain, type: SiteImageType) -> String {
-        return "\(domain.baseDomain)-\(type.rawValue)"
+    private func cacheKey(_ cacheKey: String, type: SiteImageType) -> String {
+        return "\(cacheKey)-\(type.rawValue)"
     }
 }

--- a/BrowserKit/Sources/SiteImageView/SiteImageFetcher.swift
+++ b/BrowserKit/Sources/SiteImageView/SiteImageFetcher.swift
@@ -6,10 +6,10 @@ import UIKit
 import Common
 
 protocol SiteImageFetcher {
-    func getImageModel(urlStringRequest: String,
-                       type: SiteImageType,
-                       id: UUID,
-                       usesIndirectDomain: Bool) async -> SiteImageModel
+    func getImage(urlStringRequest: String,
+                  type: SiteImageType,
+                  id: UUID,
+                  usesIndirectDomain: Bool) async -> SiteImageModel
 }
 
 class DefaultSiteImageFetcher: SiteImageFetcher {
@@ -22,10 +22,10 @@ class DefaultSiteImageFetcher: SiteImageFetcher {
         self.imageHandler = imageHandler
     }
 
-    func getImageModel(urlStringRequest: String,
-                       type: SiteImageType,
-                       id: UUID,
-                       usesIndirectDomain: Bool) async -> SiteImageModel {
+    func getImage(urlStringRequest: String,
+                  type: SiteImageType,
+                  id: UUID,
+                  usesIndirectDomain: Bool) async -> SiteImageModel {
         var imageModel = SiteImageModel(id: id,
                                         expectedImageType: type,
                                         urlStringRequest: urlStringRequest,
@@ -35,8 +35,6 @@ class DefaultSiteImageFetcher: SiteImageFetcher {
                                         faviconURL: nil,
                                         faviconImage: nil,
                                         heroImage: nil)
-
-
 
         // urlStringRequest possibly cannot be a URL
         if let siteURL = URL(string: urlStringRequest) {

--- a/BrowserKit/Sources/SiteImageView/SiteImageView.swift
+++ b/BrowserKit/Sources/SiteImageView/SiteImageView.swift
@@ -31,10 +31,10 @@ extension SiteImageView {
                      id: UUID,
                      usesIndirectDomain: Bool) {
         Task {
-            let imageModel = await imageFetcher.getImageModel(urlStringRequest: url,
-                                                              type: type,
-                                                              id: id,
-                                                              usesIndirectDomain: usesIndirectDomain)
+            let imageModel = await imageFetcher.getImage(urlStringRequest: url,
+                                                         type: type,
+                                                         id: id,
+                                                         usesIndirectDomain: usesIndirectDomain)
             guard uniqueID == imageModel.id else { return }
 
             DispatchQueue.main.async { [weak self] in

--- a/BrowserKit/Sources/SiteImageView/SiteImageView.swift
+++ b/BrowserKit/Sources/SiteImageView/SiteImageView.swift
@@ -10,8 +10,10 @@ protocol SiteImageView: UIView {
     var uniqueID: UUID? { get set }
     var imageFetcher: SiteImageFetcher { get set }
 
-    func setURL(_ urlStringRequest: String, type: SiteImageType)
-    func updateImage(url: String, type: SiteImageType, id: UUID)
+    func updateImage(url: String,
+                     type: SiteImageType,
+                     id: UUID,
+                     usesIndirectDomain: Bool)
     func setImage(imageModel: SiteImageModel)
 
     // Avoid multiple image loading in parallel. Only start a new request if the URL string has changed
@@ -24,9 +26,15 @@ extension SiteImageView {
         return requestStartedWith != urlStringRequest
     }
 
-    func updateImage(url: String, type: SiteImageType, id: UUID) {
+    func updateImage(url: String,
+                     type: SiteImageType,
+                     id: UUID,
+                     usesIndirectDomain: Bool) {
         Task {
-            let imageModel = await imageFetcher.getImage(urlStringRequest: url, type: type, id: id)
+            let imageModel = await imageFetcher.getImageModel(urlStringRequest: url,
+                                                              type: type,
+                                                              id: id,
+                                                              usesIndirectDomain: usesIndirectDomain)
             guard uniqueID == imageModel.id else { return }
 
             DispatchQueue.main.async { [weak self] in

--- a/BrowserKit/Tests/SiteImageViewTests/FaviconURLProcessing/FaviconURLHandlerTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/FaviconURLProcessing/FaviconURLHandlerTests.swift
@@ -80,7 +80,8 @@ class FaviconURLHandlerTests: XCTestCase {
                               expectedImageType: .favicon,
                               urlStringRequest: siteURL,
                               siteURL: URL(string: siteURL)!,
-                              domain: ImageDomain(baseDomain: "domain", bundleDomains: []),
+                              cacheKey: "domain",
+                              domain: ImageDomain(bundleDomains: []),
                               faviconURL: nil,
                               faviconImage: nil,
                               heroImage: nil)

--- a/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/BundleImageFetcherTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/BundleImageFetcherTests.swift
@@ -21,7 +21,7 @@ final class BundleImageFetcherTests: XCTestCase {
     func testEmptyDomain_throwsError() {
         bundleDataProvider.error = SiteImageError.noImageInBundle
         let subject = DefaultBundleImageFetcher(bundleDataProvider: bundleDataProvider)
-        let domain = ImageDomain(baseDomain: "", bundleDomains: [])
+        let domain = ImageDomain(bundleDomains: [])
 
         do {
             _ = try subject.getImageFromBundle(domain: domain)
@@ -37,7 +37,7 @@ final class BundleImageFetcherTests: XCTestCase {
     func testInvalidData_throwsError() {
         bundleDataProvider.data = generateHTMLData(string: MockBundleData.invalidData)
         let subject = DefaultBundleImageFetcher(bundleDataProvider: bundleDataProvider)
-        let domain = ImageDomain(baseDomain: "mozilla", bundleDomains: ["mozilla"])
+        let domain = ImageDomain(bundleDomains: ["mozilla"])
 
         do {
             _ = try subject.getImageFromBundle(domain: domain)
@@ -53,7 +53,7 @@ final class BundleImageFetcherTests: XCTestCase {
     func testEmptyData_throwsError() {
         bundleDataProvider.data = generateHTMLData(string: MockBundleData.emptyData)
         let subject = DefaultBundleImageFetcher(bundleDataProvider: bundleDataProvider)
-        let domain = ImageDomain(baseDomain: "mozilla", bundleDomains: ["mozilla"])
+        let domain = ImageDomain(bundleDomains: ["mozilla"])
 
         do {
             _ = try subject.getImageFromBundle(domain: domain)
@@ -69,7 +69,7 @@ final class BundleImageFetcherTests: XCTestCase {
     func testValidData_withoutPath_throwsError() {
         bundleDataProvider.data = generateHTMLData(string: MockBundleData.validData)
         let subject = DefaultBundleImageFetcher(bundleDataProvider: bundleDataProvider)
-        let domain = ImageDomain(baseDomain: "mozilla", bundleDomains: ["mozilla"])
+        let domain = ImageDomain(bundleDomains: ["mozilla"])
 
         do {
             _ = try subject.getImageFromBundle(domain: domain)
@@ -88,7 +88,7 @@ final class BundleImageFetcherTests: XCTestCase {
         bundleDataProvider.pathToReturn = "a/path/to/image"
         bundleDataProvider.data = generateHTMLData(string: MockBundleData.validData)
         let subject = DefaultBundleImageFetcher(bundleDataProvider: bundleDataProvider)
-        let domain = ImageDomain(baseDomain: "mozilla", bundleDomains: ["mozilla"])
+        let domain = ImageDomain(bundleDomains: ["mozilla"])
 
         do {
             let result = try subject.getImageFromBundle(domain: domain)
@@ -104,7 +104,7 @@ final class BundleImageFetcherTests: XCTestCase {
         bundleDataProvider.pathToReturn = "a/path/to/image"
         bundleDataProvider.data = generateHTMLData(string: MockBundleData.validData)
         let subject = DefaultBundleImageFetcher(bundleDataProvider: bundleDataProvider)
-        let domain = ImageDomain(baseDomain: "fakedomain", bundleDomains: ["fakedomain"])
+        let domain = ImageDomain(bundleDomains: ["fakedomain"])
 
         do {
             _ = try subject.getImageFromBundle(domain: domain)
@@ -122,7 +122,7 @@ final class BundleImageFetcherTests: XCTestCase {
         bundleDataProvider.data = generateHTMLData(string: MockBundleData.partlyValidData)
 
         let subject = DefaultBundleImageFetcher(bundleDataProvider: bundleDataProvider)
-        let domain = ImageDomain(baseDomain: "google", bundleDomains: ["google"])
+        let domain = ImageDomain(bundleDomains: ["google"])
 
         do {
             _ = try subject.getImageFromBundle(domain: domain)

--- a/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/ImageHandlerTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/ImageHandlerTests.swift
@@ -33,15 +33,26 @@ final class ImageHandlerTests: XCTestCase {
 
     // MARK: - Favicon
 
+    private func createSiteImageModel(cacheKey: String,
+                                      imageURL: URL? = nil,
+                                      type: SiteImageType = .favicon) -> SiteImageModel {
+        return SiteImageModel(id: UUID(),
+                              expectedImageType: type,
+                              urlStringRequest: cacheKey,
+                              siteURL: URL(string: cacheKey)!,
+                              cacheKey: cacheKey,
+                              domain: ImageDomain(bundleDomains: []),
+                              faviconURL: imageURL,
+                              faviconImage: nil,
+                              heroImage: nil)
+    }
+
     func testFavicon_whenImageInBundle_returnsBundleImage() async {
         let expectedResult = UIImage()
         bundleImageFetcher.image = expectedResult
         let subject = createSubject()
-        let domain = ImageDomain(baseDomain: "Mozilla", bundleDomains: [])
-
-        let result = await subject.fetchFavicon(imageURL: URL(string: "www.mozilla.com")!,
-                                                domain: domain,
-                                                expectedType: .favicon)
+        let site = createSiteImageModel(cacheKey: "Mozilla", imageURL: URL(string: "www.mozilla.com"))
+        let result = await subject.fetchFavicon(site: site)
         XCTAssertEqual(expectedResult, result)
         XCTAssertEqual(bundleImageFetcher.getImageFromBundleSucceedCalled, 1)
         XCTAssertEqual(bundleImageFetcher.getImageFromBundleFailedCalled, 0)
@@ -60,11 +71,8 @@ final class ImageHandlerTests: XCTestCase {
         let expectedResult = UIImage()
         siteImageCache.image = expectedResult
         let subject = createSubject()
-        let domain = ImageDomain(baseDomain: "Mozilla", bundleDomains: [])
-
-        let result = await subject.fetchFavicon(imageURL: URL(string: "www.mozilla.com")!,
-                                                domain: domain,
-                                                expectedType: .favicon)
+        let site = createSiteImageModel(cacheKey: "Mozilla", imageURL: URL(string: "www.mozilla.com"))
+        let result = await subject.fetchFavicon(site: site)
         XCTAssertEqual(expectedResult, result)
         XCTAssertEqual(bundleImageFetcher.getImageFromBundleSucceedCalled, 0)
         XCTAssertEqual(bundleImageFetcher.getImageFromBundleFailedCalled, 1)
@@ -82,11 +90,9 @@ final class ImageHandlerTests: XCTestCase {
 
     func testFavicon_whenNoUrl_returnsFallbackLetterFavicon() async {
         let subject = createSubject()
-        let domain = ImageDomain(baseDomain: "Mozilla", bundleDomains: [])
+        let site = createSiteImageModel(cacheKey: "Mozilla")
+        let result = await subject.fetchFavicon(site: site)
 
-        let result = await subject.fetchFavicon(imageURL: nil,
-                                                domain: domain,
-                                                expectedType: .favicon)
         XCTAssertEqual(letterImageGenerator.image, result)
         XCTAssertEqual(bundleImageFetcher.getImageFromBundleSucceedCalled, 0)
         XCTAssertEqual(bundleImageFetcher.getImageFromBundleFailedCalled, 1)
@@ -106,11 +112,9 @@ final class ImageHandlerTests: XCTestCase {
         let expectedResult = UIImage()
         faviconFetcher.image = expectedResult
         let subject = createSubject()
-        let domain = ImageDomain(baseDomain: "Mozilla", bundleDomains: [])
+        let site = createSiteImageModel(cacheKey: "Mozilla", imageURL: URL(string: "www.mozilla.com"))
+        let result = await subject.fetchFavicon(site: site)
 
-        let result = await subject.fetchFavicon(imageURL: URL(string: "www.mozilla.com")!,
-                                                domain: domain,
-                                                expectedType: .favicon)
         XCTAssertEqual(expectedResult, result)
         XCTAssertEqual(bundleImageFetcher.getImageFromBundleSucceedCalled, 0)
         XCTAssertEqual(bundleImageFetcher.getImageFromBundleFailedCalled, 1)
@@ -128,11 +132,9 @@ final class ImageHandlerTests: XCTestCase {
 
     func testFavicon_whenNoImages_returnsFallbackLetterFavicon() async {
         let subject = createSubject()
-        let domain = ImageDomain(baseDomain: "Mozilla", bundleDomains: [])
+        let site = createSiteImageModel(cacheKey: "Mozilla", imageURL: URL(string: "www.mozilla.com"))
+        let result = await subject.fetchFavicon(site: site)
 
-        let result = await subject.fetchFavicon(imageURL: URL(string: "www.mozilla.com")!,
-                                                domain: domain,
-                                                expectedType: .favicon)
         XCTAssertEqual(letterImageGenerator.image, result)
         XCTAssertEqual(bundleImageFetcher.getImageFromBundleSucceedCalled, 0)
         XCTAssertEqual(bundleImageFetcher.getImageFromBundleFailedCalled, 1)
@@ -154,11 +156,12 @@ final class ImageHandlerTests: XCTestCase {
         let expectedResult = UIImage()
         siteImageCache.image = expectedResult
         let subject = createSubject()
-        let domain = ImageDomain(baseDomain: "Mozilla", bundleDomains: [])
+        let site = createSiteImageModel(cacheKey: "Mozilla",
+                                        imageURL: URL(string: "www.mozilla.com"),
+                                        type: .heroImage)
 
         do {
-            let result = try await subject.fetchHeroImage(siteURL: URL(string: "www.mozilla.com")!,
-                                                          domain: domain)
+            let result = try await subject.fetchHeroImage(site: site)
             XCTAssertEqual(expectedResult, result)
             XCTAssertEqual(siteImageCache.getImageFromCacheSucceedCalled, 1)
             XCTAssertEqual(siteImageCache.getImageFromCacheFailedCalled, 0)
@@ -176,11 +179,12 @@ final class ImageHandlerTests: XCTestCase {
         let expectedResult = UIImage()
         heroImageFetcher.image = expectedResult
         let subject = createSubject()
-        let domain = ImageDomain(baseDomain: "Mozilla", bundleDomains: [])
+        let site = createSiteImageModel(cacheKey: "Mozilla",
+                                        imageURL: URL(string: "www.mozilla.com"),
+                                        type: .heroImage)
 
         do {
-            let result = try await subject.fetchHeroImage(siteURL: URL(string: "www.mozilla.com")!,
-                                                          domain: domain)
+            let result = try await subject.fetchHeroImage(site: site)
             XCTAssertEqual(expectedResult, result)
             XCTAssertEqual(siteImageCache.getImageFromCacheSucceedCalled, 0)
             XCTAssertEqual(siteImageCache.getImageFromCacheFailedCalled, 1)
@@ -195,11 +199,12 @@ final class ImageHandlerTests: XCTestCase {
 
     func testHeroImage_whenNoHeroImage_throwsNoHeroImageError() async {
         let subject = createSubject()
-        let domain = ImageDomain(baseDomain: "Mozilla", bundleDomains: [])
+        let site = createSiteImageModel(cacheKey: "Mozilla",
+                                        imageURL: URL(string: "www.mozilla.com"),
+                                        type: .heroImage)
 
         do {
-            _ = try await subject.fetchHeroImage(siteURL: URL(string: "www.mozilla.com")!,
-                                                 domain: domain)
+            _ = try await subject.fetchHeroImage(site: site)
 
             XCTFail("Should have failed with SiteImageError.noHeroImage")
         } catch let error as SiteImageError {
@@ -220,12 +225,12 @@ final class ImageHandlerTests: XCTestCase {
     func testHeroImageFallback_retrievesFromHeroImageCache() async {
         let expectedResult = UIImage()
         let subject = createSubject()
+        let site = createSiteImageModel(cacheKey: "Mozilla",
+                                        imageURL: URL(string: "www.mozilla.com"),
+                                        type: .heroImage)
         siteImageCache.image = expectedResult
-        let domain = ImageDomain(baseDomain: "Mozilla", bundleDomains: [])
 
-        let result = await subject.fetchFavicon(imageURL: URL(string: "www.mozilla.com")!,
-                                                domain: domain,
-                                                expectedType: .heroImage)
+        let result = await subject.fetchFavicon(site: site)
         XCTAssertEqual(letterImageGenerator.image, result)
         XCTAssertEqual(bundleImageFetcher.getImageFromBundleSucceedCalled, 0)
         XCTAssertEqual(bundleImageFetcher.getImageFromBundleFailedCalled, 1)
@@ -243,12 +248,12 @@ final class ImageHandlerTests: XCTestCase {
     func testHeroImageFallback_savesInHeroImageCache() async {
         let expectedResult = UIImage()
         let subject = createSubject()
+        let site = createSiteImageModel(cacheKey: "Mozilla",
+                                        imageURL: URL(string: "www.mozilla.com"),
+                                        type: .heroImage)
         faviconFetcher.image = expectedResult
-        let domain = ImageDomain(baseDomain: "Mozilla", bundleDomains: [])
 
-        let result = await subject.fetchFavicon(imageURL: URL(string: "www.mozilla.com")!,
-                                                domain: domain,
-                                                expectedType: .heroImage)
+        let result = await subject.fetchFavicon(site: site)
         XCTAssertEqual(letterImageGenerator.image, result)
         XCTAssertEqual(bundleImageFetcher.getImageFromBundleSucceedCalled, 0)
         XCTAssertEqual(bundleImageFetcher.getImageFromBundleFailedCalled, 1)
@@ -281,7 +286,7 @@ private class MockBundleImageFetcher: BundleImageFetcher {
     var getImageFromBundleSucceedCalled = 0
     var getImageFromBundleFailedCalled = 0
 
-    func getImageFromBundle(domain: ImageDomain) throws -> UIImage {
+    func getImageFromBundle(domain: ImageDomain?) throws -> UIImage {
         if let image = image {
             getImageFromBundleSucceedCalled += 1
             return image
@@ -317,8 +322,10 @@ private class MockSiteImageCache: SiteImageCache {
     var getImageFromCacheSucceedCalled = 0
     var getImageFromCacheFailedCalled = 0
     var getFromCacheWithType: SiteImageType?
+    var cacheImageCalled = 0
+    var cachedWithType: SiteImageType?
 
-    func getImageFromCache(domain: ImageDomain, type: SiteImageType) async throws -> UIImage {
+    func getImageFromCache(cacheKey: String, type: SiteImageType) async throws -> UIImage {
         getFromCacheWithType = type
         if let image = image {
             getImageFromCacheSucceedCalled += 1
@@ -329,9 +336,7 @@ private class MockSiteImageCache: SiteImageCache {
         }
     }
 
-    var cacheImageCalled = 0
-    var cachedWithType: SiteImageType?
-    func cacheImage(image: UIImage, domain: ImageDomain, type: SiteImageType) async {
+    func cacheImage(image: UIImage, cacheKey: String, type: SiteImageType) async {
         cacheImageCalled += 1
         cachedWithType = type
     }
@@ -359,7 +364,7 @@ private class MockLetterImageGenerator: LetterImageGenerator {
     var image: UIImage = UIImage()
     var generateLetterImageCalled = 0
 
-    func generateLetterImage(domain: ImageDomain) -> UIImage {
+    func generateLetterImage(siteString: String) -> UIImage {
         generateLetterImageCalled += 1
         return image
     }

--- a/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/LetterImageGeneratorTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/LetterImageGeneratorTests.swift
@@ -8,8 +8,8 @@ import XCTest
 final class LetterImageGeneratorTests: XCTestCase {
     func testEmptyDomain_doesntReturnEmptyImage() async {
         let subject = DefaultLetterImageGeneratorSpy()
-        let domain = ImageDomain(baseDomain: "", bundleDomains: [])
-        let result = await subject.generateLetterImage(domain: domain)
+        let siteString = ""
+        let result = await subject.generateLetterImage(siteString: siteString)
 
         XCTAssertEqual(subject.capturedLetter, "#")
         XCTAssertNotEqual(result, UIImage())
@@ -18,8 +18,8 @@ final class LetterImageGeneratorTests: XCTestCase {
 
     func testDomain1_returnsExpectedLetterAndColor() async {
         let subject = DefaultLetterImageGeneratorSpy()
-        let domain = ImageDomain(baseDomain: "mozilla.com", bundleDomains: [])
-        let result = await subject.generateLetterImage(domain: domain)
+        let siteString = "mozilla.com"
+        let result = await subject.generateLetterImage(siteString: siteString)
 
         XCTAssertEqual(subject.capturedLetter, "M")
         XCTAssertNotEqual(result, UIImage())
@@ -28,8 +28,8 @@ final class LetterImageGeneratorTests: XCTestCase {
 
     func testDomain2_returnsExpectedLetterAndColor() async {
         let subject = DefaultLetterImageGeneratorSpy()
-        let domain = ImageDomain(baseDomain: "firefox.com", bundleDomains: [])
-        let result = await subject.generateLetterImage(domain: domain)
+        let siteString = "firefox.com"
+        let result = await subject.generateLetterImage(siteString: siteString)
 
         XCTAssertEqual(subject.capturedLetter, "F")
         XCTAssertNotEqual(result, UIImage())
@@ -38,8 +38,8 @@ final class LetterImageGeneratorTests: XCTestCase {
 
     func testFakeDomain_returnsExpectedLetterAndColor() async {
         let subject = DefaultLetterImageGeneratorSpy()
-        let domain = ImageDomain(baseDomain: "?$%^", bundleDomains: [])
-        let result = await subject.generateLetterImage(domain: domain)
+        let siteString = "?$%^"
+        let result = await subject.generateLetterImage(siteString: siteString)
 
         XCTAssertEqual(subject.capturedLetter, "?")
         XCTAssertNotEqual(result, UIImage())

--- a/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/SiteImageCacheTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/SiteImageCacheTests.swift
@@ -24,10 +24,10 @@ final class SiteImageCacheTests: XCTestCase {
     func testGetFromCache_whenError_returnsError() async {
         imageCache.retrievalError = KingfisherError.requestError(reason: .emptyRequest)
         let subject = DefaultSiteImageCache(imageCache: imageCache)
-        let domain = ImageDomain(baseDomain: "www.example.com", bundleDomains: [])
+        let cacheKey = "www.example.com"
 
         do {
-            _ = try await subject.getImageFromCache(domain: domain, type: .favicon)
+            _ = try await subject.getImageFromCache(cacheKey: cacheKey, type: .favicon)
         } catch let error as SiteImageError {
             XCTAssertEqual(imageCache.capturedRetrievalKey, "www.example.com-favicon")
             XCTAssertEqual("Unable to retrieve image from cache with reason: The request is empty or `nil`.",
@@ -39,10 +39,10 @@ final class SiteImageCacheTests: XCTestCase {
 
     func testGetFromCache_whenEmptyImage_returnsError() async {
         let subject = DefaultSiteImageCache(imageCache: imageCache)
-        let domain = ImageDomain(baseDomain: "www.example.com", bundleDomains: [])
+        let cacheKey = "www.example.com"
 
         do {
-            _ = try await subject.getImageFromCache(domain: domain, type: .heroImage)
+            _ = try await subject.getImageFromCache(cacheKey: cacheKey, type: .heroImage)
         } catch let error as SiteImageError {
             XCTAssertEqual(imageCache.capturedRetrievalKey, "www.example.com-heroImage")
             XCTAssertEqual("Unable to retrieve image from cache with reason: Image was nil",
@@ -56,10 +56,10 @@ final class SiteImageCacheTests: XCTestCase {
         let expectedImage = UIImage()
         imageCache.image = expectedImage
         let subject = DefaultSiteImageCache(imageCache: imageCache)
-        let domain = ImageDomain(baseDomain: "www.example2.com", bundleDomains: [])
+        let cacheKey = "www.example2.com"
 
         do {
-            let result = try await subject.getImageFromCache(domain: domain, type: .favicon)
+            let result = try await subject.getImageFromCache(cacheKey: cacheKey, type: .favicon)
             XCTAssertEqual(imageCache.capturedRetrievalKey, "www.example2.com-favicon")
             XCTAssertEqual(expectedImage, result)
         } catch {
@@ -72,9 +72,9 @@ final class SiteImageCacheTests: XCTestCase {
     func testCacheImage_whenSuccess_returnsSuccess() async {
         let expectedImage = UIImage()
         let subject = DefaultSiteImageCache(imageCache: imageCache)
-        let domain = ImageDomain(baseDomain: "www.firefox.com", bundleDomains: [])
+        let cacheKey = "www.firefox.com"
 
-        _ = await subject.cacheImage(image: expectedImage, domain: domain, type: .favicon)
+        _ = await subject.cacheImage(image: expectedImage, cacheKey: cacheKey, type: .favicon)
         XCTAssertEqual(imageCache.capturedStorageKey, "www.firefox.com-favicon")
         XCTAssertEqual(imageCache.capturedImage, expectedImage)
     }

--- a/BrowserKit/Tests/SiteImageViewTests/Mocks/FaviconURLCacheMock.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/Mocks/FaviconURLCacheMock.swift
@@ -12,7 +12,7 @@ actor FaviconURLCacheMock: FaviconURLCache {
     var getURLFromCacheCalledCount = 0
     var cacheURLCalledCount = 0
 
-    var domain: ImageDomain?
+    var cacheKey: String?
     var faviconURL: URL?
 
     func setTestResult(url: URL? = nil, error: SiteImageError? = nil) {
@@ -20,7 +20,7 @@ actor FaviconURLCacheMock: FaviconURLCache {
         self.error = error
     }
 
-    func getURLFromCache(domain: ImageDomain) async throws -> URL {
+    func getURLFromCache(cacheKey: String) async throws -> URL {
         getURLFromCacheCalledCount += 1
         if let error = error {
             throw error
@@ -28,9 +28,9 @@ actor FaviconURLCacheMock: FaviconURLCache {
         return url!
     }
 
-    func cacheURL(domain: ImageDomain, faviconURL: URL) async {
+    func cacheURL(cacheKey: String, faviconURL: URL) async {
         cacheURLCalledCount += 1
-        self.domain = domain
+        self.cacheKey = cacheKey
         self.faviconURL = faviconURL
     }
 }

--- a/BrowserKit/Tests/SiteImageViewTests/SiteImageFetcherTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/SiteImageFetcherTests.swift
@@ -27,10 +27,10 @@ final class SiteImageFetcherTests: XCTestCase {
         let siteURL = "https://www.example.hello.com"
         let subject = DefaultSiteImageFetcher(urlHandler: urlHandler,
                                               imageHandler: imageHandler)
-        let result = await subject.getImageModel(urlStringRequest: siteURL,
-                                                 type: .favicon,
-                                                 id: UUID(),
-                                                 usesIndirectDomain: false)
+        let result = await subject.getImage(urlStringRequest: siteURL,
+                                            type: .favicon,
+                                            id: UUID(),
+                                            usesIndirectDomain: false)
 
         XCTAssertEqual(result.cacheKey, "example.hello")
         XCTAssertEqual(result.siteURL, URL(string: siteURL))
@@ -48,10 +48,10 @@ final class SiteImageFetcherTests: XCTestCase {
         let siteURL = "www.example.hello.com"
         let subject = DefaultSiteImageFetcher(urlHandler: urlHandler,
                                               imageHandler: imageHandler)
-        let result = await subject.getImageModel(urlStringRequest: siteURL,
-                                                 type: .favicon,
-                                                 id: UUID(),
-                                                 usesIndirectDomain: false)
+        let result = await subject.getImage(urlStringRequest: siteURL,
+                                            type: .favicon,
+                                            id: UUID(),
+                                            usesIndirectDomain: false)
 
         XCTAssertEqual(result.cacheKey, "www.example.hello.com")
         XCTAssertEqual(imageHandler.capturedSite?.cacheKey, "www.example.hello.com")
@@ -63,10 +63,10 @@ final class SiteImageFetcherTests: XCTestCase {
         urlHandler.faviconURL = faviconURL
         let subject = DefaultSiteImageFetcher(urlHandler: urlHandler,
                                               imageHandler: imageHandler)
-        let result = await subject.getImageModel(urlStringRequest: siteURL,
-                                                 type: .favicon,
-                                                 id: UUID(),
-                                                 usesIndirectDomain: false)
+        let result = await subject.getImage(urlStringRequest: siteURL,
+                                            type: .favicon,
+                                            id: UUID(),
+                                            usesIndirectDomain: false)
 
         XCTAssertEqual(result.cacheKey, "mozilla")
         XCTAssertEqual(result.siteURL, URL(string: siteURL))
@@ -85,10 +85,10 @@ final class SiteImageFetcherTests: XCTestCase {
         urlHandler.faviconURL = faviconURL
         let subject = DefaultSiteImageFetcher(urlHandler: urlHandler,
                                               imageHandler: imageHandler)
-        let result = await subject.getImageModel(urlStringRequest: siteURL,
-                                                 type: .favicon,
-                                                 id: UUID(),
-                                                 usesIndirectDomain: true)
+        let result = await subject.getImage(urlStringRequest: siteURL,
+                                            type: .favicon,
+                                            id: UUID(),
+                                            usesIndirectDomain: true)
 
         XCTAssertEqual(result.cacheKey, "https://www.mozilla.com")
         XCTAssertEqual(result.siteURL, URL(string: siteURL))
@@ -107,10 +107,10 @@ final class SiteImageFetcherTests: XCTestCase {
         let subject = DefaultSiteImageFetcher(urlHandler: urlHandler,
                                               imageHandler: imageHandler)
         let siteURL = "https://www.firefox.com"
-        let result = await subject.getImageModel(urlStringRequest: siteURL,
-                                                 type: .heroImage,
-                                                 id: UUID(),
-                                                 usesIndirectDomain: true)
+        let result = await subject.getImage(urlStringRequest: siteURL,
+                                            type: .heroImage,
+                                            id: UUID(),
+                                            usesIndirectDomain: true)
 
         XCTAssertEqual(result.cacheKey, "https://www.firefox.com")
         XCTAssertEqual(result.siteURL, URL(string: siteURL))
@@ -129,10 +129,10 @@ final class SiteImageFetcherTests: XCTestCase {
         let subject = DefaultSiteImageFetcher(urlHandler: urlHandler,
                                               imageHandler: imageHandler)
         let siteURL = "https://www.focus.com"
-        let result = await subject.getImageModel(urlStringRequest: siteURL,
-                                                 type: .heroImage,
-                                                 id: UUID(),
-                                                 usesIndirectDomain: true)
+        let result = await subject.getImage(urlStringRequest: siteURL,
+                                            type: .heroImage,
+                                            id: UUID(),
+                                            usesIndirectDomain: true)
 
         XCTAssertEqual(result.cacheKey, "https://www.focus.com")
         XCTAssertEqual(result.siteURL, URL(string: siteURL))

--- a/BrowserKit/Tests/SiteImageViewTests/SiteImageFetcherTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/SiteImageFetcherTests.swift
@@ -27,9 +27,10 @@ final class SiteImageFetcherTests: XCTestCase {
         let siteURL = "https://www.example.hello.com"
         let subject = DefaultSiteImageFetcher(urlHandler: urlHandler,
                                               imageHandler: imageHandler)
-        let result = await subject.getImage(urlStringRequest: siteURL,
-                                            type: .favicon,
-                                            id: UUID())
+        let result = await subject.getImageModel(urlStringRequest: siteURL,
+                                                 type: .favicon,
+                                                 id: UUID(),
+                                                 usesIndirectDomain: false)
 
         XCTAssertEqual(result.cacheKey, "example.hello")
         XCTAssertEqual(result.siteURL, URL(string: siteURL))
@@ -47,9 +48,10 @@ final class SiteImageFetcherTests: XCTestCase {
         let siteURL = "www.example.hello.com"
         let subject = DefaultSiteImageFetcher(urlHandler: urlHandler,
                                               imageHandler: imageHandler)
-        let result = await subject.getImage(urlStringRequest: siteURL,
-                                            type: .favicon,
-                                            id: UUID())
+        let result = await subject.getImageModel(urlStringRequest: siteURL,
+                                                 type: .favicon,
+                                                 id: UUID(),
+                                                 usesIndirectDomain: false)
 
         XCTAssertEqual(result.cacheKey, "www.example.hello.com")
         XCTAssertEqual(imageHandler.capturedSite?.cacheKey, "www.example.hello.com")
@@ -61,9 +63,10 @@ final class SiteImageFetcherTests: XCTestCase {
         urlHandler.faviconURL = faviconURL
         let subject = DefaultSiteImageFetcher(urlHandler: urlHandler,
                                               imageHandler: imageHandler)
-        let result = await subject.getImage(urlStringRequest: siteURL,
-                                            type: .favicon,
-                                            id: UUID())
+        let result = await subject.getImageModel(urlStringRequest: siteURL,
+                                                 type: .favicon,
+                                                 id: UUID(),
+                                                 usesIndirectDomain: false)
 
         XCTAssertEqual(result.cacheKey, "mozilla")
         XCTAssertEqual(result.siteURL, URL(string: siteURL))
@@ -76,17 +79,40 @@ final class SiteImageFetcherTests: XCTestCase {
         XCTAssertEqual(imageHandler.capturedSite?.cacheKey, "mozilla")
     }
 
+    func testFaviconIndirectDomain_faviconURLFound_generateFavicon() async {
+        let faviconURL = URL(string: "www.mozilla.com/resource")!
+        let siteURL = "https://www.mozilla.com"
+        urlHandler.faviconURL = faviconURL
+        let subject = DefaultSiteImageFetcher(urlHandler: urlHandler,
+                                              imageHandler: imageHandler)
+        let result = await subject.getImageModel(urlStringRequest: siteURL,
+                                                 type: .favicon,
+                                                 id: UUID(),
+                                                 usesIndirectDomain: true)
+
+        XCTAssertEqual(result.cacheKey, "https://www.mozilla.com")
+        XCTAssertEqual(result.siteURL, URL(string: siteURL))
+        XCTAssertEqual(result.faviconURL, nil)
+        XCTAssertEqual(result.expectedImageType, .favicon)
+        XCTAssertNil(result.heroImage)
+        XCTAssertNotNil(result.faviconImage)
+
+        XCTAssertEqual(imageHandler.capturedSite?.faviconURL, faviconURL)
+        XCTAssertEqual(imageHandler.capturedSite?.cacheKey, "https://www.mozilla.com")
+    }
+
     // MARK: - Hero image
 
     func testHeroImage_heroImageNotFound_returnsFavicon() async {
         let subject = DefaultSiteImageFetcher(urlHandler: urlHandler,
                                               imageHandler: imageHandler)
         let siteURL = "https://www.firefox.com"
-        let result = await subject.getImage(urlStringRequest: siteURL,
-                                            type: .heroImage,
-                                            id: UUID())
+        let result = await subject.getImageModel(urlStringRequest: siteURL,
+                                                 type: .heroImage,
+                                                 id: UUID(),
+                                                 usesIndirectDomain: true)
 
-        XCTAssertEqual(result.cacheKey, "firefox")
+        XCTAssertEqual(result.cacheKey, "https://www.firefox.com")
         XCTAssertEqual(result.siteURL, URL(string: siteURL))
         XCTAssertEqual(result.faviconURL, nil)
         XCTAssertEqual(result.expectedImageType, .heroImage)
@@ -94,7 +120,7 @@ final class SiteImageFetcherTests: XCTestCase {
         XCTAssertNotNil(result.faviconImage)
 
         XCTAssertNil(imageHandler.capturedSite?.faviconURL)
-        XCTAssertEqual(imageHandler.capturedSite?.cacheKey, "firefox")
+        XCTAssertEqual(imageHandler.capturedSite?.cacheKey, "https://www.firefox.com")
         XCTAssertEqual(imageHandler.capturedSite?.siteURL, URL(string: siteURL))
     }
 
@@ -103,11 +129,12 @@ final class SiteImageFetcherTests: XCTestCase {
         let subject = DefaultSiteImageFetcher(urlHandler: urlHandler,
                                               imageHandler: imageHandler)
         let siteURL = "https://www.focus.com"
-        let result = await subject.getImage(urlStringRequest: siteURL,
-                                            type: .heroImage,
-                                            id: UUID())
+        let result = await subject.getImageModel(urlStringRequest: siteURL,
+                                                 type: .heroImage,
+                                                 id: UUID(),
+                                                 usesIndirectDomain: true)
 
-        XCTAssertEqual(result.cacheKey, "focus")
+        XCTAssertEqual(result.cacheKey, "https://www.focus.com")
         XCTAssertEqual(result.siteURL, URL(string: siteURL))
         XCTAssertEqual(result.faviconURL, nil)
         XCTAssertEqual(result.expectedImageType, .heroImage)
@@ -115,7 +142,7 @@ final class SiteImageFetcherTests: XCTestCase {
         XCTAssertNil(result.faviconImage)
 
         XCTAssertNil(imageHandler.capturedSite?.faviconURL)
-        XCTAssertEqual(imageHandler.capturedSite?.cacheKey, "focus")
+        XCTAssertEqual(imageHandler.capturedSite?.cacheKey, "https://www.focus.com")
         XCTAssertEqual(imageHandler.capturedSite?.siteURL, URL(string: siteURL))
     }
 }

--- a/BrowserKit/Tests/SiteImageViewTests/SiteImageFetcherTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/SiteImageFetcherTests.swift
@@ -31,16 +31,15 @@ final class SiteImageFetcherTests: XCTestCase {
                                             type: .favicon,
                                             id: UUID())
 
-        XCTAssertEqual(result.domain?.baseDomain, "example.hello")
+        XCTAssertEqual(result.cacheKey, "example.hello")
         XCTAssertEqual(result.siteURL, URL(string: siteURL))
         XCTAssertEqual(result.faviconURL, nil)
         XCTAssertEqual(result.expectedImageType, .favicon)
         XCTAssertNil(result.heroImage)
         XCTAssertNotNil(result.faviconImage)
 
-        XCTAssertNil(imageHandler.capturedFaviconURL)
-        XCTAssertEqual(imageHandler.capturedDomain?.baseDomain, "example.hello")
-        XCTAssertNil(imageHandler.capturedSiteURL)
+        XCTAssertNil(imageHandler.capturedSite?.faviconURL)
+        XCTAssertEqual(imageHandler.capturedSite?.cacheKey, "example.hello")
     }
 
     func testFavicon_wrongURL_useFallbackDomain() async {
@@ -52,8 +51,8 @@ final class SiteImageFetcherTests: XCTestCase {
                                             type: .favicon,
                                             id: UUID())
 
-        XCTAssertEqual(result.domain?.baseDomain, "www.example.hello.com")
-        XCTAssertEqual(imageHandler.capturedDomain?.baseDomain, "www.example.hello.com")
+        XCTAssertEqual(result.cacheKey, "www.example.hello.com")
+        XCTAssertEqual(imageHandler.capturedSite?.cacheKey, "www.example.hello.com")
     }
 
     func testFavicon_faviconURLFound_generateFavicon() async {
@@ -66,16 +65,15 @@ final class SiteImageFetcherTests: XCTestCase {
                                             type: .favicon,
                                             id: UUID())
 
-        XCTAssertEqual(result.domain?.baseDomain, "mozilla")
+        XCTAssertEqual(result.cacheKey, "mozilla")
         XCTAssertEqual(result.siteURL, URL(string: siteURL))
         XCTAssertEqual(result.faviconURL, nil)
         XCTAssertEqual(result.expectedImageType, .favicon)
         XCTAssertNil(result.heroImage)
         XCTAssertNotNil(result.faviconImage)
 
-        XCTAssertEqual(imageHandler.capturedFaviconURL, faviconURL)
-        XCTAssertEqual(imageHandler.capturedDomain?.baseDomain, "mozilla")
-        XCTAssertNil(imageHandler.capturedSiteURL)
+        XCTAssertEqual(imageHandler.capturedSite?.faviconURL, faviconURL)
+        XCTAssertEqual(imageHandler.capturedSite?.cacheKey, "mozilla")
     }
 
     // MARK: - Hero image
@@ -88,16 +86,16 @@ final class SiteImageFetcherTests: XCTestCase {
                                             type: .heroImage,
                                             id: UUID())
 
-        XCTAssertEqual(result.domain?.baseDomain, "firefox")
+        XCTAssertEqual(result.cacheKey, "firefox")
         XCTAssertEqual(result.siteURL, URL(string: siteURL))
         XCTAssertEqual(result.faviconURL, nil)
         XCTAssertEqual(result.expectedImageType, .heroImage)
         XCTAssertNil(result.heroImage)
         XCTAssertNotNil(result.faviconImage)
 
-        XCTAssertNil(imageHandler.capturedFaviconURL)
-        XCTAssertEqual(imageHandler.capturedDomain?.baseDomain, "firefox")
-        XCTAssertEqual(imageHandler.capturedSiteURL, URL(string: siteURL))
+        XCTAssertNil(imageHandler.capturedSite?.faviconURL)
+        XCTAssertEqual(imageHandler.capturedSite?.cacheKey, "firefox")
+        XCTAssertEqual(imageHandler.capturedSite?.siteURL, URL(string: siteURL))
     }
 
     func testHeroImage_heroImageFound_returnsHeroImage() async {
@@ -109,16 +107,16 @@ final class SiteImageFetcherTests: XCTestCase {
                                             type: .heroImage,
                                             id: UUID())
 
-        XCTAssertEqual(result.domain?.baseDomain, "focus")
+        XCTAssertEqual(result.cacheKey, "focus")
         XCTAssertEqual(result.siteURL, URL(string: siteURL))
         XCTAssertEqual(result.faviconURL, nil)
         XCTAssertEqual(result.expectedImageType, .heroImage)
         XCTAssertNotNil(result.heroImage)
         XCTAssertNil(result.faviconImage)
 
-        XCTAssertNil(imageHandler.capturedFaviconURL)
-        XCTAssertEqual(imageHandler.capturedDomain?.baseDomain, "focus")
-        XCTAssertEqual(imageHandler.capturedSiteURL, URL(string: siteURL))
+        XCTAssertNil(imageHandler.capturedSite?.faviconURL)
+        XCTAssertEqual(imageHandler.capturedSite?.cacheKey, "focus")
+        XCTAssertEqual(imageHandler.capturedSite?.siteURL, URL(string: siteURL))
     }
 }
 
@@ -133,6 +131,7 @@ private class MockFaviconURLHandler: FaviconURLHandler {
                               expectedImageType: site.expectedImageType,
                               urlStringRequest: site.urlStringRequest,
                               siteURL: site.siteURL,
+                              cacheKey: site.cacheKey,
                               domain: site.domain,
                               faviconURL: faviconURL)
     }
@@ -141,21 +140,16 @@ private class MockFaviconURLHandler: FaviconURLHandler {
 // MARK: - MockImageHandler
 private class MockImageHandler: ImageHandler {
     var faviconImage = UIImage()
-    var capturedFaviconURL: URL?
-    var capturedDomain: ImageDomain?
+    var heroImage: UIImage?
+    var capturedSite: SiteImageModel?
 
-    func fetchFavicon(imageURL: URL?, domain: ImageDomain, expectedType: SiteImageType) async -> UIImage {
-        capturedFaviconURL = imageURL
-        capturedDomain = domain
+    func fetchFavicon(site: SiteImageModel) async -> UIImage {
+        capturedSite = site
         return faviconImage
     }
 
-    var capturedSiteURL: URL?
-    var heroImage: UIImage?
-
-    func fetchHeroImage(siteURL: URL, domain: ImageDomain) async throws -> UIImage {
-        capturedSiteURL = siteURL
-        capturedDomain = domain
+    func fetchHeroImage(site: SiteImageModel) async throws -> UIImage {
+        capturedSite = site
         if let image = heroImage {
             return image
         } else {

--- a/BrowserKit/Tests/SiteImageViewTests/SiteImageViewTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/SiteImageViewTests.swift
@@ -57,9 +57,10 @@ class MockSiteImageFetcher: SiteImageFetcher {
     var image = UIImage()
     var capturedType: SiteImageType?
     var capturedStringRequest: String?
-    func getImage(urlStringRequest: String,
-                  type: SiteImageType,
-                  id: UUID) async -> SiteImageModel {
+    func getImageModel(urlStringRequest: String,
+                       type: SiteImageType,
+                       id: UUID,
+                       usesIndirectDomain: Bool) async -> SiteImageModel {
         capturedStringRequest = urlStringRequest
         capturedType = type
         return SiteImageModel(id: id,

--- a/BrowserKit/Tests/SiteImageViewTests/SiteImageViewTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/SiteImageViewTests.swift
@@ -66,7 +66,8 @@ class MockSiteImageFetcher: SiteImageFetcher {
                               expectedImageType: type,
                               urlStringRequest: urlStringRequest,
                               siteURL: URL(string: urlStringRequest)!,
-                              domain: ImageDomain(baseDomain: "", bundleDomains: []),
+                              cacheKey: "",
+                              domain: ImageDomain(bundleDomains: []),
                               faviconURL: nil,
                               faviconImage: image,
                               heroImage: image)

--- a/BrowserKit/Tests/SiteImageViewTests/SiteImageViewTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/SiteImageViewTests.swift
@@ -57,10 +57,10 @@ class MockSiteImageFetcher: SiteImageFetcher {
     var image = UIImage()
     var capturedType: SiteImageType?
     var capturedStringRequest: String?
-    func getImageModel(urlStringRequest: String,
-                       type: SiteImageType,
-                       id: UUID,
-                       usesIndirectDomain: Bool) async -> SiteImageModel {
+    func getImage(urlStringRequest: String,
+                  type: SiteImageType,
+                  id: UUID,
+                  usesIndirectDomain: Bool) async -> SiteImageModel {
         capturedStringRequest = urlStringRequest
         capturedType = type
         return SiteImageModel(id: id,


### PR DESCRIPTION
[FXIOS-5464](https://mozilla-hub.atlassian.net/browse/FXIOS-5464)
#12734 

Replaced domain value with a cacheKey value on the site entity. 
Updated the logic for generating the key to use the full URL if the request is for a hero image or if it's flagged as having an indirect domain (such as favicons for sponsored tiles)

Tests and swiftlint pass locally, skipping BR because it doesn't run BrowserKit tests yet.