### PR TITLE
Bugfix FXIOS-6211 [v114] Fix status bar overlay for webview

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -589,11 +589,6 @@ class BrowserViewController: UIViewController {
         toolbar = TabToolbar()
         bottomContainer.addArrangedSubview(toolbar)
         view.addSubview(bottomContainer)
-
-        if AppConstants.useCoordinators {
-            // StatusBarOverlay at the back so homepage wallpaper with bottom URL bar can be seen under the status bar
-            view.sendSubviewToBack(statusBarOverlay)
-        }
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -1015,6 +1010,13 @@ class BrowserViewController: UIViewController {
         addChild(viewController)
         contentContainer.add(content: viewController)
         viewController.didMove(toParent: self)
+
+        // Status bar overlay at the back for some content type that need extended content
+        if let type = contentContainer.type, type.needTopContentExtended {
+            view.sendSubviewToBack(statusBarOverlay)
+        } else {
+            view.bringSubviewToFront(statusBarOverlay)
+        }
 
         UIAccessibility.post(notification: UIAccessibility.Notification.screenChanged, argument: nil)
     }

--- a/Client/Frontend/Components/ContentContainer.swift
+++ b/Client/Frontend/Components/ContentContainer.swift
@@ -7,6 +7,16 @@ import UIKit
 enum ContentType {
     case webview
     case homepage
+
+    /// Homepage wallpaper with bottom URL bar can be seen under the status bar, this means we need extended content at the top (unclipped)
+    var needTopContentExtended: Bool {
+        switch self {
+        case .homepage:
+            return true
+        default:
+            return false
+        }
+    }
 }
 
 protocol ContentContainable: UIViewController {
@@ -15,7 +25,7 @@ protocol ContentContainable: UIViewController {
 
 /// A container for view controllers, currently used to embed content in BrowserViewController
 class ContentContainer: UIView {
-    private var type: ContentType?
+    var type: ContentType?
     private var contentController: ContentContainable?
 
     var contentView: UIView? {

--- a/Tests/ClientTests/Frontend/ContentContainerTests.swift
+++ b/Tests/ClientTests/Frontend/ContentContainerTests.swift
@@ -94,4 +94,24 @@ final class ContentContainerTests: XCTestCase {
         subject.add(content: homepage)
         XCTAssertNotNil(subject.contentView)
     }
+
+    func testContentType_needTopContentExtended_trueWithHomepage() {
+        let subject = ContentContainer(frame: .zero)
+        let homepage = HomepageViewController(profile: profile, overlayManager: overlayModeManager)
+        subject.add(content: homepage)
+        XCTAssertTrue(subject.type!.needTopContentExtended)
+    }
+
+    func testContentType_needTopContentExtended_hasNotTypeWhenNil() {
+        let subject = ContentContainer(frame: .zero)
+        XCTAssertNil(subject.type)
+    }
+
+    func testContentType_needTopContentExtended_falseWithWebview() {
+        let subject = ContentContainer(frame: .zero)
+        let webview = WebviewViewController(webView: WKWebView())
+        subject.add(content: webview)
+
+        XCTAssertFalse(subject.type!.needTopContentExtended)
+    }
 }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6211)

### Description
This is kind of a hacky fix. Since we extend content on top of the homepage, I needed to set the `statusBarOverlay` to appear behind the `contentContainer`. In theory, it would have worked since the webview content shouldn't extend as well from it's bounds, but in fact the webview content does extends... I tried to ensure the webview content doesn't extend, but haven't a found a way so far. One fix it then to make sure the `statusBarOverlay` appears on top of the `contentContainer` in the case we're showing the webview.

Otherwise we end up having this problem where content is showing on top of the `contentContainer`:
![image](https://user-images.githubusercontent.com/11338480/233672999-4e0339b4-8820-4b44-98a2-cc71934992a4.png)


### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
