### PR TITLE
Bugfix FXIOS-5778 [v112] Show private browsing message on app switcher if no private tabs

### DIFF
--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -403,7 +403,7 @@ extension GridTabViewController {
 // MARK: - App Notifications
 extension GridTabViewController {
     @objc func appWillResignActiveNotification() {
-        if tabDisplayManager.isPrivate {
+        if tabDisplayManager.isPrivate && !tabManager.privateTabs.isEmpty {
             backgroundPrivacyOverlay.alpha = 1
             view.bringSubviewToFront(backgroundPrivacyOverlay)
             collectionView.alpha = 0


### PR DESCRIPTION
Fixes [Issue #13260](https://github.com/mozilla-mobile/firefox-ios/issues/13260)
https://mozilla-hub.atlassian.net/browse/FXIOS-5778

| Description  | Screenshot |
| ------------- | ------------- |
| Originally, when the user is in Private Browsing mode with zero tabs opened, and goes to the App Switcher, the normal browsing tab is visible.  | ![Simulator Screen Shot - iPhone 14 Pro - 2023-03-05 at 14 03 52](https://user-images.githubusercontent.com/122514525/222988554-08415ad5-0d81-4750-ba88-1470cb62c8d5.png)  |
| With this PR, we show the Privacy Browsing message if there aren't any private tabs opened while in Private Browsing mode.  | ![Simulator Screen Shot - iPhone 14 Pro - 2023-03-05 at 14 02 10](https://user-images.githubusercontent.com/122514525/222988598-f0a85131-3477-48ba-a7a1-6e80cf62d1ae.png)  |

I manually checked the following cases to ensure the Privacy Browsing message does not show up improperly:
1. On Private Browsing mode, I opened a new tab and then opened the App Switcher. The Privacy Overlay Screen shows up as expected.
2. On Normal Browsing mode, I opened a new tab. I went to Private Browsing mode, opened a new tab, and switched back to normal browsing mode. I opened the App Switcher and the Privacy Overlay Screen did not show up as expected.