### PR TITLE
Bugfix FXIOS-5501 [v110] "Send Link to Device" on a page in reader view sends a `http://localhost:6571/reader-mode/` URL to the other device

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -90,7 +90,7 @@ extension BrowserViewController: URLBarDelegate {
                                      value: .awesomebarShareTap,
                                      extras: nil)
 
-        if let selectedtab = tabManager.selectedTab, let tabUrl = selectedtab.url {
+        if let selectedtab = tabManager.selectedTab, let tabUrl = selectedtab.canonicalURL?.displayURL {
             presentShareSheet(tabUrl,
                               tab: selectedtab,
                               sourceView: shareView,

--- a/Client/Frontend/Browser/Tab Management/Tab.swift
+++ b/Client/Frontend/Browser/Tab Management/Tab.swift
@@ -983,22 +983,3 @@ class TabWebViewMenuHelper: UIView {
         }
     }
 }
-
-extension URL {
-    /**
-     Returns a URL without a mobile prefix (`"m."` or `"mobile."`)
-     */
-    func withoutMobilePrefix() -> URL {
-        let subDomainsToRemove: Set<String> = ["m", "mobile"]
-
-        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: true) else { return self }
-        guard let parts = components.host?.split(separator: ".").filter({ !subDomainsToRemove.contains(String($0)) }) else { return self }
-
-        let host = parts.joined(separator: ".")
-
-        guard host != publicSuffix else { return self }
-        components.host = host
-
-        return components.url ?? self
-    }
-}

--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -227,6 +227,23 @@ extension URL {
         return nil
     }
 
+    /**
+     Returns a URL without a mobile prefix (`"m."` or `"mobile."`)
+     */
+    public func withoutMobilePrefix() -> URL {
+        let subDomainsToRemove: Set<String> = ["m", "mobile"]
+
+        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: true) else { return self }
+        guard let parts = components.host?.split(separator: ".").filter({ !subDomainsToRemove.contains(String($0)) }) else { return self }
+
+        let host = parts.joined(separator: ".")
+
+        guard host != publicSuffix else { return self }
+        components.host = host
+
+        return components.url ?? self
+    }
+
     public func isWebPage(includeDataURIs: Bool = true) -> Bool {
         let schemes = includeDataURIs ? ["http", "https", "data"] : ["http", "https"]
         return scheme.map { schemes.contains($0) } ?? false

--- a/Tests/ClientTests/TabTests.swift
+++ b/Tests/ClientTests/TabTests.swift
@@ -27,4 +27,15 @@ class TabTests: XCTestCase {
         newUrl = url.withoutMobilePrefix()
         XCTAssertEqual(newUrl.host, "mobile.co.uk")
     }
+
+    func testShareURL_RemovingReaderModeComponents() {
+        let url = URL(string: "http://localhost:123/reader-mode/page?url=https://mozilla.org")!
+
+        guard let newUrl = url.displayURL else {
+            XCTFail("expected valid url without reader mode components")
+            return
+        }
+
+        XCTAssertEqual(newUrl.host, "mozilla.org")
+    }
 }


### PR DESCRIPTION
### [FXIOS-5501](https://mozilla-hub.atlassian.net/browse/FXIOS-5501)
#12807 

Use displayURL as shareURL which removes readerMode components
