### PR TITLE
Add FXIOS-5986 [v113] Create intro screen manager

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -542,6 +542,8 @@
 		8A7653C528A2E69100924ABF /* MockPocketAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7653C328A2E68B00924ABF /* MockPocketAPI.swift */; };
 		8A7A26E129D4785900EA76F1 /* MockRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7A26E029D4785900EA76F1 /* MockRouter.swift */; };
 		8A7A26E329D4ACF300EA76F1 /* SceneCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7A26E229D4ACF300EA76F1 /* SceneCoordinatorTests.swift */; };
+		8A7A26E529D4C0A800EA76F1 /* IntroScreenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7A26E429D4C0A800EA76F1 /* IntroScreenManager.swift */; };
+		8A7A26E829D4C0FE00EA76F1 /* IntroScreenManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7A26E629D4C0D800EA76F1 /* IntroScreenManagerTests.swift */; };
 		8A7A93EE2810ADF2005E7E1B /* ContileProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7A93ED2810ADF2005E7E1B /* ContileProviderTests.swift */; };
 		8A8629E2288096C40096DDB1 /* BookmarksFolderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8629E1288096C40096DDB1 /* BookmarksFolderCell.swift */; };
 		8A8629E72880B7330096DDB1 /* BookmarksPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8629E52880B69C0096DDB1 /* BookmarksPanelTests.swift */; };
@@ -3717,6 +3719,8 @@
 		8A7653C128A2E57D00924ABF /* PocketDataAdaptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketDataAdaptorTests.swift; sourceTree = "<group>"; };
 		8A7653C328A2E68B00924ABF /* MockPocketAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPocketAPI.swift; sourceTree = "<group>"; };
 		8A7A26E029D4785900EA76F1 /* MockRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRouter.swift; sourceTree = "<group>"; };
+		8A7A26E429D4C0A800EA76F1 /* IntroScreenManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroScreenManager.swift; sourceTree = "<group>"; };
+		8A7A26E629D4C0D800EA76F1 /* IntroScreenManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroScreenManagerTests.swift; sourceTree = "<group>"; };
 		8A7A26E229D4ACF300EA76F1 /* SceneCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneCoordinatorTests.swift; sourceTree = "<group>"; };
 		8A7A93ED2810ADF2005E7E1B /* ContileProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContileProviderTests.swift; sourceTree = "<group>"; };
 		8A8629E1288096C40096DDB1 /* BookmarksFolderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksFolderCell.swift; sourceTree = "<group>"; };
@@ -6360,6 +6364,7 @@
 				E1463D012981DA190074E16E /* NotificationManager.swift */,
 				96A5F73729928B3700234E5F /* GeneralizedImageFetcher.swift */,
 				E18259DE29B25E4F00E6BE76 /* UserNotificationCenterProtocol.swift */,
+				8A7A26E429D4C0A800EA76F1 /* IntroScreenManager.swift */,
 			);
 			name = Helpers;
 			sourceTree = "<group>";
@@ -6936,6 +6941,7 @@
 				8AEE284A276A973400C7104D /* RatingPromptManagerTests.swift */,
 				8A355E5D27D267A400B9AF34 /* RecentItemsHelperTests.swift */,
 				5A70EF1C295E3C3500790249 /* TestSetup.swift */,
+				8A7A26E629D4C0D800EA76F1 /* IntroScreenManagerTests.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -10924,6 +10930,7 @@
 				DDA24A431FD84D630098F159 /* DefaultSearchPrefs.swift in Sources */,
 				DFD64DB727A1A909003D4534 /* LegacyWallpaper.swift in Sources */,
 				E65075611E37F77D006961AC /* MenuHelper.swift in Sources */,
+				8A7A26E529D4C0A800EA76F1 /* IntroScreenManager.swift in Sources */,
 				8AB8574827D97CD40075C173 /* HomePanelType.swift in Sources */,
 				2128E27B292E624400FB91BE /* SendToDeviceActivity.swift in Sources */,
 				E63ED7D81BFCD9990097D08E /* LoginDetailTableViewCell.swift in Sources */,
