### PR TITLE
Refactor FXIOS-5599 [v112] Show default browser message after 72 hours from install

### DIFF
--- a/nimbus-features/messagingFeature.yaml
+++ b/nimbus-features/messagingFeature.yaml
@@ -112,6 +112,7 @@ features:
               trigger:
                 - I_AM_NOT_DEFAULT_BROWSER
                 - SUPPORTS_DEFAULT_BROWSER
+                - USER_INSTALLED_THREE_DAYS_AGO
               title: Default Browser/DefaultBrowserCard.Title
               text: Default Browser/DefaultBrowserCard.Description
               button-label: Default Browser/DefaultBrowserCard.Button.v2

--- a/nimbus-features/messagingFeature.yaml
+++ b/nimbus-features/messagingFeature.yaml
@@ -56,6 +56,7 @@ features:
             AFTER_THREE_LAUNCHES_THIS_WEEK: app_cycle.foreground|eventSum('Weeks', 1, 0) >= 3
             USER_RECENTLY_INSTALLED:  days_since_install < 7
             USER_RECENTLY_UPDATED:    days_since_update < 7 && days_since_install != days_since_update
+            USER_INSTALLED_THREE_DAYS_AGO: days_since_install >= 3
             USER_TIER_ONE_COUNTRY:    ('US' in locale || 'GB' in locale || 'CA' in locale || 'DE' in locale || 'FR' in locale)
             USER_EN_SPEAKER:          "'en' in locale"
             USER_DE_SPEAKER:          "'de' in locale"


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5599)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/12955)

### Description
This adds a trigger to only show the default browser card 3 days (72 hours) after app install.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
~- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)~
~- [ ] Unit tests written and passing~
~- [ ] Documentation / comments for complex code and public methods~
