### PR TITLE
Bugfix FXIOS-5298 [v112] Sections are missing from the Homepage after opening and closing private mode without opening any private tab

### DIFF
--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -565,6 +565,9 @@ extension TabTrayViewController {
 
     @objc func didTapDone() {
         notificationCenter.post(name: .TabsTrayDidClose)
+        // Update Private mode when closing TabTray, if the mode toggle but no tab is pressed with return to previous state
+        updatePrivateUIState()
+        viewModel.tabTrayView.didTogglePrivateMode(viewModel.tabManager.selectedTab?.isPrivate ?? false)
         self.dismiss(animated: true, completion: nil)
     }
 }

--- a/Tests/ClientTests/TabTrayViewControllerTests.swift
+++ b/Tests/ClientTests/TabTrayViewControllerTests.swift
@@ -24,6 +24,7 @@ class TabTrayViewControllerTests: XCTestCase {
         tabTray = TabTrayViewController(tabTrayDelegate: nil, profile: profile, tabToFocus: nil, tabManager: manager)
         gridTab = GridTabViewController(tabManager: manager, profile: profile)
         manager.addDelegate(gridTab)
+        FeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
     }
 
     override func tearDown() {
@@ -53,5 +54,26 @@ class TabTrayViewControllerTests: XCTestCase {
 
         XCTAssertEqual(tabTray.viewModel.normalTabsCount, "1")
         XCTAssertEqual(tabTray.countLabel.text, "1")
+    }
+
+    func testTabTrayInPrivateMode_WhenTabIsCreated() {
+        tabTray.viewModel.segmentToFocus = TabTrayViewModel.Segment.privateTabs
+        tabTray.viewDidLoad()
+        tabTray.didTapAddTab(UIBarButtonItem())
+        tabTray.didTapDone()
+
+        let privateState = UserDefaults.standard.bool(forKey: "wasLastSessionPrivate")
+        XCTAssertTrue(privateState)
+    }
+
+    func testTabTrayRevertToRegular_ForNoPrivateTabSelected() {
+        // If the user selects Private mode but doesn't focus or creates a new tab
+        // we considered that regular is actually active
+        tabTray.viewModel.segmentToFocus = TabTrayViewModel.Segment.privateTabs
+        tabTray.viewDidLoad()
+        tabTray.didTapDone()
+
+        let privateState = UserDefaults.standard.bool(forKey: "wasLastSessionPrivate")
+        XCTAssertFalse(privateState)
     }
 }


### PR DESCRIPTION

### [FXIOS-5298](https://mozilla-hub.atlassian.net/browse/FXIOS-5298) | #12457 

According to the current behavior if the user open tab tray and switch between regular/private mode it also needs to foucs on one tab, if no tab is selected we revert to the previous state. To fix this bug we notify when the tab tray is closed of the current state which is based on the last selected tab mode 