### PR TITLE
Bugfix 1817937 [v112] Move taskcluster CI from aws to gcp

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -136,7 +136,7 @@ tasks:
                                 name: "Decision Task for cron job ${cron.job_name}"
                                 description: 'Created by a [cron task](https://firefox-ci-tc.services.mozilla.com/tasks/${cron.task_id})'
                 provisionerId: "mobile-${level}"
-                workerType: "decision"
+                workerType: "decision-gcp"
                 tags:
                     $if: 'tasks_for in ["github-push", "github-pull-request"]'
                     then:

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -23,12 +23,12 @@ workers:
             provisioner: 'mobile-{level}'
             implementation: docker-worker
             os: linux
-            worker-type: 'images'
+            worker-type: 'images-gcp'
         misc:
             provisioner: 'mobile-{level}'
             implementation: docker-worker
             os: linux
-            worker-type: 'b-linux'
+            worker-type: 'b-linux-gcp'
 
 scriptworker:
     scope-prefix: mobile:firefox-ios:releng


### PR DESCRIPTION
[1817937](https://bugzilla.mozilla.org/show_bug.cgi?id=1817937)
Only the bitrise worker type remains on aws.