### PR TITLE
Add FXIOS-5981 [v113] Add basic setup code for scene coordinator

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -541,6 +541,7 @@
 		8A7653C228A2E57D00924ABF /* PocketDataAdaptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7653C128A2E57D00924ABF /* PocketDataAdaptorTests.swift */; };
 		8A7653C528A2E69100924ABF /* MockPocketAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7653C328A2E68B00924ABF /* MockPocketAPI.swift */; };
 		8A7A26E129D4785900EA76F1 /* MockRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7A26E029D4785900EA76F1 /* MockRouter.swift */; };
+		8A7A26E329D4ACF300EA76F1 /* SceneCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7A26E229D4ACF300EA76F1 /* SceneCoordinatorTests.swift */; };
 		8A7A93EE2810ADF2005E7E1B /* ContileProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7A93ED2810ADF2005E7E1B /* ContileProviderTests.swift */; };
 		8A8629E2288096C40096DDB1 /* BookmarksFolderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8629E1288096C40096DDB1 /* BookmarksFolderCell.swift */; };
 		8A8629E72880B7330096DDB1 /* BookmarksPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8629E52880B69C0096DDB1 /* BookmarksPanelTests.swift */; };
@@ -3716,6 +3717,7 @@
 		8A7653C128A2E57D00924ABF /* PocketDataAdaptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketDataAdaptorTests.swift; sourceTree = "<group>"; };
 		8A7653C328A2E68B00924ABF /* MockPocketAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPocketAPI.swift; sourceTree = "<group>"; };
 		8A7A26E029D4785900EA76F1 /* MockRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRouter.swift; sourceTree = "<group>"; };
+		8A7A26E229D4ACF300EA76F1 /* SceneCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneCoordinatorTests.swift; sourceTree = "<group>"; };
 		8A7A93ED2810ADF2005E7E1B /* ContileProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContileProviderTests.swift; sourceTree = "<group>"; };
 		8A8629E1288096C40096DDB1 /* BookmarksFolderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksFolderCell.swift; sourceTree = "<group>"; };
 		8A8629E52880B69C0096DDB1 /* BookmarksPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksPanelTests.swift; sourceTree = "<group>"; };
@@ -6853,6 +6855,7 @@
 			children = (
 				8A93F86429D37331004159D9 /* DefaultRouterTests.swift */,
 				8A93F86929D37FC9004159D9 /* CoordinatorTests.swift */,
+				8A7A26E229D4ACF300EA76F1 /* SceneCoordinatorTests.swift */,
 			);
 			path = Coordinators;
 			sourceTree = "<group>";
@@ -11247,6 +11250,7 @@
 				2137786129802B7000D01309 /* DownloadsPanelViewModelTests.swift in Sources */,
 				8A5BD95A28788A3D000FE773 /* TopSitesHelperTests.swift in Sources */,
 				5AF6254728A58AC100A90253 /* MockHistoryHighlightsDataAdaptor.swift in Sources */,
+				8A7A26E329D4ACF300EA76F1 /* SceneCoordinatorTests.swift in Sources */,
 				39C137972655798A003DC662 /* NimbusIntegrationTests.swift in Sources */,
 				215B458427DA87FC00E5E800 /* TabMetadataManagerTests.swift in Sources */,
 				215349062886007900FADB4D /* GleanPlumbMessageStoreTests.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -556,6 +556,9 @@
 		8A93F86829D373B0004159D9 /* MockNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A93F86629D373AC004159D9 /* MockNavigationController.swift */; };
 		8A93F86B29D39BDA004159D9 /* CoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A93F86929D37FC9004159D9 /* CoordinatorTests.swift */; };
 		8A93F86D29D3A131004159D9 /* DefaultRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A93F86C29D3A131004159D9 /* DefaultRouter.swift */; };
