### PR TITLE
Bugfix MTE-863 [v114] Update Perfherder data object application name

### DIFF
--- a/test-fixtures/perfTestTransform.py
+++ b/test-fixtures/perfTestTransform.py
@@ -1,7 +1,7 @@
 import json
 
 PERFHERDER_DATA = {"framework": 'mozperftest',
-                   "application": {"name": 'firefox-ios'},
+                   "application": {"name": 'fennec'},
                    "suites": []
                    }
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-863)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/FXIOS-14021)

### Description
The perfherder data object is currently set to `firefox-ios` and should be `fennec` instead.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
