### PR TITLE
Bugfix MTE-347 [v111] testUpdateTabCounter and testTabDecrement

### DIFF
--- a/Tests/XCUITests/TabCounterTests.swift
+++ b/Tests/XCUITests/TabCounterTests.swift
@@ -71,7 +71,11 @@ class TabCounterTests: BaseTestCase {
         XCTAssertEqual("1", tabsOpen as? String)
 
         navigator.goto(TabTray)
-        waitForExistence(app.navigationBars["Open Tabs"])
+        if isTablet {
+            waitForExistence(app.navigationBars["Client.TabTrayView"])
+        } else {
+            waitForExistence(app.navigationBars["Open Tabs"])
+        }
         tabsOpen = app.segmentedControls.buttons.element(boundBy: 0).label
         XCTAssertTrue(app.segmentedControls.buttons.element(boundBy: 0).isSelected)
         if !isTablet {

--- a/Tests/XCUITests/TopTabsTest.swift
+++ b/Tests/XCUITests/TopTabsTest.swift
@@ -472,11 +472,15 @@ class TopTabsTestIpad: IpadOnlyTestCase {
         XCTAssertEqual("3", numTab)
         // Remove one tab by tapping on 'x' button
         app.collectionViews["Top Tabs View"].children(matching: .cell).matching(identifier: "Homepage").element(boundBy: 1).buttons["Remove page — Homepage"].tap()
-        waitForExistence(app.buttons["Show Tabs"])
+        waitForTabsButton()
+        waitForNoExistence(app.buttons["Show Tabs"].staticTexts["3"])
+        waitForExistence(app.buttons["Show Tabs"].staticTexts["2"])
         let numTabAfterRemovingThirdTab = app.buttons["Show Tabs"].value as? String
         XCTAssertEqual("2", numTabAfterRemovingThirdTab)
         app.collectionViews["Top Tabs View"].children(matching: .cell).element(boundBy: 1).buttons["Remove page — Homepage"].tap()
-        waitForExistence(app.buttons["Show Tabs"])
+        waitForTabsButton()
+        waitForNoExistence(app.buttons["Show Tabs"].staticTexts["2"])
+        waitForExistence(app.buttons["Show Tabs"].staticTexts["1"])
         let numTabAfterRemovingSecondTab = app.buttons["Show Tabs"].value as? String
         XCTAssertEqual("1", numTabAfterRemovingSecondTab)
     }


### PR DESCRIPTION
`testTabDecrement` requires an update in the UI. On iPad, the navigation bar has the label `Client.TabTrayView` instead of `Open Tabs`.

`testUpdateTabCounter` needs to be harden. The number under `app.buttons["Show Tabs"]` may not be updated quickly. In this change, I try to ensure that the previous count does not appear before querying the updated count.

I have tested the changes repeatedly (`-test-iterations 50`) on iPad Pro simulators.

https://storage.googleapis.com/mobile-reports/public/firefox-ios-M1/FullFunctionalTests-iPad/result_61/build/reports/tests.html

https://mozilla-hub.atlassian.net/browse/MTE-347