### PR TITLE
Bugfix FXIOS-6070 [v114] URL bar image don't update when you change the default search engine

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -588,6 +588,7 @@ class BrowserViewController: UIViewController {
 
         updateTabCountUsingTabManager(tabManager, animated: false)
         performSurveySurfaceCheck()
+        urlBar.searchEnginesDidUpdate()
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -596,7 +596,7 @@ class BrowserViewController: UIViewController {
         if !AppConstants.useCoordinators {
             performSurveySurfaceCheck()
         }
-        
+
         urlBar.searchEnginesDidUpdate()
     }
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6070)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13745)

### Description
Fixed the bug when URL bar Image area doesn't reflect when changing the default search engine by calling the `urlBar.searchEnginesDidUpdate()` on viewWillAppear cause if you kept the search bar selected to change the search engine and got back it wouldn't pass through the methods that would reload the image.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
