### PR TITLE
Bugfix  FXIOS-5579 [v111] fixing attentive mode

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -29,12 +29,6 @@ enum ReferringPage {
     case tabTray
 }
 
-protocol BrowserBarViewDelegate: AnyObject {
-    var inOverlayMode: Bool { get }
-
-    func leaveOverlayMode(didCancel cancel: Bool)
-}
-
 class BrowserViewController: UIViewController {
     private enum UX {
         static let ShowHeaderTapAreaHeight: CGFloat = 32
@@ -962,7 +956,6 @@ class BrowserViewController: UIViewController {
             urlBar: urlBar)
         homepageViewController.homePanelDelegate = self
         homepageViewController.libraryPanelDelegate = self
-        homepageViewController.browserBarViewDelegate = self
         homepageViewController.sendToDeviceDelegate = self
         self.homepageViewController = homepageViewController
         addChild(homepageViewController)
@@ -1044,6 +1037,10 @@ class BrowserViewController: UIViewController {
         } else {
             self.urlBar.enterOverlayMode(nil, pasted: false, search: false)
         }
+    }
+
+    private func leaveOverlayMode(didCancel cancel: Bool) {
+        urlBar.leaveOverlayMode(didCancel: cancel)
     }
 
     func showLibrary(panel: LibraryPanelType? = nil) {
@@ -2737,16 +2734,6 @@ extension BrowserViewController {
         }
 
         return sceneDelegate.browserViewController
-    }
-}
-
-extension BrowserViewController: BrowserBarViewDelegate {
-    var inOverlayMode: Bool {
-        return urlBar.inOverlayMode
-    }
-
-    func leaveOverlayMode(didCancel cancel: Bool) {
-        urlBar.leaveOverlayMode(didCancel: cancel)
     }
 }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2029,12 +2029,12 @@ extension BrowserViewController: TabManagerDelegate {
 
         // Remove the old accessibilityLabel. Since this webview shouldn't be visible, it doesn't need it
         // and having multiple views with the same label confuses tests.
-        if let wv = previous?.webView {
-            wv.endEditing(true)
-            wv.accessibilityLabel = nil
-            wv.accessibilityElementsHidden = true
-            wv.accessibilityIdentifier = nil
-            wv.removeFromSuperview()
+        if let webView = previous?.webView {
+            webView.endEditing(true)
+            webView.accessibilityLabel = nil
+            webView.accessibilityElementsHidden = true
+            webView.accessibilityIdentifier = nil
+            webView.removeFromSuperview()
         }
 
         if let tab = selected, let webView = tab.webView {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
@@ -67,7 +67,7 @@ extension BrowserViewController {
     }
 
     func showReaderModeBar(animated: Bool) {
-        if readerModeBar == nil {
+        if self.readerModeBar == nil {
             let readerModeBar = ReaderModeBarView(frame: CGRect.zero)
             readerModeBar.delegate = self
             if isBottomSearchBar {
@@ -76,7 +76,7 @@ extension BrowserViewController {
                 header.addArrangedViewToBottom(readerModeBar)
             }
 
-            readerModeBar = readerModeBar
+            self.readerModeBar = readerModeBar
         }
 
         updateReaderModeBar()
@@ -85,7 +85,7 @@ extension BrowserViewController {
 
     func hideReaderModeBar(animated: Bool) {
         guard let readerModeBar = readerModeBar else { return }
-        
+
         if isBottomSearchBar {
             overKeyboardContainer.removeArrangedView(readerModeBar)
         } else {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
@@ -67,7 +67,7 @@ extension BrowserViewController {
     }
 
     func showReaderModeBar(animated: Bool) {
-        if self.readerModeBar == nil {
+        if readerModeBar == nil {
             let readerModeBar = ReaderModeBarView(frame: CGRect.zero)
             readerModeBar.delegate = self
             if isBottomSearchBar {
@@ -76,7 +76,7 @@ extension BrowserViewController {
                 header.addArrangedViewToBottom(readerModeBar)
             }
 
-            self.readerModeBar = readerModeBar
+            readerModeBar = readerModeBar
         }
 
         updateReaderModeBar()
@@ -85,6 +85,7 @@ extension BrowserViewController {
 
     func hideReaderModeBar(animated: Bool) {
         guard let readerModeBar = readerModeBar else { return }
+        
         if isBottomSearchBar {
             overKeyboardContainer.removeArrangedView(readerModeBar)
         } else {

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -21,12 +21,6 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
         }
     }
     weak var libraryPanelDelegate: LibraryPanelDelegate?
-    weak var browserBarViewDelegate: BrowserBarViewDelegate? {
-        didSet {
-            viewModel.jumpBackInViewModel.browserBarViewDelegate = browserBarViewDelegate
-        }
-    }
-
     weak var sendToDeviceDelegate: SendToDeviceDelegate? {
         didSet {
             contextMenuHelper.sendToDeviceDelegate = sendToDeviceDelegate

--- a/Client/Frontend/Home/HomepageViewModel.swift
+++ b/Client/Frontend/Home/HomepageViewModel.swift
@@ -125,6 +125,7 @@ class HomepageViewModel: FeatureFlaggable {
         self.jumpBackInViewModel = JumpBackInViewModel(
             profile: profile,
             isPrivate: isPrivate,
+            urlBar: urlBar,
             theme: theme,
             tabManager: tabManager,
             adaptor: adaptor,

--- a/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -22,8 +22,8 @@ class JumpBackInViewModel: FeatureFlaggable {
     var syncedTabsShowAllAction: (() -> Void)?
     var openSyncedTabAction: ((URL) -> Void)?
     var prepareContextualHint: ((SyncedTabCell) -> Void)?
+    private var urlBar: URLBarViewProtocol
 
-    weak var browserBarViewDelegate: BrowserBarViewDelegate?
     weak var delegate: HomepageDataModelDelegate?
 
     // The data that is showed to the user after layout calculation
@@ -51,6 +51,7 @@ class JumpBackInViewModel: FeatureFlaggable {
         isZeroSearch: Bool = false,
         profile: Profile,
         isPrivate: Bool,
+        urlBar: URLBarViewProtocol,
         theme: Theme,
         tabManager: TabManagerProtocol,
         adaptor: JumpBackInDataAdaptor,
@@ -59,6 +60,7 @@ class JumpBackInViewModel: FeatureFlaggable {
         self.profile = profile
         self.isZeroSearch = isZeroSearch
         self.isPrivate = isPrivate
+        self.urlBar = urlBar
         self.theme = theme
         self.tabManager = tabManager
         self.jumpBackInDataAdaptor = adaptor
@@ -66,11 +68,7 @@ class JumpBackInViewModel: FeatureFlaggable {
     }
 
     func switchTo(group: ASGroup<Tab>) {
-        guard let delegate = browserBarViewDelegate else { return }
-
-        if delegate.inOverlayMode {
-            delegate.leaveOverlayMode(didCancel: false)
-        }
+        if urlBar.inOverlayMode { urlBar.leaveOverlayMode() }
 
         guard let firstTab = group.groupedItems.first else { return }
 
@@ -86,11 +84,7 @@ class JumpBackInViewModel: FeatureFlaggable {
     }
 
     func switchTo(tab: Tab) {
-        guard let delegate = browserBarViewDelegate else { return }
-
-        if delegate.inOverlayMode {
-            delegate.leaveOverlayMode(didCancel: false)
-        }
+        if urlBar.inOverlayMode { urlBar.leaveOverlayMode() }
 
         tabManager.selectTab(tab, previous: nil)
         TelemetryWrapper.recordEvent(

--- a/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -515,7 +515,6 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
 
     func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool) {
         guard !inOverlayMode else { return }
-        print("YRD enterOverlayMode")
 
         createLocationTextField()
 
@@ -553,7 +552,6 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
     func leaveOverlayMode(didCancel cancel: Bool) {
         guard inOverlayMode else { return }
 
-        print("YRD leaveOverlayMode")
         locationTextField?.resignFirstResponder()
         animateToOverlayState(overlayMode: false, didCancel: cancel)
         delegate?.urlBarDidLeaveOverlayMode(self)

--- a/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -56,7 +56,7 @@ protocol URLBarViewProtocol {
 
 extension URLBarViewProtocol {
     func leaveOverlayMode(didCancel cancel: Bool = false) {
-        self.leaveOverlayMode(didCancel: cancel)
+        leaveOverlayMode(didCancel: cancel)
     }
 }
 

--- a/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -514,6 +514,9 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
     }
 
     func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool) {
+        guard !inOverlayMode else { return }
+        print("YRD enterOverlayMode")
+
         createLocationTextField()
 
         // Show the overlay mode UI, which includes hiding the locationView and replacing it
@@ -548,6 +551,9 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
     }
 
     func leaveOverlayMode(didCancel cancel: Bool) {
+        guard inOverlayMode else { return }
+
+        print("YRD leaveOverlayMode")
         locationTextField?.resignFirstResponder()
         animateToOverlayState(overlayMode: false, didCancel: cancel)
         delegate?.urlBarDidLeaveOverlayMode(self)
@@ -625,7 +631,7 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
         }
     }
 
-    func animateToOverlayState(overlayMode overlay: Bool, didCancel cancel: Bool = false) {
+    private func animateToOverlayState(overlayMode overlay: Bool, didCancel cancel: Bool = false) {
         prepareOverlayAnimation()
         layoutIfNeeded()
 
@@ -654,7 +660,7 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
         delegate?.urlBarDidPressTabs(self)
     }
 
-    @objc func didClickCancel() {
+    @objc private func didClickCancel() {
         leaveOverlayMode(didCancel: true)
     }
 

--- a/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
@@ -671,9 +671,6 @@ extension JumpBackInViewModelTests {
             adaptor: adaptor,
             wallpaperManager: WallpaperManager()
         )
-//        if addDelegate {
-//            subject.browserBarViewDelegate = mockBrowserBarViewDelegate
-//        }
 
         trackForMemoryLeaks(subject)
 

--- a/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
@@ -12,10 +12,9 @@ import Common
 class JumpBackInViewModelTests: XCTestCase {
     var mockProfile: MockProfile!
     var mockTabManager: MockTabManager!
+    private var urlBar: MockURLBarView!
 
-    var mockBrowserBarViewDelegate: MockBrowserBarViewDelegate!
     var stubBrowserViewController: BrowserViewController!
-
     var adaptor: JumpBackInDataAdaptorMock!
 
     let iPhone14ScreenSize = CGSize(width: 390, height: 844)
@@ -31,7 +30,7 @@ class JumpBackInViewModelTests: XCTestCase {
             profile: mockProfile,
             tabManager: TabManager(profile: mockProfile, imageStore: nil)
         )
-        mockBrowserBarViewDelegate = MockBrowserBarViewDelegate()
+        urlBar = MockURLBarView()
 
         FeatureFlagsManager.shared.initializeDeveloperFeatures(with: mockProfile)
     }
@@ -41,7 +40,7 @@ class JumpBackInViewModelTests: XCTestCase {
         AppContainer.shared.reset()
         adaptor = nil
         stubBrowserViewController = nil
-        mockBrowserBarViewDelegate = nil
+        urlBar = nil
         mockTabManager = nil
         mockProfile = nil
     }
@@ -49,7 +48,7 @@ class JumpBackInViewModelTests: XCTestCase {
     // MARK: - Switch to group
 
     func test_switchToGroup_noBrowserDelegate_doNothing() {
-        let subject = createSubject(addDelegate: false)
+        let subject = createSubject()
         let group = ASGroup<Tab>(searchTerm: "", groupedItems: [], timestamp: 0)
         var completionDidRun = false
         subject.onTapGroup = { tab in
@@ -58,15 +57,15 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.switchTo(group: group)
 
-        XCTAssertFalse(mockBrowserBarViewDelegate.inOverlayMode)
-        XCTAssertEqual(mockBrowserBarViewDelegate.leaveOverlayModeCount, 0)
+        XCTAssertFalse(urlBar.inOverlayMode)
+        XCTAssertEqual(urlBar.leaveOverlayModeCallCount, 0)
         XCTAssertFalse(completionDidRun)
     }
 
     func test_switchToGroup_noGroupedItems_doNothing() {
         let subject = createSubject()
         let group = ASGroup<Tab>(searchTerm: "", groupedItems: [], timestamp: 0)
-        mockBrowserBarViewDelegate.inOverlayMode = true
+        urlBar.inOverlayMode = true
         var completionDidRun = false
         subject.onTapGroup = { tab in
             completionDidRun = true
@@ -74,15 +73,15 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.switchTo(group: group)
 
-        XCTAssertTrue(mockBrowserBarViewDelegate.inOverlayMode)
-        XCTAssertEqual(mockBrowserBarViewDelegate.leaveOverlayModeCount, 1)
+        XCTAssertFalse(urlBar.inOverlayMode)
+        XCTAssertEqual(urlBar.leaveOverlayModeCallCount, 1)
         XCTAssertFalse(completionDidRun)
     }
 
     func test_switchToGroup_inOverlayMode_leavesOverlayMode() {
         let subject = createSubject()
         let group = ASGroup<Tab>(searchTerm: "", groupedItems: [], timestamp: 0)
-        mockBrowserBarViewDelegate.inOverlayMode = true
+        urlBar.inOverlayMode = true
         var completionDidRun = false
         subject.onTapGroup = { tab in
             completionDidRun = true
@@ -90,8 +89,8 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.switchTo(group: group)
 
-        XCTAssertTrue(mockBrowserBarViewDelegate.inOverlayMode)
-        XCTAssertEqual(mockBrowserBarViewDelegate.leaveOverlayModeCount, 1)
+        XCTAssertFalse(urlBar.inOverlayMode)
+        XCTAssertEqual(urlBar.leaveOverlayModeCallCount, 1)
         XCTAssertFalse(completionDidRun)
     }
 
@@ -99,7 +98,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let subject = createSubject()
         let expectedTab = createTab(profile: mockProfile)
         let group = ASGroup<Tab>(searchTerm: "", groupedItems: [expectedTab], timestamp: 0)
-        mockBrowserBarViewDelegate.inOverlayMode = true
+        urlBar.inOverlayMode = true
         var receivedTab: Tab?
         subject.onTapGroup = { tab in
             receivedTab = tab
@@ -107,56 +106,45 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.switchTo(group: group)
 
-        XCTAssertTrue(mockBrowserBarViewDelegate.inOverlayMode)
+        XCTAssertFalse(urlBar.inOverlayMode)
+        XCTAssertEqual(urlBar.leaveOverlayModeCallCount, 1)
         XCTAssertEqual(expectedTab, receivedTab)
     }
 
     // MARK: - Switch to tab
 
-    func test_switchToTab_noBrowserDelegate_doNothing() {
-        let subject = createSubject()
-        let expectedTab = createTab(profile: mockProfile)
-        subject.browserBarViewDelegate = nil
-
-        subject.switchTo(tab: expectedTab)
-
-        XCTAssertFalse(mockBrowserBarViewDelegate.inOverlayMode)
-        XCTAssertEqual(mockBrowserBarViewDelegate.leaveOverlayModeCount, 0)
-        XCTAssertTrue(mockTabManager.lastSelectedTabs.isEmpty)
-    }
-
     func test_switchToTab_notInOverlayMode_switchTabs() {
         let subject = createSubject()
         let tab = createTab(profile: mockProfile)
-        mockBrowserBarViewDelegate.inOverlayMode = false
+        urlBar.inOverlayMode = false
 
         subject.switchTo(tab: tab)
 
-        XCTAssertFalse(mockBrowserBarViewDelegate.inOverlayMode)
-        XCTAssertEqual(mockBrowserBarViewDelegate.leaveOverlayModeCount, 0)
+        XCTAssertFalse(urlBar.inOverlayMode)
+        XCTAssertEqual(urlBar.leaveOverlayModeCallCount, 0)
         XCTAssertFalse(mockTabManager.lastSelectedTabs.isEmpty)
     }
 
     func test_switchToTab_inOverlayMode_leaveOverlayMode() {
         let subject = createSubject()
         let tab = createTab(profile: mockProfile)
-        mockBrowserBarViewDelegate.inOverlayMode = true
+        urlBar.inOverlayMode = true
 
         subject.switchTo(tab: tab)
 
-        XCTAssertTrue(mockBrowserBarViewDelegate.inOverlayMode)
-        XCTAssertEqual(mockBrowserBarViewDelegate.leaveOverlayModeCount, 1)
+        XCTAssertFalse(urlBar.inOverlayMode)
+        XCTAssertEqual(urlBar.leaveOverlayModeCallCount, 1)
         XCTAssertFalse(mockTabManager.lastSelectedTabs.isEmpty)
     }
 
     func test_switchToTab_tabManagerSelectsTab() {
         let subject = createSubject()
         let tab1 = createTab(profile: mockProfile)
-        mockBrowserBarViewDelegate.inOverlayMode = true
+        urlBar.inOverlayMode = true
 
         subject.switchTo(tab: tab1)
 
-        XCTAssertTrue(mockBrowserBarViewDelegate.inOverlayMode)
+        XCTAssertFalse(urlBar.inOverlayMode)
         guard !mockTabManager.lastSelectedTabs.isEmpty else {
             XCTFail("No tabs were selected in mock tab manager.")
             return
@@ -672,19 +660,20 @@ class JumpBackInViewModelTests: XCTestCase {
 
 // MARK: - Helpers
 extension JumpBackInViewModelTests {
-    func createSubject(addDelegate: Bool = true) -> JumpBackInViewModel {
+    func createSubject() -> JumpBackInViewModel {
         let subject = JumpBackInViewModel(
             isZeroSearch: false,
             profile: mockProfile,
             isPrivate: false,
+            urlBar: urlBar,
             theme: LightTheme(),
             tabManager: mockTabManager,
             adaptor: adaptor,
             wallpaperManager: WallpaperManager()
         )
-        if addDelegate {
-            subject.browserBarViewDelegate = mockBrowserBarViewDelegate
-        }
+//        if addDelegate {
+//            subject.browserBarViewDelegate = mockBrowserBarViewDelegate
+//        }
 
         trackForMemoryLeaks(subject)
 
@@ -742,16 +731,5 @@ class JumpBackInDataAdaptorMock: JumpBackInDataAdaptor {
     var syncedTab: JumpBackInSyncedTab?
     func getSyncedTabData() -> JumpBackInSyncedTab? {
         return syncedTab
-    }
-}
-
-// MARK: - MockBrowserBarViewDelegate
-class MockBrowserBarViewDelegate: BrowserBarViewDelegate {
-    var inOverlayMode = false
-
-    var leaveOverlayModeCount = 0
-
-    func leaveOverlayMode(didCancel cancel: Bool) {
-        leaveOverlayModeCount += 1
     }
 }

--- a/Tests/ClientTests/Mocks/MockURLBarView.swift
+++ b/Tests/ClientTests/Mocks/MockURLBarView.swift
@@ -7,8 +7,15 @@
 class MockURLBarView: URLBarViewProtocol {
     var inOverlayMode = false
     var leaveOverlayModeCallCount = 0
+    var enterOverlayModeCallCount = 0
 
     func leaveOverlayMode(didCancel cancel: Bool) {
         leaveOverlayModeCallCount += 1
+        inOverlayMode = false
+    }
+
+    func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool) {
+        enterOverlayModeCallCount += 1
+        inOverlayMode = true
     }
 }


### PR DESCRIPTION
[FXIOS-5579](https://mozilla-hub.atlassian.net/browse/FXIOS-5579)

Some minor changes previous to actual work to fix attentive mode to make this make the process easier:
- Replace `urlBar.leaveOverlayMode()` on BVC for  `leaveOverlayMode(didCancel: cancel)`
- Replace urlBar.didClickCancel() on BVC for `leaveOverlayMode(didCancel: true)`
- Remove `BrowserBarViewDelegate` duplicate and use URLBarViewProtocol 
- Update Unit test for previous change

On BVC we are mainly calling the class `leaveOverlayMode` and `enterOverlayMode` instead of a mix of: `urlBar.leaveOverlayMode()`, `urlBar.didClickCancel()` and `leaveOverlayMode`