### PR TITLE
Bugfix FXIOS-5936 [v112] Close button is visible on URL on homepage when switching tabs

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -942,6 +942,9 @@ class BrowserViewController: UIViewController {
         homepageViewController?.view.layer.removeAllAnimations()
         view.setNeedsUpdateConstraints()
 
+        // Make sure reload button is hidden on homepage
+        urlBar.locationView.reloadButton.reloadButtonState = .disabled
+
         // Return early if the home page is already showing
         guard homepageViewController?.view.alpha != 1 else { return }
 
@@ -959,9 +962,6 @@ class BrowserViewController: UIViewController {
                 UIAccessibility.post(notification: UIAccessibility.Notification.screenChanged, argument: nil)
                 self.homepageViewController?.homepageDidAppear()
             })
-
-        // Make sure reload button is hidden on homepage
-        urlBar.locationView.reloadButton.reloadButtonState = .disabled
     }
 
     /// Once the homepage is created, browserViewController keeps a reference to it, never setting it to nil during

--- a/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -466,7 +466,7 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
         if !toolbarIsShowing {
             updateConstraintsIfNeeded()
         }
-        locationView.reloadButton.isHidden = hideReloadButton
+        shouldHideReloadButton(hideReloadButton)
         updateViewsForOverlayModeAndToolbarChanges()
     }
 
@@ -489,7 +489,7 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
     /// We hide reload button on iPad, but not in multitasking mode
     func updateReaderModeState(_ state: ReaderModeState, hideReloadButton: Bool) {
         locationView.readerModeState = state
-        locationView.reloadButton.isHidden = hideReloadButton
+        shouldHideReloadButton(hideReloadButton)
     }
 
     /// We hide reload button on iPad, but not in multitasking mode


### PR DESCRIPTION

### [FXIOS-5936](https://mozilla-hub.atlassian.net/browse/FXIOS-5936)

Call to disabled reload button (hides buttons) before guard checking for homepage alpha 