### PR TITLE
Bugfix FXIOS-6109 [v113] Fix update view model keys and tests

### DIFF
--- a/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -120,6 +120,11 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
 
     // MARK: - Public methods
     public func isNimbusEnabled(using nimbusLayer: NimbusFeatureFlagLayer) -> Bool {
+        // Provide a way to override nimbus feature enabled for tests
+        if AppConstants.isRunningUnitTest, UserDefaults.standard.bool(forKey: PrefsKeys.NimbusFeatureTestsOverride) {
+            return true
+        }
+
         let nimbusValue = nimbusLayer.checkNimbusConfigFor(featureID)
 
         switch featureID {

--- a/Client/Frontend/Update/UpdateViewModel.swift
+++ b/Client/Frontend/Update/UpdateViewModel.swift
@@ -9,7 +9,6 @@ import Shared
 class UpdateViewModel: OnboardingViewModelProtocol,
                        FeatureFlaggable,
                        AppVersionUpdateCheckerProtocol {
-    static let prefsKey: String = PrefsKeys.AppVersion.Latest
     let profile: Profile
     var hasSyncableAccount: Bool?
 
@@ -31,7 +30,11 @@ class UpdateViewModel: OnboardingViewModelProtocol,
 
     // If the feature is enabled and is not clean install
     var shouldShowFeature: Bool {
-        return featureFlags.isFeatureEnabled(.onboardingUpgrade, checking: .buildOnly) && profile.prefs.stringForKey(PrefsKeys.AppVersion.Latest) != nil
+        return featureFlags.isFeatureEnabled(.onboardingUpgrade, checking: .buildOnly) && !isFreshInstall
+    }
+
+    var isFreshInstall: Bool {
+        return profile.prefs.stringForKey(PrefsKeys.AppVersion.Latest) == nil
     }
 
     init(profile: Profile) {
@@ -47,14 +50,14 @@ class UpdateViewModel: OnboardingViewModelProtocol,
             return false
         }
 
-        // we check if there is a version number already saved
-        guard profile.prefs.stringForKey(UpdateViewModel.prefsKey) != nil else {
+        // If it's fresh install, we don't show the update onboarding
+        guard !isFreshInstall else {
             saveAppVersion(for: appVersion)
-            return true
+            return false
         }
 
         // Version number saved in user prefs is not the same as current version
-        if isMajorVersionUpdate(using: profile, and: appVersion) {
+        guard !isMajorVersionUpdate(using: profile, and: appVersion) else {
             saveAppVersion(for: appVersion)
             return true
         }
@@ -109,6 +112,6 @@ class UpdateViewModel: OnboardingViewModelProtocol,
     }
 
     private func saveAppVersion(for appVersion: String) {
-        profile.prefs.setString(appVersion, forKey: UpdateViewModel.prefsKey)
+        profile.prefs.setString(appVersion, forKey: PrefsKeys.AppVersion.Latest)
     }
 }

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -151,6 +151,9 @@ public struct PrefsKeys {
 
     // Representing whether or not the last user session was private
     public static let LastSessionWasPrivate = "wasLastSessionPrivate"
+
+    // Only used to force nimbus features to true with tests
+    public static let NimbusFeatureTestsOverride = "NimbusFeatureTestsOverride"
 }
 
 public struct PrefsDefaults {


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6109)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13820)

### Description
Adding a way to test for nimbus feature flag when we have `.buildOnly` + fixing tests/code within update view model

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [X] Documentation / comments for complex code and public methods
