### PR TITLE
Bugfix MTE-556 [v111] Tracking protection icon from BookmarkingTests

### DIFF
--- a/Tests/XCUITests/BookmarkingTests.swift
+++ b/Tests/XCUITests/BookmarkingTests.swift
@@ -13,7 +13,7 @@ let url_4 = "test-password-2.html"
 
 class BookmarkingTests: BaseTestCase {
     private func bookmark() {
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection], timeout: 5)
+        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection], timeout: TIMEOUT)
         navigator.goto(BrowserTabMenu)
         waitForExistence(app.tables.otherElements[ImageIdentifiers.addToBookmark], timeout: 15)
         app.tables.otherElements[ImageIdentifiers.addToBookmark].tap()


### PR DESCRIPTION
The test `testBookmarksAwesomeBar()` from `BookmarkingTests` fails intermittently because the test times out when waiting for the lock icon to appear.

Let's give a longer timeout and continue to monitor the `BookmarkingTests`. I have tested this change repeatedly using the `-test-iterations 100` option from `xcodebuild`.

https://mozilla-hub.atlassian.net/browse/MTE-556