### PR TITLE
Bugfix FXIOS-5711 [v114] Open Tabs view doesn’t focus the current tab

### DIFF
--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -186,7 +186,9 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate, Themeable {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.view.layoutIfNeeded()
-        focusItem()
+        DispatchQueue.main.async {
+            self.focusItem()
+        }
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5711)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13158)

### Description
This PR addresses the issue of the tab tray not focusing on the tabs that require scrolling when opened

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
