### PR TITLE
Localize [v113] Properly localize Zoom Level percentage

### DIFF
--- a/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -760,7 +760,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     private func getZoomSection() -> [PhotonRowActions] {
         var section = [PhotonRowActions]()
         guard let tab = selectedTab else { return section }
-        let zoomLevel = String(format: "%.0f%%", tab.pageZoom * 100.0)
+        let zoomLevel = NumberFormatter.localizedString(from: NSNumber(value: tab.pageZoom), number: .percent)
         let title = String(format: .AppMenu.ZoomPageTitle, zoomLevel)
         let zoomAction = SingleActionViewModel(title: title) { _ in
             self.delegate?.showZoomPage(tab: tab)

--- a/Client/Frontend/Browser/ZoomPageBar.swift
+++ b/Client/Frontend/Browser/ZoomPageBar.swift
@@ -128,7 +128,7 @@ class ZoomPageBar: UIView {
     }
 
     private func updateZoomLabel() {
-        zoomLevel.text = String(format: "%.0f%%", tab.pageZoom * 100.0)
+        zoomLevel.text = NumberFormatter.localizedString(from: NSNumber(value: tab.pageZoom), number: .percent)
         gestureRecognizer.isEnabled = !(tab.pageZoom == 1.0)
     }
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

### Description
Fixes an issue brought up in mozilla-l10n/firefoxios-l10n#186

Percentage shown in de_DE:
![image](https://user-images.githubusercontent.com/650804/227377531-9e02e4b5-10a6-4014-84e8-cb9f00664156.png)


### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
