### PR TITLE
Bump [v111] Update Sentry to 8.0.0

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -15651,7 +15651,7 @@
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa.git";
 			requirement = {
 				kind = exactVersion;
-				version = 7.31.3;
+				version = 8.0.0;
 			};
 		};
 		4368F83B279669690013419B /* XCRemoteSwiftPackageReference "SnapKit" */ = {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "c3c19e29f775ee95b77aa3168f3e2fd6c20deba6",
-        "version" : "7.31.3"
+        "revision" : "4f6838af2688f8f762afdaea5bef941121e7d473",
+        "version" : "8.0.0"
       }
     },
     {

--- a/Shared/SentryIntegration.swift
+++ b/Shared/SentryIntegration.swift
@@ -184,7 +184,7 @@ public class SentryIntegration: SentryProtocol {
     public func addBreadcrumb(category: String, message: String) {
         let breadcrumb = Breadcrumb(level: .info, category: category)
         breadcrumb.message = message
-        SentrySDK.addBreadcrumb(crumb: breadcrumb)
+        SentrySDK.addBreadcrumb(breadcrumb)
     }
 
     // MARK: - Private

--- a/Shared/SentryIntegration.swift
+++ b/Shared/SentryIntegration.swift
@@ -84,6 +84,7 @@ public class SentryIntegration: SentryProtocol {
             options.dsn = dsn
             options.environment = environment.rawValue
             options.releaseName = self.releaseName
+            options.enableFileIOTracing = false
             options.beforeSend = { event in
                 let attributes = event.extra ?? [:]
                 self.attributes = attributes.merge(with: self.attributes)


### PR DESCRIPTION
Pretty big set of changes, not entirely sure how much of a drop-in upgrade this'll be compared to most.

Changelog:
https://github.com/getsentry/sentry-cocoa/releases/tag/8.0.0