### PR TITLE
Refactor FXIOS-5631 [v111] Migrate logs storage

### DIFF
--- a/BrowserKit/Sources/Logger/DefaultLogger.swift
+++ b/BrowserKit/Sources/Logger/DefaultLogger.swift
@@ -23,6 +23,8 @@ public class DefaultLogger: Logger {
                     function: String = #function,
                     line: Int = #line) {
         switch level {
+        case .debug:
+            logger.debug(message, file, function, line: line, context: category)
         case .info:
             logger.info(message, file, function, line: line, context: category)
         case .warning:

--- a/BrowserKit/Sources/Logger/LoggerCategory.swift
+++ b/BrowserKit/Sources/Logger/LoggerCategory.swift
@@ -11,9 +11,6 @@ public enum LoggerCategory: String {
     // Related to homepage UI and it's data management
     case homepage
 
-    // Related to the keychain
-    case keychain
-
     // Related to library UI and it's data management throughout the app.
     // This includes bookmarks, downloads, reader mode and history.
     case library
@@ -24,8 +21,8 @@ public enum LoggerCategory: String {
     // Related to the setup of services on app launch
     case setup
 
-    // Related to the settings UI, setup and management
-    case settings
+    // Related to storage (keychain, SQL database, store of different types, etc)
+    case storage
 
     // Related to sync accounts and sync management
     case sync

--- a/BrowserKit/Sources/Logger/LoggerLevel.swift
+++ b/BrowserKit/Sources/Logger/LoggerLevel.swift
@@ -7,6 +7,11 @@ import Foundation
 // Log levels are kept to a minimum to make sure they are relevant and useful. If your log isn't important enough
 // to make it to this list, then it shouldn't be logged.
 public enum LoggerLevel: String {
+    // Less granular compared to the VERBOSE level, but it is more than you will need in everyday use. The
+    // DEBUG log level should be used for information that may be needed for diagnosing issues and troubleshooting or
+    // when running application in the test environment for the purpose of making sure everything is running correctly.
+    case debug
+
     // INFO messages are like the normal behavior of applications. They state what happened. For example, if a
     // particular service stopped or started or you added something to the database, or a view was shown or hidden.
     // These entries are nothing to worry about during usual operations. The information logged using the INFO log is

--- a/BrowserKit/Sources/Logger/SwiftyBeaverWrapper.swift
+++ b/BrowserKit/Sources/Logger/SwiftyBeaverWrapper.swift
@@ -7,6 +7,12 @@ import SwiftyBeaver
 
 // MARK: - SwiftyBeaverWrapper
 protocol SwiftyBeaverWrapper {
+    static func debug(_ message: @autoclosure () -> Any,
+                      _ file: String,
+                      _ function: String,
+                      line: Int,
+                      context: Any?)
+
     static func info(_ message: @autoclosure () -> Any,
                      _ file: String,
                      _ function: String,

--- a/BrowserKit/Tests/LoggerTests/LoggerTests.swift
+++ b/BrowserKit/Tests/LoggerTests/LoggerTests.swift
@@ -20,6 +20,12 @@ final class LoggerTests: XCTestCase {
         cleanUp()
     }
 
+    func testDebug() {
+        let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder)
+        subject.log("Debug log", level: .debug, category: .setup)
+        XCTAssertEqual(MockSwiftyBeaver.debugCalled, 1)
+    }
+
     func testInfo() {
         let subject = DefaultLogger(swiftyBeaverBuilder: beaverBuilder)
         subject.log("Info log", level: .info, category: .setup)
@@ -42,6 +48,7 @@ final class LoggerTests: XCTestCase {
 // MARK: - Helper
 private extension LoggerTests {
     func cleanUp() {
+        MockSwiftyBeaver.debugCalled = 0
         MockSwiftyBeaver.infoCalled = 0
         MockSwiftyBeaver.warningCalled = 0
         MockSwiftyBeaver.errorCalled = 0
@@ -62,6 +69,11 @@ class MockSwiftyBeaver: SwiftyBeaverWrapper {
     }
 
     static var fileDestination: URL?
+
+    static var debugCalled = 0
+    static func debug(_ message: @autoclosure () -> Any, _ file: String, _ function: String, line: Int, context: Any?) {
+        debugCalled += 1
+    }
 
     static var infoCalled = 0
     static func info(_ message: @autoclosure () -> Any, _ file: String, _ function: String, line: Int, context: Any?) {

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -528,7 +528,7 @@
 		8A355E5E27D267A400B9AF34 /* RecentItemsHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A355E5D27D267A400B9AF34 /* RecentItemsHelperTests.swift */; };
 		8A36AC2C2886F27F00CDC0AD /* MockTabManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A36AC2B2886F27F00CDC0AD /* MockTabManager.swift */; };
 		8A37C79F28DA4BA600B1FAD4 /* ContextualHintViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A37C79E28DA4BA600B1FAD4 /* ContextualHintViewModelTests.swift */; };
-		8A3EF05A29846ED500517C95 /* Logger in Frameworks */ = {isa = PBXBuildFile; productRef = 8A3EF05929846ED500517C95 /* Logger */; };
+		8A4016C22988485100B8EFD5 /* Logger in Frameworks */ = {isa = PBXBuildFile; productRef = 8A4016C12988485100B8EFD5 /* Logger */; };
 		8A471183287F6D9C00F5A6EA /* BookmarksPanelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A471182287F6D9C00F5A6EA /* BookmarksPanelViewModel.swift */; };
 		8A471185287F6E4800F5A6EA /* SeparatorTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A471184287F6E4800F5A6EA /* SeparatorTableViewCell.swift */; };
 		8A48CE33292FCC0800B32289 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 8A48CE32292FCC0800B32289 /* Kingfisher */; };
@@ -5326,7 +5326,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8A3EF05A29846ED500517C95 /* Logger in Frameworks */,
 				5A70EF0E295DFCCF00790249 /* Common in Frameworks */,
 				5A8FD0F4293A7E9800333AA7 /* Sentry in Frameworks */,
 				8A08EC6427EBDCAD00E119C7 /* AdServices.framework in Frameworks */,
@@ -5376,6 +5375,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8A4016C22988485100B8EFD5 /* Logger in Frameworks */,
 				5A8FD0F8293A7ECD00333AA7 /* Sentry in Frameworks */,
 				8A48CE37292FCC2700B32289 /* Kingfisher in Frameworks */,
 				43BE5809278BA9D700491291 /* RustMozillaAppServices.framework in Frameworks */,
@@ -8630,6 +8630,7 @@
 				8A48CE36292FCC2700B32289 /* Kingfisher */,
 				5A8FD0E3293A7B4600333AA7 /* XCGLogger */,
 				5A8FD0F7293A7ECD00333AA7 /* Sentry */,
+				8A4016C12988485100B8EFD5 /* Logger */,
 			);
 			productName = Storage;
 			productReference = 2FCAE21A1ABB51F800877008 /* libStorage.a */;
@@ -8939,7 +8940,6 @@
 				5A8FD0EB293A7D5E00333AA7 /* SnapKit */,
 				5A8FD0F3293A7E9800333AA7 /* Sentry */,
 				5A70EF0D295DFCCF00790249 /* Common */,
-				8A3EF05929846ED500517C95 /* Logger */,
 			);
 			productName = Client;
 			productReference = F84B21BE1A090F8100AAB793 /* Client.app */;
@@ -15931,7 +15931,7 @@
 			package = 435C85EE2788F4D00072B526 /* XCRemoteSwiftPackageReference "glean-swift" */;
 			productName = Glean;
 		};
-		8A3EF05929846ED500517C95 /* Logger */ = {
+		8A4016C12988485100B8EFD5 /* Logger */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Logger;
 		};

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -528,7 +528,6 @@
 		8A355E5E27D267A400B9AF34 /* RecentItemsHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A355E5D27D267A400B9AF34 /* RecentItemsHelperTests.swift */; };
 		8A36AC2C2886F27F00CDC0AD /* MockTabManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A36AC2B2886F27F00CDC0AD /* MockTabManager.swift */; };
 		8A37C79F28DA4BA600B1FAD4 /* ContextualHintViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A37C79E28DA4BA600B1FAD4 /* ContextualHintViewModelTests.swift */; };
