### PR TITLE
Added FXIOS-5990 [v113] Add tab group data to new tab data model

### DIFF
--- a/BrowserKit/Sources/TabDataStore/TabData.swift
+++ b/BrowserKit/Sources/TabDataStore/TabData.swift
@@ -12,4 +12,5 @@ struct TabData: Codable {
     let isPrivate: Bool
     let lastUsedTime: Date
     let createdAtTime: Date
+    var tabGroupData: TabGroupData?
 }

--- a/BrowserKit/Sources/TabDataStore/TabGroupData.swift
+++ b/BrowserKit/Sources/TabDataStore/TabGroupData.swift
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0
+
+import Foundation
+
+enum TabGroupTimerState: Codable {
+    case navSearchLoaded
+    case tabNavigatedToDifferentUrl
+    case tabSwitched
+    case tabSelected
+    case newTab
+    case openInNewTab
+    case openURLOnly
+    case none
+}
+
+struct TabGroupData: Codable {
+    var tabAssociatedSearchTerm: String?
+    var tabAssociatedSearchUrl: String?
+    var tabAssociatedNextUrl: String?
+    var tabHistoryCurrentState: TabGroupTimerState?
+}

--- a/Client/TabManagement/Legacy/LegacyTabGroupData.swift
+++ b/Client/TabManagement/Legacy/LegacyTabGroupData.swift
@@ -5,7 +5,7 @@
 import Foundation
 import MozillaAppServices
 
