### PR TITLE
Bugfix FXIOS-5639 [v112] Remove URLBar’s overlay mode state from BrowserViewController

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2606,7 +2606,8 @@ extension BrowserViewController: TopTabsDelegate {
 
     func topTabsDidPressNewTab(_ isPrivate: Bool) {
         openBlankNewTab(focusLocationField: false, isPrivate: isPrivate)
-        overlayManager.openNewTab(nil, url: nil)
+        overlayManager.openNewTab(url: nil,
+                                  newTabSettings: NewTabAccessors.getNewTabPage(profile.prefs))
     }
 
     // TODO: FXIOS-5639 Remove from protocol if it was used for keyboard handling

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2610,9 +2610,6 @@ extension BrowserViewController: TopTabsDelegate {
                                   newTabSettings: NewTabAccessors.getNewTabPage(profile.prefs))
     }
 
-    // TODO: FXIOS-5639 Remove from protocol if it was used for keyboard handling
-    func topTabsDidTogglePrivateMode() { }
-
     func topTabsDidChangeTab() {
         // Only for iPad leave overlay mode on tab change
         overlayManager.switchTab(shouldCancelLoading: true)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -215,8 +215,8 @@ class BrowserViewController: UIViewController {
         applyTheme()
     }
 
-    /// If user manually opens the keyboard and press undo the app switch to the last open tab
-    /// because of that we need to leave overlay state
+    /// If user manually opens the keyboard and presses undo, the app switches to the last
+    /// open tab, and because of that we need to leave overlay state
     @objc func didTapUndoCloseAllTabToast(notification: Notification) {
         overlayManager.switchTab(shouldCancelLoading: true)
     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -215,8 +215,11 @@ class BrowserViewController: UIViewController {
         applyTheme()
     }
 
-    // TODO: FXIOS-5639 Remove delegate keyboard
-    @objc func didTapUndoCloseAllTabToast(notification: Notification) { }
+    /// If user manually opens the keyboard and press undo the app switch to the last open tab
+    /// because of that we need to leave overlay state
+    @objc func didTapUndoCloseAllTabToast(notification: Notification) {
+        overlayManager.switchTab(shouldCancelLoading: true)
+    }
 
     @objc func openTabNotification(notification: Notification) {
         guard let openTabObject = notification.object as? OpenTabNotificationObject else {
@@ -1128,7 +1131,7 @@ class BrowserViewController: UIViewController {
 
     func finishEditingAndSubmit(_ url: URL, visitType: VisitType, forTab tab: Tab) {
         urlBar.currentURL = url
-        overlayManager.finishEdition(shouldCancelLoading: false)
+        overlayManager.finishEditing(shouldCancelLoading: false)
 
         if let nav = tab.loadRequest(URLRequest(url: url)) {
             self.recordNavigationInTab(tab, navigation: nav, visitType: visitType)
@@ -1201,7 +1204,7 @@ class BrowserViewController: UIViewController {
 
     override func accessibilityPerformEscape() -> Bool {
         if overlayManager.inOverlayMode {
-            overlayManager.finishEdition(shouldCancelLoading: true)
+            overlayManager.finishEditing(shouldCancelLoading: true)
             return true
         } else if let selectedTab = tabManager.selectedTab, selectedTab.canGoBack {
             selectedTab.goBack()

--- a/Client/Frontend/Browser/Tabs/TabTrayViewModel.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewModel.swift
@@ -103,7 +103,8 @@ extension TabTrayViewModel {
     }
 
     @objc func didTapAddTab(_ sender: UIBarButtonItem) {
-        overlayManager.openNewTab(nil, url: nil)
+        overlayManager.openNewTab(url: nil,
+                                  newTabSettings: NewTabAccessors.getNewTabPage(profile.prefs))
         tabTrayView.performToolbarAction(.addTab, sender: sender)
     }
 

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -24,7 +24,6 @@ struct TopTabsUX {
 protocol TopTabsDelegate: AnyObject {
     func topTabsDidPressTabs()
     func topTabsDidPressNewTab(_ isPrivate: Bool)
-    func topTabsDidTogglePrivateMode()
     func topTabsDidChangeTab()
 }
 
@@ -187,7 +186,6 @@ class TopTabsViewController: UIViewController, Themeable {
         topTabDisplayManager.togglePrivateMode(isOn: !topTabDisplayManager.isPrivate,
                                                createTabOnEmptyPrivateMode: true,
                                                shouldSelectMostRecentTab: true)
-        delegate?.topTabsDidTogglePrivateMode()
         self.privateModeButton.setSelected(topTabDisplayManager.isPrivate, animated: true)
     }
 

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -313,7 +313,7 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
 
     @objc private func dismissKeyboard() {
         if currentTab?.lastKnownUrl?.absoluteString.hasPrefix("internal://") ?? false {
-            overlayManager.finishEdition(shouldCancelLoading: false)
+            overlayManager.finishEditing(shouldCancelLoading: false)
         }
     }
 

--- a/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
+++ b/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
@@ -20,7 +20,7 @@ protocol OverlayModeManager: OverlayStateProtocol {
     /// Enter overlay mode when opening a new tab
     /// - Parameters:
     ///   - url: Tab url to determine if is the url is homepage or nil
-    ///   - newTabSettings: User option for new tab, if is custom url (homepage) the keyboard is not raised
+    ///   - newTabSettings: User option for new tab, if it's a custom url (homepage) the keyboard is not raised
     func openNewTab(url: URL?, newTabSettings: NewTabPage)
 
     /// Leave overlay mode when user finish editing, either pressing the go button, enter etc

--- a/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
+++ b/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
@@ -19,9 +19,9 @@ protocol OverlayModeManager: OverlayStateProtocol {
 
     /// Enter overlay mode when opening a new tab
     /// - Parameters:
-    ///   - locationText: String with initial search text
     ///   - url: Tab url to determine if is the url is homepage or nil
-    func openNewTab(_ locationText: String?, url: URL?)
+    ///   - newTabSettings: User option for new tab, if is custom url (homepage) the keyboard is not raised
+    func openNewTab(url: URL?, newTabSettings: NewTabPage)
 
     /// Leave overlay mode when user finish editing, either pressing the go button, enter etc
     /// - Parameter shouldCancelLoading: Bool value determine if the loading animation of the current search should be canceled
@@ -49,9 +49,11 @@ class DefaultOverlayModeManager: OverlayModeManager {
         enterOverlayMode(pasteContent, pasted: true, search: true)
     }
 
-    func openNewTab(_ locationText: String?, url: URL?) {
-        if url == nil || url?.isFxHomeUrl ?? false {
-            enterOverlayMode(locationText, pasted: false, search: true)
+    func openNewTab(url: URL?, newTabSettings: NewTabPage) {
+        guard newTabSettings != .homePage else { return }
+
+        if shouldEnterOverlay(for: url) {
+            enterOverlayMode(nil, pasted: false, search: true)
         }
     }
 
@@ -63,6 +65,12 @@ class DefaultOverlayModeManager: OverlayModeManager {
         guard inOverlayMode else { return }
 
         leaveOverlayMode(didCancel: shouldCancelLoading)
+    }
+
+    private func shouldEnterOverlay(for url: URL?, newTabSettings: NewTabPage) -> Bool {
+        guard let url = url else { return true }
+
+        return url.isFxHomeUrl
     }
 
     private func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool) {

--- a/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
+++ b/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
@@ -50,11 +50,9 @@ class DefaultOverlayModeManager: OverlayModeManager {
     }
 
     func openNewTab(url: URL?, newTabSettings: NewTabPage) {
-        guard newTabSettings != .homePage else { return }
+        guard shouldEnterOverlay(for: url, newTabSettings: newTabSettings) else { return }
 
-        if shouldEnterOverlay(for: url) {
-            enterOverlayMode(nil, pasted: false, search: true)
-        }
+        enterOverlayMode(nil, pasted: false, search: true)
     }
 
     func finishEditing(shouldCancelLoading: Bool) {
@@ -68,9 +66,13 @@ class DefaultOverlayModeManager: OverlayModeManager {
     }
 
     private func shouldEnterOverlay(for url: URL?, newTabSettings: NewTabPage) -> Bool {
-        guard let url = url else { return true }
-
-        return url.isFxHomeUrl
+        // The NewTabPage cases are weird topSites = homepage
+        // and homepage = customURL
+        switch newTabSettings {
+        case .topSites: return url?.isFxHomeUrl ?? true
+        case .blankPage: return true
+        case .homePage: return false
+        }
     }
 
     private func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool) {

--- a/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
+++ b/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
@@ -23,7 +23,7 @@ protocol OverlayModeManager: OverlayStateProtocol {
     ///   - newTabSettings: User option for new tab, if it's a custom url (homepage) the keyboard is not raised
     func openNewTab(url: URL?, newTabSettings: NewTabPage)
 
-    /// Leave overlay mode when user finish editing, either pressing the go button, enter etc
+    /// Leave overlay mode when user finishes editing, either by pressing the go button, enter etc
     /// - Parameter shouldCancelLoading: Bool value determine if the loading animation of the current search should be canceled
     func finishEditing(shouldCancelLoading: Bool)
 

--- a/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
+++ b/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
@@ -23,9 +23,9 @@ protocol OverlayModeManager: OverlayStateProtocol {
     ///   - url: Tab url to determine if is the url is homepage or nil
     func openNewTab(_ locationText: String?, url: URL?)
 
-    /// Leave overlay mode when user finish edition, either pressing the go button, enter etc
+    /// Leave overlay mode when user finish editing, either pressing the go button, enter etc
     /// - Parameter shouldCancelLoading: Bool value determine if the loading animation of the current search should be canceled
-    func finishEdition(shouldCancelLoading: Bool)
+    func finishEditing(shouldCancelLoading: Bool)
 
     /// Leave overlay mode when tab change happens, like switching tabs or open a site from any homepage section
     /// - Parameter shouldCancelLoading: Bool value determine if the loading animation of the current search should be canceled
@@ -55,11 +55,13 @@ class DefaultOverlayModeManager: OverlayModeManager {
         }
     }
 
-    func finishEdition(shouldCancelLoading: Bool) {
+    func finishEditing(shouldCancelLoading: Bool) {
         leaveOverlayMode(didCancel: shouldCancelLoading)
     }
 
     func switchTab(shouldCancelLoading: Bool) {
+        guard inOverlayMode else { return }
+
         leaveOverlayMode(didCancel: shouldCancelLoading)
     }
 

--- a/Tests/ClientTests/Frontend/ContextualHints/ContextualHintEligibilityUtilityTests.swift
+++ b/Tests/ClientTests/Frontend/ContextualHints/ContextualHintEligibilityUtilityTests.swift
@@ -112,7 +112,7 @@ class ContextualHintEligibilityUtilityTests: XCTestCase {
         subject = ContextualHintEligibilityUtility(with: profile,
                                                    overlayState: overlayState,
                                                    device: MockUIDevice(isIpad: true))
-        overlayState.openNewTab(nil, url: nil)
+        overlayState.openNewTab(url: nil, newTabSettings: .topSites)
         let result = subject.canPresent(.jumpBackIn)
         XCTAssertFalse(result)
     }
@@ -135,7 +135,7 @@ class ContextualHintEligibilityUtilityTests: XCTestCase {
         subject = ContextualHintEligibilityUtility(with: profile,
                                                    overlayState: overlayState,
                                                    device: MockUIDevice(isIpad: true))
-        overlayState.openNewTab(nil, url: nil)
+        overlayState.openNewTab(url: nil, newTabSettings: .topSites)
         let result = subject.canPresent(.jumpBackInSyncedTab)
         XCTAssertFalse(result)
     }

--- a/Tests/ClientTests/Mocks/MockOverlayModeManager.swift
+++ b/Tests/ClientTests/Mocks/MockOverlayModeManager.swift
@@ -20,9 +20,9 @@ class MockOverlayModeManager: DefaultOverlayModeManager {
         super.openNewTab(locationText, url: url)
     }
 
-    override func finishEdition(shouldCancelLoading: Bool) {
+    override func finishEditing(shouldCancelLoading: Bool) {
         leaveOverlayModeCallCount += 1
-        super.finishEdition(shouldCancelLoading: shouldCancelLoading)
+        super.finishEditing(shouldCancelLoading: shouldCancelLoading)
     }
 
     override func switchTab(shouldCancelLoading: Bool) {

--- a/Tests/ClientTests/Mocks/MockOverlayModeManager.swift
+++ b/Tests/ClientTests/Mocks/MockOverlayModeManager.swift
@@ -15,9 +15,9 @@ class MockOverlayModeManager: DefaultOverlayModeManager {
         super.openSearch(with: pasteContent)
     }
 
-    override func openNewTab(_ locationText: String?, url: URL?) {
+    override func openNewTab(url: URL?, newTabSettings: NewTabPage) {
         enterOverlayModeCallCount += 1
-        super.openNewTab(locationText, url: url)
+        super.openNewTab(url: url, newTabSettings: newTabSettings)
     }
 
     override func finishEditing(shouldCancelLoading: Bool) {

--- a/Tests/ClientTests/OverlayModeManagerTests.swift
+++ b/Tests/ClientTests/OverlayModeManagerTests.swift
@@ -55,7 +55,7 @@ class OverlayModeManagerTests: XCTestCase {
     // MARK: - Test EnterOverlay for finish edition
 
     func testLeaveOverlayMode_ForFinishEdition() {
-        subject.finishEdition(shouldCancelLoading: true)
+        subject.finishEditing(shouldCancelLoading: true)
 
         XCTAssertFalse(subject.inOverlayMode)
         XCTAssertEqual(subject.leaveOverlayModeCallCount, 1)

--- a/Tests/ClientTests/OverlayModeManagerTests.swift
+++ b/Tests/ClientTests/OverlayModeManagerTests.swift
@@ -65,7 +65,7 @@ class OverlayModeManagerTests: XCTestCase {
         XCTAssertEqual(subject.enterOverlayModeCallCount, 1)
     }
 
-    func testNotEnterOverlayMode_ForCustomUrl_WithURL() {
+    func testNotEnterOverlayMode_ForCustomUrl() {
         subject.setURLBar(urlBarView: urlBar)
         subject.openNewTab(url: URL(string: "https://test.com"),
                            newTabSettings: .homePage)

--- a/Tests/ClientTests/OverlayModeManagerTests.swift
+++ b/Tests/ClientTests/OverlayModeManagerTests.swift
@@ -13,7 +13,6 @@ class OverlayModeManagerTests: XCTestCase {
         super.setUp()
         urlBar = MockURLBarView()
         subject = MockOverlayModeManager()
-        subject.setURLBar(urlBarView: urlBar)
     }
 
     override func tearDown() {
@@ -23,38 +22,79 @@ class OverlayModeManagerTests: XCTestCase {
     }
 
     // MARK: - Test EnterOverlay for New tab
-    func testEnterOverlayMode_ForNewTabWithNilURL() {
-        subject.openNewTab(nil, url: nil)
-
-        XCTAssertTrue(subject.inOverlayMode)
-    }
-
-    func testEnterOverlayMode_ForNewTabWithHomeURL() {
-        subject.openNewTab(nil, url: URL(string: "internal://local/about/home"))
+    func testEnterOverlayMode_ForNewTabHome_WithNilURL() {
+        subject.setURLBar(urlBarView: urlBar)
+        subject.openNewTab(url: nil, newTabSettings: .topSites)
 
         XCTAssertTrue(subject.inOverlayMode)
         XCTAssertEqual(subject.enterOverlayModeCallCount, 1)
     }
 
-    func testEnterOverlayMode_ForNewTabWithURL() {
-        subject.openNewTab(nil, url: URL(string: "https://test.com"))
+    func testEnterOverlayMode_ForNewTabHome_WithHomeURL() {
+        subject.setURLBar(urlBarView: urlBar)
+        subject.openNewTab(url: URL(string: "internal://local/about/home"),
+                           newTabSettings: .topSites)
+
+        XCTAssertTrue(subject.inOverlayMode)
+        XCTAssertEqual(subject.enterOverlayModeCallCount, 1)
+    }
+
+    func testEnterOverlayMode_ForNewTabHome_WithURL() {
+        subject.setURLBar(urlBarView: urlBar)
+        subject.openNewTab(url: URL(string: "https://test.com"),
+                           newTabSettings: .topSites)
 
         XCTAssertFalse(subject.inOverlayMode)
         XCTAssertEqual(subject.enterOverlayModeCallCount, 1)
     }
 
+    func testEnterOverlayMode_ForBlankPage_WithNilURL() {
+        subject.setURLBar(urlBarView: urlBar)
+        subject.openNewTab(url: nil, newTabSettings: .blankPage)
+
+        XCTAssertTrue(subject.inOverlayMode)
+        XCTAssertEqual(subject.enterOverlayModeCallCount, 1)
+    }
+
+    func testEnterOverlayMode_ForBlankPage_WithURL() {
+        subject.setURLBar(urlBarView: urlBar)
+        subject.openNewTab(url: URL(string: "https://test.com"),
+                           newTabSettings: .blankPage)
+
+        XCTAssertTrue(subject.inOverlayMode)
+        XCTAssertEqual(subject.enterOverlayModeCallCount, 1)
+    }
+
+    func testNotEnterOverlayMode_ForCustomUrl_WithURL() {
+        subject.setURLBar(urlBarView: urlBar)
+        subject.openNewTab(url: URL(string: "https://test.com"),
+                           newTabSettings: .homePage)
+
+        XCTAssertFalse(subject.inOverlayMode)
+    }
+
+    func testNotEnterOverlayMode_ForCustomUrl_WithNilURL() {
+        subject.setURLBar(urlBarView: urlBar)
+        subject.openNewTab(url: nil,
+                           newTabSettings: .homePage)
+
+        XCTAssertFalse(subject.inOverlayMode)
+    }
+
     // MARK: - Test EnterOverlay for paste action
 
     func testEnterOverlayMode_ForPasteContent() {
+        subject.setURLBar(urlBarView: urlBar)
         subject.openSearch(with: "paste")
 
         XCTAssertTrue(subject.inOverlayMode)
         XCTAssertEqual(subject.enterOverlayModeCallCount, 1)
     }
 
-    // MARK: - Test EnterOverlay for finish edition
+    // MARK: - Test EnterOverlay for finish editing
 
-    func testLeaveOverlayMode_ForFinishEdition() {
+    func testLeaveOverlayMode_ForFinishEditing() {
+        subject.setURLBar(urlBarView: urlBar)
         subject.finishEditing(shouldCancelLoading: true)
 
         XCTAssertFalse(subject.inOverlayMode)
@@ -62,10 +102,27 @@ class OverlayModeManagerTests: XCTestCase {
     }
 
     // MARK: - Test EnterOverlay for Tab change
-    func testEnterOverlayMode_ForSwitchTab() {
+    func testLeaveOverlayMode_ForSwitchTab() {
+        subject.setURLBar(urlBarView: urlBar)
         subject.switchTab(shouldCancelLoading: true)
 
         XCTAssertFalse(subject.inOverlayMode)
         XCTAssertEqual(subject.leaveOverlayModeCallCount, 1)
+    }
+
+    func testLeaveOverlayMode_ForSwitchTabInOverlayMode() {
+        subject.setURLBar(urlBarView: urlBar)
+        subject.openSearch(with: "")
+        subject.switchTab(shouldCancelLoading: true)
+
+        XCTAssertFalse(subject.inOverlayMode)
+        XCTAssertEqual(subject.leaveOverlayModeCallCount, 1)
+    }
+
+    // MARK: - Test URLBarView nil
+    func testOverlayMode_ForNilURLBar() {
+        urlBar = nil
+        subject.openSearch(with: "search")
+        XCTAssertFalse(subject.inOverlayMode)
     }
 }

--- a/Tests/ClientTests/OverlayModeManagerTests.swift
+++ b/Tests/ClientTests/OverlayModeManagerTests.swift
@@ -21,6 +21,13 @@ class OverlayModeManagerTests: XCTestCase {
         subject = nil
     }
 
+    // MARK: - Test URLBarView nil
+    func testOverlayMode_ForNilURLBar() {
+        urlBar = nil
+        subject.openSearch(with: "search")
+        XCTAssertFalse(subject.inOverlayMode)
+    }
+
     // MARK: - Test EnterOverlay for New tab
     func testEnterOverlayMode_ForNewTabHome_WithNilURL() {
         subject.setURLBar(urlBarView: urlBar)
@@ -117,12 +124,5 @@ class OverlayModeManagerTests: XCTestCase {
 
         XCTAssertFalse(subject.inOverlayMode)
         XCTAssertEqual(subject.leaveOverlayModeCallCount, 1)
-    }
-
-    // MARK: - Test URLBarView nil
-    func testOverlayMode_ForNilURLBar() {
-        urlBar = nil
-        subject.openSearch(with: "search")
-        XCTAssertFalse(subject.inOverlayMode)
     }
 }


### PR DESCRIPTION

### [FXIOS-5639](https://mozilla-hub.atlassian.net/browse/FXIOS-5639) | #13023 

- Remove unnecessary delegate func related to dismissing of the keyboard
- Rename protocol func and update parameters as some where never used
- Add logic to openNewTab to have into account the user settings for new Tab
- Update unit test