-		8A4016C22988485100B8EFD5 /* Logger in Frameworks */ = {isa = PBXBuildFile; productRef = 8A4016C12988485100B8EFD5 /* Logger */; };
 		8A471183287F6D9C00F5A6EA /* BookmarksPanelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A471182287F6D9C00F5A6EA /* BookmarksPanelViewModel.swift */; };
 		8A471185287F6E4800F5A6EA /* SeparatorTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A471184287F6E4800F5A6EA /* SeparatorTableViewCell.swift */; };
 		8A48CE33292FCC0800B32289 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 8A48CE32292FCC0800B32289 /* Kingfisher */; };
@@ -597,6 +596,7 @@
 		8AC5D55F28BFE6C8001F6F7F /* Presenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC5D55E28BFE6C8001F6F7F /* Presenter.swift */; };
 		8ACA8F74291987AE00D3075D /* AccountSyncHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACA8F73291987AE00D3075D /* AccountSyncHandlerTests.swift */; };
 		8ACA8F7629198D6400D3075D /* ThrottlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACA8F7529198D6400D3075D /* ThrottlerTests.swift */; };
+		8ACD69102988BFEC00CF5F38 /* Logger in Frameworks */ = {isa = PBXBuildFile; productRef = 8ACD690F2988BFEC00CF5F38 /* Logger */; };
 		8AD08D1527E9198E00B8E907 /* TabsQuantityTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD08D1427E9198E00B8E907 /* TabsQuantityTelemetry.swift */; };
 		8AD08D1727E91AC800B8E907 /* TabsQuantityTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD08D1627E91AC800B8E907 /* TabsQuantityTelemetryTests.swift */; };
 		8AD1980F27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD1980E27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift */; };
@@ -5295,6 +5295,7 @@
 				C820439A2523DC4500740B71 /* libStorage.a in Frameworks */,
 				5A70EF12295DFD6400790249 /* Common in Frameworks */,
 				D09A0CDC1FAA24CC009A0273 /* libAccount.a in Frameworks */,
+				8ACD69102988BFEC00CF5F38 /* Logger in Frameworks */,
 				5A8FD0EA293A7D0C00333AA7 /* XCGLogger in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -5375,7 +5376,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8A4016C22988485100B8EFD5 /* Logger in Frameworks */,
 				5A8FD0F8293A7ECD00333AA7 /* Sentry in Frameworks */,
 				8A48CE37292FCC2700B32289 /* Kingfisher in Frameworks */,
 				43BE5809278BA9D700491291 /* RustMozillaAppServices.framework in Frameworks */,
@@ -8525,6 +8525,7 @@
 				8A48CE3C292FCE1A00B32289 /* Kingfisher */,
 				5A8FD0E9293A7D0C00333AA7 /* XCGLogger */,
 				5A70EF11295DFD6400790249 /* Common */,
+				8ACD690F2988BFEC00CF5F38 /* Logger */,
 			);
 			productName = Sync;
 			productReference = 2827315E1ABC9BE600AA1954 /* Sync.framework */;
@@ -8630,7 +8631,6 @@
 				8A48CE36292FCC2700B32289 /* Kingfisher */,
 				5A8FD0E3293A7B4600333AA7 /* XCGLogger */,
 				5A8FD0F7293A7ECD00333AA7 /* Sentry */,
-				8A4016C12988485100B8EFD5 /* Logger */,
 			);
 			productName = Storage;
 			productReference = 2FCAE21A1ABB51F800877008 /* libStorage.a */;
@@ -15931,10 +15931,6 @@
 			package = 435C85EE2788F4D00072B526 /* XCRemoteSwiftPackageReference "glean-swift" */;
 			productName = Glean;
 		};
-		8A4016C12988485100B8EFD5 /* Logger */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = Logger;
-		};
 		8A48CE32292FCC0800B32289 /* Kingfisher */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 4326A3C22849B8E500550F73 /* XCRemoteSwiftPackageReference "Kingfisher" */;
@@ -15964,6 +15960,10 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 4326A3C22849B8E500550F73 /* XCRemoteSwiftPackageReference "Kingfisher" */;
 			productName = Kingfisher;
+		};
+		8ACD690F2988BFEC00CF5F38 /* Logger */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Logger;
 		};
 		D433852B27ABC8150069DD33 /* MappaMundi */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Storage/Rust/RustPlaces.swift
+++ b/Storage/Rust/RustPlaces.swift
@@ -3,10 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0
 
 import Foundation
+import Logger
 import Shared
 @_exported import MozillaAppServices
