### PR TITLE
Add FXIOS-5770 [v112] PR rules for Danger

### DIFF
--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Danger
 import DangerSwiftCoverage
 import Foundation
@@ -6,6 +10,8 @@ let danger = Danger()
 
 coverage()
 changedFiles()
+checkBigPullRequest()
+checkForPRDescription()
 
 func changedFiles() {
     message("Edited \(danger.git.modifiedFiles.count) files")
@@ -22,6 +28,27 @@ func coverage() {
         .xcresultBundle(xcresult),
         minimumCoverage: 50
     )
+}
+
+// Encourage smaller PRs
+func checkBigPullRequest() {
+    let bigPRThreshold = 800
+    guard let additions = danger.github.pullRequest.additions,
+          let deletions = danger.github.pullRequest.deletions else { return }
+
+    let additionsAndDeletions = additions + deletions
+    if additionsAndDeletions > bigPRThreshold {
+        warn("Pull Request size seems relatively large. If this Pull Request contains multiple changes, please split each into separate PR will helps faster, easier review. Consider using epic branches for work that would affect main.");
+    }
+}
+
+// Encourage writing up some reasoning about the PR, rather than just leaving a title.
+func checkForPRDescription() {
+    let body = danger.github.pullRequest.body?.count ?? 0
+    let linesOfCode = danger.github.pullRequest.additions ?? 0
+    if body < 3 && linesOfCode > 10 {
+        warn("Please provide a summary of your changes in the Pull Request description. This helps reviewers to understand your code and technical decisions. Please also include the JIRA issue number and the GitHub ticket number (if available).")
+    }
 }
 
 extension String {

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -38,7 +38,7 @@ func checkBigPullRequest() {
 
     let additionsAndDeletions = additions + deletions
     if additionsAndDeletions > bigPRThreshold {
-        warn("Pull Request size seems relatively large. If this Pull Request contains multiple changes, please split each into separate PR will helps faster, easier review. Consider using epic branches for work that would affect main.");
+        warn("Pull Request size seems relatively large. If this Pull Request contains multiple changes, please split each into separate PR will helps faster, easier review. Consider using epic branches for work that would affect main.")
     }
 }
 


### PR DESCRIPTION
## [FXIOS-5770](https://mozilla-hub.atlassian.net/browse/FXIOS-5770) https://github.com/mozilla-mobile/firefox-ios/issues/13242
As discussed in Slack, this will trigger Danger to add a comment on the PR whenever:
- **Detect Big PRs**
    - Detect with deletions + additions total greater than a certain threshold to determine (I would say greater than 800) and warns about it on the PR. 
    - Goal is to encourage peeps to write smaller PRs. Reviewing big PRs is a pain and there's higher chances of introducing bugs.
- **Check a PR has a description**
    - We should always have a description on PRs. Bare minimum is having the issue numbers (Jira & GitHub), but I would highly encourage everyone to have a description of the work done. It just makes it easier for reviewers since tickets often describes feature work and not the technical decisions that were made to do the actual work.

This is only to encourage good PR practices, this won't block the PR. There could be exceptions, and the comment can then be ignored. But we should encourage smaller PRs, and PRs should have description.