### PR TITLE
Bugfix FXIOS-5467 [v112] Firefox for iOS is forgetting login information and cookies after refreshing a tab

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -112,6 +112,7 @@
 		21A7C44E283539170071D996 /* IntroViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A7C44D283539170071D996 /* IntroViewModel.swift */; };
 		21A7C45028353D0E0071D996 /* OnboardingCardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A7C44F28353D0E0071D996 /* OnboardingCardViewController.swift */; };
 		21B2844A28464FF0003EA521 /* OnboardingCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21B2844928464FF0003EA521 /* OnboardingCardViewModel.swift */; };
+		21B337BB29B67E4100E4F806 /* BrowserViewControllerWebViewDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21B337BA29B67E4100E4F806 /* BrowserViewControllerWebViewDelegateTests.swift */; };
 		21D7B60628077CA5003F7E94 /* LibraryViewController+ToolbarActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7B60528077CA5003F7E94 /* LibraryViewController+ToolbarActions.swift */; };
 		21E78A7028F9A8C500F8D687 /* MockUIDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E78A6F28F9A8C500F8D687 /* MockUIDevice.swift */; };
 		21E78A7228F9A93100F8D687 /* UIDeviceInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E78A7128F9A93100F8D687 /* UIDeviceInterface.swift */; };
@@ -1925,6 +1926,7 @@
 		21A7C44D283539170071D996 /* IntroViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroViewModel.swift; sourceTree = "<group>"; };
 		21A7C44F28353D0E0071D996 /* OnboardingCardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCardViewController.swift; sourceTree = "<group>"; };
 		21B2844928464FF0003EA521 /* OnboardingCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCardViewModel.swift; sourceTree = "<group>"; };
+		21B337BA29B67E4100E4F806 /* BrowserViewControllerWebViewDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserViewControllerWebViewDelegateTests.swift; sourceTree = "<group>"; };
 		21D7B60528077CA5003F7E94 /* LibraryViewController+ToolbarActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LibraryViewController+ToolbarActions.swift"; sourceTree = "<group>"; };
 		21DD4778B3C11A24D552AB34 /* lo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lo; path = lo.lproj/Localizable.strings; sourceTree = "<group>"; };
 		21E78A6F28F9A8C500F8D687 /* MockUIDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockUIDevice.swift; sourceTree = "<group>"; };
@@ -7713,6 +7715,7 @@
 				8A1E3BE828CBC57E003388C4 /* SearchEngines */,
 				E1AEC174286E0CF500062E29 /* WebView */,
 				8A5BD9582878871B000FE773 /* TopSitesHelperTests.swift */,
+				21B337BA29B67E4100E4F806 /* BrowserViewControllerWebViewDelegateTests.swift */,
 			);
 			path = Browser;
 			sourceTree = "<group>";
@@ -10881,6 +10884,7 @@
 				8A1E3BE328CBACDD003388C4 /* SponsoredContentFilterUtilityTests.swift in Sources */,
 				63306D452110BAF000F25400 /* TabManagerStoreTests.swift in Sources */,
 				9614BF4228A53FDF00D3F7EA /* ContextualHintEligibilityUtilityTests.swift in Sources */,