-
-private let log = LegacyLogger.syncLogger
 
 public protocol BookmarksHandler {
     func getRecentBookmarks(limit: UInt, completion: @escaping ([BookmarkItemData]) -> Void)
@@ -33,11 +32,14 @@ public class RustPlaces: BookmarksHandler, HistoryMetadataObserver {
 
     private var didAttemptToMoveToBackup = false
     private var notificationCenter: NotificationCenter
+    private var logger: Logger
 
     public init(databasePath: String,
-                notificationCenter: NotificationCenter = NotificationCenter.default) {
+                notificationCenter: NotificationCenter = NotificationCenter.default,
+                logger: Logger = DefaultLogger.shared) {
         self.databasePath = databasePath
         self.notificationCenter = notificationCenter
+        self.logger = logger
         self.writerQueue = DispatchQueue(label: "RustPlaces writer queue: \(databasePath)", attributes: [])
         self.readerQueue = DispatchQueue(label: "RustPlaces reader queue: \(databasePath)", attributes: [])
     }
@@ -209,7 +211,9 @@ public class RustPlaces: BookmarksHandler, HistoryMetadataObserver {
         return withWriter { connection in
             let result = try connection.deleteBookmarkNode(guid: guid)
             guard result else {
-                log.debug("Bookmark with GUID \(guid) does not exist.")
+                self.logger.log("Bookmark with GUID \(guid) does not exist.",
+                                level: .debug,
+                                category: .storage)
                 return
             }
 

--- a/Storage/Rust/RustShared.swift
+++ b/Storage/Rust/RustShared.swift
@@ -3,12 +3,12 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0
 
 import Foundation
+import Logger
 import Shared
 
-private let log = LegacyLogger.syncLogger
-
 public class RustShared {
-    static func moveDatabaseFileToBackupLocation(databasePath: String) {
+    static func moveDatabaseFileToBackupLocation(databasePath: String,
+                                                 logger: Logger = DefaultLogger.shared) {
         let databaseURL = URL(fileURLWithPath: databasePath)
         let databaseContainingDirURL = databaseURL.deletingLastPathComponent()
         let baseFilename = databaseURL.lastPathComponent
@@ -37,21 +37,23 @@ public class RustShared {
 
             let shmBaseFilename = baseFilename + "-shm"
             let walBaseFilename = baseFilename + "-wal"
-            log.debug("Moving \(shmBaseFilename) and \(walBaseFilename)…")
+            logger.log("Moving database \(shmBaseFilename) and \(walBaseFilename)…",
+                       level: .debug,
+                       category: .storage)
 
             let shmDatabasePath = databaseContainingDirURL.appendingPathComponent(shmBaseFilename).path
             if FileManager.default.fileExists(atPath: shmDatabasePath) {
-                log.debug("\(shmBaseFilename) exists.")
                 try FileManager.default.moveItem(atPath: shmDatabasePath, toPath: "\(bakDatabasePath)-shm")
             }
 
             let walDatabasePath = databaseContainingDirURL.appendingPathComponent(walBaseFilename).path
             if FileManager.default.fileExists(atPath: walDatabasePath) {
-                log.debug("\(walBaseFilename) exists.")
                 try FileManager.default.moveItem(atPath: shmDatabasePath, toPath: "\(bakDatabasePath)-wal")
             }
 
-            log.debug("Finished moving Rust database (\(baseFilename)) successfully.")
+            logger.log("Finished moving Rust database \(baseFilename) successfully",
+                       level: .debug,
+                       category: .storage)
         } catch let error as NSError {
             SentryIntegration.shared.sendWithStacktrace(
                 message: "Unable to move Rust database to backup location",

--- a/Storage/SQL/BrowserSchema.swift
+++ b/Storage/SQL/BrowserSchema.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0
 
 import Foundation
+import Logger
 import Shared
 
 let _TableBookmarks = "bookmarks"                                      // Removed in v12. Kept for migration.
@@ -135,14 +136,13 @@ private let AllTriggers: [String] = [
 
 private let AllTablesIndicesTriggersAndViews: [String] = AllViews + AllTriggers + AllIndices + AllTables
 
-private let log = LegacyLogger.syncLogger
-
 /**
  * The monolithic class that manages the inter-related history etc. tables.
  * We rely on BrowserDBSQLite having initialized the favicon table first.
  */
 open class BrowserSchema: Schema {
     static let DefaultVersion = 41    // PR #10553.
+    private var logger: Logger
 
     public var name: String { return "BROWSER" }
     public var version: Int { return BrowserSchema.DefaultVersion }
@@ -150,20 +150,24 @@ open class BrowserSchema: Schema {
     let sqliteVersion: Int32
     let supportsPartialIndices: Bool
 
-    public init() {
+    public init(logger: Logger = DefaultLogger.shared) {
         let v = sqlite3_libversion_number()
         self.sqliteVersion = v
         self.supportsPartialIndices = v >= 3008000          // 3.8.0.
         let ver = String(cString: sqlite3_libversion())
-        log.info("SQLite version: \(ver) (\(v)).")
+        self.logger = logger
+        logger.log("Init SQLite version: \(ver) (\(v)).",
+                   level: .info,
+                   category: .setup)
     }
 
     func run(_ db: SQLiteDBConnection, sql: String, args: Args? = nil) -> Bool {
         do {
             try db.executeChange(sql, withArgs: args)
         } catch let err as NSError {
-            log.error("Error running SQL in BrowserSchema: \(err.localizedDescription)")
-            log.error("SQL was \(sql)")
+            logger.log("Error running SQL in BrowserSchema: \(err.localizedDescription) with \(sql)",
+                       level: .warning,
+                       category: .storage)
             return false
         }
 
@@ -927,7 +931,9 @@ open class BrowserSchema: Schema {
 
         assert(queries.count == AllTablesIndicesTriggersAndViews.count, "Did you forget to add your table, index, trigger, or view to the list?")
 
-        log.debug("Creating \(queries.count) tables, views, triggers, and indices.")
+        logger.log("Creating \(queries.count) tables, views, triggers, and indices.",
+                   level: .debug,
+                   category: .storage)
 
         return self.run(db, queries: queries) &&
                self.prepopulateRootFolders(db)
@@ -936,7 +942,9 @@ open class BrowserSchema: Schema {
     public func update(_ db: SQLiteDBConnection, from: Int) -> Bool {
         let to = self.version
         if from == to {
-            log.debug("Skipping update from \(from) to \(to).")
+            logger.log("Skipping update from \(from) to \(to).",
+                       level: .debug,
+                       category: .storage)
             return true
         }
 
@@ -960,17 +968,23 @@ open class BrowserSchema: Schema {
 
             // Otherwise, this is likely an upgrade from before Bug 1160399, so
             // let's drop and re-create.
-            log.debug("Updating schema \(self.name) from zero. Assuming drop and recreate.")
+            logger.log("Updating schema \(self.name) from zero. Assuming drop and recreate.",
+                       level: .debug,
+                       category: .storage)
             return drop(db) && create(db)
         }
 
         if from > to {
             // This is likely an upgrade from before Bug 1160399.
-            log.debug("Downgrading browser tables. Assuming drop and recreate.")
+            logger.log("Downgrading browser tables. Assuming drop and recreate.",
+                       level: .debug,
+                       category: .storage)
             return drop(db) && create(db)
         }
 
-        log.debug("Updating schema \(self.name) from \(from) to \(to).")
+        logger.log("Updating schema \(self.name) from \(from) to \(to).",
+                   level: .debug,
+                   category: .storage)
 
         if from < 4 && to >= 4 {
             return drop(db) && create(db)
@@ -1440,7 +1454,9 @@ open class BrowserSchema: Schema {
     }
 
     fileprivate func migrateFromSchemaTableIfNeeded(_ db: SQLiteDBConnection) -> Bool {
-        log.info("Checking if schema table migration is needed.")
+        logger.log("Checking if schema table migration is needed.",
+                   level: .info,
+                   category: .storage)
 
         // If `PRAGMA user_version` is v31 or later, we don't need to do anything here.
         guard db.version < 31 else {
@@ -1478,7 +1494,9 @@ open class BrowserSchema: Schema {
         // No other intermediate migrations are needed for the remaining tables and
         // we have already captured the *previous* schema version specified in
         // `tableList`, so we can now safely drop it.
-        log.info("Schema table migrations complete; Dropping 'tableList' table.")
+        logger.log("Schema table migrations complete; Dropping 'tableList' table.",
+                   level: .info,
+                   category: .storage)
 
         let sql = "DROP TABLE IF EXISTS tableList"
         do {
@@ -1529,14 +1547,18 @@ open class BrowserSchema: Schema {
             return .skipped
         }
 
-        log.info("Migrating 'clients' table from version \(previousClientsTableVersion).")
+        logger.log("Migrating 'clients' table from version \(previousClientsTableVersion).",
+                   level: .info,
+                   category: .storage)
 
         if previousClientsTableVersion < 2 {
             let sql = "ALTER TABLE clients ADD COLUMN version TEXT"
             do {
                 try db.executeChange(sql)
             } catch let err as NSError {
-                log.error("Error altering clients table: \(err.localizedDescription); SQL was \(sql)")
+                logger.log("Error altering clients table: \(err.localizedDescription); SQL was \(sql)",
+                           level: .warning,
+                           category: .storage)
                 let extra = ["table": "clients", "errorDescription": "\(err.localizedDescription)", "sql": "\(sql)"]
                 SentryIntegration.shared.sendWithStacktrace(message: "Error altering table", tag: SentryTag.browserDB, severity: .error, extra: extra)
                 return .failure
@@ -1548,7 +1570,9 @@ open class BrowserSchema: Schema {
             do {
                 try db.executeChange(sql)
             } catch let err as NSError {
-                log.error("Error altering clients table: \(err.localizedDescription); SQL was \(sql)")
+                logger.log("Error altering clients table: \(err.localizedDescription); SQL was \(sql)",
+                           level: .warning,
+                           category: .storage)
                 let extra = ["table": "clients", "errorDescription": "\(err.localizedDescription)", "sql": "\(sql)"]
                 SentryIntegration.shared.sendWithStacktrace(message: "Error altering table", tag: SentryTag.browserDB, severity: .error, extra: extra)
                 return .failure
@@ -1578,7 +1602,9 @@ open class BrowserSchema: Schema {
         let tmpTable = "tmp_hostnames"
         let table = "CREATE TEMP TABLE \(tmpTable) (url TEXT NOT NULL UNIQUE, domain TEXT NOT NULL, domain_id INT)"
         if !self.run(db, sql: table, args: nil) {
-            log.error("Can't create temporary table. Unable to migrate domain names. Top Sites is likely to be broken.")
+            logger.log("Can't create temporary table. Unable to migrate domain names. Top Sites is likely to be broken.",
+                       level: .warning,
+                       category: .storage)
             return false
         }
 
@@ -1588,7 +1614,9 @@ open class BrowserSchema: Schema {
             let ins =
                 "INSERT INTO \(tmpTable) (url, domain) VALUES " + [String](repeating: "(?, ?)", count: chunk.count / 2).joined(separator: ", ")
             if !self.run(db, sql: ins, args: Array(chunk)) {
-                log.error("Couldn't insert domains into temporary table. Aborting migration.")
+                logger.log("Couldn't insert domains into temporary table. Aborting migration.",
+                           level: .warning,
+                           category: .storage)
                 return false
             }
         }
@@ -1610,7 +1638,9 @@ open class BrowserSchema: Schema {
                                    domainIDs,
                                    updateHistory,
                                    dropTemp]) {
-            log.error("Unable to migrate domains.")
+            logger.log("Unable to migrate domains.",
+                       level: .warning,
+                       category: .storage)
             return false
         }
 
@@ -1618,7 +1648,9 @@ open class BrowserSchema: Schema {
     }
 
     public func drop(_ db: SQLiteDBConnection) -> Bool {
-        log.debug("Dropping all browser tables.")
+        logger.log("Dropping all browser tables.",
+                   level: .debug,
+                   category: .storage)
         let additional = [
             "DROP TABLE IF EXISTS faviconSites" // We renamed it to match naming convention.
         ]

--- a/Storage/SQL/ReadingListSchema.swift
+++ b/Storage/SQL/ReadingListSchema.swift
@@ -3,19 +3,21 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0
 
 import Foundation
+import Logger
 import Shared
 
 private let AllTables: [String] = ["items"]
 
-private let log = LegacyLogger.syncLogger
-
 open class ReadingListSchema: Schema {
     static let DefaultVersion = 1
+    private var logger: Logger
 
     public var name: String { return "READINGLIST" }
     public var version: Int { return ReadingListSchema.DefaultVersion }
 
-    public init() {}
+    public init(logger: Logger = DefaultLogger.shared) {
+        self.logger = logger
+    }
 
     let itemsTableCreate = """
         CREATE TABLE IF NOT EXISTS items (
@@ -39,21 +41,29 @@ open class ReadingListSchema: Schema {
     public func update(_ db: SQLiteDBConnection, from: Int) -> Bool {
         let to = self.version
         if from == to {
-            log.debug("Skipping ReadingList schema update from \(from) to \(to).")
+            logger.log("Skipping ReadingList schema update from \(from) to \(to).",
+                       level: .debug,
+                       category: .storage)
             return true
         }
 
         if from < 1 && to >= 1 {
-            log.debug("Updating ReadingList database schema from \(from) to \(to).")
+            logger.log("Updating ReadingList database schema from \(from) to \(to).",
+                       level: .debug,
+                       category: .storage)
             return self.run(db, queries: [itemsTableCreate])
         }
 
-        log.debug("Dropping and re-creating ReadingList database schema from \(from) to \(to).")
+        logger.log("Dropping and re-creating ReadingList database schema from \(from) to \(to).",
+                   level: .debug,
+                   category: .storage)
         return drop(db) && create(db)
     }
 
     public func drop(_ db: SQLiteDBConnection) -> Bool {
-        log.debug("Dropping ReadingList database.")
+        logger.log("Dropping ReadingList database.",
+                   level: .debug,
+                   category: .storage)
         let tables = AllTables.map { "DROP TABLE IF EXISTS \($0)" }
         let queries = Array([tables].joined())
         return self.run(db, queries: queries)
@@ -63,8 +73,9 @@ open class ReadingListSchema: Schema {
         do {
             try db.executeChange(sql, withArgs: args)
         } catch let err as NSError {
-            log.error("Error running SQL in ReadingListSchema: \(err.localizedDescription)")
-            log.error("SQL was \(sql)")
+            logger.log("Error running SQL in ReadingListSchema: \(err.localizedDescription) with \(sql)",
+                       level: .warning,
+                       category: .storage)
             return false
         }
         return true

--- a/Storage/SQL/SQLitePinnedSites.swift
+++ b/Storage/SQL/SQLitePinnedSites.swift
@@ -6,8 +6,6 @@ import Foundation
 import Shared
 import Glean
 
-private let log = LegacyLogger.syncLogger
-
 private var ignoredSchemes = ["about"]
 
 public func isIgnoredURL(_ url: URL) -> Bool {

--- a/Storage/SQL/SQLiteRemoteClientsAndTabs.swift
+++ b/Storage/SQL/SQLiteRemoteClientsAndTabs.swift
@@ -177,9 +177,9 @@ open class SQLiteRemoteClientsAndTabs: RemoteClientsAndTabs {
             for command in commands {
                 for client in clients {
                     do {
-                        if let _ = try self.insert(connection,
-                                                   sql: "INSERT INTO commands (client_guid, value) VALUES (?, ?)",
-                                                   args: [client.guid, command.value] as Args) {
+                        if try self.insert(connection,
+                                           sql: "INSERT INTO commands (client_guid, value) VALUES (?, ?)",
+                                           args: [client.guid, command.value] as Args) != nil {
                             numberOfInserts += 1
                         } else {
                             self.logger.log("Command not inserted, but no error!",

--- a/Storage/SQL/SQLiteRemoteClientsAndTabs.swift
+++ b/Storage/SQL/SQLiteRemoteClientsAndTabs.swift
@@ -3,16 +3,18 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0
 
 import Foundation
+import Logger
 import Shared
 import SwiftyJSON
 
-private let log = LegacyLogger.syncLogger
-
 open class SQLiteRemoteClientsAndTabs: RemoteClientsAndTabs {
     let db: BrowserDB
+    private var logger: Logger
 
-    public init(db: BrowserDB) {
+    public init(db: BrowserDB,
+                logger: Logger = DefaultLogger.shared) {
         self.db = db
+        self.logger = logger
     }
 
     class func remoteClientFactory(_ row: SDRow) -> RemoteClient {
@@ -96,7 +98,9 @@ open class SQLiteRemoteClientsAndTabs: RemoteClientsAndTabs {
                     try connection.executeChange("INSERT INTO clients (guid, name, modified, type, formfactor, os, version, fxaDeviceId) VALUES (?, ?, ?, ?, ?, ?, ?, ?)", withArgs: args)
 
                     if connection.lastInsertedRowID == lastInsertedRowID {
-                        log.debug("INSERT did not change last inserted row ID.")
+                        self.logger.log("INSERT did not change last inserted row ID.",
+                                        level: .debug,
+                                        category: .storage)
                     }
                 }
 
@@ -173,14 +177,19 @@ open class SQLiteRemoteClientsAndTabs: RemoteClientsAndTabs {
             for command in commands {
                 for client in clients {
                     do {
-                        if let commandID = try self.insert(connection, sql: "INSERT INTO commands (client_guid, value) VALUES (?, ?)", args: [client.guid, command.value] as Args) {
-                            log.verbose("Inserted command: \(commandID)")
+                        if let _ = try self.insert(connection,
+                                                   sql: "INSERT INTO commands (client_guid, value) VALUES (?, ?)",
+                                                   args: [client.guid, command.value] as Args) {
                             numberOfInserts += 1
                         } else {
-                            log.warning("Command not inserted, but no error!")
+                            self.logger.log("Command not inserted, but no error!",
+                                            level: .warning,
+                                            category: .storage)
                         }
                     } catch let err as NSError {
-                        log.error("insertCommands(_:, forClients:) failed: \(err.localizedDescription) (numberOfInserts: \(numberOfInserts)")
+                        self.logger.log("insertCommands(_:, forClients:) failed: \(err.localizedDescription) (numberOfInserts: \(numberOfInserts)",
+                                        level: .warning,
+                                        category: .storage)
                         throw err
                     }
                 }
@@ -222,7 +231,9 @@ open class SQLiteRemoteClientsAndTabs: RemoteClientsAndTabs {
 
         let id = db.lastInsertedRowID
         if id == lastID {
-            log.debug("INSERT did not change last inserted row ID.")
+            logger.log("INSERT did not change last inserted row ID.",
+                       level: .debug,
+                       category: .storage)
             return nil
         }
 
@@ -271,7 +282,9 @@ extension SQLiteRemoteClientsAndTabs: ResettableSyncStorage {
 
 extension SQLiteRemoteClientsAndTabs: AccountRemovalDelegate {
     public func onRemovedAccount() -> Success {
-        log.info("Clearing clients and tabs after account removal.")
+        logger.log("Clearing clients and tabs after account removal.",
+                   level: .info,
+                   category: .storage)
         // TODO: Bug 1168690 - delete our client and tabs records from the server.
         return self.resetClient()
     }

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -32,12 +32,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import UIKit
+import Foundation
+import Logger
 import Shared
-import XCGLogger
 
 private let DatabaseBusyTimeout: Int32 = 3 * 1000
-private let log = LegacyLogger.syncLogger
 
 public class DBOperationCancelled : MaybeErrorType {
     public var description: String {
@@ -288,7 +287,7 @@ private class SQLiteDBStatement {
         }
 
         if let args = args,
-            let bindError = bind(args) {
+           let bindError = bind(args) {
             throw bindError
         }
     }
@@ -451,9 +450,16 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
     fileprivate let debug_enabled = false
 
     private var didAttemptToMoveToBackup = false
+    private var logger: Logger
 
-    init?(filename: String, flags: SwiftData.Flags, schema: Schema, files: FileAccessor) {
-        log.debug("Opening connection to \(filename).")
+    init?(filename: String, flags: SwiftData.Flags,
+          schema: Schema,
+          files: FileAccessor,
+          logger: Logger = DefaultLogger.shared) {
+        self.logger = logger
+        logger.log("Opening connection to \(filename).",
+                   level: .debug,
+                   category: .storage)
 
         self.filename = filename
         self.flags = flags
@@ -462,7 +468,9 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
 
         func doOpen() -> Bool {
             if let failure = openWithFlags(flags) {
-                log.warning("Opening connection to \(filename) failed: \(failure).")
+                logger.log("Opening connection to \(filename) failed: \(failure).",
+                           level: .warning,
+                           category: .storage)
                 return false
             }
 
@@ -493,7 +501,9 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
         // database file to a backup location and start over with a brand new one.
         switch self.prepareSchema() {
         case .success:
-            log.debug("Database successfully created or updated.")
+            logger.log("Database successfully created or updated.",
+                       level: .debug,
+                       category: .storage)
         case .failure:
             SentryIntegration.shared.sendWithStacktrace(message: "Failed to create or update the database schema.", tag: SentryTag.swiftData, severity: .error)
             return nil
@@ -516,7 +526,9 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
             // `nil` to force SwiftData into using a `FailedSQLiteDBConnection` so we can
             // retry opening again later.
             if !doOpen() {
-                log.error("Cannot re-open a database connection to the new database file to begin recovery.")
+                logger.log("Cannot re-open a database connection to the new database file to begin recovery.",
+                           level: .warning,
+                           category: .storage)
                 SentryIntegration.shared.sendWithStacktrace(message: "Cannot re-open a database connection to the new database file to begin recovery.", tag: SentryTag.swiftData, severity: .error)
                 return nil
             }
@@ -533,7 +545,9 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
             // to force SwiftData into using a `FailedSQLiteDBConnection` so we can retry
             // again later.
             if self.prepareSchema() != .success {
-                log.error("Cannot re-create the schema in the new database file to complete recovery.")
+                logger.log("Cannot re-create the schema in the new database file to complete recovery.",
+                           level: .warning,
+                           category: .storage)
                 SentryIntegration.shared.sendWithStacktrace(message: "Cannot re-create the schema in the new database file to complete recovery.", tag: SentryTag.swiftData, severity: .error)
                 return nil
             }
@@ -545,7 +559,9 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
     }
 
     deinit {
-        log.debug("deinit: closing connection on thread \(Thread.current).")
+        logger.log("deinit: closing connection on thread \(Thread.current).",
+                   level: .debug,
+                   category: .storage)
         self.closeCustomConnection()
     }
 
@@ -554,14 +570,18 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
     }
 
     public func interrupt() {
-        log.debug("Interrupt")
+        logger.log("Interrupt",
+                   level: .debug,
+                   category: .storage)
         sqlite3_interrupt(sqliteDB)
     }
 
     fileprivate func pragma<T: Equatable>(_ pragma: String, expected: T?, factory: @escaping (SDRow) -> T, message: String) throws {
         let cursorResult = self.pragma(pragma, factory: factory)
         if cursorResult != expected {
-            log.error("\(message): \(cursorResult.debugDescription), \(expected.debugDescription)")
+            logger.log("\(message): \(cursorResult.debugDescription), \(expected.debugDescription)",
+                       level: .warning,
+                       category: .storage)
             throw NSError(domain: "mozilla", code: 0, userInfo: [NSLocalizedDescriptionKey: "PRAGMA didn't return expected output: \(message)."])
         }
     }
@@ -603,18 +623,26 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
             try pragma("page_size=\(desiredPageSize)", expected: nil,
                        factory: IntFactory, message: "Page size set")
 
-            log.info("Vacuuming to alter database page size from \(currentPageSize ?? 0) to \(desiredPageSize).")
+            logger.log("Vacuuming to alter database page size from \(currentPageSize ?? 0) to \(desiredPageSize).",
+                       level: .info,
+                       category: .storage)
 
             do {
                 try vacuum()
-                log.debug("Vacuuming succeeded.")
+                logger.log("Vacuuming succeeded.",
+                           level: .debug,
+                           category: .storage)
             } catch let err as NSError {
-                log.error("Vacuuming failed: \(err.localizedDescription).")
+                logger.log("Vacuuming failed: \(err.localizedDescription).",
+                           level: .warning,
+                           category: .storage)
             }
         }
 
         if SwiftData.EnableWAL {
-            log.info("Enabling WAL mode.")
+            logger.log("Enabling WAL mode.",
+                       level: .info,
+                       category: .storage)
 
             let desiredPagesPerJournal = 16
             let desiredCheckpointSize = desiredPagesPerJournal * desiredPageSize
@@ -650,17 +678,23 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
 
     // Creates the database schema in a new database.
     fileprivate func createSchema() -> Bool {
-        log.debug("Trying to create schema \(self.schema.name) at version \(self.schema.version)")
+        logger.log("Trying to create schema \(self.schema.name) at version \(self.schema.version)",
+                   level: .debug,
+                   category: .storage)
         if !schema.create(self) {
             // If schema couldn't be created, we'll bail without setting the `PRAGMA user_version`.
-            log.debug("Creation failed.")
+            logger.log("Creation failed.",
+                       level: .debug,
+                       category: .storage)
             return false
         }
 
         do {
             try setVersion(schema.version)
         } catch let error as NSError {
-            log.error("Unable to set the schema version; \(error.localizedDescription)")
+            logger.log("Unable to set the schema version; \(error.localizedDescription)",
+                       level: .warning,
+                       category: .storage)
         }
 
         return true
@@ -668,17 +702,23 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
 
     // Updates the database schema in an existing database.
     fileprivate func updateSchema() -> Bool {
-        log.debug("Trying to update schema \(self.schema.name) from version \(self.version) to \(self.schema.version)")
+        logger.log("Trying to update schema \(self.schema.name) from version \(self.version) to \(self.schema.version)",
+                   level: .debug,
+                   category: .storage)
         if !schema.update(self, from: self.version) {
             // If schema couldn't be updated, we'll bail without setting the `PRAGMA user_version`.
-            log.debug("Updating failed.")
+            logger.log("Updating failed.",
+                       level: .debug,
+                       category: .storage)
             return false
         }
 
         do {
             try setVersion(schema.version)
         } catch let error as NSError {
-            log.error("Unable to set the schema version; \(error.localizedDescription)")
+            logger.log("Unable to set the schema version; \(error.localizedDescription)",
+                       level: .warning,
+                       category: .storage)
         }
 
         return true
@@ -686,17 +726,23 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
 
     // Drops the database schema from an existing database.
     fileprivate func dropSchema() -> Bool {
-        log.debug("Trying to drop schema \(self.schema.name)")
+        logger.log("Trying to drop schema \(self.schema.name)",
+                   level: .debug,
+                   category: .storage)
         if !self.schema.drop(self) {
             // If schema couldn't be dropped, we'll bail without setting the `PRAGMA user_version`.
-            log.debug("Dropping failed.")
+            logger.log("Dropping failed.",
+                       level: .debug,
+                       category: .storage)
             return false
         }
 
         do {
             try setVersion(0)
         } catch let error as NSError {
-            log.error("Unable to reset the schema version; \(error.localizedDescription)")
+            logger.log("Unable to reset the schema version; \(error.localizedDescription)",
+                       level: .warning,
+                       category: .storage)
         }
 
         return true
@@ -707,7 +753,9 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
     // creating or updating the schema.
     fileprivate func prepareSchema() -> SQLiteDBConnectionCreatedResult {
         if self.flags == .readOnly {
-            log.debug("Skipping schema (\(self.schema.name)) preparation for read-only connection.")
+            logger.log("Skipping schema (\(self.schema.name)) preparation for read-only connection.",
+                       level: .debug,
+                       category: .storage)
             return .success
         }
 
@@ -721,7 +769,9 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
         // NOTE: This assumes that we always use *ONE* `Schema` per database file
         // since SQLite can only track a single value in `PRAGMA user_version`.
         if currentVersion == schema.version {
-            log.debug("Schema \(self.schema.name) already exists at version \(self.schema.version). Skipping additional schema preparation.")
+            logger.log("Schema \(self.schema.name) already exists at version \(self.schema.version). Skipping additional schema preparation.",
+                       level: .debug,
+                       category: .storage)
             return .success
         }
 
@@ -737,13 +787,17 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
             return .failure
         }
 
-        log.debug("Schema \(self.schema.name) needs created or updated from version \(currentVersion) to \(self.schema.version).")
+        logger.log("Schema \(self.schema.name) needs created or updated from version \(currentVersion) to \(self.schema.version).",
+                   level: .debug,
+                   category: .storage)
 
         var success = true
 
         do {
             success = try transaction { connection -> Bool in
-                log.debug("Create or update \(self.schema.name) version \(self.schema.version) on \(Thread.current.description).")
+                self.logger.log("Create or update \(self.schema.name) version \(self.schema.version) on \(Thread.current.description).",
+                                level: .debug,
+                                category: .storage)
 
                 // If `PRAGMA user_version` is zero, check if we can safely create the
                 // database schema from scratch.
@@ -758,7 +812,9 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
                     // If the `tableList` table doesn't exist, we can simply invoke
                     // `createSchema()` to create a brand new DB from scratch.
                     if !tableListTableExists {
-                        log.debug("Schema \(self.schema.name) doesn't exist. Creating.")
+                        self.logger.log("Schema \(self.schema.name) doesn't exist. Creating.",
+                                        level: .debug,
+                                        category: .storage)
                         success = self.createSchema()
                         return success
                     }
@@ -769,7 +825,9 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
                 // If we can't create a brand new schema from scratch, we must
                 // call `updateSchema()` to go through the update process.
                 if self.updateSchema() {
-                    log.debug("Updated schema \(self.schema.name).")
+                    self.logger.log("Updated schema \(self.schema.name).",
+                                    level: .debug,
+                                    category: .storage)
                     success = true
                     return success
                 }
@@ -841,17 +899,19 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
 
                 let shm = baseFilename + "-shm"
                 let wal = baseFilename + "-wal"
-                log.debug("Moving \(shm) and \(wal)…")
+                logger.log("Moving \(shm) and \(wal)…",
+                           level: .debug,
+                           category: .storage)
                 if files.exists(shm) {
-                    log.debug("\(shm) exists.")
                     try files.move(shm, toRelativePath: bak + "-shm")
                 }
                 if files.exists(wal) {
-                    log.debug("\(wal) exists.")
                     try files.move(wal, toRelativePath: bak + "-wal")
                 }
 
-                log.debug("Finished moving database \(baseFilename) successfully.")
+                logger.log("Finished moving database \(baseFilename) successfully.",
+                           level: .debug,
+                           category: .storage)
             } catch let error as NSError {
                 SentryIntegration.shared.sendWithStacktrace(message: "Unable to move db to another location", tag: SentryTag.swiftData, severity: .error, description: "DB file '\(baseFilename)'. \(error.localizedDescription)")
             }
@@ -870,13 +930,19 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
      */
     public func checkpoint(_ mode: Int32) {
         guard sqliteDB != nil else {
-            log.warning("Trying to checkpoint a nil DB!")
+            logger.log("Trying to checkpoint a nil DB!",
+                       level: .warning,
+                       category: .storage)
             return
         }
 
-        log.debug("Running WAL checkpoint on \(self.filename) on thread \(Thread.current).")
+        logger.log("Running WAL checkpoint on \(self.filename) on thread \(Thread.current).",
+                   level: .debug,
+                   category: .storage)
         sqlite3_wal_checkpoint_v2(sqliteDB, nil, mode, nil, nil)
-        log.debug("WAL checkpoint done on \(self.filename).")
+        logger.log("WAL checkpoint done on \(self.filename).",
+                   level: .debug,
+                   category: .storage)
     }
 
     public func optimize() {
@@ -947,14 +1013,17 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
         var msg = SDError.errorMessageFromCode(status)
 
         if debug_enabled {
-            log.debug("SwiftData Error -> \(description)")
-            log.debug("                -> Code: \(status) - \(msg)")
+            logger.log("SwiftData Error: \(description), Code: \(status) - \(msg)",
+                       level: .debug,
+                       category: .storage)
         }
 
         if let errMsg = String(validatingUTF8: sqlite3_errmsg(sqliteDB)) {
             msg += " " + errMsg
             if debug_enabled {
-                log.debug("                -> Details: \(errMsg)")
+                logger.log("SwiftData Error: Details: \(errMsg)",
+                           level: .debug,
+                           category: .storage)
             }
         }
 
@@ -971,7 +1040,9 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
             // XXX: Temporarily remove this assertion until we find a way to
             // reuse the copy of sqlcipher that comes with the Rust components.
             // return createErr("Expected SQLCipher, got SQLite", status: Int(-1))
-            log.warning("Database \(self.filename) was not opened with SQLCipher")
+            logger.log("Database \(self.filename) was not opened with SQLCipher",
+                       level: .warning,
+                       category: .storage)
             return nil
         }
 
@@ -983,14 +1054,18 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
 
     /// Closes a connection. This is called via deinit. Do not call this yourself.
     @discardableResult fileprivate func closeCustomConnection(immediately: Bool = false) -> NSError? {
-        log.debug("Closing custom connection for \(self.filename) on \(Thread.current).")
+        logger.log("Closing custom connection for \(self.filename) on \(Thread.current).",
+                   level: .debug,
+                   category: .storage)
         // TODO: add a lock here?
         let db = self.sqliteDB
         self.sqliteDB = nil
 
         // Don't bother trying to call sqlite3_close multiple times.
         guard db != nil else {
-            log.warning("Connection was nil.")
+            logger.log("Connection was nil.",
+                       level: .warning,
+                       category: .storage)
             return nil
         }
 
@@ -1015,7 +1090,9 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
             }
         }
 
-        log.debug("Closed \(self.filename).")
+        logger.log("Closed \(self.filename).",
+                   level: .debug,
+                   category: .storage)
         return nil
     }
 
@@ -1049,7 +1126,7 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
         if let error = error {
             // Special case: Write additional info to the database log in the case of a database corruption.
             if error.code == Int(SQLITE_CORRUPT) {
-                writeCorruptionInfoForDBNamed(filename, toLogger: LegacyLogger.corruptLogger)
+                writeCorruptionInfoForDBNamed(filename)
                 SentryIntegration.shared.sendWithStacktrace(message: "SQLITE_CORRUPT", tag: SentryTag.swiftData, severity: .error, description: "DB file '\(filename)'. \(error.localizedDescription)")
             }
 
@@ -1105,7 +1182,7 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
         if let error = error {
             // Special case: Write additional info to the database log in the case of a database corruption.
             if error.code == Int(SQLITE_CORRUPT) {
-                writeCorruptionInfoForDBNamed(filename, toLogger: LegacyLogger.corruptLogger)
+                writeCorruptionInfoForDBNamed(filename)
                 SentryIntegration.shared.sendWithStacktrace(message: "SQLITE_CORRUPT", tag: SentryTag.swiftData, severity: .error, description: "DB file '\(filename)'. \(error.localizedDescription)")
             }
             // Don't log errors caused by `sqlite3_interrupt()` to Sentry.
@@ -1130,16 +1207,18 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
         return FilledSQLiteCursor<T>(statement: statement!, factory: factory)
     }
 
-    func writeCorruptionInfoForDBNamed(_ dbFilename: String, toLogger logger: XCGLogger) {
+    func writeCorruptionInfoForDBNamed(_ dbFilename: String) {
         DispatchQueue.global(qos: DispatchQoS.default.qosClass).sync {
             guard !SwiftData.corruptionLogsWritten.contains(dbFilename) else { return }
 
-            logger.error("Corrupt DB detected! DB filename: \(dbFilename)")
+            logger.log("Corrupt DB detected! DB filename: \(dbFilename)",
+                       level: .fatal,
+                       category: .storage)
 
             let dbFileSize = ("file://\(dbFilename)".asURL)?.allocatedFileSize() ?? 0
-            logger.error("DB file size: \(dbFileSize) bytes")
-
-            logger.error("Integrity check:")
+            logger.log("Corrupt DB file size: \(dbFileSize) bytes",
+                       level: .info,
+                       category: .storage)
 
             let args: [Any?]? = nil
             let messages = self.executeQueryUnsafe("PRAGMA integrity_check", factory: StringFactory, withArgs: args)
@@ -1147,27 +1226,37 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
 
             if messages.status == CursorStatus.success {
                 for message in messages {
-                    logger.error(message)
+                    guard let message = message else { return }
+                    logger.log(message,
+                               level: .info,
+                               category: .storage)
                 }
-                logger.error("----")
             } else {
-                logger.error("Couldn't run integrity check: \(messages.statusMessage).")
+                logger.log("Couldn't run integrity check: \(messages.statusMessage).",
+                           level: .info,
+                           category: .storage)
             }
 
             // Write call stack.
-            logger.error("Call stack: ")
+            logger.log("Call stack: ",
+                       level: .info,
+                       category: .storage)
             for message in Thread.callStackSymbols {
-                logger.error(" >> \(message)")
+                logger.log(" >> \(message)",
+                           level: .info,
+                           category: .storage)
             }
-            logger.error("----")
 
             // Write open file handles.
             let openDescriptors = FSUtils.openFileDescriptors()
-            logger.error("Open file descriptors: ")
+            logger.log("Open file descriptors: ",
+                       level: .info,
+                       category: .storage)
             for (k, v) in openDescriptors {
-                logger.error("  \(k): \(v)")
+                logger.log("  \(k): \(v)",
+                           level: .info,
+                           category: .storage)
             }
-            logger.error("----")
 
             SwiftData.corruptionLogsWritten.insert(dbFilename)
         }
@@ -1207,7 +1296,9 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
         do {
             result = try transactionClosure(self)
         } catch let err as NSError {
-            log.error("Op in transaction threw an error. Rolling back.")
+            logger.log("Op in transaction threw an error. Rolling back.",
+                       level: .warning,
+                       category: .storage)
             SentryIntegration.shared.sendWithStacktrace(message: "Op in transaction threw an error. Rolling back.", tag: SentryTag.swiftData, severity: .error)
 
             do {
@@ -1219,8 +1310,6 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
 
             throw err
         }
-
-        log.verbose("Op in transaction succeeded. Committing.")
 
         do {
             try executeChange("COMMIT")
@@ -1260,10 +1349,14 @@ open class SDRow: Sequence {
     // The columns of this database. The indices of these are assumed to match the indices
     // of the statement.
     fileprivate let columnNames: [String]
+    private var logger: Logger
 
-    fileprivate init(statement: SQLiteDBStatement, columns: [String]) {
+    fileprivate init(statement: SQLiteDBStatement,
+                     columns: [String],
+                     logger: Logger = DefaultLogger.shared) {
         self.statement = statement
         self.columnNames = columns
+        self.logger = logger
     }
 
     // Return the value at this index in the row
@@ -1291,7 +1384,9 @@ open class SDRow: Sequence {
         case SQLITE_FLOAT:
             ret = Double(sqlite3_column_double(statement.pointer, i))
         default:
-            log.warning("SwiftData Warning -> Column: \(index) is of an unrecognized type, returning nil")
+            logger.log("SwiftData Warning -> Column: \(index) is of an unrecognized type, returning nil",
+                       level: .warning,
+                       category: .storage)
         }
 
         return ret


### PR DESCRIPTION
## [FXIOS-5631](https://mozilla-hub.atlassian.net/browse/FXIOS-5631) https://github.com/mozilla-mobile/firefox-ios/issues/13010
- Use new logger in storage target
- Add debug log as Logger category for now, so we can migrate almost one to one
- Remove some debug logs that were verbose level to me
- Needed to add Logger dependency to Sync target instead of Storage target (or Client)
- Adapt `LoggerCategory` to make more sense to me, to discuss with the team