### PR TITLE
Add FXIOS-5790 [v112.1] Rust sync manager appservices component calls 

### DIFF
--- a/.experimenter.yaml
+++ b/.experimenter.yaml
@@ -106,6 +106,14 @@ onboarding-feature:
     upgrade-flow:
       type: boolean
       description: "If true, we show the Upgrade onboarding screen when the user upgrades the version.\n"
+rust-sync-manager-component:
+  description: The feature that controls whether we use the rust sync manager
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    use-rust-sync-manager:
+      type: boolean
+      description: "If true, syncs will be performed by the `RustSyncManager` class backed by the rust sync manager component."
 search:
   description: "Configuring the functionality to do with search. This will be separated into smaller sub-features in later releases.\n"
   hasExposure: true

--- a/Account/FxAPushMessageHandler.swift
+++ b/Account/FxAPushMessageHandler.swift
@@ -125,7 +125,7 @@ extension FxAPushMessageHandler {
                             }
 
                             waitForClient = Deferred<Maybe<String>>()
-                            profile.remoteClientsAndTabs.getClient(fxaDeviceId: deviceId).uponQueue(.main) { result in
+                            profile.getClient(fxaDeviceId: deviceId).uponQueue(.main) { result in
                                 guard let device = result.successValue else {
                                     waitForClient?.fill(Maybe(failure: result.failureValue ?? "Unknown Error"))
                                     return

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -1279,6 +1279,7 @@
 		F8708D2E1A0970B70051AB07 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F8708D251A0970990051AB07 /* Images.xcassets */; };
 		F8708D321A0970B70051AB07 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8708D291A0970990051AB07 /* ShareViewController.swift */; };
 		F886218C270CD3B8007F4562 /* DevicePasscodeRequiredViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F886218B270CD3B8007F4562 /* DevicePasscodeRequiredViewController.swift */; };
+		F886BFBD29AD56A400F77224 /* RustSyncManagerAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = F886BFBC29AD56A400F77224 /* RustSyncManagerAPI.swift */; };
 		F8AAC1B429663619000BCDEC /* RustAutofill.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AAC1B329663618000BCDEC /* RustAutofill.swift */; };
 		F8AAC1B7296637CE000BCDEC /* RustAutofillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AAC1B5296637B7000BCDEC /* RustAutofillTests.swift */; };
 		FA6B2AC21D41F02D00429414 /* String+Punycode.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6B2AC11D41F02D00429414 /* String+Punycode.swift */; };
@@ -5553,6 +5554,7 @@
 		F8708D261A0970990051AB07 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F8708D291A0970990051AB07 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
 		F886218B270CD3B8007F4562 /* DevicePasscodeRequiredViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevicePasscodeRequiredViewController.swift; sourceTree = "<group>"; };
+		F886BFBC29AD56A400F77224 /* RustSyncManagerAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RustSyncManagerAPI.swift; sourceTree = "<group>"; };
 		F8984594958004CB86902EE3 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		F8AAC1B329663618000BCDEC /* RustAutofill.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RustAutofill.swift; sourceTree = "<group>"; };
 		F8AAC1B5296637B7000BCDEC /* RustAutofillTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RustAutofillTests.swift; sourceTree = "<group>"; };
@@ -6061,6 +6063,7 @@
 		28CE83B91A1D1D3200576538 /* Sync */ = {
 			isa = PBXGroup;
 			children = (
+				F886BFBC29AD56A400F77224 /* RustSyncManagerAPI.swift */,
 				2894C1641AE89DBC00F1F92F /* Synchronizers */,
 				282731601ABC9BE600AA1954 /* Supporting Files */,
 				28926B3D1AC0F1A6009C0B1D /* Meta */,
@@ -10106,6 +10109,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				28926B3A1AC0F128009C0B1D /* CleartextPayloadJSON.swift in Sources */,
+				F886BFBD29AD56A400F77224 /* RustSyncManagerAPI.swift in Sources */,
 				2827319D1ABC9C2F00AA1954 /* SyncMeta.swift in Sources */,
 				D0BE845520E1660F006A1282 /* Keys.swift in Sources */,
 				282731991ABC9C2F00AA1954 /* ClientPayload.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -1281,6 +1281,9 @@
 		F886218C270CD3B8007F4562 /* DevicePasscodeRequiredViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F886218B270CD3B8007F4562 /* DevicePasscodeRequiredViewController.swift */; };
 		F886BFBD29AD56A400F77224 /* RustSyncManagerAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = F886BFBC29AD56A400F77224 /* RustSyncManagerAPI.swift */; };
 		F8A0B08229AD61FA0091C75B /* RustSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A0B08129AD61FA0091C75B /* RustSyncManager.swift */; };
+		F8A0B08329AD64790091C75B /* RustSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A0B08129AD61FA0091C75B /* RustSyncManager.swift */; };
+		F8A0B08429AD64790091C75B /* RustSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A0B08129AD61FA0091C75B /* RustSyncManager.swift */; };
+		F8A0B08529AD647B0091C75B /* RustSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A0B08129AD61FA0091C75B /* RustSyncManager.swift */; };
 		F8AAC1B429663619000BCDEC /* RustAutofill.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AAC1B329663618000BCDEC /* RustAutofill.swift */; };
 		F8AAC1B7296637CE000BCDEC /* RustAutofillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AAC1B5296637B7000BCDEC /* RustAutofillTests.swift */; };
 		FA6B2AC21D41F02D00429414 /* String+Punycode.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6B2AC11D41F02D00429414 /* String+Punycode.swift */; };
@@ -10353,6 +10356,7 @@
 				396E38DD1EE081DA00CC180F /* SyncStatusResolver.swift in Sources */,
 				6025B10E267B6C7F00F59F6B /* LoginRecordExtension.swift in Sources */,
 				396E38F21EE0C8ED00CC180F /* FxAPushMessageHandler.swift in Sources */,
+				F8A0B08329AD64790091C75B /* RustSyncManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -10523,6 +10527,7 @@
 			files = (
 				8AB8574227D963290075C173 /* UIConstants.swift in Sources */,
 				6025B10C267B6BEA00F59F6B /* LoginRecordExtension.swift in Sources */,
+				F8A0B08529AD647B0091C75B /* RustSyncManager.swift in Sources */,
 				C8CE38BB265E71FE0009B09E /* ItemListCell.swift in Sources */,
 				F8324A0A2649A188007E4BFA /* CredentialProviderViewController.swift in Sources */,
 				60CE80C12667780D004026C7 /* CredentialListPresenter.swift in Sources */,
@@ -11261,6 +11266,7 @@
 				E1D6F2D828E325D100B2C8CC /* InstructionsView.swift in Sources */,
 				FA6B2AC41D41F02D00429414 /* String+Punycode.swift in Sources */,
 				E1D6F2D928E32A5300B2C8CC /* ImageIdentifiers.swift in Sources */,
+				F8A0B08429AD64790091C75B /* RustSyncManager.swift in Sources */,
 				D38B2D8A1A8D98D00040E6B5 /* SearchEngines.swift in Sources */,
 				EB6E0C60207E6C3100FBFF7E /* SendToDevice.swift in Sources */,
 				D3C744CF1A687D6C004CE85D /* URIFixup.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -1280,6 +1280,7 @@
 		F8708D321A0970B70051AB07 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8708D291A0970990051AB07 /* ShareViewController.swift */; };
 		F886218C270CD3B8007F4562 /* DevicePasscodeRequiredViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F886218B270CD3B8007F4562 /* DevicePasscodeRequiredViewController.swift */; };
 		F886BFBD29AD56A400F77224 /* RustSyncManagerAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = F886BFBC29AD56A400F77224 /* RustSyncManagerAPI.swift */; };
+		F8A0B08229AD61FA0091C75B /* RustSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A0B08129AD61FA0091C75B /* RustSyncManager.swift */; };
 		F8AAC1B429663619000BCDEC /* RustAutofill.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AAC1B329663618000BCDEC /* RustAutofill.swift */; };
 		F8AAC1B7296637CE000BCDEC /* RustAutofillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AAC1B5296637B7000BCDEC /* RustAutofillTests.swift */; };
 		FA6B2AC21D41F02D00429414 /* String+Punycode.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6B2AC11D41F02D00429414 /* String+Punycode.swift */; };
@@ -5556,6 +5557,7 @@
 		F886218B270CD3B8007F4562 /* DevicePasscodeRequiredViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevicePasscodeRequiredViewController.swift; sourceTree = "<group>"; };
 		F886BFBC29AD56A400F77224 /* RustSyncManagerAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RustSyncManagerAPI.swift; sourceTree = "<group>"; };
 		F8984594958004CB86902EE3 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/ErrorPages.strings; sourceTree = "<group>"; };
+		F8A0B08129AD61FA0091C75B /* RustSyncManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustSyncManager.swift; sourceTree = "<group>"; };
 		F8AAC1B329663618000BCDEC /* RustAutofill.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RustAutofill.swift; sourceTree = "<group>"; };
 		F8AAC1B5296637B7000BCDEC /* RustAutofillTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RustAutofillTests.swift; sourceTree = "<group>"; };
 		F8CA43008FC72296965ED032 /* ne-NP */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ne-NP"; path = "ne-NP.lproj/ClearPrivateDataConfirm.strings"; sourceTree = "<group>"; };
