### PR TITLE
Refactor FXIOS-5626 [v111] Use URLComponents to parse mailto metadata

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -1040,6 +1040,7 @@
 		E15DE7C0293A670700B32667 /* PhotonActionSheetSeparator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15DE7BF293A670700B32667 /* PhotonActionSheetSeparator.swift */; };
 		E15DE7C2293A7AED00B32667 /* PhotonActionSheetLineSeparator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15DE7C1293A7AED00B32667 /* PhotonActionSheetLineSeparator.swift */; };
 		E15DE7C4293A7B0F00B32667 /* PhotonActionSheetTitleHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15DE7C3293A7B0F00B32667 /* PhotonActionSheetTitleHeaderView.swift */; };
+		E169C6E82979CA0E0017B8D7 /* URLMailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E169C6E72979CA0E0017B8D7 /* URLMailTests.swift */; };
 		E16E1C9628BFB2E600EE2EF5 /* WallpaperSettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16E1C9528BFB2E600EE2EF5 /* WallpaperSettingsViewModelTests.swift */; };
 		E16E1C9828C25F1D00EE2EF5 /* SiteTableViewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16E1C9728C25F1D00EE2EF5 /* SiteTableViewHeader.swift */; };
 		E1877A81286E0EFD00F5BDF2 /* WebViewNavigationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1877A80286E0EFD00F5BDF2 /* WebViewNavigationHandler.swift */; };
@@ -4802,6 +4803,7 @@
 		E15DE7C1293A7AED00B32667 /* PhotonActionSheetLineSeparator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotonActionSheetLineSeparator.swift; sourceTree = "<group>"; };
 		E15DE7C3293A7B0F00B32667 /* PhotonActionSheetTitleHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotonActionSheetTitleHeaderView.swift; sourceTree = "<group>"; };
 		E1634E1AB9F05311CD6C8C6C /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
+		E169C6E72979CA0E0017B8D7 /* URLMailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLMailTests.swift; sourceTree = "<group>"; };
 		E16E1C9528BFB2E600EE2EF5 /* WallpaperSettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperSettingsViewModelTests.swift; sourceTree = "<group>"; };
 		E16E1C9728C25F1D00EE2EF5 /* SiteTableViewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteTableViewHeader.swift; sourceTree = "<group>"; };
 		E1877A80286E0EFD00F5BDF2 /* WebViewNavigationHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebViewNavigationHandler.swift; sourceTree = "<group>"; };
@@ -6447,6 +6449,7 @@
 				2F44FA1A1A9D426A00FD20CC /* TestHashExtensions.swift */,
 				A83E5B1C1C1DA8D80026D912 /* UIPasteboardExtensionsTests.swift */,
 				8AE1E1D827B1BD380024C45E /* UIStackViewExtensionsTests.swift */,
+				E169C6E72979CA0E0017B8D7 /* URLMailTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -10826,6 +10829,7 @@
 				45D5EDC0292D619000311934 /* MockablePinnedSites.swift in Sources */,
 				2F13E79B1AC0C02700D75081 /* StringExtensionsTests.swift in Sources */,
 				CA24B52224ABD7D40093848C /* LoginsListViewModelTests.swift in Sources */,
+				E169C6E82979CA0E0017B8D7 /* URLMailTests.swift in Sources */,
 				965C3C96293431FC006499ED /* MockLaunchSessionProvider.swift in Sources */,
 				C869915628917803007ACC5C /* WallpaperJSONTestProvider.swift in Sources */,
 				965C3C9829343445006499ED /* MockAppSessionManager.swift in Sources */,

