### PR TITLE
Refactor FXIOS-5904 [v112] made GroupedTabContainerCell delegate weak

### DIFF
--- a/Client/Frontend/Browser/Tabs/GroupedTabCell.swift
+++ b/Client/Frontend/Browser/Tabs/GroupedTabCell.swift
@@ -170,7 +170,7 @@ class GroupedTabContainerCell: UITableViewCell,
                                ReusableCell,
                                ThemeApplicable {
     // Delegate
-    var delegate: GroupedTabsDelegate?
+    weak var delegate: GroupedTabsDelegate?
 
     // Views
     var selectedView = UIView()

--- a/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -33,7 +33,7 @@ class TabLocationView: UIView, FeatureFlaggable {
     }
 
     // MARK: Variables
-    var delegate: TabLocationViewDelegate?
+    weak var delegate: TabLocationViewDelegate?
     var longPressRecognizer: UILongPressGestureRecognizer!
     var tapRecognizer: UITapGestureRecognizer!
     var contentView: UIStackView!


### PR DESCRIPTION
References Issues: #13442 

I tried to make `GroupedTabContainerCell`'s delegate `weak` for avoiding reference cycles. Please review and let me know if I'm wrong.
