### PR TITLE
Bugfix FXIOS-5612 [v111] Text Indicator wasn't aligned with the placeholder text on "Add custom engine" screen

### DIFF
--- a/Client/Frontend/Settings/CustomSearchViewController.swift
+++ b/Client/Frontend/Settings/CustomSearchViewController.swift
@@ -198,7 +198,7 @@ class CustomSearchViewController: SettingsTableViewController {
 
 class CustomSearchEngineTextView: Setting, UITextViewDelegate {
     fileprivate let Padding: CGFloat = 8
-    fileprivate let TextLabelHeight: CGFloat = 44
+    fileprivate let TextLabelHeight: CGFloat = 36
     fileprivate var TextLabelWidth: CGFloat {
         let width = textField.frame.width == 0 ? 360 : textField.frame.width
         return width
@@ -261,6 +261,7 @@ class CustomSearchEngineTextView: Setting, UITextViewDelegate {
 
         textField.snp.makeConstraints { make in
             make.height.equalTo(TextFieldHeight)
+            make.top.bottom.equalTo(0).inset(Padding / 2)
             make.left.right.equalTo(cell.contentView).inset(Padding)
         }
     }


### PR DESCRIPTION
Bugfix - issue: #12970 

It had a difference of 4px but if I just added the padding top on textField it would change the placeholder alignment and the problem would still happen. So I needed to set -4 on the TextLabelHeight (don't worry, this variable is just to set the placeholder (that is a UILabel) height) and add the top inset to 4.
I did a few tests with really long strings and noticed that didn't had any padding and it would stay close to the bottom line of the textField so I added the bottom with the same top inset rule to improve that experience.

<img src="https://user-images.githubusercontent.com/69827434/213884073-c1dc6c5d-4cba-43a4-b793-620e22362dfd.png" width="190" height="400"> <img src="https://user-images.githubusercontent.com/69827434/213884166-d1e60c15-7818-4a78-b6b6-25285934dbb6.png" width="190" height="400"> <img src="https://user-images.githubusercontent.com/69827434/213884217-03514cdc-508a-456c-99b0-9bbb694fc8b4.png" width="190" height="400">

