### PR TITLE
Bugfix FXIOS-5140 [v111] Filter remote devices that do not support send tab

### DIFF
--- a/Client/Frontend/Extensions/DevicePickerViewController.swift
+++ b/Client/Frontend/Extensions/DevicePickerViewController.swift
@@ -130,7 +130,9 @@ class DevicePickerViewController: UITableViewController {
                 return
             }
 
-            self.devices = state.remoteDevices.map { device in
+            self.devices = state.remoteDevices.compactMap { device in
+                guard device.capabilities.contains(.sendTab) else { return nil }
+
                 let typeString = "\(device.deviceType)"
                 let lastAccessTime = device.lastAccessTime == nil ? nil : UInt64(clamping: device.lastAccessTime!)
                 return RemoteDevice(id: device.id,


### PR DESCRIPTION
For issue #12650.

The `profile.remoteClientsAndTabs` filtering may cause an issue with push notifications as that array is used to process the device disconnected notifications, but without it the 'send to' option will still appear in the tab peek menu when there is no capable devices.