### PR TITLE
Bugfix FXIOS-5553 [v110] Keyboard raises and lowers when homepage is restored after 4hrs

### DIFF
--- a/Client/Frontend/Browser/Tab Management/TabManager.swift
+++ b/Client/Frontend/Browser/Tab Management/TabManager.swift
@@ -38,7 +38,6 @@ protocol TabManagerProtocol {
     var recentlyAccessedNormalTabs: [Tab] { get }
     var tabs: [Tab] { get }
     var selectedTab: Tab? { get }
-    var isStartingAtHome: Bool { get set }
 
     func selectTab(_ tab: Tab?, previous: Tab?)
     func addTab(_ request: URLRequest?, afterTab: Tab?, isPrivate: Bool) -> Tab
@@ -60,7 +59,6 @@ class TabManager: NSObject, FeatureFlaggable, TabManagerProtocol {
     var didAddNewTab: Bool = true
     var tabDisplayType: TabDisplayType = .TabGrid
     let delaySelectingNewPopupTab: TimeInterval = 0.1
-    var isStartingAtHome = false
 
     // Enables undo of recently closed tabs
     var recentlyClosedForUndo = [SavedTab]()
@@ -848,7 +846,6 @@ class TabManager: NSObject, FeatureFlaggable, TabManagerProtocol {
         guard !startAtHomeManager.shouldSkipStartHome else { return }
 
         if startAtHomeManager.shouldStartAtHome() {
-            isStartingAtHome = true
             let wasLastSessionPrivate = selectedTab?.isPrivate ?? false
             let scannableTabs = wasLastSessionPrivate ? privateTabs : normalTabs
             let existingHomeTab = startAtHomeManager.scanForExistingHomeTab(in: scannableTabs,

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -169,10 +169,9 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
         super.viewDidLayoutSubviews()
 
         // make sure the keyboard is dismissed when wallpaper onboarding is shown
-        // or is StartAtHome case
         // Can be removed once underlying problem is solved (FXIOS-4904)
         if let presentedViewController = presentedViewController,
-           presentedViewController.isKind(of: BottomSheetViewController.self) || tabManager.isStartingAtHome {
+           presentedViewController.isKind(of: BottomSheetViewController.self) {
             self.dismissKeyboard()
         }
     }
@@ -264,10 +263,6 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
     func homepageDidAppear() {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) { [weak self] in
             self?.displayWallpaperSelector()
-            if self?.tabManager.isStartingAtHome ?? false {
-                self?.dismissKeyboard()
-                self?.tabManager.isStartingAtHome = false
-            }
         }
     }
 

--- a/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -9,7 +9,6 @@ import WebKit
 
 class MockTabManager: TabManagerProtocol {
     var selectedTab: Tab?
-    var isStartingAtHome = false
 
     var nextRecentlyAccessedNormalTabs = [Tab]()
 


### PR DESCRIPTION
[FXIOS-5553](https://mozilla-hub.atlassian.net/browse/FXIOS-5553)
#12884

Revert dismiss of keyboard for startAtHome feature