### PR TITLE
Bugfix MTE-432 [v111] Harden ClipBoardTests

### DIFF
--- a/Tests/XCUITests/ClipBoardTests.swift
+++ b/Tests/XCUITests/ClipBoardTests.swift
@@ -84,6 +84,7 @@ class ClipBoardTests: BaseTestCase {
         waitForNoExistence(app.staticTexts["XCUITests-Runner pasted from Fennec"])
         app.textFields["url"].press(forDuration: 3)
         waitForExistence(app.tables["Context Menu"])
+        waitForExistence(app.tables["Context Menu"].otherElements[ImageIdentifiers.pasteAndGo])
         app.tables["Context Menu"].otherElements[ImageIdentifiers.pasteAndGo].tap()
         waitForExistence(app.textFields["url"])
         waitForValueContains(app.textFields["url"], value: "www.example.com")

--- a/Tests/XCUITests/ClipBoardTests.swift
+++ b/Tests/XCUITests/ClipBoardTests.swift
@@ -84,7 +84,12 @@ class ClipBoardTests: BaseTestCase {
         waitForNoExistence(app.staticTexts["XCUITests-Runner pasted from Fennec"])
         app.textFields["url"].press(forDuration: 3)
         waitForExistence(app.tables["Context Menu"])
-        app.otherElements[ImageIdentifiers.pasteAndGo].tap()
+        /*
+        waitForExistence(app.tables["Context Menu"].otherElements["menu-PasteAndGo"])
+        waitForExistence(app.tables["Context Menu"].otherElements["menu-Paste"])
+        waitForExistence(app.tables["Context Menu"].otherElements["menu-Copy-Link"])
+         */
+        app.tables["Context Menu"].otherElements[ImageIdentifiers.pasteAndGo].tap()
         waitForExistence(app.textFields["url"])
         waitForValueContains(app.textFields["url"], value: "www.example.com")
     }

--- a/Tests/XCUITests/ClipBoardTests.swift
+++ b/Tests/XCUITests/ClipBoardTests.swift
@@ -84,11 +84,6 @@ class ClipBoardTests: BaseTestCase {
         waitForNoExistence(app.staticTexts["XCUITests-Runner pasted from Fennec"])
         app.textFields["url"].press(forDuration: 3)
         waitForExistence(app.tables["Context Menu"])
-        /*
-        waitForExistence(app.tables["Context Menu"].otherElements["menu-PasteAndGo"])
-        waitForExistence(app.tables["Context Menu"].otherElements["menu-Paste"])
-        waitForExistence(app.tables["Context Menu"].otherElements["menu-Copy-Link"])
-         */
         app.tables["Context Menu"].otherElements[ImageIdentifiers.pasteAndGo].tap()
         waitForExistence(app.textFields["url"])
         waitForValueContains(app.textFields["url"], value: "www.example.com")


### PR DESCRIPTION
The test `ClipBoardTests/testClipboardPasteAndGo` has been failing intermittently. The test failed when "Paste & Go" can't be tapped. For full functional tests, the "Paste & Go" may not be found. On my machine, a "Core-Simulator Bridge" message appears at the same step intermittently (3 out of 100 times).

After I specified that "Paste & Go" must be under `app.tables["Context Menu"]`, the test no longer failed intermittently on my end and on Mac Stadium M1. In addition, let's wait for the "Paste & Go" menu item appears before tapping on it.

We could have close MTE-432 without any code change. I'd like to put this change in just to see if the menu item "Paste & Go" is displayed just in case the test fails again.

https://storage.googleapis.com/mobile-reports/public/firefox-ios-M1/FullFunctionalTests-iPad/result_8/build/reports/tests.html

https://mozilla-hub.atlassian.net/browse/MTE-432