### PR TITLE
Refactor FXIOS-5675 [v111] Migrate shared logs to use new interface

### DIFF
--- a/BrowserKit/Sources/Logger/LoggerCategory.swift
+++ b/BrowserKit/Sources/Logger/LoggerCategory.swift
@@ -21,6 +21,9 @@ public enum LoggerCategory: String {
     // Related to the setup of services on app launch
     case setup
 
+    // Sentry calls, temporary category while we make the migration
+    case sentry
+
     // Related to storage (keychain, SQL database, store of different types, etc)
     case storage
 

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -575,6 +575,7 @@
 		8AB5958828413F6C0090F4AE /* RecentlySavedCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB5958728413F6C0090F4AE /* RecentlySavedCell.swift */; };
 		8AB5958A284145B30090F4AE /* HomepageSectionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB59589284145B30090F4AE /* HomepageSectionHandler.swift */; };
 		8AB5958C28414DF60090F4AE /* ActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB5958B28414DF60090F4AE /* ActionButton.swift */; };
+		8AB5AAB1298AC27F0054CB42 /* Logger in Frameworks */ = {isa = PBXBuildFile; productRef = 8AB5AAB0298AC27F0054CB42 /* Logger */; };
 		8AB8571D27D929350075C173 /* TopSitesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB8571C27D929350075C173 /* TopSitesViewModel.swift */; };
 		8AB8571F27D931B40075C173 /* EmptyTopSiteCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB8571E27D931B40075C173 /* EmptyTopSiteCell.swift */; };
 		8AB8572727D93AEC0075C173 /* TopSiteHistoryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43AB6FA125DC53D30016B015 /* TopSiteHistoryManager.swift */; };
@@ -595,7 +596,6 @@
 		8AC5D55F28BFE6C8001F6F7F /* Presenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC5D55E28BFE6C8001F6F7F /* Presenter.swift */; };
 		8ACA8F74291987AE00D3075D /* AccountSyncHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACA8F73291987AE00D3075D /* AccountSyncHandlerTests.swift */; };
 		8ACA8F7629198D6400D3075D /* ThrottlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACA8F7529198D6400D3075D /* ThrottlerTests.swift */; };
-		8ACD69102988BFEC00CF5F38 /* Logger in Frameworks */ = {isa = PBXBuildFile; productRef = 8ACD690F2988BFEC00CF5F38 /* Logger */; };
 		8AD08D1527E9198E00B8E907 /* TabsQuantityTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD08D1427E9198E00B8E907 /* TabsQuantityTelemetry.swift */; };
 		8AD08D1727E91AC800B8E907 /* TabsQuantityTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD08D1627E91AC800B8E907 /* TabsQuantityTelemetryTests.swift */; };
 		8AD1980F27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD1980E27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift */; };
@@ -5294,7 +5294,6 @@
 				C820439A2523DC4500740B71 /* libStorage.a in Frameworks */,
 				5A70EF12295DFD6400790249 /* Common in Frameworks */,
 				D09A0CDC1FAA24CC009A0273 /* libAccount.a in Frameworks */,
-				8ACD69102988BFEC00CF5F38 /* Logger in Frameworks */,
 				5A8FD0EA293A7D0C00333AA7 /* XCGLogger in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -5313,6 +5312,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8AB5AAB1298AC27F0054CB42 /* Logger in Frameworks */,
 				43A878FD27AB4A110071C372 /* RustMozillaAppServices.framework in Frameworks */,
 				1B0DFD25274856D60008EB0A /* SwiftyJSON in Frameworks */,
 				8A48CE3B292FCE0800B32289 /* Kingfisher in Frameworks */,
@@ -8541,7 +8541,6 @@
 				8A48CE3C292FCE1A00B32289 /* Kingfisher */,
 				5A8FD0E9293A7D0C00333AA7 /* XCGLogger */,
 				5A70EF11295DFD6400790249 /* Common */,
-				8ACD690F2988BFEC00CF5F38 /* Logger */,
 			);
 			productName = Sync;
 			productReference = 2827315E1ABC9BE600AA1954 /* Sync.framework */;
