### PR TITLE
Bugfix FXIOS-5787 [v112] runJavaScriptAlertPanelWithMessage completion handler not called from SceneDelegate

### DIFF
--- a/Client/Frontend/Browser/BrowserPrompts.swift
+++ b/Client/Frontend/Browser/BrowserPrompts.swift
@@ -44,16 +44,6 @@ struct MessageAlert: JSAlertInfo {
     let completionHandler: () -> Void
     var shouldCallCompletion: Bool
 
-    init(message: String,
-         frame: WKFrameInfo,
-         completionHandler: @escaping () -> Void,
-         shouldCallCompletion: Bool) {
-        self.message = message
-        self.frame = frame
-        self.completionHandler = completionHandler
-        self.shouldCallCompletion = shouldCallCompletion
-    }
-
     func alertController() -> JSPromptAlertController {
         let alertController = JSPromptAlertController(
             title: titleForJavaScriptPanelInitiatedByFrame(frame),
@@ -76,16 +66,6 @@ struct ConfirmPanelAlert: JSAlertInfo {
     let frame: WKFrameInfo
     let completionHandler: (Bool) -> Void
     var shouldCallCompletion: Bool
-
-    init(message: String,
-         frame: WKFrameInfo,
-         completionHandler: @escaping (Bool) -> Void,
-         shouldCallCompletion: Bool) {
-        self.message = message
-        self.frame = frame
-        self.completionHandler = completionHandler
-        self.shouldCallCompletion = shouldCallCompletion
-    }
 
     func alertController() -> JSPromptAlertController {
         // Show JavaScript confirm dialogs.
@@ -118,20 +98,10 @@ struct TextInputAlert: JSAlertInfo {
 
     var input: UITextField!
 
-    init(message: String,
-         frame: WKFrameInfo,
-         completionHandler: @escaping (String?) -> Void,
-         defaultText: String?,
-         shouldCallCompletion: Bool) {
-        self.message = message
-        self.frame = frame
-        self.completionHandler = completionHandler
-        self.defaultText = defaultText
-        self.shouldCallCompletion = shouldCallCompletion
-    }
-
     func alertController() -> JSPromptAlertController {
-        let alertController = JSPromptAlertController(title: titleForJavaScriptPanelInitiatedByFrame(frame), message: message, preferredStyle: .alert)
+        let alertController = JSPromptAlertController(title: titleForJavaScriptPanelInitiatedByFrame(frame),
+                                                      message: message,
+                                                      preferredStyle: .alert)
         var input: UITextField!
         alertController.addTextField(configurationHandler: { (textField: UITextField) in
             input = textField

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -613,6 +613,8 @@ class BrowserViewController: UIViewController {
             make.top.left.right.equalTo(self.view)
             make.height.equalTo(self.view.safeAreaInsets.top)
         }
+
+        showQueuedAlertIfAvailable()
     }
 
     override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -58,15 +58,19 @@ extension BrowserViewController: WKUIDelegate {
         return ((tabManager.selectedTab == nil ? false : tabManager.selectedTab!.webView == webView)) && (self.presentedViewController == nil)
     }
 
-    func webView(_ webView: WKWebView, runJavaScriptAlertPanelWithMessage message: String, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping () -> Void) {
-        let messageAlert = MessageAlert(message: message, frame: frame, completionHandler: completionHandler)
-        if shouldDisplayJSAlertForWebView(webView) {
+    func webView(_ webView: WKWebView,
+                 runJavaScriptAlertPanelWithMessage message: String,
+                 initiatedByFrame frame: WKFrameInfo,
+                 completionHandler: @escaping () -> Void) {
+        let shouldShowAlert = shouldDisplayJSAlertForWebView(webView)
+        let messageAlert = MessageAlert(message: message,
+                                        frame: frame,
+                                        completionHandler: completionHandler,
+                                        shouldCallCompletion: shouldShowAlert)
+        if shouldShowAlert {
             present(messageAlert.alertController(), animated: true, completion: nil)
         } else if let promptingTab = tabManager[webView] {
             promptingTab.queueJavascriptAlertPrompt(messageAlert)
-        } else {
-            // This should never happen since an alert needs to come from a web view but just in case call the handler
-            // since not calling it will result in a runtime exception.
             completionHandler()
         }
     }
@@ -77,12 +81,15 @@ extension BrowserViewController: WKUIDelegate {
         initiatedByFrame frame: WKFrameInfo,
         completionHandler: @escaping (Bool) -> Void
     ) {
-        let confirmAlert = ConfirmPanelAlert(message: message, frame: frame, completionHandler: completionHandler)
+        let shouldShowAlert = shouldDisplayJSAlertForWebView(webView)
+        let confirmAlert = ConfirmPanelAlert(message: message,
+                                             frame: frame,
+                                             completionHandler: completionHandler,
+                                             shouldCallCompletion: shouldShowAlert)
         if shouldDisplayJSAlertForWebView(webView) {
             present(confirmAlert.alertController(), animated: true, completion: nil)
         } else if let promptingTab = tabManager[webView] {
             promptingTab.queueJavascriptAlertPrompt(confirmAlert)
-        } else {
             completionHandler(false)
         }
     }
@@ -94,12 +101,16 @@ extension BrowserViewController: WKUIDelegate {
         initiatedByFrame frame: WKFrameInfo,
         completionHandler: @escaping (String?) -> Void
     ) {
-        let textInputAlert = TextInputAlert(message: prompt, frame: frame, completionHandler: completionHandler, defaultText: defaultText)
+        let shouldShowAlert = shouldDisplayJSAlertForWebView(webView)
+        let textInputAlert = TextInputAlert(message: prompt,
+                                            frame: frame,
+                                            completionHandler: completionHandler,
+                                            defaultText: defaultText,
+                                            shouldCallCompletion: shouldShowAlert)
         if shouldDisplayJSAlertForWebView(webView) {
             present(textInputAlert.alertController(), animated: true, completion: nil)
         } else if let promptingTab = tabManager[webView] {
             promptingTab.queueJavascriptAlertPrompt(textInputAlert)
-        } else {
             completionHandler(nil)
         }
     }


### PR DESCRIPTION

### [FXIOS-5787](https://mozilla-hub.atlassian.net/browse/FXIOS-5787) | #13275 

If the alert is queued we should call the completion handler right away and avoid calling once the alert is shown and the user press on of the action because this causes another crash when the `completionHandler` is called more than once

To solve this two issues if the alert is presented right away the `completionHandler` is called on the alert actions, if the alert is queued we call the `completionHandler` in the delegate and we don't call in the alert actions