### PR TITLE
Bugfix MTE-347 [v110] Harden testUpdateTabCounter

### DIFF
--- a/Tests/XCUITests/TopTabsTest.swift
+++ b/Tests/XCUITests/TopTabsTest.swift
@@ -478,7 +478,7 @@ class TopTabsTestIpad: IpadOnlyTestCase {
         XCTAssertEqual("2", numTabAfterRemovingThirdTab)
         app.collectionViews["Top Tabs View"].children(matching: .cell).element(boundBy: 1).buttons["Remove page — Homepage"].tap()
         waitForExistence(app.buttons["Show Tabs"].staticTexts["1"], timeout: TIMEOUT)
-        var numTabAfterRemovingSecondTab = app.buttons["Show Tabs"].value as? String
+        let numTabAfterRemovingSecondTab = app.buttons["Show Tabs"].value as? String
         XCTAssertEqual("1", numTabAfterRemovingSecondTab)
     }
 

--- a/Tests/XCUITests/TopTabsTest.swift
+++ b/Tests/XCUITests/TopTabsTest.swift
@@ -468,17 +468,15 @@ class TopTabsTestIpad: IpadOnlyTestCase {
         app.buttons["TopTabsViewController.newTabButton"].tap()
         app.buttons["TopTabsViewController.newTabButton"].tap()
         waitForExistence(app.buttons["TopTabsViewController.tabsButton"])
-        let numTab = app.buttons["Show Tabs"].value as? String
-        XCTAssertEqual("3", numTab)
+        waitForExistence(app.buttons["Show Tabs"].staticTexts["3"], timeout: TIMEOUT)
+        waitForValueContains(app.buttons["Show Tabs"], value: "3")
         // Remove one tab by tapping on 'x' button
         app.collectionViews["Top Tabs View"].children(matching: .cell).matching(identifier: "Homepage").element(boundBy: 1).buttons["Remove page — Homepage"].tap()
-        waitForExistence(app.buttons["Show Tabs"])
-        let numTabAfterRemovingThirdTab = app.buttons["Show Tabs"].value as? String
-        XCTAssertEqual("2", numTabAfterRemovingThirdTab)
+        waitForExistence(app.buttons["Show Tabs"].staticTexts["2"], timeout: TIMEOUT)
+        waitForValueContains(app.buttons["Show Tabs"], value: "2")
         app.collectionViews["Top Tabs View"].children(matching: .cell).element(boundBy: 1).buttons["Remove page — Homepage"].tap()
-        waitForExistence(app.buttons["Show Tabs"])
-        let numTabAfterRemovingSecondTab = app.buttons["Show Tabs"].value as? String
-        XCTAssertEqual("1", numTabAfterRemovingSecondTab)
+        waitForExistence(app.buttons["Show Tabs"].staticTexts["1"], timeout: TIMEOUT)
+        waitForValueContains(app.buttons["Show Tabs"], value: "1")
     }
 
     func cellIsSelectedTab(index: Int, url: String, title: String) {

--- a/Tests/XCUITests/TopTabsTest.swift
+++ b/Tests/XCUITests/TopTabsTest.swift
@@ -469,14 +469,17 @@ class TopTabsTestIpad: IpadOnlyTestCase {
         app.buttons["TopTabsViewController.newTabButton"].tap()
         waitForExistence(app.buttons["TopTabsViewController.tabsButton"])
         waitForExistence(app.buttons["Show Tabs"].staticTexts["3"], timeout: TIMEOUT)
-        waitForValueContains(app.buttons["Show Tabs"], value: "3")
+        let numTab = app.buttons["Show Tabs"].value as? String
+        XCTAssertEqual("3", numTab)
         // Remove one tab by tapping on 'x' button
         app.collectionViews["Top Tabs View"].children(matching: .cell).matching(identifier: "Homepage").element(boundBy: 1).buttons["Remove page — Homepage"].tap()
         waitForExistence(app.buttons["Show Tabs"].staticTexts["2"], timeout: TIMEOUT)
-        waitForValueContains(app.buttons["Show Tabs"], value: "2")
+        let numTabAfterRemovingThirdTab = app.buttons["Show Tabs"].value as? String
+        XCTAssertEqual("2", numTabAfterRemovingThirdTab)
         app.collectionViews["Top Tabs View"].children(matching: .cell).element(boundBy: 1).buttons["Remove page — Homepage"].tap()
         waitForExistence(app.buttons["Show Tabs"].staticTexts["1"], timeout: TIMEOUT)
-        waitForValueContains(app.buttons["Show Tabs"], value: "1")
+        var numTabAfterRemovingSecondTab = app.buttons["Show Tabs"].value as? String
+        XCTAssertEqual("1", numTabAfterRemovingSecondTab)
     }
 
     func cellIsSelectedTab(index: Int, url: String, title: String) {


### PR DESCRIPTION
The test `TopTabTestIpad/testUpdateTabCounter` is failing intermittently. I can reproduce the intermittent failure locally by running the test repeatedly using the `-test-iterations 10` option for the `xcodebuild` command.

This test could fail in Jenkins:

https://storage.googleapis.com/mobile-reports/public/firefox-ios-M1/FullFunctionalTests-iPad/result_44/build/reports/tests.html

Instead of querying `app.buttons["Show Tabs"]`'s value right away, I have added a `timeout` for the `waitForExistence` command. The number of tabs opened may not be shown right away.

😬 I have run the test in question 100 times locally without any failures.
```
xcodebuild test -target Client -scheme Fennec_Enterprise_XCUITests -destination 'platform=iOS Simulator,name=iPad Pro (12.9-inch) (5th generation),OS=latest' -only-testing:XCUITests/TopTabsTestIpad/testUpdateTabCounter -test-iterations 100
```

https://mozilla-hub.atlassian.net/browse/MTE-347