### PR TITLE
Refactor FXIOS-5834 [v111] Adjust Sentry options

### DIFF
--- a/BrowserKit/Sources/Common/Logger/CrashManager.swift
+++ b/BrowserKit/Sources/Common/Logger/CrashManager.swift
@@ -50,6 +50,11 @@ public class DefaultCrashManager: CrashManager {
     private var sentryWrapper: SentryWrapper
     private var isSimulator: Bool
 
+    // Only enable app hang tracking in Beta for now
+    private var shouldEnableAppHangTracking: Bool {
+        return appInfo.buildChannel == .beta
+    }
+
     public init(appInfo: BrowserKitInformation = BrowserKitInformation.shared,
                 sentryWrapper: SentryWrapper = DefaultSentry(),
                 isSimulator: Bool = DeviceInfo.isSimulator()) {
@@ -71,6 +76,8 @@ public class DefaultCrashManager: CrashManager {
             options.environment = self.environment.rawValue
             options.releaseName = self.releaseName
             options.enableFileIOTracing = false
+            options.enableNetworkTracking = false
+            options.enableAppHangTracking = self.shouldEnableAppHangTracking
             options.beforeBreadcrumb = { crumb in
                 if crumb.type == "http" || crumb.category == "http" {
                     return nil


### PR DESCRIPTION
## [FXIOS-5834](https://mozilla-hub.atlassian.net/browse/FXIOS-5834) https://github.com/mozilla-mobile/firefox-ios/issues/13343
Sentry behavior changed following 8.0.0 upgrade in v111.
- We need to turn off enableNetworkTracking and enableAppHangTracking
- We can keep enableAppHangTracking for Beta's thought for now