### PR TITLE
Bugfix FXIOS-5505 [v110] set needs layout after having changed the layout

### DIFF
--- a/Client/Frontend/Components/LabelButtonHeaderView.swift
+++ b/Client/Frontend/Components/LabelButtonHeaderView.swift
@@ -53,7 +53,6 @@ class LabelButtonHeaderView: UICollectionReusableView, ReusableCell {
         button.isHidden = true
         button.titleLabel?.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline,
                                                                                 size: UX.moreButtonTextSize)
-        button.contentHorizontalAlignment = .trailing
     }
 
     // MARK: - Variables
@@ -156,6 +155,9 @@ class LabelButtonHeaderView: UICollectionReusableView, ReusableCell {
             stackView.axis = .horizontal
             moreButton.contentHorizontalAlignment = .trailing
         }
+
+        setNeedsLayout()
+        layoutIfNeeded()
     }
 }
 


### PR DESCRIPTION
# [FXIOS-5505](https://mozilla-hub.atlassian.net/browse/FXIOS-5505) https://github.com/mozilla-mobile/firefox-ios/issues/12815
- Removed the contentHorizontalAlignment in the init since it's redundant (we're setting it in the `adjustLayout` anyway
- Specify we need a relayout after having changed the layout, this seems to have fixed the problem
- Tested in different font sizes the layout behaves as it should