### PR TITLE
Refactor FXIOS-5768 [v112] Turn breadcrumbs off

### DIFF
--- a/BrowserKit/Sources/Logger/CrashManager.swift
+++ b/BrowserKit/Sources/Logger/CrashManager.swift
@@ -79,7 +79,7 @@ public class DefaultCrashManager: CrashManager {
                 return crumb
             }
             // Turn Sentry breadcrumbs off since we have our own log swizzling
-            options.integrations = options.integrations?.filter { $0 != "SentryAutoBreadcrumbTrackingIntegration" }
+            options.enableAutoBreadcrumbTracking = false
         })
         enabled = true
 

--- a/BrowserKit/Sources/Logger/CrashManager.swift
+++ b/BrowserKit/Sources/Logger/CrashManager.swift
@@ -78,6 +78,8 @@ public class DefaultCrashManager: CrashManager {
                 }
                 return crumb
             }
+            // Turn Sentry breadcrumbs off since we have our own log swizzling
+            options.integrations = options.integrations?.filter { $0 != "SentryAutoBreadcrumbTrackingIntegration" }
         })
         enabled = true
 

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -178,6 +178,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         profile.shutdown()
     }
 
+    func applicationDidReceiveMemoryWarning(_ application: UIApplication) {
+        logger.log("Received memory warning", level: .info, category: .lifecycle)
+    }
+
     private func updateTopSitesWidget() {
         // Since we only need the topSites data in the archiver, let's write it
         // only if iOS 14 is available.


### PR DESCRIPTION
## [FXIOS-5768](https://mozilla-hub.atlassian.net/browse/FXIOS-5768) https://github.com/mozilla-mobile/firefox-ios/issues/13240
- Turn Sentry breadcrumbs off since we add our own now
- Add Memory warning to our own breadcrumbs