### PR TITLE
Add FXIOS-6014 [v114] homepage embedded from coordinator

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -530,6 +530,7 @@
 		8A33222227DFE658008F809E /* NimbusMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A33222127DFE658008F809E /* NimbusMock.swift */; };
 		8A355E5E27D267A400B9AF34 /* RecentItemsHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A355E5D27D267A400B9AF34 /* RecentItemsHelperTests.swift */; };
 		8A36AC2C2886F27F00CDC0AD /* MockTabManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A36AC2B2886F27F00CDC0AD /* MockTabManager.swift */; };
+		8A36BE2929EDBC6900AC1C5C /* ContentContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A36BE2829EDBC6900AC1C5C /* ContentContainer.swift */; };
 		8A37C79F28DA4BA600B1FAD4 /* ContextualHintViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A37C79E28DA4BA600B1FAD4 /* ContextualHintViewModelTests.swift */; };
 		8A395552299AF83400B2AFBB /* UIControl+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A395551299AF83300B2AFBB /* UIControl+Extension.swift */; };
 		8A471183287F6D9C00F5A6EA /* BookmarksPanelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A471182287F6D9C00F5A6EA /* BookmarksPanelViewModel.swift */; };
@@ -3856,6 +3857,7 @@
 		8A33222127DFE658008F809E /* NimbusMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusMock.swift; sourceTree = "<group>"; };
 		8A355E5D27D267A400B9AF34 /* RecentItemsHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentItemsHelperTests.swift; sourceTree = "<group>"; };
 		8A36AC2B2886F27F00CDC0AD /* MockTabManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTabManager.swift; sourceTree = "<group>"; };
+		8A36BE2829EDBC6900AC1C5C /* ContentContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentContainer.swift; sourceTree = "<group>"; };
 		8A37C79E28DA4BA600B1FAD4 /* ContextualHintViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualHintViewModelTests.swift; sourceTree = "<group>"; };
 		8A395551299AF83300B2AFBB /* UIControl+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIControl+Extension.swift"; sourceTree = "<group>"; };
 		8A471182287F6D9C00F5A6EA /* BookmarksPanelViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksPanelViewModel.swift; sourceTree = "<group>"; };
@@ -7317,6 +7319,7 @@
 				8A9CB41D2846F0BF00CC3A16 /* FadeScrollView.swift */,
 				43AB6F9E25DC53D20016B015 /* LabelButtonHeaderView.swift */,
 				217AEF7728480844004EED37 /* ResizableButton.swift */,
+				8A36BE2829EDBC6900AC1C5C /* ContentContainer.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -11276,6 +11279,7 @@
 				C82A94F3269F68F300624AA7 /* CoreFlaggableFeature.swift in Sources */,
 				F84B22241A09122500AAB793 /* LibraryViewController.swift in Sources */,
 				39455F771FC83F430088A22C /* TabEventHandler.swift in Sources */,
+				8A36BE2929EDBC6900AC1C5C /* ContentContainer.swift in Sources */,
 				215B458227DA420400E5E800 /* LegacyTabMetadataManager.swift in Sources */,
 				E47616C71AB74CA600E7DD25 /* ReaderModeBarView.swift in Sources */,
 				D821E90E2141B71C00452C55 /* SiriSettingsViewController.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -531,6 +531,7 @@
 		8A355E5E27D267A400B9AF34 /* RecentItemsHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A355E5D27D267A400B9AF34 /* RecentItemsHelperTests.swift */; };
 		8A36AC2C2886F27F00CDC0AD /* MockTabManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A36AC2B2886F27F00CDC0AD /* MockTabManager.swift */; };
 		8A36BE2929EDBC6900AC1C5C /* ContentContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A36BE2829EDBC6900AC1C5C /* ContentContainer.swift */; };
+		8A36BE2C29EDE16C00AC1C5C /* ContentContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A36BE2A29EDE16700AC1C5C /* ContentContainerTests.swift */; };
 		8A37C79F28DA4BA600B1FAD4 /* ContextualHintViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A37C79E28DA4BA600B1FAD4 /* ContextualHintViewModelTests.swift */; };
 		8A395552299AF83400B2AFBB /* UIControl+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A395551299AF83300B2AFBB /* UIControl+Extension.swift */; };
 		8A471183287F6D9C00F5A6EA /* BookmarksPanelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A471182287F6D9C00F5A6EA /* BookmarksPanelViewModel.swift */; };
