### PR TITLE
Bugfix FXIOS-5707 [v111] Split `attributedText(boldString:)` and `attributedText(boldIn:)`.

### DIFF
--- a/Client/Extensions/String+Extension.swift
+++ b/Client/Extensions/String+Extension.swift
@@ -5,11 +5,24 @@
 import Foundation
 
 extension String {
-    /// Handles logic to make part of string bold
+    /// Returns an attributed string in which the first occurrence of the given
+    /// substring is bold.
     /// - Parameters:
-    ///     - boldString: the portion of the string that should be bold. Current string must already include this string.
+    ///     - boldString: the substring that should be bold
     ///     - font: font for entire string, part of string will be converted to bold version of this font
     func attributedText(boldString: String, font: UIFont) -> NSAttributedString {
+        guard let range = self.range(of: boldString) else {
+            return NSAttributedString(string: self)
+        }
+        return self.attributedText(boldIn: range, font: font)
+    }
+
+    /// Returns an attributed string in which the characters in the given range
+    /// are bold.
+    /// - Parameters:
+    ///     - boldIn: the character range in the string that should be bold
+    ///     - font: font for entire string, part of string will be converted to bold version of this font
+    func attributedText(boldIn range: Range<String.Index>, font: UIFont) -> NSAttributedString {
         let attributedString = NSMutableAttributedString(string: self,
                                                          attributes: [NSAttributedString.Key.font: font])
 
@@ -22,8 +35,7 @@ extension String {
         }
 
         let boldFontAttribute = [NSAttributedString.Key.font: boldFont]
-        let range = (self as NSString).range(of: boldString)
-        attributedString.addAttributes(boldFontAttribute, range: range)
+        attributedString.addAttributes(boldFontAttribute, range: NSRange(range, in: self))
         return attributedString
     }
 }

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -640,8 +640,7 @@ class SearchViewController: SiteTableViewController,
         let range = searchPhrase.range(of: query)
         guard searchPhrase != query, let upperBound = range?.upperBound else { return nil }
 
-        let boldString = String(searchPhrase[upperBound..<searchPhrase.endIndex])
-        let attributedString = searchPhrase.attributedText(boldString: boldString,
+        let attributedString = searchPhrase.attributedText(boldIn: upperBound..<searchPhrase.endIndex,
                                                            font: DynamicFontHelper().DefaultStandardFont)
         return attributedString
     }

--- a/Tests/ClientTests/StringExtensionsTests.swift
+++ b/Tests/ClientTests/StringExtensionsTests.swift
@@ -58,4 +58,42 @@ class StringExtensionsTests: XCTestCase {
         let strip = HTTPDownload.stripUnicode(fromFilename: file)
         XCTAssert(strip == nounicode)
     }
+
+    func testBoldString() {
+        let font = UIFont.preferredFont(forTextStyle: .body)
+        let text = "abcdefbcde"
+        // The source string contains the substring twice;
+        // `attributedText(boldString:font:)` should only bold the first
+        // occurrence.
+        let attributedText = text.attributedText(boldString: "bcde", font: font)
+        var effectiveRange = NSRange()
+
+        XCTAssertEqual(attributedText.attribute(.font, at: 0, effectiveRange: &effectiveRange) as? UIFont, font)
+        XCTAssertEqual(effectiveRange, NSRange(location: 0, length: 1))
+
+        XCTAssertEqual(
+            attributedText.attribute(.font, at: 1, effectiveRange: &effectiveRange) as? UIFont,
+            DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body, size: font.pointSize)
+        )
+        XCTAssertEqual(effectiveRange, NSRange(location: 1, length: 4))
+
+        XCTAssertEqual(attributedText.attribute(.font, at: 5, effectiveRange: &effectiveRange) as? UIFont, font)
+        XCTAssertEqual(effectiveRange, NSRange(location: 5, length: 5))
+    }
+
+    func testBoldInRange() {
+        let font = UIFont.preferredFont(forTextStyle: .body)
+        let text = "abcdefbcde"
+        let attributedText = text.attributedText(boldIn: text.index(text.endIndex, offsetBy: -4)..<text.endIndex, font: font)
+        var effectiveRange = NSRange()
+
+        XCTAssertEqual(attributedText.attribute(.font, at: 0, effectiveRange: &effectiveRange) as? UIFont, font)
+        XCTAssertEqual(effectiveRange, NSRange(location: 0, length: 6))
+
+        XCTAssertEqual(
+            attributedText.attribute(.font, at: 6, effectiveRange: &effectiveRange) as? UIFont,
+            DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body, size: font.pointSize)
+        )
+        XCTAssertEqual(effectiveRange, NSRange(location: 6, length: 4))
+    }
 }


### PR DESCRIPTION
https://github.com/mozilla-mobile/firefox-ios/issues/13151 [FXIOS-5707](https://mozilla-hub.atlassian.net/browse/FXIOS-5707)
`attributedText(boldString:font:)` only bolds the first occurrence of the given substring in the source string. This commit:

* Adds a second extension method, `attributedText(boldIn:font:)`, which bolds all characters in the given range.
* Reimplements `attributedText(boldString:font:)` in terms of `attributedText(boldIn:font:)`.

`attributedText(boldIn:font:)` is also a little easier to use for callers that already work with ranges, as `SearchViewController` does.