### PR TITLE
Add FXIOS-5394 [v110] credit card autofill settings with telemetry and string update

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -308,6 +308,7 @@
 		433F87D52788F01500693368 /* KIF in Frameworks */ = {isa = PBXBuildFile; productRef = 433F87D42788F01500693368 /* KIF */; };
 		43446CF02412DDBE00F5C643 /* UpdateViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43446CEF2412DDBE00F5C643 /* UpdateViewModelTests.swift */; };
 		4345441D26D2E52600D5EEAA /* SearchTermGroupsUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4345441C26D2E52600D5EEAA /* SearchTermGroupsUtility.swift */; };
+		4346FF08295BA6A300F4D220 /* CreditCardSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4346FF07295BA6A200F4D220 /* CreditCardSettingsViewController.swift */; };
 		43470D0828B39AF80034F500 /* JumpBackIn.strings in Resources */ = {isa = PBXBuildFile; fileRef = 43470D0628B39AF80034F500 /* JumpBackIn.strings */; };
 		43470D0B28B39AF80034F500 /* ToolbarLocation.strings in Resources */ = {isa = PBXBuildFile; fileRef = 43470D0928B39AF80034F500 /* ToolbarLocation.strings */; };
 		434E733725EED32E006D3BDE /* BrowserViewController+URLBarDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434E733625EED32E006D3BDE /* BrowserViewController+URLBarDelegate.swift */; };
@@ -2468,6 +2469,7 @@
 		43446CEF2412DDBE00F5C643 /* UpdateViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateViewModelTests.swift; sourceTree = "<group>"; };
 		4344D02F292259CE00B12BF8 /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "en-GB.lproj/SearchHeaderTitle.strings"; sourceTree = "<group>"; };
 		4345441C26D2E52600D5EEAA /* SearchTermGroupsUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTermGroupsUtility.swift; sourceTree = "<group>"; };
+		4346FF07295BA6A200F4D220 /* CreditCardSettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CreditCardSettingsViewController.swift; sourceTree = "<group>"; };
 		43470D0728B39AF80034F500 /* br */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = br; path = br.lproj/JumpBackIn.strings; sourceTree = "<group>"; };
 		43470D0A28B39AF80034F500 /* br */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = br; path = br.lproj/ToolbarLocation.strings; sourceTree = "<group>"; };
 		4348441329225D1400CC0497 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/SearchHeaderTitle.strings; sourceTree = "<group>"; };
@@ -5809,6 +5811,7 @@
 				EB9A178D20E525DF00B12184 /* ThemeSettingsController.swift */,
 				66CE54A720FCF6CF00CC310B /* WebsiteDataManagementViewController.swift */,
 				6669B5E1211418A200CA117B /* WebsiteDataSearchResultsViewController.swift */,
+				4346FF07295BA6A200F4D220 /* CreditCardSettingsViewController.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -10309,6 +10312,7 @@
 				D0152245229855A8009DE753 /* OneLineTableViewCell.swift in Sources */,
 				F018F84C2719AE8300B9A52D /* ThemedDefaultNavigationController.swift in Sources */,
 				8ADED7EE276A7750009C19E6 /* CumulativeDaysOfUseCounter.swift in Sources */,
+				4346FF08295BA6A300F4D220 /* CreditCardSettingsViewController.swift in Sources */,
 				E19B38B528A42EBC00D8C541 /* WallpaperCellViewModel.swift in Sources */,
 				8A5BD95C2878AA74000FE773 /* PinnedSite.swift in Sources */,
 				5A3A7DCE2886F7880065F81A /* RecentlySavedDataAdaptor.swift in Sources */,

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -1098,7 +1098,7 @@ class AutofillCreditCardSettings: Setting, FeatureFlaggable {
         // Telemetry
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .creditCardAutofillSettings)
 
-        let viewController = CreditCardSettingsViewController()
+        let viewController = CreditCardSettingsViewController(theme: theme)
         navigationController?.pushViewController(viewController, animated: true)
     }
 }

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -1084,6 +1084,25 @@ class ClearPrivateDataSetting: Setting {
     }
 }
 
