### PR TITLE
Bugfix FXIOS-3660 [v114] Autofill Color issue in Dark Mode

### DIFF
--- a/Client/Frontend/Toolbar+URLBar/ToolbarTextField.swift
+++ b/Client/Frontend/Toolbar+URLBar/ToolbarTextField.swift
@@ -15,6 +15,7 @@ class ToolbarTextField: AutocompleteTextField {
     }
 
     private var tintedClearImage: UIImage?
+    static var isPrivate: Bool = false
 
     // MARK: - Initializers
 
@@ -67,6 +68,7 @@ extension ToolbarTextField: NotificationThemeable {
         textColor = UIColor.legacyTheme.textField.textAndTint
         clearButtonTintColor = textColor
         tintColor = AutocompleteTextField.textSelectionColor.textFieldMode
+        ToolbarTextField.applyUIMode(isPrivate: ToolbarTextField.isPrivate)
         self.refreshAutocompleteLabelTheme()
     }
 

--- a/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -878,6 +878,7 @@ extension URLBarView: PrivateModeUI {
         progressBar.setGradientColors(startColor: UIColor.legacyTheme.loadingBar.start(isPrivate),
                                       middleColor: UIColor.legacyTheme.loadingBar.middle(isPrivate),
                                       endColor: UIColor.legacyTheme.loadingBar.end(isPrivate))
+        ToolbarTextField.isPrivate = isPrivate
         ToolbarTextField.applyUIMode(isPrivate: isPrivate)
 
         applyTheme()


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5498?atlOrigin=eyJpIjoiYjQ2NjRkY2YyNjU3NDRhMTliODZlNjE1NjhmMzI4ZjMiLCJwIjoiaiJ9)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/12804)

### Description
This static isPrivate will help change the color of autocomplete background color when themes change.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
