### PR TITLE
Bugfix FXIOS-6210 [v114] Fix homepage tab tray screenshot

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2170,6 +2170,7 @@ extension BrowserViewController: TabManagerDelegate {
         // is always presented scrolled to the top when switching tabs.
         if !isRestoring, selected != previous,
            let activityStreamPanel = homepageViewController {
+            // FXIOS-6203 - Can be removed with coordinator usage, it will be scrolled at the top since we add it back
             activityStreamPanel.scrollToTop()
         }
 

--- a/Client/Frontend/Browser/ScreenshotHelper.swift
+++ b/Client/Frontend/Browser/ScreenshotHelper.swift
@@ -37,7 +37,12 @@ class ScreenshotHelper {
         }
         // Handle home page snapshots, can not use Apple API snapshot function for this
         if InternalURL(url)?.isAboutHomeURL ?? false {
-            if let homePanel = controller?.homepageViewController {
+            if AppConstants.useCoordinators, let homeview = controller?.contentContainer.contentView {
+                let screenshot = homeview.screenshot(quality: UIConstants.ActiveScreenshotQuality)
+                tab.hasHomeScreenshot = true
+                tab.setScreenshot(screenshot)
+                TabEvent.post(.didSetScreenshot(isHome: true), for: tab)
+            } else if let homePanel = controller?.homepageViewController {
                 let screenshot = homePanel.view.screenshot(quality: UIConstants.ActiveScreenshotQuality)
                 tab.hasHomeScreenshot = true
                 tab.setScreenshot(screenshot)

--- a/Client/Frontend/Components/ContentContainer.swift
+++ b/Client/Frontend/Components/ContentContainer.swift
@@ -17,6 +17,9 @@ protocol ContentContainable: UIViewController {
 class ContentContainer: UIView {
     private var type: ContentType?
     private var contentController: ContentContainable?
+    var contentView: UIView? {
+        return contentController?.view
+    }
 
     /// Determine if the content can be added, making sure we only add once
     /// - Parameters:

--- a/Tests/ClientTests/Frontend/ContentContainerTests.swift
+++ b/Tests/ClientTests/Frontend/ContentContainerTests.swift
@@ -55,4 +55,16 @@ final class ContentContainerTests: XCTestCase {
         subject.add(content: webview)
         XCTAssertFalse(subject.canAdd(content: webview))
     }
+
+    func testContentView_notContent_viewIsNil() {
+        let subject = ContentContainer(frame: .zero)
+        XCTAssertNil(subject.contentView)
+    }
+
+    func testContentView_hasContentHomepage_viewIsNotNil() {
+        let subject = ContentContainer(frame: .zero)
+        let homepage = HomepageViewController(profile: profile, overlayManager: overlayModeManager)
+        subject.add(content: homepage)
+        XCTAssertNotNil(subject.contentView)
+    }
 }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6210)

### Description
Fix homepage tab tray screenshot, since it was relying on getting the homepage view controller directly before hand. Added some method to adapt our screenshot.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
