### PR TITLE
Bugfix FXIOS-5713 [v112] Number of pocket stories in german changes

### DIFF
--- a/Client/Frontend/Home/Pocket/PocketStandardCellViewModel.swift
+++ b/Client/Frontend/Home/Pocket/PocketStandardCellViewModel.swift
@@ -13,7 +13,11 @@ class PocketStandardCellViewModel {
         if let sponsor = story.sponsor {
             return sponsor
         } else {
-            return "\(story.domain) • \(String.localizedStringWithFormat(String.FirefoxHomepage.Pocket.NumberOfMinutes, story.timeToRead ?? 0))"
+            if let timeToRead = story.timeToRead {
+                return "\(story.domain) • \(String.localizedStringWithFormat(String.FirefoxHomepage.Pocket.NumberOfMinutes, timeToRead))"
+            } else {
+               return  "\(story.domain)"
+            }
         }
     }
     var accessibilityLabel: String {

--- a/Providers/Pocket/Model/PocketFeedStory.swift
+++ b/Providers/Pocket/Model/PocketFeedStory.swift
@@ -15,7 +15,7 @@ struct PocketFeedStory {
     let title: String
     let url: URL
     let domain: String
-    let timeToRead: Int64
+    let timeToRead: Int64?
     let storyDescription: String
     let imageURL: URL
 
@@ -25,7 +25,6 @@ struct PocketFeedStory {
                   let domain = storyDict["domain"] as? String,
                   let imageURLS = storyDict["image_src"] as? String,
                   let title = storyDict["title"] as? String,
-                  let timeToRead = storyDict["time_to_read"] as? Int64,
                   let description = storyDict["excerpt"] as? String else {
                       return nil
                   }
@@ -38,7 +37,7 @@ struct PocketFeedStory {
                 title: title,
                 url: url,
                 domain: domain,
-                timeToRead: timeToRead,
+                timeToRead: storyDict["time_to_read"] as? Int64,
                 storyDescription: description,
                 imageURL: imageURL
             )

--- a/Providers/Pocket/PocketProvider.swift
+++ b/Providers/Pocket/PocketProvider.swift
@@ -115,7 +115,6 @@ class PocketProvider: PocketStoriesProviding, FeatureFlaggable, URLCaching {
         guard let feedURL = URL(string: pocketGlobalFeed)?.withQueryParams(params) else { return nil }
 
         return URLRequest(url: feedURL, cachePolicy: .reloadIgnoringCacheData, timeoutInterval: 5)
-        
     }
 
     private var shouldUseMockData: Bool {

--- a/Providers/Pocket/PocketProvider.swift
+++ b/Providers/Pocket/PocketProvider.swift
@@ -115,6 +115,7 @@ class PocketProvider: PocketStoriesProviding, FeatureFlaggable, URLCaching {
         guard let feedURL = URL(string: pocketGlobalFeed)?.withQueryParams(params) else { return nil }
 
         return URLRequest(url: feedURL, cachePolicy: .reloadIgnoringCacheData, timeoutInterval: 5)
+        
     }
 
     private var shouldUseMockData: Bool {

--- a/Tests/ClientTests/pocketglobalfeed.json
+++ b/Tests/ClientTests/pocketglobalfeed.json
@@ -4,7 +4,6 @@
         "id": 2091,
         "url": "https://www.washingtonian.com/2022/03/15/the-us-tried-permanent-daylight-saving-time-in-the-70s-people-hated-it/?utm_source=pocket-newtab",
         "title": "The US Tried Permanent Daylight Saving Time in the ’70s. People Hated It",
-        "time_to_read": 12,
         "excerpt": "The number one complaint: Children had to go to school in the dark.:",
         "domain": "washingtonian.com",
         "image_src": "https://img-getpocket.cdn.mozilla.net/direct?url=https%3A%2F%2Fwww.washingtonian.com%2Fwp-content%2Fuploads%2F2022%2F03%2FDarkness-Time-Washington-Post.png&resize=w450",


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/FXIOS-5713 https://github.com/mozilla-mobile/firefox-ios/issues/13164
The "Time to read" field sometimes is optional in the API and the story is discarded entirely. I made it optional and now the card looks like that if the info is missing. 

![image](https://user-images.githubusercontent.com/26011662/221788912-ec707a37-7879-4718-814f-7875d7ec9332.png)

