### PR TITLE
Refactor FXIOS-6095 [v113] Move "wasLastSessionPrivate" to PrefsKeys

### DIFF
--- a/Client/Application/NavigationRouter.swift
+++ b/Client/Application/NavigationRouter.swift
@@ -160,7 +160,7 @@ enum NavigationPath {
             TelemetryWrapper.gleanRecordEvent(category: .action, method: .open, object: .asDefaultBrowser)
             RatingPromptManager.isBrowserDefault = true
             // Use the last browsing mode the user was in
-            let isPrivate = UserDefaults.standard.bool(forKey: "wasLastSessionPrivate")
+            let isPrivate = UserDefaults.standard.bool(forKey: PrefsKeys.LastSessionWasPrivate)
             self = .url(webURL: url, isPrivate: isPrivate)
         } else {
             return nil
@@ -222,7 +222,7 @@ enum NavigationPath {
             return .openUrlFromComponents(components: components)
         case "widget-medium-quicklink-open-url":
             // Widget Quick Actions - medium - open url private or regular
-            let isPrivate = Bool(components.valueForQuery("private") ?? "") ?? UserDefaults.standard.bool(forKey: "wasLastSessionPrivate")
+            let isPrivate = Bool(components.valueForQuery("private") ?? "") ?? UserDefaults.standard.bool(forKey: PrefsKeys.LastSessionWasPrivate)
             TelemetryWrapper.recordEvent(category: .action, method: .open, object: isPrivate ? .mediumQuickActionPrivateSearch : .mediumQuickActionSearch)
             return .openUrlFromComponents(components: components)
         case "widget-small-quicklink-open-copied", "widget-medium-quicklink-open-copied":
@@ -250,7 +250,7 @@ enum NavigationPath {
         let url = components.valueForQuery("url")?.asURL
         // Unless the `open-url` URL specifies a `private` parameter,
         // use the last browsing mode the user was in.
-        let isPrivate = Bool(components.valueForQuery("private") ?? "") ?? UserDefaults.standard.bool(forKey: "wasLastSessionPrivate")
+        let isPrivate = Bool(components.valueForQuery("private") ?? "") ?? UserDefaults.standard.bool(forKey: PrefsKeys.LastSessionWasPrivate)
         return .url(webURL: url, isPrivate: isPrivate)
     }
 
@@ -260,7 +260,7 @@ enum NavigationPath {
             return .text(searchText)
         }
         let url = UIPasteboard.general.url
-        let isPrivate = UserDefaults.standard.bool(forKey: "wasLastSessionPrivate")
+        let isPrivate = UserDefaults.standard.bool(forKey: PrefsKeys.LastSessionWasPrivate)
         return .url(webURL: url, isPrivate: isPrivate)
     }
 

--- a/Client/Extensions/UIWindow+Extension.swift
+++ b/Client/Extensions/UIWindow+Extension.swift
@@ -41,3 +41,4 @@ extension UIWindow {
         keyWindow?.windowScene?.statusBarManager?.statusBarFrame.height ?? 0
     }
 }
+// swiftlint:enable first_where

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -319,7 +319,7 @@ class TabDisplayManager: NSObject, FeatureFlaggable {
 
         isPrivate = isOn
 
-        UserDefaults.standard.set(isPrivate, forKey: "wasLastSessionPrivate")
+        UserDefaults.standard.set(isPrivate, forKey: PrefsKeys.LastSessionWasPrivate)
 
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .privateBrowsingButton, extras: ["is-private": isOn.description] )
 

--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -270,7 +270,7 @@ class TabTrayViewController: UIViewController, Themeable {
     }
 
     func updatePrivateUIState() {
-        UserDefaults.standard.set(viewModel.tabManager.selectedTab?.isPrivate ?? false, forKey: "wasLastSessionPrivate")
+        UserDefaults.standard.set(viewModel.tabManager.selectedTab?.isPrivate ?? false, forKey: PrefsKeys.LastSessionWasPrivate)
     }
 
     private func updateTitle() {

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -156,7 +156,8 @@ class TopTabsViewController: UIViewController, Themeable {
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        UserDefaults.standard.set(tabManager.selectedTab?.isPrivate ?? false, forKey: "wasLastSessionPrivate")
+        UserDefaults.standard.set(tabManager.selectedTab?.isPrivate ?? false,
+                                  forKey: PrefsKeys.LastSessionWasPrivate)
     }
 
     func switchForegroundStatus(isInForeground reveal: Bool) {

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -4873,3 +4873,4 @@ extension String {
         value: "Connection is not secure",
         comment: "This is the value for a label that indicates if a user is on an unencrypted website.")
 }
+// swiftlint:enable line_length

--- a/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -267,7 +267,8 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager {
         // Note: we setup last session private case as the session is tied to user's selected
         // tab but there are times when tab manager isn't available and we need to know
         // users's last state (Private vs Regular)
-        UserDefaults.standard.set(selectedTab?.isPrivate ?? false, forKey: "wasLastSessionPrivate")
+        UserDefaults.standard.set(selectedTab?.isPrivate ?? false,
+                                  forKey: PrefsKeys.LastSessionWasPrivate)
     }
 
     func getMostRecentHomepageTab() -> Tab? {

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -148,6 +148,9 @@ public struct PrefsKeys {
 
     // The last timestamp we polled FxA for missing send tabs
     public static let PollCommandsTimestamp = "PollCommandsTimestamp"
+
+    // Representing whether or not the last user session was private
+    public static let LastSessionWasPrivate = "wasLastSessionPrivate"
 }
 
 public struct PrefsDefaults {

--- a/Tests/ClientTests/TabTrayViewControllerTests.swift
+++ b/Tests/ClientTests/TabTrayViewControllerTests.swift
@@ -8,6 +8,7 @@ import Foundation
 
 import XCTest
 import Common
+import Shared
 
 class TabTrayViewControllerTests: XCTestCase {
     var profile: TabManagerMockProfile!
@@ -62,7 +63,7 @@ class TabTrayViewControllerTests: XCTestCase {
         tabTray.didTapAddTab(UIBarButtonItem())
         tabTray.didTapDone()
 
-        let privateState = UserDefaults.standard.bool(forKey: "wasLastSessionPrivate")
+        let privateState = UserDefaults.standard.bool(forKey: PrefsKeys.LastSessionWasPrivate)
         XCTAssertTrue(privateState)
     }
 
@@ -73,7 +74,7 @@ class TabTrayViewControllerTests: XCTestCase {
         tabTray.viewDidLoad()
         tabTray.didTapDone()
 
-        let privateState = UserDefaults.standard.bool(forKey: "wasLastSessionPrivate")
+        let privateState = UserDefaults.standard.bool(forKey: PrefsKeys.LastSessionWasPrivate)
         XCTAssertFalse(privateState)
     }
 }

--- a/Tests/XCUITests/DesktopModeTests.swift
+++ b/Tests/XCUITests/DesktopModeTests.swift
@@ -198,3 +198,4 @@ class DesktopModeTestsIphone: IphoneOnlyTestCase {
         XCTAssert(app.webViews.staticTexts.matching(identifier: "DESKTOP_UA").count > 0)
     }
 }
+// swiftlint:enable empty_count


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6095)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13792)

### Description
This was bothering. I have fixed it. (Plus three new swiftlints).

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
~~- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)~~
~~- [ ] Unit tests written and passing~~
~~- [ ] Documentation / comments for complex code and public methods~~
