### PR TITLE
Bugfix FXIOS-6025 [v113] Fix bookmark creation crash

### DIFF
--- a/Client/Frontend/Library/Bookmarks/BookmarkDetailPanel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarkDetailPanel.swift
@@ -113,7 +113,6 @@ class BookmarkDetailPanel: SiteTableViewController {
 
         if bookmarkNodeType == .bookmark {
             self.bookmarkItemOrFolderTitle = ""
-            self.bookmarkItemURL = ""
 
             self.title = .BookmarksNewBookmark
         } else if bookmarkNodeType == .folder {

--- a/Client/Frontend/Library/Bookmarks/BookmarkDetailPanel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarkDetailPanel.swift
@@ -63,6 +63,10 @@ class BookmarkDetailPanel: SiteTableViewController {
     // along with their indentation depth.
     var bookmarkFolders: [(folder: BookmarkFolderData, indent: Int)] = []
 
+    // When `BookmarkDetailPanel` is not presented from toast, the save button is disabled.
+    // When fields are valid, updatePanelState updates Toolbar appropriaetly.
+    var updatePanelState: ((LibraryPanelSubState) -> Void)?
+
     private var maxIndentationLevel: Int {
         return Int(floor((view.frame.width - BookmarkDetailPanelUX.MinIndentedContentWidth) / BookmarkDetailPanelUX.IndentationWidth))
     }
@@ -104,7 +108,7 @@ class BookmarkDetailPanel: SiteTableViewController {
         }
     }
 
-    convenience init(profile: Profile, withNewBookmarkNodeType bookmarkNodeType: BookmarkNodeType, parentBookmarkFolder: FxBookmarkNode) {
+    convenience init(profile: Profile, withNewBookmarkNodeType bookmarkNodeType: BookmarkNodeType, parentBookmarkFolder: FxBookmarkNode, updatePanelState: ((LibraryPanelSubState) -> Void)? = nil) {
         self.init(profile: profile, bookmarkNodeGUID: nil, bookmarkNodeType: bookmarkNodeType, parentBookmarkFolder: parentBookmarkFolder)
 
         if bookmarkNodeType == .bookmark {
@@ -117,6 +121,8 @@ class BookmarkDetailPanel: SiteTableViewController {
 
             self.title = .BookmarksNewFolder
         }
+
+        self.updatePanelState = updatePanelState
     }
 
     private init(profile: Profile, bookmarkNodeGUID: GUID?, bookmarkNodeType: BookmarkNodeType, parentBookmarkFolder: FxBookmarkNode, presentedFromToast fromToast: Bool = false, bookmarkItemURL: String? = nil) {
@@ -226,8 +232,12 @@ class BookmarkDetailPanel: SiteTableViewController {
     func updateSaveButton() {
         guard bookmarkNodeType == .bookmark else { return }
 
+        navigationItem.rightBarButtonItem?.isEnabled = isBookmarkItemURLValid()
+    }
+
+    private func isBookmarkItemURLValid() -> Bool {
         let url = URL(string: bookmarkItemURL ?? "")
-        navigationItem.rightBarButtonItem?.isEnabled = url?.schemeIsValid == true && url?.host != nil
+        return url?.schemeIsValid == true && url?.host != nil
     }
 
     // MARK: - Button Actions
@@ -427,6 +437,14 @@ class BookmarkDetailPanel: SiteTableViewController {
         let header = view as? SiteTableViewHeader
         header?.showBorder(for: .top, section != 0)
     }
+
+    private func toggleSaveButton() {
+        if let title = bookmarkItemOrFolderTitle?.trimmingCharacters(in: .whitespacesAndNewlines), !title.isEmpty && isBookmarkItemURLValid() {
+            self.updatePanelState?(.itemEditMode)
+        } else {
+            self.updatePanelState?(.itemEditModeInvalidField)
+        }
+    }
 }
 
 extension BookmarkDetailPanel: TextFieldTableViewCellDelegate {
@@ -441,6 +459,10 @@ extension BookmarkDetailPanel: TextFieldTableViewCellDelegate {
             updateSaveButton()
         default:
             break
+        }
+
+        if !isPresentedFromToast {
+            toggleSaveButton()
         }
     }
 }

--- a/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
@@ -276,6 +276,7 @@ class BookmarksPanel: SiteTableViewController,
     private func indexPathIsValid(_ indexPath: IndexPath) -> Bool {
         return indexPath.section < numberOfSections(in: tableView)
         && indexPath.row < tableView(tableView, numberOfRowsInSection: indexPath.section)
+        && indexPath.row >= 0
         && viewModel.bookmarkFolderGUID != BookmarkRoots.MobileFolderGUID
     }
 

--- a/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
@@ -147,10 +147,13 @@ class BookmarksPanel: SiteTableViewController,
                                      tapHandler: { _ in
             guard let bookmarkFolder = self.viewModel.bookmarkFolder else { return }
 
-            self.updatePanelState(newState: .bookmarks(state: .itemEditMode))
+            self.updatePanelState(newState: .bookmarks(state: .itemEditModeInvalidField))
             let detailController = BookmarkDetailPanel(profile: self.profile,
                                                        withNewBookmarkNodeType: .bookmark,
-                                                       parentBookmarkFolder: bookmarkFolder)
+                                                       parentBookmarkFolder: bookmarkFolder) { state in
+                self.updatePanelState(newState: .bookmarks(state: state))
+                self.sendPanelChangeNotification()
+            }
             self.navigationController?.pushViewController(detailController, animated: true)
         }).items
     }
@@ -563,6 +566,9 @@ extension BookmarksPanel {
             presentInFolderActions()
 
         case .itemEditMode:
+            updatePanelState(newState: .bookmarks(state: .inFolderEditMode))
+
+        case .itemEditModeInvalidField:
             updatePanelState(newState: .bookmarks(state: .inFolderEditMode))
 
         default:

--- a/Client/Frontend/Library/LibraryViewController/LibraryPanelViewState.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryPanelViewState.swift
@@ -46,6 +46,7 @@ enum LibraryPanelSubState {
     case inFolder
     case inFolderEditMode
     case itemEditMode
+    case itemEditModeInvalidField
     case search
 
     // The following two functions enable checking that substate moves are legal.

--- a/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -250,7 +250,7 @@ class LibraryViewController: UIViewController, Themeable {
              .history(state: .inFolder):
             topLeftButton.image = UIImage.templateImageNamed(ImageIdentifiers.menuGoBack)?.imageFlippedForRightToLeftLayoutDirection()
             navigationItem.leftBarButtonItem = topLeftButton
-        case .bookmarks(state: .itemEditMode):
+        case .bookmarks(state: .itemEditMode), .bookmarks(state: .itemEditModeInvalidField):
             topLeftButton.image = UIImage.templateImageNamed("nav-stop")
             navigationItem.leftBarButtonItem = topLeftButton
         default:
@@ -265,9 +265,15 @@ class LibraryViewController: UIViewController, Themeable {
         case .bookmarks(state: .itemEditMode):
             topRightButton.title = .SettingsAddCustomEngineSaveButtonText
             navigationItem.rightBarButtonItem = topRightButton
+            navigationItem.rightBarButtonItem?.isEnabled = true
+        case .bookmarks(state: .itemEditModeInvalidField):
+            topRightButton.title = .SettingsAddCustomEngineSaveButtonText
+            navigationItem.rightBarButtonItem = topRightButton
+            navigationItem.rightBarButtonItem?.isEnabled = false 
         default:
             topRightButton.title = String.AppSettingsDone
             navigationItem.rightBarButtonItem = topRightButton
+            navigationItem.rightBarButtonItem?.isEnabled = true
         }
     }
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6025)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13673)

### Description
- Added functionality that disables/enables the save button when creating a bookmark. If the fields are invalid save is disabled.
- Added logic to ensure indexPath.row is nonnegative.

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