-enum TabGroupTimerState: String, Codable {
+enum LegacyTabGroupTimerState: String, Codable {
     case navSearchLoaded
     case tabNavigatedToDifferentUrl
     case tabSwitched
@@ -37,7 +37,7 @@ class LegacyTabGroupData: Codable {
         self.init(searchTerm: "",
                   searchUrl: "",
                   nextReferralUrl: "",
-                  tabHistoryCurrentState: TabGroupTimerState.none.rawValue)
+                  tabHistoryCurrentState: LegacyTabGroupTimerState.none.rawValue)
     }
 
     init(searchTerm: String, searchUrl: String, nextReferralUrl: String, tabHistoryCurrentState: String = "") {

--- a/Client/TabManagement/Legacy/LegacyTabMetadataManager.swift
+++ b/Client/TabManagement/Legacy/LegacyTabMetadataManager.swift
@@ -16,9 +16,9 @@ class LegacyTabMetadataManager {
     let minViewTimeInSeconds = 7
 
     private var shouldUpdateObservationTitle: Bool {
-        tabGroupData.tabHistoryCurrentState == TabGroupTimerState.navSearchLoaded.rawValue ||
-        tabGroupData.tabHistoryCurrentState == TabGroupTimerState.tabNavigatedToDifferentUrl.rawValue ||
-        tabGroupData.tabHistoryCurrentState == TabGroupTimerState.openURLOnly.rawValue
+        tabGroupData.tabHistoryCurrentState == LegacyTabGroupTimerState.navSearchLoaded.rawValue ||
+        tabGroupData.tabHistoryCurrentState == LegacyTabGroupTimerState.tabNavigatedToDifferentUrl.rawValue ||
+        tabGroupData.tabHistoryCurrentState == LegacyTabGroupTimerState.openURLOnly.rawValue
     }
 
     init(metadataObserver: HistoryMetadataObserver) {
@@ -35,7 +35,7 @@ class LegacyTabMetadataManager {
         nextUrl != tabGroupData.tabAssociatedNextUrl
     }
 
-    func updateTimerAndObserving(state: TabGroupTimerState,
+    func updateTimerAndObserving(state: LegacyTabGroupTimerState,
                                  searchData: LegacyTabGroupData = LegacyTabGroupData(),
                                  tabTitle: String? = nil, isPrivate: Bool) {
         guard !isPrivate else { return }
@@ -112,14 +112,14 @@ class LegacyTabMetadataManager {
         shouldResetTabGroupData = false
         tabGroupsTimerHelper.startOrResume()
         tabGroupData = searchData
-        tabGroupData.tabHistoryCurrentState = TabGroupTimerState.navSearchLoaded.rawValue
+        tabGroupData.tabHistoryCurrentState = LegacyTabGroupTimerState.navSearchLoaded.rawValue
     }
 
     private func updateNewTabState(searchData: LegacyTabGroupData) {
         shouldResetTabGroupData = false
         tabGroupsTimerHelper.resetTimer()
         tabGroupsTimerHelper.startOrResume()
-        tabGroupData.tabHistoryCurrentState = TabGroupTimerState.newTab.rawValue
+        tabGroupData.tabHistoryCurrentState = LegacyTabGroupTimerState.newTab.rawValue
     }
 
     private func updateNavigatedToDifferentUrl(searchData: LegacyTabGroupData) {
@@ -136,7 +136,7 @@ class LegacyTabMetadataManager {
             }
             tabGroupsTimerHelper.resetTimer()
             tabGroupsTimerHelper.startOrResume()
-            tabGroupData.tabHistoryCurrentState = TabGroupTimerState.tabNavigatedToDifferentUrl.rawValue
+            tabGroupData.tabHistoryCurrentState = LegacyTabGroupTimerState.tabNavigatedToDifferentUrl.rawValue
         }
     }
 
@@ -145,7 +145,7 @@ class LegacyTabMetadataManager {
             if tabGroupsTimerHelper.isPaused {
                 tabGroupsTimerHelper.startOrResume()
             }
-            tabGroupData.tabHistoryCurrentState = TabGroupTimerState.tabSelected.rawValue
+            tabGroupData.tabHistoryCurrentState = LegacyTabGroupTimerState.tabSelected.rawValue
         }
     }
 
@@ -153,7 +153,7 @@ class LegacyTabMetadataManager {
         if !shouldResetTabGroupData {
             updateObservationViewTime()
             tabGroupsTimerHelper.pauseOrStop()
-            tabGroupData.tabHistoryCurrentState = TabGroupTimerState.tabSwitched.rawValue
+            tabGroupData.tabHistoryCurrentState = LegacyTabGroupTimerState.tabSwitched.rawValue
         }
     }
 
@@ -162,7 +162,7 @@ class LegacyTabMetadataManager {
         if !searchData.tabAssociatedSearchUrl.isEmpty {
             tabGroupData = searchData
         }
-        tabGroupData.tabHistoryCurrentState = TabGroupTimerState.openInNewTab.rawValue
+        tabGroupData.tabHistoryCurrentState = LegacyTabGroupTimerState.openInNewTab.rawValue
     }
 
     /// Update observation for Regular sites (not search term)
@@ -172,7 +172,7 @@ class LegacyTabMetadataManager {
     ///   - title: Site title from webview can be empty for slow loading pages
     private func updateOpenURLOnlyState(searchData: LegacyTabGroupData, title: String?) {
         tabGroupData = searchData
-        tabGroupData.tabHistoryCurrentState = TabGroupTimerState.openURLOnly.rawValue
+        tabGroupData.tabHistoryCurrentState = LegacyTabGroupTimerState.openURLOnly.rawValue
         tabGroupsTimerHelper.startOrResume()
 
         guard let title = title, !title.isEmpty else { return }

--- a/Tests/ClientTests/Frontend/Browser/TabManagement/TabMetadataManagerTests.swift
+++ b/Tests/ClientTests/Frontend/Browser/TabManagement/TabMetadataManagerTests.swift
@@ -75,7 +75,7 @@ class TabMetadataManagerTests: XCTestCase {
         manager.tabGroupData = LegacyTabGroupData(searchTerm: "",
                                                   searchUrl: stringUrl,
                                                   nextReferralUrl: "",
-                                                  tabHistoryCurrentState: TabGroupTimerState.openURLOnly.rawValue)
+                                                  tabHistoryCurrentState: LegacyTabGroupTimerState.openURLOnly.rawValue)
 
         manager.updateObservationTitle(title) {
             XCTAssertEqual(self.metadataObserver.observation?.url, stringUrl)
@@ -92,7 +92,7 @@ class TabMetadataManagerTests: XCTestCase {
         manager.tabGroupData = LegacyTabGroupData(searchTerm: "",
                                                   searchUrl: stringUrl,
                                                   nextReferralUrl: referralURL,
-                                                  tabHistoryCurrentState: TabGroupTimerState.tabNavigatedToDifferentUrl.rawValue)
+                                                  tabHistoryCurrentState: LegacyTabGroupTimerState.tabNavigatedToDifferentUrl.rawValue)
 
         manager.updateObservationTitle(title) {
             XCTAssertEqual(self.metadataObserver.observation?.url, stringUrl)
@@ -109,7 +109,7 @@ class TabMetadataManagerTests: XCTestCase {
         manager.tabGroupData = LegacyTabGroupData(searchTerm: "",
                                                   searchUrl: stringUrl,
                                                   nextReferralUrl: referralURL,
-                                                  tabHistoryCurrentState: TabGroupTimerState.openInNewTab.rawValue)
+                                                  tabHistoryCurrentState: LegacyTabGroupTimerState.openInNewTab.rawValue)
 
         // Title should not be updated for this state
         manager.updateObservationTitle(title) {
@@ -126,7 +126,7 @@ class TabMetadataManagerTests: XCTestCase {
         manager.tabGroupData = LegacyTabGroupData(searchTerm: "",
                                                   searchUrl: stringUrl,
                                                   nextReferralUrl: referralURL,
-                                                  tabHistoryCurrentState: TabGroupTimerState.tabSwitched.rawValue)
+                                                  tabHistoryCurrentState: LegacyTabGroupTimerState.tabSwitched.rawValue)
 
         // Title should not be updated for this state
         manager.updateObservationTitle(title) {
@@ -143,7 +143,7 @@ class TabMetadataManagerTests: XCTestCase {
         manager.tabGroupData = LegacyTabGroupData(searchTerm: "",
                                                   searchUrl: stringUrl,
                                                   nextReferralUrl: referralURL,
-                                                  tabHistoryCurrentState: TabGroupTimerState.tabSwitched.rawValue)
+                                                  tabHistoryCurrentState: LegacyTabGroupTimerState.tabSwitched.rawValue)
 
         // Title should not be updated for this state
         manager.updateObservationTitle(title) {


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5990)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13598)

### Description
Renamed TabGroupTimerState to legacy
Created a similar model on the new tab data model

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
