### PR TITLE
Add EXP-3349 [v113] Bring Nimbus Messaging testing up to parity with Android

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -234,10 +234,12 @@
 		397848E21ED86605004C0C0B /* NotificationService.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 397848DB1ED86605004C0C0B /* NotificationService.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		39A359E41BFCCE94006B9E87 /* UserActivityHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39A359E31BFCCE94006B9E87 /* UserActivityHandler.swift */; };
 		39A35AED1C0662A3006B9E87 /* SpotlightHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = 39A35AEC1C0662A3006B9E87 /* SpotlightHelper.js */; };
+		39AF317429DAE37E00F8E6F7 /* NimbusMessagingMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39AF317329DAE37E00F8E6F7 /* NimbusMessagingMessageTests.swift */; };
 		39C137972655798A003DC662 /* NimbusIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C137962655798A003DC662 /* NimbusIntegrationTests.swift */; };
 		39C22C291E89791C000C0E56 /* PushCrypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395C8F201E796AD600A68E8C /* PushCrypto.swift */; };
 		39C261CC2018DE21009D97BD /* FxScreenGraphTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C261CB2018DE20009D97BD /* FxScreenGraphTests.swift */; };
 		39D056382665235700FBEE59 /* initial_experiments.json in Resources */ = {isa = PBXBuildFile; fileRef = 3964F5FB2656D2B500065278 /* initial_experiments.json */; };
+		39D0DA7629D767DE000760B8 /* NimbusMessagingTriggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D0DA7429D767D1000760B8 /* NimbusMessagingTriggerTests.swift */; };
 		39E65D271CA5B92000C63CE3 /* AsyncReducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E65D261CA5B92000C63CE3 /* AsyncReducerTests.swift */; };
 		39EB469A1E26DDB4006346E8 /* FxScreenGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EB46981E26DDB4006346E8 /* FxScreenGraph.swift */; };
 		39EF434E260A73950011E22E /* Experiments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EF434D260A73950011E22E /* Experiments.swift */; };
@@ -2235,10 +2237,12 @@
 		39A359E31BFCCE94006B9E87 /* UserActivityHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserActivityHandler.swift; path = Helpers/UserActivityHandler.swift; sourceTree = "<group>"; };
 		39A35AEC1C0662A3006B9E87 /* SpotlightHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = SpotlightHelper.js; sourceTree = "<group>"; };
 		39AD454C88A908D41BA13329 /* te */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = te; path = te.lproj/Today.strings; sourceTree = "<group>"; };
+		39AF317329DAE37E00F8E6F7 /* NimbusMessagingMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusMessagingMessageTests.swift; sourceTree = "<group>"; };
 		39B0647C1E7ADAC2000BE173 /* PushCryptoTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushCryptoTests.swift; sourceTree = "<group>"; };
 		39C137962655798A003DC662 /* NimbusIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusIntegrationTests.swift; sourceTree = "<group>"; };
 		39C22C2C1E897B9A000C0E56 /* PushClientTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushClientTests.swift; sourceTree = "<group>"; };
 		39C261CB2018DE20009D97BD /* FxScreenGraphTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FxScreenGraphTests.swift; sourceTree = "<group>"; };
+		39D0DA7429D767D1000760B8 /* NimbusMessagingTriggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusMessagingTriggerTests.swift; sourceTree = "<group>"; };
 		39DB4F1AA7B4688949522C99 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/FindInPage.strings; sourceTree = "<group>"; };
 		39DD4C8BA7FCE677AFDACC2D /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/Localizable.strings; sourceTree = "<group>"; };
 		39E65D261CA5B92000C63CE3 /* AsyncReducerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncReducerTests.swift; sourceTree = "<group>"; };
@@ -8818,6 +8822,8 @@
 				E1E6F8CD29D4B7E700068D8D /* GleanPlumbContextProviderTests.swift */,
 				215349022881FA3C00FADB4D /* GleanPlumbMessageManagerTests.swift */,
 				215349052886007900FADB4D /* GleanPlumbMessageStoreTests.swift */,
