### PR TITLE
Bugfix MTE-743 [v112] iPad does not need keyboard closed in testRecentlyVisited

### DIFF
--- a/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -231,8 +231,10 @@ class HomePageSettingsUITests: BaseTestCase {
         navigator.performAction(Action.ToggleRecentlyVisited)
         navigator.performAction(Action.GoToHomePage)
         XCTAssertFalse(app.scrollViews.cells[AccessibilityIdentifiers.FirefoxHomepage.HistoryHighlights.itemCell].staticTexts[urlMozillaLabel].exists)
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: 3)
-        navigator.performAction(Action.CloseURLBarOpen)
+        if !iPad() {
+            waitForExistence(app.buttons["urlBar-cancel"], timeout: 3)
+            navigator.performAction(Action.CloseURLBarOpen)
+        }
         navigator.nowAt(NewTabScreen)
         navigator.goto(HomeSettings)
         navigator.performAction(Action.ToggleRecentlyVisited)


### PR DESCRIPTION
`testRecentlyVisited` fails on iPad but passes on iPhone since March 5. I have determined that the keyboard does not need to be minimize for iPad only after navigating away from the settings page.

I have tested the change locally on iPhone 14, iPad Pro (5th generation) and iPad Air (5th generation) running on iOS 16.1.

https://mozilla-hub.atlassian.net/browse/MTE-743