### PR TITLE
Bugfix FXIOS-5781 [v112] Match outer container color to textfield color

### DIFF
--- a/Client/Frontend/Settings/CustomSearchViewController.swift
+++ b/Client/Frontend/Settings/CustomSearchViewController.swift
@@ -252,7 +252,7 @@ class CustomSearchEngineTextView: Setting, UITextViewDelegate {
         }
         textField.autocorrectionType = .no
         textField.delegate = self
-        textField.backgroundColor = theme.colors.layer2
+        textField.backgroundColor = theme.colors.layer5
         textField.textColor = theme.colors.textPrimary
         cell.isUserInteractionEnabled = true
         cell.accessibilityTraits = UIAccessibilityTraits.none

--- a/Client/Frontend/Theme/LegacyThemeManager/ThemedWidgets.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/ThemedWidgets.swift
@@ -56,7 +56,7 @@ class ThemedTableViewCell: UITableViewCell, ThemeApplicable {
         // Take view model color if it exists, otherwise fallback to default colors
         textLabel?.textColor = viewModel?.textColor ?? theme.colors.textPrimary
         detailTextLabel?.textColor = viewModel?.detailTextColor ?? theme.colors.textSecondary
-        backgroundColor = viewModel?.backgroundColor ?? theme.colors.layer5
+        backgroundColor = viewModel?.backgroundColor ?? theme.colors.layer2
         tintColor = viewModel?.tintColor ?? theme.colors.actionPrimary
     }
 

--- a/Client/Frontend/Theme/LegacyThemeManager/ThemedWidgets.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/ThemedWidgets.swift
@@ -56,7 +56,7 @@ class ThemedTableViewCell: UITableViewCell, ThemeApplicable {
         // Take view model color if it exists, otherwise fallback to default colors
         textLabel?.textColor = viewModel?.textColor ?? theme.colors.textPrimary
         detailTextLabel?.textColor = viewModel?.detailTextColor ?? theme.colors.textSecondary
-        backgroundColor = viewModel?.backgroundColor ?? theme.colors.layer2
+        backgroundColor = viewModel?.backgroundColor ?? theme.colors.layer5
         tintColor = viewModel?.tintColor ?? theme.colors.actionPrimary
     }
 


### PR DESCRIPTION
Fixes [Issue#13264](https://github.com/mozilla-mobile/firefox-ios/issues/13264)

The textfields in the Add Search Engine page and their encompassing containers had different background colors. Both colors now match eliminating the extra frames seen in the original screenshot..

In case the method where my change occurs touches too many files, I do have another fix that changes the insets of the textfield and subclasses the UILabel for the placeholders adding padding to create the same result.