### PR TITLE
Bugfix FXIOS-6141 [v112.1] Always send adjust ping

### DIFF
--- a/Client/AdjustTelemetryHelper.swift
+++ b/Client/AdjustTelemetryHelper.swift
@@ -30,15 +30,22 @@ class AdjustTelemetryHelper: AdjustTelemetryProtocol {
     }
 
     func setAttributionData(_ attribution: AdjustTelemetryData?) {
-        guard let campaign = attribution?.campaign,
-              let adgroup = attribution?.adgroup,
-              let creative = attribution?.creative,
-              let network = attribution?.network else { return }
+        if let campaign = attribution?.campaign {
+            GleanMetrics.Adjust.campaign.set(campaign)
+        }
 
-        GleanMetrics.Adjust.campaign.set(campaign)
-        GleanMetrics.Adjust.adGroup.set(adgroup)
-        GleanMetrics.Adjust.creative.set(creative)
-        GleanMetrics.Adjust.network.set(network)
+        if let adgroup = attribution?.adgroup {
+            GleanMetrics.Adjust.adGroup.set(adgroup)
+        }
+
+        if let creative = attribution?.creative {
+            GleanMetrics.Adjust.creative.set(creative)
+        }
+
+        if let network = attribution?.network {
+            GleanMetrics.Adjust.network.set(network)
+        }
+
         GleanMetrics.Pings.shared.firstSession.submit()
     }
 }

--- a/Tests/ClientTests/Helpers/AdjustTelemetryHelperTests.swift
+++ b/Tests/ClientTests/Helpers/AdjustTelemetryHelperTests.swift
@@ -25,15 +25,43 @@ class AdjustTelemetryHelperTests: XCTestCase {
         telemetryHelper = nil
     }
 
-    func testFailSetAttribution_WithNilData() {
+    func testFailSetAttribution_WithAllNilData() {
         // Submit the ping.
-        let attribution = MockAdjustTelemetryData(campaign: nil)
+        let attribution = MockAdjustTelemetryData(campaign: nil,
+                                                  adgroup: nil,
+                                                  creative: nil,
+                                                  network: nil)
+        let expectation = expectation(description: "The first session ping was sent")
+
+        GleanMetrics.Pings.shared.firstSession.testBeforeNextSubmit { _ in
+            XCTAssertNil(GleanMetrics.Adjust.campaign.testGetValue())
+            XCTAssertNil(GleanMetrics.Adjust.adGroup.testGetValue())
+            XCTAssertNil(GleanMetrics.Adjust.creative.testGetValue())
+            XCTAssertNil(GleanMetrics.Adjust.network.testGetValue())
+            expectation.fulfill()
+        }
+
         telemetryHelper.setAttributionData(attribution)
 
-        XCTAssertNil(GleanMetrics.Adjust.campaign.testGetValue())
-        XCTAssertNil(GleanMetrics.Adjust.adGroup.testGetValue())
-        XCTAssertNil(GleanMetrics.Adjust.creative.testGetValue())
-        XCTAssertNil(GleanMetrics.Adjust.network.testGetValue())
+        waitForExpectations(timeout: 5.0)
+    }
+
+    func testSetAttribution_WithSomeNilData() {
+        // Submit the ping.
+        let attribution = MockAdjustTelemetryData(campaign: nil)
+        let expectation = expectation(description: "The first session ping was sent")
+
+        GleanMetrics.Pings.shared.firstSession.testBeforeNextSubmit { _ in
+            XCTAssertNil(GleanMetrics.Adjust.campaign.testGetValue())
+            XCTAssertEqual("test_adgroup", GleanMetrics.Adjust.adGroup.testGetValue())
+            XCTAssertEqual("test_creative", GleanMetrics.Adjust.creative.testGetValue())
+            XCTAssertEqual("test_network", GleanMetrics.Adjust.network.testGetValue())
+            expectation.fulfill()
+        }
+
+        telemetryHelper.setAttributionData(attribution)
+
+        waitForExpectations(timeout: 5.0)
     }
 
     func testFirstSessionPing() {


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6141)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13868)

### Description
Always send the adjust ping even if the data is nil

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
