### PR TITLE
Add FXIOS-5522 [v112] Research surface: nimbus docs & setup, strings

### DIFF
--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -760,6 +760,28 @@ extension String {
     public struct PasswordsAndLogins { }
 }
 
+// MARK: - Research Surface
+extension String {
+    public struct ResearchSurface {
+        private static let tableName = "Research Surface"
+        public static let BodyText = MZLocalizedString(
+            "Body.Text",
+            tableName: tableName,
+            value: "Please help make Firefox better by taking a short survey.",
+            comment: "On the Research Survey popup, the text that explains what the screen is about.")
+        public static let TakeSurveyButtonLabel = MZLocalizedString(
+            "PrimaryButton.Label",
+            tableName: tableName,
+            value: "Take Survey",
+            comment: "On the Research Survey popup, the text for the button that, when tapped, will take the user to a survey.")
+        public static let DismissButtonLabel = MZLocalizedString(
+            "SecondaryButton.Label",
+            tableName: tableName,
+            value: "No Thanks",
+            comment: "On the Research Survey popup, the text for the button that, when tapped, will dismiss this screen, and the user will not take the survey.")
+    }
+}
+
 // MARK: - Search
 extension String {
     public struct Search {

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -763,22 +763,21 @@ extension String {
 // MARK: - Research Surface
 extension String {
     public struct ResearchSurface {
-        private static let tableName = "Research Surface"
         public static let BodyText = MZLocalizedString(
             "Body.Text",
-            tableName: tableName,
+            tableName: "Research Surface",
             value: "Please help make Firefox better by taking a short survey.",
             comment: "On the Research Survey popup, the text that explains what the screen is about.")
         public static let TakeSurveyButtonLabel = MZLocalizedString(
             "PrimaryButton.Label",
-            tableName: tableName,
+            tableName: "Research Surface",
             value: "Take Survey",
             comment: "On the Research Survey popup, the text for the button that, when tapped, will take the user to a survey.")
         public static let DismissButtonLabel = MZLocalizedString(
             "SecondaryButton.Label",
-            tableName: tableName,
+            tableName: "Research Surface",
             value: "No Thanks",
-            comment: "On the Research Survey popup, the text for the button that, when tapped, will dismiss this screen, and the user will not take the survey.")
+            comment: "On the Research Survey popup, the text for the button that, when tapped, will dismiss this screen, and the user will not be taken to the survey.")
     }
 }
 

--- a/nimbus-features/messagingFeature.yaml
+++ b/nimbus-features/messagingFeature.yaml
@@ -106,9 +106,23 @@ features:
               title: Default Browser/DefaultBrowserCard.Title
               text: Default Browser/DefaultBrowserCard.Description
               action: "MAKE_DEFAULT_BROWSER_WITH_TUTORIAL"
-              trigger: ["I_AM_NOT_DEFAULT_BROWSER", "SUPPORTS_DEFAULT_BROWSER"]
               style: "FALLBACK"
               button-label: Default Browser/DefaultBrowserCard.Button.v2
+              surface: new-tab-card
+              trigger:
+                - I_AM_NOT_DEFAULT_BROWSER
+                - SUPPORTS_DEFAULT_BROWSER
+      - channel: developer
+        value:
+          messages:
+            research-survey:
+              text: Research Surface/Body.Text
+              action: "www.macrumors.com"
+              style: "SURVEY"
+              button-label: Research Surface/PrimaryButton.Label
+              surface: survey
+              trigger:
+                - ALWAYS
 
 objects:
   MessageData:
@@ -160,8 +174,7 @@ objects:
       surface:
         type: MessageSurfaceId
         description: Each message will tell us the surface it is targeting with this.
-        # To start, we default to the new-tab-card
-        default: new-tab-card
+        default: Unknown
 
   StyleData:
     description: >

--- a/nimbus-features/messagingFeature.yaml
+++ b/nimbus-features/messagingFeature.yaml
@@ -47,6 +47,9 @@ features:
 
     defaults:
       - value:
+          # This list of triggers is the same on iOS and Android. Thus,
+          # the list should not be updated without consultation of the
+          # Nimbus team.
           triggers:
             NOT_INSTALLED_TODAY:      days_since_install > 0
             NOT_LAUNCHED_YESTERDAY:   app_cycle.foreground|eventLastSeen('Days', 1) > 1
@@ -103,26 +106,26 @@ features:
               max-display-count: 10
           messages:
             default-browser:
-              title: Default Browser/DefaultBrowserCard.Title
-              text: Default Browser/DefaultBrowserCard.Description
-              action: "MAKE_DEFAULT_BROWSER_WITH_TUTORIAL"
-              style: "FALLBACK"
-              button-label: Default Browser/DefaultBrowserCard.Button.v2
               surface: new-tab-card
+              style: FALLBACK
               trigger:
                 - I_AM_NOT_DEFAULT_BROWSER
                 - SUPPORTS_DEFAULT_BROWSER
+              title: Default Browser/DefaultBrowserCard.Title
+              text: Default Browser/DefaultBrowserCard.Description
+              button-label: Default Browser/DefaultBrowserCard.Button.v2
+              action: MAKE_DEFAULT_BROWSER_WITH_TUTORIAL
       - channel: developer
         value:
           messages:
             research-survey:
-              text: Research Surface/Body.Text
-              action: "www.macrumors.com"
-              style: "SURVEY"
-              button-label: Research Surface/PrimaryButton.Label
               surface: survey
+              style: SURVEY
               trigger:
                 - ALWAYS
+              text: Research Surface/Body.Text
+              button-label: Research Surface/PrimaryButton.Label
+              action: www.macrumors.com
 
 objects:
   MessageData:


### PR DESCRIPTION
[JIRA Reference](https://mozilla-hub.atlassian.net/browse/FXIOS-5522)
#12846

In this PR:
- added research surface message for dev builds
- added minor nimbus documentation
- added research surface strings
- Nimbus messaging updates
  - Removal of `"` for clarity in parameters
  - Making YAML more easy to read
  - Making `Unknown` the default surface. Each message should explicitly define what surface it's for
- Updated telemetry to send `.messagingSurface` and the object (ie. this is a message surface). We should be using the message ID to identify the actual surface - especially seeing as the object isn't actually getting passed into any glean reported thing.