### PR TITLE
Bugfix [v113] Swiftlint orphaned doc comment rule in a file

### DIFF
--- a/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
+++ b/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
@@ -183,7 +183,7 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
         _ surface: MessageSurfaceId,
         with feature: Messaging
     ) -> [GleanPlumbMessage] {
-        /// All these are non-expired, well formed, and descending priority messages for a requested surface.
+        // All these are non-expired, well formed, and descending priority messages for a requested surface.
         let messages = feature.messages.compactMap { key, messageData -> GleanPlumbMessage? in
             guard let message = self.createMessage(messageId: key,
                                                    message: messageData,
@@ -212,7 +212,7 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
         message: MessageData,
         lookupTables: Messaging
     ) -> GleanPlumbMessage? {
-        /// Guard against a message with a blank `text` property.
+        // Guard against a message with a blank `text` property.
         guard !message.text.isEmpty else { return nil }
 
         // Ascertain a Message's style, to know priority and max impressions.


### PR DESCRIPTION
### Description
No issue number, just fixing swiftlint warnings for orphaned doc comment in two places.
Won't run BR for this.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [X] Documentation / comments for complex code and public methods
