### PR TITLE
Add FXIOS-5989 [v114] Launch onboardings from coordinator

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -652,6 +652,7 @@
 		8AF10D9129D7761A0086351D /* MockLaunchScreenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF10D9029D776190086351D /* MockLaunchScreenManager.swift */; };
 		8AFA263227B6E9AB00D0C33B /* ToolbarBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFA263127B6E9AB00D0C33B /* ToolbarBadge.swift */; };
 		8AFCE50529DDF38300B1B253 /* LaunchScreenViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFCE50429DDF38300B1B253 /* LaunchScreenViewControllerTests.swift */; };
+		8AFCE50729DE0CD500B1B253 /* LaunchCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFCE50629DE0CD500B1B253 /* LaunchCoordinatorTests.swift */; };
 		8AFE4C2127480D0C00B97C65 /* TabTrayViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFE4C2027480D0B00B97C65 /* TabTrayViewControllerTests.swift */; };
 		8D8251811F4DE67F00780643 /* AdvancedAccountSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8251721F4DE67E00780643 /* AdvancedAccountSettingViewController.swift */; };
 		9609F4CA26B57CE800F81493 /* Calendar+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9609F4C926B57CE800F81493 /* Calendar+Extension.swift */; };
@@ -3938,6 +3939,7 @@
 		8AF10D9029D776190086351D /* MockLaunchScreenManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLaunchScreenManager.swift; sourceTree = "<group>"; };
 		8AFA263127B6E9AB00D0C33B /* ToolbarBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarBadge.swift; sourceTree = "<group>"; };
 		8AFCE50429DDF38300B1B253 /* LaunchScreenViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchScreenViewControllerTests.swift; sourceTree = "<group>"; };
+		8AFCE50629DE0CD500B1B253 /* LaunchCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchCoordinatorTests.swift; sourceTree = "<group>"; };
 		8AFE4C2027480D0B00B97C65 /* TabTrayViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabTrayViewControllerTests.swift; sourceTree = "<group>"; };
 		8B3245D190D4FA80C3B46EC8 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Search.strings"; sourceTree = "<group>"; };
 		8B674438A5487ABCD2DD7CA5 /* ses */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ses; path = ses.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -7269,6 +7271,7 @@
 			isa = PBXGroup;
 			children = (
 				8A832A9529DCBBD90025D5DD /* LaunchTypeTests.swift */,
+				8AFCE50629DE0CD500B1B253 /* LaunchCoordinatorTests.swift */,
 			);
 			path = Launch;
 			sourceTree = "<group>";
@@ -11416,6 +11419,7 @@
 				D3D488591ABB54CD00A93597 /* FileAccessorTests.swift in Sources */,
 				5AF6254528A57B6700A90253 /* MockHistoryHighlightsManager.swift in Sources */,
 				E571EE7E28756A130051D9AA /* PocketStoryProviderTests.swift in Sources */,
+				8AFCE50729DE0CD500B1B253 /* LaunchCoordinatorTests.swift in Sources */,
 				961D6B832995AF84001B9CF1 /* GeneralizedImageFetcherTests.swift in Sources */,
 				E1AEC177286E0CF500062E29 /* HistoryHighlightsViewModelTests.swift in Sources */,
 				2165B2C42860CB34004C0786 /* MockAdjustTelemetryData.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -532,6 +532,8 @@
 		8A471185287F6E4800F5A6EA /* SeparatorTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A471184287F6E4800F5A6EA /* SeparatorTableViewCell.swift */; };
 		8A4AC0EB28C929D700439F83 /* URLSessionDataTaskProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4AC0E928C929D700439F83 /* URLSessionDataTaskProtocol.swift */; };
 		8A4AC0EC28C929D700439F83 /* URLSessionProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4AC0EA28C929D700439F83 /* URLSessionProtocol.swift */; };
+		8A5604F629DF09FA00035CA3 /* MockLaunchCoordinatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5604F529DF09FA00035CA3 /* MockLaunchCoordinatorDelegate.swift */; };
+		8A5604F829DF0D2600035CA3 /* BrowserCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5604F729DF0D2600035CA3 /* BrowserCoordinatorTests.swift */; };
 		8A56955227C68AE00077A89E /* UILabel+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A56955127C68AE00077A89E /* UILabel+Extension.swift */; };
 		8A57519927AD80B800A84DBF /* ReaderModeStyleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A57519827AD80B800A84DBF /* ReaderModeStyleViewModel.swift */; };
 		8A590C6128C123100032F1AA /* OpenPassBookHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A590C6028C123100032F1AA /* OpenPassBookHelper.swift */; };
@@ -3804,6 +3806,8 @@
 		8A4AC0EA28C929D700439F83 /* URLSessionProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionProtocol.swift; sourceTree = "<group>"; };
 		8A4AC0F028C92BE500439F83 /* FxColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FxColors.swift; sourceTree = "<group>"; };
 		8A5143D6BF179870414566ED /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Search.strings; sourceTree = "<group>"; };
+		8A5604F529DF09FA00035CA3 /* MockLaunchCoordinatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLaunchCoordinatorDelegate.swift; sourceTree = "<group>"; };
+		8A5604F729DF0D2600035CA3 /* BrowserCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserCoordinatorTests.swift; sourceTree = "<group>"; };
 		8A56955127C68AE00077A89E /* UILabel+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Extension.swift"; sourceTree = "<group>"; };
 		8A57519827AD80B800A84DBF /* ReaderModeStyleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeStyleViewModel.swift; sourceTree = "<group>"; };
 		8A590C6028C123100032F1AA /* OpenPassBookHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenPassBookHelper.swift; sourceTree = "<group>"; };
@@ -7035,6 +7039,7 @@
 				8A93F86429D37331004159D9 /* DefaultRouterTests.swift */,
 				8A93F86929D37FC9004159D9 /* CoordinatorTests.swift */,
 				8A7A26E229D4ACF300EA76F1 /* SceneCoordinatorTests.swift */,
+				8A5604F729DF0D2600035CA3 /* BrowserCoordinatorTests.swift */,
 			);
 			path = Coordinators;
 			sourceTree = "<group>";