@@ -7764,6 +7766,7 @@
 				D34DC84D1A16C40C00D49B7B /* Profile.swift */,
 				1D0BA05B24F46A0400D731B5 /* TopSitesProvider.swift */,
 				8A5BD95E2878B7B6000FE773 /* TopSitesWidgetManager.swift */,
+				F8A0B08129AD61FA0091C75B /* RustSyncManager.swift */,
 			);
 			path = Providers;
 			sourceTree = "<group>";
@@ -10634,6 +10637,7 @@
 				D3C3696E1CC6B78800348A61 /* LocalRequestHelper.swift in Sources */,
 				C87DC85C27B2C94D006EFCE2 /* LegacyWallpaperResourceManager.swift in Sources */,
 				E4B423DD1ABA0318007E66C8 /* ReaderModeHandlers.swift in Sources */,
+				F8A0B08229AD61FA0091C75B /* RustSyncManager.swift in Sources */,
 				D308E4E41A5306F500842685 /* SearchEngines.swift in Sources */,
 				3BCE6D3C1CEB9E4D0080928C /* ThirdPartySearchAlerts.swift in Sources */,
 				E195440528A5AFDE00304CF0 /* BottomSheetViewController.swift in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -13,9 +13,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var notificationCenter: NotificationProtocol = NotificationCenter.default
     var orientationLock = UIInterfaceOrientationMask.all
 
+    // This variable is used to determine whether the rust sync manager will be used
+    // during the Nimbus experiment and will be removed when it is complete.
+    private let rustSyncManagerStatus = FxNimbus.shared
+                                                .features
+                                                .rustSyncManagerComponent
+                                                .value()
+                                                .useRustSyncManager
     lazy var profile: Profile = BrowserProfile(
         localName: "profile",
-        syncDelegate: UIApplication.shared.syncDelegate
+        syncDelegate: UIApplication.shared.syncDelegate,
+        rustSyncManagerEnabled: rustSyncManagerStatus
     )
     lazy var tabManager: TabManager = TabManagerImplementation(
         profile: profile,

--- a/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -28,7 +28,6 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case pullToRefresh
     case recentlySaved
     case reportSiteIssue
-    case rustSyncManagerComponent
     case searchHighlights
     case shakeToRestore
     case shareSheetChanges
@@ -102,7 +101,6 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .onboardingFreshInstall,
                 .onboardingNotificationCard,
                 .reportSiteIssue,
-                .rustSyncManagerComponent,
                 .searchHighlights,
                 .shakeToRestore,
                 .shareSheetChanges,

--- a/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -28,6 +28,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case pullToRefresh
     case recentlySaved
     case reportSiteIssue
+    case rustSyncManagerComponent
     case searchHighlights
     case shakeToRestore
     case shareSheetChanges
@@ -101,6 +102,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .onboardingFreshInstall,
                 .onboardingNotificationCard,
                 .reportSiteIssue,
+                .rustSyncManagerComponent,
                 .searchHighlights,
                 .shakeToRestore,
                 .shareSheetChanges,

--- a/Client/Frontend/Browser/TabPeekViewController.swift
+++ b/Client/Frontend/Browser/TabPeekViewController.swift
@@ -179,9 +179,7 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
                 self.isBookmarked = isBookmarked
             }
 
-            browserProfile.remoteClientsAndTabs.getClientGUIDs().uponQueue(.main) {
-                guard let clientGUIDs = $0.successValue else { return }
-
+            browserProfile.getClientGUIDs { clientGUIDs in
                 self.hasRemoteClients = !clientGUIDs.isEmpty
                 let clientPickerController = DevicePickerViewController(profile: browserProfile)
                 clientPickerController.pickerDelegate = clientPickerDelegate
@@ -190,7 +188,9 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
                     clientPickerController.shareItem = ShareItem(url: url, title: tab.title)
                 }
 
-                self.fxaDevicePicker = UINavigationController(rootViewController: clientPickerController)
+                DispatchQueue.main.async {
+                    self.fxaDevicePicker = UINavigationController(rootViewController: clientPickerController)
+                }
             }
 
             let result = browserProfile.readingList.getRecordWithURL(displayURL).value.successValue

--- a/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -72,6 +72,9 @@ final class NimbusFeatureFlagLayer {
         case .zoomFeature:
             return checkZoomFeature(from: nimbus)
 
+        case .rustSyncManagerComponent:
+            return checkNimbusForRustSyncManager(for: featureID, from: nimbus)
+
         case .engagementNotificationStatus:
             return checkNimbusForEngagementNotification(for: featureID, from: nimbus)
 
@@ -206,6 +209,17 @@ final class NimbusFeatureFlagLayer {
             }
     }
 
+    public func checkNimbusForRustSyncManager(
+        for featureID: NimbusFeatureFlagID,
+        from nimbus: FxNimbus) -> Bool {
+            let config = nimbus.features.rustSyncManagerComponent.value()
+
+            switch featureID {
+            case .rustSyncManagerComponent: return config.useRustSyncManager
+            default: return false
+            }
+    }
+
     public func checkNimbusForEngagementNotification(
         for featureID: NimbusFeatureFlagID,
         from nimbus: FxNimbus) -> Bool {
@@ -226,7 +240,7 @@ final class NimbusFeatureFlagLayer {
             case .notificationSettings: return config.notificationSettingsFeatureStatus
             default: return false
             }
-        }
+    }
 
     private func checkNimbusForOnboardingFeature(
         for featureID: NimbusFeatureFlagID,

--- a/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -72,9 +72,6 @@ final class NimbusFeatureFlagLayer {
         case .zoomFeature:
             return checkZoomFeature(from: nimbus)
 
-        case .rustSyncManagerComponent:
-            return checkNimbusForRustSyncManager(for: featureID, from: nimbus)
-
         case .engagementNotificationStatus:
             return checkNimbusForEngagementNotification(for: featureID, from: nimbus)
 
@@ -205,17 +202,6 @@ final class NimbusFeatureFlagLayer {
 
             switch featureID {
             case .creditCardAutofillStatus: return config.creditCardAutofillStatus
-            default: return false
-            }
-    }
-
-    public func checkNimbusForRustSyncManager(
-        for featureID: NimbusFeatureFlagID,
-        from nimbus: FxNimbus) -> Bool {
-            let config = nimbus.features.rustSyncManagerComponent.value()
-
-            switch featureID {
-            case .rustSyncManagerComponent: return config.useRustSyncManager
             default: return false
             }
     }

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -557,9 +557,7 @@ open class BrowserProfile: Profile {
             logger.log(msg, level: .debug, category: .sync)
 
             tabs.getClientGUIDs { (result, error) in
-                guard let guids = result else {
-                    return
-                }
+                guard let guids = result else { return }
                 completion(guids)
             }
         } else {

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -575,7 +575,8 @@ open class BrowserProfile: Profile {
         logger.log("Getting all tabs and clients", level: .debug, category: .tabs)
 
         guard let accountManager = self.rustFxA.accountManager.peek(),
-              let state = accountManager.deviceConstellation()?.state() else {
+              let state = accountManager.deviceConstellation()?.state()
+        else {
             return deferMaybe([])
         }
 

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -567,9 +567,7 @@ open class BrowserProfile: Profile {
             logger.log(msg, level: .debug, category: .sync)
 
             remoteClientsAndTabs.getClientGUIDs().upon { result in
-                guard let guids = result.successValue else {
-                    return
-                }
+                guard let guids = result.successValue else { return }
                 completion(guids)
             }
         }

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -213,6 +213,7 @@ open class BrowserProfile: Profile {
     var syncManager: SyncManager!
 
     var syncDelegate: SyncDelegate?
+    var useRustSyncManager: Bool = false
 
     /**
      * N.B., BrowserProfile is used from our extensions, often via a pattern like
@@ -228,6 +229,7 @@ open class BrowserProfile: Profile {
      */
     init(localName: String,
          syncDelegate: SyncDelegate? = nil,
+         rustSyncManagerEnabled: Bool = false,
          clear: Bool = false,
          logger: Logger = DefaultLogger.shared) {
         logger.log("Initing profile \(localName) on thread \(Thread.current).",
@@ -303,9 +305,31 @@ open class BrowserProfile: Profile {
         // By default, filter logging from Rust below `.info` level.
         try? RustLog.shared.setLevelFilter(filter: .info)
 
-        // This has to happen prior to the databases being opened, because opening them can trigger
-        // events to which the SyncManager listens.
-        self.syncManager = BrowserSyncManager(profile: self)
+        // Set to true if either the Nimbus flag is enabled or RustSyncManager has been
+        // used before. Using these two values to check whether RustSyncManager has been
+        // used will prevent BrowserSyncManager being used after upgrading to RustSyncManager
+        // in the event the Nimbus experiment is ended prematurely.
+        self.useRustSyncManager = rustSyncManagerEnabled ||
+            self.prefs.boolForKey(PrefsKeys.HasRustSyncManagerEverBeenUsed) ?? false
+
+        // Initiating the sync manager has to happen prior to the databases being opened,
+        // because opening them can trigger events to which the SyncManager listens.
+        if self.useRustSyncManager {
+            let msg = "Setting `syncManager` property to `RustSyncManager"
+            logger.log(msg, level: .debug, category: .sync)
+
+            self.syncManager = RustSyncManager(profile: self)
+
+            // Setting this pref to true in the event this is the first time
+            // RustSyncManager is being used. If it's been used before setting this pref
+            // to true does no harm.
+            self.prefs.setBool(true, forKey: PrefsKeys.HasRustSyncManagerEverBeenUsed)
+        } else {
+            let msg = "Setting `syncManager` property to `BrowserSyncManager"
+            logger.log(msg, level: .debug, category: .sync)
+
+            self.syncManager = BrowserSyncManager(profile: self)
+        }
 
         let notificationCenter = NotificationCenter.default
 
@@ -509,43 +533,117 @@ open class BrowserProfile: Profile {
         return syncDelegate ?? CommandStoringSyncDelegate(profile: self)
     }
 
-    func getTabsWithNativeClients() -> Deferred<Maybe<[ClientAndTabs]>> {
-        // Because we are now using the application services tabs component with
-        // the iOS clients component (which has additional client data), we need
-        // to ensure that the clients we get from the tabs `getAll` call also
-        // exists in the clients BrowserDB table. This function will be obsolete
-        // once the sync manager component has been integrated into iOS and the
-        // iOS client synchronizer has been removed.
+    // This function exists to service the `FxaPushMessengerHandler.handle` function and
+    // will be removed after the rust sync manager experiment is complete
+    public func getClient(fxaDeviceId: String) -> Deferred<Maybe<RemoteClient?>> {
+        if useRustSyncManager {
+            let msg = "Retrieving client records from rust tabs component"
+            logger.log(msg, level: .debug, category: .sync)
 
-        return self.tabs.getAll().bind { tabsResult in
-            if let tabsError = tabsResult.failureValue { return deferMaybe(tabsError) }
+            return tabs.getClient(fxaDeviceId: fxaDeviceId)
+        } else {
+            let msg = "Retrieving client records from BrowserDB clients table"
+            logger.log(msg, level: .debug, category: .sync)
 
-            guard let clientRemoteTabs = tabsResult.successValue else { return
-                deferMaybe([])
+            return remoteClientsAndTabs.getClient(fxaDeviceId: fxaDeviceId)
+        }
+    }
+
+    // This function exists to service the `TabPeekViewController.setState` function and
+    // will be removed after the rust sync manager experiment is complete
+    public func getClientGUIDs(completion: @escaping (Set<GUID>) -> Void) {
+        if useRustSyncManager {
+            let msg = "Retrieving client GUIDs from rust tabs component"
+            logger.log(msg, level: .debug, category: .sync)
+
+            tabs.getClientGUIDs { (result, error) in
+                guard let guids = result else {
+                    return
+                }
+                completion(guids)
             }
+        } else {
+            let msg = "Retrieving client GUIDs from BrowserDB clients table"
+            logger.log(msg, level: .debug, category: .sync)
 
-            return self.remoteClientsAndTabs.getClients().bind { result in
-                if let error = result.failureValue { return deferMaybe(error) }
+            remoteClientsAndTabs.getClientGUIDs().upon { result in
+                guard let guids = result.successValue else {
+                    return
+                }
+                completion(guids)
+            }
+        }
+    }
 
-                guard let clients = result.successValue else { return deferMaybe([]) }
+    func getRustTabsWithClients() -> Deferred<Maybe<[ClientAndTabs]>> {
+        logger.log("Getting all tabs and clients", level: .debug, category: .tabs)
 
-                let clientAndTabs: [ClientAndTabs] = clientRemoteTabs.map { record in
-                    // We check if the application services clientId matches any client
-                    // GUID. If a client is found we return a record, otherwise we
-                    // continue to the next application services record.
-                    let localClient = clients.first(where: { $0.guid == record.clientId })
+        guard let accountManager = self.rustFxA.accountManager.peek(),
+              let state = accountManager.deviceConstellation()?.state() else {
+            return deferMaybe([])
+        }
 
-                    if let client = localClient {
-                        return record.toClientAndTabs(client: client)
-                    }
+        let remoteDeviceIds: [String] = state.remoteDevices.compactMap {
+            guard $0.capabilities.contains(.sendTab) else { return nil }
+            return $0.id
+        }
 
-                    self.logger.log("Could not find client data for appservices client ID \(record.clientId).",
-                                    level: .debug,
-                                    category: .tabs)
-                    return nil
-                }.compactMap { $0 }
+        let clientAndTabs = tabs.getRemoteClients(remoteDeviceIds: remoteDeviceIds)
+        return clientAndTabs
+    }
 
-                return deferMaybe(clientAndTabs)
+    func getTabsWithNativeClients() -> Deferred<Maybe<[ClientAndTabs]>> {
+        // Retrieving tabs with clients is handled differently depending on whether the
+        // rust sync manager component is being used. The `BrowserSyncManager` class syncs
+        // tabs with the rust tabs component and clients with the `ClientSynchronizer`
+        // class. So in order to ensure accurate tabs with clients data is returned while
+        // using these classes for syncing, tab records are pulled from the component's
+        // database table and filtered by the client records in the iOS BrowserDB database
+        // table.
+
+        // The new `RustSyncManager` class has no reliance on the `ClientSynchronizer` or
+        // the clients table. So when it's being used tabs with clients can be pulled from
+        // the tab component's database table and filtered by the remote devices in the
+        // user's device constellation. Once the sync manager experiment is complete this
+        // will be the way this data is retrieved unconditionally.
+        if useRustSyncManager {
+            let msg = "Retrieving tabs with clients and filtering on remote devices"
+            logger.log(msg, level: .debug, category: .sync)
+
+            return getRustTabsWithClients()
+        } else {
+            let msg = "Retrieving tabs with clients and filtering on BrowserDB clients table"
+            logger.log(msg, level: .debug, category: .sync)
+
+            return tabs.getAll().bind { tabsResult in
+                guard tabsResult.failureValue == nil else {
+                    return deferMaybe(tabsResult.failureValue!)
+                }
+                guard let clientRemoteTabs = tabsResult.successValue else {
+                    return deferMaybe([])
+                }
+
+                return self.remoteClientsAndTabs.getClients().bind { result in
+                    guard result.failureValue == nil else { return deferMaybe(result.failureValue!)}
+                    guard let clients = result.successValue else { return deferMaybe([]) }
+
+                    let clientAndTabs: [ClientAndTabs] = clientRemoteTabs.map { record in
+                        // We check if the application services clientId matches any
+                        // client GUID. If a client is found we return a record, otherwise
+                        // we continue to the next application services record.
+                        let localClient = clients
+                                            .first(where: { $0.guid == record.clientId })
+
+                        if let client = localClient {
+                            return record.toClientAndTabs(client: client)
+                        }
+                        let msg = "Could not find client data for appservices client ID \(record.clientId)."
+                        self.logger.log(msg, level: .debug, category: .tabs)
+                        return nil
+                    }.compactMap { $0 }
+
+                    return deferMaybe(clientAndTabs)
+                }
             }
         }
     }

--- a/Providers/RustSyncManager.swift
+++ b/Providers/RustSyncManager.swift
@@ -240,7 +240,7 @@ public class RustSyncManager: NSObject, SyncManager {
                 // `SyncStateMachine.clearStateFromPrefs` to reduce RustSyncManager's
                 // dependence on the swift sync state machine logic. This will make
                 // refactoring or eliminating that code easier once the rust sync manager
-                // rollout is complete.
+                // experiment is complete.
                 Scratchpad.clearFromPrefs(self.prefsForSync.branch("scratchpad"))
                 self.prefsForSync.clearAll()
             }
@@ -315,12 +315,12 @@ public class RustSyncManager: NSObject, SyncManager {
             switch engine {
             case "tabs":
                 profile?.tabs.registerWithSyncManager()
-                rustEngines.append("tabs")
+                rustEngines.append(engine)
             case "passwords":
                 profile?.logins.registerWithSyncManager()
                 if let key = try? profile?.logins.getStoredKey() {
-                    localEncryptionKeys["passwords"] = key
-                    rustEngines.append("passwords")
+                    localEncryptionKeys[engine] = key
+                    rustEngines.append(engine)
                 } else {
                     logger.log("Login encryption key could not be retrieved for syncing",
                                level: .warning,
@@ -331,7 +331,7 @@ public class RustSyncManager: NSObject, SyncManager {
                     profile?.places.registerWithSyncManager()
                     registeredPlaces = true
                 }
-                rustEngines.append("bookmarks")
+                rustEngines.append(engine)
             default:
                 continue
             }
@@ -506,8 +506,8 @@ public class RustSyncManager: NSObject, SyncManager {
 
     public func syncClientsThenTabs() -> OldSyncResult {
         // This function exists to comply with the `SyncManager` protocol while the
-        // rust sync manager rollout is enabled. To be safe, `syncTabs` is called. Once
-        // the rollout is complete this can be removed along with an update to the
+        // rust sync manager experiment is enabled. To be safe, `syncTabs` is called. Once
+        // the experiment is complete this can be removed along with an update to the
         // protocol.
 
         return syncTabs().bind { result in
@@ -524,15 +524,15 @@ public class RustSyncManager: NSObject, SyncManager {
 
     public func syncClients() -> OldSyncResult {
         // This function exists to to comply with the `SyncManager` protocol and has
-        // no callers. It will be removed when the rust sync manager rollout is complete.
-        // To be safe, `syncClientsThenTabs` is called.
+        // no callers. It will be removed when the rust sync manager experiment is
+        // complete. To be safe, `syncClientsThenTabs` is called.
         return syncClientsThenTabs()
     }
 
     public func syncHistory() -> OldSyncResult {
         // The return type of this function has been changed to comply with the
-        // `SyncManager` protocol during the rust sync manager rollout. It will be updated
-        // once the rollout is complete.
+        // `SyncManager` protocol during the rust sync manager experiment. It will be updated
+        // once the experiment is complete.
         return syncRustEngines(why: .user, engines: ["history"]).bind { result in
             if let error = result.failureValue {
                 return deferMaybe(error)

--- a/Providers/RustSyncManager.swift
+++ b/Providers/RustSyncManager.swift
@@ -371,8 +371,7 @@ public class RustSyncManager: NSObject, SyncManager {
                     }
 
                     self.getEnginesAndKeys(engines: engines).upon { result in
-                        guard let (rustEngines, localEncryptionKeys) = result
-                            .successValue else {
+                        guard let (rustEngines, localEncryptionKeys) = result.successValue else {
                             deferred.fill(Maybe(failure: EngineAndKeyRetrievalError()))
                             return
                         }

--- a/Providers/RustSyncManager.swift
+++ b/Providers/RustSyncManager.swift
@@ -1,0 +1,547 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Account
+import Shared
+import Storage
+import Sync
+import SyncTelemetry
+import AuthenticationServices
+import Common
+
+private typealias MZSyncResult = MozillaAppServices.SyncResult
+
+// Extends NSObject so we can use timers.
+public class RustSyncManager: NSObject, SyncManager {
+    // We shouldn't live beyond our containing BrowserProfile, either in the main app
+    // or in an extension.
+    // But it's possible that we'll finish a side-effect sync after we've ditched the
+    // profile as a whole, so we hold on to our Prefs, potentially for a little while
+    // longer. This is safe as a strong reference, because there's no cycle.
+    private weak var profile: BrowserProfile?
+    private let prefs: Prefs
+    private var syncTimer: Timer?
+    private var backgrounded: Bool = true
+    private let logger: Logger
+    private let fxaDeclinedEngines = "fxa.cwts.declinedSyncEngines"
+    private var notificationCenter: NotificationProtocol
+
+    let fifteenMinutesInterval = TimeInterval(60 * 15)
+
+    public var lastSyncFinishTime: Timestamp? {
+        get {
+            return prefs.timestampForKey(PrefsKeys.KeyLastSyncFinishTime)
+        }
+
+        set(value) {
+            if let value = value {
+                prefs.setTimestamp(value,
+                                   forKey: PrefsKeys.KeyLastSyncFinishTime)
+            } else {
+                prefs.removeObjectForKey(PrefsKeys.KeyLastSyncFinishTime)
+            }
+        }
+    }
+
+    lazy var syncManagerAPI = RustSyncManagerAPI(logger: logger)
+
+    public var isSyncing: Bool {
+        return syncDisplayState != nil && syncDisplayState! == .inProgress
+    }
+
+    public var syncDisplayState: SyncDisplayState?
+
+    var prefsForSync: Prefs {
+        return prefs.branch("sync")
+    }
+
+    init(profile: BrowserProfile,
+         logger: Logger = DefaultLogger.shared,
+         notificationCenter: NotificationProtocol = NotificationCenter.default) {
+        self.profile = profile
+        self.prefs = profile.prefs
+        self.logger = logger
+        self.notificationCenter = notificationCenter
+
+        super.init()
+    }
+
+    @objc func syncOnTimer() {
+        syncEverything(why: .scheduled)
+        profile?.pollCommands()
+    }
+
+    private func repeatingTimerAtInterval(
+        _ interval: TimeInterval,
+        selector: Selector
+    ) -> Timer {
+        return Timer.scheduledTimer(timeInterval: interval,
+                                    target: self,
+                                    selector: selector,
+                                    userInfo: nil,
+                                    repeats: true)
+    }
+
+    func syncEverythingSoon() {
+        doInBackgroundAfter(SyncConstants.SyncOnForegroundAfterMillis) {
+            self.logger.log("Running delayed startup sync.",
+                            level: .debug,
+                            category: .sync)
+            self.syncEverything(why: .startup)
+        }
+    }
+
+    private func beginTimedSyncs() {
+        if syncTimer != nil {
+            logger.log("Already running sync timer.",
+                       level: .debug,
+                       category: .sync)
+            return
+        }
+
+        let interval = fifteenMinutesInterval
+        let selector = #selector(syncOnTimer)
+        logger.log("Starting sync timer.",
+                   level: .info,
+                   category: .sync)
+        syncTimer = repeatingTimerAtInterval(interval, selector: selector)
+    }
+
+    /**
+     * The caller is responsible for calling this on the same thread on which it called
+     * beginTimedSyncs.
+     */
+    public func endTimedSyncs() {
+        if let timer = syncTimer {
+            logger.log("Stopping sync timer.",
+                       level: .info,
+                       category: .sync)
+            syncTimer = nil
+            timer.invalidate()
+        }
+    }
+
+    public func applicationDidBecomeActive() {
+        backgrounded = false
+
+        guard let profile = profile, profile.hasSyncableAccount() else { return }
+
+        beginTimedSyncs()
+
+        // Sync now if it's been more than our threshold.
+        let now = Date.now()
+        let then = lastSyncFinishTime ?? 0
+        guard now >= then else {
+            logger.log("Time was modified since last sync.",
+                       level: .debug,
+                       category: .sync)
+            syncEverythingSoon()
+            return
+        }
+        let since = now - then
+        logger.log("\(since)msec since last sync.",
+                   level: .debug,
+                   category: .sync)
+        if since > SyncConstants.SyncOnForegroundMinimumDelayMillis {
+            syncEverythingSoon()
+        }
+    }
+
+    public func applicationDidEnterBackground() {
+        backgrounded = true
+    }
+
+    private func beginSyncing() {
+        syncDisplayState = .inProgress
+        notifySyncing(notification: .ProfileDidStartSyncing)
+    }
+
+    private func resolveSyncState(result: MZSyncResult) -> SyncDisplayState {
+        let hasSynced = !result.successful.isEmpty
+        let status = result.status
+
+        // This is similar to the old `SyncStatusResolver.resolveResults` call. If none of
+        // the engines successfully synced and a network issue occured we return `.bad`.
+        // If none of the engines successfully synced and an auth error occured we return
+        // `.warning`. Otherwise we return `.good`.
+
+        if !hasSynced && status == .authError {
+            return .warning(message: .FirefoxSyncOfflineTitle)
+        } else if !hasSynced && status == .networkError {
+            return .bad(message: .FirefoxSyncOfflineTitle)
+        } else {
+            return .good
+        }
+    }
+
+    private func endSyncing(_ result: MZSyncResult) {
+        logger.log("Ending all syncs.",
+                   level: .info,
+                   category: .sync)
+
+        syncDisplayState = resolveSyncState(result: result)
+
+        if let syncState = syncDisplayState, syncState == .good {
+            lastSyncFinishTime = Date.now()
+        }
+
+        if canSendUsageData() {
+            let gleanHelper = GleanSyncOperationHelper()
+            gleanHelper.reportTelemetry(result)
+        } else {
+            logger.log("Profile isn't sending usage data. Not sending sync status event.",
+                       level: .debug,
+                       category: .sync)
+        }
+
+        // Don't notify if we are performing a sync in the background. This prevents more
+        // db access from happening
+        if !backgrounded {
+            notifySyncing(notification: .ProfileDidFinishSyncing)
+        }
+    }
+
+    func canSendUsageData() -> Bool {
+        return profile?.prefs.boolForKey(AppConstants.prefSendUsageData) ?? true
+    }
+
+    private func notifySyncing(notification: Notification.Name) {
+        notificationCenter.post(name: notification)
+    }
+
+    func doInBackgroundAfter(_ millis: Int64, _ block: @escaping () -> Void) {
+        let queue = DispatchQueue.global(qos: DispatchQoS.background.qosClass)
+        queue.asyncAfter(
+            deadline: DispatchTime.now() + DispatchTimeInterval.milliseconds(Int(millis)),
+            execute: block)
+    }
+
+    public func onAddedAccount() -> Success {
+        // Only sync if we're green lit. This makes sure that we don't sync unverified
+        // accounts.
+        guard let profile = profile, profile.hasSyncableAccount() else { return succeed() }
+
+        beginTimedSyncs()
+        return syncEverything(why: .didLogin)
+    }
+
+    public func onRemovedAccount() -> Success {
+        let clearPrefs: () -> Success = {
+            withExtendedLifetime(self) {
+                // Clear prefs after we're done clearing everything else -- just in case
+                // one of them needs the prefs and we race. Clear regardless of success
+                // or failure.
+
+                // This will remove keys from the Keychain if they exist, as well
+                // as wiping the Sync prefs.
+
+                // `Scratchpad.clearFromPrefs` and `clearAll` were pulled from
+                // `SyncStateMachine.clearStateFromPrefs` to reduce RustSyncManager's
+                // dependence on the swift sync state machine logic. This will make
+                // refactoring or eliminating that code easier once the rust sync manager
+                // rollout is complete.
+                Scratchpad.clearFromPrefs(self.prefsForSync.branch("scratchpad"))
+                self.prefsForSync.clearAll()
+            }
+            return succeed()
+        }
+        self.syncManagerAPI.disconnect()
+        return clearPrefs()
+    }
+
+    private func getEngineEnablementChangesForAccount() -> [String: Bool] {
+        var engineEnablements: [String: Bool] = [:]
+        // We just created the account, the user went through the Choose What to Sync
+        // screen on FxA.
+        if let declined = UserDefaults.standard.stringArray(forKey: fxaDeclinedEngines) {
+            declined.forEach { engineEnablements[$0] = false }
+            UserDefaults.standard.removeObject(forKey: fxaDeclinedEngines)
+        } else {
+            // Bundle in authState the engines the user activated/disabled since the
+            // last sync.
+            RustTogglableEngines.forEach { engine in
+                let stateChangedPref = "engine.\(engine).enabledStateChanged"
+                if prefsForSync.boolForKey(stateChangedPref) != nil,
+                   let enabled = prefsForSync.boolForKey("engine.\(engine).enabled") {
+                    engineEnablements[engine] = enabled
+                }
+            }
+        }
+
+        if !engineEnablements.isEmpty {
+            let enabled = engineEnablements.compactMap { $0.value ? $0.key : nil }
+            logger.log("engines to enable: \(enabled)",
+                       level: .info,
+                       category: .sync)
+
+            let disabled = engineEnablements.compactMap { !$0.value ? $0.key : nil }
+            let msg = "engines to disable: \(disabled)"
+            logger.log(msg,
+                       level: .info,
+                       category: .sync)
+        }
+        return engineEnablements
+    }
+
+    public class ScopedKeyError: MaybeErrorType {
+        public let description = "No key data found for scope."
+    }
+
+    public class EncryptionKeyError: MaybeErrorType {
+        public let description = "Failed to get stored key."
+    }
+
+    public class DeviceIdError: MaybeErrorType {
+        public let description = "Failed to get deviceId."
+    }
+
+    public class NoTokenServerURLError: MaybeErrorType {
+        public let description = "Failed to get token server endpoint url."
+    }
+
+    public class EngineAndKeyRetrievalError: MaybeErrorType {
+        public let description = "Failed to get sync engine and key data."
+    }
+
+    private func getEnginesAndKeys(engines: [String]) -> Deferred<Maybe<([EngineIdentifier],
+                                                                         [String: String])>> {
+        let deferred = Deferred<Maybe<([EngineIdentifier], [String: String])>>()
+        var localEncryptionKeys: [String: String] = [:]
+        var rustEngines: [String] = []
+        var registeredPlaces: Bool = false
+
+        for engine in engines {
+            switch engine {
+            case "tabs":
+                profile?.tabs.registerWithSyncManager()
+                rustEngines.append("tabs")
+            case "passwords":
+                profile?.logins.registerWithSyncManager()
+                if let key = try? profile?.logins.getStoredKey() {
+                    localEncryptionKeys["passwords"] = key
+                    rustEngines.append("passwords")
+                } else {
+                    logger.log("Login encryption key could not be retrieved for syncing",
+                               level: .warning,
+                               category: .sync)
+                }
+            case "bookmarks", "history":
+                if !registeredPlaces {
+                    profile?.places.registerWithSyncManager()
+                    registeredPlaces = true
+                }
+                rustEngines.append("bookmarks")
+            default:
+                continue
+            }
+        }
+
+        deferred.fill(Maybe(success: (rustEngines, localEncryptionKeys)))
+        return deferred
+    }
+
+    private func syncRustEngines(why: MozillaAppServices.SyncReason,
+                                 engines: [String]) -> Deferred<Maybe<MZSyncResult>> {
+        let deferred = Deferred<Maybe<MZSyncResult>>()
+
+        logger.log("Syncing \(engines)", level: .info, category: .sync)
+        self.profile?.rustFxA.accountManager.upon { accountManager in
+            guard let device = accountManager.deviceConstellation()?
+                .state()?
+                .localDevice else {
+                self.logger.log("Device Id could not be retrieved",
+                                level: .warning,
+                                category: .sync)
+                deferred.fill(Maybe(failure: DeviceIdError()))
+                return
+            }
+
+            accountManager.getAccessToken(scope: OAuthScope.oldSync) { result in
+                guard let accessTokenInfo = try? result.get(),
+                      let key = accessTokenInfo.key else {
+                    deferred.fill(Maybe(failure: ScopedKeyError()))
+                    return
+                }
+
+                accountManager.getTokenServerEndpointURL { result in
+                    guard case .success(let tokenServerEndpointURL) = result else {
+                        deferred.fill(Maybe(failure: NoTokenServerURLError()))
+                        return
+                    }
+
+                    self.getEnginesAndKeys(engines: engines).upon { result in
+                        guard let (rustEngines, localEncryptionKeys) = result
+                            .successValue else {
+                            deferred.fill(Maybe(failure: EngineAndKeyRetrievalError()))
+                            return
+                        }
+                        let params = SyncParams(
+                            reason: why,
+                            engines: SyncEngineSelection.some(engines: rustEngines),
+                            enabledChanges: self.getEngineEnablementChangesForAccount(),
+                            localEncryptionKeys: localEncryptionKeys,
+                            authInfo: SyncAuthInfo(
+                                kid: key.kid,
+                                fxaAccessToken: accessTokenInfo.token,
+                                syncKey: key.k,
+                                tokenserverUrl: tokenServerEndpointURL.absoluteString),
+                            persistedState:
+                                self.prefs
+                                    .stringForKey(PrefsKeys.RustSyncManagerPersistedState),
+                            deviceSettings: DeviceSettings(
+                                fxaDeviceId: device.id,
+                                name: device.displayName,
+                                kind: self.toSyncManagerDeviceType(
+                                    deviceType: device.deviceType)))
+
+                        self.beginSyncing()
+                        self.syncManagerAPI.sync(params: params) { syncResult in
+                            // Save the persisted state
+                            if !syncResult.persistedState.isEmpty {
+                                self.prefs
+                                    .setString(syncResult.persistedState,
+                                               forKey: PrefsKeys.RustSyncManagerPersistedState)
+                            }
+
+                            let declinedEngines = String(describing: syncResult.declined ?? [])
+                            let telemetryData = syncResult.telemetryJson ??
+                                "(No telemetry data was returned)"
+                            let telemetryMessage = "\(String(describing: telemetryData))"
+                            let syncDetails = ["status": "\(syncResult.status)",
+                                               "declinedEngines": "\(declinedEngines)",
+                                               "telemetry": telemetryMessage]
+
+                            self.logger.log("Finished syncing",
+                                            level: .info,
+                                            category: .sync,
+                                            extra: syncDetails)
+
+                            // Save declined/enabled engines - we assume the engines
+                            // not included in the returned `declined` property of the
+                            // result of the sync manager `sync` are enabled.
+                            let updateEnginePref:
+                            (String, Bool) -> Void = { engine, enabled in
+                                let enabledPref = "engine.\(engine).enabled"
+                                self.prefsForSync.setBool(enabled, forKey: enabledPref)
+
+                                let stateChangedPref = "engine.\(engine).enabledStateChanged"
+                                self.prefsForSync.setObject(nil, forKey: stateChangedPref)
+
+                                let enablementDetails = [enabledPref: String(enabled)]
+                                self.logger.log("Finished setting \(engine) enablement prefs",
+                                                level: .info,
+                                                category: .sync,
+                                                extra: enablementDetails)
+                            }
+
+                            if let declined = syncResult.declined {
+                                RustTogglableEngines.forEach({
+                                    if declined.contains($0) {
+                                        updateEnginePref($0, false)
+                                    } else {
+                                        updateEnginePref($0, true)
+                                    }
+                                })
+                            }
+
+                            deferred.fill(Maybe(success: syncResult))
+                            self.endSyncing(syncResult)
+                        }
+                    }
+                }
+            }
+        }
+        return deferred
+    }
+
+    private func toSyncManagerDeviceType(deviceType: DeviceType) -> SyncManagerDeviceType {
+        switch deviceType {
+        case .desktop:
+            return SyncManagerDeviceType.desktop
+        case .mobile:
+            return SyncManagerDeviceType.mobile
+        case .tablet:
+            return SyncManagerDeviceType.tablet
+        case .vr:
+            return SyncManagerDeviceType.vr
+        case .tv:
+            return SyncManagerDeviceType.tv
+        case .unknown:
+            return SyncManagerDeviceType.unknown
+        }
+    }
+
+    @discardableResult public func syncEverything(why: OldSyncReason) -> Success {
+        let rustReason = toRustSyncReason(reason: why)
+        return syncRustEngines(why: rustReason, engines: RustTogglableEngines) >>> succeed
+    }
+
+    /**
+     * Allows selective sync of different collections, for use by external APIs.
+     * Some help is given to callers who use different namespaces (specifically: `passwords` is mapped to `logins`)
+     * and to preserve some ordering rules.
+     */
+    public func syncNamedCollections(why: OldSyncReason, names: [String]) -> Success {
+        // Massage the list of names into engine identifiers.var engines = [String]()
+        var engines = [String]()
+
+        for name in names {
+            // There may be duplicates in `names` so we are removing them here
+            if !engines.contains(name) {
+                engines.append(name)
+            }
+        }
+
+        // Ensuring that only valid engines are submitted
+        let filteredEngines = engines.filter { RustTogglableEngines.contains($0) }
+
+        let rustReason = toRustSyncReason(reason: why)
+        return syncRustEngines(why: rustReason, engines: filteredEngines) >>> succeed
+    }
+
+    private func syncTabs() -> Deferred<Maybe<MZSyncResult>> {
+        return syncRustEngines(why: .user, engines: ["tabs"])
+    }
+
+    public func syncClientsThenTabs() -> OldSyncResult {
+        // This function exists to comply with the `SyncManager` protocol while the
+        // rust sync manager rollout is enabled. To be safe, `syncTabs` is called. Once
+        // the rollout is complete this can be removed along with an update to the
+        // protocol.
+
+        return syncTabs().bind { result in
+            if let error = result.failureValue {
+                return deferMaybe(error)
+            }
+
+            // The current callers of `BrowserSyncManager.syncClientsThenTabs` only care
+            // whether the function fails or succeeds and does nothing with return value
+            // upon success so we are returning a meaningless value here.
+            return deferMaybe(SyncStatus.notStarted(SyncNotStartedReason.unknown))
+        }
+    }
+
+    public func syncClients() -> OldSyncResult {
+        // This function exists to to comply with the `SyncManager` protocol and has
+        // no callers. It will be removed when the rust sync manager rollout is complete.
+        // To be safe, `syncClientsThenTabs` is called.
+        return syncClientsThenTabs()
+    }
+
+    public func syncHistory() -> OldSyncResult {
+        // The return type of this function has been changed to comply with the
+        // `SyncManager` protocol during the rust sync manager rollout. It will be updated
+        // once the rollout is complete.
+        return syncRustEngines(why: .user, engines: ["history"]).bind { result in
+            if let error = result.failureValue {
+                return deferMaybe(error)
+            }
+
+            // The current callers of this function only care whether this function fails
+            // or succeeds and does nothing with return value upon success so we are
+            // returning a meaningless value here.
+            return deferMaybe(SyncStatus.notStarted(SyncNotStartedReason.unknown))
+        }
+    }
+}

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -13,6 +13,10 @@ public struct PrefsKeys {
     // Global sync state for rust sync manager
     public static let RustSyncManagerPersistedState = "rustSyncManagerPersistedStateKey"
 
+    // When this pref is set to true it signifies that RustSyncManager has been set as the
+    // sync manager
+    public static let HasRustSyncManagerEverBeenUsed = "hasRustSyncManagerEverBeenUsedKey"
+
     public static let KeyLastSyncFinishTime = "lastSyncFinishTime"
     public static let KeyDefaultHomePageURL = "KeyDefaultHomePageURL"
     public static let KeyNoImageModeStatus = "NoImageModeStatus"

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -9,6 +9,10 @@ public struct PrefsKeys {
     // When this pref is set (by the user) it overrides default behaviour which is just based on app locale.
     public static let KeyEnableChinaSyncService = "useChinaSyncService"
     public static let KeyLastRemoteTabSyncTime = "lastRemoteTabSyncTime"
+
+    // Global sync state for rust sync manager
+    public static let RustSyncManagerPersistedState = "rustSyncManagerPersistedStateKey"
+
     public static let KeyLastSyncFinishTime = "lastSyncFinishTime"
     public static let KeyDefaultHomePageURL = "KeyDefaultHomePageURL"
     public static let KeyNoImageModeStatus = "NoImageModeStatus"

--- a/Storage/Rust/RustLogins.swift
+++ b/Storage/Rust/RustLogins.swift
@@ -850,6 +850,12 @@ public class RustLogins {
         return deferred
     }
 
+    public func registerWithSyncManager() {
+        queue.async { [unowned self] in
+            self.storage?.registerWithSyncManager()
+        }
+    }
+
     private func migrateSQLCipherDBIfNeeded(key: String) {
         let keychain = MZKeychainWrapper.sharedClientAppContainerKeychain
         let rustKeys: RustLoginEncryptionKeys = RustLoginEncryptionKeys()

--- a/Storage/Rust/RustPlaces.swift
+++ b/Storage/Rust/RustPlaces.swift
@@ -353,6 +353,12 @@ public class RustPlaces: BookmarksHandler, HistoryMetadataObserver {
         return deferred
     }
 
+    public func registerWithSyncManager() {
+        writerQueue.async { [unowned self] in
+            self.api?.registerWithSyncManager()
+        }
+    }
+
     public func resetBookmarksMetadata() -> Success {
         let deferred = Success()
 

--- a/Storage/Rust/RustRemoteTabs.swift
+++ b/Storage/Rust/RustRemoteTabs.swift
@@ -157,6 +157,43 @@ public class RustRemoteTabs {
 
         return deferred
     }
+
+    public func getClient(fxaDeviceId: String) -> Deferred<Maybe<RemoteClient?>> {
+        return self.getAll().bind { result in
+            guard result.failureValue == nil else {
+                return deferMaybe(result.failureValue as! String)
+            }
+
+            guard let records = result.successValue else {
+                return deferMaybe(nil)
+            }
+
+            let client = records.first(where: { $0.clientId == fxaDeviceId })?.toRemoteClient()
+            return deferMaybe(client)
+        }
+    }
+
+    public func getClientGUIDs(completion: @escaping (Set<GUID>?, Error?) -> Void) {
+        self.getAll().upon { result in
+            guard result.failureValue == nil else {
+                completion(nil, result.failureValue as! String)
+                return
+            }
+            guard let records = result.successValue else {
+                completion(Set<GUID>(), nil)
+                return
+            }
+
+            let guids = records.map({ $0.clientId })
+            completion(Set(guids), nil)
+        }
+    }
+
+    public func registerWithSyncManager() {
+        queue.async { [unowned self] in
+           self.storage?.registerWithSyncManager()
+        }
+    }
 }
 
 public extension RemoteTabRecord {
@@ -172,5 +209,25 @@ public extension RemoteTabRecord {
 public extension ClientRemoteTabs {
     func toClientAndTabs(client: RemoteClient) -> ClientAndTabs {
         return ClientAndTabs(client: client, tabs: self.remoteTabs.map { $0.toRemoteTab(client: client)}.compactMap { $0 })
+    }
+
+    func toClientAndTabs() -> ClientAndTabs {
+        let client = self.toRemoteClient()
+        let tabs = self.remoteTabs.map { $0.toRemoteTab(client: client)}.compactMap { $0 }
+
+        let clientAndTabs = ClientAndTabs(client: client, tabs: tabs)
+        return clientAndTabs
+    }
+
+    func toRemoteClient() -> RemoteClient {
+        let remoteClient = RemoteClient(guid: self.clientId,
+                            name: self.clientName,
+                            modified: UInt64(self.lastModified),
+                            type: "\(self.deviceType)",
+                            formfactor: nil,
+                            os: nil,
+                            version: nil,
+                            fxaDeviceId: self.clientId)
+        return remoteClient
     }
 }

--- a/Storage/Rust/RustRemoteTabs.swift
+++ b/Storage/Rust/RustRemoteTabs.swift
@@ -221,13 +221,13 @@ public extension ClientRemoteTabs {
 
     func toRemoteClient() -> RemoteClient {
         let remoteClient = RemoteClient(guid: self.clientId,
-                            name: self.clientName,
-                            modified: UInt64(self.lastModified),
-                            type: "\(self.deviceType)",
-                            formfactor: nil,
-                            os: nil,
-                            version: nil,
-                            fxaDeviceId: self.clientId)
+                                        name: self.clientName,
+                                        modified: UInt64(self.lastModified),
+                                        type: "\(self.deviceType)",
+                                        formfactor: nil,
+                                        os: nil,
+                                        version: nil,
+                                        fxaDeviceId: self.clientId)
         return remoteClient
     }
 }

--- a/Sync/RustSyncManagerAPI.swift
+++ b/Sync/RustSyncManagerAPI.swift
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import Logger
+import Common
 import Shared
 @_exported import MozillaAppServices
 
@@ -17,14 +17,14 @@ open class RustSyncManagerAPI {
     }
 
     public func disconnect() {
-        DispatchQueue.global(qos: .background).async { [unowned self] in
+        DispatchQueue.global(qos: .userInitiated).async { [unowned self] in
             self.api.disconnect()
         }
     }
 
     public func sync(params: SyncParams,
                      completion: @escaping (MozillaAppServices.SyncResult) -> Void) {
-        DispatchQueue.global(qos: .background).async { [unowned self] in
+        DispatchQueue.global(qos: .userInitiated).async { [unowned self] in
             do {
                 let result = try self.api.sync(params: params)
                 completion(result)
@@ -32,8 +32,8 @@ open class RustSyncManagerAPI {
                 if let syncError = err as? SyncManagerError {
                     let syncErrDescription = syncError.localizedDescription
                     self.logger.log("Rust SyncManager sync error: \(syncErrDescription)",
-                                                        level: .warning,
-                                                        category: .sync)
+                                    level: .warning,
+                                    category: .sync)
                 } else {
                     let errDescription = err.localizedDescription
                     self.logger.log("""
@@ -48,14 +48,14 @@ open class RustSyncManagerAPI {
     }
 
     public func getAvailableEngines(completion: @escaping ([String]) -> Void) {
-        DispatchQueue.global(qos: .background).async { [unowned self] in
+        DispatchQueue.global(qos: .userInitiated).async { [unowned self] in
             let engines = self.api.getAvailableEngines()
             completion(engines)
         }
     }
 }
 
-public func toRustSyncReason(reason: Sync.SyncReason) -> MozillaAppServices.SyncReason {
+public func toRustSyncReason(reason: OldSyncReason) -> MozillaAppServices.SyncReason {
     switch reason {
     case .startup:
         return MozillaAppServices.SyncReason.startup
@@ -72,8 +72,8 @@ public func toRustSyncReason(reason: Sync.SyncReason) -> MozillaAppServices.Sync
 
 // Names of collections that can be enabled/disabled locally.
 public let RustTogglableEngines: [String] = [
+    "tabs",
     "bookmarks",
     "history",
-    "tabs",
-    "passwords"
+    "passwords",
 ]

--- a/Sync/RustSyncManagerAPI.swift
+++ b/Sync/RustSyncManagerAPI.swift
@@ -1,0 +1,79 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Logger
+import Shared
+@_exported import MozillaAppServices
+
+open class RustSyncManagerAPI {
+    private let logger: Logger
+    let api: SyncManager
+
+    public init(logger: Logger = DefaultLogger.shared) {
+        self.api = SyncManager()
+        self.logger = logger
+    }
+
+    public func disconnect() {
+        DispatchQueue.global(qos: .background).async { [unowned self] in
+            self.api.disconnect()
+        }
+    }
+
+    public func sync(params: SyncParams,
+                     completion: @escaping (MozillaAppServices.SyncResult) -> Void) {
+        DispatchQueue.global(qos: .background).async { [unowned self] in
+            do {
+                let result = try self.api.sync(params: params)
+                completion(result)
+            } catch let err as NSError {
+                if let syncError = err as? SyncManagerError {
+                    let syncErrDescription = syncError.localizedDescription
+                    self.logger.log("Rust SyncManager sync error: \(syncErrDescription)",
+                                                        level: .warning,
+                                                        category: .sync)
+                } else {
+                    let errDescription = err.localizedDescription
+                    self.logger.log("""
+                        Unknown error when attempting a rust SyncManager sync:
+                        \(errDescription)
+                        """,
+                        level: .warning,
+                        category: .sync)
+                }
+            }
+        }
+    }
+
+    public func getAvailableEngines(completion: @escaping ([String]) -> Void) {
+        DispatchQueue.global(qos: .background).async { [unowned self] in
+            let engines = self.api.getAvailableEngines()
+            completion(engines)
+        }
+    }
+}
+
+public func toRustSyncReason(reason: Sync.SyncReason) -> MozillaAppServices.SyncReason {
+    switch reason {
+    case .startup:
+        return MozillaAppServices.SyncReason.startup
+    case .scheduled:
+        return MozillaAppServices.SyncReason.scheduled
+    case .backgrounded:
+        return MozillaAppServices.SyncReason.backgrounded
+    case .push, .user, .syncNow:
+        return MozillaAppServices.SyncReason.user
+    case .didLogin, .clientNameChanged, .engineEnabled:
+        return MozillaAppServices.SyncReason.enabledChange
+    }
+}
+
+// Names of collections that can be enabled/disabled locally.
+public let RustTogglableEngines: [String] = [
+    "bookmarks",
+    "history",
+    "tabs",
+    "passwords"
+]

--- a/Sync/SyncTelemetryUtils.swift
+++ b/Sync/SyncTelemetryUtils.swift
@@ -479,8 +479,9 @@ public class GleanSyncOperationHelper {
         for sync in telemetry.syncs {
             _ = GleanMetrics.Sync.syncUuid.generateAndSet()
 
-            if let failureReason = sync.failureReason {
-                GleanMetrics.Sync.failureReason[String(describing: failureReason)].add()
+            if let reason = sync.failureReason {
+                let failureReason = convertSyncFailureReason(reason: reason)
+                GleanMetrics.Sync.failureReason[failureReason].add()
             }
 
             for engine in sync.engines {
@@ -488,10 +489,11 @@ public class GleanSyncOperationHelper {
                     self.recordRustSyncEngineStats(engine.name,
                                                    incoming: engine.incoming,
                                                    outgoing: engine.outgoing)
-                } else {
+                } else if let reason = engine.failureReason {
+                    let reason = convertEngineFailureReason(reason: reason)
                     self.recordSyncEngineFailure(
                         engine.name,
-                        String(describing: engine.failureReason))
+                        reason)
                 }
 
                 self.submitSyncEnginePing(engine.name)

--- a/Sync/SyncTelemetryUtils.swift
+++ b/Sync/SyncTelemetryUtils.swift
@@ -468,6 +468,83 @@ public class GleanSyncOperationHelper {
         GleanMetrics.Pings.shared.tempSync.submit()
     }
 
+    public func reportTelemetry(_ result: MozillaAppServices.SyncResult) {
+        guard let json = result.telemetryJson,
+              let telemetry = try? RustSyncTelemetryPing.fromJSONString(
+                jsonObjectText: json
+              ) else {
+            return
+        }
+
+        for sync in telemetry.syncs {
+            _ = GleanMetrics.Sync.syncUuid.generateAndSet()
+
+            if let failureReason = sync.failureReason {
+                GleanMetrics.Sync.failureReason[String(describing: failureReason)].add()
+            }
+
+            for engine in sync.engines {
+                if engine.failureReason == nil {
+                    self.recordRustSyncEngineStats(engine.name,
+                                                   incoming: engine.incoming,
+                                                   outgoing: engine.outgoing)
+                } else {
+                    self.recordSyncEngineFailure(
+                        engine.name,
+                        String(describing: engine.failureReason))
+                }
+
+                self.submitSyncEnginePing(engine.name)
+            }
+
+            GleanMetrics.Pings.shared.tempSync.submit()
+        }
+    }
+
+    public func convertSyncFailureReason(reason: FailureReason) -> String {
+        // The metrics.yaml for the temp sync metrics specifies the failure reasons
+        // (`httperror`, `unexpectederror`, `sqlerror`, and `othererror`) associated with
+        // the old sync manager. To prevent the rust sync manager failure reasons from
+        // being omitted, we map them to the old values. This is a stopgap measure as work
+        // has already begun to replace the sync temp metrics entirely.
+
+        switch reason.name {
+        case .http:
+            return "httperror"
+        case .other, .shutdown, .auth, .unknown:
+            return "othererror"
+        case .unexpected:
+            return "unexpectederror"
+        }
+    }
+
+    public func convertEngineFailureReason(reason: FailureReason) -> String {
+        // The metrics.yaml for the temp sync metrics specifies the failure reasons
+        // (`httperror`, `unexpectederror`, `sqlerror`, and `othererror`) associated with
+        // the old sync manager. They include the following reasons:
+        //    - no_account
+        //    - offline
+        //    - backoff
+        //    - remotely_not_enabled
+        //    - format_outdated
+        //    - format_too_new
+        //    - storage_format_outdated
+        //    - storage_format_too_new
+        //    - state_machine_not_ready
+        //    - red_light
+        //    - unknown
+        // To prevent the rust sync manager failure reasons from being omitted, we map
+        // them to the old values. This is a stopgap measure as work has already begun to
+        // replace the sync temp metrics entirely.
+
+        switch reason.name {
+        case .auth:
+            return "no_account"
+        case .unknown, .shutdown, .other, .unexpected, .http:
+            return "unknown"
+        }
+    }
+
     private func recordSyncEngineStats(_ engineName: String, _ stats: SyncEngineStatsSession) {
         // Create maps on labels to stat value,
         // keeping only the values that are above zero.
@@ -505,6 +582,45 @@ public class GleanSyncOperationHelper {
         }
     }
 
+    private func recordRustSyncEngineStats(_ engineName: String,
+                                           incoming: IncomingInfo?,
+                                           outgoing: [OutgoingInfo]) {
+        let incomingLabelsToValue = [
+            ("applied", incoming?.applied ?? 0),
+            ("reconciled", incoming?.reconciled ?? 0),
+            ("failed_to_apply", incoming?.failed ?? 0)
+        ].filter { (_, stat) in stat > 0 }
+
+        let outgoingLabelsToValue = [
+            ("uploaded", outgoing.reduce(0, { totalUploaded, rec in
+                totalUploaded + rec.sent
+            })),
+            ("failed_to_upload", outgoing.reduce(0, { totalFailed, rec in
+                totalFailed + rec.failed
+            }))
+        ].filter { (_, stat) in stat > 0 }
+
+        switch engineName {
+        case "tabs":
+            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.RustTabsSync.incoming[l].add(Int32(v))}
+            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.RustTabsSync.outgoing[l].add(Int32(v)) }
+        case "bookmarks":
+            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.BookmarksSync.incoming[l].add(Int32(v))}
+            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.BookmarksSync.outgoing[l].add(Int32(v)) }
+        case "history":
+            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.HistorySync.incoming[l].add(Int32(v))}
+            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.HistorySync.outgoing[l].add(Int32(v)) }
+        case "passwords":
+            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.LoginsSync.incoming[l].add(Int32(v))}
+            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.LoginsSync.outgoing[l].add(Int32(v)) }
+        case "clients":
+            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.ClientsSync.incoming[l].add(Int32(v))}
+            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.ClientsSync.outgoing[l].add(Int32(v)) }
+        default:
+            break
+        }
+    }
+
     private func recordSyncEngineFailure(_ engineName: String, _ reason: String) {
         let correctedReson = String(reason.dropFirst("sync.not_started.reason.".count))
 
@@ -512,7 +628,7 @@ public class GleanSyncOperationHelper {
         case "tabs": GleanMetrics.RustTabsSync.failureReason[correctedReson].add()
         case "bookmarks": GleanMetrics.BookmarksSync.failureReason[correctedReson].add()
         case "history": GleanMetrics.HistorySync.failureReason[correctedReson].add()
-        case "logins": GleanMetrics.LoginsSync.failureReason[correctedReson].add()
+        case "logins", "passwords": GleanMetrics.LoginsSync.failureReason[correctedReson].add()
         case "clients": GleanMetrics.ClientsSync.failureReason[correctedReson].add()
         default:
             break
@@ -524,7 +640,7 @@ public class GleanSyncOperationHelper {
         case "tabs": GleanMetrics.Pings.shared.tempRustTabsSync.submit()
         case "bookmarks": GleanMetrics.Pings.shared.tempBookmarksSync.submit()
         case "history": GleanMetrics.Pings.shared.tempHistorySync.submit()
-        case "logins": GleanMetrics.Pings.shared.tempLoginsSync.submit()
+        case "logins", "passwords": GleanMetrics.Pings.shared.tempLoginsSync.submit()
         case "clients": GleanMetrics.Pings.shared.tempClientsSync.submit()
         default:
             break

--- a/Sync/SyncTelemetryUtils.swift
+++ b/Sync/SyncTelemetryUtils.swift
@@ -470,11 +470,8 @@ public class GleanSyncOperationHelper {
 
     public func reportTelemetry(_ result: MozillaAppServices.SyncResult) {
         guard let json = result.telemetryJson,
-              let telemetry = try? RustSyncTelemetryPing.fromJSONString(
-                jsonObjectText: json
-              ) else {
-            return
-        }
+              let telemetry = try? RustSyncTelemetryPing.fromJSONString(jsonObjectText: json)
+        else { return }
 
         for sync in telemetry.syncs {
             _ = GleanMetrics.Sync.syncUuid.generateAndSet()

--- a/Tests/StorageTests/RustRemoteTabsTests.swift
+++ b/Tests/StorageTests/RustRemoteTabsTests.swift
@@ -6,9 +6,46 @@ import XCTest
 import Shared
 @testable import Storage
 
+class MockRustRemoteTabs: RustRemoteTabs {
+    override public func getAll() -> Deferred<Maybe<[ClientRemoteTabs]>> {
+        let url = "https://example.com"
+        let title = "example"
+        let clientGUID = "AAAAA"
+        let tab = RemoteTab(clientGUID: clientGUID,
+                            URL: URL(string: url)!,
+                            title: title,
+                            history: [URL(string: url)!],
+                            lastUsed: Date.now(),
+                            icon: nil)
+        let clientRemoteTab = ClientRemoteTabs(clientId: clientGUID,
+                                               clientName: "testClient",
+                                               deviceType: .mobile,
+                                               lastModified: Int64(Date.now()),
+                                               remoteTabs: [tab.toRemoteTabRecord()])
+
+        let url2 = "https://example2.com"
+        let title2 = "example2"
+        let clientGUID2 = "BBBBB"
+        let tab2 = RemoteTab(clientGUID: clientGUID2,
+                             URL: URL(string: url2)!,
+                             title: title2,
+                             history: [URL(string: url2)!],
+                             lastUsed: Date.now(),
+                             icon: nil)
+
+        let clientRemoteTab2 = ClientRemoteTabs(clientId: clientGUID2,
+                                                clientName: "testClient2",
+                                                deviceType: .mobile,
+                                                lastModified: Int64(Date.now()),
+                                                remoteTabs: [tab2.toRemoteTabRecord()])
+        return deferMaybe([clientRemoteTab, clientRemoteTab2])
+    }
+}
+
 class RustRemoteTabsTests: XCTestCase {
     var files: FileAccessor!
     var tabs: RustRemoteTabs!
+    var mockTabs: MockRustRemoteTabs!
 
     override func setUp() {
         super.setUp()
@@ -18,8 +55,16 @@ class RustRemoteTabsTests: XCTestCase {
             let databasePath = URL(fileURLWithPath: rootDirectory, isDirectory: true).appendingPathComponent("testTabs.db").path
             try? files.remove("testTabs.db")
 
+            let mockDatabasePath = URL(fileURLWithPath: rootDirectory,
+                                       isDirectory: true)
+                                        .appendingPathComponent("mockTestTabs.db")
+                                        .path
+            try? files.remove("mockTestTabs.db")
+
             tabs = RustRemoteTabs(databasePath: databasePath)
+            mockTabs = MockRustRemoteTabs(databasePath: mockDatabasePath)
             _ = tabs.reopenIfClosed()
+            _ = mockTabs.reopenIfClosed()
         } else {
             XCTFail("Could not retrieve root directory")
         }
@@ -44,5 +89,37 @@ class RustRemoteTabsTests: XCTestCase {
         // this function will only return values after syncing remote records.
         XCTAssertTrue(clientRemoteTabs.value.isSuccess)
         XCTAssertEqual(clientRemoteTabs.value.successValue!.count, 0)
+    }
+
+    func testGetClient() {
+        let result = mockTabs.getClient(fxaDeviceId: "BBBBB")
+        XCTAssertTrue(result.value.isSuccess)
+        let clientGUID = result.value.successValue??.guid
+        XCTAssertEqual("BBBBB", clientGUID)
+    }
+
+    func testGetClientGUIDs() {
+        mockTabs.getClientGUIDs { (result, error) in
+            XCTAssertNotNil(result)
+            XCTAssertEqual(result!.count, 2)
+            XCTAssertTrue(result!.contains("AAAAA"))
+            XCTAssertTrue(result!.contains("BBBBB"))
+        }
+    }
+
+    func testGetRemoteClients() {
+        let deviceToExclude = "CCCCC"
+        let remoteDeviceIds = ["AAAAA", "BBBBB", deviceToExclude]
+        let result = mockTabs.getRemoteClients(remoteDeviceIds: remoteDeviceIds)
+        XCTAssertTrue(result.value.isSuccess)
+        let remoteClients = result.value.successValue!
+        XCTAssertEqual(remoteClients.count, 2)
+        XCTAssertTrue(remoteDeviceIds.contains(remoteClients[0].client.fxaDeviceId!))
+        XCTAssertTrue(remoteDeviceIds.contains(remoteClients[1].client.fxaDeviceId!))
+
+        let filteredResult = remoteClients.filter {
+            $0.client.fxaDeviceId == deviceToExclude
+        }
+        XCTAssertTrue(filteredResult.isEmpty)
     }
 }

--- a/nimbus-features/rustSyncManagerFeature.yaml
+++ b/nimbus-features/rustSyncManagerFeature.yaml
@@ -1,0 +1,13 @@
+features:
+  rust-sync-manager-component:
+    description: The feature that controls whether we use the rust sync manager
+    variables:
+      use-rust-sync-manager:
+        description: If true, syncs will be performed by the `RustSyncManager` class backed by the rust sync manager component.
+        type: Boolean
+        default: false
+    defaults:
+      - channel: developer, beta
+        value: {
+            "use-rust-sync-manager": true
+        }

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -29,3 +29,4 @@ include:
   - nimbus-features/tabTrayFeature.yaml
   - nimbus-features/wallpaperFeature.yaml
   - nimbus-features/zoomFeature.yaml
+  - nimbus-features/rustSyncManagerFeature.yaml


### PR DESCRIPTION
Sync Manager

[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5790)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13278)

### Description

This PR represents the work required by the A-S team to integrate the rust sync manager component into iOS. In order to make reviewing the code easier, this work will be split out into a number of PRs which include the following work:

- Adding qualified names to the current SyncReason, SyncResult, and SyncManager types so they do not conflict with the types introduced by the rust component
        Note: The native types listed above will ultimately be replaced by the types introduced by the component once the Nimbus rollout is complete
- Adding supporting functions for sync manager integration including A-S API functions and logic to report the telemetry returned by the sync manager component's syncfunction
- Adding the RustSyncManager class
        This class will eventually replace BrowserSyncManager
    Adding the Nimbus rollout logic and updating BrowserProfile to use RustSyncManager when the experiment is enabled

Once the Sync Manager Nimbus experiment is complete, a separate PR will be created to remove the old sync code.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
~- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)~
- [x] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
