### PR TITLE
Added FXIOS-5479 [v110] Update tab tray favicons

### DIFF
--- a/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/URLFetcher/FaviconURLFetcher.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/URLFetcher/FaviconURLFetcher.swift
@@ -56,7 +56,7 @@ struct DefaultFaviconURLFetcher: FaviconURLFetcher {
         // Search for the first reference to an icon
         for link in root.xpath("//head//link[contains(@rel, 'icon')]") {
             guard let href = link["href"] else { continue }
-            if let faviconURL = URL(string: href) {
+            if let faviconURL = URL(string: href, relativeTo: siteURL) {
                 return faviconURL
             }
         }

--- a/Client/Frontend/Browser/Tab Management/SavedTab+ConfigureExtension.swift
+++ b/Client/Frontend/Browser/Tab Management/SavedTab+ConfigureExtension.swift
@@ -41,8 +41,7 @@ extension SavedTab {
     }
 
     func configureSavedTabUsing(_ tab: Tab, imageStore: DiskImageStore? = nil) -> Tab {
-        // Since this is a restored tab, reset the URL to be loaded as that will be handled by the SessionRestoreHandler
-        tab.url = nil
+        tab.url = url
 
         if let faviconURL = faviconURL {
             let icon = Favicon(url: faviconURL, date: Date())

--- a/Client/Frontend/Browser/TabCell.swift
+++ b/Client/Frontend/Browser/TabCell.swift
@@ -5,6 +5,7 @@
 import Foundation
 import UIKit
 import Shared
+import SiteImageView
 
 // MARK: - Tab Tray Cell Protocol
 protocol TabTrayCell where Self: UICollectionViewCell {
@@ -47,26 +48,14 @@ class TabCell: UICollectionViewCell,
         view.isUserInteractionEnabled = false
     }
 
-    lazy var smallFaviconView: UIImageView = .build { view in
-        view.contentMode = .scaleAspectFill
-        view.clipsToBounds = true
-        view.isUserInteractionEnabled = false
-        view.backgroundColor = UIColor.clear
-        view.layer.cornerRadius = HomepageViewModel.UX.generalIconCornerRadius
-        view.layer.masksToBounds = true
-    }
-
     lazy var titleText: UILabel = .build { label in
         label.isUserInteractionEnabled = false
         label.numberOfLines = 1
         label.font = DynamicFontHelper.defaultHelper.DefaultSmallFontBold
     }
 
-    lazy var favicon: UIImageView = .build { favicon in
-        favicon.backgroundColor = UIColor.clear
-        favicon.layer.cornerRadius = 2.0
-        favicon.layer.masksToBounds = true
-    }
+    lazy var smallFaviconView: FaviconImageView = .build { _ in }
+    lazy var favicon: FaviconImageView = .build { _ in }
 
     lazy var closeButton: UIButton = .build { button in
         button.setImage(UIImage.templateImageNamed("tab_close"), for: [])
@@ -175,13 +164,8 @@ class TabCell: UICollectionViewCell,
         accessibilityHint = .TabTraySwipeToCloseAccessibilityHint
 
         favicon.image = UIImage(named: ImageIdentifiers.defaultFavicon)
-
-        if let favIcon = tab.displayFavicon, let url = URL(string: favIcon.url) {
-            ImageLoadingHandler.shared.getImageFromCacheOrDownload(with: url,
-                                                                   limit: ImageLoadingConstants.NoLimitImageSize) { image, error in
-                guard error == nil, let image = image else { return }
-                self.favicon.image = image
-            }
+        if !tab.isFxHomeTab {
+            favicon.setFavicon(DefaultFaviconImageViewModel(urlStringRequest: tab.url?.absoluteString ?? ""))
         }
 
         if selected {
@@ -202,7 +186,9 @@ class TabCell: UICollectionViewCell,
         // Favicon or letter image when home screenshot is present for a regular (non-internal) url
         } else if let url = tab.url, (!url.absoluteString.starts(with: "internal") &&
             tab.hasHomeScreenshot) {
-            setFaviconImage(for: tab, with: smallFaviconView)
+            smallFaviconView.image = UIImage(named: ImageIdentifiers.defaultFavicon)
+            faviconBG.isHidden = false
+            screenshotView.image = nil
 
         // Tab screenshot when available
         } else if let tabScreenshot = tab.screenshot {
@@ -210,7 +196,9 @@ class TabCell: UICollectionViewCell,
 
         // Favicon or letter image when tab screenshot isn't available
         } else {
-            setFaviconImage(for: tab, with: smallFaviconView)
+            smallFaviconView.setFavicon(DefaultFaviconImageViewModel(urlStringRequest: tab.url?.absoluteString ?? ""))
+            faviconBG.isHidden = false
+            screenshotView.image = nil
         }
     }
 
@@ -263,14 +251,6 @@ class TabCell: UICollectionViewCell,
         layer.shadowOffset = CGSize(width: -TabCell.borderWidth, height: -TabCell.borderWidth)
         let shadowPath = CGRect(width: layer.frame.width + (TabCell.borderWidth * 2), height: layer.frame.height + (TabCell.borderWidth * 2))
         layer.shadowPath = UIBezierPath(roundedRect: shadowPath, cornerRadius: GridTabTrayControllerUX.CornerRadius+TabCell.borderWidth).cgPath
-    }
-
-    func setFaviconImage(for tab: Tab, with imageView: UIImageView) {
-        if let url = tab.url?.domainURL ?? tab.sessionData?.urls.last?.domainURL {
-            imageView.setImageAndBackground(forIcon: tab.displayFavicon, website: url) {}
-            faviconBG.isHidden = false
-            screenshotView.image = nil
-        }
     }
 }
 

--- a/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsCell.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsCell.swift
@@ -84,7 +84,7 @@ class HistoryHighlightsCell: UICollectionViewCell, ReusableCell {
         accessibilityLabel = options.accessibilityLabel
 
         if let url = options.urlString {
-            let faviconViewModel = HomepageFaviconImageViewModel(urlStringRequest: url)
+            let faviconViewModel = DefaultFaviconImageViewModel(urlStringRequest: url)
             imageView.setFavicon(faviconViewModel)
         } else {
             imageView.image = UIImage.templateImageNamed(ImageIdentifiers.stackedTabsIcon)

--- a/Client/Frontend/Home/HomepageFaviconImageViewModel.swift
+++ b/Client/Frontend/Home/HomepageFaviconImageViewModel.swift
@@ -5,7 +5,7 @@
 import Foundation
 import SiteImageView
 
-struct HomepageFaviconImageViewModel: FaviconImageViewModel {
+struct DefaultFaviconImageViewModel: FaviconImageViewModel {
     var urlStringRequest: String
     var type: SiteImageView.SiteImageType = .favicon
     var faviconCornerRadius: CGFloat = HomepageViewModel.UX.generalIconCornerRadius

--- a/Client/Frontend/Home/JumpBackIn/Cell/JumpBackInCell.swift
+++ b/Client/Frontend/Home/JumpBackIn/Cell/JumpBackInCell.swift
@@ -121,7 +121,7 @@ class JumpBackInCell: UICollectionViewCell, ReusableCell {
                                                             heroImageSize: UX.heroImageSize)
         heroImage.setHeroImage(heroImageViewModel)
 
-        let faviconViewModel = HomepageFaviconImageViewModel(urlStringRequest: viewModel.siteURL)
+        let faviconViewModel = DefaultFaviconImageViewModel(urlStringRequest: viewModel.siteURL)
         websiteImage.setFavicon(faviconViewModel)
 
         itemTitle.text = viewModel.titleText

--- a/Client/Frontend/Home/TopSites/Cell/TopSiteItemCell.swift
+++ b/Client/Frontend/Home/TopSites/Cell/TopSiteItemCell.swift
@@ -147,7 +147,7 @@ class TopSiteItemCell: UICollectionViewCell, ReusableCell {
         titleLabel.text = topSite.title
         accessibilityLabel = topSite.accessibilityLabel
 
-        let viewModel = HomepageFaviconImageViewModel(urlStringRequest: topSite.site.url)
+        let viewModel = DefaultFaviconImageViewModel(urlStringRequest: topSite.site.url)
         imageView.setFavicon(viewModel)
         self.textColor = textColor
 


### PR DESCRIPTION
[FXIOS-5479](https://mozilla-hub.atlassian.net/browse/FXIOS-5479)
#12763 

Fixed a bug that caused some favicons to have malformed urls.
Updated the tabs tray to use SiteImageView.

The sync panel is not included. I will attempted to see if it's feasible to update all of the TwoLineImageOverlayCell at the same time as part of a separate PR.
