### PR TITLE
Refactor MTE-593 [v111] Bitrise update stacks

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -210,7 +210,7 @@ workflows:
         - webhook_url: $WEBHOOK_SLACK_TOKEN_2
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x
+        stack: osx-xcode-14.1.x-ventura
         machine_type_id: g2.8core
   build_and_test_1_SmokeTest2:
     before_run:
@@ -247,7 +247,7 @@ workflows:
         - pipeline_intermediate_files: '$BITRISE_XCRESULT_PATH:BITRISE_UITESTS_2_XCRESULT_PATH'
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x
+        stack: osx-xcode-14.1.x-ventura
         machine_type_id: g2-m1.8core
   build_and_test_2_SmokeTest:
     before_run:
@@ -295,7 +295,7 @@ workflows:
         run_if: '{{getenv "RUN_UI_TESTS" | eq "Run_UI_Tests"}}'
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x
+        stack: osx-xcode-14.1.x-ventura
         machine_type_id: g2.4core
   build_and_test_3_SmokeTest3:
     before_run:
@@ -343,7 +343,7 @@ workflows:
         run_if: '{{getenv "RUN_UI_TESTS" | eq "Run_UI_Tests"}}'
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x
+        stack: osx-xcode-14.1.x-ventura
         machine_type_id: g2.4core
   build_and_test_4_SmokeTest4:
     before_run:
@@ -383,7 +383,7 @@ workflows:
         - pipeline_intermediate_files: '$BITRISE_XCRESULT_PATH:BITRISE_UITESTS_4_XCRESULT_PATH'
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x
+        stack: osx-xcode-14.1.x-ventura
         machine_type_id: g2.4core
   send_slack_notification:
     steps:
@@ -762,7 +762,7 @@ workflows:
     description: This Workflow is to build the app using latest xcode available in Bitrise
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x
+        stack: osx-xcode-14.1.x-ventura
         machine_type_id: g2.4core
   RunAllXCUITests:
     steps: []
@@ -774,7 +774,7 @@ workflows:
     - 5_deploy_and_slack
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x
+        stack: osx-xcode-14.1.x-ventura
         machine_type_id: g2.4core
   RunSmokeXCUITestsiPad:
     steps:
@@ -812,7 +812,7 @@ workflows:
         description: This Workflow is to run SmokeTest on iPad simulator device Smoketest4
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x
+        stack: osx-xcode-14.1.x-ventura
         machine_type_id: g2.4core
     before_run:
     - 1_git_clone_and_post_clone
@@ -835,7 +835,7 @@ workflows:
         is_always_run: true
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x
+        stack: osx-xcode-14.1.x-ventura
         machine_type_id: g2.4core
     before_run:
     - 1_git_clone_and_post_clone
@@ -950,7 +950,7 @@ workflows:
       This Workflow is to run L10n tests in one locale and then share the bundle with the rest of the builds
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x
+        stack: osx-xcode-14.1.x-ventura
         machine_type_id: g2.4core
 
   L10nScreenshotsTests:
@@ -1030,7 +1030,7 @@ workflows:
       This Workflow is to run L10n tests for all locales
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x
+        stack: osx-xcode-14.1.x-ventura
         machine_type_id: g2.4core
 
   RunUnitTests:
@@ -1069,7 +1069,7 @@ workflows:
       in master
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x
+        stack: osx-xcode-14.1.x-ventura
         machine_type_id: g2.8core
     before_run:
     - 1_git_clone_and_post_clone
@@ -1095,7 +1095,7 @@ workflows:
     description: This Workflow is to run tests UI TESTS
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x
+        stack: osx-xcode-14.1.x-ventura
         machine_type_id: g2.8core
   SPM_Deploy_Prod_Beta:
     steps:
@@ -1225,7 +1225,7 @@ workflows:
     description: This step is to build, archive and upload Firefox Release and Beta
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x
+        stack: osx-xcode-14.1.x-ventura
         machine_type_id: g2.8core
   SPM_Deploy_Beta_Only:
     steps:
@@ -1326,7 +1326,7 @@ workflows:
     description: This step is to build, archive and upload Firefox Release and Beta
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x
+        stack: osx-xcode-14.1.x-ventura
         machine_type_id: g2.8core
   SPM_Nightly_Beta_Only:
     steps:
@@ -1428,7 +1428,7 @@ workflows:
     description: This step is to build, archive and upload Firefox Release and Beta
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x
+        stack: osx-xcode-14.1.x-ventura
         machine_type_id: g2.8core
 app:
   envs:
@@ -1450,7 +1450,7 @@ app:
 
 meta:
   bitrise.io:
-    stack: osx-xcode-14.1.x
+    stack: osx-xcode-14.1.x-ventura
     machine_type_id: g2.4core
 
 trigger_map:


### PR DESCRIPTION
PR to address the warning we are seeing on Bitrise about deprecated Monterey stacks,  let's use Ventura instead