### PR TITLE
Bugfix MTE-767 [v112] Update string for new tab settings

### DIFF
--- a/Tests/XCUITests/NewTabSettings.swift
+++ b/Tests/XCUITests/NewTabSettings.swift
@@ -91,7 +91,7 @@ class NewTabSettingsTest: BaseTestCase {
         waitForValueContains(app.textFields["NewTabAsCustomURLTextField"], value: "mozilla")
         navigator.goto(SettingsScreen)
         // Assert that the label showing up in Settings is equal to the URL entered (NOT CURRENTLY WORKING, SHOWING HOMEPAGE INSTEAD)
-        XCTAssertEqual(app.tables.cells["NewTab"].label, "New Tab, Homepage")
+        XCTAssertEqual(app.tables.cells["NewTab"].label, "New Tab, Custom")
         // Switch to Blank page and check label
         navigator.performAction(Action.SelectNewTabAsBlankPage)
         navigator.nowAt(NewTabSettings)


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-767)

### Description
[FXIOS-5375](https://mozilla-hub.atlassian.net/browse/FXIOS-5375) consists of an update to the “New Tab” settings. When a custom URL is used for the new tab, the “General” section of the settings page now says “Custom” instead of “Homepage”. Here’s a screenshot of the most recent settings page when a custom URL is used in the “New Tab” settings.

![Simulator Screenshot - iPhone 14 - 2023-03-11 at 00 50 44](https://user-images.githubusercontent.com/1740517/224468816-61037a96-a081-4d1c-b164-1b9d09e94839.png)

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
