### PR TITLE
Refactor FXIOS-5209 [v110] Update theme toast

### DIFF
--- a/Client/Application/ImageIdentifiers.swift
+++ b/Client/Application/ImageIdentifiers.swift
@@ -22,6 +22,7 @@ public struct ImageIdentifiers {
     public static let bookmarkFolder = "bookmarkFolder"
     public static let bottomSheetClose = "bottomSheet-close"
     public static let contextualHintClose = "find_close"
+    public static let check = "check"
     public static let copyLink = "menu-Copy-Link"
     public static let closeLargeButton = "close-large"
     public static let closeMediumButton = "close-medium"

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1171,9 +1171,10 @@ class BrowserViewController: UIViewController {
     }
 
     private func showBookmarksToast() {
-        let toast = ButtonToast(labelText: .AppMenu.AddBookmarkConfirmMessage,
-                                buttonText: .BookmarksEdit,
-                                textAlignment: .left) { isButtonTapped in
+        let viewModel = ButtonToastViewModel(labelText: .AppMenu.AddBookmarkConfirmMessage,
+                                             buttonText: .BookmarksEdit,
+                                             textAlignment: .left)
+        let toast = ButtonToast(viewModel: viewModel) { isButtonTapped in
             isButtonTapped ? self.openBookmarkEditPanel() : nil
         }
         self.show(toast: toast)
@@ -1657,8 +1658,18 @@ class BrowserViewController: UIViewController {
 extension BrowserViewController: SearchBarLocationProvider {}
 
 extension BrowserViewController: ClipboardBarDisplayHandlerDelegate {
-    func shouldDisplay(clipboardBar bar: ButtonToast) {
-        show(toast: bar, duration: ClipboardBarToastUX.ToastDelay)
+    func shouldDisplay(clipBoardURL url: URL) {
+        let viewModel = ButtonToastViewModel(labelText: .GoToCopiedLink,
+                                             descriptionText: url.absoluteDisplayString,
+                                             buttonText: .GoButtonTittle)
+        let toast = ButtonToast(viewModel: viewModel,
+                                completion: { buttonPressed in
+            if buttonPressed {
+                self.settingsOpenURLInNewTab(url)
+            }
+        })
+        clipboardBarDisplayHandler?.clipboardToast = toast
+        show(toast: toast, duration: ClipboardBarDisplayHandler.UX.toastDelay)
     }
 }
 
@@ -1874,7 +1885,9 @@ extension BrowserViewController: LibraryPanelDelegate {
         // If in overlay mode switching doesnt correctly dismiss the homepanels
         guard !topTabsVisible, !self.urlBar.inOverlayMode else { return }
         // We're not showing the top tabs; show a toast to quick switch to the fresh new tab.
-        let toast = ButtonToast(labelText: .ContextMenuButtonToastNewTabOpenedLabelText, buttonText: .ContextMenuButtonToastNewTabOpenedButtonText, completion: { buttonPressed in
+        let viewModel = ButtonToastViewModel(labelText: .ContextMenuButtonToastNewTabOpenedLabelText,
+                                             buttonText: .ContextMenuButtonToastNewTabOpenedButtonText)
+        let toast = ButtonToast(viewModel: viewModel, completion: { buttonPressed in
             if buttonPressed {
                 self.tabManager.selectTab(tab)
             }
@@ -1928,7 +1941,9 @@ extension BrowserViewController: HomePanelDelegate {
         guard !topTabsVisible else { return }
 
         // We're not showing the top tabs; show a toast to quick switch to the fresh new tab.
-        let toast = ButtonToast(labelText: .ContextMenuButtonToastNewTabOpenedLabelText, buttonText: .ContextMenuButtonToastNewTabOpenedButtonText, completion: { buttonPressed in
+        let viewModel = ButtonToastViewModel(labelText: .ContextMenuButtonToastNewTabOpenedLabelText,
+                                             buttonText: .ContextMenuButtonToastNewTabOpenedButtonText)
+        let toast = ButtonToast(viewModel: viewModel, completion: { buttonPressed in
             if buttonPressed {
                 self.tabManager.selectTab(tab)
             }
@@ -2132,7 +2147,9 @@ extension BrowserViewController: TabManagerDelegate {
         urlFromAnotherApp = nil
     }
 
-    func show(toast: Toast, afterWaiting delay: DispatchTimeInterval = Toast.UX.toastDelayBefore, duration: DispatchTimeInterval? = Toast.UX.toastDismissAfter) {
+    func show(toast: Toast,
+              afterWaiting delay: DispatchTimeInterval = Toast.UX.toastDelayBefore,
+              duration: DispatchTimeInterval? = Toast.UX.toastDismissAfter) {
         if let downloadToast = toast as? DownloadToast {
             self.downloadToast = downloadToast
         }
@@ -2316,7 +2333,9 @@ extension BrowserViewController: ContextMenuHelperDelegate {
                 let tab = self.tabManager.addTab(URLRequest(url: rURL as URL), afterTab: currentTab, isPrivate: isPrivate)
                 guard !self.topTabsVisible else { return }
                 // We're not showing the top tabs; show a toast to quick switch to the fresh new tab.
-                let toast = ButtonToast(labelText: .ContextMenuButtonToastNewTabOpenedLabelText, buttonText: .ContextMenuButtonToastNewTabOpenedButtonText, completion: { buttonPressed in
+                let viewModel = ButtonToastViewModel(labelText: .ContextMenuButtonToastNewTabOpenedLabelText,
+                                                     buttonText: .ContextMenuButtonToastNewTabOpenedButtonText)
+                let toast = ButtonToast(viewModel: viewModel, completion: { buttonPressed in
                     if buttonPressed {
                         self.tabManager.selectTab(tab)
                     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -570,7 +570,7 @@ class BrowserViewController: UIViewController {
 
         if let toast = self.pendingToast {
             self.pendingToast = nil
-            show(toast: toast, afterWaiting: ButtonToast.UX.ToastDelay)
+            show(toast: toast, afterWaiting: ButtonToast.UX.toastDelay)
         }
         showQueuedAlertIfAvailable()
 
@@ -1174,7 +1174,8 @@ class BrowserViewController: UIViewController {
         let viewModel = ButtonToastViewModel(labelText: .AppMenu.AddBookmarkConfirmMessage,
                                              buttonText: .BookmarksEdit,
                                              textAlignment: .left)
-        let toast = ButtonToast(viewModel: viewModel) { isButtonTapped in
+        let toast = ButtonToast(viewModel: viewModel,
+                                theme: themeManager.currentTheme) { isButtonTapped in
             isButtonTapped ? self.openBookmarkEditPanel() : nil
         }
         self.show(toast: toast)
@@ -1663,6 +1664,7 @@ extension BrowserViewController: ClipboardBarDisplayHandlerDelegate {
                                              descriptionText: url.absoluteDisplayString,
                                              buttonText: .GoButtonTittle)
         let toast = ButtonToast(viewModel: viewModel,
+                                theme: themeManager.currentTheme,
                                 completion: { buttonPressed in
             if buttonPressed {
                 self.settingsOpenURLInNewTab(url)
@@ -1887,7 +1889,9 @@ extension BrowserViewController: LibraryPanelDelegate {
         // We're not showing the top tabs; show a toast to quick switch to the fresh new tab.
         let viewModel = ButtonToastViewModel(labelText: .ContextMenuButtonToastNewTabOpenedLabelText,
                                              buttonText: .ContextMenuButtonToastNewTabOpenedButtonText)
-        let toast = ButtonToast(viewModel: viewModel, completion: { buttonPressed in
+        let toast = ButtonToast(viewModel: viewModel,
+                                theme: themeManager.currentTheme,
+                                completion: { buttonPressed in
             if buttonPressed {
                 self.tabManager.selectTab(tab)
             }
@@ -1943,7 +1947,9 @@ extension BrowserViewController: HomePanelDelegate {
         // We're not showing the top tabs; show a toast to quick switch to the fresh new tab.
         let viewModel = ButtonToastViewModel(labelText: .ContextMenuButtonToastNewTabOpenedLabelText,
                                              buttonText: .ContextMenuButtonToastNewTabOpenedButtonText)
-        let toast = ButtonToast(viewModel: viewModel, completion: { buttonPressed in
+        let toast = ButtonToast(viewModel: viewModel,
+                                theme: themeManager.currentTheme,
+                                completion: { buttonPressed in
             if buttonPressed {
                 self.tabManager.selectTab(tab)
             }
@@ -2171,7 +2177,11 @@ extension BrowserViewController: TabManagerDelegate {
 
     func tabManagerDidRemoveAllTabs(_ tabManager: TabManager, toast: ButtonToast?) {
         guard let toast = toast, !(tabManager.selectedTab?.isPrivate ?? false) else { return }
-        show(toast: toast, afterWaiting: ButtonToast.UX.ToastDelay)
+        // The toast is created from TabManager which doesn't have access to themeManager
+        // The whole toast system needs some rework so as compromised solution before the rework I create the toast
+        // with light theme and force apply theme with real theme before showing
+        toast.applyTheme(theme: themeManager.currentTheme)
+        show(toast: toast, afterWaiting: ButtonToast.UX.toastDelay)
     }
 
     func updateTabCountUsingTabManager(_ tabManager: TabManager, animated: Bool = true) {
@@ -2335,7 +2345,9 @@ extension BrowserViewController: ContextMenuHelperDelegate {
                 // We're not showing the top tabs; show a toast to quick switch to the fresh new tab.
                 let viewModel = ButtonToastViewModel(labelText: .ContextMenuButtonToastNewTabOpenedLabelText,
                                                      buttonText: .ContextMenuButtonToastNewTabOpenedButtonText)
-                let toast = ButtonToast(viewModel: viewModel, completion: { buttonPressed in
+                let toast = ButtonToast(viewModel: viewModel,
+                                        theme: self.themeManager.currentTheme,
+                                        completion: { buttonPressed in
                     if buttonPressed {
                         self.tabManager.selectTab(tab)
                     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -570,7 +570,7 @@ class BrowserViewController: UIViewController {
 
         if let toast = self.pendingToast {
             self.pendingToast = nil
-            show(toast: toast, afterWaiting: ButtonToast.UX.toastDelay)
+            show(toast: toast, afterWaiting: ButtonToast.UX.delay)
         }
         showQueuedAlertIfAvailable()
 
@@ -2181,7 +2181,7 @@ extension BrowserViewController: TabManagerDelegate {
         // The whole toast system needs some rework so as compromised solution before the rework I create the toast
         // with light theme and force apply theme with real theme before showing
         toast.applyTheme(theme: themeManager.currentTheme)
-        show(toast: toast, afterWaiting: ButtonToast.UX.toastDelay)
+        show(toast: toast, afterWaiting: ButtonToast.UX.delay)
     }
 
     func updateTabCountUsingTabManager(_ tabManager: TabManager, animated: Bool = true) {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -570,7 +570,7 @@ class BrowserViewController: UIViewController {
 
         if let toast = self.pendingToast {
             self.pendingToast = nil
-            show(toast: toast, afterWaiting: ButtonToastUX.ToastDelay)
+            show(toast: toast, afterWaiting: ButtonToast.UX.ToastDelay)
         }
         showQueuedAlertIfAvailable()
 
@@ -2131,12 +2131,12 @@ extension BrowserViewController: TabManagerDelegate {
         urlFromAnotherApp = nil
     }
 
-    func show(toast: Toast, afterWaiting delay: DispatchTimeInterval = SimpleToastUX.ToastDelayBefore, duration: DispatchTimeInterval? = SimpleToastUX.ToastDismissAfter) {
+    func show(toast: Toast, afterWaiting delay: DispatchTimeInterval = Toast.UX.toastDelayBefore, duration: DispatchTimeInterval? = Toast.UX.toastDismissAfter) {
         if let downloadToast = toast as? DownloadToast {
             self.downloadToast = downloadToast
         }
 
-        // If BVC isnt visible hold on to this toast until viewDidAppear
+        // If BVC isn't visible hold on to this toast until viewDidAppear
         if self.view.window == nil {
             self.pendingToast = toast
             return
@@ -2153,7 +2153,7 @@ extension BrowserViewController: TabManagerDelegate {
 
     func tabManagerDidRemoveAllTabs(_ tabManager: TabManager, toast: ButtonToast?) {
         guard let toast = toast, !(tabManager.selectedTab?.isPrivate ?? false) else { return }
-        show(toast: toast, afterWaiting: ButtonToastUX.ToastDelay)
+        show(toast: toast, afterWaiting: ButtonToast.UX.ToastDelay)
     }
 
     func updateTabCountUsingTabManager(_ tabManager: TabManager, animated: Bool = true) {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -152,7 +152,7 @@ class BrowserViewController: UIViewController {
     let downloadQueue: DownloadQueue
 
     private var keyboardPressesHandlerValue: Any?
-    private var themeManager: ThemeManager
+    var themeManager: ThemeManager
 
     @available(iOS 13.4, *)
     func keyboardPressesHandler() -> KeyboardPressesHandler {
@@ -1502,7 +1502,8 @@ class BrowserViewController: UIViewController {
                 self.showSendToDevice()
             case CustomActivityAction.copyLink.actionType:
                 SimpleToast().showAlertWithText(.AppMenu.AppMenuCopyURLConfirmMessage,
-                                                bottomContainer: webViewContainer)
+                                                bottomContainer: webViewContainer,
+                                                theme: themeManager.currentTheme)
             default: break
             }
 
@@ -2638,7 +2639,9 @@ extension BrowserViewController: DevicePickerViewControllerDelegate, Instruction
         profile.sendItem(shareItem, toDevices: devices).uponQueue(.main) { _ in
             self.popToBVC()
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                SimpleToast().showAlertWithText(.AppMenu.AppMenuTabSentConfirmMessage, bottomContainer: self.webViewContainer)
+                SimpleToast().showAlertWithText(.AppMenu.AppMenuTabSentConfirmMessage,
+                                                bottomContainer: self.webViewContainer,
+                                                theme: self.themeManager.currentTheme)
             }
         }
     }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+DownloadQueueDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+DownloadQueueDelegate.swift
@@ -18,11 +18,9 @@ extension BrowserViewController: DownloadQueueDelegate {
                 if buttonPressed, !downloadQueue.isEmpty {
                     downloadQueue.cancelAll()
 
-                    let viewModel = ButtonToastViewModel(labelText: .DownloadCancelledToastLabelText,
-                                                         textAlignment: .center)
-                    let downloadCancelledToast = ButtonToast(viewModel: viewModel,
-                                                             theme: self.themeManager.currentTheme)
-                    self.show(toast: downloadCancelledToast)
+                    SimpleToast().showAlertWithText(.DownloadCancelledToastLabelText,
+                                                    bottomContainer: self.webViewContainer,
+                                                    theme: self.themeManager.currentTheme)
                 }
             })
 
@@ -65,10 +63,9 @@ extension BrowserViewController: DownloadQueueDelegate {
 
                 self.show(toast: downloadCompleteToast, duration: DispatchTimeInterval.seconds(8))
             } else {
-                let viewModel = ButtonToastViewModel(labelText: .DownloadFailedToastLabelText, textAlignment: .center)
-                let downloadFailedToast = ButtonToast(viewModel: viewModel,
-                                                      theme: self.themeManager.currentTheme)
-                self.show(toast: downloadFailedToast, duration: nil)
+                SimpleToast().showAlertWithText(.DownloadCancelledToastLabelText,
+                                                bottomContainer: self.webViewContainer,
+                                                theme: self.themeManager.currentTheme)
             }
         }
     }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+DownloadQueueDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+DownloadQueueDelegate.swift
@@ -18,8 +18,9 @@ extension BrowserViewController: DownloadQueueDelegate {
                 if buttonPressed, !downloadQueue.isEmpty {
                     downloadQueue.cancelAll()
 
-                    let downloadCancelledToast = ButtonToast(labelText: .DownloadCancelledToastLabelText, backgroundColor: UIColor.Photon.Grey60, textAlignment: .center)
-
+                    let viewModel = ButtonToastViewModel(labelText: .DownloadCancelledToastLabelText,
+                                                         textAlignment: .center)
+                    let downloadCancelledToast = ButtonToast(viewModel: viewModel)
                     self.show(toast: downloadCancelledToast)
                 }
             })
@@ -49,7 +50,10 @@ extension BrowserViewController: DownloadQueueDelegate {
             downloadToast.dismiss(false)
 
             if error == nil {
-                let downloadCompleteToast = ButtonToast(labelText: download.filename, imageName: "check", buttonText: .DownloadsButtonTitle, completion: { buttonPressed in
+                let viewModel = ButtonToastViewModel(labelText: download.filename,
+                                                     imageName: ImageIdentifiers.check,
+                                                     buttonText: .DownloadsButtonTitle)
+                let downloadCompleteToast = ButtonToast(viewModel: viewModel, completion: { buttonPressed in
                     guard buttonPressed else { return }
 
                     self.showLibrary(panel: .downloads)
@@ -58,8 +62,8 @@ extension BrowserViewController: DownloadQueueDelegate {
 
                 self.show(toast: downloadCompleteToast, duration: DispatchTimeInterval.seconds(8))
             } else {
-                let downloadFailedToast = ButtonToast(labelText: .DownloadFailedToastLabelText, backgroundColor: UIColor.Photon.Grey60, textAlignment: .center)
-
+                let viewModel = ButtonToastViewModel(labelText: .DownloadFailedToastLabelText, textAlignment: .center)
+                let downloadFailedToast = ButtonToast(viewModel: viewModel)
                 self.show(toast: downloadFailedToast, duration: nil)
             }
         }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+DownloadQueueDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+DownloadQueueDelegate.swift
@@ -20,7 +20,8 @@ extension BrowserViewController: DownloadQueueDelegate {
 
                     let viewModel = ButtonToastViewModel(labelText: .DownloadCancelledToastLabelText,
                                                          textAlignment: .center)
-                    let downloadCancelledToast = ButtonToast(viewModel: viewModel)
+                    let downloadCancelledToast = ButtonToast(viewModel: viewModel,
+                                                             theme: self.themeManager.currentTheme)
                     self.show(toast: downloadCancelledToast)
                 }
             })
@@ -53,7 +54,9 @@ extension BrowserViewController: DownloadQueueDelegate {
                 let viewModel = ButtonToastViewModel(labelText: download.filename,
                                                      imageName: ImageIdentifiers.check,
                                                      buttonText: .DownloadsButtonTitle)
-                let downloadCompleteToast = ButtonToast(viewModel: viewModel, completion: { buttonPressed in
+                let downloadCompleteToast = ButtonToast(viewModel: viewModel,
+                                                        theme: self.themeManager.currentTheme,
+                                                        completion: { buttonPressed in
                     guard buttonPressed else { return }
 
                     self.showLibrary(panel: .downloads)
@@ -63,7 +66,8 @@ extension BrowserViewController: DownloadQueueDelegate {
                 self.show(toast: downloadCompleteToast, duration: DispatchTimeInterval.seconds(8))
             } else {
                 let viewModel = ButtonToastViewModel(labelText: .DownloadFailedToastLabelText, textAlignment: .center)
-                let downloadFailedToast = ButtonToast(viewModel: viewModel)
+                let downloadFailedToast = ButtonToast(viewModel: viewModel,
+                                                      theme: self.themeManager.currentTheme)
                 self.show(toast: downloadFailedToast, duration: nil)
             }
         }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
@@ -203,7 +203,8 @@ extension BrowserViewController: ToolBarActionMenuDelegate {
             let viewModel = ButtonToastViewModel(labelText: message,
                                                  buttonText: .UndoString,
                                                  textAlignment: .left)
-            let toast = ButtonToast(viewModel: viewModel) { isButtonTapped in
+            let toast = ButtonToast(viewModel: viewModel,
+                                    theme: themeManager.currentTheme) { isButtonTapped in
                 isButtonTapped ? self.addBookmark(url: url ?? "") : nil
             }
             show(toast: toast)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
@@ -205,7 +205,9 @@ extension BrowserViewController: ToolBarActionMenuDelegate {
             }
             show(toast: toast)
         default:
-            SimpleToast().showAlertWithText(message, bottomContainer: webViewContainer)
+            SimpleToast().showAlertWithText(message,
+                                            bottomContainer: webViewContainer,
+                                            theme: themeManager.currentTheme)
         }
     }
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
@@ -200,7 +200,10 @@ extension BrowserViewController: ToolBarActionMenuDelegate {
     func showToast(message: String, toastAction: MenuButtonToastAction, url: String?) {
         switch toastAction {
         case .removeBookmark:
-            let toast = ButtonToast(labelText: message, buttonText: .UndoString, textAlignment: .left) { isButtonTapped in
+            let viewModel = ButtonToastViewModel(labelText: message,
+                                                 buttonText: .UndoString,
+                                                 textAlignment: .left)
+            let toast = ButtonToast(viewModel: viewModel) { isButtonTapped in
                 isButtonTapped ? self.addBookmark(url: url ?? "") : nil
             }
             show(toast: toast)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -46,7 +46,8 @@ extension BrowserViewController: URLBarDelegate {
             // If in overlay mode switching doesnt correctly dismiss the homepanels
             guard !self.topTabsVisible, !self.urlBar.inOverlayMode else { return }
             // We're not showing the top tabs; show a toast to quick switch to the fresh new tab.
-            let toast = ButtonToast(labelText: .ContextMenuButtonToastNewTabOpenedLabelText, buttonText: .ContextMenuButtonToastNewTabOpenedButtonText, completion: { buttonPressed in
+            let viewModel = ButtonToastViewModel(labelText: .ContextMenuButtonToastNewTabOpenedLabelText, buttonText: .ContextMenuButtonToastNewTabOpenedButtonText)
+            let toast = ButtonToast(viewModel: viewModel, completion: { buttonPressed in
                 if buttonPressed {
                     self.tabManager.selectTab(tab)
                 }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -46,7 +46,8 @@ extension BrowserViewController: URLBarDelegate {
             // If in overlay mode switching doesnt correctly dismiss the homepanels
             guard !self.topTabsVisible, !self.urlBar.inOverlayMode else { return }
             // We're not showing the top tabs; show a toast to quick switch to the fresh new tab.
-            let viewModel = ButtonToastViewModel(labelText: .ContextMenuButtonToastNewTabOpenedLabelText, buttonText: .ContextMenuButtonToastNewTabOpenedButtonText)
+            let viewModel = ButtonToastViewModel(labelText: .ContextMenuButtonToastNewTabOpenedLabelText,
+                                                 buttonText: .ContextMenuButtonToastNewTabOpenedButtonText)
             let toast = ButtonToast(viewModel: viewModel, completion: { buttonPressed in
                 if buttonPressed {
                     self.tabManager.selectTab(tab)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -177,7 +177,9 @@ extension BrowserViewController: URLBarDelegate {
         switch result.value {
         case .success:
             UIAccessibility.post(notification: UIAccessibility.Notification.announcement, argument: String.ReaderModeAddPageSuccessAcessibilityLabel)
-            SimpleToast().showAlertWithText(.ShareAddToReadingListDone, bottomContainer: self.webViewContainer)
+            SimpleToast().showAlertWithText(.ShareAddToReadingListDone,
+                                            bottomContainer: self.webViewContainer,
+                                            theme: themeManager.currentTheme)
         case .failure(let error):
             UIAccessibility.post(notification: UIAccessibility.Notification.announcement, argument: String.ReaderModeAddPageMaybeExistsErrorAccessibilityLabel)
             print("readingList.createRecordWithURL(url: \"\(url.absoluteString)\", ...) failed with error: \(error)")

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -48,7 +48,9 @@ extension BrowserViewController: URLBarDelegate {
             // We're not showing the top tabs; show a toast to quick switch to the fresh new tab.
             let viewModel = ButtonToastViewModel(labelText: .ContextMenuButtonToastNewTabOpenedLabelText,
                                                  buttonText: .ContextMenuButtonToastNewTabOpenedButtonText)
-            let toast = ButtonToast(viewModel: viewModel, completion: { buttonPressed in
+            let toast = ButtonToast(viewModel: viewModel,
+                                    theme: self.themeManager.currentTheme,
+                                    completion: { buttonPressed in
                 if buttonPressed {
                     self.tabManager.selectTab(tab)
                 }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -190,7 +190,9 @@ extension BrowserViewController: WKUIDelegate {
                     // We're not showing the top tabs; show a toast to quick switch to the fresh new tab.
                     let viewModel = ButtonToastViewModel(labelText: toastLabelText,
                                                          buttonText: .ContextMenuButtonToastNewTabOpenedButtonText)
-                    let toast = ButtonToast(viewModel: viewModel, completion: { buttonPressed in
+                    let toast = ButtonToast(viewModel: viewModel,
+                                            theme: self.themeManager.currentTheme,
+                                            completion: { buttonPressed in
                         if buttonPressed {
                             self.tabManager.selectTab(tab)
                         }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -188,7 +188,8 @@ extension BrowserViewController: WKUIDelegate {
                         toastLabelText = .ContextMenuButtonToastNewTabOpenedLabelText
                     }
                     // We're not showing the top tabs; show a toast to quick switch to the fresh new tab.
-                    let viewModel = ButtonToastViewModel(labelText: toastLabelText, buttonText: .ContextMenuButtonToastNewTabOpenedButtonText)
+                    let viewModel = ButtonToastViewModel(labelText: toastLabelText,
+                                                         buttonText: .ContextMenuButtonToastNewTabOpenedButtonText)
                     let toast = ButtonToast(viewModel: viewModel, completion: { buttonPressed in
                         if buttonPressed {
                             self.tabManager.selectTab(tab)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -188,7 +188,8 @@ extension BrowserViewController: WKUIDelegate {
                         toastLabelText = .ContextMenuButtonToastNewTabOpenedLabelText
                     }
                     // We're not showing the top tabs; show a toast to quick switch to the fresh new tab.
-                    let toast = ButtonToast(labelText: toastLabelText, buttonText: .ContextMenuButtonToastNewTabOpenedButtonText, completion: { buttonPressed in
+                    let viewModel = ButtonToastViewModel(labelText: toastLabelText, buttonText: .ContextMenuButtonToastNewTabOpenedButtonText)
+                    let toast = ButtonToast(viewModel: viewModel, completion: { buttonPressed in
                         if buttonPressed {
                             self.tabManager.selectTab(tab)
                         }

--- a/Client/Frontend/Browser/ButtonToast.swift
+++ b/Client/Frontend/Browser/ButtonToast.swift
@@ -4,40 +4,36 @@
 
 import Foundation
 
-struct ButtonToastUX {
-    static let ToastHeight: CGFloat = 55.0
-    static let ToastPadding: CGFloat = 15.0
-    static let ToastButtonPadding: CGFloat = 10.0
-    static let ToastDelay = DispatchTimeInterval.milliseconds(900)
-    static let ToastButtonBorderRadius: CGFloat = 5
-    static let ToastButtonBorderWidth: CGFloat = 1
-    static let ToastLabelFont = UIFont.systemFont(ofSize: 15, weight: .semibold)
-    static let ToastDescriptionFont = UIFont.systemFont(ofSize: 13)
-
-    struct ToastButtonPaddedView {
-        static let WidthOffset: CGFloat = 20.0
-        static let TopOffset: CGFloat = 5.0
-        static let BottomOffset: CGFloat = 20.0
+class HighlightableButton: UIButton {
+    override var isHighlighted: Bool {
+        didSet {
+            backgroundColor = isHighlighted ? .white : .clear
+        }
     }
 }
 
 class ButtonToast: Toast {
-    class HighlightableButton: UIButton {
-        override var isHighlighted: Bool {
-            didSet {
-                backgroundColor = isHighlighted ? .white : .clear
-            }
-        }
+    struct UX {
+        static let ToastPadding: CGFloat = 15.0
+        static let ToastButtonPadding: CGFloat = 10.0
+        static let ToastDelay = DispatchTimeInterval.milliseconds(900)
+        static let ToastButtonBorderRadius: CGFloat = 5
+        static let ToastButtonBorderWidth: CGFloat = 1
+        static let ToastDescriptionFont = UIFont.systemFont(ofSize: 13)
+        // Padded View
+        static let WidthOffset: CGFloat = 20.0
+        static let TopOffset: CGFloat = 5.0
+        static let BottomOffset: CGFloat = 20.0
     }
 
-    init(
-        labelText: String,
-        descriptionText: String? = nil,
-        imageName: String? = nil,
-        buttonText: String? = nil,
-        backgroundColor: UIColor = SimpleToastUX.ToastDefaultColor,
-        textAlignment: NSTextAlignment = .left,
-        completion: ((_ buttonPressed: Bool) -> Void)? = nil, autoDismissCompletion: (() -> Void)? = nil
+    init(labelText: String,
+         descriptionText: String? = nil,
+         imageName: String? = nil,
+         buttonText: String? = nil,
+         backgroundColor: UIColor = SimpleToast.UX.toastDefaultColor,
+         textAlignment: NSTextAlignment = .left,
+         completion: ((_ buttonPressed: Bool) -> Void)? = nil,
+         autoDismissCompletion: (() -> Void)? = nil
     ) {
         super.init(frame: .zero)
 
@@ -59,10 +55,11 @@ class ButtonToast: Toast {
             toastView.trailingAnchor.constraint(equalTo: trailingAnchor),
             toastView.heightAnchor.constraint(equalTo: heightAnchor),
 
-            heightAnchor.constraint(greaterThanOrEqualToConstant: ButtonToastUX.ToastHeight)
+            heightAnchor.constraint(greaterThanOrEqualToConstant: Toast.UX.toastHeight)
         ])
 
-        animationConstraint = toastView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor, constant: ButtonToastUX.ToastHeight)
+        animationConstraint = toastView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor,
+                                                             constant: Toast.UX.toastHeight)
         animationConstraint?.isActive = true
     }
 
@@ -70,11 +67,11 @@ class ButtonToast: Toast {
         fatalError("init(coder:) has not been implemented")
     }
 
-    fileprivate func createView(_ labelText: String, descriptionText: String?, imageName: String?, buttonText: String?, textAlignment: NSTextAlignment) -> UIView {
+    private func createView(_ labelText: String, descriptionText: String?, imageName: String?, buttonText: String?, textAlignment: NSTextAlignment) -> UIView {
         let horizontalStackView: UIStackView = .build { stackView in
             stackView.axis = .horizontal
             stackView.alignment = .center
-            stackView.spacing = ButtonToastUX.ToastPadding
+            stackView.spacing = UX.ToastPadding
         }
 
         if let imageName = imageName {
@@ -91,7 +88,7 @@ class ButtonToast: Toast {
         let titleLabel: UILabel = .build { label in
             label.textAlignment = textAlignment
             label.textColor = UIColor.Photon.White100
-            label.font = ButtonToastUX.ToastLabelFont
+            label.font = UIFont.systemFont(ofSize: 15, weight: .semibold)
             label.text = labelText
             label.lineBreakMode = .byWordWrapping
             label.numberOfLines = 0
@@ -108,7 +105,7 @@ class ButtonToast: Toast {
             descriptionLabel = .build { label in
                 label.textAlignment = textAlignment
                 label.textColor = UIColor.Photon.White100
-                label.font = ButtonToastUX.ToastDescriptionFont
+                label.font = UX.ToastDescriptionFont
                 label.text = descriptionText
                 label.lineBreakMode = .byTruncatingTail
             }
@@ -128,11 +125,11 @@ class ButtonToast: Toast {
         NSLayoutConstraint.activate([
             labelStackView.centerYAnchor.constraint(equalTo: horizontalStackView.centerYAnchor),
 
-            horizontalStackView.leadingAnchor.constraint(equalTo: toastView.leadingAnchor, constant: ButtonToastUX.ToastPadding),
+            horizontalStackView.leadingAnchor.constraint(equalTo: toastView.leadingAnchor, constant: UX.ToastPadding),
             horizontalStackView.trailingAnchor.constraint(equalTo: toastView.trailingAnchor),
             horizontalStackView.bottomAnchor.constraint(equalTo: toastView.safeAreaLayoutGuide.bottomAnchor),
             horizontalStackView.topAnchor.constraint(equalTo: toastView.topAnchor),
-            horizontalStackView.heightAnchor.constraint(equalToConstant: ButtonToastUX.ToastHeight),
+            horizontalStackView.heightAnchor.constraint(equalToConstant: Toast.UX.toastHeight),
         ])
         return toastView
     }
@@ -146,12 +143,13 @@ class ButtonToast: Toast {
 
         let roundedButton = HighlightableButton()
         roundedButton.translatesAutoresizingMaskIntoConstraints = false
-        roundedButton.layer.cornerRadius = ButtonToastUX.ToastButtonBorderRadius
-        roundedButton.layer.borderWidth = ButtonToastUX.ToastButtonBorderWidth
+        roundedButton.layer.cornerRadius = UX.ToastButtonBorderRadius
+        roundedButton.layer.borderWidth = UX.ToastButtonBorderWidth
         roundedButton.layer.borderColor = UIColor.Photon.White100.cgColor
         roundedButton.setTitle(buttonText, for: [])
         roundedButton.setTitleColor(toastView.backgroundColor, for: .highlighted)
-        roundedButton.titleLabel?.font = SimpleToastUX.ToastFont
+        roundedButton.titleLabel?.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
+                                                                                       size: Toast.UX.fontSize)
         roundedButton.titleLabel?.numberOfLines = 1
         roundedButton.titleLabel?.lineBreakMode = .byClipping
         roundedButton.titleLabel?.adjustsFontSizeToFitWidth = true
@@ -159,14 +157,14 @@ class ButtonToast: Toast {
         paddedView.addSubview(roundedButton)
 
         NSLayoutConstraint.activate([
-            roundedButton.heightAnchor.constraint(equalToConstant: roundedButton.titleLabel!.intrinsicContentSize.height + 2 * ButtonToastUX.ToastButtonPadding),
-            roundedButton.widthAnchor.constraint(equalToConstant: roundedButton.titleLabel!.intrinsicContentSize.width + 2 * ButtonToastUX.ToastButtonPadding),
+            roundedButton.heightAnchor.constraint(equalToConstant: roundedButton.titleLabel!.intrinsicContentSize.height + 2 * UX.ToastButtonPadding),
+            roundedButton.widthAnchor.constraint(equalToConstant: roundedButton.titleLabel!.intrinsicContentSize.width + 2 * UX.ToastButtonPadding),
             roundedButton.centerYAnchor.constraint(equalTo: paddedView.centerYAnchor),
             roundedButton.centerXAnchor.constraint(equalTo: paddedView.centerXAnchor),
 
             paddedView.topAnchor.constraint(equalTo: stackView.topAnchor),
             paddedView.bottomAnchor.constraint(equalTo: stackView.bottomAnchor),
-            paddedView.widthAnchor.constraint(equalTo: roundedButton.widthAnchor, constant: ButtonToastUX.ToastButtonPaddedView.WidthOffset)
+            paddedView.widthAnchor.constraint(equalTo: roundedButton.widthAnchor, constant: UX.WidthOffset)
         ])
 
         roundedButton.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(buttonPressed)))
@@ -175,8 +173,8 @@ class ButtonToast: Toast {
     }
 
     override func showToast(viewController: UIViewController? = nil,
-                            delay: DispatchTimeInterval = SimpleToastUX.ToastDelayBefore,
-                            duration: DispatchTimeInterval? = SimpleToastUX.ToastDismissAfter,
+                            delay: DispatchTimeInterval = Toast.UX.toastDelayBefore,
+                            duration: DispatchTimeInterval? = Toast.UX.toastDismissAfter,
                             updateConstraintsOn: @escaping (Toast) -> [NSLayoutConstraint]) {
         super.showToast(viewController: viewController, delay: delay, duration: duration, updateConstraintsOn: updateConstraintsOn)
     }

--- a/Client/Frontend/Browser/ButtonToast.swift
+++ b/Client/Frontend/Browser/ButtonToast.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0
 
 import Foundation
+import Shared
 
 class HighlightableButton: UIButton {
     override var isHighlighted: Bool {
@@ -10,6 +11,15 @@ class HighlightableButton: UIButton {
             backgroundColor = isHighlighted ? .white : .clear
         }
     }
+}
+
+struct ButtonToastViewModel {
+    var labelText: String
+    var descriptionText: String?
+    var imageName: String?
+    var buttonText: String?
+    var backgroundColor: UIColor = ButtonToast.UX.toastDefaultColor
+    var textAlignment: NSTextAlignment = .left
 }
 
 class ButtonToast: Toast {
@@ -20,18 +30,17 @@ class ButtonToast: Toast {
         static let ToastButtonBorderRadius: CGFloat = 5
         static let ToastButtonBorderWidth: CGFloat = 1
         static let ToastDescriptionFont = UIFont.systemFont(ofSize: 13)
+        static let toastDefaultColor = UIColor.Photon.Blue40
         // Padded View
         static let WidthOffset: CGFloat = 20.0
         static let TopOffset: CGFloat = 5.0
         static let BottomOffset: CGFloat = 20.0
     }
 
-    init(labelText: String,
-         descriptionText: String? = nil,
-         imageName: String? = nil,
-         buttonText: String? = nil,
-         backgroundColor: UIColor = SimpleToast.UX.toastDefaultColor,
-         textAlignment: NSTextAlignment = .left,
+    // Pass themeManager to call on init
+    init(
+         viewModel: ButtonToastViewModel,
+//         theme: Theme,
          completion: ((_ buttonPressed: Bool) -> Void)? = nil,
          autoDismissCompletion: (() -> Void)? = nil
     ) {
@@ -41,13 +50,10 @@ class ButtonToast: Toast {
         self.didDismissWithoutTapHandler = autoDismissCompletion
 
         self.clipsToBounds = true
-        let createdToastView = createView(labelText,
-                                          descriptionText: descriptionText,
-                                          imageName: imageName,
-                                          buttonText: buttonText,
-                                          textAlignment: textAlignment)
+        let createdToastView = createView(viewModel: viewModel)
         self.addSubview(createdToastView)
 
+        // TODO: Handle on applyTheme
         self.toastView.backgroundColor = backgroundColor
 
         NSLayoutConstraint.activate([
@@ -67,14 +73,14 @@ class ButtonToast: Toast {
         fatalError("init(coder:) has not been implemented")
     }
 
-    private func createView(_ labelText: String, descriptionText: String?, imageName: String?, buttonText: String?, textAlignment: NSTextAlignment) -> UIView {
+    private func createView(viewModel: ButtonToastViewModel) -> UIView {
         let horizontalStackView: UIStackView = .build { stackView in
             stackView.axis = .horizontal
             stackView.alignment = .center
             stackView.spacing = UX.ToastPadding
         }
 
-        if let imageName = imageName {
+        if let imageName = viewModel.imageName {
             let icon = UIImageView(image: UIImage.templateImageNamed(imageName))
             icon.tintColor = UIColor.Photon.White100
             horizontalStackView.addArrangedSubview(icon)
@@ -86,10 +92,10 @@ class ButtonToast: Toast {
         }
 
         let titleLabel: UILabel = .build { label in
-            label.textAlignment = textAlignment
+            label.textAlignment = viewModel.textAlignment
             label.textColor = UIColor.Photon.White100
             label.font = UIFont.systemFont(ofSize: 15, weight: .semibold)
-            label.text = labelText
+            label.text = viewModel.labelText
             label.lineBreakMode = .byWordWrapping
             label.numberOfLines = 0
         }
@@ -97,13 +103,13 @@ class ButtonToast: Toast {
         labelStackView.addArrangedSubview(titleLabel)
 
         var descriptionLabel: UILabel?
-        if let descriptionText = descriptionText {
+        if let descriptionText = viewModel.descriptionText {
             titleLabel.lineBreakMode = .byClipping
             titleLabel.numberOfLines = 1 // if showing a description we cant wrap to the second line
             titleLabel.adjustsFontSizeToFitWidth = true
 
             descriptionLabel = .build { label in
-                label.textAlignment = textAlignment
+                label.textAlignment = viewModel.textAlignment
                 label.textColor = UIColor.Photon.White100
                 label.font = UX.ToastDescriptionFont
                 label.text = descriptionText
@@ -114,10 +120,10 @@ class ButtonToast: Toast {
         }
 
         horizontalStackView.addArrangedSubview(labelStackView)
-        setupPaddedButton(stackView: horizontalStackView, buttonText: buttonText)
+        setupPaddedButton(stackView: horizontalStackView, buttonText: viewModel.buttonText)
         toastView.addSubview(horizontalStackView)
 
-        if textAlignment == .center {
+        if viewModel.textAlignment == .center {
             titleLabel.centerXAnchor.constraint(equalTo: toastView.centerXAnchor).isActive = true
             descriptionLabel?.centerXAnchor.constraint(equalTo: toastView.centerXAnchor).isActive = true
         }
@@ -172,12 +178,12 @@ class ButtonToast: Toast {
         paddedView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(buttonPressed)))
     }
 
-    override func showToast(viewController: UIViewController? = nil,
-                            delay: DispatchTimeInterval = Toast.UX.toastDelayBefore,
-                            duration: DispatchTimeInterval? = Toast.UX.toastDismissAfter,
-                            updateConstraintsOn: @escaping (Toast) -> [NSLayoutConstraint]) {
-        super.showToast(viewController: viewController, delay: delay, duration: duration, updateConstraintsOn: updateConstraintsOn)
-    }
+//    override func showToast(viewController: UIViewController? = nil,
+//                            delay: DispatchTimeInterval = Toast.UX.toastDelayBefore,
+//                            duration: DispatchTimeInterval? = Toast.UX.toastDismissAfter,
+//                            updateConstraintsOn: @escaping (Toast) -> [NSLayoutConstraint]) {
+//        super.showToast(viewController: viewController, delay: delay, duration: duration, updateConstraintsOn: updateConstraintsOn)
+//    }
 
     // MARK: - Button action
     @objc func buttonPressed() {

--- a/Client/Frontend/Browser/ButtonToast.swift
+++ b/Client/Frontend/Browser/ButtonToast.swift
@@ -15,23 +15,20 @@ struct ButtonToastViewModel {
 
 class ButtonToast: Toast {
     struct UX {
-        static let toastDelay = DispatchTimeInterval.milliseconds(900)
-        static let toastPadding: CGFloat = 15.0
-        static let toastButtonPadding: CGFloat = 10.0
-        static let toastButtonBorderRadius: CGFloat = 5
-        static let toastButtonBorderWidth: CGFloat = 1
+        static let delay = DispatchTimeInterval.milliseconds(900)
+        static let padding: CGFloat = 15.0
+        static let buttonPadding: CGFloat = 10.0
+        static let buttonBorderRadius: CGFloat = 5
+        static let buttonBorderWidth: CGFloat = 1
         static let descriptionFontSize: CGFloat = 13
-        // Padded View
-        static let WidthOffset: CGFloat = 20.0
-        static let TopOffset: CGFloat = 5.0
-        static let BottomOffset: CGFloat = 20.0
+        static let widthOffset: CGFloat = 20.0
     }
 
     // MARK: - UI
     private var horizontalStackView: UIStackView = .build { stackView in
         stackView.axis = .horizontal
         stackView.alignment = .center
-        stackView.spacing = UX.toastPadding
+        stackView.spacing = UX.padding
     }
 
     private var imageView: UIImageView = .build { imageView in }
@@ -42,7 +39,8 @@ class ButtonToast: Toast {
     }
 
     private var titleLabel: UILabel = .build { label in
-        label.font = UIFont.systemFont(ofSize: 15, weight: .semibold)
+        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
+                                                                   size: UX.descriptionFontSize)
         label.lineBreakMode = .byWordWrapping
         label.numberOfLines = 0
     }
@@ -54,8 +52,8 @@ class ButtonToast: Toast {
     }
 
     private var roundedButton: UIButton = .build { button in
-        button.layer.cornerRadius = UX.toastButtonBorderRadius
-        button.layer.borderWidth = UX.toastButtonBorderWidth
+        button.layer.cornerRadius = UX.buttonBorderRadius
+        button.layer.borderWidth = UX.buttonBorderWidth
         button.titleLabel?.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
                                                                                 size: Toast.UX.fontSize)
         button.titleLabel?.numberOfLines = 1
@@ -67,13 +65,10 @@ class ButtonToast: Toast {
     // Pass themeManager to call on init
     init(viewModel: ButtonToastViewModel,
          theme: Theme,
-         completion: ((_ buttonPressed: Bool) -> Void)? = nil,
-         autoDismissCompletion: (() -> Void)? = nil
-    ) {
+         completion: ((_ buttonPressed: Bool) -> Void)? = nil) {
         super.init(frame: .zero)
 
         self.completionHandler = completion
-        self.didDismissWithoutTapHandler = autoDismissCompletion
 
         self.clipsToBounds = true
         let createdToastView = createView(viewModel: viewModel)
@@ -130,7 +125,7 @@ class ButtonToast: Toast {
         NSLayoutConstraint.activate([
             labelStackView.centerYAnchor.constraint(equalTo: horizontalStackView.centerYAnchor),
 
-            horizontalStackView.leadingAnchor.constraint(equalTo: toastView.leadingAnchor, constant: UX.toastPadding),
+            horizontalStackView.leadingAnchor.constraint(equalTo: toastView.leadingAnchor, constant: UX.padding),
             horizontalStackView.trailingAnchor.constraint(equalTo: toastView.trailingAnchor),
             horizontalStackView.bottomAnchor.constraint(equalTo: toastView.safeAreaLayoutGuide.bottomAnchor),
             horizontalStackView.topAnchor.constraint(equalTo: toastView.topAnchor),
@@ -150,14 +145,14 @@ class ButtonToast: Toast {
         paddedView.addSubview(roundedButton)
 
         NSLayoutConstraint.activate([
-            roundedButton.heightAnchor.constraint(equalToConstant: roundedButton.titleLabel!.intrinsicContentSize.height + 2 * UX.toastButtonPadding),
-            roundedButton.widthAnchor.constraint(equalToConstant: roundedButton.titleLabel!.intrinsicContentSize.width + 2 * UX.toastButtonPadding),
+            roundedButton.heightAnchor.constraint(equalToConstant: roundedButton.titleLabel!.intrinsicContentSize.height + 2 * UX.buttonPadding),
+            roundedButton.widthAnchor.constraint(equalToConstant: roundedButton.titleLabel!.intrinsicContentSize.width + 2 * UX.buttonPadding),
             roundedButton.centerYAnchor.constraint(equalTo: paddedView.centerYAnchor),
             roundedButton.centerXAnchor.constraint(equalTo: paddedView.centerXAnchor),
 
             paddedView.topAnchor.constraint(equalTo: stackView.topAnchor),
             paddedView.bottomAnchor.constraint(equalTo: stackView.bottomAnchor),
-            paddedView.widthAnchor.constraint(equalTo: roundedButton.widthAnchor, constant: UX.WidthOffset)
+            paddedView.widthAnchor.constraint(equalTo: roundedButton.widthAnchor, constant: UX.widthOffset)
         ])
 
         roundedButton.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(buttonPressed)))

--- a/Client/Frontend/Browser/ButtonToast.swift
+++ b/Client/Frontend/Browser/ButtonToast.swift
@@ -5,32 +5,22 @@
 import Foundation
 import Shared
 
-class HighlightableButton: UIButton {
-    override var isHighlighted: Bool {
-        didSet {
-            backgroundColor = isHighlighted ? .white : .clear
-        }
-    }
-}
-
 struct ButtonToastViewModel {
     var labelText: String
     var descriptionText: String?
     var imageName: String?
     var buttonText: String?
-    var backgroundColor: UIColor = ButtonToast.UX.toastDefaultColor
     var textAlignment: NSTextAlignment = .left
 }
 
 class ButtonToast: Toast {
     struct UX {
-        static let ToastPadding: CGFloat = 15.0
-        static let ToastButtonPadding: CGFloat = 10.0
-        static let ToastDelay = DispatchTimeInterval.milliseconds(900)
-        static let ToastButtonBorderRadius: CGFloat = 5
-        static let ToastButtonBorderWidth: CGFloat = 1
+        static let toastDelay = DispatchTimeInterval.milliseconds(900)
+        static let toastPadding: CGFloat = 15.0
+        static let toastButtonPadding: CGFloat = 10.0
+        static let toastButtonBorderRadius: CGFloat = 5
+        static let toastButtonBorderWidth: CGFloat = 1
         static let descriptionFontSize: CGFloat = 13
-        static let toastDefaultColor = UIColor.Photon.Blue40
         // Padded View
         static let WidthOffset: CGFloat = 20.0
         static let TopOffset: CGFloat = 5.0
@@ -41,7 +31,7 @@ class ButtonToast: Toast {
     private var horizontalStackView: UIStackView = .build { stackView in
         stackView.axis = .horizontal
         stackView.alignment = .center
-        stackView.spacing = UX.ToastPadding
+        stackView.spacing = UX.toastPadding
     }
 
     private var imageView: UIImageView = .build { imageView in }
@@ -63,10 +53,9 @@ class ButtonToast: Toast {
         label.lineBreakMode = .byTruncatingTail
     }
 
-    private var roundedButton: HighlightableButton = .build { button in
-        button.layer.cornerRadius = UX.ToastButtonBorderRadius
-        button.layer.borderWidth = UX.ToastButtonBorderWidth
-        button.layer.borderColor = UIColor.Photon.White100.cgColor
+    private var roundedButton: UIButton = .build { button in
+        button.layer.cornerRadius = UX.toastButtonBorderRadius
+        button.layer.borderWidth = UX.toastButtonBorderWidth
         button.titleLabel?.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
                                                                                 size: Toast.UX.fontSize)
         button.titleLabel?.numberOfLines = 1
@@ -77,6 +66,7 @@ class ButtonToast: Toast {
 
     // Pass themeManager to call on init
     init(viewModel: ButtonToastViewModel,
+         theme: Theme,
          completion: ((_ buttonPressed: Bool) -> Void)? = nil,
          autoDismissCompletion: (() -> Void)? = nil
     ) {
@@ -89,9 +79,6 @@ class ButtonToast: Toast {
         let createdToastView = createView(viewModel: viewModel)
         self.addSubview(createdToastView)
 
-        // TODO: Handle on applyTheme
-        self.toastView.backgroundColor = viewModel.backgroundColor
-
         NSLayoutConstraint.activate([
             toastView.leadingAnchor.constraint(equalTo: leadingAnchor),
             toastView.trailingAnchor.constraint(equalTo: trailingAnchor),
@@ -103,6 +90,7 @@ class ButtonToast: Toast {
         animationConstraint = toastView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor,
                                                              constant: Toast.UX.toastHeight)
         animationConstraint?.isActive = true
+        applyTheme(theme: theme)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -142,7 +130,7 @@ class ButtonToast: Toast {
         NSLayoutConstraint.activate([
             labelStackView.centerYAnchor.constraint(equalTo: horizontalStackView.centerYAnchor),
 
-            horizontalStackView.leadingAnchor.constraint(equalTo: toastView.leadingAnchor, constant: UX.ToastPadding),
+            horizontalStackView.leadingAnchor.constraint(equalTo: toastView.leadingAnchor, constant: UX.toastPadding),
             horizontalStackView.trailingAnchor.constraint(equalTo: toastView.trailingAnchor),
             horizontalStackView.bottomAnchor.constraint(equalTo: toastView.safeAreaLayoutGuide.bottomAnchor),
             horizontalStackView.topAnchor.constraint(equalTo: toastView.topAnchor),
@@ -162,8 +150,8 @@ class ButtonToast: Toast {
         paddedView.addSubview(roundedButton)
 
         NSLayoutConstraint.activate([
-            roundedButton.heightAnchor.constraint(equalToConstant: roundedButton.titleLabel!.intrinsicContentSize.height + 2 * UX.ToastButtonPadding),
-            roundedButton.widthAnchor.constraint(equalToConstant: roundedButton.titleLabel!.intrinsicContentSize.width + 2 * UX.ToastButtonPadding),
+            roundedButton.heightAnchor.constraint(equalToConstant: roundedButton.titleLabel!.intrinsicContentSize.height + 2 * UX.toastButtonPadding),
+            roundedButton.widthAnchor.constraint(equalToConstant: roundedButton.titleLabel!.intrinsicContentSize.width + 2 * UX.toastButtonPadding),
             roundedButton.centerYAnchor.constraint(equalTo: paddedView.centerYAnchor),
             roundedButton.centerXAnchor.constraint(equalTo: paddedView.centerXAnchor),
 
@@ -178,12 +166,11 @@ class ButtonToast: Toast {
     }
 
     override func applyTheme(theme: Theme) {
-        print("YRD apply theme on button toast")
-
-        titleLabel.textColor = theme.colors.textPrimary
-        descriptionLabel.textColor = theme.colors.textPrimary
-        imageView.tintColor = theme.colors.iconPrimary
-        roundedButton.setTitleColor(theme.colors.actionPrimary, for: .highlighted)
+        titleLabel.textColor = theme.colors.textInverted
+        descriptionLabel.textColor = theme.colors.textInverted
+        imageView.tintColor = theme.colors.textInverted
+        roundedButton.setTitleColor(theme.colors.textInverted, for: [])
+        roundedButton.layer.borderColor = theme.colors.borderInverted.cgColor
         super.applyTheme(theme: theme)
     }
 

--- a/Client/Frontend/Browser/ButtonToast.swift
+++ b/Client/Frontend/Browser/ButtonToast.swift
@@ -16,12 +16,13 @@ struct ButtonToastViewModel {
 class ButtonToast: Toast {
     struct UX {
         static let delay = DispatchTimeInterval.milliseconds(900)
-        static let padding: CGFloat = 15.0
-        static let buttonPadding: CGFloat = 10.0
+        static let padding: CGFloat = 15
+        static let buttonPadding: CGFloat = 10
         static let buttonBorderRadius: CGFloat = 5
         static let buttonBorderWidth: CGFloat = 1
+        static let titleFontSize: CGFloat = 15
         static let descriptionFontSize: CGFloat = 13
-        static let widthOffset: CGFloat = 20.0
+        static let widthOffset: CGFloat = 20
     }
 
     // MARK: - UI
@@ -35,20 +36,19 @@ class ButtonToast: Toast {
 
     private var labelStackView: UIStackView = .build { stackView in
         stackView.axis = .vertical
-        stackView.alignment = .leading
+        stackView.alignment = .fill
     }
 
     private var titleLabel: UILabel = .build { label in
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
-                                                                   size: UX.descriptionFontSize)
-        label.lineBreakMode = .byWordWrapping
+        label.font = DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
+                                                                       size: UX.titleFontSize)
         label.numberOfLines = 0
     }
 
     private var descriptionLabel: UILabel = .build { label in
         label.font = DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
                                                                        size: UX.descriptionFontSize)
-        label.lineBreakMode = .byTruncatingTail
+        label.numberOfLines = 0
     }
 
     private var roundedButton: UIButton = .build { button in
@@ -64,7 +64,7 @@ class ButtonToast: Toast {
 
     // Pass themeManager to call on init
     init(viewModel: ButtonToastViewModel,
-         theme: Theme,
+         theme: Theme?,
          completion: ((_ buttonPressed: Bool) -> Void)? = nil) {
         super.init(frame: .zero)
 
@@ -85,7 +85,9 @@ class ButtonToast: Toast {
         animationConstraint = toastView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor,
                                                              constant: Toast.UX.toastHeight)
         animationConstraint?.isActive = true
-        applyTheme(theme: theme)
+        if let theme = theme {
+            applyTheme(theme: theme)
+        }
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -117,11 +119,6 @@ class ButtonToast: Toast {
         setupPaddedButton(stackView: horizontalStackView, buttonText: viewModel.buttonText)
         toastView.addSubview(horizontalStackView)
 
-        if viewModel.textAlignment == .center {
-            titleLabel.centerXAnchor.constraint(equalTo: toastView.centerXAnchor).isActive = true
-            descriptionLabel.centerXAnchor.constraint(equalTo: toastView.centerXAnchor).isActive = true
-        }
-
         NSLayoutConstraint.activate([
             labelStackView.centerYAnchor.constraint(equalTo: horizontalStackView.centerYAnchor),
 
@@ -145,8 +142,10 @@ class ButtonToast: Toast {
         paddedView.addSubview(roundedButton)
 
         NSLayoutConstraint.activate([
-            roundedButton.heightAnchor.constraint(equalToConstant: roundedButton.titleLabel!.intrinsicContentSize.height + 2 * UX.buttonPadding),
-            roundedButton.widthAnchor.constraint(equalToConstant: roundedButton.titleLabel!.intrinsicContentSize.width + 2 * UX.buttonPadding),
+            roundedButton.heightAnchor.constraint(
+                equalToConstant: roundedButton.titleLabel!.intrinsicContentSize.height + 2 * UX.buttonPadding),
+            roundedButton.widthAnchor.constraint(
+                equalToConstant: roundedButton.titleLabel!.intrinsicContentSize.width + 2 * UX.buttonPadding),
             roundedButton.centerYAnchor.constraint(equalTo: paddedView.centerYAnchor),
             roundedButton.centerXAnchor.constraint(equalTo: paddedView.centerXAnchor),
 
@@ -161,12 +160,13 @@ class ButtonToast: Toast {
     }
 
     override func applyTheme(theme: Theme) {
+        super.applyTheme(theme: theme)
+
         titleLabel.textColor = theme.colors.textInverted
         descriptionLabel.textColor = theme.colors.textInverted
         imageView.tintColor = theme.colors.textInverted
         roundedButton.setTitleColor(theme.colors.textInverted, for: [])
         roundedButton.layer.borderColor = theme.colors.borderInverted.cgColor
-        super.applyTheme(theme: theme)
     }
 
     // MARK: - Button action

--- a/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
+++ b/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
@@ -5,15 +5,15 @@
 import Foundation
 import Shared
 
-public struct ClipboardBarToastUX {
-    static let ToastDelay = DispatchTimeInterval.milliseconds(4000)
-}
-
 protocol ClipboardBarDisplayHandlerDelegate: AnyObject {
-    func shouldDisplay(clipboardBar bar: ButtonToast)
+    func shouldDisplay(clipBoardURL url: URL)
 }
 
 class ClipboardBarDisplayHandler: NSObject, URLChangeDelegate {
+    public struct UX {
+        static let toastDelay = DispatchTimeInterval.milliseconds(10000)
+    }
+
     weak var delegate: (ClipboardBarDisplayHandlerDelegate & SettingsDelegate)?
     weak var settingsDelegate: SettingsDelegate?
     weak var tabManager: TabManager?
@@ -128,21 +128,7 @@ class ClipboardBarDisplayHandler: NSObject, URLChangeDelegate {
               let url = UIPasteboard.general.url,
               shouldDisplayBar(url.absoluteString) else { return }
 
-        self.lastDisplayedURL = url.absoluteString
-
-        self.clipboardToast =
-        ButtonToast(
-            labelText: .GoToCopiedLink,
-            descriptionText: url.absoluteDisplayString,
-            buttonText: .GoButtonTittle,
-            completion: { buttonPressed in
-                if buttonPressed {
-                    self.delegate?.settingsOpenURLInNewTab(url)
-                }
-            })
-
-        if let toast = self.clipboardToast {
-            delegate?.shouldDisplay(clipboardBar: toast)
-        }
+        lastDisplayedURL = url.absoluteString
+        delegate?.shouldDisplay(clipBoardURL: url)
     }
 }

--- a/Client/Frontend/Browser/DownloadToast.swift
+++ b/Client/Frontend/Browser/DownloadToast.swift
@@ -9,6 +9,7 @@ class DownloadToast: Toast {
     struct UX {
         static let ToastBackgroundColor = UIColor.Photon.Blue40
         static let ToastProgressColor = UIColor.Photon.Blue50
+        static let ToastDescriptionFont = UIFont.systemFont(ofSize: 13)
     }
 
     lazy var progressView: UIView = .build { view in
@@ -132,7 +133,7 @@ class DownloadToast: Toast {
         labelStackView.addArrangedSubview(label)
 
         descriptionLabel.textColor = UIColor.Photon.White100
-        descriptionLabel.font = ButtonToast.UX.ToastDescriptionFont
+        descriptionLabel.font = UX.ToastDescriptionFont
         descriptionLabel.text = descriptionText
         descriptionLabel.lineBreakMode = .byTruncatingTail
         labelStackView.addArrangedSubview(descriptionLabel)

--- a/Client/Frontend/Browser/DownloadToast.swift
+++ b/Client/Frontend/Browser/DownloadToast.swift
@@ -5,15 +5,20 @@
 import Shared
 import UIKit
 
-struct DownloadToastUX {
-    static let ToastBackgroundColor = UIColor.Photon.Blue40
-    static let ToastProgressColor = UIColor.Photon.Blue50
-}
-
 class DownloadToast: Toast {
-    lazy var progressView: UIView = .build { view in
-        view.backgroundColor = DownloadToastUX.ToastProgressColor
+    struct UX {
+        static let ToastBackgroundColor = UIColor.Photon.Blue40
+        static let ToastProgressColor = UIColor.Photon.Blue50
     }
+
+    lazy var progressView: UIView = .build { view in
+        view.backgroundColor = UX.ToastProgressColor
+    }
+
+    let descriptionLabel = UILabel()
+    var progressWidthConstraint: NSLayoutConstraint?
+
+    var downloads: [Download] = []
 
     var percent: CGFloat = 0.0 {
         didSet {
@@ -51,11 +56,6 @@ class DownloadToast: Toast {
         return String(format: .DownloadMultipleFilesAndProgressToastDescriptionText, fileCountDescription, descriptionText)
     }
 
-    var downloads: [Download] = []
-
-    let descriptionLabel = UILabel()
-    var progressWidthConstraint: NSLayoutConstraint?
-
     init(download: Download, completion: @escaping (_ buttonPressed: Bool) -> Void) {
         super.init(frame: .zero)
 
@@ -73,10 +73,10 @@ class DownloadToast: Toast {
             toastView.trailingAnchor.constraint(equalTo: trailingAnchor),
             toastView.heightAnchor.constraint(equalTo: heightAnchor),
 
-            heightAnchor.constraint(equalToConstant: ButtonToastUX.ToastHeight)
+            heightAnchor.constraint(equalToConstant: Toast.UX.toastHeight)
         ])
 
-        animationConstraint = toastView.topAnchor.constraint(equalTo: topAnchor, constant: ButtonToastUX.ToastHeight)
+        animationConstraint = toastView.topAnchor.constraint(equalTo: topAnchor, constant: Toast.UX.toastHeight)
         animationConstraint?.isActive = true
     }
 
@@ -111,7 +111,7 @@ class DownloadToast: Toast {
         let horizontalStackView: UIStackView = .build { stackView in
             stackView.axis = .horizontal
             stackView.alignment = .center
-            stackView.spacing = ButtonToastUX.ToastPadding
+            stackView.spacing = ButtonToast.UX.ToastPadding
         }
 
         let icon = UIImageView(image: UIImage.templateImageNamed("download"))
@@ -124,7 +124,7 @@ class DownloadToast: Toast {
 
         let label = UILabel()
         label.textColor = UIColor.Photon.White100
-        label.font = ButtonToastUX.ToastLabelFont
+        label.font = UIFont.systemFont(ofSize: 15, weight: .semibold)
         label.text = labelText
         label.lineBreakMode = .byWordWrapping
         label.numberOfLines = 1
@@ -132,7 +132,7 @@ class DownloadToast: Toast {
         labelStackView.addArrangedSubview(label)
 
         descriptionLabel.textColor = UIColor.Photon.White100
-        descriptionLabel.font = ButtonToastUX.ToastDescriptionFont
+        descriptionLabel.font = ButtonToast.UX.ToastDescriptionFont
         descriptionLabel.text = descriptionText
         descriptionLabel.lineBreakMode = .byTruncatingTail
         labelStackView.addArrangedSubview(descriptionLabel)
@@ -145,7 +145,7 @@ class DownloadToast: Toast {
         cancel.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(buttonPressed)))
         horizontalStackView.addArrangedSubview(cancel)
 
-        toastView.backgroundColor = DownloadToastUX.ToastBackgroundColor
+        toastView.backgroundColor = UX.ToastBackgroundColor
 
         toastView.addSubview(progressView)
         toastView.addSubview(horizontalStackView)
@@ -157,7 +157,7 @@ class DownloadToast: Toast {
 
             horizontalStackView.centerXAnchor.constraint(equalTo: toastView.centerXAnchor),
             horizontalStackView.centerYAnchor.constraint(equalTo: toastView.centerYAnchor),
-            horizontalStackView.widthAnchor.constraint(equalTo: toastView.widthAnchor, constant: -2 * ButtonToastUX.ToastPadding)
+            horizontalStackView.widthAnchor.constraint(equalTo: toastView.widthAnchor, constant: -2 * ButtonToast.UX.ToastPadding)
         ])
 
         progressWidthConstraint = progressView.widthAnchor.constraint(equalToConstant: 0)
@@ -179,6 +179,6 @@ class DownloadToast: Toast {
     }
 
     override func handleTap(_ gestureRecognizer: UIGestureRecognizer) {
-        // Intentional NOOP to override superclass behavior for dismissing the toast.
+        // Intentional NOOP to override superclass behaviour for dismissing the toast.
     }
 }

--- a/Client/Frontend/Browser/DownloadToast.swift
+++ b/Client/Frontend/Browser/DownloadToast.swift
@@ -112,7 +112,7 @@ class DownloadToast: Toast {
         let horizontalStackView: UIStackView = .build { stackView in
             stackView.axis = .horizontal
             stackView.alignment = .center
-            stackView.spacing = ButtonToast.UX.ToastPadding
+            stackView.spacing = ButtonToast.UX.toastPadding
         }
 
         let icon = UIImageView(image: UIImage.templateImageNamed("download"))
@@ -158,7 +158,7 @@ class DownloadToast: Toast {
 
             horizontalStackView.centerXAnchor.constraint(equalTo: toastView.centerXAnchor),
             horizontalStackView.centerYAnchor.constraint(equalTo: toastView.centerYAnchor),
-            horizontalStackView.widthAnchor.constraint(equalTo: toastView.widthAnchor, constant: -2 * ButtonToast.UX.ToastPadding)
+            horizontalStackView.widthAnchor.constraint(equalTo: toastView.widthAnchor, constant: -2 * ButtonToast.UX.toastPadding)
         ])
 
         progressWidthConstraint = progressView.widthAnchor.constraint(equalToConstant: 0)

--- a/Client/Frontend/Browser/DownloadToast.swift
+++ b/Client/Frontend/Browser/DownloadToast.swift
@@ -112,7 +112,7 @@ class DownloadToast: Toast {
         let horizontalStackView: UIStackView = .build { stackView in
             stackView.axis = .horizontal
             stackView.alignment = .center
-            stackView.spacing = ButtonToast.UX.toastPadding
+            stackView.spacing = ButtonToast.UX.padding
         }
 
         let icon = UIImageView(image: UIImage.templateImageNamed("download"))
@@ -158,7 +158,7 @@ class DownloadToast: Toast {
 
             horizontalStackView.centerXAnchor.constraint(equalTo: toastView.centerXAnchor),
             horizontalStackView.centerYAnchor.constraint(equalTo: toastView.centerYAnchor),
-            horizontalStackView.widthAnchor.constraint(equalTo: toastView.widthAnchor, constant: -2 * ButtonToast.UX.toastPadding)
+            horizontalStackView.widthAnchor.constraint(equalTo: toastView.widthAnchor, constant: -2 * ButtonToast.UX.padding)
         ])
 
         progressWidthConstraint = progressView.widthAnchor.constraint(equalToConstant: 0)

--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -514,6 +514,12 @@ extension GridTabViewController: TabPeekDelegate {
     func tabPeekRequestsPresentationOf(_ viewController: UIViewController) {
         present(viewController, animated: true, completion: nil)
     }
+
+    func tabPeekDidCopyUrl() {
+        SimpleToast().showAlertWithText(.AppMenu.AppMenuCopyURLConfirmMessage,
+                                        bottomContainer: view,
+                                        theme: themeManager.currentTheme)
+    }
 }
 
 // MARK: - TabDisplayCompeltionDelegate & RecentlyClosedPanelDelegate

--- a/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -57,8 +57,8 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     private let tabUrl: URL?
     private let isFileURL: Bool
     private let showFXASyncAction: (FXASyncClosure) -> Void
-    private let themeManager: ThemeManager
 
+    let themeManager: ThemeManager
     var bookmarksHandler: BookmarksHandler
     let profile: Profile
     let tabManager: TabManager

--- a/Client/Frontend/Browser/SimpleToast.swift
+++ b/Client/Frontend/Browser/SimpleToast.swift
@@ -12,14 +12,14 @@ struct SimpleToast: ThemeApplicable {
     }
 
     private let toastLabel: UILabel = .build { label in
-        label.textColor = UIColor.Photon.White100
-        label.backgroundColor = UX.toastDefaultColor
         label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
                                                                    size: Toast.UX.fontSize)
         label.textAlignment = .center
     }
 
-    func showAlertWithText(_ text: String, bottomContainer: UIView) {
+    func showAlertWithText(_ text: String,
+                           bottomContainer: UIView,
+                           theme: Theme) {
         toastLabel.text = text
         bottomContainer.addSubview(toastLabel)
         NSLayoutConstraint.activate([
@@ -28,11 +28,13 @@ struct SimpleToast: ThemeApplicable {
             toastLabel.bottomAnchor.constraint(equalTo: bottomContainer.bottomAnchor),
             toastLabel.heightAnchor.constraint(equalToConstant: Toast.UX.toastHeight),
         ])
+        applyTheme(theme: theme)
         animate(toastLabel)
     }
 
     func applyTheme(theme: Theme) {
-        print("YRD apply theme in Simple Toast")
+        toastLabel.textColor = theme.colors.textInverted
+        toastLabel.backgroundColor = theme.colors.actionPrimary
     }
 
     private func dismiss(_ toast: UIView) {

--- a/Client/Frontend/Browser/SimpleToast.swift
+++ b/Client/Frontend/Browser/SimpleToast.swift
@@ -7,7 +7,7 @@ import Shared
 
 struct SimpleToast: ThemeApplicable {
     private let toastLabel: UILabel = .build { label in
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
+        label.font = DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
                                                                    size: Toast.UX.fontSize)
         label.numberOfLines = 0
         label.textAlignment = .center

--- a/Client/Frontend/Browser/SimpleToast.swift
+++ b/Client/Frontend/Browser/SimpleToast.swift
@@ -8,7 +8,7 @@ import Shared
 struct SimpleToast: ThemeApplicable {
     private let toastLabel: UILabel = .build { label in
         label.font = DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
-                                                                   size: Toast.UX.fontSize)
+                                                                       size: Toast.UX.fontSize)
         label.numberOfLines = 0
         label.textAlignment = .center
     }

--- a/Client/Frontend/Browser/SimpleToast.swift
+++ b/Client/Frontend/Browser/SimpleToast.swift
@@ -6,14 +6,10 @@ import Foundation
 import Shared
 
 struct SimpleToast: ThemeApplicable {
-    struct UX {
-        static let toastAnimationDuration = 0.5
-        static let toastDefaultColor = UIColor.Photon.Blue40
-    }
-
     private let toastLabel: UILabel = .build { label in
         label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
                                                                    size: Toast.UX.fontSize)
+        label.numberOfLines = 0
         label.textAlignment = .center
     }
 
@@ -39,7 +35,7 @@ struct SimpleToast: ThemeApplicable {
 
     private func dismiss(_ toast: UIView) {
         UIView.animate(
-            withDuration: UX.toastAnimationDuration,
+            withDuration: Toast.UX.toastAnimationDuration,
             animations: {
                 var frame = toast.frame
                 frame.origin.y = frame.origin.y + Toast.UX.toastHeight
@@ -54,7 +50,7 @@ struct SimpleToast: ThemeApplicable {
 
     private func animate(_ toast: UIView) {
         UIView.animate(
-            withDuration: UX.toastAnimationDuration,
+            withDuration: Toast.UX.toastAnimationDuration,
             animations: {
                 var frame = toast.frame
                 frame.origin.y = frame.origin.y - Toast.UX.toastHeight

--- a/Client/Frontend/Browser/SimpleToast.swift
+++ b/Client/Frontend/Browser/SimpleToast.swift
@@ -5,22 +5,17 @@
 import Foundation
 import Shared
 
-struct SimpleToastUX {
-    static let ToastHeight = BottomToolbarHeight
-    static let ToastAnimationDuration = 0.5
-    static let ToastDefaultColor = UIColor.Photon.Blue40
-    static let ToastFont = UIFont.systemFont(ofSize: 15)
-    static let ToastDismissAfter = DispatchTimeInterval.milliseconds(4500) // 4.5 seconds.
-    static let ToastDelayBefore = DispatchTimeInterval.milliseconds(0) // 0 seconds
-    static let ToastPrivateModeDelayBefore = DispatchTimeInterval.milliseconds(750)
-    static let BottomToolbarHeight = CGFloat(45)
-}
+struct SimpleToast: ThemeApplicable {
+    struct UX {
+        static let toastAnimationDuration = 0.5
+        static let toastDefaultColor = UIColor.Photon.Blue40
+    }
 
-struct SimpleToast {
-    fileprivate let toastLabel: UILabel = .build { label in
+    private let toastLabel: UILabel = .build { label in
         label.textColor = UIColor.Photon.White100
-        label.backgroundColor = SimpleToastUX.ToastDefaultColor
-        label.font = SimpleToastUX.ToastFont
+        label.backgroundColor = UX.toastDefaultColor
+        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
+                                                                   size: Toast.UX.fontSize)
         label.textAlignment = .center
     }
 
@@ -31,17 +26,21 @@ struct SimpleToast {
             toastLabel.widthAnchor.constraint(equalTo: bottomContainer.widthAnchor),
             toastLabel.leadingAnchor.constraint(equalTo: bottomContainer.leadingAnchor),
             toastLabel.bottomAnchor.constraint(equalTo: bottomContainer.bottomAnchor),
-            toastLabel.heightAnchor.constraint(equalToConstant: SimpleToastUX.ToastHeight),
+            toastLabel.heightAnchor.constraint(equalToConstant: Toast.UX.toastHeight),
         ])
         animate(toastLabel)
     }
 
-    fileprivate func dismiss(_ toast: UIView) {
+    func applyTheme(theme: Theme) {
+        print("YRD apply theme in Simple Toast")
+    }
+
+    private func dismiss(_ toast: UIView) {
         UIView.animate(
-            withDuration: SimpleToastUX.ToastAnimationDuration,
+            withDuration: UX.toastAnimationDuration,
             animations: {
                 var frame = toast.frame
-                frame.origin.y = frame.origin.y + SimpleToastUX.ToastHeight
+                frame.origin.y = frame.origin.y + Toast.UX.toastHeight
                 frame.size.height = 0
                 toast.frame = frame
             },
@@ -51,17 +50,17 @@ struct SimpleToast {
         )
     }
 
-    fileprivate func animate(_ toast: UIView) {
+    private func animate(_ toast: UIView) {
         UIView.animate(
-            withDuration: SimpleToastUX.ToastAnimationDuration,
+            withDuration: UX.toastAnimationDuration,
             animations: {
                 var frame = toast.frame
-                frame.origin.y = frame.origin.y - SimpleToastUX.ToastHeight
-                frame.size.height = SimpleToastUX.ToastHeight
+                frame.origin.y = frame.origin.y - Toast.UX.toastHeight
+                frame.size.height = Toast.UX.toastHeight
                 toast.frame = frame
             },
             completion: { finished in
-                let dispatchTime = DispatchTime.now() + SimpleToastUX.ToastDismissAfter
+                let dispatchTime = DispatchTime.now() + Toast.UX.toastDismissAfter
 
                 DispatchQueue.main.asyncAfter(deadline: dispatchTime, execute: {
                     self.dismiss(toast)

--- a/Client/Frontend/Browser/Tab Management/TabManager.swift
+++ b/Client/Frontend/Browser/Tab Management/TabManager.swift
@@ -725,8 +725,10 @@ class TabManager: NSObject, FeatureFlaggable, TabManagerProtocol {
         let viewModel = ButtonToastViewModel(
             labelText: String.localizedStringWithFormat(.TabsDeleteAllUndoTitle, recentlyClosedTabs.count),
             buttonText: .TabsDeleteAllUndoAction)
+        // Passing nil theme because themeManager is not available,
+        // calling to applyTheme with proper theme before showing
         let toast = ButtonToast(viewModel: viewModel,
-                                theme: LightTheme(),
+                                theme: nil,
                                 completion: { buttonPressed in
             // Handles undo to Close tabs
             if buttonPressed {

--- a/Client/Frontend/Browser/Tab Management/TabManager.swift
+++ b/Client/Frontend/Browser/Tab Management/TabManager.swift
@@ -707,54 +707,46 @@ class TabManager: NSObject, FeatureFlaggable, TabManagerProtocol {
     func makeToastFromRecentlyClosedUrls(_ recentlyClosedTabs: [Tab],
                                          isPrivate: Bool,
                                          previousTabUUID: String) {
-        var toast: ButtonToast?
-        let numberOfTabs = recentlyClosedTabs.count
-        if numberOfTabs > 0 {
-            // Add last 10 tab(s) to recently closed list
-            // Note: The recently closed tab list is only updated when the undo
-            // snackbar disappears and does not update if someone taps on undo button
-            recentlyClosedTabs.suffix(10).forEach { tab in
-                if let url = tab.lastKnownUrl, !(InternalURL(url)?.isAboutURL ?? false), !tab.isPrivate {
-                    profile.recentlyClosedTabs.addTab(url as URL,
-                                                      title: tab.lastTitle,
-                                                      faviconURL: tab.displayFavicon?.url,
-                                                      lastExecutedTime: tab.lastExecutedTime)
+        guard !recentlyClosedTabs.isEmpty else { return }
+
+        // Add last 10 tab(s) to recently closed list
+        // Note: The recently closed tab list is only updated when the undo
+        // snackbar disappears and does not update if someone taps on undo button
+        recentlyClosedTabs.suffix(10).forEach { tab in
+            if let url = tab.lastKnownUrl, !(InternalURL(url)?.isAboutURL ?? false), !tab.isPrivate {
+                profile.recentlyClosedTabs.addTab(url as URL,
+                                                  title: tab.lastTitle,
+                                                  faviconURL: tab.displayFavicon?.url,
+                                                  lastExecutedTime: tab.lastExecutedTime)
+            }
+        }
+
+        // Toast
+        let viewModel = ButtonToastViewModel(
+            labelText: String.localizedStringWithFormat(.TabsDeleteAllUndoTitle, recentlyClosedTabs.count),
+            buttonText: .TabsDeleteAllUndoAction)
+        let toast = ButtonToast(viewModel: viewModel,
+                                theme: LightTheme(),
+                                completion: { buttonPressed in
+            // Handles undo to Close tabs
+            if buttonPressed {
+                self.reAddTabs(tabsToAdd: recentlyClosedTabs,
+                               previousTabUUID: previousTabUUID)
+                NotificationCenter.default.post(name: .DidTapUndoCloseAllTabToast, object: nil)
+            } else {
+                // Finish clean up for recently close tabs
+                DispatchQueue.global(qos: .background).async { [unowned self] in
+                    let previousTab = tabs.filter {
+                        $0.tabUUID == previousTabUUID
+                    }.first
+
+                    self.cleanupClosedTabs(recentlyClosedTabs,
+                                           previous: previousTab,
+                                           isPrivate: isPrivate)
                 }
             }
-
-            // Toast
-            var didPressButton = false
-            let viewModel = ButtonToastViewModel(
-                labelText: String.localizedStringWithFormat(.TabsDeleteAllUndoTitle, numberOfTabs),
-                buttonText: .TabsDeleteAllUndoAction)
-            toast = ButtonToast(
-                viewModel: viewModel,
-                theme: LightTheme(),
-                completion: { buttonPressed in
-                    if buttonPressed {
-                        self.reAddTabs(tabsToAdd: recentlyClosedTabs,
-                                       previousTabUUID: previousTabUUID)
-                        NotificationCenter.default.post(name: .DidTapUndoCloseAllTabToast, object: nil)
-                    }
-                    didPressButton = true
-                },
-                autoDismissCompletion: {
-                    guard !didPressButton else { return }
-                    DispatchQueue.global(qos: .background).async { [unowned self] in
-                        let previousTab = tabs.filter {
-                            $0.tabUUID == previousTabUUID
-                        }.first
-
-                        self.cleanupClosedTabs(recentlyClosedTabs,
-                                               previous: previousTab,
-                                               isPrivate: isPrivate)
-                    }
-                })
-        }
-
-        if let toast = toast {
-            delegates.forEach { $0.get()?.tabManagerDidRemoveAllTabs(self, toast: toast) }
-        }
+        })
+        delegates.forEach { $0.get()?.tabManagerDidRemoveAllTabs(self, toast: toast) }
     }
 
     // MARK: - Private

--- a/Client/Frontend/Browser/Tab Management/TabManager.swift
+++ b/Client/Frontend/Browser/Tab Management/TabManager.swift
@@ -729,7 +729,7 @@ class TabManager: NSObject, FeatureFlaggable, TabManagerProtocol {
                 buttonText: .TabsDeleteAllUndoAction)
             toast = ButtonToast(
                 viewModel: viewModel,
-//                theme:
+                theme: LightTheme(),
                 completion: { buttonPressed in
                     if buttonPressed {
                         self.reAddTabs(tabsToAdd: recentlyClosedTabs,

--- a/Client/Frontend/Browser/Tab Management/TabManager.swift
+++ b/Client/Frontend/Browser/Tab Management/TabManager.swift
@@ -724,9 +724,12 @@ class TabManager: NSObject, FeatureFlaggable, TabManagerProtocol {
 
             // Toast
             var didPressButton = false
-            toast = ButtonToast(
+            let viewModel = ButtonToastViewModel(
                 labelText: String.localizedStringWithFormat(.TabsDeleteAllUndoTitle, numberOfTabs),
-                buttonText: .TabsDeleteAllUndoAction,
+                buttonText: .TabsDeleteAllUndoAction)
+            toast = ButtonToast(
+                viewModel: viewModel,
+//                theme:
                 completion: { buttonPressed in
                     if buttonPressed {
                         self.reAddTabs(tabsToAdd: recentlyClosedTabs,
@@ -734,7 +737,8 @@ class TabManager: NSObject, FeatureFlaggable, TabManagerProtocol {
                         NotificationCenter.default.post(name: .DidTapUndoCloseAllTabToast, object: nil)
                     }
                     didPressButton = true
-                }, autoDismissCompletion: {
+                },
+                autoDismissCompletion: {
                     guard !didPressButton else { return }
                     DispatchQueue.global(qos: .background).async { [unowned self] in
                         let previousTab = tabs.filter {

--- a/Client/Frontend/Browser/TabPeekViewController.swift
+++ b/Client/Frontend/Browser/TabPeekViewController.swift
@@ -12,6 +12,7 @@ protocol TabPeekDelegate: AnyObject {
     @discardableResult func tabPeekDidAddToReadingList(_ tab: Tab) -> ReadingListItem?
     func tabPeekRequestsPresentationOf(_ viewController: UIViewController)
     func tabPeekDidCloseTab(_ tab: Tab)
+    func tabPeekDidCopyUrl()
 }
 
 class TabPeekViewController: UIViewController, WKNavigationDelegate {
@@ -52,10 +53,11 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
             // only add the copy URL action if we don't already have 3 items in our list
             // as we are only allowed 4 in total and we always want to display close tab
             if actions.count < 3 {
-                actions.append(UIPreviewAction(title: .TabPeekCopyUrl, style: .default) {[weak self] previewAction, viewController in
+                actions.append(UIPreviewAction(title: .TabPeekCopyUrl, style: .default) { [weak self] previewAction, viewController in
                     guard let wself = self, let url = wself.tab?.canonicalURL else { return }
+
                     UIPasteboard.general.url = url
-                    SimpleToast().showAlertWithText(.AppMenu.AppMenuCopyURLConfirmMessage, bottomContainer: wself.view)
+                    wself.delegate?.tabPeekDidCopyUrl()
                 })
             }
         }
@@ -87,8 +89,9 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
             }
             actions.append(UIAction(title: .TabPeekCopyUrl, image: UIImage.templateImageNamed(ImageIdentifiers.copyLink), identifier: nil) { [weak self] _ in
                 guard let wself = self, let url = wself.tab?.canonicalURL else { return }
+
                 UIPasteboard.general.url = url
-                SimpleToast().showAlertWithText(.AppMenu.AppMenuCopyURLConfirmMessage, bottomContainer: wself.view)
+                wself.delegate?.tabPeekDidCopyUrl()
             })
         }
         actions.append(UIAction(title: .TabPeekCloseTab,

--- a/Client/Frontend/Browser/Toast.swift
+++ b/Client/Frontend/Browser/Toast.swift
@@ -18,7 +18,6 @@ class Toast: UIView, ThemeApplicable {
 
     var animationConstraint: NSLayoutConstraint?
     var completionHandler: ((Bool) -> Void)?
-//    var didDismissWithoutTapHandler: (() -> Void)?
 
     weak var viewController: UIViewController?
 

--- a/Client/Frontend/Browser/Toast.swift
+++ b/Client/Frontend/Browser/Toast.swift
@@ -5,7 +5,15 @@
 import Foundation
 import UIKit
 
-class Toast: UIView {
+class Toast: UIView, ThemeApplicable {
+    struct UX {
+        static let toastHeight: CGFloat = 56
+        static let toastDismissAfter = DispatchTimeInterval.milliseconds(4500) // 4.5 seconds.
+        static let toastDelayBefore = DispatchTimeInterval.milliseconds(0) // 0 seconds
+        static let toastPrivateModeDelayBefore = DispatchTimeInterval.milliseconds(750)
+        static let fontSize: CGFloat = 15
+    }
+
     var animationConstraint: NSLayoutConstraint?
     var completionHandler: ((Bool) -> Void)?
     var didDismissWithoutTapHandler: (() -> Void)?
@@ -21,7 +29,7 @@ class Toast: UIView {
     }()
 
     lazy var toastView: UIView = .build { view in
-        view.backgroundColor = SimpleToastUX.ToastDefaultColor
+        view.backgroundColor = SimpleToast.UX.toastDefaultColor
     }
 
     override func didMoveToSuperview() {
@@ -45,7 +53,7 @@ class Toast: UIView {
             self.layoutIfNeeded()
 
             UIView.animate(
-                withDuration: SimpleToastUX.ToastAnimationDuration,
+                withDuration: SimpleToast.UX.toastAnimationDuration,
                 animations: {
                     self.animationConstraint?.constant = 0
                     self.layoutIfNeeded()
@@ -62,13 +70,14 @@ class Toast: UIView {
 
     func dismiss(_ buttonPressed: Bool) {
         guard !dismissed else { return }
+
         dismissed = true
         superview?.removeGestureRecognizer(gestureRecognizer)
 
         UIView.animate(
-            withDuration: SimpleToastUX.ToastAnimationDuration,
+            withDuration: SimpleToast.UX.toastAnimationDuration,
             animations: {
-                self.animationConstraint?.constant = SimpleToastUX.ToastHeight
+                self.animationConstraint?.constant = Toast.UX.toastHeight
                 self.layoutIfNeeded()
             }) { finished in
                 self.removeFromSuperview()
@@ -80,5 +89,9 @@ class Toast: UIView {
 
     @objc func handleTap(_ gestureRecognizer: UIGestureRecognizer) {
         dismiss(false)
+    }
+
+    func applyTheme(theme: Theme) {
+        print("YRD apply theme on toast")
     }
 }

--- a/Client/Frontend/Browser/Toast.swift
+++ b/Client/Frontend/Browser/Toast.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import UIKit
+import Shared
 
 class Toast: UIView, ThemeApplicable {
     struct UX {
@@ -11,6 +12,7 @@ class Toast: UIView, ThemeApplicable {
         static let toastDismissAfter = DispatchTimeInterval.milliseconds(4500) // 4.5 seconds.
         static let toastDelayBefore = DispatchTimeInterval.milliseconds(0) // 0 seconds
         static let toastPrivateModeDelayBefore = DispatchTimeInterval.milliseconds(750)
+        static let toastAnimationDuration = 0.5
         static let fontSize: CGFloat = 15
     }
 
@@ -28,9 +30,7 @@ class Toast: UIView, ThemeApplicable {
         return gestureRecognizer
     }()
 
-    lazy var toastView: UIView = .build { view in
-        view.backgroundColor = SimpleToast.UX.toastDefaultColor
-    }
+    lazy var toastView: UIView = .build { view in }
 
     override func didMoveToSuperview() {
         super.didMoveToSuperview()
@@ -53,7 +53,7 @@ class Toast: UIView, ThemeApplicable {
             self.layoutIfNeeded()
 
             UIView.animate(
-                withDuration: SimpleToast.UX.toastAnimationDuration,
+                withDuration: UX.toastAnimationDuration,
                 animations: {
                     self.animationConstraint?.constant = 0
                     self.layoutIfNeeded()
@@ -75,9 +75,9 @@ class Toast: UIView, ThemeApplicable {
         superview?.removeGestureRecognizer(gestureRecognizer)
 
         UIView.animate(
-            withDuration: SimpleToast.UX.toastAnimationDuration,
+            withDuration: UX.toastAnimationDuration,
             animations: {
-                self.animationConstraint?.constant = Toast.UX.toastHeight
+                self.animationConstraint?.constant = UX.toastHeight
                 self.layoutIfNeeded()
             }) { finished in
                 self.removeFromSuperview()
@@ -93,5 +93,6 @@ class Toast: UIView, ThemeApplicable {
 
     func applyTheme(theme: Theme) {
         print("YRD apply theme on toast")
+        toastView.backgroundColor = theme.colors.actionPrimary
     }
 }

--- a/Client/Frontend/Browser/Toast.swift
+++ b/Client/Frontend/Browser/Toast.swift
@@ -92,7 +92,6 @@ class Toast: UIView, ThemeApplicable {
     }
 
     func applyTheme(theme: Theme) {
-        print("YRD apply theme on toast")
         toastView.backgroundColor = theme.colors.actionPrimary
     }
 }

--- a/Client/Frontend/Browser/Toast.swift
+++ b/Client/Frontend/Browser/Toast.swift
@@ -18,7 +18,7 @@ class Toast: UIView, ThemeApplicable {
 
     var animationConstraint: NSLayoutConstraint?
     var completionHandler: ((Bool) -> Void)?
-    var didDismissWithoutTapHandler: (() -> Void)?
+//    var didDismissWithoutTapHandler: (() -> Void)?
 
     weak var viewController: UIViewController?
 
@@ -60,7 +60,6 @@ class Toast: UIView, ThemeApplicable {
                 }) { finished in
                     if let duration = duration {
                         DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
-                            self.didDismissWithoutTapHandler?()
                             self.dismiss(false)
                         }
                     }

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -711,7 +711,7 @@ extension HomepageViewController: HomepageContextMenuHelperDelegate {
     }
 
     func showToast(message: String) {
-        SimpleToast().showAlertWithText(message, bottomContainer: self.view)
+        SimpleToast().showAlertWithText(message, bottomContainer: self.view, theme: themeManager.currentTheme)
     }
 }
 

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -711,7 +711,7 @@ extension HomepageViewController: HomepageContextMenuHelperDelegate {
     }
 
     func showToast(message: String) {
-        SimpleToast().showAlertWithText(message, bottomContainer: self.view, theme: themeManager.currentTheme)
+        SimpleToast().showAlertWithText(message, bottomContainer: view, theme: themeManager.currentTheme)
     }
 }
 

--- a/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
@@ -497,7 +497,8 @@ extension BookmarksPanel: LibraryPanelContextMenu {
             self.profile.pinnedSites.addPinnedTopSite(site).uponQueue(.main) { result in
                 if result.isSuccess {
                     SimpleToast().showAlertWithText(.AppMenu.AddPinToShortcutsConfirmMessage,
-                                                    bottomContainer: self.view)
+                                                    bottomContainer: self.view,
+                                                    theme: self.themeManager.currentTheme)
                 } else {
                     self.browserLog.debug("Could not add pinned top site")
                 }

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -739,7 +739,9 @@ extension HistoryPanel {
     func pinToTopSites(_ site: Site) {
         profile.pinnedSites.addPinnedTopSite(site).uponQueue(.main) { result in
             if result.isSuccess {
-                SimpleToast().showAlertWithText(.AppMenu.AddPinToShortcutsConfirmMessage, bottomContainer: self.view)
+                SimpleToast().showAlertWithText(.AppMenu.AddPinToShortcutsConfirmMessage,
+                                                bottomContainer: self.view,
+                                                theme: self.themeManager.currentTheme)
             }
         }
     }

--- a/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewController.swift
+++ b/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewController.swift
@@ -217,6 +217,7 @@ private extension WallpaperSettingsViewController {
                                              buttonText: WallpaperSettingsViewModel.Constants.Strings.Toast.button)
         let toast = ButtonToast(
             viewModel: viewModel,
+            theme: themeManager.currentTheme,
             completion: { buttonPressed in
             if buttonPressed { self.dismissView() }
         })

--- a/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewController.swift
+++ b/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewController.swift
@@ -221,8 +221,8 @@ private extension WallpaperSettingsViewController {
         })
 
         toast.showToast(viewController: self,
-                        delay: SimpleToastUX.ToastDelayBefore,
-                        duration: SimpleToastUX.ToastDismissAfter) { toast in
+                        delay: Toast.UX.toastDelayBefore,
+                        duration: Toast.UX.toastDismissAfter) { toast in
             [
                 toast.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
                 toast.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),

--- a/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewController.swift
+++ b/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewController.swift
@@ -213,9 +213,10 @@ private extension WallpaperSettingsViewController {
     }
 
     func showToast() {
+        let viewModel = ButtonToastViewModel(labelText: WallpaperSettingsViewModel.Constants.Strings.Toast.label,
+                                             buttonText: WallpaperSettingsViewModel.Constants.Strings.Toast.button)
         let toast = ButtonToast(
-            labelText: WallpaperSettingsViewModel.Constants.Strings.Toast.label,
-            buttonText: WallpaperSettingsViewModel.Constants.Strings.Toast.button,
+            viewModel: viewModel,
             completion: { buttonPressed in
             if buttonPressed { self.dismissView() }
         })

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -168,7 +168,9 @@ class SearchSettingsTableViewController: ThemedTableViewController {
             customSearchEngineForm.profile = self.profile
             customSearchEngineForm.successCallback = {
                 guard let window = self.view.window else { return }
-                SimpleToast().showAlertWithText(.ThirdPartySearchEngineAdded, bottomContainer: window)
+                SimpleToast().showAlertWithText(.ThirdPartySearchEngineAdded,
+                                                bottomContainer: window,
+                                                theme: self.themeManager.currentTheme)
             }
             navigationController?.pushViewController(customSearchEngineForm, animated: true)
         }

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
@@ -10,6 +10,7 @@ import UIKit
 protocol PhotonActionSheetProtocol {
     var tabManager: TabManager { get }
     var profile: Profile { get }
+    var themeManager: ThemeManager { get }
 }
 
 extension PhotonActionSheetProtocol {
@@ -55,7 +56,8 @@ extension PhotonActionSheetProtocol {
             if let url = tabManager.selectedTab?.canonicalURL?.displayURL ?? urlBar.currentURL {
                 UIPasteboard.general.url = url
                 SimpleToast().showAlertWithText(.AppMenu.AppMenuCopyURLConfirmMessage,
-                                                bottomContainer: webViewContainer)
+                                                bottomContainer: webViewContainer,
+                                                theme: themeManager.currentTheme)
             }
         }.items
 

--- a/Shared/Theme/DarkTheme.swift
+++ b/Shared/Theme/DarkTheme.swift
@@ -67,6 +67,7 @@ private struct DarkColourPalette: ThemeColourPalette {
     var borderAccent: UIColor = FXColors.Blue30
     var borderAccentNonOpaque: UIColor = FXColors.Blue20.withAlphaComponent(0.2)
     var borderAccentPrivate: UIColor = FXColors.Purple60
+    var borderInverted: UIColor = FXColors.DarkGrey90
 
     // MARK: - Shadow
     var shadowDefault: UIColor = FXColors.DarkGrey90.withAlphaComponent(0.16)

--- a/Shared/Theme/LightTheme.swift
+++ b/Shared/Theme/LightTheme.swift
@@ -67,6 +67,7 @@ private struct LightColourPalette: ThemeColourPalette {
     var borderAccent: UIColor = FXColors.Blue50
     var borderAccentNonOpaque: UIColor = FXColors.Blue50.withAlphaComponent(0.1)
     var borderAccentPrivate: UIColor = FXColors.Purple60
+    var borderInverted: UIColor = FXColors.LightGrey05
 
     // MARK: - Shadow
     var shadowDefault: UIColor = FXColors.DarkGrey40.withAlphaComponent(0.16)

--- a/Shared/Theme/Theme.swift
+++ b/Shared/Theme/Theme.swift
@@ -76,6 +76,7 @@ public protocol ThemeColourPalette {
     var borderAccent: UIColor { get }
     var borderAccentNonOpaque: UIColor { get }
     var borderAccentPrivate: UIColor { get }
+    var borderInverted: UIColor { get }
 
     // MARK: - Shadow
     var shadowDefault: UIColor { get }


### PR DESCRIPTION
## [FXIOS-5209](https://mozilla-hub.atlassian.net/browse/FXIOS-5209)
#12313 

- Update theme for `SimpleToast`, `Toast` and `ButtonToast`
- Support dynamic Font for `SimpleToast`, `Toast` and `ButtonToast`
- Create viewModel for `ButtonToast`
- Replace `ButtonToast` usage of text only with `SimpleToast`

Remaining work:
- Update theme for `DownloadToast` in next PR
- Other issues identified on this work but goes beyond the scope like the fact we 4 different toast classes with repeated views and logic.