@@ -8589,6 +8588,7 @@
 				5A8FD0E7293A7CD100333AA7 /* XCGLogger */,
 				5A8FD0FD293A7F0000333AA7 /* Sentry */,
 				5A9FF8482942454600DF9FBB /* Common */,
+				8AB5AAB0298AC27F0054CB42 /* Logger */,
 			);
 			productName = Shared;
 			productReference = 288A2D861AB8B3260023ABC3 /* Shared.framework */;
@@ -15975,7 +15975,7 @@
 			package = 4326A3C22849B8E500550F73 /* XCRemoteSwiftPackageReference "Kingfisher" */;
 			productName = Kingfisher;
 		};
-		8ACD690F2988BFEC00CF5F38 /* Logger */ = {
+		8AB5AAB0298AC27F0054CB42 /* Logger */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Logger;
 		};

--- a/Shared/Extensions/KeychainWrapperExtensions.swift
+++ b/Shared/Extensions/KeychainWrapperExtensions.swift
@@ -3,9 +3,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0
 
 import Foundation
+import Logger
 import MozillaAppServices
-
-private let log = LegacyLogger.keychainLogger
 
 public extension MZKeychainWrapper {
     static var sharedClientAppContainerKeychain: MZKeychainWrapper {
@@ -17,43 +16,63 @@ public extension MZKeychainWrapper {
 }
 
 public extension MZKeychainWrapper {
-    func ensureClientStringItemAccessibility(_ accessibility: MZKeychainItemAccessibility, forKey key: String) {
+    func ensureClientStringItemAccessibility(_ accessibility: MZKeychainItemAccessibility,
+                                             forKey key: String,
+                                             logger: Logger = DefaultLogger.shared) {
         if self.hasValue(forKey: key) {
             if self.accessibilityOfKey(key) != .afterFirstUnlock {
-                log.debug("updating item \(key) with \(accessibility)")
+                logger.log("updating item \(key) with \(accessibility)",
+                           level: .debug,
+                           category: .storage)
 
                 guard let value = self.string(forKey: key) else {
-                    log.error("failed to get item \(key)")
+                    logger.log("failed to get item \(key)",
+                               level: .warning,
+                               category: .storage)
                     return
                 }
 
                 if !self.removeObject(forKey: key) {
-                    log.warning("failed to remove item \(key)")
+                    logger.log("failed to remove item \(key)",
+                               level: .warning,
+                               category: .storage)
                 }
 
                 if !self.set(value, forKey: key, withAccessibility: accessibility) {
-                    log.warning("failed to update item \(key)")
+                    logger.log("failed to update item \(key)",
+                               level: .warning,
+                               category: .storage)
                 }
             }
         }
     }
 
-    func ensureDictonaryItemAccessibility(_ accessibility: MZKeychainItemAccessibility, forKey key: String) {
+    func ensureDictonaryItemAccessibility(_ accessibility: MZKeychainItemAccessibility,
+                                          forKey key: String,
+                                          logger: Logger = DefaultLogger.shared) {
         if self.hasValue(forKey: key) {
             if self.accessibilityOfKey(key) != .afterFirstUnlock {
-                log.debug("updating item \(key) with \(accessibility)")
+                logger.log("updating item \(key) with \(accessibility)",
+                           level: .debug,
+                           category: .storage)
 
                 guard let value = self.object(forKey: key, ofClass: NSDictionary.self) else {
-                    log.error("failed to get item \(key)")
+                    logger.log("failed to get item \(key)",
+                               level: .warning,
+                               category: .storage)
                     return
                 }
 
                 if !self.removeObject(forKey: key) {
-                    log.warning("failed to remove item \(key)")
+                    logger.log("failed to remove item \(key)",
+                               level: .warning,
+                               category: .storage)
                 }
 
                 if !self.set(value, forKey: key, withAccessibility: accessibility) {
-                    log.warning("failed to update item \(key)")
+                    logger.log("failed to update item \(key)",
+                               level: .warning,
+                               category: .storage)
                 }
             }
         }

--- a/Shared/KeychainCache.swift
+++ b/Shared/KeychainCache.swift
@@ -4,9 +4,8 @@
 
 import Foundation
 import SwiftyJSON
+import Logger
 import MozillaAppServices
-
-private let log = LegacyLogger.keychainLogger
 
 public protocol JSONLiteralConvertible {
     func asJSON() -> JSON
@@ -28,31 +27,44 @@ open class KeychainCache<T: JSONLiteralConvertible> {
         self.value = value
     }
 
-    open class func fromBranch(_ branch: String, withLabel label: String?, withDefault defaultValue: T? = nil, factory: (JSON) -> T?) -> KeychainCache<T> {
+    open class func fromBranch(_ branch: String,
+                               withLabel label: String?,
+                               withDefault defaultValue: T? = nil,
+                               factory: (JSON) -> T?,
+                               logger: Logger = DefaultLogger.shared) -> KeychainCache<T> {
         if let l = label {
             let key = "\(branch).\(l)"
             MZKeychainWrapper.sharedClientAppContainerKeychain.ensureStringItemAccessibility(.afterFirstUnlock, forKey: key)
             if let s = MZKeychainWrapper.sharedClientAppContainerKeychain.string(forKey: key) {
                 if let t = factory(JSON(parseJSON: s)) {
-                    log.info("Read \(branch) from Keychain with label \(branch).\(l).")
+                    logger.log("Read \(branch) from Keychain with label \(branch).\(l).",
+                               level: .debug,
+                               category: .storage)
                     return KeychainCache(branch: branch, label: l, value: t)
                 } else {
-                    log.warning("Found \(branch) in Keychain with label \(branch).\(l), but could not parse it.")
+                    logger.log("Found \(branch) in Keychain with label \(branch).\(l), but could not parse it.",
+                               level: .warning,
+                               category: .storage)
                 }
             } else {
-                log.warning("Did not find \(branch) in Keychain with label \(branch).\(l).")
+                logger.log("Did not find \(branch) in Keychain with label \(branch).\(l).",
+                           level: .warning,
+                           category: .storage)
             }
         } else {
-            log.warning("Did not find \(branch) label in Keychain.")
+            logger.log("Did not find \(branch) label in Keychain.",
+                       level: .warning,
+                       category: .storage)
         }
         // Fall through to missing.
-        log.warning("Failed to read \(branch) from Keychain.")
+        logger.log("Failed to read \(branch) from Keychain.",
+                   level: .warning,
+                   category: .storage)
         let label = label ?? Bytes.generateGUID()
         return KeychainCache(branch: branch, label: label, value: defaultValue)
     }
 
     open func checkpoint() {
-        log.info("Storing \(self.branch) in Keychain with label \(self.branch).\(self.label).")
         if let value = value,
             let jsonString = value.asJSON().stringify() {
             MZKeychainWrapper.sharedClientAppContainerKeychain.set(jsonString, forKey: "\(branch).\(label)", withAccessibility: .afterFirstUnlock)

--- a/Sync/Synchronizers/Downloader.swift
+++ b/Sync/Synchronizers/Downloader.swift
@@ -53,9 +53,6 @@ class BatchingDownloader<T: CleartextPayloadJSON> {
         let branchName = "downloader." + collection + "."
         let prefs = basePrefs.branch(branchName)
 
-        let lm = prefs.timestampForKey("lastModified")
-        let bt = prefs.timestampForKey("baseTimestamp")
-
         prefs.removeObjectForKey("nextOffset")
         prefs.removeObjectForKey("offsetNewer")
         prefs.removeObjectForKey("baseTimestamp")


### PR DESCRIPTION
## [FXIOS-5675](https://mozilla-hub.atlassian.net/browse/FXIOS-5675) https://github.com/mozilla-mobile/firefox-ios/issues/13085
- Migrate shared logs to use new interface
- Add a temporary `LoggerCategory` for Sentry. This is temporary, since `SentryIntegration` isn't part of the Logger yet. Each Sentry logs will be part of existing category instead once migration is done.