### PR TITLE
Bugfix MTE-638 [v111] SaveLoginTest for M1

### DIFF
--- a/Tests/XCUITests/SaveLoginsTests.swift
+++ b/Tests/XCUITests/SaveLoginsTests.swift
@@ -90,11 +90,15 @@ class SaveLoginTest: BaseTestCase {
         waitForExistence(app.tables["Login List"])
         XCTAssertTrue(app.staticTexts[domain].exists)
         // XCTAssertTrue(app.staticTexts[domainSecondLogin].exists)
-        // Change to 3 entries for iPhone since the hostname is not saved and only one entry appears
-        if iPad() {
+        if processIsTranslatedStr() == m1Rosetta {
             XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList + 2)
         } else {
-            XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList + 1)
+            // Change to 3 entries for iPhone since the hostname is not saved and only one entry appears
+            if iPad() {
+                XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList + 2)
+            } else {
+                XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList + 1)
+            }
         }
     }
 


### PR DESCRIPTION
The behaviour of `SaveLoginTest/testSaveLogin()` differs between Intel and M1. The test in its current form passes on Bitrise, which uses an Intel stack. The same test fails during smoketest on MacStadium, which is an M1 machine.

On M1, the list of login is the same on both iPhone and iPad.

https://mozilla-hub.atlassian.net/browse/MTE-638