@@ -7828,6 +7833,7 @@
 				8AF10D8B29D714A90086351D /* MockOpenURLDelegate.swift */,
 				8AF10D9029D776190086351D /* MockLaunchScreenManager.swift */,
 				2173326929CCF901007F20C7 /* UIPanGestureRecognizerMock.swift */,
+				8A5604F529DF09FA00035CA3 /* MockLaunchCoordinatorDelegate.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -11514,6 +11520,7 @@
 				5A9A09D628B01FD500B6F51E /* MockURLBarView.swift in Sources */,
 				8A33222227DFE658008F809E /* NimbusMock.swift in Sources */,
 				8A8629E72880B7330096DDB1 /* BookmarksPanelTests.swift in Sources */,
+				8A5604F829DF0D2600035CA3 /* BrowserCoordinatorTests.swift in Sources */,
 				7BBFEE741BB405D900A305AA /* LegacyTabManagerTests.swift in Sources */,
 				39236E721FCC600200A38F1B /* TabEventHandlerTests.swift in Sources */,
 				C83B7DD629BBB49D005565C2 /* SurveySurfaceManagerTests.swift in Sources */,
@@ -11546,6 +11553,7 @@
 				8A33221F27DFE318008F809E /* TopSitesDataAdaptorTests.swift in Sources */,
 				2165B2C02860BB41004C0786 /* AdjustTelemetryHelperTests.swift in Sources */,
 				C869915428917803007ACC5C /* WallpaperTestDataProvider.swift in Sources */,
+				8A5604F629DF09FA00035CA3 /* MockLaunchCoordinatorDelegate.swift in Sources */,
 				C807CCCC28367446008E6A5A /* FeatureFlagManagerTests.swift in Sources */,
 				8A5C3BC5282ABF8E003A8CCF /* RemoteTabsPanelTests.swift in Sources */,
 				D8EFFA261FF702A8001D3A09 /* NavigationRouterTests.swift in Sources */,

--- a/Client/Coordinators/BrowserCoordinator.swift
+++ b/Client/Coordinators/BrowserCoordinator.swift
@@ -5,7 +5,7 @@
 import Common
 import Foundation
 
