### PR TITLE
Add FXIOS-5749 [v111] UIControl logs

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -522,6 +522,7 @@
 		8A355E5E27D267A400B9AF34 /* RecentItemsHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A355E5D27D267A400B9AF34 /* RecentItemsHelperTests.swift */; };
 		8A36AC2C2886F27F00CDC0AD /* MockTabManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A36AC2B2886F27F00CDC0AD /* MockTabManager.swift */; };
 		8A37C79F28DA4BA600B1FAD4 /* ContextualHintViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A37C79E28DA4BA600B1FAD4 /* ContextualHintViewModelTests.swift */; };
+		8A395552299AF83400B2AFBB /* UIControl+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A395551299AF83300B2AFBB /* UIControl+Extension.swift */; };
 		8A471183287F6D9C00F5A6EA /* BookmarksPanelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A471182287F6D9C00F5A6EA /* BookmarksPanelViewModel.swift */; };
 		8A471185287F6E4800F5A6EA /* SeparatorTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A471184287F6E4800F5A6EA /* SeparatorTableViewCell.swift */; };
 		8A48CE33292FCC0800B32289 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 8A48CE32292FCC0800B32289 /* Kingfisher */; };
@@ -3335,6 +3336,7 @@
 		8A355E5D27D267A400B9AF34 /* RecentItemsHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentItemsHelperTests.swift; sourceTree = "<group>"; };
 		8A36AC2B2886F27F00CDC0AD /* MockTabManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTabManager.swift; sourceTree = "<group>"; };
 		8A37C79E28DA4BA600B1FAD4 /* ContextualHintViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualHintViewModelTests.swift; sourceTree = "<group>"; };
+		8A395551299AF83300B2AFBB /* UIControl+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIControl+Extension.swift"; sourceTree = "<group>"; };
 		8A471182287F6D9C00F5A6EA /* BookmarksPanelViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksPanelViewModel.swift; sourceTree = "<group>"; };
 		8A471184287F6E4800F5A6EA /* SeparatorTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeparatorTableViewCell.swift; sourceTree = "<group>"; };
 		8A4AC0E928C929D700439F83 /* URLSessionDataTaskProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionDataTaskProtocol.swift; sourceTree = "<group>"; };
@@ -5759,16 +5761,17 @@
 				E1A6AB4528CA6A4C00EBEBDD /* String+Extension.swift */,
 				E1442FC5294782D7003680B0 /* UIAlertController+Extension.swift */,
 				E12BD0AB28AC37F00029AAF0 /* UIColor+Extension.swift */,
+				8A395551299AF83300B2AFBB /* UIControl+Extension.swift */,
 				E18EA56E28AD3279003F97FC /* UIDevice+Extension.swift */,
 				E12BD0AF28AC3A7E0029AAF0 /* UIEdgeInsets+Extension.swift */,
 				E12BD0AD28AC38480029AAF0 /* UIImage+Extension.swift */,
 				8A56955127C68AE00077A89E /* UILabel+Extension.swift */,
 				E1442FC6294782D7003680B0 /* UIModalPresentationStyle+Photon.swift */,
 				E1442FCD294782D8003680B0 /* UIPasteboard+Extension.swift */,
-				E1442FC8294782D8003680B0 /* UIView+Constraints.swift */,
-				E1442FCB294782D8003680B0 /* UIView+Extension.swift */,
 				966B0DC72926F60500A85A7E /* UIResponder+Extensions.swift */,
 				8AD5702E27AB4DEA005BFDC8 /* UIStackView+Extension.swift */,
+				E1442FC8294782D8003680B0 /* UIView+Constraints.swift */,
+				E1442FCB294782D8003680B0 /* UIView+Extension.swift */,
 				E1442FC4294782D7003680B0 /* UIView+Screenshot.swift */,
 				E1442FCA294782D8003680B0 /* UIView+SnapKit.swift */,
 				E1442FC7294782D7003680B0 /* UIViewController+Extension.swift */,
@@ -10304,6 +10307,7 @@
 				8AE80BBE2891C21A00BC12EA /* JumpBackInSyncedTab.swift in Sources */,
 				D3B6923F1B9F9A58004B87A4 /* FindInPageHelper.swift in Sources */,
 				8AE80BBC2891C20D00BC12EA /* JumpBackInList.swift in Sources */,
+				8A395552299AF83400B2AFBB /* UIControl+Extension.swift in Sources */,
 				F85C7F122721048E004BDBA4 /* Layout.swift in Sources */,
 				DF036E43274FD434002E834E /* HistoryHighlightsCell.swift in Sources */,
 				EB9A179C20E69A7F00B12184 /* LegacyDarkTheme.swift in Sources */,