@@ -11165,6 +11172,7 @@
 				213B67A827CE721E000542F5 /* StartAtHomeHelperTests.swift in Sources */,
 				8A7653C228A2E57D00924ABF /* PocketDataAdaptorTests.swift in Sources */,
 				E1AEC176286E0CF500062E29 /* JumpBackInViewModelTests.swift in Sources */,
+				8A7A26E829D4C0FE00EA76F1 /* IntroScreenManagerTests.swift in Sources */,
 				E1AEC17A286E0CF500062E29 /* WebViewNavigationHandlerTests.swift in Sources */,
 				D3D488591ABB54CD00A93597 /* FileAccessorTests.swift in Sources */,
 				5AF6254528A57B6700A90253 /* MockHistoryHighlightsManager.swift in Sources */,

--- a/Client/Application/AppLaunchUtil.swift
+++ b/Client/Application/AppLaunchUtil.swift
@@ -13,12 +13,14 @@ class AppLaunchUtil {
     private var logger: Logger
     private var adjustHelper: AdjustHelper
     private var profile: Profile
+    private let introScreenManager: IntroScreenManager
 
     init(logger: Logger = DefaultLogger.shared,
          profile: Profile) {
         self.logger = logger
         self.profile = profile
         self.adjustHelper = AdjustHelper(profile: profile)
+        self.introScreenManager = IntroScreenManager(prefs: profile.prefs)
     }
 
     func setUpPreLaunchDependencies() {
@@ -86,16 +88,15 @@ class AppLaunchUtil {
 
     func setUpPostLaunchDependencies() {
         let persistedCurrentVersion = InstallType.persistedCurrentVersion()
-        let introScreen = profile.prefs.intForKey(PrefsKeys.IntroSeen)
         // upgrade install - Intro screen shown & persisted current version does not match
-        if introScreen != nil && persistedCurrentVersion != AppInfo.appVersion {
+        if !introScreenManager.shouldShowIntroScreen && persistedCurrentVersion != AppInfo.appVersion {
             InstallType.set(type: .upgrade)
             InstallType.updateCurrentVersion(version: AppInfo.appVersion)
         }
 
         // We need to check if the app is a clean install to use for
         // preventing the What's New URL from appearing.
-        if introScreen == nil {
+        if introScreenManager.shouldShowIntroScreen {
             // fresh install - Intro screen not yet shown
             InstallType.set(type: .fresh)
             InstallType.updateCurrentVersion(version: AppInfo.appVersion)

--- a/Client/Application/UITestAppDelegate.swift
+++ b/Client/Application/UITestAppDelegate.swift
@@ -124,7 +124,7 @@ class UITestAppDelegate: AppDelegate, FeatureFlaggable {
 
         // Skip the intro when requested by for example tests or automation
         if launchArguments.contains(LaunchArguments.SkipIntro) {
-            profile.prefs.setInt(1, forKey: PrefsKeys.IntroSeen)
+            IntroScreenManager(prefs: profile.prefs).didSeeIntroScreen()
         }
 
         if launchArguments.contains(LaunchArguments.StageServer) {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -159,8 +159,6 @@ class BrowserViewController: UIViewController {
         return keyboardPressesHandlerValue
     }
 
-    fileprivate var shouldShowIntroScreen: Bool { profile.prefs.intForKey(PrefsKeys.IntroSeen) == nil }
-
     init(
         profile: Profile,
         tabManager: TabManager,
@@ -594,7 +592,7 @@ class BrowserViewController: UIViewController {
     }
 
     private func presentContextualHint() {
-        if shouldShowIntroScreen { return }
+        if IntroScreenManager(prefs: profile.prefs).shouldShowIntroScreen { return }
         present(contextHintVC, animated: true)
 
         UIAccessibility.post(notification: .layoutChanged, argument: contextHintVC)
@@ -2259,7 +2257,7 @@ extension BrowserViewController: UIAdaptivePresentationControllerDelegate {
 
 extension BrowserViewController {
     func presentIntroViewController(_ alwaysShow: Bool = false) {
-        if alwaysShow || shouldShowIntroScreen {
+        if alwaysShow || IntroScreenManager(prefs: profile.prefs).shouldShowIntroScreen {
             showProperIntroVC()
         }
     }
@@ -2322,7 +2320,7 @@ extension BrowserViewController {
         let introViewModel = IntroViewModel()
         let introViewController = IntroViewController(viewModel: introViewModel, profile: profile)
         introViewController.didFinishFlow = {
-            self.profile.prefs.setInt(1, forKey: PrefsKeys.IntroSeen)
+            IntroScreenManager(prefs: self.profile.prefs).didSeeIntroScreen()
             introViewController.dismiss(animated: true)
         }
         self.introVCPresentHelper(introViewController: introViewController)

--- a/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
+++ b/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
@@ -99,7 +99,7 @@ class ClipboardBarDisplayHandler: NSObject, URLChangeDelegate {
             !sessionRestored ||
             !firstTabLoaded ||
             isClipboardURLAlreadyDisplayed(copiedURL) ||
-            self.prefs.intForKey(PrefsKeys.IntroSeen) == nil {
+            IntroScreenManager(prefs: prefs).shouldShowIntroScreen {
             return false
         }
         sessionStarted = false

--- a/Client/IntroScreenManager.swift
+++ b/Client/IntroScreenManager.swift
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Shared
+
+struct IntroScreenManager {
+    var prefs: Prefs
+
+    var shouldShowIntroScreen: Bool {
+        prefs.intForKey(PrefsKeys.IntroSeen) == nil
+    }
+
+    func didSeeIntroScreen() {
+        prefs.setInt(1, forKey: PrefsKeys.IntroSeen)
+    }
+}

--- a/Tests/ClientTests/Frontend/Browser/TabManagement/TabEventHandlerTests.swift
+++ b/Tests/ClientTests/Frontend/Browser/TabManagement/TabEventHandlerTests.swift
@@ -30,7 +30,7 @@ class TabEventHandlerTests: XCTestCase {
 //        let manager = TabManager(profile: profile, imageStore: nil)
 //
 //        // Hide intro so it is easier to see the test running and debug it
-//        profile.prefs.setInt(1, forKey: PrefsKeys.IntroSeen)
+//        IntroScreenManager(prefs: profile.prefs).didSeeIntroScreen()
 //
 //        let webServer = GCDWebServer()
 //        webServer.addHandler(forMethod: "GET", path: "/blankpopup", request: GCDWebServerRequest.self) { (request) -> GCDWebServerResponse in

--- a/Tests/ClientTests/Helpers/IntroScreenManagerTests.swift
+++ b/Tests/ClientTests/Helpers/IntroScreenManagerTests.swift
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Shared
+import XCTest
+
+@testable import Client
+
+final class IntroScreenManagerTests: XCTestCase {
+    var prefs: MockProfilePrefs!
+
+    override func setUp() {
+        super.setUp()
+        prefs = MockProfilePrefs()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        prefs = nil
+    }
+
+    func testHasntSeenIntroScreenYet_shouldShowIt() {
+        let subject = IntroScreenManager(prefs: prefs)
+        XCTAssertTrue(subject.shouldShowIntroScreen)
+    }
+
+    func testHasSeenIntroScreen_shouldNotShowIt() {
+        let subject = IntroScreenManager(prefs: prefs)
+        subject.didSeeIntroScreen()
+        XCTAssertFalse(subject.shouldShowIntroScreen)
+    }
+}


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5986)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13594)

### Description
This change is in preparation of adding LaunchInstructor.  This creates an intro screen manager. That way we're not directly using `Prefs` to know about whether we should show the intro screen or not, and save when it has been shown. I find it nicer that way than setting a pref integer to 1, and checking if a key is nil.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [X] Documentation / comments for complex code and public methods
