### PR TITLE
Bugfix FXIOS-5660 [v110] Continuation crash attempt 3

### DIFF
--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/FaviconFetcher.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/FaviconFetcher.swift
@@ -7,19 +7,24 @@ import Kingfisher
 
 protocol FaviconFetcher {
     /// Fetches a favicon image from a specific URL
-    /// - Parameter imageURL: Given a certain image URL
+    /// - Parameters:
+    ///   - imageURL: Given a certain image URL
+    ///   - imageDownloader: The SiteImageDownloader the image will be downloaded with
     /// - Returns: An image or an image error following Result type
-    func fetchFavicon(from imageURL: URL) async throws -> UIImage
+    func fetchFavicon(from imageURL: URL,
+                      imageDownloader: SiteImageDownloader) async throws -> UIImage
+}
+
+extension FaviconFetcher {
+    func fetchFavicon(from imageURL: URL,
+                      imageDownloader: SiteImageDownloader = DefaultSiteImageDownloader()) async throws -> UIImage {
+        return try await fetchFavicon(from: imageURL, imageDownloader: imageDownloader)
+    }
 }
 
 struct DefaultFaviconFetcher: FaviconFetcher {
-    private let imageDownloader: SiteImageDownloader
-
-    init(imageDownloader: SiteImageDownloader = DefaultSiteImageDownloader()) {
-        self.imageDownloader = imageDownloader
-    }
-
-    func fetchFavicon(from imageURL: URL) async throws -> UIImage {
+    func fetchFavicon(from imageURL: URL,
+                      imageDownloader: SiteImageDownloader = DefaultSiteImageDownloader()) async throws -> UIImage {
         do {
             let result = try await imageDownloader.downloadImage(with: imageURL)
             return result.image

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/SiteImageDownloader.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/SiteImageDownloader.swift
@@ -41,6 +41,7 @@ extension SiteImageDownloader {
                         case .failure(let error):
                             continuation.resume(throwing: error)
                         }
+                        self.continuation = nil
                     }
                 }
             }

--- a/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/FaviconFetcherTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/FaviconFetcherTests.swift
@@ -21,10 +21,11 @@ final class FaviconFetcherTests: XCTestCase {
 
     func testReturnsFailure_onAnyError() async {
         mockImageDownloader.error = KingfisherError.requestError(reason: .emptyRequest)
-        let subject = DefaultFaviconFetcher(imageDownloader: mockImageDownloader)
+        let subject = DefaultFaviconFetcher()
 
         do {
-            _ = try await subject.fetchFavicon(from: URL(string: "www.mozilla.com")!)
+            _ = try await subject.fetchFavicon(from: URL(string: "www.mozilla.com")!,
+                                               imageDownloader: mockImageDownloader)
             XCTFail("Should have failed with error")
         } catch let error as SiteImageError {
             XCTAssertEqual("Unable to download image with reason: The request is empty or `nil`.",
@@ -37,10 +38,11 @@ final class FaviconFetcherTests: XCTestCase {
     func testReturnsSuccess_onImage() async {
         let resultImage = UIImage()
         mockImageDownloader.image = resultImage
-        let subject = DefaultFaviconFetcher(imageDownloader: mockImageDownloader)
+        let subject = DefaultFaviconFetcher()
 
         do {
-            let result = try await subject.fetchFavicon(from: URL(string: "www.mozilla.com")!)
+            let result = try await subject.fetchFavicon(from: URL(string: "www.mozilla.com")!,
+                                                        imageDownloader: mockImageDownloader)
             XCTAssertEqual(resultImage, result)
         } catch {
             XCTFail("Should have succeeded with image")
@@ -49,10 +51,11 @@ final class FaviconFetcherTests: XCTestCase {
 
     func testTimeout_completesWithoutImageOrError() async {
         mockImageDownloader.timeoutDelay = 1
-        let subject = DefaultFaviconFetcher(imageDownloader: mockImageDownloader)
+        let subject = DefaultFaviconFetcher()
 
         do {
-            _ = try await subject.fetchFavicon(from: URL(string: "www.mozilla.com")!)
+            _ = try await subject.fetchFavicon(from: URL(string: "www.mozilla.com")!,
+                                               imageDownloader: mockImageDownloader)
             XCTFail("Should have failed with error")
         } catch let error as SiteImageError {
             XCTAssertEqual("Unable to download image with reason: Timeout reached", error.description)

--- a/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/ImageHandlerTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/ImageHandlerTests.swift
@@ -361,7 +361,7 @@ private class MockFaviconFetcher: FaviconFetcher {
     var fetchImageSucceedCalled = 0
     var fetchImageFailedCalled = 0
 
-    func fetchFavicon(from imageURL: URL) async throws -> UIImage {
+    func fetchFavicon(from imageURL: URL, imageDownloader: SiteImageDownloader) async throws -> UIImage {
         if let image = image {
             fetchImageSucceedCalled += 1
             return image


### PR DESCRIPTION
## [FXIOS-5660](https://mozilla-hub.atlassian.net/browse/FXIOS-5660) https://github.com/mozilla-mobile/firefox-ios/issues/13067
- Set continuation to `nil` after it has resumed to ensure it's not called twice
- New favicon fetcher per request to avoid a problem where an existing request for a different URL on a `siteImageView` could conflict with a new request.