### PR TITLE
Bugfix FXIOS-6069 [v113] Copy URL toast on TabTray is shown behind the toolbar

### DIFF
--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -47,6 +47,7 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate, Themeable {
     var contextualHintViewController: ContextualHintViewController
     var themeManager: ThemeManager
     var themeObserver: NSObjectProtocol?
+    var toolbarHeight: CGFloat = 0
 
     // This is an optional variable used if we wish to focus a tab that is not the
     // currently selected tab. This allows us to force the scroll behaviour to move
@@ -521,7 +522,8 @@ extension GridTabViewController: TabPeekDelegate {
     func tabPeekDidCopyUrl() {
         SimpleToast().showAlertWithText(.AppMenu.AppMenuCopyURLConfirmMessage,
                                         bottomContainer: view,
-                                        theme: themeManager.currentTheme)
+                                        theme: themeManager.currentTheme,
+                                        bottomConstraintPadding: -toolbarHeight)
     }
 }
 
@@ -602,6 +604,10 @@ extension GridTabViewController {
                              accessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCancelButton)
         controller.popoverPresentationController?.barButtonItem = sender
         present(controller, animated: true, completion: nil)
+    }
+
+    func setToolbarHeight(height: CGFloat) {
+        toolbarHeight = height
     }
 }
 

--- a/Client/Frontend/Browser/SimpleToast.swift
+++ b/Client/Frontend/Browser/SimpleToast.swift
@@ -15,13 +15,14 @@ struct SimpleToast: ThemeApplicable {
 
     func showAlertWithText(_ text: String,
                            bottomContainer: UIView,
-                           theme: Theme) {
+                           theme: Theme,
+                           bottomConstraintPadding: CGFloat = 0) {
         toastLabel.text = text
         bottomContainer.addSubview(toastLabel)
         NSLayoutConstraint.activate([
             toastLabel.widthAnchor.constraint(equalTo: bottomContainer.widthAnchor),
             toastLabel.leadingAnchor.constraint(equalTo: bottomContainer.leadingAnchor),
-            toastLabel.bottomAnchor.constraint(equalTo: bottomContainer.bottomAnchor),
+            toastLabel.bottomAnchor.constraint(equalTo: bottomContainer.bottomAnchor, constant: bottomConstraintPadding),
             toastLabel.heightAnchor.constraint(equalToConstant: Toast.UX.toastHeight),
         ])
         applyTheme(theme: theme)

--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -17,6 +17,7 @@ enum TabTrayViewAction {
 protocol TabTrayViewDelegate: UIViewController {
     func didTogglePrivateMode(_ togglePrivateModeOn: Bool)
     func performToolbarAction(_ action: TabTrayViewAction, sender: UIBarButtonItem)
+    func setToolbarHeight(height: CGFloat)
 }
 // swiftlint:enable class_delegate_protocol
 
@@ -227,6 +228,11 @@ class TabTrayViewController: UIViewController, Themeable {
         viewModel.layout = shouldUseiPadSetup() ? .regular : .compact
 
         updateLayout()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        viewModel.tabTrayView.setToolbarHeight(height: view.safeAreaInsets.bottom)
     }
 
     private func viewSetup() {


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6069)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13742)

### Description
Add bottom constraint value to push the toast over views

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
