### PR TITLE
Remove FXIOS-5788 [v112] Remove Explore more from wallpaper onboarding

### DIFF
--- a/Client/Application/AccessibilityIdentifiers.swift
+++ b/Client/Application/AccessibilityIdentifiers.swift
@@ -163,7 +163,6 @@ public struct AccessibilityIdentifiers {
             static let card = "wallpaperCard"
             static let title = "wallpaperOnboardingTitle"
             static let description = "wallpaperOnboardingDescription"
-            static let settingsButton = "wallpaperOnboardingSettingsButton"
         }
     }
 

--- a/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperSelectorViewController.swift
+++ b/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperSelectorViewController.swift
@@ -58,13 +58,13 @@ class WallpaperSelectorViewController: WallpaperBaseViewController, Themeable {
         return collectionView
     }()
 
-    private lazy var settingsButton: ResizableButton = .build { button in
-        button.titleLabel?.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
-                                                                                size: 16)
-        button.titleLabel?.textAlignment = .center
-        button.setTitle(.Onboarding.WallpaperSelectorAction, for: .normal)
-        button.accessibilityIdentifier = AccessibilityIdentifiers.Onboarding.Wallpaper.settingsButton
-    }
+//    private lazy var settingsButton: ResizableButton = .build { button in
+//        button.titleLabel?.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
+//                                                                                size: 16)
+//        button.titleLabel?.textAlignment = .center
+//        button.setTitle(.Onboarding.WallpaperSelectorAction, for: .normal)
+//        button.accessibilityIdentifier = AccessibilityIdentifiers.Onboarding.Wallpaper.settingsButton
+//    }
 
     // MARK: - Initializers
     init(viewModel: WallpaperSelectorViewModel,
@@ -86,7 +86,7 @@ class WallpaperSelectorViewController: WallpaperBaseViewController, Themeable {
         listenForThemeChange()
         setupView()
 
-        settingsButton.addTarget(self, action: #selector(self.settingsButtonTapped), for: .touchUpInside)
+//        settingsButton.addTarget(self, action: #selector(self.settingsButtonTapped), for: .touchUpInside)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -144,7 +144,7 @@ private extension WallpaperSelectorViewController {
     func setupView() {
         configureCollectionView()
 
-        contentView.addSubviews(headerLabel, instructionLabel, collectionView, settingsButton)
+        contentView.addSubviews(headerLabel, instructionLabel, collectionView)
         view.addSubview(contentView)
 
         collectionViewHeightConstraint = collectionView.heightAnchor.constraint(equalToConstant: 300)
@@ -166,13 +166,13 @@ private extension WallpaperSelectorViewController {
             instructionLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -34),
 
             collectionView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-            collectionView.bottomAnchor.constraint(equalTo: settingsButton.topAnchor, constant: -14),
+            collectionView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -43),
             collectionView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
             collectionViewHeightConstraint,
 
-            settingsButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 34),
-            settingsButton.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -43),
-            settingsButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -34),
+//            settingsButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 34),
+//            settingsButton.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -43),
+//            settingsButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -34),
         ])
     }
 

--- a/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperSelectorViewController.swift
+++ b/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperSelectorViewController.swift
@@ -58,14 +58,6 @@ class WallpaperSelectorViewController: WallpaperBaseViewController, Themeable {
         return collectionView
     }()
 
-//    private lazy var settingsButton: ResizableButton = .build { button in
-//        button.titleLabel?.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
-//                                                                                size: 16)
-//        button.titleLabel?.textAlignment = .center
-//        button.setTitle(.Onboarding.WallpaperSelectorAction, for: .normal)
-//        button.accessibilityIdentifier = AccessibilityIdentifiers.Onboarding.Wallpaper.settingsButton
-//    }
-
     // MARK: - Initializers
     init(viewModel: WallpaperSelectorViewModel,
          notificationCenter: NotificationProtocol = NotificationCenter.default,
@@ -85,8 +77,6 @@ class WallpaperSelectorViewController: WallpaperBaseViewController, Themeable {
         super.viewDidLoad()
         listenForThemeChange()
         setupView()
-
-//        settingsButton.addTarget(self, action: #selector(self.settingsButtonTapped), for: .touchUpInside)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -113,7 +103,6 @@ class WallpaperSelectorViewController: WallpaperBaseViewController, Themeable {
         contentView.backgroundColor = theme.colors.layer1
         headerLabel.textColor = theme.colors.textPrimary
         instructionLabel.textColor = theme.colors.textPrimary
-        settingsButton.setTitleColor(theme.colors.actionPrimary, for: .normal)
     }
 }
 
@@ -168,11 +157,7 @@ private extension WallpaperSelectorViewController {
             collectionView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             collectionView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -43),
             collectionView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            collectionViewHeightConstraint,
-
-//            settingsButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 34),
-//            settingsButton.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -43),
-//            settingsButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -34),
+            collectionViewHeightConstraint
         ])
     }
 
@@ -234,11 +219,6 @@ private extension WallpaperSelectorViewController {
                 }
             }
         }
-    }
-
-    /// Settings button tapped
-    @objc func settingsButtonTapped(_ sender: UIButton) {
-        viewModel.openSettingsAction()
     }
 }
 

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -686,11 +686,6 @@ extension String {
             tableName: nil,
             value: "Choose a wallpaper that speaks to you.",
             comment: "Description for the wallpaper onboarding modal displayed on top of the homepage. This describes to the user that they can choose different wallpapers.")
-        public static let WallpaperSelectorAction = MZLocalizedString(
-            "Onboarding.Wallpaper.Action.v106",
-            tableName: nil,
-            value: "Explore more wallpapers",
-            comment: "Description for the wallpaper onboarding modal displayed on top of the homepage. This describes to the user that they can set a wallpaper.")
         public static let ClassicWallpaper = MZLocalizedString(
             "Onboarding.Wallpaper.Accessibility.Classic.v106",
             tableName: nil,


### PR DESCRIPTION
Remove the "Explore more wallpapers" from WallpaperSelectorView

![Simulator Screen Shot - iPad Air (5th generation) - 2023-02-23 at 12 43 59](https://user-images.githubusercontent.com/16647663/220884867-6bcbe5d8-a0ca-451c-8acf-0a725723c04b.png)
