### PR TITLE
Add FXIOS-6013 [v114] Settings the basics of the basics for the container work in BVC

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -336,7 +336,11 @@ extension BrowserViewController: URLBarDelegate {
                 toast.removeFromSuperview()
             }
 
-            showHomepage(inline: false)
+            if !AppConstants.useCoordinators {
+                showHomepage(inline: false)
+            } else {
+                // FXIOS-6014 - Homepage in container
+            }
         }
     }
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6013)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13657)

### Description
- Settings the basics of the basics for the container work in BVC. This adds a container that we'll use for homepage and webview. If the constant to use coordinator is set to true, then we're showing this (red) container. If the flag is set to false, then it shouldn't affect anything. 
- Added some comments to explain the different containers.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
