### PR TITLE
Remove FXIOS-5954 [v112] Scene delegate user activity clean up

### DIFF
--- a/Client/Application/SceneDelegate.swift
+++ b/Client/Application/SceneDelegate.swift
@@ -116,7 +116,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // If the `NSUserActivity` has a `webpageURL`, it is either a deep link or an old history item
         // reached via a "Spotlight" search before we began indexing visited pages via CoreSpotlight.
         if let url = userActivity.webpageURL {
-            let query = url.getQuery()
             browserViewController.switchToTabForURLOrOpen(url)
         }
 

--- a/Client/Application/SceneDelegate.swift
+++ b/Client/Application/SceneDelegate.swift
@@ -117,19 +117,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // reached via a "Spotlight" search before we began indexing visited pages via CoreSpotlight.
         if let url = userActivity.webpageURL {
             let query = url.getQuery()
-
-            // Check for fxa sign-in code and launch the login screen directly
-            if query["signin"] != nil {
-                // bvc.launchFxAFromDeeplinkURL(url) // Was using Adjust. Consider hooking up again when replacement system in-place.
-            }
-
-            // Per Adjust documentation, https://docs.adjust.com/en/universal-links/#running-campaigns-through-universal-links,
-            // it is recommended that links contain the `deep_link` query parameter. This link will also
-            // be url encoded.
-            if let deepLink = query["deep_link"]?.removingPercentEncoding, let url = URL(string: deepLink) {
-                browserViewController.switchToTabForURLOrOpen(url)
-            }
-
             browserViewController.switchToTabForURLOrOpen(url)
         }
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5954)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13528)

## Description
Proposal to remove the two following code paths:

### Path 1
Is commented since 2020 from [this PR](https://github.com/mozilla-mobile/firefox-ios/pull/7215) & `launchFxAFromDeeplinkURL` doesn't exist on BVC anymore.
```
            // Check for fxa sign-in code and launch the login screen directly
            if query["signin"] != nil {
                // bvc.launchFxAFromDeeplinkURL(url) // Was using Adjust. Consider hooking up again when replacement system in-place.
            }
```

### Path 2
Was added in 2017 to support universal link, in [this PR](https://github.com/mozilla-mobile/firefox-ios/pull/2845). From what I understood we don't support universal links so this can be removed as well?
```
            // Per Adjust documentation, https://docs.adjust.com/en/universal-links/#running-campaigns-through-universal-links,
            // it is recommended that links contain the `deep_link` query parameter. This link will also
            // be url encoded.
            if let deepLink = query["deep_link"]?.removingPercentEncoding, let url = URL(string: deepLink) {
                browserViewController.switchToTabForURLOrOpen(url)
            }
```

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
~~- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)~~
~~- [ ] Unit tests written and passing~~
~~- [ ] Documentation / comments for complex code and public methods~~
