### PR TITLE
Refactor FXIOS-6148 [v114] Add MockLaunchFinishedLoadingDelegate to improve unit tests

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -659,6 +659,7 @@
 		8AFA263227B6E9AB00D0C33B /* ToolbarBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFA263127B6E9AB00D0C33B /* ToolbarBadge.swift */; };
 		8AFCE50529DDF38300B1B253 /* LaunchScreenViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFCE50429DDF38300B1B253 /* LaunchScreenViewControllerTests.swift */; };
 		8AFCE50729DE0CD500B1B253 /* LaunchCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFCE50629DE0CD500B1B253 /* LaunchCoordinatorTests.swift */; };
+		8AFCE50929DE136300B1B253 /* MockLaunchFinishedLoadingDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFCE50829DE136300B1B253 /* MockLaunchFinishedLoadingDelegate.swift */; };
 		8AFE4C2127480D0C00B97C65 /* TabTrayViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFE4C2027480D0B00B97C65 /* TabTrayViewControllerTests.swift */; };
 		8D8251811F4DE67F00780643 /* AdvancedAccountSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8251721F4DE67E00780643 /* AdvancedAccountSettingViewController.swift */; };
 		9609F4CA26B57CE800F81493 /* Calendar+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9609F4C926B57CE800F81493 /* Calendar+Extension.swift */; };
@@ -3996,6 +3997,7 @@
 		8AFA263127B6E9AB00D0C33B /* ToolbarBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarBadge.swift; sourceTree = "<group>"; };
 		8AFCE50429DDF38300B1B253 /* LaunchScreenViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchScreenViewControllerTests.swift; sourceTree = "<group>"; };
 		8AFCE50629DE0CD500B1B253 /* LaunchCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchCoordinatorTests.swift; sourceTree = "<group>"; };
+		8AFCE50829DE136300B1B253 /* MockLaunchFinishedLoadingDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLaunchFinishedLoadingDelegate.swift; sourceTree = "<group>"; };
 		8AFE4C2027480D0B00B97C65 /* TabTrayViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabTrayViewControllerTests.swift; sourceTree = "<group>"; };
 		8B3245D190D4FA80C3B46EC8 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Search.strings"; sourceTree = "<group>"; };
 		8B674438A5487ABCD2DD7CA5 /* ses */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ses; path = ses.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -7901,6 +7903,7 @@
 				8AF10D9029D776190086351D /* MockLaunchScreenManager.swift */,
 				2173326929CCF901007F20C7 /* UIPanGestureRecognizerMock.swift */,
 				8A5604F529DF09FA00035CA3 /* MockLaunchCoordinatorDelegate.swift */,
+				8AFCE50829DE136300B1B253 /* MockLaunchFinishedLoadingDelegate.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -11609,6 +11612,7 @@
 				965C3C96293431FC006499ED /* MockLaunchSessionProvider.swift in Sources */,
 				C869915628917803007ACC5C /* WallpaperJSONTestProvider.swift in Sources */,
 				965C3C9829343445006499ED /* MockAppSessionManager.swift in Sources */,
+				8AFCE50929DE136300B1B253 /* MockLaunchFinishedLoadingDelegate.swift in Sources */,
 				8AE1E1DB27B1C1320024C45E /* SearchBarSettingsViewModelTests.swift in Sources */,
 				CA24B53924ABFE250093848C /* LoginsListSelectionHelperTests.swift in Sources */,
 				39D0DA7629D767DE000760B8 /* NimbusMessagingTriggerTests.swift in Sources */,

--- a/Client/Coordinators/LaunchView/LaunchScreenViewController.swift
+++ b/Client/Coordinators/LaunchView/LaunchScreenViewController.swift
@@ -25,15 +25,27 @@ class LaunchScreenViewController: UIViewController, LaunchFinishedLoadingDelegat
         fatalError()
     }
 
+    // MARK: - View cycles
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        viewModel.startLoading()
+        Task {
+            await startLoading()
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         setupLayout()
     }
