### PR TITLE
Bugfix MTE-350 [v110] Fix DomainAutocompleteTest, HomeButtonTests and PhotonActionSheetTest and PhotonActionSheetTest

### DIFF
--- a/Tests/XCUITests/DomainAutocompleteTest.swift
+++ b/Tests/XCUITests/DomainAutocompleteTest.swift
@@ -35,7 +35,11 @@ class DomainAutocompleteTest: BaseTestCase {
         // The autocomplete does not display the history item from the DB. Workaroud is to manually visit "mozilla.org".
         navigator.openURL("mozilla.org")
         waitUntilPageLoad()
-        navigator.performAction(Action.CloseTabFromTabTrayLongPressMenu)
+        if isTablet {
+            navigator.performAction(Action.AcceptRemovingAllTabs)
+        } else {
+            navigator.performAction(Action.CloseTabFromTabTrayLongPressMenu)
+        }
         app.textFields["address"].typeText("moz")
 
         waitForValueContains(app.textFields["address"], value: website["value"]!)

--- a/Tests/XCUITests/HomeButtonTests.swift
+++ b/Tests/XCUITests/HomeButtonTests.swift
@@ -24,7 +24,7 @@ class HomeButtonTests: BaseTestCase {
         waitForTabsButton()
 
         if iPad() {
-            XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton].label, "Menu")
+            XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton].label, "Home")
         } else {
             XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton].label, "Search")
         }

--- a/Tests/XCUITests/PhotonActionSheetTest.swift
+++ b/Tests/XCUITests/PhotonActionSheetTest.swift
@@ -108,7 +108,7 @@ class PhotonActionSheetTest: BaseTestCase {
         }
         waitForExistence(fennecElement, timeout: 5)
         fennecElement.tap()
-        waitForExistence(app.navigationBars["ShareTo.ShareView"], timeout: 10)
+        waitForExistence(app.navigationBars["ShareTo.ShareView"], timeout: TIMEOUT)
     }
 
     // Smoketest

--- a/Tests/XCUITests/PhotonActionSheetTest.swift
+++ b/Tests/XCUITests/PhotonActionSheetTest.swift
@@ -101,9 +101,10 @@ class PhotonActionSheetTest: BaseTestCase {
 
         // This is not ideal but only way to get the element on iPhone 8
         // for iPhone 11, that would be boundBy: 2
+        waitForExistence(app.collectionViews.buttons["Copy"], timeout: TIMEOUT)
+        waitForExistence(app.collectionViews.scrollViews.cells["XCElementSnapshotPrivilegedValuePlaceholder"].firstMatch, timeout: TIMEOUT)
         var  fennecElement = app.collectionViews.scrollViews.cells.element(boundBy: 2)
         if iPad() {
-            waitForExistence(app.collectionViews.buttons["Copy"], timeout: 10)
             fennecElement = app.collectionViews.scrollViews.cells.element(boundBy: 1)
         }
         waitForExistence(fennecElement, timeout: 5)


### PR DESCRIPTION
DomainAutocompleteTest, HomeButtonTests and PhotonActionSheetTest and PhotonActionSheetTest have been failing on iPad. I amended those tests and ran them using the iPad simulator (iOS 16.1) on my M1 computer.

https://storage.googleapis.com/mobile-reports/public/firefox-ios-M1/FullFunctionalTests-iPad/result_44/build/reports/tests.html

https://mozilla-hub.atlassian.net/browse/MTE-350