### PR TITLE
Bugfix MTE-860 [v114] Smoke tests for iPad

### DIFF
--- a/Tests/XCUITests/ActivityStreamTest.swift
+++ b/Tests/XCUITests/ActivityStreamTest.swift
@@ -115,7 +115,6 @@ class ActivityStreamTest: BaseTestCase {
     func testTopSitesRemoveAllExceptPinnedClearPrivateData() {
         waitForExistence(TopSiteCellgroup, timeout: TIMEOUT)
         if iPad() {
-            navigator.performAction(Action.CloseURLBarOpen)
             app.textFields.element(boundBy: 0).tap()
             app.typeText("mozilla.org\n")
         } else {
@@ -173,9 +172,8 @@ class ActivityStreamTest: BaseTestCase {
     // Smoketest
     func testTopSitesOpenInNewPrivateTab() throws {
         XCTExpectFailure("The app was not launched", strict: false) {
-            waitForExistence(app.buttons["urlBar-cancel"], timeout: 35)
+            waitForExistence(TopSiteCellgroup, timeout: 60)
         }
-        navigator.performAction(Action.CloseURLBarOpen)
         waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 5)
         // Long tap on Wikipedia top site
         waitForExistence(app.collectionViews.cells.staticTexts["Wikipedia"], timeout: 3)
@@ -206,9 +204,8 @@ class ActivityStreamTest: BaseTestCase {
     // Smoketest
     func testTopSitesOpenInNewPrivateTabDefaultTopSite() {
         XCTExpectFailure("The app was not launched", strict: false) {
-            waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT_LONG)
+            waitForExistence(TopSiteCellgroup, timeout: 60)
         }
-        navigator.performAction(Action.CloseURLBarOpen)
         waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 5)
         navigator.nowAt(NewTabScreen)
         // Open one of the sites from Topsites and wait until page is loaded
@@ -247,9 +244,6 @@ class ActivityStreamTest: BaseTestCase {
         // can't scroll only to that area. Needs investigation
         if iPad() {
             XCUIDevice.shared.orientation = .landscapeLeft
-            waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
-            navigator.performAction(Action.CloseURLBarOpen)
-
             waitForExistence(TopSiteCellgroup, timeout: TIMEOUT)
             app.collectionViews.cells.staticTexts["Wikipedia"].press(forDuration: 1)
 

--- a/Tests/XCUITests/BookmarkingTests.swift
+++ b/Tests/XCUITests/BookmarkingTests.swift
@@ -114,7 +114,7 @@ class BookmarkingTests: BaseTestCase {
     // Smoketest
     func testBookmarksAwesomeBar() {
         XCTExpectFailure("The app was not launched", strict: false) {
-            waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
+            waitForExistence(app.textFields["url"], timeout: 60)
         }
         typeOnSearchBar(text: "www.google")
         waitForExistence(app.tables["SiteTable"])
@@ -145,7 +145,6 @@ class BookmarkingTests: BaseTestCase {
         waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
         navigator.performAction(Action.AcceptClearPrivateData)
         navigator.goto(BrowserTab)
-        navigator.goto(URLBarOpen)
         typeOnSearchBar(text: "mozilla.org")
         waitForExistence(app.tables["SiteTable"])
         waitForExistence(app.cells.staticTexts["mozilla.org"])
@@ -242,7 +241,7 @@ class BookmarkingTests: BaseTestCase {
 
     private func typeOnSearchBar(text: String) {
         waitForExistence(app.textFields["url"], timeout: 5)
-        app.textFields["address"].tap()
+        app.textFields["url"].tap()
         app.textFields["address"].typeText(text)
     }
 
@@ -250,9 +249,8 @@ class BookmarkingTests: BaseTestCase {
     func testBookmarkLibraryAddDeleteBookmark() {
         // Verify that there are only 1 cell (desktop bookmark folder)
         XCTExpectFailure("The app was not launched", strict: false) {
-            waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT_LONG)
+            waitForExistence(app.textFields["url"], timeout: 60)
         }
-        navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
         navigator.goto(LibraryPanel_Bookmarks)

--- a/Tests/XCUITests/DesktopModeTests.swift
+++ b/Tests/XCUITests/DesktopModeTests.swift
@@ -26,7 +26,6 @@ class DesktopModeTestsIpad: IpadOnlyTestCase {
 
         // Covering scenario that when closing a tab and re-opening should preserve Mobile mode
         navigator.createNewTab()
-        navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         navigator.openURL(path(forTestPage: "test-user-agent.html"))
         waitUntilPageLoad()

--- a/Tests/XCUITests/DownloadFilesTests.swift
+++ b/Tests/XCUITests/DownloadFilesTests.swift
@@ -17,7 +17,8 @@ class DownloadFilesTests: BaseTestCase {
         waitForExistence(app.tables["DownloadsTable"])
         if processIsTranslatedStr() == m1Rosetta {
             navigator.nowAt(LibraryPanel_Downloads)
-            navigator.goto(NewTabScreen)
+            navigator.goto(HomePanelsScreen)
+            navigator.nowAt(NewTabScreen)
             navigator.goto(ClearPrivateDataSettings)
             app.cells.switches["Downloaded Files"].tap()
             app.tables.cells["ClearPrivateData"].tap()

--- a/Tests/XCUITests/DownloadFilesTests.swift
+++ b/Tests/XCUITests/DownloadFilesTests.swift
@@ -18,8 +18,6 @@ class DownloadFilesTests: BaseTestCase {
         if processIsTranslatedStr() == m1Rosetta {
             navigator.nowAt(LibraryPanel_Downloads)
             navigator.goto(NewTabScreen)
-            navigator.performAction(Action.CloseURLBarOpen)
-            navigator.nowAt(NewTabScreen)
             navigator.goto(ClearPrivateDataSettings)
             app.cells.switches["Downloaded Files"].tap()
             app.tables.cells["ClearPrivateData"].tap()

--- a/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -232,7 +232,6 @@ class HomePageSettingsUITests: BaseTestCase {
         navigator.nowAt(HomeSettings)
         navigator.performAction(Action.OpenNewTabFromTabTray)
         checkRecentlySaved()
-        navigator.performAction(Action.CloseURLBarOpen)
         app.scrollViews.cells[AccessibilityIdentifiers.FirefoxHomepage.RecentlySaved.itemCell].staticTexts[urlExampleLabel].tap()
         navigator.nowAt(BrowserTab)
         waitForTabsButton()

--- a/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -278,8 +278,10 @@ class HomePageSettingsUITests: BaseTestCase {
 
     func testCustomizeHomepage() {
         if !iPad() {
-            waitForExistence(app.collectionViews.firstMatch, timeout: TIMEOUT)
-            app.collectionViews.firstMatch.swipeUp()
+            waitForExistence(app.collectionViews["FxCollectionView"], timeout: TIMEOUT)
+            app.collectionViews["FxCollectionView"].swipeUp()
+            app.collectionViews["FxCollectionView"].swipeUp()
+            app.collectionViews["FxCollectionView"].swipeUp()
             waitForExistence(app.cells.otherElements.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.customizeHomePage], timeout: TIMEOUT)
         }
         app.cells.otherElements.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.customizeHomePage].tap()

--- a/Tests/XCUITests/ReaderViewUITest.swift
+++ b/Tests/XCUITests/ReaderViewUITest.swift
@@ -217,7 +217,7 @@ class ReaderViewTest: BaseTestCase {
     // Smoketest
     func testAddToReaderListOptions() throws {
         XCTExpectFailure("The app was not launched", strict: false) {
-            waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT_LONG)
+            waitForExistence(app.collectionViews["FxCollectionView"], timeout: TIMEOUT)
         }
         addContentToReaderView()
         // Check that Settings layouts options are shown

--- a/Tests/XCUITests/SaveLoginsTests.swift
+++ b/Tests/XCUITests/SaveLoginsTests.swift
@@ -181,10 +181,6 @@ class SaveLoginTest: BaseTestCase {
 
     // Smoketest
     func testSavedLoginAutofilled() {
-        if iPad() {
-            navigator.performAction(Action.CloseURLBarOpen)
-            navigator.nowAt(NewTabScreen)
-        }
         navigator.openURL(urlLogin)
         waitUntilPageLoad()
         // Provided text fields are completely empty
@@ -208,10 +204,6 @@ class SaveLoginTest: BaseTestCase {
 
         navigator.goto(TabTray)
         navigator.performAction(Action.OpenNewTabFromTabTray)
-        if iPad() {
-            navigator.performAction(Action.CloseURLBarOpen)
-            navigator.nowAt(NewTabScreen)
-        }
         navigator.openURL(urlLogin)
         waitUntilPageLoad()
         waitForExistence(app.webViews.textFields.element(boundBy: 0), timeout: 3)

--- a/Tests/XCUITests/TopTabsTest.swift
+++ b/Tests/XCUITests/TopTabsTest.swift
@@ -19,9 +19,8 @@ let toastUrl = ["url": "twitter.com", "link": "About", "urlLabel": "about"]
 class TopTabsTest: BaseTestCase {
     func testAddTabFromTabTray() throws {
         XCTExpectFailure("The app was not launched", strict: false) {
-            waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT_LONG)
+            waitForExistence(app.collectionViews["FxCollectionView"], timeout: TIMEOUT)
         }
-        navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
         navigator.goto(TabTray)


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-860)

### Description
FXIOS-5639 introduces the fixes for the attentive mode. By default, the keyboard won't be shown when the browser is opened.

I've ensured that the smoke tests pass for both iPhone and iPad.

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
