### PR TITLE
Bugfix FXIOS-5992 [v114] Shared or sent tabs can arrive behind the search screen and be replaced by the search result

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -923,7 +923,7 @@ class BrowserViewController: UIViewController {
                     let urls = cursor.compactMap { $0?.url.asURL }.filter { !receivedURLs.contains($0) }
                     if !urls.isEmpty {
                         DispatchQueue.main.async {
-                            self.tabManager.addTabsForURLs(urls, zombie: false)
+                            self.tabManager.addTabsForURLs(urls, zombie: false, shouldSelectTab: false)
                         }
                     }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -941,7 +941,7 @@ class BrowserViewController: UIViewController {
                 }
 
                 if !receivedURLs.isEmpty || cursorCount > 0 {
-                    // Because the notification service runs as a seperate process
+                    // Because the notification service runs as a separate process
                     // we need to make sure that our account manager picks up any persisted state
                     // the notification services persisted.
                     self.profile.rustFxA.accountManager.peek()?.resetPersistedAccount()

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -923,7 +923,8 @@ class BrowserViewController: UIViewController {
                     let urls = cursor.compactMap { $0?.url.asURL }.filter { !receivedURLs.contains($0) }
                     if !urls.isEmpty {
                         DispatchQueue.main.async {
-                            self.tabManager.addTabsForURLs(urls, zombie: false, shouldSelectTab: false)
+                            let shouldSelectTab = !self.overlayManager.inOverlayMode
+                            self.tabManager.addTabsForURLs(urls, zombie: false, shouldSelectTab: shouldSelectTab)
                         }
                     }
 

--- a/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -421,7 +421,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager {
                       isPrivate: isPrivate)
     }
 
-    func addTabsForURLs(_ urls: [URL], zombie: Bool) {
+    func addTabsForURLs(_ urls: [URL], zombie: Bool, shouldSelectTab: Bool) {
         if urls.isEmpty {
             return
         }
@@ -431,8 +431,11 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager {
             tab = addTab(URLRequest(url: url), flushToDisk: false, zombie: zombie)
         }
 
-        // Select the most recent.
-        selectTab(tab)
+        if shouldSelectTab {
+            // Select the most recent.
+            selectTab(tab)
+        }
+
         // Okay now notify that we bulk-loaded so we can adjust counts and animate changes.
         delegates.forEach { $0.get()?.tabManagerDidAddTabs(self) }
 

--- a/Client/TabManagement/TabManager.swift
+++ b/Client/TabManagement/TabManager.swift
@@ -28,7 +28,7 @@ protocol TabManager: AnyObject {
     func removeDelegate(_ delegate: TabManagerDelegate, completion: (() -> Void)?)
     func selectTab(_ tab: Tab?, previous: Tab?)
     func addTab(_ request: URLRequest?, afterTab: Tab?, isPrivate: Bool) -> Tab
-    func addTabsForURLs(_ urls: [URL], zombie: Bool)
+    func addTabsForURLs(_ urls: [URL], zombie: Bool, shouldSelectTab: Bool)
     func removeTab(_ tab: Tab, completion: (() -> Void)?)
     func removeTabs(_ tabs: [Tab])
     func getMostRecentHomepageTab() -> Tab?
@@ -108,5 +108,9 @@ extension TabManager {
                                                           _ previousTabUUID: String) -> Void) {
         backgroundRemoveAllTabs(isPrivate: isPrivate,
                                 didClearTabs: didClearTabs)
+    }
+
+    func addTabsForURLs(_ urls: [URL], zombie: Bool, shouldSelectTab: Bool = true) {
+        addTabsForURLs(urls, zombie: zombie, shouldSelectTab: shouldSelectTab)
     }
 }

--- a/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -65,7 +65,7 @@ class MockTabManager: TabManager {
 
     func removeDelegate(_ delegate: TabManagerDelegate, completion: (() -> Void)?) {}
 
-    func addTabsForURLs(_ urls: [URL], zombie: Bool) {}
+    func addTabsForURLs(_ urls: [URL], zombie: Bool, shouldSelectTab: Bool) {}
 
     func removeTab(_ tab: Tab, completion: (() -> Void)?) {}
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5992)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13603)

### Description
Fixes shared tabs arriving behind the search screen and being replaced by the search result. When we are in overlay mode we open these tabs in the background now.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
~- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)~
- [ ] Unit tests written and passing
~- [ ] Documentation / comments for complex code and public methods~
