### PR TITLE
Refactor FXIOS-5463 [v110] Update theming related items in remoteTabsPanel

### DIFF
--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsClientAndTabsDataSource.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsClientAndTabsDataSource.swift
@@ -10,8 +10,6 @@ import SiteImageView
 class RemoteTabsClientAndTabsDataSource: NSObject, RemoteTabsPanelDataSource {
     struct UX {
         static let headerHeight = SiteTableViewControllerUX.RowHeight
-        static let iconBorderColor = UIColor.Photon.Grey30
-        static let iconBorderWidth: CGFloat = 0.5
     }
 
     weak var collapsibleSectionDelegate: CollapsibleTableViewSection?
@@ -105,8 +103,6 @@ class RemoteTabsClientAndTabsDataSource: NSObject, RemoteTabsPanelDataSource {
         cell.titleLabel.text = tab.title
         cell.descriptionLabel.text = tab.URL.absoluteString
         cell.leftImageView.setFavicon(FaviconImageViewModel(urlStringRequest: tab.URL.absoluteString))
-        cell.leftImageView.layer.borderColor = UX.iconBorderColor.cgColor
-        cell.leftImageView.layer.borderWidth = UX.iconBorderWidth
         cell.accessoryView = nil
         cell.applyTheme(theme: theme)
         return cell

--- a/Client/Frontend/Widgets/TwoLineImageOverlayCell.swift
+++ b/Client/Frontend/Widgets/TwoLineImageOverlayCell.swift
@@ -12,6 +12,7 @@ class TwoLineImageOverlayCell: UITableViewCell,
     struct UX {
         static let ImageSize: CGFloat = 29
         static let BorderViewMargin: CGFloat = 16
+        static let iconBorderWidth: CGFloat = 0.5
     }
 
     /// Cell reuse causes the chevron to appear where it shouldn't. So, we use a different reuseIdentifier to prevent that.
@@ -29,6 +30,8 @@ class TwoLineImageOverlayCell: UITableViewCell,
         imageView.contentMode = .scaleAspectFit
         imageView.layer.cornerRadius = 5.0
         imageView.clipsToBounds = true
+        imageView.layer.borderWidth = UX.iconBorderWidth
+        imageView.backgroundColor = .clear
     }
 
     lazy var leftOverlayImageView: UIImageView = .build { imageView in
@@ -115,6 +118,7 @@ class TwoLineImageOverlayCell: UITableViewCell,
         selectedView.backgroundColor = theme.colors.layer5Hover
         titleLabel.textColor = theme.colors.textPrimary
         descriptionLabel.textColor = theme.colors.textSecondary
+        leftImageView.layer.borderColor = theme.colors.borderPrimary.cgColor
     }
 
     override func prepareForReuse() {


### PR DESCRIPTION
# [FXIOS-5463](https://mozilla-hub.atlassian.net/browse/FXIOS-5463) | #12733

TLDR: TwoLineImageOverlayCell has been updated to follow the new theming standards. Some cell customization stuff has been moved out of `RemoteTabsClientAndTabsDataSource` and into the `TwoLineImageOverlayCell`.

See https://github.com/mozilla-mobile/firefox-ios/pull/12742 for reference. It's an old PR that was mistakenly closed. It was reviewed by Design. 