### PR TITLE
Refactor MTE-812 [v113] Modify Beta deploy trigger

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1447,7 +1447,7 @@ trigger_map:
 - push_branch: epic-branch/*
   pipeline: pipeline_multiple_shards
 - push_branch: release/v112
-  workflow: SPM_Deploy_Prod_Beta
+  pipeline: pipeline_multiple_shards
 - pull_request_target_branch: main
   pipeline: pipeline_multiple_shards
 - pull_request_target_branch: epic-branch/*


### PR DESCRIPTION
After the conversation in the mobile rapid release, this PR address a bigger change of having beta builds scheduled instead of on push events to the branch. 

- Using this trigger, we will have a regular build + tests when there is a push in a release branch
- Beta builds will be scheduled 3 times a week
- Beta builds can still be triggered if needed via Bitrise UI
![Screenshot 2023-03-28 at 16 24 15](https://user-images.githubusercontent.com/1897507/228269936-b4de8355-728b-4497-8217-1a7efa0e77e5.png)

@jevans-mozilla @rvandermeulen @DonalMe double checking with you here to have 👍 to the change
