### PR TITLE
Refactor MTE-628 v113 Re-enable failing smoke tests

### DIFF
--- a/Tests/XCUITests/HistoryTests.swift
+++ b/Tests/XCUITests/HistoryTests.swift
@@ -436,7 +436,6 @@ class HistoryTests: BaseTestCase {
         } else {
             navigateToGoogle()
             navigator.goto(LibraryPanel_History)
-            print(app.debugDescription)
             waitForExistence(app.cells.staticTexts["http://example.com/"], timeout: TIMEOUT)
             app.cells.staticTexts["http://example.com/"].firstMatch.swipeLeft()
             waitForExistence(app.buttons["Delete"], timeout: TIMEOUT)

--- a/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -192,25 +192,20 @@ class HomePageSettingsUITests: BaseTestCase {
         XCTAssertEqual(numberOfTopSites, numberOfExpectedTopSites)
     }
 
-    func testJumpBackIn() throws {
-        throw XCTSkip("Disabled failing in BR - investigating")
-//        navigator.openURL(path(forTestPage: exampleUrl))
-//        waitUntilPageLoad()
-//        navigator.goto(TabTray)
-//        navigator.performAction(Action.OpenNewTabFromTabTray)
-//        navigator.nowAt(NewTabScreen)
-//        waitForExistence(app.buttons["urlBar-cancel"], timeout: 5)
-//        navigator.performAction(Action.CloseURLBarOpen)
-//        waitForExistence(app.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.jumpBackIn], timeout: 5)
-//        // Swipe up needed to see the content below the Jump Back In section
-//        app.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.jumpBackIn].swipeUp()
-//        XCTAssertTrue(app.cells.collectionViews.staticTexts["Example Domain"].exists)
-//        // Swipe down to be able to click on Show all option
-//        app.buttons["More"].swipeDown()
-//        waitForExistence(app.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.jumpBackIn], timeout: 5)
-//        app.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.jumpBackIn].tap()
-//        // Tab tray is open with recently open tab
-//        waitForExistence(app.cells.staticTexts["Example Domain"], timeout: 3)
+    func testJumpBackIn() {
+        navigator.openURL(path(forTestPage: exampleUrl))
+        waitUntilPageLoad()
+        navigator.goto(TabTray)
+        navigator.performAction(Action.OpenNewTabFromTabTray)
+        navigator.nowAt(NewTabScreen)
+        waitForExistence(app.buttons["urlBar-cancel"], timeout: 5)
+        navigator.performAction(Action.CloseURLBarOpen)
+        waitForExistence(app.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.jumpBackIn], timeout: 5)
+        XCTAssertTrue(app.otherElements.cells[AccessibilityIdentifiers.FirefoxHomepage.JumpBackIn.itemCell].staticTexts[urlExampleLabel].exists)
+        waitForExistence(app.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.jumpBackIn], timeout: 5)
+        app.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.jumpBackIn].tap()
+        // Tab tray is open with recently open tab
+        waitForExistence(app.otherElements.cells[AccessibilityIdentifiers.FirefoxHomepage.JumpBackIn.itemCell].staticTexts[urlExampleLabel], timeout: 3)
     }
 
     func testRecentlySaved() {

--- a/Tests/XCUITests/PhotonActionSheetTest.swift
+++ b/Tests/XCUITests/PhotonActionSheetTest.swift
@@ -6,29 +6,27 @@ import XCTest
 
 class PhotonActionSheetTest: BaseTestCase {
     // Smoketest
-    func testPinToTop() throws {
-        throw XCTSkip("Skipping this test due to issue 8715")
-//        navigator.openURL("http://example.com")
-//        waitUntilPageLoad()
-//        // Open Page Action Menu Sheet and Pin the site
-//        navigator.performAction(Action.PinToTopSitesPAM)
-//
-//        // Navigate to topsites to verify that the site has been pinned
-//        navigator.nowAt(BrowserTab)
-//        navigator.performAction(Action.OpenNewTabFromTabTray)
-//
-//        // Verify that the site is pinned to top
-//        waitForExistence(app.cells["example"])
-//        let cell = app.cells["example"]
-//        waitForExistence(cell)
-//
-//        // Remove pin
-//        app.cells["example"].press(forDuration: 2)
-//        app.cells[ImageIdentifiers.removeFromShortcut].tap()
-//
-//        // Check that it has been unpinned
-//        cell.press(forDuration: 2)
-//        waitForExistence(app.cells[ImageIdentifiers.addShortcut])
+    func testPinToTop() {
+        navigator.openURL("http://example.com")
+        waitUntilPageLoad()
+        // Open Page Action Menu Sheet and Pin the site
+        navigator.performAction(Action.PinToTopSitesPAM)
+
+        // Navigate to topsites to verify that the site has been pinned
+        navigator.nowAt(BrowserTab)
+        navigator.performAction(Action.OpenNewTabFromTabTray)
+
+        // Verify that the site is pinned to top
+        let cell = app.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell].staticTexts["Example Domain"]
+        waitForExistence(cell)
+
+        // Remove pin
+        cell.press(forDuration: 2)
+        app.tables.cells.otherElements[ImageIdentifiers.removeFromShortcut].tap()
+
+        // Check that it has been unpinned
+        cell.press(forDuration: 2)
+        waitForExistence(app.tables.cells.otherElements[ImageIdentifiers.addShortcut])
     }
 
     func testShareOptionIsShown() {

--- a/Tests/XCUITests/TopTabsTest.swift
+++ b/Tests/XCUITests/TopTabsTest.swift
@@ -266,55 +266,50 @@ class TopTabsTest: BaseTestCase {
     }
 
     // Smoketest
-    func testLongTapTabCounter() throws {
-        throw XCTSkip("This test is failing. Isabel will be looking into it")
-//        if !iPad() {
-//            waitForExistence(app.buttons["urlBar-cancel"], timeout: 5)
-//            // Long tap on Tab Counter should show the correct options
-//            navigator.performAction(Action.CloseURLBarOpen)
-//            navigator.nowAt(NewTabScreen)
-//            waitForExistence(app.buttons["Show Tabs"], timeout: 10)
-//            app.buttons["Show Tabs"].press(forDuration: 1)
-//            waitForExistence(app.cells[ImageIdentifiers.newTab])
-//            XCTAssertTrue(app.cells[ImageIdentifiers.newTab].exists)
-//            XCTAssertTrue(app.cells["tab_close"].exists)
-//
-//            // Open New Tab
-//            app.cells[ImageIdentifiers.newTab].tap()
-//            navigator.performAction(Action.CloseURLBarOpen)
-//
-//            waitForTabsButton()
-//            checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
-//            waitForExistence(app.cells.staticTexts["Home"])
-//            app.cells.staticTexts["Home"].firstMatch.tap()
-//
-//            // Close tab
-//            navigator.nowAt(HomePanelsScreen)
-//            navigator.performAction(Action.CloseURLBarOpen)
-//            navigator.nowAt(NewTabScreen)
-//
-//            waitForExistence(app.buttons["Show Tabs"])
-//            app.buttons["Show Tabs"].press(forDuration: 1)
-//            waitForExistence(app.cells[ImageIdentifiers.newTab])
-//            app.cells["tab_close"].tap()
-//            navigator.performAction(Action.CloseURLBarOpen)
-//            navigator.nowAt(NewTabScreen)
-//            checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
-//
-//            // Go to Private Mode
-//            waitForExistence(app.cells.staticTexts["Home"])
-//            app.cells.staticTexts["Home"].firstMatch.tap()
-//            navigator.nowAt(HomePanelsScreen)
-//            navigator.performAction(Action.CloseURLBarOpen)
-//            navigator.nowAt(NewTabScreen)
-//            waitForExistence(app.buttons["Show Tabs"])
-//            app.buttons["Show Tabs"].press(forDuration: 1)
-//            waitForExistence(app.cells["nav-tabcounter"])
-//            app.cells["nav-tabcounter"].tap()
-//            navigator.performAction(Action.CloseURLBarOpen)
-//            navigator.nowAt(NewTabScreen)
-//            checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
-//        }
+    func testLongTapTabCounter() {
+        if !iPad() {
+            // Long tap on Tab Counter should show the correct options
+            navigator.nowAt(NewTabScreen)
+            waitForExistence(app.buttons["Show Tabs"], timeout: 10)
+            app.buttons["Show Tabs"].press(forDuration: 1)
+            waitForExistence(app.cells.otherElements[ImageIdentifiers.newTab])
+            XCTAssertTrue(app.cells.otherElements[ImageIdentifiers.newTab].exists)
+            XCTAssertTrue(app.cells.otherElements["tab_close"].exists)
+
+            // Open New Tab
+            app.cells.otherElements[ImageIdentifiers.newTab].tap()
+            navigator.performAction(Action.CloseURLBarOpen)
+
+            waitForTabsButton()
+            checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
+            waitForExistence(app.cells.staticTexts["Homepage"])
+            app.cells.staticTexts["Homepage"].firstMatch.tap()
+            waitForExistence(app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
+
+            // Close tab
+            navigator.nowAt(HomePanelsScreen)
+            navigator.nowAt(NewTabScreen)
+
+            waitForExistence(app.buttons["Show Tabs"])
+            app.buttons["Show Tabs"].press(forDuration: 1)
+            waitForExistence(app.tables.cells.otherElements[ImageIdentifiers.newTab])
+            app.tables.cells.otherElements["tab_close"].tap()
+            navigator.nowAt(NewTabScreen)
+            checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
+
+            // Go to Private Mode
+            waitForExistence(app.cells.staticTexts["Homepage"])
+            app.cells.staticTexts["Homepage"].firstMatch.tap()
+            waitForExistence(app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
+            navigator.nowAt(HomePanelsScreen)
+            navigator.nowAt(NewTabScreen)
+            waitForExistence(app.buttons["Show Tabs"])
+            app.buttons["Show Tabs"].press(forDuration: 1)
+            waitForExistence(app.tables.cells.otherElements["Private Browsing Mode"])
+            app.tables.cells.otherElements["Private Browsing Mode"].tap()
+            navigator.nowAt(NewTabScreen)
+            checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
+        }
     }
 }
 
@@ -335,35 +330,32 @@ fileprivate extension BaseTestCase {
 }
 
 class TopTabsTestIphone: IphoneOnlyTestCase {
-    func testCloseTabFromLongPressTabsButton() throws {
-        throw XCTSkip("This test is failing. Isabel will be looking into it")
-//        if skipPlatform { return }
-//        navigator.goto(URLBarOpen)
-//        navigator.back()
-//        waitForTabsButton()
-//        // This menu is available in HomeScreen or NewTabScreen, so no need to open new websites
-//        navigator.performAction(Action.OpenNewTabFromTabTray)
-//        navigator.performAction(Action.CloseURLBarOpen)
-//        navigator.nowAt(NewTabScreen)
-//        waitForTabsButton()
-//        checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
-//        closeTabTrayView(goBackToBrowserTab: "Home")
-//        navigator.performAction(Action.CloseURLBarOpen)
-//        navigator.nowAt(NewTabScreen)
-//        navigator.performAction(Action.CloseTabFromTabTrayLongPressMenu)
-//        navigator.performAction(Action.CloseURLBarOpen)
-//        navigator.nowAt(NewTabScreen)
-//        waitForTabsButton()
-//        checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
-//        closeTabTrayView(goBackToBrowserTab: "Home")
-//        navigator.performAction(Action.CloseURLBarOpen)
-//        navigator.nowAt(NewTabScreen)
-//        navigator.performAction(Action.CloseTabFromTabTrayLongPressMenu)
-//        navigator.performAction(Action.CloseURLBarOpen)
-//        navigator.nowAt(NewTabScreen)
-//        waitForTabsButton()
-//        checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
-//        closeTabTrayView(goBackToBrowserTab: "Home")
+    func testCloseTabFromLongPressTabsButton() {
+        if skipPlatform { return }
+        navigator.goto(URLBarOpen)
+        navigator.back()
+        waitForTabsButton()
+        // This menu is available in HomeScreen or NewTabScreen, so no need to open new websites
+        navigator.performAction(Action.OpenNewTabFromTabTray)
+        navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
+        waitForTabsButton()
+        checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
+        closeTabTrayView(goBackToBrowserTab: "Homepage")
+        navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
+        navigator.performAction(Action.CloseTabFromTabTrayLongPressMenu)
+        navigator.nowAt(NewTabScreen)
+        waitForTabsButton()
+        checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
+        closeTabTrayView(goBackToBrowserTab: "Homepage")
+        navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
+        navigator.performAction(Action.CloseTabFromTabTrayLongPressMenu)
+        navigator.nowAt(NewTabScreen)
+        waitForTabsButton()
+        checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
+        closeTabTrayView(goBackToBrowserTab: "Homepage")
     }
 
     // This test only runs for iPhone see bug 1409750


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

### Still needs addresing
- testDeleteHistoryEntryBySwiping() - still needs to be check if it fails on M1
- testTopSitesRemoveAllExceptDefaultClearPrivateData() - Database not loading

### Pull requests checks where applicable
- testJumpBackIn() - passing locally
- testCloseTabFromLongPressTabsButton() - passing locally
- testLongTapTabCounter() - passing locally
- testPinToTop() - passing locally