@@ -3858,6 +3859,7 @@
 		8A355E5D27D267A400B9AF34 /* RecentItemsHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentItemsHelperTests.swift; sourceTree = "<group>"; };
 		8A36AC2B2886F27F00CDC0AD /* MockTabManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTabManager.swift; sourceTree = "<group>"; };
 		8A36BE2829EDBC6900AC1C5C /* ContentContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentContainer.swift; sourceTree = "<group>"; };
+		8A36BE2A29EDE16700AC1C5C /* ContentContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentContainerTests.swift; sourceTree = "<group>"; };
 		8A37C79E28DA4BA600B1FAD4 /* ContextualHintViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualHintViewModelTests.swift; sourceTree = "<group>"; };
 		8A395551299AF83300B2AFBB /* UIControl+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIControl+Extension.swift"; sourceTree = "<group>"; };
 		8A471182287F6D9C00F5A6EA /* BookmarksPanelViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksPanelViewModel.swift; sourceTree = "<group>"; };
@@ -8431,6 +8433,7 @@
 				E1AEC173286E0CF500062E29 /* Browser */,
 				9614BF3F28A53F2000D3F7EA /* ContextualHints */,
 				E1AEC16E286E0CF500062E29 /* Home */,
+				8A36BE2A29EDE16700AC1C5C /* ContentContainerTests.swift */,
 			);
 			path = Frontend;
 			sourceTree = "<group>";
@@ -11642,6 +11645,7 @@
 				39D0DA7629D767DE000760B8 /* NimbusMessagingTriggerTests.swift in Sources */,
 				21B41A1D298B187A008BC0A2 /* MockOverlayModeManager.swift in Sources */,
 				2FDB10931A9FBEC5006CF312 /* PrefsTests.swift in Sources */,
+				8A36BE2C29EDE16C00AC1C5C /* ContentContainerTests.swift in Sources */,
 				5A9A09D228AFD51900B6F51E /* MockHomepageDataModelDelegate.swift in Sources */,
 				D525DFB325FBE5E000B18763 /* TabTests.swift in Sources */,
 				C8E78BDD27F4A1E700C48BAA /* HistoryDeletionUtilityTests.swift in Sources */,

--- a/Client/Coordinators/BrowserCoordinator.swift
+++ b/Client/Coordinators/BrowserCoordinator.swift
@@ -57,7 +57,6 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
 
     // MARK: - BrowserDelegate
 
