### PR TITLE
Fixes FXIOS-5574 [v110] Adds a top sites notification once history migration is done

### DIFF
--- a/Client/Application/AppLaunchUtil.swift
+++ b/Client/Application/AppLaunchUtil.swift
@@ -199,6 +199,7 @@ class AppLaunchUtil {
                 GleanMetrics.PlacesHistoryMigration.numToMigrate.set(Int64(result.numTotal))
                 GleanMetrics.PlacesHistoryMigration.migrationEndedRate.addToDenominator(1)
                 UserDefaults.standard.setValue(true, forKey: PrefsKeys.PlacesHistoryMigrationSucceeded)
+                NotificationCenter.default.post(name: .TopSitesUpdated, object: nil)
             },
             errCallback: { err in
                 let errDescription = err?.localizedDescription ?? "Unknown error during History migration"


### PR DESCRIPTION
Fixes #12911 

The migration could end after the top sites are loaded for the first time, this PR posts a `.TopSitesUpdated` notification after the migration so the top sites are reloaded right away.


cc @lmarceau this is a minor bug with #12420 
