### PR TITLE
Bugfix FXIOS-2046 [v110] Arrow keys do not work in the location bar when fully selected

### DIFF
--- a/Client/Frontend/Toolbar+URLBar/ToolbarTextField.swift
+++ b/Client/Frontend/Toolbar+URLBar/ToolbarTextField.swift
@@ -80,7 +80,6 @@ extension ToolbarTextField: NotificationThemeable {
 extension ToolbarTextField {
     override var keyCommands: [UIKeyCommand]? {
         let commands = [
-            // Navigate the suggestions
             UIKeyCommand(action: #selector(handleKeyboardArrowKey(sender:)),
                          input: UIKeyCommand.inputRightArrow),
             UIKeyCommand(action: #selector(handleKeyboardArrowKey(sender:)),

--- a/Client/Frontend/Toolbar+URLBar/ToolbarTextField.swift
+++ b/Client/Frontend/Toolbar+URLBar/ToolbarTextField.swift
@@ -74,3 +74,22 @@ extension ToolbarTextField: NotificationThemeable {
        textSelectionColor = UIColor.theme.urlbar.textSelectionHighlight(isPrivate)
     }
 }
+
+// MARK: - Key commands
+
+extension ToolbarTextField {
+    override var keyCommands: [UIKeyCommand]? {
+        let commands = [
+            // Navigate the suggestions
+            UIKeyCommand(action: #selector(handleKeyboardArrowKey(sender:)),
+                         input: UIKeyCommand.inputRightArrow),
+            UIKeyCommand(action: #selector(handleKeyboardArrowKey(sender:)),
+                         input: UIKeyCommand.inputLeftArrow),
+        ]
+        return commands
+    }
+
+    @objc private func handleKeyboardArrowKey(sender: UIKeyCommand) {
+        self.selectedTextRange = nil
+    }
+}


### PR DESCRIPTION
[FXIOS-2046](https://mozilla-hub.atlassian.net/browse/FXIOS-2046) || [Github](https://github.com/mozilla-mobile/firefox-ios/issues/8565)

Sample video of arrow keys working when keyboard is connected in sim
---

https://user-images.githubusercontent.com/8919439/209754440-2ca5c950-7801-4674-a8c9-b10b2388d948.mov

