### PR TITLE
Add FXIOS-5544 [v112] CC deletion support in edit view

### DIFF
--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardEditView.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardEditView.swift
@@ -69,7 +69,7 @@ struct CreditCardEditView_Previews: PreviewProvider {
                                           timeLastUsed: nil,
                                           timeLastModified: 1234,
                                           timesUsed: 1234)
-        
+
         let viewModel = CreditCardEditViewModel(firstName: "Mike",
                                                 lastName: "Simmons",
                                                 errorState: "Temp",

--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardEditView.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardEditView.swift
@@ -59,17 +59,17 @@ struct CreditCardEditView: View {
 struct CreditCardEditView_Previews: PreviewProvider {
     static var previews: some View {
         let sampleCreditCard = CreditCard(guid: "12345678",
-                                    ccName: "Tim Apple",
-                                    ccNumberEnc: "12345678",
-                                    ccNumberLast4: "4321",
-                                    ccExpMonth: 1234,
-                                    ccExpYear: 2026,
-                                    ccType: "Discover",
-                                    timeCreated: 1234,
-                                    timeLastUsed: nil,
-                                    timeLastModified: 1234,
-                                    timesUsed: 1234)
-
+                                          ccName: "Tim Apple",
+                                          ccNumberEnc: "12345678",
+                                          ccNumberLast4: "4321",
+                                          ccExpMonth: 1234,
+                                          ccExpYear: 2026,
+                                          ccType: "Discover",
+                                          timeCreated: 1234,
+                                          timeLastUsed: nil,
+                                          timeLastModified: 1234,
+                                          timesUsed: 1234)
+        
         let viewModel = CreditCardEditViewModel(firstName: "Mike",
                                                 lastName: "Simmons",
                                                 errorState: "Temp",

--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardEditView.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardEditView.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import Storage
 import SwiftUI
 
 struct CreditCardEditView: View {
@@ -57,7 +58,24 @@ struct CreditCardEditView: View {
 
 struct CreditCardEditView_Previews: PreviewProvider {
     static var previews: some View {
-        let viewModel = CreditCardEditViewModel(firstName: "Mike", lastName: "Simmons", errorState: "Temp", enteredValue: "")
+        let sampleCreditCard = CreditCard(guid: "12345678",
+                                    ccName: "Tim Apple",
+                                    ccNumberEnc: "12345678",
+                                    ccNumberLast4: "4321",
+                                    ccExpMonth: 1234,
+                                    ccExpYear: 2026,
+                                    ccType: "Discover",
+                                    timeCreated: 1234,
+                                    timeLastUsed: nil,
+                                    timeLastModified: 1234,
+                                    timesUsed: 1234)
+
+        let viewModel = CreditCardEditViewModel(firstName: "Mike",
+                                                lastName: "Simmons",
+                                                errorState: "Temp",
+                                                enteredValue: "",
+                                                creditCard: sampleCreditCard)
+
         CreditCardEditView(viewModel: viewModel,
                            removeButtonColor: .gray,
                            borderColor: .gray)

--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardEditViewModel.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardEditViewModel.swift
@@ -5,10 +5,14 @@
 import Foundation
 import SwiftUI
 import Common
+import Storage
 
 class CreditCardEditViewModel: ObservableObject {
     typealias CreditCardText = String.CreditCard.Alert
+
     let profile: Profile
+    let autofill: RustAutofill
+    let creditCard: CreditCard?
 
     @Published var firstName: String = ""
     @Published var lastName: String = ""
@@ -42,7 +46,11 @@ class CreditCardEditViewModel: ObservableObject {
             return RemoveCardButton.AlertDetails(
                 alertTitle: Text(CreditCardText.RemoveCardTitle),
                 alertBody: Text(CreditCardText.RemoveCardSublabel),
-                primaryButtonStyleAndText: .destructive(Text(CreditCardText.RemovedCardLabel)),
+                primaryButtonStyleAndText: .destructive(Text(CreditCardText.RemovedCardLabel)) { [self] in
+                    guard let creditCard = creditCard else { return }
+
+                    removeSelectedCreditCard(creditCard: creditCard)
+                },
                 secondaryButtonStyleAndText: .cancel(),
                 primaryButtonAction: {},
                 secondaryButtonAction: {})
@@ -51,26 +59,46 @@ class CreditCardEditViewModel: ObservableObject {
         return RemoveCardButton.AlertDetails(
             alertTitle: Text(CreditCardText.RemoveCardTitle),
             alertBody: nil,
-            primaryButtonStyleAndText: .destructive(Text(CreditCardText.RemovedCardLabel)),
+            primaryButtonStyleAndText: .destructive(Text(CreditCardText.RemovedCardLabel)) { [self] in
+                guard let creditCard = creditCard else { return }
+
+                removeSelectedCreditCard(creditCard: creditCard)
+            },
             secondaryButtonStyleAndText: .cancel(),
             primaryButtonAction: {},
             secondaryButtonAction: {}
         )
     }
 
-    init(profile: Profile) {
+    init(profile: Profile,
+         creditCard: CreditCard? = nil
+    ) {
         self.profile = profile
+        self.autofill = profile.autofill
+        self.creditCard = creditCard
     }
 
     init(profile: Profile = AppContainer.shared.resolve(),
          firstName: String,
          lastName: String,
          errorState: String,
-         enteredValue: String) {
+         enteredValue: String,
+         creditCard: CreditCard? = nil
+    ) {
         self.profile = profile
         self.firstName = firstName
         self.lastName = lastName
         self.errorState = errorState
         self.enteredValue = enteredValue
+        self.autofill = profile.autofill
+        self.creditCard = creditCard
+    }
+
+    // MARK: - Private helpers
+
+    private func removeSelectedCreditCard(creditCard: CreditCard) {
+        autofill.deleteCreditCard(id: creditCard.guid) { _, error in
+            // no-op
+        }
     }
 }

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -80,6 +80,7 @@ class CommandStoringSyncDelegate: SyncDelegate {
  * A Profile manages access to the user's data.
  */
 protocol Profile: AnyObject {
+    var autofill: RustAutofill { get }
     var places: RustPlaces { get }
     var prefs: Prefs { get }
     var queue: TabQueue { get }


### PR DESCRIPTION
# [FXIOS-5544](https://mozilla-hub.atlassian.net/browse/FXIOS-5544)

TLDR:
Add support to delete CC upon confirming deletion in the CC edit view. 

This PR operates under the assumption that we we KNOW which `CreditCard` we're referring to in the deletion closure, since we clicked into the edit view of that particular card. 