### PR TITLE
Add FXIOS-5539 [v111] add setting to allow blocking of autoplay media

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -223,6 +223,8 @@
 		2FDE87FE1ABB3817005317B1 /* RemoteTabsPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FDE87FD1ABB3817005317B1 /* RemoteTabsPanel.swift */; };
 		318FB6EB1DB5600D0004E40F /* SQLiteHistoryFactories.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318FB6EA1DB5600D0004E40F /* SQLiteHistoryFactories.swift */; };
 		31ADB5DA1E58CEC300E87909 /* ClipboardBarDisplayHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31ADB5D91E58CEC300E87909 /* ClipboardBarDisplayHandler.swift */; };
+		322EE2632960CD4F006F169A /* AutoplaySettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322EE2622960CD4F006F169A /* AutoplaySettingsViewController.swift */; };
+		322EE2652962567D006F169A /* AutoplayAccessors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322EE2642962567D006F169A /* AutoplayAccessors.swift */; };
 		39012F281F8ED262002E3D31 /* ScreenGraphTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39012F271F8ED262002E3D31 /* ScreenGraphTest.swift */; };
 		3905274C1C874D35007E0BB7 /* NotificationCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3905274B1C874D35007E0BB7 /* NotificationCenter.framework */; };
 		3905274F1C874D35007E0BB7 /* TodayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3905274E1C874D35007E0BB7 /* TodayViewController.swift */; };
@@ -2170,6 +2172,8 @@
 		31F04694829964F04E966C26 /* mr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = mr; path = mr.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
 		31F64FBE80361C40D332CCFD /* id */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = id; path = id.lproj/Localizable.strings; sourceTree = "<group>"; };
 		322A4607BAF7CAD92743461C /* he */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
+		322EE2622960CD4F006F169A /* AutoplaySettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoplaySettingsViewController.swift; sourceTree = "<group>"; };
+		322EE2642962567D006F169A /* AutoplayAccessors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AutoplayAccessors.swift; path = Accessors/AutoplayAccessors.swift; sourceTree = "<group>"; };
 		324A457A81DC988B0C8B7C67 /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bg; path = bg.lproj/FindInPage.strings; sourceTree = "<group>"; };
 		324A4946887D6B29445BBB40 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
 		324A4A9BAC13F4C07CD026B3 /* fa */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fa; path = fa.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
@@ -5789,6 +5793,7 @@
 		2F44FC551A9E83E200FD20CC /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				322EE2622960CD4F006F169A /* AutoplaySettingsViewController.swift */,
 				EBB895322193FFF400EB91A0 /* ContentBlockerSettingViewController.swift */,
 				7B4980A71CE363ED0017547C /* Settings.xcassets */,
 				8D8251721F4DE67E00780643 /* AdvancedAccountSettingViewController.swift */,
