### PR TITLE
Refactor FXIOS-5638 [v112] Integrate OverlayModeManager in HomepageViewController and BVC

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -105,6 +105,7 @@
 		217AEF76284666D4004EED37 /* IntroViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217AEF75284666D4004EED37 /* IntroViewModelTests.swift */; };
 		217AEF7828480844004EED37 /* ResizableButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217AEF7728480844004EED37 /* ResizableButton.swift */; };
 		2197DF8A287624BF00215624 /* LibraryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2197DF89287624BF00215624 /* LibraryViewModelTests.swift */; };
+		21A1C3C72996AFF800181B7C /* OverlayModeManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A1C3C62996AFF800181B7C /* OverlayModeManagerTests.swift */; };
 		21A43CDD291461C700B1206D /* ReaderModeFontTypeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A43CDC291461C700B1206D /* ReaderModeFontTypeButton.swift */; };
 		21A7C44E283539170071D996 /* IntroViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A7C44D283539170071D996 /* IntroViewModel.swift */; };
 		21A7C45028353D0E0071D996 /* OnboardingCardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A7C44F28353D0E0071D996 /* OnboardingCardViewController.swift */; };
@@ -1923,6 +1924,7 @@
 		2194437EA9B44A00EDC037FA /* gu-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "gu-IN"; path = "gu-IN.lproj/FindInPage.strings"; sourceTree = "<group>"; };
 		2197DF89287624BF00215624 /* LibraryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryViewModelTests.swift; sourceTree = "<group>"; };
 		219F41288625C09DD40F008C /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
+		21A1C3C62996AFF800181B7C /* OverlayModeManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayModeManagerTests.swift; sourceTree = "<group>"; };
 		21A43CDC291461C700B1206D /* ReaderModeFontTypeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeFontTypeButton.swift; sourceTree = "<group>"; };
 		21A7C44D283539170071D996 /* IntroViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroViewModel.swift; sourceTree = "<group>"; };
 		21A7C44F28353D0E0071D996 /* OnboardingCardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCardViewController.swift; sourceTree = "<group>"; };
@@ -8261,6 +8263,7 @@
 				C8E1BC0928085AA700C62964 /* NimbusFeatureFlagLayerTests.swift */,
 				39C137962655798A003DC662 /* NimbusIntegrationTests.swift */,
 				21371FA128A6C4A200BC3F37 /* OnboardingCardViewModelTests.swift */,
+				21A1C3C62996AFF800181B7C /* OverlayModeManagerTests.swift */,
 				2FDB10921A9FBEC5006CF312 /* PrefsTests.swift */,
 				0BA896491A250E6500C1010C /* ProfileTest.swift */,
 				8AF0CFF427A0B0ED00C1A4A2 /* QuickActionsTests.swift */,
@@ -10788,6 +10791,7 @@
 				C80C11EE28B3C8B80062922A /* WallpaperMetadataTrackerTests.swift in Sources */,
 				8AEE284B276A973400C7104D /* RatingPromptManagerTests.swift in Sources */,
 				5A9A09D828B2E8F000B6F51E /* MockHistoryDeletionProtocol.swift in Sources */,
