### PR TITLE
Bugfix MTE-775 [v113] Workaround for welcome screen on performance tests

### DIFF
--- a/Tests/XCUITests/TabsPerformanceTests.swift
+++ b/Tests/XCUITests/TabsPerformanceTests.swift
@@ -17,6 +17,11 @@ class TabsPerformanceTest: BaseTestCase {
             launchArguments.append(LaunchArguments.LoadTabsStateArchive + archiveName!)
         }
         super.setUp()
+        // Workaround: Welcome screen shows up first time after the simulator has been erased.
+        // The LaunchArguments could not suppress the welcome screen when PerformanceTest is specified.
+        if (app.buttons["No Thanks"].exists) {
+            app.buttons["No Thanks"].tap()
+        }
     }
 
     override func tearDown() {


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-775)

### Description

Since March 11, the `LaunchArguments` cannot disable the intro screen. Such screen appears after the iOS simulator has been erased and restarted. This screen is not shown when the app is launched the next time.

![Simulator Screen Shot - iPhone 14 - 2023-03-16 at 00 38 25](https://user-images.githubusercontent.com/1740517/225814220-4b880716-baf6-4193-bee7-8f091d9f0007.png)

I have tried the following but was not successful:
* Remove `LaunchArguments.PerformanceTest`. This way, the intro screen isn't shown, but the archive database containing many number of tabs is not loaded.
* Add` LaunchArguments.ClearProfile`. The intro screen is still shown.
* Add `LaunchArguments.SkipDefaultBrowserOnboarding`. The intro screen is still shown.

The commits on March 10 are not obvious if one of them is the cause of the issue.

For a quick workaround, I've decided that clicking "No Thanks" when the intro screen is shown.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