+		8A93F87029D3A597004159D9 /* SceneCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A93F86F29D3A597004159D9 /* SceneCoordinator.swift */; };
+		8A93F87229D3A5AD004159D9 /* BrowserCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A93F87129D3A5AD004159D9 /* BrowserCoordinator.swift */; };
+		8A93F87429D3A5C1004159D9 /* OnboardingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A93F87329D3A5C1004159D9 /* OnboardingCoordinator.swift */; };
 		8A96C4BB28F9E7B300B75884 /* XCTestCaseRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A96C4BA28F9E7B300B75884 /* XCTestCaseRootViewController.swift */; };
 		8A9AC465276CEC4E0047F5B0 /* JumpBackInCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9AC464276CEC4E0047F5B0 /* JumpBackInCell.swift */; };
 		8A9AC46B276D11280047F5B0 /* PocketViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9AC46A276D11280047F5B0 /* PocketViewModel.swift */; };
@@ -3729,6 +3732,9 @@
 		8A93F86629D373AC004159D9 /* MockNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNavigationController.swift; sourceTree = "<group>"; };
 		8A93F86929D37FC9004159D9 /* CoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatorTests.swift; sourceTree = "<group>"; };
 		8A93F86C29D3A131004159D9 /* DefaultRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultRouter.swift; sourceTree = "<group>"; };
+		8A93F86F29D3A597004159D9 /* SceneCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneCoordinator.swift; sourceTree = "<group>"; };
+		8A93F87129D3A5AD004159D9 /* BrowserCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserCoordinator.swift; sourceTree = "<group>"; };
+		8A93F87329D3A5C1004159D9 /* OnboardingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCoordinator.swift; sourceTree = "<group>"; };
 		8A96C4B828F9DD8700B75884 /* ThemableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemableTests.swift; sourceTree = "<group>"; };
 		8A96C4BA28F9E7B300B75884 /* XCTestCaseRootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestCaseRootViewController.swift; sourceTree = "<group>"; };
 		8A99DB9727C6DD3E007EA6BD /* is */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = is; path = "is.lproj/Default Browser.strings"; sourceTree = "<group>"; };
@@ -6835,6 +6841,9 @@
 			children = (
 				8A93F86E29D3A147004159D9 /* Router */,
 				8A93F85D29D36DA9004159D9 /* Coordinator.swift */,
+				8A93F86F29D3A597004159D9 /* SceneCoordinator.swift */,
+				8A93F87129D3A5AD004159D9 /* BrowserCoordinator.swift */,
+				8A93F87329D3A5C1004159D9 /* OnboardingCoordinator.swift */,
 			);
 			path = Coordinators;
 			sourceTree = "<group>";
@@ -10732,6 +10741,7 @@
 				8A05123927D17EC3009930CC /* LegacyWallpaperStorageUtility.swift in Sources */,
 				DFACBF81277B916B003D5F41 /* ConfigurableGradientView.swift in Sources */,
 				7482205C1DBAB56300EEEA72 /* MailProviders.swift in Sources */,
+				8A93F87029D3A597004159D9 /* SceneCoordinator.swift in Sources */,
 				C40046FA1CF8E0B200B08303 /* BackForwardListAnimator.swift in Sources */,
 				DD31E0FB1B382B520077078A /* TabPrintPageRenderer.swift in Sources */,
 				D81E45131F82C56D004EFFBA /* NewTabContentSettingsViewController.swift in Sources */,
@@ -10966,6 +10976,7 @@
 				2F44FCCB1A9E972E00FD20CC /* SearchEnginePicker.swift in Sources */,
 				1DA3CE5F24EEE7C600422BB2 /* LegacyTabDataRetriever.swift in Sources */,
 				D04D1B92209790B60074B35F /* Toast.swift in Sources */,
+				8A93F87429D3A5C1004159D9 /* OnboardingCoordinator.swift in Sources */,
 				8AD5702F27AB4DEA005BFDC8 /* UIStackView+Extension.swift in Sources */,
 				210E0EB8298D9D4500BB4F33 /* DefaultSearchEngineProvider.swift in Sources */,
 				8AE80BBA2891C0C300BC12EA /* JumpBackInSectionLayout.swift in Sources */,
