### PR TITLE
refactor FXIOS-5587: update nimbus experiments update workflow

### DIFF
--- a/.github/workflows/update-nimbus-experiments.yml
+++ b/.github/workflows/update-nimbus-experiments.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Main Branch"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: firefox-ios
           ref: main
           fetch-depth: 0
       - name: "Update Experiments JSON"
         id: update-experiments-json
-        uses: mozilla-mobile/update-experiments@v2
+        uses: mozilla-mobile/update-experiments@v3
         with:
           repo-path: firefox-ios
           output-path: Client/Experiments/initial_experiments.json
@@ -27,7 +27,7 @@ jobs:
           branch: automation/update-nimbus-experiments
       - name: Create Pull Request
         id: create-pull-request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         if: steps.update-experiments-json.outputs.changed == 1 && steps.update-experiments-json.outputs.changed-branch == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR updates the versions of various Github actions. They need to be updated as a result of changes being made to the Github action workflow described here: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/