### PR TITLE
Refactor FXIOS-5096 [v111] Remove client import from storage tests

### DIFF
--- a/Tests/AccountTests/TokenServerClientTests.swift
+++ b/Tests/AccountTests/TokenServerClientTests.swift
@@ -7,7 +7,6 @@ import UIKit
 import XCTest
 
 @testable import Account
-@testable import Client
 
 // Testing client state is so delicate that I'm not going to test this.  The test below does two
 // requests; we would need a third, and a guarantee of the server state, to test this completely.

--- a/Tests/StorageTests/CertTests.swift
+++ b/Tests/StorageTests/CertTests.swift
@@ -5,7 +5,6 @@
 import XCTest
 import Storage
 
-@testable import Client
 class CertTests: XCTestCase {
     func testCertStore() {
         let certStore = CertStore()

--- a/Tests/StorageTests/DiskImageStoreTests.swift
+++ b/Tests/StorageTests/DiskImageStoreTests.swift
@@ -4,9 +4,7 @@
 
 import Shared
 @testable import Storage
-@testable import Client
 import UIKit
-
 import XCTest
 
 class DiskImageStoreTests: XCTestCase {

--- a/Tests/StorageTests/MockFiles.swift
+++ b/Tests/StorageTests/MockFiles.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 @testable import Storage
-@testable import Client
 import XCTest
 
 class MockFiles: FileAccessor {

--- a/Tests/StorageTests/RustAutofillTests.swift
+++ b/Tests/StorageTests/RustAutofillTests.swift
@@ -4,7 +4,6 @@
 
 import XCTest
 import Shared
-@testable import Client
 @testable import Storage
 
 class RustAutofillTests: XCTestCase {

--- a/Tests/StorageTests/RustLoginsTests.swift
+++ b/Tests/StorageTests/RustLoginsTests.swift
@@ -4,7 +4,6 @@
 
 import XCTest
 import Shared
-@testable import Client
 @testable import Storage
 
 class RustLoginsTests: XCTestCase {

--- a/Tests/StorageTests/RustPlacesTests.swift
+++ b/Tests/StorageTests/RustPlacesTests.swift
@@ -4,7 +4,6 @@
 
 import XCTest
 import Shared
-@testable import Client
 @testable import Storage
 
 class RustPlacesTests: XCTestCase {

--- a/Tests/StorageTests/RustRemoteTabsTests.swift
+++ b/Tests/StorageTests/RustRemoteTabsTests.swift
@@ -4,7 +4,6 @@
 
 import XCTest
 import Shared
-@testable import Client
 @testable import Storage
 
 class RustRemoteTabsTests: XCTestCase {

--- a/Tests/StorageTests/StorageTestUtils.swift
+++ b/Tests/StorageTests/StorageTestUtils.swift
@@ -7,8 +7,6 @@
 import Foundation
 import Shared
 @testable import Storage
-@testable import Client
-
 import XCTest
 
 let threeMonthsInMillis: UInt64 = 3 * 30 * 24 * 60 * 60 * 1000

--- a/Tests/StorageTests/StorageTestUtils.swift
+++ b/Tests/StorageTests/StorageTestUtils.swift
@@ -7,6 +7,8 @@
 import Foundation
 import Shared
 @testable import Storage
+@testable import Client
+
 import XCTest
 
 let threeMonthsInMillis: UInt64 = 3 * 30 * 24 * 60 * 60 * 1000

--- a/Tests/StorageTests/SyncCommandsTests.swift
+++ b/Tests/StorageTests/SyncCommandsTests.swift
@@ -6,8 +6,6 @@ import Common
 import Foundation
 import Shared
 @testable import Storage
-@testable import Client
-
 import XCTest
 import SwiftyJSON
 

--- a/Tests/StorageTests/TestBrowserDB.swift
+++ b/Tests/StorageTests/TestBrowserDB.swift
@@ -5,8 +5,6 @@
 import Foundation
 import Shared
 @testable import Storage
-@testable import Client
-
 import XCTest
 
 class TestBrowserDB: XCTestCase {

--- a/Tests/StorageTests/TestSQLiteMetadata.swift
+++ b/Tests/StorageTests/TestSQLiteMetadata.swift
@@ -5,8 +5,6 @@
 import Foundation
 import Shared
 @testable import Storage
-@testable import Client
-
 import XCTest
 
 class TestSQLiteMetadata: XCTestCase {

--- a/Tests/StorageTests/TestSQLitePinnedSites.swift
+++ b/Tests/StorageTests/TestSQLitePinnedSites.swift
@@ -5,7 +5,6 @@
 import Foundation
 import Shared
 @testable import Storage
-@testable import Client
 
 import XCTest
 

--- a/Tests/StorageTests/TestSQLiteReadingList.swift
+++ b/Tests/StorageTests/TestSQLiteReadingList.swift
@@ -5,8 +5,6 @@
 import Foundation
 import Shared
 @testable import Storage
-@testable import Client
-
 import XCTest
 
 class TestSQLiteReadingList: XCTestCase {

--- a/Tests/StorageTests/TestSQLiteRemoteClientsAndTabs.swift
+++ b/Tests/StorageTests/TestSQLiteRemoteClientsAndTabs.swift
@@ -6,8 +6,6 @@ import Common
 import Foundation
 import Shared
 @testable import Storage
-@testable import Client
-
 import XCTest
 
 open class MockRemoteClientsAndTabs: RemoteClientsAndTabs {

--- a/Tests/StorageTests/TestSwiftData.swift
+++ b/Tests/StorageTests/TestSwiftData.swift
@@ -6,8 +6,6 @@ import Common
 import Foundation
 import Shared
 @testable import Storage
-@testable import Client
-
 import XCTest
 
 // TODO: rewrite this test to not use BrowserSchema. It used to use HistoryTable…


### PR DESCRIPTION
[FXIOS-5096](https://mozilla-hub.atlassian.net/browse/FXIOS-5691)
#13118 

I noticed an oddity while looking at the client bridging header, the warnings that were firing were all from storage tests that import the client target, but storage should never rely on client.