### PR TITLE
Refactor SYNC-3664 [v114] app-services update code

### DIFF
--- a/test-fixtures/update-rust-component-version.py
+++ b/test-fixtures/update-rust-component-version.py
@@ -14,15 +14,20 @@ def get_newest_rust_components_version():
     g = Github()
     try:
         repo = g.get_repo(GITHUB_REPO)
-
-        newest_tag = repo.get_tags()[0].name
-        newest_commit = str(repo.get_tags()[0].commit)
+        nightly_tag = find_latest_nightly_tag(repo.get_tags())
+        newest_tag = nightly_tag.name
+        newest_commit = str(nightly_tag.commit)
         only_commit = re.findall(r'"([^"]*)"', newest_commit)
     except requests.exceptions.HTTPError as err:
         raise SystemExit(err)
 
-
     return (str(newest_tag), str(only_commit[0]))
+
+def find_latest_nightly_tag(tags):
+    for tag in tags:
+        if re.match(r'\d+\.0\.\d+', tag.name) is not None:
+            return tag
+    raise SyntaxError("No nightly tags found in rust-components-swift")
 
 def read_rust_components_tag_version():
     # Read Package file to find the current rust-component version


### PR DESCRIPTION
[SYNC Jira ticket](https://mozilla-hub.atlassian.net/browse/SYNC-3664)

### Description
App-services versions are now going to change and to follow the moz-central release cycle closer.  For rust-components-swift this means the versions will look like:

  - `113.0.YYYYMMDDMMSS` for nightly releases
  - `113.1.X` for "real" releases.

Modified the update script to only try to use nightly releases.

- Does the script change look okay?  Is there a good way to test this other than just seeing how it runs in practice?
- Does the new versioning scheme seem okay?  The app-services releases will only have 2 components, so I figured we could use the extra component to separate out nightlies from non-nightlies.  I'm happy to work with any scheme that the iOS team wants though.
- Does any code or docs need to change to handle non-nightly releases?  This includes switching from a nightly release to the `XXX.1.0` release at the end of the nightly cycle and also would include bumping that version to `XXX.1.1` if app-services did an uplift release (which has historically been very rare).  AFAIK, those are currently handled by hand and they can continue to be with the new versioning system, but please tell me if I should update anything in this repo for that.
### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
