### PR TITLE
Refactor FXIOS-5842 [v112] fix testable import client warnings

### DIFF
--- a/Account/Account-Bridging-Header.h
+++ b/Account/Account-Bridging-Header.h
@@ -6,5 +6,6 @@
 
 #import <Foundation/Foundation.h>
 #import "Shared-Bridging-Header.h"
+#import "Client-Bridging-Header.h"
 
 #endif

--- a/Account/Account-Bridging-Header.h
+++ b/Account/Account-Bridging-Header.h
@@ -6,6 +6,7 @@
 
 #import <Foundation/Foundation.h>
 #import "Shared-Bridging-Header.h"
+//bridgding header from the client that was previously implicitely imported
 #import "Client-Bridging-Header.h"
 
 #endif

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -666,6 +666,7 @@
 		A83E5B1D1C1DA8D80026D912 /* UIPasteboardExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83E5B1C1C1DA8D80026D912 /* UIPasteboardExtensionsTests.swift */; };
 		A9072B801D07B34100459960 /* NoImageModeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9072B7F1D07B34100459960 /* NoImageModeHelper.swift */; };
 		A93067E81D0FE18E00C49C6E /* NightModeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93067E71D0FE18E00C49C6E /* NightModeHelper.swift */; };
+		AB7D4C3129ACAED100626427 /* Tab+ChangeUserAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB7D4C3029ACAED100626427 /* Tab+ChangeUserAgentTests.swift */; };
 		BA6E311FBCA7A2157F48568A /* Telemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6E371A3948814CAA0C83E4 /* Telemetry.swift */; };
 		BA6E3BF4B5AC115E7DBCAA5E /* FxATelemtryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6E376117A53502756759A2 /* FxATelemtryTests.swift */; };
 		C400467C1CF4E43E00B08303 /* BackForwardListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C400467B1CF4E43E00B08303 /* BackForwardListViewController.swift */; };
@@ -3750,6 +3751,7 @@
 		AAF64ABAB8A585208603D45B /* dsb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = dsb; path = dsb.lproj/LoginManager.strings; sourceTree = "<group>"; };
 		AB2B45078A7F1E09F65ACEC5 /* cy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cy; path = cy.lproj/Shared.strings; sourceTree = "<group>"; };
 		AB7C4D658AB44D577390B61F /* an */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = an; path = an.lproj/Menu.strings; sourceTree = "<group>"; };
+		AB7D4C3029ACAED100626427 /* Tab+ChangeUserAgentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Tab+ChangeUserAgentTests.swift"; sourceTree = "<group>"; };
 		AC1846BB804B44D52BA6F0F2 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/LoginManager.strings; sourceTree = "<group>"; };
 		AC434095AC70313F20D9EEFE /* fil */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fil; path = fil.lproj/Shared.strings; sourceTree = "<group>"; };
 		AC65443AB444EAE083C479E5 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Shared.strings; sourceTree = "<group>"; };
