### PR TITLE
Bugfix FXIOS-5765 [v112] Visibility of the last item in the synced tabs list

### DIFF
--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanel.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanel.swift
@@ -149,6 +149,7 @@ class RemoteTabsTableViewController: UITableViewController, Themeable {
 
         tableView.rowHeight = UX.rowHeight
         tableView.separatorInset = .zero
+        tableView.alwaysBounceVertical = false
 
         if #available(iOS 15.0, *) {
             tableView.sectionHeaderTopPadding = 0.0


### PR DESCRIPTION
## [FXIOS-5765](https://mozilla-hub.atlassian.net/browse/FXIOS-5765)

The last item is now visible also when the user stops scrolling, since the scroll does not bounce.

https://user-images.githubusercontent.com/46751540/223367267-fcd953c2-c70d-41dc-afb2-771e436770b0.mov

