### PR TITLE
Add FXIOS-6106 [v113] Add back show tour in the application

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -513,6 +513,11 @@ class BrowserViewController: UIViewController {
             selector: #selector(openTabNotification),
             name: .OpenTabNotification,
             object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(presentIntroFrom),
+            name: .PresentIntroView,
+            object: nil)
     }
 
     func addSubviews() {
@@ -2266,8 +2271,13 @@ extension BrowserViewController: UIAdaptivePresentationControllerDelegate {
 }
 
 extension BrowserViewController {
-    func presentIntroViewController(_ alwaysShow: Bool = false) {
-        if alwaysShow || IntroScreenManager(prefs: profile.prefs).shouldShowIntroScreen {
+    @objc
+    func presentIntroFrom(notification: Notification) {
+        presentIntroViewController(force: true)
+    }
+
+    func presentIntroViewController(force: Bool = false) {
+        if force || IntroScreenManager(prefs: profile.prefs).shouldShowIntroScreen {
             showProperIntroVC()
         }
     }

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -765,6 +765,32 @@ class YourRightsSetting: Setting {
     }
 }
 
+// Opens the on-boarding screen again
+class ShowIntroductionSetting: Setting {
+    let profile: Profile
+
+    override var accessibilityIdentifier: String? { return "ShowTour" }
+
+    init(settings: SettingsTableViewController) {
+        self.profile = settings.profile
+        let attributes = [NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary]
+        super.init(title: NSAttributedString(string: .AppSettingsShowTour,
+                                             attributes: attributes))
+    }
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        navigationController?.dismiss(animated: true, completion: {
+            NotificationCenter.default.post(name: .PresentIntroView, object: self)
+
+            TelemetryWrapper.recordEvent(
+                category: .action,
+                method: .tap,
+                object: .settingsMenuShowTour
+            )
+        })
+    }
+}
+
 class SendFeedbackSetting: Setting {
     override var title: NSAttributedString? {
         return NSAttributedString(string: .AppSettingsSendFeedback, attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -210,6 +210,7 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
         settings += [
             SettingSection(title: NSAttributedString(string: .AppSettingsPrivacyTitle), children: privacySettings),
             SettingSection(title: NSAttributedString(string: .AppSettingsSupport), children: [
+                ShowIntroductionSetting(settings: self),
                 SendFeedbackSetting(),
                 SendAnonymousUsageDataSetting(prefs: prefs, delegate: settingsDelegate, theme: themeManager.currentTheme),
                 StudiesToggleSetting(prefs: prefs, delegate: settingsDelegate, theme: themeManager.currentTheme),

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -408,6 +408,7 @@ extension TelemetryWrapper {
         case appMenu = "app_menu"
         case settings = "settings"
         case settingsMenuSetAsDefaultBrowser = "set-as-default-browser-menu-go-to-settings"
+        case settingsMenuShowTour = "show-tour"
         case creditCardAutofillSettings = "creditCardAutofillSettings"
         case notificationPermission = "notificationPermission"
         case engagementNotification = "engagementNotification"
@@ -784,6 +785,9 @@ extension TelemetryWrapper {
         // MARK: Settings Menu
         case (.action, .open, .settingsMenuSetAsDefaultBrowser, _, _):
             GleanMetrics.SettingsMenu.setAsDefaultBrowserPressed.add()
+
+        case(.action, .tap, .settingsMenuShowTour, _, _):
+            GleanMetrics.SettingsMenu.showTourPressed.record()
 
         // MARK: Start Search Button
         case (.action, .tap, .startSearchButton, _, _):

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -2093,7 +2093,7 @@ settings_menu:
       - https://github.com/mozilla-mobile/firefox-ios/issues/13814
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/12462
-      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/13827
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2023-06-01"

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -2083,6 +2083,20 @@ settings_menu:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2023-06-01"
+  show_tour_pressed:
+    type: event
+    description: |
+      Metric recorded when a user taps on the Show Tour option
+      from the app settings menu.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/12433
+      - https://github.com/mozilla-mobile/firefox-ios/issues/13814
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/12462
+      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2023-06-01"
 
 # Search and search releated metrics
 search:

--- a/Shared/NotificationConstants.swift
+++ b/Shared/NotificationConstants.swift
@@ -100,4 +100,6 @@ extension Notification.Name {
     public static let ReadingListUpdated = Notification.Name("ReadingListUpdated")
     public static let TopSitesUpdated = Notification.Name("TopSitesUpdated")
     public static let HistoryUpdated = Notification.Name("HistoryUpdated")
+
+    public static let PresentIntroView = Notification.Name("PresentIntroView")
 }

--- a/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -429,6 +429,18 @@ class TelemetryWrapperTests: XCTestCase {
         testEventMetricRecordingSuccess(metric: GleanMetrics.Accessibility.dynamicText)
     }
 
+    // MARK: - App Settings Menu
+
+    func test_showTour_GleanIsCalled() {
+        TelemetryWrapper.recordEvent(
+            category: .action,
+            method: .tap,
+            object: .settingsMenuShowTour
+        )
+
+        testEventMetricRecordingSuccess(metric: GleanMetrics.SettingsMenu.showTourPressed)
+    }
+
     // MARK: - Credit card autofill
 
     func test_autofill_credit_card_settings_tapped_GleanIsCalled() {


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

### Description
Based on PR that removed the feature initially [here](https://github.com/mozilla-mobile/firefox-ios/pull/13341/files).
- Using same telemetry as before
- Strings weren't removed, so translations are still there no need to export strings
- Use notification instead of BVC foreground we had in the past, good for now for our single scene app. We'll improve on this with ticket https://github.com/mozilla-mobile/firefox-ios/issues/13813

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [X] Documentation / comments for complex code and public methods
