### PR TITLE
Refactor MTE-565 [v111] Bump MappaMundi version

### DIFF
--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -78,7 +78,7 @@
       "location" : "https://github.com/mozilla-mobile/MappaMundi.git",
       "state" : {
         "branch" : "master",
-        "revision" : "04601f30f9d1f67b1e197a19c8fcdbf5782f9360"
+        "revision" : "f56a6e483163a761adc8cd25c337db0ed1eac524"
       }
     },
     {


### PR DESCRIPTION
The change in MappaMundi is to increase the timeout for the app to start. We've observed a few tests failing intermittently because the app was not launched at all.

I will continue to keep an eye on the test result.