### PR TITLE
Refactor MTE-441 [v110] Performance tests reporting issue

### DIFF
--- a/Tests/PerformanceTestPlan.xctestplan
+++ b/Tests/PerformanceTestPlan.xctestplan
@@ -42,6 +42,7 @@
         "IntegrationTests",
         "IpadOnlyTestCase",
         "IphoneOnlyTestCase",
+        "JumpBackInTests",
         "LibraryTestsIpad",
         "MailAppSettingsTests",
         "NavigationTest",


### PR DESCRIPTION
The performance tests are running but the data is not being reported. The problem might be related with a test suite that was added to its test plan which should not be there. 