### PR TITLE
Remove FXIOS-5212 [v112] Session restore url check in sponsored content filter

### DIFF
--- a/Client/Utils/SponsoredContentFilterUtility.swift
+++ b/Client/Utils/SponsoredContentFilterUtility.swift
@@ -24,12 +24,7 @@ struct SponsoredContentFilterUtility {
 
     func filterSponsoredHighlights(from items: [HistoryHighlight]) -> [HistoryHighlight] {
         return items.filter {
-            // As part of bug FXIOS-5113, session restore URLs have been saved in metadata for a while
-            // This means that to abstain already recorded restore session URLs to appear in recently visited we
-            // need to manually filter them out for now. In a couple of release (greater than v110) this can be removed
-            // with task FXIOS-5212
-            let sessionRestoreURL = "\(InternalURL.baseUrl)/\(SessionRestoreHandler.path)"
-            return !$0.url.contains(hideWithSearchParam) && !$0.url.contains(sessionRestoreURL)
+            return !$0.url.contains(hideWithSearchParam)
         }
     }
 }

--- a/Tests/ClientTests/Utils/SponsoredContentFilterUtilityTests.swift
+++ b/Tests/ClientTests/Utils/SponsoredContentFilterUtilityTests.swift
@@ -121,16 +121,6 @@ class SponsoredContentFilterUtilityTests: XCTestCase {
         let result = subject.filterSponsoredHighlights(from: highlights)
         XCTAssertEqual(result.count, 3, "All sponsored highlights were removed")
     }
-
-    func testSponsoredHighlightsFilterSessionRestoreURLs () {
-        let subject = SponsoredContentFilterUtility()
-        let highlights = createHistoryHighlight(normalHighlightsCount: 3,
-                                                sponsoredHighlightsCount: 2,
-                                                sponsoredUrl: sessionRestoreURL)
-        XCTAssertEqual(highlights.count, 5)
-        let result = subject.filterSponsoredHighlights(from: highlights)
-        XCTAssertEqual(result.count, 3, "All sponsored highlights were removed")
-    }
 }
 
 // MARK: - Helpers


### PR DESCRIPTION
## [FXIOS-5212](https://mozilla-hub.atlassian.net/browse/FXIOS-5212) https://github.com/mozilla-mobile/firefox-ios/issues/12319
This `SponsoredContentFilterUtility` code can now be removed since it has been 4 versions we're having that patch. The real fix implemented in https://github.com/mozilla-mobile/firefox-ios/pull/12320 in `TabMetadataManager` is now enough.