### PR TITLE
Added FXIOS-5470 [v110] Cache favicon url on page load

### DIFF
--- a/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/FaviconURLHandler.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/FaviconURLHandler.swift
@@ -6,6 +6,7 @@ import Foundation
 
 protocol FaviconURLHandler {
     func getFaviconURL(site: SiteImageModel) async throws -> SiteImageModel
+    func cacheFaviconURL(cacheKey: String, faviconURL: URL)
 }
 
 struct DefaultFaviconURLHandler: FaviconURLHandler {
@@ -38,6 +39,12 @@ struct DefaultFaviconURLHandler: FaviconURLHandler {
             } catch {
                 throw SiteImageError.noFaviconURLFound
             }
+        }
+    }
+
+    func cacheFaviconURL(cacheKey: String, faviconURL: URL) {
+        Task {
+            await urlCache.cacheURL(cacheKey: cacheKey, faviconURL: faviconURL)
         }
     }
 }

--- a/BrowserKit/Sources/SiteImageView/SiteImageFetcher.swift
+++ b/BrowserKit/Sources/SiteImageView/SiteImageFetcher.swift
@@ -10,6 +10,7 @@ public protocol SiteImageFetcher {
                   type: SiteImageType,
                   id: UUID,
                   usesIndirectDomain: Bool) async -> SiteImageModel
+    func cacheFaviconURL(siteURL: URL?, faviconURL: URL?)
 }
 
 public class DefaultSiteImageFetcher: SiteImageFetcher {
@@ -63,6 +64,18 @@ public class DefaultSiteImageFetcher: SiteImageFetcher {
         }
 
         return imageModel
+    }
+
+    public func cacheFaviconURL(siteURL: URL?, faviconURL: URL?) {
+        guard let siteURL = siteURL,
+              let faviconURL = faviconURL else {
+            return
+        }
+
+        let cacheKey = generateCacheKey(siteURL: siteURL,
+                                        type: .favicon,
+                                        usesIndirectDomain: false)
+        urlHandler.cacheFaviconURL(cacheKey: cacheKey, faviconURL: faviconURL)
     }
 
     // MARK: - Private

--- a/BrowserKit/Tests/SiteImageViewTests/SiteImageFetcherTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/SiteImageFetcherTests.swift
@@ -145,12 +145,25 @@ final class SiteImageFetcherTests: XCTestCase {
         XCTAssertEqual(imageHandler.capturedSite?.cacheKey, "https://www.focus.com")
         XCTAssertEqual(imageHandler.capturedSite?.siteURL, URL(string: siteURL))
     }
+
+    // Test cache
+    func testCacheFavicon() {
+        let subject = DefaultSiteImageFetcher(urlHandler: urlHandler,
+                                              imageHandler: imageHandler)
+        subject.cacheFaviconURL(siteURL: URL(string: "https://firefox.com"),
+                                faviconURL: URL(string: "https://firefox.com/favicon.ico"))
+
+        XCTAssertEqual(urlHandler.faviconURL?.absoluteString, "https://firefox.com/favicon.ico")
+        XCTAssertEqual(urlHandler.cacheKey, "firefox")
+    }
 }
 
 // MARK: - MockFaviconURLHandler
 private class MockFaviconURLHandler: FaviconURLHandler {
     var faviconURL: URL?
     var capturedImageModel: SiteImageModel?
+    var cacheKey: String?
+    var cacheFaviconURLCalled = 0
 
     func getFaviconURL(site: SiteImageModel) async throws -> SiteImageModel {
         capturedImageModel = site
@@ -161,6 +174,12 @@ private class MockFaviconURLHandler: FaviconURLHandler {
                               cacheKey: site.cacheKey,
                               domain: site.domain,
                               faviconURL: faviconURL)
+    }
+
+    func cacheFaviconURL(cacheKey: String, faviconURL: URL) {
+        self.cacheKey = cacheKey
+        self.faviconURL = faviconURL
+        cacheFaviconURLCalled += 1
     }
 }
 

--- a/BrowserKit/Tests/SiteImageViewTests/SiteImageViewTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/SiteImageViewTests.swift
@@ -57,6 +57,10 @@ class MockSiteImageFetcher: SiteImageFetcher {
     var image = UIImage()
     var capturedType: SiteImageType?
     var capturedStringRequest: String?
+    var siteURL: URL?
+    var faviconURL: URL?
+    var cacheFaviconURLCalled = 0
+
     func getImage(urlStringRequest: String,
                   type: SiteImageType,
                   id: UUID,
@@ -72,5 +76,11 @@ class MockSiteImageFetcher: SiteImageFetcher {
                               faviconURL: nil,
                               faviconImage: image,
                               heroImage: image)
+    }
+
+    func cacheFaviconURL(siteURL: URL?, faviconURL: URL?) {
+        self.siteURL = siteURL
+        self.faviconURL = faviconURL
+        cacheFaviconURLCalled += 1
     }
 }

--- a/Client/Frontend/Browser/Tab Management/Tab.swift
+++ b/Client/Frontend/Browser/Tab Management/Tab.swift
@@ -6,6 +6,7 @@ import Foundation
 import WebKit
 import Storage
 import Shared
+import SiteImageView
 
 private var debugTabCount = 0
 
@@ -239,7 +240,13 @@ class Tab: NSObject {
     var lastExecutedTime: Timestamp?
     var firstCreatedTime: Timestamp?
     var sessionData: SessionData?
-    var faviconURL: String?
+    private let faviconHelper: SiteImageFetcher
+    var faviconURL: String? {
+        didSet {
+            faviconHelper.cacheFaviconURL(siteURL: url,
+                                          faviconURL: URL(string: faviconURL ?? ""))
+        }
+    }
     fileprivate var lastRequest: URLRequest?
     var isRestoring: Bool = false
     var pendingScreenshot = false
@@ -367,12 +374,16 @@ class Tab: NSObject {
 
     var profile: Profile
 
-    init(profile: Profile, configuration: WKWebViewConfiguration, isPrivate: Bool = false) {
+    init(profile: Profile,
+         configuration: WKWebViewConfiguration,
+         isPrivate: Bool = false,
+         faviconHelper: SiteImageFetcher = DefaultSiteImageFetcher.factory()) {
         self.configuration = configuration
         self.nightMode = false
         self.noImageMode = false
         self.profile = profile
         self.metadataManager = TabMetadataManager(metadataObserver: profile.places)
+        self.faviconHelper = faviconHelper
         super.init()
         self.isPrivate = isPrivate
         debugTabCount += 1


### PR DESCRIPTION
[FXIOS-5470](https://mozilla-hub.atlassian.net/browse/FXIOS-5470)
#12751 

This will stop an extra redundant call being made to the site to grab the favicon if we have recently visited the site directly.