### PR TITLE
Bugfix FXIOS-6054 [v114] [Crash] when closing the tabs in PB/switching to normal browsing on iPad

### DIFF
--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -1042,6 +1042,10 @@ extension TabDisplayManager: TabManagerDelegate {
         else { return }
 
         performingChainedOperations = true
+        /// Fix crash related to bug from `collectionView.performBatchUpdates` when the
+        /// collectionView is not visible the dataSource section/items differs from the actions to be perform
+        /// which causes the crash
+        collectionView.numberOfItems(inSection: 0)
         collectionView.performBatchUpdates({ [weak self] in
             // Baseline animation speed is 1.0, which is too slow, this (odd) code sets it to 3x
             self?.collectionView.forFirstBaselineLayout.layer.speed = 3.0

--- a/Tests/ClientTests/TabDisplayManagerTests.swift
+++ b/Tests/ClientTests/TabDisplayManagerTests.swift
@@ -319,6 +319,8 @@ class TabDisplayManagerTests: XCTestCase {
         tabDisplayManager.inactiveViewModel?.inactiveTabs = [inactiveTab1,
                                                              inactiveTab2]
 
+        // Force collectionView reload section to avoid crash
+        collectionView.reloadSections(IndexSet(integer: 0))
         cfrDelegate.confirmClose = true
         tabDisplayManager.didTapCloseInactiveTabs(tabsCount: 2)
 
@@ -347,6 +349,8 @@ class TabDisplayManagerTests: XCTestCase {
         tabDisplayManager.inactiveViewModel?.inactiveTabs = [inactiveTab1,
                                                              inactiveTab2]
 
+        // Force collectionView reload section to avoid crash
+        collectionView.reloadSections(IndexSet(integer: 0))
         cfrDelegate.confirmClose = false
         tabDisplayManager.didTapCloseInactiveTabs(tabsCount: 2)
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6054)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13711)


### Description
- Fix failing test for TabDisplayManagerTest on XCode 14.3 related to adding a tab
- Add magic line to force collection view to update collectionView indexPath before `performPatchUpdate` which avoids crash due to dataStore inconsistency 
- Includes fix for [FXIOS-5550](https://mozilla-hub.atlassian.net/browse/FXIOS-5550)

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