+class AutofillCreditCardSettings: Setting, FeatureFlaggable {
+    override var accessoryView: UIImageView? { return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme) }
+
+    override var accessibilityIdentifier: String? { return "AutofillCreditCard" }
+
+    init(settings: SettingsTableViewController) {
+        let title: String = .SettingsAutofillCreditCard
+        super.init(title: NSAttributedString(string: title, attributes: [NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary]))
+    }
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        // Telemetry
+        TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .creditCardAutofillSettings)
+
+        let viewController = CreditCardSettingsViewController()
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+}
+
 class PrivacyPolicySetting: Setting {
     override var title: NSAttributedString? {
         return NSAttributedString(string: .AppSettingsPrivacyPolicy, attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -121,6 +121,7 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
             generalSettings.insert(SearchBarSetting(settings: self), at: 5)
         }
 
+        let autofillCreditCardStatus = featureFlags.isFeatureEnabled(.creditCardAutofillStatus, checking: .buildOnly)
         let tabTrayGroupsAreBuildActive = featureFlags.isFeatureEnabled(.tabTrayGroups, checking: .buildOnly)
         let inactiveTabsAreBuildActive = featureFlags.isFeatureEnabled(.inactiveTabs, checking: .buildOnly)
         if tabTrayGroupsAreBuildActive || inactiveTabsAreBuildActive {
@@ -183,6 +184,10 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
         privacySettings.append(LoginsSetting(settings: self, delegate: settingsDelegate))
 
         privacySettings.append(ClearPrivateDataSetting(settings: self))
+
+        if autofillCreditCardStatus {
+            privacySettings.append(AutofillCreditCardSettings(settings: self))
+        }
 
         privacySettings += [
             BoolSetting(prefs: prefs,

--- a/Client/Frontend/Settings/CreditCardSettingsViewController.swift
+++ b/Client/Frontend/Settings/CreditCardSettingsViewController.swift
@@ -4,18 +4,14 @@
 
 import Foundation
 import UIKit
+import Shared
 
-class CreditCardSettingsViewController: UIViewController, Themeable {
-
-    var themeManager: ThemeManager
+class CreditCardSettingsViewController: UIViewController, ThemeApplicable {
     var themeObserver: NSObjectProtocol?
-    var notificationCenter: NotificationProtocol
+    var theme: Theme
 
-
-    init(themeManager: ThemeManager = AppContainer.shared.resolve(),
-         notificationCenter: NotificationCenter = NotificationCenter.default) {
-        self.themeManager = themeManager
-        self.notificationCenter = notificationCenter
+    init(theme: Theme) {
+        self.theme = theme
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -25,11 +21,10 @@ class CreditCardSettingsViewController: UIViewController, Themeable {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        listenForThemeChange()
-        applyTheme()
+        applyTheme(theme: theme)
     }
 
-    func applyTheme() {
-        view.backgroundColor = themeManager.currentTheme.colors.layer1
+    func applyTheme(theme: Theme) {
+        view.backgroundColor = theme.colors.layer1
     }
 }

--- a/Client/Frontend/Settings/CreditCardSettingsViewController.swift
+++ b/Client/Frontend/Settings/CreditCardSettingsViewController.swift
@@ -1,0 +1,35 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import UIKit
+
+class CreditCardSettingsViewController: UIViewController, Themeable {
+
+    var themeManager: ThemeManager
+    var themeObserver: NSObjectProtocol?
+    var notificationCenter: NotificationProtocol
+
+
+    init(themeManager: ThemeManager = AppContainer.shared.resolve(),
+         notificationCenter: NotificationCenter = NotificationCenter.default) {
+        self.themeManager = themeManager
+        self.notificationCenter = notificationCenter
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("not implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        listenForThemeChange()
+        applyTheme()
+    }
+
+    func applyTheme() {
+        view.backgroundColor = themeManager.currentTheme.colors.layer1
+    }
+}

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -1429,6 +1429,11 @@ extension String {
         tableName: nil,
         value: "Copied to clipboard",
         comment: "Copy app version alert shown in settings.")
+    public static let SettingsAutofillCreditCard = MZLocalizedString(
+        "Settings.AutofillCreditCard.Title.v110",
+        tableName: nil,
+        value: "Autofill Credit Card",
+        comment: "Label used as an item in Settings screen. When touched, it will take user to credit card settings page to that will allows to add or modify saved credit cards to allow for autofill in a webpage.")
 }
 
 // MARK: - Error pages

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -407,6 +407,7 @@ extension TelemetryWrapper {
         case settings = "settings"
         case settingsMenuSetAsDefaultBrowser = "set-as-default-browser-menu-go-to-settings"
         case settingsMenuShowTour = "show-tour"
+        case creditCardAutofillSettings = "creditCardAutofillSettings"
         // MARK: New Onboarding
         case onboardingClose = "onboarding-close"
         case onboardingCardView = "onboarding-card-view"
@@ -755,6 +756,9 @@ extension TelemetryWrapper {
         case(.action, .tap, .reloadFromUrlBar, _, _):
             GleanMetrics.Tabs.reloadFromUrlBar.add()
 
+        // MARK: - QR Codes
+        case(.action, .tap, .creditCardAutofillSettings, _, _):
+            GleanMetrics.CreditCard.autofillSettingsTapped.record()
         case(.information, .background, .tabNormalQuantity, _, let extras):
             if let quantity = extras?[EventExtraKey.tabsQuantity.rawValue] as? Int64 {
                 GleanMetrics.Tabs.normalTabsQuantity.set(quantity)

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -3419,3 +3419,18 @@ places_history_migration:
       - teshaq@mozilla.com
       - sync-team@mozilla.com
     expires: "2023-10-17"
+
+# Credit card autofill
+credit_card:
+  autofill_settings_tapped:
+    type: event
+    description: |
+      Recorded when the user taps on credit card autofill
+      settings item in settings screen.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-5394
+    data_reviews:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-5394
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2023-09-01"

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -3430,7 +3430,7 @@ credit_card:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-5394
     data_reviews:
-      - https://mozilla-hub.atlassian.net/browse/FXIOS-5394
+      - https://github.com/mozilla-mobile/firefox-ios/pull/12813/
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2023-09-01"

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -3428,9 +3428,9 @@ credit_card:
       Recorded when the user taps on credit card autofill
       settings item in settings screen.
     bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXIOS-5394
+      - https://github.com/mozilla-mobile/firefox-ios/pull/12813
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/12813/
+      - https://github.com/mozilla-mobile/firefox-ios/pull/12813
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2023-09-01"

--- a/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -414,6 +414,18 @@ class TelemetryWrapperTests: XCTestCase {
         testEventMetricRecordingSuccess(metric: GleanMetrics.SettingsMenu.showTourPressed)
     }
 
+    // MARK: - Credit card autofill
+
+    func test_autofill_credit_card_settings_tapped_GleanIsCalled() {
+        TelemetryWrapper.recordEvent(
+            category: .action,
+            method: .tap,
+            object: .creditCardAutofillSettings
+        )
+
+        testEventMetricRecordingSuccess(metric: GleanMetrics.CreditCard.autofillSettingsTapped)
+    }
+
     // MARK: - Nimbus Calls
 
     func test_appForeground_NimbusIsCalled() throws {

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -488,11 +488,11 @@ features:
     defaults:
       - channel: developer
         value: {
-            "credit-card-autofill-status:": true,
+            "credit-card-autofill-status": true
         }
       - channel: beta
         value: {
-            "credit-card-autofill-status:": true,
+            "credit-card-autofill-status": true
         }
 
 types:


### PR DESCRIPTION
[Jira: FXIOS-5394](https://mozilla-hub.atlassian.net/browse/FXIOS-5394) 

- added the string changes for the settings screen
- added telemetry when the user taps on the credit card autofill settings button
- added a draft view controller for the actual credit card settings page to be worked upon in another ticket