--- a/Client/Frontend/Browser/MailProviders.swift
+++ b/Client/Frontend/Browser/MailProviders.swift
@@ -9,7 +9,7 @@ import Shared
 
 enum MailProviderEmailFormat {
     case standard
-    case userAndPassword // used for Protonmail
+    case protonmail // used for Protonmail
 }
 
 protocol MailProvider {
@@ -48,8 +48,8 @@ extension MailProvider {
         queryItems.append(contentsOf: additionalQueryItems)
         urlComponents.queryItems = queryItems.isEmpty ? nil : queryItems
 
-        if emailFormat == .userAndPassword {
-            urlComponents = addUserAndPasswordComponents(urlComponents, toQueryItem: toQueryItem)
+        if emailFormat == .protonmail {
+            urlComponents = addProtonmailComponents(urlComponents, toQueryItem: toQueryItem)
         }
 
         return urlComponents
@@ -57,8 +57,8 @@ extension MailProvider {
 
     // Used to build Protonmail URL correctly (format: "protonmail://mailto:email@test.com")
     // We use the user, password and host component parts for this URL format.
-    private func addUserAndPasswordComponents(_ components: URLComponents,
-                                              toQueryItem: URLQueryItem) -> URLComponents {
+    private func addProtonmailComponents(_ components: URLComponents,
+                                         toQueryItem: URLQueryItem) -> URLComponents {
         var urlComponents = components
         let queryItems: [URLQueryItem]? = components.queryItems
 
@@ -296,6 +296,6 @@ class ProtonMailIntegration: MailProvider {
                                        metadata: metadata,
                                        supportedHeaders: supportedHeaders,
                                        toHName: "mailto",
-                                       emailFormat: .userAndPassword).url
+                                       emailFormat: .protonmail).url
     }
 }

--- a/Client/Frontend/Browser/MailProviders.swift
+++ b/Client/Frontend/Browser/MailProviders.swift
@@ -7,75 +7,107 @@ import Shared
 
 // mailto headers: subject, body, cc, bcc
 
+enum MailProviderEmailFormat {
+    case standard
+    case userAndPassword
+}
+
 protocol MailProvider {
-    var urlFormat: String {get set}
-    var supportedHeaders: [String] {get set}
+    var components: URLComponents { get }
+    var supportedHeaders: [String] { get set }
     func newEmailURLFromMetadata(_ metadata: MailToMetadata) -> URL?
 }
 
 extension MailProvider {
-    fileprivate func constructEmailURLString(_ urlFormat: String,
+    fileprivate func constructEmailURLString(_ urlComponents: URLComponents,
                                              metadata: MailToMetadata,
                                              supportedHeaders: [String],
                                              bodyHName: String = "body",
                                              toHName: String = "to",
-                                             toParamFormat: String = "%@=%@") -> String {
+                                             emailFormat: MailProviderEmailFormat = .standard) -> URLComponents {
         var lowercasedHeaders = prepareHeaders(metadata: metadata)
 
         // Evaluate "to" parameter
-        var toParam: String
-        if let toHValue = lowercasedHeaders["to"] {
-            let value = metadata.to.isEmpty ? toHValue : [metadata.to, toHValue].joined(separator: "%2C%20")
+        var toQueryItem: URLQueryItem
+        if let toHeaderValue = lowercasedHeaders["to"] {
+            let value = metadata.to.isEmpty ? toHeaderValue : [metadata.to, toHeaderValue].joined(separator: ",")
             lowercasedHeaders.removeValue(forKey: "to")
-            toParam = String(format: toParamFormat, toHName, value)
+            toQueryItem = URLQueryItem(name: toHName, value: value)
         } else {
-            toParam = String(format: toParamFormat, toHName, metadata.to)
+            toQueryItem = URLQueryItem(name: toHName, value: metadata.to)
         }
 
         // Create string of additional parameters
-        let stringParams = prepareParams(headers: lowercasedHeaders,
-                                         supportedHeaders: supportedHeaders,
-                                         bodyHName: bodyHName)
+        let additionalQueryItems = prepareParams(headers: lowercasedHeaders,
+                                                 supportedHeaders: supportedHeaders,
+                                                 bodyHName: bodyHName)
 
         // Create url based on scheme
-        var finalURLString = String(format: urlFormat, toParam, (stringParams.isEmpty ? "" : stringParams))
+        var urlComponents = urlComponents
+        var queryItems: [URLQueryItem] = [toQueryItem]
+        queryItems.append(contentsOf: additionalQueryItems)
+        urlComponents.queryItems = queryItems.isEmpty ? nil : queryItems
 
-        // Clean up url scheme. Remove ? or & if parameters are empty
-        if stringParams.isEmpty, ["?", "&"].contains(finalURLString.last) {
-            finalURLString = String(finalURLString.dropLast())
+        if emailFormat == .userAndPassword {
+            urlComponents = addUserAndPasswordComponents(urlComponents, toQueryItem: toQueryItem)
         }
 
-        return finalURLString
+        return urlComponents
+    }
+
+    private func addUserAndPasswordComponents(_ components: URLComponents, toQueryItem: URLQueryItem) -> URLComponents {
+        var urlComponents = components
+        let queryItems: [URLQueryItem]? = components.queryItems
+
+        // Split email in user name and domain
+        guard let emailComponents = toQueryItem.value?.components(separatedBy: "@"),
+              emailComponents.count >= 2
+        else { return urlComponents }
+
+        urlComponents.password = emailComponents[0...emailComponents.count - 2].joined(separator: "@")
+        urlComponents.host = emailComponents.last
+
+        if var items = queryItems, let index = items.firstIndex(of: toQueryItem) {
+            items.remove(at: index)
+            urlComponents.queryItems = items.isEmpty ? nil : items
+        }
+
+        return urlComponents
     }
 
     private func prepareHeaders(metadata: MailToMetadata) -> [String: String] {
         var lowercasedHeaders = [String: String]()
 
-        metadata.headers.forEach { (hname, hvalue) in
-            lowercasedHeaders[hname.lowercased()] = hvalue
+        metadata.headers.forEach { (name, value) in
+            lowercasedHeaders[name.lowercased()] = value
         }
         return lowercasedHeaders
     }
 
     private func prepareParams(headers: [String: String],
                                supportedHeaders: [String],
-                               bodyHName: String = "body") -> String {
-        var queryParams: [String] = []
+                               bodyName: String = "body") -> [URLQueryItem] {
+        var queryItems = [URLQueryItem]()
 
-        headers.forEach({ (hname, hvalue) in
-            if supportedHeaders.contains(hname) {
-                queryParams.append("\(hname)=\(hvalue)")
-            } else if hname == "body" {
-                queryParams.append("\(bodyHName)=\(hvalue)")
+        headers.forEach({ (name, value) in
+            if supportedHeaders.contains(name) {
+                queryItems.append(URLQueryItem(name: name, value: value))
+            } else if name == "body" {
+                queryItems.append(URLQueryItem(name: bodyName, value: value))
             }
         })
 
-        return queryParams.joined(separator: "&")
+        return queryItems
     }
 }
 
 class ReaddleSparkIntegration: MailProvider {
-    var urlFormat = "readdle-spark://compose?%@&%@"
+    var components: URLComponents {
+        var components = URLComponents()
+        components.scheme = "readdle-spark"
+        components.host = "compose"
+        return components
+    }
     var supportedHeaders = [
         "subject",
         "recipient",
@@ -86,16 +118,21 @@ class ReaddleSparkIntegration: MailProvider {
     ]
 
     func newEmailURLFromMetadata(_ metadata: MailToMetadata) -> URL? {
-        return constructEmailURLString(urlFormat,
+        return constructEmailURLString(components,
                                        metadata: metadata,
                                        supportedHeaders: supportedHeaders,
                                        bodyHName: "textbody",
-                                       toHName: "recipient").asURL
+                                       toHName: "recipient").url
     }
 }
 
 class AirmailIntegration: MailProvider {
-    var urlFormat = "airmail://compose?%@&%@"
+    var components: URLComponents {
+        var components = URLComponents()
+        components.scheme = "airmail"
+        components.host = "compose"
+        return components
+    }
     var supportedHeaders = [
         "subject",
         "from",
@@ -107,15 +144,20 @@ class AirmailIntegration: MailProvider {
     ]
 
     func newEmailURLFromMetadata(_ metadata: MailToMetadata) -> URL? {
-        return constructEmailURLString(urlFormat,
+        return constructEmailURLString(components,
                                        metadata: metadata,
                                        supportedHeaders: supportedHeaders,
-                                       bodyHName: "htmlBody").asURL
+                                       bodyHName: "htmlBody").url
     }
 }
 
 class MyMailIntegration: MailProvider {
-    var urlFormat = "mymail-mailto://?%@&%@"
+    var components: URLComponents {
+        var components = URLComponents()
+        components.scheme = "mymail-mailto"
+        components.host = ""
+        return components
+    }
     var supportedHeaders = [
         "to",
         "subject",
@@ -125,21 +167,27 @@ class MyMailIntegration: MailProvider {
     ]
 
     func newEmailURLFromMetadata(_ metadata: MailToMetadata) -> URL? {
-        return constructEmailURLString(urlFormat,
+        return constructEmailURLString(components,
                                        metadata: metadata,
-                                       supportedHeaders: supportedHeaders).asURL
+                                       supportedHeaders: supportedHeaders).url
     }
 }
 
 class MailRuIntegration: MyMailIntegration {
-    override init() {
-        super.init()
-        self.urlFormat = "mailru-mailto://?%@&%@"
+    override var components: URLComponents {
+        var components = super.components
+        components.scheme = "mailru-mailto"
+        return components
     }
 }
 
 class MSOutlookIntegration: MailProvider {
-    var urlFormat = "ms-outlook://emails/new?%@&%@"
+    var components: URLComponents {
+        var components = URLComponents()
+        components.scheme = "ms-outlook"
+        components.path = "emails/new"
+        return components
+    }
     var supportedHeaders = [
         "to",
         "cc",
@@ -149,14 +197,19 @@ class MSOutlookIntegration: MailProvider {
     ]
 
     func newEmailURLFromMetadata(_ metadata: MailToMetadata) -> URL? {
-        return constructEmailURLString(urlFormat,
+        return constructEmailURLString(components,
                                        metadata: metadata,
-                                       supportedHeaders: supportedHeaders).asURL
+                                       supportedHeaders: supportedHeaders).url
     }
 }
 
 class YMailIntegration: MailProvider {
-    var urlFormat = "ymail://mail/any/compose?%@&%@"
+    var components: URLComponents {
+        var components = URLComponents()
+        components.scheme = "ymail"
+        components.path = "mail/any/compose"
+        return components
+    }
     var supportedHeaders = [
         "to",
         "cc",
@@ -165,14 +218,19 @@ class YMailIntegration: MailProvider {
     ]
 
     func newEmailURLFromMetadata(_ metadata: MailToMetadata) -> URL? {
-        return constructEmailURLString(urlFormat,
+        return constructEmailURLString(components,
                                        metadata: metadata,
-                                       supportedHeaders: supportedHeaders).asURL
+                                       supportedHeaders: supportedHeaders).url
     }
 }
 
 class GoogleGmailIntegration: MailProvider {
-    var urlFormat = "googlegmail:///co?%@&%@"
+    var components: URLComponents {
+        var components = URLComponents()
+        components.scheme = "googlegmail"
+        components.host = "co"
+        return components
+    }
     var supportedHeaders = [
         "to",
         "cc",
@@ -182,14 +240,19 @@ class GoogleGmailIntegration: MailProvider {
     ]
 
     func newEmailURLFromMetadata(_ metadata: MailToMetadata) -> URL? {
-        return constructEmailURLString(urlFormat,
+        return constructEmailURLString(components,
                                        metadata: metadata,
-                                       supportedHeaders: supportedHeaders).asURL
+                                       supportedHeaders: supportedHeaders).url
     }
 }
 
 class FastmailIntegration: MailProvider {
-    var urlFormat = "fastmail://mail/compose?%@&%@"
+    var components: URLComponents {
+        var components = URLComponents()
+        components.scheme = "fastmail"
+        components.path = "mail/compose"
+        return components
+    }
     var supportedHeaders = [
         "to",
         "cc",
@@ -199,14 +262,19 @@ class FastmailIntegration: MailProvider {
     ]
 
     func newEmailURLFromMetadata(_ metadata: MailToMetadata) -> URL? {
-        return constructEmailURLString(urlFormat,
+        return constructEmailURLString(components,
                                        metadata: metadata,
-                                       supportedHeaders: supportedHeaders).asURL
+                                       supportedHeaders: supportedHeaders).url
     }
 }
 
 class ProtonMailIntegration: MailProvider {
-    var urlFormat = "protonmail://%@?%@"
+    var components: URLComponents {
+        var components = URLComponents()
+        components.scheme = "protonmail"
+        components.user = "mailto"
+        return components
+    }
     var supportedHeaders = [
         "to",
         "cc",
@@ -216,10 +284,10 @@ class ProtonMailIntegration: MailProvider {
     ]
 
     func newEmailURLFromMetadata(_ metadata: MailToMetadata) -> URL? {
-        return constructEmailURLString(urlFormat,
+        return constructEmailURLString(components,
                                        metadata: metadata,
                                        supportedHeaders: supportedHeaders,
                                        toHName: "mailto",
-                                       toParamFormat: "%@:%@").asURL
+                                       emailFormat: .userAndPassword).url
     }
 }

--- a/Client/Frontend/Browser/MailProviders.swift
+++ b/Client/Frontend/Browser/MailProviders.swift
@@ -40,7 +40,7 @@ extension MailProvider {
         // Create string of additional parameters
         let additionalQueryItems = prepareParams(headers: lowercasedHeaders,
                                                  supportedHeaders: supportedHeaders,
-                                                 bodyHName: bodyHName)
+                                                 bodyName: bodyHName)
 
         // Create url based on scheme
         var urlComponents = urlComponents

--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -160,14 +160,13 @@ extension URL {
 
     public func getQuery() -> [String: String] {
         var results = [String: String]()
-        let keyValues = self.query?.components(separatedBy: "&")
+        let components = URLComponents(url: self, resolvingAgainstBaseURL: false)
 
-        if keyValues?.count ?? 0 > 0 {
-            for pair in keyValues! {
-                let kv = pair.components(separatedBy: "=")
-                if kv.count > 1 {
-                    results[kv[0]] = kv[1]
-                }
+        guard let queryItems = components?.queryItems else { return results }
+
+        for item in queryItems {
+            if let value = item.value {
+                results[item.name] = value
             }
         }
 

--- a/Tests/ClientTests/Extensions/URLMailTests.swift
+++ b/Tests/ClientTests/Extensions/URLMailTests.swift
@@ -1,0 +1,61 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import XCTest
+
+@testable import Client
+
+class URLMailTests: XCTestCase {
+    func testMailToMetadata_noMailto() {
+        let url = URL(string: "https://test.com")
+        XCTAssertNil(url!.mailToMetadata(), "Metadata should be nil")
+    }
+
+    func testMailToMetadata_emailOnly() {
+        let url = URL(string: "mailto:someone@example.com")
+        let metadata = url!.mailToMetadata()
+        XCTAssertNotNil(metadata, "Metadata should not be nil")
+        XCTAssertEqual(metadata?.to, "someone@example.com", "Should have a to value")
+        XCTAssertEqual(metadata?.headers.count, 0, "Should have no headers")
+    }
+
+    func testMailToMetadata_multipleEmails() {
+        let url = URL(string: "mailto:someone@example.com,someoneelse@example.com")
+        let metadata = url!.mailToMetadata()
+        XCTAssertNotNil(metadata, "Metadata should not be nil")
+        XCTAssertEqual(metadata?.to, "someone@example.com,someoneelse@example.com", "Should have a to value")
+        XCTAssertEqual(metadata?.headers.count, 0, "Should have no headers")
+    }
+
+    func testMailToMetadata_headerFields() {
+        let url = URL(string: "mailto:someone@example.com?subject=This%20is%20the%20subject&cc=someone_else@example.com&body=This%20is%20the%20body")
+        let metadata = url!.mailToMetadata()
+        XCTAssertNotNil(metadata, "Metadata should not be nil")
+        XCTAssertEqual(metadata?.to, "someone@example.com", "Should have a to value")
+        XCTAssertEqual(metadata?.headers.count, 3, "Should have 3 headers")
+        XCTAssertEqual(metadata?.headers["subject"], "This is the subject")
+        XCTAssertEqual(metadata?.headers["cc"], "someone_else@example.com")
+        XCTAssertEqual(metadata?.headers["body"], "This is the body")
+    }
+
+    func testMailToMetadata_noToAddress() {
+        let url = URL(string: "mailto:?to=&subject=mailto%20with%20examples&body=https%3A%2F%2Fen.wikipedia.org%2Fwiki%2FMailto")
+        let metadata = url!.mailToMetadata()
+        XCTAssertNotNil(metadata, "Metadata should not be nil")
+        XCTAssertEqual(metadata?.to, "", "Should have empty to value")
+        XCTAssertEqual(metadata?.headers.count, 3, "Should have 3 headers")
+        XCTAssertEqual(metadata?.headers["subject"], "mailto with examples")
+        XCTAssertEqual(metadata?.headers["body"], "https://en.wikipedia.org/wiki/Mailto")
+    }
+
+    func testMailToMetadata_blubb() {
+        let url = URL(string: "mailto:someone@example.com?subject=This%20is%20the%20subject&body")
+        let metadata = url!.mailToMetadata()
+        XCTAssertNotNil(metadata, "Metadata should not be nil")
+        XCTAssertEqual(metadata?.to, "someone@example.com", "Should have a to value")
+        XCTAssertEqual(metadata?.headers.count, 1, "Should have 1 headers")
+        XCTAssertEqual(metadata?.headers["subject"], "This is the subject")
+    }
+}

--- a/Tests/ClientTests/Helpers/MailProvidersTests.swift
+++ b/Tests/ClientTests/Helpers/MailProvidersTests.swift
@@ -10,8 +10,8 @@ class MailProvidersTests: XCTestCase {
     let toEmail = "name1@test.com"
     let ccEmail = "name2@test.com"
     let bccEmail = "name3@test.com"
-    let subject = "The%20subject%20of%20the%20email"
-    let body = "The%20body%20of%20the%20email"
+    let subject = "The subject of the email"
+    let body = "The body of the email"
 
     // MARK: - Readdle Spark
     func testReaddleSparkIntegration_basicMetadata() {
@@ -27,9 +27,21 @@ class MailProvidersTests: XCTestCase {
             return
         }
 
+        let expectedResult = ["recipient": toEmail,
+                              "subject": subject,
+                              "textbody": body,
+                              "cc": ccEmail,
+                              "bcc": bccEmail]
+
         XCTAssertEqual(urlStringWithoutQuery(url: mailURL)!, "readdle-spark://compose")
-        XCTAssertEqual(mailURL.getQuery(),
-                       ["recipient": toEmail, "subject": subject, "textbody": body, "cc": ccEmail, "bcc": bccEmail])
+        XCTAssertTrue(NSDictionary(dictionary: mailURL.getQuery()).isEqual(to: expectedResult))
+    }
+
+    func testReaddleSparkIntegration_multipleEmails() {
+        let provider = ReaddleSparkIntegration()
+        let metadata = MailToMetadata(to: "\(toEmail),\(ccEmail)", headers: [:])
+        let mailURL = provider.newEmailURLFromMetadata(metadata)
+        XCTAssertEqual(mailURL?.absoluteString, "readdle-spark://compose?recipient=\(metadata.to)")
     }
 
     // MARK: - Airmail
@@ -46,9 +58,14 @@ class MailProvidersTests: XCTestCase {
             return
         }
 
+        let expectedResult = ["to": toEmail,
+                              "subject": subject,
+                              "htmlBody": body,
+                              "cc": ccEmail,
+                              "bcc": bccEmail]
+
         XCTAssertEqual(urlStringWithoutQuery(url: mailURL)!, "airmail://compose")
-        XCTAssertEqual(mailURL.getQuery(),
-                       ["to": toEmail, "subject": subject, "htmlBody": body, "cc": ccEmail, "bcc": bccEmail])
+        XCTAssertTrue(NSDictionary(dictionary: mailURL.getQuery()).isEqual(to: expectedResult))
     }
 
     // MARK: - MyMail
@@ -65,9 +82,14 @@ class MailProvidersTests: XCTestCase {
             return
         }
 
+        let expectedResult = ["to": toEmail,
+                              "subject": subject,
+                              "body": body,
+                              "cc": ccEmail,
+                              "bcc": bccEmail]
+
         XCTAssertEqual(urlStringWithoutQuery(url: mailURL)!, "mymail-mailto://")
-        XCTAssertEqual(mailURL.getQuery(),
-                       ["to": toEmail, "subject": subject, "body": body, "cc": ccEmail, "bcc": bccEmail])
+        XCTAssertTrue(NSDictionary(dictionary: mailURL.getQuery()).isEqual(to: expectedResult))
     }
 
     // MARK: - MailRuIntegration
@@ -84,16 +106,21 @@ class MailProvidersTests: XCTestCase {
             return
         }
 
+        let expectedResult = ["to": toEmail,
+                              "subject": subject,
+                              "body": body,
+                              "cc": ccEmail,
+                              "bcc": bccEmail]
+
         XCTAssertEqual(urlStringWithoutQuery(url: mailURL)!, "mailru-mailto://")
-        XCTAssertEqual(mailURL.getQuery(),
-                       ["to": toEmail, "subject": subject, "body": body, "cc": ccEmail, "bcc": bccEmail])
+        XCTAssertTrue(NSDictionary(dictionary: mailURL.getQuery()).isEqual(to: expectedResult))
     }
 
     // MARK: - MS Outlook
     func testMSOutlookIntegration_basicMetadata() {
         let provider = MSOutlookIntegration()
         let mailURL = provider.newEmailURLFromMetadata(buildBasicMetadata())
-        XCTAssertEqual(mailURL?.absoluteString, "ms-outlook://emails/new?to=\(toEmail)")
+        XCTAssertEqual(mailURL?.absoluteString, "ms-outlook:emails/new?to=\(toEmail)")
     }
 
     func testMSOutlookIntegration_fullMetadata() {
@@ -103,16 +130,21 @@ class MailProvidersTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(urlStringWithoutQuery(url: mailURL)!, "ms-outlook://emails/new")
-        XCTAssertEqual(mailURL.getQuery(),
-                       ["to": toEmail, "subject": subject, "body": body, "cc": ccEmail, "bcc": bccEmail])
+        let expectedResult = ["to": toEmail,
+                              "subject": subject,
+                              "body": body,
+                              "cc": ccEmail,
+                              "bcc": bccEmail]
+
+        XCTAssertEqual(urlStringWithoutQuery(url: mailURL)!, "ms-outlook:emails/new")
+        XCTAssertTrue(NSDictionary(dictionary: mailURL.getQuery()).isEqual(to: expectedResult))
     }
 
     // MARK: - YMail
     func testYMailIntegration_basicMetadata() {
         let provider = YMailIntegration()
         let mailURL = provider.newEmailURLFromMetadata(buildBasicMetadata())
-        XCTAssertEqual(mailURL?.absoluteString, "ymail://mail/any/compose?to=\(toEmail)")
+        XCTAssertEqual(mailURL?.absoluteString, "ymail:mail/any/compose?to=\(toEmail)")
     }
 
     func testYMailIntegration_fullMetadata() {
@@ -122,16 +154,20 @@ class MailProvidersTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(urlStringWithoutQuery(url: mailURL)!, "ymail://mail/any/compose")
-        XCTAssertEqual(mailURL.getQuery(),
-                       ["to": toEmail, "subject": subject, "body": body, "cc": ccEmail])
+        let expectedResult = ["to": toEmail,
+                              "subject": subject,
+                              "body": body,
+                              "cc": ccEmail]
+
+        XCTAssertEqual(urlStringWithoutQuery(url: mailURL)!, "ymail:mail/any/compose")
+        XCTAssertTrue(NSDictionary(dictionary: mailURL.getQuery()).isEqual(to: expectedResult))
     }
 
     // MARK: - Google Gmail
     func testGoogleGmailIntegration_basicMetadata() {
         let provider = GoogleGmailIntegration()
         let mailURL = provider.newEmailURLFromMetadata(buildBasicMetadata())
-        XCTAssertEqual(mailURL?.absoluteString, "googlegmail:///co?to=\(toEmail)")
+        XCTAssertEqual(mailURL?.absoluteString, "googlegmail://co?to=\(toEmail)")
     }
 
     func testGoogleGmailIntegration_fullMetadata() {
@@ -141,16 +177,21 @@ class MailProvidersTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(urlStringWithoutQuery(url: mailURL)!, "googlegmail:///co")
-        XCTAssertEqual(mailURL.getQuery(),
-                       ["to": toEmail, "subject": subject, "body": body, "cc": ccEmail, "bcc": bccEmail])
+        let expectedResult = ["to": toEmail,
+                              "subject": subject,
+                              "body": body,
+                              "cc": ccEmail,
+                              "bcc": bccEmail]
+
+        XCTAssertEqual(urlStringWithoutQuery(url: mailURL)!, "googlegmail://co")
+        XCTAssertTrue(NSDictionary(dictionary: mailURL.getQuery()).isEqual(to: expectedResult))
     }
 
     // MARK: - Fastmail
     func testFastmailIntegration_basicMetadata() {
         let provider = FastmailIntegration()
         let mailURL = provider.newEmailURLFromMetadata(buildBasicMetadata())
-        XCTAssertEqual(mailURL?.absoluteString, "fastmail://mail/compose?to=\(toEmail)")
+        XCTAssertEqual(mailURL?.absoluteString, "fastmail:mail/compose?to=\(toEmail)")
     }
 
     func testFastmailSparkIntegration_fullMetadata() {
@@ -160,9 +201,14 @@ class MailProvidersTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(urlStringWithoutQuery(url: mailURL)!, "fastmail://mail/compose")
-        XCTAssertEqual(mailURL.getQuery(),
-                       ["to": toEmail, "subject": subject, "body": body, "cc": ccEmail, "bcc": bccEmail])
+        let expectedResult = ["to": toEmail,
+                              "subject": subject,
+                              "body": body,
+                              "cc": ccEmail,
+                              "bcc": bccEmail]
+
+        XCTAssertEqual(urlStringWithoutQuery(url: mailURL)!, "fastmail:mail/compose")
+        XCTAssertTrue(NSDictionary(dictionary: mailURL.getQuery()).isEqual(to: expectedResult))
     }
 
     // MARK: - ProtonMail
@@ -179,9 +225,21 @@ class MailProvidersTests: XCTestCase {
             return
         }
 
+        let expectedResult = ["subject": subject,
+                              "body": body,
+                              "cc": ccEmail,
+                              "bcc": bccEmail]
+
         XCTAssertEqual(urlStringWithoutQuery(url: mailURL)!, "protonmail://mailto:\(toEmail)")
-        XCTAssertEqual(mailURL.getQuery(),
-                       ["subject": subject, "body": body, "cc": ccEmail, "bcc": bccEmail])
+        XCTAssertTrue(NSDictionary(dictionary: mailURL.getQuery()).isEqual(to: expectedResult))
+    }
+
+    func testProtonMailIntegration_multipleEmails() {
+        let provider = ProtonMailIntegration()
+        let metadata = MailToMetadata(to: "\(toEmail),\(ccEmail)", headers: [:])
+        let mailURL = provider.newEmailURLFromMetadata(metadata)
+        let expectedResult = "\(toEmail.addingPercentEncoding(withAllowedCharacters: .urlPasswordAllowed)!),\(ccEmail)"
+        XCTAssertEqual(mailURL?.absoluteString, "protonmail://mailto:\(expectedResult)")
     }
 
     // MARK: - Private


### PR DESCRIPTION
[FXIOS-5626](https://mozilla-hub.atlassian.net/browse/FXIOS-5626)
#12998

We are now using URLComponents to parse mailto links and build the link to open the correct mail app.