### PR TITLE
Bugfix FXIOS-5868 [v113] Change What's new link

### DIFF
--- a/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -535,8 +535,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
         whatsNewAction = SingleActionViewModel(title: .AppMenu.WhatsNewString,
                                                iconString: ImageIdentifiers.whatsNew,
                                                isEnabled: showBadgeForWhatsNew) { _ in
-            if let whatsNewTopic = AppInfo.whatsNewTopic,
-                let whatsNewURL = SupportUtils.URLForTopic(whatsNewTopic) {
+            if let whatsNewURL = SupportUtils.URLForWhatsNew {
                 TelemetryWrapper.recordEvent(category: .action, method: .open, object: .whatsNew)
                 self.delegate?.openURLInNewTab(whatsNewURL, isPrivate: false)
             }

--- a/Shared/SupportUtils.swift
+++ b/Shared/SupportUtils.swift
@@ -9,6 +9,7 @@ import UIKit
 /// Utility functions related to SUMO and Webcompat
 public struct SupportUtils {
     public static var URLForWhatsNew: URL? {
+        // Returns the predefined URL associated to what's new button action.
         return URL(string: "https://www.mozilla.org/en-US/firefox/ios/notes/")
     }
 

--- a/Shared/SupportUtils.swift
+++ b/Shared/SupportUtils.swift
@@ -8,6 +8,10 @@ import UIKit
 
 /// Utility functions related to SUMO and Webcompat
 public struct SupportUtils {
+    public static var URLForWhatsNew: URL? {
+        return URL(string: "https://www.mozilla.org/en-US/firefox/ios/notes/")
+    }
+
     public static func URLForTopic(_ topic: String) -> URL? {
         // Construct a NSURL pointing to a specific topic on SUMO. The topic should be a non-escaped string. It will
         // be properly escaped by this function.

--- a/Tests/SharedTests/SupportUtilsTests.swift
+++ b/Tests/SharedTests/SupportUtilsTests.swift
@@ -15,4 +15,8 @@ class SupportUtilsTests: XCTestCase {
         XCTAssertEqual(SupportUtils.URLForTopic("Cheese & Crackers")?.absoluteString, "https://support.mozilla.org/1/mobile/\(appVersion)/iOS/\(languageIdentifier)/Cheese%20&%20Crackers")
         XCTAssertEqual(SupportUtils.URLForTopic("Möbelträgerfüße")?.absoluteString, "https://support.mozilla.org/1/mobile/\(appVersion)/iOS/\(languageIdentifier)/M%C3%B6beltr%C3%A4gerf%C3%BC%C3%9Fe")
     }
+
+    func testURLForWhatsNew() {
+        XCTAssertEqual(SupportUtils.URLForWhatsNew?.absoluteString, "https://www.mozilla.org/en-US/firefox/ios/notes/")
+    }
 }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5868)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13389)

### Description
Replaces the URL associated to what's new button action.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