@@ -11133,6 +11144,7 @@
 				8AC5D55F28BFE6C8001F6F7F /* Presenter.swift in Sources */,
 				C8501F4F2850FB72003B09AB /* LegacyWallpaperMigrationUtility.swift in Sources */,
 				C8741FE928C4D30F00030029 /* FileManagerInterface.swift in Sources */,
+				8A93F87229D3A5AD004159D9 /* BrowserCoordinator.swift in Sources */,
 				8A3233FE28627446003E1C33 /* LocalDesktopFolder.swift in Sources */,
 				8AD40FCA27BADC4B00672675 /* ReaderModeButton.swift in Sources */,
 				8AB5958C28414DF60090F4AE /* ActionButton.swift in Sources */,

--- a/Client/Coordinators/BrowserCoordinator.swift
+++ b/Client/Coordinators/BrowserCoordinator.swift
@@ -1,0 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+class BrowserCoordinator: BaseCoordinator {}

--- a/Client/Coordinators/BrowserCoordinator.swift
+++ b/Client/Coordinators/BrowserCoordinator.swift
@@ -4,4 +4,6 @@
 
 import Foundation
 
-class BrowserCoordinator: BaseCoordinator {}
+class BrowserCoordinator: BaseCoordinator {
+    func start() {}
+}

