### PR TITLE
Bugfix FXIOS-5958 [v112] Trim search engine name in settings

### DIFF
--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -868,7 +868,7 @@ class SearchSetting: Setting {
 
     override var style: UITableViewCell.CellStyle { return .value1 }
 
-    override var status: NSAttributedString { return NSAttributedString(string: profile.searchEngines.defaultEngine?.shortName ?? "") }
+    override var status: NSAttributedString { return NSAttributedString(string: String((profile.searchEngines.defaultEngine?.shortName ?? "").prefix(20))) }
 
     override var accessibilityIdentifier: String? { return "Search" }
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5958)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13538)

### Description
When the name of the selected search engine is too long it causes the text to overflow on the menu.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
