### PR TITLE
Bugfix FXIOS-5852 [v113] Make TopTabBar cells visible returning from foreground in private view

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -396,11 +396,14 @@ class BrowserViewController: UIViewController {
             animations: {
                 self.webViewContainer.alpha = 1
                 self.urlBar.locationContainer.alpha = 1
-                self.topTabsViewController?.switchForegroundStatus(isInForeground: true)
                 self.presentedViewController?.popoverPresentationController?.containerView?.alpha = 1
                 self.presentedViewController?.view.alpha = 1
             }, completion: { _ in
                 self.webViewContainerBackdrop.alpha = 0
+                // This has to be at the end of the animation, because `switchForegroundStatus` gets the tab cells by
+                // using `collectionView.visibleCells` and before the animation is complete, the cells are not going to
+                // be visible, so it will always return an empty array.
+                self.topTabsViewController?.switchForegroundStatus(isInForeground: true)
                 self.view.sendSubviewToBack(self.webViewContainerBackdrop)
             })
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5852)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13366)

### Description

Tab title were disappearing when we put Firefox into background and foreground again while it's on private mode. This PR fixes that issue. I described the STR in the issue comment here: https://github.com/mozilla-mobile/firefox-ios/issues/13366#issuecomment-1500900034

STR:

1. Open Firefox and open a few tabs and navigate to some websites.
2. Switch to private window and open a few private tabs as well.
3. Swipe up / use home button to return to iOS home screen.
4. Return to Firefox again.
5. See that some (sometimes all) private tab titles are gone now.
6. Switch back to normal tabs. See that some (or sometimes all) non-private tab titles are gone as well.

This was happening because we were setting `self.topTabsViewController?.switchForegroundStatus(isInForeground: true)` too soon. Inside that function, we get the tabs with `collectionView.visibleCells` here:
https://github.com/mozilla-mobile/firefox-ios/blob/9aff4cd1444726bee7f682c3070861892507dfd7/Client/Frontend/Browser/TopTabsViewController.swift#L164
But the problem is, since we go from background to foreground, there is a purple overlay in the top layer that occludes this top tabs view. That's why calling `collectionView.visibleCells` when this layer is visible returns zero. I moved that to `completion` handler so now we can properly get the visible cells.

Before:

https://user-images.githubusercontent.com/466239/230732266-ef95cba3-fe22-4de7-8ac7-87376fcab85e.mov

After:

https://user-images.githubusercontent.com/466239/230732287-76f9c0e5-f808-4717-84d5-91700b19f602.mov


### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [X] Documentation / comments for complex code and public methods
