### PR TITLE
Refactor FXIOS-5671 [v111] Sentry logs migration

### DIFF
--- a/BrowserKit/Sources/Logger/LoggerCategory.swift
+++ b/BrowserKit/Sources/Logger/LoggerCategory.swift
@@ -24,7 +24,7 @@ public enum LoggerCategory: String {
     // Related to the application lifecycle
     case lifecycle
 
-    // Related to the setup of services on app launch
+    // Related to the setup of services on app launch and general setup of the app
     case setup
 
     // Sentry calls, temporary category while we make the migration
@@ -39,6 +39,6 @@ public enum LoggerCategory: String {
     // Related to the tabs UI, setup and management
     case tabs
 
-    // Webview scripts, webview delegate, webserver like GCDWebserver
+    // Webview scripts, webview delegate, webserver like GCDWebserver, showing webview alerts, webview navigation
     case webview
 }

--- a/Client/Application/AppDelegate+PushNotifications.swift
+++ b/Client/Application/AppDelegate+PushNotifications.swift
@@ -123,7 +123,8 @@ extension AppDelegate {
     }
 
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
-        print("failed to register. \(error)")
-        SentryIntegration.shared.send(message: "Failed to register for APNS")
+        logger.log("Failed to register for APNS",
+                   level: .info,
+                   category: .setup)
     }
 }

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -10,7 +10,7 @@ import Common
 import Logger
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    private let logger = DefaultLogger.shared
+    let logger = DefaultLogger.shared
     var notificationCenter: NotificationProtocol = NotificationCenter.default
     var orientationLock = UIInterfaceOrientationMask.all
 

