### PR TITLE
Bump [v111] Update Sentry to 8.1.0

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -15669,7 +15669,7 @@
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa.git";
 			requirement = {
 				kind = exactVersion;
-				version = 8.0.0;
+				version = 8.1.0;
 			};
 		};
 		4368F83B279669690013419B /* XCRemoteSwiftPackageReference "SnapKit" */ = {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "4f6838af2688f8f762afdaea5bef941121e7d473",
-        "version" : "8.0.0"
+        "revision" : "24fa90aa4ef8f81c65eb5803e40875f685de0dcd",
+        "version" : "8.1.0"
       }
     },
     {


### PR DESCRIPTION
Changelog:
https://github.com/getsentry/sentry-cocoa/releases/tag/8.1.0