### PR TITLE
Refactor FXIOS-6216 [v113] Sync telemetry reporting updated

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -1340,6 +1340,7 @@
 		F8A0B08529AD647B0091C75B /* RustSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A0B08129AD61FA0091C75B /* RustSyncManager.swift */; };
 		F8AAC1B429663619000BCDEC /* RustAutofill.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AAC1B329663618000BCDEC /* RustAutofill.swift */; };
 		F8AAC1B7296637CE000BCDEC /* RustAutofillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AAC1B5296637B7000BCDEC /* RustAutofillTests.swift */; };
+		F8B18F5529EE01A2008724A8 /* RustSyncManagerAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B18F5429EE01A1008724A8 /* RustSyncManagerAPITests.swift */; };
 		FA6B2AC21D41F02D00429414 /* String+Punycode.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6B2AC11D41F02D00429414 /* String+Punycode.swift */; };
 		FA6B2AC41D41F02D00429414 /* String+Punycode.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6B2AC11D41F02D00429414 /* String+Punycode.swift */; };
 		FA9293D41D6580E100AC8D33 /* QRCodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9293D31D6580E100AC8D33 /* QRCodeViewController.swift */; };
@@ -5814,6 +5815,7 @@
 		F8A0B08129AD61FA0091C75B /* RustSyncManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustSyncManager.swift; sourceTree = "<group>"; };
 		F8AAC1B329663618000BCDEC /* RustAutofill.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RustAutofill.swift; sourceTree = "<group>"; };
 		F8AAC1B5296637B7000BCDEC /* RustAutofillTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RustAutofillTests.swift; sourceTree = "<group>"; };
+		F8B18F5429EE01A1008724A8 /* RustSyncManagerAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustSyncManagerAPITests.swift; sourceTree = "<group>"; };
 		F8CA43008FC72296965ED032 /* ne-NP */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ne-NP"; path = "ne-NP.lproj/ClearPrivateDataConfirm.strings"; sourceTree = "<group>"; };
 		F8DB4306B31FC3DC90685A8C /* af */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = af; path = af.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
 		F8EF4290ACE53B2692EA362F /* hr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hr; path = hr.lproj/LoginManager.strings; sourceTree = "<group>"; };
@@ -6321,6 +6323,7 @@
 				E6EDE81D1D524475007A0732 /* BatchingClientTests.swift */,
 				2F3724C51ABF3C01007607FA /* StorageClientTests.swift */,
 				E6BA20111E52165800697F9C /* SyncTelemetryTests.swift */,
+				F8B18F5429EE01A1008724A8 /* RustSyncManagerAPITests.swift */,
 			);
 			path = SyncTests;
 			sourceTree = "<group>";
@@ -10582,6 +10585,7 @@
 				289A4C141C4EB90600A460E3 /* StorageTestUtils.swift in Sources */,
 				28532CC11C473977000072D9 /* MockFiles.swift in Sources */,
 				D8BA1791206D47A80023AC00 /* DeferredTestUtils.swift in Sources */,
+				F8B18F5529EE01A2008724A8 /* RustSyncManagerAPITests.swift in Sources */,
 				2F8C76571BC32F3C00D5E4E0 /* MockSyncServerTests.swift in Sources */,
 				2F67C5261BB0CB4E00E7B73A /* MetaGlobalTests.swift in Sources */,
 				2827319E1ABC9C5900AA1954 /* RecordTests.swift in Sources */,
@@ -16945,7 +16949,7 @@
 			repositoryURL = "https://github.com/mozilla/rust-components-swift.git";
 			requirement = {
 				kind = exactVersion;
-				version = 97.4.1;
+				version = 97.5.1;
 			};
 		};
 		435C85EE2788F4D00072B526 /* XCRemoteSwiftPackageReference "glean-swift" */ = {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla/rust-components-swift.git",
       "state" : {
-        "revision" : "3bdd9bf032bf3c9085a073d12bbd5d633896511d",
-        "version" : "97.4.1"
+        "revision" : "a04e73953be1f81fa0f2358f36b5255414bbca01",
+        "version" : "97.5.1"
       }
     },
     {

--- a/Providers/RustSyncManager.swift
+++ b/Providers/RustSyncManager.swift
@@ -188,8 +188,7 @@ public class RustSyncManager: NSObject, SyncManager {
         }
 
         if canSendUsageData() {
-            let gleanHelper = GleanSyncOperationHelper()
-            gleanHelper.reportTelemetry(result)
+            self.syncManagerAPI.reportSyncTelemetry(syncResult: result) {_ in }
         } else {
             logger.log("Profile isn't sending usage data. Not sending sync status event.",
                        level: .debug,

--- a/Tests/SyncTests/RustSyncManagerAPITests.swift
+++ b/Tests/SyncTests/RustSyncManagerAPITests.swift
@@ -1,0 +1,36 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import Common
+@testable import Sync
+
+class RustSyncManagerAPITests: XCTestCase {
+    var rustSyncManagerApi: RustSyncManagerAPI!
+
+    override func setUp() {
+        super.setUp()
+    }
+
+    func testReportSyncTelemetry() {
+        self.rustSyncManagerApi = RustSyncManagerAPI()
+        let expectation = expectation(description: "Completed telemetry reporting")
+        var actual = ""
+        var expected = "The operation couldn’t be completed. (MozillaAppServices.TelemetryJSONError error 0.)"
+        let invalidSyncResult = SyncResult(status: ServiceStatus.ok,
+                                           successful: [],
+                                           failures: [:],
+                                           persistedState: "",
+                                           declined: nil,
+                                           nextSyncAllowedAt: nil,
+                                           telemetryJson: "{\"version\": \"invalidVersion\"}")
+        self.rustSyncManagerApi
+            .reportSyncTelemetry(syncResult: invalidSyncResult) { description in
+            actual = description
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 5)
+        XCTAssertEqual(actual, expected)
+    }
+}


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6216)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14015)

### Description
This PR updates the A-S version to expose a new sync manager function, `reportSyncTelemetry`, which will be called to report sync metrics for the `RustSyncManager` class instead of the [SyncTelemetryUtils reportTelemetry function](https://github.com/mozilla-mobile/firefox-ios/blob/main/Sync/SyncTelemetryUtils.swift#L471). The old function used the `temp` metrics (defined [here](https://github.com/mozilla-mobile/firefox-ios/blob/main/Sync/metrics.yaml)), which only collected a subset of the data we need on syncs. 

**NOTE:** The old `BrowserSyncManager` class will still report the temp sync metrics via `reportTelemetry` so the old telemetry logic will stay in place until the rust sync manager is available to all users in release. At that point the cleanup PR will be created where the temp sync telemetry logic can be removed with  the `BrowserSyncManager` class and other obsolete logic.

### Pull requests checks where applicable
- [ x ] Fill in the three TODOs above (tickets number and description of your work)
- [ x ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
