### PR TITLE
Bugfix MTE-787 [v113] Fix for testRecentlySaved from HomePageSettingsUITests

### DIFF
--- a/Tests/XCUITests/BaseTestCase.swift
+++ b/Tests/XCUITests/BaseTestCase.swift
@@ -170,8 +170,10 @@ class BaseTestCase: XCTestCase {
         app.buttons["Add to Reading List"].tap()
     }
     func removeContentFromReaderView() {
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
-        navigator.performAction(Action.CloseURLBarOpen)
+        if !iPad() {
+            waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
+            navigator.performAction(Action.CloseURLBarOpen)
+        }
         navigator.nowAt(NewTabScreen)
         navigator.goto(LibraryPanel_ReadingList)
         let savedToReadingList = app.tables["ReadingTable"].cells.staticTexts["The Book of Mozilla"]

--- a/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -242,6 +242,7 @@ class HomePageSettingsUITests: BaseTestCase {
         navigator.nowAt(HomeSettings)
         navigator.performAction(Action.OpenNewTabFromTabTray)
         checkRecentlySaved()
+        navigator.performAction(Action.CloseURLBarOpen)
         app.scrollViews.cells[AccessibilityIdentifiers.FirefoxHomepage.RecentlySaved.itemCell].staticTexts[urlExampleLabel].tap()
         navigator.nowAt(BrowserTab)
         waitForTabsButton()


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-787)

### Description
On iPhone, `testRecentlySaved` fails when all `Smoketest3` are run on MacStadium (M1). The test passes when it is run by itself. This PR ensures that the keyboard would not interfere with clicking a Recently Saved link.

On iPad, the same test fails at `removeContentFromReaderView()` on MacStadium (M1). We should ensure that the URL bar is closed only for iPhone

I have run `Smoketest3` on both iPhone and iPad.

```
xcodebuild test -target Client -scheme Fennec_Enterprise_XCUITests -destination 'platform=iOS Simulator,name=iPad Pro (12.9-inch) (5th generation)' -testPlan Smoketest3
```

```
xcodebuild test -target Client -scheme Fennec_Enterprise_XCUITests -destination 'platform=iOS Simulator,name=iPhone 14' -testPlan Smoketest3
```

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
