### PR TITLE
Bugfix FXIOS-5173 [v113] Empty top bar shown when it should be hidden due to scrolling

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -91,6 +91,8 @@
 		2165B2C22860C2F4004C0786 /* AdjustTelemetryHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2165B2C12860C2F4004C0786 /* AdjustTelemetryHelper.swift */; };
 		2165B2C42860CB34004C0786 /* MockAdjustTelemetryData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2165B2C32860CB34004C0786 /* MockAdjustTelemetryData.swift */; };
 		2165B2CC28748CD7004C0786 /* LibraryPanelDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2165B2CB28748CD7004C0786 /* LibraryPanelDescriptor.swift */; };
+		2173326829CCDA8E007F20C7 /* TabScrollControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2173326629CCD259007F20C7 /* TabScrollControllerTests.swift */; };
+		2173326A29CCF901007F20C7 /* UIPanGestureRecognizerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2173326929CCF901007F20C7 /* UIPanGestureRecognizerMock.swift */; };
 		21737FB72878A4BD000A9A92 /* HistoryPanelViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21737FB528789EA9000A9A92 /* HistoryPanelViewModelTests.swift */; };
 		2178A6A0291454B5002EC290 /* ReaderModeThemeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2178A69F291454B5002EC290 /* ReaderModeThemeButton.swift */; };
 		2178A6A229145506002EC290 /* ReaderModeFontSizeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2178A6A129145506002EC290 /* ReaderModeFontSizeLabel.swift */; };
@@ -1923,6 +1925,8 @@
 		2165B2C12860C2F4004C0786 /* AdjustTelemetryHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdjustTelemetryHelper.swift; sourceTree = "<group>"; };
 		2165B2C32860CB34004C0786 /* MockAdjustTelemetryData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAdjustTelemetryData.swift; sourceTree = "<group>"; };
 		2165B2CB28748CD7004C0786 /* LibraryPanelDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryPanelDescriptor.swift; sourceTree = "<group>"; };
+		2173326629CCD259007F20C7 /* TabScrollControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabScrollControllerTests.swift; sourceTree = "<group>"; };
+		2173326929CCF901007F20C7 /* UIPanGestureRecognizerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIPanGestureRecognizerMock.swift; sourceTree = "<group>"; };
 		21737FB528789EA9000A9A92 /* HistoryPanelViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryPanelViewModelTests.swift; sourceTree = "<group>"; };
 		2178A69F291454B5002EC290 /* ReaderModeThemeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeThemeButton.swift; sourceTree = "<group>"; };
 		2178A6A129145506002EC290 /* ReaderModeFontSizeLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeFontSizeLabel.swift; sourceTree = "<group>"; };
@@ -7629,6 +7633,7 @@
 				8AE80BB02891A39F00BC12EA /* SpyNotificationCenter.swift */,
 				8A93F86629D373AC004159D9 /* MockNavigationController.swift */,
 				8A7A26E029D4785900EA76F1 /* MockRouter.swift */,
+				2173326929CCF901007F20C7 /* UIPanGestureRecognizerMock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -8167,6 +8172,7 @@
 				E1AEC174286E0CF500062E29 /* WebView */,
 				8A5BD9582878871B000FE773 /* TopSitesHelperTests.swift */,
 				21B337BA29B67E4100E4F806 /* BrowserViewControllerWebViewDelegateTests.swift */,
+				2173326629CCD259007F20C7 /* TabScrollControllerTests.swift */,
 			);
 			path = Browser;
 			sourceTree = "<group>";
@@ -11292,6 +11298,7 @@
 				39C137972655798A003DC662 /* NimbusIntegrationTests.swift in Sources */,
 				215B458427DA87FC00E5E800 /* TabMetadataManagerTests.swift in Sources */,
 				215349062886007900FADB4D /* GleanPlumbMessageStoreTests.swift in Sources */,
+				2173326A29CCF901007F20C7 /* UIPanGestureRecognizerMock.swift in Sources */,
 				5A9A09D628B01FD500B6F51E /* MockURLBarView.swift in Sources */,
 				8A33222227DFE658008F809E /* NimbusMock.swift in Sources */,
 				8A8629E72880B7330096DDB1 /* BookmarksPanelTests.swift in Sources */,
@@ -11328,6 +11335,7 @@
 				8A5C3BC5282ABF8E003A8CCF /* RemoteTabsPanelTests.swift in Sources */,
 				D8EFFA261FF702A8001D3A09 /* NavigationRouterTests.swift in Sources */,
 				8A1E3BE328CBACDD003388C4 /* SponsoredContentFilterUtilityTests.swift in Sources */,
