### PR TITLE
Add FXIOS-2604 [v113] Can't undo deletion of an opened tab

### DIFF
--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -1468,6 +1468,11 @@ extension String {
                 tableName: "TabsTray",
                 value: "Tabs Closed: %d",
                 comment: "When the user closes tabs in the tab tray, a popup will appear informing them how many tabs were closed. This is the text for the popup. The placeholder is the number of tabs")
+            public static let SingleTabTitle = MZLocalizedString(
+                "CloseTabsToast.SingleTabTitle.v113",
+                tableName: "TabsTray",
+                value: "Tab Closed",
+                comment: "When the user closes an individual tab in the tab tray, a popup will appear informing them the tab was closed. This is the text for the popup.")
             public static let Action = MZLocalizedString(
                 "CloseTabsToast.Button.v113",
                 tableName: "TabsTray",


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-2604)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/7574)

### Description
Add string for undo close individual tab

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
