### PR TITLE
Add MTE-781 [v113] New Bitrise trigger for PRs on release branches

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1452,3 +1452,5 @@ trigger_map:
   pipeline: pipeline_multiple_shards
 - pull_request_target_branch: epic-branch/*
   pipeline: pipeline_multiple_shards
+- pull_request_target_branch: release/v*
+  pipeline: pipeline_multiple_shards


### PR DESCRIPTION
We are missing a trigger when there is a PR on a release branch. We should have one to build the app and run the tests. 
Then a push will run the `SPM_Deploy_Prod_Beta`

This PRs tries to fix the issue found in https://github.com/mozilla-mobile/firefox-ios/pull/13587