### PR TITLE
Add FXIOS-5937 [v112] Filter notifications based on user preferences

### DIFF
--- a/Client/Application/AppDelegate+PushNotifications.swift
+++ b/Client/Application/AppDelegate+PushNotifications.swift
@@ -127,7 +127,10 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 extension AppDelegate {
     func application(_ application: UIApplication,
                      didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-        let notificationAllowed = profile.prefs.boolForKey(PrefsKeys.Notifications.SyncNotifications) ?? true
+        var notificationAllowed = true
+        if featureFlags.isFeatureEnabled(.notificationSettings, checking: .buildOnly) {
+            notificationAllowed = profile.prefs.boolForKey(PrefsKeys.Notifications.SyncNotifications) ?? true
+        }
 
         RustFirefoxAccounts.shared.pushNotifications.didRegister(withDeviceToken: deviceToken,
                                                                  notificationAllowed: notificationAllowed)

--- a/Client/Application/AppDelegate+PushNotifications.swift
+++ b/Client/Application/AppDelegate+PushNotifications.swift
@@ -128,7 +128,7 @@ extension AppDelegate {
     func application(_ application: UIApplication,
                      didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         var notificationAllowed = true
-        if featureFlags.isFeatureEnabled(.notificationSettings, checking: .buildOnly) {
+        if FeatureFlagsManager.shared.isFeatureEnabled(.notificationSettings, checking: .buildOnly) {
             notificationAllowed = profile.prefs.boolForKey(PrefsKeys.Notifications.SyncNotifications) ?? true
         }
 

--- a/Client/Application/AppDelegate+PushNotifications.swift
+++ b/Client/Application/AppDelegate+PushNotifications.swift
@@ -125,8 +125,12 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 }
 
 extension AppDelegate {
-    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-        RustFirefoxAccounts.shared.pushNotifications.didRegister(withDeviceToken: deviceToken)
+    func application(_ application: UIApplication,
+                     didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        let notificationAllowed = profile.prefs.boolForKey(PrefsKeys.Notifications.SyncNotifications) ?? true
+
+        RustFirefoxAccounts.shared.pushNotifications.didRegister(withDeviceToken: deviceToken,
+                                                                 notificationAllowed: notificationAllowed)
     }
 
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {

--- a/Client/EngagementNotificationHelper.swift
+++ b/Client/EngagementNotificationHelper.swift
@@ -25,6 +25,11 @@ class EngagementNotificationHelper: FeatureFlaggable {
     }
     private lazy var featureEnabled: Bool = featureFlags.isFeatureEnabled(.engagementNotificationStatus,
                                                                           checking: .buildOnly)
+    private var allowedTipsNotifications: Bool {
+        let featureEnabled = featureFlags.isFeatureEnabled(.notificationSettings, checking: .buildOnly)
+        let userPreference = prefs?.boolForKey(PrefsKeys.Notifications.TipsAndFeaturesNotifications) ?? true
+        return featureEnabled && userPreference
+    }
 
     init(prefs: Prefs?, notificationManager: NotificationManagerProtocol = NotificationManager()) {
         self.prefs = prefs
@@ -36,9 +41,9 @@ class EngagementNotificationHelper: FeatureFlaggable {
 
         // schedule notifications only if notification permission was granted and the tips notifications are allowed
         notificationManager.hasPermission { [weak self] hasPermission in
-            guard hasPermission, self?.prefs?.boolForKey(PrefsKeys.Notifications.TipsAndFeaturesNotifications) ?? true
+            guard let strongSelf = self, hasPermission, strongSelf.allowedTipsNotifications
             else { return }
-            self?.scheduleNotification()
+            strongSelf.scheduleNotification()
         }
     }
 

--- a/Client/EngagementNotificationHelper.swift
+++ b/Client/EngagementNotificationHelper.swift
@@ -34,10 +34,16 @@ class EngagementNotificationHelper: FeatureFlaggable {
     func schedule() {
         guard featureEnabled else { return }
 
+        // schedule notifications only if notification permission was granted and the tips notifications are allowed
         notificationManager.hasPermission { [weak self] hasPermission in
-            guard hasPermission else { return }
+            guard hasPermission, self?.prefs?.boolForKey(PrefsKeys.Notifications.TipsAndFeaturesNotifications) ?? true
+            else { return }
             self?.scheduleNotification()
         }
+    }
+
+    func cancelAll() {
+        notificationManager.removePendingNotificationsWithId(ids: [Constant.notificationId])
     }
 
     // MARK: - Private
@@ -55,7 +61,7 @@ class EngagementNotificationHelper: FeatureFlaggable {
         // If they are not active in the second 24 hours after first use we send them a notification.
         if now > Date.fromTimestamp(firstAppUse + Constant.twentyFourHours) {
             // cancel as user used app between firstAppUse + 24h and firstAppUse + 48h
-            notificationManager.removePendingNotificationsWithId(ids: [Constant.notificationId])
+            cancelAll()
             TelemetryWrapper.recordEvent(category: .action,
                                          method: .cancel,
                                          object: .engagementNotification)

--- a/Client/Frontend/Settings/NotificationsSettingsViewController.swift
+++ b/Client/Frontend/Settings/NotificationsSettingsViewController.swift
@@ -5,6 +5,7 @@
 import Foundation
 import Shared
 import Common
+import MozillaAppServices
 
 class NotificationsSettingsViewController: SettingsTableViewController, FeatureFlaggable {
     private lazy var engagementNotificationHelper = EngagementNotificationHelper(prefs: prefs)
@@ -23,9 +24,13 @@ class NotificationsSettingsViewController: SettingsTableViewController, FeatureF
                 let shouldEnable = await self.notificationsChanged(value)
                 self.syncNotifications.control.setOn(shouldEnable, animated: true)
                 self.syncNotifications.writeBool(self.syncNotifications.control)
-            }
 
-            // enable/disable syncSignIn notifications
+                // enable/disable sync notifications
+                MZKeychainWrapper.sharedClientAppContainerKeychain.removeObject(
+                    forKey: KeychainKey.apnsToken,
+                    withAccessibility: MZKeychainItemAccessibility.afterFirstUnlock)
+                NotificationCenter.default.post(name: .RegisterForPushNotifications, object: nil)
+            }
         }
     }()
 

--- a/Client/Frontend/Settings/NotificationsSettingsViewController.swift
+++ b/Client/Frontend/Settings/NotificationsSettingsViewController.swift
@@ -6,7 +6,9 @@ import Foundation
 import Shared
 import Common
 
-class NotificationsSettingsViewController: SettingsTableViewController {
+class NotificationsSettingsViewController: SettingsTableViewController, FeatureFlaggable {
+    private lazy var engagementNotificationHelper = EngagementNotificationHelper(prefs: prefs)
+    
     private lazy var syncNotifications: BoolNotificationSetting = {
         return BoolNotificationSetting(
             title: .Settings.Notifications.SyncNotificationsTitle,
@@ -41,9 +43,15 @@ class NotificationsSettingsViewController: SettingsTableViewController {
                 let shouldEnable = await self.notificationsChanged(value)
                 self.tipsAndFeaturesNotifications.control.setOn(shouldEnable, animated: true)
                 self.tipsAndFeaturesNotifications.writeBool(self.tipsAndFeaturesNotifications.control)
-            }
 
-            // enable/disable tipsAndFeatures notifications
+                if shouldEnable {
+                    // schedule engagement notifications if necessary
+                    self.engagementNotificationHelper.schedule()
+                } else {
+                    // cancel all pending engagement notifications
+                    self.engagementNotificationHelper.cancelAll()
+                }
+            }
         }
     }()
 

--- a/Client/Frontend/Settings/NotificationsSettingsViewController.swift
+++ b/Client/Frontend/Settings/NotificationsSettingsViewController.swift
@@ -9,7 +9,7 @@ import MozillaAppServices
 
 class NotificationsSettingsViewController: SettingsTableViewController, FeatureFlaggable {
     private lazy var engagementNotificationHelper = EngagementNotificationHelper(prefs: prefs)
-    
+
     private lazy var syncNotifications: BoolNotificationSetting = {
         return BoolNotificationSetting(
             title: .Settings.Notifications.SyncNotificationsTitle,

--- a/RustFxA/PushNotificationSetup.swift
+++ b/RustFxA/PushNotificationSetup.swift
@@ -10,11 +10,17 @@ open class PushNotificationSetup {
     private var pushClient: PushClient?
     private var pushRegistration: PushRegistration?
 
+    /// Registers the users device with the push notification server. If notificationAllowed is false the device will
+    /// be unsubscribed from receiving notifications.
+    /// - Parameters:
+    ///   - deviceToken: A token that identifies the device to Apple Push Notification Service (APNS).
+    ///   - notificationAllowed: Indicates if the user allowed sync push notification in the settings.
     public func didRegister(withDeviceToken deviceToken: Data, notificationAllowed: Bool) {
         // If we've already registered this push subscription, we don't need to do it again.
         let apnsToken = deviceToken.hexEncodedString
         let keychain = MZKeychainWrapper.sharedClientAppContainerKeychain
-        guard keychain.string(forKey: KeychainKey.apnsToken, withAccessibility: .afterFirstUnlock) != apnsToken else { return }
+        guard keychain.string(forKey: KeychainKey.apnsToken, withAccessibility: .afterFirstUnlock) != apnsToken
+        else { return }
 
         RustFirefoxAccounts.shared.accountManager.uponQueue(.main) { accountManager in
             let config = PushConfigurationLabel(rawValue: AppConstants.scheme)!.toConfiguration()

--- a/RustFxA/PushNotificationSetup.swift
+++ b/RustFxA/PushNotificationSetup.swift
@@ -10,7 +10,7 @@ open class PushNotificationSetup {
     private var pushClient: PushClient?
     private var pushRegistration: PushRegistration?
 
-    public func didRegister(withDeviceToken deviceToken: Data) {
+    public func didRegister(withDeviceToken deviceToken: Data, notificationAllowed: Bool) {
         // If we've already registered this push subscription, we don't need to do it again.
         let apnsToken = deviceToken.hexEncodedString
         let keychain = MZKeychainWrapper.sharedClientAppContainerKeychain
@@ -26,9 +26,15 @@ open class PushNotificationSetup {
                 self?.pushRegistration = pushRegistration
 
                 let subscription = pushRegistration.defaultSubscription
-                let devicePush = DevicePushSubscription(endpoint: subscription.endpoint.absoluteString,
-                                                        publicKey: subscription.p256dhPublicKey,
-                                                        authKey: subscription.authKey)
+
+                // send empty parameters for push subscription if no notifications should be send to device
+                let endpoint = notificationAllowed ? subscription.endpoint.absoluteString : ""
+                let publicKey = notificationAllowed ? subscription.p256dhPublicKey : ""
+                let authKey = notificationAllowed ? subscription.authKey : ""
+
+                let devicePush = DevicePushSubscription(endpoint: endpoint,
+                                                        publicKey: publicKey,
+                                                        authKey: authKey)
                 accountManager.deviceConstellation()?.setDevicePushSubscription(sub: devicePush)
                 // We set our apnsToken **after** the call to set the push subscription completes
                 // This helps ensure that if that call fails, we will try again with a new token next time

--- a/Tests/ClientTests/Helpers/EngagementNotificationHelperTests.swift
+++ b/Tests/ClientTests/Helpers/EngagementNotificationHelperTests.swift
@@ -68,4 +68,24 @@ class EngagementNotificationHelperTests: XCTestCase {
         XCTAssertTrue(notificationManager.removePendingNotificationsWithIdWasCalled)
         XCTAssertEqual(notificationManager.scheduledNotifications, -1)
     }
+
+    func testSchedule_userPrefOff() {
+        let timestamp = Date.now() - EngagementNotificationHelper.Constant.twentyFourHours * UInt64(0.5)
+        profile.prefs.setTimestamp(timestamp, forKey: PrefsKeys.KeyFirstAppUse)
+        profile.prefs.setBool(false, forKey: PrefsKeys.Notifications.TipsAndFeaturesNotifications)
+        engagementNotificationHelper.schedule()
+        XCTAssertFalse(notificationManager.scheduleWithDateWasCalled)
+        XCTAssertFalse(notificationManager.removePendingNotificationsWithIdWasCalled)
+        XCTAssertEqual(notificationManager.scheduledNotifications, 0)
+    }
+
+    func testSchedule_userPrefOn() {
+        let timestamp = Date.now() - EngagementNotificationHelper.Constant.twentyFourHours * UInt64(0.5)
+        profile.prefs.setTimestamp(timestamp, forKey: PrefsKeys.KeyFirstAppUse)
+        profile.prefs.setBool(true, forKey: PrefsKeys.Notifications.TipsAndFeaturesNotifications)
+        engagementNotificationHelper.schedule()
+        XCTAssertTrue(notificationManager.scheduleWithDateWasCalled)
+        XCTAssertFalse(notificationManager.removePendingNotificationsWithIdWasCalled)
+        XCTAssertEqual(notificationManager.scheduledNotifications, 1)
+    }
 }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5937)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13488)

### Description
This registers/unregisters from receiving push notifications based on the users preferences. All local notifications a canceled if needed and can only be scheduled if users preferences permit.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
~- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)~
- [x] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
