### PR TITLE
Add FXIOS-6015 [v114] webview embedded

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -660,6 +660,7 @@
 		8AF10D9129D7761A0086351D /* MockLaunchScreenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF10D9029D776190086351D /* MockLaunchScreenManager.swift */; };
 		8AF99B4D29EF076800108DEC /* WebviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF99B4C29EF076800108DEC /* WebviewViewController.swift */; };
 		8AF99B4F29EF1BA700108DEC /* BrowserDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF99B4E29EF1BA700108DEC /* BrowserDelegate.swift */; };
+		8AF99B5429EF2AF100108DEC /* MockLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF99B5329EF2AF100108DEC /* MockLogger.swift */; };
 		8AFA263227B6E9AB00D0C33B /* ToolbarBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFA263127B6E9AB00D0C33B /* ToolbarBadge.swift */; };
 		8AFCE50529DDF38300B1B253 /* LaunchScreenViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFCE50429DDF38300B1B253 /* LaunchScreenViewControllerTests.swift */; };
 		8AFCE50729DE0CD500B1B253 /* LaunchCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFCE50629DE0CD500B1B253 /* LaunchCoordinatorTests.swift */; };
@@ -4028,6 +4029,7 @@
 		8AF10D9029D776190086351D /* MockLaunchScreenManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLaunchScreenManager.swift; sourceTree = "<group>"; };
 		8AF99B4C29EF076800108DEC /* WebviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebviewViewController.swift; sourceTree = "<group>"; };
 		8AF99B4E29EF1BA700108DEC /* BrowserDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDelegate.swift; sourceTree = "<group>"; };
+		8AF99B5329EF2AF100108DEC /* MockLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLogger.swift; sourceTree = "<group>"; };
 		8AFA263127B6E9AB00D0C33B /* ToolbarBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarBadge.swift; sourceTree = "<group>"; };
 		8AFCE50429DDF38300B1B253 /* LaunchScreenViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchScreenViewControllerTests.swift; sourceTree = "<group>"; };
 		8AFCE50629DE0CD500B1B253 /* LaunchCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -7966,6 +7968,7 @@
 				2173326929CCF901007F20C7 /* UIPanGestureRecognizerMock.swift */,
 				8A5604F529DF09FA00035CA3 /* MockLaunchCoordinatorDelegate.swift */,
 				8AFCE50829DE136300B1B253 /* MockLaunchFinishedLoadingDelegate.swift */,
+				8AF99B5329EF2AF100108DEC /* MockLogger.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -11675,6 +11678,7 @@
 				C83B7DD629BBB49D005565C2 /* SurveySurfaceManagerTests.swift in Sources */,
 				E1E6F8CE29D4B7E700068D8D /* GleanPlumbContextProviderTests.swift in Sources */,
 				0BA8964C1A250E6500C1010C /* TestBookmarks.swift in Sources */,
+				8AF99B5429EF2AF100108DEC /* MockLogger.swift in Sources */,
 				5A9A09D428B01D8700B6F51E /* MockTelemetryWrapper.swift in Sources */,
 				C80C11F028B3C9150062922A /* MockUserDefaults.swift in Sources */,
 				D8BA1790206D47830023AC00 /* DeferredTestUtils.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -658,6 +658,8 @@
 		8AF10D8C29D714A90086351D /* MockOpenURLDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF10D8B29D714A90086351D /* MockOpenURLDelegate.swift */; };
 		8AF10D8F29D774090086351D /* SceneSetupHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF10D8E29D774090086351D /* SceneSetupHelper.swift */; };
 		8AF10D9129D7761A0086351D /* MockLaunchScreenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF10D9029D776190086351D /* MockLaunchScreenManager.swift */; };
+		8AF99B4D29EF076800108DEC /* WebviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF99B4C29EF076800108DEC /* WebviewViewController.swift */; };
+		8AF99B4F29EF1BA700108DEC /* BrowserDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF99B4E29EF1BA700108DEC /* BrowserDelegate.swift */; };
 		8AFA263227B6E9AB00D0C33B /* ToolbarBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFA263127B6E9AB00D0C33B /* ToolbarBadge.swift */; };
 		8AFCE50529DDF38300B1B253 /* LaunchScreenViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFCE50429DDF38300B1B253 /* LaunchScreenViewControllerTests.swift */; };
 		8AFCE50729DE0CD500B1B253 /* LaunchCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFCE50629DE0CD500B1B253 /* LaunchCoordinatorTests.swift */; };
