### PR TITLE
Bugfix MTE-892 [v114] Fix Premature Escaping for UI Test Filtering

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -553,13 +553,13 @@ workflows:
         inputs:
         - content: |-
             #!/usr/bin/env bash
-            set -e
+            set -ex
 
             # Manual triggers leave empty commits. 
             # Check for empty commit and exit blacklist check if found to avoid erroring out.
             git log -n 1 origin/main --pretty=format:"%H" && echo "non-empty commit. Continuing Blacklist check..." \
                 || echo "empty commit from manually triggered test detected. Skipping Blacklist check..." && \
-                envman add --key RUN_UI_TESTS --value Run_UI_Tests; exit 0
+                envman add --key RUN_UI_TESTS --value Run_UI_Tests && exit 0
             echo "Commit on origin/main"
             COMMIT_ON_MAIN_ORIGIN=`git log -n 1 origin/main --pretty=format:"%H"` || true
             if [[ ! "failed" == *"$COMMIT_ON_MAIN_ORIGIN"* ]]; then

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -557,10 +557,10 @@ workflows:
 
             # Manual triggers leave empty commits. 
             # Check for empty commit and exit blacklist check if found to avoid erroring out.
-            if git log -n 1 origin/main --pretty=format:"%H"
-            then echo "non-empty commit. Continuing Blacklist check..."
-            else echo "empty commit from manually triggered test detected. Skipping Blacklist check..." && \
-                envman add --key RUN_UI_TESTS --value Run_UI_Tests && exit 0
+            { git log -n 1 origin/main --pretty=format:"%H" && echo "non-empty commit. Continuing Blacklist check..."; } || \
+                { echo "empty commit from manually triggered test detected. Skipping Blacklist check..." && \
+                envman add --key RUN_UI_TESTS --value Run_UI_Tests && exit 0; }
+
             echo "Commit on origin/main"
             COMMIT_ON_MAIN_ORIGIN=`git log -n 1 origin/main --pretty=format:"%H"` || true
             if [[ ! "failed" == *"$COMMIT_ON_MAIN_ORIGIN"* ]]; then

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -557,8 +557,9 @@ workflows:
 
             # Manual triggers leave empty commits. 
             # Check for empty commit and exit blacklist check if found to avoid erroring out.
-            git log -n 1 origin/main --pretty=format:"%H" && echo "non-empty commit. Continuing Blacklist check..." \
-                || echo "empty commit from manually triggered test detected. Skipping Blacklist check..." && \
+            if git log -n 1 origin/main --pretty=format:"%H"
+            then echo "non-empty commit. Continuing Blacklist check..."
+            else echo "empty commit from manually triggered test detected. Skipping Blacklist check..." && \
                 envman add --key RUN_UI_TESTS --value Run_UI_Tests && exit 0
             echo "Commit on origin/main"
             COMMIT_ON_MAIN_ORIGIN=`git log -n 1 origin/main --pretty=format:"%H"` || true


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-892)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/FXIOS-14075)

### Description
The UI SmokeTest Suites are being triggered intermittently when some blacklisted files are changed. These changes shouldn't trigger smoke tests, but sometimes do.

In some cases the `commit change-log` logic is being escaped and needs to be fixed.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
