### PR TITLE
Bugfix FXIOS-5444 [v111] Layout breaks in tabs tray after changing device orientation

### DIFF
--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -10,7 +10,6 @@ import Common
 struct GridTabTrayControllerUX {
     static let CornerRadius = CGFloat(6.0)
     static let TextBoxHeight = CGFloat(32.0)
-    static let NavigationToolbarHeight = CGFloat(44)
     static let FaviconSize = CGFloat(20)
     static let Margin = CGFloat(15)
     static let ToolbarButtonOffset = CGFloat(10.0)

--- a/Client/Frontend/Browser/Tabs/EmptyPrivateTabsView.swift
+++ b/Client/Frontend/Browser/Tabs/EmptyPrivateTabsView.swift
@@ -13,7 +13,7 @@ class EmptyPrivateTabsView: UIView {
         static let descriptionSizeFont: CGFloat = 17
         static let buttonSizeFont: CGFloat = 15
         static let paddingInBetweenItems: CGFloat = 15
-        static let verticalPadding: CGFloat = 100
+        static let verticalPadding: CGFloat = 20
         static let horizontalPadding: CGFloat = 24
         static let imageSize: CGSize = CGSize(width: 90, height: 90)
     }

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsErrorCell.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsErrorCell.swift
@@ -7,7 +7,7 @@ import Shared
 
 class RemoteTabsErrorCell: UITableViewCell, ReusableCell, ThemeApplicable {
     struct UX {
-        static let verticalPadding: CGFloat = 60
+        static let verticalPadding: CGFloat = 40
         static let horizontalPadding: CGFloat = 24
         static let paddingInBetweenItems: CGFloat = 15
         static let buttonCornerRadius: CGFloat = 13

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanel.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanel.swift
@@ -151,6 +151,10 @@ class RemoteTabsTableViewController: UITableViewController, Themeable {
         tableView.rowHeight = UX.rowHeight
         tableView.separatorInset = .zero
 
+        if #available(iOS 15.0, *) {
+            tableView.sectionHeaderTopPadding = 0.0
+        }
+
         tableView.delegate = nil
         tableView.dataSource = nil
 

--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -39,6 +39,7 @@ class TabTrayViewController: UIViewController, Themeable {
 
     // MARK: - UI Elements
     private var titleWidthConstraint: NSLayoutConstraint?
+    private var containerView: UIView = .build { view in }
 
     // Buttons & Menus
     private lazy var deleteButtonIpad: UIBarButtonItem = {
@@ -241,13 +242,17 @@ class TabTrayViewController: UIViewController, Themeable {
         view.addSubview(navigationToolbar)
         navigationToolbar.setItems([UIBarButtonItem(customView: segmentedControlIphone)], animated: false)
 
+        view.addSubviews(containerView)
+
         NSLayoutConstraint.activate([
             navigationToolbar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             navigationToolbar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             navigationToolbar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
 
-            segmentedControlIphone.widthAnchor.constraint(lessThanOrEqualToConstant: UX.NavigationMenu.width),
-            segmentedControlIphone.heightAnchor.constraint(equalToConstant: UX.NavigationMenu.height)
+            containerView.topAnchor.constraint(equalTo: navigationToolbar.bottomAnchor),
+            containerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            containerView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            containerView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
 
         showPanel(viewModel.tabTrayView)
@@ -316,17 +321,16 @@ class TabTrayViewController: UIViewController, Themeable {
     private func showPanel(_ panel: UIViewController) {
         addChild(panel)
         panel.beginAppearanceTransition(true, animated: true)
-        view.addSubview(panel.view)
-        view.bringSubviewToFront(navigationToolbar)
-        let topEdgeInset = viewModel.layout == .regular ? 0 : GridTabTrayControllerUX.NavigationToolbarHeight
-        panel.additionalSafeAreaInsets = UIEdgeInsets(top: topEdgeInset, left: 0, bottom: 0, right: 0)
+        containerView.addSubview(panel.view)
+        containerView.bringSubviewToFront(navigationToolbar)
         panel.endAppearanceTransition()
+        panel.view.translatesAutoresizingMaskIntoConstraints = false
 
         NSLayoutConstraint.activate([
-            panel.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            panel.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            panel.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            panel.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            panel.view.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+            panel.view.topAnchor.constraint(equalTo: containerView.topAnchor),
+            panel.view.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+            panel.view.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
         ])
 
         panel.didMove(toParent: self)
@@ -443,11 +447,6 @@ class TabTrayViewController: UIViewController, Themeable {
 
         segmentedControlIpad.isHidden = !shouldUseiPadSetup
         navigationToolbar.isHidden = shouldUseiPadSetup
-
-        if let panel = children.first {
-            let topEdgeInset = shouldUseiPadSetup ? 0 : GridTabTrayControllerUX.NavigationToolbarHeight
-            panel.additionalSafeAreaInsets = UIEdgeInsets(top: topEdgeInset, left: 0, bottom: 0, right: 0)
-        }
 
         updateToolbarItems(forSyncTabs: viewModel.profile.hasSyncableAccount())
         updateTitle()


### PR DESCRIPTION
[FXIOS-5444](https://mozilla-hub.atlassian.net/browse/FXIOS-5444)
#12699 

Add container view for child view controller panel fixing constraint issues on rotation, now the panels are correctly added below the segmented view instead to the parent view which caused that tabs collectionView and remote tabs tableView where behind the segmented controller and bottom toolbar