### PR TITLE
Add FXIOS-5790 [v112] rust sync manager added

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -1271,6 +1271,7 @@
 		F8708D321A0970B70051AB07 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8708D291A0970990051AB07 /* ShareViewController.swift */; };
 		F886218C270CD3B8007F4562 /* DevicePasscodeRequiredViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F886218B270CD3B8007F4562 /* DevicePasscodeRequiredViewController.swift */; };
 		F886BFBD29AD56A400F77224 /* RustSyncManagerAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = F886BFBC29AD56A400F77224 /* RustSyncManagerAPI.swift */; };
+		F8A0B08229AD61FA0091C75B /* RustSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A0B08129AD61FA0091C75B /* RustSyncManager.swift */; };
 		F8AAC1B429663619000BCDEC /* RustAutofill.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AAC1B329663618000BCDEC /* RustAutofill.swift */; };
 		F8AAC1B7296637CE000BCDEC /* RustAutofillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AAC1B5296637B7000BCDEC /* RustAutofillTests.swift */; };
 		FA6B2AC21D41F02D00429414 /* String+Punycode.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6B2AC11D41F02D00429414 /* String+Punycode.swift */; };
@@ -5210,6 +5211,7 @@
 		F886218B270CD3B8007F4562 /* DevicePasscodeRequiredViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevicePasscodeRequiredViewController.swift; sourceTree = "<group>"; };
 		F886BFBC29AD56A400F77224 /* RustSyncManagerAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RustSyncManagerAPI.swift; sourceTree = "<group>"; };
 		F8984594958004CB86902EE3 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/ErrorPages.strings; sourceTree = "<group>"; };
+		F8A0B08129AD61FA0091C75B /* RustSyncManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustSyncManager.swift; sourceTree = "<group>"; };
 		F8AAC1B329663618000BCDEC /* RustAutofill.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RustAutofill.swift; sourceTree = "<group>"; };
 		F8AAC1B5296637B7000BCDEC /* RustAutofillTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RustAutofillTests.swift; sourceTree = "<group>"; };
 		F8CA43008FC72296965ED032 /* ne-NP */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ne-NP"; path = "ne-NP.lproj/ClearPrivateDataConfirm.strings"; sourceTree = "<group>"; };
@@ -7407,6 +7409,7 @@
 				D34DC84D1A16C40C00D49B7B /* Profile.swift */,
 				1D0BA05B24F46A0400D731B5 /* TopSitesProvider.swift */,
 				8A5BD95E2878B7B6000FE773 /* TopSitesWidgetManager.swift */,
+				F8A0B08129AD61FA0091C75B /* RustSyncManager.swift */,
 			);
 			path = Providers;
 			sourceTree = "<group>";
@@ -10322,6 +10325,7 @@
 				D3C3696E1CC6B78800348A61 /* LocalRequestHelper.swift in Sources */,
 				C87DC85C27B2C94D006EFCE2 /* LegacyWallpaperResourceManager.swift in Sources */,
 				E4B423DD1ABA0318007E66C8 /* ReaderModeHandlers.swift in Sources */,
+				F8A0B08229AD61FA0091C75B /* RustSyncManager.swift in Sources */,
 				D308E4E41A5306F500842685 /* SearchEngines.swift in Sources */,
 				048B4C8924A53F81001B56E8 /* UIButtonExtensions.swift in Sources */,
 				3BCE6D3C1CEB9E4D0080928C /* ThirdPartySearchAlerts.swift in Sources */,

