### PR TITLE
Refactor FXIOS-5905 [v113] made MockHistoryHighlightsDataAdaptor's delegate weak, add memory leak unit test

### DIFF
--- a/Tests/ClientTests/Frontend/Home/HistoryHighlights/HistoryHighlightsDataAdaptorTests.swift
+++ b/Tests/ClientTests/Frontend/Home/HistoryHighlights/HistoryHighlightsDataAdaptorTests.swift
@@ -113,7 +113,7 @@ class HistoryHighlightsDataAdaptorTests: XCTestCase {
 
         XCTAssertEqual(historyManager.getHighlightsDataCallCount, 2)
     }
-    
+
     func testDelegateMemoryLeak() {
         let delegate = MockHistoryHighlightsDelegate()
         let deletionUtility = MockHistoryDeletionProtocol()
@@ -124,7 +124,7 @@ class HistoryHighlightsDataAdaptorTests: XCTestCase {
             tabManager: MockTabManager(),
             notificationCenter: notificationCenter,
             deletionUtility: deletionUtility)
-        
+
         subject.delegate = delegate
         trackForMemoryLeaks(subject)
     }

--- a/Tests/ClientTests/Frontend/Home/HistoryHighlights/HistoryHighlightsDataAdaptorTests.swift
+++ b/Tests/ClientTests/Frontend/Home/HistoryHighlights/HistoryHighlightsDataAdaptorTests.swift
@@ -113,4 +113,19 @@ class HistoryHighlightsDataAdaptorTests: XCTestCase {
 
         XCTAssertEqual(historyManager.getHighlightsDataCallCount, 2)
     }
+    
+    func testDelegateMemoryLeak() {
+        let delegate = MockHistoryHighlightsDelegate()
+        let deletionUtility = MockHistoryDeletionProtocol()
+
+        let subject = HistoryHighlightsDataAdaptorImplementation(
+            historyManager: historyManager,
+            profile: MockProfile(),
+            tabManager: MockTabManager(),
+            notificationCenter: notificationCenter,
+            deletionUtility: deletionUtility)
+        
+        subject.delegate = delegate
+        trackForMemoryLeaks(subject)
+    }
 }

--- a/Tests/ClientTests/Frontend/Home/HistoryHighlights/MockHistoryHighlightsDataAdaptor.swift
+++ b/Tests/ClientTests/Frontend/Home/HistoryHighlights/MockHistoryHighlightsDataAdaptor.swift
@@ -6,7 +6,7 @@
 
 class MockHistoryHighlightsDataAdaptor: HistoryHighlightsDataAdaptor {
     var mockHistoryItems = [HighlightItem]()
-    var delegate: HistoryHighlightsDelegate?
+    weak var delegate: HistoryHighlightsDelegate?
     var deleteCallCount = 0
 
     func getHistoryHightlights() -> [HighlightItem] {


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5905)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13443)

### Description
- Made MockHistoryHighlightsDataAdaptor's delegate weak
- Added memory leak unit test for HistoryHighlightsDataAdaptorImplementation

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
