### PR TITLE
Add FXIOS- 5733 [v112] Toggle tint color in CC empty view

### DIFF
--- a/Client/Frontend/Autofill/CreditCard/ViewComponents/CreditCardAutofillToggle.swift
+++ b/Client/Frontend/Autofill/CreditCard/ViewComponents/CreditCardAutofillToggle.swift
@@ -34,11 +34,20 @@ struct CreditCardAutofillToggle: View {
                 .padding(.leading, 16)
                 .hidden()
             HStack {
-                Toggle(String.CreditCard.EditCard.ToggleToAllowAutofillTitle, isOn: $model.isEnabled)
-                    .font(.body)
-                    .foregroundColor(textColor)
-                    .padding(.leading, 16)
-                    .padding(.trailing, 16)
+                if #available(iOS 14.0, *) {
+                    Toggle(String.CreditCard.EditCard.ToggleToAllowAutofillTitle, isOn: $model.isEnabled)
+                        .font(.body)
+                        .foregroundColor(textColor)
+                        .padding(.leading, 16)
+                        .padding(.trailing, 16)
+                        .toggleStyle(SwitchToggleStyle(tint: .blue))
+                } else {
+                    Toggle(String.CreditCard.EditCard.ToggleToAllowAutofillTitle, isOn: $model.isEnabled)
+                        .font(.body)
+                        .foregroundColor(textColor)
+                        .padding(.leading, 16)
+                        .padding(.trailing, 16)
+                }
             }
             Divider()
                 .frame(height: 0.7)


### PR DESCRIPTION
# [FXIOS-5733](https://mozilla-hub.atlassian.net/browse/FXIOS-5733)


TLDR: The toggle tint color for the CC empty view now has a blue tint for iOS14 onwards. iOS13 will continue with a green tint (assuming this is okay given the discussion in planning).