@@ -4024,6 +4026,8 @@
 		8AF10D8B29D714A90086351D /* MockOpenURLDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOpenURLDelegate.swift; sourceTree = "<group>"; };
 		8AF10D8E29D774090086351D /* SceneSetupHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneSetupHelper.swift; sourceTree = "<group>"; };
 		8AF10D9029D776190086351D /* MockLaunchScreenManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLaunchScreenManager.swift; sourceTree = "<group>"; };
+		8AF99B4C29EF076800108DEC /* WebviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebviewViewController.swift; sourceTree = "<group>"; };
+		8AF99B4E29EF1BA700108DEC /* BrowserDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDelegate.swift; sourceTree = "<group>"; };
 		8AFA263127B6E9AB00D0C33B /* ToolbarBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarBadge.swift; sourceTree = "<group>"; };
 		8AFCE50429DDF38300B1B253 /* LaunchScreenViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchScreenViewControllerTests.swift; sourceTree = "<group>"; };
 		8AFCE50629DE0CD500B1B253 /* LaunchCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -7119,12 +7123,12 @@
 		8A93F85C29D36D9F004159D9 /* Coordinators */ = {
 			isa = PBXGroup;
 			children = (
+				8AF99B5029EF1BB600108DEC /* Browser */,
 				8AFCE50229DDC96B00B1B253 /* LaunchView */,
 				8A832A8E29DC96AD0025D5DD /* Launch */,
 				8AF10D8D29D773FC0086351D /* Scene */,
 				8A93F86E29D3A147004159D9 /* Router */,
 				8A93F85D29D36DA9004159D9 /* Coordinator.swift */,
-				8A93F87129D3A5AD004159D9 /* BrowserCoordinator.swift */,
 			);
 			path = Coordinators;
 			sourceTree = "<group>";
@@ -7393,6 +7397,15 @@
 				8AF10D8E29D774090086351D /* SceneSetupHelper.swift */,
 			);
 			path = Scene;
