### PR TITLE
Refactor FXIOS-5637 [v113] Attentive Mode fixes to main

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		2137785F297F3B1B00D01309 /* DownloadsPanelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2137785E297F3B1B00D01309 /* DownloadsPanelViewModel.swift */; };
 		2137786129802B7000D01309 /* DownloadsPanelViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2137786029802B7000D01309 /* DownloadsPanelViewModelTests.swift */; };
 		213778632980448C00D01309 /* DownloadFileFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213778622980448C00D01309 /* DownloadFileFetcher.swift */; };
+		2137786529832C8900D01309 /* OverlayModeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2137786429832C8900D01309 /* OverlayModeManager.swift */; };
 		213B67A627CE682B000542F5 /* StartAtHomeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213B67A527CE682B000542F5 /* StartAtHomeHelper.swift */; };
 		213B67A827CE721E000542F5 /* StartAtHomeHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213B67A727CE721E000542F5 /* StartAtHomeHelperTests.swift */; };
 		21534904288201E300FADB4D /* GleanPlumbMessageManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215349022881FA3C00FADB4D /* GleanPlumbMessageManagerTests.swift */; };
@@ -103,6 +104,7 @@
 		21A7C45028353D0E0071D996 /* OnboardingCardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A7C44F28353D0E0071D996 /* OnboardingCardViewController.swift */; };
 		21B2844A28464FF0003EA521 /* OnboardingCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21B2844928464FF0003EA521 /* OnboardingCardViewModel.swift */; };
 		21B337BB29B67E4100E4F806 /* BrowserViewControllerWebViewDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21B337BA29B67E4100E4F806 /* BrowserViewControllerWebViewDelegateTests.swift */; };
+		21B41A1D298B187A008BC0A2 /* MockOverlayModeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21B41A1B298B1876008BC0A2 /* MockOverlayModeManager.swift */; };
 		21D7B60628077CA5003F7E94 /* LibraryViewController+ToolbarActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7B60528077CA5003F7E94 /* LibraryViewController+ToolbarActions.swift */; };
 		21E78A7028F9A8C500F8D687 /* MockUIDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E78A6F28F9A8C500F8D687 /* MockUIDevice.swift */; };
 		21E78A7228F9A93100F8D687 /* UIDeviceInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E78A7128F9A93100F8D687 /* UIDeviceInterface.swift */; };
@@ -1912,6 +1914,7 @@
 		2137785E297F3B1B00D01309 /* DownloadsPanelViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadsPanelViewModel.swift; sourceTree = "<group>"; };
 		2137786029802B7000D01309 /* DownloadsPanelViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadsPanelViewModelTests.swift; sourceTree = "<group>"; };
 		213778622980448C00D01309 /* DownloadFileFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadFileFetcher.swift; sourceTree = "<group>"; };
+		2137786429832C8900D01309 /* OverlayModeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayModeManager.swift; sourceTree = "<group>"; };
 		213B67A527CE682B000542F5 /* StartAtHomeHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartAtHomeHelper.swift; sourceTree = "<group>"; };
 		213B67A727CE721E000542F5 /* StartAtHomeHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartAtHomeHelperTests.swift; sourceTree = "<group>"; };
 		215349022881FA3C00FADB4D /* GleanPlumbMessageManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanPlumbMessageManagerTests.swift; sourceTree = "<group>"; };
@@ -1937,6 +1940,7 @@
 		21A7C44F28353D0E0071D996 /* OnboardingCardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCardViewController.swift; sourceTree = "<group>"; };
 		21B2844928464FF0003EA521 /* OnboardingCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCardViewModel.swift; sourceTree = "<group>"; };
 		21B337BA29B67E4100E4F806 /* BrowserViewControllerWebViewDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserViewControllerWebViewDelegateTests.swift; sourceTree = "<group>"; };
+		21B41A1B298B1876008BC0A2 /* MockOverlayModeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOverlayModeManager.swift; sourceTree = "<group>"; };
 		21D7B60528077CA5003F7E94 /* LibraryViewController+ToolbarActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LibraryViewController+ToolbarActions.swift"; sourceTree = "<group>"; };
 		21DD4778B3C11A24D552AB34 /* lo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lo; path = lo.lproj/Localizable.strings; sourceTree = "<group>"; };
 		21E78A6F28F9A8C500F8D687 /* MockUIDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockUIDevice.swift; sourceTree = "<group>"; };
@@ -6972,6 +6976,7 @@
 				8AD40FC627BADC3400672675 /* ToolbarTextField.swift */,
 				0BF0DB931A8545800039F300 /* URLBarView.swift */,
 				8AD40FCE27BADC6A00672675 /* URLTextField.swift */,
+				2137786429832C8900D01309 /* OverlayModeManager.swift */,
 			);
 			path = "Toolbar+URLBar";
 			sourceTree = "<group>";
@@ -7615,6 +7620,7 @@
 				965C3C95293431FC006499ED /* MockLaunchSessionProvider.swift */,
 				5AB4237B28A1947A003BC40C /* MockNotificationCenter.swift */,
 				E18259E229B2A51B00E6BE76 /* MockNotificationManager.swift */,
+				21B41A1B298B1876008BC0A2 /* MockOverlayModeManager.swift */,
 				8A7653C328A2E68B00924ABF /* MockPocketAPI.swift */,
 				281B2BE91ADF4D90002917DC /* MockProfile.swift */,
 				8A2366F928A302E500846D1B /* MockSponsoredPocketAPI.swift */,
@@ -11077,6 +11083,7 @@
 				8A8629E2288096C40096DDB1 /* BookmarksFolderCell.swift in Sources */,
 				DAE6DF1B29AD78DA0094BD1B /* BrowserViewController+ZoomPage.swift in Sources */,
 				8AB8574A27D97CE90075C173 /* HomePanelDelegate.swift in Sources */,
+				2137786529832C8900D01309 /* OverlayModeManager.swift in Sources */,
 				3B39EDCB1E16E1AA00EF029F /* CustomSearchViewController.swift in Sources */,
 				C8B0F5F7283B7CCE007AE65D /* PocketFeedStory.swift in Sources */,
 				96A562A027D6D0E80045144A /* ContileProvider.swift in Sources */,
@@ -11314,6 +11321,7 @@
 				965C3C9829343445006499ED /* MockAppSessionManager.swift in Sources */,
 				8AE1E1DB27B1C1320024C45E /* SearchBarSettingsViewModelTests.swift in Sources */,
 				CA24B53924ABFE250093848C /* LoginsListSelectionHelperTests.swift in Sources */,
+				21B41A1D298B187A008BC0A2 /* MockOverlayModeManager.swift in Sources */,
 				2FDB10931A9FBEC5006CF312 /* PrefsTests.swift in Sources */,
 				5A9A09D228AFD51900B6F51E /* MockHomepageDataModelDelegate.swift in Sources */,
 				D525DFB325FBE5E000B18763 /* TabTests.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		217AEF76284666D4004EED37 /* IntroViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217AEF75284666D4004EED37 /* IntroViewModelTests.swift */; };
 		217AEF7828480844004EED37 /* ResizableButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217AEF7728480844004EED37 /* ResizableButton.swift */; };
 		2197DF8A287624BF00215624 /* LibraryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2197DF89287624BF00215624 /* LibraryViewModelTests.swift */; };
+		21A1C3C72996AFF800181B7C /* OverlayModeManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A1C3C62996AFF800181B7C /* OverlayModeManagerTests.swift */; };
 		21A43CDD291461C700B1206D /* ReaderModeFontTypeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A43CDC291461C700B1206D /* ReaderModeFontTypeButton.swift */; };
 		21A7C44E283539170071D996 /* IntroViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A7C44D283539170071D996 /* IntroViewModel.swift */; };
 		21A7C45028353D0E0071D996 /* OnboardingCardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A7C44F28353D0E0071D996 /* OnboardingCardViewController.swift */; };
@@ -1935,6 +1936,7 @@
 		2194437EA9B44A00EDC037FA /* gu-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "gu-IN"; path = "gu-IN.lproj/FindInPage.strings"; sourceTree = "<group>"; };
 		2197DF89287624BF00215624 /* LibraryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryViewModelTests.swift; sourceTree = "<group>"; };
 		219F41288625C09DD40F008C /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
+		21A1C3C62996AFF800181B7C /* OverlayModeManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayModeManagerTests.swift; sourceTree = "<group>"; };
 		21A43CDC291461C700B1206D /* ReaderModeFontTypeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeFontTypeButton.swift; sourceTree = "<group>"; };
 		21A7C44D283539170071D996 /* IntroViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroViewModel.swift; sourceTree = "<group>"; };
 		21A7C44F28353D0E0071D996 /* OnboardingCardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCardViewController.swift; sourceTree = "<group>"; };
@@ -8752,6 +8754,7 @@
 				39C137962655798A003DC662 /* NimbusIntegrationTests.swift */,
 				E1312FCF29D23775008DDA85 /* NotificationSurface */,
 				21371FA128A6C4A200BC3F37 /* OnboardingCardViewModelTests.swift */,
+				21A1C3C62996AFF800181B7C /* OverlayModeManagerTests.swift */,
 				2FDB10921A9FBEC5006CF312 /* PrefsTests.swift */,
 				0BA896491A250E6500C1010C /* ProfileTest.swift */,
 				8AF0CFF427A0B0ED00C1A4A2 /* QuickActionsTests.swift */,
@@ -11243,6 +11246,7 @@
 				5A9A09D828B2E8F000B6F51E /* MockHistoryDeletionProtocol.swift in Sources */,
 				E18259E329B2A51B00E6BE76 /* MockNotificationManager.swift in Sources */,
 				96A5F736298D8EDF00234E5F /* MockSearchEngineProvider.swift in Sources */,