--- a/Providers/RustSyncManager.swift
+++ b/Providers/RustSyncManager.swift
@@ -1,0 +1,546 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Account
+import Shared
+import Storage
+import Sync
+import SyncTelemetry
+import AuthenticationServices
+import Common
+
+// Extends NSObject so we can use timers.
+public class RustSyncManager: NSObject, SyncManager {
+    // We shouldn't live beyond our containing BrowserProfile, either in the main app
+    // or in an extension.
+    // But it's possible that we'll finish a side-effect sync after we've ditched the
+    // profile as a whole, so we hold on to our Prefs, potentially for a little while
+    // longer. This is safe as a strong reference, because there's no cycle.
+    private weak var profile: BrowserProfile?
+    private let prefs: Prefs
+    private var syncTimer: Timer?
+    private var backgrounded: Bool = true
+    private let logger: Logger
+    private let fxaDeclinedEngines = "fxa.cwts.declinedSyncEngines"
+    private var notificationCenter: NotificationProtocol
+
+    let fifteenMinutesInterval = TimeInterval(60 * 15)
+
+    public var lastSyncFinishTime: Timestamp? {
+        get {
+            return prefs.timestampForKey(PrefsKeys.KeyLastSyncFinishTime)
+        }
+
+        set(value) {
+            if let value = value {
+                prefs.setTimestamp(value,
+                                   forKey: PrefsKeys.KeyLastSyncFinishTime)
+            } else {
+                prefs.removeObjectForKey(PrefsKeys.KeyLastSyncFinishTime)
+            }
+        }
+    }
+
+    lazy var syncManagerAPI = RustSyncManagerAPI(logger: logger)
+
+    public var isSyncing: Bool {
+        return syncDisplayState != nil && syncDisplayState! == .inProgress
+    }
+
+    public var syncDisplayState: SyncDisplayState?
+
+    @objc func syncOnTimer() {
+        syncEverything(why: .scheduled)
+        profile?.pollCommands()
+    }
+
+    fileprivate func repeatingTimerAtInterval(
+        _ interval: TimeInterval,
+        selector: Selector
+    ) -> Timer {
+        return Timer.scheduledTimer(timeInterval: interval,
+                                    target: self,
+                                    selector: selector,
+                                    userInfo: nil,
+                                    repeats: true)
+    }
+
+    func syncEverythingSoon() {
+        doInBackgroundAfter(SyncConstants.SyncOnForegroundAfterMillis) {
+            self.logger.log("Running delayed startup sync.",
+                            level: .debug,
+                            category: .sync)
+            self.syncEverything(why: .startup)
+        }
+    }
+
+    private func beginTimedSyncs() {
+        if syncTimer != nil {
+            logger.log("Already running sync timer.",
+                       level: .debug,
+                       category: .sync)
+            return
+        }
+
+        let interval = fifteenMinutesInterval
+        let selector = #selector(syncOnTimer)
+        logger.log("Starting sync timer.",
+                   level: .info,
+                   category: .sync)
+        syncTimer = repeatingTimerAtInterval(interval, selector: selector)
+    }
+
+    /**
+     * The caller is responsible for calling this on the same thread on which it called
+     * beginTimedSyncs.
+     */
+    public func endTimedSyncs() {
+        if let timer = syncTimer {
+            logger.log("Stopping sync timer.",
+                       level: .info,
+                       category: .sync)
+            syncTimer = nil
+            timer.invalidate()
+        }
+    }
+
+    public func applicationDidBecomeActive() {
+        backgrounded = false
+
+        guard let profile = profile, profile.hasSyncableAccount() else { return }
+
+        beginTimedSyncs()
+
+        // Sync now if it's been more than our threshold.
+        let now = Date.now()
+        let then = lastSyncFinishTime ?? 0
+        guard now >= then else {
+            logger.log("Time was modified since last sync.",
+                       level: .debug,
+                       category: .sync)
+            syncEverythingSoon()
+            return
+        }
+        let since = now - then
+        logger.log("\(since)msec since last sync.",
+                   level: .debug,
+                   category: .sync)
+        if since > SyncConstants.SyncOnForegroundMinimumDelayMillis {
+            syncEverythingSoon()
+        }
+    }
+
+    public func applicationDidEnterBackground() {
+        backgrounded = true
+    }
+
+    fileprivate func beginSyncing() {
+        syncDisplayState = .inProgress
+        notifySyncing(notification: .ProfileDidStartSyncing)
+    }
+
+    private func resolveSyncState(
+        result: MozillaAppServices.SyncResult
+    ) -> SyncDisplayState {
+        let hasSynced = !result.successful.isEmpty
+        let status = result.status
+
+        // This is similar to the old `SyncStatusResolver.resolveResults` call. If none of
+        // the engines successfully synced and a network issue occured we return `.bad`.
+        // If none of the engines successfully synced and an auth error occured we return
+        // `.warning`. Otherwise we return `.good`.
+
+        if !hasSynced && status == .authError {
+            return .warning(message: .FirefoxSyncOfflineTitle)
+        } else if !hasSynced && status == .networkError {
+            return .bad(message: .FirefoxSyncOfflineTitle)
+        } else {
+            return .good
+        }
+    }
+
+    fileprivate func endSyncing(_ result: MozillaAppServices.SyncResult) {
+        logger.log("Ending all syncs.",
+                   level: .info,
+                   category: .sync)
+
+        syncDisplayState = resolveSyncState(result: result)
+
+        if let syncState = syncDisplayState, syncState == .good {
+            lastSyncFinishTime = Date.now()
+        }
+
+        if canSendUsageData() {
+            let gleanHelper = GleanSyncOperationHelper()
+            gleanHelper.reportTelemetry(result)
+        } else {
+            logger.log("Profile isn't sending usage data. Not sending sync status event.",
+                       level: .debug,
+                       category: .sync)
+        }
+
+        // Don't notify if we are performing a sync in the background. This prevents more
+        // db access from happening
+        if !backgrounded {
+            notifySyncing(notification: .ProfileDidFinishSyncing)
+        }
+    }
+
+    func canSendUsageData() -> Bool {
+        return profile?.prefs.boolForKey(AppConstants.prefSendUsageData) ?? true
+    }
+
+    private func notifySyncing(notification: Notification.Name) {
+        notificationCenter.post(name: notification)
+    }
+
+    init(profile: BrowserProfile,
+         logger: Logger = DefaultLogger.shared,
+         notificationCenter: NotificationProtocol = NotificationCenter.default) {
+        self.profile = profile
+        self.prefs = profile.prefs
+        self.logger = logger
+        self.notificationCenter = notificationCenter
+
+        super.init()
+    }
+
+    func doInBackgroundAfter(_ millis: Int64, _ block: @escaping () -> Void) {
+        let queue = DispatchQueue.global(qos: DispatchQoS.background.qosClass)
+        queue.asyncAfter(
+            deadline: DispatchTime.now() + DispatchTimeInterval.milliseconds(Int(millis)),
+            execute: block)
+    }
+
+    var prefsForSync: Prefs {
+        return prefs.branch("sync")
+    }
+
+    public func onAddedAccount() -> Success {
+        // Only sync if we're green lit. This makes sure that we don't sync unverified
+        // accounts.
+        guard let profile = profile, profile.hasSyncableAccount() else { return succeed() }
+
+        beginTimedSyncs()
+        return syncEverything(why: .didLogin)
+    }
+
+    public func onRemovedAccount() -> Success {
+        let clearPrefs: () -> Success = {
+            withExtendedLifetime(self) {
+                // Clear prefs after we're done clearing everything else -- just in case
+                // one of them needs the prefs and we race. Clear regardless of success
+                // or failure.
+
+                // This will remove keys from the Keychain if they exist, as well
+                // as wiping the Sync prefs.
+
+                // `Scratchpad.clearFromPrefs` and `clearAll` were pulled from
+                // `SyncStateMachine.clearStateFromPrefs` to reduce RustSyncManager's
+                // dependence on the swift sync state machine logic. This will make
+                // refactoring or eliminating that code easier once the rust sync manager
+                // rollout is complete.
+                Scratchpad.clearFromPrefs(self.prefsForSync.branch("scratchpad"))
+                self.prefsForSync.clearAll()
+            }
+            return succeed()
+        }
+        self.syncManagerAPI.disconnect()
+        return clearPrefs()
+    }
+
+    private func getEngineEnablementChangesForAccount() -> [String: Bool] {
+        var engineEnablements: [String: Bool] = [:]
+        // We just created the account, the user went through the Choose What to Sync
+        // screen on FxA.
+        if let declined = UserDefaults.standard.stringArray(forKey: fxaDeclinedEngines) {
+            declined.forEach { engineEnablements[$0] = false }
+            UserDefaults.standard.removeObject(forKey: fxaDeclinedEngines)
+        } else {
+            // Bundle in authState the engines the user activated/disabled since the
+            // last sync.
+            RustTogglableEngines.forEach { engine in
+                let stateChangedPref = "engine.\(engine).enabledStateChanged"
+                if prefsForSync.boolForKey(stateChangedPref) != nil,
+                   let enabled = prefsForSync.boolForKey("engine.\(engine).enabled") {
+                    engineEnablements[engine] = enabled
+                    prefsForSync.setObject(nil, forKey: stateChangedPref)
+                }
+            }
+        }
+
+        if !engineEnablements.isEmpty {
+            let enabled = engineEnablements.compactMap { $0.value ? $0.key : nil }
+            logger.log("engines to enable: \(enabled)",
+                       level: .info,
+                       category: .sync)
+
+            let disabled = engineEnablements.compactMap { !$0.value ? $0.key : nil }
+            let msg = "engines to disable: \(disabled)"
+            logger.log(msg,
+                       level: .info,
+                       category: .sync)
+        }
+        return engineEnablements
+    }
+
+    public class ScopedKeyError: MaybeErrorType {
+        public let description = "No key data found for scope."
+    }
+
+    public class EncryptionKeyError: MaybeErrorType {
+        public let description = "Failed to get stored key."
+    }
+
+    public class DeviceIdError: MaybeErrorType {
+        public let description = "Failed to get deviceId."
+    }
+
+    public class NoTokenServerURLError: MaybeErrorType {
+        public let description = "Failed to get token server endpoint url."
+    }
+
+    public class EngineAndKeyRetrievalError: MaybeErrorType {
+        public let description = "Failed to get sync engine and key data."
+    }
+
+    fileprivate func getEnginesAndKeys(
+        engines: [String]
+    ) -> Deferred<Maybe<([EngineIdentifier], [String: String])>> {
+        let deferred = Deferred<Maybe<([EngineIdentifier], [String: String])>>()
+        var localEncryptionKeys: [String: String] = [:]
+        var rustEngines: [String] = []
+        var registeredPlaces: Bool = false
+
+        for engine in engines {
+            switch engine {
+            case "tabs":
+                profile?.tabs.registerWithSyncManager()
+                rustEngines.append("tabs")
+            case "passwords":
+                profile?.logins.registerWithSyncManager()
+                if let key = try? profile?.logins.getStoredKey() {
+                    localEncryptionKeys["passwords"] = key
+                    rustEngines.append("passwords")
+                } else {
+                    logger.log("Login encryption key could not be retrieved for syncing",
+                               level: .warning,
+                               category: .sync)
+                }
+            case "bookmarks", "history":
+                if !registeredPlaces {
+                    profile?.places.registerWithSyncManager()
+                    registeredPlaces = true
+                }
+                rustEngines.append("bookmarks")
+            default:
+                continue
+            }
+        }
+
+        deferred.fill(Maybe(success: (rustEngines, localEncryptionKeys)))
+        return deferred
+    }
+
+    fileprivate func syncRustEngines(
+        why: MozillaAppServices.SyncReason,
+        engines: [String]
+    ) -> Deferred<Maybe<MozillaAppServices.SyncResult>> {
+        let deferred = Deferred<Maybe<MozillaAppServices.SyncResult>>()
+
+        logger.log("Syncing \(engines)", level: .info, category: .sync)
+        self.profile?.rustFxA.accountManager.upon { accountManager in
+            guard let device = accountManager.deviceConstellation()?
+                .state()?
+                .localDevice else {
+                self.logger.log("Device Id could not be retrieved",
+                                level: .warning,
+                                category: .sync)
+                deferred.fill(Maybe(failure: DeviceIdError()))
+                return
+            }
+
+            accountManager.getAccessToken(scope: OAuthScope.oldSync) { result in
+                guard let accessTokenInfo = try? result.get(),
+                      let key = accessTokenInfo.key else {
+                    deferred.fill(Maybe(failure: ScopedKeyError()))
+                    return
+                }
+
+                accountManager.getTokenServerEndpointURL { result in
+                    guard case .success(let tokenServerEndpointURL) = result else {
+                        deferred.fill(Maybe(failure: NoTokenServerURLError()))
+                        return
+                    }
+
+                    self.getEnginesAndKeys(engines: engines).upon { result in
+                        guard let (rustEngines, localEncryptionKeys) = result
+                            .successValue else {
+                            deferred.fill(Maybe(failure: EngineAndKeyRetrievalError()))
+                            return
+                        }
+                        let params = SyncParams(
+                            reason: why,
+                            engines: SyncEngineSelection.some(engines: rustEngines),
+                            enabledChanges: self.getEngineEnablementChangesForAccount(),
+                            localEncryptionKeys: localEncryptionKeys,
+                            authInfo: SyncAuthInfo(
+                                kid: key.kid,
+                                fxaAccessToken: accessTokenInfo.token,
+                                syncKey: key.k,
+                                tokenserverUrl: tokenServerEndpointURL.absoluteString),
+                            persistedState:
+                                self.prefs
+                                    .stringForKey(PrefsKeys.RustSyncManagerPersistedState),
+                            deviceSettings: DeviceSettings(
+                                fxaDeviceId: device.id,
+                                name: device.displayName,
+                                kind: self.toSyncManagerDeviceType(
+                                    deviceType: device.deviceType)))
+
+                        self.beginSyncing()
+                        self.syncManagerAPI.sync(params: params) { syncResult in
+                            // Save the persisted state
+                            self.prefs
+                                .setString(syncResult.persistedState,
+                                           forKey: PrefsKeys.RustSyncManagerPersistedState)
+
+                            let declinedEngines = String(describing: syncResult.declined ?? [])
+                            let telemetryData = syncResult.telemetryJson ??
+                                "(No telemetry data was returned)"
+                            let telemetryMessage = "\(String(describing: telemetryData))"
+                            let syncDetails = ["status": "\(syncResult.status)",
+                                               "declinedEngines": "\(declinedEngines)",
+                                               "telemetry": telemetryMessage]
+
+                            self.logger.log("Finished syncing",
+                                            level: .info,
+                                            category: .sync,
+                                            extra: syncDetails)
+
+                            // Save declined/enabled engines - we assume the engines
+                            // not included in the returned `declined` property of the
+                            // result of the sync manager `sync` are enabled.
+                            let updateEnginePref:
+                            (String, Bool) -> Void = { engine, enabled in
+                                self.prefsForSync
+                                    .setBool(enabled,
+                                             forKey: "engine.\(engine).enabled")
+                            }
+
+                            if let declined = syncResult.declined {
+                                RustTogglableEngines.forEach({
+                                    if declined.contains($0) {
+                                        updateEnginePref($0, false)
+                                    } else {
+                                        updateEnginePref($0, true)
+                                    }
+                                })
+                            } else {
+                                RustTogglableEngines.forEach({
+                                    updateEnginePref($0, true)
+                                })
+                            }
+                            deferred.fill(Maybe(success: syncResult))
+                            self.endSyncing(syncResult)
+                        }
+                    }
+                }
+            }
+        }
+        return deferred
+    }
+
+    fileprivate func toSyncManagerDeviceType(
+        deviceType: DeviceType
+    ) -> SyncManagerDeviceType {
+        switch deviceType {
+        case .desktop:
+            return SyncManagerDeviceType.desktop
+        case .mobile:
+            return SyncManagerDeviceType.mobile
+        case .tablet:
+            return SyncManagerDeviceType.tablet
+        case .vr:
+            return SyncManagerDeviceType.vr
+        case .tv:
+            return SyncManagerDeviceType.tv
+        case .unknown:
+            return SyncManagerDeviceType.unknown
+        }
+    }
+
+    @discardableResult public func syncEverything(why: OldSyncReason) -> Success {
+        let rustReason = toRustSyncReason(reason: why)
+        return syncRustEngines(why: rustReason, engines: RustTogglableEngines) >>> succeed
+    }
+
+    /**
+     * Allows selective sync of different collections, for use by external APIs.
+     * Some help is given to callers who use different namespaces (specifically: `passwords` is mapped to `logins`)
+     * and to preserve some ordering rules.
+     */
+    public func syncNamedCollections(why: OldSyncReason, names: [String]) -> Success {
+        // Massage the list of names into engine identifiers.var engines = [String]()
+        var engines = [String]()
+
+        for name in names {
+            // There may be duplicates in `names` so we are removing them here
+            if !engines.contains(name) {
+                engines.append(name)
+            }
+        }
+
+        // Ensuring that only valid engines are submitted
+        let filteredEngines = engines.filter { RustTogglableEngines.contains($0) }
+
+        let rustReason = toRustSyncReason(reason: why)
+        return syncRustEngines(why: rustReason, engines: filteredEngines) >>> succeed
+    }
+
+    public func syncTabs() -> Deferred<Maybe<MozillaAppServices.SyncResult>> {
+        return syncRustEngines(why: .user, engines: ["tabs"])
+    }
+
+    public func syncClientsThenTabs() -> OldSyncResult {
+        // This function exists to comply with the `SyncManager` protocol while the
+        // rust sync manager rollout is enabled. To be safe, `syncTabs` is called. Once
+        // the rollout is complete this can be removed along with an update to the
+        // protocol.
+
+        return syncTabs().bind { result in
+            if let error = result.failureValue {
+                return deferMaybe(error)
+            }
+
+            // The current callers of `BrowserSyncManager.syncClientsThenTabs` only care
+            // whether the function fails or succeeds and does nothing with return value
+            // upon success so we are returning a meaningless value here.
+            return deferMaybe(SyncStatus.notStarted(SyncNotStartedReason.unknown))
+        }
+    }
+
+    public func syncClients() -> OldSyncResult {
+        // This function exists to to comply with the `SyncManager` protocol and has
+        // no callers. It will be removed when the rust sync manager rollout is complete.
+        // To be safe, `syncClientsThenTabs` is called.
+        return syncClientsThenTabs()
+    }
+
+    public func syncHistory() -> OldSyncResult {
+        // The return type of this function has been changed to comply with the
+        // `SyncManager` protocol during the rust sync manager rollout. It will be updated
+        // once the rollout is complete.
+        return syncRustEngines(why: .user, engines: ["history"]).bind { result in
+            if let error = result.failureValue {
+                return deferMaybe(error)
+            }
+
+            // The current callers of this function only care whether this function fails
+            // or succeeds and does nothing with return value upon success so we are
+            // returning a meaningless value here.
+            return deferMaybe(SyncStatus.notStarted(SyncNotStartedReason.unknown))
+        }
+    }
+}

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -9,6 +9,10 @@ public struct PrefsKeys {
     // When this pref is set (by the user) it overrides default behaviour which is just based on app locale.
     public static let KeyEnableChinaSyncService = "useChinaSyncService"
     public static let KeyLastRemoteTabSyncTime = "lastRemoteTabSyncTime"
+
+    // Global sync state for rust sync manager
+    public static let RustSyncManagerPersistedState = "rustSyncManagerPersistedStateKey"
+
     public static let KeyLastSyncFinishTime = "lastSyncFinishTime"
     public static let KeyDefaultHomePageURL = "KeyDefaultHomePageURL"
     public static let KeyNoImageModeStatus = "NoImageModeStatus"

--- a/Storage/Rust/RustRemoteTabs.swift
+++ b/Storage/Rust/RustRemoteTabs.swift
@@ -221,13 +221,13 @@ public extension ClientRemoteTabs {
 
     func toRemoteClient() -> RemoteClient {
         let remoteClient = RemoteClient(guid: self.clientId,
-                            name: self.clientName,
-                            modified: UInt64(self.lastModified),
-                            type: "\(self.deviceType)",
-                            formfactor: nil,
-                            os: nil,
-                            version: nil,
-                            fxaDeviceId: self.clientId)
+                                        name: self.clientName,
+                                        modified: UInt64(self.lastModified),
+                                        type: "\(self.deviceType)",
+                                        formfactor: nil,
+                                        os: nil,
+                                        version: nil,
+                                        fxaDeviceId: self.clientId)
         return remoteClient
     }
 }

