### PR TITLE
Refactor FXIOS-5649 [v111] refactor favicon interface

### DIFF
--- a/BrowserKit/Sources/SiteImageView/Entities/SiteImageModel.swift
+++ b/BrowserKit/Sources/SiteImageView/Entities/SiteImageModel.swift
@@ -12,14 +12,14 @@ public struct SiteImageModel {
     /// The image type expected when making a request
     let expectedImageType: SiteImageType
 
-    /// Always present, used to make the initial request
-    let urlStringRequest: String
+    /// Represents the website and not the resource
+    let siteURLString: String?
 
     /// URL can be nil in case the urlStringRequest cannot be used to build a URL
     var siteURL: URL?
 
     /// Used to cache any resources related to this request
-    var cacheKey: String
+    var cacheKey: String = ""
 
     /// Domain can be nil in case we don't have a siteURL to get the domain from
     var domain: ImageDomain?
@@ -32,4 +32,23 @@ public struct SiteImageModel {
 
     /// The fetched hero image
     var heroImage: UIImage?
+
+    public init(id: UUID,
+                expectedImageType: SiteImageType,
+                siteURLString: String?,
+                siteURL: URL? = nil,
+                cacheKey: String = "",
+                faviconURL: URL? = nil,
+                faviconImage: UIImage? = nil,
+                heroImage: UIImage? = nil) {
+        self.id = id
+        self.expectedImageType = expectedImageType
+        self.siteURLString = siteURLString
+        self.siteURL = siteURL
+        self.cacheKey = cacheKey
+        self.domain = nil
+        self.faviconURL = faviconURL
+        self.faviconImage = faviconImage
+        self.heroImage = heroImage
+    }
 }

--- a/BrowserKit/Sources/SiteImageView/Entities/SiteImageModel.swift
+++ b/BrowserKit/Sources/SiteImageView/Entities/SiteImageModel.swift
@@ -35,7 +35,7 @@ public struct SiteImageModel {
 
     public init(id: UUID,
                 expectedImageType: SiteImageType,
-                siteURLString: String?,
+                siteURLString: String? = nil,
                 siteURL: URL? = nil,
                 cacheKey: String = "",
                 faviconURL: URL? = nil,

--- a/BrowserKit/Sources/SiteImageView/FaviconImageView.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconImageView.swift
@@ -50,14 +50,16 @@ public class FaviconImageView: UIImageView, SiteImageView {
     // MARK: - SiteImageView
 
     func setURL(_ viewModel: FaviconImageViewModel) {
-        guard canMakeRequest(with: viewModel.urlStringRequest) else { return }
+        guard canMakeRequest(with: viewModel.siteURLString) else { return }
 
         let id = UUID()
         uniqueID = id
-        updateImage(url: viewModel.urlStringRequest,
-                    type: .favicon,
-                    id: id,
-                    usesIndirectDomain: viewModel.usesIndirectDomain)
+
+        let model = SiteImageModel(id: id,
+                                   expectedImageType: .favicon,
+                                   siteURLString: viewModel.siteURLString,
+                                   faviconURL: viewModel.faviconURL)
+        updateImage(site: model)
     }
 
     func setImage(imageModel: SiteImageModel) {

--- a/BrowserKit/Sources/SiteImageView/FaviconImageViewModel.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconImageViewModel.swift
@@ -5,15 +5,15 @@
 import UIKit
 
 public struct FaviconImageViewModel {
-    var urlStringRequest: String
+    var siteURLString: String?
+    var faviconURL: URL?
     var faviconCornerRadius: CGFloat
-    var usesIndirectDomain: Bool
 
-    public init(urlStringRequest: String,
-                faviconCornerRadius: CGFloat = 4,
-                usesIndirectDomain: Bool = false) {
-        self.urlStringRequest = urlStringRequest
+    public init(siteURLString: String? = nil,
+                faviconURL: URL? = nil,
+                faviconCornerRadius: CGFloat = 4) {
+        self.siteURLString = siteURLString
+        self.faviconURL = faviconURL
         self.faviconCornerRadius = faviconCornerRadius
-        self.usesIndirectDomain = usesIndirectDomain
     }
 }

--- a/BrowserKit/Sources/SiteImageView/HeroImageView.swift
+++ b/BrowserKit/Sources/SiteImageView/HeroImageView.swift
@@ -76,15 +76,16 @@ public class HeroImageView: UIView, SiteImageView {
 
     // MARK: - SiteImageView
 
-    func setURL(_ urlStringRequest: String, type: SiteImageType) {
-        guard canMakeRequest(with: urlStringRequest) else { return }
+    func setURL(_ siteURLString: String, type: SiteImageType) {
+        guard canMakeRequest(with: siteURLString) else { return }
 
         let id = UUID()
         uniqueID = id
-        updateImage(url: urlStringRequest,
-                    type: type,
-                    id: id,
-                    usesIndirectDomain: true)
+
+        let model = SiteImageModel(id: id,
+                                   expectedImageType: .heroImage,
+                                   siteURLString: siteURLString)
+        updateImage(site: model)
     }
 
     func setImage(imageModel: SiteImageModel) {

--- a/BrowserKit/Sources/SiteImageView/SiteImageHandler.swift
+++ b/BrowserKit/Sources/SiteImageView/SiteImageHandler.swift
@@ -75,7 +75,7 @@ public class DefaultSiteImageHandler: SiteImageHandler {
     private func generateCacheKey(siteURL: URL?,
                                   faviconURL: URL? = nil,
                                   type: SiteImageType) -> String {
-        // If we alredy have a favicon url use the url as the cache key
+        // If we already have a favicon url use the url as the cache key
         if let faviconURL = faviconURL {
             return faviconURL.absoluteString
         }

--- a/BrowserKit/Sources/SiteImageView/SiteImageHandler.swift
+++ b/BrowserKit/Sources/SiteImageView/SiteImageHandler.swift
@@ -33,11 +33,11 @@ public class DefaultSiteImageHandler: SiteImageHandler {
             let domain = generateDomainURL(siteURL: siteURL)
             imageModel.siteURL = siteURL
             imageModel.domain = domain
-
-            imageModel.cacheKey = generateCacheKey(siteURL: siteURL,
-                                                   faviconURL: imageModel.faviconURL,
-                                                   type: imageModel.expectedImageType)
         }
+
+        imageModel.cacheKey = generateCacheKey(siteURL: URL(string: site.siteURLString ?? ""),
+                                               faviconURL: imageModel.faviconURL,
+                                               type: imageModel.expectedImageType)
 
         do {
             switch site.expectedImageType {

--- a/BrowserKit/Sources/SiteImageView/SiteImageHandler.swift
+++ b/BrowserKit/Sources/SiteImageView/SiteImageHandler.swift
@@ -6,10 +6,7 @@ import UIKit
 import Common
 
 public protocol SiteImageHandler {
-    func getImage(urlStringRequest: String,
-                  type: SiteImageType,
-                  id: UUID,
-                  usesIndirectDomain: Bool) async -> SiteImageModel
+    func getImage(site: SiteImageModel) async -> SiteImageModel
     func cacheFaviconURL(siteURL: URL?, faviconURL: URL?)
     func clearAllCaches()
 }
@@ -28,38 +25,22 @@ public class DefaultSiteImageHandler: SiteImageHandler {
         self.imageHandler = imageHandler
     }
 
-    public func getImage(urlStringRequest: String,
-                         type: SiteImageType,
-                         id: UUID,
-                         usesIndirectDomain: Bool) async -> SiteImageModel {
-        var imageModel = SiteImageModel(id: id,
-                                        expectedImageType: type,
-                                        urlStringRequest: urlStringRequest,
-                                        siteURL: nil,
-                                        cacheKey: "",
-                                        domain: nil,
-                                        faviconURL: nil,
-                                        faviconImage: nil,
-                                        heroImage: nil)
+    public func getImage(site: SiteImageModel) async -> SiteImageModel {
+        var imageModel = site
 
         // urlStringRequest possibly cannot be a URL
-        if let siteURL = URL(string: urlStringRequest) {
+        if let siteURL = URL(string: site.siteURLString ?? "") {
             let domain = generateDomainURL(siteURL: siteURL)
             imageModel.siteURL = siteURL
             imageModel.domain = domain
-            imageModel.cacheKey = generateCacheKey(siteURL: siteURL,
-                                                   type: type,
-                                                   usesIndirectDomain: usesIndirectDomain)
-        }
 
-        // For favicons with the usesIndirectDomain flag set we want to use the provided
-        // url directly to retrieve the image
-        if usesIndirectDomain, type == .favicon {
-            imageModel.faviconURL = URL(string: urlStringRequest)
+            imageModel.cacheKey = generateCacheKey(siteURL: siteURL,
+                                                   faviconURL: imageModel.faviconURL,
+                                                   type: imageModel.expectedImageType)
         }
 
         do {
-            switch type {
+            switch site.expectedImageType {
             case .heroImage:
                 imageModel.heroImage = try await getHeroImage(imageModel: imageModel)
             case .favicon:
@@ -80,8 +61,7 @@ public class DefaultSiteImageHandler: SiteImageHandler {
         }
 
         let cacheKey = generateCacheKey(siteURL: siteURL,
-                                        type: .favicon,
-                                        usesIndirectDomain: false)
+                                        type: .favicon)
         urlHandler.cacheFaviconURL(cacheKey: cacheKey, faviconURL: faviconURL)
     }
 
@@ -92,13 +72,24 @@ public class DefaultSiteImageHandler: SiteImageHandler {
 
     // MARK: - Private
 
-    private func generateCacheKey(siteURL: URL,
-                                  type: SiteImageType,
-                                  usesIndirectDomain: Bool) -> String {
-        guard usesIndirectDomain else {
-            return siteURL.shortDomain ?? siteURL.shortDisplayString
+    private func generateCacheKey(siteURL: URL?,
+                                  faviconURL: URL? = nil,
+                                  type: SiteImageType) -> String {
+        // If we alredy have a favicon url use the url as the cache key
+        if let faviconURL = faviconURL {
+            return faviconURL.absoluteString
         }
-        return siteURL.absoluteString
+
+        guard let siteURL = siteURL else { return "" }
+
+        // Always use the full site URL as the cache key for hero images
+        if type == .heroImage {
+            return siteURL.absoluteString
+        }
+
+        // For everything else use the domain as the key to avoid caching
+        // and fetching unneccessary duplicates
+        return siteURL.shortDomain ?? siteURL.shortDisplayString
     }
 
     private func getHeroImage(imageModel: SiteImageModel) async throws -> UIImage {

--- a/BrowserKit/Sources/SiteImageView/SiteImageView.swift
+++ b/BrowserKit/Sources/SiteImageView/SiteImageView.swift
@@ -10,31 +10,22 @@ protocol SiteImageView: UIView {
     var uniqueID: UUID? { get set }
     var imageFetcher: SiteImageHandler { get set }
 
-    func updateImage(url: String,
-                     type: SiteImageType,
-                     id: UUID,
-                     usesIndirectDomain: Bool)
+    func updateImage(site: SiteImageModel)
     func setImage(imageModel: SiteImageModel)
 
     // Avoid multiple image loading in parallel. Only start a new request if the URL string has changed
     var requestStartedWith: String? { get set }
-    func canMakeRequest(with urlStringRequest: String) -> Bool
+    func canMakeRequest(with urlStringRequest: String?) -> Bool
 }
 
 extension SiteImageView {
-    func canMakeRequest(with urlStringRequest: String) -> Bool {
+    func canMakeRequest(with urlStringRequest: String?) -> Bool {
         return requestStartedWith != urlStringRequest
     }
 
-    func updateImage(url: String,
-                     type: SiteImageType,
-                     id: UUID,
-                     usesIndirectDomain: Bool) {
+    func updateImage(site: SiteImageModel) {
         Task {
-            let imageModel = await imageFetcher.getImage(urlStringRequest: url,
-                                                         type: type,
-                                                         id: id,
-                                                         usesIndirectDomain: usesIndirectDomain)
+            let imageModel = await imageFetcher.getImage(site: site)
             guard uniqueID == imageModel.id else { return }
 
             DispatchQueue.main.async { [weak self] in

--- a/BrowserKit/Tests/SiteImageViewTests/FaviconURLProcessing/FaviconURLHandlerTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/FaviconURLProcessing/FaviconURLHandlerTests.swift
@@ -100,10 +100,9 @@ class FaviconURLHandlerTests: XCTestCase {
     private func createSiteImageModel(siteURL: String) -> SiteImageModel {
         return SiteImageModel(id: UUID(),
                               expectedImageType: .favicon,
-                              urlStringRequest: siteURL,
+                              siteURLString: siteURL,
                               siteURL: URL(string: siteURL)!,
                               cacheKey: "domain",
-                              domain: ImageDomain(bundleDomains: []),
                               faviconURL: nil,
                               faviconImage: nil,
                               heroImage: nil)

--- a/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/ImageHandlerTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/ImageHandlerTests.swift
@@ -38,10 +38,9 @@ final class ImageHandlerTests: XCTestCase {
                                       type: SiteImageType = .favicon) -> SiteImageModel {
         return SiteImageModel(id: UUID(),
                               expectedImageType: type,
-                              urlStringRequest: cacheKey,
+                              siteURLString: cacheKey,
                               siteURL: URL(string: cacheKey)!,
                               cacheKey: cacheKey,
-                              domain: ImageDomain(bundleDomains: []),
                               faviconURL: imageURL,
                               faviconImage: nil,
                               heroImage: nil)

--- a/BrowserKit/Tests/SiteImageViewTests/SiteImageHandlerTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/SiteImageHandlerTests.swift
@@ -27,10 +27,10 @@ final class SiteImageHandlerTests: XCTestCase {
         let siteURL = "https://www.example.hello.com"
         let subject = DefaultSiteImageHandler(urlHandler: urlHandler,
                                               imageHandler: imageHandler)
-        let result = await subject.getImage(urlStringRequest: siteURL,
-                                            type: .favicon,
-                                            id: UUID(),
-                                            usesIndirectDomain: false)
+        let model = SiteImageModel(id: UUID(),
+                                   expectedImageType: .favicon,
+                                   siteURLString: siteURL)
+        let result = await subject.getImage(site: model)
 
         XCTAssertEqual(result.cacheKey, "example.hello")
         XCTAssertEqual(result.siteURL, URL(string: siteURL))
@@ -48,10 +48,10 @@ final class SiteImageHandlerTests: XCTestCase {
         let siteURL = "www.example.hello.com"
         let subject = DefaultSiteImageHandler(urlHandler: urlHandler,
                                               imageHandler: imageHandler)
-        let result = await subject.getImage(urlStringRequest: siteURL,
-                                            type: .favicon,
-                                            id: UUID(),
-                                            usesIndirectDomain: false)
+        let model = SiteImageModel(id: UUID(),
+                                   expectedImageType: .favicon,
+                                   siteURLString: siteURL)
+        let result = await subject.getImage(site: model)
 
         XCTAssertEqual(result.cacheKey, "www.example.hello.com")
         XCTAssertEqual(imageHandler.capturedSite?.cacheKey, "www.example.hello.com")
@@ -63,10 +63,10 @@ final class SiteImageHandlerTests: XCTestCase {
         urlHandler.faviconURL = faviconURL
         let subject = DefaultSiteImageHandler(urlHandler: urlHandler,
                                               imageHandler: imageHandler)
-        let result = await subject.getImage(urlStringRequest: siteURL,
-                                            type: .favicon,
-                                            id: UUID(),
-                                            usesIndirectDomain: false)
+        let model = SiteImageModel(id: UUID(),
+                                   expectedImageType: .favicon,
+                                   siteURLString: siteURL)
+        let result = await subject.getImage(site: model)
 
         XCTAssertEqual(result.cacheKey, "mozilla")
         XCTAssertEqual(result.siteURL, URL(string: siteURL))
@@ -80,16 +80,15 @@ final class SiteImageHandlerTests: XCTestCase {
     }
 
     func testFaviconIndirectDomain_faviconURLFound_generateFavicon() async {
-        let siteURL = "https://www.mozilla.com"
+        let siteURL = URL(string: "https://www.mozilla.com")
         let subject = DefaultSiteImageHandler(urlHandler: urlHandler,
                                               imageHandler: imageHandler)
-        let result = await subject.getImage(urlStringRequest: siteURL,
-                                            type: .favicon,
-                                            id: UUID(),
-                                            usesIndirectDomain: true)
+        let model = SiteImageModel(id: UUID(),
+                                   expectedImageType: .favicon,
+                                   faviconURL: siteURL)
+        let result = await subject.getImage(site: model)
 
         XCTAssertEqual(result.cacheKey, "https://www.mozilla.com")
-        XCTAssertEqual(result.siteURL, URL(string: siteURL))
         XCTAssertEqual(result.faviconURL?.absoluteString, "https://www.mozilla.com")
         XCTAssertEqual(result.expectedImageType, .favicon)
         XCTAssertNil(result.heroImage)
@@ -105,10 +104,10 @@ final class SiteImageHandlerTests: XCTestCase {
         let subject = DefaultSiteImageHandler(urlHandler: urlHandler,
                                               imageHandler: imageHandler)
         let siteURL = "https://www.firefox.com"
-        let result = await subject.getImage(urlStringRequest: siteURL,
-                                            type: .heroImage,
-                                            id: UUID(),
-                                            usesIndirectDomain: true)
+        let model = SiteImageModel(id: UUID(),
+                                   expectedImageType: .heroImage,
+                                   siteURLString: siteURL)
+        let result = await subject.getImage(site: model)
 
         XCTAssertEqual(result.cacheKey, "https://www.firefox.com")
         XCTAssertEqual(result.siteURL, URL(string: siteURL))
@@ -127,10 +126,10 @@ final class SiteImageHandlerTests: XCTestCase {
         let subject = DefaultSiteImageHandler(urlHandler: urlHandler,
                                               imageHandler: imageHandler)
         let siteURL = "https://www.focus.com"
-        let result = await subject.getImage(urlStringRequest: siteURL,
-                                            type: .heroImage,
-                                            id: UUID(),
-                                            usesIndirectDomain: true)
+        let model = SiteImageModel(id: UUID(),
+                                   expectedImageType: .heroImage,
+                                   siteURLString: siteURL)
+        let result = await subject.getImage(site: model)
 
         XCTAssertEqual(result.cacheKey, "https://www.focus.com")
         XCTAssertEqual(result.siteURL, URL(string: siteURL))
@@ -177,10 +176,9 @@ private class MockFaviconURLHandler: FaviconURLHandler {
         capturedImageModel = site
         return SiteImageModel(id: site.id,
                               expectedImageType: site.expectedImageType,
-                              urlStringRequest: site.urlStringRequest,
+                              siteURLString: site.siteURLString,
                               siteURL: site.siteURL,
                               cacheKey: site.cacheKey,
-                              domain: site.domain,
                               faviconURL: faviconURL)
     }
 

--- a/BrowserKit/Tests/SiteImageViewTests/SiteImageViewTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/SiteImageViewTests.swift
@@ -29,8 +29,8 @@ final class SiteImageViewTests: XCTestCase {
         subject.setFavicon(viewModel)
 
         waitForExpectations(timeout: 0.1)
-        XCTAssertEqual(imageFetcher.capturedStringRequest, url)
-        XCTAssertEqual(imageFetcher.capturedType, .favicon)
+        XCTAssertEqual(imageFetcher.capturedSite?.siteURLString, url)
+        XCTAssertEqual(imageFetcher.capturedSite?.expectedImageType, .favicon)
     }
 
     func testHeroImageSetup() {
@@ -48,35 +48,22 @@ final class SiteImageViewTests: XCTestCase {
         subject.setHeroImage(viewModel)
 
         waitForExpectations(timeout: 0.1)
-        XCTAssertEqual(imageFetcher.capturedStringRequest, url)
-        XCTAssertEqual(imageFetcher.capturedType, .heroImage)
+        XCTAssertEqual(imageFetcher.capturedSite?.siteURLString, url)
+        XCTAssertEqual(imageFetcher.capturedSite?.expectedImageType, .heroImage)
     }
 }
 
 class MockSiteImageHandler: SiteImageHandler {
     var image = UIImage()
-    var capturedType: SiteImageType?
-    var capturedStringRequest: String?
+    var capturedSite: SiteImageModel?
     var siteURL: URL?
     var faviconURL: URL?
     var cacheFaviconURLCalled = 0
     var clearAllCachesCalled = 0
 
-    func getImage(urlStringRequest: String,
-                  type: SiteImageType,
-                  id: UUID,
-                  usesIndirectDomain: Bool) async -> SiteImageModel {
-        capturedStringRequest = urlStringRequest
-        capturedType = type
-        return SiteImageModel(id: id,
-                              expectedImageType: type,
-                              urlStringRequest: urlStringRequest,
-                              siteURL: URL(string: urlStringRequest)!,
-                              cacheKey: "",
-                              domain: ImageDomain(bundleDomains: []),
-                              faviconURL: nil,
-                              faviconImage: image,
-                              heroImage: image)
+    func getImage(site: SiteImageModel) async -> SiteImageModel {
+        capturedSite = site
+        return site
     }
 
     func cacheFaviconURL(siteURL: URL?, faviconURL: URL?) {

--- a/BrowserKit/Tests/SiteImageViewTests/SiteImageViewTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/SiteImageViewTests.swift
@@ -21,7 +21,7 @@ final class SiteImageViewTests: XCTestCase {
     func testFaviconSetup() {
         let expectation = expectation(description: "Completed image setup")
         let url = "https://www.firefox.com"
-        let viewModel = FaviconImageViewModel(urlStringRequest: url,
+        let viewModel = FaviconImageViewModel(siteURLString: url,
                                               faviconCornerRadius: 8)
         let subject = FaviconImageView(frame: .zero, imageFetcher: imageFetcher) {
             expectation.fulfill()

--- a/Client/Frontend/Browser/BackForwardTableViewCell.swift
+++ b/Client/Frontend/Browser/BackForwardTableViewCell.swift
@@ -112,7 +112,7 @@ class BackForwardTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
             faviconView.image = UIImage(named: ImageIdentifiers.defaultFavicon)?.withRenderingMode(.alwaysTemplate)
             faviconView.backgroundColor = .clear
         } else {
-            faviconView.setFavicon(FaviconImageViewModel(urlStringRequest: viewModel.site.url,
+            faviconView.setFavicon(FaviconImageViewModel(siteURLString: viewModel.site.url,
                                                          faviconCornerRadius: UX.faviconCornerRadius))
         }
 

--- a/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionDetailsVC.swift
+++ b/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionDetailsVC.swift
@@ -181,7 +181,7 @@ extension EnhancedTrackingProtectionDetailsVC {
         closeButton.setTitleColor(theme.colors.actionPrimary, for: .normal)
         connectionImage.image = viewModel.getLockIcon(theme.type)
 
-        siteInfoImage.setFavicon(FaviconImageViewModel(urlStringRequest: viewModel.URL,
+        siteInfoImage.setFavicon(FaviconImageViewModel(siteURLString: viewModel.URL,
                                                        faviconCornerRadius: ETPMenuUX.UX.faviconCornerRadius))
 
         setNeedsStatusBarAppearanceUpdate()

--- a/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVC.swift
+++ b/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVC.swift
@@ -337,7 +337,7 @@ class EnhancedTrackingProtectionMenuVC: UIViewController, Themeable {
 
     private func updateViewDetails() {
         if let urlString = viewModel.tab.url?.absoluteString {
-            favicon.setFavicon(FaviconImageViewModel(urlStringRequest: urlString,
+            favicon.setFavicon(FaviconImageViewModel(siteURLString: urlString,
                                                      faviconCornerRadius: ETPMenuUX.UX.faviconCornerRadius))
         }
 

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -682,7 +682,7 @@ class SearchViewController: SiteTableViewController,
                 twoLineCell.leftImageView.layer.borderColor = SearchViewControllerUX.IconBorderColor.cgColor
                 twoLineCell.leftImageView.layer.borderWidth = SearchViewControllerUX.IconBorderWidth
                 let urlString = openedTab.url?.absoluteString ?? ""
-                twoLineCell.leftImageView.setFavicon(FaviconImageViewModel(urlStringRequest: urlString))
+                twoLineCell.leftImageView.setFavicon(FaviconImageViewModel(siteURLString: urlString))
                 twoLineCell.accessoryView = nil
                 cell = twoLineCell
             }
@@ -697,7 +697,7 @@ class SearchViewController: SiteTableViewController,
                 twoLineCell.leftImageView.layer.borderColor = SearchViewControllerUX.IconBorderColor.cgColor
                 twoLineCell.leftImageView.layer.borderWidth = SearchViewControllerUX.IconBorderWidth
                 let urlString = remoteTab.URL.absoluteString
-                twoLineCell.leftImageView.setFavicon(FaviconImageViewModel(urlStringRequest: urlString))
+                twoLineCell.leftImageView.setFavicon(FaviconImageViewModel(siteURLString: urlString))
                 twoLineCell.accessoryView = nil
                 cell = twoLineCell
             }
@@ -711,7 +711,7 @@ class SearchViewController: SiteTableViewController,
                 twoLineCell.leftOverlayImageView.image = isBookmark ? self.bookmarkedBadge : nil
                 twoLineCell.leftImageView.layer.borderColor = SearchViewControllerUX.IconBorderColor.cgColor
                 twoLineCell.leftImageView.layer.borderWidth = SearchViewControllerUX.IconBorderWidth
-                twoLineCell.leftImageView.setFavicon(FaviconImageViewModel(urlStringRequest: site.url))
+                twoLineCell.leftImageView.setFavicon(FaviconImageViewModel(siteURLString: site.url))
                 twoLineCell.accessoryView = nil
                 cell = twoLineCell
             }
@@ -725,7 +725,7 @@ class SearchViewController: SiteTableViewController,
             twoLineCell.descriptionLabel.text = urlString
             twoLineCell.leftImageView.layer.borderColor = SearchViewControllerUX.IconBorderColor.cgColor
             twoLineCell.leftImageView.layer.borderWidth = SearchViewControllerUX.IconBorderWidth
-            twoLineCell.leftImageView.setFavicon(FaviconImageViewModel(urlStringRequest: site.url))
+            twoLineCell.leftImageView.setFavicon(FaviconImageViewModel(siteURLString: site.url))
             twoLineCell.accessoryView = nil
             cell = twoLineCell
         }

--- a/Client/Frontend/Browser/TabCell.swift
+++ b/Client/Frontend/Browser/TabCell.swift
@@ -165,7 +165,7 @@ class TabCell: UICollectionViewCell,
 
         favicon.image = UIImage(named: ImageIdentifiers.defaultFavicon)
         if !tab.isFxHomeTab {
-            favicon.setFavicon(FaviconImageViewModel(urlStringRequest: tab.url?.absoluteString ?? ""))
+            favicon.setFavicon(FaviconImageViewModel(siteURLString: tab.url?.absoluteString ?? ""))
         }
 
         if selected {
@@ -196,7 +196,7 @@ class TabCell: UICollectionViewCell,
 
         // Favicon or letter image when tab screenshot isn't available
         } else {
-            smallFaviconView.setFavicon(FaviconImageViewModel(urlStringRequest: tab.url?.absoluteString ?? ""))
+            smallFaviconView.setFavicon(FaviconImageViewModel(siteURLString: tab.url?.absoluteString ?? ""))
             faviconBG.isHidden = false
             screenshotView.image = nil
         }

--- a/Client/Frontend/Browser/Tabs/InactiveTabItemCell.swift
+++ b/Client/Frontend/Browser/Tabs/InactiveTabItemCell.swift
@@ -49,7 +49,7 @@ class InactiveTabItemCell: UITableViewCell, NotificationThemeable, ReusableCell 
 
         if let urlString = viewModel.website?.absoluteString {
             let cornerRadius = InactiveTabItemCellModel.UX.FaviconCornerRadius
-            leftImageView.setFavicon(FaviconImageViewModel(urlStringRequest: urlString,
+            leftImageView.setFavicon(FaviconImageViewModel(siteURLString: urlString,
                                                            faviconCornerRadius: cornerRadius))
         }
         separatorInset = UIEdgeInsets(top: 0,

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsClientAndTabsDataSource.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsClientAndTabsDataSource.swift
@@ -102,7 +102,7 @@ class RemoteTabsClientAndTabsDataSource: NSObject, RemoteTabsPanelDataSource {
         let tab = tabAtIndexPath(indexPath)
         cell.titleLabel.text = tab.title
         cell.descriptionLabel.text = tab.URL.absoluteString
-        cell.leftImageView.setFavicon(FaviconImageViewModel(urlStringRequest: tab.URL.absoluteString))
+        cell.leftImageView.setFavicon(FaviconImageViewModel(siteURLString: tab.URL.absoluteString))
         cell.accessoryView = nil
         cell.applyTheme(theme: theme)
         return cell

--- a/Client/Frontend/Browser/TopTabCell.swift
+++ b/Client/Frontend/Browser/TopTabCell.swift
@@ -92,7 +92,7 @@ class TopTabCell: UICollectionViewCell, NotificationThemeable, TabTrayCell, Reus
         favicon.backgroundColor = .clear
 
         if let siteURL = tab.url?.absoluteString, !tab.isFxHomeTab {
-            favicon.setFavicon(FaviconImageViewModel(urlStringRequest: siteURL,
+            favicon.setFavicon(FaviconImageViewModel(siteURLString: siteURL,
                                                      faviconCornerRadius: UX.faviconCornerRadius))
         }
     }

--- a/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsCell.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsCell.swift
@@ -84,7 +84,7 @@ class HistoryHighlightsCell: UICollectionViewCell, ReusableCell {
         accessibilityLabel = options.accessibilityLabel
 
         if let url = options.urlString {
-            let faviconViewModel = FaviconImageViewModel(urlStringRequest: url)
+            let faviconViewModel = FaviconImageViewModel(siteURLString: url)
             imageView.setFavicon(faviconViewModel)
         } else {
             imageView.image = UIImage.templateImageNamed(ImageIdentifiers.stackedTabsIcon)

--- a/Client/Frontend/Home/JumpBackIn/Cell/JumpBackInCell.swift
+++ b/Client/Frontend/Home/JumpBackIn/Cell/JumpBackInCell.swift
@@ -121,7 +121,7 @@ class JumpBackInCell: UICollectionViewCell, ReusableCell {
                                                             heroImageSize: UX.heroImageSize)
         heroImage.setHeroImage(heroImageViewModel)
 
-        let faviconViewModel = FaviconImageViewModel(urlStringRequest: viewModel.siteURL)
+        let faviconViewModel = FaviconImageViewModel(siteURLString: viewModel.siteURL)
         websiteImage.setFavicon(faviconViewModel)
 
         itemTitle.text = viewModel.titleText

--- a/Client/Frontend/Home/TopSites/Cell/TopSiteItemCell.swift
+++ b/Client/Frontend/Home/TopSites/Cell/TopSiteItemCell.swift
@@ -148,11 +148,13 @@ class TopSiteItemCell: UICollectionViewCell, ReusableCell {
         accessibilityLabel = topSite.accessibilityLabel
 
         var urlRequest = topSite.site.url
+        var imageURL: URL?
+
         if let site = topSite.site as? SponsoredTile {
-            urlRequest = site.imageURL
+            imageURL = URL(string: site.imageURL)
         }
-        let viewModel = FaviconImageViewModel(urlStringRequest: urlRequest,
-                                              usesIndirectDomain: topSite.isSponsoredTile)
+        let viewModel = FaviconImageViewModel(siteURLString: urlRequest,
+                                              faviconURL: imageURL)
         imageView.setFavicon(viewModel)
         self.textColor = textColor
 

--- a/Client/Frontend/Home/TopSites/Cell/TopSiteItemCell.swift
+++ b/Client/Frontend/Home/TopSites/Cell/TopSiteItemCell.swift
@@ -147,7 +147,7 @@ class TopSiteItemCell: UICollectionViewCell, ReusableCell {
         titleLabel.text = topSite.title
         accessibilityLabel = topSite.accessibilityLabel
 
-        var urlRequest = topSite.site.url
+        let urlRequest = topSite.site.url
         var imageURL: URL?
 
         if let site = topSite.site as? SponsoredTile {

--- a/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
@@ -388,7 +388,7 @@ class BookmarksPanel: SiteTableViewController,
 
             if let site = site,
                viewModel.leftImageView == nil {
-                cell.leftImageView.setFavicon(FaviconImageViewModel(urlStringRequest: site.url))
+                cell.leftImageView.setFavicon(FaviconImageViewModel(siteURLString: site.url))
             }
 
             cell.configure(viewModel: viewModel)

--- a/Client/Frontend/Library/HistoryPanel/GeneralizedTableView/SearchGroupedItemsViewController.swift
+++ b/Client/Frontend/Library/HistoryPanel/GeneralizedTableView/SearchGroupedItemsViewController.swift
@@ -126,7 +126,7 @@ class SearchGroupedItemsViewController: UIViewController, Loggable {
                 cell.descriptionLabel.isHidden = false
                 cell.leftImageView.layer.borderColor = self.themeManager.currentTheme.colors.layer4.cgColor
                 cell.leftImageView.layer.borderWidth = 0.5
-                cell.leftImageView.setFavicon(FaviconImageViewModel(urlStringRequest: site.url))
+                cell.leftImageView.setFavicon(FaviconImageViewModel(siteURLString: site.url))
 
                 return cell
             }

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -397,7 +397,7 @@ class HistoryPanel: UIViewController,
         cell.descriptionLabel.isHidden = false
         cell.leftImageView.layer.borderColor = themeManager.currentTheme.colors.borderPrimary.cgColor
         cell.leftImageView.layer.borderWidth = UX.IconBorderWidth
-        cell.leftImageView.setFavicon(FaviconImageViewModel(urlStringRequest: site.url))
+        cell.leftImageView.setFavicon(FaviconImageViewModel(siteURLString: site.url))
         cell.accessoryView = nil
         cell.applyTheme(theme: themeManager.currentTheme)
         return cell

--- a/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
+++ b/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
@@ -109,7 +109,7 @@ class RecentlyClosedTabsPanelSiteTableViewController: SiteTableViewController {
         twoLineCell.descriptionLabel.text = displayURL.absoluteDisplayString
         twoLineCell.leftImageView.layer.borderColor = RecentlyClosedPanelUX.IconBorderColor.cgColor
         twoLineCell.leftImageView.layer.borderWidth = RecentlyClosedPanelUX.IconBorderWidth
-        twoLineCell.leftImageView.setFavicon(FaviconImageViewModel(urlStringRequest: displayURL.absoluteString))
+        twoLineCell.leftImageView.setFavicon(FaviconImageViewModel(siteURLString: displayURL.absoluteString))
 
         return twoLineCell
     }

--- a/Client/Frontend/Settings/CustomSearchViewController.swift
+++ b/Client/Frontend/Settings/CustomSearchViewController.swift
@@ -98,10 +98,10 @@ class CustomSearchViewController: SettingsTableViewController {
             throw CustomSearchError(.DuplicateEngine)
         }
 
-        let result = await faviconFetcher.getImage(urlStringRequest: url.absoluteString,
-                                                   type: .favicon,
-                                                   id: UUID(),
-                                                   usesIndirectDomain: false)
+        let siteImageModel = SiteImageModel(id: UUID(),
+                                            expectedImageType: .favicon,
+                                            siteURLString: url.absoluteString)
+        let result = await faviconFetcher.getImage(site: siteImageModel)
 
         let engine = OpenSearchEngine(engineID: nil,
                                       shortName: name,

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetSiteHeaderView.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetSiteHeaderView.swift
@@ -48,7 +48,7 @@ class PhotonActionSheetSiteHeaderView: UITableViewHeaderFooterView, ReusableCell
     }
 
     func configure(with site: Site) {
-        siteImageView.setFavicon(FaviconImageViewModel(urlStringRequest: site.url))
+        siteImageView.setFavicon(FaviconImageViewModel(siteURLString: site.url))
         titleLabel.text = site.title.isEmpty ? site.url : site.title
         descriptionLabel.text = site.tileURL.baseDomain
     }

--- a/Client/Helpers/UserActivityHandler.swift
+++ b/Client/Helpers/UserActivityHandler.swift
@@ -108,10 +108,10 @@ extension UserActivityHandler {
         case .favicon:
             if let urlString = tab.url?.absoluteString {
                 let faviconFetcher = DefaultSiteImageHandler.factory()
-                let image = await faviconFetcher.getImage(urlStringRequest: urlString,
-                                                          type: .favicon,
-                                                          id: UUID(),
-                                                          usesIndirectDomain: false)
+                let siteImageModel = SiteImageModel(id: UUID(),
+                                                    expectedImageType: .favicon,
+                                                    siteURLString: urlString)
+                let image = await faviconFetcher.getImage(site: siteImageModel)
                 attributeSet.thumbnailData = image.faviconImage?.pngData()
             }
         default:

--- a/WidgetKit/OpenTabs/TabProvider.swift
+++ b/WidgetKit/OpenTabs/TabProvider.swift
@@ -29,12 +29,12 @@ struct TabProvider: TimelineProvider {
             let tabFaviconDictionary = await withTaskGroup(of: (String, SiteImageModel).self,
                                                            returning: [String: Image].self) { group in
                 for (_, tab) in simpleTabs {
+                    let siteImageModel = SiteImageModel(id: UUID(),
+                                                        expectedImageType: .favicon,
+                                                        siteURLString: tab.url?.absoluteString ?? "")
                     group.addTask {
                         await (tab.imageKey,
-                               siteImageFetcher.getImage(urlStringRequest: tab.url?.absoluteString ?? "",
-                                                         type: .favicon,
-                                                         id: UUID(),
-                                                         usesIndirectDomain: false))
+                               siteImageFetcher.getImage(site: siteImageModel))
                     }
                 }
 

--- a/WidgetKit/TopSites/TopSitesProvider.swift
+++ b/WidgetKit/TopSites/TopSitesProvider.swift
@@ -22,12 +22,12 @@ struct TopSitesProvider: TimelineProvider {
             let tabFaviconDictionary = await withTaskGroup(of: (String, SiteImageModel).self,
                                                            returning: [String: Image].self) { group in
                 for site in widgetKitTopSites {
+                    let siteImageModel = SiteImageModel(id: UUID(),
+                                                        expectedImageType: .favicon,
+                                                        siteURLString: site.url.absoluteString)
                     group.addTask {
                         await (site.imageKey,
-                               siteImageFetcher.getImage(urlStringRequest: site.url.absoluteString,
-                                                         type: .favicon,
-                                                         id: UUID(),
-                                                         usesIndirectDomain: false))
+                               siteImageFetcher.getImage(site: siteImageModel))
                     }
                 }
 


### PR DESCRIPTION
Renamed urlStringRequest to siteURLString and made it optional. getImage now takes a SiteImageModel type and has either siteURLString or FaviconURL populated. IF FaviconURL is populated then it will always use that value to fetch the resource. 

The FaviconImageView model is now simpler, it takes a site url or a favicon url. Same as above, if a favicon url is provided then it will default to using that.

I want to do some further clean up by removing domain from the SiteImageMode and moving it closer to where it is used but figured this PR is already getting difficult to read so I will follow up with another PR.