### PR TITLE
Add MTE-392 [v110] Mergify rule to land PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,22 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This CODEOWNERS file defines individuals or teams that are responsible
+# for code in this repository. Code owners are automatically requested
+# for review when someone opens a pull request that modifies code that
+# they own. Order is important; the last matching pattern takes the most
+# precedence.
+#
+# A CODEOWNERS file uses a pattern that follows the same rules used in
+# gitignore files. The pattern is followed by one or more GitHub usernames
+# or team names using the standard @username or @org/team-name format.
+# You can also refer to a user by an email address that has been added
+# to their GitHub account, for example user@example.com.
+# https://help.github.com/articles/about-codeowners/
+
+
+# By default the Firefox iOS Engineering team will be the owner for everything
+# in the repo. Unless a later match takes precedence.
+
+* @mozilla-mobile/firefox-ios-eng

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -23,3 +23,25 @@ pull_request_rules:
       queue:
         method: rebase
         name: default
+  - name: Needs landing - Rebase
+    conditions:
+      - label=Needs Landing
+      - "#approved-reviews-by>=1"
+      - -draft
+      - label!=Work In Progress
+      - label!=Do Not Land
+    actions:
+      queue:
+        method: rebase
+        name: default
+  - name: Needs landing - Squash
+    conditions:
+      - label=Needs Landing (Squash)
+      - "#approved-reviews-by>=1"
+      - -draft
+      - label!=work in progress
+      - label!=do not land
+    actions:
+      queue:
+        method: squash
+        name: default

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -23,7 +23,7 @@ pull_request_rules:
       queue:
         method: rebase
         name: default
-  - name: Needs landing - Rebase
+  - name: Needs landing
     conditions:
       - label=Needs Landing
       - "#approved-reviews-by>=1"
@@ -32,7 +32,7 @@ pull_request_rules:
       - label!=Do Not Land
     actions:
       queue:
-        method: rebase
+        method: merge
         name: default
   - name: Needs landing - Squash
     conditions:
@@ -43,5 +43,5 @@ pull_request_rules:
       - label!=do not land
     actions:
       queue:
-        method: squash
+        method: merge
         name: default


### PR DESCRIPTION
As discussed in sync meetings, let's try to use mergify to automatically land PRs. In order for this to happen:
- PR has to be green on Bitrise
- PR has to be approved by at least one team member
- PR has to be labelled properly: `Needs Landing` or `Needs Landing (Squash)` (I have created both labels)
- If PR is still draft, or has `Do Not Land` label, it will not land

To be sure the approval comes to one team member, on focus when a PR is created, the team is added as reviewer automatically. I don't have permissions to configure that on firefox @adudenamedruby (since you are around this week) could you help me with that please?