### PR TITLE
Add FXIOS-6129 [v113] Prevent bad input in CC expiry field

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -664,6 +664,7 @@
 		9636D92E27F9E5D900771F5E /* GleanPlumbMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9636D92D27F9E5D900771F5E /* GleanPlumbMessage.swift */; };
 		9638332327E14ACC0011EEFC /* AccessibilityIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C84266742728462900382274 /* AccessibilityIdentifiers.swift */; };
 		963A879A29AFE89B006DEE34 /* SensitiveHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 963A879929AFE89B006DEE34 /* SensitiveHostingController.swift */; };
+		96441BD629DF823D00FE041F /* MockAppAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96441BD529DF823D00FE041F /* MockAppAuthenticator.swift */; };
 		964FA97528A1A8F20024BB3B /* ContextualHintEligibilityUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964FA97428A1A8F20024BB3B /* ContextualHintEligibilityUtility.swift */; };
 		964FA97728A2A55C0024BB3B /* ContextualHintPrefsKeysProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964FA97628A2A55C0024BB3B /* ContextualHintPrefsKeysProvider.swift */; };
 		965C3C8F29313A1B006499ED /* AppSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 965C3C8E29313A1B006499ED /* AppSessionManager.swift */; };
@@ -684,7 +685,6 @@
 		96A5F73829928B3700234E5F /* GeneralizedImageFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A5F73729928B3700234E5F /* GeneralizedImageFetcher.swift */; };
 		96C11E9B2864C2DD00840E7C /* DependencyHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96C11E9A2864C2DD00840E7C /* DependencyHelper.swift */; };
 		96CB5D6329B22EF50034AE0A /* SensitiveHostingControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96CB5D6229B22EF50034AE0A /* SensitiveHostingControllerTests.swift */; };
-		96CB5D6529B23D4D0034AE0A /* MockAppAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96CB5D6429B23D4D0034AE0A /* MockAppAuthenticator.swift */; };
 		96D95016270238500079D39D /* Throttler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D95015270238500079D39D /* Throttler.swift */; };
 		96EA9454293655BF00123345 /* AppSession+Enums.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96EA9453293655BF00123345 /* AppSession+Enums.swift */; };
 		96EB6C3827D821B800A9D159 /* HistoryPanelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96EB6C3727D821B800A9D159 /* HistoryPanelViewModel.swift */; };
@@ -2938,7 +2938,6 @@
 		43B3D33929DAEB53006B3FBC /* en-CA */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-CA"; path = "en-CA.lproj/ResearchSurface.strings"; sourceTree = "<group>"; };
 		43B3D33A29DAEB53006B3FBC /* en-CA */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-CA"; path = "en-CA.lproj/Settings.strings"; sourceTree = "<group>"; };
 		43B3D33B29DAEB53006B3FBC /* en-CA */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-CA"; path = "en-CA.lproj/SnackBar.strings"; sourceTree = "<group>"; };
-		43B658D829CE251C00C9EF08 /* CreditCardEditViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditCardEditViewModelTests.swift; sourceTree = "<group>"; };
 		43B658D829CE251C00C9EF08 /* CreditCardInputViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditCardInputViewModelTests.swift; sourceTree = "<group>"; };
 		43B7BFCA28B905E700AAA92F /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/ToolbarLocation.strings; sourceTree = "<group>"; };
 		43B7E64828B39D1E0003A141 /* ia */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ia; path = ia.lproj/JumpBackIn.strings; sourceTree = "<group>"; };
