### PR TITLE
Bugfix FXIOS-5898 [v112] remove border for empty bookmark cells

### DIFF
--- a/Client/Frontend/Home/TopSites/Cell/EmptyTopSiteCell.swift
+++ b/Client/Frontend/Home/TopSites/Cell/EmptyTopSiteCell.swift
@@ -13,7 +13,6 @@ class EmptyTopSiteCell: UICollectionViewCell, ReusableCell {
 
     lazy private var emptyBG: UIView = .build { view in
         view.layer.cornerRadius = HomepageViewModel.UX.generalCornerRadius
-        view.layer.borderWidth = HomepageViewModel.UX.generalBorderWidth
     }
 
     override init(frame: CGRect) {


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5898)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13434)

### Description
Removed the border around empty bookmarks

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