+				21A1C3C72996AFF800181B7C /* OverlayModeManagerTests.swift in Sources */,
 				6A3E5D8A283831D1001E706E /* DownloadQueueTests.swift in Sources */,
 				8AE80BB62891AEA100BC12EA /* MockDispatchGroup.swift in Sources */,
 				8AA6ADB52742B567004EEE23 /* TelemetryWrapperTests.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -68,7 +68,7 @@ class BrowserViewController: UIViewController {
     var passBookHelper: OpenPassBookHelper?
     // TODO: Remove at FXIOS-5639 Feature flag like to use during the refactoring
     private var shouldUseOverlayManager = true
-    private var overlayManager: OverlayModeManager!
+    var overlayManager: OverlayModeManager!
 
     var contextHintVC: ContextualHintViewController
 
@@ -2126,7 +2126,7 @@ extension BrowserViewController: TabManagerDelegate {
         if topTabsVisible {
             topTabsDidChangeTab()
             // Only for iPad leave overlay mode on tab change
-            overlayManager.leaveOverlayMode(didCancel: true)
+            overlayManager.switchTab()
         }
 
         updateInContentHomePanel(selected?.url as URL?, focusUrlBar: true)
@@ -2135,7 +2135,7 @@ extension BrowserViewController: TabManagerDelegate {
     func tabManager(_ tabManager: TabManager, didAddTab tab: Tab, placeNextToParentTab: Bool, isRestoring: Bool) {
         // If we are restoring tabs then we update the count once at the end
         if !isRestoring {
-            overlayManager?.enterOverlayMode()
+            overlayManager?.openNewTab(nil, url: tab.url)
             updateTabCountUsingTabManager(tabManager)
         }
         tab.tabDelegate = self

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2124,27 +2124,10 @@ extension BrowserViewController: TabManagerDelegate {
         }
 
         updateInContentHomePanel(selected?.url as URL?, focusUrlBar: true)
-
-        // TODO: Remove this block was added to fix https://mozilla-hub.atlassian.net/browse/FXIOS-4018
-        // but will be handled in the refactoring
-        if let tab = selected, NewTabAccessors.getNewTabPage(self.profile.prefs) == .blankPage {
-            if tab.url == nil, !tab.isRestoring {
-                if tabManager.didChangedPanelSelection && !tabManager.didAddNewTab {
-                    tabManager.didChangedPanelSelection = false
-                    leaveOverlayMode(didCancel: false)
-                } else {
-                    tabManager.didAddNewTab = false
-                    urlBar.tabLocationViewDidTapLocation(urlBar.locationView)
-                }
-            } else {
-                leaveOverlayMode(didCancel: false)
-            }
-        }
     }
 
     func tabManager(_ tabManager: TabManager, didAddTab tab: Tab, placeNextToParentTab: Bool, isRestoring: Bool) {
         // If we are restoring tabs then we update the count once at the end
-        tabManager.didAddNewTab = true
         if !isRestoring {
             // TODO: Call to manager enterOverlayMode here
             updateTabCountUsingTabManager(tabManager)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2125,6 +2125,8 @@ extension BrowserViewController: TabManagerDelegate {
 
         if topTabsVisible {
             topTabsDidChangeTab()
+            // Only for iPad leave overlay mode on tab change
+            overlayManager.leaveOverlayMode(didCancel: true)
         }
 
         updateInContentHomePanel(selected?.url as URL?, focusUrlBar: true)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -68,7 +68,7 @@ class BrowserViewController: UIViewController {
     var passBookHelper: OpenPassBookHelper?
     // TODO: Remove at FXIOS-5639 Feature flag like to use during the refactoring
     private var shouldUseOverlayManager = true
-    private var overlayManager: OverlayModeManager?
+    private var overlayManager: OverlayModeManager!
 
     var contextHintVC: ContextualHintViewController
 
@@ -968,7 +968,6 @@ class BrowserViewController: UIViewController {
         let homepageViewController = HomepageViewController(
             profile: profile,
             tabManager: tabManager,
-            urlBar: urlBar,
             overlayManager: overlayManager)
         homepageViewController.homePanelDelegate = self
         homepageViewController.libraryPanelDelegate = self

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -67,7 +67,7 @@ class BrowserViewController: UIViewController {
     var openedUrlFromExternalSource = false
     var passBookHelper: OpenPassBookHelper?
     // TODO: Remove at FXIOS-5639 Feature flag like to use during the refactoring
-    private var shouldUseOverlayManager = false
+    private var shouldUseOverlayManager = true
     private var overlayManager: OverlayModeManager?
 
     var contextHintVC: ContextualHintViewController
@@ -1153,7 +1153,8 @@ class BrowserViewController: UIViewController {
 
     func finishEditingAndSubmit(_ url: URL, visitType: VisitType, forTab tab: Tab) {
         urlBar.currentURL = url
-        leaveOverlayMode(didCancel: false)
+        // TODO: Check all flows that call finishEditing we could leaveOverlayMode from autocompleteTextFieldShouldReturn
+        overlayManager?.leaveOverlayMode(didCancel: false)
 
         if let nav = tab.loadRequest(URLRequest(url: url)) {
             self.recordNavigationInTab(tab, navigation: nav, visitType: visitType)
@@ -2136,7 +2137,6 @@ extension BrowserViewController: TabManagerDelegate {
     }
 
     func tabManager(_ tabManager: TabManager, didRemoveTab tab: Tab, isRestoring: Bool) {
-        tabManager.didChangedPanelSelection = true
         if let url = tab.lastKnownUrl, !(InternalURL(url)?.isAboutURL ?? false), !tab.isPrivate {
             profile.recentlyClosedTabs.addTab(url as URL,
                                               title: tab.lastTitle,
@@ -2147,7 +2147,6 @@ extension BrowserViewController: TabManagerDelegate {
 
     func tabManagerDidAddTabs(_ tabManager: TabManager) {
         updateTabCountUsingTabManager(tabManager)
-        tabManager.didChangedPanelSelection = true
     }
 
     func tabManagerDidRestoreTabs(_ tabManager: TabManager) {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -66,7 +66,7 @@ class BrowserViewController: UIViewController {
     private var customSearchBarButton: UIBarButtonItem?
     var openedUrlFromExternalSource = false
     var passBookHelper: OpenPassBookHelper?
-    var overlayManager: OverlayModeManager!
+    var overlayManager: OverlayModeManager
 
     var contextHintVC: ContextualHintViewController
 
@@ -177,6 +177,7 @@ class BrowserViewController: UIViewController {
         self.downloadQueue = downloadQueue
         self.logger = logger
 
+        self.overlayManager = DefaultOverlayModeManager()
         let contextViewModel = ContextualHintViewModel(forHintType: .toolbarLocation,
                                                        with: profile)
         self.contextHintVC = ContextualHintViewController(with: contextViewModel)
@@ -437,7 +438,7 @@ class BrowserViewController: UIViewController {
         // Awesomebar Location Telemetry
         SearchBarSettingsViewModel.recordLocationTelemetry(for: isBottomSearchBar ? .bottom : .top)
 
-        overlayManager = DefaultOverlayModeManager(urlBarView: urlBar)
+        overlayManager.setURLBar(urlBarView: urlBar)
     }
 
     private func setupAccessibleActions() {
@@ -1124,7 +1125,7 @@ class BrowserViewController: UIViewController {
 
     func finishEditingAndSubmit(_ url: URL, visitType: VisitType, forTab tab: Tab) {
         urlBar.currentURL = url
-        overlayManager?.finishEdition(didCancel: false)
+        overlayManager.finishEdition(didCancel: false)
 
         if let nav = tab.loadRequest(URLRequest(url: url)) {
             self.recordNavigationInTab(tab, navigation: nav, visitType: visitType)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1125,7 +1125,7 @@ class BrowserViewController: UIViewController {
 
     func finishEditingAndSubmit(_ url: URL, visitType: VisitType, forTab tab: Tab) {
         urlBar.currentURL = url
-        overlayManager.finishEdition(didCancelLoading: false)
+        overlayManager.finishEdition(shouldCancelLoading: false)
 
         if let nav = tab.loadRequest(URLRequest(url: url)) {
             self.recordNavigationInTab(tab, navigation: nav, visitType: visitType)
@@ -1198,7 +1198,7 @@ class BrowserViewController: UIViewController {
 
     override func accessibilityPerformEscape() -> Bool {
         if overlayManager.inOverlayMode {
-            overlayManager.finishEdition(didCancelLoading: true)
+            overlayManager.finishEdition(shouldCancelLoading: true)
             return true
         } else if let selectedTab = tabManager.selectedTab, selectedTab.canGoBack {
             selectedTab.goBack()
@@ -1970,7 +1970,7 @@ extension BrowserViewController: SearchViewControllerDelegate {
 
     // In searchViewController when user selects an open tabs and switch to it
     func searchViewController(_ searchViewController: SearchViewController, uuid: String) {
-        overlayManager.switchTab(didCancelLoading: true)
+        overlayManager.switchTab(shouldCancelLoading: true)
         if let tab = tabManager.getTabForUUID(uuid: uuid) {
             tabManager.selectTab(tab)
         }
@@ -2596,7 +2596,7 @@ extension BrowserViewController: JSPromptAlertControllerDelegate {
 extension BrowserViewController: TopTabsDelegate {
     func topTabsDidPressTabs() {
         // Technically is not changing tabs but is loosing focus on urlbar
-        overlayManager.switchTab(didCancelLoading: true)
+        overlayManager.switchTab(shouldCancelLoading: true)
         self.urlBarDidPressTabs(urlBar)
     }
 
@@ -2610,7 +2610,7 @@ extension BrowserViewController: TopTabsDelegate {
 
     func topTabsDidChangeTab() {
         // Only for iPad leave overlay mode on tab change
-        overlayManager.switchTab(didCancelLoading: true)
+        overlayManager.switchTab(shouldCancelLoading: true)
     }
 }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -215,7 +215,7 @@ class BrowserViewController: UIViewController {
         applyTheme()
     }
 
-    // TODO: YRD Remove delegate keyboard should't raise on first place
+    // TODO: FXIOS-5639 Remove delegate keyboard
     @objc func didTapUndoCloseAllTabToast(notification: Notification) { }
 
     @objc func openTabNotification(notification: Notification) {
@@ -1124,7 +1124,7 @@ class BrowserViewController: UIViewController {
 
     func finishEditingAndSubmit(_ url: URL, visitType: VisitType, forTab tab: Tab) {
         urlBar.currentURL = url
-        overlayManager?.finishEdition()
+        overlayManager?.finishEdition(didCancel: false)
 
         if let nav = tab.loadRequest(URLRequest(url: url)) {
             self.recordNavigationInTab(tab, navigation: nav, visitType: visitType)
@@ -1197,7 +1197,7 @@ class BrowserViewController: UIViewController {
 
     override func accessibilityPerformEscape() -> Bool {
         if overlayManager.inOverlayMode {
-            overlayManager.finishEdition()
+            overlayManager.finishEdition(didCancel: true)
             return true
         } else if let selectedTab = tabManager.selectedTab, selectedTab.canGoBack {
             selectedTab.goBack()
@@ -2604,6 +2604,7 @@ extension BrowserViewController: TopTabsDelegate {
         overlayManager.openNewTab(nil, url: nil)
     }
 
+    // TODO: FXIOS-5639 Remove from protocol if it was used for keyboard handling
     func topTabsDidTogglePrivateMode() { }
 
     func topTabsDidChangeTab() {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -455,7 +455,7 @@ class BrowserViewController: UIViewController {
         pasteAction = AccessibleAction(name: .PasteTitle, handler: { () -> Bool in
             if let pasteboardContents = UIPasteboard.general.string {
                 // Enter overlay mode and make the search controller appear.
-                self.overlayManager.pasteContent(pasteContent: pasteboardContents)
+                self.overlayManager.openSearch(with: pasteboardContents)
 
                 return true
             }
@@ -1125,7 +1125,7 @@ class BrowserViewController: UIViewController {
 
     func finishEditingAndSubmit(_ url: URL, visitType: VisitType, forTab tab: Tab) {
         urlBar.currentURL = url
-        overlayManager.finishEdition(didCancel: false)
+        overlayManager.finishEdition(didCancelLoading: false)
 
         if let nav = tab.loadRequest(URLRequest(url: url)) {
             self.recordNavigationInTab(tab, navigation: nav, visitType: visitType)
@@ -1198,7 +1198,7 @@ class BrowserViewController: UIViewController {
 
     override func accessibilityPerformEscape() -> Bool {
         if overlayManager.inOverlayMode {
-            overlayManager.finishEdition(didCancel: true)
+            overlayManager.finishEdition(didCancelLoading: true)
             return true
         } else if let selectedTab = tabManager.selectedTab, selectedTab.canGoBack {
             selectedTab.goBack()
@@ -1970,7 +1970,7 @@ extension BrowserViewController: SearchViewControllerDelegate {
 
     // In searchViewController when user selects an open tabs and switch to it
     func searchViewController(_ searchViewController: SearchViewController, uuid: String) {
-        overlayManager.switchTab(didCancel: true)
+        overlayManager.switchTab(didCancelLoading: true)
         if let tab = tabManager.getTabForUUID(uuid: uuid) {
             tabManager.selectTab(tab)
         }
@@ -2596,7 +2596,7 @@ extension BrowserViewController: JSPromptAlertControllerDelegate {
 extension BrowserViewController: TopTabsDelegate {
     func topTabsDidPressTabs() {
         // Technically is not changing tabs but is loosing focus on urlbar
-        overlayManager.switchTab(didCancel: true)
+        overlayManager.switchTab(didCancelLoading: true)
         self.urlBarDidPressTabs(urlBar)
     }
 
@@ -2610,7 +2610,7 @@ extension BrowserViewController: TopTabsDelegate {
 
     func topTabsDidChangeTab() {
         // Only for iPad leave overlay mode on tab change
-        overlayManager.switchTab(didCancel: true)
+        overlayManager.switchTab(didCancelLoading: true)
     }
 }
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -38,6 +38,7 @@ extension BrowserViewController: URLBarDelegate {
             profile: profile,
             tabToFocus: tabToFocus,
             tabManager: tabManager,
+            overlayManager: overlayManager,
             focusedSegment: focusedSegment)
 
         tabTrayViewController?.openInNewTab = { url, isPrivate in

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -198,6 +198,7 @@ extension BrowserViewController: WKUIDelegate {
                                             completion: { buttonPressed in
                         if buttonPressed {
                             self.tabManager.selectTab(tab)
+                            self.overlayManager.switchTab()
                         }
                     })
                     self.show(toast: toast)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -198,7 +198,7 @@ extension BrowserViewController: WKUIDelegate {
                                             completion: { buttonPressed in
                         if buttonPressed {
                             self.tabManager.selectTab(tab)
-                            self.overlayManager.switchTab()
+                            self.overlayManager.switchTab(didCancel: true)
                         }
                     })
                     self.show(toast: toast)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -198,7 +198,7 @@ extension BrowserViewController: WKUIDelegate {
                                             completion: { buttonPressed in
                         if buttonPressed {
                             self.tabManager.selectTab(tab)
-                            self.overlayManager.switchTab(didCancelLoading: true)
+                            self.overlayManager.switchTab(shouldCancelLoading: true)
                         }
                     })
                     self.show(toast: toast)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -198,7 +198,7 @@ extension BrowserViewController: WKUIDelegate {
                                             completion: { buttonPressed in
                         if buttonPressed {
                             self.tabManager.selectTab(tab)
-                            self.overlayManager.switchTab(didCancel: true)
+                            self.overlayManager.switchTab(didCancelLoading: true)
                         }
                     })
                     self.show(toast: toast)

--- a/Client/Frontend/Browser/Tab Management/TabManager.swift
+++ b/Client/Frontend/Browser/Tab Management/TabManager.swift
@@ -58,9 +58,6 @@ class TabManager: NSObject, FeatureFlaggable, TabManagerProtocol {
     var selectedIndex: Int { return _selectedIndex }
     private let logger: Logger
 
-    // TODO: Remove FXIOS-5639 it was introduced to fix bug that will be taken care on refactoring
-    var didChangedPanelSelection: Bool = true
-    var didAddNewTab: Bool = true
     var tabDisplayType: TabDisplayType = .TabGrid
     let delaySelectingNewPopupTab: TimeInterval = 0.1
 

--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -320,8 +320,6 @@ class TabTrayViewController: UIViewController, Themeable {
     }
 
     private func switchBetweenLocalPanels(withPrivateMode privateMode: Bool) {
-        viewModel.tabManager.didChangedPanelSelection = true
-        viewModel.tabManager.didAddNewTab = true
         if children.first != viewModel.tabTrayView {
             hideCurrentPanel()
             showPanel(viewModel.tabTrayView)

--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -177,6 +177,7 @@ class TabTrayViewController: UIViewController, Themeable {
          profile: Profile,
          tabToFocus: Tab? = nil,
          tabManager: TabManager,
+         overlayManager: OverlayModeManager,
          focusedSegment: TabTrayViewModel.Segment? = nil,
          themeManager: ThemeManager = AppContainer.shared.resolve(),
          and notificationCenter: NotificationProtocol = NotificationCenter.default,
@@ -189,6 +190,7 @@ class TabTrayViewController: UIViewController, Themeable {
                                           profile: profile,
                                           tabToFocus: tabToFocus,
                                           tabManager: tabManager,
+                                          overlayManager: overlayManager,
                                           segmentToFocus: focusedSegment)
 
         super.init(nibName: nil, bundle: nil)

--- a/Client/Frontend/Browser/Tabs/TabTrayViewModel.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewModel.swift
@@ -52,6 +52,7 @@ class TabTrayViewModel {
 
     let profile: Profile
     let tabManager: TabManager
+    let overlayManager: OverlayModeManager
 
     // Tab Tray Views
     let tabTrayView: TabTrayViewDelegate
@@ -68,9 +69,11 @@ class TabTrayViewModel {
          profile: Profile,
          tabToFocus: Tab? = nil,
          tabManager: TabManager,
+         overlayManager: OverlayModeManager,
          segmentToFocus: TabTrayViewModel.Segment? = nil) {
         self.profile = profile
         self.tabManager = tabManager
+        self.overlayManager = overlayManager
 
         self.tabTrayView = GridTabViewController(tabManager: self.tabManager,
                                                  profile: profile,
@@ -100,6 +103,7 @@ extension TabTrayViewModel {
     }
 
     @objc func didTapAddTab(_ sender: UIBarButtonItem) {
+        overlayManager.openNewTab(nil, url: nil)
         tabTrayView.performToolbarAction(.addTab, sender: sender)
     }
 

--- a/Client/Frontend/Contextual Hint/ContextualHintEligibilityUtility.swift
+++ b/Client/Frontend/Contextual Hint/ContextualHintEligibilityUtility.swift
@@ -12,16 +12,20 @@ protocol ContextualHintEligibilityUtilityProtocol {
 struct ContextualHintEligibilityUtility: ContextualHintEligibilityUtilityProtocol, ContextualHintPrefsKeysProvider {
     var profile: Profile
     var device: UIDeviceInterface
+    // For contextual hints shown in Homepage that can overlap with keyboard being raised by user interaction
+    private var overlayState: OverlayStateProtocol?
 
     init(with profile: Profile,
+         overlayState: OverlayStateProtocol?,
          device: UIDeviceInterface = UIDevice.current) {
         self.profile = profile
+        self.overlayState = overlayState
         self.device = device
     }
 
     /// Determine if this hint is eligible to present, outside of Nimbus flag settings.
     func canPresent(_ hintType: ContextualHintType) -> Bool {
-        guard isDeviceReady else { return false }
+        guard isDeviceReady, !isInOverlayMode else { return false }
 
         var hintTypeShouldBePresented = false
 
@@ -44,6 +48,12 @@ struct ContextualHintEligibilityUtility: ContextualHintEligibilityUtilityProtoco
     // Do not present contextual hint in landscape on iPhone
     private var isDeviceReady: Bool {
         !UIWindow.isLandscape || device.userInterfaceIdiom == .pad
+    }
+
+    private var isInOverlayMode: Bool {
+        guard overlayState != nil else { return false }
+
+        return overlayState?.inOverlayMode ?? false
     }
 
     /// If device is iPhone we present JumpBackIn and SyncTab CFRs only after Toolbar CFR has been presented

--- a/Client/Frontend/Contextual Hint/ContextualHintViewController.swift
+++ b/Client/Frontend/Contextual Hint/ContextualHintViewController.swift
@@ -257,7 +257,8 @@ class ContextualHintViewController: UIViewController, OnViewDismissable, Themeab
         withActionBeforeAppearing preAction: (() -> Void)? = nil,
         actionOnDismiss postAction: (() -> Void)? = nil,
         andActionForButton buttonAction: (() -> Void)? = nil,
-        andShouldStartTimerRightAway shouldStartTimer: Bool = true
+        andShouldStartTimerRightAway shouldStartTimer: Bool = true,
+        overlayState: OverlayStateProtocol? = nil
     ) {
         stopTimer()
         modalPresentationStyle = .popover
@@ -270,6 +271,7 @@ class ContextualHintViewController: UIViewController, OnViewDismissable, Themeab
         onActionTapped = buttonAction
         viewModel.presentFromTimer = presentation
         viewModel.arrowDirection = arrowDirection
+        viewModel.overlayState = overlayState
 
         setupContent()
         toggleArrowBasedConstraints()

--- a/Client/Frontend/Contextual Hint/ContextualHintViewModel.swift
+++ b/Client/Frontend/Contextual Hint/ContextualHintViewModel.swift
@@ -30,6 +30,7 @@ class ContextualHintViewModel: ContextualHintPrefsKeysProvider {
     private var profile: Profile
     private var hasSentTelemetryEvent = false
     var arrowDirection = UIPopoverArrowDirection.down
+    var overlayState: OverlayStateProtocol?
 
     // MARK: - Initializers
 
@@ -41,7 +42,8 @@ class ContextualHintViewModel: ContextualHintPrefsKeysProvider {
     // MARK: - Interface
 
     func shouldPresentContextualHint() -> Bool {
-        let hintEligibilityUtility = ContextualHintEligibilityUtility(with: profile)
+        let hintEligibilityUtility = ContextualHintEligibilityUtility(with: profile,
+                                                                      overlayState: overlayState)
 
         return hintEligibilityUtility.canPresent(hintType)
     }

--- a/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
@@ -67,8 +67,6 @@ class HistoryHighlightsViewModel {
     var historyItems = [HighlightItem]()
     private var profile: Profile
     private var isPrivate: Bool
-    // TODO: FXIOS-5639 Remove opening new tab should handle itself the dismissal of the keyboard
-    private var urlBar: URLBarViewProtocol
     private var hasSentSectionEvent = false
     private var historyHighlightsDataAdaptor: HistoryHighlightsDataAdaptor
     private let dispatchQueue: DispatchQueueInterface
@@ -110,7 +108,6 @@ class HistoryHighlightsViewModel {
     // MARK: - Inits
     init(with profile: Profile,
          isPrivate: Bool,
-         urlBar: URLBarViewProtocol,
          theme: Theme,
          historyHighlightsDataAdaptor: HistoryHighlightsDataAdaptor,
          dispatchQueue: DispatchQueueInterface = DispatchQueue.main,
@@ -118,7 +115,6 @@ class HistoryHighlightsViewModel {
          wallpaperManager: WallpaperManager) {
         self.profile = profile
         self.isPrivate = isPrivate
-        self.urlBar = urlBar
         self.theme = theme
         self.dispatchQueue = dispatchQueue
         self.telemetry = telemetry
@@ -141,8 +137,6 @@ class HistoryHighlightsViewModel {
     }
 
     func switchTo(_ highlight: HighlightItem) {
-        if urlBar.inOverlayMode { urlBar.leaveOverlayMode() }
-
         onTapItem?(highlight)
         telemetry.recordEvent(category: .action,
                               method: .tap,

--- a/Client/Frontend/Home/HomePanelDelegate.swift
+++ b/Client/Frontend/Home/HomePanelDelegate.swift
@@ -11,7 +11,6 @@ protocol HomePanelDelegate: AnyObject {
     func homePanelDidRequestToOpenLibrary(panel: LibraryPanelType)
     func homePanelDidRequestToOpenTabTray(withFocusedTab tabToFocus: Tab?, focusedSegment: TabTrayViewModel.Segment?)
     func homePanelDidRequestToOpenSettings(at settingsPage: AppSettingsDeeplinkOption)
-    func homePanelDidPresentContextualHintOf(type: ContextualHintType)
 }
 
 extension HomePanelDelegate {

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -30,7 +30,6 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
     private var viewModel: HomepageViewModel
     private var contextMenuHelper: HomepageContextMenuHelper
     private var tabManager: TabManagerProtocol
-    // TODO: FXIOS-5639 Remove urlBar direct access from homepage
     private var urlBar: URLBarViewProtocol
     private var overlayManager: OverlayModeManager?
     private var userDefaults: UserDefaultsInterface
@@ -78,7 +77,6 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
         self.viewModel = HomepageViewModel(profile: profile,
                                            isPrivate: isPrivate,
                                            tabManager: tabManager,
-                                           urlBar: urlBar,
                                            theme: themeManager.currentTheme)
 
         let jumpBackInContextualViewModel = ContextualHintViewModel(forHintType: .jumpBackIn,

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -158,16 +158,17 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
         }
     }
 
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-
-        // make sure the keyboard is dismissed when wallpaper onboarding is shown
-        // Can be removed once underlying problem is solved (FXIOS-4904)
-        if let presentedViewController = presentedViewController,
-           presentedViewController.isKind(of: BottomSheetViewController.self) {
-            self.dismissKeyboard()
-        }
-    }
+    // TODO: Remove, bottom sheet needs to check if isInOverlayMode to show
+//    override func viewDidLayoutSubviews() {
+//        super.viewDidLayoutSubviews()
+//
+//        // make sure the keyboard is dismissed when wallpaper onboarding is shown
+//        // Can be removed once underlying problem is solved (FXIOS-4904)
+//        if let presentedViewController = presentedViewController,
+//           presentedViewController.isKind(of: BottomSheetViewController.self) {
+//            self.dismissKeyboard()
+//        }
+//    }
 
     // MARK: - Layout
 

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -30,8 +30,7 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
     private var viewModel: HomepageViewModel
     private var contextMenuHelper: HomepageContextMenuHelper
     private var tabManager: TabManagerProtocol
-    private var urlBar: URLBarViewProtocol
-    private var overlayManager: OverlayModeManager?
+    private var overlayManager: OverlayModeManager
     private var userDefaults: UserDefaultsInterface
     private lazy var wallpaperView: WallpaperBackgroundView = .build { _ in }
     private var jumpBackInContextualHintViewController: ContextualHintViewController
@@ -63,13 +62,11 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
     // MARK: - Initializers
     init(profile: Profile,
          tabManager: TabManagerProtocol,
-         urlBar: URLBarViewProtocol,
-         overlayManager: OverlayModeManager?,
+         overlayManager: OverlayModeManager,
          userDefaults: UserDefaultsInterface = UserDefaults.standard,
          themeManager: ThemeManager = AppContainer.shared.resolve(),
          notificationCenter: NotificationProtocol = NotificationCenter.default
     ) {
-        self.urlBar = urlBar
         self.overlayManager = overlayManager
         self.tabManager = tabManager
         self.userDefaults = userDefaults
@@ -317,7 +314,7 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
 
     @objc private func dismissKeyboard() {
         if currentTab?.lastKnownUrl?.absoluteString.hasPrefix("internal://") ?? false {
-            urlBar.leaveOverlayMode()
+            overlayManager.leaveOverlayMode()
         }
     }
 

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -315,7 +315,7 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
 
     @objc private func dismissKeyboard() {
         if currentTab?.lastKnownUrl?.absoluteString.hasPrefix("internal://") ?? false {
-            overlayManager.leaveOverlayMode()
+            overlayManager.leaveOverlayMode(didCancel: true)
         }
     }
 

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -303,7 +303,7 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
 
     @objc private func dismissKeyboard() {
         if currentTab?.lastKnownUrl?.absoluteString.hasPrefix("internal://") ?? false {
-            overlayManager.finishEdition(didCancel: false)
+            overlayManager.finishEdition(didCancelLoading: false)
         }
     }
 

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -303,7 +303,7 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
 
     @objc private func dismissKeyboard() {
         if currentTab?.lastKnownUrl?.absoluteString.hasPrefix("internal://") ?? false {
-            overlayManager.finishEdition(didCancelLoading: false)
+            overlayManager.finishEdition(shouldCancelLoading: false)
         }
     }
 

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -315,7 +315,7 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
 
     @objc private func dismissKeyboard() {
         if currentTab?.lastKnownUrl?.absoluteString.hasPrefix("internal://") ?? false {
-            overlayManager.leaveOverlayMode(didCancel: true)
+            overlayManager.finishEdition()
         }
     }
 
@@ -353,11 +353,10 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
 
     func displayWallpaperSelector() {
         let wallpaperManager = WallpaperManager(userDefaults: userDefaults)
-        guard wallpaperManager.canOnboardingBeShown(using: viewModel.profile),
+        guard !overlayManager.inOverlayMode,
+              wallpaperManager.canOnboardingBeShown(using: viewModel.profile),
               canModalBePresented
         else { return }
-
-        self.dismissKeyboard()
 
         let viewModel = WallpaperSelectorViewModel(wallpaperManager: wallpaperManager, openSettingsAction: {
             self.homePanelDidRequestToOpenSettings(at: .wallpaper)
@@ -398,8 +397,8 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
             andDelegate: self,
             presentedUsing: { self.presentContextualHint(contextualHintViewController: self.jumpBackInContextualHintViewController) },
             sourceRect: rect,
-            withActionBeforeAppearing: { self.contextualHintPresented(type: .jumpBackIn) },
-            andActionForButton: { self.openTabsSettings() })
+            andActionForButton: { self.openTabsSettings() },
+            overlayState: overlayManager)
     }
 
     private func prepareSyncedTabContextualHint(onCell cell: SyncedTabCell) {
@@ -415,7 +414,7 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
             withArrowDirection: .down,
             andDelegate: self,
             presentedUsing: { self.presentContextualHint(contextualHintViewController: self.syncTabContextualHintViewController) },
-            withActionBeforeAppearing: { self.contextualHintPresented(type: .jumpBackInSyncedTab) })
+            overlayState: overlayManager)
     }
 
     @objc private func presentContextualHint(contextualHintViewController: ContextualHintViewController) {
@@ -669,10 +668,6 @@ private extension HomepageViewController {
                                      method: .tap,
                                      object: .firefoxHomepage,
                                      value: .customizeHomepageButton)
-    }
-
-    func contextualHintPresented(type: ContextualHintType) {
-        homePanelDelegate?.homePanelDidPresentContextualHintOf(type: type)
     }
 
     func openTabsSettings() {

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -158,18 +158,6 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
         }
     }
 
-    // TODO: Remove, bottom sheet needs to check if isInOverlayMode to show
-//    override func viewDidLayoutSubviews() {
-//        super.viewDidLayoutSubviews()
-//
-//        // make sure the keyboard is dismissed when wallpaper onboarding is shown
-//        // Can be removed once underlying problem is solved (FXIOS-4904)
-//        if let presentedViewController = presentedViewController,
-//           presentedViewController.isKind(of: BottomSheetViewController.self) {
-//            self.dismissKeyboard()
-//        }
-//    }
-
     // MARK: - Layout
 
     func configureCollectionView() {
@@ -315,7 +303,7 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
 
     @objc private func dismissKeyboard() {
         if currentTab?.lastKnownUrl?.absoluteString.hasPrefix("internal://") ?? false {
-            overlayManager.finishEdition()
+            overlayManager.finishEdition(didCancel: false)
         }
     }
 

--- a/Client/Frontend/Home/HomepageViewModel.swift
+++ b/Client/Frontend/Home/HomepageViewModel.swift
@@ -125,7 +125,6 @@ class HomepageViewModel: FeatureFlaggable {
         self.jumpBackInViewModel = JumpBackInViewModel(
             profile: profile,
             isPrivate: isPrivate,
-            urlBar: urlBar,
             theme: theme,
             tabManager: tabManager,
             adaptor: adaptor,
@@ -143,7 +142,6 @@ class HomepageViewModel: FeatureFlaggable {
         self.historyHighlightsViewModel = HistoryHighlightsViewModel(
             with: profile,
             isPrivate: isPrivate,
-            urlBar: urlBar,
             theme: theme,
             historyHighlightsDataAdaptor: historyDataAdaptor,
             wallpaperManager: wallpaperManager)

--- a/Client/Frontend/Home/HomepageViewModel.swift
+++ b/Client/Frontend/Home/HomepageViewModel.swift
@@ -102,7 +102,6 @@ class HomepageViewModel: FeatureFlaggable {
     init(profile: Profile,
          isPrivate: Bool,
          tabManager: TabManagerProtocol,
-         urlBar: URLBarViewProtocol,
          nimbus: FxNimbus = FxNimbus.shared,
          isZeroSearch: Bool = false,
          theme: Theme,

--- a/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -22,8 +22,6 @@ class JumpBackInViewModel: FeatureFlaggable {
     var syncedTabsShowAllAction: (() -> Void)?
     var openSyncedTabAction: ((URL) -> Void)?
     var prepareContextualHint: ((SyncedTabCell) -> Void)?
-    // TODO: FXIOS-5639 Remove opening new tab should handle itself the dismissal of the keyboard
-    private var urlBar: URLBarViewProtocol
 
     weak var delegate: HomepageDataModelDelegate?
 
@@ -52,7 +50,6 @@ class JumpBackInViewModel: FeatureFlaggable {
         isZeroSearch: Bool = false,
         profile: Profile,
         isPrivate: Bool,
-        urlBar: URLBarViewProtocol,
         theme: Theme,
         tabManager: TabManagerProtocol,
         adaptor: JumpBackInDataAdaptor,
@@ -61,7 +58,6 @@ class JumpBackInViewModel: FeatureFlaggable {
         self.profile = profile
         self.isZeroSearch = isZeroSearch
         self.isPrivate = isPrivate
-        self.urlBar = urlBar
         self.theme = theme
         self.tabManager = tabManager
         self.jumpBackInDataAdaptor = adaptor
@@ -69,8 +65,6 @@ class JumpBackInViewModel: FeatureFlaggable {
     }
 
     func switchTo(group: ASGroup<Tab>) {
-        if urlBar.inOverlayMode { urlBar.leaveOverlayMode() }
-
         guard let firstTab = group.groupedItems.first else { return }
 
         onTapGroup?(firstTab)
@@ -85,8 +79,6 @@ class JumpBackInViewModel: FeatureFlaggable {
     }
 
     func switchTo(tab: Tab) {
-        if urlBar.inOverlayMode { urlBar.leaveOverlayMode() }
-
         tabManager.selectTab(tab, previous: nil)
         TelemetryWrapper.recordEvent(
             category: .action,

--- a/Client/Frontend/Home/Wallpapers/v1/Interface/WallpaperManager.swift
+++ b/Client/Frontend/Home/Wallpapers/v1/Interface/WallpaperManager.swift
@@ -64,8 +64,9 @@ class WallpaperManager: WallpaperManagerInterface, FeatureFlaggable {
     }
 
     /// Determines whether the wallpaper onboarding can be shown
+    /// Doesn't need overlayState to check for CFR because the state was previously check
     func canOnboardingBeShown(using profile: Profile) -> Bool {
-        let cfrHintUtility = ContextualHintEligibilityUtility(with: profile)
+        let cfrHintUtility = ContextualHintEligibilityUtility(with: profile, overlayState: nil)
         let toolbarCFRShown = !cfrHintUtility.canPresent(.toolbarLocation)
         let jumpBackInCFRShown = !cfrHintUtility.canPresent(.jumpBackIn)
         let cfrsHaveBeenShown = toolbarCFRShown && jumpBackInCFRShown

--- a/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
+++ b/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
@@ -8,16 +8,8 @@ protocol OverlayModeManager {
     var inOverlayMode: Bool { get }
     func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool)
     func leaveOverlayMode(didCancel cancel: Bool)
-}
-
-extension OverlayModeManager {
-    func enterOverlayMode(_ locationText: String? = nil, pasted: Bool = false, search: Bool = true) {
-        enterOverlayMode(locationText, pasted: pasted, search: search)
-    }
-
-    func leaveOverlayMode(didCancel cancel: Bool = false) {
-        leaveOverlayMode(didCancel: cancel)
-    }
+    func openNewTab(_ locationText: String?, url: URL?)
+    func switchTab()
 }
 
 class DefaultOverlayModeManager: OverlayModeManager {
@@ -29,6 +21,16 @@ class DefaultOverlayModeManager: OverlayModeManager {
 
     init(urlBarView: URLBarViewProtocol) {
         self.urlBarView = urlBarView
+    }
+
+    func openNewTab(_ locationText: String?, url: URL?) {
+        if url == nil || url?.isFxHomeUrl ?? false {
+            enterOverlayMode(locationText, pasted: false, search: true)
+        }
+    }
+
+    func switchTab() {
+        leaveOverlayMode(didCancel: true)
     }
 
     func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool) {

--- a/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
+++ b/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
@@ -29,6 +29,7 @@ class DefaultOverlayModeManager: OverlayModeManager {
         }
     }
 
+    // TODO: YRD might need some parameters
     func switchTab() {
         leaveOverlayMode(didCancel: true)
     }

--- a/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
+++ b/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
@@ -45,14 +45,10 @@ class DefaultOverlayModeManager: OverlayModeManager {
     }
 
     private func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool) {
-        guard !inOverlayMode else { return }
-
         urlBarView.enterOverlayMode(locationText, pasted: pasted, search: search)
     }
 
     private func leaveOverlayMode(didCancel cancel: Bool) {
-        guard inOverlayMode else { return }
-
         urlBarView.leaveOverlayMode(didCancel: cancel)
     }
 }

--- a/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
+++ b/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
@@ -4,10 +4,13 @@
 
 import Foundation
 
-protocol OverlayModeManager {
+protocol OverlayStateProtocol {
     var inOverlayMode: Bool { get }
-    func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool)
-    func leaveOverlayMode(didCancel cancel: Bool)
+}
+
+protocol OverlayModeManager: OverlayStateProtocol {
+    func finishEdition()
+    func pasteContent(pasteContent: String)
     func openNewTab(_ locationText: String?, url: URL?)
     func switchTab(didCancel: Bool)
 }
@@ -23,24 +26,31 @@ class DefaultOverlayModeManager: OverlayModeManager {
         self.urlBarView = urlBarView
     }
 
+    func finishEdition() {
+        leaveOverlayMode(didCancel: false)
+    }
+
+    func pasteContent(pasteContent: String) {
+        enterOverlayMode(pasteContent, pasted: true, search: true)
+    }
+
     func openNewTab(_ locationText: String?, url: URL?) {
         if url == nil || url?.isFxHomeUrl ?? false {
             enterOverlayMode(locationText, pasted: false, search: true)
         }
     }
 
-    // TODO: YRD might need some parameters
     func switchTab(didCancel: Bool) {
         leaveOverlayMode(didCancel: didCancel)
     }
 
-    func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool) {
+    private func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool) {
         guard !inOverlayMode else { return }
 
         urlBarView.enterOverlayMode(locationText, pasted: pasted, search: search)
     }
 
-    func leaveOverlayMode(didCancel cancel: Bool) {
+    private func leaveOverlayMode(didCancel cancel: Bool) {
         guard inOverlayMode else { return }
 
         urlBarView.leaveOverlayMode(didCancel: cancel)

--- a/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
+++ b/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
@@ -9,7 +9,7 @@ protocol OverlayModeManager {
     func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool)
     func leaveOverlayMode(didCancel cancel: Bool)
     func openNewTab(_ locationText: String?, url: URL?)
-    func switchTab()
+    func switchTab(didCancel: Bool)
 }
 
 class DefaultOverlayModeManager: OverlayModeManager {
@@ -30,8 +30,8 @@ class DefaultOverlayModeManager: OverlayModeManager {
     }
 
     // TODO: YRD might need some parameters
-    func switchTab() {
-        leaveOverlayMode(didCancel: true)
+    func switchTab(didCancel: Bool) {
+        leaveOverlayMode(didCancel: didCancel)
     }
 
     func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool) {

--- a/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
+++ b/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
@@ -9,9 +9,9 @@ protocol OverlayStateProtocol {
 }
 
 protocol OverlayModeManager: OverlayStateProtocol {
-    func finishEdition()
     func pasteContent(pasteContent: String)
     func openNewTab(_ locationText: String?, url: URL?)
+    func finishEdition(didCancel: Bool)
     func switchTab(didCancel: Bool)
 }
 
@@ -26,8 +26,8 @@ class DefaultOverlayModeManager: OverlayModeManager {
         self.urlBarView = urlBarView
     }
 
-    func finishEdition() {
-        leaveOverlayMode(didCancel: false)
+    func finishEdition(didCancel: Bool) {
+        leaveOverlayMode(didCancel: didCancel)
     }
 
     func pasteContent(pasteContent: String) {

--- a/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
+++ b/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
@@ -9,11 +9,27 @@ protocol OverlayStateProtocol {
 }
 
 protocol OverlayModeManager: OverlayStateProtocol {
+    /// Set URLBar which is not available when the manager is created
+    /// - Parameter urlBarView: URLBar that contains textfield which open and dismiss the keyboard
     func setURLBar(urlBarView: URLBarViewProtocol)
-    func pasteContent(pasteContent: String)
+
+    /// Enter overlay mode with paste content
+    /// - Parameter pasteContent: String with the content to paste on the search
+    func openSearch(with pasteContent: String)
+
+    /// Enter overlay mode when opening a new tab
+    /// - Parameters:
+    ///   - locationText: String with initial search text
+    ///   - url: Tab url to determine if is the url is homepage or nil
     func openNewTab(_ locationText: String?, url: URL?)
-    func finishEdition(didCancel: Bool)
-    func switchTab(didCancel: Bool)
+
+    /// Leave overlay mode when user finish edition, either pressing the go button, enter etc
+    /// - Parameter didCancelLoading: Bool value determine if the loading animation of the current search should be canceled
+    func finishEdition(didCancelLoading: Bool)
+
+    /// Leave overlay mode when tab change happens, like switching tabs or open a site from any homepage section
+    /// - Parameter didCancelLoading: Bool value determine if the loading animation of the current search should be canceled
+    func switchTab(didCancelLoading: Bool)
 }
 
 class DefaultOverlayModeManager: OverlayModeManager {
@@ -29,11 +45,7 @@ class DefaultOverlayModeManager: OverlayModeManager {
         self.urlBarView = urlBarView
     }
 
-    func finishEdition(didCancel: Bool) {
-        leaveOverlayMode(didCancel: didCancel)
-    }
-
-    func pasteContent(pasteContent: String) {
+    func openSearch(with pasteContent: String) {
         enterOverlayMode(pasteContent, pasted: true, search: true)
     }
 
@@ -43,8 +55,12 @@ class DefaultOverlayModeManager: OverlayModeManager {
         }
     }
 
-    func switchTab(didCancel: Bool) {
-        leaveOverlayMode(didCancel: didCancel)
+    func finishEdition(didCancelLoading: Bool) {
+        leaveOverlayMode(didCancel: didCancelLoading)
+    }
+
+    func switchTab(didCancelLoading: Bool) {
+        leaveOverlayMode(didCancel: didCancelLoading)
     }
 
     private func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool) {

--- a/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
+++ b/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
@@ -24,12 +24,12 @@ protocol OverlayModeManager: OverlayStateProtocol {
     func openNewTab(_ locationText: String?, url: URL?)
 
     /// Leave overlay mode when user finish edition, either pressing the go button, enter etc
-    /// - Parameter didCancelLoading: Bool value determine if the loading animation of the current search should be canceled
-    func finishEdition(didCancelLoading: Bool)
+    /// - Parameter shouldCancelLoading: Bool value determine if the loading animation of the current search should be canceled
+    func finishEdition(shouldCancelLoading: Bool)
 
     /// Leave overlay mode when tab change happens, like switching tabs or open a site from any homepage section
-    /// - Parameter didCancelLoading: Bool value determine if the loading animation of the current search should be canceled
-    func switchTab(didCancelLoading: Bool)
+    /// - Parameter shouldCancelLoading: Bool value determine if the loading animation of the current search should be canceled
+    func switchTab(shouldCancelLoading: Bool)
 }
 
 class DefaultOverlayModeManager: OverlayModeManager {
@@ -55,12 +55,12 @@ class DefaultOverlayModeManager: OverlayModeManager {
         }
     }
 
-    func finishEdition(didCancelLoading: Bool) {
-        leaveOverlayMode(didCancel: didCancelLoading)
+    func finishEdition(shouldCancelLoading: Bool) {
+        leaveOverlayMode(didCancel: shouldCancelLoading)
     }
 
-    func switchTab(didCancelLoading: Bool) {
-        leaveOverlayMode(didCancel: didCancelLoading)
+    func switchTab(shouldCancelLoading: Bool) {
+        leaveOverlayMode(didCancel: shouldCancelLoading)
     }
 
     private func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool) {

--- a/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
+++ b/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
@@ -9,6 +9,7 @@ protocol OverlayStateProtocol {
 }
 
 protocol OverlayModeManager: OverlayStateProtocol {
+    func setURLBar(urlBarView: URLBarViewProtocol)
     func pasteContent(pasteContent: String)
     func openNewTab(_ locationText: String?, url: URL?)
     func finishEdition(didCancel: Bool)
@@ -16,13 +17,15 @@ protocol OverlayModeManager: OverlayStateProtocol {
 }
 
 class DefaultOverlayModeManager: OverlayModeManager {
-    private var urlBarView: URLBarViewProtocol
+    private var urlBarView: URLBarViewProtocol?
 
     var inOverlayMode: Bool {
-        return urlBarView.inOverlayMode
+        return urlBarView?.inOverlayMode ?? false
     }
 
-    init(urlBarView: URLBarViewProtocol) {
+    init() {}
+
+    func setURLBar(urlBarView: URLBarViewProtocol) {
         self.urlBarView = urlBarView
     }
 
@@ -45,10 +48,10 @@ class DefaultOverlayModeManager: OverlayModeManager {
     }
 
     private func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool) {
-        urlBarView.enterOverlayMode(locationText, pasted: pasted, search: search)
+        urlBarView?.enterOverlayMode(locationText, pasted: pasted, search: search)
     }
 
     private func leaveOverlayMode(didCancel cancel: Bool) {
-        urlBarView.leaveOverlayMode(didCancel: cancel)
+        urlBarView?.leaveOverlayMode(didCancel: cancel)
     }
 }

--- a/Tests/ClientTests/ContextMenuHelperTests.swift
+++ b/Tests/ClientTests/ContextMenuHelperTests.swift
@@ -30,7 +30,6 @@ class ContextMenuHelperTests: XCTestCase {
         let viewModel = HomepageViewModel(profile: profile,
                                           isPrivate: false,
                                           tabManager: MockTabManager(),
-                                          urlBar: URLBarView(profile: profile),
                                           theme: LightTheme())
         let helper = HomepageContextMenuHelper(viewModel: viewModel)
 

--- a/Tests/ClientTests/Frontend/ContextualHints/ContextualHintEligibilityUtilityTests.swift
+++ b/Tests/ClientTests/Frontend/ContextualHints/ContextualHintEligibilityUtilityTests.swift
@@ -44,6 +44,14 @@ class ContextualHintEligibilityUtilityTests: XCTestCase {
         XCTAssertTrue(result)
     }
 
+    func test_shouldPresentInactiveTabsHint_WithNilOverlayMode() {
+        subject = ContextualHintEligibilityUtility(with: profile,
+                                                   overlayState: nil,
+                                                   device: MockUIDevice(isIpad: true))
+        let result = subject.canPresent(.inactiveTabs)
+        XCTAssertTrue(result)
+    }
+
     func test_shouldPresentJumpBackHint() {
         profile.prefs.setBool(true, forKey: CFRPrefsKeys.toolbarOnboardingKey.rawValue)
 

--- a/Tests/ClientTests/Frontend/ContextualHints/ContextualHintEligibilityUtilityTests.swift
+++ b/Tests/ClientTests/Frontend/ContextualHints/ContextualHintEligibilityUtilityTests.swift
@@ -12,12 +12,17 @@ class ContextualHintEligibilityUtilityTests: XCTestCase {
 
     var profile: MockProfile!
     var subject: ContextualHintEligibilityUtility!
+    var urlBar: MockURLBarView!
+    var overlayState: MockOverlayModeManager!
 
     override func setUp() {
         super.setUp()
 
         profile = MockProfile()
+        urlBar = MockURLBarView()
+        overlayState = MockOverlayModeManager(urlBarView: urlBar)
         subject = ContextualHintEligibilityUtility(with: profile,
+                                                   overlayState: nil,
                                                    device: MockUIDevice(isIpad: false))
     }
 
@@ -26,6 +31,8 @@ class ContextualHintEligibilityUtilityTests: XCTestCase {
 
         profile.shutdown()
         profile = nil
+        urlBar = nil
+        overlayState = nil
         subject = nil
     }
 
@@ -50,6 +57,7 @@ class ContextualHintEligibilityUtilityTests: XCTestCase {
 
     func test_shouldPresentJumpBackHint_iPadWithoutToolbar() {
         subject = ContextualHintEligibilityUtility(with: profile,
+                                                   overlayState: overlayState,
                                                    device: MockUIDevice(isIpad: true))
         let result = subject.canPresent(.jumpBackIn)
         XCTAssertTrue(result)
@@ -69,6 +77,7 @@ class ContextualHintEligibilityUtilityTests: XCTestCase {
 
     func test_shouldPresentSyncedHint_iPadWithoutToolbar() {
         subject = ContextualHintEligibilityUtility(with: profile,
+                                                   overlayState: overlayState,
                                                    device: MockUIDevice(isIpad: true))
         let result = subject.canPresent(.jumpBackInSyncedTab)
         XCTAssertTrue(result)
@@ -90,6 +99,15 @@ class ContextualHintEligibilityUtilityTests: XCTestCase {
         XCTAssertFalse(result)
     }
 
+    func test_shouldNotPresentJumpBackHint_WithOverlayMode() {
+        subject = ContextualHintEligibilityUtility(with: profile,
+                                                   overlayState: overlayState,
+                                                   device: MockUIDevice(isIpad: true))
+        overlayState.openNewTab(nil, url: nil)
+        let result = subject.canPresent(.jumpBackIn)
+        XCTAssertFalse(result)
+    }
+
     func test_shouldNotPresentJumpBackInWhenSyncedTabConfigured() {
         profile.prefs.setBool(true, forKey: CFRPrefsKeys.jumpBackInSyncedTabConfiguredKey.rawValue)
 
@@ -100,6 +118,15 @@ class ContextualHintEligibilityUtilityTests: XCTestCase {
     func test_shouldNotPresentSyncedTabHint() {
         profile.prefs.setBool(true, forKey: CFRPrefsKeys.jumpBackInSyncedTabKey.rawValue)
 
+        let result = subject.canPresent(.jumpBackInSyncedTab)
+        XCTAssertFalse(result)
+    }
+
+    func test_shouldNotPresentSyncedHint_WithOverlayMode() {
+        subject = ContextualHintEligibilityUtility(with: profile,
+                                                   overlayState: overlayState,
+                                                   device: MockUIDevice(isIpad: true))
+        overlayState.openNewTab(nil, url: nil)
         let result = subject.canPresent(.jumpBackInSyncedTab)
         XCTAssertFalse(result)
     }

--- a/Tests/ClientTests/Frontend/ContextualHints/ContextualHintEligibilityUtilityTests.swift
+++ b/Tests/ClientTests/Frontend/ContextualHints/ContextualHintEligibilityUtilityTests.swift
@@ -20,7 +20,8 @@ class ContextualHintEligibilityUtilityTests: XCTestCase {
 
         profile = MockProfile()
         urlBar = MockURLBarView()
-        overlayState = MockOverlayModeManager(urlBarView: urlBar)
+        overlayState = MockOverlayModeManager()
+        overlayState.setURLBar(urlBarView: urlBar)
         subject = ContextualHintEligibilityUtility(with: profile,
                                                    overlayState: nil,
                                                    device: MockUIDevice(isIpad: false))

--- a/Tests/ClientTests/Frontend/Home/FirefoxHomeViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/FirefoxHomeViewModelTests.swift
@@ -32,7 +32,6 @@ class FirefoxHomeViewModelTests: XCTestCase {
         let viewModel = HomepageViewModel(profile: profile,
                                           isPrivate: false,
                                           tabManager: MockTabManager(),
-                                          urlBar: URLBarView(profile: profile),
                                           theme: LightTheme())
         XCTAssertEqual(viewModel.shownSections.count, 3)
         XCTAssertEqual(viewModel.shownSections[0], HomepageSectionType.logoHeader)

--- a/Tests/ClientTests/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModelTests.swift
@@ -13,7 +13,6 @@ class HistoryHighlightsViewModelTests: XCTestCase {
     private var dataAdaptor: MockHistoryHighlightsDataAdaptor!
     private var delegate: MockHomepageDataModelDelegate!
     private var telemetry: MockTelemetryWrapper!
-    private var urlBar: MockURLBarView!
 
     override func setUp() {
         super.setUp()
@@ -23,7 +22,6 @@ class HistoryHighlightsViewModelTests: XCTestCase {
         dataAdaptor = MockHistoryHighlightsDataAdaptor()
         delegate = MockHomepageDataModelDelegate()
         telemetry = MockTelemetryWrapper()
-        urlBar = MockURLBarView()
     }
 
     override func tearDown() {
@@ -34,7 +32,6 @@ class HistoryHighlightsViewModelTests: XCTestCase {
         subject = nil
         delegate = nil
         telemetry = nil
-        urlBar = nil
     }
 
     func testLoadNewDataIsEnabled() {
@@ -123,11 +120,9 @@ class HistoryHighlightsViewModelTests: XCTestCase {
 
     func testSwitchToWhileInOverlayMode() {
         setupSubject()
-        urlBar.inOverlayMode = true
 
         subject.switchTo(getItemWithTitle(title: "item"))
 
-        XCTAssertEqual(urlBar.leaveOverlayModeCallCount, 1)
         XCTAssertEqual(telemetry.recordEventCallCount, 1)
         XCTAssertTrue(telemetry.recordedCategories.contains(.action))
         XCTAssertTrue(telemetry.recordedMethods.contains(.tap))
@@ -234,7 +229,6 @@ class HistoryHighlightsViewModelTests: XCTestCase {
         subject = HistoryHighlightsViewModel(
             with: profile,
             isPrivate: isPrivate,
-            urlBar: urlBar,
             theme: LightTheme(),
             historyHighlightsDataAdaptor: dataAdaptor,
             dispatchQueue: MockDispatchQueue(),

--- a/Tests/ClientTests/Frontend/Home/HomepageViewControllerTests.swift
+++ b/Tests/ClientTests/Frontend/Home/HomepageViewControllerTests.swift
@@ -50,7 +50,7 @@ class HomepageViewControllerTests: XCTestCase {
     func testHomepageViewController_simpleCreation_hasNoLeaks() {
         let tabManager = TabManager(profile: profile, imageStore: nil)
         let urlBar = URLBarView(profile: profile)
-        let overlayManager = MockOverlayModeManager()
+        let overlayManager = MockOverlayModeManager(urlBarView: urlBar)
 
         FeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
 

--- a/Tests/ClientTests/Frontend/Home/HomepageViewControllerTests.swift
+++ b/Tests/ClientTests/Frontend/Home/HomepageViewControllerTests.swift
@@ -56,7 +56,6 @@ class HomepageViewControllerTests: XCTestCase {
 
         let firefoxHomeViewController = HomepageViewController(profile: profile,
                                                                tabManager: tabManager,
-                                                               urlBar: urlBar,
                                                                overlayManager: overlayManager)
 
         trackForMemoryLeaks(firefoxHomeViewController)

--- a/Tests/ClientTests/Frontend/Home/HomepageViewControllerTests.swift
+++ b/Tests/ClientTests/Frontend/Home/HomepageViewControllerTests.swift
@@ -50,7 +50,8 @@ class HomepageViewControllerTests: XCTestCase {
     func testHomepageViewController_simpleCreation_hasNoLeaks() {
         let tabManager = TabManager(profile: profile, imageStore: nil)
         let urlBar = URLBarView(profile: profile)
-        let overlayManager = MockOverlayModeManager(urlBarView: urlBar)
+        let overlayManager = MockOverlayModeManager()
+        overlayManager.setURLBar(urlBarView: urlBar)
 
         FeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
 

--- a/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
@@ -12,7 +12,6 @@ import Common
 class JumpBackInViewModelTests: XCTestCase {
     var mockProfile: MockProfile!
     var mockTabManager: MockTabManager!
-    private var urlBar: MockURLBarView!
 
     var stubBrowserViewController: BrowserViewController!
     var adaptor: JumpBackInDataAdaptorMock!
@@ -30,7 +29,6 @@ class JumpBackInViewModelTests: XCTestCase {
             profile: mockProfile,
             tabManager: TabManager(profile: mockProfile, imageStore: nil)
         )
-        urlBar = MockURLBarView()
 
         FeatureFlagsManager.shared.initializeDeveloperFeatures(with: mockProfile)
     }
@@ -40,7 +38,6 @@ class JumpBackInViewModelTests: XCTestCase {
         AppContainer.shared.reset()
         adaptor = nil
         stubBrowserViewController = nil
-        urlBar = nil
         mockTabManager = nil
         mockProfile = nil
     }
@@ -57,15 +54,12 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.switchTo(group: group)
 
-        XCTAssertFalse(urlBar.inOverlayMode)
-        XCTAssertEqual(urlBar.leaveOverlayModeCallCount, 0)
         XCTAssertFalse(completionDidRun)
     }
 
     func test_switchToGroup_noGroupedItems_doNothing() {
         let subject = createSubject()
         let group = ASGroup<Tab>(searchTerm: "", groupedItems: [], timestamp: 0)
-        urlBar.inOverlayMode = true
         var completionDidRun = false
         subject.onTapGroup = { tab in
             completionDidRun = true
@@ -73,24 +67,6 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.switchTo(group: group)
 
-        XCTAssertFalse(urlBar.inOverlayMode)
-        XCTAssertEqual(urlBar.leaveOverlayModeCallCount, 1)
-        XCTAssertFalse(completionDidRun)
-    }
-
-    func test_switchToGroup_inOverlayMode_leavesOverlayMode() {
-        let subject = createSubject()
-        let group = ASGroup<Tab>(searchTerm: "", groupedItems: [], timestamp: 0)
-        urlBar.inOverlayMode = true
-        var completionDidRun = false
-        subject.onTapGroup = { tab in
-            completionDidRun = true
-        }
-
-        subject.switchTo(group: group)
-
-        XCTAssertFalse(urlBar.inOverlayMode)
-        XCTAssertEqual(urlBar.leaveOverlayModeCallCount, 1)
         XCTAssertFalse(completionDidRun)
     }
 
@@ -98,7 +74,6 @@ class JumpBackInViewModelTests: XCTestCase {
         let subject = createSubject()
         let expectedTab = createTab(profile: mockProfile)
         let group = ASGroup<Tab>(searchTerm: "", groupedItems: [expectedTab], timestamp: 0)
-        urlBar.inOverlayMode = true
         var receivedTab: Tab?
         subject.onTapGroup = { tab in
             receivedTab = tab
@@ -106,8 +81,6 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.switchTo(group: group)
 
-        XCTAssertFalse(urlBar.inOverlayMode)
-        XCTAssertEqual(urlBar.leaveOverlayModeCallCount, 1)
         XCTAssertEqual(expectedTab, receivedTab)
     }
 
@@ -116,35 +89,27 @@ class JumpBackInViewModelTests: XCTestCase {
     func test_switchToTab_notInOverlayMode_switchTabs() {
         let subject = createSubject()
         let tab = createTab(profile: mockProfile)
-        urlBar.inOverlayMode = false
 
         subject.switchTo(tab: tab)
 
-        XCTAssertFalse(urlBar.inOverlayMode)
-        XCTAssertEqual(urlBar.leaveOverlayModeCallCount, 0)
         XCTAssertFalse(mockTabManager.lastSelectedTabs.isEmpty)
     }
 
     func test_switchToTab_inOverlayMode_leaveOverlayMode() {
         let subject = createSubject()
         let tab = createTab(profile: mockProfile)
-        urlBar.inOverlayMode = true
 
         subject.switchTo(tab: tab)
 
-        XCTAssertFalse(urlBar.inOverlayMode)
-        XCTAssertEqual(urlBar.leaveOverlayModeCallCount, 1)
         XCTAssertFalse(mockTabManager.lastSelectedTabs.isEmpty)
     }
 
     func test_switchToTab_tabManagerSelectsTab() {
         let subject = createSubject()
         let tab1 = createTab(profile: mockProfile)
-        urlBar.inOverlayMode = true
 
         subject.switchTo(tab: tab1)
 
-        XCTAssertFalse(urlBar.inOverlayMode)
         guard !mockTabManager.lastSelectedTabs.isEmpty else {
             XCTFail("No tabs were selected in mock tab manager.")
             return
@@ -665,7 +630,6 @@ extension JumpBackInViewModelTests {
             isZeroSearch: false,
             profile: mockProfile,
             isPrivate: false,
-            urlBar: urlBar,
             theme: LightTheme(),
             tabManager: mockTabManager,
             adaptor: adaptor,

--- a/Tests/ClientTests/Mocks/MockOverlayModeManager.swift
+++ b/Tests/ClientTests/Mocks/MockOverlayModeManager.swift
@@ -6,18 +6,17 @@ import XCTest
 
 @testable import Client
 
-class MockOverlayModeManager: OverlayModeManager {
-    var inOverlayMode = false
+class MockOverlayModeManager: DefaultOverlayModeManager {
     var leaveOverlayModeCallCount = 0
     var enterOverlayModeCallCount = 0
 
-    func leaveOverlayMode(didCancel cancel: Bool) {
+    override func leaveOverlayMode(didCancel cancel: Bool) {
         leaveOverlayModeCallCount += 1
-        inOverlayMode = false
+        super.leaveOverlayMode(didCancel: cancel)
     }
 
-    func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool) {
+    override func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool) {
         enterOverlayModeCallCount += 1
-        inOverlayMode = true
+        super.enterOverlayMode(locationText, pasted: pasted, search: search)
     }
 }

--- a/Tests/ClientTests/Mocks/MockOverlayModeManager.swift
+++ b/Tests/ClientTests/Mocks/MockOverlayModeManager.swift
@@ -10,11 +10,6 @@ class MockOverlayModeManager: DefaultOverlayModeManager {
     var leaveOverlayModeCallCount = 0
     var enterOverlayModeCallCount = 0
 
-    override func finishEdition(didCancelLoading: Bool) {
-        leaveOverlayModeCallCount += 1
-        super.finishEdition(didCancelLoading: didCancelLoading)
-    }
-
     override func openSearch(with pasteContent: String) {
         enterOverlayModeCallCount += 1
         super.openSearch(with: pasteContent)
@@ -25,8 +20,13 @@ class MockOverlayModeManager: DefaultOverlayModeManager {
         super.openNewTab(locationText, url: url)
     }
 
-    override func switchTab(didCancelLoading: Bool) {
+    override func finishEdition(shouldCancelLoading: Bool) {
         leaveOverlayModeCallCount += 1
-        super.switchTab(didCancelLoading: didCancelLoading)
+        super.finishEdition(shouldCancelLoading: shouldCancelLoading)
+    }
+
+    override func switchTab(shouldCancelLoading: Bool) {
+        leaveOverlayModeCallCount += 1
+        super.switchTab(shouldCancelLoading: shouldCancelLoading)
     }
 }

--- a/Tests/ClientTests/Mocks/MockOverlayModeManager.swift
+++ b/Tests/ClientTests/Mocks/MockOverlayModeManager.swift
@@ -10,13 +10,23 @@ class MockOverlayModeManager: DefaultOverlayModeManager {
     var leaveOverlayModeCallCount = 0
     var enterOverlayModeCallCount = 0
 
-    override func leaveOverlayMode(didCancel cancel: Bool) {
+    override func finishEdition() {
         leaveOverlayModeCallCount += 1
-        super.leaveOverlayMode(didCancel: cancel)
+        super.finishEdition()
     }
 
-    override func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool) {
+    override func pasteContent(pasteContent: String) {
         enterOverlayModeCallCount += 1
-        super.enterOverlayMode(locationText, pasted: pasted, search: search)
+        super.pasteContent(pasteContent: pasteContent)
+    }
+
+    override func openNewTab(_ locationText: String?, url: URL?) {
+        enterOverlayModeCallCount += 1
+        super.openNewTab(locationText, url: url)
+    }
+
+    override func switchTab(didCancel: Bool) {
+        leaveOverlayModeCallCount += 1
+        super.switchTab(didCancel: didCancel)
     }
 }

--- a/Tests/ClientTests/Mocks/MockOverlayModeManager.swift
+++ b/Tests/ClientTests/Mocks/MockOverlayModeManager.swift
@@ -10,14 +10,14 @@ class MockOverlayModeManager: DefaultOverlayModeManager {
     var leaveOverlayModeCallCount = 0
     var enterOverlayModeCallCount = 0
 
-    override func finishEdition() {
+    override func finishEdition(didCancelLoading: Bool) {
         leaveOverlayModeCallCount += 1
-        super.finishEdition()
+        super.finishEdition(didCancelLoading: didCancelLoading)
     }
 
-    override func pasteContent(pasteContent: String) {
+    override func openSearch(with pasteContent: String) {
         enterOverlayModeCallCount += 1
-        super.pasteContent(pasteContent: pasteContent)
+        super.openSearch(with: pasteContent)
     }
 
     override func openNewTab(_ locationText: String?, url: URL?) {
@@ -25,8 +25,8 @@ class MockOverlayModeManager: DefaultOverlayModeManager {
         super.openNewTab(locationText, url: url)
     }
 
-    override func switchTab(didCancel: Bool) {
+    override func switchTab(didCancelLoading: Bool) {
         leaveOverlayModeCallCount += 1
-        super.switchTab(didCancel: didCancel)
+        super.switchTab(didCancelLoading: didCancelLoading)
     }
 }

--- a/Tests/ClientTests/OverlayModeManagerTests.swift
+++ b/Tests/ClientTests/OverlayModeManagerTests.swift
@@ -1,0 +1,40 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+@testable import Client
+class OverlayModeManagerTests: XCTestCase {
+    private var urlBar: MockURLBarView!
+    private var subject: OverlayModeManager!
+
+    override func setUp() {
+        super.setUp()
+
+        urlBar = MockURLBarView()
+        subject = MockOverlayModeManager(urlBarView: urlBar)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func testEnterOverlayMode_ForNewTabWithNilURL() {
+        subject.openNewTab(nil, url: nil)
+
+        XCTAssertTrue(subject.inOverlayMode)
+    }
+
+    func testEnterOverlayMode_ForNewTabWithHomeURL() {
+        subject.openNewTab(nil, url: URL(string: "internal://local/about/home"))
+
+        XCTAssertTrue(subject.inOverlayMode)
+    }
+
+    func testEnterOverlayMode_ForNewTabWithURL() {
+        subject.openNewTab(nil, url: URL(string: "https://test.com"))
+
+        XCTAssertFalse(subject.inOverlayMode)
+    }
+}

--- a/Tests/ClientTests/OverlayModeManagerTests.swift
+++ b/Tests/ClientTests/OverlayModeManagerTests.swift
@@ -30,6 +30,7 @@ class OverlayModeManagerTests: XCTestCase {
         subject.openNewTab(nil, url: URL(string: "internal://local/about/home"))
 
         XCTAssertTrue(subject.inOverlayMode)
+        XCTAssertEqual(subject.enterOverlayModeCallCount, 1)
     }
 
     func testEnterOverlayMode_ForNewTabWithURL() {

--- a/Tests/ClientTests/OverlayModeManagerTests.swift
+++ b/Tests/ClientTests/OverlayModeManagerTests.swift
@@ -7,17 +7,19 @@ import XCTest
 @testable import Client
 class OverlayModeManagerTests: XCTestCase {
     private var urlBar: MockURLBarView!
-    private var subject: OverlayModeManager!
+    private var subject: MockOverlayModeManager!
 
     override func setUp() {
         super.setUp()
-
         urlBar = MockURLBarView()
-        subject = MockOverlayModeManager(urlBarView: urlBar)
+        subject = MockOverlayModeManager()
+        subject.setURLBar(urlBarView: urlBar)
     }
 
     override func tearDown() {
         super.tearDown()
+        urlBar = nil
+        subject = nil
     }
 
     func testEnterOverlayMode_ForNewTabWithNilURL() {

--- a/Tests/ClientTests/OverlayModeManagerTests.swift
+++ b/Tests/ClientTests/OverlayModeManagerTests.swift
@@ -22,6 +22,7 @@ class OverlayModeManagerTests: XCTestCase {
         subject = nil
     }
 
+    // MARK: - Test EnterOverlay for New tab
     func testEnterOverlayMode_ForNewTabWithNilURL() {
         subject.openNewTab(nil, url: nil)
 
@@ -39,5 +40,32 @@ class OverlayModeManagerTests: XCTestCase {
         subject.openNewTab(nil, url: URL(string: "https://test.com"))
 
         XCTAssertFalse(subject.inOverlayMode)
+        XCTAssertEqual(subject.enterOverlayModeCallCount, 1)
+    }
+
+    // MARK: - Test EnterOverlay for paste action
+
+    func testEnterOverlayMode_ForPasteContent() {
+        subject.openSearch(with: "paste")
+
+        XCTAssertTrue(subject.inOverlayMode)
+        XCTAssertEqual(subject.enterOverlayModeCallCount, 1)
+    }
+
+    // MARK: - Test EnterOverlay for finish edition
+
+    func testLeaveOverlayMode_ForFinishEdition() {
+        subject.finishEdition(shouldCancelLoading: true)
+
+        XCTAssertFalse(subject.inOverlayMode)
+        XCTAssertEqual(subject.leaveOverlayModeCallCount, 1)
+    }
+
+    // MARK: - Test EnterOverlay for Tab change
+    func testEnterOverlayMode_ForSwitchTab() {
+        subject.switchTab(shouldCancelLoading: true)
+
+        XCTAssertFalse(subject.inOverlayMode)
+        XCTAssertEqual(subject.leaveOverlayModeCallCount, 1)
     }
 }

--- a/Tests/ClientTests/TabTrayViewControllerTests.swift
+++ b/Tests/ClientTests/TabTrayViewControllerTests.swift
@@ -14,6 +14,8 @@ class TabTrayViewControllerTests: XCTestCase {
     var manager: TabManager!
     var tabTray: TabTrayViewController!
     var gridTab: GridTabViewController!
+    var overlayManager: MockOverlayModeManager!
+    var urlBar: MockURLBarView!
 
     override func setUp() {
         super.setUp()
@@ -21,9 +23,17 @@ class TabTrayViewControllerTests: XCTestCase {
         DependencyHelperMock().bootstrapDependencies()
         profile = TabManagerMockProfile()
         manager = TabManager(profile: profile, imageStore: nil)
-        tabTray = TabTrayViewController(tabTrayDelegate: nil, profile: profile, tabToFocus: nil, tabManager: manager)
+        urlBar = MockURLBarView()
+        overlayManager = MockOverlayModeManager()
+        overlayManager.setURLBar(urlBarView: urlBar)
+        tabTray = TabTrayViewController(tabTrayDelegate: nil,
+                                        profile: profile,
+                                        tabToFocus: nil,
+                                        tabManager: manager,
+                                        overlayManager: overlayManager)
         gridTab = GridTabViewController(tabManager: manager, profile: profile)
         manager.addDelegate(gridTab)
+        FeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
     }
 
     override func tearDown() {
@@ -32,6 +42,8 @@ class TabTrayViewControllerTests: XCTestCase {
         AppContainer.shared.reset()
         profile = nil
         manager = nil
+        urlBar = nil
+        overlayManager = nil
         tabTray = nil
         gridTab = nil
     }


### PR DESCRIPTION
### [FXIOS-5638](https://mozilla-hub.atlassian.net/browse/FXIOS-5638) | #13022

- Update `OverlayModeManager` protocol function names to be directly related to actions that involved enter/leave overlay mode. At the moment the logic in this function is pretty simple most of them just call `enterOverlayMode` or `leaveOverlayMode` but as we build the new behavior we could logic easily
- Set `enterOverlayMode` and `leaveOverlayMode` to private to avoid direct overusage like we had in the past
- Added OverlayStateProtocol with `inOverlayMode` property for Views that only need to know the Overlay mode state like CFRs and Wallpaper bottom sheet
- Change in logic on how we present Onboarding, CFRs and Wallpaper bottom sheet instead of dismissing the keyboard like we did in the past we now check if app is not in OverlayMode to show them
- Added OverlayManager to TabTrayViewModel to trigger openNewTab state when the + button is pressed on iPhone I tried to call this function on BVC delegate chain of the action but it was causing side effects where the keyboard was raising when it shouldn't