### PR TITLE
Bugfix FXIOS-6050 [v113] Don’t launch UITests in debug mode

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Fennec_Enterprise_XCUITests.xcscheme
@@ -168,8 +168,8 @@
    </BuildAction>
    <TestAction
       buildConfiguration = "Fennec"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       shouldUseLaunchSchemeArgsEnv = "NO"
       language = "en"
       region = "US">


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6050)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13706)

### Description
It seems enabling the debugger from the scheme was causing this issue. I was previously able to reproduce the issue one in every 4 or 5 tests but now I have been running the tests non stop for over a half an hour and I haven't been able to reproduce 🤞 

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