-class BrowserCoordinator: BaseCoordinator {
+class BrowserCoordinator: BaseCoordinator, OpenURLDelegate {
     var browserViewController: BrowserViewController
 
     init(router: Router,
@@ -27,10 +27,17 @@ class BrowserCoordinator: BaseCoordinator {
 
     private func startLaunch(with launchType: LaunchType) {
         let launchCoordinator = LaunchCoordinator(router: router)
+        launchCoordinator.parentCoordinator = self
         add(child: launchCoordinator)
         launchCoordinator.start(with: launchType) {
             self.router.dismiss(animated: true, completion: nil)
             self.remove(child: launchCoordinator)
         }
+    }
+
+    // MARK: - Routes
+
+    func didRequestToOpenInNewTab(url: URL, isPrivate: Bool, selectNewTab: Bool) {
+        // FXIOS-6030: Handle open in new tab route
     }
 }

--- a/Client/Coordinators/BrowserCoordinator.swift
+++ b/Client/Coordinators/BrowserCoordinator.swift
@@ -5,7 +5,7 @@
 import Common
 import Foundation
 
-class BrowserCoordinator: BaseCoordinator, OpenURLDelegate {
+class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate {
     var browserViewController: BrowserViewController
 
     init(router: Router,
@@ -29,13 +29,15 @@ class BrowserCoordinator: BaseCoordinator, OpenURLDelegate {
         let launchCoordinator = LaunchCoordinator(router: router)
         launchCoordinator.parentCoordinator = self
         add(child: launchCoordinator)
-        launchCoordinator.start(with: launchType) {
-            self.router.dismiss(animated: true, completion: nil)
-            self.remove(child: launchCoordinator)
-        }
+        launchCoordinator.start(with: launchType)
     }
 
-    // MARK: - Routes
+    // MARK: - LaunchCoordinatorDelegate
+
+    func didFinishLaunch(from coordinator: LaunchCoordinator) {
+        router.dismiss(animated: true, completion: nil)
+        remove(child: coordinator)
+    }
 
     func didRequestToOpenInNewTab(url: URL, isPrivate: Bool, selectNewTab: Bool) {
         // FXIOS-6030: Handle open in new tab route

--- a/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -2,23 +2,120 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
 
 // Manages different types of onboarding that gets shown at the launch of the application
 class LaunchCoordinator: BaseCoordinator {
+    private let profile: Profile
+    private let logger: Logger
+    private let isIphone: Bool
+
+    init(router: Router,
+         profile: Profile = AppContainer.shared.resolve(),
+         isIphone: Bool = UIDevice.current.userInterfaceIdiom == .phone,
+         logger: Logger = DefaultLogger.shared) {
+        self.profile = profile
+        self.logger = logger
+        self.isIphone = isIphone
+        super.init(router: router)
+    }
+
     func start(with launchType: LaunchType, onCompletion: @escaping () -> Void) {
-        // FXIOS-5989: Handle different onboarding types
+        print("Laurie - LaunchCoordinator init")
+        let isFullScreen = launchType.isFullScreenAvailable(isIphone: isIphone)
         switch launchType {
-        case .intro:
-            break
-        case .update:
-            break
+        case .intro(let manager):
+            presentIntroOnboarding(with: manager, isFullScreen: isFullScreen, onCompletion: onCompletion)
+        case .update(let viewModel):
+            presentUpdateOnboarding(with: viewModel, isFullScreen: isFullScreen, onCompletion: onCompletion)
         case .defaultBrowser:
-            break
-        case .survey:
-            break
+            presentDefaultBrowserOnboarding(onCompletion: onCompletion)
+        case .survey(let manager):
+            presentSurvey(with: manager, onCompletion: onCompletion)
         }
     }
 
-    // FXIOS-5989: Make sure OpenURLDelegate is set on survey manager
+    deinit {
+        print("Laurie - LaunchCoordinator deinit")
+    }
+
+    // FXIOS-5989: Laurie - Make sure OpenURLDelegate is set on survey manager
+
+    // MARK: - Intro
+    private func presentIntroOnboarding(with manager: IntroScreenManager,
+                                        isFullScreen: Bool,
+                                        onCompletion: @escaping () -> Void) {
+        let introViewModel = IntroViewModel(introScreenManager: manager)
+        let introViewController = IntroViewController(viewModel: introViewModel,
+                                                      profile: profile)
+        introViewController.didFinishFlow = {
+            onCompletion()
+        }
+
+        if isFullScreen {
+            introViewController.modalPresentationStyle = .fullScreen
+            router.setRootViewController(introViewController, hideBar: true)
+        } else {
+            introViewController.preferredContentSize = CGSize(
+                width: ViewControllerConsts.PreferredSize.IntroViewController.width,
+                height: ViewControllerConsts.PreferredSize.IntroViewController.height)
+            introViewController.modalPresentationStyle = .formSheet
+            router.present(introViewController, animated: true)
+        }
+    }
+
+    // MARK: - Update
+    private func presentUpdateOnboarding(with updateViewModel: UpdateViewModel,
+                                         isFullScreen: Bool,
+                                         onCompletion: @escaping () -> Void) {
+        let updateViewController = UpdateViewController(viewModel: updateViewModel)
+        updateViewController.didFinishFlow = {
+            onCompletion()
+        }
+
+        if isFullScreen {
+            updateViewController.modalPresentationStyle = .fullScreen
+            router.setRootViewController(updateViewController, hideBar: true)
+        } else {
+            updateViewController.preferredContentSize = CGSize(
+                width: ViewControllerConsts.PreferredSize.UpdateViewController.width,
+                height: ViewControllerConsts.PreferredSize.UpdateViewController.height)
+            updateViewController.modalPresentationStyle = .formSheet
+            router.present(updateViewController)
+        }
+    }
+
+    // MARK: - Default Browser
+    func presentDefaultBrowserOnboarding(onCompletion: @escaping () -> Void) {
+        let defaultOnboardingViewController = DefaultBrowserOnboardingViewController()
+        defaultOnboardingViewController.viewModel.goToSettings = {
+            onCompletion()
+        }
+
+        defaultOnboardingViewController.viewModel.didAskToDismissView = {
+            onCompletion()
+        }
+
+        defaultOnboardingViewController.preferredContentSize = CGSize(
+            width: ViewControllerConsts.PreferredSize.DBOnboardingViewController.width,
+            height: ViewControllerConsts.PreferredSize.DBOnboardingViewController.height)
+        defaultOnboardingViewController.modalPresentationStyle = .formSheet
+        router.present(defaultOnboardingViewController)
+    }
+
+    // MARK: - Survey
+    func presentSurvey(with manager: SurveySurfaceManager, onCompletion: @escaping () -> Void) {
+        guard let surveySurface = manager.getSurveySurface() else {
+            logger.log("Tried presenting survey but no surface was found", level: .warning, category: .lifecycle)
+            onCompletion()
+            return
+        }
+        surveySurface.modalPresentationStyle = .fullScreen
+        manager.dismissClosure = {
+            onCompletion()
+        }
+
+        router.setRootViewController(surveySurface, hideBar: true)
+    }
 }

--- a/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -23,7 +23,6 @@ class LaunchCoordinator: BaseCoordinator, OpenURLDelegate {
     }
 
     func start(with launchType: LaunchType, onCompletion: @escaping () -> Void) {
-        print("Laurie - LaunchCoordinator init")
         let isFullScreen = launchType.isFullScreenAvailable(isIphone: isIphone)
         switch launchType {
         case .intro(let manager):
@@ -35,10 +34,6 @@ class LaunchCoordinator: BaseCoordinator, OpenURLDelegate {
         case .survey(let manager):
             presentSurvey(with: manager, onCompletion: onCompletion)
         }
-    }
-
-    deinit {
-        print("Laurie - LaunchCoordinator deinit")
     }
 
     // MARK: - Intro

--- a/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -6,10 +6,11 @@ import Common
 import Foundation
 
 // Manages different types of onboarding that gets shown at the launch of the application
-class LaunchCoordinator: BaseCoordinator {
+class LaunchCoordinator: BaseCoordinator, OpenURLDelegate {
     private let profile: Profile
     private let logger: Logger
     private let isIphone: Bool
+    weak var parentCoordinator: OpenURLDelegate?
 
     init(router: Router,
          profile: Profile = AppContainer.shared.resolve(),
@@ -39,8 +40,6 @@ class LaunchCoordinator: BaseCoordinator {
     deinit {
         print("Laurie - LaunchCoordinator deinit")
     }
-
-    // FXIOS-5989: Laurie - Make sure OpenURLDelegate is set on survey manager
 
     // MARK: - Intro
     private func presentIntroOnboarding(with manager: IntroScreenManager,
@@ -112,10 +111,17 @@ class LaunchCoordinator: BaseCoordinator {
             return
         }
         surveySurface.modalPresentationStyle = .fullScreen
+        manager.openURLDelegate = self
         manager.dismissClosure = {
             onCompletion()
         }
 
         router.setRootViewController(surveySurface, hideBar: true)
+    }
+
+    // MARK: OpenURLDelegate
+
+    func didRequestToOpenInNewTab(url: URL, isPrivate: Bool, selectNewTab: Bool) {
+        parentCoordinator?.didRequestToOpenInNewTab(url: url, isPrivate: isPrivate, selectNewTab: selectNewTab)
     }
 }

--- a/Client/Coordinators/LaunchView/LaunchScreenViewController.swift
+++ b/Client/Coordinators/LaunchView/LaunchScreenViewController.swift
@@ -30,10 +30,6 @@ class LaunchScreenViewController: UIViewController, LaunchFinishedLoadingDelegat
         viewModel.startLoading()
     }
 
-    deinit {
-        print("Laurie - LaunchScreenViewController deinit")
-    }
-
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         setupLayout()

--- a/Client/Coordinators/LaunchView/LaunchScreenViewController.swift
+++ b/Client/Coordinators/LaunchView/LaunchScreenViewController.swift
@@ -2,17 +2,21 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
 
 class LaunchScreenViewController: UIViewController, LaunchFinishedLoadingDelegate {
     private lazy var launchScreen = LaunchScreenView.fromNib()
     private weak var coordinator: LaunchFinishedLoadingDelegate?
     private var viewModel: LaunchScreenViewModel
+    private var mainQueue: DispatchQueueInterface
 
     init(coordinator: LaunchFinishedLoadingDelegate,
-         viewModel: LaunchScreenViewModel = LaunchScreenViewModel()) {
+         viewModel: LaunchScreenViewModel = LaunchScreenViewModel(),
+         mainQueue: DispatchQueueInterface = DispatchQueue.main) {
         self.coordinator = coordinator
         self.viewModel = viewModel
+        self.mainQueue = mainQueue
         super.init(nibName: nil, bundle: nil)
         viewModel.delegate = self
     }
@@ -24,6 +28,10 @@ class LaunchScreenViewController: UIViewController, LaunchFinishedLoadingDelegat
     override func viewDidLoad() {
         super.viewDidLoad()
         viewModel.startLoading()
+    }
+
+    deinit {
+        print("Laurie - LaunchScreenViewController deinit")
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -46,10 +54,14 @@ class LaunchScreenViewController: UIViewController, LaunchFinishedLoadingDelegat
     // MARK: - LaunchFinishedLoadingDelegate
 
     func launchWith(launchType: LaunchType) {
-        coordinator?.launchWith(launchType: launchType)
+        mainQueue.async {
+            self.coordinator?.launchWith(launchType: launchType)
+        }
     }
 
     func launchBrowser() {
-        coordinator?.launchBrowser()
+        mainQueue.async {
+            self.coordinator?.launchBrowser()
+        }
     }
 }

--- a/Client/Coordinators/Scene/SceneCoordinator.swift
+++ b/Client/Coordinators/Scene/SceneCoordinator.swift
@@ -7,7 +7,7 @@ import UIKit
 import Shared
 
 /// Each scene has it's own scene coordinator, which is the root coordinator for a scene.
-class SceneCoordinator: BaseCoordinator, LaunchFinishedLoadingDelegate {
+class SceneCoordinator: BaseCoordinator, LaunchFinishedLoadingDelegate, OpenURLDelegate {
     var window: UIWindow?
 
     init(scene: UIScene,
@@ -45,6 +45,7 @@ class SceneCoordinator: BaseCoordinator, LaunchFinishedLoadingDelegate {
 
     private func startLaunch(with launchType: LaunchType) {
         let launchCoordinator = LaunchCoordinator(router: router)
+        launchCoordinator.parentCoordinator = self
         add(child: launchCoordinator)
         launchCoordinator.start(with: launchType) {
             self.remove(child: launchCoordinator)
@@ -56,5 +57,11 @@ class SceneCoordinator: BaseCoordinator, LaunchFinishedLoadingDelegate {
         let browserCoordinator = BrowserCoordinator(router: router)
         add(child: browserCoordinator)
         browserCoordinator.start(with: launchType)
+    }
+
+    // MARK: - Routes
+
+    func didRequestToOpenInNewTab(url: URL, isPrivate: Bool, selectNewTab: Bool) {
+        // FXIOS-6030: Handle open in new tab route
     }
 }

--- a/Client/Coordinators/Scene/SceneCoordinator.swift
+++ b/Client/Coordinators/Scene/SceneCoordinator.swift
@@ -7,7 +7,7 @@ import UIKit
 import Shared
 
 /// Each scene has it's own scene coordinator, which is the root coordinator for a scene.
-class SceneCoordinator: BaseCoordinator, LaunchFinishedLoadingDelegate, OpenURLDelegate {
+class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinishedLoadingDelegate {
     var window: UIWindow?
 
     init(scene: UIScene,
@@ -47,10 +47,7 @@ class SceneCoordinator: BaseCoordinator, LaunchFinishedLoadingDelegate, OpenURLD
         let launchCoordinator = LaunchCoordinator(router: router)
         launchCoordinator.parentCoordinator = self
         add(child: launchCoordinator)
-        launchCoordinator.start(with: launchType) { [weak self] in
-            self?.remove(child: launchCoordinator)
-            self?.startBrowser(with: nil)
-        }
+        launchCoordinator.start(with: launchType)
     }
 
     private func startBrowser(with launchType: LaunchType?) {
@@ -59,7 +56,14 @@ class SceneCoordinator: BaseCoordinator, LaunchFinishedLoadingDelegate, OpenURLD
         browserCoordinator.start(with: launchType)
     }
 
-    // MARK: - Routes
+    // MARK: - LaunchCoordinatorDelegate
+
+    func didFinishLaunch(from coordinator: LaunchCoordinator) {
+        remove(child: coordinator)
+        startBrowser(with: nil)
+    }
+
+    // MARK: - LaunchFinishedLoadingDelegate
 
     func didRequestToOpenInNewTab(url: URL, isPrivate: Bool, selectNewTab: Bool) {
         // FXIOS-6030: Handle open in new tab route

--- a/Client/Coordinators/Scene/SceneCoordinator.swift
+++ b/Client/Coordinators/Scene/SceneCoordinator.swift
@@ -47,9 +47,9 @@ class SceneCoordinator: BaseCoordinator, LaunchFinishedLoadingDelegate, OpenURLD
         let launchCoordinator = LaunchCoordinator(router: router)
         launchCoordinator.parentCoordinator = self
         add(child: launchCoordinator)
-        launchCoordinator.start(with: launchType) {
-            self.remove(child: launchCoordinator)
-            self.startBrowser(with: nil)
+        launchCoordinator.start(with: launchType) { [weak self] in
+            self?.remove(child: launchCoordinator)
+            self?.startBrowser(with: nil)
         }
     }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -557,10 +557,12 @@ class BrowserViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        // Setting the view alpha to 0 so that there's no weird flash in between the
-        // check of view appearance and the `performSurveySurfaceCheck`, where the
-        // alpha will be set to 1.
-        self.view.alpha = 0
+        if !AppConstants.useCoordinators {
+            // Setting the view alpha to 0 so that there's no weird flash in between the
+            // check of view appearance and the `performSurveySurfaceCheck`, where the
+            // alpha will be set to 1.
+            self.view.alpha = 0
+        }
 
         if !displayedRestoreTabsAlert && crashedLastLaunch() {
             logger.log("The application crashed on last session",
@@ -573,14 +575,19 @@ class BrowserViewController: UIViewController {
         }
 
         updateTabCountUsingTabManager(tabManager, animated: false)
-        performSurveySurfaceCheck()
+
+        if !AppConstants.useCoordinators {
+            performSurveySurfaceCheck()
+        }
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        presentIntroViewController()
-        presentUpdateViewController()
+        if !AppConstants.useCoordinators {
+            presentIntroViewController()
+            presentUpdateViewController()
+        }
         screenshotHelper.viewIsVisible = true
 
         if let toast = self.pendingToast {

--- a/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
+++ b/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
@@ -249,7 +249,12 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
     // Button Actions
     @objc
     private func dismissAnimated() {
-        self.dismiss(animated: true, completion: nil)
+        if AppConstants.useCoordinators {
+            // Note: this could be one closure only and not two with goToSettings
+            viewModel.didAskToDismissView?()
+        } else {
+            self.dismiss(animated: true, completion: nil)
+        }
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .dismissDefaultBrowserOnboarding)
     }
 
@@ -258,6 +263,10 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
         viewModel.goToSettings?()
         UserDefaults.standard.set(true, forKey: PrefsKeys.DidDismissDefaultBrowserMessage) // Don't show default browser card if this button is clicked
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .goToSettingsDefaultBrowserOnboarding)
+
+        if AppConstants.useCoordinators {
+            UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!, options: [:])
+        }
     }
 
     // Theme

--- a/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewModel.swift
+++ b/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewModel.swift
@@ -43,6 +43,7 @@ struct DefaultBrowserOnboardingModel {
 
 class DefaultBrowserOnboardingViewModel {
     var goToSettings: (() -> Void)?
+    var didAskToDismissView: (() -> Void)?
     var model: DefaultBrowserOnboardingModel?
 
     private static let maxSessionCount = 3

--- a/Client/Frontend/Intro/IntroViewController.swift
+++ b/Client/Frontend/Intro/IntroViewController.swift
@@ -116,6 +116,7 @@ class IntroViewController: UIViewController, OnboardingViewControllerProtocol, T
 
     @objc
     private func closeOnboarding() {
+        viewModel.saveHasSeenOnboarding()
         didFinishFlow?()
         viewModel.sendCloseButtonTelemetry(index: pageControl.currentPage)
     }
@@ -174,6 +175,7 @@ extension IntroViewController: UIPageViewControllerDataSource, UIPageViewControl
 extension IntroViewController: OnboardingCardDelegate {
     func showNextPage(_ cardType: IntroViewModel.InformationCards) {
         guard cardType != viewModel.enabledCards.last else {
+            viewModel.saveHasSeenOnboarding()
             self.didFinishFlow?()
             return
         }

--- a/Client/Frontend/Intro/IntroViewModel.swift
+++ b/Client/Frontend/Intro/IntroViewModel.swift
@@ -44,6 +44,9 @@ struct IntroViewModel: OnboardingViewModelProtocol, FeatureFlaggable {
         }
     }
 
+    // FXIOS-6036 - Make this non optional when coordinators are used
+    var introScreenManager: IntroScreenManager?
+
     var isFeatureEnabled: Bool {
         return featureFlags.isFeatureEnabled(.onboardingFreshInstall, checking: .buildOnly)
     }
@@ -105,5 +108,9 @@ struct IntroViewModel: OnboardingViewModelProtocol, FeatureFlaggable {
                                      method: .tap,
                                      object: .onboardingClose,
                                      extras: extra)
+    }
+
+    func saveHasSeenOnboarding() {
+        introScreenManager?.didSeeIntroScreen()
     }
 }

--- a/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -1,0 +1,72 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import XCTest
+@testable import Client
+
+final class BrowserCoordinatorTests: XCTestCase {
+    private var mockRouter: MockRouter!
+    private var profile: MockProfile!
+
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+        self.mockRouter = MockRouter(navigationController: MockNavigationController())
+        self.profile = MockProfile()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        self.mockRouter = nil
+        self.profile = nil
+        AppContainer.shared.reset()
+    }
+
+    func testInitialState() {
+        let subject = createSubject()
+
+        XCTAssertNotNil(subject.browserViewController)
+        XCTAssertTrue(subject.childCoordinators.isEmpty)
+        XCTAssertEqual(mockRouter.setRootViewControllerCalled, 0)
+    }
+
+    func testWithoutLaunchType_startsBrowserOnly() {
+        let subject = createSubject()
+        subject.start(with: nil)
+
+        XCTAssertNotNil(mockRouter.rootViewController as? BrowserViewController)
+        XCTAssertEqual(mockRouter.setRootViewControllerCalled, 1)
+        XCTAssertTrue(subject.childCoordinators.isEmpty)
+    }
+
+    func testWithLaunchType_startsLaunchCoordinator() {
+        let subject = createSubject()
+        subject.start(with: .defaultBrowser)
+
+        XCTAssertNotNil(mockRouter.rootViewController as? BrowserViewController)
+        XCTAssertEqual(mockRouter.setRootViewControllerCalled, 1)
+        XCTAssertEqual(subject.childCoordinators.count, 1)
+        XCTAssertNotNil(subject.childCoordinators[0] as? LaunchCoordinator)
+    }
+
+    func testChildLaunchCoordinatorIsDone_deallocatesAndDismiss() throws {
+        let subject = createSubject()
+        subject.start(with: .defaultBrowser)
+
+        let childLaunchCoordinator = try XCTUnwrap(subject.childCoordinators[0] as? LaunchCoordinator)
+        subject.didFinishLaunch(from: childLaunchCoordinator)
+
+        XCTAssertTrue(subject.childCoordinators.isEmpty)
+        XCTAssertEqual(mockRouter.dismissCalled, 1)
+    }
+
+    // MARK: - Helpers
+    private func createSubject(file: StaticString = #file,
+                       line: UInt = #line) -> BrowserCoordinator {
+        let subject = BrowserCoordinator(router: mockRouter, profile: profile)
+        trackForMemoryLeaks(subject, file: file, line: line)
+        return subject
+    }
+}

--- a/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -64,7 +64,7 @@ final class BrowserCoordinatorTests: XCTestCase {
 
     // MARK: - Helpers
     private func createSubject(file: StaticString = #file,
-                       line: UInt = #line) -> BrowserCoordinator {
+                               line: UInt = #line) -> BrowserCoordinator {
         let subject = BrowserCoordinator(router: mockRouter, profile: profile)
         trackForMemoryLeaks(subject, file: file, line: line)
         return subject

--- a/Tests/ClientTests/Coordinators/Launch/LaunchCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/Launch/LaunchCoordinatorTests.swift
@@ -1,0 +1,173 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import XCTest
+@testable import Client
+
+final class LaunchCoordinatorTests: XCTestCase {
+    private var profile: MockProfile!
+    private var mockRouter: MockRouter!
+    private var delegate: MockOpenURLDelegate!
+
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+        profile = MockProfile()
+        FeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
+        mockRouter = MockRouter(navigationController: MockNavigationController())
+        delegate = MockOpenURLDelegate()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        profile = nil
+        mockRouter = nil
+        delegate = nil
+        AppContainer.shared.reset()
+    }
+
+    func testInitialState() {
+        let subject = LaunchCoordinator(router: mockRouter, profile: profile)
+
+        XCTAssertEqual(mockRouter.presentCalled, 0)
+        XCTAssertEqual(mockRouter.setRootViewControllerCalled, 0)
+        XCTAssertTrue(subject.childCoordinators.isEmpty)
+    }
+
+    // MARK: - Intro
+    func testStart_introNotIphone_present() throws {
+        let introScreenManager = IntroScreenManager(prefs: profile.prefs)
+        let subject = LaunchCoordinator(router: mockRouter, profile: profile, isIphone: false)
+        subject.start(with: .intro(manager: introScreenManager)) {}
+
+        XCTAssertEqual(mockRouter.presentCalled, 1)
+        XCTAssertEqual(mockRouter.setRootViewControllerCalled, 0)
+        let presentedViewController = try XCTUnwrap(mockRouter.presentedViewController)
+        XCTAssertNotNil(presentedViewController as? IntroViewController)
+    }
+
+    func testStart_introIsIphone_setRootView() throws {
+        let introScreenManager = IntroScreenManager(prefs: profile.prefs)
+        let subject = LaunchCoordinator(router: mockRouter, profile: profile, isIphone: true)
+        subject.start(with: .intro(manager: introScreenManager)) {}
+
+        XCTAssertEqual(mockRouter.presentCalled, 0)
+        XCTAssertEqual(mockRouter.setRootViewControllerCalled, 1)
+        let rootViewController = try XCTUnwrap(mockRouter.rootViewController)
+        XCTAssertNotNil(rootViewController as? IntroViewController)
+    }
+
+    // MARK: - Update
+    func testStart_updateNotIphone_present() throws {
+        let viewModel = UpdateViewModel(profile: profile)
+        let subject = LaunchCoordinator(router: mockRouter, profile: profile, isIphone: false)
+        subject.start(with: .update(viewModel: viewModel)) {}
+
+        XCTAssertEqual(mockRouter.presentCalled, 1)
+        XCTAssertEqual(mockRouter.setRootViewControllerCalled, 0)
+        let presentedViewController = try XCTUnwrap(mockRouter.presentedViewController)
+        XCTAssertNotNil(presentedViewController as? UpdateViewController)
+    }
+
+    func testStart_updateIsIphone_setRootView() throws {
+        let viewModel = UpdateViewModel(profile: profile)
+        let subject = LaunchCoordinator(router: mockRouter, profile: profile, isIphone: true)
+        subject.start(with: .update(viewModel: viewModel)) {}
+
+        XCTAssertEqual(mockRouter.presentCalled, 0)
+        XCTAssertEqual(mockRouter.setRootViewControllerCalled, 1)
+        let rootViewController = try XCTUnwrap(mockRouter.rootViewController)
+        XCTAssertNotNil(rootViewController as? UpdateViewController)
+    }
+
+    // MARK: - Default browser
+    func testStart_defaultBrowser_present() throws {
+        let subject = LaunchCoordinator(router: mockRouter, profile: profile, isIphone: false)
+        subject.start(with: .defaultBrowser) {}
+
+        XCTAssertEqual(mockRouter.presentCalled, 1)
+        XCTAssertEqual(mockRouter.setRootViewControllerCalled, 0)
+        let presentedViewController = try XCTUnwrap(mockRouter.presentedViewController)
+        XCTAssertNotNil(presentedViewController as? DefaultBrowserOnboardingViewController)
+    }
+
+    // MARK: - Survey
+    func testStart_surveyNoMessage_completes() throws {
+        let manager = SurveySurfaceManager()
+        let subject = LaunchCoordinator(router: mockRouter, profile: profile, isIphone: false)
+        let expectation = expectation(description: "Completion is called")
+        subject.start(with: .survey(manager: manager)) {
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 0.1)
+        XCTAssertEqual(mockRouter.presentCalled, 0)
+        XCTAssertEqual(mockRouter.setRootViewControllerCalled, 0)
+        XCTAssertNil(mockRouter.presentedViewController)
+    }
+
+    func testStart_surveyWithMessage_setRootView() throws {
+        let messageManager = MockGleanPlumbMessageManagerProtocol()
+        let message = createMessage(isExpired: false)
+        messageManager.message = message
+        let manager = SurveySurfaceManager(and: messageManager)
+        XCTAssertTrue(manager.shouldShowSurveySurface)
+
+        let subject = LaunchCoordinator(router: mockRouter, profile: profile, isIphone: false)
+        subject.start(with: .survey(manager: manager)) {}
+
+        XCTAssertEqual(mockRouter.presentCalled, 0)
+        XCTAssertEqual(mockRouter.setRootViewControllerCalled, 1)
+        let rootViewController = try XCTUnwrap(mockRouter.rootViewController)
+        XCTAssertNotNil(rootViewController as? SurveySurfaceViewController)
+    }
+
+    // MARK: - Delegates
+    func testStart_surveySetsDelegate() {
+        let messageManager = MockGleanPlumbMessageManagerProtocol()
+        let message = createMessage(isExpired: false)
+        messageManager.message = message
+        let manager = SurveySurfaceManager(and: messageManager)
+        XCTAssertNil(manager.openURLDelegate)
+        XCTAssertTrue(manager.shouldShowSurveySurface)
+
+        let subject = LaunchCoordinator(router: mockRouter, profile: profile, isIphone: false)
+        subject.start(with: .survey(manager: manager)) {}
+
+        XCTAssertNotNil(manager.openURLDelegate)
+        XCTAssertNotNil(manager.dismissClosure)
+    }
+
+    func testOpenURLDelegate() {
+        let subject = LaunchCoordinator(router: mockRouter, profile: profile, isIphone: false)
+        subject.parentCoordinator = delegate
+        let mockURL = URL(string: "www.firefox.com")!
+        subject.didRequestToOpenInNewTab(url: mockURL,
+                                         isPrivate: false,
+                                         selectNewTab: false)
+
+        XCTAssertEqual(delegate.savedURL, mockURL)
+        XCTAssertEqual(delegate.savedIsPrivate, false)
+        XCTAssertEqual(delegate.savedSelectedNewTab, false)
+    }
+
+    // MARK: - Helpers
+    func createMessage(
+        for surface: MessageSurfaceId = .survey,
+        isExpired: Bool
+    ) -> GleanPlumbMessage {
+        let metadata = GleanPlumbMessageMetaData(id: "",
+                                                 impressions: 0,
+                                                 dismissals: 0,
+                                                 isExpired: isExpired)
+
+        return GleanPlumbMessage(id: "12345",
+                                 data: MockSurveyMessageDataProtocol(surface: surface),
+                                 action: "https://mozilla.com",
+                                 triggers: [],
+                                 style: MockStyleDataProtocol(),
+                                 metadata: metadata)
+    }
+}

--- a/Tests/ClientTests/Coordinators/Launch/LaunchCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/Launch/LaunchCoordinatorTests.swift
@@ -9,7 +9,7 @@ import XCTest
 final class LaunchCoordinatorTests: XCTestCase {
     private var profile: MockProfile!
     private var mockRouter: MockRouter!
-    private var delegate: MockOpenURLDelegate!
+    private var delegate: MockLaunchCoordinatorDelegate!
 
     override func setUp() {
         super.setUp()
@@ -17,7 +17,7 @@ final class LaunchCoordinatorTests: XCTestCase {
         profile = MockProfile()
         FeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
         mockRouter = MockRouter(navigationController: MockNavigationController())
-        delegate = MockOpenURLDelegate()
+        delegate = MockLaunchCoordinatorDelegate()
     }
 
     override func tearDown() {
@@ -40,7 +40,7 @@ final class LaunchCoordinatorTests: XCTestCase {
     func testStart_introNotIphone_present() throws {
         let introScreenManager = IntroScreenManager(prefs: profile.prefs)
         let subject = LaunchCoordinator(router: mockRouter, profile: profile, isIphone: false)
-        subject.start(with: .intro(manager: introScreenManager)) {}
+        subject.start(with: .intro(manager: introScreenManager))
 
         XCTAssertEqual(mockRouter.presentCalled, 1)
         XCTAssertEqual(mockRouter.setRootViewControllerCalled, 0)
@@ -51,7 +51,7 @@ final class LaunchCoordinatorTests: XCTestCase {
     func testStart_introIsIphone_setRootView() throws {
         let introScreenManager = IntroScreenManager(prefs: profile.prefs)
         let subject = LaunchCoordinator(router: mockRouter, profile: profile, isIphone: true)
-        subject.start(with: .intro(manager: introScreenManager)) {}
+        subject.start(with: .intro(manager: introScreenManager))
 
         XCTAssertEqual(mockRouter.presentCalled, 0)
         XCTAssertEqual(mockRouter.setRootViewControllerCalled, 1)
@@ -63,7 +63,7 @@ final class LaunchCoordinatorTests: XCTestCase {
     func testStart_updateNotIphone_present() throws {
         let viewModel = UpdateViewModel(profile: profile)
         let subject = LaunchCoordinator(router: mockRouter, profile: profile, isIphone: false)
-        subject.start(with: .update(viewModel: viewModel)) {}
+        subject.start(with: .update(viewModel: viewModel))
 
         XCTAssertEqual(mockRouter.presentCalled, 1)
         XCTAssertEqual(mockRouter.setRootViewControllerCalled, 0)
@@ -74,7 +74,7 @@ final class LaunchCoordinatorTests: XCTestCase {
     func testStart_updateIsIphone_setRootView() throws {
         let viewModel = UpdateViewModel(profile: profile)
         let subject = LaunchCoordinator(router: mockRouter, profile: profile, isIphone: true)
-        subject.start(with: .update(viewModel: viewModel)) {}
+        subject.start(with: .update(viewModel: viewModel))
 
         XCTAssertEqual(mockRouter.presentCalled, 0)
         XCTAssertEqual(mockRouter.setRootViewControllerCalled, 1)
@@ -85,7 +85,7 @@ final class LaunchCoordinatorTests: XCTestCase {
     // MARK: - Default browser
     func testStart_defaultBrowser_present() throws {
         let subject = LaunchCoordinator(router: mockRouter, profile: profile, isIphone: false)
-        subject.start(with: .defaultBrowser) {}
+        subject.start(with: .defaultBrowser)
 
         XCTAssertEqual(mockRouter.presentCalled, 1)
         XCTAssertEqual(mockRouter.setRootViewControllerCalled, 0)
@@ -97,12 +97,8 @@ final class LaunchCoordinatorTests: XCTestCase {
     func testStart_surveyNoMessage_completes() throws {
         let manager = SurveySurfaceManager()
         let subject = LaunchCoordinator(router: mockRouter, profile: profile, isIphone: false)
-        let expectation = expectation(description: "Completion is called")
-        subject.start(with: .survey(manager: manager)) {
-            expectation.fulfill()
-        }
+        subject.start(with: .survey(manager: manager))
 
-        waitForExpectations(timeout: 0.1)
         XCTAssertEqual(mockRouter.presentCalled, 0)
         XCTAssertEqual(mockRouter.setRootViewControllerCalled, 0)
         XCTAssertNil(mockRouter.presentedViewController)
@@ -116,7 +112,7 @@ final class LaunchCoordinatorTests: XCTestCase {
         XCTAssertTrue(manager.shouldShowSurveySurface)
 
         let subject = LaunchCoordinator(router: mockRouter, profile: profile, isIphone: false)
-        subject.start(with: .survey(manager: manager)) {}
+        subject.start(with: .survey(manager: manager))
 
         XCTAssertEqual(mockRouter.presentCalled, 0)
         XCTAssertEqual(mockRouter.setRootViewControllerCalled, 1)
@@ -134,7 +130,7 @@ final class LaunchCoordinatorTests: XCTestCase {
         XCTAssertTrue(manager.shouldShowSurveySurface)
 
         let subject = LaunchCoordinator(router: mockRouter, profile: profile, isIphone: false)
-        subject.start(with: .survey(manager: manager)) {}
+        subject.start(with: .survey(manager: manager))
 
         XCTAssertNotNil(manager.openURLDelegate)
         XCTAssertNotNil(manager.dismissClosure)
@@ -154,7 +150,7 @@ final class LaunchCoordinatorTests: XCTestCase {
     }
 
     // MARK: - Helpers
-    func createMessage(
+    private func createMessage(
         for surface: MessageSurfaceId = .survey,
         isExpired: Bool
     ) -> GleanPlumbMessage {

--- a/Tests/ClientTests/Coordinators/LaunchView/LaunchScreenViewModelTests.swift
+++ b/Tests/ClientTests/Coordinators/LaunchView/LaunchScreenViewModelTests.swift
@@ -9,7 +9,6 @@ import XCTest
 
 final class LaunchScreenViewModelTests: XCTestCase, LaunchFinishedLoadingDelegate {
     private var messageManager: MockGleanPlumbMessageManagerProtocol!
-    private var delegate: MockOpenURLDelegate!
     private var profile: MockProfile!
 
     private var launchTypeLoadedClosure: ((LaunchType) -> Void)?
@@ -20,7 +19,6 @@ final class LaunchScreenViewModelTests: XCTestCase, LaunchFinishedLoadingDelegat
         DependencyHelperMock().bootstrapDependencies()
         profile = MockProfile()
         FeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
-        delegate = MockOpenURLDelegate()
         messageManager = MockGleanPlumbMessageManagerProtocol()
 
         UserDefaults.standard.set(true, forKey: PrefsKeys.NimbusFeatureTestsOverride)
@@ -31,7 +29,6 @@ final class LaunchScreenViewModelTests: XCTestCase, LaunchFinishedLoadingDelegat
         AppContainer.shared.reset()
         profile = nil
         messageManager = nil
-        delegate = nil
         launchTypeLoadedClosure = nil
         launchBrowserClosure = nil
 

--- a/Tests/ClientTests/Coordinators/SceneCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/SceneCoordinatorTests.swift
@@ -65,12 +65,23 @@ final class SceneCoordinatorTests: XCTestCase {
         XCTAssertNotNil(subject.childCoordinators[0] as? BrowserCoordinator)
     }
 
+    func testChildLaunchCoordinatorIsDone_startsBrowser() throws {
+        let subject = createSubject()
+        subject.launchWith(launchType: .intro(manager: IntroScreenManager(prefs: MockProfile().prefs)))
+
+        let childLaunchCoordinator = try XCTUnwrap(subject.childCoordinators[0] as? LaunchCoordinator)
+        subject.didFinishLaunch(from: childLaunchCoordinator)
+
+        XCTAssertEqual(subject.childCoordinators.count, 1)
+        XCTAssertNotNil(subject.childCoordinators[0] as? BrowserCoordinator)
+    }
+
     func testEnsureCoordinatorIsntEnabled() {
         XCTAssertFalse(AppConstants.useCoordinators)
     }
 
     // MARK: - Helpers
-    func createSubject(file: StaticString = #file,
+    private func createSubject(file: StaticString = #file,
                        line: UInt = #line) -> SceneCoordinator {
         let scene = UIApplication.shared.windows.first?.windowScene
         let subject = SceneCoordinator(scene: scene!)

--- a/Tests/ClientTests/Coordinators/SceneCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/SceneCoordinatorTests.swift
@@ -82,7 +82,7 @@ final class SceneCoordinatorTests: XCTestCase {
 
     // MARK: - Helpers
     private func createSubject(file: StaticString = #file,
-                       line: UInt = #line) -> SceneCoordinator {
+                               line: UInt = #line) -> SceneCoordinator {
         let scene = UIApplication.shared.windows.first?.windowScene
         let subject = SceneCoordinator(scene: scene!)
         // Replace created router from scene with a mock router so we don't trigger real navigation in our tests

--- a/Tests/ClientTests/Mocks/MockLaunchCoordinatorDelegate.swift
+++ b/Tests/ClientTests/Mocks/MockLaunchCoordinatorDelegate.swift
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+@testable import Client
+
+class MockLaunchCoordinatorDelegate: LaunchCoordinatorDelegate {
+    var savedURL: URL?
+    var savedIsPrivate: Bool?
+    var savedSelectedNewTab: Bool?
+    var savedDidFinishCoordinator: LaunchCoordinator?
+
+    func didFinishLaunch(from coordinator: LaunchCoordinator) {
+        savedDidFinishCoordinator = coordinator
+    }
+
+    func didRequestToOpenInNewTab(url: URL, isPrivate: Bool, selectNewTab: Bool) {
+        savedURL = url
+        savedIsPrivate = isPrivate
+        savedSelectedNewTab = selectNewTab
+    }
+}


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5989)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13597)

### Description
- Add LaunchCoordinator logic so we launch intro, update, survey and default browser from that coordinator. Some changes needed to be made to related classes so the flow can work. Added comments in code and used the flag to ensure prod code isn't affected. I'll ask QA to test onboardings once this PR is merged.
- Create LaunchCoordinatorDelegate to know when the launch is done, and other functionalities has been asked so the parent coordinator can handle those
- Make sure launch is done from the main queue once LaunchScreenViewModel has loaded it's stuff, since we need to do UI on the main thread.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [X] Documentation / comments for complex code and public methods
