### PR TITLE
Refactor FXIOS-5843 [v113] Address assertions on main thread

### DIFF
--- a/Client/DispatchQueueHelper.swift
+++ b/Client/DispatchQueueHelper.swift
@@ -15,3 +15,13 @@ public func ensureMainThread(execute work: @escaping @convention(block) () -> Sw
         }
     }
 }
+
+public func ensureMainThread<T>(execute work: @escaping () -> T) {
+    if Thread.isMainThread {
+        _ = work()
+    } else {
+        DispatchQueue.main.async {
+            _ = work()
+        }
+    }
+}

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1559,20 +1559,20 @@ class BrowserViewController: UIViewController {
     }
 
     @objc func openSettings() {
-        assert(Thread.isMainThread, "Opening settings requires being invoked on the main thread")
+        ensureMainThread { [self] in
+            if let presentedViewController = self.presentedViewController {
+                presentedViewController.dismiss(animated: true, completion: nil)
+            }
 
-        if let presentedViewController = self.presentedViewController {
-            presentedViewController.dismiss(animated: true, completion: nil)
+            let settingsTableViewController = AppSettingsTableViewController(
+                with: profile,
+                and: tabManager,
+                delegate: self)
+
+            let controller = ThemedNavigationController(rootViewController: settingsTableViewController)
+            controller.presentingModalViewControllerDelegate = self
+            self.present(controller, animated: true, completion: nil)
         }
-
-        let settingsTableViewController = AppSettingsTableViewController(
-            with: profile,
-            and: tabManager,
-            delegate: self)
-
-        let controller = ThemedNavigationController(rootViewController: settingsTableViewController)
-        controller.presentingModalViewControllerDelegate = self
-        self.present(controller, animated: true, completion: nil)
     }
 
     fileprivate func postLocationChangeNotificationForTab(_ tab: Tab, navigation: WKNavigation?) {

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -382,17 +382,19 @@ class SearchViewController: SiteTableViewController,
     }
 
     private func getCachedTabs() {
-        assert(Thread.isMainThread)
         // Short circuit if the user is not logged in
         guard profile.hasSyncableAccount() else { return }
-        // Get cached tabs
-        self.profile.getCachedClientsAndTabs().uponQueue(.main) { result in
-            guard let clientAndTabs = result.successValue else { return }
-            self.remoteClientTabs.removeAll()
-            // Update UI with cached data.
-            clientAndTabs.forEach { value in
-                value.tabs.forEach { (tab) in
-                    self.remoteClientTabs.append(ClientTabsSearchWrapper(client: value.client, tab: tab))
+
+        ensureMainThread {
+            // Get cached tabs
+            self.profile.getCachedClientsAndTabs().uponQueue(.main) { result in
+                guard let clientAndTabs = result.successValue else { return }
+                self.remoteClientTabs.removeAll()
+                // Update UI with cached data.
+                clientAndTabs.forEach { value in
+                    value.tabs.forEach { (tab) in
+                        self.remoteClientTabs.append(ClientTabsSearchWrapper(client: value.client, tab: tab))
+                    }
                 }
             }
         }

--- a/Client/Frontend/Browser/TabManagement/SavedTab+ConfigureExtension.swift
+++ b/Client/Frontend/Browser/TabManagement/SavedTab+ConfigureExtension.swift
@@ -10,20 +10,22 @@ import Shared
 // This cannot be easily imported into extension targets, so we break it out here.
 extension SavedTab {
     convenience init?(tab: Tab, isSelected: Bool) {
-        assert(Thread.isMainThread)
         var sessionData = tab.sessionData
-        if sessionData == nil {
-            let currentItem: WKBackForwardListItem! = tab.webView?.backForwardList.currentItem
 
-            // Freshly created web views won't have any history entries at all.
-            // If we have no history, abort.
-            if currentItem != nil {
-                // The back & forward list keep track of the users history within the session
-                let backList = tab.webView?.backForwardList.backList ?? []
-                let forwardList = tab.webView?.backForwardList.forwardList ?? []
-                let urls = (backList + [currentItem] + forwardList).map { $0.url }
-                let currentPage = -forwardList.count
-                sessionData = SessionData(currentPage: currentPage, urls: urls, lastUsedTime: tab.lastExecutedTime ?? Date.now())
+        ensureMainThread {
+            if sessionData == nil {
+                let currentItem: WKBackForwardListItem! = tab.webView?.backForwardList.currentItem
+
+                // Freshly created web views won't have any history entries at all.
+                // If we have no history, abort.
+                if currentItem != nil {
+                    // The back & forward list keep track of the users history within the session
+                    let backList = tab.webView?.backForwardList.backList ?? []
+                    let forwardList = tab.webView?.backForwardList.forwardList ?? []
+                    let urls = (backList + [currentItem] + forwardList).map { $0.url }
+                    let currentPage = -forwardList.count
+                    sessionData = SessionData(currentPage: currentPage, urls: urls, lastUsedTime: tab.lastExecutedTime ?? Date.now())
+                }
             }
         }
 

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanel.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanel.swift
@@ -248,42 +248,42 @@ class RemoteTabsTableViewController: UITableViewController, Themeable {
     func refreshTabs(updateCache: Bool = false, completion: (() -> Void)? = nil) {
         guard let remoteTabsPanel = remoteTabsPanel else { return }
 
-        assert(Thread.isMainThread)
-
-        // Short circuit if the user is not logged in
-        guard profile.hasSyncableAccount() else {
-            self.endRefreshing()
-            self.tableViewDelegate = RemoteTabsErrorDataSource(remoteTabsPanel: remoteTabsPanel,
-                                                               error: .notLoggedIn,
-                                                               theme: themeManager.currentTheme)
-            return
-        }
-
-        // Get cached tabs.
-        profile.getCachedClientsAndTabs().uponQueue(.main) { [weak self] result in
-            guard let clientAndTabs = result.successValue else {
-                self?.endRefreshing()
-                self?.showFailedToSync()
+        ensureMainThread { [self] in
+            // Short circuit if the user is not logged in
+            guard profile.hasSyncableAccount() else {
+                endRefreshing()
+                tableViewDelegate = RemoteTabsErrorDataSource(remoteTabsPanel: remoteTabsPanel,
+                                                              error: .notLoggedIn,
+                                                              theme: themeManager.currentTheme)
                 return
             }
 
-            // Update UI with cached data.
-            self?.updateDelegateClientAndTabData(clientAndTabs)
+            // Get cached tabs.
+            profile.getCachedClientsAndTabs().uponQueue(.main) { [weak self] result in
+                guard let clientAndTabs = result.successValue else {
+                    self?.endRefreshing()
+                    self?.showFailedToSync()
+                    return
+                }
 
-            if updateCache {
-                // Fetch updated tabs.
-                self?.profile.getClientsAndTabs().uponQueue(.main) { result in
-                    if let clientAndTabs = result.successValue {
-                        // Update UI with updated tabs.
-                        self?.updateDelegateClientAndTabData(clientAndTabs)
+                // Update UI with cached data.
+                self?.updateDelegateClientAndTabData(clientAndTabs)
+
+                if updateCache {
+                    // Fetch updated tabs.
+                    self?.profile.getClientsAndTabs().uponQueue(.main) { result in
+                        if let clientAndTabs = result.successValue {
+                            // Update UI with updated tabs.
+                            self?.updateDelegateClientAndTabData(clientAndTabs)
+                        }
+
+                        self?.endRefreshing()
+                        completion?()
                     }
-
+                } else {
                     self?.endRefreshing()
                     completion?()
                 }
-            } else {
-                self?.endRefreshing()
-                completion?()
             }
         }
     }

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -192,25 +192,25 @@ class TopTabsViewController: UIViewController, Themeable {
     }
 
     func scrollToCurrentTab(_ animated: Bool = true, centerCell: Bool = false) {
-        assertIsMainThread("Only animate on the main thread")
-
         guard let currentTab = tabManager.selectedTab,
               let index = topTabDisplayManager.dataStore.index(of: currentTab),
               !collectionView.frame.isEmpty
         else { return }
 
-        if let frame = collectionView.layoutAttributesForItem(at: IndexPath(row: index, section: 0))?.frame {
-            if centerCell {
-                collectionView.scrollToItem(at: IndexPath(item: index, section: 0), at: .centeredHorizontally, animated: false)
-            } else {
-                // Padding is added to ensure the tab is completely visible (none of the tab is under the fader)
-                let padFrame = frame.insetBy(dx: -(TopTabsUX.TopTabsBackgroundShadowWidth+TopTabsUX.FaderPading), dy: 0)
-                if animated {
-                    UIView.animate(withDuration: TopTabsUX.AnimationSpeed, animations: {
-                        self.collectionView.scrollRectToVisible(padFrame, animated: true)
-                    })
+        ensureMainThread { [self] in
+            if let frame = collectionView.layoutAttributesForItem(at: IndexPath(row: index, section: 0))?.frame {
+                if centerCell {
+                    collectionView.scrollToItem(at: IndexPath(item: index, section: 0), at: .centeredHorizontally, animated: false)
                 } else {
-                    collectionView.scrollRectToVisible(padFrame, animated: false)
+                    // Padding is added to ensure the tab is completely visible (none of the tab is under the fader)
+                    let padFrame = frame.insetBy(dx: -(TopTabsUX.TopTabsBackgroundShadowWidth+TopTabsUX.FaderPading), dy: 0)
+                    if animated {
+                        UIView.animate(withDuration: TopTabsUX.AnimationSpeed, animations: {
+                            self.collectionView.scrollRectToVisible(padFrame, animated: true)
+                        })
+                    } else {
+                        collectionView.scrollRectToVisible(padFrame, animated: false)
+                    }
                 }
             }
         }

--- a/Client/Frontend/LoginManagement/LoginListViewModel.swift
+++ b/Client/Frontend/LoginManagement/LoginListViewModel.swift
@@ -23,8 +23,9 @@ final class LoginListViewModel {
     private(set) var titles = [Character]()
     private(set) var loginRecordSections = [Character: [LoginRecord]]() {
         didSet {
-            assert(Thread.isMainThread)
-            delegate?.loginSectionsDidUpdate()
+            ensureMainThread {
+                self.delegate?.loginSectionsDidUpdate()
+            }
         }
     }
     fileprivate let helper = LoginListDataSourceHelper()

--- a/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -347,27 +347,29 @@ extension TabLocationView: TabEventHandler {
     }
 
     private func updateBlockerStatus(forTab tab: Tab) {
-        assertIsMainThread("UI changes must be on the main thread")
         guard let blocker = tab.contentBlocker else { return }
-        trackingProtectionButton.alpha = 1.0
 
-        var lockImage: UIImage?
-        // TODO: FXIOS-5101 Use theme.type.getThemedImageName()
-        let imageID = LegacyThemeManager.instance.currentName == .dark ? "lock_blocked_dark" : "lock_blocked"
-        if !(tab.webView?.hasOnlySecureContent ?? false) {
-            lockImage = UIImage(imageLiteralResourceName: imageID)
-        } else if let tintColor = trackingProtectionButton.tintColor {
-            lockImage = UIImage(imageLiteralResourceName: ImageIdentifiers.lockVerifed)
-                .withTintColor(tintColor, renderingMode: .alwaysTemplate)
-        }
+        ensureMainThread { [self] in
+            trackingProtectionButton.alpha = 1.0
 
-        switch blocker.status {
-        case .blocking, .noBlockedURLs:
-            trackingProtectionButton.setImage(lockImage, for: .normal)
-        case .safelisted:
-            trackingProtectionButton.setImage(lockImage?.overlayWith(image: UIImage(imageLiteralResourceName: "MarkAsRead")), for: .normal)
-        case .disabled:
-            trackingProtectionButton.setImage(lockImage, for: .normal)
+            var lockImage: UIImage?
+            // TODO: FXIOS-5101 Use theme.type.getThemedImageName()
+            let imageID = LegacyThemeManager.instance.currentName == .dark ? "lock_blocked_dark" : "lock_blocked"
+            if !(tab.webView?.hasOnlySecureContent ?? false) {
+                lockImage = UIImage(imageLiteralResourceName: imageID)
+            } else if let tintColor = trackingProtectionButton.tintColor {
+                lockImage = UIImage(imageLiteralResourceName: ImageIdentifiers.lockVerifed)
+                    .withTintColor(tintColor, renderingMode: .alwaysTemplate)
+            }
+
+            switch blocker.status {
+            case .blocking, .noBlockedURLs:
+                trackingProtectionButton.setImage(lockImage, for: .normal)
+            case .safelisted:
+                trackingProtectionButton.setImage(lockImage?.overlayWith(image: UIImage(imageLiteralResourceName: "MarkAsRead")), for: .normal)
+            case .disabled:
+                trackingProtectionButton.setImage(lockImage, for: .normal)
+            }
         }
     }
 

--- a/Shared/GeneralUtils.swift
+++ b/Shared/GeneralUtils.swift
@@ -2,16 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0
 
-import CoreFoundation
-import Network
-
-/**
- Assertion for checking that the call is being made on the main thread.
-
- - parameter message: Message to display in case of assertion.
- */
-public func assertIsMainThread(_ message: String) {
-    assert(Thread.isMainThread, message)
-}
+import Foundation
 
 public var debugSimulateSlowDBOperations = false

--- a/Tests/ClientTests/Frontend/Browser/TabManagement/TabManagerStoreTests.swift
+++ b/Tests/ClientTests/Frontend/Browser/TabManagement/TabManagerStoreTests.swift
@@ -114,7 +114,7 @@ class TabManagerStoreTests: XCTestCase {
         let tabToSelect = manager.restoreStartupTabs(clearPrivateTabs: false,
                                                      addTabClosure: { isPrivate in
             XCTFail("Should not be called since there's no tabs to restore")
-            return self.createTab(isPrivate: isPrivate)
+            return createTab(isPrivate: isPrivate)
         })
 
         XCTAssertNil(tabToSelect, "There's no tabs to restore, so nothing is selected")
@@ -131,7 +131,7 @@ class TabManagerStoreTests: XCTestCase {
         let tabToSelect = manager.restoreStartupTabs(clearPrivateTabs: false,
                                                      addTabClosure: { isPrivate in
             XCTAssertFalse(isPrivate)
-            return self.createTab(isPrivate: isPrivate)
+            return createTab(isPrivate: isPrivate)
         })
 
         XCTAssertNil(tabToSelect, "No tab was selected in restore, tab manager is expected to select one")
@@ -148,7 +148,7 @@ class TabManagerStoreTests: XCTestCase {
         let tabToSelect = manager.restoreStartupTabs(clearPrivateTabs: false,
                                                      addTabClosure: { isPrivate in
             XCTAssertFalse(isPrivate)
-            return self.createTab(isPrivate: isPrivate)
+            return createTab(isPrivate: isPrivate)
         })
 
         XCTAssertNotNil(tabToSelect, "Tab was selected in restore")
@@ -166,7 +166,7 @@ class TabManagerStoreTests: XCTestCase {
         let tabToSelect = manager.restoreStartupTabs(clearPrivateTabs: false,
                                                      addTabClosure: { isPrivate in
             XCTAssertTrue(isPrivate)
-            return self.createTab(isPrivate: isPrivate)
+            return createTab(isPrivate: isPrivate)
         })
 
         XCTAssertNil(tabToSelect, "No tab was selected in restore, tab manager is expected to select one")
@@ -183,7 +183,7 @@ class TabManagerStoreTests: XCTestCase {
         let tabToSelect = manager.restoreStartupTabs(clearPrivateTabs: false,
                                                      addTabClosure: { isPrivate in
             XCTAssertTrue(isPrivate)
-            return self.createTab(isPrivate: isPrivate)
+            return createTab(isPrivate: isPrivate)
         })
 
         XCTAssertNotNil(tabToSelect, "Tab was selected in restore")
@@ -201,7 +201,7 @@ class TabManagerStoreTests: XCTestCase {
         let tabToSelect = manager.restoreStartupTabs(clearPrivateTabs: true,
                                                      addTabClosure: { isPrivate in
             XCTFail("Shouldn't be called as there's no more tabs after clear private tabs is done")
-            return self.createTab(isPrivate: isPrivate)
+            return createTab(isPrivate: isPrivate)
         })
 
         XCTAssertNil(tabToSelect, "No tab is selected since all tabs were removed (since they were private)")
@@ -217,7 +217,7 @@ class TabManagerStoreTests: XCTestCase {
         let tabToSelect = manager.restoreStartupTabs(clearPrivateTabs: true,
                                                      addTabClosure: { isPrivate in
             XCTAssertFalse(isPrivate)
-            return self.createTab(isPrivate: isPrivate)
+            return createTab(isPrivate: isPrivate)
         })
 
         XCTAssertNil(tabToSelect, "No tab selected since the selected one was deleted, tab manager will deal with it")
@@ -235,7 +235,7 @@ class TabManagerStoreTests: XCTestCase {
         let tabToSelect = manager.restoreStartupTabs(clearPrivateTabs: false,
                                                      addTabClosure: { isPrivate in
             XCTAssertFalse(isPrivate)
-            return self.createTab(isPrivate: isPrivate)
+            return createTab(isPrivate: isPrivate)
         })
 
         XCTAssertNil(tabToSelect, "No tab was selected in restore, tab manager is expected to select one")

--- a/Tests/ClientTests/Frontend/Browser/TabManagement/TabManagerStoreTests.swift
+++ b/Tests/ClientTests/Frontend/Browser/TabManagement/TabManagerStoreTests.swift
@@ -114,7 +114,7 @@ class TabManagerStoreTests: XCTestCase {
         let tabToSelect = manager.restoreStartupTabs(clearPrivateTabs: false,
                                                      addTabClosure: { isPrivate in
             XCTFail("Should not be called since there's no tabs to restore")
-            return createTab(isPrivate: isPrivate)
+            return self.createTab(isPrivate: isPrivate)
         })
 
         XCTAssertNil(tabToSelect, "There's no tabs to restore, so nothing is selected")
@@ -131,7 +131,7 @@ class TabManagerStoreTests: XCTestCase {
         let tabToSelect = manager.restoreStartupTabs(clearPrivateTabs: false,
                                                      addTabClosure: { isPrivate in
             XCTAssertFalse(isPrivate)
-            return createTab(isPrivate: isPrivate)
+            return self.createTab(isPrivate: isPrivate)
         })
 
         XCTAssertNil(tabToSelect, "No tab was selected in restore, tab manager is expected to select one")
@@ -148,7 +148,7 @@ class TabManagerStoreTests: XCTestCase {
         let tabToSelect = manager.restoreStartupTabs(clearPrivateTabs: false,
                                                      addTabClosure: { isPrivate in
             XCTAssertFalse(isPrivate)
-            return createTab(isPrivate: isPrivate)
+            return self.createTab(isPrivate: isPrivate)
         })
 
         XCTAssertNotNil(tabToSelect, "Tab was selected in restore")
@@ -166,7 +166,7 @@ class TabManagerStoreTests: XCTestCase {
         let tabToSelect = manager.restoreStartupTabs(clearPrivateTabs: false,
                                                      addTabClosure: { isPrivate in
             XCTAssertTrue(isPrivate)
-            return createTab(isPrivate: isPrivate)
+            return self.createTab(isPrivate: isPrivate)
         })
 
         XCTAssertNil(tabToSelect, "No tab was selected in restore, tab manager is expected to select one")
@@ -183,7 +183,7 @@ class TabManagerStoreTests: XCTestCase {
         let tabToSelect = manager.restoreStartupTabs(clearPrivateTabs: false,
                                                      addTabClosure: { isPrivate in
             XCTAssertTrue(isPrivate)
-            return createTab(isPrivate: isPrivate)
+            return self.createTab(isPrivate: isPrivate)
         })
 
         XCTAssertNotNil(tabToSelect, "Tab was selected in restore")
@@ -201,7 +201,7 @@ class TabManagerStoreTests: XCTestCase {
         let tabToSelect = manager.restoreStartupTabs(clearPrivateTabs: true,
                                                      addTabClosure: { isPrivate in
             XCTFail("Shouldn't be called as there's no more tabs after clear private tabs is done")
-            return createTab(isPrivate: isPrivate)
+            return self.createTab(isPrivate: isPrivate)
         })
 
         XCTAssertNil(tabToSelect, "No tab is selected since all tabs were removed (since they were private)")
@@ -217,7 +217,7 @@ class TabManagerStoreTests: XCTestCase {
         let tabToSelect = manager.restoreStartupTabs(clearPrivateTabs: true,
                                                      addTabClosure: { isPrivate in
             XCTAssertFalse(isPrivate)
-            return createTab(isPrivate: isPrivate)
+            return self.createTab(isPrivate: isPrivate)
         })
 
         XCTAssertNil(tabToSelect, "No tab selected since the selected one was deleted, tab manager will deal with it")
@@ -235,7 +235,7 @@ class TabManagerStoreTests: XCTestCase {
         let tabToSelect = manager.restoreStartupTabs(clearPrivateTabs: false,
                                                      addTabClosure: { isPrivate in
             XCTAssertFalse(isPrivate)
-            return createTab(isPrivate: isPrivate)
+            return self.createTab(isPrivate: isPrivate)
         })
 
         XCTAssertNil(tabToSelect, "No tab was selected in restore, tab manager is expected to select one")


### PR DESCRIPTION
# [FXIOS-5843](https://mozilla-hub.atlassian.net/browse/FXIOS-5843)

TLDR: Address assert on mains by replacing them with `ensureMainThread`. 

Note that the assertMain in `RustFirefoxAccounts` was left out because that case interacts with deferred.

UPDATE Mar 3, 2023
TabManagerStore's restoreTabs method exits with a `return nil` if the operation isn't run on main thread. I believe it must run on main because TabManager runs the restore to find the tab to select and show a user. However, when given back a `nil`, TabManager's restore tabs method can handle that case and find a way out of that error state. 

Rather than keeping the assertion to allow this error state to continue in release builds, I prefer the above.