+				39AF317329DAE37E00F8E6F7 /* NimbusMessagingMessageTests.swift */,
+				39D0DA7429D767D1000760B8 /* NimbusMessagingTriggerTests.swift */,
 				5F97DD5E27FB0FE800AD3C60 /* GleanTelemetryTests.swift */,
 				C889D7D32858CD4500121E1D /* HistoryHighlights */,
 				217AEF75284666D4004EED37 /* IntroViewModelTests.swift */,
@@ -11328,6 +11334,7 @@
 				8AA6ADB52742B567004EEE23 /* TelemetryWrapperTests.swift in Sources */,
 				21534904288201E300FADB4D /* GleanPlumbMessageManagerTests.swift in Sources */,
 				E1390FB628B040E900C9EF3E /* WallpaperSelectorViewModelTests.swift in Sources */,
+				39AF317429DAE37E00F8E6F7 /* NimbusMessagingMessageTests.swift in Sources */,
 				C889D7D52858CD8800121E1D /* HistoryHighlightsTestEntryProvider.swift in Sources */,
 				E19B38B128A3E69300D8C541 /* WallpaperCollectionAvailabilityTests.swift in Sources */,
 				21737FB72878A4BD000A9A92 /* HistoryPanelViewModelTests.swift in Sources */,
@@ -11402,6 +11409,7 @@
 				965C3C9829343445006499ED /* MockAppSessionManager.swift in Sources */,
 				8AE1E1DB27B1C1320024C45E /* SearchBarSettingsViewModelTests.swift in Sources */,
 				CA24B53924ABFE250093848C /* LoginsListSelectionHelperTests.swift in Sources */,
+				39D0DA7629D767DE000760B8 /* NimbusMessagingTriggerTests.swift in Sources */,
 				2FDB10931A9FBEC5006CF312 /* PrefsTests.swift in Sources */,
 				5A9A09D228AFD51900B6F51E /* MockHomepageDataModelDelegate.swift in Sources */,
 				D525DFB325FBE5E000B18763 /* TabTests.swift in Sources */,

--- a/Client/Experiments/Messaging/GleanPlumbContextProvider.swift
+++ b/Client/Experiments/Messaging/GleanPlumbContextProvider.swift
@@ -55,7 +55,7 @@ class GleanPlumbContextProvider {
     }
 
     private var allowedTipsNotifications: Bool {
-        let featureEnabled = FeatureFlagsManager.shared.isFeatureEnabled(.notificationSettings, checking: .buildOnly)
+        let featureEnabled = FxNimbus.shared.features.notificationSettingsFeature.value().notificationSettingsFeatureStatus
         let userPreference = userDefaults.bool(forKey: PrefsKeys.Notifications.TipsAndFeaturesNotifications)
         return featureEnabled && userPreference
     }

