### PR TITLE
Bugfix  FXIOS-5501 [v111] "Send Link to Device" on a page in reader view sends a `http://localhost:6571/reader-mode/` URL to the other device

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1531,7 +1531,7 @@ class BrowserViewController: UIViewController {
 
     private func showSendToDevice() {
         guard let selectedTab = tabManager.selectedTab,
-              let url = selectedTab.url
+              let url = selectedTab.canonicalURL?.displayURL
         else { return }
 
         let themeColors = themeManager.currentTheme.colors

--- a/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -367,7 +367,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
                                      iconString: ImageIdentifiers.sendToDevice) { _ in
             guard let delegate = self.sendToDeviceDelegate,
                   let selectedTab = self.selectedTab,
-                  let url = selectedTab.url
+                  let url = selectedTab.canonicalURL?.displayURL
             else { return }
 
             let themeColors = self.themeManager.currentTheme.colors


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/FXIOS-5501
#12807 

Apply display URL to send to device link which removes reader mode prefix