--- a/Sync/RustSyncManagerAPI.swift
+++ b/Sync/RustSyncManagerAPI.swift
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import Logger
+import Common
 import Shared
 @_exported import MozillaAppServices
 

--- a/Sync/RustSyncManagerAPI.swift
+++ b/Sync/RustSyncManagerAPI.swift
@@ -17,14 +17,14 @@ open class RustSyncManagerAPI {
     }
 
     public func disconnect() {
-        DispatchQueue.global(qos: .background).async { [unowned self] in
+        DispatchQueue.global(qos: .userInitiated).async { [unowned self] in
             self.api.disconnect()
         }
     }
 
     public func sync(params: SyncParams,
                      completion: @escaping (MozillaAppServices.SyncResult) -> Void) {
-        DispatchQueue.global(qos: .background).async { [unowned self] in
+        DispatchQueue.global(qos: .userInitiated).async { [unowned self] in
             do {
                 let result = try self.api.sync(params: params)
                 completion(result)
@@ -32,8 +32,8 @@ open class RustSyncManagerAPI {
                 if let syncError = err as? SyncManagerError {
                     let syncErrDescription = syncError.localizedDescription
                     self.logger.log("Rust SyncManager sync error: \(syncErrDescription)",
-                                                        level: .warning,
-                                                        category: .sync)
+                                    level: .warning,
+                                    category: .sync)
                 } else {
                     let errDescription = err.localizedDescription
                     self.logger.log("""
@@ -48,14 +48,14 @@ open class RustSyncManagerAPI {
     }
 
     public func getAvailableEngines(completion: @escaping ([String]) -> Void) {
-        DispatchQueue.global(qos: .background).async { [unowned self] in
+        DispatchQueue.global(qos: .userInitiated).async { [unowned self] in
             let engines = self.api.getAvailableEngines()
             completion(engines)
         }
     }
 }
 
-public func toRustSyncReason(reason: Sync.SyncReason) -> MozillaAppServices.SyncReason {
+public func toRustSyncReason(reason: OldSyncReason) -> MozillaAppServices.SyncReason {
     switch reason {
     case .startup:
         return MozillaAppServices.SyncReason.startup
@@ -72,8 +72,8 @@ public func toRustSyncReason(reason: Sync.SyncReason) -> MozillaAppServices.Sync
 
 // Names of collections that can be enabled/disabled locally.
 public let RustTogglableEngines: [String] = [
+    "tabs",
     "bookmarks",
     "history",
-    "tabs",
-    "passwords"
+    "passwords",
 ]

--- a/Sync/SyncTelemetryUtils.swift
+++ b/Sync/SyncTelemetryUtils.swift
@@ -480,7 +480,7 @@ public class GleanSyncOperationHelper {
             _ = GleanMetrics.Sync.syncUuid.generateAndSet()
 
             if let reason = sync.failureReason {
-                let failureReason = convertSyncFailureReason(reason: String(describing: reason))
+                let failureReason = convertSyncFailureReason(reason: reason)
                 GleanMetrics.Sync.failureReason[failureReason].add()
             }
 
@@ -489,8 +489,8 @@ public class GleanSyncOperationHelper {
                     self.recordRustSyncEngineStats(engine.name,
                                                    incoming: engine.incoming,
                                                    outgoing: engine.outgoing)
-                } else {
-                    let reason = convertEngineFailureReason(String(describing: engine.failureReason))
+                } else if let reason = engine.failureReason {
+                    let reason = convertEngineFailureReason(reason: reason)
                     self.recordSyncEngineFailure(
                         engine.name,
                         reason)
@@ -574,85 +574,6 @@ public class GleanSyncOperationHelper {
             incomingLabelsToValue.forEach { (l, v) in GleanMetrics.HistorySync.incoming[l].add(Int32(v))}
             outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.HistorySync.outgoing[l].add(Int32(v)) }
         case "logins":
-            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.LoginsSync.incoming[l].add(Int32(v))}
-            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.LoginsSync.outgoing[l].add(Int32(v)) }
-        case "clients":
-            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.ClientsSync.incoming[l].add(Int32(v))}
-            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.ClientsSync.outgoing[l].add(Int32(v)) }
-        default:
-            break
-        }
-    }
-    
-    private func recordRustSyncEngineStats(_ engineName: String,
-                                           incoming: IncomingInfo?,
-                                           outgoing: [OutgoingInfo])
-    {
-        let incomingLabelsToValue = [
-            ("applied", incoming?.applied ?? 0),
-            ("reconciled", incoming?.reconciled ?? 0),
-            ("failed_to_apply", incoming?.failed ?? 0)
-        ].filter { (_, stat) in stat > 0 }
-
-        let outgoingLabelsToValue = [
-            ("uploaded", outgoing.reduce (0, { totalUploaded, rec in
-                totalUploaded + rec.sent
-            })),
-            ("failed_to_upload", outgoing.reduce (0, { totalFailed, rec in
-                totalFailed + rec.failed
-            }))
-        ].filter { (_, stat) in stat > 0 }
-        
-        switch engineName {
-        case "tabs":
-            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.RustTabsSync.incoming[l].add(Int32(v))}
-            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.RustTabsSync.outgoing[l].add(Int32(v)) }
-        case "bookmarks":
-            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.BookmarksSync.incoming[l].add(Int32(v))}
-            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.BookmarksSync.outgoing[l].add(Int32(v)) }
-        case "history":
-            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.HistorySync.incoming[l].add(Int32(v))}
-            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.HistorySync.outgoing[l].add(Int32(v)) }
-        case "logins":
-            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.LoginsSync.incoming[l].add(Int32(v))}
-            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.LoginsSync.outgoing[l].add(Int32(v)) }
-        case "clients":
-            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.ClientsSync.incoming[l].add(Int32(v))}
-            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.ClientsSync.outgoing[l].add(Int32(v)) }
-        default:
-            break
-        }
-    }
-
-    private func recordRustSyncEngineStats(_ engineName: String,
-                                           incoming: IncomingInfo?,
-                                           outgoing: [OutgoingInfo]) {
-        let incomingLabelsToValue = [
-            ("applied", incoming?.applied ?? 0),
-            ("reconciled", incoming?.reconciled ?? 0),
-            ("failed_to_apply", incoming?.failed ?? 0)
-        ].filter { (_, stat) in stat > 0 }
-
-        let outgoingLabelsToValue = [
-            ("uploaded", outgoing.reduce(0, { totalUploaded, rec in
-                totalUploaded + rec.sent
-            })),
-            ("failed_to_upload", outgoing.reduce(0, { totalFailed, rec in
-                totalFailed + rec.failed
-            }))
-        ].filter { (_, stat) in stat > 0 }
-
-        switch engineName {
-        case "tabs":
-            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.RustTabsSync.incoming[l].add(Int32(v))}
-            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.RustTabsSync.outgoing[l].add(Int32(v)) }
-        case "bookmarks":
-            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.BookmarksSync.incoming[l].add(Int32(v))}
-            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.BookmarksSync.outgoing[l].add(Int32(v)) }
-        case "history":
-            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.HistorySync.incoming[l].add(Int32(v))}
-            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.HistorySync.outgoing[l].add(Int32(v)) }
-        case "passwords":
             incomingLabelsToValue.forEach { (l, v) in GleanMetrics.LoginsSync.incoming[l].add(Int32(v))}
             outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.LoginsSync.outgoing[l].add(Int32(v)) }
         case "clients":

--- a/Sync/SyncTelemetryUtils.swift
+++ b/Sync/SyncTelemetryUtils.swift
@@ -479,8 +479,9 @@ public class GleanSyncOperationHelper {
         for sync in telemetry.syncs {
             _ = GleanMetrics.Sync.syncUuid.generateAndSet()
 
-            if let failureReason = sync.failureReason {
-                GleanMetrics.Sync.failureReason[String(describing: failureReason)].add()
+            if let reason = sync.failureReason {
+                let failureReason = convertSyncFailureReason(reason: String(describing: reason))
+                GleanMetrics.Sync.failureReason[failureReason].add()
             }
 
             for engine in sync.engines {
@@ -489,9 +490,10 @@ public class GleanSyncOperationHelper {
                                                    incoming: engine.incoming,
                                                    outgoing: engine.outgoing)
                 } else {
+                    let reason = convertEngineFailureReason(String(describing: engine.failureReason))
                     self.recordSyncEngineFailure(
                         engine.name,
-                        String(describing: engine.failureReason))
+                        reason)
                 }
 
                 self.submitSyncEnginePing(engine.name)
@@ -572,6 +574,85 @@ public class GleanSyncOperationHelper {
             incomingLabelsToValue.forEach { (l, v) in GleanMetrics.HistorySync.incoming[l].add(Int32(v))}
             outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.HistorySync.outgoing[l].add(Int32(v)) }
         case "logins":
+            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.LoginsSync.incoming[l].add(Int32(v))}
+            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.LoginsSync.outgoing[l].add(Int32(v)) }
+        case "clients":
+            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.ClientsSync.incoming[l].add(Int32(v))}
+            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.ClientsSync.outgoing[l].add(Int32(v)) }
+        default:
+            break
+        }
+    }
+    
+    private func recordRustSyncEngineStats(_ engineName: String,
+                                           incoming: IncomingInfo?,
+                                           outgoing: [OutgoingInfo])
+    {
+        let incomingLabelsToValue = [
+            ("applied", incoming?.applied ?? 0),
+            ("reconciled", incoming?.reconciled ?? 0),
+            ("failed_to_apply", incoming?.failed ?? 0)
+        ].filter { (_, stat) in stat > 0 }
+
+        let outgoingLabelsToValue = [
+            ("uploaded", outgoing.reduce (0, { totalUploaded, rec in
+                totalUploaded + rec.sent
+            })),
+            ("failed_to_upload", outgoing.reduce (0, { totalFailed, rec in
+                totalFailed + rec.failed
+            }))
+        ].filter { (_, stat) in stat > 0 }
+        
+        switch engineName {
+        case "tabs":
+            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.RustTabsSync.incoming[l].add(Int32(v))}
+            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.RustTabsSync.outgoing[l].add(Int32(v)) }
+        case "bookmarks":
+            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.BookmarksSync.incoming[l].add(Int32(v))}
+            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.BookmarksSync.outgoing[l].add(Int32(v)) }
+        case "history":
+            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.HistorySync.incoming[l].add(Int32(v))}
+            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.HistorySync.outgoing[l].add(Int32(v)) }
+        case "logins":
+            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.LoginsSync.incoming[l].add(Int32(v))}
+            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.LoginsSync.outgoing[l].add(Int32(v)) }
+        case "clients":
+            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.ClientsSync.incoming[l].add(Int32(v))}
+            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.ClientsSync.outgoing[l].add(Int32(v)) }
+        default:
+            break
+        }
+    }
+
+    private func recordRustSyncEngineStats(_ engineName: String,
+                                           incoming: IncomingInfo?,
+                                           outgoing: [OutgoingInfo]) {
+        let incomingLabelsToValue = [
+            ("applied", incoming?.applied ?? 0),
+            ("reconciled", incoming?.reconciled ?? 0),
+            ("failed_to_apply", incoming?.failed ?? 0)
+        ].filter { (_, stat) in stat > 0 }
+
+        let outgoingLabelsToValue = [
+            ("uploaded", outgoing.reduce(0, { totalUploaded, rec in
+                totalUploaded + rec.sent
+            })),
+            ("failed_to_upload", outgoing.reduce(0, { totalFailed, rec in
+                totalFailed + rec.failed
+            }))
+        ].filter { (_, stat) in stat > 0 }
+
+        switch engineName {
+        case "tabs":
+            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.RustTabsSync.incoming[l].add(Int32(v))}
+            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.RustTabsSync.outgoing[l].add(Int32(v)) }
+        case "bookmarks":
+            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.BookmarksSync.incoming[l].add(Int32(v))}
+            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.BookmarksSync.outgoing[l].add(Int32(v)) }
+        case "history":
+            incomingLabelsToValue.forEach { (l, v) in GleanMetrics.HistorySync.incoming[l].add(Int32(v))}
+            outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.HistorySync.outgoing[l].add(Int32(v)) }
+        case "passwords":
             incomingLabelsToValue.forEach { (l, v) in GleanMetrics.LoginsSync.incoming[l].add(Int32(v))}
             outgoingLabelsToValue.forEach { (l, v) in GleanMetrics.LoginsSync.outgoing[l].add(Int32(v)) }
         case "clients":


### PR DESCRIPTION
This is the third task in #13278 which is adding the `RustSyncManager` class for the sync manager integration. This class will replace the existing `BrowserSyncManager` class.

**Note:** The changes in `RustRemoteTabs.swift`, `RustSyncManagerAPI.swift`, and `SyncTelemetryUtils.swift` should have been included in #13330 but were omitted because of the Glean build issues.
