### PR TITLE
Add FXIOS-5522 [v112] Update messaging telemetry

### DIFF
--- a/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
+++ b/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
@@ -115,7 +115,7 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
 
         TelemetryWrapper.recordEvent(category: .information,
                                      method: .view,
-                                     object: .homeTabBanner,
+                                     object: .messagingSurface,
                                      value: .messageImpression,
                                      extras: [TelemetryWrapper.EventExtraKey.messageKey.rawValue: message.id])
     }
@@ -147,7 +147,7 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
 
         TelemetryWrapper.recordEvent(category: .action,
                                      method: .tap,
-                                     object: .homeTabBanner,
+                                     object: .messagingSurface,
                                      value: .messageInteracted,
                                      extras: [TelemetryWrapper.EventExtraKey.messageKey.rawValue: message.id,
                                               TelemetryWrapper.EventExtraKey.actionUUID.rawValue: uuid ?? "nil"])
@@ -160,7 +160,7 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
 
         TelemetryWrapper.recordEvent(category: .action,
                                      method: .tap,
-                                     object: .homeTabBanner,
+                                     object: .messagingSurface,
                                      value: .messageDismissed,
                                      extras: [TelemetryWrapper.EventExtraKey.messageKey.rawValue: message.id])
     }
@@ -168,7 +168,7 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
     func onMalformedMessage(messageKey: String) {
         TelemetryWrapper.recordEvent(category: .information,
                                      method: .application,
-                                     object: .homeTabBanner,
+                                     object: .messagingSurface,
                                      value: .messageMalformed,
                                      extras: [TelemetryWrapper.EventExtraKey.messageKey.rawValue: messageKey])
     }

--- a/Client/Experiments/Messaging/GleanPlumbMessageStore.swift
+++ b/Client/Experiments/Messaging/GleanPlumbMessageStore.swift
@@ -77,7 +77,7 @@ class GleanPlumbMessageStore: GleanPlumbMessageStoreProtocol {
         if shouldReport {
             TelemetryWrapper.recordEvent(category: .information,
                                          method: .view,
-                                         object: .homeTabBanner,
+                                         object: .messagingSurface,
                                          value: .messageExpired,
                                          extras:
                                             [TelemetryWrapper.EventExtraKey.messageKey.rawValue: messageData.id])

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -444,7 +444,7 @@ extension TelemetryWrapper {
         case siteMenu = "site-menu"
         case library = "library"
         case home = "home-page"
-        case homeTabBanner = "home-tab-banner"
+        case messagingSurface = "messaging-surface"
         case blockImagesEnabled = "block-images-enabled"
         case blockImagesDisabled = "block-images-disabled"
         case navigateTabHistoryBack = "navigate-tab-history-back"
@@ -1302,19 +1302,19 @@ extension TelemetryWrapper {
         case (.action, .drag, .locationBar, _, _):
             GleanMetrics.Awesomebar.dragLocationBar.record()
         // MARK: - GleanPlumb Messaging
-        case (.information, .view, .homeTabBanner, .messageImpression, let extras):
+        case (.information, .view, .messagingSurface, .messageImpression, let extras):
             if let messageId = extras?[EventExtraKey.messageKey.rawValue] as? String {
                 GleanMetrics.Messaging.shown.record(
                     GleanMetrics.Messaging.ShownExtra(messageKey: messageId)
                 )
             }
-        case(.action, .tap, .homeTabBanner, .messageDismissed, let extras):
+        case(.action, .tap, .messagingSurface, .messageDismissed, let extras):
             if let messageId = extras?[EventExtraKey.messageKey.rawValue] as? String {
                 GleanMetrics.Messaging.dismissed.record(
                     GleanMetrics.Messaging.DismissedExtra(messageKey: messageId)
                 )
             }
-        case(.action, .tap, .homeTabBanner, .messageInteracted, let extras):
+        case(.action, .tap, .messagingSurface, .messageInteracted, let extras):
             if let messageId = extras?[EventExtraKey.messageKey.rawValue] as? String,
                 let actionUUID = extras?[EventExtraKey.actionUUID.rawValue] as? String {
                 GleanMetrics.Messaging.clicked.record(
@@ -1325,13 +1325,13 @@ extension TelemetryWrapper {
                     GleanMetrics.Messaging.ClickedExtra(messageKey: messageId)
                 )
             }
-        case(.information, .view, .homeTabBanner, .messageExpired, let extras):
+        case(.information, .view, .messagingSurface, .messageExpired, let extras):
             if let messageId = extras?[EventExtraKey.messageKey.rawValue] as? String {
                 GleanMetrics.Messaging.expired.record(
                     GleanMetrics.Messaging.ExpiredExtra(messageKey: messageId)
                 )
             }
-        case(.information, .application, .homeTabBanner, .messageMalformed, let extras):
+        case(.information, .application, .messagingSurface, .messageMalformed, let extras):
             if let messageId = extras?[EventExtraKey.messageKey.rawValue] as? String {
                 GleanMetrics.Messaging.malformed.record(
                     GleanMetrics.Messaging.MalformedExtra(messageKey: messageId)


### PR DESCRIPTION
Updated telemetry to send `.messagingSurface` as the object (ie. this is a message surface). We should be using the message ID to identify the actual surface - especially seeing as the object isn't actually getting passed into any glean reported thing.

I forgot to include this work in my last PR. It was stashed.