### PR TITLE
Bugfix FXIOS-5711 [v112] Open-Tabs-view-does-not-focus-a-current-tab

### DIFF
--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -254,7 +254,11 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate, Themeable {
                     self.collectionView.scrollRectToVisible(rect, animated: false)
                 }
             } else {
-                self.collectionView.scrollToItem(at: indexPath, at: [.centeredVertically, .centeredHorizontally], animated: false)
+                DispatchQueue.main.async {
+                    self.collectionView.scrollToItem(at: indexPath,
+                                                     at: [.centeredVertically, .centeredHorizontally],
+                                                     animated: false)
+                }
             }
         }
     }


### PR DESCRIPTION
## [FXIOS-5711](https://mozilla-hub.atlassian.net/browse/FXIOS-5711?filter=-1) | https://github.com/mozilla-mobile/firefox-ios/issues/13158

## Video

https://user-images.githubusercontent.com/51127880/222137721-98ac35c1-e3f1-42bc-808e-4da6503454bd.mp4

