### PR TITLE
Refactor MTE-636 [v111] Disable test_sync_tabs_from_desktop from sync integration test

### DIFF
--- a/SyncIntegrationTests/test_integration.py
+++ b/SyncIntegrationTests/test_integration.py
@@ -27,9 +27,11 @@ def test_sync_logins_from_desktop(tps, xcodebuild):
     tps.run('test_password_desktop.js')
     xcodebuild.test('XCUITests/IntegrationTests/testFxASyncPasswordDesktop')
 
+'''
 def test_sync_tabs_from_desktop(tps, xcodebuild):
     tps.run('test_tabs_desktop.js')
     xcodebuild.test('XCUITests/IntegrationTests/testFxASyncTabsDesktop')
+'''
 
 def test_sync_disconnect_connect_fxa(tps, xcodebuild):
     tps.run('test_bookmark_login.js')


### PR DESCRIPTION
The test`test_sync_tabs_from_desktop` from the sync integration test has been failing consistently. (It's sort of a good news to see that it's not an intermittent failure so that it's easier to debug!) Let's disable this test when we investigate the cause.

https://mozilla-hub.atlassian.net/browse/MTE-636
