### PR TITLE
Refactor FXIOS-5790 [v112] Add qualified names for SyncResult, SyncReason, and SyncManager

### DIFF
--- a/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -136,7 +136,7 @@ class SyncContentSettingsViewController: SettingsTableViewController {
 
     override func viewWillDisappear(_ animated: Bool) {
         if !enginesToSyncOnExit.isEmpty {
-            _ = self.profile.syncManager.syncNamedCollections(why: SyncReason.engineEnabled, names: Array(enginesToSyncOnExit))
+            _ = self.profile.syncManager.syncNamedCollections(why: OldSyncReason.engineEnabled, names: Array(enginesToSyncOnExit))
             enginesToSyncOnExit.removeAll()
         }
         super.viewWillDisappear(animated)

--- a/Extensions/NotificationService/ExtensionProfile.swift
+++ b/Extensions/NotificationService/ExtensionProfile.swift
@@ -33,7 +33,7 @@ class ExtensionSyncManager: BrowserProfile.BrowserSyncManager {
     }
 
     // We should probably only want to sync client commands while we're in the extension.
-    override func syncNamedCollections(why: SyncReason, names: [String]) -> Success {
+    override func syncNamedCollections(why: OldSyncReason, names: [String]) -> Success {
         let names = names.filter { extensionSafeNames.contains($0) }
         return super.syncNamedCollections(why: why, names: names)
     }

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -23,11 +23,11 @@ public protocol SyncManager {
     var lastSyncFinishTime: Timestamp? { get set }
     var syncDisplayState: SyncDisplayState? { get }
 
-    func syncClients() -> SyncResult
-    func syncClientsThenTabs() -> SyncResult
-    func syncHistory() -> SyncResult
-    @discardableResult func syncEverything(why: SyncReason) -> Success
-    func syncNamedCollections(why: SyncReason, names: [String]) -> Success
+    func syncClients() -> OldSyncResult
+    func syncClientsThenTabs() -> OldSyncResult
+    func syncHistory() -> OldSyncResult
+    @discardableResult func syncEverything(why: OldSyncReason) -> Success
+    func syncNamedCollections(why: OldSyncReason, names: [String]) -> Success
 
     func endTimedSyncs()
     func applicationDidBecomeActive()
@@ -37,7 +37,7 @@ public protocol SyncManager {
     @discardableResult func onAddedAccount() -> Success
 }
 
-typealias SyncFunction = (SyncDelegate, Prefs, Ready, SyncReason) -> SyncResult
+typealias SyncFunction = (SyncDelegate, Prefs, Ready, OldSyncReason) -> OldSyncResult
 
 class ProfileFileAccessor: FileAccessor {
     convenience init(profile: Profile) {
@@ -1074,7 +1074,7 @@ open class BrowserProfile: Profile {
             }
         }
 
-        fileprivate func syncClientsWithDelegate(_ delegate: SyncDelegate, prefs: Prefs, ready: Ready, why: SyncReason) -> SyncResult {
+        fileprivate func syncClientsWithDelegate(_ delegate: SyncDelegate, prefs: Prefs, ready: Ready, why: OldSyncReason) -> OldSyncResult {
             logger.log("Syncing clients to storage.",
                        level: .info,
                        category: .sync)
@@ -1180,7 +1180,7 @@ open class BrowserProfile: Profile {
             return syncUnlockInfo
         }
 
-        fileprivate func syncLoginsWithDelegate(_ delegate: SyncDelegate, prefs: Prefs, ready: Ready, why: SyncReason) -> SyncResult {
+        fileprivate func syncLoginsWithDelegate(_ delegate: SyncDelegate, prefs: Prefs, ready: Ready, why: OldSyncReason) -> OldSyncResult {
             self.logger.log("Syncing logins to storage.",
                             level: .debug,
                             category: .sync)
@@ -1205,7 +1205,7 @@ open class BrowserProfile: Profile {
             })
         }
 
-        fileprivate func syncBookmarksWithDelegate(_ delegate: SyncDelegate, prefs: Prefs, ready: Ready, why: SyncReason) -> SyncResult {
+        fileprivate func syncBookmarksWithDelegate(_ delegate: SyncDelegate, prefs: Prefs, ready: Ready, why: OldSyncReason) -> OldSyncResult {
             logger.log("Syncing bookmarks to storage.",
                        level: .debug,
                        category: .storage)
@@ -1225,7 +1225,7 @@ open class BrowserProfile: Profile {
             })
         }
 
-        fileprivate func syncHistoryWithDelegate(_ delegate: SyncDelegate, prefs: Prefs, ready: Ready, why: SyncReason) -> SyncResult {
+        fileprivate func syncHistoryWithDelegate(_ delegate: SyncDelegate, prefs: Prefs, ready: Ready, why: OldSyncReason) -> OldSyncResult {
             logger.log("Syncing History to storage.",
                        level: .debug,
                        category: .storage)
@@ -1245,7 +1245,7 @@ open class BrowserProfile: Profile {
             })
         }
 
-        fileprivate func syncTabsWithDelegate(_ delegate: SyncDelegate, prefs: Prefs, ready: Ready, why: SyncReason) -> SyncResult {
+        fileprivate func syncTabsWithDelegate(_ delegate: SyncDelegate, prefs: Prefs, ready: Ready, why: OldSyncReason) -> OldSyncResult {
             logger.log("Syncing tabs to storage.",
                        level: .debug,
                        category: .storage)
@@ -1295,8 +1295,8 @@ open class BrowserProfile: Profile {
         /**
          * Runs the single provided synchronization function and returns its status.
          */
-        fileprivate func sync(_ label: EngineIdentifier, function: @escaping SyncFunction) -> SyncResult {
-            let syncSeveralItems: SyncResult = syncSeveral(why: .user, synchronizers: [(label, function)]) >>== { statuses in
+        fileprivate func sync(_ label: EngineIdentifier, function: @escaping SyncFunction) -> OldSyncResult {
+            let syncSeveralItems: OldSyncResult = syncSeveral(why: .user, synchronizers: [(label, function)]) >>== { statuses in
                 if let status = statuses.find({ label == $0.0 }) {
                     return deferMaybe(status.1)
                 }
@@ -1309,7 +1309,7 @@ open class BrowserProfile: Profile {
         /**
          * Convenience method for syncSeveral([(EngineIdentifier, SyncFunction)])
          */
-        private func syncSeveral(why: SyncReason, synchronizers: (EngineIdentifier, SyncFunction)...) -> Deferred<Maybe<[(EngineIdentifier, SyncStatus)]>> {
+        private func syncSeveral(why: OldSyncReason, synchronizers: (EngineIdentifier, SyncFunction)...) -> Deferred<Maybe<[(EngineIdentifier, SyncStatus)]>> {
             return syncSeveral(why: why, synchronizers: synchronizers)
         }
 
@@ -1328,7 +1328,7 @@ open class BrowserProfile: Profile {
          * The statuses returned will be a superset of the ones that are requested here.
          * While a sync is ongoing, each engine from successive calls to this method will only be called once.
          */
-        fileprivate func syncSeveral(why: SyncReason, synchronizers: [(EngineIdentifier, SyncFunction)]) -> Deferred<Maybe<[(EngineIdentifier, SyncStatus)]>> {
+        fileprivate func syncSeveral(why: OldSyncReason, synchronizers: [(EngineIdentifier, SyncFunction)]) -> Deferred<Maybe<[(EngineIdentifier, SyncStatus)]>> {
             guard let (profile, deviceID) = self.getProfileAndDeviceId() else {
                 return deferMaybe(NoAccountError())
             }
@@ -1418,7 +1418,7 @@ open class BrowserProfile: Profile {
 
         // This SHOULD NOT be called directly: use syncSeveral instead.
         fileprivate func syncWith(synchronizers: [(EngineIdentifier, SyncFunction)],
-                                  statsSession: SyncOperationStatsSession, why: SyncReason) -> Deferred<Maybe<[(EngineIdentifier, SyncStatus)]>> {
+                                  statsSession: SyncOperationStatsSession, why: OldSyncReason) -> Deferred<Maybe<[(EngineIdentifier, SyncStatus)]>> {
             logger.log("Syncing \(synchronizers.map { $0.0 })",
                        level: .info,
                        category: .sync)
@@ -1466,7 +1466,7 @@ open class BrowserProfile: Profile {
             }
         }
 
-        @discardableResult public func syncEverything(why: SyncReason) -> Success {
+        @discardableResult public func syncEverything(why: OldSyncReason) -> Success {
             if let accountManager = RustFirefoxAccounts.shared.accountManager.peek(), accountManager.accountMigrationInFlight() {
                 accountManager.retryMigration { _ in }
                 return Success()
@@ -1497,7 +1497,7 @@ open class BrowserProfile: Profile {
          * Some help is given to callers who use different namespaces (specifically: `passwords` is mapped to `logins`)
          * and to preserve some ordering rules.
          */
-        public func syncNamedCollections(why: SyncReason, names: [String]) -> Success {
+        public func syncNamedCollections(why: OldSyncReason, names: [String]) -> Success {
             // Massage the list of names into engine identifiers.
             let engineIdentifiers = names.map { name -> [EngineIdentifier] in
                 switch name {
@@ -1531,12 +1531,12 @@ open class BrowserProfile: Profile {
             self.profile.pollCommands()
         }
 
-        public func syncClients() -> SyncResult {
+        public func syncClients() -> OldSyncResult {
             // TODO: recognize .NotStarted.
             return self.sync("clients", function: syncClientsWithDelegate)
         }
 
-        public func syncClientsThenTabs() -> SyncResult {
+        public func syncClientsThenTabs() -> OldSyncResult {
             // Previously we were making two separate `self.sync` calls, each of which
             // made a `self.syncSeveral` call. Because `self.syncSeveral` is meant to batch
             // engine syncs, this caused the second `self.sync` call (for the tabs engine)
@@ -1555,7 +1555,7 @@ open class BrowserProfile: Profile {
             }
         }
 
-        public func syncHistory() -> SyncResult {
+        public func syncHistory() -> OldSyncResult {
             return self.sync("history", function: syncHistoryWithDelegate)
         }
     }

--- a/Sync/SyncStateMachine.swift
+++ b/Sync/SyncStateMachine.swift
@@ -341,7 +341,7 @@ open class BaseSyncState: SyncState {
                    category: .sync)
     }
 
-    open func synchronizer<T: Synchronizer>(_ synchronizerClass: T.Type, delegate: SyncDelegate, prefs: Prefs, why: SyncReason) -> T {
+    open func synchronizer<T: Synchronizer>(_ synchronizerClass: T.Type, delegate: SyncDelegate, prefs: Prefs, why: OldSyncReason) -> T {
         return T(scratchpad: self.scratchpad, delegate: delegate, basePrefs: prefs, why: why, logger: DefaultLogger.shared)
     }
 

--- a/Sync/SyncTelemetryUtils.swift
+++ b/Sync/SyncTelemetryUtils.swift
@@ -10,6 +10,8 @@ import Storage
 import SwiftyJSON
 import SyncTelemetry
 
+public typealias OldSyncReason = SyncReason
+
 public enum SyncReason: String {
     case startup = "startup"
     case scheduled = "scheduled"
@@ -190,13 +192,13 @@ extension SyncEngineStatsSession: DictionaryRepresentable {
 
 // Stats and metadata for a sync operation.
 public class SyncOperationStatsSession: StatsSession {
-    public let why: SyncReason
+    public let why: OldSyncReason
     public var uid: String?
     public var deviceID: String?
 
     fileprivate let didLogin: Bool
 
-    public init(why: SyncReason, uid: String, deviceID: String?) {
+    public init(why: OldSyncReason, uid: String, deviceID: String?) {
         self.why = why
         self.uid = uid
         self.deviceID = deviceID

--- a/Sync/Synchronizers/ClientsSynchronizer.swift
+++ b/Sync/Synchronizers/ClientsSynchronizer.swift
@@ -108,7 +108,7 @@ open class ClientsSynchronizer: TimestampedSingleCollectionSynchronizer, Synchro
     public required init(scratchpad: Scratchpad,
                          delegate: SyncDelegate,
                          basePrefs: Prefs,
-                         why: SyncReason,
+                         why: OldSyncReason,
                          logger: Logger = DefaultLogger.shared) {
         self.logger = logger
         super.init(scratchpad: scratchpad, delegate: delegate, basePrefs: basePrefs, why: why, collection: "clients")
@@ -403,7 +403,7 @@ open class ClientsSynchronizer: TimestampedSingleCollectionSynchronizer, Synchro
         }
     }
 
-    open func synchronizeLocalClients(_ localClients: RemoteClientsAndTabs, withServer storageClient: Sync15StorageClient, info: InfoCollections) -> SyncResult {
+    open func synchronizeLocalClients(_ localClients: RemoteClientsAndTabs, withServer storageClient: Sync15StorageClient, info: InfoCollections) -> OldSyncResult {
         logger.log("Synchronizing clients.",
                    level: .debug,
                    category: .sync)

--- a/Sync/Synchronizers/Synchronizer.swift
+++ b/Sync/Synchronizers/Synchronizer.swift
@@ -57,7 +57,7 @@ public protocol Synchronizer {
     init(scratchpad: Scratchpad,
          delegate: SyncDelegate,
          basePrefs: Prefs,
-         why: SyncReason,
+         why: OldSyncReason,
          logger: Logger)
 
     /**
@@ -94,7 +94,7 @@ public enum SyncStatus {
 }
 
 public typealias DeferredTimestamp = Deferred<Maybe<Timestamp>>
-public typealias SyncResult = Deferred<Maybe<SyncStatus>>
+public typealias OldSyncResult = Deferred<Maybe<SyncStatus>>
 public typealias EngineIdentifier = String
 public typealias EngineStatus = (EngineIdentifier, SyncStatus)
 public typealias EngineResults = [EngineStatus]
@@ -175,7 +175,7 @@ open class BaseCollectionSynchronizer {
     let delegate: SyncDelegate
     let basePrefs: Prefs
     let prefs: Prefs
-    let why: SyncReason
+    let why: OldSyncReason
 
     var statsSession: SyncEngineStatsSession
 
@@ -187,7 +187,7 @@ open class BaseCollectionSynchronizer {
     init(scratchpad: Scratchpad,
          delegate: SyncDelegate,
          basePrefs: Prefs,
-         why: SyncReason,
+         why: OldSyncReason,
          collection: String,
          logger: Logger = DefaultLogger.shared) {
         self.scratchpad = scratchpad

--- a/Tests/ClientTests/GleanTelemetryTests.swift
+++ b/Tests/ClientTests/GleanTelemetryTests.swift
@@ -50,7 +50,7 @@ class GleanTelemetryTests: XCTestCase {
         }
 
         _ = syncManager.syncNamedCollections(
-            why: SyncReason.didLogin,
+            why: OldSyncReason.didLogin,
             names: ["tabs", "logins", "bookmarks", "history", "clients"]
         )
 

--- a/Tests/ClientTests/Mocks/MockProfile.swift
+++ b/Tests/ClientTests/Mocks/MockProfile.swift
@@ -10,7 +10,9 @@ import Storage
 import Sync
 import XCTest
 
-open class MockSyncManager: SyncManager {
+public typealias ClientSyncManager = Client.SyncManager
+
+open class MockSyncManager: ClientSyncManager {
     open var isSyncing = false
     open var lastSyncFinishTime: Timestamp?
     open var syncDisplayState: SyncDisplayState?
@@ -19,15 +21,15 @@ open class MockSyncManager: SyncManager {
         return deferMaybe(SyncStatus.completed(SyncEngineStatsSession(collection: collection)))
     }
 
-    open func syncClients() -> SyncResult { return completedWithStats(collection: "mock_clients") }
-    open func syncClientsThenTabs() -> SyncResult { return completedWithStats(collection: "mock_clientsandtabs") }
-    open func syncHistory() -> SyncResult { return completedWithStats(collection: "mock_history") }
-    open func syncEverything(why: SyncReason) -> Success {
+    open func syncClients() -> OldSyncResult { return completedWithStats(collection: "mock_clients") }
+    open func syncClientsThenTabs() -> OldSyncResult { return completedWithStats(collection: "mock_clientsandtabs") }
+    open func syncHistory() -> OldSyncResult { return completedWithStats(collection: "mock_history") }
+    open func syncEverything(why: OldSyncReason) -> Success {
         return succeed()
     }
 
     var syncNamedCollectionsCalled = 0
-    open func syncNamedCollections(why: SyncReason, names: [String]) -> Success {
+    open func syncNamedCollections(why: OldSyncReason, names: [String]) -> Success {
         syncNamedCollectionsCalled += 1
         return succeed()
     }
@@ -79,7 +81,7 @@ open class MockProfile: Client.Profile {
     public var tabs: RustRemoteTabs
     public var files: FileAccessor
     public var logins: RustLogins
-    public var syncManager: SyncManager!
+    public var syncManager: ClientSyncManager!
 
     fileprivate var legacyPlaces: PinnedSites
 


### PR DESCRIPTION
https://github.com/mozilla-mobile/firefox-ios/issues/13278
Creating aliases for `SyncResult`, `SyncReason`, and `SyncManager` types to avoid the conflicts that will arise with the rust sync manager integration.

Normally we would handle these naming collisions in A-S, but since the old types used by `BrowserSyncManager` will eventually be replaced, meaning these aliases are only temporary, we're addressing them here. We also want to avoid blocking the build pipeline, which would happen if we included these changes with the integration logic and a hot fix of A-S was needed after the rust sync manager API was exposed to iOS.
