### PR TITLE
Bugfix FXIOS-6073 [v113] Delete old cache file from documents

### DIFF
--- a/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/Cache/URLCacheFileManager.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/Cache/URLCacheFileManager.swift
@@ -26,7 +26,9 @@ actor DefaultURLCacheFileManager: URLCacheFileManager {
             return try? Data(contentsOf: directory)
         } else {
             let oldDirectory = getOldCacheDirectory()
-            return try? Data(contentsOf: oldDirectory)
+            let data = try? Data(contentsOf: oldDirectory)
+            try? fileManager.removeItem(atPath: oldDirectory.path)
+            return data
         }
     }
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6073)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13753)

### Description
I forgot to actually delete the old cache file in the documents directory after the migration in my previous PR.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
