### PR TITLE
Bugfix FXIOS-5416 [v113] changed address bar’s lock icon’s Enhanced Tracking Protection disabled badge to blue instead of white

### DIFF
--- a/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -366,7 +366,9 @@ extension TabLocationView: TabEventHandler {
             case .blocking, .noBlockedURLs:
                 trackingProtectionButton.setImage(lockImage, for: .normal)
             case .safelisted:
-                trackingProtectionButton.setImage(lockImage?.overlayWith(image: UIImage(imageLiteralResourceName: "MarkAsRead")), for: .normal)
+                if let smallDotImage = UIImage(systemName: "circle.fill")?.withTintColor(UIColor.Photon.Blue40) {
+                    trackingProtectionButton.setImage(lockImage?.overlayWith(image: smallDotImage), for: .normal)
+                }
             case .disabled:
                 trackingProtectionButton.setImage(lockImage, for: .normal)
             }


### PR DESCRIPTION
…racking Protection disabled badge to blue instead of white

[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5416)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/12664)

### Description
TODO

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
