### PR TITLE
Add FXIOS-5931 [v113] App Authenticator string updates to use universal string

### DIFF
--- a/Client/Frontend/AuthenticationManager/AppAuthenticator.swift
+++ b/Client/Frontend/AuthenticationManager/AppAuthenticator.swift
@@ -18,12 +18,10 @@ class AppAuthenticator {
         //  That's usually not what you want.
         let context = LAContext()
 
-        context.localizedFallbackTitle = .AuthenticationEnterPasscode
-
         // First check if we have the needed hardware support.
         var error: NSError?
         if context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) {
-            context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: .Settings.Passwords.FingerPrintReason) { success, error in
+            context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: .Biometry.Screen.UniversalAuthenticationReason) { success, error in
                 if success {
                     DispatchQueue.main.async {
                         completion(.success(()))

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -86,7 +86,7 @@ extension String {
     public struct Biometry {
         public struct Screen {
             public static let UniversalAuthenticationReason = MZLocalizedString(
-                "Biometry.Screen.UniversalAuthenticationReason",
+                "Biometry.Screen.UniversalAuthenticationReason.v113",
                 tableName: "BiometricAuthentication",
                 value: "Enter your device passcode",
                 comment: "Biometric authentication is when the system prompts users for Face ID or fingerprint before accessing protected information. This string asks the user to enter their device passcode to access the protected screen.")

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -85,26 +85,11 @@ extension String {
 extension String {
     public struct Biometry {
         public struct Screen {
-            public static let PasswordsWithFingerprint = MZLocalizedString(
-                "Biometry.Screen.PasswordsWithFingerprint.v112",
+            public static let UniversalAuthenticationReason = MZLocalizedString(
+                "Biometry.Screen.UniversalAuthenticationReason",
                 tableName: "BiometricAuthentication",
-                value: "Use your fingerprint to access passwords.",
-                comment: "Biometric authentication is when the system prompts users for Face ID or fingerprint before accessing protected information. This string asks users to verify with fingerprint before accessing the Passwords screen.")
-            public static let PasswordsWithFaceId = MZLocalizedString(
-                "Biometry.Screen.PasswordsWithFaceId.v112",
-                tableName: "BiometricAuthentication",
-                value: "Use Face ID to access passwords.",
-                comment: "Biometric authentication is when the system prompts users for Face ID or fingerprint before accessing protected information. This string asks users to verify with Face ID before accessing the Passwords screen.")
-            public static let EditCreditCardWithFingerprint = MZLocalizedString(
-                "Biometry.Screen.EditCreditCardWithFingerprint.v112",
-                tableName: "BiometricAuthentication",
-                value: "Use your fingerprint to access credit cards.",
-                comment: "Biometric authentication is when the system prompts users for Face ID or fingerprint before accessing protected information. This string asks users to verify with fingerprint before accessing the Edit Credit Card screen.")
-            public static let EditCreditCardWithFaceId = MZLocalizedString(
-                "Biometry.Screen.EditCreditCardWithFaceId.v112",
-                tableName: "BiometricAuthentication",
-                value: "Use Face ID to access credit cards.",
-                comment: "Biometric authentication is when the system prompts users for Face ID or fingerprint before accessing protected information. This string asks users to verify with Face ID before accessing the Edit Credit Card screen.")
+                value: "Enter your device passcode",
+                comment: "Biometric authentication is when the system prompts users for Face ID or fingerprint before accessing protected information. This string asks the user to enter their device passcode to access the protected screen.")
         }
     }
 }
@@ -3815,15 +3800,6 @@ extension String {
         tableName: "LoginManager",
         value: nil,
         comment: "Label for the button used to delete the current login.")
-}
-
-// MARK: - Strings used in multiple areas within the Authentication Manager
-extension String {
-    public static let AuthenticationEnterPasscode = MZLocalizedString(
-        "Enter passcode",
-        tableName: "AuthenticationManager",
-        value: nil,
-        comment: "Text displayed above the input field when changing the existing passcode")
 }
 
 // MARK: - Authenticator strings


### PR DESCRIPTION
# [FXIOS-5931](https://mozilla-hub.atlassian.net/browse/FXIOS-5931)

### Description
Change the authentication reason string for all screens to something that's not screen specific, and more generalized. 

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
