### PR TITLE
Bugfix MTE-790 [v114] Check for empty commits to allow manual Bitrise triggers

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -540,6 +540,11 @@ workflows:
             #!/usr/bin/env bash
             set -e
 
+            # Manual triggers leave empty commits. 
+            # Check for empty commit and exit blacklist check if found to avoid erroring out.
+            git log -n 1 origin/main --pretty=format:"%H" && echo "non-empty commit. Continuing Blacklist check..." \
+                || echo "empty commit from manually triggered test detected. Skipping Blacklist check..." && \
+                envman add --key RUN_UI_TESTS --value Run_UI_Tests; exit 0
             echo "Commit on origin/main"
             COMMIT_ON_MAIN_ORIGIN=`git log -n 1 origin/main --pretty=format:"%H"` || true
             if [[ ! "failed" == *"$COMMIT_ON_MAIN_ORIGIN"* ]]; then


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-790)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/FXIOS-14036)

### Description
We need to add a condition to check for empty commits and if found adding the env var `RUN_UI_TESTS`. If empty, then the file blacklist should be skipped.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
