### PR TITLE
Add FXIOS-5572 [v111] BrowserKit tests run with all unit tests

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec.xcscheme
@@ -379,6 +379,26 @@
                ReferencedContainer = "container:FxA/FxA.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CommonTests"
+               BuildableName = "CommonTests"
+               BlueprintName = "CommonTests"
+               ReferencedContainer = "container:BrowserKit">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SiteImageViewTests"
+               BuildableName = "SiteImageViewTests"
+               BlueprintName = "SiteImageViewTests"
+               ReferencedContainer = "container:BrowserKit">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise.xcscheme
@@ -26,9 +26,18 @@
       buildConfiguration = "Fennec_Enterprise"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "NO"
       language = "en"
-      region = "US"
-      shouldUseLaunchSchemeArgsEnv = "NO">
+      region = "US">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F84B21BD1A090F8100AAB793"
+            BuildableName = "Client.app"
+            BlueprintName = "Client"
+            ReferencedContainer = "container:Client.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -147,18 +156,27 @@
                ReferencedContainer = "container:Client.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CommonTests"
+               BuildableName = "CommonTests"
+               BlueprintName = "CommonTests"
+               ReferencedContainer = "container:BrowserKit">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SiteImageViewTests"
+               BuildableName = "SiteImageViewTests"
+               BlueprintName = "SiteImageViewTests"
+               ReferencedContainer = "container:BrowserKit">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "F84B21BD1A090F8100AAB793"
-            BuildableName = "Client.app"
-            BlueprintName = "Client"
-            ReferencedContainer = "container:Client.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Fennec_Enterprise"
@@ -187,8 +205,6 @@
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Fennec_Enterprise"

--- a/Client.xcodeproj/xcshareddata/xcschemes/Firefox.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Firefox.xcscheme
@@ -142,6 +142,26 @@
                </Test>
             </SkippedTests>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CommonTests"
+               BuildableName = "CommonTests"
+               BlueprintName = "CommonTests"
+               ReferencedContainer = "container:BrowserKit">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SiteImageViewTests"
+               BuildableName = "SiteImageViewTests"
+               BlueprintName = "SiteImageViewTests"
+               ReferencedContainer = "container:BrowserKit">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Client.xcodeproj/xcshareddata/xcschemes/FirefoxBeta.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/FirefoxBeta.xcscheme
@@ -142,6 +142,26 @@
                </Test>
             </SkippedTests>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CommonTests"
+               BuildableName = "CommonTests"
+               BlueprintName = "CommonTests"
+               ReferencedContainer = "container:BrowserKit">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SiteImageViewTests"
+               BuildableName = "SiteImageViewTests"
+               BlueprintName = "SiteImageViewTests"
+               ReferencedContainer = "container:BrowserKit">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Tests/UnitTest.xctestplan
+++ b/Tests/UnitTest.xctestplan
@@ -71,6 +71,20 @@
         "identifier" : "282731671ABC9BE700AA1954",
         "name" : "SyncTests"
       }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:BrowserKit",
+        "identifier" : "CommonTests",
+        "name" : "CommonTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:BrowserKit",
+        "identifier" : "SiteImageViewTests",
+        "name" : "SiteImageViewTests"
+      }
     }
   ],
   "version" : 1


### PR DESCRIPTION
# [FXIOS-5572](Tests/UnitTest.xctestplan) | #12909

BrowserKit tests run with all unit tests (for now). They've been included within the UnitTest test plan, and schemes that run unit tests also have been updated to run BrowserKit tests. 

Running BrowserKit tests specifically will come at a later time with the support of the QA team. 