--- a/Client/Coordinators/Coordinator.swift
+++ b/Client/Coordinators/Coordinator.swift
@@ -7,7 +7,7 @@ import Foundation
 protocol Coordinator {
     var id: UUID { get }
     var childCoordinators: [Coordinator] { get }
-    var router: Router { get }
+    var router: Router? { get }
 
     func add(child coordinator: Coordinator)
     func remove(child coordinator: Coordinator?)
@@ -16,9 +16,10 @@ protocol Coordinator {
 open class BaseCoordinator: Coordinator {
     var id: UUID = UUID()
     var childCoordinators: [Coordinator] = []
-    var router: Router
+    var router: Router?
 
-    init(router: Router) {
+    convenience init(router: Router) {
+        self.init()
         self.router = router
     }
 

--- a/Client/Coordinators/OnboardingCoordinator.swift
+++ b/Client/Coordinators/OnboardingCoordinator.swift
@@ -1,0 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+class OnboardingCoordinator: BaseCoordinator {}

--- a/Client/Coordinators/SceneCoordinator.swift
+++ b/Client/Coordinators/SceneCoordinator.swift
@@ -1,0 +1,50 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+import Shared
+
+/// Each scene has it's own scene coordinator, which is the root coordinator for a scene.
+class SceneCoordinator: BaseCoordinator {
+    var window: UIWindow?
+    var mainCoordinator: Coordinator?
+
+    func start(with scene: UIScene) {
+        self.window = configureWindowFor(scene)
+        let navigationController = createNavigationController()
+
+        // FXIOS-5986: Add launch instructor to either start onboarding or normal browsing
+
+        window?.rootViewController = navigationController
+        window?.makeKeyAndVisible()
+    }
+
+    // MARK: - Helpers
+
+    private func configureWindowFor(_ scene: UIScene) -> UIWindow {
+        guard let windowScene = (scene as? UIWindowScene) else {
+            return UIWindow(frame: UIScreen.main.bounds)
+        }
+
+        // FXIOS-6087: Handle screenshot service since this won't be done from Scene Delegate anymore
+        // windowScene.screenshotService?.delegate = self
+
+        let window = UIWindow(windowScene: windowScene)
+
+        // Setting the initial theme correctly as we don't have a window attached yet to let ThemeManager set it
+        let themeManager: ThemeManager = AppContainer.shared.resolve()
+        window.overrideUserInterfaceStyle = themeManager.currentTheme.type.getInterfaceStyle()
+
+        return window
+    }
+
+    private func createNavigationController() -> UINavigationController {
+        let navigationController = UINavigationController()
+        navigationController.isNavigationBarHidden = true
+        navigationController.edgesForExtendedLayout = UIRectEdge(rawValue: 0)
+
+        return navigationController
+    }
+}

--- a/Client/Coordinators/SceneCoordinator.swift
+++ b/Client/Coordinators/SceneCoordinator.swift
@@ -9,13 +9,16 @@ import Shared
 /// Each scene has it's own scene coordinator, which is the root coordinator for a scene.
 class SceneCoordinator: BaseCoordinator {
     var window: UIWindow?
-    var mainCoordinator: Coordinator?
+    var browserCoordinator: BrowserCoordinator?
 
     func start(with scene: UIScene) {
         self.window = configureWindowFor(scene)
         let navigationController = createNavigationController()
 
-        // FXIOS-5986: Add launch instructor to either start onboarding or normal browsing
+        // FXIOS-5986: Add launch instructor to either start onboarding or browser
+        let router = DefaultRouter(navigationController: navigationController)
+        browserCoordinator = BrowserCoordinator(router: router)
+        browserCoordinator?.start()
 
         window?.rootViewController = navigationController
         window?.makeKeyAndVisible()

--- a/Tests/ClientTests/Coordinators/SceneCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/SceneCoordinatorTests.swift
@@ -1,0 +1,49 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import Shared
+import Common
+@testable import Client
+
+final class SceneCoordinatorTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        addContainerDependencies()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        resetContainerDependencies()
+    }
+
+    func testInitialState() {
+        let subject = SceneCoordinator()
+
+        XCTAssertNil(subject.window)
+        XCTAssertNil(subject.browserCoordinator)
+    }
+
+    func testInitScene_createObjects() {
+        let subject = SceneCoordinator()
+
+        let scene = UIApplication.shared.windows.first?.windowScene
+        subject.start(with: scene!)
+
+        XCTAssertNotNil(subject.window)
+        XCTAssertNotNil(subject.browserCoordinator)
+    }
+
+    // MARK: - Helpers
+    func addContainerDependencies() {
+        resetContainerDependencies()
+        let themeManager: ThemeManager = DefaultThemeManager()
+        AppContainer.shared.register(service: themeManager)
+        AppContainer.shared.bootstrap()
+    }
+
+    func resetContainerDependencies() {
+        AppContainer.shared.reset()
+    }
+}

--- a/Tests/ClientTests/Coordinators/SceneCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/SceneCoordinatorTests.swift
@@ -10,12 +10,12 @@ import Common
 final class SceneCoordinatorTests: XCTestCase {
     override func setUp() {
         super.setUp()
-        addContainerDependencies()
+        DependencyHelperMock().bootstrapDependencies()
     }
 
     override func tearDown() {
         super.tearDown()
-        resetContainerDependencies()
+        AppContainer.shared.reset()
     }
 
     func testInitialState() {
@@ -33,17 +33,5 @@ final class SceneCoordinatorTests: XCTestCase {
 
         XCTAssertNotNil(subject.window)
         XCTAssertNotNil(subject.browserCoordinator)
-    }
-
-    // MARK: - Helpers
-    func addContainerDependencies() {
-        resetContainerDependencies()
-        let themeManager: ThemeManager = DefaultThemeManager()
-        AppContainer.shared.register(service: themeManager)
-        AppContainer.shared.bootstrap()
-    }
-
-    func resetContainerDependencies() {
-        AppContainer.shared.reset()
     }
 }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5981)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13589)

### Description
- Add basic setup code for scene coordinator
- Empty browser and onboarding coordinators for now
- Made Router optional on protocol, with a conveniance init since in the case of SceneCoordinator we don't have a router yet at first.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [X] Documentation / comments for complex code and public methods
