### PR TITLE
Bugfix FXIOS-5316 [v111] Add bundle for fallback of translations

### DIFF
--- a/Client/Experiments/Experiments.swift
+++ b/Client/Experiments/Experiments.swift
@@ -165,7 +165,11 @@ enum Experiments {
             return NimbusDisabled.shared
         }
 
-        let bundles = [Bundle.main, Strings.bundle]
+        let bundles = [
+            Bundle.main,
+            Strings.bundle,
+            Strings.bundle.fallbackTranslationBundle()
+        ].compactMap { $0 }
 
         let builder = NimbusBuilder(dbPath: dbPath)
         builder.with(url: remoteSettingsURL) // with(url:) returns void.

--- a/Tests/ClientTests/NimbusIntegrationTests.swift
+++ b/Tests/ClientTests/NimbusIntegrationTests.swift
@@ -19,6 +19,30 @@ class NimbusIntegrationTests: XCTestCase {
         XCTAssertEqual(stringWithTable, "Switch Your Default Browser")
     }
 
+    func testStringFallbackBundleAccessExplicitLanguage() throws {
+        let bundles = [
+            Bundle.main,
+            Strings.bundle.fallbackTranslationBundle(language: "es"),
+        ].compactMap { $0 }
+        let stringWithNoTable = bundles.getString(named: "ShareExtension.OpenInFirefoxAction.Title")
+        XCTAssertEqual(stringWithNoTable, "Abrir en Firefox")
+
+        let stringWithTable = bundles.getString(named: "Default Browser/DefaultBrowserCard.Title")
+        XCTAssertEqual(stringWithTable, "Cambia tu navegador predeterminado")
+    }
+
+    func testStringFallbackBundleAccessImplicitLanguage() throws {
+        let bundles = [
+            Bundle.main,
+            Strings.bundle.fallbackTranslationBundle(),
+        ].compactMap { $0 }
+        let stringWithNoTable = bundles.getString(named: "ShareExtension.OpenInFirefoxAction.Title")
+        XCTAssertEqual(stringWithNoTable, "Open in Firefox")
+
+        let stringWithTable = bundles.getString(named: "Default Browser/DefaultBrowserCard.Title")
+        XCTAssertEqual(stringWithTable, "Switch Your Default Browser")
+    }
+
     func testNSLocalizedStringAccess() throws {
         XCTAssertEqual(Locale.current.languageCode, "en")
         let stringWithNoTable = NSLocalizedString("ShareExtension.OpenInFirefoxAction.Title", bundle: Strings.bundle, comment: "")


### PR DESCRIPTION
Fixes [EXP-3042](https://mozilla-hub.atlassian.net/browse/EXP-3042).
Fixes [FXIOS-5316](https://mozilla-hub.atlassian.net/browse/FXIOS-5316).
Fixes #12484.

This adds the English translations as a fallback if no other translation is available.

---

*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Please make sure you've run the test scheme and all the tests pass. If your changes affect existing tests please make sure to update the tests as well.

Below is the PR naming guidelines we follow:

https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide
