### PR TITLE
Bugfix FXIOS-5872 [v112] Link engine header visibility to search suggestion setting

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1076,7 +1076,7 @@ class BrowserViewController: UIViewController {
 
         let isPrivate = tabManager.selectedTab?.isPrivate ?? false
         let searchViewModel = SearchViewModel(isPrivate: isPrivate, isBottomSearchBar: isBottomSearchBar)
-        let searchController = SearchViewController(profile: profile, viewModel: searchViewModel, tabManager: tabManager)
+        let searchController = SearchViewController(profile: profile, viewModel: searchViewModel, model: profile.searchEngines, tabManager: tabManager)
         searchController.searchEngines = profile.searchEngines
         searchController.searchDelegate = self
 

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -62,6 +62,7 @@ class SearchViewController: SiteTableViewController,
                             Notifiable {
     var searchDelegate: SearchViewControllerDelegate?
     private let viewModel: SearchViewModel
+    private let model: SearchEngines
     private var suggestClient: SearchSuggestClient?
     private var remoteClientTabs = [ClientTabsSearchWrapper]()
     private var filteredRemoteClientTabs = [ClientTabsSearchWrapper]()
@@ -100,10 +101,12 @@ class SearchViewController: SiteTableViewController,
 
     init(profile: Profile,
          viewModel: SearchViewModel,
+         model: SearchEngines,
          tabManager: TabManager,
          featureConfig: FeatureHolder<Search> = FxNimbus.shared.features.search,
          highlightManager: HistoryHighlightsManagerProtocol = HistoryHighlightsManager()) {
         self.viewModel = viewModel
+        self.model = model
         self.tabManager = tabManager
         self.searchFeature = featureConfig
         self.highlightManager = highlightManager
@@ -731,7 +734,7 @@ class SearchViewController: SiteTableViewController,
         case SearchListSection.remoteTabs.rawValue:
             return hasFirefoxSuggestions
         case SearchListSection.searchSuggestions.rawValue:
-            return true
+            return model.shouldShowSearchSuggestions
         default:
             return false
         }


### PR DESCRIPTION
Fixes [#13396](https://github.com/mozilla-mobile/firefox-ios/issues/13396)

These code changes link the boolean state from the toggle “Show Search Suggestions” setting to the engine header visibility switch statement.  That state is then used in to ensure that the header is only shown if the boolean is true instead of always being true like before.  Does not affect Firefox Suggest listings.