### PR TITLE
Bugfix FXIOS-5510 [v113] Red Caution Symbols in Password Manager

### DIFF
--- a/Client/Frontend/LoginManagement/BreachAlertsDetailView.swift
+++ b/Client/Frontend/LoginManagement/BreachAlertsDetailView.swift
@@ -7,10 +7,14 @@ import Shared
 
 // TODO: FXIOS-4995 - BreachAlertsManager theming
 class BreachAlertsDetailView: UIView {
+    private struct UX {
+        static let horizontalMargin: CGFloat = 14
+    }
+
     private let textColor = UIColor.white
     private let titleIconSize: CGFloat = 24
     private lazy var titleIconContainerSize: CGFloat = {
-        return titleIconSize + LoginTableViewCellUX.HorizontalMargin * 2
+        return titleIconSize + UX.horizontalMargin * 2
     }()
 
     lazy var titleIcon: UIImageView = {
@@ -147,7 +151,7 @@ class BreachAlertsDetailView: UIView {
             make.trailing.equalToSuperview()
         }
         contentStack.snp.remakeConstraints { make in
-            make.bottom.trailing.equalToSuperview().inset(LoginTableViewCellUX.HorizontalMargin)
+            make.bottom.trailing.equalToSuperview().inset(UX.horizontalMargin)
             make.leading.top.equalToSuperview()
         }
         self.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)

--- a/Client/Frontend/LoginManagement/LoginDetailTableViewCell.swift
+++ b/Client/Frontend/LoginManagement/LoginDetailTableViewCell.swift
@@ -14,12 +14,6 @@ protocol LoginDetailTableViewCellDelegate: AnyObject {
     func textFieldDidEndEditing(_ cell: LoginDetailTableViewCell)
 }
 
-public struct LoginTableViewCellUX {
-    static let highlightedLabelFont = UIFont.systemFont(ofSize: 12)
-    static let descriptionLabelFont = UIFont.systemFont(ofSize: 16)
-    static let HorizontalMargin: CGFloat = 14
-}
-
 enum LoginTableViewCellStyle {
     case iconAndBothLabels
     case noIconAndBothLabels
@@ -27,6 +21,12 @@ enum LoginTableViewCellStyle {
 }
 
 class LoginDetailTableViewCell: ThemedTableViewCell, ReusableCell {
+    private struct UX {
+        static let highlightedLabelFont = UIFont.systemFont(ofSize: 12)
+        static let descriptionLabelFont = UIFont.systemFont(ofSize: 16)
+        static let horizontalMargin: CGFloat = 14
+    }
+
     fileprivate lazy var labelContainer: UIView = .build { _ in }
 
     weak var delegate: LoginDetailTableViewCellDelegate?
@@ -50,7 +50,7 @@ class LoginDetailTableViewCell: ThemedTableViewCell, ReusableCell {
     lazy var descriptionLabel: UITextField = .build { [weak self] label in
         guard let self = self else { return }
 
-        label.font = LoginTableViewCellUX.descriptionLabelFont
+        label.font = UX.descriptionLabelFont
         label.isUserInteractionEnabled = false
         label.autocapitalizationType = .none
         label.autocorrectionType = .no
@@ -65,7 +65,7 @@ class LoginDetailTableViewCell: ThemedTableViewCell, ReusableCell {
     // produce a EX_BAD_ACCESS error when dequeuing the cell. For now, this label is made private
     // and the text property is exposed using a get/set property below.
     fileprivate lazy var highlightedLabel: UILabel = .build { label in
-        label.font = LoginTableViewCellUX.highlightedLabelFont
+        label.font = UX.highlightedLabelFont
         label.numberOfLines = 1
     }
 
@@ -88,7 +88,7 @@ class LoginDetailTableViewCell: ThemedTableViewCell, ReusableCell {
         guard let descriptionText = descriptionLabel.text else { return nil }
 
         let attributes = [
-            NSAttributedString.Key.font: LoginTableViewCellUX.descriptionLabelFont
+            NSAttributedString.Key.font: UX.descriptionLabelFont
         ]
 
         return descriptionText.size(withAttributes: attributes)
@@ -149,8 +149,8 @@ class LoginDetailTableViewCell: ThemedTableViewCell, ReusableCell {
     fileprivate func configureLayout() {
         NSLayoutConstraint.activate([
             labelContainer.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            labelContainer.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -LoginTableViewCellUX.HorizontalMargin),
-            labelContainer.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: LoginTableViewCellUX.HorizontalMargin),
+            labelContainer.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -UX.horizontalMargin),
+            labelContainer.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: UX.horizontalMargin),
 
             highlightedLabel.leadingAnchor.constraint(equalTo: labelContainer.leadingAnchor),
             highlightedLabel.topAnchor.constraint(equalTo: labelContainer.topAnchor),

--- a/Client/Frontend/LoginManagement/LoginListTableViewCell.swift
+++ b/Client/Frontend/LoginManagement/LoginListTableViewCell.swift
@@ -16,6 +16,10 @@ class LoginListTableViewSettingsCell: ThemedTableViewCell, ReusableCell {
 }
 
 class LoginListTableViewCell: ThemedTableViewCell, ReusableCell {
+    private struct UX {
+        static let horizontalMargin: CGFloat = 14
+    }
+
     private let breachAlertSize: CGFloat = 24
     lazy var breachAlertImageView: UIImageView = .build { imageView in
         imageView.image = BreachAlertsManager.icon
@@ -30,7 +34,7 @@ class LoginListTableViewCell: ThemedTableViewCell, ReusableCell {
     }
 
     lazy var breachMargin: CGFloat = {
-        return breachAlertSize + LoginTableViewCellUX.HorizontalMargin * 2
+        return breachAlertSize + UX.horizontalMargin * 2
     }()
 
     lazy var hostnameLabel: UILabel = .build { label in

--- a/Client/Frontend/Settings/LoginDetailViewController.swift
+++ b/Client/Frontend/Settings/LoginDetailViewController.swift
@@ -49,6 +49,10 @@ private class CenteredDetailCell: ThemedTableViewCell, ReusableCell {
 }
 
 class LoginDetailViewController: SensitiveViewController, Themeable {
+    private struct UX {
+        static let horizontalMargin: CGFloat = 14
+    }
+
     var themeManager: ThemeManager
     var themeObserver: NSObjectProtocol?
     var notificationCenter: NotificationProtocol
@@ -160,10 +164,14 @@ extension LoginDetailViewController: UITableViewDataSource {
             breachCell.contentView.addSubview(breachDetailView)
 
             NSLayoutConstraint.activate([
-                breachDetailView.leadingAnchor.constraint(equalTo: breachCell.contentView.leadingAnchor, constant: LoginTableViewCellUX.HorizontalMargin),
-                breachDetailView.topAnchor.constraint(equalTo: breachCell.contentView.topAnchor, constant: LoginTableViewCellUX.HorizontalMargin),
-                breachDetailView.trailingAnchor.constraint(equalTo: breachCell.contentView.trailingAnchor, constant: -LoginTableViewCellUX.HorizontalMargin),
-                breachDetailView.bottomAnchor.constraint(equalTo: breachCell.contentView.bottomAnchor, constant: -LoginTableViewCellUX.HorizontalMargin)
+                breachDetailView.leadingAnchor.constraint(equalTo: breachCell.contentView.leadingAnchor,
+                                                          constant: UX.horizontalMargin),
+                breachDetailView.topAnchor.constraint(equalTo: breachCell.contentView.topAnchor,
+                                                      constant: UX.horizontalMargin),
+                breachDetailView.trailingAnchor.constraint(equalTo: breachCell.contentView.trailingAnchor,
+                                                           constant: -UX.horizontalMargin),
+                breachDetailView.bottomAnchor.constraint(equalTo: breachCell.contentView.bottomAnchor,
+                                                         constant: -UX.horizontalMargin)
             ])
             breachDetailView.setup(breach)
 

--- a/Client/Frontend/Settings/LoginDetailViewController.swift
+++ b/Client/Frontend/Settings/LoginDetailViewController.swift
@@ -156,14 +156,14 @@ extension LoginDetailViewController: UITableViewDataSource {
             }
             guard let breach = breach else { return breachCell }
             breachCell.isHidden = false
-            let breachDetailView = BreachAlertsDetailView()
+            let breachDetailView: BreachAlertsDetailView = .build()
             breachCell.contentView.addSubview(breachDetailView)
 
             NSLayoutConstraint.activate([
                 breachDetailView.leadingAnchor.constraint(equalTo: breachCell.contentView.leadingAnchor, constant: LoginTableViewCellUX.HorizontalMargin),
                 breachDetailView.topAnchor.constraint(equalTo: breachCell.contentView.topAnchor, constant: LoginTableViewCellUX.HorizontalMargin),
-                breachDetailView.trailingAnchor.constraint(equalTo: breachCell.contentView.trailingAnchor, constant: LoginTableViewCellUX.HorizontalMargin),
-                breachDetailView.bottomAnchor.constraint(equalTo: breachCell.contentView.bottomAnchor, constant: LoginTableViewCellUX.HorizontalMargin)
+                breachDetailView.trailingAnchor.constraint(equalTo: breachCell.contentView.trailingAnchor, constant: -LoginTableViewCellUX.HorizontalMargin),
+                breachDetailView.bottomAnchor.constraint(equalTo: breachCell.contentView.bottomAnchor, constant: -LoginTableViewCellUX.HorizontalMargin)
             ])
             breachDetailView.setup(breach)
 


### PR DESCRIPTION
[FXIOS-5510](https://mozilla-hub.atlassian.net/browse/FXIOS-5510?filter=-1)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/12824)

### Description
Fix the breach view that was not showing in the details of the saved logins, in Password section of the app

iPhone
| Portrait  | Landscape | 
| ------------- | ------------- |
| ![Portrait](https://user-images.githubusercontent.com/51127880/224996198-d995e5a6-b4f6-447a-bb99-56c5e6c92c2e.jpeg) | ![Landscape](https://user-images.githubusercontent.com/51127880/224996256-c21cbe56-3cd9-4acc-9608-80f2536baf06.jpeg) |


### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
