### PR TITLE
Build MTE-335 [v114] Add build and test files to Bitrise UI Testing Blacklist

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -571,8 +571,23 @@ workflows:
                     filesChanged=`git diff --name-only $GIT_CLONE_COMMIT_HASH $COMMIT_ON_MAIN_PR`
                     echo $filesChanged
                 fi
-
-                doNotRunTests='^(\.[a-zA-Z]+\.y*|Docs/*|Sync*/*|.github/|[a-zA-Z]+\.md|[a-zA-Z]+\.sh|[a-zA-Z0-9]+[-_]+[a-zA-Z]+\.sh)|fastlane/*|taskcluster/*|L10nSnapshotTests/*|Shared/[a-zA-Z]+\.lproj/*|Shared/[A-Za-z]/[a-zA-Z]+\.lproj/*|WidgetKit/[a-zA-Z]+\.lproj/*|Client/*/[a-zA-Z]+\.lproj/*)'
+                # Match on file names in all directories and subdirectories
+                #
+                # Project Configs
+                #   .*[^bitrise]\.y[^/]*$ -> matches all files not named bitrise whose file extension begins with a 'y'
+                #   .*\.sh$ -> matches all files whose file extension begins with 'sh'
+                #   .*\.md$ -> matches all files whose file extension begins with 'md'
+                #   .*\.lproj/.* -> matches all files whose parent directory begins with 'lproj'
+                #   fastlane/* -> matches all files in the fastlane directory
+                #   taskcluster/* -> matches all files in the taskcluster directory
+                #
+                # Features tested outside bitrise
+                #   Sync*/* -> matches all files in the Sync,SyncIntegrationTests,SyncTelemetry directories
+                #   L10nSnapshotTests/* -> matches all files in the L10nSnapshotTests directory
+                #
+                # Test Helpers
+                #   test-fixtures/.py$ -> matches all files whose file extension begine with 'py'
+                doNotRunTests='^(.*[^bitrise]\.y[^/]*$|.*\.sh$|.*\.md$|.*\.lproj/.*|Sync*/*|fastlane/*|taskcluster/*|L10nSnapshotTests/*|test-fixtures/.py$)'
 
                 if egrep -v "${doNotRunTests}" <<< "${filesChanged}" && [ ! -z "$filesChanged" ];
                 then
@@ -1452,4 +1467,4 @@ trigger_map:
 - pull_request_target_branch: epic-branch/*
   pipeline: pipeline_multiple_shards
 - pull_request_target_branch: release/v*
-  pipeline: pipeline_multiple_shards
+  pipeline: pipeline_multiple_shardsz

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1467,4 +1467,4 @@ trigger_map:
 - pull_request_target_branch: epic-branch/*
   pipeline: pipeline_multiple_shards
 - pull_request_target_branch: release/v*
-  pipeline: pipeline_multiple_shardsz
+  pipeline: pipeline_multiple_shards

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -587,7 +587,7 @@ workflows:
                 #
                 # Test Helpers
                 #   test-fixtures/.py$ -> matches all files whose file extension begine with 'py'
-                doNotRunTests='^(.*[^bitrise]\.y[^/]*$|.*\.sh$|.*\.md$|.*\.lproj/.*|Sync*/*|fastlane/*|taskcluster/*|L10nSnapshotTests/*|test-fixtures/.py$)'
+                doNotRunTests='^(.*[^bitrise]\.y[^/]*$|.*\.sh$|.*\.md$|.*\.lproj/.*|Sync*/*|fastlane/*|taskcluster/*|L10nSnapshotTests/*|test-fixtures/.*.py$)'
 
                 if egrep -v "${doNotRunTests}" <<< "${filesChanged}" && [ ! -z "$filesChanged" ];
                 then


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-335)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/FXIOS-14026)

### Description
Adding additional files to Bitrise UI Testing blacklist to save on costs of running unnecessary tests.

All files are now located across all directories and subdirectories which include:
- .yml/.yaml not named 'bitrise'.yml
- .sh
- .md
- .lproj
- everything in fastlane
- everything in taskcluster
- All Sync feature files
- All L10nSnapshotTests
- All test-fixture .py helpers

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
