### PR TITLE
Add FXIOS-5558 [v111] Add stalebot yml

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,17 +1,19 @@
 # Number of days of inactivity before an issue becomes stale
-# 365 * 2.5 ~= 900 days to start with, then we can lower later on
-daysUntilStale: 900
+# 365 * 2.5 ~= 570 days to start with, then we can lower later on
+daysUntilStale: 570
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 30
 # Issues with these labels will never be considered stale
 exemptLabels:
   - Do not stale
+  - Feature-Request
 # Label to use when marking an issue as stale
 staleLabel: staled
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions.
+  recent activity. It will be closed if no further activity occurs. 
+  Please comment on the issue if you want this issue to be kept open. 
+  Thank you for your contributions.
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,17 @@
+# Number of days of inactivity before an issue becomes stale
+# 365 * 2.5 ~= 900 days to start with, then we can lower later on
+daysUntilStale: 900
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 30
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - Do not stale
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,5 +1,5 @@
 # Number of days of inactivity before an issue becomes stale
-# 365 * 2.5 ~= 570 days to start with, then we can lower later on
+# 570 days to start with, then we can lower later on
 daysUntilStale: 570
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 30

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,7 +7,7 @@ daysUntilClose: 30
 exemptLabels:
   - Do not stale
 # Label to use when marking an issue as stale
-staleLabel: wontfix
+staleLabel: staled
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had


### PR DESCRIPTION
# [FXIOS-5558](https://mozilla-hub.atlassian.net/browse/FXIOS-5558) https://github.com/mozilla-mobile/firefox-ios/issues/12878
Add stalebot to help triage our backlog, remove issues that are sometimes already fixed since code changed or not relevant anymore.
1. Issues older than 900 days will be marked as stale. Starting with a very high number here since our backlog is huge lol. If this bot is useful, we can decrease the 900 threshold a bit to make it even more useful.
2. After 30 days, if an issue has no activities (no comments on it by anyone) it will be closed by the bot.

Issues that are staled by the bot will be easy to find with the `staled` label.
<img width="606" alt="Screen Shot 2023-01-06 at 2 39 18 PM" src="https://user-images.githubusercontent.com/11338480/211086969-964d61b0-6272-4089-839a-3c160e5e856f.png">

It's possible to make an issue with the `Do not stale` label so an issue will never stale after 900 days. Please use sparingly since this removes the purpose of this bot. 
<img width="589" alt="Screen Shot 2023-01-06 at 2 31 13 PM" src="https://user-images.githubusercontent.com/11338480/211085809-8e6a95ae-6c0e-42e0-922b-ef6dfec871b2.png">
