### PR TITLE
Add FXIOS-6085 [v113] Add trigger for research surface

### DIFF
--- a/nimbus-features/messagingFeature.yaml
+++ b/nimbus-features/messagingFeature.yaml
@@ -56,6 +56,8 @@ features:
             AFTER_THREE_LAUNCHES_THIS_WEEK: app_cycle.foreground|eventSum('Weeks', 1, 0) >= 3
             USER_RECENTLY_INSTALLED:  days_since_install < 7
             USER_RECENTLY_UPDATED:    days_since_update < 7 && days_since_install != days_since_update
+            USER_INSTALLED_YESTERDAY:  days_since_install >= 1
+            USER_UPDATED_YESTERDAY:    days_since_update >= 1 && days_since_install != days_since_update
             USER_TIER_ONE_COUNTRY:    ('US' in locale || 'GB' in locale || 'CA' in locale || 'DE' in locale || 'FR' in locale)
             USER_EN_SPEAKER:          "'en' in locale"
             USER_DE_SPEAKER:          "'de' in locale"

--- a/nimbus-features/messagingFeature.yaml
+++ b/nimbus-features/messagingFeature.yaml
@@ -52,8 +52,8 @@ features:
           # Nimbus team.
           triggers:
             NOT_INSTALLED_TODAY:      days_since_install > 0
-            NOT_LAUNCHED_YESTERDAY:   app_cycle.foreground|eventLastSeen('Days', 1) > 1
-            AFTER_THREE_LAUNCHES_THIS_WEEK: app_cycle.foreground|eventSum('Weeks', 1, 0) >= 3
+            NOT_LAUNCHED_YESTERDAY:   "'app_cycle.foreground'|eventLastSeen('Days', 1) > 1"
+            AFTER_THREE_LAUNCHES_THIS_WEEK: "'app_cycle.foreground'|eventSum('Weeks', 1, 0) >= 3"
             USER_RECENTLY_INSTALLED:  days_since_install < 7
             USER_RECENTLY_UPDATED:    days_since_update < 7 && days_since_install != days_since_update
             MORE_THAN_24H_SINCE_INSTALLED_OR_UPDATED: days_since_update >= 1

--- a/nimbus-features/messagingFeature.yaml
+++ b/nimbus-features/messagingFeature.yaml
@@ -56,8 +56,7 @@ features:
             AFTER_THREE_LAUNCHES_THIS_WEEK: app_cycle.foreground|eventSum('Weeks', 1, 0) >= 3
             USER_RECENTLY_INSTALLED:  days_since_install < 7
             USER_RECENTLY_UPDATED:    days_since_update < 7 && days_since_install != days_since_update
-            USER_INSTALLED_YESTERDAY:  days_since_install >= 1
-            USER_UPDATED_YESTERDAY:    days_since_update >= 1 && days_since_install != days_since_update
+            USER_INSTALLED_OR_UPDATED_YESTERDAY: days_since_install >= 1 || days_since_update >= 1
             USER_TIER_ONE_COUNTRY:    ('US' in locale || 'GB' in locale || 'CA' in locale || 'DE' in locale || 'FR' in locale)
             USER_EN_SPEAKER:          "'en' in locale"
             USER_DE_SPEAKER:          "'de' in locale"

--- a/nimbus-features/messagingFeature.yaml
+++ b/nimbus-features/messagingFeature.yaml
@@ -57,7 +57,7 @@ features:
             USER_RECENTLY_INSTALLED:  days_since_install < 7
             USER_RECENTLY_UPDATED:    days_since_update < 7 && days_since_install != days_since_update
             MORE_THAN_24H_SINCE_INSTALLED_OR_UPDATED: days_since_update >= 1
