### PR TITLE
Bugfix MTE-737 [v112] Update login page for FxA China

### DIFF
--- a/Tests/XCUITests/IntegrationTests.swift
+++ b/Tests/XCUITests/IntegrationTests.swift
@@ -94,12 +94,12 @@ class IntegrationTests: BaseTestCase {
         navigator.goto(BrowserTabMenu)
         navigator.goto(Intro_FxASignin)
         navigator.performAction(Action.OpenEmailToSignIn)
-        waitForExistence(app.navigationBars[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaNavigationBar], timeout: TIMEOUT_LONG)
-        waitForExistence(app.webViews.textFields[AccessibilityIdentifiers.Settings.FirefoxAccount.emailTextFieldChinaFxA], timeout: TIMEOUT_LONG)
 
-        // Wait for element not present on FxA sign in page China FxA server
-        waitForNoExistence(app.webViews.otherElements.staticTexts["Firefox Monitor"])
-        XCTAssertFalse(app.webViews.otherElements.staticTexts["Firefox Monitor"].exists)
+        sleep(5)
+        waitForExistence(app.navigationBars[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaNavigationBar], timeout: TIMEOUT_LONG)
+        waitForExistence(app.webViews.staticTexts["Continue to Firefox accounts"], timeout: TIMEOUT_LONG)
+        waitForExistence(app.webViews.textFields[AccessibilityIdentifiers.Settings.FirefoxAccount.emailTextField])
+        waitForExistence(app.webViews.buttons[AccessibilityIdentifiers.Settings.FirefoxAccount.continueButton])
     }
 
     func testFxASyncBookmark () {

--- a/Tests/XCUITests/IntegrationTests.swift
+++ b/Tests/XCUITests/IntegrationTests.swift
@@ -95,7 +95,6 @@ class IntegrationTests: BaseTestCase {
         navigator.goto(Intro_FxASignin)
         navigator.performAction(Action.OpenEmailToSignIn)
 
-        sleep(5)
         waitForExistence(app.navigationBars[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaNavigationBar], timeout: TIMEOUT_LONG)
         waitForExistence(app.webViews.staticTexts["Continue to Firefox accounts"], timeout: TIMEOUT_LONG)
         waitForExistence(app.webViews.textFields[AccessibilityIdentifiers.Settings.FirefoxAccount.emailTextField])


### PR DESCRIPTION
The sync integration test `testFxASyncPageUsingChinaFxA()` has been failing because the login page for Firefox Accounts China (https://accounts.firefox.com.cn) has been updated. The existing test assumes the old login page, which is distinct from the regular one. The new Firefox Accounts China login page now has the same look as the regular one's.

Since there's a separate server for the Firefox Accounts China, we would just check if the login page loads instead of attempting to enter the credentials. The temporary credentials generated for other tests are only good for the regular server. 

I've verified that the updated test is passing by the following command:
```
pipenv run pytest test_integration.py::test_sync_china_fxa_server
```

https://mozilla-hub.atlassian.net/browse/MTE-737