### PR TITLE
Localize [v114] add reveal and conceal strings for credit card

### DIFF
--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -241,6 +241,16 @@ extension String {
 
         // Editing and saving credit card
         public struct EditCard {
+            public static let RevealLabel = MZLocalizedString(
+                "CreditCard.EditCard.RevealLabel.v114",
+                tableName: "EditCard",
+                value: "Reveal",
+                comment: "Label for revealing the contents of the credit card number")
+            public static let ConcealLabel = MZLocalizedString(
+                "CreditCard.EditCard.ConcealLabel.v114",
+                tableName: "EditCard",
+                value: "Conceal",
+                comment: "Label for concealing contents of the credit card number")
             public static let CopyLabel = MZLocalizedString(
                 "CreditCard.EditCard.CopyLabel.v113",
                 tableName: "EditCard",


### PR DESCRIPTION

### Description
After discussion with the UX team, we add reveal and conceal strings to show and hide credit card info. This pr is only for the string update 

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
~- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)~
~- [ ] Unit tests written and passing~
~- [ ] Documentation / comments for complex code and public methods~
