### PR TITLE
Add FXIOS-5670 [v111] Lifecycle logs

### DIFF
--- a/Client/Application/AppLaunchUtil.swift
+++ b/Client/Application/AppLaunchUtil.swift
@@ -72,6 +72,9 @@ class AppLaunchUtil {
         RustFirefoxAccounts.startup(prefs: profile.prefs).uponQueue(.main) { _ in
             self.logger.log("RustFirefoxAccounts started", level: .info, category: .sync)
         }
+
+        // Add swizzle on UIViewControllers to automatically log when there's a new view showing
+        UIViewController.loggerSwizzle()
     }
 
     func setUpPostLaunchDependencies() {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -549,6 +549,9 @@ class BrowserViewController: UIViewController {
         }
 
         if !displayedRestoreTabsAlert && crashedLastLaunch() {
+            logger.log("The application crashed on last session",
+                       level: .info,
+                       category: .lifecycle)
             displayedRestoreTabsAlert = true
             showRestoreTabsAlert()
         } else {

--- a/Client/Frontend/Browser/Tab Management/Tab.swift
+++ b/Client/Frontend/Browser/Tab Management/Tab.swift
@@ -960,23 +960,3 @@ class TabWebView: WKWebView, MenuHelperInterface {
         super.evaluateJavaScript(javaScriptString, completionHandler: completionHandler)
     }
 }
-
-///
-// Temporary fix for Bug 1390871 - NSInvalidArgumentException: -[WKContentView menuHelperFindInPage]: unrecognized selector
-//
-// This class only exists to contain the swizzledMenuHelperFindInPage. This class is actually never
-// instantiated. It only serves as a placeholder for the method. When the method is called, self is
-// actually pointing to a WKContentView. Which is not public, but that is fine, we only need to know
-// that it is a UIView subclass to access its superview.
-//
-
-class TabWebViewMenuHelper: UIView {
-    @objc func swizzledMenuHelperFindInPage() {
-        if let tabWebView = superview?.superview as? TabWebView {
-            tabWebView.evaluateJavascriptInDefaultContentWorld("getSelection().toString()") { result, _ in
-                let selection = result as? String ?? ""
-                tabWebView.delegate?.tabWebView(tabWebView, didSelectFindInPageForSelection: selection)
-            }
-        }
-    }
-}

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -8,6 +8,7 @@ import Storage
 import SyncTelemetry
 import MozillaAppServices
 import Common
+import Logger
 
 class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, Themeable {
     // MARK: - Typealiases
@@ -36,6 +37,7 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
     private var jumpBackInContextualHintViewController: ContextualHintViewController
     private var syncTabContextualHintViewController: ContextualHintViewController
     private var collectionView: UICollectionView! = nil
+    private var logger: Logger
 
     var themeManager: ThemeManager
     var notificationCenter: NotificationProtocol
@@ -65,7 +67,8 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
          urlBar: URLBarViewProtocol,
          userDefaults: UserDefaultsInterface = UserDefaults.standard,
          themeManager: ThemeManager = AppContainer.shared.resolve(),
-         notificationCenter: NotificationProtocol = NotificationCenter.default
+         notificationCenter: NotificationProtocol = NotificationCenter.default,
+         logger: Logger = DefaultLogger.shared
     ) {
         self.urlBar = urlBar
         self.tabManager = tabManager
@@ -87,6 +90,7 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
 
         self.themeManager = themeManager
         self.notificationCenter = notificationCenter
+        self.logger = logger
         super.init(nibName: nil, bundle: nil)
 
         contextMenuHelper.delegate = self
@@ -250,6 +254,8 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
     /// This is a problem that need to be fixed but until then we have to rely on the methods here.
 
     func homepageWillAppear(isZeroSearch: Bool) {
+        logger.log("\(type(of: self)) will appear", level: .info, category: .lifecycle)
+
         viewModel.isZeroSearch = isZeroSearch
         viewModel.recordViewAppeared()
     }


### PR DESCRIPTION
## [FXIOS-5670](https://mozilla-hub.atlassian.net/browse/FXIOS-5670) https://github.com/mozilla-mobile/firefox-ios/issues/13080
Add lifecycle logs on view controllers. Adding an extra one for homepage view contoller since we can't rely on normal view cycle for that view controller.