-    // Laurie - tests
     func showHomepage(inline: Bool,
                       homepanelDelegate: HomePanelDelegate,
                       libraryPanelDelegate: LibraryPanelDelegate,

--- a/Client/Coordinators/BrowserCoordinator.swift
+++ b/Client/Coordinators/BrowserCoordinator.swift
@@ -5,7 +5,7 @@
 import Common
 import Foundation
 
-protocol HomepageDelegate: AnyObject {
+protocol BrowserDelegate: AnyObject {
     func showHomepage(homepanelDelegate: HomePanelDelegate,
                       libraryPanelDelegate: LibraryPanelDelegate,
                       sendToDeviceDelegate: HomepageViewController.SendToDeviceDelegate,
@@ -13,7 +13,7 @@ protocol HomepageDelegate: AnyObject {
     func showWebView()
 }
 
-class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, HomepageDelegate {
+class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDelegate {
     var browserViewController: BrowserViewController
     private var profile: Profile
 
@@ -23,7 +23,7 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, HomepageDe
         self.profile = profile
         self.browserViewController = BrowserViewController(profile: profile, tabManager: tabManager)
         super.init(router: router)
-        self.browserViewController.homepageDelegate = self
+        self.browserViewController.browserDelegate = self
     }
 
     func start(with launchType: LaunchType?) {
@@ -54,17 +54,17 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, HomepageDe
         // FXIOS-6030: Handle open in new tab route
     }
 
-    // MARK: - HomepageDelegate
+    // MARK: - BrowserDelegate
 
+    // Laurie - tests
     func showHomepage(homepanelDelegate: HomePanelDelegate,
                       libraryPanelDelegate: LibraryPanelDelegate,
                       sendToDeviceDelegate: HomepageViewController.SendToDeviceDelegate,
                       overlayManager: OverlayModeManager) {
-        let tabManager: TabManager = AppContainer.shared.resolve()
         let homepageViewController = HomepageViewController(
             profile: profile,
-            tabManager: tabManager,
-            overlayManager: overlayManager)
+            overlayManager: overlayManager
+        )
         homepageViewController.homePanelDelegate = homepanelDelegate
         homepageViewController.libraryPanelDelegate = libraryPanelDelegate
         homepageViewController.sendToDeviceDelegate = sendToDeviceDelegate

--- a/Client/Coordinators/BrowserCoordinator.swift
+++ b/Client/Coordinators/BrowserCoordinator.swift
@@ -6,7 +6,8 @@ import Common
 import Foundation
 
 protocol BrowserDelegate: AnyObject {
-    func showHomepage(homepanelDelegate: HomePanelDelegate,
+    func showHomepage(inline: Bool,
+                      homepanelDelegate: HomePanelDelegate,
                       libraryPanelDelegate: LibraryPanelDelegate,
                       sendToDeviceDelegate: HomepageViewController.SendToDeviceDelegate,
                       overlayManager: OverlayModeManager)
@@ -57,12 +58,14 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
     // MARK: - BrowserDelegate
 
     // Laurie - tests
-    func showHomepage(homepanelDelegate: HomePanelDelegate,
+    func showHomepage(inline: Bool,
+                      homepanelDelegate: HomePanelDelegate,
                       libraryPanelDelegate: LibraryPanelDelegate,
                       sendToDeviceDelegate: HomepageViewController.SendToDeviceDelegate,
                       overlayManager: OverlayModeManager) {
         let homepageViewController = HomepageViewController(
             profile: profile,
+            isZeroSearch: inline,
             overlayManager: overlayManager
         )
         homepageViewController.homePanelDelegate = homepanelDelegate
@@ -70,12 +73,6 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
         homepageViewController.sendToDeviceDelegate = sendToDeviceDelegate
 
         browserViewController.embedContent(homepageViewController)
-
-        // TODO: Laurie - Put this in homepage view controller view did appear
-//        homepageViewController?.applyTheme()
-//        homepageViewController?.homepageWillAppear(isZeroSearch: !inline)
-//        homepageViewController?.reloadView()
-//        NotificationCenter.default.post(name: .ShowHomepage, object: nil)
     }
 
     func showWebView() {

--- a/Client/Coordinators/BrowserCoordinator.swift
+++ b/Client/Coordinators/BrowserCoordinator.swift
@@ -5,14 +5,25 @@
 import Common
 import Foundation
 
-class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate {
+protocol HomepageDelegate: AnyObject {
+    func showHomepage(homepanelDelegate: HomePanelDelegate,
+                      libraryPanelDelegate: LibraryPanelDelegate,
+                      sendToDeviceDelegate: HomepageViewController.SendToDeviceDelegate,
+                      overlayManager: OverlayModeManager)
+    func showWebView()
+}
+
+class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, HomepageDelegate {
     var browserViewController: BrowserViewController
+    private var profile: Profile
 
     init(router: Router,
          profile: Profile = AppContainer.shared.resolve(),
          tabManager: TabManager = AppContainer.shared.resolve()) {
+        self.profile = profile
         self.browserViewController = BrowserViewController(profile: profile, tabManager: tabManager)
         super.init(router: router)
+        self.browserViewController.homepageDelegate = self
     }
 
     func start(with launchType: LaunchType?) {
@@ -41,5 +52,33 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate {
 
     func didRequestToOpenInNewTab(url: URL, isPrivate: Bool, selectNewTab: Bool) {
         // FXIOS-6030: Handle open in new tab route
+    }
+
+    // MARK: - HomepageDelegate
+
+    func showHomepage(homepanelDelegate: HomePanelDelegate,
+                      libraryPanelDelegate: LibraryPanelDelegate,
+                      sendToDeviceDelegate: HomepageViewController.SendToDeviceDelegate,
+                      overlayManager: OverlayModeManager) {
+        let tabManager: TabManager = AppContainer.shared.resolve()
+        let homepageViewController = HomepageViewController(
+            profile: profile,
+            tabManager: tabManager,
+            overlayManager: overlayManager)
+        homepageViewController.homePanelDelegate = homepanelDelegate
+        homepageViewController.libraryPanelDelegate = libraryPanelDelegate
+        homepageViewController.sendToDeviceDelegate = sendToDeviceDelegate
+
+        browserViewController.embedContent(homepageViewController)
+
+        // TODO: Laurie - Put this in homepage view controller view did appear
+//        homepageViewController?.applyTheme()
+//        homepageViewController?.homepageWillAppear(isZeroSearch: !inline)
+//        homepageViewController?.reloadView()
+//        NotificationCenter.default.post(name: .ShowHomepage, object: nil)
+    }
+
+    func showWebView() {
+        // FXIOS-6015 - Show webview embedded content
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -591,8 +591,8 @@ class BrowserViewController: UIViewController {
         view.addSubview(bottomContainer)
 
         if AppConstants.useCoordinators {
-            // Due to homepage constraints with wallpaper and status bar, we need to ensure content is at the top
-            view.bringSubviewToFront(contentContainer)
+            // StatusBarOverlay at the back so homepage wallpaper with bottom URL bar can be seen under the status bar
+            view.sendSubviewToBack(statusBarOverlay)
         }
     }
 
@@ -758,8 +758,15 @@ class BrowserViewController: UIViewController {
         header.snp.remakeConstraints { make in
             if isBottomSearchBar {
                 make.left.right.top.equalTo(view)
-                // Making sure we cover at least the status bar
-                make.bottom.equalTo(view.safeArea.top)
+                if AppConstants.useCoordinators {
+                    // The status bar is covered by the statusBarOverlay,
+                    // if we don't have the URL bar at the top then header height is 0
+                    make.height.equalTo(0)
+                } else {
+                    // Making sure we cover at least the status bar
+                    make.bottom.equalTo(view.safeArea.top)
+                }
+
             } else {
                 scrollController.headerTopConstraint = make.top.equalTo(view.safeArea.top).constraint
                 make.left.right.equalTo(view)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -766,7 +766,6 @@ class BrowserViewController: UIViewController {
                     // Making sure we cover at least the status bar
                     make.bottom.equalTo(view.safeArea.top)
                 }
-
             } else {
                 scrollController.headerTopConstraint = make.top.equalTo(view.safeArea.top).constraint
                 make.left.right.equalTo(view)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1043,7 +1043,7 @@ class BrowserViewController: UIViewController {
     /// it's the zero search page, aka when the home page is shown by clicking the url bar from a loaded web page.
     func showHomepage(inline: Bool) {
         if self.homepageViewController == nil {
-            createHomepage()
+            createHomepage(inline: inline)
         }
 
         if self.readerModeBar != nil {
@@ -1078,7 +1078,7 @@ class BrowserViewController: UIViewController {
     // FXIOS-6036 - Remove this function as part of cleanup
     /// Once the homepage is created, browserViewController keeps a reference to it, never setting it to nil during
     /// an app session. The homepage can be nil in the case of a user having a Blank Page or custom URL as it's new tab and homepage
-    private func createHomepage() {
+    private func createHomepage(inline: Bool) {
         let homepageViewController = HomepageViewController(
             profile: profile,
             tabManager: tabManager,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1009,16 +1009,18 @@ class BrowserViewController: UIViewController {
         UIAccessibility.post(notification: UIAccessibility.Notification.screenChanged, argument: nil)
     }
 
+    /// Show the home page embedded in the contentContainer
+    /// - Parameter inline: Inline is true when the homepage is created from the tab tray, a long press
+    /// on the tab bar to open a new tab or by pressing the home page button on the tab bar. Inline is false when
+    /// it's the zero search page, aka when the home page is shown by clicking the url bar from a loaded web page.
     func showEmbeddedHomepage(inline: Bool) {
         hideReaderModeBar(animated: false)
 
         // Make sure reload button is hidden on homepage
         urlBar.locationView.reloadButton.reloadButtonState = .disabled
 
-        // TODO: Laurie - needed?
-//        view.setNeedsUpdateConstraints()
-
-        browserDelegate?.showHomepage(homepanelDelegate: self,
+        browserDelegate?.showHomepage(inline: inline,
+                                      homepanelDelegate: self,
                                       libraryPanelDelegate: self,
                                       sendToDeviceDelegate: self,
                                       overlayManager: overlayManager)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -43,7 +43,7 @@ class BrowserViewController: UIViewController {
         .title,
     ]
 
-    weak var homepageDelegate: HomepageDelegate?
+    weak var browserDelegate: BrowserDelegate?
     var homepageViewController: HomepageViewController?
     var libraryViewController: LibraryViewController?
     var webViewContainer: UIView!
@@ -999,55 +999,9 @@ class BrowserViewController: UIViewController {
         statusBarOverlay.isHidden = false
     }
 
-    // laurie - move this
-    class ContentContainer: UIView {
-        enum ContentType {
-            case webview
-            case homepage
-        }
-
-        var type: ContentType?
-        var contentController: UIViewController?
-
-        func canAdd(viewController: UIViewController) -> Bool {
-            switch type {
-            case .homepage:
-                return !(viewController is HomepageViewController)
-            case .webview:
-                // FXIOS-6015 - Handle Webview add content
-                return true
-            case .none:
-                return true
-            }
-        }
-
-        func addContent(viewController: UIViewController) {
-            if viewController is HomepageViewController {
-                type = .homepage
-            } else {
-                // FXIOS-6015 - Handle Webview add content
-            }
-            contentController = viewController
-
-            // laurie - fix constraints of homepage, fix white top bar
-            addSubview(viewController.view)
-        }
-
-        func removeContent() {
-            contentController?.willMove(toParent: nil)
-            contentController?.view.removeFromSuperview()
-            contentController?.removeFromParent()
-        }
-    }
-
     func embedContent(_ viewController: UIViewController) {
-        // Make sure we only add once
         guard contentContainer.canAdd(viewController: viewController) else { return }
 
-        // Remove previous embedded content
-        contentContainer.removeContent()
-
-        // Add new embedded content
         addChild(viewController)
         contentContainer.addContent(viewController: viewController)
         viewController.didMove(toParent: self)
@@ -1056,9 +1010,7 @@ class BrowserViewController: UIViewController {
     }
 
     func showEmbeddedHomepage(inline: Bool) {
-        if self.readerModeBar != nil {
-            hideReaderModeBar(animated: false)
-        }
+        hideReaderModeBar(animated: false)
 
         // Make sure reload button is hidden on homepage
         urlBar.locationView.reloadButton.reloadButtonState = .disabled
@@ -1066,19 +1018,20 @@ class BrowserViewController: UIViewController {
         // TODO: Laurie - needed?
 //        view.setNeedsUpdateConstraints()
 
-        homepageDelegate?.showHomepage(homepanelDelegate: self,
-                                       libraryPanelDelegate: self,
-                                       sendToDeviceDelegate: self,
-                                       overlayManager: overlayManager)
+        browserDelegate?.showHomepage(homepanelDelegate: self,
+                                      libraryPanelDelegate: self,
+                                      sendToDeviceDelegate: self,
+                                      overlayManager: overlayManager)
     }
 
     func showEmbeddedWebview() {
-        // Make sure reload button is working after leaving homepage
+        // Make sure reload button is working when showing webview
         urlBar.locationView.reloadButton.reloadButtonState = .reload
 
         // FXIOS-6015 - Show webview (and remove the homepage)
     }
 
+    // FXIOS-6036 - Remove this function as part of cleanup
     /// Show the home page
     /// - Parameter inline: Inline is true when the homepage is created from the tab tray, a long press
     /// on the tab bar to open a new tab or by pressing the home page button on the tab bar. Inline is false when
@@ -1117,6 +1070,7 @@ class BrowserViewController: UIViewController {
             })
     }
 
+    // FXIOS-6036 - Remove this function as part of cleanup
     /// Once the homepage is created, browserViewController keeps a reference to it, never setting it to nil during
     /// an app session. The homepage can be nil in the case of a user having a Blank Page or custom URL as it's new tab and homepage
     private func createHomepage() {
@@ -1136,6 +1090,7 @@ class BrowserViewController: UIViewController {
         view.bringSubviewToFront(overKeyboardContainer)
     }
 
+    // FXIOS-6036 - Remove this function as part of cleanup
     func hideHomepage(completion: (() -> Void)? = nil) {
         guard let homepageViewController = self.homepageViewController else { return }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -107,9 +107,7 @@ class BrowserViewController: UIViewController {
     }
 
     // The content container contains the homepage or webview. Embeded by the coordinator.
-    var contentContainer: ContentContainer = .build { view in
-        view.backgroundColor = .red
-    }
+    var contentContainer: ContentContainer = .build { _ in }
 
     lazy var isBottomSearchBar: Bool = {
         guard isSearchBarLocationFeatureEnabled else { return false }
@@ -591,6 +589,11 @@ class BrowserViewController: UIViewController {
         toolbar = TabToolbar()
         bottomContainer.addArrangedSubview(toolbar)
         view.addSubview(bottomContainer)
+
+        if AppConstants.useCoordinators {
+            // Due to homepage constraints with wallpaper and status bar, we need to ensure content is at the top
+            view.bringSubviewToFront(contentContainer)
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -339,7 +339,7 @@ extension BrowserViewController: URLBarDelegate {
             if !AppConstants.useCoordinators {
                 showHomepage(inline: false)
             } else {
-                // FXIOS-6014 - Homepage in container
+                showEmbeddedHomepage(inline: false)
             }
         }
     }

--- a/Client/Frontend/Components/ContentContainer.swift
+++ b/Client/Frontend/Components/ContentContainer.swift
@@ -1,0 +1,70 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+
+// TODO: Laurie - tests
+/// A container for view controllers, currently used to embed content in BrowserViewController
+class ContentContainer: UIView {
+    private enum ContentType {
+        case webview
+        case homepage
+    }
+
+    private var type: ContentType?
+    private var contentController: UIViewController?
+
+    /// Determine if the content can be added, making sure we only add once
+    /// - Parameter viewController: The view controller to add to the container
+    /// - Returns: True when we can add the view controller to the container
+    func canAdd(viewController: UIViewController) -> Bool {
+        switch type {
+        case .homepage:
+            return !(viewController is HomepageViewController)
+        case .webview:
+            // FXIOS-6015 - Handle Webview add content
+            return true
+        case .none:
+            return true
+        }
+    }
+
+    /// Add content view controller to the container, we remove the previous content if present before adding new one
+    /// - Parameter viewController: The view controller to add
+    func addContent(viewController: UIViewController) {
+        removePreviousContent()
+        saveContentType(viewController: viewController)
+        addToView(viewController: viewController)
+    }
+
+    // MARK: - Private
+
+    private func removePreviousContent() {
+        contentController?.willMove(toParent: nil)
+        contentController?.view.removeFromSuperview()
+        contentController?.removeFromParent()
+    }
+
+    private func saveContentType(viewController: UIViewController) {
+        if viewController is HomepageViewController {
+            type = .homepage
+        } else {
+            // FXIOS-6015 - Handle Webview add content in a else if
+            fatalError("Content type not supported")
+        }
+
+        contentController = viewController
+    }
+
+    private func addToView(viewController: UIViewController) {
+        addSubview(viewController.view)
+        viewController.view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            viewController.view.topAnchor.constraint(equalTo: topAnchor),
+            viewController.view.leadingAnchor.constraint(equalTo: leadingAnchor),
+            viewController.view.bottomAnchor.constraint(equalTo: bottomAnchor),
+            viewController.view.trailingAnchor.constraint(equalTo: trailingAnchor)
+        ])
+    }
+}

--- a/Client/Frontend/Components/ContentContainer.swift
+++ b/Client/Frontend/Components/ContentContainer.swift
@@ -4,7 +4,6 @@
 
 import UIKit
 
-// TODO: Laurie - tests
 /// A container for view controllers, currently used to embed content in BrowserViewController
 class ContentContainer: UIView {
     private enum ContentType {

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -62,6 +62,7 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
 
     // MARK: - Initializers
     init(profile: Profile,
+         isZeroSearch: Bool = false,
          tabManager: TabManager = AppContainer.shared.resolve(),
          overlayManager: OverlayModeManager,
          userDefaults: UserDefaultsInterface = UserDefaults.standard,
@@ -90,6 +91,8 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
         self.notificationCenter = notificationCenter
         self.logger = logger
         super.init(nibName: nil, bundle: nil)
+
+        viewModel.isZeroSearch = isZeroSearch
 
         contextMenuHelper.delegate = self
         contextMenuHelper.getPopoverSourceRect = { [weak self] popoverView in
@@ -133,6 +136,24 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
 
         listenForThemeChange(view)
         applyTheme()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        applyTheme()
+        homepageWillAppear(isZeroSearch: viewModel.isZeroSearch)
+        reloadView()
+        NotificationCenter.default.post(name: .ShowHomepage, object: nil)
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        homepageDidAppear()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        homepageWillDisappear()
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -242,6 +263,7 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
         viewModel.handleLongPress(with: collectionView, indexPath: indexPath)
     }
 
+    // FXIOS-6203 - Clean up custom homepage view cycles
     // MARK: - Homepage view cycle
     /// Normal view controller view cycles cannot be relied on the homepage since the current way of showing and hiding the homepage is through alpha.
     /// This is a problem that need to be fixed but until then we have to rely on the methods here.

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -756,7 +756,12 @@ extension HomepageViewController {
 
         // The scrollview content offset is automatically adjusted to account for the status bar.
         // We want to start showing the status bar background as soon as the user scrolls.
-        var offset = (scrollView.contentOffset.y + statusBarHeight) / statusBarHeight
+        var offset: CGFloat
+        if AppConstants.useCoordinators {
+            offset = scrollView.contentOffset.y / statusBarHeight
+        } else {
+            offset = (scrollView.contentOffset.y + statusBarHeight) / statusBarHeight
+        }
 
         if offset > 1 {
             offset = 1

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -62,7 +62,7 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
 
     // MARK: - Initializers
     init(profile: Profile,
-         tabManager: TabManager,
+         tabManager: TabManager = AppContainer.shared.resolve(),
          overlayManager: OverlayModeManager,
          userDefaults: UserDefaultsInterface = UserDefaults.standard,
          themeManager: ThemeManager = AppContainer.shared.resolve(),
@@ -197,8 +197,13 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
 
     func configureWallpaperView() {
         view.addSubview(wallpaperView)
+        var wallpaperTopConstant: CGFloat = 0
+        if AppConstants.useCoordinators {
+            // Constraint so wallpaper appears under the status bar
+            wallpaperTopConstant = statusBarFrame?.height ?? 0
+        }
         NSLayoutConstraint.activate([
-            wallpaperView.topAnchor.constraint(equalTo: view.topAnchor),
+            wallpaperView.topAnchor.constraint(equalTo: view.topAnchor, constant: -wallpaperTopConstant),
             wallpaperView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             wallpaperView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             wallpaperView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
@@ -705,7 +710,14 @@ extension HomepageViewController {
     var statusBarFrame: CGRect? {
         guard let keyWindow = UIWindow.keyWindow else { return nil }
 
-        return keyWindow.windowScene?.statusBarManager?.statusBarFrame
+        // Status bar constraint is above the homepage frame
+        if AppConstants.useCoordinators,
+            var statusBarFrame = keyWindow.windowScene?.statusBarManager?.statusBarFrame {
+            statusBarFrame.origin.y -= statusBarFrame.height
+            return statusBarFrame
+        } else {
+            return keyWindow.windowScene?.statusBarManager?.statusBarFrame
+        }
     }
 
     // Returns a value between 0 and 1 which indicates how far the user has scrolled.

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -732,14 +732,7 @@ extension HomepageViewController {
     var statusBarFrame: CGRect? {
         guard let keyWindow = UIWindow.keyWindow else { return nil }
 
-        // Status bar constraint is above the homepage frame
-        if AppConstants.useCoordinators,
-            var statusBarFrame = keyWindow.windowScene?.statusBarManager?.statusBarFrame {
-            statusBarFrame.origin.y -= statusBarFrame.height
-            return statusBarFrame
-        } else {
-            return keyWindow.windowScene?.statusBarManager?.statusBarFrame
-        }
+        return keyWindow.windowScene?.statusBarManager?.statusBarFrame
     }
 
     // Returns a value between 0 and 1 which indicates how far the user has scrolled.

--- a/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -13,6 +13,7 @@ final class BrowserCoordinatorTests: XCTestCase {
     override func setUp() {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
+        FeatureFlagsManager.shared.initializeDeveloperFeatures(with: AppContainer.shared.resolve())
         self.mockRouter = MockRouter(navigationController: MockNavigationController())
         self.profile = MockProfile()
     }
@@ -60,6 +61,19 @@ final class BrowserCoordinatorTests: XCTestCase {
 
         XCTAssertTrue(subject.childCoordinators.isEmpty)
         XCTAssertEqual(mockRouter.dismissCalled, 1)
+    }
+
+    func testShowHomepage_addsOneHomepageOnly() {
+        let overlayModeManager = DefaultOverlayModeManager()
+        let subject = createSubject()
+        subject.showHomepage(inline: true,
+                             homepanelDelegate: subject.browserViewController,
+                             libraryPanelDelegate: subject.browserViewController,
+                             sendToDeviceDelegate: subject.browserViewController,
+                             overlayManager: overlayModeManager)
+
+        let secondHomepage = HomepageViewController(profile: profile, overlayManager: overlayModeManager)
+        XCTAssertFalse(subject.browserViewController.contentContainer.canAdd(viewController: secondHomepage))
     }
 
     // MARK: - Helpers

--- a/Tests/ClientTests/Frontend/ContentContainerTests.swift
+++ b/Tests/ClientTests/Frontend/ContentContainerTests.swift
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import XCTest
+@testable import Client
+
+final class ContentContainerTests: XCTestCase {
+    private var profile: MockProfile!
+    private var overlayModeManager: MockOverlayModeManager!
+
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+        FeatureFlagsManager.shared.initializeDeveloperFeatures(with: AppContainer.shared.resolve())
+        self.profile = MockProfile()
+        self.overlayModeManager = MockOverlayModeManager()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        self.profile = nil
+        self.overlayModeManager = nil
+        AppContainer.shared.reset()
+    }
+
+    func testCanAddHomepage() {
+        let subject = ContentContainer(frame: .zero)
+        let homepage = HomepageViewController(profile: profile, overlayManager: overlayModeManager)
+
+        XCTAssertTrue(subject.canAdd(viewController: homepage))
+    }
+
+    func testCanAddHomepageOnceOnly() {
+        let subject = ContentContainer(frame: .zero)
+        let homepage = HomepageViewController(profile: profile, overlayManager: overlayModeManager)
+
+        subject.addContent(viewController: homepage)
+        XCTAssertFalse(subject.canAdd(viewController: homepage))
+    }
+}


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6014)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13658)

### Description
- Show the homepage by embedding it in the `contentContainer` inside BVC, using the BrowserCoordinator. The homepage is now shown without alpha/animation. This will enable us to remove a lot of code when we can clean it up at the end of this project, and we'll be able to clean our lifecycle usage in the homepage (will be done with [FXIOS-6203](https://mozilla-hub.atlassian.net/browse/FXIOS-6203)).
- Due to homepage status bar/wallpaper needing to be shown under the status bar, and since we want to have one container only for both web view and homepage, we move the responsibility of the constraints for this in homepage. Meaning, the homepage constraints the wallpaper negatively (so above the `contentContainer`).
- For this to work, I had to make sure the `statusBarOverlay` is behind other views. Otherwise our status fade in on the homepage was hidden by the `statusBarOverlay` present for the web view.
- We now have a `ContentContainer` that keep tracks of which content is embedded, this is useful to remove/add content in the `UIView`, but also will be used in another task with [FXIOS-6175](https://mozilla-hub.atlassian.net/browse/FXIOS-6175)) to know if we're showing the homepage or not (needed for some part of our codebase).

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