+				21A1C3C72996AFF800181B7C /* OverlayModeManagerTests.swift in Sources */,
 				6A3E5D8A283831D1001E706E /* DownloadQueueTests.swift in Sources */,
 				8AE80BB62891AEA100BC12EA /* MockDispatchGroup.swift in Sources */,
 				8AA6ADB52742B567004EEE23 /* TelemetryWrapperTests.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -63,9 +63,12 @@ class BrowserViewController: UIViewController {
     var urlFromAnotherApp: UrlToOpenModel?
     var isCrashAlertShowing: Bool = false
     var currentMiddleButtonState: MiddleButtonState?
-    fileprivate var customSearchBarButton: UIBarButtonItem?
+    private var customSearchBarButton: UIBarButtonItem?
     var openedUrlFromExternalSource = false
     var passBookHelper: OpenPassBookHelper?
+    // TODO: Remove at FXIOS-5639 Feature flag like to use during the refactoring
+    private var shouldUseOverlayManager = false
+    private var overlayManager: OverlayModeManager?
 
     var surveySurfaceManager: SurveySurfaceManager?
     var contextHintVC: ContextualHintViewController
@@ -470,6 +473,10 @@ class BrowserViewController: UIViewController {
 
         // Awesomebar Location Telemetry
         SearchBarSettingsViewModel.recordLocationTelemetry(for: isBottomSearchBar ? .bottom : .top)
+
+        if shouldUseOverlayManager {
+            overlayManager = DefaultOverlayModeManager(urlBarView: urlBar)
+        }
     }
 
     private func setupNotifications() {
@@ -973,7 +980,8 @@ class BrowserViewController: UIViewController {
         let homepageViewController = HomepageViewController(
             profile: profile,
             tabManager: tabManager,
-            urlBar: urlBar)
+            urlBar: urlBar,
+            overlayManager: overlayManager)
         homepageViewController.homePanelDelegate = self
         homepageViewController.libraryPanelDelegate = self
         homepageViewController.sendToDeviceDelegate = self
@@ -1043,6 +1051,8 @@ class BrowserViewController: UIViewController {
     }
 
     private func enterOverlayMode() {
+        guard !shouldUseOverlayManager else { return }
+
         // Delay enterOverlay mode after dismissableView is dismiss
         if let viewcontroller = presentedViewController as? OnViewDismissable {
             viewcontroller.onViewDismissed = { [weak self] in
@@ -1060,6 +1070,8 @@ class BrowserViewController: UIViewController {
     }
 
     private func leaveOverlayMode(didCancel cancel: Bool) {
+        guard !shouldUseOverlayManager else { return }
+
         urlBar.leaveOverlayMode(didCancel: cancel)
     }
 
@@ -2153,6 +2165,8 @@ extension BrowserViewController: TabManagerDelegate {
 
         updateInContentHomePanel(selected?.url as URL?, focusUrlBar: true)
 
+        // TODO: Remove this block was added to fix https://mozilla-hub.atlassian.net/browse/FXIOS-4018
+        // but will be handled in the refactoring
         if let tab = selected, NewTabAccessors.getNewTabPage(self.profile.prefs) == .blankPage {
             if tab.url == nil, !tab.isRestoring {
                 if tabManager.didChangedPanelSelection && !tabManager.didAddNewTab {
@@ -2172,6 +2186,7 @@ extension BrowserViewController: TabManagerDelegate {
         // If we are restoring tabs then we update the count once at the end
         tabManager.didAddNewTab = true
         if !isRestoring {
+            // TODO: Call to manager enterOverlayMode here
             updateTabCountUsingTabManager(tabManager)
         }
         tab.tabDelegate = self

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -216,8 +216,11 @@ class BrowserViewController: UIViewController {
         applyTheme()
     }
 
-    // TODO: FXIOS-5639 Remove delegate keyboard
-    @objc func didTapUndoCloseAllTabToast(notification: Notification) { }
+    /// If user manually opens the keyboard and presses undo, the app switches to the last
+    /// open tab, and because of that we need to leave overlay state
+    @objc func didTapUndoCloseAllTabToast(notification: Notification) {
+        overlayManager.switchTab(shouldCancelLoading: true)
+    }
 
     @objc
     func openTabNotification(notification: Notification) {
@@ -1140,7 +1143,7 @@ class BrowserViewController: UIViewController {
 
     func finishEditingAndSubmit(_ url: URL, visitType: VisitType, forTab tab: Tab) {
         urlBar.currentURL = url
-        overlayManager.finishEdition(shouldCancelLoading: false)
+        overlayManager.finishEditing(shouldCancelLoading: false)
 
         if let nav = tab.loadRequest(URLRequest(url: url)) {
             self.recordNavigationInTab(tab, navigation: nav, visitType: visitType)
@@ -1213,7 +1216,7 @@ class BrowserViewController: UIViewController {
 
     override func accessibilityPerformEscape() -> Bool {
         if overlayManager.inOverlayMode {
-            overlayManager.finishEdition(shouldCancelLoading: true)
+            overlayManager.finishEditing(shouldCancelLoading: true)
             return true
         } else if let selectedTab = tabManager.selectedTab, selectedTab.canGoBack {
             selectedTab.goBack()
@@ -2638,11 +2641,9 @@ extension BrowserViewController: TopTabsDelegate {
 
     func topTabsDidPressNewTab(_ isPrivate: Bool) {
         openBlankNewTab(focusLocationField: false, isPrivate: isPrivate)
-        overlayManager.openNewTab(nil, url: nil)
+        overlayManager.openNewTab(url: nil,
+                                  newTabSettings: NewTabAccessors.getNewTabPage(profile.prefs))
     }
-
-    // TODO: FXIOS-5639 Remove from protocol if it was used for keyboard handling
-    func topTabsDidTogglePrivateMode() { }
 
     func topTabsDidChangeTab() {
         // Only for iPad leave overlay mode on tab change

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -954,6 +954,9 @@ class BrowserViewController: UIViewController {
         homepageViewController?.view.layer.removeAllAnimations()
         view.setNeedsUpdateConstraints()
 
+        // Make sure reload button is hidden on homepage
+        urlBar.locationView.reloadButton.reloadButtonState = .disabled
+
         // Return early if the home page is already showing
         guard homepageViewController?.view.alpha != 1 else { return }
 
@@ -971,9 +974,6 @@ class BrowserViewController: UIViewController {
                 UIAccessibility.post(notification: UIAccessibility.Notification.screenChanged, argument: nil)
                 self.homepageViewController?.homepageDidAppear()
             })
-
-        // Make sure reload button is hidden on homepage
-        urlBar.locationView.reloadButton.reloadButtonState = .disabled
     }
 
     /// Once the homepage is created, browserViewController keeps a reference to it, never setting it to nil during

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -151,6 +151,10 @@ class BrowserViewController: UIViewController {
     var themeManager: ThemeManager
     var logger: Logger
 
+    var newTabSettings: NewTabPage {
+        return NewTabAccessors.getNewTabPage(profile.prefs)
+    }
+
     @available(iOS 13.4, *)
     func keyboardPressesHandler() -> KeyboardPressesHandler {
         guard let keyboardPressesHandlerValue = keyboardPressesHandlerValue as? KeyboardPressesHandler else {
@@ -2642,7 +2646,7 @@ extension BrowserViewController: TopTabsDelegate {
     func topTabsDidPressNewTab(_ isPrivate: Bool) {
         openBlankNewTab(focusLocationField: false, isPrivate: isPrivate)
         overlayManager.openNewTab(url: nil,
-                                  newTabSettings: NewTabAccessors.getNewTabPage(profile.prefs))
+                                  newTabSettings: newTabSettings)
     }
 
     func topTabsDidChangeTab() {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1938,7 +1938,6 @@ extension BrowserViewController: HomePanelDelegate {
     }
 
     func homePanelDidRequestToOpenInNewTab(_ url: URL, isPrivate: Bool, selectNewTab: Bool = false) {
-        leaveOverlayMode(didCancel: false)
         let tab = tabManager.addTab(URLRequest(url: url), afterTab: tabManager.selectedTab, isPrivate: isPrivate)
         // Select new tab automatically if needed
         guard !selectNewTab else {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -66,9 +66,7 @@ class BrowserViewController: UIViewController {
     private var customSearchBarButton: UIBarButtonItem?
     var openedUrlFromExternalSource = false
     var passBookHelper: OpenPassBookHelper?
-    // TODO: Remove at FXIOS-5639 Feature flag like to use during the refactoring
-    private var shouldUseOverlayManager = false
-    private var overlayManager: OverlayModeManager?
+    var overlayManager: OverlayModeManager
 
     var surveySurfaceManager: SurveySurfaceManager?
     var contextHintVC: ContextualHintViewController
@@ -178,6 +176,7 @@ class BrowserViewController: UIViewController {
         self.downloadQueue = downloadQueue
         self.logger = logger
 
+        self.overlayManager = DefaultOverlayModeManager()
         let contextViewModel = ContextualHintViewModel(forHintType: .toolbarLocation,
                                                        with: profile)
         self.contextHintVC = ContextualHintViewController(with: contextViewModel)
@@ -217,10 +216,8 @@ class BrowserViewController: UIViewController {
         applyTheme()
     }
 
-    @objc
-    func didTapUndoCloseAllTabToast(notification: Notification) {
-        leaveOverlayMode(didCancel: true)
-    }
+    // TODO: FXIOS-5639 Remove delegate keyboard
+    @objc func didTapUndoCloseAllTabToast(notification: Notification) { }
 
     @objc
     func openTabNotification(notification: Notification) {
@@ -425,31 +422,7 @@ class BrowserViewController: UIViewController {
         setupNotifications()
         addSubviews()
 
-        // UIAccessibilityCustomAction subclass holding an AccessibleAction instance does not work,
-        // thus unable to generate AccessibleActions and UIAccessibilityCustomActions "on-demand" and need
-        // to make them "persistent" e.g. by being stored in BVC
-        pasteGoAction = AccessibleAction(name: .PasteAndGoTitle, handler: { () -> Bool in
-            if let pasteboardContents = UIPasteboard.general.string {
-                self.urlBar(self.urlBar, didSubmitText: pasteboardContents)
-                return true
-            }
-            return false
-        })
-        pasteAction = AccessibleAction(name: .PasteTitle, handler: { () -> Bool in
-            if let pasteboardContents = UIPasteboard.general.string {
-                // Enter overlay mode and make the search controller appear.
-                self.urlBar.enterOverlayMode(pasteboardContents, pasted: true, search: true)
-
-                return true
-            }
-            return false
-        })
-        copyAddressAction = AccessibleAction(name: .CopyAddressTitle, handler: { () -> Bool in
-            if let url = self.tabManager.selectedTab?.canonicalURL?.displayURL ?? self.urlBar.currentURL {
-                UIPasteboard.general.url = url
-            }
-            return true
-        })
+        setupAccessibleActions()
 
         clipboardBarDisplayHandler = ClipboardBarDisplayHandler(prefs: profile.prefs, tabManager: tabManager)
         clipboardBarDisplayHandler?.delegate = self
@@ -474,9 +447,35 @@ class BrowserViewController: UIViewController {
         // Awesomebar Location Telemetry
         SearchBarSettingsViewModel.recordLocationTelemetry(for: isBottomSearchBar ? .bottom : .top)
 
-        if shouldUseOverlayManager {
-            overlayManager = DefaultOverlayModeManager(urlBarView: urlBar)
-        }
+        overlayManager.setURLBar(urlBarView: urlBar)
+    }
+
+    private func setupAccessibleActions() {
+        // UIAccessibilityCustomAction subclass holding an AccessibleAction instance does not work,
+        // thus unable to generate AccessibleActions and UIAccessibilityCustomActions "on-demand" and need
+        // to make them "persistent" e.g. by being stored in BVC
+        pasteGoAction = AccessibleAction(name: .PasteAndGoTitle, handler: { () -> Bool in
+            if let pasteboardContents = UIPasteboard.general.string {
+                self.urlBar(self.urlBar, didSubmitText: pasteboardContents)
+                return true
+            }
+            return false
+        })
+        pasteAction = AccessibleAction(name: .PasteTitle, handler: { () -> Bool in
+            if let pasteboardContents = UIPasteboard.general.string {
+                // Enter overlay mode and make the search controller appear.
+                self.overlayManager.openSearch(with: pasteboardContents)
+
+                return true
+            }
+            return false
+        })
+        copyAddressAction = AccessibleAction(name: .CopyAddressTitle, handler: { () -> Bool in
+            if let url = self.tabManager.selectedTab?.canonicalURL?.displayURL ?? self.urlBar.currentURL {
+                UIPasteboard.general.url = url
+            }
+            return true
+        })
     }
 
     private func setupNotifications() {
@@ -603,8 +602,8 @@ class BrowserViewController: UIViewController {
             withArrowDirection: isBottomSearchBar ? .down : .up,
             andDelegate: self,
             presentedUsing: { self.presentContextualHint() },
-            withActionBeforeAppearing: { self.homePanelDidPresentContextualHintOf(type: .toolbarLocation) },
-            andActionForButton: { self.homePanelDidRequestToOpenSettings(at: .customizeToolbar) })
+            andActionForButton: { self.homePanelDidRequestToOpenSettings(at: .customizeToolbar) },
+            overlayState: overlayManager)
     }
 
     private func presentContextualHint() {
@@ -980,7 +979,6 @@ class BrowserViewController: UIViewController {
         let homepageViewController = HomepageViewController(
             profile: profile,
             tabManager: tabManager,
-            urlBar: urlBar,
             overlayManager: overlayManager)
         homepageViewController.homePanelDelegate = self
         homepageViewController.libraryPanelDelegate = self
@@ -1037,8 +1035,6 @@ class BrowserViewController: UIViewController {
 
             if userHasPressedHomeButton {
                 userHasPressedHomeButton = false
-            } else if focusUrlBar && !contextHintVC.shouldPresentHint() {
-                enterOverlayMode()
             }
         } else if !url.absoluteString.hasPrefix("\(InternalURL.baseUrl)/\(SessionRestoreHandler.path)") {
             hideHomepage()
@@ -1048,31 +1044,6 @@ class BrowserViewController: UIViewController {
         if UIDevice.current.userInterfaceIdiom == .pad {
             topTabsViewController?.refreshTabs()
         }
-    }
-
-    private func enterOverlayMode() {
-        guard !shouldUseOverlayManager else { return }
-
-        // Delay enterOverlay mode after dismissableView is dismiss
-        if let viewcontroller = presentedViewController as? OnViewDismissable {
-            viewcontroller.onViewDismissed = { [weak self] in
-                let shouldEnterOverlay = self?.tabManager.selectedTab?.url.flatMap { InternalURL($0)?.isAboutHomeURL } ?? false
-                if shouldEnterOverlay {
-                    self?.urlBar.enterOverlayMode(nil, pasted: false, search: false)
-                }
-            }
-        } else if presentedViewController is OnboardingViewControllerProtocol {
-            // leave from overlay mode while in onboarding is displayed on iPad
-            leaveOverlayMode(didCancel: false)
-        } else {
-            self.urlBar.enterOverlayMode(nil, pasted: false, search: false)
-        }
-    }
-
-    private func leaveOverlayMode(didCancel cancel: Bool) {
-        guard !shouldUseOverlayManager else { return }
-
-        urlBar.leaveOverlayMode(didCancel: cancel)
     }
 
     func showLibrary(panel: LibraryPanelType? = nil) {
@@ -1169,7 +1140,7 @@ class BrowserViewController: UIViewController {
 
     func finishEditingAndSubmit(_ url: URL, visitType: VisitType, forTab tab: Tab) {
         urlBar.currentURL = url
-        leaveOverlayMode(didCancel: false)
+        overlayManager.finishEdition(shouldCancelLoading: false)
 
         if let nav = tab.loadRequest(URLRequest(url: url)) {
             self.recordNavigationInTab(tab, navigation: nav, visitType: visitType)
@@ -1241,8 +1212,8 @@ class BrowserViewController: UIViewController {
     }
 
     override func accessibilityPerformEscape() -> Bool {
-        if urlBar.inOverlayMode {
-            leaveOverlayMode(didCancel: true)
+        if overlayManager.inOverlayMode {
+            overlayManager.finishEdition(shouldCancelLoading: true)
             return true
         } else if let selectedTab = tabManager.selectedTab, selectedTab.canGoBack {
             selectedTab.goBack()
@@ -1508,8 +1479,6 @@ class BrowserViewController: UIViewController {
 
         if currentViewController != self {
             _ = self.navigationController?.popViewController(animated: true)
-        } else if let urlBar = urlBar, urlBar.inOverlayMode {
-            leaveOverlayMode(didCancel: true)
         }
     }
 
@@ -1990,16 +1959,6 @@ extension BrowserViewController: HomePanelDelegate {
         showTabTray(withFocusOnUnselectedTab: tabToFocus, focusedSegment: focusedSegment)
     }
 
-    func homePanelDidPresentContextualHintOf(type: ContextualHintType) {
-        switch type {
-        case .jumpBackIn,
-                .jumpBackInSyncedTab,
-                .toolbarLocation:
-            leaveOverlayMode(didCancel: false)
-        default: break
-        }
-    }
-
     func homePanelDidRequestToOpenSettings(at settingsPage: AppSettingsDeeplinkOption) {
         showSettingsWithDeeplink(to: settingsPage)
     }
@@ -2051,7 +2010,7 @@ extension BrowserViewController: SearchViewControllerDelegate {
 
     // In searchViewController when user selects an open tabs and switch to it
     func searchViewController(_ searchViewController: SearchViewController, uuid: String) {
-        leaveOverlayMode(didCancel: true)
+        overlayManager.switchTab(shouldCancelLoading: true)
         if let tab = tabManager.getTabForUUID(uuid: uuid) {
             tabManager.selectTab(tab)
         }
@@ -2164,36 +2123,17 @@ extension BrowserViewController: TabManagerDelegate {
         }
 
         updateInContentHomePanel(selected?.url as URL?, focusUrlBar: true)
-
-        // TODO: Remove this block was added to fix https://mozilla-hub.atlassian.net/browse/FXIOS-4018
-        // but will be handled in the refactoring
-        if let tab = selected, NewTabAccessors.getNewTabPage(self.profile.prefs) == .blankPage {
-            if tab.url == nil, !tab.isRestoring {
-                if tabManager.didChangedPanelSelection && !tabManager.didAddNewTab {
-                    tabManager.didChangedPanelSelection = false
-                    leaveOverlayMode(didCancel: false)
-                } else {
-                    tabManager.didAddNewTab = false
-                    urlBar.tabLocationViewDidTapLocation(urlBar.locationView)
-                }
-            } else {
-                leaveOverlayMode(didCancel: false)
-            }
-        }
     }
 
     func tabManager(_ tabManager: TabManager, didAddTab tab: Tab, placeNextToParentTab: Bool, isRestoring: Bool) {
         // If we are restoring tabs then we update the count once at the end
-        tabManager.didAddNewTab = true
         if !isRestoring {
-            // TODO: Call to manager enterOverlayMode here
             updateTabCountUsingTabManager(tabManager)
         }
         tab.tabDelegate = self
     }
 
     func tabManager(_ tabManager: TabManager, didRemoveTab tab: Tab, isRestoring: Bool) {
-        tabManager.didChangedPanelSelection = true
         if let url = tab.lastKnownUrl, !(InternalURL(url)?.isAboutURL ?? false), !tab.isPrivate {
             profile.recentlyClosedTabs.addTab(url as URL,
                                               title: tab.lastTitle,
@@ -2204,7 +2144,6 @@ extension BrowserViewController: TabManagerDelegate {
 
     func tabManagerDidAddTabs(_ tabManager: TabManager) {
         updateTabCountUsingTabManager(tabManager)
-        tabManager.didChangedPanelSelection = true
     }
 
     func tabManagerDidRestoreTabs(_ tabManager: TabManager) {
@@ -2692,21 +2631,22 @@ extension BrowserViewController: JSPromptAlertControllerDelegate {
 
 extension BrowserViewController: TopTabsDelegate {
     func topTabsDidPressTabs() {
-        leaveOverlayMode(didCancel: true)
+        // Technically is not changing tabs but is loosing focus on urlbar
+        overlayManager.switchTab(shouldCancelLoading: true)
         self.urlBarDidPressTabs(urlBar)
     }
 
     func topTabsDidPressNewTab(_ isPrivate: Bool) {
         openBlankNewTab(focusLocationField: false, isPrivate: isPrivate)
+        overlayManager.openNewTab(nil, url: nil)
     }
 
-    func topTabsDidTogglePrivateMode() {
-        guard tabManager.selectedTab != nil else { return }
-        urlBar.leaveOverlayMode()
-    }
+    // TODO: FXIOS-5639 Remove from protocol if it was used for keyboard handling
+    func topTabsDidTogglePrivateMode() { }
 
     func topTabsDidChangeTab() {
-        leaveOverlayMode(didCancel: true)
+        // Only for iPad leave overlay mode on tab change
+        overlayManager.switchTab(shouldCancelLoading: true)
     }
 }
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
@@ -109,7 +109,7 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
 
         func action() {
             let result = tabManager.switchPrivacyMode()
-            if result == .createdNewTab, NewTabAccessors.getNewTabPage(self.profile.prefs) == .blankPage {
+            if result == .createdNewTab, self.newTabSettings == .blankPage {
                 focusLocationTextField(forTab: tabManager.selectedTab)
             }
         }
@@ -136,12 +136,13 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
 
     func getMoreTabToolbarLongPressActions() -> [PhotonRowActions] {
         let newTab = SingleActionViewModel(title: .KeyboardShortcuts.NewTab, iconString: ImageIdentifiers.newTab, iconType: .Image) { _ in
-            let shouldFocusLocationField = NewTabAccessors.getNewTabPage(self.profile.prefs) == .blankPage
+            let shouldFocusLocationField = self.newTabSettings == .blankPage
+            self.overlayManager.openNewTab(url: nil, newTabSettings: self.newTabSettings)
             self.openBlankNewTab(focusLocationField: shouldFocusLocationField, isPrivate: false)
         }.items
 
         let newPrivateTab = SingleActionViewModel(title: .KeyboardShortcuts.NewPrivateTab, iconString: ImageIdentifiers.newTab, iconType: .Image) { _ in
-            let shouldFocusLocationField = NewTabAccessors.getNewTabPage(self.profile.prefs) == .blankPage
+            let shouldFocusLocationField = self.newTabSettings == .blankPage
             self.openBlankNewTab(focusLocationField: shouldFocusLocationField, isPrivate: true)
         }.items
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -39,6 +39,7 @@ extension BrowserViewController: URLBarDelegate {
             profile: profile,
             tabToFocus: tabToFocus,
             tabManager: tabManager,
+            overlayManager: overlayManager,
             focusedSegment: focusedSegment)
 
         tabTrayViewController?.openInNewTab = { url, isPrivate in

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -192,6 +192,7 @@ extension BrowserViewController: WKUIDelegate {
                                             completion: { buttonPressed in
                         if buttonPressed {
                             self.tabManager.selectTab(tab)
+                            self.overlayManager.switchTab(shouldCancelLoading: true)
                         }
                     })
                     self.show(toast: toast)

--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -177,6 +177,7 @@ class TabTrayViewController: UIViewController, Themeable {
          profile: Profile,
          tabToFocus: Tab? = nil,
          tabManager: TabManager,
+         overlayManager: OverlayModeManager,
          focusedSegment: TabTrayViewModel.Segment? = nil,
          themeManager: ThemeManager = AppContainer.shared.resolve(),
          and notificationCenter: NotificationProtocol = NotificationCenter.default,
@@ -189,6 +190,7 @@ class TabTrayViewController: UIViewController, Themeable {
                                           profile: profile,
                                           tabToFocus: tabToFocus,
                                           tabManager: tabManager,
+                                          overlayManager: overlayManager,
                                           segmentToFocus: focusedSegment)
 
         super.init(nibName: nil, bundle: nil)
@@ -322,8 +324,6 @@ class TabTrayViewController: UIViewController, Themeable {
     }
 
     private func switchBetweenLocalPanels(withPrivateMode privateMode: Bool) {
-        viewModel.tabManager.didChangedPanelSelection = true
-        viewModel.tabManager.didAddNewTab = true
         if children.first != viewModel.tabTrayView {
             hideCurrentPanel()
             showPanel(viewModel.tabTrayView)

--- a/Client/Frontend/Browser/Tabs/TabTrayViewModel.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewModel.swift
@@ -52,6 +52,7 @@ class TabTrayViewModel {
 
     let profile: Profile
     let tabManager: TabManager
+    let overlayManager: OverlayModeManager
 
     // Tab Tray Views
     let tabTrayView: TabTrayViewDelegate
@@ -68,9 +69,11 @@ class TabTrayViewModel {
          profile: Profile,
          tabToFocus: Tab? = nil,
          tabManager: TabManager,
+         overlayManager: OverlayModeManager,
          segmentToFocus: TabTrayViewModel.Segment? = nil) {
         self.profile = profile
         self.tabManager = tabManager
+        self.overlayManager = overlayManager
 
         self.tabTrayView = GridTabViewController(tabManager: self.tabManager,
                                                  profile: profile,
@@ -100,8 +103,8 @@ extension TabTrayViewModel {
         tabTrayView.performToolbarAction(.deleteTab, sender: sender)
     }
 
-    @objc
-    func didTapAddTab(_ sender: UIBarButtonItem) {
+    @objc func didTapAddTab(_ sender: UIBarButtonItem) {
+        overlayManager.openNewTab(nil, url: nil)
         tabTrayView.performToolbarAction(.addTab, sender: sender)
     }
 

--- a/Client/Frontend/Browser/Tabs/TabTrayViewModel.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewModel.swift
@@ -104,7 +104,8 @@ extension TabTrayViewModel {
     }
 
     @objc func didTapAddTab(_ sender: UIBarButtonItem) {
-        overlayManager.openNewTab(nil, url: nil)
+        overlayManager.openNewTab(url: nil,
+                                  newTabSettings: NewTabAccessors.getNewTabPage(profile.prefs))
         tabTrayView.performToolbarAction(.addTab, sender: sender)
     }
 

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -24,7 +24,6 @@ struct TopTabsUX {
 protocol TopTabsDelegate: AnyObject {
     func topTabsDidPressTabs()
     func topTabsDidPressNewTab(_ isPrivate: Bool)
-    func topTabsDidTogglePrivateMode()
     func topTabsDidChangeTab()
 }
 
@@ -191,7 +190,6 @@ class TopTabsViewController: UIViewController, Themeable {
         topTabDisplayManager.togglePrivateMode(isOn: !topTabDisplayManager.isPrivate,
                                                createTabOnEmptyPrivateMode: true,
                                                shouldSelectMostRecentTab: true)
-        delegate?.topTabsDidTogglePrivateMode()
         self.privateModeButton.setSelected(topTabDisplayManager.isPrivate, animated: true)
     }
 

--- a/Client/Frontend/ContextualHint/ContextualHintEligibilityUtility.swift
+++ b/Client/Frontend/ContextualHint/ContextualHintEligibilityUtility.swift
@@ -12,16 +12,20 @@ protocol ContextualHintEligibilityUtilityProtocol {
 struct ContextualHintEligibilityUtility: ContextualHintEligibilityUtilityProtocol, ContextualHintPrefsKeysProvider {
     var profile: Profile
     var device: UIDeviceInterface
+    // For contextual hints shown in Homepage that can overlap with keyboard being raised by user interaction
+    private var overlayState: OverlayStateProtocol?
 
     init(with profile: Profile,
+         overlayState: OverlayStateProtocol?,
          device: UIDeviceInterface = UIDevice.current) {
         self.profile = profile
+        self.overlayState = overlayState
         self.device = device
     }
 
     /// Determine if this hint is eligible to present, outside of Nimbus flag settings.
     func canPresent(_ hintType: ContextualHintType) -> Bool {
-        guard isDeviceReady else { return false }
+        guard isDeviceReady, !isInOverlayMode else { return false }
 
         var hintTypeShouldBePresented = false
 
@@ -44,6 +48,12 @@ struct ContextualHintEligibilityUtility: ContextualHintEligibilityUtilityProtoco
     // Do not present contextual hint in landscape on iPhone
     private var isDeviceReady: Bool {
         !UIWindow.isLandscape || device.userInterfaceIdiom == .pad
+    }
+
+    private var isInOverlayMode: Bool {
+        guard overlayState != nil else { return false }
+
+        return overlayState?.inOverlayMode ?? false
     }
 
     /// If device is iPhone we present JumpBackIn and SyncTab CFRs only after Toolbar CFR has been presented

--- a/Client/Frontend/ContextualHint/ContextualHintViewController.swift
+++ b/Client/Frontend/ContextualHint/ContextualHintViewController.swift
@@ -259,7 +259,8 @@ class ContextualHintViewController: UIViewController, OnViewDismissable, Themeab
         withActionBeforeAppearing preAction: (() -> Void)? = nil,
         actionOnDismiss postAction: (() -> Void)? = nil,
         andActionForButton buttonAction: (() -> Void)? = nil,
-        andShouldStartTimerRightAway shouldStartTimer: Bool = true
+        andShouldStartTimerRightAway shouldStartTimer: Bool = true,
+        overlayState: OverlayStateProtocol? = nil
     ) {
         stopTimer()
         modalPresentationStyle = .popover
@@ -272,6 +273,7 @@ class ContextualHintViewController: UIViewController, OnViewDismissable, Themeab
         onActionTapped = buttonAction
         viewModel.presentFromTimer = presentation
         viewModel.arrowDirection = arrowDirection
+        viewModel.overlayState = overlayState
 
         setupContent()
         toggleArrowBasedConstraints()

--- a/Client/Frontend/ContextualHint/ContextualHintViewModel.swift
+++ b/Client/Frontend/ContextualHint/ContextualHintViewModel.swift
@@ -30,6 +30,7 @@ class ContextualHintViewModel: ContextualHintPrefsKeysProvider {
     private var profile: Profile
     private var hasSentTelemetryEvent = false
     var arrowDirection = UIPopoverArrowDirection.down
+    var overlayState: OverlayStateProtocol?
 
     // MARK: - Initializers
 
@@ -41,7 +42,8 @@ class ContextualHintViewModel: ContextualHintPrefsKeysProvider {
     // MARK: - Interface
 
     func shouldPresentContextualHint() -> Bool {
-        let hintEligibilityUtility = ContextualHintEligibilityUtility(with: profile)
+        let hintEligibilityUtility = ContextualHintEligibilityUtility(with: profile,
+                                                                      overlayState: overlayState)
 
         return hintEligibilityUtility.canPresent(hintType)
     }

--- a/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
@@ -67,6 +67,7 @@ class HistoryHighlightsViewModel {
     var historyItems = [HighlightItem]()
     private var profile: Profile
     private var isPrivate: Bool
+    // TODO: FXIOS-5639 Remove opening new tab should handle itself the dismissal of the keyboard
     private var urlBar: URLBarViewProtocol
     private var hasSentSectionEvent = false
     private var historyHighlightsDataAdaptor: HistoryHighlightsDataAdaptor

--- a/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
@@ -67,8 +67,6 @@ class HistoryHighlightsViewModel {
     var historyItems = [HighlightItem]()
     private var profile: Profile
     private var isPrivate: Bool
-    // TODO: FXIOS-5639 Remove opening new tab should handle itself the dismissal of the keyboard
-    private var urlBar: URLBarViewProtocol
     private var hasSentSectionEvent = false
     private var historyHighlightsDataAdaptor: HistoryHighlightsDataAdaptor
     private let dispatchQueue: DispatchQueueInterface
@@ -110,7 +108,6 @@ class HistoryHighlightsViewModel {
     // MARK: - Inits
     init(with profile: Profile,
          isPrivate: Bool,
-         urlBar: URLBarViewProtocol,
          theme: Theme,
          historyHighlightsDataAdaptor: HistoryHighlightsDataAdaptor,
          dispatchQueue: DispatchQueueInterface = DispatchQueue.main,
@@ -118,7 +115,6 @@ class HistoryHighlightsViewModel {
          wallpaperManager: WallpaperManager) {
         self.profile = profile
         self.isPrivate = isPrivate
-        self.urlBar = urlBar
         self.theme = theme
         self.dispatchQueue = dispatchQueue
         self.telemetry = telemetry
@@ -141,8 +137,6 @@ class HistoryHighlightsViewModel {
     }
 
     func switchTo(_ highlight: HighlightItem) {
-        if urlBar.inOverlayMode { urlBar.leaveOverlayMode() }
-
         onTapItem?(highlight)
         telemetry.recordEvent(category: .action,
                               method: .tap,

--- a/Client/Frontend/Home/HomePanelDelegate.swift
+++ b/Client/Frontend/Home/HomePanelDelegate.swift
@@ -11,7 +11,6 @@ protocol HomePanelDelegate: AnyObject {
     func homePanelDidRequestToOpenLibrary(panel: LibraryPanelType)
     func homePanelDidRequestToOpenTabTray(withFocusedTab tabToFocus: Tab?, focusedSegment: TabTrayViewModel.Segment?)
     func homePanelDidRequestToOpenSettings(at settingsPage: AppSettingsDeeplinkOption)
-    func homePanelDidPresentContextualHintOf(type: ContextualHintType)
 }
 
 extension HomePanelDelegate {

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -29,8 +29,10 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
 
     private var viewModel: HomepageViewModel
     private var contextMenuHelper: HomepageContextMenuHelper
-    private var tabManager: TabManager
+    private var tabManager: TabManagerProtocol
+    // TODO: FXIOS-5639 Remove urlBar direct access from homepage
     private var urlBar: URLBarViewProtocol
+    private var overlayManager: OverlayModeManager?
     private var userDefaults: UserDefaultsInterface
     private lazy var wallpaperView: WallpaperBackgroundView = .build { _ in }
     private var jumpBackInContextualHintViewController: ContextualHintViewController
@@ -64,12 +66,14 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
     init(profile: Profile,
          tabManager: TabManager,
          urlBar: URLBarViewProtocol,
+         overlayManager: OverlayModeManager?,
          userDefaults: UserDefaultsInterface = UserDefaults.standard,
          themeManager: ThemeManager = AppContainer.shared.resolve(),
          notificationCenter: NotificationProtocol = NotificationCenter.default,
          logger: Logger = DefaultLogger.shared
     ) {
         self.urlBar = urlBar
+        self.overlayManager = overlayManager
         self.tabManager = tabManager
         self.userDefaults = userDefaults
         let isPrivate = tabManager.selectedTab?.isPrivate ?? true

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -30,9 +30,7 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
     private var viewModel: HomepageViewModel
     private var contextMenuHelper: HomepageContextMenuHelper
     private var tabManager: TabManagerProtocol
-    // TODO: FXIOS-5639 Remove urlBar direct access from homepage
-    private var urlBar: URLBarViewProtocol
-    private var overlayManager: OverlayModeManager?
+    private var overlayManager: OverlayModeManager
     private var userDefaults: UserDefaultsInterface
     private lazy var wallpaperView: WallpaperBackgroundView = .build { _ in }
     private var jumpBackInContextualHintViewController: ContextualHintViewController
@@ -64,15 +62,13 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
 
     // MARK: - Initializers
     init(profile: Profile,
-         tabManager: TabManager,
-         urlBar: URLBarViewProtocol,
-         overlayManager: OverlayModeManager?,
+         tabManager: TabManagerProtocol,
+         overlayManager: OverlayModeManager,
          userDefaults: UserDefaultsInterface = UserDefaults.standard,
          themeManager: ThemeManager = AppContainer.shared.resolve(),
          notificationCenter: NotificationProtocol = NotificationCenter.default,
          logger: Logger = DefaultLogger.shared
     ) {
-        self.urlBar = urlBar
         self.overlayManager = overlayManager
         self.tabManager = tabManager
         self.userDefaults = userDefaults
@@ -80,7 +76,6 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
         self.viewModel = HomepageViewModel(profile: profile,
                                            isPrivate: isPrivate,
                                            tabManager: tabManager,
-                                           urlBar: urlBar,
                                            theme: themeManager.currentTheme)
 
         let jumpBackInContextualViewModel = ContextualHintViewModel(forHintType: .jumpBackIn,
@@ -163,17 +158,6 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
         if previousTraitCollection?.horizontalSizeClass != traitCollection.horizontalSizeClass
             || previousTraitCollection?.verticalSizeClass != traitCollection.verticalSizeClass {
             reloadOnRotation(newSize: view.frame.size)
-        }
-    }
-
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-
-        // make sure the keyboard is dismissed when wallpaper onboarding is shown
-        // Can be removed once underlying problem is solved (FXIOS-4904)
-        if let presentedViewController = presentedViewController,
-           presentedViewController.isKind(of: BottomSheetViewController.self) {
-            self.dismissKeyboard()
         }
     }
 
@@ -332,7 +316,7 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
     @objc
     private func dismissKeyboard() {
         if currentTab?.lastKnownUrl?.absoluteString.hasPrefix("internal://") ?? false {
-            urlBar.leaveOverlayMode()
+            overlayManager.finishEdition(shouldCancelLoading: false)
         }
     }
 
@@ -370,11 +354,10 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
 
     func displayWallpaperSelector() {
         let wallpaperManager = WallpaperManager(userDefaults: userDefaults)
-        guard wallpaperManager.canOnboardingBeShown(using: viewModel.profile),
+        guard !overlayManager.inOverlayMode,
+              wallpaperManager.canOnboardingBeShown(using: viewModel.profile),
               canModalBePresented
         else { return }
-
-        self.dismissKeyboard()
 
         let viewModel = WallpaperSelectorViewModel(wallpaperManager: wallpaperManager, openSettingsAction: {
             self.homePanelDidRequestToOpenSettings(at: .wallpaper)
@@ -415,8 +398,8 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
             andDelegate: self,
             presentedUsing: { self.presentContextualHint(contextualHintViewController: self.jumpBackInContextualHintViewController) },
             sourceRect: rect,
-            withActionBeforeAppearing: { self.contextualHintPresented(type: .jumpBackIn) },
-            andActionForButton: { self.openTabsSettings() })
+            andActionForButton: { self.openTabsSettings() },
+            overlayState: overlayManager)
     }
 
     private func prepareSyncedTabContextualHint(onCell cell: SyncedTabCell) {
@@ -432,7 +415,7 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
             withArrowDirection: .down,
             andDelegate: self,
             presentedUsing: { self.presentContextualHint(contextualHintViewController: self.syncTabContextualHintViewController) },
-            withActionBeforeAppearing: { self.contextualHintPresented(type: .jumpBackInSyncedTab) })
+            overlayState: overlayManager)
     }
 
     @objc
@@ -684,10 +667,6 @@ private extension HomepageViewController {
                                      method: .tap,
                                      object: .firefoxHomepage,
                                      value: .customizeHomepageButton)
-    }
-
-    func contextualHintPresented(type: ContextualHintType) {
-        homePanelDelegate?.homePanelDidPresentContextualHintOf(type: type)
     }
 
     func openTabsSettings() {

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -316,7 +316,7 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
     @objc
     private func dismissKeyboard() {
         if currentTab?.lastKnownUrl?.absoluteString.hasPrefix("internal://") ?? false {
-            overlayManager.finishEdition(shouldCancelLoading: false)
+            overlayManager.finishEditing(shouldCancelLoading: false)
         }
     }
 

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -29,7 +29,7 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
 
     private var viewModel: HomepageViewModel
     private var contextMenuHelper: HomepageContextMenuHelper
-    private var tabManager: TabManagerProtocol
+    private var tabManager: TabManager
     private var overlayManager: OverlayModeManager
     private var userDefaults: UserDefaultsInterface
     private lazy var wallpaperView: WallpaperBackgroundView = .build { _ in }
@@ -62,7 +62,7 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
 
     // MARK: - Initializers
     init(profile: Profile,
-         tabManager: TabManagerProtocol,
+         tabManager: TabManager,
          overlayManager: OverlayModeManager,
          userDefaults: UserDefaultsInterface = UserDefaults.standard,
          themeManager: ThemeManager = AppContainer.shared.resolve(),

--- a/Client/Frontend/Home/HomepageViewModel.swift
+++ b/Client/Frontend/Home/HomepageViewModel.swift
@@ -101,8 +101,7 @@ class HomepageViewModel: FeatureFlaggable {
     // MARK: - Initializers
     init(profile: Profile,
          isPrivate: Bool,
-         tabManager: TabManager,
-         urlBar: URLBarViewProtocol,
+         tabManager: TabManagerProtocol,
          nimbus: FxNimbus = FxNimbus.shared,
          isZeroSearch: Bool = false,
          theme: Theme,
@@ -125,7 +124,6 @@ class HomepageViewModel: FeatureFlaggable {
         self.jumpBackInViewModel = JumpBackInViewModel(
             profile: profile,
             isPrivate: isPrivate,
-            urlBar: urlBar,
             theme: theme,
             tabManager: tabManager,
             adaptor: jumpBackInAdaptor,
@@ -142,7 +140,6 @@ class HomepageViewModel: FeatureFlaggable {
         self.historyHighlightsViewModel = HistoryHighlightsViewModel(
             with: profile,
             isPrivate: isPrivate,
-            urlBar: urlBar,
             theme: theme,
             historyHighlightsDataAdaptor: historyDataAdaptor,
             wallpaperManager: wallpaperManager)

--- a/Client/Frontend/Home/HomepageViewModel.swift
+++ b/Client/Frontend/Home/HomepageViewModel.swift
@@ -101,7 +101,7 @@ class HomepageViewModel: FeatureFlaggable {
     // MARK: - Initializers
     init(profile: Profile,
          isPrivate: Bool,
-         tabManager: TabManagerProtocol,
+         tabManager: TabManager,
          nimbus: FxNimbus = FxNimbus.shared,
          isZeroSearch: Bool = false,
          theme: Theme,

--- a/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -22,8 +22,6 @@ class JumpBackInViewModel: FeatureFlaggable {
     var syncedTabsShowAllAction: (() -> Void)?
     var openSyncedTabAction: ((URL) -> Void)?
     var prepareContextualHint: ((SyncedTabCell) -> Void)?
-    // TODO: FXIOS-5639 Remove opening new tab should handle itself the dismissal of the keyboard
-    private var urlBar: URLBarViewProtocol
 
     weak var delegate: HomepageDataModelDelegate?
 
@@ -52,7 +50,6 @@ class JumpBackInViewModel: FeatureFlaggable {
         isZeroSearch: Bool = false,
         profile: Profile,
         isPrivate: Bool,
-        urlBar: URLBarViewProtocol,
         theme: Theme,
         tabManager: TabManager,
         adaptor: JumpBackInDataAdaptor,
@@ -61,7 +58,6 @@ class JumpBackInViewModel: FeatureFlaggable {
         self.profile = profile
         self.isZeroSearch = isZeroSearch
         self.isPrivate = isPrivate
-        self.urlBar = urlBar
         self.theme = theme
         self.tabManager = tabManager
         self.jumpBackInDataAdaptor = adaptor
@@ -69,8 +65,6 @@ class JumpBackInViewModel: FeatureFlaggable {
     }
 
     func switchTo(group: ASGroup<Tab>) {
-        if urlBar.inOverlayMode { urlBar.leaveOverlayMode() }
-
         guard let firstTab = group.groupedItems.first else { return }
 
         onTapGroup?(firstTab)
@@ -85,8 +79,6 @@ class JumpBackInViewModel: FeatureFlaggable {
     }
 
     func switchTo(tab: Tab) {
-        if urlBar.inOverlayMode { urlBar.leaveOverlayMode() }
-
         tabManager.selectTab(tab, previous: nil)
         TelemetryWrapper.recordEvent(
             category: .action,

--- a/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -22,6 +22,7 @@ class JumpBackInViewModel: FeatureFlaggable {
     var syncedTabsShowAllAction: (() -> Void)?
     var openSyncedTabAction: ((URL) -> Void)?
     var prepareContextualHint: ((SyncedTabCell) -> Void)?
+    // TODO: FXIOS-5639 Remove opening new tab should handle itself the dismissal of the keyboard
     private var urlBar: URLBarViewProtocol
 
     weak var delegate: HomepageDataModelDelegate?

--- a/Client/Frontend/Home/Wallpapers/v1/Interface/WallpaperManager.swift
+++ b/Client/Frontend/Home/Wallpapers/v1/Interface/WallpaperManager.swift
@@ -63,8 +63,9 @@ class WallpaperManager: WallpaperManagerInterface, FeatureFlaggable {
     }
 
     /// Determines whether the wallpaper onboarding can be shown
+    /// Doesn't need overlayState to check for CFR because the state was previously check
     func canOnboardingBeShown(using profile: Profile) -> Bool {
-        let cfrHintUtility = ContextualHintEligibilityUtility(with: profile)
+        let cfrHintUtility = ContextualHintEligibilityUtility(with: profile, overlayState: nil)
         let toolbarCFRShown = !cfrHintUtility.canPresent(.toolbarLocation)
         let jumpBackInCFRShown = !cfrHintUtility.canPresent(.jumpBackIn)
         let cfrsHaveBeenShown = toolbarCFRShown && jumpBackInCFRShown

--- a/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
+++ b/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
@@ -19,13 +19,13 @@ protocol OverlayModeManager: OverlayStateProtocol {
 
     /// Enter overlay mode when opening a new tab
     /// - Parameters:
-    ///   - locationText: String with initial search text
     ///   - url: Tab url to determine if is the url is homepage or nil
-    func openNewTab(_ locationText: String?, url: URL?)
+    ///   - newTabSettings: User option for new tab, if it's a custom url (homepage) the keyboard is not raised
+    func openNewTab(url: URL?, newTabSettings: NewTabPage)
 
-    /// Leave overlay mode when user finish edition, either pressing the go button, enter etc
+    /// Leave overlay mode when user finishes editing, either by pressing the go button, enter etc
     /// - Parameter shouldCancelLoading: Bool value determine if the loading animation of the current search should be canceled
-    func finishEdition(shouldCancelLoading: Bool)
+    func finishEditing(shouldCancelLoading: Bool)
 
     /// Leave overlay mode when tab change happens, like switching tabs or open a site from any homepage section
     /// - Parameter shouldCancelLoading: Bool value determine if the loading animation of the current search should be canceled
@@ -49,18 +49,30 @@ class DefaultOverlayModeManager: OverlayModeManager {
         enterOverlayMode(pasteContent, pasted: true, search: true)
     }
 
-    func openNewTab(_ locationText: String?, url: URL?) {
-        if url == nil || url?.isFxHomeUrl ?? false {
-            enterOverlayMode(locationText, pasted: false, search: true)
-        }
+    func openNewTab(url: URL?, newTabSettings: NewTabPage) {
+        guard shouldEnterOverlay(for: url, newTabSettings: newTabSettings) else { return }
+
+        enterOverlayMode(nil, pasted: false, search: true)
     }
 
-    func finishEdition(shouldCancelLoading: Bool) {
+    func finishEditing(shouldCancelLoading: Bool) {
         leaveOverlayMode(didCancel: shouldCancelLoading)
     }
 
     func switchTab(shouldCancelLoading: Bool) {
+        guard inOverlayMode else { return }
+
         leaveOverlayMode(didCancel: shouldCancelLoading)
+    }
+
+    private func shouldEnterOverlay(for url: URL?, newTabSettings: NewTabPage) -> Bool {
+        // The NewTabPage cases are weird topSites = homepage
+        // and homepage = customURL
+        switch newTabSettings {
+        case .topSites: return url?.isFxHomeUrl ?? true
+        case .blankPage: return true
+        case .homePage: return false
+        }
     }
 
     private func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool) {

--- a/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
+++ b/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
@@ -1,0 +1,45 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+protocol OverlayModeManager {
+    var inOverlayMode: Bool { get }
+    func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool)
+    func leaveOverlayMode(didCancel cancel: Bool)
+}
+
+extension OverlayModeManager {
+    func enterOverlayMode(_ locationText: String? = nil, pasted: Bool = false, search: Bool = true) {
+        enterOverlayMode(locationText, pasted: pasted, search: search)
+    }
+
+    func leaveOverlayMode(didCancel cancel: Bool = false) {
+        leaveOverlayMode(didCancel: cancel)
+    }
+}
+
+class DefaultOverlayModeManager: OverlayModeManager {
+    private var urlBarView: URLBarViewProtocol
+
+    var inOverlayMode: Bool {
+        return urlBarView.inOverlayMode
+    }
+
+    init(urlBarView: URLBarViewProtocol) {
+        self.urlBarView = urlBarView
+    }
+
+    func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool) {
+        guard !inOverlayMode else { return }
+
+        urlBarView.enterOverlayMode(locationText, pasted: pasted, search: search)
+    }
+
+    func leaveOverlayMode(didCancel cancel: Bool) {
+        guard inOverlayMode else { return }
+
+        urlBarView.leaveOverlayMode(didCancel: cancel)
+    }
+}

--- a/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
+++ b/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
@@ -4,42 +4,70 @@
 
 import Foundation
 
-protocol OverlayModeManager {
+protocol OverlayStateProtocol {
     var inOverlayMode: Bool { get }
-    func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool)
-    func leaveOverlayMode(didCancel cancel: Bool)
 }
 
-extension OverlayModeManager {
-    func enterOverlayMode(_ locationText: String? = nil, pasted: Bool = false, search: Bool = true) {
-        enterOverlayMode(locationText, pasted: pasted, search: search)
-    }
+protocol OverlayModeManager: OverlayStateProtocol {
+    /// Set URLBar which is not available when the manager is created
+    /// - Parameter urlBarView: URLBar that contains textfield which open and dismiss the keyboard
+    func setURLBar(urlBarView: URLBarViewProtocol)
 
-    func leaveOverlayMode(didCancel cancel: Bool = false) {
-        leaveOverlayMode(didCancel: cancel)
-    }
+    /// Enter overlay mode with paste content
+    /// - Parameter pasteContent: String with the content to paste on the search
+    func openSearch(with pasteContent: String)
+
+    /// Enter overlay mode when opening a new tab
+    /// - Parameters:
+    ///   - locationText: String with initial search text
+    ///   - url: Tab url to determine if is the url is homepage or nil
+    func openNewTab(_ locationText: String?, url: URL?)
+
+    /// Leave overlay mode when user finish edition, either pressing the go button, enter etc
+    /// - Parameter shouldCancelLoading: Bool value determine if the loading animation of the current search should be canceled
+    func finishEdition(shouldCancelLoading: Bool)
+
+    /// Leave overlay mode when tab change happens, like switching tabs or open a site from any homepage section
+    /// - Parameter shouldCancelLoading: Bool value determine if the loading animation of the current search should be canceled
+    func switchTab(shouldCancelLoading: Bool)
 }
 
 class DefaultOverlayModeManager: OverlayModeManager {
-    private var urlBarView: URLBarViewProtocol
+    private var urlBarView: URLBarViewProtocol?
 
     var inOverlayMode: Bool {
-        return urlBarView.inOverlayMode
+        return urlBarView?.inOverlayMode ?? false
     }
 
-    init(urlBarView: URLBarViewProtocol) {
+    init() {}
+
+    func setURLBar(urlBarView: URLBarViewProtocol) {
         self.urlBarView = urlBarView
     }
 
-    func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool) {
-        guard !inOverlayMode else { return }
-
-        urlBarView.enterOverlayMode(locationText, pasted: pasted, search: search)
+    func openSearch(with pasteContent: String) {
+        enterOverlayMode(pasteContent, pasted: true, search: true)
     }
 
-    func leaveOverlayMode(didCancel cancel: Bool) {
-        guard inOverlayMode else { return }
+    func openNewTab(_ locationText: String?, url: URL?) {
+        if url == nil || url?.isFxHomeUrl ?? false {
+            enterOverlayMode(locationText, pasted: false, search: true)
+        }
+    }
 
-        urlBarView.leaveOverlayMode(didCancel: cancel)
+    func finishEdition(shouldCancelLoading: Bool) {
+        leaveOverlayMode(didCancel: shouldCancelLoading)
+    }
+
+    func switchTab(shouldCancelLoading: Bool) {
+        leaveOverlayMode(didCancel: shouldCancelLoading)
+    }
+
+    private func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool) {
+        urlBarView?.enterOverlayMode(locationText, pasted: pasted, search: search)
+    }
+
+    private func leaveOverlayMode(didCancel cancel: Bool) {
+        urlBarView?.leaveOverlayMode(didCancel: cancel)
     }
 }

--- a/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -467,7 +467,7 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
         if !toolbarIsShowing {
             updateConstraintsIfNeeded()
         }
-        locationView.reloadButton.isHidden = hideReloadButton
+        shouldHideReloadButton(hideReloadButton)
         updateViewsForOverlayModeAndToolbarChanges()
     }
 
@@ -490,7 +490,7 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
     /// We hide reload button on iPad, but not in multitasking mode
     func updateReaderModeState(_ state: ReaderModeState, hideReloadButton: Bool) {
         locationView.readerModeState = state
-        locationView.reloadButton.isHidden = hideReloadButton
+        shouldHideReloadButton(hideReloadButton)
     }
 
     /// We hide reload button on iPad, but not in multitasking mode

--- a/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -52,6 +52,7 @@ protocol URLBarDelegate: AnyObject {
 
 protocol URLBarViewProtocol {
     var inOverlayMode: Bool { get }
+    func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool)
     func leaveOverlayMode(didCancel cancel: Bool)
 }
 

--- a/Tests/ClientTests/ContextMenuHelperTests.swift
+++ b/Tests/ClientTests/ContextMenuHelperTests.swift
@@ -30,7 +30,6 @@ class ContextMenuHelperTests: XCTestCase {
         let viewModel = HomepageViewModel(profile: profile,
                                           isPrivate: false,
                                           tabManager: MockTabManager(),
-                                          urlBar: URLBarView(profile: profile),
                                           theme: LightTheme())
         let helper = HomepageContextMenuHelper(viewModel: viewModel)
 

--- a/Tests/ClientTests/Frontend/ContextualHints/ContextualHintEligibilityUtilityTests.swift
+++ b/Tests/ClientTests/Frontend/ContextualHints/ContextualHintEligibilityUtilityTests.swift
@@ -112,7 +112,7 @@ class ContextualHintEligibilityUtilityTests: XCTestCase {
         subject = ContextualHintEligibilityUtility(with: profile,
                                                    overlayState: overlayState,
                                                    device: MockUIDevice(isIpad: true))
-        overlayState.openNewTab(nil, url: nil)
+        overlayState.openNewTab(url: nil, newTabSettings: .topSites)
         let result = subject.canPresent(.jumpBackIn)
         XCTAssertFalse(result)
     }
@@ -135,7 +135,7 @@ class ContextualHintEligibilityUtilityTests: XCTestCase {
         subject = ContextualHintEligibilityUtility(with: profile,
                                                    overlayState: overlayState,
                                                    device: MockUIDevice(isIpad: true))
-        overlayState.openNewTab(nil, url: nil)
+        overlayState.openNewTab(url: nil, newTabSettings: .topSites)
         let result = subject.canPresent(.jumpBackInSyncedTab)
         XCTAssertFalse(result)
     }

--- a/Tests/ClientTests/Frontend/Home/FirefoxHomeViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/FirefoxHomeViewModelTests.swift
@@ -32,7 +32,6 @@ class FirefoxHomeViewModelTests: XCTestCase {
         let viewModel = HomepageViewModel(profile: profile,
                                           isPrivate: false,
                                           tabManager: MockTabManager(),
-                                          urlBar: URLBarView(profile: profile),
                                           theme: LightTheme())
         XCTAssertEqual(viewModel.shownSections.count, 3)
         XCTAssertEqual(viewModel.shownSections[0], HomepageSectionType.logoHeader)

--- a/Tests/ClientTests/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModelTests.swift
@@ -13,7 +13,6 @@ class HistoryHighlightsViewModelTests: XCTestCase {
     private var dataAdaptor: MockHistoryHighlightsDataAdaptor!
     private var delegate: MockHomepageDataModelDelegate!
     private var telemetry: MockTelemetryWrapper!
-    private var urlBar: MockURLBarView!
 
     override func setUp() {
         super.setUp()
@@ -23,7 +22,6 @@ class HistoryHighlightsViewModelTests: XCTestCase {
         dataAdaptor = MockHistoryHighlightsDataAdaptor()
         delegate = MockHomepageDataModelDelegate()
         telemetry = MockTelemetryWrapper()
-        urlBar = MockURLBarView()
     }
 
     override func tearDown() {
@@ -34,7 +32,6 @@ class HistoryHighlightsViewModelTests: XCTestCase {
         subject = nil
         delegate = nil
         telemetry = nil
-        urlBar = nil
     }
 
     func testLoadNewDataIsEnabled() {
@@ -123,11 +120,9 @@ class HistoryHighlightsViewModelTests: XCTestCase {
 
     func testSwitchToWhileInOverlayMode() {
         setupSubject()
-        urlBar.inOverlayMode = true
 
         subject.switchTo(getItemWithTitle(title: "item"))
 
-        XCTAssertEqual(urlBar.leaveOverlayModeCallCount, 1)
         XCTAssertEqual(telemetry.recordEventCallCount, 1)
         XCTAssertTrue(telemetry.recordedCategories.contains(.action))
         XCTAssertTrue(telemetry.recordedMethods.contains(.tap))
@@ -234,7 +229,6 @@ class HistoryHighlightsViewModelTests: XCTestCase {
         subject = HistoryHighlightsViewModel(
             with: profile,
             isPrivate: isPrivate,
-            urlBar: urlBar,
             theme: LightTheme(),
             historyHighlightsDataAdaptor: dataAdaptor,
             dispatchQueue: MockDispatchQueue(),

--- a/Tests/ClientTests/Frontend/Home/HomepageViewControllerTests.swift
+++ b/Tests/ClientTests/Frontend/Home/HomepageViewControllerTests.swift
@@ -50,12 +50,14 @@ class HomepageViewControllerTests: XCTestCase {
     func testHomepageViewController_simpleCreation_hasNoLeaks() {
         let tabManager = LegacyTabManager(profile: profile, imageStore: nil)
         let urlBar = URLBarView(profile: profile)
+        let overlayManager = MockOverlayModeManager()
 
         FeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
 
         let firefoxHomeViewController = HomepageViewController(profile: profile,
                                                                tabManager: tabManager,
-                                                               urlBar: urlBar)
+                                                               urlBar: urlBar,
+                                                               overlayManager: overlayManager)
 
         trackForMemoryLeaks(firefoxHomeViewController)
     }

--- a/Tests/ClientTests/Frontend/Home/HomepageViewControllerTests.swift
+++ b/Tests/ClientTests/Frontend/Home/HomepageViewControllerTests.swift
@@ -51,12 +51,12 @@ class HomepageViewControllerTests: XCTestCase {
         let tabManager = LegacyTabManager(profile: profile, imageStore: nil)
         let urlBar = URLBarView(profile: profile)
         let overlayManager = MockOverlayModeManager()
+        overlayManager.setURLBar(urlBarView: urlBar)
 
         FeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
 
         let firefoxHomeViewController = HomepageViewController(profile: profile,
                                                                tabManager: tabManager,
-                                                               urlBar: urlBar,
                                                                overlayManager: overlayManager)
 
         trackForMemoryLeaks(firefoxHomeViewController)

--- a/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
@@ -13,7 +13,6 @@ import Common
 class JumpBackInViewModelTests: XCTestCase {
     var mockProfile: MockProfile!
     var mockTabManager: MockTabManager!
-    private var urlBar: MockURLBarView!
 
     var stubBrowserViewController: BrowserViewController!
     var adaptor: JumpBackInDataAdaptorMock!
@@ -31,7 +30,6 @@ class JumpBackInViewModelTests: XCTestCase {
             profile: mockProfile,
             tabManager: LegacyTabManager(profile: mockProfile, imageStore: nil)
         )
-        urlBar = MockURLBarView()
 
         FeatureFlagsManager.shared.initializeDeveloperFeatures(with: mockProfile)
     }
@@ -41,7 +39,6 @@ class JumpBackInViewModelTests: XCTestCase {
         AppContainer.shared.reset()
         adaptor = nil
         stubBrowserViewController = nil
-        urlBar = nil
         mockTabManager = nil
         mockProfile = nil
     }
@@ -58,15 +55,12 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.switchTo(group: group)
 
-        XCTAssertFalse(urlBar.inOverlayMode)
-        XCTAssertEqual(urlBar.leaveOverlayModeCallCount, 0)
         XCTAssertFalse(completionDidRun)
     }
 
     func test_switchToGroup_noGroupedItems_doNothing() {
         let subject = createSubject()
         let group = ASGroup<Tab>(searchTerm: "", groupedItems: [], timestamp: 0)
-        urlBar.inOverlayMode = true
         var completionDidRun = false
         subject.onTapGroup = { tab in
             completionDidRun = true
@@ -74,24 +68,6 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.switchTo(group: group)
 
-        XCTAssertFalse(urlBar.inOverlayMode)
-        XCTAssertEqual(urlBar.leaveOverlayModeCallCount, 1)
-        XCTAssertFalse(completionDidRun)
-    }
-
-    func test_switchToGroup_inOverlayMode_leavesOverlayMode() {
-        let subject = createSubject()
-        let group = ASGroup<Tab>(searchTerm: "", groupedItems: [], timestamp: 0)
-        urlBar.inOverlayMode = true
-        var completionDidRun = false
-        subject.onTapGroup = { tab in
-            completionDidRun = true
-        }
-
-        subject.switchTo(group: group)
-
-        XCTAssertFalse(urlBar.inOverlayMode)
-        XCTAssertEqual(urlBar.leaveOverlayModeCallCount, 1)
         XCTAssertFalse(completionDidRun)
     }
 
@@ -99,7 +75,6 @@ class JumpBackInViewModelTests: XCTestCase {
         let subject = createSubject()
         let expectedTab = createTab(profile: mockProfile)
         let group = ASGroup<Tab>(searchTerm: "", groupedItems: [expectedTab], timestamp: 0)
-        urlBar.inOverlayMode = true
         var receivedTab: Tab?
         subject.onTapGroup = { tab in
             receivedTab = tab
@@ -107,8 +82,6 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.switchTo(group: group)
 
-        XCTAssertFalse(urlBar.inOverlayMode)
-        XCTAssertEqual(urlBar.leaveOverlayModeCallCount, 1)
         XCTAssertEqual(expectedTab, receivedTab)
     }
 
@@ -117,35 +90,27 @@ class JumpBackInViewModelTests: XCTestCase {
     func test_switchToTab_notInOverlayMode_switchTabs() {
         let subject = createSubject()
         let tab = createTab(profile: mockProfile)
-        urlBar.inOverlayMode = false
 
         subject.switchTo(tab: tab)
 
-        XCTAssertFalse(urlBar.inOverlayMode)
-        XCTAssertEqual(urlBar.leaveOverlayModeCallCount, 0)
         XCTAssertFalse(mockTabManager.lastSelectedTabs.isEmpty)
     }
 
     func test_switchToTab_inOverlayMode_leaveOverlayMode() {
         let subject = createSubject()
         let tab = createTab(profile: mockProfile)
-        urlBar.inOverlayMode = true
 
         subject.switchTo(tab: tab)
 
-        XCTAssertFalse(urlBar.inOverlayMode)
-        XCTAssertEqual(urlBar.leaveOverlayModeCallCount, 1)
         XCTAssertFalse(mockTabManager.lastSelectedTabs.isEmpty)
     }
 
     func test_switchToTab_tabManagerSelectsTab() {
         let subject = createSubject()
         let tab1 = createTab(profile: mockProfile)
-        urlBar.inOverlayMode = true
 
         subject.switchTo(tab: tab1)
 
-        XCTAssertFalse(urlBar.inOverlayMode)
         guard !mockTabManager.lastSelectedTabs.isEmpty else {
             XCTFail("No tabs were selected in mock tab manager.")
             return
@@ -691,7 +656,6 @@ extension JumpBackInViewModelTests {
             isZeroSearch: false,
             profile: mockProfile,
             isPrivate: false,
-            urlBar: urlBar,
             theme: LightTheme(),
             tabManager: mockTabManager,
             adaptor: adaptor,

--- a/Tests/ClientTests/Mocks/MockOverlayModeManager.swift
+++ b/Tests/ClientTests/Mocks/MockOverlayModeManager.swift
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+@testable import Client
+
+class MockOverlayModeManager: OverlayModeManager {
+    var inOverlayMode = false
+    var leaveOverlayModeCallCount = 0
+    var enterOverlayModeCallCount = 0
+
+    func leaveOverlayMode(didCancel cancel: Bool) {
+        leaveOverlayModeCallCount += 1
+        inOverlayMode = false
+    }
+
+    func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool) {
+        enterOverlayModeCallCount += 1
+        inOverlayMode = true
+    }
+}

--- a/Tests/ClientTests/Mocks/MockOverlayModeManager.swift
+++ b/Tests/ClientTests/Mocks/MockOverlayModeManager.swift
@@ -15,14 +15,14 @@ class MockOverlayModeManager: DefaultOverlayModeManager {
         super.openSearch(with: pasteContent)
     }
 
-    override func openNewTab(_ locationText: String?, url: URL?) {
+    override func openNewTab(url: URL?, newTabSettings: NewTabPage) {
         enterOverlayModeCallCount += 1
-        super.openNewTab(locationText, url: url)
+        super.openNewTab(url: url, newTabSettings: newTabSettings)
     }
 
-    override func finishEdition(shouldCancelLoading: Bool) {
+    override func finishEditing(shouldCancelLoading: Bool) {
         leaveOverlayModeCallCount += 1
-        super.finishEdition(shouldCancelLoading: shouldCancelLoading)
+        super.finishEditing(shouldCancelLoading: shouldCancelLoading)
     }
 
     override func switchTab(shouldCancelLoading: Bool) {

--- a/Tests/ClientTests/Mocks/MockOverlayModeManager.swift
+++ b/Tests/ClientTests/Mocks/MockOverlayModeManager.swift
@@ -6,18 +6,27 @@ import XCTest
 
 @testable import Client
 
-class MockOverlayModeManager: OverlayModeManager {
-    var inOverlayMode = false
+class MockOverlayModeManager: DefaultOverlayModeManager {
     var leaveOverlayModeCallCount = 0
     var enterOverlayModeCallCount = 0
 
-    func leaveOverlayMode(didCancel cancel: Bool) {
-        leaveOverlayModeCallCount += 1
-        inOverlayMode = false
+    override func openSearch(with pasteContent: String) {
+        enterOverlayModeCallCount += 1
+        super.openSearch(with: pasteContent)
     }
 
-    func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool) {
+    override func openNewTab(_ locationText: String?, url: URL?) {
         enterOverlayModeCallCount += 1
-        inOverlayMode = true
+        super.openNewTab(locationText, url: url)
+    }
+
+    override func finishEdition(shouldCancelLoading: Bool) {
+        leaveOverlayModeCallCount += 1
+        super.finishEdition(shouldCancelLoading: shouldCancelLoading)
+    }
+
+    override func switchTab(shouldCancelLoading: Bool) {
+        leaveOverlayModeCallCount += 1
+        super.switchTab(shouldCancelLoading: shouldCancelLoading)
     }
 }

--- a/Tests/ClientTests/OverlayModeManagerTests.swift
+++ b/Tests/ClientTests/OverlayModeManagerTests.swift
@@ -13,7 +13,6 @@ class OverlayModeManagerTests: XCTestCase {
         super.setUp()
         urlBar = MockURLBarView()
         subject = MockOverlayModeManager()
-        subject.setURLBar(urlBarView: urlBar)
     }
 
     override func tearDown() {
@@ -22,47 +21,105 @@ class OverlayModeManagerTests: XCTestCase {
         subject = nil
     }
 
-    // MARK: - Test EnterOverlay for New tab
-    func testEnterOverlayMode_ForNewTabWithNilURL() {
-        subject.openNewTab(nil, url: nil)
-
-        XCTAssertTrue(subject.inOverlayMode)
+    // MARK: - Test URLBarView nil
+    func testOverlayMode_ForNilURLBar() {
+        urlBar = nil
+        subject.openSearch(with: "search")
+        XCTAssertFalse(subject.inOverlayMode)
     }
 
-    func testEnterOverlayMode_ForNewTabWithHomeURL() {
-        subject.openNewTab(nil, url: URL(string: "internal://local/about/home"))
+    // MARK: - Test EnterOverlay for New tab
+    func testEnterOverlayMode_ForNewTabHome_WithNilURL() {
+        subject.setURLBar(urlBarView: urlBar)
+        subject.openNewTab(url: nil, newTabSettings: .topSites)
 
         XCTAssertTrue(subject.inOverlayMode)
         XCTAssertEqual(subject.enterOverlayModeCallCount, 1)
     }
 
-    func testEnterOverlayMode_ForNewTabWithURL() {
-        subject.openNewTab(nil, url: URL(string: "https://test.com"))
+    func testEnterOverlayMode_ForNewTabHome_WithHomeURL() {
+        subject.setURLBar(urlBarView: urlBar)
+        subject.openNewTab(url: URL(string: "internal://local/about/home"),
+                           newTabSettings: .topSites)
+
+        XCTAssertTrue(subject.inOverlayMode)
+        XCTAssertEqual(subject.enterOverlayModeCallCount, 1)
+    }
+
+    func testEnterOverlayMode_ForNewTabHome_WithURL() {
+        subject.setURLBar(urlBarView: urlBar)
+        subject.openNewTab(url: URL(string: "https://test.com"),
+                           newTabSettings: .topSites)
 
         XCTAssertFalse(subject.inOverlayMode)
         XCTAssertEqual(subject.enterOverlayModeCallCount, 1)
     }
 
+    func testEnterOverlayMode_ForBlankPage_WithNilURL() {
+        subject.setURLBar(urlBarView: urlBar)
+        subject.openNewTab(url: nil, newTabSettings: .blankPage)
+
+        XCTAssertTrue(subject.inOverlayMode)
+        XCTAssertEqual(subject.enterOverlayModeCallCount, 1)
+    }
+
+    func testEnterOverlayMode_ForBlankPage_WithURL() {
+        subject.setURLBar(urlBarView: urlBar)
+        subject.openNewTab(url: URL(string: "https://test.com"),
+                           newTabSettings: .blankPage)
+
+        XCTAssertTrue(subject.inOverlayMode)
+        XCTAssertEqual(subject.enterOverlayModeCallCount, 1)
+    }
+
+    func testNotEnterOverlayMode_ForCustomUrl() {
+        subject.setURLBar(urlBarView: urlBar)
+        subject.openNewTab(url: URL(string: "https://test.com"),
+                           newTabSettings: .homePage)
+
+        XCTAssertFalse(subject.inOverlayMode)
+    }
+
+    func testNotEnterOverlayMode_ForCustomUrl_WithNilURL() {
+        subject.setURLBar(urlBarView: urlBar)
+        subject.openNewTab(url: nil,
+                           newTabSettings: .homePage)
+
+        XCTAssertFalse(subject.inOverlayMode)
+    }
+
     // MARK: - Test EnterOverlay for paste action
 
     func testEnterOverlayMode_ForPasteContent() {
+        subject.setURLBar(urlBarView: urlBar)
         subject.openSearch(with: "paste")
 
         XCTAssertTrue(subject.inOverlayMode)
         XCTAssertEqual(subject.enterOverlayModeCallCount, 1)
     }
 
-    // MARK: - Test EnterOverlay for finish edition
+    // MARK: - Test EnterOverlay for finish editing
 
-    func testLeaveOverlayMode_ForFinishEdition() {
-        subject.finishEdition(shouldCancelLoading: true)
+    func testLeaveOverlayMode_ForFinishEditing() {
+        subject.setURLBar(urlBarView: urlBar)
+        subject.finishEditing(shouldCancelLoading: true)
 
         XCTAssertFalse(subject.inOverlayMode)
         XCTAssertEqual(subject.leaveOverlayModeCallCount, 1)
     }
 
     // MARK: - Test EnterOverlay for Tab change
-    func testEnterOverlayMode_ForSwitchTab() {
+    func testLeaveOverlayMode_ForSwitchTab() {
+        subject.setURLBar(urlBarView: urlBar)
+        subject.switchTab(shouldCancelLoading: true)
+
+        XCTAssertFalse(subject.inOverlayMode)
+        XCTAssertEqual(subject.leaveOverlayModeCallCount, 1)
+    }
+
+    func testLeaveOverlayMode_ForSwitchTabInOverlayMode() {
+        subject.setURLBar(urlBarView: urlBar)
+        subject.openSearch(with: "")
         subject.switchTab(shouldCancelLoading: true)
 
         XCTAssertFalse(subject.inOverlayMode)

--- a/Tests/ClientTests/OverlayModeManagerTests.swift
+++ b/Tests/ClientTests/OverlayModeManagerTests.swift
@@ -1,0 +1,71 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+@testable import Client
+class OverlayModeManagerTests: XCTestCase {
+    private var urlBar: MockURLBarView!
+    private var subject: MockOverlayModeManager!
+
+    override func setUp() {
+        super.setUp()
+        urlBar = MockURLBarView()
+        subject = MockOverlayModeManager()
+        subject.setURLBar(urlBarView: urlBar)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        urlBar = nil
+        subject = nil
+    }
+
+    // MARK: - Test EnterOverlay for New tab
+    func testEnterOverlayMode_ForNewTabWithNilURL() {
+        subject.openNewTab(nil, url: nil)
+
+        XCTAssertTrue(subject.inOverlayMode)
+    }
+
+    func testEnterOverlayMode_ForNewTabWithHomeURL() {
+        subject.openNewTab(nil, url: URL(string: "internal://local/about/home"))
+
+        XCTAssertTrue(subject.inOverlayMode)
+        XCTAssertEqual(subject.enterOverlayModeCallCount, 1)
+    }
+
+    func testEnterOverlayMode_ForNewTabWithURL() {
+        subject.openNewTab(nil, url: URL(string: "https://test.com"))
+
+        XCTAssertFalse(subject.inOverlayMode)
+        XCTAssertEqual(subject.enterOverlayModeCallCount, 1)
+    }
+
+    // MARK: - Test EnterOverlay for paste action
+
+    func testEnterOverlayMode_ForPasteContent() {
+        subject.openSearch(with: "paste")
+
+        XCTAssertTrue(subject.inOverlayMode)
+        XCTAssertEqual(subject.enterOverlayModeCallCount, 1)
+    }
+
+    // MARK: - Test EnterOverlay for finish edition
+
+    func testLeaveOverlayMode_ForFinishEdition() {
+        subject.finishEdition(shouldCancelLoading: true)
+
+        XCTAssertFalse(subject.inOverlayMode)
+        XCTAssertEqual(subject.leaveOverlayModeCallCount, 1)
+    }
+
+    // MARK: - Test EnterOverlay for Tab change
+    func testEnterOverlayMode_ForSwitchTab() {
+        subject.switchTab(shouldCancelLoading: true)
+
+        XCTAssertFalse(subject.inOverlayMode)
+        XCTAssertEqual(subject.leaveOverlayModeCallCount, 1)
+    }
+}

--- a/Tests/ClientTests/TabTrayViewControllerTests.swift
+++ b/Tests/ClientTests/TabTrayViewControllerTests.swift
@@ -23,7 +23,7 @@ class TabTrayViewControllerTests: XCTestCase {
 
         DependencyHelperMock().bootstrapDependencies()
         profile = TabManagerMockProfile()
-        manager = TabManager(profile: profile, imageStore: nil)
+        manager = LegacyTabManager(profile: profile, imageStore: nil)
         urlBar = MockURLBarView()
         overlayManager = MockOverlayModeManager()
         overlayManager.setURLBar(urlBarView: urlBar)

--- a/Tests/ClientTests/TabTrayViewControllerTests.swift
+++ b/Tests/ClientTests/TabTrayViewControllerTests.swift
@@ -15,14 +15,23 @@ class TabTrayViewControllerTests: XCTestCase {
     var manager: TabManager!
     var tabTray: TabTrayViewController!
     var gridTab: GridTabViewController!
+    var overlayManager: MockOverlayModeManager!
+    var urlBar: MockURLBarView!
 
     override func setUp() {
         super.setUp()
 
         DependencyHelperMock().bootstrapDependencies()
         profile = TabManagerMockProfile()
-        manager = LegacyTabManager(profile: profile, imageStore: nil)
-        tabTray = TabTrayViewController(tabTrayDelegate: nil, profile: profile, tabToFocus: nil, tabManager: manager)
+        manager = TabManager(profile: profile, imageStore: nil)
+        urlBar = MockURLBarView()
+        overlayManager = MockOverlayModeManager()
+        overlayManager.setURLBar(urlBarView: urlBar)
+        tabTray = TabTrayViewController(tabTrayDelegate: nil,
+                                        profile: profile,
+                                        tabToFocus: nil,
+                                        tabManager: manager,
+                                        overlayManager: overlayManager)
         gridTab = GridTabViewController(tabManager: manager, profile: profile)
         manager.addDelegate(gridTab)
         FeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
@@ -34,6 +43,8 @@ class TabTrayViewControllerTests: XCTestCase {
         AppContainer.shared.reset()
         profile = nil
         manager = nil
+        urlBar = nil
+        overlayManager = nil
         tabTray = nil
         gridTab = nil
     }

--- a/Tests/XCUITests/BaseTestCase.swift
+++ b/Tests/XCUITests/BaseTestCase.swift
@@ -169,11 +169,8 @@ class BaseTestCase: XCTestCase {
         waitForExistence(app.buttons["Add to Reading List"])
         app.buttons["Add to Reading List"].tap()
     }
+
     func removeContentFromReaderView() {
-        if !iPad() {
-            waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
-            navigator.performAction(Action.CloseURLBarOpen)
-        }
         navigator.nowAt(NewTabScreen)
         navigator.goto(LibraryPanel_ReadingList)
         let savedToReadingList = app.tables["ReadingTable"].cells.staticTexts["The Book of Mozilla"]

--- a/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -223,10 +223,6 @@ class HomePageSettingsUITests: BaseTestCase {
         navigator.performAction(Action.ToggleRecentlySaved)
         navigator.performAction(Action.GoToHomePage)
         XCTAssertFalse(app.scrollViews.cells[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.recentlySaved].exists)
-        if !iPad() {
-            waitForExistence(app.buttons["urlBar-cancel"], timeout: 3)
-            navigator.performAction(Action.CloseURLBarOpen)
-        }
         navigator.nowAt(NewTabScreen)
         navigator.performAction(Action.ToggleRecentlySaved)
         navigator.nowAt(HomeSettings)
@@ -244,10 +240,6 @@ class HomePageSettingsUITests: BaseTestCase {
         navigator.nowAt(LibraryPanel_ReadingList)
         navigator.performAction(Action.CloseReadingListPanel)
         navigator.goto(NewTabScreen)
-        if !iPad() {
-            waitForExistence(app.buttons["urlBar-cancel"], timeout: 3)
-            navigator.performAction(Action.CloseURLBarOpen)
-        }
         checkRecentlySavedUpdated()
     }
 
@@ -260,10 +252,6 @@ class HomePageSettingsUITests: BaseTestCase {
         navigator.performAction(Action.ToggleRecentlyVisited)
         navigator.performAction(Action.GoToHomePage)
         XCTAssertFalse(app.scrollViews.cells[AccessibilityIdentifiers.FirefoxHomepage.HistoryHighlights.itemCell].staticTexts[urlMozillaLabel].exists)
-        if !iPad() {
-            waitForExistence(app.buttons["urlBar-cancel"], timeout: 3)
-            navigator.performAction(Action.CloseURLBarOpen)
-        }
         navigator.nowAt(NewTabScreen)
         navigator.goto(HomeSettings)
         navigator.performAction(Action.ToggleRecentlyVisited)

--- a/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -37,7 +37,6 @@ class HomePageSettingsUITests: BaseTestCase {
         super.setUp()
     }
     func testCheckHomeSettingsByDefault() {
-        navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         navigator.goto(HomeSettings)
 
@@ -70,7 +69,6 @@ class HomePageSettingsUITests: BaseTestCase {
     }
 
     func testTyping() {
-        navigator.performAction(Action.CloseURLBarOpen)
         waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.goto(HomeSettings)
@@ -99,7 +97,6 @@ class HomePageSettingsUITests: BaseTestCase {
         if processIsTranslatedStr() == m1Rosetta {
             throw XCTSkip("Copy & paste may not work on M1")
         } else {
-            navigator.performAction(Action.CloseURLBarOpen)
             navigator.nowAt(NewTabScreen)
             // Check that what's in clipboard is copied
             UIPasteboard.general.string = websiteUrl1
@@ -117,7 +114,6 @@ class HomePageSettingsUITests: BaseTestCase {
 
     func testSetFirefoxHomeAsHome() {
         // Start by setting to History since FF Home is default
-        navigator.performAction(Action.CloseURLBarOpen)
         waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.goto(HomeSettings)
@@ -138,7 +134,6 @@ class HomePageSettingsUITests: BaseTestCase {
     }
 
     func testSetCustomURLAsHome() {
-        navigator.performAction(Action.CloseURLBarOpen)
         waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.goto(HomeSettings)
@@ -159,8 +154,6 @@ class HomePageSettingsUITests: BaseTestCase {
     }
 
     func testDisableTopSitesSettingsRemovesSection() {
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
-        navigator.performAction(Action.CloseURLBarOpen)
         waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: TIMEOUT)
         navigator.nowAt(NewTabScreen)
         navigator.goto(HomeSettings)
@@ -176,8 +169,6 @@ class HomePageSettingsUITests: BaseTestCase {
     }
 
     func testChangeHomeSettingsLabel() {
-        navigator.performAction(Action.CloseURLBarOpen)
-        navigator.nowAt(NewTabScreen)
         // Go to New Tab settings and select Custom URL option
         navigator.performAction(Action.SelectHomeAsCustomURL)
         navigator.nowAt(HomeSettings)
@@ -224,7 +215,6 @@ class HomePageSettingsUITests: BaseTestCase {
 
     func testRecentlySaved() {
         // Preconditons: Create 6 bookmarks & add 1 items to reading list
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
         bookmarkPages()
         addContentToReaderView()
         navigator.performAction(Action.GoToHomePage)
@@ -262,7 +252,6 @@ class HomePageSettingsUITests: BaseTestCase {
     }
 
     func testRecentlyVisited() {
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: 3)
         navigator.openURL(websiteUrl1)
         waitUntilPageLoad()
         navigator.performAction(Action.GoToHomePage)
@@ -294,7 +283,6 @@ class HomePageSettingsUITests: BaseTestCase {
 
     func testCustomizeHomepage() {
         if !iPad() {
-            navigator.performAction(Action.CloseURLBarOpen)
             waitForExistence(app.collectionViews.firstMatch, timeout: TIMEOUT)
             app.collectionViews.firstMatch.swipeUp()
             waitForExistence(app.cells.otherElements.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.customizeHomePage], timeout: TIMEOUT)

--- a/Tests/XCUITests/JumpBackInTests.swift
+++ b/Tests/XCUITests/JumpBackInTests.swift
@@ -6,8 +6,6 @@ import XCTest
 
 class JumpBackInTests: BaseTestCase {
     func closeKeyboard() {
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
-        navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
     }

--- a/Tests/XCUITests/JumpBackInTests.swift
+++ b/Tests/XCUITests/JumpBackInTests.swift
@@ -131,7 +131,7 @@ class JumpBackInTests: BaseTestCase {
         navigator.performAction(Action.OpenNewTabFromTabTray)
         closeKeyboard()
 
-        // Amazon and Tiwtter are visible in the "Jump Back In" section
+        // Amazon and Twitter are visible in the "Jump Back In" section
         scrollDown()
         waitForExistence(app.cells["JumpBackInCell"].firstMatch)
         waitForExistence(app.cells["JumpBackInCell"].staticTexts["Amazon"])

--- a/Tests/XCUITests/NavigationTest.swift
+++ b/Tests/XCUITests/NavigationTest.swift
@@ -334,8 +334,6 @@ class NavigationTest: BaseTestCase {
 
     // Smoketest
     func testPopUpBlocker() {
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
-        navigator.performAction(Action.CloseURLBarOpen)
         // Check that it is enabled by default
         navigator.nowAt(BrowserTab)
         waitForExistence(app.buttons["TabToolbar.menuButton"], timeout: TIMEOUT)
@@ -371,8 +369,6 @@ class NavigationTest: BaseTestCase {
 
     // Smoketest
     func testSSL() {
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
-        navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
 
         navigator.openURL("https://expired.badssl.com/")
@@ -405,8 +401,6 @@ class NavigationTest: BaseTestCase {
 
     // Smoketest
     func testVerifyBrowserTabMenu() {
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
-        navigator.performAction(Action.CloseURLBarOpen)
         waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: TIMEOUT)
         navigator.nowAt(NewTabScreen)
         navigator.goto(BrowserTabMenu)

--- a/Tests/XCUITests/NewTabSettings.swift
+++ b/Tests/XCUITests/NewTabSettings.swift
@@ -8,8 +8,6 @@ let websiteUrl = "www.mozilla.org"
 class NewTabSettingsTest: BaseTestCase {
     // Smoketest
     func testCheckNewTabSettingsByDefault() {
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: 15)
-        navigator.performAction(Action.CloseURLBarOpen)
         waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 5)
         navigator.nowAt(NewTabScreen)
         navigator.goto(NewTabSettings)
@@ -21,8 +19,6 @@ class NewTabSettingsTest: BaseTestCase {
 
     // Smoketest
     func testChangeNewTabSettingsShowBlankPage() {
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: 25)
-        navigator.performAction(Action.CloseURLBarOpen)
         waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 5)
         navigator.nowAt(NewTabScreen)
         navigator.goto(NewTabSettings)
@@ -56,8 +52,6 @@ class NewTabSettingsTest: BaseTestCase {
     }
 
     func testChangeNewTabSettingsShowCustomURL() {
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: 15)
-        navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         navigator.goto(NewTabSettings)
         waitForExistence(app.navigationBars["New Tab"])

--- a/Tests/XCUITests/ReaderViewUITest.swift
+++ b/Tests/XCUITests/ReaderViewUITest.swift
@@ -163,7 +163,6 @@ class ReaderViewTest: BaseTestCase {
     }
 
     func testAddToReadingListFromBrowserTabMenu() {
-        navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         // First time Reading list is empty
         navigator.goto(LibraryPanel_ReadingList)

--- a/Tests/XCUITests/SaveLoginsTests.swift
+++ b/Tests/XCUITests/SaveLoginsTests.swift
@@ -261,8 +261,6 @@ class SaveLoginTest: BaseTestCase {
     }
 
     func closeURLBar () {
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: 10)
-        navigator.performAction(Action.CloseURLBarOpen)
         waitForTabsButton()
         navigator.nowAt(NewTabScreen)
     }

--- a/Tests/XCUITests/SaveLoginsTests.swift
+++ b/Tests/XCUITests/SaveLoginsTests.swift
@@ -223,7 +223,6 @@ class SaveLoginTest: BaseTestCase {
 
     // Smoketest
     func testCreateLoginManually() {
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: 25)
         closeURLBar()
         navigator.goto(LoginsSettings)
         // This only appears the first time

--- a/Tests/XCUITests/SearchTest.swift
+++ b/Tests/XCUITests/SearchTest.swift
@@ -173,8 +173,6 @@ class SearchTests: BaseTestCase {
 
     // Smoketest
     func testSearchEngine() {
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: 15)
-        navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         // Change to the each search engine and verify the search uses it
         changeSearchEngine(searchEngine: "Bing")

--- a/Tests/XCUITests/TopTabsTest.swift
+++ b/Tests/XCUITests/TopTabsTest.swift
@@ -120,7 +120,6 @@ class TopTabsTest: BaseTestCase {
 
     // Smoketest
     func testCloseAllTabsUndo() {
-        navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         // A different tab than home is open to do the proper checks
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
@@ -246,8 +245,6 @@ class TopTabsTest: BaseTestCase {
 
     // Smoketest
     func testOpenNewTabLandscape() {
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT_LONG)
-        navigator.performAction(Action.CloseURLBarOpen)
         XCUIDevice.shared.orientation = .landscapeLeft
         // Verify the '+' icon is shown and open a tab with it
         if iPad() {
@@ -372,8 +369,6 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
     // This test only runs for iPhone see bug 1409750
     func testAddTabByLongPressTabsButton() {
         if skipPlatform { return }
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT_LONG)
-        navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(BrowserTab)
         waitForTabsButton()
         navigator.performAction(Action.OpenNewTabLongPressTabsButton)
@@ -385,8 +380,6 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
     // This test only runs for iPhone see bug 1409750
     func testAddPrivateTabByLongPressTabsButton() {
         if skipPlatform { return }
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT_LONG)
-        navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(BrowserTab)
         waitForTabsButton()
         navigator.performAction(Action.OpenPrivateTabLongPressTabsButton)


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5637)

### Description
Merge epic branch into Main
This PR contains the implementation for the desired UX behavior for Overlaymode.
The intended interaction for the keyboard is to only raise in response to user interaction:
- A tap into the address bar
- A tap on the new tab button in the tab tray
- A tap on the search icon
- In the main toolbar when on the homepage

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
