### PR TITLE
Bugfix MTE-773 [v114] Attentive mode fixes

### DIFF
--- a/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
@@ -78,7 +78,6 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
     }
 
     func testWebViewAuthenticationDialog() {
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: 15)
         navigator.openURL("https://jigsaw.w3.org/HTTP/Basic/", waitForLoading: false)
         waitForNoExistence(app.staticTexts["XCUITests-Runner pasted from Fennec"])
         navigator.nowAt(BasicAuthDialog)
@@ -100,8 +99,6 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
 
     func testTopSitesMenu() {
         sleep(3)
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: 15)
-        app.buttons["urlBar-cancel"].tap()
         // waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 15)
         navigator.nowAt(NewTabScreen)
         app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell].firstMatch.swipeUp()
@@ -138,9 +135,10 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
         waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 15)
         navigator.performAction(Action.Bookmark)
         navigator.createNewTab()
-        app.buttons["urlBar-cancel"].tap()
         // Disable due to issue #7521
         // navigator.goto(BookmarksPanelContextMenu)
+        navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
         navigator.goto(LibraryPanel_Bookmarks)
         snapshot("BookmarksTableContextMenu-01")
     }
@@ -156,8 +154,6 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
     }*/
 
     func testETPperSite() {
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: 15)
-        app.buttons["urlBar-cancel"].tap()
         waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
         navigator.nowAt(NewTabScreen)
         // Enable Strict ETP
@@ -181,8 +177,6 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
     }
 
     func testSettingsETP() {
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: 15)
-        app.buttons["urlBar-cancel"].tap()
         waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
         navigator.nowAt(NewTabScreen)
         navigator.goto(TrackingProtectionSettings)
@@ -205,8 +199,6 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
     func testMenuOnTopSites() {
         typealias homeTabBannerA11y = AccessibilityIdentifiers.FirefoxHomepage.HomeTabBanner
 
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: 15)
-        app.buttons["urlBar-cancel"].tap()
         waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
         navigator.nowAt(NewTabScreen)
         navigator.goto(BrowserTabMenu)
@@ -222,8 +214,6 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
 
     func testSettings() {
         let table = app.tables.element(boundBy: 0)
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: 15)
-        app.buttons["urlBar-cancel"].tap()
         waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
         navigator.nowAt(NewTabScreen)
         navigator.goto(SettingsScreen)
@@ -240,8 +230,6 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
     }
 
     func testPrivateBrowsingTabsEmptyState() {
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: 15)
-        app.buttons["urlBar-cancel"].tap()
         waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
         navigator.nowAt(NewTabScreen)
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)

--- a/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
@@ -8,8 +8,6 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
     let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
 
     func testPanelsEmptyState() {
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: 15)
-        app.buttons["urlBar-cancel"].tap()
         waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
         navigator.nowAt(NewTabScreen)
         navigator.goto(LibraryPanel_Bookmarks)
@@ -38,7 +36,6 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
     }
 
     func testURLBar() {
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: 15)
         navigator.goto(URLBarOpen)
         snapshot("URLBar-01")
 
@@ -103,8 +100,6 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
     }
 
     func testLoginDetails() {
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: 15)
-        app.buttons["urlBar-cancel"].tap()
         navigator.nowAt(NewTabScreen)
         navigator.goto(SettingsScreen)
         waitForExistence(app.cells["Search"], timeout: 5)


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-773)

### Description
The existing tests are not working even for the `en` locale due to the recent change in the keyboard's behaviour. Now the screenshots should be generated at least for `en` locales.

I will address the issues of other locales in a separate PR.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