+				21B337BB29B67E4100E4F806 /* BrowserViewControllerWebViewDelegateTests.swift in Sources */,
 				6ADB651B285C03B100947EA4 /* DownloadHelperTests.swift in Sources */,
 				8A6B77CC2811C468001110D2 /* URLProtocolStub.swift in Sources */,
 				CA7BD568248189E800A0A61B /* BreachAlertsTests.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -11,6 +11,7 @@ import UIKit
 /// List of schemes that are allowed to be opened in new tabs.
 private let schemesAllowedToBeOpenedAsPopups = ["http", "https", "javascript", "data", "about"]
 
+// MARK: - WKUIDelegate
 extension BrowserViewController: WKUIDelegate {
     func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
         guard let parentTab = tabManager[webView] else { return nil }
@@ -40,7 +41,7 @@ extension BrowserViewController: WKUIDelegate {
         return newTab.webView
     }
 
-    fileprivate func shouldRequestBeOpenedAsPopup(_ request: URLRequest) -> Bool {
+    private func shouldRequestBeOpenedAsPopup(_ request: URLRequest) -> Bool {
         // Treat `window.open("")` the same as `window.open("about:blank")`.
         if request.url?.absoluteString.isEmpty ?? false {
             return true
@@ -53,15 +54,17 @@ extension BrowserViewController: WKUIDelegate {
         return false
     }
 
-    fileprivate func shouldDisplayJSAlertForWebView(_ webView: WKWebView) -> Bool {
+    private func shouldDisplayJSAlertForWebView(_ webView: WKWebView) -> Bool {
         // Only display a JS Alert if we are selected and there isn't anything being shown
         return ((tabManager.selectedTab == nil ? false : tabManager.selectedTab!.webView == webView)) && (self.presentedViewController == nil)
     }
 
-    func webView(_ webView: WKWebView,
-                 runJavaScriptAlertPanelWithMessage message: String,
-                 initiatedByFrame frame: WKFrameInfo,
-                 completionHandler: @escaping () -> Void) {
+    func webView(
+        _ webView: WKWebView,
+        runJavaScriptAlertPanelWithMessage message: String,
+        initiatedByFrame frame: WKFrameInfo,
+        completionHandler: @escaping () -> Void
+    ) {
         let shouldShowAlert = shouldDisplayJSAlertForWebView(webView)
         let messageAlert = MessageAlert(message: message,
                                         frame: frame,
@@ -124,7 +127,11 @@ extension BrowserViewController: WKUIDelegate {
         }
     }
 
-    func webView(_ webView: WKWebView, contextMenuConfigurationForElement elementInfo: WKContextMenuElementInfo, completionHandler: @escaping (UIContextMenuConfiguration?) -> Void) {
+    func webView(
+        _ webView: WKWebView,
+        contextMenuConfigurationForElement elementInfo: WKContextMenuElementInfo,
+        completionHandler: @escaping (UIContextMenuConfiguration?) -> Void
+    ) {
         completionHandler(UIContextMenuConfiguration(
             identifier: nil,
             previewProvider: {
@@ -378,19 +385,7 @@ extension BrowserViewController: WKUIDelegate {
     }
 }
 
-extension WKNavigationAction {
-    /// Allow local requests only if the request is privileged.
-    var isInternalUnprivileged: Bool {
-        guard let url = request.url else { return true }
-
-        if let url = InternalURL(url) {
-            return !url.isAuthorized
-        } else {
-            return false
-        }
-    }
-}
-
+// MARK: - WKNavigationDelegate
 extension BrowserViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView, didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation!) {
         guard let tab = tabManager[webView] else { return }
@@ -420,63 +415,14 @@ extension BrowserViewController: WKNavigationDelegate {
         }
     }
 
-    // Handle Universal link for Firefox wallpaper setting
-    private func isFirefoxUniversalWallpaperSetting(_ url: URL) -> Bool {
-        guard let scheme = url.scheme,
-              [URL.mozPublicScheme, URL.mozInternalScheme].contains(scheme)
-        else { return false }
-
-        let deeplinkUrl = "\(scheme)://deep-link?url=/settings/wallpaper"
-        if url.absoluteString == deeplinkUrl { return true }
-
-        return false
-    }
-
-    // Recognize an Apple Maps URL. This will trigger the native app. But only if a search query is present. Otherwise
-    // it could just be a visit to a regular page on maps.apple.com.
-    fileprivate func isAppleMapsURL(_ url: URL) -> Bool {
-        if url.scheme == "http" || url.scheme == "https" {
-            if url.host == "maps.apple.com" && url.query != nil {
-                return true
-            }
-        }
-        return false
-    }
-
-    // Recognize a iTunes Store URL. These all trigger the native apps. Note that appstore.com and phobos.apple.com
-    // used to be in this list. I have removed them because they now redirect to itunes.apple.com. If we special case
-    // them then iOS will actually first open Safari, which then redirects to the app store. This works but it will
-    // leave a 'Back to Safari' button in the status bar, which we do not want.
-    fileprivate func isStoreURL(_ url: URL) -> Bool {
-        if url.scheme == "http" || url.scheme == "https" || url.scheme == "itms-apps" {
-            if url.host == "itunes.apple.com" {
-                return true
-            }
-        }
-        return false
-    }
-
-    // Use for sms and mailto links, which do not show a confirmation before opening.
-    fileprivate func showSnackbar(forExternalUrl url: URL, tab: Tab, completion: @escaping (Bool) -> Void) {
-        let snackBar = TimerSnackBar(text: .ExternalLinkGenericConfirmation + "\n\(url.absoluteString)", img: nil)
-        let ok = SnackButton(title: .OKString, accessibilityIdentifier: "AppOpenExternal.button.ok") { bar in
-            tab.removeSnackbar(bar)
-            completion(true)
-        }
-        let cancel = SnackButton(title: .CancelString, accessibilityIdentifier: "AppOpenExternal.button.cancel") { bar in
-            tab.removeSnackbar(bar)
-            completion(false)
-        }
-        snackBar.addButton(ok)
-        snackBar.addButton(cancel)
-        tab.addSnackbar(snackBar)
-    }
-
     // This is the place where we decide what to do with a new navigation action. There are a number of special schemes
     // and http(s) urls that need to be handled in a different way. All the logic for that is inside this delegate
     // method.
-
-    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+    ) {
         guard let url = navigationAction.request.url,
               let tab = tabManager[webView]
         else {
@@ -629,7 +575,11 @@ extension BrowserViewController: WKNavigationDelegate {
         decisionHandler(.cancel)
     }
 
-    func webView(_ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse, decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void) {
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationResponse: WKNavigationResponse,
+        decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void
+    ) {
         let response = navigationResponse.response
         let responseURL = response.url
 
@@ -731,7 +681,11 @@ extension BrowserViewController: WKNavigationDelegate {
     }
 
     /// Invoked when an error occurs while starting to load data for the main frame.
-    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+    func webView(
+        _ webView: WKWebView,
+        didFailProvisionalNavigation navigation: WKNavigation!,
+        withError error: Error
+    ) {
         // Ignore the "Frame load interrupted" error that is triggered when we cancel a request
         // to open an external application and hand it over to UIApplication.openURL(). The result
         // will be that we switch to the external app, for example the app store, while keeping the
@@ -741,9 +695,7 @@ extension BrowserViewController: WKNavigationDelegate {
             return
         }
 
-        if checkIfWebContentProcessHasCrashed(webView, error: error as NSError) {
-            return
-        }
+        guard !checkIfWebContentProcessHasCrashed(webView, error: error as NSError) else { return }
 
         if error.code == Int(CFNetworkErrors.cfurlErrorCancelled.rawValue) {
             if let tab = tabManager[webView], tab === tabManager.selectedTab {
@@ -757,26 +709,13 @@ extension BrowserViewController: WKNavigationDelegate {
         }
     }
 
-    fileprivate func checkIfWebContentProcessHasCrashed(_ webView: WKWebView, error: NSError) -> Bool {
-        if error.code == WKError.webContentProcessTerminated.rawValue && error.domain == "WebKitErrorDomain" {
-            logger.log("WebContent process has crashed. Trying to reload to restart it.",
-                       level: .warning,
-                       category: .webview)
-            webView.reload()
-            return true
-        }
-
-        return false
-    }
-
-    func webView(_ webView: WKWebView, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-        // If this is a certificate challenge, see if the certificate has previously been
-        // accepted by the user.
-        let origin = "\(challenge.protectionSpace.host):\(challenge.protectionSpace.port)"
-        if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
-           let trust = challenge.protectionSpace.serverTrust,
-           let cert = SecTrustGetCertificateAtIndex(trust, 0), profile.certStore.containsCertificate(cert, forOrigin: origin) {
-            completionHandler(.useCredential, URLCredential(trust: trust))
+    func webView(
+        _ webView: WKWebView,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        guard challenge.protectionSpace.authenticationMethod != NSURLAuthenticationMethodServerTrust else {
+            handleServerTrust(challenge: challenge, completionHandler: completionHandler)
             return
         }
 
@@ -790,7 +729,8 @@ extension BrowserViewController: WKNavigationDelegate {
         }
 
         // If this is a request to our local web server, use our private credentials.
-        if challenge.protectionSpace.host == "localhost" && challenge.protectionSpace.port == Int(WebServer.sharedInstance.server.port) {
+        if challenge.protectionSpace.host == "localhost" &&
+            challenge.protectionSpace.port == Int(WebServer.sharedInstance.server.port) {
             completionHandler(.useCredential, WebServer.sharedInstance.credentials)
             return
         }
@@ -875,8 +815,93 @@ extension BrowserViewController: WKNavigationDelegate {
             }
         }
     }
+}
 
-    private func updateObservationReferral(metadataManager: TabMetadataManager, url: String?, isPrivate: Bool) {
+// MARK: - Private
+private extension BrowserViewController {
+    // Handle Universal link for Firefox wallpaper setting
+    func isFirefoxUniversalWallpaperSetting(_ url: URL) -> Bool {
+        guard let scheme = url.scheme,
+              [URL.mozPublicScheme, URL.mozInternalScheme].contains(scheme)
+        else { return false }
+
+        let deeplinkUrl = "\(scheme)://deep-link?url=/settings/wallpaper"
+        if url.absoluteString == deeplinkUrl { return true }
+
+        return false
+    }
+
+    // Recognize an Apple Maps URL. This will trigger the native app. But only if a search query is present. Otherwise
+    // it could just be a visit to a regular page on maps.apple.com.
+    func isAppleMapsURL(_ url: URL) -> Bool {
+        if url.scheme == "http" || url.scheme == "https" {
+            if url.host == "maps.apple.com" && url.query != nil {
+                return true
+            }
+        }
+        return false
+    }
+
+    // Recognize a iTunes Store URL. These all trigger the native apps. Note that appstore.com and phobos.apple.com
+    // used to be in this list. I have removed them because they now redirect to itunes.apple.com. If we special case
+    // them then iOS will actually first open Safari, which then redirects to the app store. This works but it will
+    // leave a 'Back to Safari' button in the status bar, which we do not want.
+    func isStoreURL(_ url: URL) -> Bool {
+        if url.scheme == "http" || url.scheme == "https" || url.scheme == "itms-apps" {
+            if url.host == "itunes.apple.com" {
+                return true
+            }
+        }
+        return false
+    }
+
+    // Use for sms and mailto links, which do not show a confirmation before opening.
+    func showSnackbar(forExternalUrl url: URL, tab: Tab, completion: @escaping (Bool) -> Void) {
+        let snackBar = TimerSnackBar(text: .ExternalLinkGenericConfirmation + "\n\(url.absoluteString)", img: nil)
+        let ok = SnackButton(title: .OKString, accessibilityIdentifier: "AppOpenExternal.button.ok") { bar in
+            tab.removeSnackbar(bar)
+            completion(true)
+        }
+        let cancel = SnackButton(title: .CancelString, accessibilityIdentifier: "AppOpenExternal.button.cancel") { bar in
+            tab.removeSnackbar(bar)
+            completion(false)
+        }
+        snackBar.addButton(ok)
+        snackBar.addButton(cancel)
+        tab.addSnackbar(snackBar)
+    }
+
+     func checkIfWebContentProcessHasCrashed(_ webView: WKWebView, error: NSError) -> Bool {
+        if error.code == WKError.webContentProcessTerminated.rawValue && error.domain == "WebKitErrorDomain" {
+            logger.log("WebContent process has crashed. Trying to reload to restart it.",
+                       level: .warning,
+                       category: .webview)
+            webView.reload()
+            return true
+        }
+
+        return false
+    }
+
+    func handleServerTrust(challenge: URLAuthenticationChallenge,
+                           completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        // If this is a certificate challenge, see if the certificate has previously been
+        // accepted by the user.
+        let origin = "\(challenge.protectionSpace.host):\(challenge.protectionSpace.port)"
+
+        guard let trust = challenge.protectionSpace.serverTrust,
+              let cert = SecTrustGetCertificateAtIndex(trust, 0),
+              profile.certStore.containsCertificate(cert, forOrigin: origin)
+        else {
+            completionHandler(.performDefaultHandling, nil)
+            return
+        }
+
+        completionHandler(.useCredential, URLCredential(trust: trust))
+    }
+
+    func updateObservationReferral(metadataManager: TabMetadataManager, url: String?, isPrivate: Bool) {
         let searchData = TabGroupData(searchTerm: metadataManager.tabGroupData.tabAssociatedSearchTerm,
                                       searchUrl: metadataManager.tabGroupData.tabAssociatedSearchUrl,
                                       nextReferralUrl: url ?? "")
@@ -884,5 +909,18 @@ extension BrowserViewController: WKNavigationDelegate {
             state: .tabNavigatedToDifferentUrl,
             searchData: searchData,
             isPrivate: isPrivate)
+    }
+}
+
+extension WKNavigationAction {
+    /// Allow local requests only if the request is privileged.
+    var isInternalUnprivileged: Bool {
+        guard let url = request.url else { return true }
+
+        if let url = InternalURL(url) {
+            return !url.isAuthorized
+        } else {
+            return false
+        }
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -41,24 +41,6 @@ extension BrowserViewController: WKUIDelegate {
         return newTab.webView
     }
 
-    private func shouldRequestBeOpenedAsPopup(_ request: URLRequest) -> Bool {
-        // Treat `window.open("")` the same as `window.open("about:blank")`.
-        if request.url?.absoluteString.isEmpty ?? false {
-            return true
-        }
-
-        if let scheme = request.url?.scheme?.lowercased(), schemesAllowedToBeOpenedAsPopups.contains(scheme) {
-            return true
-        }
-
-        return false
-    }
-
-    private func shouldDisplayJSAlertForWebView(_ webView: WKWebView) -> Bool {
-        // Only display a JS Alert if we are selected and there isn't anything being shown
-        return ((tabManager.selectedTab == nil ? false : tabManager.selectedTab!.webView == webView)) && (self.presentedViewController == nil)
-    }
-
     func webView(
         _ webView: WKWebView,
         runJavaScriptAlertPanelWithMessage message: String,
@@ -869,6 +851,25 @@ private extension BrowserViewController {
         snackBar.addButton(ok)
         snackBar.addButton(cancel)
         tab.addSnackbar(snackBar)
+    }
+
+    func shouldRequestBeOpenedAsPopup(_ request: URLRequest) -> Bool {
+        // Treat `window.open("")` the same as `window.open("about:blank")`.
+        if request.url?.absoluteString.isEmpty ?? false {
+            return true
+        }
+
+        if let scheme = request.url?.scheme?.lowercased(), schemesAllowedToBeOpenedAsPopups.contains(scheme) {
+            return true
+        }
+
+        return false
+    }
+
+    func shouldDisplayJSAlertForWebView(_ webView: WKWebView) -> Bool {
+        // Only display a JS Alert if we are selected and there isn't anything being shown
+        return ((tabManager.selectedTab == nil ? false : tabManager.selectedTab!.webView == webView))
+            && (self.presentedViewController == nil)
     }
 
      func checkIfWebContentProcessHasCrashed(_ webView: WKWebView, error: NSError) -> Bool {

--- a/Tests/ClientTests/CustomSearchEnginesTest.swift
+++ b/Tests/ClientTests/CustomSearchEnginesTest.swift
@@ -12,10 +12,12 @@ import XCTest
 
 class CustomSearchEnginesTest: XCTestCase {
     override func setUp() {
+        super.setUp()
         DependencyHelperMock().bootstrapDependencies()
     }
 
     override func tearDown() {
+        super.tearDown()
         AppContainer.shared.reset()
     }
 

--- a/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
+++ b/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
@@ -1,0 +1,107 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import Common
+import Storage
+import WebKit
+
+@testable import Client
+
+class BrowserViewControllerWebViewDelegateTests: XCTestCase {
+    var subject: BrowserViewController!
+    var profile: MockProfile!
+    var tabManager: TabManager!
+    var tabManagerDelegate: TabManagerNavDelegate!
+
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+        profile = MockProfile()
+        tabManager = TabManager(profile: profile, imageStore: nil)
+        subject = BrowserViewController(profile: profile, tabManager: tabManager)
+        tabManagerDelegate = TabManagerNavDelegate()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        AppContainer.shared.reset()
+        profile = nil
+        tabManager = nil
+        subject = nil
+        tabManagerDelegate = nil
+    }
+
+    func testWebViewDidReceiveChallenge_MethodServerTrust() {
+        tabManagerDelegate.insert(subject)
+
+        tabManagerDelegate.webView(anyWebView(),
+                                   didReceive: anyAuthenticationChallenge(for: "NSURLAuthenticationMethodServerTrust")) { disposition, credential in
+            XCTAssertEqual(disposition, .performDefaultHandling)
+            XCTAssertNil(credential)
+        }
+    }
+
+    func testWebViewDidReceiveChallenge_MethodHTTPDigest() {
+        tabManagerDelegate.insert(subject)
+
+        tabManagerDelegate.webView(anyWebView(),
+                                   didReceive: anyAuthenticationChallenge(for: "NSURLAuthenticationMethodHTTPDigest")) { disposition, credential in
+            XCTAssertEqual(disposition, .performDefaultHandling)
+            XCTAssertNil(credential)
+        }
+    }
+
+    func testWebViewDidReceiveChallenge_MethodHTTPNTLM() {
+        tabManagerDelegate.insert(subject)
+
+        tabManagerDelegate.webView(anyWebView(),
+                                   didReceive: anyAuthenticationChallenge(for: "NSURLAuthenticationMethodNTLM")) { disposition, credential in
+            XCTAssertEqual(disposition, .performDefaultHandling)
+            XCTAssertNil(credential)
+        }
+    }
+
+    func testWebViewDidReceiveChallenge_MethodHTTPBasic() {
+        tabManagerDelegate.insert(subject)
+
+        tabManagerDelegate.webView(anyWebView(),
+                                   didReceive: anyAuthenticationChallenge(for: "NSURLAuthenticationMethodHTTPBasic")) { disposition, credential in
+            XCTAssertEqual(disposition, .performDefaultHandling)
+            XCTAssertNil(credential)
+        }
+    }
+
+    private func anyWebView() -> WKWebView {
+        return WKWebView(frame: CGRect(width: 100, height: 100))
+    }
+
+    private func anyAuthenticationChallenge(for authenticationMethod: String) -> URLAuthenticationChallenge {
+        let protectionSpace = URLProtectionSpace(host: "https:test.com",
+                                                 port: 443,
+                                                 protocol: nil,
+                                                 realm: nil,
+                                                 authenticationMethod: authenticationMethod)
+        return URLAuthenticationChallenge(protectionSpace: protectionSpace,
+                                          proposedCredential: nil,
+                                          previousFailureCount: 0,
+                                          failureResponse: nil,
+                                          error: nil,
+                                          sender: MockURLAuthenticationChallengeSender())
+    }
+
+    private func getCertificate(_ file: String) -> SecCertificate {
+        let path = Bundle(for: type(of: self)).path(forResource: file, ofType: "pem")
+        let data = try? Data(contentsOf: URL(fileURLWithPath: path!))
+        return SecCertificateCreateWithData(nil, data! as CFData)!
+    }
+}
+
+class MockURLAuthenticationChallengeSender: NSObject, URLAuthenticationChallengeSender {
+    func use(_ credential: URLCredential, for challenge: URLAuthenticationChallenge) {}
+
+    func continueWithoutCredential(for challenge: URLAuthenticationChallenge) {}
+
+    func cancel(_ challenge: URLAuthenticationChallenge) {}
+}

--- a/Tests/ClientTests/Frontend/Browser/TabManagement/TabManagerNavDelegateTests.swift
+++ b/Tests/ClientTests/Frontend/Browser/TabManagement/TabManagerNavDelegateTests.swift
@@ -80,6 +80,21 @@ class TabManagerNavDelegateTests: XCTestCase {
         XCTAssertEqual(delegate2.receivedMessages, [.webViewWebContentProcessDidTerminate])
     }
 
+    func test_webViewDidReceiveAuthenticationChallenge_sendsCorrectMessage() {
+        let subjectConstructor = createSubject()
+        let subject = subjectConstructor.subject
+        let delegate1 = subjectConstructor.delegate1
+        let delegate2 = subjectConstructor.delegate2
+
+        subject.insert(delegate1)
+        subject.insert(delegate2)
+        subject.webView(anyWebView(), didReceive: anyAuthenticationChallenge()) { (_, _) in  }
+
+        /// This message is send only to the first delegate that respond to to authentication challenge (BVC)
+        XCTAssertEqual(delegate1.receivedMessages, [.webViewDidReceiveAuthenticationChallenge])
+        XCTAssertEqual(delegate2.receivedMessages, [])
+    }
+
     func test_webViewDidReceiveServerRedirectForProvisionalNavigation_sendsCorrectMessage() {
         let subjectConstructor = createSubject()
         let subject = subjectConstructor.subject
@@ -169,6 +184,10 @@ private extension TabManagerNavDelegateTests {
     func anyError() -> NSError {
         return NSError(domain: "any error", code: 0)
     }
+
+    func anyAuthenticationChallenge() -> URLAuthenticationChallenge {
+        return URLAuthenticationChallenge()
+    }
 }
 
 // MARK: - WKNavigationDelegateSpy
@@ -179,6 +198,7 @@ private class WKNavigationDelegateSpy: NSObject, WKNavigationDelegate {
         case webViewDidFailProvisionalNavigation
         case webViewDidFinish
         case webViewWebContentProcessDidTerminate
+        case webViewDidReceiveAuthenticationChallenge
         case webViewDidReceiveServerRedirectForProvisionalNavigation
         case webViewDidStartProvisionalNavigation
         case webViewDecidePolicyWithActionPolicy
@@ -205,6 +225,10 @@ private class WKNavigationDelegateSpy: NSObject, WKNavigationDelegate {
 
     func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
         receivedMessages.append(.webViewWebContentProcessDidTerminate)
+    }
+
+    func webView(_ webView: WKWebView, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+        receivedMessages.append(.webViewDidReceiveAuthenticationChallenge)
     }
 
     func webView(_ webView: WKWebView, didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation!) {

--- a/Tests/ClientTests/Library/BookmarksPanelTests.swift
+++ b/Tests/ClientTests/Library/BookmarksPanelTests.swift
@@ -11,10 +11,12 @@ import Common
 
 class BookmarksPanelTests: XCTestCase {
     override func setUp() {
+        super.setUp()
         DependencyHelperMock().bootstrapDependencies()
     }
 
     override func tearDown() {
+        super.tearDown()
         AppContainer.shared.reset()
     }
 


### PR DESCRIPTION

### [FXIOS-5467](https://mozilla-hub.atlassian.net/browse/FXIOS-5467) | #12740

- Refactor logic to handle `NSURLAuthenticationMethodServerTrust` in 
```
func webView(
        _ webView: WKWebView,
        didReceive challenge: URLAuthenticationChallenge,
        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
```
- Organize and indent class move move all private functions to a private extension
