### PR TITLE
Refactor FXIOS-5825 [v112] Rename BrowserKit.String.remove(_)

### DIFF
--- a/BrowserKit/Sources/Common/Extensions/StringExtension.swift
+++ b/BrowserKit/Sources/Common/Extensions/StringExtension.swift
@@ -4,8 +4,10 @@
 
 import Foundation
 
-extension String {
-    public func remove(_ string: String?) -> String {
-        return replacingOccurrences(of: string ?? "", with: "")
+extension StringProtocol {
+    /// Returns a new string in which all occurrences of a target
+    /// string within the receiver are removed.
+    public func removingOccurrences<Target>(of target: Target) -> String where Target: StringProtocol {
+        return replacingOccurrences(of: target, with: "")
     }
 }

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/BundleImageFetcher/BundleDomainBuilder.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/BundleImageFetcher/BundleDomainBuilder.swift
@@ -12,7 +12,7 @@ import Foundation
 struct BundleDomainBuilder {
     func buildDomains(for siteURL: URL) -> [String] {
         let shortURL = siteURL.shortDisplayString
-        let absoluteURL = siteURL.absoluteDisplayString.remove("\(siteURL.scheme ?? "")://")
+        let absoluteURL = siteURL.absoluteDisplayString.removingOccurrences(of: "\(siteURL.scheme ?? "")://")
         var domains = [shortURL, absoluteURL]
 
         if let baseDomain = siteURL.baseDomain {

--- a/Client/Frontend/Home/Wallpapers/v1/Models/Wallpaper.swift
+++ b/Client/Frontend/Home/Wallpapers/v1/Models/Wallpaper.swift
@@ -151,7 +151,7 @@ extension Wallpaper: Encodable {
 
     private func dropOctothorpeIfAvailable(from string: String) -> String {
         if string.hasPrefix("#") {
-            return string.remove("#")
+            return string.removingOccurrences(of: "#")
         }
 
         return string


### PR DESCRIPTION
Fixes https://github.com/mozilla-mobile/firefox-ios/issues/13317

Refactors `BrowserKit.String.remove(_ string: String)` to better follow swift and StdLib naming conventions. 
Also took the opportunity to make it usable from and with any StringProtocol conformer.
