### PR TITLE
Added FXIOS-5754 [v113] Create new tab manager

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -396,6 +396,7 @@
 		5A70EF1D295E3C3500790249 /* TestSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A70EF1C295E3C3500790249 /* TestSetup.swift */; };
 		5A70EF1F295E3DFC00790249 /* UnitTestAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A70EF1E295E3DFC00790249 /* UnitTestAppDelegate.swift */; };
 		5A70EF21295E3E0B00790249 /* UnitTestSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A70EF20295E3E0B00790249 /* UnitTestSceneDelegate.swift */; };
+		5A8017E029CE15D90047120D /* TabManagerImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8017DF29CE15D90047120D /* TabManagerImplementation.swift */; };
 		5A871488292EA1440039A5BD /* Fuzi in Frameworks */ = {isa = PBXBuildFile; productRef = 5A871487292EA1440039A5BD /* Fuzi */; };
 		5A87148A292EA1520039A5BD /* Fuzi in Frameworks */ = {isa = PBXBuildFile; productRef = 5A871489292EA1520039A5BD /* Fuzi */; };
 		5A87148C292EA1640039A5BD /* Fuzi in Frameworks */ = {isa = PBXBuildFile; productRef = 5A87148B292EA1640039A5BD /* Fuzi */; };
@@ -3158,6 +3159,7 @@
 		5A70EF1C295E3C3500790249 /* TestSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSetup.swift; sourceTree = "<group>"; };
 		5A70EF1E295E3DFC00790249 /* UnitTestAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitTestAppDelegate.swift; sourceTree = "<group>"; };
 		5A70EF20295E3E0B00790249 /* UnitTestSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitTestSceneDelegate.swift; sourceTree = "<group>"; };
+		5A8017DF29CE15D90047120D /* TabManagerImplementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerImplementation.swift; sourceTree = "<group>"; };
 		5A8E7B6E29B8E5E500BF060F /* UIButton+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIButton+Extensions.swift"; sourceTree = "<group>"; };
 		5A9A09D128AFD51900B6F51E /* MockHomepageDataModelDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHomepageDataModelDelegate.swift; sourceTree = "<group>"; };
 		5A9A09D328B01D8700B6F51E /* MockTelemetryWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTelemetryWrapper.swift; sourceTree = "<group>"; };
@@ -6715,6 +6717,7 @@
 				C82CDD45233E8996002E2743 /* Tab+ChangeUserAgent.swift */,
 				D3968F241A38FE8500CEFD3B /* TabManager.swift */,
 				6ACB550B28633860007A6ABD /* TabManagerNavDelegate.swift */,
+				5A8017DF29CE15D90047120D /* TabManagerImplementation.swift */,
 			);
 			path = TabManagement;
 			sourceTree = "<group>";
@@ -10932,6 +10935,7 @@
 				9636D92E27F9E5D900771F5E /* GleanPlumbMessage.swift in Sources */,
 				8D8251811F4DE67F00780643 /* AdvancedAccountSettingViewController.swift in Sources */,
 				C869912E28917688007ACC5C /* WallpaperDataService.swift in Sources */,
+				5A8017E029CE15D90047120D /* TabManagerImplementation.swift in Sources */,
 				E633E2DA1C21EAF8001FFF6C /* LoginDetailViewController.swift in Sources */,
 				8A9AC46B276D11280047F5B0 /* PocketViewModel.swift in Sources */,
 				8A7653BF28A2C92600924ABF /* PocketStandardCellViewModel.swift in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -17,7 +17,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         localName: "profile",
         syncDelegate: UIApplication.shared.syncDelegate
     )
-    lazy var tabManager: TabManager = LegacyTabManager(
+    lazy var tabManager: TabManager = TabManagerImplementation(
         profile: profile,
         imageStore: DiskImageStore(
             files: profile.files,

--- a/Client/TabManagement/TabManagerImplementation.swift
+++ b/Client/TabManagement/TabManagerImplementation.swift
@@ -1,0 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+// This class subclasses the legacy tab manager temporarily so we can
+// gradually migrate to the new system
+class TabManagerImplementation: LegacyTabManager {}

--- a/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
+++ b/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
@@ -17,7 +17,7 @@ class DependencyHelperMock {
         )
         AppContainer.shared.register(service: profile)
 
-        let tabManager: TabManager = LegacyTabManager(
+        let tabManager: TabManager = TabManagerImplementation(
             profile: profile,
             imageStore: DiskImageStore(
                 files: profile.files,

--- a/Tests/ClientTests/Frontend/Browser/TabManagement/TabManagerTests.swift
+++ b/Tests/ClientTests/Frontend/Browser/TabManagement/TabManagerTests.swift
@@ -96,7 +96,7 @@ open class MockTabManagerDelegate: TabManagerDelegate {
     }
 }
 
-class TabManagerTests: XCTestCase {
+class LegacyTabManagerTests: XCTestCase {
     let didRemove = MethodSpy(functionName: "tabManager(_:didRemoveTab:isRestoring:)")
     let didAdd = MethodSpy(functionName: "tabManager(_:didAddTab:placeNextToParentTab:isRestoring:)")
     let didSelect = MethodSpy(functionName: spyDidSelectedTabChange)
@@ -680,7 +680,7 @@ class TabManagerTests: XCTestCase {
 }
 
 // MARK: - Helper methods
-private extension TabManagerTests {
+private extension LegacyTabManagerTests {
     func removeTabAndAssert(tab: Tab, completion: @escaping () -> Void) {
         let expectation = self.expectation(description: "Tab is removed")
         manager.removeTab(tab) {

--- a/Tests/ClientTests/Frontend/Browser/TabManagement/TabManagerTests.swift
+++ b/Tests/ClientTests/Frontend/Browser/TabManagement/TabManagerTests.swift
@@ -303,11 +303,13 @@ class LegacyTabManagerTests: XCTestCase {
         let tab = manager.addTab()
         manager.selectTab(tab)
         manager.selectTab(manager.addTab())
-        manager.selectTab(manager.addTab(isPrivate: true))
 
         manager.willSwitchTabMode(leavingPBM: false)
+        manager.selectTab(manager.addTab(isPrivate: true))
         XCTAssertEqual(manager.privateTabs.count, 1, "There should be 1 private tab")
+
         manager.willSwitchTabMode(leavingPBM: true)
+        manager.selectTab(tab)
         XCTAssertEqual(manager.privateTabs.count, 0, "There should be 0 private tab")
 
         removeTabAndAssert(tab: tab) {


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5754)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13220)

### Description
I ended up taking a slightly different approach for this than discussed which is why the PR is so small but I'd like feedback on this approach so opening it anyway.

Instead of duplicating the old tab manager and possibly running into the scenarios where additions need to be updated in both I have instead subclassed the old tab manager from the new one. The feature flag can live in the new one and anytime and interface is refactored the flag can either call super for the function or do the new thing instead. Eventually the super class can be removed and hopefully deleted.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
