### PR TITLE
Bugfix MTE-773 [v113] Update L10n Snapshot tests

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/L10nSnapshotTests.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/L10nSnapshotTests.xcscheme
@@ -24,8 +24,8 @@
    </BuildAction>
    <TestAction
       buildConfiguration = "Fennec"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       shouldUseLaunchSchemeArgsEnv = "YES"
       systemAttachmentLifetime = "keepAlways">
       <Testables>
@@ -61,8 +61,8 @@
    </TestAction>
    <LaunchAction
       buildConfiguration = "Fennec"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
@@ -166,7 +166,6 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
         app.cells["Settings.TrackingProtectionOption.BlockListStrict"].tap()
 
         snapshot("TrackingProtectionStrictWarning-01")
-        app.alerts.buttons.firstMatch.tap()
 
         // Website without blocked elements
         navigator.openURL(loremIpsumURL)

--- a/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
@@ -116,8 +116,8 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         // by Face ID..." is present when the Firefox app is run after the
         // simulator has been erased.
         waitForNoExistence(app.navigationBars["settings"])
-        if app.buttons["Continue"].exists {
-            app.buttons["Continue"].tap()
+        if app.otherElements.buttons["Continue"].exists {
+            app.otherElements.buttons["Continue"].tap()
         }
 
         let passcodeInput = springboard.secureTextFields.firstMatch

--- a/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
@@ -111,11 +111,15 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         app.cells["Search"].swipeUp()
         waitForExistence(app.cells["Logins"], timeout: 15)
         app.cells["Logins"].tap()
-        
-        if (springboard.buttons["Continue"].exists) {
-            springboard.buttons["Continue"].tap()
+
+        // First time only: The message "Your passwords are now protected
+        // by Face ID..." is present when the Firefox app is run after the
+        // simulator has been erased.
+        waitForNoExistence(app.navigationBars["settings"])
+        if app.navigationBars["Passwords"].exists {
+            app.buttons["Continue"].tap()
         }
-            
+
         let passcodeInput = springboard.secureTextFields.firstMatch
         waitForExistence(passcodeInput, timeout: 20)
         passcodeInput.tap()

--- a/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
@@ -116,7 +116,7 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         // by Face ID..." is present when the Firefox app is run after the
         // simulator has been erased.
         waitForNoExistence(app.navigationBars["settings"])
-        if app.navigationBars["Passwords"].exists {
+        if app.buttons["Continue"].exists {
             app.buttons["Continue"].tap()
         }
 

--- a/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
@@ -111,10 +111,11 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         app.cells["Search"].swipeUp()
         waitForExistence(app.cells["Logins"], timeout: 15)
         app.cells["Logins"].tap()
-
-        waitForExistence(app.navigationBars.buttons.firstMatch, timeout: 15)
-        app.otherElements.buttons.element(boundBy: 2).tap()
-
+        
+        if (springboard.buttons["Continue"].exists) {
+            springboard.buttons["Continue"].tap()
+        }
+            
         let passcodeInput = springboard.secureTextFields.firstMatch
         waitForExistence(passcodeInput, timeout: 20)
         passcodeInput.tap()

--- a/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
@@ -115,10 +115,9 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         // First time only: The message "Your passwords are now protected
         // by Face ID..." is present when the Firefox app is run after the
         // simulator has been erased.
-        waitForNoExistence(app.navigationBars["settings"])
-        if app.otherElements.buttons["Continue"].exists {
-            app.otherElements.buttons["Continue"].tap()
-        }
+        waitForExistence(app.navigationBars.element(boundBy: 0), timeout: 3)
+        waitForExistence(app.otherElements.buttons.element(boundBy: 2))
+        app.otherElements.buttons.element(boundBy: 2).tap()
 
         let passcodeInput = springboard.secureTextFields.firstMatch
         waitForExistence(passcodeInput, timeout: 20)

--- a/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
@@ -122,6 +122,7 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         let passcodeInput = springboard.secureTextFields.firstMatch
         waitForExistence(passcodeInput, timeout: 20)
         passcodeInput.tap()
+        sleep(1)
         passcodeInput.typeText("foo\n")
 
         waitForExistence(app.tables["Login List"], timeout: 10)
@@ -129,10 +130,13 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         waitForExistence(app.tables["Add Credential"], timeout: 10)
         snapshot("CreateLogin")
         app.tables["Add Credential"].cells.element(boundBy: 0).tap()
+        sleep(1)
         app.keyboards.keys.element(boundBy: 3).tap()
         app.tables["Add Credential"].cells.element(boundBy: 1).tap()
+        sleep(1)
         app.keyboards.keys.element(boundBy: 3).tap()
         app.tables["Add Credential"].cells.element(boundBy: 2).tap()
+        sleep(1)
         app.keyboards.keys.element(boundBy: 3).tap()
         app.navigationBars["Client.AddCredentialView"].buttons.element(boundBy: 1).tap()
 

--- a/l10n-screenshots.sh
+++ b/l10n-screenshots.sh
@@ -39,10 +39,11 @@ for lang in $LOCALES; do
     echo "$(date) Snapshotting $lang"
     mkdir "l10n-screenshots/$lang"
     fastlane snapshot --project Client.xcodeproj --scheme L10nSnapshotTests \
+        --number_of_retries 0 \
         --skip_open_summary \
         --xcargs "-maximum-parallel-testing-workers 2" \
         --derived_data_path l10n-screenshots-dd \
-        --ios_version "16.0" \
+        --ios_version "16.1" \
         --erase_simulator --localize_simulator \
         --devices "iPhone 14" --languages "$lang" \
         --output_directory "l10n-screenshots/$lang" \


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-773)

### Description
Some L10n snapshot tests have been failing because of UI updates. In particular, `testETPperSite` and `testLoginDetails` have been failing.

This PR addresses the (minor) changes in the interactions on tracking protection and authentication.

The changes have been tested using this command:
```
xcodebuild test -target Client -scheme L10nSnapshotTests -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.1'
```

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
