### PR TITLE
Refactor MTE-561 Disable Danger until getting service token

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -158,7 +158,7 @@ workflows:
             # Fail if any command fails
             set -e
             echo "Run danger"
-            swift run danger-swift ci
+            #swift run danger-swift ci
     - script@1.1:
         title: Detect number of warnings
         is_always_run: true


### PR DESCRIPTION
Let's disable danger until we get a service token instead of using a personal one