### PR TITLE
Bugfix MTE-515 [v111] testTabCountShowsOnlyNormalOrPrivateTabCount and testiPadDirectAccessPrivateModeBrowserTab

### DIFF
--- a/Tests/XCUITests/PrivateBrowsingTest.swift
+++ b/Tests/XCUITests/PrivateBrowsingTest.swift
@@ -73,8 +73,8 @@ class PrivateBrowsingTest: BaseTestCase {
         // Go back to regular mode and check the total number of tabs
         navigator.toggleOff(userState.isPrivate, withAction: Action.ToggleRegularMode)
 
-        waitForExistence(app.otherElements["Tabs Tray"].cells.staticTexts[url2Label])
-        waitForNoExistence(app.otherElements["Tabs Tray"].cells.staticTexts[url1And3Label])
+        waitForExistence(app.otherElements["Tabs Tray"].collectionViews.cells.staticTexts[url2Label])
+        waitForNoExistence(app.otherElements["Tabs Tray"].collectionViews.cells.staticTexts[url1And3Label])
         let numRegularTabs = app.otherElements["Tabs Tray"].cells.count
         XCTAssertEqual(numRegularTabs, 2, "The number of regular tabs is not correct")
     }

--- a/Tests/XCUITests/PrivateBrowsingTest.swift
+++ b/Tests/XCUITests/PrivateBrowsingTest.swift
@@ -67,14 +67,14 @@ class PrivateBrowsingTest: BaseTestCase {
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
         navigator.goto(TabTray)
-        waitForExistence(app.cells.staticTexts[url1And3Label])
+        waitForExistence(app.otherElements["Tabs Tray"].cells.staticTexts[url1And3Label])
         let numPrivTabs = app.otherElements["Tabs Tray"].cells.count
         XCTAssertEqual(numPrivTabs, 1, "The number of private tabs is not correct")
         // Go back to regular mode and check the total number of tabs
         navigator.toggleOff(userState.isPrivate, withAction: Action.ToggleRegularMode)
 
-        waitForExistence(app.cells.staticTexts[url2Label])
-        waitForNoExistence(app.cells.staticTexts[url1And3Label])
+        waitForExistence(app.otherElements["Tabs Tray"].cells.staticTexts[url2Label])
+        waitForNoExistence(app.otherElements["Tabs Tray"].cells.staticTexts[url1And3Label])
         let numRegularTabs = app.otherElements["Tabs Tray"].cells.count
         XCTAssertEqual(numRegularTabs, 2, "The number of regular tabs is not correct")
     }
@@ -273,7 +273,7 @@ class PrivateBrowsingTestIpad: IpadOnlyTestCase {
         navigator.goto(LibraryPanel_History)
         waitForExistence(app.tables[HistoryPanelA11y.tableView])
         // History without counting Clear Recent History, Recently Closed
-        let history = app.tables[HistoryPanelA11y.tableView].cells.count - 2
+        let history = app.tables[HistoryPanelA11y.tableView].cells.count - 1
         XCTAssertEqual(history, 1, "There should be one entry in History")
         let savedToHistory = app.tables[HistoryPanelA11y.tableView].cells.staticTexts[url2Label]
         waitForExistence(savedToHistory)


### PR DESCRIPTION
The underlying tree structures that these tests encountered have been updated.

For `testTabCountShowsOnlyNormalOrPrivateTabCount`, the private tabs are still in the tree structure (as shown in `print(app.debugDescription)`) but are covered by the regular mode. We can then be specific if the tabs appears under regular mode.

For `testiPadDirectAccessPrivateModeBrowserTab`, there's no more "Recent History" from the History page. "Recently Closed" is still on the page, so we can just not counting one cell from `HistoryPanelA11y.tableView` to get the correct number of websites displayed.

https://mozilla-hub.atlassian.net/browse/MTE-515