### PR TITLE
Refactor FXIOS-5994 [v112] made ReaderModeStyleViewController delegate weak

### DIFF
--- a/Client/Frontend/Reader/View/ReaderModeStyleViewController.swift
+++ b/Client/Frontend/Reader/View/ReaderModeStyleViewController.swift
@@ -38,7 +38,7 @@ class ReaderModeStyleViewController: UIViewController, Themeable {
     private var isUsingUserDefinedColor = false
 
     private var viewModel: ReaderModeStyleViewModel!
-    var delegate: ReaderModeStyleViewControllerDelegate?
+    weak var delegate: ReaderModeStyleViewControllerDelegate?
     var themeManager: ThemeManager
     var themeObserver: NSObjectProtocol?
     var notificationCenter: NotificationProtocol

--- a/Tests/ClientTests/ReaderModeStyleTests.swift
+++ b/Tests/ClientTests/ReaderModeStyleTests.swift
@@ -110,7 +110,7 @@ class ReaderModeStyleTests: XCTestCase {
     func test_delegateMemoryLeak() {
         let mockReaderModeStyleViewControllerDelegate = MockReaderModeStyleViewControllerDelegate()
         let readerModeStyleViewModel = ReaderModeStyleViewModel(isBottomPresented: false)
-        var readerModeStyleViewController = ReaderModeStyleViewController(viewModel: readerModeStyleViewModel)
+        let readerModeStyleViewController = ReaderModeStyleViewController(viewModel: readerModeStyleViewModel)
         readerModeStyleViewController.delegate = mockReaderModeStyleViewControllerDelegate
         trackForMemoryLeaks(readerModeStyleViewController)
     }

--- a/Tests/ClientTests/ReaderModeStyleTests.swift
+++ b/Tests/ClientTests/ReaderModeStyleTests.swift
@@ -107,7 +107,7 @@ class ReaderModeStyleTests: XCTestCase {
         XCTAssertEqual(readerModeStyle.theme, .dark)
     }
 
-    func test_DelegateMemoryLeak() {
+    func test_delegateMemoryLeak() {
         let mockReaderModeStyleViewControllerDelegate = MockReaderModeStyleViewControllerDelegate()
         let readerModeStyleViewModel = ReaderModeStyleViewModel(isBottomPresented: false)
         var readerModeStyleViewController = ReaderModeStyleViewController(viewModel: readerModeStyleViewModel)

--- a/Tests/ClientTests/ReaderModeStyleTests.swift
+++ b/Tests/ClientTests/ReaderModeStyleTests.swift
@@ -110,10 +110,9 @@ class ReaderModeStyleTests: XCTestCase {
     func test_DelegateMemoryLeak() {
         let mockReaderModeStyleViewControllerDelegate = MockReaderModeStyleViewControllerDelegate()
         let readerModeStyleViewModel = ReaderModeStyleViewModel(isBottomPresented: false)
-        var readerModeStyleViewController: ReaderModeStyleViewController! = ReaderModeStyleViewController(viewModel: readerModeStyleViewModel)
+        var readerModeStyleViewController = ReaderModeStyleViewController(viewModel: readerModeStyleViewModel)
         readerModeStyleViewController.delegate = mockReaderModeStyleViewControllerDelegate
         trackForMemoryLeaks(readerModeStyleViewController)
-        readerModeStyleViewController = nil
     }
 }
 

--- a/Tests/ClientTests/ReaderModeStyleTests.swift
+++ b/Tests/ClientTests/ReaderModeStyleTests.swift
@@ -106,4 +106,21 @@ class ReaderModeStyleTests: XCTestCase {
         readerModeStyle.ensurePreferredColorThemeIfNeeded()
         XCTAssertEqual(readerModeStyle.theme, .dark)
     }
+
+    func test_DelegateMemoryLeak() {
+        let mockReaderModeStyleViewControllerDelegate = MockReaderModeStyleViewControllerDelegate()
+        let readerModeStyleViewModel = ReaderModeStyleViewModel(isBottomPresented: false)
+        var readerModeStyleViewController: ReaderModeStyleViewController! = ReaderModeStyleViewController(viewModel: readerModeStyleViewModel)
+        readerModeStyleViewController.delegate = mockReaderModeStyleViewControllerDelegate
+        trackForMemoryLeaks(readerModeStyleViewController)
+        readerModeStyleViewController = nil
+    }
+}
+
+class MockReaderModeStyleViewControllerDelegate: ReaderModeStyleViewControllerDelegate {
+    init() {}
+
+    func readerModeStyleViewController(_ readerModeStyleViewController: ReaderModeStyleViewController,
+                                       didConfigureStyle style: ReaderModeStyle,
+                                       isUsingUserDefinedColor: Bool) {}
 }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5994)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13612)

### Description
Mark ReaderModeStyleViewController delegate as weak

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
