### PR TITLE
Refactor EXP-3033 [v111] Simplify Nimbus startup using NimbusBuilder

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -15625,7 +15625,7 @@
 			repositoryURL = "https://github.com/mozilla/rust-components-swift.git";
 			requirement = {
 				kind = exactVersion;
-				version = 96.2.1;
+				version = 96.3.0;
 			};
 		};
 		435C85EE2788F4D00072B526 /* XCRemoteSwiftPackageReference "glean-swift" */ = {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla/rust-components-swift.git",
       "state" : {
-        "revision" : "2ff7705e4956c3b06311a0d265e9e1d87b02a65c",
-        "version" : "96.2.1"
+        "revision" : "34abd7056e973a2edf04a79a8d1bb759243b50f3",
+        "version" : "96.3.0"
       }
     },
     {

--- a/Client/Application/AppLaunchUtil.swift
+++ b/Client/Application/AppLaunchUtil.swift
@@ -115,45 +115,7 @@ class AppLaunchUtil {
     }
 
     private func initializeExperiments() {
-        // We initialize the generated FxNimbus singleton very early on with a lazily
-        // constructed singleton.
-        FxNimbus.shared.initialize(with: { Experiments.shared })
-        // We also make sure that any cache invalidation happens after each applyPendingExperiments().
-        NotificationCenter.default.addObserver(forName: .nimbusExperimentsApplied, object: nil, queue: nil) { _ in
-            FxNimbus.shared.invalidateCachedValues()
-        }
-
-        let defaults = UserDefaults.standard
-        let nimbusFirstRun = "NimbusFirstRun"
-        let isFirstRun = defaults.object(forKey: nimbusFirstRun) == nil
-        defaults.set(false, forKey: nimbusFirstRun)
-        Experiments.customTargetingAttributes =  ["isFirstRun": "\(isFirstRun)"]
-        let initialExperiments = Bundle.main.url(forResource: "initial_experiments", withExtension: "json")
-        let serverURL = Experiments.remoteSettingsURL
-        let savedOptions = Experiments.getLocalExperimentData()
-        let options: Experiments.InitializationOptions
-        switch (savedOptions, isFirstRun, initialExperiments, serverURL) {
-        // QA testing case: experiments come from the Experiments setting screen.
-        case (let payload, _, _, _) where payload != nil:
-            log.info("Nimbus: Loading from experiments provided by settings screen")
-            options = Experiments.InitializationOptions.testing(localPayload: payload!)
-        // First startup case:
-        case (nil, true, let file, _) where file != nil:
-            log.info("Nimbus: Loading from experiments from bundle, at first startup")
-            options = Experiments.InitializationOptions.preload(fileUrl: file!)
-        // Local development case: load from the bundled initial_experiments.json
-        case (_, _, let file, let url) where file != nil && url == nil:
-            log.info("Nimbus: Loading from experiments from bundle, with no URL")
-            options = Experiments.InitializationOptions.preload(fileUrl: file!)
-        case (_, _, _, let url) where url != nil:
-            log.info("Nimbus: server exists")
-            options = Experiments.InitializationOptions.normal
-        default:
-            log.info("Nimbus: server does not exist")
-            options = Experiments.InitializationOptions.normal
-        }
-
-        Experiments.intialize(options)
+        Experiments.intialize()
     }
 
     private func updateSessionCount() {

--- a/Client/Experiments/Experiments.swift
+++ b/Client/Experiments/Experiments.swift
@@ -11,6 +11,7 @@ private let nimbusAppName = "firefox_ios"
 private let NIMBUS_URL_KEY = "NimbusURL"
 private let NIMBUS_LOCAL_DATA_KEY = "nimbus_local_data"
 private let NIMBUS_USE_PREVIEW_COLLECTION_KEY = "nimbus_use_preview_collection"
+private let NIMBUS_IS_FIRST_RUN_KEY = "NimbusFirstRun"
 
 /// `Experiments` is the main entry point to use the `Nimbus` experimentation platform in Firefox for iOS.
 ///
@@ -44,25 +45,6 @@ private let NIMBUS_USE_PREVIEW_COLLECTION_KEY = "nimbus_use_preview_collection"
 ///
 /// Rust errors are not expected, but will be reported via Sentry.
 enum Experiments {
-    /// `InitializationOptions` controls how we initially initialize Nimbus.
-    ///
-    /// - **preload**: includes a file URL that stores the initial experiments document.
-    ///     This will preload Nimbus with experiment data and also fetch new data from the remote server
-    /// - **normal**: initialize Nimbus with no custom configuration.
-    /// - **testing**: initialize Nimbus with custom experiments data.
-    enum InitializationOptions {
-        case preload(fileUrl: URL)
-        case normal
-        case testing(localPayload: String)
-
-        var isTesting: Bool {
-            switch self {
-            case .testing: return true
-            default: return false
-            }
-        }
-    }
-
     private static var studiesSetting: Bool?
     private static var telemetrySetting: Bool?
 
@@ -145,29 +127,18 @@ enum Experiments {
         storage.bool(forKey: NIMBUS_USE_PREVIEW_COLLECTION_KEY)
     }
 
-    static var customTargetingAttributes: [String: String] = [:]
-
-    static var serverSettings: NimbusServerSettings? = {
-        // If no URL is specified, or it's not valid continue with as if
-        // we're enabled. This to allow testing of the app, without standing
-        // up a `RemoteSettings` server.
-        guard let urlString = Experiments.remoteSettingsURL,
-              let url = URL(string: urlString)
-        else { return nil }
-
-        if usePreviewCollection() {
-            return NimbusServerSettings(url: url, collection: "nimbus-preview")
-        } else {
-            return NimbusServerSettings(url: url)
-        }
-    }()
-
     /// The `NimbusApi` object. This is the entry point to do anything with the Nimbus SDK on device.
-    public static var shared: NimbusApi = {
-        guard let dbPath = Experiments.dbPath else {
-            log.error("Nimbus didn't get to create, because of a nil dbPath")
-            return NimbusDisabled.shared
+    public static var shared: NimbusInterface = {
+        let defaults = UserDefaults.standard
+        let isFirstRun: Bool = defaults.object(forKey: NIMBUS_IS_FIRST_RUN_KEY) == nil
+        if isFirstRun {
+            defaults.set(false, forKey: NIMBUS_IS_FIRST_RUN_KEY)
         }
+
+        let customTargetingAttributes: [String: Any] =  [
+            "isFirstRun": "\(isFirstRun)",
+            "is_first_run": isFirstRun,
+        ]
 
         // App settings, to allow experiments to target the app name and the
         // channel. The values given here should match what `Experimenter`
@@ -175,7 +146,7 @@ enum Experiments {
         let appSettings = NimbusAppSettings(
             appName: nimbusAppName,
             channel: AppConstants.BuildChannel.nimbusString,
-            customTargetingAttributes: Experiments.customTargetingAttributes
+            customTargetingAttributes: customTargetingAttributes
         )
 
         let errorReporter: NimbusErrorReporter = { err in
@@ -187,21 +158,28 @@ enum Experiments {
             )
         }
 
-        do {
-            let nimbus = try Nimbus.create(
-                serverSettings,
-                appSettings: appSettings,
-                dbPath: dbPath,
-                resourceBundles: [Strings.bundle, Bundle.main],
-                errorReporter: errorReporter
-            )
-            log.info("Nimbus is now available!")
-            return nimbus
-        } catch {
-            errorReporter(error)
-            log.error("Nimbus errored during create")
+        let initialExperiments = Bundle.main.url(forResource: "initial_experiments", withExtension: "json")
+
+        guard let dbPath = Experiments.dbPath else {
+            log.error("Nimbus didn't get to create, because of a nil dbPath")
             return NimbusDisabled.shared
         }
+
+        let bundles = [Bundle.main, Strings.bundle]
+
+        let builder = NimbusBuilder(dbPath: dbPath)
+        builder.with(url: remoteSettingsURL) // with(url:) returns void.
+
+        builder
+            .using(previewCollection: usePreviewCollection())
+            .with(errorReporter: errorReporter)
+            .with(initialExperiments: initialExperiments)
+            .isFirstRun(isFirstRun)
+            .with(bundles: bundles)
+            .onCreate { nimbus in FxNimbus.shared.initialize { nimbus }}
+            .onApply { _ in FxNimbus.shared.invalidateCachedValues() }
+
+        return builder.build(appInfo: appSettings)
     }()
 
     /// A convenience method to initialize the `NimbusApi` object at startup.
@@ -214,28 +192,15 @@ enum Experiments {
     /// - Parameters:
     ///     - fireURL: an optional file URL that stores the initial experiments document.
     ///     - firstRun: a flag indicating that this is the first time that the app has been run.
-    public static func intialize(_ options: InitializationOptions) {
+    public static func intialize() {
+        // Getting the singleton first time initializes it.
         let nimbus = Experiments.shared
 
-        nimbus.initialize()
+        log.info("Nimbus is ready!")
 
-        switch options {
-        case .preload(let url): nimbus.setExperimentsLocally(url)
-        case .testing(let payload): nimbus.setExperimentsLocally(payload)
-        default: break /* noop */
-        }
-
-        // We should immediately calculate the experiment enrollments
-        // that we've just acquired from the fileURL, or we fetched last run.
-        _ = nimbus.applyPendingExperiments()
-
-        // if we're not testing, we should download the next version of the experiments
-        // document. This happens in the background
-        if !options.isTesting {
-            nimbus.fetchExperiments()
-        }
-
-        log.info("Nimbus is initializing!")
+        // This does its work on another thread, downloading the experiment recipes
+        // for the next run. It should be the last thing we do before returning.
+        nimbus.fetchExperiments()
     }
 }
 


### PR DESCRIPTION
Fixes [EXP-3033](https://mozilla-hub.atlassian.net/browse/EXP-3033), pushing a lot of logic around initialization of Nimbus into a new safer (no racing at startup) builder.

This bundles [an upgrade to Application Services 96.3.0](https://github.com/mozilla/application-services/releases/tag/v96.3.0).