### PR TITLE
Refactor FXIOS-5583 [v110] Use the default favicon image insetead of a # letter image

### DIFF
--- a/BrowserKit/Sources/SiteImageView/Entities/SiteImageError.swift
+++ b/BrowserKit/Sources/SiteImageView/Entities/SiteImageError.swift
@@ -14,6 +14,7 @@ enum SiteImageError: Error, CustomStringConvertible {
     case noURLInCache
     case noHeroImage
     case noImageInBundle
+    case noLetterImage
 
     var description: String {
         switch self {
@@ -35,6 +36,8 @@ enum SiteImageError: Error, CustomStringConvertible {
             return "No hero image was found"
         case .noImageInBundle:
             return "No image in bundle was found"
+        case .noLetterImage:
+            return "The first character is nil or empty so no letter image"
         }
     }
 }

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/ImageHandler.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/ImageHandler.swift
@@ -105,8 +105,12 @@ class DefaultImageHandler: ImageHandler {
     }
 
     private func fallbackToLetterFavicon(site: SiteImageModel) async -> UIImage {
-        let image = await letterImageGenerator.generateLetterImage(siteString: site.cacheKey)
-        await imageCache.cacheImage(image: image, cacheKey: site.cacheKey, type: site.expectedImageType)
-        return image
+        do {
+            let image = try await letterImageGenerator.generateLetterImage(siteString: site.cacheKey)
+            await imageCache.cacheImage(image: image, cacheKey: site.cacheKey, type: site.expectedImageType)
+            return image
+        } catch {
+            return UIImage(named: "defaultFavicon")?.withRenderingMode(.alwaysTemplate) ?? UIImage()
+        }
     }
 }

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/LetterImageGenerator.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/LetterImageGenerator.swift
@@ -10,14 +10,14 @@ protocol LetterImageGenerator {
     /// Runs main thread due to UILabel.initWithFrame(:)
     /// - Parameter domain: The string domain name
     /// - Returns: The generated letter image
-    @MainActor func generateLetterImage(siteString: String) async -> UIImage
+    @MainActor func generateLetterImage(siteString: String) async throws -> UIImage
 }
 
 class DefaultLetterImageGenerator: LetterImageGenerator {
-    private let defaultLetter: Character = "#"
-
-    @MainActor func generateLetterImage(siteString: String) async -> UIImage {
-        let letter: Character = siteString.first ?? defaultLetter
+    @MainActor func generateLetterImage(siteString: String) async throws -> UIImage {
+        guard let letter: Character = siteString.first else {
+            throw SiteImageError.noLetterImage
+        }
         let capitalizedLetter = letter.uppercased()
 
         let color = generateBackgroundColor(forSite: siteString)

--- a/BrowserKit/Sources/SiteImageView/SiteImageFetcher.swift
+++ b/BrowserKit/Sources/SiteImageView/SiteImageFetcher.swift
@@ -70,6 +70,9 @@ public class DefaultSiteImageFetcher: SiteImageFetcher {
     private func generateCacheKey(siteURL: URL,
                                   type: SiteImageType,
                                   usesIndirectDomain: Bool) -> String {
+        guard siteURL.absoluteString.lowercased().contains("internal") else {
+            return ""
+        }
         guard usesIndirectDomain else {
             return siteURL.shortDomain ?? siteURL.shortDisplayString
         }

--- a/BrowserKit/Sources/SiteImageView/SiteImageFetcher.swift
+++ b/BrowserKit/Sources/SiteImageView/SiteImageFetcher.swift
@@ -70,9 +70,6 @@ public class DefaultSiteImageFetcher: SiteImageFetcher {
     private func generateCacheKey(siteURL: URL,
                                   type: SiteImageType,
                                   usesIndirectDomain: Bool) -> String {
-        guard siteURL.absoluteString.lowercased().contains("internal") else {
-            return ""
-        }
         guard usesIndirectDomain else {
             return siteURL.shortDomain ?? siteURL.shortDisplayString
         }

--- a/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/LetterImageGeneratorTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/LetterImageGeneratorTests.swift
@@ -6,44 +6,59 @@ import XCTest
 @testable import SiteImageView
 
 final class LetterImageGeneratorTests: XCTestCase {
-    func testEmptyDomain_doesntReturnEmptyImage() async {
+    func testEmptyDomain_throws() async {
         let subject = DefaultLetterImageGeneratorSpy()
         let siteString = ""
-        let result = await subject.generateLetterImage(siteString: siteString)
 
-        XCTAssertEqual(subject.capturedLetter, "#")
-        XCTAssertNotEqual(result, UIImage())
-        testColor(subject: subject, red: 0.850, green: 0.133, blue: 0.082, alpha: 1.0)
+        do {
+            _ = try await subject.generateLetterImage(siteString: siteString)
+        } catch {
+            XCTAssertEqual(error.localizedDescription, SiteImageError.noLetterImage.localizedDescription)
+        }
     }
 
     func testDomain1_returnsExpectedLetterAndColor() async {
         let subject = DefaultLetterImageGeneratorSpy()
         let siteString = "mozilla.com"
-        let result = await subject.generateLetterImage(siteString: siteString)
 
-        XCTAssertEqual(subject.capturedLetter, "M")
-        XCTAssertNotEqual(result, UIImage())
-        testColor(subject: subject, red: 0.223, green: 0.576, blue: 0.125, alpha: 1.0)
+        do {
+            let result = try await subject.generateLetterImage(siteString: siteString)
+
+            XCTAssertEqual(subject.capturedLetter, "M")
+            XCTAssertNotEqual(result, UIImage())
+            testColor(subject: subject, red: 0.223, green: 0.576, blue: 0.125, alpha: 1.0)
+        } catch {
+            XCTFail("Failed to generate a letter image")
+        }
     }
 
     func testDomain2_returnsExpectedLetterAndColor() async {
         let subject = DefaultLetterImageGeneratorSpy()
         let siteString = "firefox.com"
-        let result = await subject.generateLetterImage(siteString: siteString)
 
-        XCTAssertEqual(subject.capturedLetter, "F")
-        XCTAssertNotEqual(result, UIImage())
-        testColor(subject: subject, red: 0.584, green: 0.803, blue: 1.0, alpha: 1.0)
+        do {
+            let result = try await subject.generateLetterImage(siteString: siteString)
+
+            XCTAssertEqual(subject.capturedLetter, "F")
+            XCTAssertNotEqual(result, UIImage())
+            testColor(subject: subject, red: 0.584, green: 0.803, blue: 1.0, alpha: 1.0)
+        } catch {
+            XCTFail("Failed to generate a letter image")
+        }
     }
 
     func testFakeDomain_returnsExpectedLetterAndColor() async {
         let subject = DefaultLetterImageGeneratorSpy()
         let siteString = "?$%^"
-        let result = await subject.generateLetterImage(siteString: siteString)
+        do {
+            let result = try await subject.generateLetterImage(siteString: siteString)
 
-        XCTAssertEqual(subject.capturedLetter, "?")
-        XCTAssertNotEqual(result, UIImage())
-        testColor(subject: subject, red: 0.003, green: 0.639, blue: 0.615, alpha: 1.0)
+            XCTAssertEqual(subject.capturedLetter, "?")
+            XCTAssertNotEqual(result, UIImage())
+            testColor(subject: subject, red: 0.003, green: 0.639, blue: 0.615, alpha: 1.0)
+        } catch {
+            XCTFail("Failed to generate a letter image")
+        }
     }
 }
 

--- a/Client/Frontend/Browser/TabCell.swift
+++ b/Client/Frontend/Browser/TabCell.swift
@@ -208,6 +208,7 @@ class TabCell: UICollectionViewCell,
         titleText.textColor = theme.colors.textPrimary
         screenshotView.backgroundColor = theme.colors.layer1
         favicon.tintColor = theme.colors.textPrimary
+        smallFaviconView.tintColor = theme.colors.textPrimary
     }
 
     override func prepareForReuse() {

--- a/Storage/Rust/RustAutofill.swift
+++ b/Storage/Rust/RustAutofill.swift
@@ -374,6 +374,7 @@ public class RustAutofill {
         }
     }
 
+    @discardableResult
     public func getStoredKey() throws -> String {
         let rustKeys = RustAutofillEncryptionKeys()
         let key = rustKeys.keychain.string(forKey: rustKeys.ccKeychainKey)


### PR DESCRIPTION
Originally we believed there would pretty much never be a case where we request a favicon with an empty string so we added a # as the default fallback when using a letter image. It turns out there are a couple of places where this was showing up (most visibly in the tab tray briefly when opening a new tab).
This PR uses the default favicon icon (the wireframe globe) instead.