### PR TITLE
Refactor MTE-514 [v111] Database fixture not loading properly

### DIFF
--- a/Tests/XCUITests/ActivityStreamTest.swift
+++ b/Tests/XCUITests/ActivityStreamTest.swift
@@ -66,6 +66,7 @@ class ActivityStreamTest: BaseTestCase {
 
     func testTopSites2Add() throws {
         throw XCTSkip("MTE-514 Database may not be loaded")
+        /*
         waitForExistence(app.buttons["urlBar-cancel"], timeout: 10)
         navigator.performAction(Action.CloseURLBarOpen)
         if iPad() {
@@ -73,6 +74,7 @@ class ActivityStreamTest: BaseTestCase {
         } else {
             checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 8)
         }
+        */
     }
 
     func testTopSites3RemoveDefaultTopSite() {
@@ -85,6 +87,7 @@ class ActivityStreamTest: BaseTestCase {
 
     func testTopSitesRemoveAllExceptDefaultClearPrivateData() throws {
         throw XCTSkip("MTE-514 Database may not be loaded")
+        /*
         waitForExistence(app.cells.staticTexts[newTopSite["bookmarkLabel"]!], timeout: 15)
         XCTAssertTrue(app.cells.staticTexts[newTopSite["bookmarkLabel"]!].exists)
         // A new site has been added to the top sites
@@ -106,6 +109,7 @@ class ActivityStreamTest: BaseTestCase {
         }
         checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 5)
         XCTAssertFalse(app.cells.staticTexts[newTopSite["bookmarkLabel"]!].exists)
+        */
     }
 
     func testTopSitesRemoveAllExceptPinnedClearPrivateData() {

--- a/Tests/XCUITests/ActivityStreamTest.swift
+++ b/Tests/XCUITests/ActivityStreamTest.swift
@@ -64,7 +64,8 @@ class ActivityStreamTest: BaseTestCase {
         XCTAssertTrue(app.collectionViews.cells.staticTexts["Facebook"].exists)
     }
 
-    func testTopSites2Add() {
+    func testTopSites2Add() throws {
+        throw XCTSkip("MTE-514 Database may not be loaded")
         waitForExistence(app.buttons["urlBar-cancel"], timeout: 10)
         navigator.performAction(Action.CloseURLBarOpen)
         if iPad() {
@@ -82,7 +83,8 @@ class ActivityStreamTest: BaseTestCase {
         checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 4)
     }
 
-    func testTopSitesRemoveAllExceptDefaultClearPrivateData() {
+    func testTopSitesRemoveAllExceptDefaultClearPrivateData() throws {
+        throw XCTSkip("MTE-514 Database may not be loaded")
         waitForExistence(app.cells.staticTexts[newTopSite["bookmarkLabel"]!], timeout: 15)
         XCTAssertTrue(app.cells.staticTexts[newTopSite["bookmarkLabel"]!].exists)
         // A new site has been added to the top sites

--- a/Tests/XCUITests/DatabaseFixtureTest.swift
+++ b/Tests/XCUITests/DatabaseFixtureTest.swift
@@ -46,7 +46,8 @@ class DatabaseFixtureTest: BaseTestCase {
         XCTAssertEqual(bookmarksList, 1013, "There should be an entry in the bookmarks list")
     }*/
 
-    func testHistoryDatabaseFixture() {
+    func testHistoryDatabaseFixture() throws {
+        throw XCTSkip("MTE-514 Database may not be loaded")
         waitForExistence(app.buttons["urlBar-cancel"], timeout: 15)
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)

--- a/Tests/XCUITests/DatabaseFixtureTest.swift
+++ b/Tests/XCUITests/DatabaseFixtureTest.swift
@@ -48,6 +48,7 @@ class DatabaseFixtureTest: BaseTestCase {
 
     func testHistoryDatabaseFixture() throws {
         throw XCTSkip("MTE-514 Database may not be loaded")
+        /*
         waitForExistence(app.buttons["urlBar-cancel"], timeout: 15)
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
@@ -58,6 +59,7 @@ class DatabaseFixtureTest: BaseTestCase {
         let loaded = NSPredicate(format: "count == 101")
         expectation(for: loaded, evaluatedWith: app.tables[AccessibilityIdentifiers.LibraryPanels.HistoryPanel.tableView].cells, handler: nil)
         waitForExpectations(timeout: 30, handler: nil)
+        */
     }
 
     func testPerfHistory4000startUp() {

--- a/Tests/XCUITests/DragAndDropTests.swift
+++ b/Tests/XCUITests/DragAndDropTests.swift
@@ -255,7 +255,7 @@ class DragAndDropTestIpad: IpadOnlyTestCase {
 
     func test3DragAndDropHistoryEntry() throws {
         throw XCTSkip("MTE-514 Database may not be loaded")
-
+        /*
         if skipPlatform { return }
 
         typealias historyPanelA11y = AccessibilityIdentifiers.LibraryPanels.HistoryPanel
@@ -280,11 +280,12 @@ class DragAndDropTestIpad: IpadOnlyTestCase {
 
         XCTAssertTrue(firstEntryOnList.exists, "first entry after is not correct")
         XCTAssertTrue(secondEntryOnList.exists, "second entry after is not correct")
+        */
     }
 
     func testDragAndDropBookmarkEntry() throws {
         throw XCTSkip("MTE-514 Database may not be loaded")
-
+        /*
         if skipPlatform { return }
 
         waitForExistence(app.textFields["url"], timeout: 5)
@@ -305,6 +306,7 @@ class DragAndDropTestIpad: IpadOnlyTestCase {
 
         XCTAssertTrue(firstEntryOnList.exists, "first entry after is not correct")
         XCTAssertTrue(secondEntryOnList.exists, "second entry after is not correct")
+        */
     }
 
     // Test disabled due to new way bookmark panel is shown, url is not available. Library implementation bug 1506989

--- a/Tests/XCUITests/DragAndDropTests.swift
+++ b/Tests/XCUITests/DragAndDropTests.swift
@@ -253,7 +253,9 @@ class DragAndDropTestIpad: IpadOnlyTestCase {
         XCTAssertEqual(app.webViews.searchFields.element(boundBy: 0).value as? String, websiteWithSearchField)
     }*/
 
-    func test3DragAndDropHistoryEntry() {
+    func test3DragAndDropHistoryEntry() throws {
+        throw XCTSkip("MTE-514 Database may not be loaded")
+
         if skipPlatform { return }
 
         typealias historyPanelA11y = AccessibilityIdentifiers.LibraryPanels.HistoryPanel
@@ -280,7 +282,9 @@ class DragAndDropTestIpad: IpadOnlyTestCase {
         XCTAssertTrue(secondEntryOnList.exists, "second entry after is not correct")
     }
 
-    func testDragAndDropBookmarkEntry() {
+    func testDragAndDropBookmarkEntry() throws {
+        throw XCTSkip("MTE-514 Database may not be loaded")
+
         if skipPlatform { return }
 
         waitForExistence(app.textFields["url"], timeout: 5)

--- a/Tests/XCUITests/HistoryTests.swift
+++ b/Tests/XCUITests/HistoryTests.swift
@@ -57,7 +57,8 @@ class HistoryTests: BaseTestCase {
         XCTAssertTrue(app.tables.buttons["Sync and Save Data"].exists, "Sign in button does not appear")
     }
 
-    func testClearHistoryFromSettings() {
+    func testClearHistoryFromSettings() throws {
+        throw XCTSkip("MTE-514 Database may not be loaded")
         closeKeyboard()
         navigator.nowAt(NewTabScreen)
 

--- a/Tests/XCUITests/HistoryTests.swift
+++ b/Tests/XCUITests/HistoryTests.swift
@@ -59,6 +59,7 @@ class HistoryTests: BaseTestCase {
 
     func testClearHistoryFromSettings() throws {
         throw XCTSkip("MTE-514 Database may not be loaded")
+        /*
         closeKeyboard()
         navigator.nowAt(NewTabScreen)
 
@@ -81,6 +82,7 @@ class HistoryTests: BaseTestCase {
         waitForExistence(app.tables.cells[HistoryPanelA11y.recentlyClosedCell])
         XCTAssertFalse(app.tables.cells.staticTexts[webpage["label"]!].exists)
         XCTAssertTrue(app.tables[HistoryPanelA11y.tableView].staticTexts[emptyRecentlyClosedMesg].exists)
+        */
     }
 
     // Smoketest


### PR DESCRIPTION
The database from the fixtures may not be loaded before the tests begin. We have not been able to pinpoint the cause or to reproduce the failure consistently.

Let's mark the tests as skipped with a reference to the Jira ticket.

One of the most recent reports: https://storage.googleapis.com/mobile-reports/public/firefox-ios-M1/FullFunctionalTests-iPad/result_64/build/reports/tests.html

https://mozilla-hub.atlassian.net/browse/MTE-514