### PR TITLE
Bugfix FXIOS-5374 [v113] Bookmarks panel fix the way context menu is triggered

### DIFF
--- a/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
@@ -106,6 +106,7 @@ class BookmarksPanel: SiteTableViewController,
         tableView.addGestureRecognizer(tableViewLongPressRecognizer)
         tableView.accessibilityIdentifier = AccessibilityIdentifiers.LibraryPanels.BookmarksPanel.tableView
         tableView.allowsSelectionDuringEditing = true
+        tableView.dragInteractionEnabled = false
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -250,6 +251,7 @@ class BookmarksPanel: SiteTableViewController,
     func enableEditMode() {
         updatePanelState(newState: .bookmarks(state: .inFolderEditMode))
         self.tableView.setEditing(true, animated: true)
+        self.tableView.dragInteractionEnabled = true
         sendPanelChangeNotification()
     }
 
@@ -257,6 +259,7 @@ class BookmarksPanel: SiteTableViewController,
         let substate: LibraryPanelSubState = viewModel.isRootNode ? .mainView : .inFolder
         updatePanelState(newState: .bookmarks(state: substate))
         self.tableView.setEditing(false, animated: true)
+        self.tableView.dragInteractionEnabled = false
         sendPanelChangeNotification()
     }
 


### PR DESCRIPTION

[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5374)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/12585)

### Description
The context menu that appears after long tap on any item from  Bookmarks panel now is triggered the same way as it is triggered from History Panel for keeping consistency. We allow reordering bookmarks in edit mode and keep the drag functionality for bookmarks panel that permits moving items only for edit mode.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
