### PR TITLE
Bugfix FXIOS-5428 [v112] "Open in external app" prompt is incorrectly displayed

### DIFF
--- a/Client/Frontend/Widgets/SnackBar.swift
+++ b/Client/Frontend/Widgets/SnackBar.swift
@@ -68,6 +68,7 @@ class SnackButton: UIButton {
 class SnackBar: UIView {
     let snackbarClassIdentifier: String
     let backgroundView = UIVisualEffectView(effect: UIBlurEffect(style: .extraLight))
+    private let scrollView: UIScrollView = .build()
     private lazy var imageView: UIImageView = {
         let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFit
@@ -83,7 +84,6 @@ class SnackBar: UIView {
         let label = UILabel()
         label.font = DynamicFontHelper.defaultHelper.DefaultStandardFont
         label.lineBreakMode = .byWordWrapping
-        label.setContentCompressionResistancePriority(.required, for: .horizontal)
         label.numberOfLines = 0
         label.textColor = UIColor.Photon.Grey90 // If making themeable, change to UIColor.legacyTheme.tableView.rowText
         label.backgroundColor = UIColor.clear
@@ -102,6 +102,8 @@ class SnackBar: UIView {
         stack.distribution = .fill
         stack.axis = .horizontal
         stack.alignment = .center
+        stack.layoutMargins = UIEdgeInsets(top: 4, left: 0, bottom: 4, right: 0)
+        stack.isLayoutMarginsRelativeArrangement = true
         return stack
     }()
 
@@ -118,15 +120,24 @@ class SnackBar: UIView {
 
     fileprivate func setup() {
         addSubview(backgroundView)
+        addSubview(scrollView)
+
+        scrollView.addSubview(titleView)
+
         titleView.addArrangedSubview(imageView)
         titleView.addArrangedSubview(textLabel)
 
         let separator = UIView()
         separator.backgroundColor = UIColor.legacyTheme.snackbar.border
 
-        addSubview(titleView)
         addSubview(separator)
         addSubview(buttonsView)
+
+        scrollView.snp.makeConstraints { make in
+            make.top.leading.trailing.equalToSuperview()
+            make.bottom.equalTo(buttonsView.snp.top)
+            make.height.greaterThanOrEqualTo(UIConstants.SnackbarButtonHeight * 2)
+        }
 
         separator.snp.makeConstraints { make in
             make.leading.trailing.equalTo(self)
@@ -140,8 +151,8 @@ class SnackBar: UIView {
         }
 
         titleView.snp.makeConstraints { make in
-            make.top.equalTo(self).offset(UIConstants.DefaultPadding)
-            make.height.greaterThanOrEqualTo(UIConstants.SnackbarButtonHeight - 2 * UIConstants.DefaultPadding)
+            make.top.bottom.equalToSuperview()
+            make.height.greaterThanOrEqualTo(UIConstants.SnackbarButtonHeight * 2)
             make.centerX.equalTo(self).priority(500)
             make.width.lessThanOrEqualTo(self).inset(UIConstants.DefaultPadding * 2).priority(1000)
         }
@@ -171,7 +182,6 @@ class SnackBar: UIView {
         super.updateConstraints()
 
         buttonsView.snp.remakeConstraints { make in
-            make.top.equalTo(titleView.snp.bottom).offset(UIConstants.DefaultPadding)
             make.bottom.equalTo(self.snp.bottom)
             make.leading.trailing.equalTo(self)
             if !self.buttonsView.subviews.isEmpty {

--- a/Client/Frontend/Widgets/SnackBar.swift
+++ b/Client/Frontend/Widgets/SnackBar.swift
@@ -102,7 +102,7 @@ class SnackBar: UIView {
         stack.distribution = .fill
         stack.axis = .horizontal
         stack.alignment = .center
-        stack.layoutMargins = UIEdgeInsets(top: 4, left: 0, bottom: 4, right: 0)
+        stack.layoutMargins = UIEdgeInsets(top: 12, left: 0, bottom: 12, right: 0)
         stack.isLayoutMarginsRelativeArrangement = true
         return stack
     }()
@@ -133,12 +133,6 @@ class SnackBar: UIView {
         addSubview(separator)
         addSubview(buttonsView)
 
-        scrollView.snp.makeConstraints { make in
-            make.top.leading.trailing.equalToSuperview()
-            make.bottom.equalTo(buttonsView.snp.top)
-            make.height.greaterThanOrEqualTo(UIConstants.SnackbarButtonHeight * 2)
-        }
-
         separator.snp.makeConstraints { make in
             make.leading.trailing.equalTo(self)
             make.height.equalTo(SnackBarUX.BorderWidth)
@@ -152,7 +146,7 @@ class SnackBar: UIView {
 
         titleView.snp.makeConstraints { make in
             make.top.bottom.equalToSuperview()
-            make.height.greaterThanOrEqualTo(UIConstants.SnackbarButtonHeight * 2)
+            make.height.equalTo(scrollView).priority(250)
             make.centerX.equalTo(self).priority(500)
             make.width.lessThanOrEqualTo(self).inset(UIConstants.DefaultPadding * 2).priority(1000)
         }
@@ -176,6 +170,15 @@ class SnackBar: UIView {
      */
     func shouldPersist(_ tab: Tab) -> Bool {
         return true
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        scrollView.snp.remakeConstraints { make in
+            make.top.leading.trailing.equalToSuperview()
+            make.bottom.equalTo(buttonsView.snp.top)
+            make.height.lessThanOrEqualTo(UIScreen.main.bounds.height / 2)
+        }
     }
 
     override func updateConstraints() {

--- a/Client/Frontend/Widgets/SnackBar.swift
+++ b/Client/Frontend/Widgets/SnackBar.swift
@@ -172,6 +172,18 @@ class SnackBar: UIView {
         return true
     }
 
+    private func setupButtonViewLayout(constant: CGFloat = 0) {
+        buttonsView.snp.remakeConstraints { make in
+            make.bottom.equalTo(self.snp.bottom).inset(constant)
+            make.leading.trailing.equalTo(self)
+            if !self.buttonsView.subviews.isEmpty {
+                make.height.equalTo(UIConstants.SnackbarButtonHeight)
+            } else {
+                make.height.equalTo(0)
+            }
+        }
+    }
+
     override func layoutSubviews() {
         super.layoutSubviews()
         scrollView.snp.remakeConstraints { make in
@@ -183,16 +195,16 @@ class SnackBar: UIView {
 
     override func updateConstraints() {
         super.updateConstraints()
+        setupButtonViewLayout()
+    }
 
-        buttonsView.snp.remakeConstraints { make in
-            make.bottom.equalTo(self.snp.bottom)
-            make.leading.trailing.equalTo(self)
-            if !self.buttonsView.subviews.isEmpty {
-                make.height.equalTo(UIConstants.SnackbarButtonHeight)
-            } else {
-                make.height.equalTo(0)
-            }
-        }
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        if traitCollection.horizontalSizeClass == .compact
+            && UIDevice.current.userInterfaceIdiom == .pad {
+            setupButtonViewLayout(constant: UIConstants.ToolbarHeight)
+        } else { setupButtonViewLayout() }
     }
 
     var showing: Bool {


### PR DESCRIPTION
## [FXIOS-5428](https://mozilla-hub.atlassian.net/browse/FXIOS-5776?filter=11726) | https://github.com/mozilla-mobile/firefox-ios/issues/13259

### I think it's better to have a fixed view for the scrolling behavior. Otherwise, it would be a challenge to support various screen sizes and take into account different text lengths. Do you think this is a good approach @dnarcese?

## Video

https://user-images.githubusercontent.com/51127880/221608098-7cb0b73b-5f17-4960-a336-0de12980ccd4.mp4
