### PR TITLE
Refactor FXIOS-5605 [v111] Remove Deferred from UIPasteboard+Extension

### DIFF
--- a/Client/Extensions/UIPasteboard+Extension.swift
+++ b/Client/Extensions/UIPasteboard+Extension.swift
@@ -32,29 +32,16 @@ extension UIPasteboard {
     /// Preferred method to get strings out of the clipboard.
     /// When iCloud pasteboards are enabled, the usually fast, synchronous calls
     /// become slow and synchronous causing very slow start up times.
-    func asyncString() -> Deferred<Maybe<String?>> {
-        return fetchAsync {
-            return UIPasteboard.general.string
+    func asyncString(completionHandler: @escaping (String?) -> Void) {
+        DispatchQueue.global().async {
+            completionHandler(UIPasteboard.general.string)
         }
     }
 
     /// Preferred method to get URLs out of the clipboard.
-    /// We use Deferred<Maybe<T?>> to fit in to the rest of the Deferred<Maybe> tools
-    /// we already use; but use optionals instead of errorTypes, because not having a URL
-    /// on the clipboard isn't an error.
-    func asyncURL() -> Deferred<Maybe<URL?>> {
-        return fetchAsync {
-            return self.syncURL
-        }
-    }
-
-    // Converts the potentially long running synchronous operation into an asynchronous one.
-    private func fetchAsync<T>(getter: @escaping () -> T) -> Deferred<Maybe<T>> {
-        let deferred = Deferred<Maybe<T>>()
+    func asyncURL(completionHandler: @escaping (URL?) -> Void) {
         DispatchQueue.global().async {
-            let value = getter()
-            deferred.fill(Maybe(success: value))
+            completionHandler(self.syncURL)
         }
-        return deferred
     }
 }

--- a/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
+++ b/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
@@ -39,16 +39,17 @@ class ClipboardBarDisplayHandler: NSObject, URLChangeDelegate {
         // UIPasteboardChanged gets triggered when calling UIPasteboard.general.
         NotificationCenter.default.removeObserver(self, name: UIPasteboard.changedNotification, object: nil)
 
-        UIPasteboard.general.asyncURL().uponQueue(.main) { res in
-            defer {
-                NotificationCenter.default.addObserver(self, selector: #selector(self.UIPasteboardChanged), name: UIPasteboard.changedNotification, object: nil)
-            }
+        UIPasteboard.general.asyncURL { url in
+            ensureMainThread {
+                defer {
+                    NotificationCenter.default.addObserver(self, selector: #selector(self.UIPasteboardChanged), name: UIPasteboard.changedNotification, object: nil)
+                }
 
-            guard let copiedURL: URL? = res.successValue,
-                let url = copiedURL else {
+                guard let url = url else {
                     return
+                }
+                self.lastDisplayedURL = url.absoluteString
             }
-            self.lastDisplayedURL = url.absoluteString
         }
     }
 

--- a/Extensions/Today/TodayViewModel.swift
+++ b/Extensions/Today/TodayViewModel.swift
@@ -18,13 +18,15 @@ class TodayWidgetViewModel {
 
     func updateCopiedLink() {
         if UIPasteboard.general.hasURLs {
-            UIPasteboard.general.asyncURL().uponQueue(.main) { res in
-                guard let url: URL? = res.successValue else {
-                    TodayModel.copiedURL = nil
-                    return
+            UIPasteboard.general.asyncURL { url in
+                DispatchQueue.main.async {
+                    guard let url: URL = url else {
+                        TodayModel.copiedURL = nil
+                        return
+                    }
+                    TodayModel.copiedURL = url
+                    self.AppearanceDelegate?.openContainingApp("?url=\(TodayModel.copiedURL?.absoluteString.escape() ?? "")", query: "open-url")
                 }
-                TodayModel.copiedURL = url
-                self.AppearanceDelegate?.openContainingApp("?url=\(TodayModel.copiedURL?.absoluteString.escape() ?? "")", query: "open-url")
             }
         } else {
             guard let searchText = UIPasteboard.general.string else {


### PR DESCRIPTION
#12963 

Could not get the clipboard bar to display with an iCloud pasteboard URL (although that seems to be the case for me on beta and release as well). It still displayed with a locally copied URL, and the Today extension worked as expected with both a local and iCloud URL.