--- a/Client/Application/AppLaunchUtil.swift
+++ b/Client/Application/AppLaunchUtil.swift
@@ -75,6 +75,9 @@ class AppLaunchUtil {
 
         // Add swizzle on UIViewControllers to automatically log when there's a new view showing
         UIViewController.loggerSwizzle()
+
+        // Add swizzle on top of UIControl to automatically log when there's an action sent
+        UIControl.loggerSwizzle()
     }
 
     func setUpPostLaunchDependencies() {

--- a/Client/Extensions/UIControl+Extension.swift
+++ b/Client/Extensions/UIControl+Extension.swift
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import Logger
+
+extension UIControl {
+    // MARK: - Logger Swizzling
+
+    static func loggerSwizzle() {
+        let originalSingleSelector = #selector(UIControl.sendAction(_:to:for:))
+        let swizzledSingleSelector = #selector(UIControl.loggerSendAction(_:to:for:))
+
+        guard let originalSingleMethod = class_getInstanceMethod(self, originalSingleSelector),
+              let swizzledSingleMethod = class_getInstanceMethod(self, swizzledSingleSelector) else { return }
+
+        method_exchangeImplementations(originalSingleMethod, swizzledSingleMethod)
+    }
+
+    @objc private func loggerSendAction(_ action: Selector,
+                                        to target: Any?,
+                                        for event: UIEvent?) {
+        var message: String = "Button \(Self.self) [action: \(action)]"
+        if let target = target {
+            message.append(" [target: \(String(describing: type(of: target)))]")
+        }
+        message.append(" was clicked")
+
+        DefaultLogger.shared.log(message, level: .info, category: .lifecycle)
+        self.loggerSendAction(action, to: target, for: event)
+    }
+}

--- a/Client/Extensions/UIViewController+Extension.swift
+++ b/Client/Extensions/UIViewController+Extension.swift
@@ -107,6 +107,7 @@ extension UIViewController {
     /// Ignore some view controller out of logs to avoid spamming the logger, which would reduce the usefulness of logging view controllers
     private enum LoggerIgnoreViewController: String, CaseIterable {
         case compatibility = "UICompatibilityInputViewController"
+        case defaultTheme = "ThemedDefaultNavigationController"
         case dismissable = "DismissableNavigationViewController"
         case editingOverlay = "UIEditingOverlayViewController"
         case inputWindow = "UIInputWindowController"
@@ -124,7 +125,7 @@ extension UIViewController {
         method_exchangeImplementations(originalMethod, swizzledMethod)
     }
 
-    @objc func loggerViewWillAppear(_ animated: Bool) {
+    @objc private func loggerViewWillAppear(_ animated: Bool) {
         let values: [String] = LoggerIgnoreViewController.allCases.map { $0.rawValue }
         if !values.contains("\(type(of: self))") {
             DefaultLogger.shared.log("\(type(of: self)) will appear", level: .info, category: .lifecycle)


### PR DESCRIPTION
## [FXIOS-5749](https://mozilla-hub.atlassian.net/browse/FXIOS-5749) https://github.com/mozilla-mobile/firefox-ios/issues/13214
- Add UIControl logs with swizzle
- Add a view controller to ignore for view controller logs

### Example
UIControl logs going through different part of the app, as well as writting on keyboard (only `textDidChange` appears). Let me know if you think other cases should be tested.
```
2023-02-13 18:30:51.675 💙 INFO [lifecycle] UIControl+Extension - Button StatefulButton [action: tapReloadButton] [target: TabLocationView] was clicked 
2023-02-13 18:30:55.327 💙 INFO [lifecycle] UIControl+Extension - Button ShareButton [action: didPressShareButton:] [target: TabLocationView] was clicked 
2023-02-13 18:31:01.691 💙 INFO [lifecycle] UIControl+Extension - Button LockButton [action: didPressTPShieldButton:] [target: TabLocationView] was clicked 
2023-02-13 18:31:05.668 💙 INFO [lifecycle] UIControl+Extension - Button ToolbarButton [action: didPressMultiStateButton] [target: TabToolbarHelper] was clicked 
2023-02-13 18:31:05.671 💙 INFO [lifecycle] UIControl+Extension - Button ToolbarButton [action: didClickHome] [target: TabToolbarHelper] was clicked 
2023-02-13 18:31:10.356 💙 INFO [lifecycle] UIControl+Extension - Button ToolbarButton [action: didClickMenu] [target: TabToolbarHelper] was clicked 
2023-02-13 18:31:18.454 💙 INFO [lifecycle] UIControl+Extension - Button ToolbarTextField [action: textDidChange:] [target: ToolbarTextField] was clicked 
2023-02-13 18:31:20.038 💙 INFO [lifecycle] UIControl+Extension - Button ToolbarTextField [action: textDidChange:] [target: ToolbarTextField] was clicked 
2023-02-13 18:31:20.711 💙 INFO [lifecycle] UIControl+Extension - Button ToolbarTextField [action: textDidChange:] [target: ToolbarTextField] was clicked 
2023-02-13 18:31:26.574 💙 INFO [lifecycle] UIControl+Extension - Button TabsButton [action: didClickTabs] [target: TabToolbarHelper] was clicked 
2023-02-13 18:31:29.247 💙 INFO [lifecycle] UIControl+Extension - Button UISegmentedControl [action: segmentIphoneChanged] [target: TabTrayViewController] was clicked
2023-02-13 18:31:31.499 💙 INFO [lifecycle] UIControl+Extension - Button UISegmentedControl [action: segmentIphoneChanged] [target: TabTrayViewController] was clicked 
2023-02-13 18:31:32.907 💙 INFO [lifecycle] UIControl+Extension - Button ResizableButton [action: presentSignIn] [target: RemoteTabsErrorCell] was clicked 
2023-02-13 18:31:38.148 💙 INFO [lifecycle] UIControl+Extension - Button ResizableButton [action: scanbuttonTapped:] [target: FirefoxAccountSignInViewController] was clicked 
2023-02-13 18:31:39.888 💙 INFO [lifecycle] UIControl+Extension - Button ResizableButton [action: emailLoginTapped:] [target: FirefoxAccountSignInViewController] was clicked
```