### PR TITLE
Refactor FXIOS-5604 [v111] Removed Deferred from the Avatar class

### DIFF
--- a/RustFxA/Avatar.swift
+++ b/RustFxA/Avatar.swift
@@ -26,7 +26,10 @@ open class Avatar {
     }
 
     private func downloadAvatar(completionHandler: @escaping(UIImage?, Error?) -> Void) {
-        guard let url = url else { return }
+        guard let url = url else {
+            completionHandler(nil, ImageLoadingError.unableToFetchImage)
+            return
+        }
         
         DispatchQueue.global().async {
             DefaultImageLoadingHandler.shared.getImageFromCacheOrDownload(with: url, limit: ImageLoadingConstants.NoLimitImageSize) { image, error in

--- a/RustFxA/Avatar.swift
+++ b/RustFxA/Avatar.swift
@@ -6,7 +6,7 @@ import UIKit
 import Shared
 
 open class Avatar {
-    open var image : UIImage?
+    open var image: UIImage?
     public let url: URL?
 
     init(url: URL?) {
@@ -19,7 +19,7 @@ open class Avatar {
                 NotificationCenter.default.post(name: .FirefoxAccountProfileChanged, object: self)
                 return
             }
-            
+
             self.image = image
             NotificationCenter.default.post(name: .FirefoxAccountProfileChanged, object: self)
         }
@@ -30,7 +30,7 @@ open class Avatar {
             completionHandler(nil, ImageLoadingError.unableToFetchImage)
             return
         }
-        
+
         DispatchQueue.global().async {
             DefaultImageLoadingHandler.shared.getImageFromCacheOrDownload(with: url, limit: ImageLoadingConstants.NoLimitImageSize) { image, error in
                 guard error == nil,
@@ -39,7 +39,7 @@ open class Avatar {
                     completionHandler(image, error)
                     return
                 }
-                
+
                 self.image = image
                 completionHandler(image, nil)
             }

--- a/RustFxA/Avatar.swift
+++ b/RustFxA/Avatar.swift
@@ -6,31 +6,40 @@ import UIKit
 import Shared
 
 open class Avatar {
-    open var image = Deferred<UIImage>()
+    open var image : UIImage?
     public let url: URL?
 
     init(url: URL?) {
         self.url = url
-        downloadAvatar()
-    }
-
-    private func downloadAvatar() {
-        guard let url = url else { return }
-
-        DefaultImageLoadingHandler.shared.getImageFromCacheOrDownload(
-            with: url,
-            limit: ImageLoadingConstants.NoLimitImageSize
-        ) { image, error in
+        downloadAvatar { image, error in
             guard error == nil,
                   let image = image
             else {
-                self.image.fill(UIImage(named: ImageIdentifiers.placeholderAvatar)!)
+                self.image = UIImage(named: ImageIdentifiers.placeholderAvatar)
                 NotificationCenter.default.post(name: .FirefoxAccountProfileChanged, object: self)
                 return
             }
-
-            self.image.fill(image)
+            
+            self.image = image
             NotificationCenter.default.post(name: .FirefoxAccountProfileChanged, object: self)
+        }
+    }
+
+    private func downloadAvatar(completionHandler: @escaping(UIImage?, Error?) -> Void) {
+        guard let url = url else { return }
+        
+        DispatchQueue.global().async {
+            DefaultImageLoadingHandler.shared.getImageFromCacheOrDownload(with: url, limit: ImageLoadingConstants.NoLimitImageSize) { image, error in
+                guard error == nil,
+                      let image = image
+                else {
+                    completionHandler(image, error)
+                    return
+                }
+                
+                self.image = image
+                completionHandler(image, nil)
+            }
         }
     }
 }


### PR DESCRIPTION
Referenced Issue: #12962 

I improved getting the Avatar's profile image with a completion handler and `DispatchQueue.global().async`. But I don't really know where to write the test for this. I would really appreciate it if someone would correct me if I'm wrong. Thanks.