@@ -6673,6 +6675,7 @@
 			isa = PBXGroup;
 			children = (
 				6A5F591C28627C0100FABA92 /* TabManagerNavDelegateTests.swift */,
+				AB7D4C3029ACAED100626427 /* Tab+ChangeUserAgentTests.swift */,
 				63306D442110BAF000F25400 /* TabManagerStoreTests.swift */,
 				7BBFEE731BB405D900A305AA /* TabManagerTests.swift */,
 				215B458327DA87FC00E5E800 /* TabMetadataManagerTests.swift */,
@@ -10775,6 +10778,7 @@
 				2F44FA1B1A9D426A00FD20CC /* TestHashExtensions.swift in Sources */,
 				5AF6254928A58BB400A90253 /* MockHistoryHighlightsDelegate.swift in Sources */,
 				8A04136B2825ABEA00D20B10 /* SponsoredTileTelemetryTests.swift in Sources */,
+				AB7D4C3129ACAED100626427 /* Tab+ChangeUserAgentTests.swift in Sources */,
 				5A70EF19295E2E1600790249 /* DependencyHelperMock.swift in Sources */,
 				8A96C4BB28F9E7B300B75884 /* XCTestCaseRootViewController.swift in Sources */,
 				8ADED7EC27691351009C19E6 /* CalendarExtensionsTests.swift in Sources */,

--- a/Client/Frontend/Browser/TabManagement/Tab+ChangeUserAgent.swift
+++ b/Client/Frontend/Browser/TabManagement/Tab+ChangeUserAgent.swift
@@ -13,7 +13,8 @@ extension Tab {
         }()
 
         private static var baseDomainList: Set<String> = {
-            if let hosts = NSKeyedUnarchiver.unarchiveObject(withFile: ChangeUserAgent.file.path) as? Set<String> {
+            if let data = try? Data(contentsOf: ChangeUserAgent.file),
+               let hosts = try? NSKeyedUnarchiver.unarchivedObject(ofClasses: [NSSet.self, NSArray.self, NSString.self], from: data) as? Set<String> {
                 return hosts
             }
             return Set<String>()
@@ -53,7 +54,7 @@ extension Tab {
 
             // At this point, saving to disk takes place.
             do {
-                let data = try NSKeyedArchiver.archivedData(withRootObject: baseDomainList, requiringSecureCoding: false)
+                let data = try NSKeyedArchiver.archivedData(withRootObject: baseDomainList, requiringSecureCoding: true)
                 try data.write(to: ChangeUserAgent.file)
             } catch {}
         }

--- a/Client/Frontend/Browser/TabManagement/Tab+ChangeUserAgent.swift
+++ b/Client/Frontend/Browser/TabManagement/Tab+ChangeUserAgent.swift
@@ -54,7 +54,7 @@ extension Tab {
 
             // At this point, saving to disk takes place.
             do {
-                let data = try NSKeyedArchiver.archivedData(withRootObject: baseDomainList, requiringSecureCoding: true)
+                let data = try NSKeyedArchiver.archivedData(withRootObject: baseDomainList, requiringSecureCoding: false)
                 try data.write(to: ChangeUserAgent.file)
             } catch {}
         }

--- a/Storage/Storage-Bridging-Header.h
+++ b/Storage/Storage-Bridging-Header.h
@@ -6,5 +6,6 @@
 #import <sqlite3.h>
 
 #import "Shared-Bridging-Header.h"
+#import "Client-Bridging-Header.h"
 
 #endif

--- a/Tests/ClientTests/Frontend/Browser/TabManagement/Tab+ChangeUserAgentTests.swift
+++ b/Tests/ClientTests/Frontend/Browser/TabManagement/Tab+ChangeUserAgentTests.swift
@@ -1,0 +1,44 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+@testable import Client
+
+import XCTest
+
+class ChangeUserAgentTests: XCTestCase {
+    struct ChangeUserAgentsMockData {
+        let urlString: String
+        let userAgentWasChanged: Bool
+        let isPrivate: Bool
+        let expectContainsURL: Bool
+    }
+    // Create a mock file to use for testing
+    let testFile = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("test-changed-ua-set-of-hosts.xcarchive")
+    override func setUp() {
+        // Ensure test file is empty before each test
+        try? Data().write(to: testFile)
+    }
+    func testUpdateAndContains() {
+        let testMockData1 = ChangeUserAgentsMockData(urlString: "https://www.google.com", userAgentWasChanged: true, isPrivate: false, expectContainsURL: true)
+        let testMockData2 = ChangeUserAgentsMockData(urlString: "https://www.mozilla.org", userAgentWasChanged: true, isPrivate: true, expectContainsURL: true)
+        let testMockData3 = ChangeUserAgentsMockData(urlString: "https://www.apple.com", userAgentWasChanged: false, isPrivate: false, expectContainsURL: false)
+        let testMockData4 = ChangeUserAgentsMockData(urlString: "https://www.yahoo.com", userAgentWasChanged: false, isPrivate: true, expectContainsURL: false)
+        let testCases = [testMockData1, testMockData2, testMockData3, testMockData4]
+        for testCase in testCases {
+            let url = URL(string: testCase.urlString)!
+            Tab.ChangeUserAgent.updateDomainList(forUrl: url, isChangedUA: testCase.userAgentWasChanged, isPrivate: testCase.isPrivate)
+            XCTAssertEqual(Tab.ChangeUserAgent.contains(url: url), testCase.expectContainsURL)
+        }
+    }
+    func testClear() {
+        let url = URL(string: "https://www.google.com")!
+        Tab.ChangeUserAgent.updateDomainList(forUrl: url, isChangedUA: true, isPrivate: false)
+        XCTAssert(Tab.ChangeUserAgent.contains(url: url))
+
+        Tab.ChangeUserAgent.clear()
+        XCTAssertFalse(Tab.ChangeUserAgent.contains(url: url))
+    }
+}


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/FXIOS-5842
The test module is implicitly importing the main module's bridging header. You don't need to import it. Everything is OK.
Everything is OK now, but it won't be OK later because this "implicit" import will disappear soon (deprecated) and thus, it's not gonna be OK anymore.
In order to stay OK, you should "explicitly" import your main module's bridging header in your test module's bridging header.