### PR TITLE
Bugfix FXIOS-6206 [v112.2] Restore iOS version checks on js injection

### DIFF
--- a/Shared/Extensions/WKWebViewExtensions.swift
+++ b/Shared/Extensions/WKWebViewExtensions.swift
@@ -1,6 +1,6 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
 import WebKit

--- a/Shared/Extensions/WKWebViewExtensions.swift
+++ b/Shared/Extensions/WKWebViewExtensions.swift
@@ -12,6 +12,7 @@ extension WKWebView {
     /// - Parameters:
     ///     - javascript: String representing javascript to be evaluated
     public func evaluateJavascriptInDefaultContentWorld(_ javascript: String) {
+        // iOS 14.3 is required here because of a webkit bug in lower iOS versions with this API
         if #available(iOS 14.3, *) {
             self.evaluateJavaScript(javascript, in: nil, in: .defaultClient, completionHandler: { _ in })
         } else {
@@ -26,6 +27,7 @@ extension WKWebView {
     ///     - javascript: String representing javascript to be evaluated
     ///     - completion: Tuple containing optional data and an optional error
     public func evaluateJavascriptInDefaultContentWorld(_ javascript: String, _ completion: @escaping (Any?, Error?) -> Void) {
+        // iOS 14.3 is required here because of a webkit bug in lower iOS versions with this API
         if #available(iOS 14.3, *) {
             self.evaluateJavaScript(javascript, in: nil, in: .defaultClient) { result in
                 switch result {
@@ -45,6 +47,7 @@ extension WKWebView {
 
 extension WKUserContentController {
     public func addInDefaultContentWorld(scriptMessageHandler: WKScriptMessageHandler, name: String) {
+        // iOS 14.3 is required here because of a webkit bug in lower iOS versions with this API
         if #available(iOS 14.3, *) {
             add(scriptMessageHandler, contentWorld: .defaultClient, name: name)
         } else {
@@ -53,6 +56,7 @@ extension WKUserContentController {
     }
 
     public func addInPageContentWorld(scriptMessageHandler: WKScriptMessageHandler, name: String) {
+        // iOS 14.3 is required here because of a webkit bug in lower iOS versions with this API
         if #available(iOS 14.3, *) {
             add(scriptMessageHandler, contentWorld: .page, name: name)
         } else {
@@ -63,6 +67,7 @@ extension WKUserContentController {
 
 extension WKUserScript {
     public class func createInDefaultContentWorld(source: String, injectionTime: WKUserScriptInjectionTime, forMainFrameOnly: Bool) -> WKUserScript {
+        // iOS 14.3 is required here because of a webkit bug in lower iOS versions with this API
         if #available(iOS 14.3, *) {
             return WKUserScript(source: source, injectionTime: injectionTime, forMainFrameOnly: forMainFrameOnly, in: .defaultClient)
         } else {
@@ -71,6 +76,7 @@ extension WKUserScript {
     }
 
     public class func createInPageContentWorld(source: String, injectionTime: WKUserScriptInjectionTime, forMainFrameOnly: Bool) -> WKUserScript {
+        // iOS 14.3 is required here because of a webkit bug in lower iOS versions with this API
         if #available(iOS 14.3, *) {
             return WKUserScript(source: source, injectionTime: injectionTime, forMainFrameOnly: forMainFrameOnly, in: .page)
         } else {


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6206)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13987)

### Description
Restoring the iOS verison checks in the JS injection logic. I removed these before because the API's were available in 14.0 so figured the checks were no longer needed, but it appears there is a webkit bug in 14.2 and lower with these API's. Brave had a similar issue https://github.com/brave/brave-ios/issues/4967

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