+			sourceTree = "<group>";
+		};
+		8AF99B5029EF1BB600108DEC /* Browser */ = {
+			isa = PBXGroup;
+			children = (
+				8A93F87129D3A5AD004159D9 /* BrowserCoordinator.swift */,
+				8AF99B4E29EF1BA700108DEC /* BrowserDelegate.swift */,
+			);
+			path = Browser;
 			sourceTree = "<group>";
 		};
 		8AFCE50229DDC96B00B1B253 /* LaunchView */ = {
@@ -8451,6 +8464,7 @@
 			isa = PBXGroup;
 			children = (
 				E1877A80286E0EFD00F5BDF2 /* WebViewNavigationHandler.swift */,
+				8AF99B4C29EF076800108DEC /* WebviewViewController.swift */,
 			);
 			path = WebView;
 			sourceTree = "<group>";
@@ -11084,6 +11098,7 @@
 				2137785D297F1F2800D01309 /* DownloadedFile.swift in Sources */,
 				745DAB301CDAAFAA00D44181 /* RecentlyClosedTabsPanel.swift in Sources */,
 				D0B9483D22A18B78002F4AA1 /* TextFieldTableViewCell.swift in Sources */,
+				8AF99B4F29EF1BA700108DEC /* BrowserDelegate.swift in Sources */,
 				C87D8B802818333F00A6307D /* NimbusManager.swift in Sources */,
 				8A4AC0EB28C929D700439F83 /* URLSessionDataTaskProtocol.swift in Sources */,
 				C45F44691D087DB600CB7EF0 /* TopTabsViewController.swift in Sources */,
@@ -11423,6 +11438,7 @@
 				DAE6DF1B29AD78DA0094BD1B /* BrowserViewController+ZoomPage.swift in Sources */,
 				8AB8574A27D97CE90075C173 /* HomePanelDelegate.swift in Sources */,
 				2137786529832C8900D01309 /* OverlayModeManager.swift in Sources */,
+				8AF99B4D29EF076800108DEC /* WebviewViewController.swift in Sources */,
 				3B39EDCB1E16E1AA00EF029F /* CustomSearchViewController.swift in Sources */,
 				C8B0F5F7283B7CCE007AE65D /* PocketFeedStory.swift in Sources */,
 				96A562A027D6D0E80045144A /* ContileProvider.swift in Sources */,

--- a/Client/Coordinators/Browser/BrowserDelegate.swift
+++ b/Client/Coordinators/Browser/BrowserDelegate.swift
@@ -1,0 +1,25 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import WebKit
+
+protocol BrowserDelegate: AnyObject {
+    /// Show the homepBrage to the user
+    /// - Parameters:
+    ///   - inline: See showEmbeddedHomepage function in BVC for description
+    ///   - homepanelDelegate: The homepanel delegate for the homepage
+    ///   - libraryPanelDelegate:  The library panel delegate for the homepage
+    ///   - sendToDeviceDelegate: The send to device delegate for the homepage
+    ///   - overlayManager: The overlay manager for the homepage
+    func showHomepage(inline: Bool,
+                      homepanelDelegate: HomePanelDelegate,
+                      libraryPanelDelegate: LibraryPanelDelegate,
+                      sendToDeviceDelegate: HomepageViewController.SendToDeviceDelegate,
+                      overlayManager: OverlayModeManager)
+
+    /// Show the webview to navigate
+    /// - Parameter webView: When nil, will show the already existing webview
+    func show(webView: WKWebView?)
+}

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1008,11 +1008,11 @@ class BrowserViewController: UIViewController {
         statusBarOverlay.isHidden = false
     }
 
-    func embedContent(_ viewController: UIViewController, forceEmbed: Bool = false) {
-        guard contentContainer.canAdd(viewController: viewController) || forceEmbed else { return }
+    func embedContent(_ viewController: ContentContainable, forceEmbed: Bool = false) {
+        guard contentContainer.canAdd(content: viewController) || forceEmbed else { return }
 
         addChild(viewController)
-        contentContainer.addContent(viewController: viewController)
+        contentContainer.add(content: viewController)
         viewController.didMove(toParent: self)
 
         UIAccessibility.post(notification: UIAccessibility.Notification.screenChanged, argument: nil)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1008,8 +1008,8 @@ class BrowserViewController: UIViewController {
         statusBarOverlay.isHidden = false
     }
 
-    func embedContent(_ viewController: UIViewController) {
-        guard contentContainer.canAdd(viewController: viewController) else { return }
+    func embedContent(_ viewController: UIViewController, forceEmbed: Bool = false) {
+        guard contentContainer.canAdd(viewController: viewController) || forceEmbed else { return }
 
         addChild(viewController)
         contentContainer.addContent(viewController: viewController)
@@ -1039,7 +1039,7 @@ class BrowserViewController: UIViewController {
         // Make sure reload button is working when showing webview
         urlBar.locationView.reloadButton.reloadButtonState = .reload
 
-        // FXIOS-6015 - Show webview (and remove the homepage)
+        browserDelegate?.show(webView: nil)
     }
 
     // FXIOS-6036 - Remove this function as part of cleanup
@@ -1866,7 +1866,7 @@ extension BrowserViewController: LegacyTabDelegate {
         if !AppConstants.useCoordinators {
             webView.frame = webViewContainer.frame
         } else {
-            // FXIOS-6015 - webview in container
+            browserDelegate?.show(webView: webView)
         }
         // Observers that live as long as the tab. Make sure these are all cleared in willDeleteWebView below!
         KVOs.forEach { webView.addObserver(self, forKeyPath: $0.rawValue, options: .new, context: nil) }
@@ -2207,7 +2207,7 @@ extension BrowserViewController: TabManagerDelegate {
                     make.left.right.top.bottom.equalTo(self.webViewContainer)
                 }
             } else {
-                // FXIOS-6015 - webview in container
+                browserDelegate?.show(webView: webView)
             }
 
             webView.accessibilityLabel = .WebViewAccessibilityLabel

--- a/Client/Frontend/Browser/WebView/WebviewViewController.swift
+++ b/Client/Frontend/Browser/WebView/WebviewViewController.swift
@@ -5,8 +5,9 @@
 import Foundation
 import WebKit
 
-class WebviewViewController: UIViewController {
+class WebviewViewController: UIViewController, ContentContainable {
     private let webView: WKWebView
+    var contentType: ContentType = .webview
 
     init(webView: WKWebView) {
         self.webView = webView

--- a/Client/Frontend/Browser/WebView/WebviewViewController.swift
+++ b/Client/Frontend/Browser/WebView/WebviewViewController.swift
@@ -1,0 +1,35 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import WebKit
+
+class WebviewViewController: UIViewController {
+    private let webView: WKWebView
+
+    init(webView: WKWebView) {
+        self.webView = webView
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("not implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupLayout()
+    }
+
+    private func setupLayout() {
+        view.addSubview(webView)
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            view.topAnchor.constraint(equalTo: webView.topAnchor),
+            view.leadingAnchor.constraint(equalTo: webView.leadingAnchor),
+            view.bottomAnchor.constraint(equalTo: webView.bottomAnchor),
+            view.trailingAnchor.constraint(equalTo: webView.trailingAnchor)
+        ])
+    }
+}

--- a/Client/Frontend/Components/ContentContainer.swift
+++ b/Client/Frontend/Components/ContentContainer.swift
@@ -4,6 +4,7 @@
 
 import UIKit
 
+// Laurie - tests for new functionnality
 /// A container for view controllers, currently used to embed content in BrowserViewController
 class ContentContainer: UIView {
     private enum ContentType {
@@ -15,15 +16,15 @@ class ContentContainer: UIView {
     private var contentController: UIViewController?
 
     /// Determine if the content can be added, making sure we only add once
-    /// - Parameter viewController: The view controller to add to the container
+    /// - Parameters:
+    ///   - viewController: The view controller to add to the container
     /// - Returns: True when we can add the view controller to the container
     func canAdd(viewController: UIViewController) -> Bool {
         switch type {
         case .homepage:
             return !(viewController is HomepageViewController)
         case .webview:
-            // FXIOS-6015 - Handle Webview add content
-            return true
+            return !(viewController is WebviewViewController)
         case .none:
             return true
         }
@@ -48,9 +49,10 @@ class ContentContainer: UIView {
     private func saveContentType(viewController: UIViewController) {
         if viewController is HomepageViewController {
             type = .homepage
+        } else if viewController is WebviewViewController {
+            type = .webview
         } else {
-            // FXIOS-6015 - Handle Webview add content in a else if
-            fatalError("Content type not supported")
+            fatalError("Content type not supported, this is a developer error.")
         }
 
         contentController = viewController

--- a/Client/Frontend/Components/ContentContainer.swift
+++ b/Client/Frontend/Components/ContentContainer.swift
@@ -4,27 +4,30 @@
 
 import UIKit
 
-// Laurie - tests for new functionnality
+enum ContentType {
+    case webview
+    case homepage
+}
+
+protocol ContentContainable: UIViewController {
+    var contentType: ContentType { get }
+}
+
 /// A container for view controllers, currently used to embed content in BrowserViewController
 class ContentContainer: UIView {
-    private enum ContentType {
-        case webview
-        case homepage
-    }
-
     private var type: ContentType?
-    private var contentController: UIViewController?
+    private var contentController: ContentContainable?
 
     /// Determine if the content can be added, making sure we only add once
     /// - Parameters:
     ///   - viewController: The view controller to add to the container
     /// - Returns: True when we can add the view controller to the container
-    func canAdd(viewController: UIViewController) -> Bool {
+    func canAdd(content: ContentContainable) -> Bool {
         switch type {
         case .homepage:
-            return !(viewController is HomepageViewController)
+            return !(content is HomepageViewController)
         case .webview:
-            return !(viewController is WebviewViewController)
+            return !(content is WebviewViewController)
         case .none:
             return true
         }
@@ -32,10 +35,10 @@ class ContentContainer: UIView {
 
     /// Add content view controller to the container, we remove the previous content if present before adding new one
     /// - Parameter viewController: The view controller to add
-    func addContent(viewController: UIViewController) {
+    func add(content: ContentContainable) {
         removePreviousContent()
-        saveContentType(viewController: viewController)
-        addToView(viewController: viewController)
+        saveContentType(content: content)
+        addToView(content: content)
     }
 
     // MARK: - Private
@@ -46,26 +49,19 @@ class ContentContainer: UIView {
         contentController?.removeFromParent()
     }
 
-    private func saveContentType(viewController: UIViewController) {
-        if viewController is HomepageViewController {
-            type = .homepage
-        } else if viewController is WebviewViewController {
-            type = .webview
-        } else {
-            fatalError("Content type not supported, this is a developer error.")
-        }
-
-        contentController = viewController
+    private func saveContentType(content: ContentContainable) {
+        type = content.contentType
+        contentController = content
     }
 
-    private func addToView(viewController: UIViewController) {
-        addSubview(viewController.view)
-        viewController.view.translatesAutoresizingMaskIntoConstraints = false
+    private func addToView(content: ContentContainable) {
+        addSubview(content.view)
+        content.view.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            viewController.view.topAnchor.constraint(equalTo: topAnchor),
-            viewController.view.leadingAnchor.constraint(equalTo: leadingAnchor),
-            viewController.view.bottomAnchor.constraint(equalTo: bottomAnchor),
-            viewController.view.trailingAnchor.constraint(equalTo: trailingAnchor)
+            content.view.topAnchor.constraint(equalTo: topAnchor),
+            content.view.leadingAnchor.constraint(equalTo: leadingAnchor),
+            content.view.bottomAnchor.constraint(equalTo: bottomAnchor),
+            content.view.trailingAnchor.constraint(equalTo: trailingAnchor)
         ])
     }
 }

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -9,7 +9,7 @@ import SyncTelemetry
 import MozillaAppServices
 import Common
 
-class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, Themeable {
+class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, Themeable, ContentContainable {
     // MARK: - Typealiases
     private typealias a11y = AccessibilityIdentifiers.FirefoxHomepage
     typealias SendToDeviceDelegate = InstructionsViewDelegate & DevicePickerViewControllerDelegate
@@ -37,6 +37,7 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
     private var syncTabContextualHintViewController: ContextualHintViewController
     private var collectionView: UICollectionView! = nil
     private var logger: Logger
+    var contentType: ContentType = .homepage
 
     var themeManager: ThemeManager
     var notificationCenter: NotificationProtocol

--- a/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -4,11 +4,14 @@
 
 import Common
 import XCTest
+import WebKit
 @testable import Client
 
 final class BrowserCoordinatorTests: XCTestCase {
     private var mockRouter: MockRouter!
     private var profile: MockProfile!
+    private var overlayModeManager: MockOverlayModeManager!
+    private var logger: MockLogger!
 
     override func setUp() {
         super.setUp()
@@ -16,12 +19,16 @@ final class BrowserCoordinatorTests: XCTestCase {
         FeatureFlagsManager.shared.initializeDeveloperFeatures(with: AppContainer.shared.resolve())
         self.mockRouter = MockRouter(navigationController: MockNavigationController())
         self.profile = MockProfile()
+        self.overlayModeManager = MockOverlayModeManager()
+        self.logger = MockLogger()
     }
 
     override func tearDown() {
         super.tearDown()
         self.mockRouter = nil
         self.profile = nil
+        self.overlayModeManager = nil
+        self.logger = nil
         AppContainer.shared.reset()
     }
 
@@ -64,7 +71,6 @@ final class BrowserCoordinatorTests: XCTestCase {
     }
 
     func testShowHomepage_addsOneHomepageOnly() {
-        let overlayModeManager = DefaultOverlayModeManager()
         let subject = createSubject()
         subject.showHomepage(inline: true,
                              homepanelDelegate: subject.browserViewController,
@@ -73,13 +79,65 @@ final class BrowserCoordinatorTests: XCTestCase {
                              overlayManager: overlayModeManager)
 
         let secondHomepage = HomepageViewController(profile: profile, overlayManager: overlayModeManager)
-        XCTAssertFalse(subject.browserViewController.contentContainer.canAdd(viewController: secondHomepage))
+        XCTAssertFalse(subject.browserViewController.contentContainer.canAdd(content: secondHomepage))
+        XCTAssertNotNil(subject.homepageViewController)
+        XCTAssertNil(subject.webviewController)
+    }
+
+    func testShowHomepage_reuseExistingHomepage() {
+        let subject = createSubject()
+        subject.showHomepage(inline: true,
+                             homepanelDelegate: subject.browserViewController,
+                             libraryPanelDelegate: subject.browserViewController,
+                             sendToDeviceDelegate: subject.browserViewController,
+                             overlayManager: overlayModeManager)
+        let firstHomepage = subject.homepageViewController
+        XCTAssertNotNil(subject.homepageViewController)
+
+        subject.showHomepage(inline: true,
+                             homepanelDelegate: subject.browserViewController,
+                             libraryPanelDelegate: subject.browserViewController,
+                             sendToDeviceDelegate: subject.browserViewController,
+                             overlayManager: overlayModeManager)
+        let secondHomepage = subject.homepageViewController
+        XCTAssertEqual(firstHomepage, secondHomepage)
+    }
+
+    func testShowWebview_withoutPreviousSendsFatal() {
+        let subject = createSubject()
+        subject.show(webView: nil)
+        XCTAssertEqual(logger.savedMessage, "Webview controller couldn't be shown, this shouldn't happen.")
+        XCTAssertEqual(logger.savedLevel, .fatal)
+
+        XCTAssertNil(subject.homepageViewController)
+        XCTAssertNil(subject.webviewController)
+    }
+
+    func testShowWebview_embedNewWebview() {
+        let webview = WKWebView()
+        let subject = createSubject()
+        subject.show(webView: webview)
+
+        XCTAssertNil(subject.homepageViewController)
+        XCTAssertNotNil(subject.webviewController)
+    }
+
+    func testShowWebview_reuseExistingWebview() {
+        let webview = WKWebView()
+        let subject = createSubject()
+        subject.show(webView: webview)
+        let firstWebview = subject.webviewController
+        XCTAssertNotNil(firstWebview)
+
+        subject.show(webView: nil)
+        let secondWebview = subject.webviewController
+        XCTAssertEqual(firstWebview, secondWebview)
     }
 
     // MARK: - Helpers
     private func createSubject(file: StaticString = #file,
                                line: UInt = #line) -> BrowserCoordinator {
-        let subject = BrowserCoordinator(router: mockRouter, profile: profile)
+        let subject = BrowserCoordinator(router: mockRouter, profile: profile, logger: logger)
         trackForMemoryLeaks(subject, file: file, line: line)
         return subject
     }

--- a/Tests/ClientTests/Frontend/ContentContainerTests.swift
+++ b/Tests/ClientTests/Frontend/ContentContainerTests.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
+import WebKit
 import XCTest
 @testable import Client
 
@@ -29,14 +30,29 @@ final class ContentContainerTests: XCTestCase {
         let subject = ContentContainer(frame: .zero)
         let homepage = HomepageViewController(profile: profile, overlayManager: overlayModeManager)
 
-        XCTAssertTrue(subject.canAdd(viewController: homepage))
+        XCTAssertTrue(subject.canAdd(content: homepage))
     }
 
     func testCanAddHomepageOnceOnly() {
         let subject = ContentContainer(frame: .zero)
         let homepage = HomepageViewController(profile: profile, overlayManager: overlayModeManager)
 
-        subject.addContent(viewController: homepage)
-        XCTAssertFalse(subject.canAdd(viewController: homepage))
+        subject.add(content: homepage)
+        XCTAssertFalse(subject.canAdd(content: homepage))
+    }
+
+    func testCanAddWebview() {
+        let subject = ContentContainer(frame: .zero)
+        let webview = WebviewViewController(webView: WKWebView())
+
+        XCTAssertTrue(subject.canAdd(content: webview))
+    }
+
+    func testCanAddWebviewOnceOnly() {
+        let subject = ContentContainer(frame: .zero)
+        let webview = WebviewViewController(webView: WKWebView())
+
+        subject.add(content: webview)
+        XCTAssertFalse(subject.canAdd(content: webview))
     }
 }

--- a/Tests/ClientTests/Mocks/MockLogger.swift
+++ b/Tests/ClientTests/Mocks/MockLogger.swift
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+
+class MockLogger: Logger {
+    var crashedLastLaunch = false
+    var savedMessage: String?
+    var savedLevel: LoggerLevel?
+    var savedCategory: LoggerCategory?
+
+    func setup(sendUsageData: Bool) {}
+    func configure(crashManager: Common.CrashManager) {}
+    func copyLogsToDocuments() {}
+
+    func log(_ message: String,
+             level: LoggerLevel,
+             category: LoggerCategory,
+             extra: [String: String]? = nil,
+             description: String? = nil,
+             file: String = #file,
+             function: String = #function,
+             line: Int = #line) {
+        savedMessage = message
+        savedLevel = level
+        savedCategory = category
+    }
+}


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6015)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13659)

### Description
- Embed the web view from the coordinator. This PR adds a `WebviewViewController` for this, so we add into the `contentContainer` as it was done for the homepage.
- Add the possibility to reuse the same homepage (keeping the exiting behavior that once we create the homepage, we reuse the same one). If we're not doing that, we see significant flickers in the UI from the things getting loaded. The homepage view cycle still gets called with that method.
- Our BVC logic is made in a way that sometimes we have access to a new webview, and sometimes we just want to hide the homepage to show the webview. This supports that with the `BrowserDelegate` protocol passing an optional webview parameter.
- Add `ContentContainable` protocol so we know what type we're adding into the `contentContainer` rather than adding a generic `UIViewController`. 
- Add MockLogger to test we log properly in BrowserCoordinator

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
