### PR TITLE
Refactor FXIOS-5904 [v112] made GroupedTabContainerCell delegate weak

### DIFF
--- a/Client/Frontend/Browser/Tabs/GroupedTabCell.swift
+++ b/Client/Frontend/Browser/Tabs/GroupedTabCell.swift
@@ -170,7 +170,7 @@ class GroupedTabContainerCell: UITableViewCell,
                                ReusableCell,
                                ThemeApplicable {
     // Delegate
-    var delegate: GroupedTabsDelegate?
+    weak var delegate: GroupedTabsDelegate?
 
     // Views
     var selectedView = UIView()

--- a/Tests/ClientTests/GroupedTabContainerCellTests.swift
+++ b/Tests/ClientTests/GroupedTabContainerCellTests.swift
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+@testable import Client
+
+class GroupedTabContainerCellTests: XCTestCase {
+    func testGroupedTabContainerCell_hasNoLeaks() throws {
+        let cell = GroupedTabContainerCell()
+        let delegate = MockGroupedTabsDelegate()
+        cell.delegate = delegate
+        trackForMemoryLeaks(cell)
+    }
+}
+
+class MockGroupedTabsDelegate: GroupedTabsDelegate {
+    func didSelectGroupedTab(tab: Client.Tab?) {}
+    func closeTab(tab: Client.Tab) {}
+    func performSearchOfGroupInNewTab(searchTerm: String?) {}
+}


### PR DESCRIPTION
References Issues: #13442 
The last PR looks messed up. I'll try it again then.