-            APP_USED_SINCE_INSTALL_OR_UPDATE: app_cycle.foreground|eventSum('Days', days_since_update, 0) > 1
+            APP_USED_SINCE_INSTALL_OR_UPDATE: "'app_cycle.foreground'|eventSum('Days', days_since_update, 0) > 1"
             USER_TIER_ONE_COUNTRY:    ('US' in locale || 'GB' in locale || 'CA' in locale || 'DE' in locale || 'FR' in locale)
             USER_EN_SPEAKER:          "'en' in locale"
             USER_DE_SPEAKER:          "'de' in locale"

--- a/nimbus-features/messagingFeature.yaml
+++ b/nimbus-features/messagingFeature.yaml
@@ -57,6 +57,7 @@ features:
             USER_RECENTLY_INSTALLED:  days_since_install < 7
             USER_RECENTLY_UPDATED:    days_since_update < 7 && days_since_install != days_since_update
             USER_INSTALLED_OR_UPDATED_YESTERDAY: days_since_install >= 1 || days_since_update >= 1
+            APP_USED_SINCE_INSTALL_OR_UPDATE: app_cycle.foreground|eventSum('Days', days_since_install, 0) >= 1 || app_cycle.foreground|eventSum('Days', days_since_update, 0) >= 1
             USER_TIER_ONE_COUNTRY:    ('US' in locale || 'GB' in locale || 'CA' in locale || 'DE' in locale || 'FR' in locale)
             USER_EN_SPEAKER:          "'en' in locale"
             USER_DE_SPEAKER:          "'de' in locale"

--- a/nimbus-features/messagingFeature.yaml
+++ b/nimbus-features/messagingFeature.yaml
@@ -56,8 +56,8 @@ features:
             AFTER_THREE_LAUNCHES_THIS_WEEK: app_cycle.foreground|eventSum('Weeks', 1, 0) >= 3
             USER_RECENTLY_INSTALLED:  days_since_install < 7
             USER_RECENTLY_UPDATED:    days_since_update < 7 && days_since_install != days_since_update
-            USER_INSTALLED_OR_UPDATED_YESTERDAY: days_since_install >= 1 || days_since_update >= 1
-            APP_USED_SINCE_INSTALL_OR_UPDATE: app_cycle.foreground|eventSum('Days', days_since_install, 0) >= 1 || app_cycle.foreground|eventSum('Days', days_since_update, 0) >= 1
+            USER_INSTALLED_OR_UPDATED_YESTERDAY: days_since_update >= 1
+            APP_USED_SINCE_INSTALL_OR_UPDATE: app_cycle.foreground|eventSum('Days', days_since_update, 0) > 1
             USER_TIER_ONE_COUNTRY:    ('US' in locale || 'GB' in locale || 'CA' in locale || 'DE' in locale || 'FR' in locale)
             USER_EN_SPEAKER:          "'en' in locale"
             USER_DE_SPEAKER:          "'de' in locale"

--- a/nimbus-features/messagingFeature.yaml
+++ b/nimbus-features/messagingFeature.yaml
@@ -56,7 +56,7 @@ features:
             AFTER_THREE_LAUNCHES_THIS_WEEK: app_cycle.foreground|eventSum('Weeks', 1, 0) >= 3
             USER_RECENTLY_INSTALLED:  days_since_install < 7
             USER_RECENTLY_UPDATED:    days_since_update < 7 && days_since_install != days_since_update
-            USER_INSTALLED_OR_UPDATED_YESTERDAY: days_since_update >= 1
+            MORE_THAN_24H_SINCE_INSTALLED_OR_UPDATED: days_since_update >= 1
             APP_USED_SINCE_INSTALL_OR_UPDATE: app_cycle.foreground|eventSum('Days', days_since_update, 0) > 1
             USER_TIER_ONE_COUNTRY:    ('US' in locale || 'GB' in locale || 'CA' in locale || 'DE' in locale || 'FR' in locale)
             USER_EN_SPEAKER:          "'en' in locale"


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6085)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13769)

### Description
This adds two triggers to messaging:

- App used since install or update
- App installed or updated yesterday (24h)

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
~- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)~
~- [ ] Unit tests written and passing~
~- [ ] Documentation / comments for complex code and public methods~