+
+    // MARK: - Loading
+
+    func startLoading() async {
+        await viewModel.startLoading()
+    }
+
+    // MARK: - Setup
 
     private func setupLayout() {
         launchScreen.translatesAutoresizingMaskIntoConstraints = false

--- a/Client/Coordinators/LaunchView/LaunchScreenViewModel.swift
+++ b/Client/Coordinators/LaunchView/LaunchScreenViewModel.swift
@@ -24,10 +24,8 @@ class LaunchScreenViewModel {
         self.surveySurfaceManager = SurveySurfaceManager(and: messageManager)
     }
 
-    func startLoading(appVersion: String = AppInfo.appVersion) {
-        Task {
-            await loadLaunchType(appVersion: appVersion)
-        }
+    func startLoading(appVersion: String = AppInfo.appVersion) async {
+        await loadLaunchType(appVersion: appVersion)
     }
 
     private func loadLaunchType(appVersion: String) async {

--- a/Tests/ClientTests/Coordinators/Launch/LaunchCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/Launch/LaunchCoordinatorTests.swift
@@ -29,7 +29,7 @@ final class LaunchCoordinatorTests: XCTestCase {
     }
 
     func testInitialState() {
-        let subject = LaunchCoordinator(router: mockRouter, profile: profile)
+        let subject = createSubject(isIphone: true)
 
         XCTAssertEqual(mockRouter.presentCalled, 0)
         XCTAssertEqual(mockRouter.setRootViewControllerCalled, 0)
@@ -39,7 +39,7 @@ final class LaunchCoordinatorTests: XCTestCase {
     // MARK: - Intro
     func testStart_introNotIphone_present() throws {
         let introScreenManager = IntroScreenManager(prefs: profile.prefs)
-        let subject = LaunchCoordinator(router: mockRouter, profile: profile, isIphone: false)
+        let subject = createSubject(isIphone: false)
         subject.start(with: .intro(manager: introScreenManager))
 
         XCTAssertEqual(mockRouter.presentCalled, 1)
@@ -50,7 +50,7 @@ final class LaunchCoordinatorTests: XCTestCase {
 
     func testStart_introIsIphone_setRootView() throws {
         let introScreenManager = IntroScreenManager(prefs: profile.prefs)
-        let subject = LaunchCoordinator(router: mockRouter, profile: profile, isIphone: true)
+        let subject = createSubject(isIphone: true)
         subject.start(with: .intro(manager: introScreenManager))
 
         XCTAssertEqual(mockRouter.presentCalled, 0)
@@ -62,7 +62,7 @@ final class LaunchCoordinatorTests: XCTestCase {
     // MARK: - Update
     func testStart_updateNotIphone_present() throws {
         let viewModel = UpdateViewModel(profile: profile)
-        let subject = LaunchCoordinator(router: mockRouter, profile: profile, isIphone: false)
+        let subject = createSubject(isIphone: false)
         subject.start(with: .update(viewModel: viewModel))
 
         XCTAssertEqual(mockRouter.presentCalled, 1)
@@ -73,7 +73,7 @@ final class LaunchCoordinatorTests: XCTestCase {
 
     func testStart_updateIsIphone_setRootView() throws {
         let viewModel = UpdateViewModel(profile: profile)
-        let subject = LaunchCoordinator(router: mockRouter, profile: profile, isIphone: true)
+        let subject = createSubject(isIphone: true)
         subject.start(with: .update(viewModel: viewModel))
 
         XCTAssertEqual(mockRouter.presentCalled, 0)
@@ -84,7 +84,7 @@ final class LaunchCoordinatorTests: XCTestCase {
 
     // MARK: - Default browser
     func testStart_defaultBrowser_present() throws {
-        let subject = LaunchCoordinator(router: mockRouter, profile: profile, isIphone: false)
+        let subject = createSubject(isIphone: false)
         subject.start(with: .defaultBrowser)
 
         XCTAssertEqual(mockRouter.presentCalled, 1)
@@ -96,7 +96,7 @@ final class LaunchCoordinatorTests: XCTestCase {
     // MARK: - Survey
     func testStart_surveyNoMessage_completes() throws {
         let manager = SurveySurfaceManager()
-        let subject = LaunchCoordinator(router: mockRouter, profile: profile, isIphone: false)
+        let subject = createSubject(isIphone: false)
         subject.start(with: .survey(manager: manager))
 
         XCTAssertEqual(mockRouter.presentCalled, 0)
@@ -111,7 +111,7 @@ final class LaunchCoordinatorTests: XCTestCase {
         let manager = SurveySurfaceManager(and: messageManager)
         XCTAssertTrue(manager.shouldShowSurveySurface)
 
-        let subject = LaunchCoordinator(router: mockRouter, profile: profile, isIphone: false)
+        let subject = createSubject(isIphone: false)
         subject.start(with: .survey(manager: manager))
 
         XCTAssertEqual(mockRouter.presentCalled, 0)
@@ -129,7 +129,7 @@ final class LaunchCoordinatorTests: XCTestCase {
         XCTAssertNil(manager.openURLDelegate)
         XCTAssertTrue(manager.shouldShowSurveySurface)
 
-        let subject = LaunchCoordinator(router: mockRouter, profile: profile, isIphone: false)
+        let subject = createSubject(isIphone: false)
         subject.start(with: .survey(manager: manager))
 
         XCTAssertNotNil(manager.openURLDelegate)
@@ -137,7 +137,7 @@ final class LaunchCoordinatorTests: XCTestCase {
     }
 
     func testOpenURLDelegate() {
-        let subject = LaunchCoordinator(router: mockRouter, profile: profile, isIphone: false)
+        let subject = createSubject(isIphone: false)
         subject.parentCoordinator = delegate
         let mockURL = URL(string: "www.firefox.com")!
         subject.didRequestToOpenInNewTab(url: mockURL,
@@ -150,6 +150,14 @@ final class LaunchCoordinatorTests: XCTestCase {
     }
 
     // MARK: - Helpers
+    private func createSubject(isIphone: Bool,
+                       file: StaticString = #file,
+                       line: UInt = #line) -> LaunchCoordinator {
+        let subject = LaunchCoordinator(router: mockRouter, profile: profile, isIphone: isIphone)
+        trackForMemoryLeaks(subject, file: file, line: line)
+        return subject
+    }
+
     private func createMessage(
         for surface: MessageSurfaceId = .survey,
         isExpired: Bool

--- a/Tests/ClientTests/Coordinators/Launch/LaunchCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/Launch/LaunchCoordinatorTests.swift
@@ -151,8 +151,8 @@ final class LaunchCoordinatorTests: XCTestCase {
 
     // MARK: - Helpers
     private func createSubject(isIphone: Bool,
-                       file: StaticString = #file,
-                       line: UInt = #line) -> LaunchCoordinator {
+                               file: StaticString = #file,
+                               line: UInt = #line) -> LaunchCoordinator {
         let subject = LaunchCoordinator(router: mockRouter, profile: profile, isIphone: isIphone)
         trackForMemoryLeaks(subject, file: file, line: line)
         return subject

--- a/Tests/ClientTests/Coordinators/LaunchView/LaunchScreenViewControllerTests.swift
+++ b/Tests/ClientTests/Coordinators/LaunchView/LaunchScreenViewControllerTests.swift
@@ -6,78 +6,67 @@ import Common
 import XCTest
 @testable import Client
 
-final class LaunchScreenViewControllerTests: XCTestCase, LaunchFinishedLoadingDelegate {
+final class LaunchScreenViewControllerTests: XCTestCase {
     private var viewModel: MockLaunchScreenViewModel!
-    private var launchTypeLoadedClosure: ((LaunchType) -> Void)?
-    private var launchBrowserClosure: (() -> Void)?
+    private var coordinatorDelegate: MockLaunchFinishedLoadingDelegate!
 
     override func setUp() {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         viewModel = MockLaunchScreenViewModel(profile: MockProfile())
-        viewModel.delegate = self
+        coordinatorDelegate = MockLaunchFinishedLoadingDelegate()
     }
 
     override func tearDown() {
         super.tearDown()
         AppContainer.shared.reset()
         viewModel = nil
-        launchTypeLoadedClosure = nil
-        launchBrowserClosure = nil
+        coordinatorDelegate = nil
     }
 
     func testNotLoaded_notCalled() {
-        _ = LaunchScreenViewController(coordinator: self,
-                                       viewModel: viewModel)
+        _ = createSubject()
         XCTAssertEqual(viewModel.startLoadingCalled, 0)
     }
 
-    func testViewDidLoad_whenLaunchType_callsCoordinatorLaunch() {
+    func testViewDidLoad_whenLaunchType_callsCoordinatorLaunch() async {
         viewModel.mockLaunchType = .intro(manager: viewModel.introScreenManager)
-        let expectation = expectation(description: "LaunchTypeLoaded called")
-        launchTypeLoadedClosure = { launchType in
-            guard case .intro = launchType else {
-                XCTFail("Expected intro, but was \(launchType)")
-                return
-            }
-            expectation.fulfill()
-        }
-        let subject = LaunchScreenViewController(coordinator: self,
-                                                 viewModel: viewModel)
-        subject.viewDidLoad()
+        let subject = createSubject()
+        await subject.startLoading()
 
-        waitForExpectations(timeout: 0.1)
+        guard case .intro = coordinatorDelegate.savedLaunchType else {
+            XCTFail("Expected intro, but was \(String(describing: coordinatorDelegate.savedLaunchType))")
+            return
+        }
+        XCTAssertEqual(coordinatorDelegate.launchWithTypeCalled, 1)
+        XCTAssertEqual(coordinatorDelegate.launchBrowserCalled, 0)
         XCTAssertEqual(viewModel.startLoadingCalled, 1)
     }
 
-    func testViewDidLoad_whenNilLaunchType_callsCoordinatorBrowser() {
+    func testViewDidLoad_whenNilLaunchType_callsCoordinatorBrowser() async {
         viewModel.mockLaunchType = nil
-        let expectation = expectation(description: "LaunchBrowserClosure called")
-        launchBrowserClosure = { expectation.fulfill() }
+        let subject = createSubject()
+        await subject.startLoading()
 
-        let subject = LaunchScreenViewController(coordinator: self,
-                                                 viewModel: viewModel)
-        subject.viewDidLoad()
-
-        waitForExpectations(timeout: 0.1)
+        XCTAssertEqual(coordinatorDelegate.launchWithTypeCalled, 0)
+        XCTAssertEqual(coordinatorDelegate.launchBrowserCalled, 1)
         XCTAssertEqual(viewModel.startLoadingCalled, 1)
     }
 
     func testAddLaunchView_whenViewWillAppear() {
-        let subject = LaunchScreenViewController(coordinator: self,
+        let subject = LaunchScreenViewController(coordinator: coordinatorDelegate,
                                                  viewModel: viewModel)
         XCTAssertTrue(subject.view.subviews.isEmpty)
         subject.viewWillAppear(false)
         XCTAssertNotNil(subject.view.subviews[0])
     }
 
-    // MARK: - LaunchFinishedLoadingDelegate
-
-    func launchWith(launchType: LaunchType) {
-        launchTypeLoadedClosure?(launchType)
-    }
-
-    func launchBrowser() {
-        launchBrowserClosure?()
+    // MARK: - Helpers
+    private func createSubject(file: StaticString = #file,
+                               line: UInt = #line) -> LaunchScreenViewController {
+        let subject = LaunchScreenViewController(coordinator: coordinatorDelegate,
+                                                 viewModel: viewModel)
+        trackForMemoryLeaks(subject, file: file, line: line)
+        return subject
     }
 }

--- a/Tests/ClientTests/Coordinators/LaunchView/LaunchScreenViewControllerTests.swift
+++ b/Tests/ClientTests/Coordinators/LaunchView/LaunchScreenViewControllerTests.swift
@@ -29,6 +29,7 @@ final class LaunchScreenViewControllerTests: XCTestCase {
         XCTAssertEqual(viewModel.startLoadingCalled, 0)
     }
 
+    @MainActor
     func testViewDidLoad_whenLaunchType_callsCoordinatorLaunch() async {
         viewModel.mockLaunchType = .intro(manager: viewModel.introScreenManager)
         let subject = createSubject()
@@ -43,6 +44,7 @@ final class LaunchScreenViewControllerTests: XCTestCase {
         XCTAssertEqual(viewModel.startLoadingCalled, 1)
     }
 
+    @MainActor
     func testViewDidLoad_whenNilLaunchType_callsCoordinatorBrowser() async {
         viewModel.mockLaunchType = nil
         let subject = createSubject()

--- a/Tests/ClientTests/Mocks/MockLaunchFinishedLoadingDelegate.swift
+++ b/Tests/ClientTests/Mocks/MockLaunchFinishedLoadingDelegate.swift
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+@testable import Client
+
+class MockLaunchFinishedLoadingDelegate: LaunchFinishedLoadingDelegate {
+    var savedLaunchType: LaunchType?
+    var launchWithTypeCalled = 0
+    var launchBrowserCalled = 0
+
+    func launchWith(launchType: LaunchType) {
+        launchWithTypeCalled += 1
+        savedLaunchType = launchType
+    }
+
+    func launchBrowser() {
+        launchBrowserCalled += 1
+    }
+}

--- a/Tests/ClientTests/Mocks/MockLaunchScreenManager.swift
+++ b/Tests/ClientTests/Mocks/MockLaunchScreenManager.swift
@@ -19,7 +19,7 @@ class MockLaunchScreenViewModel: LaunchScreenViewModel {
         self.surveySurfaceManager = SurveySurfaceManager(and: messageManager)
     }
 
-    override func startLoading(appVersion: String) {
+    override func startLoading(appVersion: String) async {
         startLoadingCalled += 1
         if let mockLaunchType = mockLaunchType {
             delegate?.launchWith(launchType: mockLaunchType)


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6148)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13889)

### Description
Using async await a bit differently in LaunchScreenViewModel and view controller, improves tests.
Also fix two failings tests on `main` caused by missing setting the initial state of the unit test properly.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
