### PR TITLE
Refactor MTE-726 [v112] Remove testShowTourFromSettings() from FirstRunTourTests

### DIFF
--- a/Tests/SmokeXCUITests.xctestplan
+++ b/Tests/SmokeXCUITests.xctestplan
@@ -74,7 +74,6 @@
         "FindInPageTests\/testFindInPageTwoWordsSearch()",
         "FindInPageTests\/testFindInPageTwoWordsSearchLargeDoc()",
         "FindInPageTests\/testQueryWithNoMatches()",
-        "FirstRunTourTests\/testShowTourFromSettings()",
         "FirstRunTourTests\/testStartBrowsingFromSecondScreen()",
         "FxScreenGraphTests",
         "HistoryTests",

--- a/Tests/XCUITests/FirstRunTourTests.swift
+++ b/Tests/XCUITests/FirstRunTourTests.swift
@@ -43,13 +43,6 @@ class FirstRunTourTests: BaseTestCase {
         waitForExistence(topSites)
     }
 
-    func testShowTourFromSettings() {
-        goToNextScreen()
-        tapStartBrowsingButton()
-        navigator.goto(ShowTourInSettings)
-        waitForExistence(app.staticTexts["Welcome to an independent internet"])
-    }
-
     // MARK: Private
     private func goToNextScreen() {
         waitForExistence(app.buttons["\(rootA11yId)PrimaryButton"], timeout: 10)


### PR DESCRIPTION
The test `FirstRunTourTests/testShowTourFromSettings()` is no longer needed because we can no longer launch the tour from the settings page. Such a functionality has been removed as a part of FXIOS-5402.