@@ -5977,6 +5982,7 @@
 		392ED7D51D0AEEEE009D9B62 /* Accessors */ = {
 			isa = PBXGroup;
 			children = (
+				322EE2642962567D006F169A /* AutoplayAccessors.swift */,
 				392ED7E31D0AEF56009D9B62 /* NewTabAccessors.swift */,
 				392ED7E51D0AEFEF009D9B62 /* HomePageAccessors.swift */,
 			);
@@ -10619,6 +10625,7 @@
 				C84655FF2887A06B00861B4A /* WallpaperFilePathProvider.swift in Sources */,
 				E1442FD6294782D9003680B0 /* UIView+Extension.swift in Sources */,
 				274A36CE239EB9EC00A21587 /* LibraryViewController+LibraryPanelDelegate.swift in Sources */,
+				322EE2652962567D006F169A /* AutoplayAccessors.swift in Sources */,
 				C869912D28917688007ACC5C /* WallpaperImageLoader.swift in Sources */,
 				43F7952525795F69005AEE40 /* SearchTelemetry.swift in Sources */,
 				E65075541E37F6FC006961AC /* DynamicFontHelper.swift in Sources */,
@@ -10752,6 +10759,7 @@
 				C8F457AA1F1FDD9B000CB895 /* BrowserViewController+KeyCommands.swift in Sources */,
 				21357F2F294237D8004BF9FD /* RemoteTabsClientAndTabsDataSource.swift in Sources */,
 				59A68FD5260B8D520F890F4A /* ReaderPanel.swift in Sources */,
+				322EE2632960CD4F006F169A /* AutoplaySettingsViewController.swift in Sources */,
 				C849E46126B9C39B00260F0B /* EnhancedTrackingProtectionVC.swift in Sources */,
 				E40FAB0C1A7ABB77009CB80D /* WebServer.swift in Sources */,
 				59A68D66379CFA85C4EAF00B /* TwoLineImageOverlayCell.swift in Sources */,

--- a/Client/Application/AccessibilityIdentifiers.swift
+++ b/Client/Application/AccessibilityIdentifiers.swift
@@ -236,7 +236,7 @@ public struct AccessibilityIdentifiers {
             static let topSetting = "TopSearchBar"
             static let bottomSetting = "BottomSearchBar"
         }
-        
+
         struct Autoplay {
             static let allowAudioAndVideo = "AllowAudioAndVideo"
             static let blockAudio = "BlockAudio"

--- a/Client/Application/AccessibilityIdentifiers.swift
+++ b/Client/Application/AccessibilityIdentifiers.swift
@@ -236,6 +236,12 @@ public struct AccessibilityIdentifiers {
             static let topSetting = "TopSearchBar"
             static let bottomSetting = "BottomSearchBar"
         }
+        
+        struct Autoplay {
+            static let allowAudioAndVideo = "AllowAudioAndVideo"
+            static let blockAudio = "BlockAudio"
+            static let blockAudioAndVideo = "BlockAudioAndVideo"
+        }
     }
 
     struct ShareTo {

--- a/Client/Frontend/Accessors/AutoplayAccessors.swift
+++ b/Client/Frontend/Accessors/AutoplayAccessors.swift
@@ -1,0 +1,55 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Shared
+import WebKit
+
+/// Accessors to find what should happen when the user opens a web page with media that will autoplay.
+struct AutoplayAccessors {
+    static let AutoplayPrefKey = PrefsKeys.AutoplayMediaKey
+    static let Default = AutoplayAction.allowAudioAndVideo
+    
+    static func getAutoplayAction(_ prefs: Prefs?) -> AutoplayAction {
+        guard let raw = prefs?.stringForKey(AutoplayPrefKey) else { return Default }
+
+        let option = AutoplayAction(rawValue: raw) ?? Default
+        return option
+    }
+
+    static func getMediaTypesRequiringUserActionForPlayback(_ prefs: Prefs?) -> WKAudiovisualMediaTypes {
+        // https://developer.apple.com/documentation/webkit/wkaudiovisualmediatypes
+        switch getAutoplayAction(prefs) {
+        case AutoplayAction.allowAudioAndVideo:
+            // To indicate that no user gestures are required to play media, use an empty set of audio/visual media types, indicated by the empty array literal, [].
+            return []
+        case AutoplayAction.blockAudio:
+            // Media types that contain audio require a user gesture to begin playing
+            return WKAudiovisualMediaTypes.audio
+        case AutoplayAction.blockAudioAndVideo:
+            // All media types require a user gesture to begin playing.
+            return WKAudiovisualMediaTypes.all
+        }
+    }
+}
+
+/// Enum to encode what should happen when the user opens a web page with media that will autoplay.
+enum AutoplayAction: String {
+    case allowAudioAndVideo
+    case blockAudio
+    case blockAudioAndVideo
+    
+    var settingTitle: String {
+        switch self {
+        case .allowAudioAndVideo:
+            return .Settings.Autoplay.AllowAudioAndVideo
+        case .blockAudio:
+            return .Settings.Autoplay.BlockAudio
+        case .blockAudioAndVideo:
+            return .Settings.Autoplay.BlockAudioAndVideo
+        }
+    }
+
+}
+

--- a/Client/Frontend/Accessors/AutoplayAccessors.swift
+++ b/Client/Frontend/Accessors/AutoplayAccessors.swift
@@ -10,7 +10,7 @@ import WebKit
 struct AutoplayAccessors {
     static let AutoplayPrefKey = PrefsKeys.AutoplayMediaKey
     static let Default = AutoplayAction.allowAudioAndVideo
-    
+
     static func getAutoplayAction(_ prefs: Prefs?) -> AutoplayAction {
         guard let raw = prefs?.stringForKey(AutoplayPrefKey) else { return Default }
 
@@ -39,7 +39,7 @@ enum AutoplayAction: String {
     case allowAudioAndVideo
     case blockAudio
     case blockAudioAndVideo
-    
+
     var settingTitle: String {
         switch self {
         case .allowAudioAndVideo:
@@ -50,6 +50,4 @@ enum AutoplayAction: String {
             return .Settings.Autoplay.BlockAudioAndVideo
         }
     }
-
 }
-

--- a/Client/Frontend/Browser/Tab Management/TabManager.swift
+++ b/Client/Frontend/Browser/Tab Management/TabManager.swift
@@ -184,6 +184,7 @@ class TabManager: NSObject, FeatureFlaggable, TabManagerProtocol {
         configuration.processPool = WKProcessPool()
         let blockPopups = prefs?.boolForKey(PrefsKeys.KeyBlockPopups) ?? true
         configuration.preferences.javaScriptCanOpenWindowsAutomatically = !blockPopups
+        configuration.mediaTypesRequiringUserActionForPlayback = AutoplayAccessors.getMediaTypesRequiringUserActionForPlayback(prefs);
         // We do this to go against the configuration of the <meta name="viewport">
         // tag to behave the same way as Safari :-(
         configuration.ignoresViewportScaleLimits = true
@@ -764,6 +765,8 @@ class TabManager: NSObject, FeatureFlaggable, TabManagerProtocol {
             // The default tab configurations also need to change.
             self.configuration.preferences.javaScriptCanOpenWindowsAutomatically = allowPopups
             self.privateConfiguration.preferences.javaScriptCanOpenWindowsAutomatically = allowPopups
+            
+            self.configuration.mediaTypesRequiringUserActionForPlayback = AutoplayAccessors.getMediaTypesRequiringUserActionForPlayback(self.profile.prefs);
         }
     }
 

--- a/Client/Frontend/Browser/Tab Management/TabManager.swift
+++ b/Client/Frontend/Browser/Tab Management/TabManager.swift
@@ -184,7 +184,7 @@ class TabManager: NSObject, FeatureFlaggable, TabManagerProtocol {
         configuration.processPool = WKProcessPool()
         let blockPopups = prefs?.boolForKey(PrefsKeys.KeyBlockPopups) ?? true
         configuration.preferences.javaScriptCanOpenWindowsAutomatically = !blockPopups
-        configuration.mediaTypesRequiringUserActionForPlayback = AutoplayAccessors.getMediaTypesRequiringUserActionForPlayback(prefs);
+        configuration.mediaTypesRequiringUserActionForPlayback = AutoplayAccessors.getMediaTypesRequiringUserActionForPlayback(prefs)
         // We do this to go against the configuration of the <meta name="viewport">
         // tag to behave the same way as Safari :-(
         configuration.ignoresViewportScaleLimits = true
@@ -765,8 +765,8 @@ class TabManager: NSObject, FeatureFlaggable, TabManagerProtocol {
             // The default tab configurations also need to change.
             self.configuration.preferences.javaScriptCanOpenWindowsAutomatically = allowPopups
             self.privateConfiguration.preferences.javaScriptCanOpenWindowsAutomatically = allowPopups
-            
-            self.configuration.mediaTypesRequiringUserActionForPlayback = AutoplayAccessors.getMediaTypesRequiringUserActionForPlayback(self.profile.prefs);
+
+            self.configuration.mediaTypesRequiringUserActionForPlayback = AutoplayAccessors.getMediaTypesRequiringUserActionForPlayback(self.profile.prefs)
         }
     }
 

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -1400,3 +1400,30 @@ class SearchBarSetting: Setting {
         navigationController?.pushViewController(viewController, animated: true)
     }
 }
+
+class AutoplaySetting: Setting {
+    let profile: Profile
+
+    override var accessoryView: UIImageView? { return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme) }
+
+    override var accessibilityIdentifier: String? { return "AutoplaySettings" }
+
+    override var status: NSAttributedString {
+        return NSAttributedString(string: AutoplayAccessors.getAutoplayAction(profile.prefs).settingTitle)
+    }
+
+    override var style: UITableViewCell.CellStyle { return .value1 }
+
+    init(settings: SettingsTableViewController) {
+        self.profile = settings.profile
+
+        super.init(title: NSAttributedString(string: .Settings.Autoplay.Autoplay,
+                                             attributes: [NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary]))
+    }
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        let viewController = AutoplaySettingsViewController(prefs: profile.prefs)
+        viewController.profile = profile
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+}

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -108,6 +108,7 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
             OpenWithSetting(settings: self),
             ThemeSetting(settings: self),
             SiriPageSetting(settings: self),
+            AutoplaySetting(settings: self),
             BoolSetting(
                 prefs: prefs,
                 theme: themeManager.currentTheme,

--- a/Client/Frontend/Settings/AutoplaySettingsViewController.swift
+++ b/Client/Frontend/Settings/AutoplaySettingsViewController.swift
@@ -1,0 +1,75 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0
+
+import Foundation
+import Shared
+
+class AutoplaySettingsViewController: SettingsTableViewController {
+    /* variables for checkmark settings */
+    let prefs: Prefs
+    var currentChoice: AutoplayAction!
+    init(prefs: Prefs) {
+        self.prefs = prefs
+        super.init(style: .grouped)
+
+        self.title = .Settings.Autoplay.Autoplay
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func generateSettings() -> [SettingSection] {
+        self.currentChoice = prefs.stringForKey(AutoplayAccessors.AutoplayPrefKey).flatMap({AutoplayAction(rawValue: $0)}) ?? AutoplayAccessors.Default
+
+        let onFinished = {
+            self.prefs.setString(self.currentChoice.rawValue, forKey: AutoplayAccessors.AutoplayPrefKey)
+            self.tableView.reloadData()
+        }
+
+        let allowAudioAndVideo = CheckmarkSetting(
+            title: NSAttributedString(string: .Settings.Autoplay.AllowAudioAndVideo),
+            subtitle: nil,
+            accessibilityIdentifier: "AllowAudioAndVideo",
+            isChecked: {return self.currentChoice == AutoplayAction.allowAudioAndVideo},
+            onChecked: {
+                self.currentChoice = AutoplayAction.allowAudioAndVideo
+                onFinished()
+        })
+        let blockAudio = CheckmarkSetting(
+            title: NSAttributedString(string: .Settings.Autoplay.BlockAudio),
+            subtitle: nil,
+            accessibilityIdentifier: "BlockAudio",
+            isChecked: {return self.currentChoice == AutoplayAction.blockAudio},
+            onChecked: {
+                self.currentChoice = AutoplayAction.blockAudio
+                onFinished()
+        })
+        let blockAudioAndVideo = CheckmarkSetting(
+            title: NSAttributedString(string: .Settings.Autoplay.BlockAudioAndVideo),
+            subtitle: nil,
+            accessibilityIdentifier: "BlockAudioAndVideo",
+            isChecked: {return self.currentChoice == AutoplayAction.blockAudioAndVideo},
+            onChecked: {
+                self.currentChoice = AutoplayAction.blockAudioAndVideo
+                onFinished()
+        })
+
+        let section = SettingSection(
+            title: NSAttributedString(string: .Settings.Autoplay.Autoplay),
+            children: [allowAudioAndVideo, blockAudio, blockAudioAndVideo])
+
+        return [section]
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        NotificationCenter.default.post(name: .HomePanelPrefsChanged, object: nil)
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.tableView.keyboardDismissMode = .onDrag
+    }
+}

--- a/Client/Frontend/Settings/AutoplaySettingsViewController.swift
+++ b/Client/Frontend/Settings/AutoplaySettingsViewController.swift
@@ -63,11 +63,6 @@ class AutoplaySettingsViewController: SettingsTableViewController {
         return [section]
     }
 
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        NotificationCenter.default.post(name: .HomePanelPrefsChanged, object: nil)
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
         self.tableView.keyboardDismissMode = .onDrag

--- a/Client/Frontend/Settings/AutoplaySettingsViewController.swift
+++ b/Client/Frontend/Settings/AutoplaySettingsViewController.swift
@@ -65,6 +65,6 @@ class AutoplaySettingsViewController: SettingsTableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.tableView.keyboardDismissMode = .onDrag
+       tableView.keyboardDismissMode = .onDrag
     }
 }

--- a/Client/Frontend/Settings/AutoplaySettingsViewController.swift
+++ b/Client/Frontend/Settings/AutoplaySettingsViewController.swift
@@ -31,7 +31,7 @@ class AutoplaySettingsViewController: SettingsTableViewController {
         let allowAudioAndVideo = CheckmarkSetting(
             title: NSAttributedString(string: .Settings.Autoplay.AllowAudioAndVideo),
             subtitle: nil,
-            accessibilityIdentifier: "AllowAudioAndVideo",
+            accessibilityIdentifier: AccessibilityIdentifiers.Settings.Autoplay.allowAudioAndVideo,
             isChecked: {return self.currentChoice == AutoplayAction.allowAudioAndVideo},
             onChecked: {
                 self.currentChoice = AutoplayAction.allowAudioAndVideo
@@ -40,7 +40,7 @@ class AutoplaySettingsViewController: SettingsTableViewController {
         let blockAudio = CheckmarkSetting(
             title: NSAttributedString(string: .Settings.Autoplay.BlockAudio),
             subtitle: nil,
-            accessibilityIdentifier: "BlockAudio",
+            accessibilityIdentifier: AccessibilityIdentifiers.Settings.Autoplay.blockAudio,
             isChecked: {return self.currentChoice == AutoplayAction.blockAudio},
             onChecked: {
                 self.currentChoice = AutoplayAction.blockAudio
@@ -49,7 +49,7 @@ class AutoplaySettingsViewController: SettingsTableViewController {
         let blockAudioAndVideo = CheckmarkSetting(
             title: NSAttributedString(string: .Settings.Autoplay.BlockAudioAndVideo),
             subtitle: nil,
-            accessibilityIdentifier: "BlockAudioAndVideo",
+            accessibilityIdentifier: AccessibilityIdentifiers.Settings.Autoplay.blockAudioAndVideo,
             isChecked: {return self.currentChoice == AutoplayAction.blockAudioAndVideo},
             onChecked: {
                 self.currentChoice = AutoplayAction.blockAudioAndVideo

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -1053,6 +1053,29 @@ extension String {
                 comment: "In the settings menu, in the Toolbar customization section, this label indicates that selecting this will make the toolbar appear at the bottom of the screen.")
         }
 
+        public struct Autoplay {
+            public static let Autoplay = MZLocalizedString(
+                "Settings.Autoplay.SettingsTitle",
+                tableName: nil,
+                value: "Autoplay",
+                comment: "In the settings menu, this label indicates that there is an option of customizing the Autoplay behaviour.")
+            public static let AllowAudioAndVideo = MZLocalizedString(
+                "Settings.Autoplay.AllowAudioAndVideo",
+                tableName: nil,
+                value: "Allow Audio and Video",
+                comment: "In the settings menu, in the Autoplay customization section, this label indicates that selecting this will allow audio and video content to autoplay.")
+            public static let BlockAudio = MZLocalizedString(
+                "Settings.Autoplay.BlockAudio",
+                tableName: nil,
+                value: "Block Audio",
+                comment: "In the settings menu, in the Autoplay customization section, this label indicates that selecting this will block audio from autoplaying.")
+            public static let BlockAudioAndVideo = MZLocalizedString(
+                "Settings.Autoplay.BlockAudioAndVideo",
+                tableName: nil,
+                value: "Block Audio and Video",
+                comment: "In the settings menu, in the Autoplay customization section, this label indicates that selecting this will block audio and video content from autoplaying.")
+        }
+
         public struct Toggle {
             public static let NoImageMode = MZLocalizedString(
                 "Settings.NoImageModeBlockImages.Label.v99",

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -1055,22 +1055,22 @@ extension String {
 
         public struct Autoplay {
             public static let Autoplay = MZLocalizedString(
-                "Settings.Autoplay.SettingsTitle",
+                "Settings.Autoplay.SettingsTitle.v111",
                 tableName: nil,
                 value: "Autoplay",
                 comment: "In the settings menu, this label indicates that there is an option of customizing the Autoplay behaviour.")
             public static let AllowAudioAndVideo = MZLocalizedString(
-                "Settings.Autoplay.AllowAudioAndVideo",
+                "Settings.Autoplay.AllowAudioAndVideo.v111",
                 tableName: nil,
                 value: "Allow Audio and Video",
                 comment: "In the settings menu, in the Autoplay customization section, this label indicates that selecting this will allow audio and video content to autoplay.")
             public static let BlockAudio = MZLocalizedString(
-                "Settings.Autoplay.BlockAudio",
+                "Settings.Autoplay.BlockAudio.v111",
                 tableName: nil,
                 value: "Block Audio",
                 comment: "In the settings menu, in the Autoplay customization section, this label indicates that selecting this will block audio from autoplaying.")
             public static let BlockAudioAndVideo = MZLocalizedString(
-                "Settings.Autoplay.BlockAudioAndVideo",
+                "Settings.Autoplay.BlockAudioAndVideo.v111",
                 tableName: nil,
                 value: "Block Audio and Video",
                 comment: "In the settings menu, in the Autoplay customization section, this label indicates that selecting this will block audio and video content from autoplaying.")

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -113,6 +113,7 @@ public struct PrefsKeys {
     public static let AppExtensionTelemetryOpenUrl = "AppExtensionTelemetryOpenUrl"
     public static let AppExtensionTelemetryEventArray = "AppExtensionTelemetryEvents"
     public static let KeyBlockPopups = "blockPopups"
+    public static let AutoplayMediaKey = "autoplayMedia"
 
     // Tabs Tray
     public static let KeyInactiveTabsModel = "KeyInactiveTabsModelKey"


### PR DESCRIPTION
Issue https://github.com/mozilla-mobile/firefox-ios/issues/12862 [FXIOS-5539](https://mozilla-hub.atlassian.net/browse/FXIOS-5539)

this is the same feature that is available in the desktop and android versions.

Settings -> Autoplay
- Allow Audio and Video (default)
- Block Audio
- Block Audio and Video

the setting is mapped to the appropriate webkit configuration 