+				2173326829CCDA8E007F20C7 /* TabScrollControllerTests.swift in Sources */,
 				63306D452110BAF000F25400 /* TabManagerStoreTests.swift in Sources */,
 				9614BF4228A53FDF00D3F7EA /* ContextualHintEligibilityUtilityTests.swift in Sources */,
 				21B337BB29B67E4100E4F806 /* BrowserViewControllerWebViewDelegateTests.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1043,6 +1043,7 @@ class BrowserViewController: UIViewController {
     }
 
     private func enterOverlayMode() {
+        scrollController.isKeyboardOpen = true
         // Delay enterOverlay mode after dismissableView is dismiss
         if let viewcontroller = presentedViewController as? OnViewDismissable {
             viewcontroller.onViewDismissed = { [weak self] in
@@ -1060,6 +1061,7 @@ class BrowserViewController: UIViewController {
     }
 
     private func leaveOverlayMode(didCancel cancel: Bool) {
+        scrollController.isKeyboardOpen = false
         urlBar.leaveOverlayMode(didCancel: cancel)
     }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2565,7 +2565,6 @@ extension BrowserViewController: KeyboardHelperDelegate {
         keyboardState = state
         updateViewConstraints()
         scrollController.isKeyboardOpen = true
-        print("YRD keyboard open")
 
         UIView.animate(
             withDuration: state.animationDuration,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -685,10 +685,6 @@ class BrowserViewController: UIViewController {
         webViewContainerBackdrop.snp.makeConstraints { make in
             make.edges.equalTo(view)
         }
-    }
-
-    override func updateViewConstraints() {
-        super.updateViewConstraints()
 
         header.snp.remakeConstraints { make in
             if isBottomSearchBar {
@@ -700,6 +696,10 @@ class BrowserViewController: UIViewController {
                 make.left.right.equalTo(view)
             }
         }
+    }
+
+    override func updateViewConstraints() {
+        super.updateViewConstraints()
 
         topTouchArea.snp.remakeConstraints { make in
             make.top.left.right.equalTo(view)
@@ -2564,7 +2564,6 @@ extension BrowserViewController: KeyboardHelperDelegate {
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillShowWithState state: KeyboardState) {
         keyboardState = state
         updateViewConstraints()
-        scrollController.isKeyboardOpen = true
 
         UIView.animate(
             withDuration: state.animationDuration,
@@ -2578,7 +2577,6 @@ extension BrowserViewController: KeyboardHelperDelegate {
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {
         keyboardState = nil
         updateViewConstraints()
-        scrollController.isKeyboardOpen = false
 
         UIView.animate(
             withDuration: state.animationDuration,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1043,7 +1043,6 @@ class BrowserViewController: UIViewController {
     }
 
     private func enterOverlayMode() {
-        scrollController.isKeyboardOpen = true
         // Delay enterOverlay mode after dismissableView is dismiss
         if let viewcontroller = presentedViewController as? OnViewDismissable {
             viewcontroller.onViewDismissed = { [weak self] in
@@ -1061,7 +1060,6 @@ class BrowserViewController: UIViewController {
     }
 
     private func leaveOverlayMode(didCancel cancel: Bool) {
-        scrollController.isKeyboardOpen = false
         urlBar.leaveOverlayMode(didCancel: cancel)
     }
 
@@ -2566,6 +2564,8 @@ extension BrowserViewController: KeyboardHelperDelegate {
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillShowWithState state: KeyboardState) {
         keyboardState = state
         updateViewConstraints()
+        scrollController.isKeyboardOpen = true
+        print("YRD keyboard open")
 
         UIView.animate(
             withDuration: state.animationDuration,
@@ -2579,6 +2579,7 @@ extension BrowserViewController: KeyboardHelperDelegate {
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {
         keyboardState = nil
         updateViewConstraints()
+        scrollController.isKeyboardOpen = false
 
         UIView.animate(
             withDuration: state.animationDuration,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -258,6 +258,7 @@ class BrowserViewController: UIViewController {
 
         isBottomSearchBar = newPositionIsBottom
         updateViewConstraints()
+        updateHeaderConstraints()
         toolbar.setNeedsDisplay()
         urlBar.updateConstraints()
     }
@@ -686,6 +687,10 @@ class BrowserViewController: UIViewController {
             make.edges.equalTo(view)
         }
 
+        updateHeaderConstraints()
+    }
+
+    private func updateHeaderConstraints() {
         header.snp.remakeConstraints { make in
             if isBottomSearchBar {
                 make.left.right.top.equalTo(view)

--- a/Client/Frontend/Browser/TabScrollController.swift
+++ b/Client/Frontend/Browser/TabScrollController.swift
@@ -6,8 +6,6 @@ import UIKit
 import SnapKit
 
 private let ToolbarBaseAnimationDuration: CGFloat = 0.2
-
-
 class TabScrollingController: NSObject, FeatureFlaggable {
     enum ScrollDirection {
         case up
@@ -48,7 +46,7 @@ class TabScrollingController: NSObject, FeatureFlaggable {
 
     private var toolbarsShowing: Bool {
         let bottomShowing = overKeyboardContainerOffset == 0 && bottomContainerOffset == 0
-        return isBottomSearchBar ? bottomShowing : toolbarState == .visible
+        return isBottomSearchBar ? bottomShowing : headerTopOffset == 0
     }
 
     private var isZoomedOut: Bool = false
@@ -108,7 +106,7 @@ class TabScrollingController: NSObject, FeatureFlaggable {
     // If scrollview contentSize height is bigger that device height plus delta
     var isAbleToScroll: Bool {
         return (UIScreen.main.bounds.size.height + 2 * UIConstants.ToolbarHeight) <
-            contentSize.height ?? 0
+            contentSize.height
     }
 
     override init() {

--- a/Client/Frontend/Browser/TabScrollController.swift
+++ b/Client/Frontend/Browser/TabScrollController.swift
@@ -88,9 +88,7 @@ class TabScrollingController: NSObject, FeatureFlaggable {
     private var contentOffset: CGPoint { return scrollView?.contentOffset ?? .zero }
     private var scrollViewHeight: CGFloat { return scrollView?.frame.height ?? 0 }
     private var topScrollHeight: CGFloat { header?.frame.height ?? 0 }
-    lazy var contentSize: CGSize = {
-        return scrollView?.contentSize ?? .zero
-    }()
+    private var contentSize: CGSize { return scrollView?.contentSize ?? .zero }
 
     // Over keyboard content and bottom content
     private var overKeyboardScrollHeight: CGFloat {
@@ -159,21 +157,6 @@ class TabScrollingController: NSObject, FeatureFlaggable {
             completion: nil)
     }
 
-    func hideToolbars(animated: Bool) {
-        guard toolbarState != .collapsed else { return }
-        toolbarState = .collapsed
-
-        let actualDuration = TimeInterval(ToolbarBaseAnimationDuration * hideDurationRation)
-        self.animateToolbarsWithOffsets(
-            animated,
-            duration: actualDuration,
-            headerOffset: -topScrollHeight,
-            bottomContainerOffset: bottomContainerScrollHeight,
-            overKeyboardOffset: overKeyboardScrollHeight,
-            alpha: 0,
-            completion: nil)
-    }
-
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
         if keyPath == "contentSize" {
             guard isAbleToScroll, toolbarsShowing else { return }
@@ -206,6 +189,21 @@ extension TabScrollingController: SearchBarLocationProvider {}
 
 // MARK: - Private
 private extension TabScrollingController {
+    func hideToolbars(animated: Bool) {
+        guard toolbarState != .collapsed else { return }
+        toolbarState = .collapsed
+
+        let actualDuration = TimeInterval(ToolbarBaseAnimationDuration * hideDurationRation)
+        self.animateToolbarsWithOffsets(
+            animated,
+            duration: actualDuration,
+            headerOffset: -topScrollHeight,
+            bottomContainerOffset: bottomContainerScrollHeight,
+            overKeyboardOffset: overKeyboardScrollHeight,
+            alpha: 0,
+            completion: nil)
+    }
+
     func configureRefreshControl() {
         scrollView?.refreshControl = UIRefreshControl()
         scrollView?.refreshControl?.addTarget(self, action: #selector(reload), for: .valueChanged)

--- a/Client/Frontend/Browser/TabScrollController.swift
+++ b/Client/Frontend/Browser/TabScrollController.swift
@@ -111,7 +111,8 @@ class TabScrollingController: NSObject, FeatureFlaggable {
         super.init()
     }
 
-    @objc func handlePan(_ gesture: UIPanGestureRecognizer) {
+    @objc
+    func handlePan(_ gesture: UIPanGestureRecognizer) {
         guard gesture.state != .ended, gesture.state != .cancelled else {
             lastContentOffset = 0
             return

--- a/Tests/ClientTests/Frontend/Browser/TabScrollControllerTests.swift
+++ b/Tests/ClientTests/Frontend/Browser/TabScrollControllerTests.swift
@@ -1,0 +1,56 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import WebKit
+
+@testable import Client
+
+final class TabScrollControllerTests: XCTestCase {
+    var tab: Tab!
+    var subject: TabScrollingController!
+    var mockProfile: MockProfile!
+    var mockGesture: UIPanGestureRecognizerMock!
+
+    override func setUp() {
+        super.setUp()
+
+        self.mockProfile = MockProfile()
+        self.subject = TabScrollingController()
+        self.tab = Tab(profile: mockProfile, configuration: WKWebViewConfiguration())
+        FeatureFlagsManager.shared.initializeDeveloperFeatures(with: mockProfile)
+        mockGesture = UIPanGestureRecognizerMock()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        mockProfile?.shutdown()
+        self.mockProfile = nil
+        self.subject = nil
+        self.tab = nil
+    }
+
+    func testHandlePan_ScrollingUp() {
+        tab.createWebview()
+        subject.tab = tab
+        subject.contentSize = CGSize(width: 200, height: 2000)
+
+        mockGesture.gestureTranslation = CGPoint(x: 0, y: 100)
+        subject.handlePan(mockGesture)
+
+        XCTAssertEqual(subject.toolbarState, TabScrollingController.ToolbarState.collapsed)
+    }
+
+    func testHandlePan_ScrollingDown() {
+        tab.createWebview()
+        subject.tab = tab
+        subject.contentSize = CGSize(width: 200, height: 2000)
+
+        mockGesture.gestureTranslation = CGPoint(x: 0, y: -100)
+        subject.handlePan(mockGesture)
+
+        XCTAssertEqual(subject.toolbarState, TabScrollingController.ToolbarState.visible)
+    }
+}

--- a/Tests/ClientTests/Frontend/Browser/TabScrollControllerTests.swift
+++ b/Tests/ClientTests/Frontend/Browser/TabScrollControllerTests.swift
@@ -34,8 +34,8 @@ final class TabScrollControllerTests: XCTestCase {
 
     func testHandlePan_ScrollingUp() {
         tab.createWebview()
+        tab.webView?.scrollView.contentSize = CGSize(width: 200, height: 2000)
         subject.tab = tab
-        subject.contentSize = CGSize(width: 200, height: 2000)
 
         mockGesture.gestureTranslation = CGPoint(x: 0, y: 100)
         subject.handlePan(mockGesture)
@@ -45,8 +45,8 @@ final class TabScrollControllerTests: XCTestCase {
 
     func testHandlePan_ScrollingDown() {
         tab.createWebview()
+        tab.webView?.scrollView.contentSize = CGSize(width: 200, height: 2000)
         subject.tab = tab
-        subject.contentSize = CGSize(width: 200, height: 2000)
 
         mockGesture.gestureTranslation = CGPoint(x: 0, y: -100)
         subject.handlePan(mockGesture)

--- a/Tests/ClientTests/Mocks/UIPanGestureRecognizerMock.swift
+++ b/Tests/ClientTests/Mocks/UIPanGestureRecognizerMock.swift
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+class UIPanGestureRecognizerMock: UIPanGestureRecognizer {
+    var gestureTranslation: CGPoint?
+    var gestureVelocity: CGPoint?
+
+    override func translation(in view: UIView?) -> CGPoint {
+        if let gestureTranslation = gestureTranslation {
+            return gestureTranslation
+        }
+        return super.translation(in: view)
+    }
+
+    override func velocity(in view: UIView?) -> CGPoint {
+        if let gestureVelocity = gestureVelocity {
+            return gestureVelocity
+        }
+        return super.velocity(in: view)
+    }
+}

--- a/Tests/ClientTests/Mocks/UIPanGestureRecognizerMock.swift
+++ b/Tests/ClientTests/Mocks/UIPanGestureRecognizerMock.swift
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import Foundation
+import UIKit
 
 class UIPanGestureRecognizerMock: UIPanGestureRecognizer {
     var gestureTranslation: CGPoint?


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5173)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/12262)

### Description
- Avoid redoing header constraints in updateViewConstraints that caused this bug due to a race condition between the keyboard dismissal and the animation to hide the header when scrolling
- Add unit test to TabScrollController

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
