### PR TITLE
Bugfix MTE-402 [v111] Add more checks to ensure pop-up disappears

### DIFF
--- a/Tests/XCUITests/HistoryTests.swift
+++ b/Tests/XCUITests/HistoryTests.swift
@@ -91,6 +91,7 @@ class HistoryTests: BaseTestCase {
             waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT_LONG)
         }
         navigator.performAction(Action.CloseURLBarOpen)
+        waitForNoExistence(app.buttons["urlBar-cancel"], timeoutValue: TIMEOUT)
         navigator.nowAt(NewTabScreen)
         waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: TIMEOUT)
         // Clear private data from settings and confirm

--- a/Tests/XCUITests/HistoryTests.swift
+++ b/Tests/XCUITests/HistoryTests.swift
@@ -101,7 +101,8 @@ class HistoryTests: BaseTestCase {
 
         // Wait for OK pop-up to disappear after confirming
         waitForNoExistence(app.alerts.buttons["OK"], timeoutValue: TIMEOUT)
-        sleep(1)
+        waitForNoExistence(app.alerts.buttons["Cancel"], timeoutValue: TIMEOUT)
+        waitForNoExistence(app.alerts.staticTexts["This action will clear all of your private data. It cannot be undone."], timeoutValue: TIMEOUT)
 
         // Try to tap on the disabled Clear Private Data button
         app.tables.cells["ClearPrivateData"].tap()

--- a/Tests/XCUITests/HistoryTests.swift
+++ b/Tests/XCUITests/HistoryTests.swift
@@ -101,6 +101,7 @@ class HistoryTests: BaseTestCase {
 
         // Wait for OK pop-up to disappear after confirming
         waitForNoExistence(app.alerts.buttons["OK"], timeoutValue: TIMEOUT)
+        sleep(1)
 
         // Try to tap on the disabled Clear Private Data button
         app.tables.cells["ClearPrivateData"].tap()


### PR DESCRIPTION
`HistoryTests/testClearPrivateDataButtonDisabled()` fails intermittently. The test expects the "Clear Private Data" button to be disabled, but in practice the button may still be enabled after the private data has been cleared.

I observed that the "Clear Private Data" button may not be disabled right away when the alert is closed. The button eventually becomes disabled. Let me add a `sleep()` to allow enough time for the button to transition to disabled.

I can't reproduce the failure on my end using `iPhone 14` or `iPad Pro (12.9-inch) (5th generation)` even after the test has been run 100 times.

https://mozilla-hub.atlassian.net/browse/MTE-402