### PR TITLE
Add FXIOS-5790 [v112] appservices component calls

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -1268,6 +1268,7 @@
 		F8708D2E1A0970B70051AB07 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F8708D251A0970990051AB07 /* Images.xcassets */; };
 		F8708D321A0970B70051AB07 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8708D291A0970990051AB07 /* ShareViewController.swift */; };
 		F886218C270CD3B8007F4562 /* DevicePasscodeRequiredViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F886218B270CD3B8007F4562 /* DevicePasscodeRequiredViewController.swift */; };
+		F886BFBD29AD56A400F77224 /* RustSyncManagerAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = F886BFBC29AD56A400F77224 /* RustSyncManagerAPI.swift */; };
 		F8AAC1B429663619000BCDEC /* RustAutofill.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AAC1B329663618000BCDEC /* RustAutofill.swift */; };
 		F8AAC1B7296637CE000BCDEC /* RustAutofillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AAC1B5296637B7000BCDEC /* RustAutofillTests.swift */; };
 		FA6B2AC21D41F02D00429414 /* String+Punycode.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6B2AC11D41F02D00429414 /* String+Punycode.swift */; };
@@ -5203,6 +5204,7 @@
 		F8708D261A0970990051AB07 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F8708D291A0970990051AB07 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
 		F886218B270CD3B8007F4562 /* DevicePasscodeRequiredViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevicePasscodeRequiredViewController.swift; sourceTree = "<group>"; };
+		F886BFBC29AD56A400F77224 /* RustSyncManagerAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RustSyncManagerAPI.swift; sourceTree = "<group>"; };
 		F8984594958004CB86902EE3 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		F8AAC1B329663618000BCDEC /* RustAutofill.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RustAutofill.swift; sourceTree = "<group>"; };
 		F8AAC1B5296637B7000BCDEC /* RustAutofillTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RustAutofillTests.swift; sourceTree = "<group>"; };
@@ -5722,6 +5724,7 @@
 		28CE83B91A1D1D3200576538 /* Sync */ = {
 			isa = PBXGroup;
 			children = (
+				F886BFBC29AD56A400F77224 /* RustSyncManagerAPI.swift */,
 				2894C1641AE89DBC00F1F92F /* Synchronizers */,
 				282731601ABC9BE600AA1954 /* Supporting Files */,
 				28926B3D1AC0F1A6009C0B1D /* Meta */,
@@ -9777,6 +9780,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				28926B3A1AC0F128009C0B1D /* CleartextPayloadJSON.swift in Sources */,
+				F886BFBD29AD56A400F77224 /* RustSyncManagerAPI.swift in Sources */,
 				2827319D1ABC9C2F00AA1954 /* SyncMeta.swift in Sources */,
 				D0BE845520E1660F006A1282 /* Keys.swift in Sources */,
 				282731991ABC9C2F00AA1954 /* ClientPayload.swift in Sources */,

--- a/Storage/Rust/RustLogins.swift
+++ b/Storage/Rust/RustLogins.swift
@@ -850,6 +850,12 @@ public class RustLogins {
         return deferred
     }
 
+    public func registerWithSyncManager() {
+        queue.async { [unowned self] in
+            self.storage?.registerWithSyncManager()
+        }
+    }
+
     private func migrateSQLCipherDBIfNeeded(key: String) {
         let keychain = MZKeychainWrapper.sharedClientAppContainerKeychain
         let rustKeys: RustLoginEncryptionKeys = RustLoginEncryptionKeys()

--- a/Storage/Rust/RustPlaces.swift
+++ b/Storage/Rust/RustPlaces.swift
@@ -353,6 +353,12 @@ public class RustPlaces: BookmarksHandler, HistoryMetadataObserver {
         return deferred
     }
 
+    public func registerWithSyncManager() {
+        writerQueue.async { [unowned self] in
+            self.api?.registerWithSyncManager()
+        }
+    }
+
     public func resetBookmarksMetadata() -> Success {
         let deferred = Success()
 

--- a/Storage/Rust/RustRemoteTabs.swift
+++ b/Storage/Rust/RustRemoteTabs.swift
@@ -157,6 +157,43 @@ public class RustRemoteTabs {
 
         return deferred
     }
+
+    public func getClient(fxaDeviceId: String) -> Deferred<Maybe<RemoteClient?>> {
+        return self.getAll().bind { result in
+            guard result.failureValue == nil else {
+                return deferMaybe(result.failureValue as! String)
+            }
+
+            guard let records = result.successValue else {
+                return deferMaybe(nil)
+            }
+
+            let client = records.first(where: { $0.clientId == fxaDeviceId })?.toRemoteClient()
+            return deferMaybe(client)
+        }
+    }
+
+    public func getClientGUIDs(completion: @escaping (Set<GUID>?, Error?) -> Void) {
+        self.getAll().upon { result in
+            guard result.failureValue == nil else {
+                completion(nil, result.failureValue as! String)
+                return
+            }
+            guard let records = result.successValue else {
+                completion(Set<GUID>(), nil)
+                return
+            }
+
+            let guids = records.map({ $0.clientId })
+            completion(Set(guids), nil)
+        }
+    }
+
+    public func registerWithSyncManager() {
+        queue.async { [unowned self] in
+           self.storage?.registerWithSyncManager()
+        }
+    }
 }
 
 public extension RemoteTabRecord {
@@ -172,5 +209,25 @@ public extension RemoteTabRecord {
 public extension ClientRemoteTabs {
     func toClientAndTabs(client: RemoteClient) -> ClientAndTabs {
         return ClientAndTabs(client: client, tabs: self.remoteTabs.map { $0.toRemoteTab(client: client)}.compactMap { $0 })
+    }
+
+    func toClientAndTabs() -> ClientAndTabs {
+        let client = self.toRemoteClient()
+        let tabs = self.remoteTabs.map { $0.toRemoteTab(client: client)}.compactMap { $0 }
+
+        let clientAndTabs = ClientAndTabs(client: client, tabs: tabs)
+        return clientAndTabs
+    }
+
+    func toRemoteClient() -> RemoteClient {
+        let remoteClient = RemoteClient(guid: self.clientId,
+                            name: self.clientName,
+                            modified: UInt64(self.lastModified),
+                            type: "\(self.deviceType)",
+                            formfactor: nil,
+                            os: nil,
+                            version: nil,
+                            fxaDeviceId: self.clientId)
+        return remoteClient
     }
 }

--- a/Sync/RustSyncManagerAPI.swift
+++ b/Sync/RustSyncManagerAPI.swift
@@ -1,0 +1,79 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Logger
+import Shared
+@_exported import MozillaAppServices
+
+open class RustSyncManagerAPI {
+    private let logger: Logger
+    let api: SyncManager
+
+    public init(logger: Logger = DefaultLogger.shared) {
+        self.api = SyncManager()
+        self.logger = logger
+    }
+
+    public func disconnect() {
+        DispatchQueue.global(qos: .background).async { [unowned self] in
+            self.api.disconnect()
+        }
+    }
+
+    public func sync(params: SyncParams,
+                     completion: @escaping (MozillaAppServices.SyncResult) -> Void) {
+        DispatchQueue.global(qos: .background).async { [unowned self] in
+            do {
+                let result = try self.api.sync(params: params)
+                completion(result)
+            } catch let err as NSError {
+                if let syncError = err as? SyncManagerError {
+                    let syncErrDescription = syncError.localizedDescription
+                    self.logger.log("Rust SyncManager sync error: \(syncErrDescription)",
+                                                        level: .warning,
+                                                        category: .sync)
+                } else {
+                    let errDescription = err.localizedDescription
+                    self.logger.log("""
+                        Unknown error when attempting a rust SyncManager sync:
+                        \(errDescription)
+                        """,
+                        level: .warning,
+                        category: .sync)
+                }
+            }
+        }
+    }
+
+    public func getAvailableEngines(completion: @escaping ([String]) -> Void) {
+        DispatchQueue.global(qos: .background).async { [unowned self] in
+            let engines = self.api.getAvailableEngines()
+            completion(engines)
+        }
+    }
+}
+
+public func toRustSyncReason(reason: Sync.SyncReason) -> MozillaAppServices.SyncReason {
+    switch reason {
+    case .startup:
+        return MozillaAppServices.SyncReason.startup
+    case .scheduled:
+        return MozillaAppServices.SyncReason.scheduled
+    case .backgrounded:
+        return MozillaAppServices.SyncReason.backgrounded
+    case .push, .user, .syncNow:
+        return MozillaAppServices.SyncReason.user
+    case .didLogin, .clientNameChanged, .engineEnabled:
+        return MozillaAppServices.SyncReason.enabledChange
+    }
+}
+
+// Names of collections that can be enabled/disabled locally.
+public let RustTogglableEngines: [String] = [
+    "bookmarks",
+    "history",
+    "tabs",
+    "passwords"
+]

--- a/Sync/SyncTelemetryUtils.swift
+++ b/Sync/SyncTelemetryUtils.swift
@@ -468,6 +468,83 @@ public class GleanSyncOperationHelper {
         GleanMetrics.Pings.shared.tempSync.submit()
     }
 
+    public func reportTelemetry(_ result: MozillaAppServices.SyncResult) {
+        guard let json = result.telemetryJson,
+              let telemetry = try? RustSyncTelemetryPing.fromJSONString(
+                jsonObjectText: json
+              ) else {
+            return
+        }
+
+        for sync in telemetry.syncs {
+            _ = GleanMetrics.Sync.syncUuid.generateAndSet()
+
+            if let failureReason = sync.failureReason {
+                GleanMetrics.Sync.failureReason[String(describing: failureReason)].add()
+            }
+
+            for engine in sync.engines {
+                if engine.failureReason == nil {
+                    self.recordRustSyncEngineStats(engine.name,
+                                                   incoming: engine.incoming,
+                                                   outgoing: engine.outgoing)
+                } else {
+                    self.recordSyncEngineFailure(
+                        engine.name,
+                        String(describing: engine.failureReason))
+                }
+
+                self.submitSyncEnginePing(engine.name)
+            }
+
+            GleanMetrics.Pings.shared.tempSync.submit()
+        }
+    }
+
+    public func convertSyncFailureReason(reason: FailureReason) -> String {
+        // The metrics.yaml for the temp sync metrics specifies the failure reasons
+        // (`httperror`, `unexpectederror`, `sqlerror`, and `othererror`) associated with
+        // the old sync manager. To prevent the rust sync manager failure reasons from
+        // being omitted, we map them to the old values. This is a stopgap measure as work
+        // has already begun to replace the sync temp metrics entirely.
+
+        switch reason.name {
+        case .http:
+            return "httperror"
+        case .other, .shutdown, .auth, .unknown:
+            return "othererror"
+        case .unexpected:
+            return "unexpectederror"
+        }
+    }
+
+    public func convertEngineFailureReason(reason: FailureReason) -> String {
+        // The metrics.yaml for the temp sync metrics specifies the failure reasons
+        // (`httperror`, `unexpectederror`, `sqlerror`, and `othererror`) associated with
+        // the old sync manager. They include the following reasons:
+        //    - no_account
+        //    - offline
+        //    - backoff
+        //    - remotely_not_enabled
+        //    - format_outdated
+        //    - format_too_new
+        //    - storage_format_outdated
+        //    - storage_format_too_new
+        //    - state_machine_not_ready
+        //    - red_light
+        //    - unknown
+        // To prevent the rust sync manager failure reasons from being omitted, we map
+        // them to the old values. This is a stopgap measure as work has already begun to
+        // replace the sync temp metrics entirely.
+
+        switch reason.name {
+        case .auth:
+            return "no_account"
+        case .unknown, .shutdown, .other, .unexpected, .http:
+            return "unknown"
+        }
+    }
+
     private func recordSyncEngineStats(_ engineName: String, _ stats: SyncEngineStatsSession) {
         // Create maps on labels to stat value,
         // keeping only the values that are above zero.
@@ -505,6 +582,45 @@ public class GleanSyncOperationHelper {
         }
     }
 
+    private func recordRustSyncEngineStats(_ engineName: String,
+                                           incoming: IncomingInfo?,
+                                           outgoing: [OutgoingInfo]) {
+        let incomingLabelsToValue = [
+            ("applied", incoming?.applied ?? 0),
+            ("reconciled", incoming?.reconciled ?? 0),
+            ("failed_to_apply", incoming?.failed ?? 0)
+        ].filter { (_, stat) in stat > 0 }
+
+        let outgoingLabelsToValue = [
+            ("uploaded", outgoing.reduce(0, { totalUploaded, rec in
+                totalUploaded + rec.sent
+            })),
+            ("failed_to_upload", outgoing.reduce(0, { totalFailed, rec in
+                totalFailed + rec.failed
+            }))
+        ].filter { (_, stat) in stat > 0 }
+
+        switch engineName {
+        case "tabs":
+            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.RustTabsSync.incoming[l].add(Int32(v))}
+            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.RustTabsSync.outgoing[l].add(Int32(v)) }
+        case "bookmarks":
+            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.BookmarksSync.incoming[l].add(Int32(v))}
+            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.BookmarksSync.outgoing[l].add(Int32(v)) }
+        case "history":
+            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.HistorySync.incoming[l].add(Int32(v))}
+            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.HistorySync.outgoing[l].add(Int32(v)) }
+        case "passwords":
+            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.LoginsSync.incoming[l].add(Int32(v))}
+            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.LoginsSync.outgoing[l].add(Int32(v)) }
+        case "clients":
+            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.ClientsSync.incoming[l].add(Int32(v))}
+            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.ClientsSync.outgoing[l].add(Int32(v)) }
+        default:
+            break
+        }
+    }
+
     private func recordSyncEngineFailure(_ engineName: String, _ reason: String) {
         let correctedReson = String(reason.dropFirst("sync.not_started.reason.".count))
 
@@ -512,7 +628,7 @@ public class GleanSyncOperationHelper {
         case "tabs": GleanMetrics.RustTabsSync.failureReason[correctedReson].add()
         case "bookmarks": GleanMetrics.BookmarksSync.failureReason[correctedReson].add()
         case "history": GleanMetrics.HistorySync.failureReason[correctedReson].add()
-        case "logins": GleanMetrics.LoginsSync.failureReason[correctedReson].add()
+        case "logins", "passwords": GleanMetrics.LoginsSync.failureReason[correctedReson].add()
         case "clients": GleanMetrics.ClientsSync.failureReason[correctedReson].add()
         default:
             break
@@ -524,7 +640,7 @@ public class GleanSyncOperationHelper {
         case "tabs": GleanMetrics.Pings.shared.tempRustTabsSync.submit()
         case "bookmarks": GleanMetrics.Pings.shared.tempBookmarksSync.submit()
         case "history": GleanMetrics.Pings.shared.tempHistorySync.submit()
-        case "logins": GleanMetrics.Pings.shared.tempLoginsSync.submit()
+        case "logins", "passwords": GleanMetrics.Pings.shared.tempLoginsSync.submit()
         case "clients": GleanMetrics.Pings.shared.tempClientsSync.submit()
         default:
             break


### PR DESCRIPTION
This is the second task in #13278 which is adding additional function call for the sync manager integration work. This includes the `registerWithSyncManager` API function of each component, the sync manager component's API, and the functions required to report the telemetry returned by sync manager's `sync` function.

**NOTE:** This PR depends on functions exposed in [A-S PR #5359](https://github.com/mozilla/application-services/pull/5359) and should not be merged until that PR has been merged and released.