### PR TITLE
Bugfix MTE-346 [v111] Update SaveLoginTest/testSaveLogin test

### DIFF
--- a/Tests/XCUITests/SaveLoginsTests.swift
+++ b/Tests/XCUITests/SaveLoginsTests.swift
@@ -91,11 +91,8 @@ class SaveLoginTest: BaseTestCase {
         XCTAssertTrue(app.staticTexts[domain].exists)
         // XCTAssertTrue(app.staticTexts[domainSecondLogin].exists)
         // Change to 3 entries for iPhone since the hostname is not saved and only one entry appears
-        if iPad() {
-            XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList + 2)
-        } else {
-            XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList + 1)
-        }
+        print(app.debugDescription)
+        XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList + 2)
     }
 
     func testDoNotSaveLogin() {

--- a/Tests/XCUITests/SaveLoginsTests.swift
+++ b/Tests/XCUITests/SaveLoginsTests.swift
@@ -89,9 +89,7 @@ class SaveLoginTest: BaseTestCase {
         openLoginsSettings()
         waitForExistence(app.tables["Login List"])
         XCTAssertTrue(app.staticTexts[domain].exists)
-        // XCTAssertTrue(app.staticTexts[domainSecondLogin].exists)
-        // Change to 3 entries for iPhone since the hostname is not saved and only one entry appears
-        print(app.debugDescription)
+        XCTAssertTrue(app.staticTexts[domainSecondLogin].exists)
         XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList + 2)
     }
 


### PR DESCRIPTION
Upon upgrading XCode to v14.1 and iOS to 16.1, the `testSaveLogin` test requires an update. The table showing the saved logins are now identical on both iPhone and iPad (see screenshots)

<img width="300" alt="Screenshot 2023-01-17 at 3 40 19 PM" src="https://user-images.githubusercontent.com/1740517/213009024-9a3b90dd-e665-49b2-aace-ce19e4e5689a.png">
<img width="200" alt="Screenshot 2023-01-17 at 3 41 32 PM" src="https://user-images.githubusercontent.com/1740517/213009026-c529ab39-cf41-4525-8284-133a6a536ac3.png">

I have run the changes repeatedly on the command line using the `-test-iterations` option against both `iPhone 14` and `iPad Air (6th generation)` on both my computer and MacStadium. Note that there may be some other potentially intermittent test failures, but I could not reproduce them at this point. 😞 

https://mozilla-hub.atlassian.net/browse/MTE-346