### PR TITLE
Refactor FXIOS-6175 [v114] Handle alpha and nil checks with homepage container changes

### DIFF
--- a/Client/Application/SceneDelegate.swift
+++ b/Client/Application/SceneDelegate.swift
@@ -48,7 +48,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             sceneCoordinator = SceneCoordinator(scene: scene)
             sceneCoordinator?.start()
 
-            // FXIOS-5827: Handle deeplinks from willConnectTo
+            // FXIOS-6214: Handle deeplinks from willConnectTo
         } else {
             let window = configureWindowFor(scene)
             let rootVC = configureRootViewController()

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -47,8 +47,12 @@ extension BrowserViewController {
 
     @objc
     func addBookmarkKeyCommand() {
-        if let tab = tabManager.selectedTab, homepageViewController?.view.alpha == 0 {
-            guard let url = tab.canonicalURL?.displayURL else { return }
+        guard let tab = tabManager.selectedTab,
+              let url = tab.canonicalURL?.displayURL else { return }
+
+        if AppConstants.useCoordinators, contentContainer.hasHomepage {
+            addBookmark(url: url.absoluteString, title: tab.title)
+        } else if homepageViewController?.view.alpha == 0 {
             addBookmark(url: url.absoluteString, title: tab.title)
         }
     }
@@ -60,7 +64,11 @@ extension BrowserViewController {
                                      object: .keyCommand,
                                      extras: ["action": "reload"])
 
-        if let tab = tabManager.selectedTab, homepageViewController?.view.alpha == 0 {
+        guard let tab = tabManager.selectedTab else { return }
+
+        if AppConstants.useCoordinators, contentContainer.hasHomepage {
+            tab.reload()
+        } else if homepageViewController?.view.alpha == 0 {
             tab.reload()
         }
     }
@@ -71,8 +79,11 @@ extension BrowserViewController {
                                      method: .press,
                                      object: .keyCommand,
                                      extras: ["action": "reload-no-cache"])
+        guard let tab = tabManager.selectedTab else { return }
 
-        if let tab = tabManager.selectedTab, homepageViewController?.view.alpha == 0 {
+        if AppConstants.useCoordinators, contentContainer.hasHomepage {
+            tab.reload(bypassCache: true)
+        } else if homepageViewController?.view.alpha == 0 {
             tab.reload(bypassCache: true)
         }
     }
@@ -84,7 +95,11 @@ extension BrowserViewController {
                                      object: .keyCommand,
                                      extras: ["action": "go-back"])
 
-        if let tab = tabManager.selectedTab, tab.canGoBack, homepageViewController?.view.alpha == 0 {
+        guard let tab = tabManager.selectedTab, tab.canGoBack else { return }
+
+        if AppConstants.useCoordinators, contentContainer.hasHomepage {
+            tab.goBack()
+        } else if homepageViewController?.view.alpha == 0 {
             tab.goBack()
         }
     }
@@ -96,7 +111,11 @@ extension BrowserViewController {
                                      object: .keyCommand,
                                      extras: ["action": "go-forward"])
 
-        if let tab = tabManager.selectedTab, tab.canGoForward {
+        guard let tab = tabManager.selectedTab, tab.canGoForward else { return }
+
+        if AppConstants.useCoordinators, contentContainer.hasHomepage {
+            tab.goForward()
+        } else if homepageViewController?.view.alpha == 0 {
             tab.goForward()
         }
     }
@@ -116,7 +135,11 @@ extension BrowserViewController {
     }
 
     private func findInPage(withText text: String) {
-        if let tab = tabManager.selectedTab, homepageViewController?.view.alpha == 0 {
+        guard let tab = tabManager.selectedTab else { return }
+
+        if AppConstants.useCoordinators, contentContainer.hasHomepage {
+            self.tab(tab, didSelectFindInPageForSelection: text)
+        } else if homepageViewController?.view.alpha == 0 {
             self.tab(tab, didSelectFindInPageForSelection: text)
         }
     }
@@ -310,29 +333,35 @@ extension BrowserViewController {
 
     @objc
     func zoomIn() {
-        guard let currentTab = tabManager.selectedTab,
-              homepageViewController?.view.alpha == 0
-        else { return }
+        guard let currentTab = tabManager.selectedTab else { return }
 
-        currentTab.zoomIn()
+        if AppConstants.useCoordinators, contentContainer.hasHomepage {
+            currentTab.zoomIn()
+        } else if homepageViewController?.view.alpha == 0 {
+            currentTab.zoomIn()
+        }
     }
 
     @objc
     func zoomOut() {
-        guard let currentTab = tabManager.selectedTab,
-              homepageViewController?.view.alpha == 0
-        else { return }
+        guard let currentTab = tabManager.selectedTab else { return }
 
-        currentTab.zoomOut()
+        if AppConstants.useCoordinators, contentContainer.hasHomepage {
+            currentTab.zoomOut()
+        } else if homepageViewController?.view.alpha == 0 {
+            currentTab.zoomOut()
+        }
     }
 
     @objc
     func resetZoom() {
-        guard let currentTab = tabManager.selectedTab,
-              homepageViewController?.view.alpha == 0
-        else { return }
+        guard let currentTab = tabManager.selectedTab else { return }
 
-        currentTab.resetZoom()
+        if AppConstants.useCoordinators, contentContainer.hasHomepage {
+            currentTab.resetZoom()
+        } else if homepageViewController?.view.alpha == 0 {
+            currentTab.resetZoom()
+        }
     }
 
     // MARK: - KeyCommands

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -50,7 +50,7 @@ extension BrowserViewController {
         guard let tab = tabManager.selectedTab,
               let url = tab.canonicalURL?.displayURL else { return }
 
-        if AppConstants.useCoordinators, contentContainer.hasHomepage {
+        if AppConstants.useCoordinators, !contentContainer.hasHomepage {
             addBookmark(url: url.absoluteString, title: tab.title)
         } else if homepageViewController?.view.alpha == 0 {
             addBookmark(url: url.absoluteString, title: tab.title)
@@ -66,7 +66,7 @@ extension BrowserViewController {
 
         guard let tab = tabManager.selectedTab else { return }
 
-        if AppConstants.useCoordinators, contentContainer.hasHomepage {
+        if AppConstants.useCoordinators, !contentContainer.hasHomepage {
             tab.reload()
         } else if homepageViewController?.view.alpha == 0 {
             tab.reload()
@@ -81,7 +81,7 @@ extension BrowserViewController {
                                      extras: ["action": "reload-no-cache"])
         guard let tab = tabManager.selectedTab else { return }
 
-        if AppConstants.useCoordinators, contentContainer.hasHomepage {
+        if AppConstants.useCoordinators, !contentContainer.hasHomepage {
             tab.reload(bypassCache: true)
         } else if homepageViewController?.view.alpha == 0 {
             tab.reload(bypassCache: true)
@@ -97,7 +97,7 @@ extension BrowserViewController {
 
         guard let tab = tabManager.selectedTab, tab.canGoBack else { return }
 
-        if AppConstants.useCoordinators, contentContainer.hasHomepage {
+        if AppConstants.useCoordinators, !contentContainer.hasHomepage {
             tab.goBack()
         } else if homepageViewController?.view.alpha == 0 {
             tab.goBack()
@@ -113,7 +113,7 @@ extension BrowserViewController {
 
         guard let tab = tabManager.selectedTab, tab.canGoForward else { return }
 
-        if AppConstants.useCoordinators, contentContainer.hasHomepage {
+        if AppConstants.useCoordinators, !contentContainer.hasHomepage {
             tab.goForward()
         } else if homepageViewController?.view.alpha == 0 {
             tab.goForward()
@@ -137,7 +137,7 @@ extension BrowserViewController {
     private func findInPage(withText text: String) {
         guard let tab = tabManager.selectedTab else { return }
 
-        if AppConstants.useCoordinators, contentContainer.hasHomepage {
+        if AppConstants.useCoordinators, !contentContainer.hasHomepage {
             self.tab(tab, didSelectFindInPageForSelection: text)
         } else if homepageViewController?.view.alpha == 0 {
             self.tab(tab, didSelectFindInPageForSelection: text)
@@ -335,7 +335,7 @@ extension BrowserViewController {
     func zoomIn() {
         guard let currentTab = tabManager.selectedTab else { return }
 
-        if AppConstants.useCoordinators, contentContainer.hasHomepage {
+        if AppConstants.useCoordinators, !contentContainer.hasHomepage {
             currentTab.zoomIn()
         } else if homepageViewController?.view.alpha == 0 {
             currentTab.zoomIn()
@@ -346,7 +346,7 @@ extension BrowserViewController {
     func zoomOut() {
         guard let currentTab = tabManager.selectedTab else { return }
 
-        if AppConstants.useCoordinators, contentContainer.hasHomepage {
+        if AppConstants.useCoordinators, !contentContainer.hasHomepage {
             currentTab.zoomOut()
         } else if homepageViewController?.view.alpha == 0 {
             currentTab.zoomOut()
@@ -357,7 +357,7 @@ extension BrowserViewController {
     func resetZoom() {
         guard let currentTab = tabManager.selectedTab else { return }
 
-        if AppConstants.useCoordinators, contentContainer.hasHomepage {
+        if AppConstants.useCoordinators, !contentContainer.hasHomepage {
             currentTab.resetZoom()
         } else if homepageViewController?.view.alpha == 0 {
             currentTab.resetZoom()

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -239,7 +239,7 @@ extension BrowserViewController: URLBarDelegate {
 
     func urlBarDidPressScrollToTop(_ urlBar: URLBarView) {
         guard let selectedTab = tabManager.selectedTab else { return }
-        if AppConstants.useCoordinators, contentContainer.hasHomepage {
+        if AppConstants.useCoordinators, !contentContainer.hasHomepage {
             // Only scroll to top if we are not showing the home view controller
             selectedTab.webView?.scrollView.setContentOffset(CGPoint.zero, animated: true)
         } else if homepageViewController == nil {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -238,7 +238,11 @@ extension BrowserViewController: URLBarDelegate {
     }
 
     func urlBarDidPressScrollToTop(_ urlBar: URLBarView) {
-        if let selectedTab = tabManager.selectedTab, homepageViewController == nil {
+        guard let selectedTab = tabManager.selectedTab else { return }
+        if AppConstants.useCoordinators, contentContainer.hasHomepage {
+            // Only scroll to top if we are not showing the home view controller
+            selectedTab.webView?.scrollView.setContentOffset(CGPoint.zero, animated: true)
+        } else if homepageViewController == nil {
             // Only scroll to top if we are not showing the home view controller
             selectedTab.webView?.scrollView.setContentOffset(CGPoint.zero, animated: true)
         }

--- a/Client/Frontend/Components/ContentContainer.swift
+++ b/Client/Frontend/Components/ContentContainer.swift
@@ -17,6 +17,9 @@ protocol ContentContainable: UIViewController {
 class ContentContainer: UIView {
     private var type: ContentType?
     private var contentController: ContentContainable?
+    var hasHomepage: Bool {
+        return type == .homepage
+    }
 
     /// Determine if the content can be added, making sure we only add once
     /// - Parameters:

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -405,7 +405,11 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable, The
     // Check if we already present something on top of the homepage,
     // if the homepage is actually being shown to the user and if the page is shown from a loaded webpage (zero search).
     private var canModalBePresented: Bool {
-        return presentedViewController == nil && view.alpha == 1 && !viewModel.isZeroSearch
+        if AppConstants.useCoordinators {
+            return presentedViewController == nil && !viewModel.isZeroSearch
+        } else {
+            return presentedViewController == nil && view.alpha == 1 && !viewModel.isZeroSearch
+        }
     }
 
     // MARK: - Contextual hint

--- a/Tests/ClientTests/Frontend/ContentContainerTests.swift
+++ b/Tests/ClientTests/Frontend/ContentContainerTests.swift
@@ -55,4 +55,25 @@ final class ContentContainerTests: XCTestCase {
         subject.add(content: webview)
         XCTAssertFalse(subject.canAdd(content: webview))
     }
+
+    func testHasHomepage_trueWhenHomepage() {
+        let subject = ContentContainer(frame: .zero)
+        let homepage = HomepageViewController(profile: profile, overlayManager: overlayModeManager)
+        subject.add(content: homepage)
+
+        XCTAssertTrue(subject.hasHomepage)
+    }
+
+    func testHasHomepage_falseWhenNil() {
+        let subject = ContentContainer(frame: .zero)
+        XCTAssertFalse(subject.hasHomepage)
+    }
+
+    func testHasHomepage_falseWhenWebview() {
+        let subject = ContentContainer(frame: .zero)
+        let webview = WebviewViewController(webView: WKWebView())
+        subject.add(content: webview)
+
+        XCTAssertFalse(subject.hasHomepage)
+    }
 }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6175)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13933)

### Description
Handle alpha and nil checks with homepage container changes. Needed since BrowserViewController won't hold the homepage view controller directly, and it won't be handled with alpha anymore. Added a conveniance method on the `contentContainer` to know if we have the homepage showing or not.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