@@ -4042,6 +4041,7 @@
 		9636D92B27F9E50100771F5E /* GleanPlumbMessageStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanPlumbMessageStore.swift; sourceTree = "<group>"; };
 		9636D92D27F9E5D900771F5E /* GleanPlumbMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanPlumbMessage.swift; sourceTree = "<group>"; };
 		963A879929AFE89B006DEE34 /* SensitiveHostingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensitiveHostingController.swift; sourceTree = "<group>"; };
+		96441BD529DF823D00FE041F /* MockAppAuthenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAppAuthenticator.swift; sourceTree = "<group>"; };
 		964FA97428A1A8F20024BB3B /* ContextualHintEligibilityUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualHintEligibilityUtility.swift; sourceTree = "<group>"; };
 		964FA97628A2A55C0024BB3B /* ContextualHintPrefsKeysProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualHintPrefsKeysProvider.swift; sourceTree = "<group>"; };
 		965C3C8E29313A1B006499ED /* AppSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSessionManager.swift; sourceTree = "<group>"; };
@@ -4089,7 +4089,6 @@
 		96B14F71BAAD012EA8852135 /* ne-NP */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ne-NP"; path = "ne-NP.lproj/LoginManager.strings"; sourceTree = "<group>"; };
 		96C11E9A2864C2DD00840E7C /* DependencyHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyHelper.swift; sourceTree = "<group>"; };
 		96CB5D6229B22EF50034AE0A /* SensitiveHostingControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensitiveHostingControllerTests.swift; sourceTree = "<group>"; };
-		96CB5D6429B23D4D0034AE0A /* MockAppAuthenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAppAuthenticator.swift; sourceTree = "<group>"; };
 		96D95015270238500079D39D /* Throttler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Throttler.swift; sourceTree = "<group>"; };
 		96EA9453293655BF00123345 /* AppSession+Enums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppSession+Enums.swift"; sourceTree = "<group>"; };
 		96EB6C3727D821B800A9D159 /* HistoryPanelViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryPanelViewModel.swift; sourceTree = "<group>"; };
@@ -7344,6 +7343,14 @@
 			path = Messaging;
 			sourceTree = "<group>";
 		};
+		96441BD229DF7DA500FE041F /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+				96CB5D6429B23D4D0034AE0A /* MockAppAuthenticator.swift */,
+			);
+			name = "Recovered References";
+			sourceTree = "<group>";
+		};
 		965C3C8B29313949006499ED /* Services */ = {
 			isa = PBXGroup;
 			children = (
@@ -7853,6 +7860,7 @@
 				8A93F86629D373AC004159D9 /* MockNavigationController.swift */,
 				8A7A26E029D4785900EA76F1 /* MockRouter.swift */,
 				2173326929CCF901007F20C7 /* UIPanGestureRecognizerMock.swift */,
+				96441BD529DF823D00FE041F /* MockAppAuthenticator.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -8879,6 +8887,7 @@
 				28CE83EF1A1D246900576538 /* Third-Party Source */,
 				E15A8B2B286CFD48004BB2B8 /* Tests */,
 				43BE578B278BA4D900491291 /* RustMozillaAppServices-Info.plist */,
+				96441BD229DF7DA500FE041F /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -11498,6 +11507,7 @@
 				E1390FB628B040E900C9EF3E /* WallpaperSelectorViewModelTests.swift in Sources */,
 				C889D7D52858CD8800121E1D /* HistoryHighlightsTestEntryProvider.swift in Sources */,
 				E19B38B128A3E69300D8C541 /* WallpaperCollectionAvailabilityTests.swift in Sources */,
+				96441BD629DF823D00FE041F /* MockAppAuthenticator.swift in Sources */,
 				21737FB72878A4BD000A9A92 /* HistoryPanelViewModelTests.swift in Sources */,
 				43B658D929CE251C00C9EF08 /* CreditCardInputViewModelTests.swift in Sources */,
 				C8501F5128510DA1003B09AB /* WallpaperMigrationUtilityTests.swift in Sources */,
@@ -11622,7 +11632,6 @@
 				3B61CD591F2A750800D38DE1 /* PocketFeedTests.swift in Sources */,
 				C8E1BC0A28085AA700C62964 /* NimbusFeatureFlagLayerTests.swift in Sources */,
 				C8D0D6F4281C231200AFAED9 /* FeatureFlagsUserPrefsMigrationUtilityTests.swift in Sources */,
-				96CB5D6529B23D4D0034AE0A /* MockAppAuthenticator.swift in Sources */,
 				43446CF02412DDBE00F5C643 /* UpdateViewModelTests.swift in Sources */,
 				8A93F86829D373B0004159D9 /* MockNavigationController.swift in Sources */,
 				8AE1E1D927B1BD380024C45E /* UIStackViewExtensionsTests.swift in Sources */,

--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewController.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewController.swift
@@ -173,7 +173,8 @@ class CreditCardSettingsViewController: UIViewController, Themeable {
         present(creditCardAddEditView, animated: true, completion: nil)
     }
 
-    @objc private func addCreditCard() {
+    @objc
+    private func addCreditCard() {
         updateState(type: .add)
     }
 

--- a/Client/Frontend/Autofill/CreditCard/ViewComponents/SensitiveHostingController.swift
+++ b/Client/Frontend/Autofill/CreditCard/ViewComponents/SensitiveHostingController.swift
@@ -95,7 +95,8 @@ class SensitiveHostingController<Content>: UIHostingController<Content> where Co
         }
     }
 
-    @objc private func handleNotifications(_ notification: Notification) {
+    @objc
+    private func handleNotifications(_ notification: Notification) {
         switch notification.name {
         case UIApplication.didEnterBackgroundNotification:
             isAuthenticated = false

--- a/Tests/ClientTests/CreditCard/CreditCardInputFieldTests.swift
+++ b/Tests/ClientTests/CreditCard/CreditCardInputFieldTests.swift
@@ -168,4 +168,44 @@ class CreditCardInputFieldTests: XCTestCase {
         inputField.handleTextInputWith("1255", and: "125")
         XCTAssertFalse(viewModel.expirationIsValid)
     }
+
+    func testSanitizeGoodCardNumber() {
+        let inputField = CreditCardInputField(inputType: .number,
+                                              text: $testableString,
+                                              showError: false,
+                                              inputViewModel: viewModel)
+
+        let result = inputField.sanitizeInputOn("4100100010001000")
+        XCTAssertEqual(result, "4100100010001000")
+    }
+
+    func testSanitizeGarbledCardNumber() {
+        let inputField = CreditCardInputField(inputType: .number,
+                                              text: $testableString,
+                                              showError: false,
+                                              inputViewModel: viewModel)
+
+        let result = inputField.sanitizeInputOn("4100^&*(*&^%10    00100:><>?><> 0  *&*(100))----!!!!!0")
+        XCTAssertEqual(result, "4100100010001000")
+    }
+
+    func testSanitizeGoodExpiryInput() {
+        let inputField = CreditCardInputField(inputType: .expiration,
+                                              text: $testableString,
+                                              showError: false,
+                                              inputViewModel: viewModel)
+
+        let result = inputField.sanitizeInputOn("1029")
+        XCTAssertEqual(result, "1029")
+    }
+
+    func testSanitizeGarbledExpiryInput() {
+        let inputField = CreditCardInputField(inputType: .expiration,
+                                              text: $testableString,
+                                              showError: false,
+                                              inputViewModel: viewModel)
+
+        let result = inputField.sanitizeInputOn(" 1  )(*&^0 ><>::?:  2!!!&**&*~~@@@9")
+        XCTAssertEqual(result, "1029")
+    }
 }


### PR DESCRIPTION
# [FXIOS-6129](https://mozilla-hub.atlassian.net/browse/FXIOS-6129)

### Description
We now prevent bad input (non-numeric) from being entered in the CC expiry field.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
