### PR TITLE
Bugfix FXIOS-6062 [v114] Fix get query url encoding

### DIFF
--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -148,9 +148,12 @@ extension URL {
 
     public func getQuery() -> [String: String] {
         var results = [String: String]()
-        let components = URLComponents(url: self, resolvingAgainstBaseURL: false)
 
-        guard let queryItems = components?.queryItems else { return results }
+        guard let components = URLComponents(url: self, resolvingAgainstBaseURL: false),
+              let queryItems = components.percentEncodedQueryItems
+        else {
+            return results
+        }
 
         for item in queryItems {
             if let value = item.value {

--- a/Tests/ClientTests/Helpers/MailProvidersTests.swift
+++ b/Tests/ClientTests/Helpers/MailProvidersTests.swift
@@ -28,8 +28,8 @@ class MailProvidersTests: XCTestCase {
         }
 
         let expectedResult = ["recipient": toEmail,
-                              "subject": subject,
-                              "textbody": body,
+                              "subject": subject.replacingOccurrences(of: " ", with: "%20"),
+                              "textbody": body.replacingOccurrences(of: " ", with: "%20"),
                               "cc": ccEmail,
                               "bcc": bccEmail]
 
@@ -59,8 +59,8 @@ class MailProvidersTests: XCTestCase {
         }
 
         let expectedResult = ["to": toEmail,
-                              "subject": subject,
-                              "htmlBody": body,
+                              "subject": subject.replacingOccurrences(of: " ", with: "%20"),
+                              "htmlBody": body.replacingOccurrences(of: " ", with: "%20"),
                               "cc": ccEmail,
                               "bcc": bccEmail]
 
@@ -83,8 +83,8 @@ class MailProvidersTests: XCTestCase {
         }
 
         let expectedResult = ["to": toEmail,
-                              "subject": subject,
-                              "body": body,
+                              "subject": subject.replacingOccurrences(of: " ", with: "%20"),
+                              "body": body.replacingOccurrences(of: " ", with: "%20"),
                               "cc": ccEmail,
                               "bcc": bccEmail]
 
@@ -107,8 +107,8 @@ class MailProvidersTests: XCTestCase {
         }
 
         let expectedResult = ["to": toEmail,
-                              "subject": subject,
-                              "body": body,
+                              "subject": subject.replacingOccurrences(of: " ", with: "%20"),
+                              "body": body.replacingOccurrences(of: " ", with: "%20"),
                               "cc": ccEmail,
                               "bcc": bccEmail]
 
@@ -131,8 +131,8 @@ class MailProvidersTests: XCTestCase {
         }
 
         let expectedResult = ["to": toEmail,
-                              "subject": subject,
-                              "body": body,
+                              "subject": subject.replacingOccurrences(of: " ", with: "%20"),
+                              "body": body.replacingOccurrences(of: " ", with: "%20"),
                               "cc": ccEmail,
                               "bcc": bccEmail]
 
@@ -155,8 +155,8 @@ class MailProvidersTests: XCTestCase {
         }
 
         let expectedResult = ["to": toEmail,
-                              "subject": subject,
-                              "body": body,
+                              "subject": subject.replacingOccurrences(of: " ", with: "%20"),
+                              "body": body.replacingOccurrences(of: " ", with: "%20"),
                               "cc": ccEmail]
 
         XCTAssertEqual(urlStringWithoutQuery(url: mailURL)!, "ymail:mail/any/compose")
@@ -178,8 +178,8 @@ class MailProvidersTests: XCTestCase {
         }
 
         let expectedResult = ["to": toEmail,
-                              "subject": subject,
-                              "body": body,
+                              "subject": subject.replacingOccurrences(of: " ", with: "%20"),
+                              "body": body.replacingOccurrences(of: " ", with: "%20"),
                               "cc": ccEmail,
                               "bcc": bccEmail]
 
@@ -202,8 +202,8 @@ class MailProvidersTests: XCTestCase {
         }
 
         let expectedResult = ["to": toEmail,
-                              "subject": subject,
-                              "body": body,
+                              "subject": subject.replacingOccurrences(of: " ", with: "%20"),
+                              "body": body.replacingOccurrences(of: " ", with: "%20"),
                               "cc": ccEmail,
                               "bcc": bccEmail]
 
@@ -225,8 +225,8 @@ class MailProvidersTests: XCTestCase {
             return
         }
 
-        let expectedResult = ["subject": subject,
-                              "body": body,
+        let expectedResult = ["subject": subject.replacingOccurrences(of: " ", with: "%20"),
+                              "body": body.replacingOccurrences(of: " ", with: "%20"),
                               "cc": ccEmail,
                               "bcc": bccEmail]
 

--- a/Tests/SharedTests/NSURLExtensionsTests.swift
+++ b/Tests/SharedTests/NSURLExtensionsTests.swift
@@ -308,6 +308,12 @@ class NSURLExtensionsTests: XCTestCase {
         params.forEach { XCTAssertEqual(urlParams[$0], $1, "The values in params should be the same in urlParams") }
     }
 
+    func testGetQueryWithPercentEncodedParams() {
+        let url = URL(string: "http://example.com/path?a=%20")!
+        let urlParams = url.getQuery()
+        XCTAssertEqual(urlParams["a"], "%20")
+    }
+
     func testwithQueryParams() {
         let url = URL(string: "http://example.com/path")!
         let params = ["a": "1", "b": "2", "c": "3"]


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6062)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13729)

### Description
Fix percent encoding on getQuery function in the URL extension

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
