### PR TITLE
Bugfix MTE-550 [v111] Pin website without making it a shortcut

### DIFF
--- a/Tests/XCUITests/ActivityStreamTest.swift
+++ b/Tests/XCUITests/ActivityStreamTest.swift
@@ -11,7 +11,7 @@ let allDefaultTopSites = ["Facebook", "YouTube", "Amazon", "Wikipedia", "Twitter
 class ActivityStreamTest: BaseTestCase {
     let TopSiteCellgroup = XCUIApplication().cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]
 
-    let testWithDB = ["testActivityStreamPages", "testTopSites2Add", "testTopSitesRemoveAllExceptDefaultClearPrivateData"]
+    let testWithDB = ["testActivityStreamPages", "testTopSites2Add"]
 
     // Using the DDDBBs created for these tests containing enough entries for the tests that used them listed above
     let pagesVisitediPad = "browserActivityStreamPagesiPad.db"

--- a/Tests/XCUITests/ActivityStreamTest.swift
+++ b/Tests/XCUITests/ActivityStreamTest.swift
@@ -123,18 +123,16 @@ class ActivityStreamTest: BaseTestCase {
         }
         waitUntilPageLoad()
 
-        app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton].tap()
-        app.otherElements[ImageIdentifiers.addShortcut].tap()
         // Workaround to have visited website in top sites
         navigator.performAction(Action.AcceptRemovingAllTabs)
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.performAction(Action.OpenNewTabFromTabTray)
 
-        waitForExistence(app.collectionViews.cells.staticTexts[newTopSite["topSiteLabel"]!], timeout: TIMEOUT)
-        XCTAssertTrue(app.collectionViews.cells.staticTexts[newTopSite["topSiteLabel"]!].exists)
+        waitForExistence(app.collectionViews.cells.staticTexts[newTopSite["bookmarkLabel"]!], timeout: TIMEOUT)
+        XCTAssertTrue(app.collectionViews.cells.staticTexts[newTopSite["bookmarkLabel"]!].exists)
         checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 6)
 
-        app.collectionViews.cells.staticTexts[newTopSite["topSiteLabel"]!].press(forDuration: 1)
+        app.collectionViews.cells.staticTexts[newTopSite["bookmarkLabel"]!].press(forDuration: 1)
         selectOptionFromContextMenu(option: "Pin")
         waitForExistence(app.collectionViews.cells.staticTexts[newTopSite["bookmarkLabel"]!], timeout: TIMEOUT)
         XCTAssertTrue(app.collectionViews.cells.staticTexts[newTopSite["bookmarkLabel"]!].exists)


### PR DESCRIPTION
The test `testTopSitesRemoveAllExceptPinnedClearPrivateData()` fails because the recently visited site is now referred by the `bookmarkLabel` and not the `topSiteLabel`. (The cause may be caused by the database loading issue described by MTE-514. The database may contain some previously visited sites.) In addition, when the site is added as a shortcut, the site is pinned.

This test has been updated by the following:
* Use `bookmarkLabel` to refer to the pinned site.
* We no longer add the site to the shortcuts before pinning it.

I have run the test repeatedly to ensure that the behaviour is consistent.
```
xcodebuild test-without-building -target Client -scheme Fennec_Enterprise_XCUITests -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.1' -only-testing:XCUITests/ActivityStreamTest/testTopSitesRemoveAllExceptPinnedClearPrivateData -test-iterations 100
```

https://storage.googleapis.com/mobile-reports/public/firefox-ios-M1/FullFunctionalTests/result_110/build/reports/index.html

https://storage.googleapis.com/mobile-reports/public/firefox-ios-M1/FullFunctionalTests-iPad/result_68/build/reports/tests.html

https://mozilla-hub.atlassian.net/browse/FXIOS-5659