### PR TITLE
Bugfix 1819036 [v112] Get mergify config on par with firefox-android

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -37,3 +37,25 @@ pull_request_rules:
       queue:
         method: rebase
         name: default
+  - name: Needs landing - Rebase
+    conditions:
+      - check-success=Bitrise
+      - label=Needs Landing
+      - "#approved-reviews-by>=1"
+      - -draft
+      - label!=Do Not Merge ⛔️
+    actions:
+      queue:
+        method: rebase
+        name: default
+  - name: Needs landing - Squash
+    conditions:
+      - check-success=Bitrise
+      - label=Needs Landing (Squash)
+      - "#approved-reviews-by>=1"
+      - -draft
+      - label!=Do Not Merge ⛔️
+    actions:
+      queue:
+        method: squash
+        name: default

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -24,3 +24,16 @@ pull_request_rules:
       queue:
         method: rebase
         name: default
+  - name: L10N - Auto Merge
+    conditions:
+      - author=github-actions[bot]
+      - check-success=Bitrise
+      - files~=^.+\.strings$
+      - -files~=^(?!^.+\.strings).+$
+    actions:
+      review:
+        type: APPROVE
+        message: LGTM 😎
+      queue:
+        method: rebase
+        name: default

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,7 +9,7 @@ pull_request_rules:
       - conflict
     actions:
         comment:
-          message: This pull request has conflicts when rebasing. Could you fix it @{{author}}?
+          message: This pull request has conflicts when rebasing. Could you fix it @{{author}}? 🙏
   - name: github-actions
     conditions:
       - author=github-actions[bot]

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -10,9 +10,10 @@ pull_request_rules:
     actions:
         comment:
           message: This pull request has conflicts when rebasing. Could you fix it @{{author}}? 🙏
-  - name: github-actions
+  - name: Bitrise update - Auto Merge
     conditions:
       - author=github-actions[bot]
+      - check-success=Bitrise
       - files=bitrise.yml
       - -files~=^(?!bitrise.yml).+$
       - head=update-br-new-xcode-version


### PR DESCRIPTION
[1819036](https://bugzilla.mozilla.org/show_bug.cgi?id=1819036)
This PR makes the current `.mergify.yml` file similar to https://github.com/mozilla-mobile/firefox-android/blob/457d88002e0dd413725fb1f99033c6ccc3a65e58/.mergify.yml

I changed the Github labels to match this repo. I also checked the `regex` for the `.strings` files. I see Mergify is already active (e.g. https://github.com/mozilla-mobile/firefox-ios/pull/10998) so we don't need to do anything but making changes to `.mergify.yml`.