### PR TITLE
Bugfix MTE-880 [v114] Add Bitrise mirror bypass for homebrew-core services

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -82,17 +82,6 @@ workflows:
         - deploy_path: "${BITRISE_SOURCE_DIR}/DerivedData.zip"
         - pipeline_intermediate_files: "$BITRISE_XCRESULT_PATH:BITRISE_XCRESULT_PATH"
     - script@1.1:
-        title: Bypass Bitrise Mirror for Swiftlint Upgrade
-        inputs:
-        - content: |
-            #!/usr/bin/env bash
-            set -ex
-
-            cd "$(brew --repository)/Library/Taps/homebrew/homebrew-core"
-            # Bypass Bitrise mirror that lags 1 week to 1 month behind homebrew-core versions
-            git remote set-url origin https://github.com/Homebrew/homebrew-core.git
-            brew upgrade swiftlint
-    - script@1.1:
         title: Run Danger 2
         inputs:
         - content: |
@@ -414,6 +403,21 @@ workflows:
             export XCODE_XCCONFIG_FILE=/tmp/tmp.xcconfig
             envman add --key XCODE_XCCONFIG_FILE --value /tmp/tmp.xcconfig
         title: Workaround carthage lipo
+    - script@1.1:
+        title: Bypass Bitrise Mirror for Swiftlint Upgrade
+        inputs:
+        - content: |
+            #!/usr/bin/env bash
+            set -ex
+
+            echo "Swiftlint version before mirror swap"
+            swiftlint version
+            cd "$(brew --repository)/Library/Taps/homebrew/homebrew-core"
+            # Bypass Bitrise mirror that lags 1 week to 1 month behind homebrew-core versions
+            git remote set-url origin https://github.com/Homebrew/homebrew-core.git
+            brew upgrade swiftlint
+            echo "Swiftlint version after mirror swap"
+            swiftlint version
     - script@1:
         inputs:
         - content: |-

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -406,7 +406,7 @@ workflows:
     - script@1.1:
         title: Bypass Bitrise Mirror for Swiftlint Upgrade
         inputs:
-        - content: |
+        - content: |-
             #!/usr/bin/env bash
             set -ex
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -80,7 +80,18 @@ workflows:
     - deploy-to-bitrise-io@2:
         inputs:
         - deploy_path: "${BITRISE_SOURCE_DIR}/DerivedData.zip"
-        - pipeline_intermediate_files: "$BITRISE_XCRESULT_PATH:BITRISE_XCRESULT_PATH" 
+        - pipeline_intermediate_files: "$BITRISE_XCRESULT_PATH:BITRISE_XCRESULT_PATH"
+    - script@1.1:
+        title: Bypass Bitrise Mirror for Swiftlint Upgrade
+        inputs:
+        - content: |
+            #!/usr/bin/env bash
+            set -ex
+
+            cd "$(brew --repository)/Library/Taps/homebrew/homebrew-core"
+            # Bypass Bitrise mirror that lags 1 week to 1 month behind homebrew-core versions
+            git remote set-url origin https://github.com/Homebrew/homebrew-core.git
+            brew upgrade swiftlint
     - script@1.1:
         title: Run Danger 2
         inputs:


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-880)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/FXIOS-14043)

### Description
We need to update the bitrise build script to bypass the mirror they use and upgrade the services based on `homebrew-core`'s `@latest` version.

Starting with `swiftlint` and can expand services as needed or wholesale should the need arise.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
