### PR TITLE
Refactor FXIOS-5903 [v112] made TabLocationView delegate weak

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -669,6 +669,7 @@
 		A9072B801D07B34100459960 /* NoImageModeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9072B7F1D07B34100459960 /* NoImageModeHelper.swift */; };
 		A93067E81D0FE18E00C49C6E /* NightModeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93067E71D0FE18E00C49C6E /* NightModeHelper.swift */; };
 		AB7D4C3129ACAED100626427 /* Tab+ChangeUserAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB7D4C3029ACAED100626427 /* Tab+ChangeUserAgentTests.swift */; };
+		B640467E29B9B58200C5C7B6 /* TabLocationViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B640467D29B9B58200C5C7B6 /* TabLocationViewTests.swift */; };
 		BA6E311FBCA7A2157F48568A /* Telemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6E371A3948814CAA0C83E4 /* Telemetry.swift */; };
 		BA6E3BF4B5AC115E7DBCAA5E /* FxATelemtryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6E376117A53502756759A2 /* FxATelemtryTests.swift */; };
 		C400467C1CF4E43E00B08303 /* BackForwardListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C400467B1CF4E43E00B08303 /* BackForwardListViewController.swift */; };
@@ -3832,6 +3833,7 @@
 		B60B46D4BD055D52822BF77D /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
 		B621470BA1595932CE4DE6D6 /* sq */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sq; path = sq.lproj/Storage.strings; sourceTree = "<group>"; };
 		B6294993A13ABCA515E68613 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
+		B640467D29B9B58200C5C7B6 /* TabLocationViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabLocationViewTests.swift; sourceTree = "<group>"; };
 		B65A4A74B6ACC13CB9EC1C77 /* hu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hu; path = "hu.lproj/Default Browser.strings"; sourceTree = "<group>"; };
 		B679456D8CFE4AB9DDD14D84 /* sk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sk; path = sk.lproj/Menu.strings; sourceTree = "<group>"; };
 		B68C4D8E8EE80F3BAC05DF91 /* bn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bn; path = bn.lproj/Storage.strings; sourceTree = "<group>"; };
@@ -8300,6 +8302,7 @@
 				E4CD9F1C1A6D9C2800318571 /* WebServerTests.swift */,
 				D3BA41671BD82F2200DA5457 /* XCTestCaseExtensions.swift */,
 				8A96C4BA28F9E7B300B75884 /* XCTestCaseRootViewController.swift */,
+				B640467D29B9B58200C5C7B6 /* TabLocationViewTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -10808,6 +10811,7 @@
 				8A2366FA28A302E500846D1B /* MockSponsoredPocketAPI.swift in Sources */,
 				8A8A05E42746ACAC004267A0 /* TabDisplayManagerTests.swift in Sources */,
 				C869916328918C36007ACC5C /* WallpaperNetworkingModuleTests.swift in Sources */,
+				B640467E29B9B58200C5C7B6 /* TabLocationViewTests.swift in Sources */,
 				8ABA9C8D28931223002C0077 /* MockDispatchQueue.swift in Sources */,
 				D3FA777B1A43B2990010CD32 /* SearchTests.swift in Sources */,
 				D3BA41681BD82F2200DA5457 /* XCTestCaseExtensions.swift in Sources */,

--- a/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -33,7 +33,7 @@ class TabLocationView: UIView, FeatureFlaggable {
     }
 
     // MARK: Variables
-    var delegate: TabLocationViewDelegate?
+    weak var delegate: TabLocationViewDelegate?
     var longPressRecognizer: UILongPressGestureRecognizer!
     var tapRecognizer: UITapGestureRecognizer!
     var contentView: UIStackView!

--- a/Tests/ClientTests/TabLocationViewTests.swift
+++ b/Tests/ClientTests/TabLocationViewTests.swift
@@ -6,9 +6,37 @@ import XCTest
 
 @testable import Client
 
-final class TabLocationViewTests: XCTestCase {
-    func testTabLocationView_hasNoLeaks() {
+class TabLocationViewTests: XCTestCase {
+    func testDelegateMemoryLeak() {
         let tabLocationView = TabLocationView()
-        trackForMemoryLeaks(tabLocationView)
+        let delegate = MockTabLocationViewDelegate()
+        tabLocationView.delegate = delegate
+        delegate.cleanup()
+        trackForMemoryLeaks(delegate)
+    }
+}
+
+// A mock delegate
+class MockTabLocationViewDelegate: TabLocationViewDelegate {
+    weak var delegate: TabLocationViewDelegate?
+
+    func tabLocationViewDidTapLocation(_ tabLocationView: TabLocationView) {}
+    func tabLocationViewDidLongPressLocation(_ tabLocationView: TabLocationView) {}
+    func tabLocationViewDidTapReaderMode(_ tabLocationView: TabLocationView) {}
+    func tabLocationViewDidTapReload(_ tabLocationView: TabLocationView) {}
+    func tabLocationViewDidTapShield(_ tabLocationView: TabLocationView) {}
+    func tabLocationViewDidBeginDragInteraction(_ tabLocationView: TabLocationView) {}
+    func tabLocationViewDidTapShare(_ tabLocationView: TabLocationView, button: UIButton) {}
+    func tabLocationViewDidLongPressReaderMode(_ tabLocationView: TabLocationView) -> Bool {
+        return false
+    }
+    func tabLocationViewDidLongPressReload(_ tabLocationView: TabLocationView) {}
+    func tabLocationViewLocationAccessibilityActions(_ tabLocationView: TabLocationView) -> [UIAccessibilityCustomAction]? {
+        return nil
+    }
+
+    // cleanup
+    func cleanup() {
+        delegate = nil
     }
 }

--- a/Tests/ClientTests/TabLocationViewTests.swift
+++ b/Tests/ClientTests/TabLocationViewTests.swift
@@ -11,15 +11,12 @@ class TabLocationViewTests: XCTestCase {
         let tabLocationView = TabLocationView()
         let delegate = MockTabLocationViewDelegate()
         tabLocationView.delegate = delegate
-        delegate.cleanup()
-        trackForMemoryLeaks(delegate)
+        trackForMemoryLeaks(tabLocationView)
     }
 }
 
 // A mock delegate
 class MockTabLocationViewDelegate: TabLocationViewDelegate {
-    weak var delegate: TabLocationViewDelegate?
-
     func tabLocationViewDidTapLocation(_ tabLocationView: TabLocationView) {}
     func tabLocationViewDidLongPressLocation(_ tabLocationView: TabLocationView) {}
     func tabLocationViewDidTapReaderMode(_ tabLocationView: TabLocationView) {}
@@ -33,10 +30,5 @@ class MockTabLocationViewDelegate: TabLocationViewDelegate {
     func tabLocationViewDidLongPressReload(_ tabLocationView: TabLocationView) {}
     func tabLocationViewLocationAccessibilityActions(_ tabLocationView: TabLocationView) -> [UIAccessibilityCustomAction]? {
         return nil
-    }
-
-    // cleanup
-    func cleanup() {
-        delegate = nil
     }
 }

--- a/Tests/ClientTests/TabLocationViewTests.swift
+++ b/Tests/ClientTests/TabLocationViewTests.swift
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+@testable import Client
+
+final class TabLocationViewTests: XCTestCase {
+    func testTabLocationView_hasNoLeaks() {
+        let tabLocationView = TabLocationView()
+        trackForMemoryLeaks(tabLocationView)
+    }
+}


### PR DESCRIPTION
Reference Issue: #13441 

I tried to make `TabLocationView`'s `delegate` `weak` for avoiding reference cycles. Please review and let me know if I'm wrong.