--- a/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
+++ b/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
@@ -37,7 +37,7 @@ protocol GleanPlumbMessageManagerProtocol {
     func onMalformedMessage(id: String, surface: MessageSurfaceId)
 
     /// Finds a message for a specified id on a specified surface.
-    func messageForId(_ id: String, surface: MessageSurfaceId) -> GleanPlumbMessage?
+    func messageForId(_ id: String) -> GleanPlumbMessage?
 }
 
 protocol GleanPlumbMessagePressedDelegate: AnyObject {
@@ -63,7 +63,7 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
 
     private let messagingUtility: GleanPlumbMessageUtility
     private let messagingStore: GleanPlumbMessageStoreProtocol
-    private let feature = FxNimbus.shared.features.messaging.value()
+    private let messagingFeature = FxNimbus.shared.features.messaging
 
     weak var pressedDelegate: GleanPlumbMessagePressedDelegate?
 
@@ -91,7 +91,11 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
     /// Returns the next valid and triggered message for the surface, if one exists.
     func getNextMessage(for surface: MessageSurfaceId) -> GleanPlumbMessage? {
         // All these are non-expired, well formed, and descending priority ordered messages for a requested surface.
-        let messages = getAllValidMessagesFor(surface, with: feature)
+        let feature = messagingFeature.value()
+        let messages = getMessages(feature)
+            .filter {
+                $0.data.surface == surface
+            }
 
         // If `GleanPlumbHelper` creation fails, we cannot continue with this feature! For that reason, return `nil`.
         // We need to recreate the helper for each request to get a message because device context can change.
@@ -189,16 +193,12 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
     /// Finds a message for a specified id on a specified surface.
     /// - Parameters:
     ///   - id: the id of the message.
-    ///   - surface: the surface the message should be disaplayed on.
     /// - Returns: the message if existent, otherwise nil.
-    func messageForId(_ id: String, surface: MessageSurfaceId) -> GleanPlumbMessage? {
-        let messageData = feature.messages.first { key, messageData in
-            return key == id && messageData.surface == surface
-        }
-
-        guard let messageData = messageData,
-              let message = self.createMessage(messageId: messageData.key,
-                                               message: messageData.value,
+    func messageForId(_ id: String) -> GleanPlumbMessage? {
+        let feature = messagingFeature.value()
+        guard let messageData = feature.messages[id],
+              let message = self.createMessage(messageId: id,
+                                               message: messageData,
                                                lookupTables: feature)
         else { return nil }
 
@@ -207,12 +207,9 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
 
     // MARK: - Misc. Private helpers
 
-    /// - Returns: All well-formed, non-expired messages for a surface in descending priority order for a specified surface.
-    private func getAllValidMessagesFor(
-        _ surface: MessageSurfaceId,
-        with feature: Messaging
-    ) -> [GleanPlumbMessage] {
-        // All these are non-expired, well formed, and descending priority messages for a requested surface.
+    /// - Returns: All well-formed, non-expired messages in descending priority order.
+    func getMessages(_ feature: Messaging) -> [GleanPlumbMessage] {
+        // All these are non-expired, well formed, and descending priority messages.
         let messages = feature.messages.compactMap { key, messageData -> GleanPlumbMessage? in
             guard let message = self.createMessage(messageId: key,
                                                    message: messageData,
@@ -225,8 +222,6 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
             return message
         }.filter { message in
             !message.isExpired
-        }.filter { message in
-            message.data.surface == surface
         }.sorted { message1, message2 in
             message1.style.priority > message2.style.priority
         }
@@ -283,13 +278,14 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
     ///
     /// - Returns: The next triggered message, if one exists.
     private func getNextTriggeredMessage(_ messages: [GleanPlumbMessage], _ helper: GleanPlumbMessageHelper) -> GleanPlumbMessage? {
-        messages.first( where: { message in
+        var jexlCache = [String: Bool]()
+        return messages.first { message in
             do {
-                return try messagingUtility.isMessageEligible(message, messageHelper: helper)
+                return try messagingUtility.isMessageEligible(message, messageHelper: helper, jexlCache: &jexlCache)
             } catch {
                 return false
             }
-        })
+        }
     }
 
     /// If a message is under experiment, we need to handle it a certain way.
@@ -310,7 +306,7 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
                                               _ messages: [GleanPlumbMessage],
                                               _ helper: GleanPlumbMessageHelper,
                                               _ onControl: ControlMessageBehavior) -> GleanPlumbMessage? {
-        FxNimbus.shared.features.messaging.recordExposure()
+        messagingFeature.recordExposure()
         let onControlActions = onControl
 
         if !message.data.isControl {
@@ -320,9 +316,10 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
         case .showNone:
             return nil
         case .showNextMessage:
+            var jexlCache = [String: Bool]()
             return messages.first { message in
                 do {
-                    return try messagingUtility.isMessageEligible(message, messageHelper: helper)
+                    return try messagingUtility.isMessageEligible(message, messageHelper: helper, jexlCache: &jexlCache)
                     && !message.data.isControl
                 } catch {
                     onMalformedMessage(id: message.id, surface: message.data.surface)

--- a/Client/Frontend/NotificationSurface/NotificationSurfaceManager.swift
+++ b/Client/Frontend/NotificationSurface/NotificationSurfaceManager.swift
@@ -67,7 +67,7 @@ class NotificationSurfaceManager: NotificationSurfaceDelegate {
 
     func didTapNotification(_ userInfo: [AnyHashable: Any]) {
         guard let messageId = userInfo[Constant.messageIdKey] as? String,
-              let message = messagingManager.messageForId(messageId, surface: notificationSurfaceID)
+              let message = messagingManager.messageForId(messageId)
         else { return }
 
         switch message.action {

--- a/Tests/ClientTests/Frontend/Home/MessageCard/HomepageMessageCardViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/MessageCard/HomepageMessageCardViewModelTests.swift
@@ -205,9 +205,8 @@ class MockGleanPlumbMessageManagerProtocol: GleanPlumbMessageManagerProtocol {
 
     func onMalformedMessage(id: String, surface: MessageSurfaceId) {}
 
-    func messageForId(_ id: String, surface: Client.MessageSurfaceId) -> Client.GleanPlumbMessage? {
-        recordedSurface = surface
-        if message?.data.surface == recordedSurface, message?.id == id { return message }
+    func messageForId(_ id: String) -> Client.GleanPlumbMessage? {
+        if message?.id == id { return message }
 
         return nil
     }

--- a/Tests/ClientTests/NimbusMessagingMessageTests.swift
+++ b/Tests/ClientTests/NimbusMessagingMessageTests.swift
@@ -1,0 +1,50 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+import Common
+import Foundation
+import MozillaAppServices
+import Shared
+
+@testable import Client
+
+final class NimbusMessagingMessageTests: XCTestCase {
+    var feature = FxNimbus.shared.features.messaging.value()
+    lazy var subject: GleanPlumbMessageManager = GleanPlumbMessageManager(
+        messagingStore: MockGleanPlumbMessageStore(messageId: "")
+    )
+
+    func testAllMessageIntegrity() throws {
+        let messages = subject.getMessages(feature)
+        let rawMessages = feature.messages
+
+        XCTAssertFalse(rawMessages.isEmpty)
+
+        if rawMessages.count != messages.count {
+            let expected = Set(rawMessages.keys)
+            let observed = Set(messages.map { $0.id })
+            let missing = expected.symmetricDifference(observed)
+            XCTFail("Problem with message(s) in FML: \(missing)")
+        }
+
+        XCTAssertEqual(rawMessages.count, messages.count)
+    }
+
+    func testAllMessageTriggers() throws {
+        let utility = GleanPlumbMessageUtility()
+        let helper = utility.createGleanPlumbHelper()!
+
+        let messages = subject.getMessages(feature)
+        var cache = [String: Bool]()
+        messages.forEach { message in
+            do {
+                _ = try utility.isMessageEligible(message, messageHelper: helper, jexlCache: &cache)
+            } catch {
+                XCTFail("Message \(message.id) failed with invalid JEXL triggers")
+            }
+        }
+    }
+}

--- a/Tests/ClientTests/NimbusMessagingTriggerTests.swift
+++ b/Tests/ClientTests/NimbusMessagingTriggerTests.swift
@@ -1,0 +1,53 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+import Common
+import Foundation
+import MozillaAppServices
+import Shared
+
+@testable import Client
+
+final class NimbusMessagingTriggerTests: XCTestCase {
+    lazy var feature: Messaging = {
+        FxNimbus.shared.features.messaging.value()
+    }()
+
+    lazy var nimbus: NimbusInterface = {
+        Experiments.shared
+    }()
+
+    lazy var helper: GleanPlumbMessageHelper = {
+        let utility = GleanPlumbMessageUtility()
+        return utility.createGleanPlumbHelper()!
+    }()
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        XCTAssert(nimbus is Nimbus)
+    }
+
+    func testTriggers() throws {
+        let helper = self.helper
+        let triggers = feature.triggers
+
+        var badJexlExpressions = [String: String]()
+        triggers.forEach { (key, expression) in
+            do {
+                _ = try helper.evalJexl(expression: expression)
+            } catch {
+                DefaultLogger.shared.log("Failed to evaluate \(key) expression: \(expression)",
+                                         level: .warning,
+                                         category: .experiments)
+                badJexlExpressions[key] = expression
+            }
+        }
+
+        if !badJexlExpressions.isEmpty {
+            XCTFail("JEXL trigger expressions \(badJexlExpressions.keys) are not valid")
+        }
+    }
+}


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/EXP-3349)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

### Description
This PR adds testing for Nimbus Messaging (né GleanPlumb), especially for triggers and messages added via the FML.

It tests that the messages are constructed:
* all messages have valid styles, triggers, etc
* all triggers are syntactically valid JEXL.

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
