### PR TITLE
Remove FXIOS-5859 [v114] Get rid of SwiftyJSON from KeychainStore

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -217,6 +217,7 @@
 		2FDE87FE1ABB3817005317B1 /* RemoteTabsPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FDE87FD1ABB3817005317B1 /* RemoteTabsPanel.swift */; };
 		318FB6EB1DB5600D0004E40F /* SQLiteHistoryFactories.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318FB6EA1DB5600D0004E40F /* SQLiteHistoryFactories.swift */; };
 		31ADB5DA1E58CEC300E87909 /* ClipboardBarDisplayHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31ADB5D91E58CEC300E87909 /* ClipboardBarDisplayHandler.swift */; };
+		385A966829DDFBE50033B3AC /* KeychainStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385A966729DDFBE50033B3AC /* KeychainStoreTests.swift */; };
 		39012F281F8ED262002E3D31 /* ScreenGraphTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39012F271F8ED262002E3D31 /* ScreenGraphTest.swift */; };
 		391B4FFF1F9767F50094F841 /* FxScreenGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EB46981E26DDB4006346E8 /* FxScreenGraph.swift */; };
 		39236E721FCC600200A38F1B /* TabEventHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39236E711FCC600200A38F1B /* TabEventHandlerTests.swift */; };
@@ -2260,6 +2261,7 @@
 		381844E180D003720B5E2499 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		383D47EEAB4E12E6B657C8CB /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
 		3840498CB36D14A6131110A0 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
+		385A966729DDFBE50033B3AC /* KeychainStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStoreTests.swift; sourceTree = "<group>"; };
 		388646D292305C259ACDC38B /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Storage.strings; sourceTree = "<group>"; };
 		389B44EEA4AAA49F0D86656C /* sq */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sq; path = sq.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
 		38D94387A7F935DB357BF25F /* ur */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ur; path = ur.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
@@ -8976,6 +8978,7 @@
 				E4E7EB6C1C4AED5E0094275D /* SupportUtilsTests.swift */,
 				28A6CE891AC082E200C1A2D4 /* UtilsTests.swift */,
 				C8C1880E287608BF00BF3735 /* DateExtensionsTests.swift */,
+				385A966729DDFBE50033B3AC /* KeychainStoreTests.swift */,
 			);
 			path = SharedTests;
 			sourceTree = "<group>";
@@ -11095,6 +11098,7 @@
 				28532BEA1C472008000072D9 /* DeferredTests.swift in Sources */,
 				5A292129295CA8A900242235 /* ThemableTests.swift in Sources */,
 				39E65D271CA5B92000C63CE3 /* AsyncReducerTests.swift in Sources */,
+				385A966829DDFBE50033B3AC /* KeychainStoreTests.swift in Sources */,
 				E4E7EB6D1C4AED5E0094275D /* SupportUtilsTests.swift in Sources */,
 				3964B09C1EA8F32C00F2EEF4 /* FeatureSwitchTests.swift in Sources */,
 				C8C1880F287608BF00BF3735 /* DateExtensionsTests.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -217,6 +217,7 @@
 		2FDE87FE1ABB3817005317B1 /* RemoteTabsPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FDE87FD1ABB3817005317B1 /* RemoteTabsPanel.swift */; };
 		318FB6EB1DB5600D0004E40F /* SQLiteHistoryFactories.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318FB6EA1DB5600D0004E40F /* SQLiteHistoryFactories.swift */; };
 		31ADB5DA1E58CEC300E87909 /* ClipboardBarDisplayHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31ADB5D91E58CEC300E87909 /* ClipboardBarDisplayHandler.swift */; };
+		3850272E29FB4606008F9DE2 /* FakeKeychainWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3850272D29FB4606008F9DE2 /* FakeKeychainWrapper.swift */; };
 		385A966829DDFBE50033B3AC /* KeychainStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385A966729DDFBE50033B3AC /* KeychainStoreTests.swift */; };
 		39012F281F8ED262002E3D31 /* ScreenGraphTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39012F271F8ED262002E3D31 /* ScreenGraphTest.swift */; };
 		391B4FFF1F9767F50094F841 /* FxScreenGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EB46981E26DDB4006346E8 /* FxScreenGraph.swift */; };
@@ -2261,6 +2262,7 @@
 		381844E180D003720B5E2499 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		383D47EEAB4E12E6B657C8CB /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
 		3840498CB36D14A6131110A0 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
+		3850272D29FB4606008F9DE2 /* FakeKeychainWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeKeychainWrapper.swift; sourceTree = "<group>"; };
 		385A966729DDFBE50033B3AC /* KeychainStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStoreTests.swift; sourceTree = "<group>"; };
 		388646D292305C259ACDC38B /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Storage.strings; sourceTree = "<group>"; };
 		389B44EEA4AAA49F0D86656C /* sq */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sq; path = sq.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
