### PR TITLE
Refactor MTE-713 [v112] Temporary workaround for test_sync_tabs_from_desktop

### DIFF
--- a/SyncIntegrationTests/test_integration.py
+++ b/SyncIntegrationTests/test_integration.py
@@ -27,11 +27,9 @@ def test_sync_logins_from_desktop(tps, xcodebuild):
     tps.run('test_password_desktop.js')
     xcodebuild.test('XCUITests/IntegrationTests/testFxASyncPasswordDesktop')
 
-'''
 def test_sync_tabs_from_desktop(tps, xcodebuild):
     tps.run('test_tabs_desktop.js')
     xcodebuild.test('XCUITests/IntegrationTests/testFxASyncTabsDesktop')
-'''
 
 def test_sync_disconnect_connect_fxa(tps, xcodebuild):
     tps.run('test_bookmark_login.js')

--- a/SyncIntegrationTests/test_tabs_desktop.js
+++ b/SyncIntegrationTests/test_tabs_desktop.js
@@ -24,7 +24,8 @@ Phase("phase1", [
 ]);
 
 Phase("phase2", [
-  [Sync]
+  [Sync],
+  [Sync],
   [Tabs.verify, tabs1],
   [Sync]
 ]);

--- a/SyncIntegrationTests/test_tabs_desktop.js
+++ b/SyncIntegrationTests/test_tabs_desktop.js
@@ -8,7 +8,7 @@
  */
 EnableEngines(["tabs"]);
 
-var phases = { "phase1": "profile1" };
+var phases = { "phase1": "profile1", "phase2": "profile1" };
 
 
 var tabs1 = [
@@ -19,7 +19,12 @@ var tabs1 = [
 
 // sync and verify tabs
 Phase("phase1", [
-  [Sync],
   [Tabs.add, tabs1],
+  [Sync]
+]);
+
+Phase("phase2", [
+  [Sync]
+  [Tabs.verify, tabs1],
   [Sync]
 ]);


### PR DESCRIPTION
`test_sync_tabs_from_desktop` from Sync Integration tests has been failing since mid-January because of a regression from TPS. We've disabled this test in MTE-636. Now we have a workaround so this test may be enabled with the workaround before the fix arrives.

https://bugzilla.mozilla.org/show_bug.cgi?id=1818349
https://mozilla-hub.atlassian.net/browse/MTE-636
https://mozilla-hub.atlassian.net/browse/MTE-713