### PR TITLE
Refactor [v112] Improve codeowners files for automation related file changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# By default, PRs needs an approval from a team member from fxios-eng
+# Global owners, PRs needs an approval from a team member from fxios-eng by default
 * @mozilla-mobile/fxios-eng
 
 # Order is important; the last matching pattern takes the most

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,10 +7,10 @@
 # When someone opens a pull request that only modifies those folders / files, 
 # only @mozilla-mobile/fxios-automation and not the global
 # owners will be requested for a review.
-/Tests/UITests @mozilla-mobile/fxios-automation
-/Tests/XCUITests @mozilla-mobile/fxios-automation
-bitrise.yml @mozilla-mobile/fxios-automation
-.taskcluster.yml @mozilla-mobile/fxios-automation
-/taskcluster @mozilla-mobile/fxios-automation
-.github/workflows @mozilla-mobile/fxios-automation
-/test-fixtures @mozilla-mobile/fxios-automation
+/Tests/UITests @mozilla-mobile/fxios-automation-1
+/Tests/XCUITests @mozilla-mobile/fxios-automation-1
+bitrise.yml @mozilla-mobile/fxios-automation-1
+.taskcluster.yml @mozilla-mobile/fxios-automation-1
+/taskcluster @mozilla-mobile/fxios-automation-1
+.github/workflows @mozilla-mobile/fxios-automation-1
+/test-fixtures @mozilla-mobile/fxios-automation-1

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,16 @@
+# By default, PRs needs an approval from a team member from fxios-eng
 * @mozilla-mobile/fxios-eng
+
+# Order is important; the last matching pattern takes the most
+# precedence. 
+
+# When someone opens a pull request that only modifies those folders / files, 
+# only @mozilla-mobile/fxios-automation and not the global
+# owners will be requested for a review.
+/Tests/UITests @mozilla-mobile/fxios-automation
+/Tests/XCUITests @mozilla-mobile/fxios-automation
+bitrise.yml @mozilla-mobile/fxios-automation
+.taskcluster.yml @mozilla-mobile/fxios-automation
+/taskcluster @mozilla-mobile/fxios-automation
+.github/workflows @mozilla-mobile/fxios-automation
+/test-fixtures @mozilla-mobile/fxios-automation


### PR DESCRIPTION
## Documentation about codeowners file [here](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)
@isabelrios we just added codeowners to the project to alleviate having to add reviewers on each PRs. This will be done automatically for us. The thing is that this wouldn't work for automation work, which needs different reviewers. This PR adjusts the codeowners file, so we can get correct default reviewers for work related to automation. The [team](https://github.com/orgs/mozilla-mobile/teams/fxios-automation-1/members) `@mozilla-mobile/fxios-automation-1` was created the right teammates needs to be added in there. Let me know if some other files/folder needs to be added to the list!

I won't run Bitrise for this change.