### PR TITLE
Bugfix FXIOS-5660 [v110] Continuation crash try 2

### DIFF
--- a/BrowserKit/Sources/SiteImageView/FaviconImageView.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconImageView.swift
@@ -50,7 +50,7 @@ public class FaviconImageView: UIImageView, SiteImageView {
     // MARK: - SiteImageView
 
     func setURL(_ viewModel: FaviconImageViewModel) {
-        guard canMakeRequest(with: viewModel.siteURLString) else { return }
+        guard canMakeRequest(with: viewModel.siteURLString ?? viewModel.faviconURL?.absoluteString) else { return }
 
         let id = UUID()
         uniqueID = id

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/DefaultSiteImageDownloader.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/DefaultSiteImageDownloader.swift
@@ -1,0 +1,30 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0
+
+import Foundation
+import Kingfisher
+
+class DefaultSiteImageDownloader: ImageDownloader, SiteImageDownloader {
+    var continuation: CheckedContinuation<SiteImageLoadingResult, Error>?
+    var timeoutDelay: UInt64 { return 10 }
+
+    override init(name: String = "default") {
+        super.init(name: name)
+    }
+
+    func downloadImage(with url: URL,
+                       completionHandler: ((Result<SiteImageLoadingResult, Error>) -> Void)?
+    ) -> DownloadTask? {
+        return downloadImage(with: url,
+                             options: nil,
+                             completionHandler: { result in
+            switch result {
+            case .success(let value):
+                completionHandler?(.success(value))
+            case .failure(let error):
+                completionHandler?(.failure(error))
+            }
+        })
+    }
+}

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/FaviconFetcher.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/FaviconFetcher.swift
@@ -15,7 +15,7 @@ protocol FaviconFetcher {
 struct DefaultFaviconFetcher: FaviconFetcher {
     private let imageDownloader: SiteImageDownloader
 
-    init(imageDownloader: SiteImageDownloader = ImageDownloader.default) {
+    init(imageDownloader: SiteImageDownloader = DefaultSiteImageDownloader()) {
         self.imageDownloader = imageDownloader
     }
 
@@ -25,6 +25,8 @@ struct DefaultFaviconFetcher: FaviconFetcher {
             return result.image
         } catch let error as KingfisherError {
             throw SiteImageError.unableToDownloadImage(error.errorDescription ?? "No description")
+        } catch let error as SiteImageError {
+            throw error
         } catch {
             throw SiteImageError.unableToDownloadImage("No description")
         }

--- a/BrowserKit/Sources/SiteImageView/SiteImageView.swift
+++ b/BrowserKit/Sources/SiteImageView/SiteImageView.swift
@@ -15,12 +15,17 @@ protocol SiteImageView: UIView {
 
     // Avoid multiple image loading in parallel. Only start a new request if the URL string has changed
     var requestStartedWith: String? { get set }
-    func canMakeRequest(with urlStringRequest: String?) -> Bool
+    func canMakeRequest(with siteURLString: String?) -> Bool
 }
 
 extension SiteImageView {
-    func canMakeRequest(with urlStringRequest: String?) -> Bool {
-        return requestStartedWith != urlStringRequest
+    func canMakeRequest(with siteURLString: String?) -> Bool {
+        guard requestStartedWith != nil else {
+            requestStartedWith = siteURLString
+            return true
+        }
+
+        return requestStartedWith != siteURLString
     }
 
     func updateImage(site: SiteImageModel) {

--- a/BrowserKit/Tests/SiteImageViewTests/SiteImageViewTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/SiteImageViewTests.swift
@@ -51,6 +51,23 @@ final class SiteImageViewTests: XCTestCase {
         XCTAssertEqual(imageFetcher.capturedSite?.siteURLString, url)
         XCTAssertEqual(imageFetcher.capturedSite?.expectedImageType, .heroImage)
     }
+
+    func testCanMakeRequest_firstTime_true() {
+        let url = "https://www.firefox.com"
+        let subject = FaviconImageView(frame: .zero, imageFetcher: imageFetcher) {}
+        let canMakeRequestFirstTime = subject.canMakeRequest(with: url)
+
+        XCTAssertTrue(canMakeRequestFirstTime)
+    }
+
+    func testCanMakeRequest_secondTime_false() {
+        let url = "https://www.firefox.com"
+        let subject = FaviconImageView(frame: .zero, imageFetcher: imageFetcher) {}
+        _ = subject.canMakeRequest(with: url)
+        let canMakeRequestSecondTime = subject.canMakeRequest(with: url)
+
+        XCTAssertFalse(canMakeRequestSecondTime)
+    }
 }
 
 class MockSiteImageHandler: SiteImageHandler {


### PR DESCRIPTION
## [FXIOS-5660](https://mozilla-hub.atlassian.net/browse/FXIOS-5660) https://github.com/mozilla-mobile/firefox-ios/issues/13067
- Second attempt to fix the continuation crash in v110 as detected by Beta usage (in SiteImageDownloader).
- First attempt wasn't a success since continuation was called two times (only on real device, not simulator). Turns out this second issue was cause by the `requestStartedWith` that wasn't set (although it was used). The request was made more than once, and so the continuation on the download image with was called more than once. 

Hopefully this fixes both crash cases and there's not a third one haha.
I'll ask QA to test Nightly before I uplift this to 110.