### PR TITLE
Bugfix FXIOS-5486 [v110] Fix issue with favicon failing to download

### DIFF
--- a/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/URLFetcher/FaviconURLFetcher.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/URLFetcher/FaviconURLFetcher.swift
@@ -56,8 +56,6 @@ struct DefaultFaviconURLFetcher: FaviconURLFetcher {
         // Search for the first reference to an icon
         for link in root.xpath("//head//link[contains(@rel, 'icon')]") {
             guard let href = link["href"] else { continue }
-            print("href: \(href)")
-            print("href: \(siteURL.absoluteString)")
             if let faviconURL = URL(string: href) {
                 return faviconURL
             }

--- a/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/URLFetcher/FaviconURLFetcher.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/URLFetcher/FaviconURLFetcher.swift
@@ -56,8 +56,9 @@ struct DefaultFaviconURLFetcher: FaviconURLFetcher {
         // Search for the first reference to an icon
         for link in root.xpath("//head//link[contains(@rel, 'icon')]") {
             guard let href = link["href"] else { continue }
-
-            if let faviconURL = URL(string: siteURL.absoluteString + "/" + href) {
+            print("href: \(href)")
+            print("href: \(siteURL.absoluteString)")
+            if let faviconURL = URL(string: href) {
                 return faviconURL
             }
         }

--- a/BrowserKit/Tests/SiteImageViewTests/FaviconURLProcessing/FaviconURLFetcherTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/FaviconURLProcessing/FaviconURLFetcherTests.swift
@@ -56,7 +56,7 @@ private enum ImageURLTestHTML {
     static let mockHTMLWithIcon = """
         <html>
             <head>
-                <link rel="icon" href="image.png"></link>
+                <link rel="icon" href="http://firefox.com/image.png"></link>
                 <title>Firefox</title>
             </head>
         </html>


### PR DESCRIPTION
[FXIOS-5486](https://mozilla-hub.atlassian.net/browse/FXIOS-5486)
#12770 

The url was being formatted incorrectly 

Tests and swiftlint pass locally, skipping BR because it doesn't run BrowserKit tests yet.