### PR TITLE
Refactor FXIOS-6107 [v113] Singular/plural string in close tab toast

### DIFF
--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -858,9 +858,11 @@ extension GridTabViewController: InactiveTabsCFRProtocol {
     }
 
     func presentUndoToast(tabsCount: Int, completion: @escaping (Bool) -> Void) {
+        typealias ToastString = String.TabsTray.CloseTabsToast
+        let title = tabsCount == 1 ? ToastString.TitleSingular : ToastString.TitlePlural
         let viewModel = ButtonToastViewModel(
-            labelText: String.localizedStringWithFormat(.TabsDeleteAllUndoTitle, tabsCount),
-            buttonText: .TabsDeleteAllUndoAction)
+            labelText: String.localizedStringWithFormat(title, tabsCount),
+            buttonText: ToastString.Action)
         let toast = ButtonToast(viewModel: viewModel,
                                 theme: themeManager.currentTheme,
                                 completion: { buttonPressed in

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -1441,7 +1441,7 @@ extension String {
     public struct SyncScreen { }
 }
 
-// MARK: Tabs Tray
+// MARK: - Tabs Tray
 extension String {
     public struct TabsTray {
         public struct InactiveTabs {
@@ -1460,6 +1460,24 @@ extension String {
                 tableName: nil,
                 value: "Close All Inactive Tabs",
                 comment: "In the Tabs Tray, in the Inactive Tabs section, this is the button the user must tap in order to close all inactive tabs.")
+        }
+
+        public struct CloseTabsToast {
+            public static let TitleSingular = MZLocalizedString(
+                "CloseTabsToast.Title.Singular.v113",
+                tableName: "TabsTray",
+                value: "%d Tab Closed",
+                comment: "When the user closes tabs in the tab tray, a popup will appear. This is the title for the popup. If only one tab was closed, this is the title that will be used (in singular). The placeholder is the number of tabs; in this case, it would be '1'")
+            public static let TitlePlural = MZLocalizedString(
+                "CloseTabsToast.Title.Plural.v113",
+                tableName: "TabsTray",
+                value: "%d Tabs Closed",
+                comment: "When the user closes tabs in the tab tray, a popup will appear. This is the title for the popup. If multiple tabs were closed, this is the title that will be used (in plural form). The placeholder is the number of tabs; in this case, it would be '2' or more.")
+            public static let Action = MZLocalizedString(
+                "CloseTabsToast.Button.v113",
+                tableName: "TabsTray",
+                value: "Undo",
+                comment: "When the user closes tabs in the tab tray, a popup will appear. This is the title for the button to undo the deletion of those tabs")
         }
 
         public struct Sync {
@@ -2301,20 +2319,6 @@ extension String {
         tableName: nil,
         value: "URL",
         comment: "The label for the URL field when editing a bookmark")
-}
-
-// MARK: - Tabs Delete All Undo Toast
-extension String {
-    public static let TabsDeleteAllUndoTitle = MZLocalizedString(
-        "Tabs.DeleteAllUndo.Title.v113",
-        tableName: nil,
-        value: "%d Tab(s) Closed",
-        comment: "The label indicating that all the tabs were closed")
-    public static let TabsDeleteAllUndoAction = MZLocalizedString(
-        "Tabs.DeleteAllUndo.Button",
-        tableName: nil,
-        value: "Undo",
-        comment: "The button to undo the delete all tabs")
 }
 
 // MARK: - Tab tray (chronological tabs)

--- a/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -718,9 +718,11 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager {
         }
 
         // Toast
+        typealias ToastString = String.TabsTray.CloseTabsToast
+        let title = recentlyClosedTabs.count == 1 ? ToastString.TitleSingular : ToastString.TitlePlural
         let viewModel = ButtonToastViewModel(
-            labelText: String.localizedStringWithFormat(.TabsDeleteAllUndoTitle, recentlyClosedTabs.count),
-            buttonText: .TabsDeleteAllUndoAction)
+            labelText: String.localizedStringWithFormat(title, recentlyClosedTabs.count),
+            buttonText: .TabsTray.CloseTabsToast.Action)
         // Passing nil theme because themeManager is not available,
         // calling to applyTheme with proper theme before showing
         let toast = ButtonToast(viewModel: viewModel,

--- a/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -722,7 +722,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager {
         let title = recentlyClosedTabs.count == 1 ? ToastString.TitleSingular : ToastString.TitlePlural
         let viewModel = ButtonToastViewModel(
             labelText: String.localizedStringWithFormat(title, recentlyClosedTabs.count),
-            buttonText: .TabsTray.CloseTabsToast.Action)
+            buttonText: ToastString.Action)
         // Passing nil theme because themeManager is not available,
         // calling to applyTheme with proper theme before showing
         let toast = ButtonToast(viewModel: viewModel,


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6107)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13815)

### Description
Updates a string behaviour for the close all tabs toast. Now it respects singular vs plural

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
