### PR TITLE
Add FXIOS-5733 [v112] Alerts in edit card view

### DIFF
--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardEditView.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardEditView.swift
@@ -43,8 +43,11 @@ struct CreditCardEditView: View {
 
             Spacer()
 
-            RemoveCardButton(removeButtonColor: removeButtonColor,
-                             borderColor: borderColor)
+            RemoveCardButton(
+                removeButtonColor: removeButtonColor,
+                borderColor: borderColor,
+                alertDetails: viewModel.removeButtonDetails
+            )
         }
         .padding(.top, 20)
     }

--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardEditViewModel.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardEditViewModel.swift
@@ -4,8 +4,12 @@
 
 import Foundation
 import SwiftUI
+import Common
 
 class CreditCardEditViewModel: ObservableObject {
+    typealias CreditCardText = String.CreditCard.Alert
+    let profile: Profile
+
     @Published var firstName: String = ""
     @Published var lastName: String = ""
     @Published var errorState: String = ""
@@ -31,12 +35,39 @@ class CreditCardEditViewModel: ObservableObject {
         }
     }
 
-    init() {}
+    var removeButtonDetails: RemoveCardButton.AlertDetails {
+        let isSignedIn = profile.hasSyncableAccount()
 
-    init(firstName: String,
+        if isSignedIn {
+            return RemoveCardButton.AlertDetails(
+                alertTitle: Text(CreditCardText.RemoveCardTitle),
+                alertBody: Text(CreditCardText.RemoveCardSublabel),
+                primaryButtonStyleAndText: .destructive(Text(CreditCardText.RemovedCardLabel)),
+                secondaryButtonStyleAndText: .cancel(),
+                primaryButtonAction: {},
+                secondaryButtonAction: {})
+        }
+
+        return RemoveCardButton.AlertDetails(
+            alertTitle: Text(CreditCardText.RemoveCardTitle),
+            alertBody: nil,
+            primaryButtonStyleAndText: .destructive(Text(CreditCardText.RemovedCardLabel)),
+            secondaryButtonStyleAndText: .cancel(),
+            primaryButtonAction: {},
+            secondaryButtonAction: {}
+        )
+    }
+
+    init(profile: Profile) {
+        self.profile = profile
+    }
+
+    init(profile: Profile = AppContainer.shared.resolve(),
+         firstName: String,
          lastName: String,
          errorState: String,
          enteredValue: String) {
+        self.profile = profile
         self.firstName = firstName
         self.lastName = lastName
         self.errorState = errorState

--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewModel.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewModel.swift
@@ -23,9 +23,11 @@ struct CreditCardSettingsStartingConfig {
 class CreditCardSettingsViewModel {
     var autofill: RustAutofill?
     var profile: Profile
-    var addEditViewModel: CreditCardEditViewModel = CreditCardEditViewModel()
+
+    lazy var addEditViewModel: CreditCardEditViewModel = CreditCardEditViewModel(profile: profile)
     var creditCardTableViewModel: CreditCardTableViewModel = CreditCardTableViewModel()
     var toggleModel: ToggleModel!
+    
 
     public init(profile: Profile) {
         self.profile = profile

--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewModel.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewModel.swift
@@ -27,7 +27,6 @@ class CreditCardSettingsViewModel {
     lazy var addEditViewModel: CreditCardEditViewModel = CreditCardEditViewModel(profile: profile)
     var creditCardTableViewModel: CreditCardTableViewModel = CreditCardTableViewModel()
     var toggleModel: ToggleModel!
-    
 
     public init(profile: Profile) {
         self.profile = profile

--- a/Client/Frontend/Autofill/CreditCard/ViewComponents/RemoveCardButton.swift
+++ b/Client/Frontend/Autofill/CreditCard/ViewComponents/RemoveCardButton.swift
@@ -6,8 +6,21 @@ import Foundation
 import SwiftUI
 
 struct RemoveCardButton: View {
+    @State private var showAlert = false
+
+    struct AlertDetails {
+        let alertTitle: Text
+        let alertBody: Text?
+        let primaryButtonStyleAndText: Alert.Button
+        let secondaryButtonStyleAndText: Alert.Button
+
+        let primaryButtonAction: () -> Void
+        let secondaryButtonAction: (() -> Void)?
+    }
+
     let removeButtonColor: Color
     let borderColor: Color
+    let alertDetails: AlertDetails
 
     var body: some View {
         VStack {
@@ -19,7 +32,15 @@ struct RemoveCardButton: View {
                 .padding(.trailing, 10)
             VStack {
                 Button(String.CreditCard.EditCard.RemoveCardButtonTitle) {
-                    print("Button pressed")
+                    showAlert.toggle()
+                }
+                .alert(isPresented: $showAlert) {
+                    Alert(
+                        title: alertDetails.alertTitle,
+                        message: alertDetails.alertBody,
+                        primaryButton: alertDetails.primaryButtonStyleAndText,
+                        secondaryButton: alertDetails.secondaryButtonStyleAndText
+                    )
                 }
                 .font(.body)
                 .foregroundColor(removeButtonColor)

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -4614,7 +4614,7 @@ extension String {
                 "SnackBar.RemovedCard.Button.v112",
                 tableName: "Alert",
                 value: "Remove",
-                comment: "Button text to dimiss the dialog box that gets presented as a confirmation to to remove card and perform the the operation of removing the credit card.")
+                comment: "Button text to dimiss the dialog box that gets presented as a confirmation to to remove card and perform the operation of removing the credit card.")
         }
     }
 }

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -4614,7 +4614,7 @@ extension String {
                 "SnackBar.RemovedCard.Button.v112",
                 tableName: "Alert",
                 value: "Remove",
-                comment: "Button text to dimiss the dialog box that gets presented as a confirmation to to remove card and perform the operation of removing the credit card.")
+                comment: "Button text to dismiss the dialog box that gets presented as a confirmation to to remove card and perform the operation of removing the credit card.")
         }
     }
 }


### PR DESCRIPTION
# [FXIOS-5721](https://mozilla-hub.atlassian.net/browse/FXIOS-5721)
## Overview
TLDR: Add the alert view for the CC Edit View.

## Details
We forego the approach of creating a custom alert view, given that Alerts are changing quite a bit between versions. It seems  the native solution is flexible enough for our needs in the future. 

We use Alert here, but it'll need updates to follow along with the updates SwiftUI's alerts have undergone in later versions.

Button actions are left as empty closures for now. In a future ticket, when UX is clean and the datasource integration begins, those closures will have the right methods to remove cards locally and in AS. 

We `init` inject `Profile` because a preview is using that one. In normal cases, I expect `Profile` to be passed along like the rest of the app is doing. 