### PR TITLE
Bugfix FXIOS-5428 [v112] Broken tab after closing the Inactive tabs

### DIFF
--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -630,7 +630,7 @@ extension TabDisplayManager: InactiveTabsDelegate {
     private func removeInactiveTabAndReloadView(tabs: [Tab]) {
         // Remove inactive tabs from tab manager
         tabManager.removeTabs(tabs)
-
+        tabManager.selectTab(mostRecentTab(inTabs: tabManager.normalTabs) ?? tabManager.normalTabs.last)
         let allTabs = isPrivate ? tabManager.privateTabs : tabManager.normalTabs
         inactiveViewModel?.updateInactiveTabs(with: tabManager.selectedTab, tabs: allTabs)
         let indexPath = IndexPath(row: 0, section: TabDisplaySection.inactiveTabs.rawValue)


### PR DESCRIPTION
## [FXIOS-5428](https://mozilla-hub.atlassian.net/browse/FXIOS-5428?filter=-1) | https://github.com/mozilla-mobile/firefox-ios/issues/12684

## Video

https://user-images.githubusercontent.com/51127880/223172068-213eac86-6bab-449b-a4ce-cbebb51e7a48.mp4