@@ -6687,6 +6689,14 @@
 			path = ThirdParty;
 			sourceTree = "<group>";
 		};
+		3850272C29FB45D7008F9DE2 /* Fakes */ = {
+			isa = PBXGroup;
+			children = (
+				3850272D29FB4606008F9DE2 /* FakeKeychainWrapper.swift */,
+			);
+			name = Fakes;
+			sourceTree = "<group>";
+		};
 		392ED7D51D0AEEEE009D9B62 /* Accessors */ = {
 			isa = PBXGroup;
 			children = (
@@ -8967,6 +8977,7 @@
 		E6F9650D1B2F1CF20034B023 /* SharedTests */ = {
 			isa = PBXGroup;
 			children = (
+				3850272C29FB45D7008F9DE2 /* Fakes */,
 				E6F9650E1B2F1CF20034B023 /* Supporting Files */,
 				3B4AA24A1D8B8C4C00A2E008 /* ArrayExtensionTests.swift */,
 				39E65D261CA5B92000C63CE3 /* AsyncReducerTests.swift */,
@@ -11558,6 +11569,7 @@
 				C81AC6B626160091007800C5 /* TabTrayViewModel.swift in Sources */,
 				C8EDDBF229DF1159003A4C07 /* URLScanner.swift in Sources */,
 				EBB89504219398E500EB91A0 /* TrackingProtectionPageStats.swift in Sources */,
+				3850272E29FB4606008F9DE2 /* FakeKeychainWrapper.swift in Sources */,
 				D31F95E91AC226CB005C9F3B /* ScreenshotHelper.swift in Sources */,
 				D3968F251A38FE8500CEFD3B /* TabManager.swift in Sources */,
 				2178A6A229145506002EC290 /* ReaderModeFontSizeLabel.swift in Sources */,

--- a/Shared/KeychainStore.swift
+++ b/Shared/KeychainStore.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import SwiftyJSON
 import MozillaAppServices
 
 public class KeychainStore {
@@ -16,14 +15,7 @@ public class KeychainStore {
     }
 
     public func setDictionary(_ value: [String: Any]?, forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility = .afterFirstUnlock) {
-        guard let value = value else {
-            setString(nil, forKey: key, withAccessibility: accessibility)
-            return
-        }
-
-        let stringValue = JSON(value).stringify()
-
-        setString(stringValue, forKey: key, withAccessibility: accessibility)
+        setString(value?.asString, forKey: key, withAccessibility: accessibility)
     }
 
     public func setString(_ value: String?, forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility = .afterFirstUnlock) {
@@ -36,12 +28,12 @@ public class KeychainStore {
     }
 
     public func dictionary(forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility = .afterFirstUnlock) -> [String: Any]? {
-        guard let stringValue = string(forKey: key, withAccessibility: accessibility) else { return nil }
-
-        let json = JSON(parseJSON: stringValue)
-        let dictionary = json.dictionaryObject
-
-        return dictionary
+        guard let stringValue = string(forKey: key, withAccessibility: accessibility),
+              let data = stringValue.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as? [String: Any]
+        else { return nil }
+        
+        return json
     }
 
     public func string(forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility = .afterFirstUnlock) -> String? {

--- a/Shared/KeychainStore.swift
+++ b/Shared/KeychainStore.swift
@@ -11,7 +11,7 @@ public class KeychainStore {
 
     private let keychainWrapper: MZKeychainWrapper
 
-    private init() {
+    public init() {
         self.keychainWrapper = MZKeychainWrapper.sharedClientAppContainerKeychain
     }
 

--- a/Shared/KeychainStore.swift
+++ b/Shared/KeychainStore.swift
@@ -32,7 +32,7 @@ public class KeychainStore {
               let data = stringValue.data(using: .utf8),
               let json = try? JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as? [String: Any]
         else { return nil }
-        
+
         return json
     }
 

--- a/Shared/KeychainStore.swift
+++ b/Shared/KeychainStore.swift
@@ -10,8 +10,8 @@ public class KeychainStore {
 
     private let keychainWrapper: MZKeychainWrapper
 
-    public init() {
-        self.keychainWrapper = MZKeychainWrapper.sharedClientAppContainerKeychain
+    public init(keychainWrapper: MZKeychainWrapper = MZKeychainWrapper.sharedClientAppContainerKeychain) {
+        self.keychainWrapper = keychainWrapper
     }
 
     public func setDictionary(_ value: [String: Any]?, forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility = .afterFirstUnlock) {

--- a/Tests/SharedTests/FakeKeychainWrapper.swift
+++ b/Tests/SharedTests/FakeKeychainWrapper.swift
@@ -1,0 +1,26 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import MozillaAppServices
+
+public class FakeKeychainWrapper: MZKeychainWrapper {
+    private var fakeDictionary: [String: Any] = [:]
+
+    override public func set(_ value: String, forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Bool {
+        fakeDictionary[key] = value
+        return true
+    }
+
+    override public func removeObject(forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> Bool {
+        guard fakeDictionary[key] != nil else { return false }
+        fakeDictionary.removeValue(forKey: key)
+        return true
+    }
+
+    override public func string(forKey key: String, withAccessibility accessibility: MZKeychainItemAccessibility? = nil, isSynchronizable: Bool = false) -> String? {
+        guard let value = fakeDictionary[key] else { return nil }
+        return value as? String
+    }
+}

--- a/Tests/SharedTests/KeychainStoreTests.swift
+++ b/Tests/SharedTests/KeychainStoreTests.swift
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+@testable import Client
+
 import Shared
 import XCTest
 
@@ -10,7 +12,7 @@ class KeychainStoreTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        keychainStore = KeychainStore()
+        keychainStore = KeychainStore(keychainWrapper: FakeKeychainWrapper(serviceName: "fakeServiceName"))
     }
 
     override func tearDown() {

--- a/Tests/SharedTests/KeychainStoreTests.swift
+++ b/Tests/SharedTests/KeychainStoreTests.swift
@@ -7,17 +7,17 @@ import XCTest
 
 class KeychainStoreTests: XCTestCase {
     private var keychainStore: KeychainStore!
-    
+
     override func setUp() {
         super.setUp()
         keychainStore = KeychainStore()
     }
-    
+
     override func tearDown() {
         super.tearDown()
         keychainStore = nil
     }
-    
+
     func testDictionary() throws {
         let fakeKey = "fakeKey"
         var fakeKeychainDict: [String: Any] = [
@@ -25,21 +25,21 @@ class KeychainStoreTests: XCTestCase {
             "intValue": 123,
             "boolValue": true
         ]
-        
+
         keychainStore.setDictionary(fakeKeychainDict, forKey: fakeKey)
         var keychainDict = try XCTUnwrap(keychainStore.dictionary(forKey: fakeKey))
         XCTAssertEqual(keychainDict.count, 3)
-        
+
         fakeKeychainDict["anotherStringValue"] = "anotherStringKey"
         keychainStore.setDictionary(fakeKeychainDict, forKey: fakeKey)
         keychainDict = try XCTUnwrap(keychainStore.dictionary(forKey: fakeKey))
         XCTAssertEqual(keychainDict.count, 4)
     }
-    
+
     func testString() throws {
         let fakeKey = "fakeKey"
         let fakeValue = "fakeValue"
-        
+
         keychainStore.setString(fakeValue, forKey: fakeKey)
         let keychainString = try XCTUnwrap(keychainStore.string(forKey: fakeKey))
         XCTAssertEqual(keychainString, fakeValue)

--- a/Tests/SharedTests/KeychainStoreTests.swift
+++ b/Tests/SharedTests/KeychainStoreTests.swift
@@ -1,0 +1,47 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Shared
+import XCTest
+
+class KeychainStoreTests: XCTestCase {
+    private var keychainStore: KeychainStore!
+    
+    override func setUp() {
+        super.setUp()
+        keychainStore = KeychainStore()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        keychainStore = nil
+    }
+    
+    func testDictionary() throws {
+        let fakeKey = "fakeKey"
+        var fakeKeychainDict: [String: Any] = [
+            "stringValue": "stringKey",
+            "intValue": 123,
+            "boolValue": true
+        ]
+        
+        keychainStore.setDictionary(fakeKeychainDict, forKey: fakeKey)
+        var keychainDict = try XCTUnwrap(keychainStore.dictionary(forKey: fakeKey))
+        XCTAssertEqual(keychainDict.count, 3)
+        
+        fakeKeychainDict["anotherStringValue"] = "anotherStringKey"
+        keychainStore.setDictionary(fakeKeychainDict, forKey: fakeKey)
+        keychainDict = try XCTUnwrap(keychainStore.dictionary(forKey: fakeKey))
+        XCTAssertEqual(keychainDict.count, 4)
+    }
+    
+    func testString() throws {
+        let fakeKey = "fakeKey"
+        let fakeValue = "fakeValue"
+        
+        keychainStore.setString(fakeValue, forKey: fakeKey)
+        let keychainString = try XCTUnwrap(keychainStore.string(forKey: fakeKey))
+        XCTAssertEqual(keychainString, fakeValue)
+    }
+}


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5859)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13377)

### Description
Removes SwiftyJSON from Keychain Store.

The ticket mentioned adding Unit Tests if necessary, and I can certainly test out the functions in this class if we still want this. Please let me know.
