### PR TITLE
Bugfix [v110] Fix merge conflicts

### DIFF
--- a/BrowserKit/Sources/SiteImageView/FaviconImageView.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconImageView.swift
@@ -50,7 +50,7 @@ public class FaviconImageView: UIImageView, SiteImageView {
     // MARK: - SiteImageView
 
     func setURL(_ viewModel: FaviconImageViewModel) {
-        guard canMakeRequest(with: viewModel.siteURLString ?? viewModel.faviconURL?.absoluteString) else { return }
+        guard canMakeRequest(with: viewModel.urlStringRequest) else { return }
 
         let id = UUID()
         uniqueID = id


### PR DESCRIPTION
`siteURLString` and `faviconURL` doesn't exist in v110 inside `FaviconImageViewModel`