--- a/Client/Application/AppLaunchUtil.swift
+++ b/Client/Application/AppLaunchUtil.swift
@@ -164,8 +164,6 @@ class AppLaunchUtil {
                 GleanMetrics.PlacesHistoryMigration.duration.cancel(id)
                 GleanMetrics.PlacesHistoryMigration.migrationEndedRate.addToDenominator(1)
                 GleanMetrics.PlacesHistoryMigration.migrationErrorRate.addToDenominator(1)
-                // We also send the error to sentry
-                SentryIntegration.shared.sendWithStacktrace(message: "Error executing application services history migration", tag: SentryTag.rustPlaces, severity: .error, description: errDescription)
             })
         } else {
             self.logger.log("History Migration skipped",

--- a/Client/Experiments/Experiments.swift
+++ b/Client/Experiments/Experiments.swift
@@ -150,12 +150,10 @@ enum Experiments {
         )
 
         let errorReporter: NimbusErrorReporter = { err in
-            SentryIntegration.shared.sendWithStacktrace(
-                message: "Error in Nimbus SDK",
-                tag: SentryTag.nimbus,
-                severity: .error,
-                description: err.localizedDescription
-            )
+            DefaultLogger.shared.log("Error in Nimbus SDK",
+                                     level: .warning,
+                                     category: .experiments,
+                                     description: err.localizedDescription)
         }
 
         let initialExperiments = Bundle.main.url(forResource: "initial_experiments", withExtension: "json")

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1265,11 +1265,10 @@ class BrowserViewController: UIViewController {
         guard let kp = keyPath,
               let path = KVOConstants(rawValue: kp)
         else {
-            SentryIntegration.shared.send(
-                message: "BVC observeValue webpage unhandled KVO",
-                tag: .general,
-                severity: .error,
-                description: "Unhandled KVO key: \(keyPath ?? "nil")")
+            logger.log("BVC observeValue webpage unhandled KVO",
+                       level: .info,
+                       category: .webview,
+                       description: "Unhandled KVO key: \(keyPath ?? "nil")")
             return
         }
 
@@ -2731,15 +2730,19 @@ extension BrowserViewController {
     /// We're currently seeing crashes from cases of there being no `connectedScene`, or being unable to cast to a SceneDelegate.
     /// Although those instances should be rare, we will return an optional until we can investigate when and why we end up in this situation.
     ///
-    /// With this change, we are aware that certain functionality that depends on a non-nil BVC will fail, but not fatally for now. 
+    /// With this change, we are aware that certain functionality that depends on a non-nil BVC will fail, but not fatally for now.
     public static func foregroundBVC() -> BrowserViewController? {
         guard let scene = UIApplication.shared.connectedScenes.first else {
-            SentryIntegration.shared.send(message: "No connected scenes exist.", severity: .fatal)
+            DefaultLogger.shared.log("No connected scenes exist.",
+                                     level: .fatal,
+                                     category: .setup)
             return nil
         }
 
         guard let sceneDelegate = scene.delegate as? SceneDelegate else {
-            SentryIntegration.shared.send(message: "Scene could not be cast as SceneDelegate.", severity: .fatal)
+            DefaultLogger.shared.log("Scene could not be cast as SceneDelegate.",
+                                     level: .fatal,
+                                     category: .setup)
             return nil
         }
 

--- a/Client/Frontend/Browser/OpenInHelper/OpenPassBookHelper.swift
+++ b/Client/Frontend/Browser/OpenInHelper/OpenPassBookHelper.swift
@@ -5,6 +5,7 @@
 import PassKit
 import Shared
 import WebKit
+import Logger
 
 class OpenPassBookHelper {
     private enum InvalidPassError: Error {
@@ -30,14 +31,17 @@ class OpenPassBookHelper {
     private let cookieStore: WKHTTPCookieStore
     private lazy var session = makeURLSession(userAgent: UserAgent.fxaUserAgent,
                                               configuration: .ephemeral)
+    private let logger: Logger
 
     init(response: URLResponse,
          cookieStore: WKHTTPCookieStore,
-         presenter: Presenter) {
+         presenter: Presenter,
+         logger: Logger = DefaultLogger.shared) {
         self.response = response
         self.url = response.url
         self.cookieStore = cookieStore
         self.presenter = presenter
+        self.logger = logger
     }
 
     static func shouldOpenWithPassBook(response: URLResponse,
@@ -161,9 +165,10 @@ class OpenPassBookHelper {
     }
 
     private func sendLogError(with errorDescription: String) {
-        // Log error on sentry to help debug https://github.com/mozilla-mobile/firefox-ios/issues/12331
-        SentryIntegration.shared.sendWithStacktrace(message: "Unknown error when adding pass to Apple Wallet",
-                                                    severity: .error,
-                                                    description: errorDescription)
+        // Log error to help debug https://github.com/mozilla-mobile/firefox-ios/issues/12331
+        logger.log("Unknown error when adding pass to Apple Wallet",
+                   level: .warning,
+                   category: .webview,
+                   description: errorDescription)
     }
 }

--- a/Client/Frontend/Browser/QRCodeViewController.swift
+++ b/Client/Frontend/Browser/QRCodeViewController.swift
@@ -5,6 +5,7 @@
 import Foundation
 import AVFoundation
 import Shared
+import Logger
 
 protocol QRCodeViewControllerDelegate: AnyObject {
     func didScanQRCodeWithURL(_ url: URL)
@@ -68,6 +69,17 @@ class QRCodeViewController: UIViewController {
             scanBorderSize = minSize / 2
         }
         return scanBorderSize
+    }
+
+    private let logger: Logger
+
+    init(logger: Logger = DefaultLogger.shared) {
+        self.logger = logger
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 
     override func viewDidLoad() {
@@ -315,12 +327,12 @@ extension QRCodeViewController: AVCaptureMetadataOutputObjectsDelegate {
             self.dismiss(animated: true, completion: {
                 guard let metaData = metadataObjects.first as? AVMetadataMachineReadableCodeObject,
                       let qrCodeDelegate = self.qrCodeDelegate,
-                        let text = metaData.stringValue
+                      let text = metaData.stringValue
                 else {
-                        SentryIntegration.shared.sendWithStacktrace(
-                            message: "Unable to scan QR code",
-                            tag: .general)
-                        return
+                    self.logger.log("Unable to scan QR code",
+                                    level: .debug,
+                                    category: .webview)
+                    return
                 }
 
                 if let url = URIFixup.getURL(text) {

--- a/Client/Frontend/Browser/Tab Management/TabManagerStore.swift
+++ b/Client/Frontend/Browser/Tab Management/TabManagerStore.swift
@@ -161,10 +161,10 @@ class TabManagerStoreImplementation: TabManagerStore, FeatureFlaggable {
         do {
             try fileManager.removeItem(at: path)
         } catch let error {
-            SentryIntegration.shared.send(message: "Clear archive couldn't be completed",
-                                          tag: .tabManager,
-                                          severity: .warning,
-                                          description: error.localizedDescription)
+            logger.log("Clear archive couldn't be completed",
+                       level: .warning,
+                       category: .tabs,
+                       description: error.localizedDescription)
         }
     }
 
@@ -175,10 +175,10 @@ class TabManagerStoreImplementation: TabManagerStore, FeatureFlaggable {
         do {
             try archiver.encodeEncodable(savedTabs, forKey: tabsKey)
         } catch let error {
-            SentryIntegration.shared.send(message: "Archiving savedTabs failed",
-                                          tag: .tabManager,
-                                          severity: .warning,
-                                          description: error.localizedDescription)
+            logger.log("Archiving savedTabs failed",
+                       level: .warning,
+                       category: .tabs,
+                       description: error.localizedDescription)
             return nil
         }
 
@@ -204,10 +204,10 @@ class TabManagerStoreImplementation: TabManagerStore, FeatureFlaggable {
     }
 
     private func savedTabError(description: String) -> [SavedTab] {
-        SentryIntegration.shared.send(message: "Failed to restore tabs",
-                                      tag: .tabManager,
-                                      severity: .error,
-                                      description: description)
+        logger.log("Failed to restore tabs",
+                   level: .warning,
+                   category: .tabs,
+                   description: description)
         SimpleTab.saveSimpleTab(tabs: nil)
         return [SavedTab]()
     }
@@ -294,10 +294,10 @@ class TabManagerStoreImplementation: TabManagerStore, FeatureFlaggable {
         do {
             try fileManager.removeItem(at: deprecatedPath)
         } catch let error {
-            SentryIntegration.shared.send(message: "Clear deprecated archive couldn't be completed",
-                                          tag: .tabManager,
-                                          severity: .warning,
-                                          description: error.localizedDescription)
+            logger.log("Clear deprecated archive couldn't be completed",
+                       level: .warning,
+                       category: .tabs,
+                       description: error.localizedDescription)
         }
     }
 }

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -6,6 +6,7 @@ import Foundation
 import Shared
 import Storage
 import Common
+import Logger
 
 extension UIGestureRecognizer {
     func cancel() {
@@ -1061,7 +1062,10 @@ extension TabDisplayOrder {
                 let order = try jsonDecoder.decode(TabDisplayOrder.self, from: tabDisplayOrder)
                 return order
             } catch let error as NSError {
-                SentryIntegration.shared.send(message: "Error: Unable to decode tab display order", tag: SentryTag.tabDisplayManager, severity: .error, description: error.debugDescription)
+                DefaultLogger.shared.log("Error: Unable to decode tab display order",
+                                         level: .warning,
+                                         category: .tabs,
+                                         description: error.debugDescription)
             }
         }
         return nil

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
@@ -149,12 +149,10 @@ class HistoryPanelViewModel: FeatureFlaggable {
             self.isFetchInProgress = false
 
             guard result.isSuccess else {
-                SentryIntegration.shared.sendWithStacktrace(
-                    message: "Error searching history panel",
-                    tag: .rustPlaces,
-                    severity: .error,
-                    description: result.failureValue?.localizedDescription ?? "Unkown error searching history"
-                )
+                self.logger.log("Error searching history panel",
+                                level: .warning,
+                                category: .sync,
+                                description: result.failureValue?.localizedDescription ?? "Unkown error searching history")
                 completion(false)
                 return
             }

--- a/Client/Frontend/Login Management/BreachAlertsClient.swift
+++ b/Client/Frontend/Login Management/BreachAlertsClient.swift
@@ -34,7 +34,6 @@ public class BreachAlertsClient: BreachAlertsClientProtocol {
         dataTask = URLSession.shared.dataTask(with: request) { _, response, _ in
             guard let response = response as? HTTPURLResponse else { return }
             guard response.statusCode < 400 else {
-                SentryIntegration.shared.send(message: "BreachAlerts: fetchEtag: HTTP status code: \(response.statusCode)")
                 completion(nil)
                 return
             }
@@ -58,17 +57,14 @@ public class BreachAlertsClient: BreachAlertsClientProtocol {
         dataTask = URLSession.shared.dataTask(with: url) { data, response, error in
             guard let response = response as? HTTPURLResponse else { return }
             guard response.statusCode < 400 else {
-                SentryIntegration.shared.send(message: "BreachAlerts: fetchData: HTTP status code: \(response.statusCode)")
                 return
             }
             if let error = error {
                 completion(Maybe(failure: BreachAlertsError(description: error.localizedDescription)))
-                SentryIntegration.shared.send(message: "BreachAlerts: fetchData: \(error)")
                 return
             }
             guard let data = data else {
                 completion(Maybe(failure: BreachAlertsError(description: "invalid data")))
-                SentryIntegration.shared.send(message: "BreachAlerts: fetchData: invalid data")
                 assertionFailure("Error unwrapping data")
                 return
             }

--- a/Client/Frontend/Login Management/BreachAlertsManager.swift
+++ b/Client/Frontend/Login Management/BreachAlertsManager.swift
@@ -62,7 +62,6 @@ final public class BreachAlertsManager {
         // 1b. local file exists, so load from that
         guard let fileData = FileManager.default.contents(atPath: cacheURL.path) else {
             completion(Maybe(failure: BreachAlertsError(description: "failed to get data from breach.json")))
-            SentryIntegration.shared.send(message: "BreachAlerts: failed to get data from breach.json")
             try? FileManager.default.removeItem(at: cacheURL) // bad file, so delete it
             self.fetchAndSaveBreaches(completion)
             return

--- a/Client/RatingPromptManager.swift
+++ b/Client/RatingPromptManager.swift
@@ -7,6 +7,7 @@ import StoreKit
 import Shared
 import Storage
 import Common
+import Logger
 
 // The `RatingPromptManager` handles app store review requests and the internal logic of when they can be presented to a user.
 final class RatingPromptManager {
@@ -15,7 +16,7 @@ final class RatingPromptManager {
 
     private var hasMinimumMobileBookmarksCount = false
     private let minimumMobileBookmarksCount = 5
-    private let sentry: SentryProtocol?
+    private let logger: Logger
     private let group: DispatchGroupInterface
 
     private let dataQueue = DispatchQueue(label: "com.moz.ratingPromptManager.queue")
@@ -34,11 +35,11 @@ final class RatingPromptManager {
     ///   - sentry: Sentry protocol to override in Unit test
     init(profile: Profile,
          daysOfUseCounter: CumulativeDaysOfUseCounter = CumulativeDaysOfUseCounter(),
-         sentry: SentryProtocol = SentryIntegration.shared,
+         logger: Logger = DefaultLogger.shared,
          group: DispatchGroupInterface = DispatchGroup()) {
         self.profile = profile
         self.daysOfUseCounter = daysOfUseCounter
-        self.sentry = sentry
+        self.logger = logger
         self.group = group
     }
 
@@ -103,7 +104,7 @@ final class RatingPromptManager {
         guard daysOfUseCounter.hasRequiredCumulativeDaysOfUse else { return false }
 
         // Required: has not crashed in the last session
-        guard let sentry = sentry, !sentry.crashedLastLaunch else { return false }
+        guard !logger.crashedLastLaunch else { return false }
 
         // One of the following
         let isBrowserDefault = RatingPromptManager.isBrowserDefault

--- a/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/RustFxA/FirefoxAccountSignInViewController.swift
@@ -6,6 +6,7 @@ import Foundation
 import Shared
 import Account
 import Common
+import Logger
 
 /// Reflects parent page that launched FirefoxAccountSignInViewController
 enum FxASignInParentType {
@@ -41,6 +42,7 @@ class FirefoxAccountSignInViewController: UIViewController {
     /// Dismissal style for FxAWebViewController
     /// Changes based on whether or not this VC is launched from the app menu or settings
     private let fxaDismissStyle: DismissType
+    private let logger: Logger
 
     // UI
     private lazy var scrollView: UIScrollView = .build { view in
@@ -136,7 +138,10 @@ class FirefoxAccountSignInViewController: UIViewController {
     ///   - profile: User Profile info
     ///   - parentType: FxASignInParentType is an enum parent page that presented this VC. Parameter used in telemetry button events.
     ///   - deepLinkParams: URL args passed in from deep link that propagate to FxA web view
-    init(profile: Profile, parentType: FxASignInParentType, deepLinkParams: FxALaunchParams) {
+    init(profile: Profile,
+         parentType: FxASignInParentType,
+         deepLinkParams: FxALaunchParams,
+         logger: Logger = DefaultLogger.shared) {
         self.deepLinkParams = deepLinkParams
         self.profile = profile
         switch parentType {
@@ -156,6 +161,7 @@ class FirefoxAccountSignInViewController: UIViewController {
             self.telemetryObject = .tabTray
             self.fxaDismissStyle = .popToTabTray
         }
+        self.logger = logger
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -276,7 +282,9 @@ extension FirefoxAccountSignInViewController: QRCodeViewControllerDelegate {
     }
 
     func didScanQRCodeWithText(_ text: String) {
-        SentryIntegration.shared.send(message: "FirefoxAccountSignInVC Error: `didScanQRCodeWithText` should not be called")
+        logger.log("FirefoxAccountSignInVC Error: `didScanQRCodeWithText` should not be called",
+                   level: .info,
+                   category: .sync)
     }
 }
 

--- a/RustFxA/FxAWebViewController.swift
+++ b/RustFxA/FxAWebViewController.swift
@@ -4,6 +4,7 @@
 
 import WebKit
 import Account
+import Logger
 import Shared
 
 enum DismissType {
@@ -22,6 +23,7 @@ class FxAWebViewController: UIViewController {
     /// Used to show a second WKWebView to browse help links.
     fileprivate var helpBrowser: WKWebView?
     fileprivate let viewModel: FxAWebViewModel
+    private let logger: Logger
     /// Closure for dismissing higher up FxA Sign in view controller
     var shouldDismissFxASignInViewController: (() -> Void)?
 
@@ -33,7 +35,11 @@ class FxAWebViewController: UIViewController {
      - parameter dismissalStyle: depending on how this was presented, it uses modal dismissal, or if part of a UINavigationController stack it will pop to the root.
      - parameter deepLinkParams: URL args passed in from deep link that propagate to FxA web view
      */
-    init(pageType: FxAPageType, profile: Profile, dismissalStyle: DismissType, deepLinkParams: FxALaunchParams) {
+    init(pageType: FxAPageType,
+         profile: Profile,
+         dismissalStyle: DismissType,
+         deepLinkParams: FxALaunchParams,
+         logger: Logger = DefaultLogger.shared) {
         self.viewModel = FxAWebViewModel(pageType: pageType, profile: profile, deepLinkParams: deepLinkParams)
 
         self.dismissType = dismissalStyle
@@ -48,6 +54,8 @@ class FxAWebViewController: UIViewController {
         webView.accessibilityLabel = .FxAWebContentAccessibilityLabel
         webView.scrollView.bounces = false  // Don't allow overscrolling.
         webView.customUserAgent = FxAWebViewModel.mobileUserAgent
+
+        self.logger = logger
 
         super.init(nibName: nil, bundle: nil)
         let scriptMessageHandler = WKScriptMessageHandleDelegate(self)
@@ -233,9 +241,9 @@ extension FxAWebViewController {
     }
 
     private func sendSentryObserveValueError(forKeyPath keyPath: String?) {
-        SentryIntegration.shared.send(message: "FxA webpage unhandled KVO",
-                                      tag: .rustLog,
-                                      severity: .error,
-                                      description: "Unhandled KVO key: \(keyPath ?? "nil")")
+        logger.log("FxA webpage unhandled KVO",
+                   level: .info,
+                   category: .sync,
+                   description: "Unhandled KVO key: \(keyPath ?? "nil")")
     }
 }

--- a/RustFxA/RustFirefoxAccounts.swift
+++ b/RustFxA/RustFirefoxAccounts.swift
@@ -5,6 +5,7 @@
 import Common
 import UIKit
 import Shared
+import Logger
 import MozillaAppServices
 
 let PendingAccountDisconnectedKey = "PendingAccountDisconnect"
@@ -150,7 +151,7 @@ open class RustFirefoxAccounts {
         return FxAccountManager(config: config, deviceConfig: deviceConfig, applicationScopes: [OAuthScope.profile, OAuthScope.oldSync, OAuthScope.session], keychainAccessGroup: accessGroupIdentifier)
     }
 
-    private init() {
+    private init(logger: Logger = DefaultLogger.shared) {
         // Set-up Rust network stack. Note that this has to be called
         // before any Application Services component gets used.
         Viaduct.shared.useReqwestBackend()
@@ -181,7 +182,10 @@ open class RustFirefoxAccounts {
             if let error = notification.userInfo?["error"] as? Error {
                 info = error.localizedDescription
             }
-            SentryIntegration.shared.send(message: "RustFxa failed account migration", tag: .rustLog, severity: .error, description: info)
+            logger.log("RustFxa failed account migration",
+                       level: .warning,
+                       category: .sync,
+                       description: info)
             self?.accountMigrationFailed = true
             NotificationCenter.default.post(name: .FirefoxAccountStateChange, object: nil)
         }

--- a/Storage/Rust/RustAutofill.swift
+++ b/Storage/Rust/RustAutofill.swift
@@ -5,6 +5,7 @@
 import Foundation
 import Shared
 @_exported import MozillaAppServices
+import Logger
 
 typealias AutofillStore = Store
 
@@ -53,7 +54,11 @@ public class RustAutofillEncryptionKeys {
     let ccCanaryPhraseKey = "creditCardCanaryPhrase"
     let canaryPhrase = "a string for checking validity of the key"
 
-    public init() {}
+    private let logger: Logger
+
+    public init(logger: Logger = DefaultLogger.shared) {
+        self.logger = logger
+    }
 
     fileprivate func createAndStoreKey() throws -> String {
         do {
@@ -76,10 +81,10 @@ public class RustAutofillEncryptionKeys {
 
                 throw AutofillEncryptionKeyError.noKeyCreated
             } else {
-                SentryIntegration.shared.sendWithStacktrace(message: "Unknown error while creating and storing credit card key",
-                                                            tag: SentryTag.rustAutofill,
-                                                            severity: .error,
-                                                            description: err.localizedDescription)
+                logger.log("Unknown error while creating and storing credit card key",
+                           level: .warning,
+                           category: .storage,
+                           description: err.localizedDescription)
 
                 throw AutofillEncryptionKeyError.noKeyCreated
             }
@@ -99,10 +104,10 @@ public class RustAutofillEncryptionKeys {
                                                errorDomain: err.domain,
                                                errorMessage: "Error while decrypting credit card")
             } else {
-                SentryIntegration.shared.sendWithStacktrace(message: "Unknown error while decrypting credit card",
-                                                            tag: SentryTag.rustAutofill,
-                                                            severity: .error,
-                                                            description: err.localizedDescription)
+                logger.log("Unknown error while decrypting credit card",
+                           level: .warning,
+                           category: .storage,
+                           description: err.localizedDescription)
             }
             return nil
         }
@@ -127,10 +132,10 @@ public class RustAutofillEncryptionKeys {
                                                errorDomain: err.domain,
                                                errorMessage: "Error while encrypting credit card")
             } else {
-                SentryIntegration.shared.sendWithStacktrace(message: "Unknown error while encrypting credit card",
-                                                            tag: SentryTag.rustAutofill,
-                                                            severity: .error,
-                                                            description: err.localizedDescription)
+                logger.log("Unknown error while encrypting credit card",
+                           level: .warning,
+                           category: .storage,
+                           description: err.localizedDescription)
             }
         }
         return nil
@@ -156,11 +161,10 @@ public class RustAutofillEncryptionKeys {
             }
         }
 
-        SentryIntegration.shared.sendWithStacktrace(
-            message: errorMessage,
-            tag: SentryTag.rustAutofill,
-            severity: .error,
-            description: "\(errorDomain) - \(err.descriptionValue): \(message)")
+        logger.log(errorMessage,
+                   level: .warning,
+                   category: .storage,
+                   description: "\(errorDomain) - \(err.descriptionValue): \(message)")
     }
 }
 
@@ -174,11 +178,15 @@ public class RustAutofill {
 
     private var didAttemptToMoveToBackup = false
 
-    public init(databasePath: String) {
+    private let logger: Logger
+
+    public init(databasePath: String,
+                logger: Logger = DefaultLogger.shared) {
         self.databasePath = databasePath
 
         queue = DispatchQueue(label: "RustAutofill queue: \(databasePath)",
                               attributes: [])
+        self.logger = logger
     }
 
     private func open() -> NSError? {
@@ -192,17 +200,15 @@ public class RustAutofill {
                 // This is an unrecoverable
                 // state unless we can move the existing file to a backup
                 // location and start over.
-                SentryIntegration.shared.sendWithStacktrace(
-                    message: "Rust Autofill store error when opening database",
-                    tag: SentryTag.rustAutofill,
-                    severity: .error,
-                    description: autofillStoreError.localizedDescription)
+                logger.log("Rust Autofill store error when opening database",
+                           level: .warning,
+                           category: .storage,
+                           description: autofillStoreError.localizedDescription)
             } else {
-                SentryIntegration.shared.sendWithStacktrace(
-                    message: "Unknown error when opening Rust Autofill database",
-                    tag: SentryTag.rustAutofill,
-                    severity: .error,
-                    description: err.localizedDescription)
+                logger.log("Unknown error when opening Rust Autofill database",
+                           level: .warning,
+                           category: .storage,
+                           description: err.localizedDescription)
             }
 
             if !didAttemptToMoveToBackup {
@@ -392,28 +398,25 @@ public class RustAutofill {
                 if canaryIsValid {
                     return key!
                 } else {
-                    SentryIntegration.shared.sendWithStacktrace(
-                        message: "Autofill key was corrupted, new one generated",
-                        tag: SentryTag.rustAutofill,
-                        severity: .warning)
+                    logger.log("Autofill key was corrupted, new one generated",
+                               level: .warning,
+                               category: .storage)
 
                     self.scrubCreditCardNums(completion: {_, _ in })
                     return try rustKeys.createAndStoreKey()
                 }
             } catch let error as NSError {
-                SentryIntegration.shared.sendWithStacktrace(
-                    message: "Error retrieving autofill encryption key",
-                    tag: SentryTag.rustAutofill,
-                    severity: .error,
-                    description: error.localizedDescription)
+                logger.log("Error retrieving autofill encryption key",
+                           level: .warning,
+                           category: .storage,
+                           description: error.localizedDescription)
             }
         case (.some(key), .none):
             // The key is present, but we didn't expect it to be there.
             do {
-                SentryIntegration.shared.sendWithStacktrace(
-                    message: "Autofill key lost due to storage malfunction, new one generated",
-                    tag: SentryTag.rustAutofill,
-                    severity: .warning)
+                logger.log("Autofill key lost due to storage malfunction, new one generated",
+                           level: .warning,
+                           category: .storage)
 
                 self.scrubCreditCardNums(completion: {_, _ in })
                 return try rustKeys.createAndStoreKey()
@@ -423,10 +426,9 @@ public class RustAutofill {
         case (.none, .some(encryptedCanaryPhrase)):
             // We expected the key to be present, but it's gone missing on us.
             do {
-                SentryIntegration.shared.sendWithStacktrace(
-                    message: "Autofill key lost, new one generated",
-                    tag: SentryTag.rustAutofill,
-                    severity: .warning)
+                logger.log("Autofill key lost, new one generated",
+                           level: .warning,
+                           category: .storage)
 
                 self.scrubCreditCardNums(completion: {_, _ in })
                 return try rustKeys.createAndStoreKey()

--- a/Storage/Rust/RustPlaces.swift
+++ b/Storage/Rust/RustPlaces.swift
@@ -52,17 +52,15 @@ public class RustPlaces: BookmarksHandler, HistoryMetadataObserver {
             return nil
         } catch let err as NSError {
             if let placesError = err as? PlacesApiError {
-                SentryIntegration.shared.sendWithStacktrace(
-                    message: "Places error when opening Rust Places database",
-                    tag: SentryTag.rustPlaces,
-                    severity: .error,
-                    description: placesError.localizedDescription)
+                logger.log("Places error when opening Rust Places database",
+                           level: .warning,
+                           category: .storage,
+                           description: placesError.localizedDescription)
             } else {
-                SentryIntegration.shared.sendWithStacktrace(
-                    message: "Unknown error when opening Rust Places database",
-                    tag: SentryTag.rustPlaces,
-                    severity: .error,
-                    description: err.localizedDescription)
+                logger.log("Unknown error when opening Rust Places database",
+                           level: .warning,
+                           category: .storage,
+                           description: err.localizedDescription)
             }
 
             return err
@@ -305,17 +303,15 @@ public class RustPlaces: BookmarksHandler, HistoryMetadataObserver {
                 deferred.fill(Maybe(success: ()))
             } catch let err as NSError {
                 if let placesError = err as? PlacesApiError {
-                    SentryIntegration.shared.sendWithStacktrace(
-                        message: "Places error when syncing Places database",
-                        tag: SentryTag.rustPlaces,
-                        severity: .error,
-                        description: placesError.localizedDescription)
+                    self.logger.log("Places error when syncing Places database",
+                                    level: .warning,
+                                    category: .storage,
+                                    description: placesError.localizedDescription)
                 } else {
-                    SentryIntegration.shared.sendWithStacktrace(
-                        message: "Unknown error when opening Rust Places database",
-                        tag: SentryTag.rustPlaces,
-                        severity: .error,
-                        description: err.localizedDescription)
+                    self.logger.log("Unknown error when opening Rust Places database",
+                                    level: .warning,
+                                    category: .storage,
+                                    description: err.localizedDescription)
                 }
 
                 deferred.fill(Maybe(failure: err))
@@ -339,15 +335,15 @@ public class RustPlaces: BookmarksHandler, HistoryMetadataObserver {
                 deferred.fill(Maybe(success: ()))
             } catch let err as NSError {
                 if let placesError = err as? PlacesApiError {
-                    SentryIntegration.shared.sendWithStacktrace(message: "Places error when syncing Places database",
-                                                                tag: SentryTag.rustPlaces,
-                                                                severity: .error,
-                                                                description: placesError.localizedDescription)
+                    self.logger.log("Places error when syncing Places database",
+                                    level: .warning,
+                                    category: .storage,
+                                    description: placesError.localizedDescription)
                 } else {
-                    SentryIntegration.shared.sendWithStacktrace(message: "Unknown error when opening Rust Places database",
-                                                                tag: SentryTag.rustPlaces,
-                                                                severity: .error,
-                                                                description: err.localizedDescription)
+                    self.logger.log("Unknown error when opening Rust Places database",
+                                    level: .warning,
+                                    category: .sync,
+                                    description: err.localizedDescription)
                 }
 
                 deferred.fill(Maybe(failure: err))

--- a/Storage/Rust/RustShared.swift
+++ b/Storage/Rust/RustShared.swift
@@ -16,11 +16,11 @@ public class RustShared {
         // Attempt to make a backup as long as the database file still exists.
         guard FileManager.default.fileExists(atPath: databasePath) else {
             // No backup was attempted since the database file did not exist.
-            SentryIntegration.shared.sendWithStacktrace(message: "The Rust database was deleted while in use", tag: SentryTag.rustLogins)
+            logger.log("The Rust database was deleted while in use",
+                       level: .info,
+                       category: .storage)
             return
         }
-
-        SentryIntegration.shared.sendWithStacktrace(message: "Unable to open Rust database", tag: SentryTag.rustLogins, severity: .warning, description: "Attempting to move '\(baseFilename)'")
 
         // Note that a backup file might already exist! We append a counter to avoid this.
         var bakCounter = 0
@@ -55,11 +55,10 @@ public class RustShared {
                        level: .debug,
                        category: .storage)
         } catch let error as NSError {
-            SentryIntegration.shared.sendWithStacktrace(
-                message: "Unable to move Rust database to backup location",
-                tag: SentryTag.rustLogins,
-                severity: .error,
-                description: "Attempted to move to '\(bakBaseFilename)'. \(error.localizedDescription)")
+            logger.log("Unable to move Rust database to backup location",
+                       level: .warning,
+                       category: .storage,
+                       description: "Attempted to move to '\(bakBaseFilename)'. \(error.localizedDescription)")
         }
     }
 }

--- a/Storage/SQL/BrowserSchema.swift
+++ b/Storage/SQL/BrowserSchema.swift
@@ -1502,7 +1502,10 @@ open class BrowserSchema: Schema {
         do {
             try db.executeChange(sql)
         } catch let err as NSError {
-            SentryIntegration.shared.sendWithStacktrace(message: "Error dropping tableList table", tag: SentryTag.browserDB, severity: .error, description: "\(err.localizedDescription)")
+            logger.log("Error dropping tableList table",
+                       level: .warning,
+                       category: .storage,
+                       description: err.localizedDescription)
             return false
         }
 
@@ -1511,7 +1514,10 @@ open class BrowserSchema: Schema {
         do {
             try db.setVersion(previousVersion)
         } catch let err as NSError {
-            SentryIntegration.shared.sendWithStacktrace(message: "Error setting database version", tag: SentryTag.browserDB, severity: .error, description: "\(err.localizedDescription)")
+            logger.log("Error setting database version",
+                       level: .warning,
+                       category: .storage,
+                       description: err.localizedDescription)
             return false
         }
 
@@ -1560,7 +1566,9 @@ open class BrowserSchema: Schema {
                            level: .warning,
                            category: .storage)
                 let extra = ["table": "clients", "errorDescription": "\(err.localizedDescription)", "sql": "\(sql)"]
-                SentryIntegration.shared.sendWithStacktrace(message: "Error altering table", tag: SentryTag.browserDB, severity: .error, extra: extra)
+                logger.log("Error altering table",
+                           level: .warning,
+                           category: .storage)
                 return .failure
             }
         }
@@ -1570,11 +1578,11 @@ open class BrowserSchema: Schema {
             do {
                 try db.executeChange(sql)
             } catch let err as NSError {
-                logger.log("Error altering clients table: \(err.localizedDescription); SQL was \(sql)",
-                           level: .warning,
-                           category: .storage)
                 let extra = ["table": "clients", "errorDescription": "\(err.localizedDescription)", "sql": "\(sql)"]
-                SentryIntegration.shared.sendWithStacktrace(message: "Error altering table", tag: SentryTag.browserDB, severity: .error, extra: extra)
+                logger.log("Error altering clients table",
+                           level: .warning,
+                           category: .storage,
+                           extra: extra)
                 return .failure
             }
         }

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -487,7 +487,10 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
         // into using a `FailedSQLiteDBConnection` so we can retry opening again later.
         if !doOpen() {
             let extra = ["filename" : filename]
-            SentryIntegration.shared.sendWithStacktrace(message: "Cannot open a database connection.", tag: SentryTag.swiftData, severity: .error, extra: extra)
+            logger.log("Cannot open a database connection.",
+                       level: .warning,
+                       category: .storage,
+                       extra: extra)
             return nil
         }
 
@@ -505,17 +508,24 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
                        level: .debug,
                        category: .storage)
         case .failure:
-            SentryIntegration.shared.sendWithStacktrace(message: "Failed to create or update the database schema.", tag: SentryTag.swiftData, severity: .error)
+            logger.log("Failed to create or update the database schema.",
+                       level: .warning,
+                       category: .storage)
             return nil
         case .needsRecovery:
-            SentryIntegration.shared.sendWithStacktrace(message: "Database schema cannot be created or updated due to an unrecoverable error.", tag: SentryTag.swiftData, severity: .error)
+            logger.log("Database schema cannot be created or updated due to an unrecoverable error.",
+                       level: .warning,
+                       category: .storage)
 
             // We need to close this new connection before we can move the database file to
             // its backup location. If we cannot even close the connection, something has
             // gone really wrong. In that case, bail out and return `nil` to force SwiftData
             // into using a `FailedSQLiteDBConnection` so we can retry again later.
             if let error = self.closeCustomConnection(immediately: true) {
-                SentryIntegration.shared.sendWithStacktrace(message: "Cannot close the database connection to begin recovery.", tag: SentryTag.swiftData, severity: .error, description: error.localizedDescription)
+                logger.log("Cannot close the database connection to begin recovery.",
+                           level: .warning,
+                           category: .storage,
+                           description: error.localizedDescription)
                 return nil
             }
 
@@ -529,7 +539,6 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
                 logger.log("Cannot re-open a database connection to the new database file to begin recovery.",
                            level: .warning,
                            category: .storage)
-                SentryIntegration.shared.sendWithStacktrace(message: "Cannot re-open a database connection to the new database file to begin recovery.", tag: SentryTag.swiftData, severity: .error)
                 return nil
             }
 
@@ -548,7 +557,6 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
                 logger.log("Cannot re-create the schema in the new database file to complete recovery.",
                            level: .warning,
                            category: .storage)
-                SentryIntegration.shared.sendWithStacktrace(message: "Cannot re-create the schema in the new database file to complete recovery.", tag: SentryTag.swiftData, severity: .error)
                 return nil
             }
         }
@@ -759,8 +767,6 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
             return .success
         }
 
-        SentryIntegration.shared.addAttributes(["dbSchema.\(schema.name).version": schema.version])
-
         // Get the current schema version for the database.
         let currentVersion = self.version
 
@@ -775,15 +781,14 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
             return .success
         }
 
-        // Set an attribute for Sentry to include with any future error/crash
-        // logs to indicate what schema version we're coming from and going to.
-        SentryIntegration.shared.addAttributes(["dbUpgrade.\(self.schema.name).from": currentVersion, "dbUpgrade.\(self.schema.name).to": self.schema.version])
-
         // This should not ever happen since the schema version should always be
         // increasing whenever a structural change is made in an app update.
         guard currentVersion <= schema.version else {
             let errorString = "\(self.schema.name) cannot be downgraded from version \(currentVersion) to \(self.schema.version)."
-            SentryIntegration.shared.sendWithStacktrace(message: "Schema cannot be downgraded.", tag: SentryTag.swiftData, severity: .error, description: errorString)
+            logger.log("Schema cannot be downgraded.",
+                       level: .warning,
+                       category: .storage,
+                       description: errorString)
             return .failure
         }
 
@@ -820,7 +825,10 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
                     }
                 }
 
-                SentryIntegration.shared.send(message: "Attempting to update schema", tag: SentryTag.swiftData, severity: .info, description: "\(currentVersion) to \(self.schema.version).")
+                self.logger.log("Attempting to update schema",
+                                level: .info,
+                                category: .storage,
+                                description: "\(currentVersion) to \(self.schema.version).")
 
                 // If we can't create a brand new schema from scratch, we must
                 // call `updateSchema()` to go through the update process.
@@ -834,13 +842,19 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
 
                 // If we failed to update the schema, we'll drop everything from the DB
                 // and create everything again from scratch. Assuming our schema upgrade
-                // code is correct, this *shouldn't* happen. If it does, log it to Sentry.
-                SentryIntegration.shared.sendWithStacktrace(message: "Update failed for schema. Dropping and re-creating.", tag: SentryTag.swiftData, severity: .error, description: "\(self.schema.name) from version \(currentVersion) to \(self.schema.version)")
+                // code is correct, this *shouldn't* happen.
+                self.logger.log("Update failed for schema. Dropping and re-creating.",
+                                level: .warning,
+                                category: .storage,
+                                description: "\(self.schema.name) from version \(currentVersion) to \(self.schema.version)")
 
                 // If we can't even drop the schema here, something has gone really wrong, so
                 // return `false` which should force us into recovery.
                 if !self.dropSchema() {
-                    SentryIntegration.shared.sendWithStacktrace(message: "Unable to drop schema.", tag: SentryTag.swiftData, severity: .error, description: "\(self.schema.name) from version \(currentVersion).")
+                    self.logger.log("Unable to drop schema.",
+                                    level: .warning,
+                                    category: .storage,
+                                    description: "\(self.schema.name) from version \(currentVersion).")
                     success = false
                     return success
                 }
@@ -854,7 +868,10 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
             // If we got an error trying to get a transaction, then we either bail out early and return
             // `.failure` if we think we can retry later or return `.needsRecovery` if the error is not
             // recoverable.
-            SentryIntegration.shared.sendWithStacktrace(message: "Unable to get a transaction", tag: SentryTag.swiftData, severity: .error, description: "\(error.localizedDescription)")
+            logger.log("Unable to get a transaction",
+                       level: .warning,
+                       category: .storage,
+                       description: error.localizedDescription)
 
             // Check if the error we got is recoverable (e.g. SQLITE_BUSY, SQLITE_LOCK, SQLITE_FULL).
             // If so, just return `.failure` so we can retry preparing the schema again later.
@@ -884,7 +901,10 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
 
         // Attempt to make a backup as long as the database file still exists.
         if files.exists(baseFilename) {
-            SentryIntegration.shared.sendWithStacktrace(message: "Couldn't create or update schema. Attempted to move db to another location.", tag: SentryTag.swiftData, severity: .warning, description: "Attempting to move '\(baseFilename)' for schema '\(self.schema.name)'")
+            logger.log("Couldn't create or update schema. Attempted to move db to another location.",
+                       level: .info,
+                       category: .storage,
+                       description: "Attempting to move '\(baseFilename)' for schema '\(self.schema.name)'")
 
             // Note that a backup file might already exist! We append a counter to avoid this.
             var bakCounter = 0
@@ -913,11 +933,17 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
                            level: .debug,
                            category: .storage)
             } catch let error as NSError {
-                SentryIntegration.shared.sendWithStacktrace(message: "Unable to move db to another location", tag: SentryTag.swiftData, severity: .error, description: "DB file '\(baseFilename)'. \(error.localizedDescription)")
+                logger.log("Unable to move db to another location",
+                           level: .warning,
+                           category: .storage,
+                           description: "DB file '\(baseFilename)'. \(error.localizedDescription)")
             }
         } else {
             // No backup was attempted since the database file did not exist.
-            SentryIntegration.shared.sendWithStacktrace(message: "The database file has been deleted while previously in use.", tag: SentryTag.swiftData, description: "DB file '\(baseFilename)'")
+            logger.log("The database file has been deleted while previously in use.",
+                       level: .info,
+                       category: .storage,
+                       description: "DB file '\(baseFilename)'")
         }
     }
 
@@ -1072,7 +1098,10 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
         var status = sqlite3_close(db)
 
         if status != SQLITE_OK {
-            SentryIntegration.shared.sendWithStacktrace(message: "Got error status while attempting to close.", tag: SentryTag.swiftData, severity: .error, description: "SQLite status: \(status)")
+            logger.log("Got error status while attempting to close.",
+                       level: .warning,
+                       category: .storage,
+                       description: "SQLite status: \(status)")
 
             if immediately {
                 return createErr("During: closing database with flags", status: Int(status))
@@ -1083,9 +1112,11 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
             status = sqlite3_close_v2(db)
 
             if status != SQLITE_OK {
-
                 // Based on the above comment regarding sqlite3_close_v2, this shouldn't happen.
-                SentryIntegration.shared.sendWithStacktrace(message: "Got error status while attempting to close_v2.", tag: SentryTag.swiftData, severity: .error, description: "SQLite status: \(status)")
+                logger.log("Got error status while attempting to close_v2.",
+                           level: .warning,
+                           category: .storage,
+                           description: "SQLite status: \(status)")
                 return createErr("During: closing database with flags", status: Int(status))
             }
         }
@@ -1127,11 +1158,17 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
             // Special case: Write additional info to the database log in the case of a database corruption.
             if error.code == Int(SQLITE_CORRUPT) {
                 writeCorruptionInfoForDBNamed(filename)
-                SentryIntegration.shared.sendWithStacktrace(message: "SQLITE_CORRUPT", tag: SentryTag.swiftData, severity: .error, description: "DB file '\(filename)'. \(error.localizedDescription)")
+                logger.log("Execute change SQLITE_CORRUPT",
+                           level: .warning,
+                           category: .storage,
+                           description: "DB file '\(filename)'. \(error.localizedDescription)")
             }
 
-            let message = "Error code: \(error.code), \(error) for SQL \(String(sqlStr.prefix(500)))."
-            SentryIntegration.shared.sendWithStacktrace(message: "SQL error", tag: SentryTag.swiftData, severity: .error, description: message)
+            let description = "Error code: \(error.code), \(error) for SQL \(String(sqlStr.prefix(500)))."
+            logger.log("Execute change SQL error",
+                       level: .warning,
+                       category: .storage,
+                       description: description)
 
             throw error
         }
@@ -1171,7 +1208,10 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
         } catch let error1 as NSError {
             error = error1
             statement = nil
-            SentryIntegration.shared.sendWithStacktrace(message: "Execute error DBStatement", tag: SentryTag.swiftData, severity: .error, description: error1.localizedDescription)
+            logger.log("Execute error DBStatement",
+                       level: .warning,
+                       category: .storage,
+                       description: error1.localizedDescription)
             return Cursor<T>(err: error1)
         }
 
@@ -1183,14 +1223,22 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
             // Special case: Write additional info to the database log in the case of a database corruption.
             if error.code == Int(SQLITE_CORRUPT) {
                 writeCorruptionInfoForDBNamed(filename)
-                SentryIntegration.shared.sendWithStacktrace(message: "SQLITE_CORRUPT", tag: SentryTag.swiftData, severity: .error, description: "DB file '\(filename)'. \(error.localizedDescription)")
+                logger.log("Execute error SQLITE_CORRUPT",
+                           level: .warning,
+                           category: .storage,
+                           description: "DB file '\(filename)'. \(error.localizedDescription)")
             }
             // Don't log errors caused by `sqlite3_interrupt()` to Sentry.
-            if error.code != Int(SQLITE_INTERRUPT) {
-                SentryIntegration.shared.sendWithStacktrace(message: "SQL error", tag: SentryTag.swiftData, severity: .error, description: "Error code: \(error.code), \(error) for SQL \(String(sqlStr.prefix(500))).")
+            else if error.code != Int(SQLITE_INTERRUPT) {
+                logger.log("Execute error SQL error",
+                           level: .warning,
+                           category: .storage,
+                           description: "Error code: \(error.code), \(error) for SQL \(String(sqlStr.prefix(500))).")
             }
-            
-            SentryIntegration.shared.sendWithStacktrace(message: "Execute error", tag: SentryTag.swiftData, severity: .error, description: error.localizedDescription)
+            logger.log("Execute error general",
+                       level: .warning,
+                       category: .storage,
+                       description: error.localizedDescription)
 
             return Cursor<T>(err: error)
         }
@@ -1287,7 +1335,10 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
         do {
             try executeChange("BEGIN EXCLUSIVE")
         } catch let err as NSError {
-            SentryIntegration.shared.sendWithStacktrace(message: "BEGIN EXCLUSIVE failed.", tag: SentryTag.swiftData, severity: .error, description: "\(err.code), \(err)")
+            logger.log("BEGIN EXCLUSIVE failed.",
+                       level: .warning,
+                       category: .storage,
+                       description: "\(err.code), \(err)")
             throw err
         }
 
@@ -1299,12 +1350,14 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
             logger.log("Op in transaction threw an error. Rolling back.",
                        level: .warning,
                        category: .storage)
-            SentryIntegration.shared.sendWithStacktrace(message: "Op in transaction threw an error. Rolling back.", tag: SentryTag.swiftData, severity: .error)
 
             do {
                 try executeChange("ROLLBACK")
             } catch let err as NSError {
-                SentryIntegration.shared.sendWithStacktrace(message: "ROLLBACK after errored op in transaction failed", tag: SentryTag.swiftData, severity: .error, description: "\(err.code), \(err)")
+                logger.log("ROLLBACK after errored op in transaction failed",
+                           level: .warning,
+                           category: .storage,
+                           description: "\(err.code), \(err)")
                 throw err
             }
 
@@ -1314,12 +1367,18 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
         do {
             try executeChange("COMMIT")
         } catch let err as NSError {
-            SentryIntegration.shared.sendWithStacktrace(message: "COMMIT failed. Rolling back.", tag: SentryTag.swiftData, severity: .error, description: "\(err.code), \(err)")
+            logger.log("COMMIT failed. Rolling back.",
+                       level: .warning,
+                       category: .storage,
+                       description: "\(err.code), \(err)")
 
             do {
                 try executeChange("ROLLBACK")
             } catch let err as NSError {
-                SentryIntegration.shared.sendWithStacktrace(message: "ROLLBACK after failed COMMIT failed.", tag: SentryTag.swiftData, severity: .error, description: "\(err.code), \(err)")
+                logger.log("ROLLBACK after failed COMMIT failed.",
+                           level: .warning,
+                           category: .storage,
+                           description: "\(err.code), \(err)")
                 throw err
             }
 

--- a/Sync/Synchronizers/ClientsSynchronizer.swift
+++ b/Sync/Synchronizers/ClientsSynchronizer.swift
@@ -352,7 +352,9 @@ open class ClientsSynchronizer: TimestampedSingleCollectionSynchronizer, Synchro
                                level: .debug,
                                category: .sync)
                 } else {
-                    SentryIntegration.shared.send(message: "An unmigrated client record was found with a GUID for an ID", tag: SentryTag.clientSynchronizer, severity: .error)
+                    logger.log("An unmigrated client record was found with a GUID for an ID",
+                               level: .warning,
+                               category: .sync)
                 }
             } else if rec.id == ourFxaDeviceId {
                 ourClientRecordExists = true


### PR DESCRIPTION
## [FXIOS-5671](https://mozilla-hub.atlassian.net/browse/FXIOS-5671) https://github.com/mozilla-mobile/firefox-ios/issues/13081
- Migrate Sentry logs to new Logger interface
- Note that logs are sent to Sentry when they reach the required log level given the build channel we are on