### PR TITLE
Refactor FXIOS-6230 [v114] Make key parameter specified on MZLocalizedString

### DIFF
--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -26,7 +26,7 @@ public struct Strings {
 ///   - comment: The comment is an explanation aimed towards people that will translate the string value. Make sure it follow
 ///   https://mozilla-l10n.github.io/documentation/localization/dev_best_practices.html#add-localization-notes
 private func MZLocalizedString(
-    _ key: String,
+    key: String,
     tableName: String?,
     value: String?,
     comment: String
@@ -58,22 +58,22 @@ extension String {
     public struct Alerts {
         public struct RestoreTabs {
             public static let Title = MZLocalizedString(
-                "Alerts.RestoreTabs.Title.v109.v2",
+                key: "Alerts.RestoreTabs.Title.v109.v2",
                 tableName: "Alerts",
                 value: "%@ crashed. Restore your tabs?",
                 comment: "The title of the restore tabs pop-up alert. This alert shows when opening up Firefox after it crashed. The placeholder will be the Firefox name.")
             public static let Message = MZLocalizedString(
-                "Alerts.RestoreTabs.Message.v109",
+                key: "Alerts.RestoreTabs.Message.v109",
                 tableName: "Alerts",
                 value: "Sorry about that. Restore tabs to pick up where you left off.",
                 comment: "The body of the restore tabs pop-up alert. This alert shows when opening up Firefox after it crashed.")
             public static let ButtonNo = MZLocalizedString(
-                "Alerts.RestoreTabs.Button.No.v109",
+                key: "Alerts.RestoreTabs.Button.No.v109",
                 tableName: "Alerts",
                 value: "No",
                 comment: "The title for the negative action of the restore tabs pop-up alert. This alert shows when opening up Firefox after it crashed, and will reject the action of restoring tabs.")
             public static let ButtonYes = MZLocalizedString(
-                "Alerts.RestoreTabs.Button.Yes.v109",
+                key: "Alerts.RestoreTabs.Button.Yes.v109",
                 tableName: "Alerts",
                 value: "Restore tabs",
                 comment: "The title for the affirmative action of the restore tabs pop-up alert. This alert shows when opening up Firefox after it crashed, and will restore existing tabs.")
@@ -86,7 +86,7 @@ extension String {
     public struct Biometry {
         public struct Screen {
             public static let UniversalAuthenticationReason = MZLocalizedString(
-                "Biometry.Screen.UniversalAuthenticationReason.v113",
+                key: "Biometry.Screen.UniversalAuthenticationReason.v113",
                 tableName: "BiometricAuthentication",
                 value: "Enter your device passcode",
                 comment: "Biometric authentication is when the system prompts users for Face ID or fingerprint before accessing protected information. This string asks the user to enter their device passcode to access the protected screen.")
@@ -99,7 +99,7 @@ extension String {
     public struct Bookmarks {
         public struct Menu {
             public static let DesktopBookmarks = MZLocalizedString(
-                "Bookmarks.Menu.DesktopBookmarks",
+                key: "Bookmarks.Menu.DesktopBookmarks",
                 tableName: nil,
                 value: "Desktop Bookmarks",
                 comment: "A label indicating all bookmarks grouped under the category 'Desktop Bookmarks'.")
@@ -127,7 +127,7 @@ extension String {
 extension String {
     public struct ContextualHints {
         public static let ContextualHintsCloseAccessibility = MZLocalizedString(
-            "ContextualHintsCloseButtonAccessibility.v105",
+            key: "ContextualHintsCloseButtonAccessibility.v105",
             tableName: nil,
             value: "Close",
             comment: "Accessibility label for action denoting closing contextual hint.")
@@ -135,12 +135,12 @@ extension String {
         public struct FirefoxHomepage {
             public struct JumpBackIn {
                 public static let PersonalizedHome = MZLocalizedString(
-                    "ContextualHints.FirefoxHomepage.JumpBackIn.PersonalizedHome",
+                    key: "ContextualHints.FirefoxHomepage.JumpBackIn.PersonalizedHome",
                     tableName: "JumpBackIn",
                     value: "Meet your personalized homepage. Recent tabs, bookmarks, and search results will appear here.",
                     comment: "Contextual hints are little popups that appear for the users informing them of new features. This one talks about additions to the Firefox homepage regarding a more personalized experience.")
                 public static let SyncedTab = MZLocalizedString(
-                    "ContextualHints.FirefoxHomepage.JumpBackIn.SyncedTab.v106",
+                    key: "ContextualHints.FirefoxHomepage.JumpBackIn.SyncedTab.v106",
                     tableName: "JumpBackIn",
                     value: "Your tabs are syncing! Pick up where you left off on your other device.",
                     comment: "Contextual hints are little popups that appear for the users informing them of new features. When a user is logged in and has a tab synced from desktop, this popup indicates which tab that is within the Jump Back In section.")
@@ -150,12 +150,12 @@ extension String {
         public struct TabsTray {
             public struct InactiveTabs {
                 public static let Action = MZLocalizedString(
-                    "ContextualHints.TabTray.InactiveTabs.CallToAction",
+                    key: "ContextualHints.TabTray.InactiveTabs.CallToAction",
                     tableName: nil,
                     value: "Turn off in settings",
                     comment: "Contextual hints are little popups that appear for the users informing them of new features. This one is the call to action for the inactive tabs contextual popup.")
                 public static let Body = MZLocalizedString(
-                    "ContextualHints.TabTray.InactiveTabs",
+                    key: "ContextualHints.TabTray.InactiveTabs",
                     tableName: nil,
                     value: "Tabs you haven’t viewed for two weeks get moved here.",
                     comment: "Contextual hints are little popups that appear for the users informing them of new features. This one talks about the inactive tabs feature.")
@@ -164,17 +164,17 @@ extension String {
 
         public struct Toolbar {
             public static let SearchBarPlacementButtonText = MZLocalizedString(
-                "ContextualHints.SearchBarPlacement.CallToAction",
+                key: "ContextualHints.SearchBarPlacement.CallToAction",
                 tableName: nil,
                 value: "Toolbar Settings",
                 comment: "Contextual hints are little popups that appear for the users informing them of new features. This one is a call to action for the popup describing search bar placement. It indicates a user can navigate to the settings page that allows them to customize the placement of the search bar.")
             public static let SearchBarTopPlacement = MZLocalizedString(
-                "ContextualHints.Toolbar.Top.Description.v107",
+                key: "ContextualHints.Toolbar.Top.Description.v107",
                 tableName: "ToolbarLocation",
                 value: "Move the toolbar to the bottom if that’s more your style.",
                 comment: "Contextual hints are little popups that appear for the users informing them of new features. This one indicates a user can navigate to the Settings page to move the search bar to the bottom.")
             public static let SearchBarBottomPlacement = MZLocalizedString(
-                "ContextualHints.Toolbar.Bottom.Description.v107",
+                key: "ContextualHints.Toolbar.Bottom.Description.v107",
                 tableName: "ToolbarLocation",
                 value: "Move the toolbar to the top if that’s more your style.",
                 comment: "Contextual hints are little popups that appear for the users informing them of new features. This one indicates a user can navigate to the Settings page to move the search bar to the top.")
@@ -188,52 +188,52 @@ extension String {
         // Settings / Empty State / Keyboard input accessory view
         public struct Settings {
             public static let EmptyListTitle = MZLocalizedString(
-                "CreditCard.Settings.EmptyListTitle.v112",
+                key: "CreditCard.Settings.EmptyListTitle.v112",
                 tableName: "Settings",
                 value: "Save Credit Cards to %@",
                 comment: "Title label for when there are no credit cards shown in credit card list in autofill settings screen. %@ is the product name and should not be altered.")
             public static let EmptyListDescription = MZLocalizedString(
-                "CreditCard.Settings.EmptyListDescription.v112",
+                key: "CreditCard.Settings.EmptyListDescription.v112",
                 tableName: "Settings",
                 value: "Save your card information securely to check out faster next time.",
                 comment: "Description label for when there are no credit cards shown in credit card list in autofill settings screen.")
             public static let RememberThisCard = MZLocalizedString(
-                "CreditCard.Settings.RememberThisCard.v112",
+                key: "CreditCard.Settings.RememberThisCard.v112",
                 tableName: "Settings",
                 value: "Remember this card?",
                 comment: "When a user is in the process or has finished making a purchase with a card not saved in Firefox's list of stored cards, we ask the user if they would like to save this card for future purchases. This string is a title string of the overall message that asks the user if they would like Firefox to remember the card that is being used.")
             public static let Yes = MZLocalizedString(
-                "CreditCard.Settings.Yes.v112",
+                key: "CreditCard.Settings.Yes.v112",
                 tableName: "Settings",
                 value: "Yes",
                 comment: "When a user is in the process or has finished making a purchase with a card not saved in Firefox's list of stored cards, we ask the user if they would like to save this card for future purchases. This string asks users to confirm if they would like Firefox to remember the card that is being used.")
             public static let NotNow = MZLocalizedString(
-                "CreditCard.Settings.NotNow.v112",
+                key: "CreditCard.Settings.NotNow.v112",
                 tableName: "Settings",
                 value: "Not now",
                 comment: "When a user is in the process or has finished making a purchase with a card not saved in Firefox's list of stored cards, we ask the user if they would like to save this card for future purchases. This string indicates to users that they can deny Firefox from remembering the card that is being used.")
             public static let UpdateThisCard = MZLocalizedString(
-                "CreditCard.Settings.UpdateThisCard.v112",
+                key: "CreditCard.Settings.UpdateThisCard.v112",
                 tableName: "Settings",
                 value: "Update this card?",
                 comment: "When a user is in the process or has finished making a purchase with a remembered card, and if the credit card information doesn't match the contents of the stored information of that card, we show this string. We ask this user if they would like Firefox update the staled information of that credit card.")
             public static let ManageCards = MZLocalizedString(
-                "CreditCards.Settings.ManageCards.v112",
+                key: "CreditCards.Settings.ManageCards.v112",
                 tableName: "Settings",
                 value: "Manage cards",
                 comment: "When a user is in the process or has finished making a purchase, and has at least one card saved, we show this tappable string. This indicates to users that they can navigate to their list of stored credit cards in the app's credit card list screen.")
             public static let UseASavedCard = MZLocalizedString(
-                "CreditCards.Settings.UseASavedCard.v112",
+                key: "CreditCards.Settings.UseASavedCard.v112",
                 tableName: "Settings",
                 value: "Use a saved card?",
                 comment: "When a user is in the process of making a purchase, and has at least one saved card, we show this label used as a title. This indicates to the user that there are stored cards available for use on this pending purchase.")
             public static let UseSavedCardFromKeyboard = MZLocalizedString(
-                "CreditCards.Settings.UseSavedCardFromKeyboard.v112",
+                key: "CreditCards.Settings.UseSavedCardFromKeyboard.v112",
                 tableName: "Settings",
                 value: "Use saved card",
                 comment: "When a user is in the process of making a purchase, and has at least one saved card, we show this label inside the keyboard hint. This indicates to the user that there are stored cards available for use on this pending purchase.")
             public static let ListItemA11y = MZLocalizedString(
-                "CreditCard.Settings.ListItemA11y.v112",
+                key: "CreditCard.Settings.ListItemA11y.v112",
                 tableName: "Settings",
                 value: "%1$@ ending in %2$@, issued to %3$@, expires %4$@",
                 comment: "Accessibility label for a credit card list item in autofill settings screen. The first parameter is the credit card type (e.g. Visa). The second parameter is the last 4 digits of the credit card. The third parameter is the name of the credit card holder. The fourth and fifth parameters are the month and year of the credit card's expiration date.")
@@ -242,92 +242,92 @@ extension String {
         // Editing and saving credit card
         public struct EditCard {
             public static let RevealLabel = MZLocalizedString(
-                "CreditCard.EditCard.RevealLabel.v114",
+                key: "CreditCard.EditCard.RevealLabel.v114",
                 tableName: "EditCard",
                 value: "Reveal",
                 comment: "Label for revealing the contents of the credit card number")
             public static let ConcealLabel = MZLocalizedString(
-                "CreditCard.EditCard.ConcealLabel.v114",
+                key: "CreditCard.EditCard.ConcealLabel.v114",
                 tableName: "EditCard",
                 value: "Conceal",
                 comment: "Label for concealing contents of the credit card number")
             public static let CopyLabel = MZLocalizedString(
-                "CreditCard.EditCard.CopyLabel.v113",
+                key: "CreditCard.EditCard.CopyLabel.v113",
                 tableName: "EditCard",
                 value: "Copy",
                 comment: "Label for copying contents of the form")
             public static let CloseNavBarButtonLabel = MZLocalizedString(
-                "CreditCard.EditCard.CloseNavBarButtonLabel.v113",
+                key: "CreditCard.EditCard.CloseNavBarButtonLabel.v113",
                 tableName: "EditCard",
                 value: "Close",
                 comment: "Button label for closing the view where user can view their credit card info")
             public static let SaveNavBarButtonLabel = MZLocalizedString(
-                "CreditCard.EditCard.SaveNavBarButtonLabel.v113",
+                key: "CreditCard.EditCard.SaveNavBarButtonLabel.v113",
                 tableName: "EditCard",
                 value: "Save",
                 comment: "Button label for saving the credit card details user entered in the form")
             public static let EditNavBarButtonLabel = MZLocalizedString(
-                "CreditCard.EditCard.EditNavBarButtonLabel.v113",
+                key: "CreditCard.EditCard.EditNavBarButtonLabel.v113",
                 tableName: "EditCard",
                 value: "Edit",
                 comment: "Button label for editing the credit card details shown in the form")
             public static let CancelNavBarButtonLabel = MZLocalizedString(
-                "CreditCard.EditCard.CancelNavBarButtonLabel.v113",
+                key: "CreditCard.EditCard.CancelNavBarButtonLabel.v113",
                 tableName: "EditCard",
                 value: "Cancel",
                 comment: "Button label for cancelling editing of the credit card details shown in the form")
             public static let ViewCreditCardTitle = MZLocalizedString(
-                "CreditCard.EditCard.ViewCreditCardTitle.v113",
+                key: "CreditCard.EditCard.ViewCreditCardTitle.v113",
                 tableName: "EditCard",
                 value: "View Credit Card",
                 comment: "Title label for the view where user can view their credit card info")
             public static let AddCreditCardTitle = MZLocalizedString(
-                "CreditCard.EditCard.AddCreditCardTitle.v113",
+                key: "CreditCard.EditCard.AddCreditCardTitle.v113",
                 tableName: "EditCard",
                 value: "Add Credit Card",
                 comment: "Title label for the view where user can add their credit card info")
             public static let EditCreditCardTitle = MZLocalizedString(
-                "CreditCard.EditCard.EditCreditCardTitle.v113",
+                key: "CreditCard.EditCard.EditCreditCardTitle.v113",
                 tableName: "Edit Card",
                 value: "Edit Credit Card",
                 comment: "Title label for the view where user can edit their credit card info")
             public static let NameOnCardTitle = MZLocalizedString(
-                "CreditCard.EditCard.NameOnCardTitle.v112",
+                key: "CreditCard.EditCard.NameOnCardTitle.v112",
                 tableName: "EditCard",
                 value: "Name on Card",
                 comment: "Title label for user to input their name printed on their credit card in the text box below.")
             public static let CardNumberTitle = MZLocalizedString(
-                "CreditCard.EditCard.CardNumberTitle.v112",
+                key: "CreditCard.EditCard.CardNumberTitle.v112",
                 tableName: "EditCard",
                 value: "Card Number",
                 comment: "Title label for user to input their credit card number printed on their credit card in the text box below.")
             public static let CardExpirationDateTitle = MZLocalizedString(
-                "CreditCard.EditCard.CardExpirationDateTitle.v112",
+                key: "CreditCard.EditCard.CardExpirationDateTitle.v112",
                 tableName: "EditCard",
                 value: "Expiration MM / YY",
                 comment: "Title label for user to input their credit card Expiration date in the format MM / YY printed on their credit card in the text box below.")
             public static let RemoveCardButtonTitle = MZLocalizedString(
-                "CreditCard.EditCard.RemoveCardButtonTitle.v112",
+                key: "CreditCard.EditCard.RemoveCardButtonTitle.v112",
                 tableName: "EditCard",
                 value: "Remove Card",
                 comment: "Title label for button that allows user to remove their saved credit card.")
             public static let ToggleToAllowAutofillTitle = MZLocalizedString(
-                "CreditCard.EditCard.ToggleToAllowAutofillTitle.v112",
+                key: "CreditCard.EditCard.ToggleToAllowAutofillTitle.v112",
                 tableName: "EditCard",
                 value: "Save and autofill cards",
                 comment: "Title label for user to use the toggle settings to allow saving and autofilling of credit cards for webpages.")
             public static let SavedCardListTitle = MZLocalizedString(
-                "CreditCard.EditCard.SavedCardListTitle.v112",
+                key: "CreditCard.EditCard.SavedCardListTitle.v112",
                 tableName: "EditCard",
                 value: "SAVED CARDS",
                 comment: "Title label for user to pick a credit card from the list below to be updated.")
             public static let ExpiredDateTitle = MZLocalizedString(
-                "CreditCard.EditCard.ExpiredDateTitle.v112",
+                key: "CreditCard.EditCard.ExpiredDateTitle.v112",
                 tableName: "EditCard",
                 value: "Expires %@",
                 comment: "Label for credit card expiration date. The %@ will be replaced by the actual date and thus doesn't need translation.")
             public static let NavButtonSaveTitle = MZLocalizedString(
-                "CreditCard.EditCard.NavButtonSaveTitle.v112",
+                key: "CreditCard.EditCard.NavButtonSaveTitle.v112",
                 tableName: "EditCard",
                 value: "Save",
                 comment: "Button title which, when tapped, will allow the user to save valid credit card details.")
@@ -336,17 +336,17 @@ extension String {
         // Error States for wrong input while editing credit card
         public struct ErrorState {
             public static let NameOnCardSublabel = MZLocalizedString(
-                "CreditCard.ErrorState.NameOnCardSublabel.v112",
+                key: "CreditCard.ErrorState.NameOnCardSublabel.v112",
                 tableName: "ErrorState",
                 value: "Add a name",
                 comment: "Sub label error string that gets shown when user enters incorrect input for their name printed on their credit card in the text box.")
             public static let CardNumberSublabel = MZLocalizedString(
-                "CreditCard.ErrorState.CardNumberSublabel.v112",
+                key: "CreditCard.ErrorState.CardNumberSublabel.v112",
                 tableName: "ErrorState",
                 value: "Enter a valid card number",
                 comment: "Sub label error string that gets shown when user enters incorrect input for their number printed on their credit card in the text box.")
             public static let CardExpirationDateSublabel = MZLocalizedString(
-                "CreditCard.ErrorState.CardExpirationDateSublabel.v112",
+                key: "CreditCard.ErrorState.CardExpirationDateSublabel.v112",
                 tableName: "ErrorState",
                 value: "Enter a valid expiration date",
                 comment: "Sub label error string that gets shown when user enters incorrect input for their expiration date on their credit card in the text box.")
@@ -355,17 +355,17 @@ extension String {
         // Snackbar / toast
         public struct SnackBar {
             public static let SavedCardLabel = MZLocalizedString(
-                "CreditCard.SnackBar.SavedCardLabel.v112",
+                key: "CreditCard.SnackBar.SavedCardLabel.v112",
                 tableName: "SnackBar",
                 value: "New card saved",
                 comment: "Label text that gets presented as a confirmation at the bottom of screen when credit card information gets saved successfully")
             public static let UpdatedCardLabel = MZLocalizedString(
-                "CreditCard.SnackBar.UpdatedCardLabel.v112",
+                key: "CreditCard.SnackBar.UpdatedCardLabel.v112",
                 tableName: "SnackBar",
                 value: "Card information updated",
                 comment: "Label text that gets presented as a confirmation at the bottom of screen when credit card information gets updated successfully")
             public static let RemovedCardLabel = MZLocalizedString(
-                "CreditCard.SnackBar.RemovedCardLabel.v112",
+                key: "CreditCard.SnackBar.RemovedCardLabel.v112",
                 tableName: "SnackBar",
                 value: "Card removed",
                 comment: "Label text that gets presented as a confirmation at the bottom of screen when the credit card is successfully removed.")
@@ -374,25 +374,25 @@ extension String {
         // System alert actions and descriptions
         public struct Alert {
             public static let RemoveCardTitle = MZLocalizedString(
-                "CreditCard.SnackBar.RemoveCardTitle.v112",
+                key: "CreditCard.SnackBar.RemoveCardTitle.v112",
                 tableName: "Alert",
                 value: "Remove This Card?",
                 comment: "Title label for the dialog box that gets presented as a confirmation to ask user if they would like to remove the saved credit card")
 
             public static let RemoveCardSublabel = MZLocalizedString(
-                "CreditCard.SnackBar.RemoveCardSublabel.v112",
+                key: "CreditCard.SnackBar.RemoveCardSublabel.v112",
                 tableName: "Alert",
                 value: "This will remove the card from all of your synced devices.",
                 comment: "Sub label for the dialog box that gets presented as a confirmation to ask user if they would like to remove the saved credit card from local as well as all their synced devices")
 
             public static let CancelRemoveCardButton = MZLocalizedString(
-                "CreditCard.SnackBar.CancelRemoveCardButton.v112",
+                key: "CreditCard.SnackBar.CancelRemoveCardButton.v112",
                 tableName: "Alert",
                 value: "Cancel",
                 comment: "Button text to dismiss the dialog box that gets presented as a confirmation to to remove card and cancel the the operation.")
 
             public static let RemovedCardLabel = MZLocalizedString(
-                "CreditCard.SnackBar.RemovedCardButton.v112",
+                key: "CreditCard.SnackBar.RemovedCardButton.v112",
                 tableName: "Alert",
                 value: "Remove",
                 comment: "Button text to dismiss the dialog box that gets presented as a confirmation to to remove card and perform the operation of removing the credit card.")
@@ -411,7 +411,7 @@ extension String {
     public struct FirefoxHomepage {
         public struct Common {
             public static let PagesCount = MZLocalizedString(
-                "FirefoxHomepage.Common.PagesCount.v112",
+                key: "FirefoxHomepage.Common.PagesCount.v112",
                 tableName: nil,
                 value: "Pages: %d",
                 comment: "Label showing how many pages there is in a search group. %d represents a number")
@@ -419,7 +419,7 @@ extension String {
 
         public struct CustomizeHomepage {
             public static let ButtonTitle = MZLocalizedString(
-                "FirefoxHome.CustomizeHomeButton.Title",
+                key: "FirefoxHome.CustomizeHomeButton.Title",
                 tableName: nil,
                 value: "Customize Homepage",
                 comment: "A button at bottom of the Firefox homepage that, when clicked, takes users straight to the settings options, where they can customize the Firefox Home page")
@@ -428,52 +428,52 @@ extension String {
         public struct HomeTabBanner {
             public struct EvergreenMessage {
                 public static let HomeTabBannerTitle = MZLocalizedString(
-                    "DefaultBrowserCard.Title",
+                    key: "DefaultBrowserCard.Title",
                     tableName: "Default Browser",
                     value: "Switch Your Default Browser",
                     comment: "Title for small home tab banner shown that allows the user to switch their default browser to Firefox.")
                 public static let HomeTabBannerDescription = MZLocalizedString(
-                    "DefaultBrowserCard.Description",
+                    key: "DefaultBrowserCard.Description",
                     tableName: "Default Browser",
                     value: "Set links from websites, emails, and Messages to open automatically in Firefox.",
                     comment: "Description for small home tab banner shown that allows the user to switch their default browser to Firefox.")
                 public static let HomeTabBannerButton = MZLocalizedString(
-                    "DefaultBrowserCard.Button.v2",
+                    key: "DefaultBrowserCard.Button.v2",
                     tableName: "Default Browser",
                     value: "Learn How",
                     comment: "Button string to learn how to set your default browser.")
                 public static let HomeTabBannerCloseAccessibility = MZLocalizedString(
-                    "DefaultBrowserCloseButtonAccessibility.v102",
+                    key: "DefaultBrowserCloseButtonAccessibility.v102",
                     tableName: nil,
                     value: "Close",
                     comment: "Accessibility label for action denoting closing default browser home tab banner.")
                 public static let PeaceOfMindTitle = MZLocalizedString(
-                    "DefaultBrowserCard.PeaceOfMind.Title.v108",
+                    key: "DefaultBrowserCard.PeaceOfMind.Title.v108",
                     tableName: "Default Browser",
                     value: "Firefox Has Privacy Covered",
                     comment: "Title for small home tab banner shown that allows the user to switch their default browser to Firefox.")
                 public static let PeaceOfMindDescription = MZLocalizedString(
-                    "DefaultBrowserCard.PeaceOfMind.Description.v108",
+                    key: "DefaultBrowserCard.PeaceOfMind.Description.v108",
                     tableName: "Default Browser",
                     value: "Firefox blocks 3,000+ trackers per user each month on average. Make us your default browser for privacy peace of mind.",
                     comment: "Description for small home tab banner shown that allows the user to switch their default browser to Firefox.")
                 public static let BetterInternetTitle = MZLocalizedString(
-                    "DefaultBrowserCard.BetterInternet.Title.v108",
+                    key: "DefaultBrowserCard.BetterInternet.Title.v108",
                     tableName: "Default Browser",
                     value: "Default to a Better Internet",
                     comment: "Title for small home tab banner shown that allows the user to switch their default browser to Firefox.")
                 public static let BetterInternetDescription = MZLocalizedString(
-                    "DefaultBrowserCard.BetterInternet.Description.v108",
+                    key: "DefaultBrowserCard.BetterInternet.Description.v108",
                     tableName: "Default Browser",
                     value: "Making Firefox your default browser is a vote for an open, accessible internet.",
                     comment: "Description for small home tab banner shown that allows the user to switch their default browser to Firefox.")
                 public static let NextLevelTitle = MZLocalizedString(
-                    "DefaultBrowserCard.NextLevel.Title.v108",
+                    key: "DefaultBrowserCard.NextLevel.Title.v108",
                     tableName: "Default Browser",
                     value: "Elevate Everyday Browsing",
                     comment: "Title for small home tab banner shown that allows the user to switch their default browser to Firefox.")
                 public static let NextLevelDescription = MZLocalizedString(
-                    "DefaultBrowserCard.NextLevel.Description.v108",
+                    key: "DefaultBrowserCard.NextLevel.Description.v108",
                     tableName: "Default Browser",
                     value: "Choose Firefox as your default browser to make speed, safety, and privacy automatic.",
                     comment: "Description for small home tab banner shown that allows the user to switch their default browser to Firefox.")
@@ -482,22 +482,22 @@ extension String {
 
         public struct JumpBackIn {
             public static let GroupSiteCount = MZLocalizedString(
-                "ActivityStream.JumpBackIn.TabGroup.SiteCount",
+                key: "ActivityStream.JumpBackIn.TabGroup.SiteCount",
                 tableName: nil,
                 value: "Tabs: %d",
                 comment: "On the Firefox homepage in the Jump Back In section, if a Tab group item - a collection of grouped tabs from a related search - exists underneath the search term for the tab group, there will be a subtitle with a number for how many tabs are in that group. The placeholder is for a number. It will read 'Tabs: 5' or similar.")
             public static let SyncedTabTitle = MZLocalizedString(
-                "FirefoxHomepage.JumpBackIn.TabPickup.v104",
+                key: "FirefoxHomepage.JumpBackIn.TabPickup.v104",
                 tableName: nil,
                 value: "Tab pickup",
                 comment: "If a user is signed in, and a sync has been performed to collect their recent tabs from other signed in devices, their most recent tab from another device can now appear in the Jump Back In section. This label specifically points out which cell inside the Jump Back In section shows that synced tab.")
             public static let SyncedTabShowAllButtonTitle = MZLocalizedString(
-                "FirefoxHomepage.JumpBackIn.TabPickup.ShowAll.ButtonTitle.v104",
+                key: "FirefoxHomepage.JumpBackIn.TabPickup.ShowAll.ButtonTitle.v104",
                 tableName: nil,
                 value: "See all synced tabs",
                 comment: "Button title shown for tab pickup on the Firefox homepage in the Jump Back In section.")
             public static let SyncedTabOpenTabA11y = MZLocalizedString(
-                "FirefoxHomepage.JumpBackIn.TabPickup.OpenTab.A11y.v106",
+                key: "FirefoxHomepage.JumpBackIn.TabPickup.OpenTab.A11y.v106",
                 tableName: nil,
                 value: "Open synced tab",
                 comment: "Accessibility action title to open the synced tab for tab pickup on the Firefox homepage in the Jump Back In section.")
@@ -505,22 +505,22 @@ extension String {
 
         public struct Pocket {
             public static let SectionTitle = MZLocalizedString(
-                "FirefoxHome.Pocket.SectionTitle",
+                key: "FirefoxHome.Pocket.SectionTitle",
                 tableName: nil,
                 value: "Thought-Provoking Stories",
                 comment: "This is the title of the Pocket section on Firefox Homepage.")
             public static let DiscoverMore = MZLocalizedString(
-                "FirefoxHome.Pocket.DiscoverMore",
+                key: "FirefoxHome.Pocket.DiscoverMore",
                 tableName: nil,
                 value: "Discover more",
                 comment: "At the end of the Pocket section on the Firefox Homepage, this button appears and indicates tapping it will navigate the user to more Pocket Stories.")
             public static let NumberOfMinutes = MZLocalizedString(
-                "FirefoxHome.Pocket.Minutes.v99",
+                key: "FirefoxHome.Pocket.Minutes.v99",
                 tableName: nil,
                 value: "%d min",
                 comment: "On each Pocket Stories on the Firefox Homepage, this label appears and indicates the number of minutes to read an article. Minutes should be abbreviated due to space constraints. %d represents the number of minutes")
             public static let Sponsored = MZLocalizedString(
-                "FirefoxHomepage.Pocket.Sponsored.v103",
+                key: "FirefoxHomepage.Pocket.Sponsored.v103",
                 tableName: nil,
                 value: "Sponsored",
                 comment: "This string will show under the description on pocket story, indicating that the story is sponsored.")
@@ -530,12 +530,12 @@ extension String {
 
         public struct HistoryHighlights {
             public static let Title = MZLocalizedString(
-                "ActivityStream.RecentHistory.Title",
+                key: "ActivityStream.RecentHistory.Title",
                 tableName: nil,
                 value: "Recently Visited",
                 comment: "Section title label for recently visited websites")
             public static let Remove = MZLocalizedString(
-                "FirefoxHome.RecentHistory.Remove",
+                key: "FirefoxHome.RecentHistory.Remove",
                 tableName: nil,
                 value: "Remove",
                 comment: "When a user taps and holds on an item from the Recently Visited section, this label will appear indicating the option to remove that item.")
@@ -543,7 +543,7 @@ extension String {
 
         public struct Shortcuts {
             public static let Sponsored = MZLocalizedString(
-                "FirefoxHomepage.Shortcuts.Sponsored.v100",
+                key: "FirefoxHomepage.Shortcuts.Sponsored.v100",
                 tableName: nil,
                 value: "Sponsored",
                 comment: "This string will show under a shortcuts tile on the firefox home page, indicating that the tile is a sponsored tile. Space is limited, please keep as short as possible.")
@@ -553,12 +553,12 @@ extension String {
 
         public struct ContextualMenu {
             public static let Settings = MZLocalizedString(
-                "FirefoxHomepage.ContextualMenu.Settings.v101",
+                key: "FirefoxHomepage.ContextualMenu.Settings.v101",
                 tableName: nil,
                 value: "Settings",
                 comment: "The title for the Settings context menu action for sponsored tiles in the Firefox home page shortcuts section. Clicking this brings the users to the Shortcuts Settings.")
             public static let SponsoredContent = MZLocalizedString(
-                "FirefoxHomepage.ContextualMenu.SponsoredContent.v101",
+                key: "FirefoxHomepage.ContextualMenu.SponsoredContent.v101",
                 tableName: nil,
                 value: "Our Sponsors & Your Privacy",
                 comment: "The title for the Sponsored Content context menu action for sponsored tiles in the Firefox home page shortcuts section. Clicking this brings the users to a support page where users can learn more about Sponsored content and how it works.")
@@ -571,164 +571,164 @@ extension String {
     /// Identifiers of all new strings should begin with `Keyboard.Shortcuts.`
     public struct KeyboardShortcuts {
         public static let ActualSize = MZLocalizedString(
-            "Keyboard.Shortcuts.ActualSize",
+            key: "Keyboard.Shortcuts.ActualSize",
             tableName: nil,
             value: "Actual Size",
             comment: "A label indicating the keyboard shortcut of resetting a web page's view to the standard viewing size. This label is displayed in the Discoverability overlay when a user presses the Command key. The Discoverability overlay and shortcut become available only when a user has connected a hardware keyboard to an iPad. See https://drive.google.com/file/d/1gH3tbvDceg7yG5N67NIHS-AXgDgCzBHN/view?usp=sharing for more details.")
         public static let AddBookmark = MZLocalizedString(
-            "Keyboard.Shortcuts.AddBookmark",
+            key: "Keyboard.Shortcuts.AddBookmark",
             tableName: nil,
             value: "Add Bookmark",
             comment: "A label indicating the keyboard shortcut of adding the currently viewing web page as a bookmark. This label is displayed in the Discoverability overlay when a user presses the Command key. The Discoverability overlay and shortcut become available only when a user has connected a hardware keyboard to an iPad. See https://drive.google.com/file/d/1gH3tbvDceg7yG5N67NIHS-AXgDgCzBHN/view?usp=sharing for more details.")
         public static let Back = MZLocalizedString(
-            "Hotkeys.Back.DiscoveryTitle",
+            key: "Hotkeys.Back.DiscoveryTitle",
             tableName: nil,
             value: "Back",
             comment: "A label indicating the keyboard shortcut to navigate backwards, through session history, inside the current tab. This label is displayed in the Discoverability overlay when a user presses the Command key. The Discoverability overlay and shortcut become available only when a user has connected a hardware keyboard to an iPad. See https://drive.google.com/file/d/1gH3tbvDceg7yG5N67NIHS-AXgDgCzBHN/view?usp=sharing for more details.")
         public static let ClearRecentHistory = MZLocalizedString(
-            "Keyboard.Shortcuts.ClearRecentHistory",
+            key: "Keyboard.Shortcuts.ClearRecentHistory",
             tableName: nil,
             value: "Clear Recent History",
             comment: "A label indicating the keyboard shortcut of clearing recent history. This label is displayed in the Discoverability overlay when a user presses the Command key. The Discoverability overlay and shortcut become available only when a user has connected a hardware keyboard to an iPad. See https://drive.google.com/file/d/1gH3tbvDceg7yG5N67NIHS-AXgDgCzBHN/view?usp=sharing for more details.")
         public static let CloseAllTabsInTabTray = MZLocalizedString(
-            "TabTray.CloseAllTabs.KeyCodeTitle",
+            key: "TabTray.CloseAllTabs.KeyCodeTitle",
             tableName: nil,
             value: "Close All Tabs",
             comment: "A label indicating the keyboard shortcut of closing all tabs from the tab tray. This label is displayed inside the Discoverability overlay when a user presses the Command key. The Discoverability overlay and shortcut become available only when a user has connected a hardware keyboard to an iPad. See https://drive.google.com/file/d/1gH3tbvDceg7yG5N67NIHS-AXgDgCzBHN/view?usp=sharing for more details.")
         public static let CloseCurrentTab = MZLocalizedString(
-            "Hotkeys.CloseTab.DiscoveryTitle",
+            key: "Hotkeys.CloseTab.DiscoveryTitle",
             tableName: nil,
             value: "Close Tab",
             comment: "A label indicating the keyboard shortcut of closing the current tab a user is in. This label is displayed inside the Discoverability overlay when a user presses the Command key. The Discoverability overlay and shortcut become available only when a user has connected a hardware keyboard to an iPad. See https://drive.google.com/file/d/1gH3tbvDceg7yG5N67NIHS-AXgDgCzBHN/view?usp=sharing for more details.")
         public static let Find = MZLocalizedString(
-            "Hotkeys.Find.DiscoveryTitle",
+            key: "Hotkeys.Find.DiscoveryTitle",
             tableName: nil,
             value: "Find",
             comment: "A label indicating the keyboard shortcut of finding text a user desires within a page. This label is displayed inside the Discoverability overlay when a user presses the Command key. The Discoverability overlay and shortcut become available only when a user has connected a hardware keyboard to an iPad. See https://drive.google.com/file/d/1gH3tbvDceg7yG5N67NIHS-AXgDgCzBHN/view?usp=sharing for more details.")
         public static let FindAgain = MZLocalizedString(
-            "Keyboard.Shortcuts.FindAgain",
+            key: "Keyboard.Shortcuts.FindAgain",
             tableName: nil,
             value: "Find Again",
             comment: "A label indicating the keyboard shortcut of finding text a user desires within a page again. This label is displayed in the Discoverability overlay when a user presses the Command key. The Discoverability overlay and shortcut become available only when a user has connected a hardware keyboard to an iPad. See https://drive.google.com/file/d/1gH3tbvDceg7yG5N67NIHS-AXgDgCzBHN/view?usp=sharing for more details.")
         public static let Forward = MZLocalizedString(
-            "Hotkeys.Forward.DiscoveryTitle",
+            key: "Hotkeys.Forward.DiscoveryTitle",
             tableName: nil,
             value: "Forward",
             comment: "A label indicating the keyboard shortcut of switching to a subsequent tab. This label is displayed inside the Discoverability overlay when a user presses the Command key. The Discoverability overlay and shortcut become available only when a user has connected a hardware keyboard to an iPad. See https://drive.google.com/file/d/1gH3tbvDceg7yG5N67NIHS-AXgDgCzBHN/view?usp=sharing for more details.")
         public static let NewPrivateTab = MZLocalizedString(
-            "Hotkeys.NewPrivateTab.DiscoveryTitle",
+            key: "Hotkeys.NewPrivateTab.DiscoveryTitle",
             tableName: nil,
             value: "New Private Tab",
             comment: "A label indicating the keyboard shortcut of creating a new private tab. This label is displayed inside the Discoverability overlay when a user presses the Command key. The Discoverability overlay and shortcut become available only when a user has connected a hardware keyboard to an iPad. See https://drive.google.com/file/d/1gH3tbvDceg7yG5N67NIHS-AXgDgCzBHN/view?usp=sharing for more details.")
         public static let NewTab = MZLocalizedString(
-            "Hotkeys.NewTab.DiscoveryTitle",
+            key: "Hotkeys.NewTab.DiscoveryTitle",
             tableName: nil,
             value: "New Tab",
             comment: "A label indicating the keyboard shortcut of creating a new tab. This label is displayed inside the Discoverability overlay when a user presses the Command key. The Discoverability overlay and shortcut become available only when a user has connected a hardware keyboard to an iPad. See https://drive.google.com/file/d/1gH3tbvDceg7yG5N67NIHS-AXgDgCzBHN/view?usp=sharing for more details.")
         public static let NormalBrowsingMode = MZLocalizedString(
-            "Hotkeys.NormalMode.DiscoveryTitle",
+            key: "Hotkeys.NormalMode.DiscoveryTitle",
             tableName: nil,
             value: "Normal Browsing Mode",
             comment: "A label indicating the keyboard shortcut of switching from Private Browsing to Normal Browsing Mode. This label is displayed inside the Discoverability overlay when a user presses the Command key. The Discoverability overlay and shortcut become available only when a user has connected a hardware keyboard to an iPad. See https://drive.google.com/file/d/1gH3tbvDceg7yG5N67NIHS-AXgDgCzBHN/view?usp=sharing for more details.")
         public static let OpenNewTabInTabTray = MZLocalizedString(
-            "TabTray.OpenNewTab.KeyCodeTitle",
+            key: "TabTray.OpenNewTab.KeyCodeTitle",
             tableName: nil,
             value: "Open New Tab",
             comment: "A label indicating the keyboard shortcut of opening a new tab in the tab tray. This label is displayed inside the Discoverability overlay when a user presses the Command key. The Discoverability overlay and shortcut become available only when a user has connected a hardware keyboard to an iPad. See https://drive.google.com/file/d/1gH3tbvDceg7yG5N67NIHS-AXgDgCzBHN/view?usp=sharing for more details.")
         public static let PrivateBrowsingMode = MZLocalizedString(
-            "Hotkeys.PrivateMode.DiscoveryTitle",
+            key: "Hotkeys.PrivateMode.DiscoveryTitle",
             tableName: nil,
             value: "Private Browsing Mode",
             comment: "A label indicating the keyboard shortcut of switching from Normal Browsing mode to Private Browsing Mode. This label is displayed inside the Discoverability overlay when a user presses the Command key. The Discoverability overlay and shortcut become available only when a user has connected a hardware keyboard to an iPad. See https://drive.google.com/file/d/1gH3tbvDceg7yG5N67NIHS-AXgDgCzBHN/view?usp=sharing for more details.")
         public static let ReloadPage = MZLocalizedString(
-            "Hotkeys.Reload.DiscoveryTitle",
+            key: "Hotkeys.Reload.DiscoveryTitle",
             tableName: nil,
             value: "Reload Page",
             comment: "A label indicating the keyboard shortcut of reloading the current page. This label is displayed inside the Discoverability overlay when a user presses the Command key. The Discoverability overlay and shortcut become available only when a user has connected a hardware keyboard to an iPad. See https://drive.google.com/file/d/1gH3tbvDceg7yG5N67NIHS-AXgDgCzBHN/view?usp=sharing for more details.")
         public static let ReloadWithoutCache = MZLocalizedString(
-            "Keyboard.Shortcuts.RefreshWithoutCache.v108",
+            key: "Keyboard.Shortcuts.RefreshWithoutCache.v108",
             tableName: nil,
             value: "Reload Ignoring Cache",
             comment: "A label indicating the keyboard shortcut to reload a tab without it's cache. This label is displayed in the Discoverability overlay when a user presses the Command key. The Discoverability overlay and shortcut become available only when a user has connected a hardware keyboard to an iPad.")
         public static let SelectLocationBar = MZLocalizedString(
-            "Hotkeys.SelectLocationBar.DiscoveryTitle",
+            key: "Hotkeys.SelectLocationBar.DiscoveryTitle",
             tableName: nil,
             value: "Select Location Bar",
             comment: "A label indicating the keyboard shortcut of directly accessing the URL, location, bar. This label is displayed inside the Discoverability overlay when a user presses the Command key. The Discoverability overlay and shortcut become available only when a user has connected a hardware keyboard to an iPad. See https://drive.google.com/file/d/1gH3tbvDceg7yG5N67NIHS-AXgDgCzBHN/view?usp=sharing for more details.")
         public static let Settings = MZLocalizedString(
-            "Keyboard.Shortcuts.Settings",
+            key: "Keyboard.Shortcuts.Settings",
             tableName: nil,
             value: "Settings",
             comment: "A label indicating the keyboard shortcut of opening the application's settings menu. This label is displayed inside the Discoverability overlay when a user presses the Command key. The Discoverability overlay and shortcut become available only when a user has connected a hardware keyboard to an iPad. See https://drive.google.com/file/d/1gH3tbvDceg7yG5N67NIHS-AXgDgCzBHN/view?usp=sharing for more details.")
         public static let ShowBookmarks = MZLocalizedString(
-            "Keyboard.Shortcuts.ShowBookmarks",
+            key: "Keyboard.Shortcuts.ShowBookmarks",
             tableName: nil,
             value: "Show Bookmarks",
             comment: "A label indicating the keyboard shortcut of showing all bookmarks. This label is displayed in the Discoverability overlay when a user presses the Command key. The Discoverability overlay and shortcut become available only when a user has connected a hardware keyboard to an iPad. See https://drive.google.com/file/d/1gH3tbvDceg7yG5N67NIHS-AXgDgCzBHN/view?usp=sharing for more details.")
         public static let ShowDownloads = MZLocalizedString(
-            "Keyboard.Shortcuts.ShowDownloads",
+            key: "Keyboard.Shortcuts.ShowDownloads",
             tableName: nil,
             value: "Show Downloads",
             comment: "A label indcating the keyboard shortcut of showing all downloads. This label is displayed in the Discoverability overlay when a user presses the Command key. The Discoverability overlay and shortcut become available only when a user has connected a hardware keyboard to an iPad. See https://drive.google.com/file/d/1gH3tbvDceg7yG5N67NIHS-AXgDgCzBHN/view?usp=sharing for more details.")
         public static let ShowFirstTab = MZLocalizedString(
-            "Keyboard.Shortcuts.ShowFirstTab",
+            key: "Keyboard.Shortcuts.ShowFirstTab",
             tableName: nil,
             value: "Show First Tab",
             comment: "A label indicating the keyboard shortcut to switch from the current tab to the first tab. This label is displayed in the Discoverability overlay when a user presses the Command key. The Discoverability overlay and shortcut become available only when a user has connected a hardware keyboard to an iPad. See https://drive.google.com/file/d/1gH3tbvDceg7yG5N67NIHS-AXgDgCzBHN/view?usp=sharing for more details.")
         public static let ShowHistory = MZLocalizedString(
-            "Keyboard.Shortcuts.ShowHistory",
+            key: "Keyboard.Shortcuts.ShowHistory",
             tableName: nil,
             value: "Show History",
             comment: "A label indicating the keyboard shortcut of showing all history. This label is displayed in the Discoverability overlay when a user presses the Command key. The Discoverability overlay and shortcut become available only when a user has connected a hardware keyboard to an iPad. See https://drive.google.com/file/d/1gH3tbvDceg7yG5N67NIHS-AXgDgCzBHN/view?usp=sharing for more details.")
         public static let ShowLastTab = MZLocalizedString(
-            "Keyboard.Shortcuts.ShowLastTab",
+            key: "Keyboard.Shortcuts.ShowLastTab",
             tableName: nil,
             value: "Show Last Tab",
             comment: "A label indicating the keyboard shortcut switch from your current tab to the last tab. This label is displayed in the Discoverability overlay when a user presses the Command key. The Discoverability overlay and shortcut become available only when a user has connected a hardware keyboard to an iPad. See https://drive.google.com/file/d/1gH3tbvDceg7yG5N67NIHS-AXgDgCzBHN/view?usp=sharing for more details.")
         public static let ShowNextTab = MZLocalizedString(
-            "Hotkeys.ShowNextTab.DiscoveryTitle",
+            key: "Hotkeys.ShowNextTab.DiscoveryTitle",
             tableName: nil,
             value: "Show Next Tab",
             comment: "A label indicating the keyboard shortcut of switching to a subsequent tab. This label is displayed inside the Discoverability overlay when a user presses the Command key. The Discoverability overlay and shortcut become available only when a user has connected a hardware keyboard to an iPad. See https://drive.google.com/file/d/1gH3tbvDceg7yG5N67NIHS-AXgDgCzBHN/view?usp=sharing for more details.")
         public static let ShowPreviousTab = MZLocalizedString(
-            "Hotkeys.ShowPreviousTab.DiscoveryTitle",
+            key: "Hotkeys.ShowPreviousTab.DiscoveryTitle",
             tableName: nil,
             value: "Show Previous Tab",
             comment: "A label indicating the keyboard shortcut of switching to a tab immediately preceding to the currently selected tab. This label is displayed inside the Discoverability overlay when a user presses the Command key. The Discoverability overlay and shortcut become available only when a user has connected a hardware keyboard to an iPad. See https://drive.google.com/file/d/1gH3tbvDceg7yG5N67NIHS-AXgDgCzBHN/view?usp=sharing for more details.")
         public static let ShowTabTray = MZLocalizedString(
-            "Tab.ShowTabTray.KeyCodeTitle",
+            key: "Tab.ShowTabTray.KeyCodeTitle",
             tableName: nil,
             value: "Show All Tabs",
             comment: "A label indicating the keyboard shortcut of showing the tab tray. This label is displayed inside the Discoverability overlay when a user presses the Command key. The Discoverability overlay and shortcut become available only when a user has connected a hardware keyboard to an iPad. See https://drive.google.com/file/d/1gH3tbvDceg7yG5N67NIHS-AXgDgCzBHN/view?usp=sharing for more details.")
         public static let ZoomIn = MZLocalizedString(
-            "Keyboard.Shortcuts.ZoomIn",
+            key: "Keyboard.Shortcuts.ZoomIn",
             tableName: nil,
             value: "Zoom In",
             comment: "A label indicating the keyboard shortcut of enlarging the view of the current web page. This label is displayed in the Discoverability overlay when a user presses the Command key. The Discoverability overlay and shortcut become available only when a user has connected a hardware keyboard to an iPad. See https://drive.google.com/file/d/1gH3tbvDceg7yG5N67NIHS-AXgDgCzBHN/view?usp=sharing for more details.")
         public static let ZoomOut = MZLocalizedString(
-            "Keyboard.Shortcuts.ZoomOut",
+            key: "Keyboard.Shortcuts.ZoomOut",
             tableName: nil,
             value: "Zoom Out",
             comment: "A label indicating the keyboard shortcut of shrinking the view of the current web page. This label is displayed in the Discoverability overlay when a user presses the Command key. The Discoverability overlay and shortcut become available only when a user has connected a hardware keyboard to an iPad. See https://drive.google.com/file/d/1gH3tbvDceg7yG5N67NIHS-AXgDgCzBHN/view?usp=sharing for more details.")
 
         public struct Sections {
             public static let Bookmarks = MZLocalizedString(
-                "Keyboard.Shortcuts.Section.Bookmark",
+                key: "Keyboard.Shortcuts.Section.Bookmark",
                 tableName: nil,
                 value: "Bookmarks",
                 comment: "A label indicating a grouping of related keyboard shortcuts describing actions a user can do with Bookmarks. This label is displayed inside the Discoverability overlay when a user presses the Command key. The Discoverability overlay and shortcut become available only when a user has connected a hardware keyboard to an iPad. See https://drive.google.com/file/d/1gH3tbvDceg7yG5N67NIHS-AXgDgCzBHN/view?usp=sharing for more details.")
             public static let History = MZLocalizedString(
-                "Keyboard.Shortcuts.Section.History",
+                key: "Keyboard.Shortcuts.Section.History",
                 tableName: nil,
                 value: "History",
                 comment: "A label indicating a grouping of related keyboard shortcuts describing actions a user can do with History. This label is displayed inside the Discoverability overlay when a user presses the Command key. The Discoverability overlay and shortcut become available only when a user has connected a hardware keyboard to an iPad. See https://drive.google.com/file/d/1gH3tbvDceg7yG5N67NIHS-AXgDgCzBHN/view?usp=sharing for more details.")
             public static let Tools = MZLocalizedString(
-                "Keyboard.Shortcuts.Section.Tools",
+                key: "Keyboard.Shortcuts.Section.Tools",
                 tableName: nil,
                 value: "Tools",
                 comment: "A label indicating a grouping of related keyboard shortcuts describing actions a user can do with locally saved items. This label is displayed inside the Discoverability overlay when a user presses the Command key. The Discoverability overlay and shortcut become available only when a user has connected a hardware keyboard to an iPad. See https://drive.google.com/file/d/1gH3tbvDceg7yG5N67NIHS-AXgDgCzBHN/view?usp=sharing for more details.")
             public static let Window = MZLocalizedString(
-                "Keyboard.Shortcuts.Section.Window",
+                key: "Keyboard.Shortcuts.Section.Window",
                 tableName: nil,
                 value: "Window",
                 comment: "A label indicating a grouping of related keyboard shortcuts describing actions a user can take when navigating between their availale set of tabs. This label is displayed inside the Discoverability overlay when a user presses the Command key. The Discoverability overlay and shortcut become available only when a user has connected a hardware keyboard to an iPad. See https://drive.google.com/file/d/1gH3tbvDceg7yG5N67NIHS-AXgDgCzBHN/view?usp=sharing for more details.")
@@ -742,27 +742,27 @@ extension String {
     public struct LibraryPanel {
         public struct Sections {
             public static let Today = MZLocalizedString(
-                "Today",
+                key: "Today",
                 tableName: nil,
                 value: "Today",
                 comment: "This label is meant to signify the section containing a group of items from the current day.")
             public static let Yesterday = MZLocalizedString(
-                "Yesterday",
+                key: "Yesterday",
                 tableName: nil,
                 value: "Yesterday",
                 comment: "This label is meant to signify the section containing a group of items from the past 24 hours.")
             public static let LastWeek = MZLocalizedString(
-                "Last week",
+                key: "Last week",
                 tableName: nil,
                 value: "Last week",
                 comment: "This label is meant to signify the section containing a group of items from the past seven days.")
             public static let LastMonth = MZLocalizedString(
-                "Last month",
+                key: "Last month",
                 tableName: nil,
                 value: "Last month",
                 comment: "This label is meant to signify the section containing a group of items from the past thirty days.")
             public static let Older = MZLocalizedString(
-                "LibraryPanel.Section.Older",
+                key: "LibraryPanel.Section.Older",
                 tableName: nil,
                 value: "Older",
                 comment: "This label is meant to signify the section containing a group of items that are older than thirty days.")
@@ -772,57 +772,57 @@ extension String {
 
         public struct History {
             public static let HistoryPanelClearHistoryButtonTitle = MZLocalizedString(
-                "HistoryPanel.ClearHistoryButtonTitle",
+                key: "HistoryPanel.ClearHistoryButtonTitle",
                 tableName: nil,
                 value: "Clear Recent History…",
                 comment: "Title for button in the history panel to clear recent history")
             public static let SearchHistoryPlaceholder = MZLocalizedString(
-                "LibraryPanel.History.SearchHistoryPlaceholder.v99",
+                key: "LibraryPanel.History.SearchHistoryPlaceholder.v99",
                 tableName: nil,
                 value: "Enter search terms",
                 comment: "In the history panel, users will be able to search terms in their browsing history. This placeholder text inside the search component will indicate that a user can search through their browsing history.")
             public static let NoHistoryResult = MZLocalizedString(
-                "LibraryPanel.History.NoHistoryFound.v99",
+                key: "LibraryPanel.History.NoHistoryFound.v99",
                 tableName: nil,
                 value: "No history found",
                 comment: "In the history panel, users will be able to search terms in their browsing history. This label is shown when there is no results after querying the search terms in the user's history.")
             public static let RecentlyClosedTabs = MZLocalizedString(
-                "LibraryPanel.History.RecentlyClosedTabs.v99",
+                key: "LibraryPanel.History.RecentlyClosedTabs.v99",
                 tableName: nil,
                 value: "Recently Closed Tabs",
                 comment: "In the history panel, this is the title on the button that navigates the user to a screen showing their recently closed tabs.")
             public static let RecentlyClosedTabsButtonTitle = MZLocalizedString(
-                "HistoryPanel.RecentlyClosedTabsButton.Title",
+                key: "HistoryPanel.RecentlyClosedTabsButton.Title",
                 tableName: nil,
                 value: "Recently Closed",
                 comment: "Title for the Recently Closed button in the History Panel")
             public static let SyncedHistory = MZLocalizedString(
-                "LibraryPanel.History.SyncedHistory.v100",
+                key: "LibraryPanel.History.SyncedHistory.v100",
                 tableName: nil,
                 value: "Synced History",
                 comment: "Within the History Panel, users can see the option of viewing their history from synced tabs.")
             public static let ClearHistoryMenuTitle = MZLocalizedString(
-                "LibraryPanel.History.ClearHistoryMenuTitle.v100",
+                key: "LibraryPanel.History.ClearHistoryMenuTitle.v100",
                 tableName: nil,
                 value: "Removes history (including history synced from other devices), cookies and other browsing data.",
                 comment: "Within the History Panel, users can open an action menu to clear recent history.")
             public static let ClearGroupedTabsTitle = MZLocalizedString(
-                "LibraryPanel.History.ClearGroupedTabsTitle.v100",
+                key: "LibraryPanel.History.ClearGroupedTabsTitle.v100",
                 tableName: nil,
                 value: "Delete all sites in %@?",
                 comment: "Within the History Panel, users can delete search group sites history. %@ represents the search group name.")
             public static let ClearGroupedTabsCancel = MZLocalizedString(
-                "LibraryPanel.History.ClearGroupedTabsCancel.v100",
+                key: "LibraryPanel.History.ClearGroupedTabsCancel.v100",
                 tableName: nil,
                 value: "Cancel",
                 comment: "Within the History Panel, users can delete search group sites history. They can cancel this action by pressing a cancel button.")
             public static let ClearGroupedTabsDelete = MZLocalizedString(
-                "LibraryPanel.History.ClearGroupedTabsDelete.v100",
+                key: "LibraryPanel.History.ClearGroupedTabsDelete.v100",
                 tableName: nil,
                 value: "Delete",
                 comment: "Within the History Panel, users can delete search group sites history. They need to confirm the action by pressing the delete button.")
             public static let Delete = MZLocalizedString(
-                "LibraryPanel.History.DeleteGroupedItem.v104",
+                key: "LibraryPanel.History.DeleteGroupedItem.v104",
                 tableName: nil,
                 value: "Delete",
                 comment: "Within the history panel, a user can navigate into a screen with only grouped history items. Within that screen, a user can now swipe to delete a single item in the list. This label informs the user of a deletion action on the item.")
@@ -838,112 +838,112 @@ extension String {
 extension String {
     public struct Onboarding {
         public static let IntroDescriptionPart1 = MZLocalizedString(
-            "Onboarding.IntroDescriptionPart1.v102",
+            key: "Onboarding.IntroDescriptionPart1.v102",
             tableName: nil,
             value: "Indie. Non-profit. For good.",
             comment: "String used to describes what Firefox is on the first onboarding page in our Onboarding screens. Indie means small independant.")
         public static let IntroDescriptionPart2 = MZLocalizedString(
-            "Onboarding.IntroDescriptionPart2.v102",
+            key: "Onboarding.IntroDescriptionPart2.v102",
             tableName: nil,
             value: "Committed to the promise of a better Internet for everyone.",
             comment: "String used to describes what Firefox is on the first onboarding page in our Onboarding screens.")
         public static let IntroAction = MZLocalizedString(
-            "Onboarding.IntroAction.v102",
+            key: "Onboarding.IntroAction.v102",
             tableName: nil,
             value: "Get Started",
             comment: "Describes the action on the first onboarding page in our Onboarding screen. This string will be on a button so user can continue the onboarding.")
         public static let WallpaperTitle = MZLocalizedString(
-            "Onboarding.WallpaperTitle.v102",
+            key: "Onboarding.WallpaperTitle.v102",
             tableName: nil,
             value: "Choose a Firefox Wallpaper",
             comment: "Title for the wallpaper onboarding page in our Onboarding screens. This describes to the user that they can choose different wallpapers.")
         public static let WallpaperAction = MZLocalizedString(
-            "Onboarding.WallpaperAction.v102",
+            key: "Onboarding.WallpaperAction.v102",
             tableName: nil,
             value: "Set Wallpaper",
             comment: "Description for the wallpaper onboarding page in our Onboarding screens. This describes to the user that they can set a wallpaper.")
         public static let LaterAction = MZLocalizedString(
-            "Onboarding.LaterAction.v102",
+            key: "Onboarding.LaterAction.v102",
             tableName: nil,
             value: "Not Now",
             comment: "Describes an action on some of the Onboarding screen, including the wallpaper onboarding screen. This string will be on a button so user can skip that onboarding page.")
         public static let SyncTitle = MZLocalizedString(
-            "Onboarding.SyncTitle.v102",
+            key: "Onboarding.SyncTitle.v102",
             tableName: nil,
             value: "Sync to Stay In Your Flow",
             comment: "Title for the sync onboarding page in our Onboarding screens. The user will be able to setup their Firefox sync account from that screen. 'Stay in the flow' means that a person is fully immersed in an activity. The user will sync with their Firefox sync account to stay connected and immersed in the activity they are doing.")
         public static let SyncDescription = MZLocalizedString(
-            "Onboarding.SyncDescription.v102",
+            key: "Onboarding.SyncDescription.v102",
             tableName: nil,
             value: "Automatically sync tabs and bookmarks across devices for seamless screen-hopping.",
             comment: "Description for the sync onboarding page in our Onboarding screens. The user will be able to setup their Firefox sync account from that screen.")
         public static let SyncAction = MZLocalizedString(
-            "Onboarding.SyncAction.v102",
+            key: "Onboarding.SyncAction.v102",
             tableName: nil,
             value: "Sign Up and Log In",
             comment: "Describes an action on the sync onboarding page in our Onboarding screens. This string will be on a button so user can sign up or login directly in the onboarding.")
         public static let IntroWelcomeTitle = MZLocalizedString(
-            "Onboarding.Welcome.Title.v106",
+            key: "Onboarding.Welcome.Title.v106",
             tableName: nil,
             value: "Welcome to an independent internet",
             comment: "String used to describes the title of what Firefox is on the welcome onboarding page for 106 version in our Onboarding screens.")
         public static let IntroWelcomeDescription = MZLocalizedString(
-            "Onboarding.Welcome.Description.v106",
+            key: "Onboarding.Welcome.Description.v106",
             tableName: nil,
             value: "Firefox puts people over profits and defends your privacy by default.",
             comment: "String used to describes the description of what Firefox is on the welcome onboarding page for 106 version in our Onboarding screens.")
         public static let IntroSyncTitle = MZLocalizedString(
-            "Onboarding.Sync.Title.v106",
+            key: "Onboarding.Sync.Title.v106",
             tableName: nil,
             value: "Hop from phone to laptop and back",
             comment: "String used to describes the title of what Firefox is on the Sync onboarding page for 106 version in our Onboarding screens.")
         public static let IntroSyncDescription = MZLocalizedString(
-            "Onboarding.Sync.Description.v106",
+            key: "Onboarding.Sync.Description.v106",
             tableName: nil,
             value: "Grab tabs and passwords from your other devices to pick up where you left off.",
             comment: "String used to describes the description of what Firefox is on the Sync onboarding page for 106 version in our Onboarding screens.")
         public static let IntroSyncSkipAction = MZLocalizedString(
-            "Onboarding.Sync.Skip.Action.v106",
+            key: "Onboarding.Sync.Skip.Action.v106",
             tableName: nil,
             value: "Skip",
             comment: "String used to describes the option to skip the Sync sign in during onboarding for 106 version in Firefox Onboarding screens.")
         public static let IntroNotificationTitle = MZLocalizedString(
-            "Onboarding.Notification.Title.v112",
+            key: "Onboarding.Notification.Title.v112",
             tableName: "Onboarding",
             value: "Notifications help you do more with %@",
             comment: "String used to describe the title of the notification onboarding page in our Onboarding screens. Placeholder is for the app name.")
         public static let IntroNotificationDescription = MZLocalizedString(
-            "Onboarding.Notification.Description.v112",
+            key: "Onboarding.Notification.Description.v112",
             tableName: "Onboarding",
             value: "Send tabs between your devices and get tips about how to get the most out of %@.",
             comment: "String used to describe the description of the notification onboarding page in our Onboarding screens. Placeholder is for the app name.")
         public static let IntroNotificationContinueAction = MZLocalizedString(
-            "Onboarding.Notification.Continue.Action.v112",
+            key: "Onboarding.Notification.Continue.Action.v112",
             tableName: "Onboarding",
             value: "Continue",
             comment: "String used to describe the option to continue to ask for the notification permission in Firefox Onboarding screens.")
         public static let IntroNotificationSkipAction = MZLocalizedString(
-            "Onboarding.Notification.Skip.Action.v112",
+            key: "Onboarding.Notification.Skip.Action.v112",
             tableName: "Onboarding",
             value: "Not now",
             comment: "String used to describe the option to skip the notification permission in Firefox Onboarding screens.")
         public static let WallpaperSelectorTitle = MZLocalizedString(
-            "Onboarding.Wallpaper.Title.v106",
+            key: "Onboarding.Wallpaper.Title.v106",
             tableName: nil,
             value: "Try a splash of color",
             comment: "Title for the wallpaper onboarding modal displayed on top of the homepage. This describes to the user that they can choose different wallpapers.")
         public static let WallpaperSelectorDescription = MZLocalizedString(
-            "Onboarding.Wallpaper.Description.v106",
+            key: "Onboarding.Wallpaper.Description.v106",
             tableName: nil,
             value: "Choose a wallpaper that speaks to you.",
             comment: "Description for the wallpaper onboarding modal displayed on top of the homepage. This describes to the user that they can choose different wallpapers.")
         public static let ClassicWallpaper = MZLocalizedString(
-            "Onboarding.Wallpaper.Accessibility.Classic.v106",
+            key: "Onboarding.Wallpaper.Accessibility.Classic.v106",
             tableName: nil,
             value: "Classic Wallpaper",
             comment: "Accessibility label for the wallpaper onboarding modal displayed on top of the homepage. This describes to the user that which type of wallpaper they are seeing.")
         public static let LimitedEditionWallpaper = MZLocalizedString(
-            "Onboarding.Wallpaper.Accessibility.LimitedEdition.v106",
+            key: "Onboarding.Wallpaper.Accessibility.LimitedEdition.v106",
             tableName: nil,
             value: "Limited Edition Wallpaper",
             comment: "Accessibility label for the wallpaper onboarding modal displayed on top of the homepage. This describes to the user that which type of wallpaper they are seeing.")
@@ -954,32 +954,32 @@ extension String {
 extension String {
     public struct Upgrade {
         public static let WelcomeTitle = MZLocalizedString(
-            "Upgrade.Welcome.Title.v106",
+            key: "Upgrade.Welcome.Title.v106",
             tableName: nil,
             value: "Welcome to a more personal internet",
             comment: "Title string used to welcome back users in the Upgrade screens. This screen is shown after user upgrades Firefox version.")
         public static let WelcomeDescription = MZLocalizedString(
-            "Upgrade.Welcome.Description.v106",
+            key: "Upgrade.Welcome.Description.v106",
             tableName: nil,
             value: "New colors. New convenience. Same commitment to people over profits.",
             comment: "Description string used to welcome back users in the Upgrade screens. This screen is shown after user upgrades Firefox version.")
         public static let WelcomeAction = MZLocalizedString(
-            "Upgrade.Welcome.Action.v106",
+            key: "Upgrade.Welcome.Action.v106",
             tableName: nil,
             value: "Get Started",
             comment: "Describes the action on the first upgrade page in the Upgrade screen. This string will be on a button so user can continue the Upgrade.")
         public static let SyncSignTitle = MZLocalizedString(
-            "Upgrade.SyncSign.Title.v106",
+            key: "Upgrade.SyncSign.Title.v106",
             tableName: nil,
             value: "Switching screens is easier than ever",
             comment: "Title string used to sign in to sync in the Upgrade screens. This screen is shown after user upgrades Firefox version.")
         public static let SyncSignDescription = MZLocalizedString(
-            "Upgrade.SyncSign.Description.v106",
+            key: "Upgrade.SyncSign.Description.v106",
             tableName: nil,
             value: "Pick up where you left off with tabs from other devices now on your homepage.",
             comment: "Description string used to to sign in to sync in the Upgrade screens. This screen is shown after user upgrades Firefox version.")
         public static let SyncAction = MZLocalizedString(
-            "Upgrade.SyncSign.Action.v106",
+            key: "Upgrade.SyncSign.Action.v106",
             tableName: nil,
             value: "Sign In",
             comment: "Describes an action on the sync upgrade page in our Upgrade screens. This string will be on a button so user can sign up or login directly in the upgrade.")
@@ -995,17 +995,17 @@ extension String {
 extension String {
     public struct ResearchSurface {
         public static let BodyText = MZLocalizedString(
-            "Body.Text.v112",
+            key: "Body.Text.v112",
             tableName: "ResearchSurface",
             value: "Please help make %@ better by taking a short survey.",
             comment: "On the Research Survey popup, the text that explains what the screen is about. Placeholder is for the app name.")
         public static let TakeSurveyButtonLabel = MZLocalizedString(
-            "PrimaryButton.Label.v112",
+            key: "PrimaryButton.Label.v112",
             tableName: "ResearchSurface",
             value: "Take Survey",
             comment: "On the Research Survey popup, the text for the button that, when tapped, will dismiss the popup and take the user to a survey.")
         public static let DismissButtonLabel = MZLocalizedString(
-            "SecondaryButton.Label.v112",
+            key: "SecondaryButton.Label.v112",
             tableName: "ResearchSurface",
             value: "No Thanks",
             comment: "On the Research Survey popup, the text for the button that, when tapped, will dismiss this screen, and the user will not be taken to the survey.")
@@ -1016,17 +1016,17 @@ extension String {
 extension String {
     public struct Search {
         public static let SuggestSectionTitle = MZLocalizedString(
-            "Search.SuggestSectionTitle.v102",
+            key: "Search.SuggestSectionTitle.v102",
             tableName: nil,
             value: "Firefox Suggest",
             comment: "When making a new search from the awesome bar, suggestions appear to the user as they write new letters in their search. Different types of suggestions can appear. This string will be used as a header to separate Firefox suggestions from normal suggestions.")
         public static let EngineSectionTitle = MZLocalizedString(
-            "Search.EngineSection.Title.v108",
+            key: "Search.EngineSection.Title.v108",
             tableName: "SearchHeaderTitle",
             value: "%@ search",
             comment: "When making a new search from the awesome bar, search results appear as the user write new letters in their search. Different sections with results from the selected search engine will appear. This string will be used as a header to separate the selected engine search results from current search query.")
         public static let GoogleEngineSectionTitle = MZLocalizedString(
-            "Search.Google.Title.v108",
+            key: "Search.Google.Title.v108",
             tableName: "SearchHeaderTitle",
             value: "Google Search",
             comment: "When making a new search from the awesome bar, search results appear as the user write new letters in their search. This string will be used as a header for Google search results listed as suggestions.")
@@ -1038,7 +1038,7 @@ extension String {
     public struct Settings {
         public struct About {
             public static let RateOnAppStore = MZLocalizedString(
-                "Ratings.Settings.RateOnAppStore",
+                key: "Ratings.Settings.RateOnAppStore",
                 tableName: nil,
                 value: "Rate on App Store",
                 comment: "A label indicating the action that a user can rate the Firefox app in the App store.")
@@ -1046,7 +1046,7 @@ extension String {
 
         public struct SectionTitles {
             public static let TabsTitle = MZLocalizedString(
-                "Settings.Tabs.Title",
+                key: "Settings.Tabs.Title",
                 tableName: nil,
                 value: "Tabs",
                 comment: "In the settings menu, this is the title for the Tabs customization section option")
@@ -1055,7 +1055,7 @@ extension String {
         public struct Homepage {
             public struct Current {
                 public static let Description = MZLocalizedString(
-                    "Settings.Home.Current.Description.v101",
+                    key: "Settings.Home.Current.Description.v101",
                     tableName: nil,
                     value: "Choose what displays as the homepage.",
                     comment: "This is the description below the settings section located in the menu under customize current homepage. It describes what the options in the section are for.")
@@ -1063,47 +1063,47 @@ extension String {
 
             public struct CustomizeFirefoxHome {
                 public static let JumpBackIn = MZLocalizedString(
-                    "Settings.Home.Option.JumpBackIn",
+                    key: "Settings.Home.Option.JumpBackIn",
                     tableName: nil,
                     value: "Jump Back In",
                     comment: "In the settings menu, in the Firefox homepage customization section, this is the title for the option that allows users to toggle the Jump Back In section on homepage on or off")
                 public static let RecentlyVisited = MZLocalizedString(
-                    "Settings.Home.Option.RecentlyVisited",
+                    key: "Settings.Home.Option.RecentlyVisited",
                     tableName: nil,
                     value: "Recently Visited",
                     comment: "In the settings menu, in the Firefox homepage customization section, this is the title for the option that allows users to toggle Recently Visited section on the Firfox homepage on or off")
                 public static let RecentlySaved = MZLocalizedString(
-                    "Settings.Home.Option.RecentlySaved",
+                    key: "Settings.Home.Option.RecentlySaved",
                     tableName: nil,
                     value: "Recently Saved",
                     comment: "In the settings menu, in the Firefox homepage customization section, this is the title for the option that allows users to toggle Recently Saved section on the Firefox homepage on or off")
                 public static let Shortcuts = MZLocalizedString(
-                    "Settings.Home.Option.Shortcuts",
+                    key: "Settings.Home.Option.Shortcuts",
                     tableName: nil,
                     value: "Shortcuts",
                     comment: "In the settings menu, in the Firefox homepage customization section, this is the title for the option that allows users to toggle Shortcuts section on the Firefox homepage on or off")
                 public static let Pocket = MZLocalizedString(
-                    "Settings.Home.Option.Pocket",
+                    key: "Settings.Home.Option.Pocket",
                     tableName: nil,
                     value: "Recommended by Pocket",
                     comment: "In the settings menu, in the Firefox homepage customization section, this is the title for the option that allows users to turn the Pocket Recommendations section on the Firefox homepage on or off")
                 public static let SponsoredPocket = MZLocalizedString(
-                    "Settings.Home.Option.SponsoredPocket.v103",
+                    key: "Settings.Home.Option.SponsoredPocket.v103",
                     tableName: nil,
                     value: "Sponsored stories",
                     comment: "In the settings menu, in the Firefox homepage customization section, this is the title for the option that allows users to turn the Pocket Sponsored Stories on the Firefox homepage on or off")
                 public static let Title = MZLocalizedString(
-                    "Settings.Home.Option.Title.v101",
+                    key: "Settings.Home.Option.Title.v101",
                     tableName: nil,
                     value: "Include on Homepage",
                     comment: "In the settings menu, this is the title of the Firefox Homepage customization settings section")
                 public static let Description = MZLocalizedString(
-                    "Settings.Home.Option.Description.v101",
+                    key: "Settings.Home.Option.Description.v101",
                     tableName: nil,
                     value: "Choose what’s included on the Firefox homepage.",
                     comment: "In the settings menu, on the Firefox homepage customization section, this is the description below the section, describing what the options in the section are for.")
                 public static let Wallpaper = MZLocalizedString(
-                    "Settings.Home.Option.Wallpaper",
+                    key: "Settings.Home.Option.Wallpaper",
                     tableName: nil,
                     value: "Wallpaper",
                     comment: "In the settings menu, on the Firefox homepage customization section, this is the title for the option that allows users to access the wallpaper settings for the application.")
@@ -1111,42 +1111,42 @@ extension String {
 
             public struct Shortcuts {
                 public static let RowSettingFooter = MZLocalizedString(
-                    "ActivityStream.TopSites.RowSettingFooter",
+                    key: "ActivityStream.TopSites.RowSettingFooter",
                     tableName: nil,
                     value: "Set Rows",
                     comment: "The title for the setting page which lets you select the number of top site rows")
                 public static let ToggleOn = MZLocalizedString(
-                    "Settings.Homepage.Shortcuts.ToggleOn.v100",
+                    key: "Settings.Homepage.Shortcuts.ToggleOn.v100",
                     tableName: nil,
                     value: "On",
                     comment: "Toggled ON to show the shortcuts section")
                 public static let ToggleOff = MZLocalizedString(
-                    "Settings.Homepage.Shortcuts.ToggleOff.v100",
+                    key: "Settings.Homepage.Shortcuts.ToggleOff.v100",
                     tableName: nil,
                     value: "Off",
                     comment: "Toggled OFF to hide the shortcuts section")
                 public static let ShortcutsPageTitle = MZLocalizedString(
-                    "Settings.Homepage.Shortcuts.ShortcutsPageTitle.v100",
+                    key: "Settings.Homepage.Shortcuts.ShortcutsPageTitle.v100",
                     tableName: nil,
                     value: "Shortcuts",
                     comment: "Users can disable or enable shortcuts related settings. This string is the title of the page to change your shortcuts settings.")
                 public static let ShortcutsToggle = MZLocalizedString(
-                    "Settings.Homepage.Shortcuts.ShortcutsToggle.v100",
+                    key: "Settings.Homepage.Shortcuts.ShortcutsToggle.v100",
                     tableName: nil,
                     value: "Shortcuts",
                     comment: "This string is the title of the toggle to disable the shortcuts section in the settings page.")
                 public static let SponsoredShortcutsToggle = MZLocalizedString(
-                    "Settings.Homepage.Shortcuts.SponsoredShortcutsToggle.v100",
+                    key: "Settings.Homepage.Shortcuts.SponsoredShortcutsToggle.v100",
                     tableName: nil,
                     value: "Sponsored Shortcuts",
                     comment: "This string is the title of the toggle to disable the sponsored shortcuts functionnality which can be enabled in the shortcut sections. This toggle is in the settings page.")
                 public static let Rows = MZLocalizedString(
-                    "Settings.Homepage.Shortcuts.Rows.v100",
+                    key: "Settings.Homepage.Shortcuts.Rows.v100",
                     tableName: nil,
                     value: "Rows",
                     comment: "This string is the title of the setting button which can be clicked to open a page to customize the number of rows in the shortcuts section")
                 public static let RowsPageTitle = MZLocalizedString(
-                    "Settings.Homepage.Shortcuts.RowsPageTitle.v100",
+                    key: "Settings.Homepage.Shortcuts.RowsPageTitle.v100",
                     tableName: nil,
                     value: "Rows",
                     comment: "This string is the title of the page to customize the number of rows in the shortcuts section")
@@ -1154,27 +1154,27 @@ extension String {
 
             public struct StartAtHome {
                 public static let SectionTitle = MZLocalizedString(
-                    "Settings.Home.Option.StartAtHome.Title",
+                    key: "Settings.Home.Option.StartAtHome.Title",
                     tableName: nil,
                     value: "Opening screen",
                     comment: "Title for the section in the settings menu where users can configure the behaviour of the Start at Home feature on the Firefox Homepage.")
                 public static let SectionDescription = MZLocalizedString(
-                    "Settings.Home.Option.StartAtHome.Description",
+                    key: "Settings.Home.Option.StartAtHome.Description",
                     tableName: nil,
                     value: "Choose what you see when you return to Firefox.",
                     comment: "In the settings menu, in the Start at Home customization options, this is text that appears below the section, describing what the section settings do.")
                 public static let AfterFourHours = MZLocalizedString(
-                    "Settings.Home.Option.StartAtHome.AfterFourHours",
+                    key: "Settings.Home.Option.StartAtHome.AfterFourHours",
                     tableName: nil,
                     value: "Homepage after four hours of inactivity",
                     comment: "In the settings menu, on the Start at Home homepage customization option, this allows users to set this setting to return to the Homepage after four hours of inactivity.")
                 public static let Always = MZLocalizedString(
-                    "Settings.Home.Option.StartAtHome.Always",
+                    key: "Settings.Home.Option.StartAtHome.Always",
                     tableName: nil,
                     value: "Homepage",
                     comment: "In the settings menu, on the Start at Home homepage customization option, this allows users to set this setting to return to the Homepage every time they open up Firefox")
                 public static let Never = MZLocalizedString(
-                    "Settings.Home.Option.StartAtHome.Never",
+                    key: "Settings.Home.Option.StartAtHome.Never",
                     tableName: nil,
                     value: "Last tab",
                     comment: "In the settings menu, on the Start at Home homepage customization option, this allows users to set this setting to return to the last tab they were on, every time they open up Firefox")
@@ -1182,53 +1182,53 @@ extension String {
 
             public struct Wallpaper {
                 public static let PageTitle = MZLocalizedString(
-                    "Settings.Home.Option.Wallpaper.Title",
+                    key: "Settings.Home.Option.Wallpaper.Title",
                     tableName: nil,
                     value: "Wallpaper",
                     comment: "In the settings menu, on the Firefox wallpaper customization screen, this is the title of that screen, which allows users to change the wallpaper settings for the application.")
                 public static let CollectionTitle = MZLocalizedString(
-                    "Settings.Home.Option.Wallpaper.CollectionTitle",
+                    key: "Settings.Home.Option.Wallpaper.CollectionTitle",
                     tableName: nil,
                     value: "OPENING SCREEN",
                     comment: "In the settings menu, on the Firefox wallpaper customization screen, this is the title of the section that allows users to change the wallpaper settings for the application.")
                 public static let SwitchTitle = MZLocalizedString(
-                    "Settings.Home.Option.Wallpaper.SwitchTitle.v99",
+                    key: "Settings.Home.Option.Wallpaper.SwitchTitle.v99",
                     tableName: nil,
                     value: "Change wallpaper by tapping Firefox homepage logo",
                     comment: "In the settings menu, on the Firefox wallpaper customization screen, this is the string titling the switch button's function, which allows a user to toggle wallpaper switching from the homepage logo on or off.")
                 public static let WallpaperUpdatedToastLabel = MZLocalizedString(
-                    "Settings.Home.Option.Wallpaper.UpdatedToast",
+                    key: "Settings.Home.Option.Wallpaper.UpdatedToast",
                     tableName: nil,
                     value: "Wallpaper Updated!",
                     comment: "In the settings menu, on the Firefox wallpaper customization screen, this is the title of toast that comes up when the user changes wallpaper, which lets them know that the wallpaper has been updated.")
                 public static let WallpaperUpdatedToastButton = MZLocalizedString(
-                    "Settings.Home.Option.Wallpaper.UpdatedToastButton",
+                    key: "Settings.Home.Option.Wallpaper.UpdatedToastButton",
                     tableName: nil,
                     value: "View",
                     comment: "In the settings menu, on the Firefox wallpaper customization screen, this is the title of the button found on the toast that comes up once the user changes wallpaper, and allows users to dismiss the settings page. In this case, consider View as a verb - the action of dismissing settings and seeing the wallpaper.")
 
                 public static let ClassicWallpaper = MZLocalizedString(
-                    "Settings.Home.Option.Wallpaper.Classic.Title.v106",
+                    key: "Settings.Home.Option.Wallpaper.Classic.Title.v106",
                     tableName: nil,
                     value: "Classic %@",
                     comment: "In the settings menu, on the Firefox wallpaper customization screen, this is the title of the group of wallpapers that are always available to the user. The %@ will be replaced by the app name and thus doesn't need translation.")
                 public static let LimitedEditionWallpaper = MZLocalizedString(
-                    "Settings.Home.Option.Wallpaper.LimitedEdition.Title.v106",
+                    key: "Settings.Home.Option.Wallpaper.LimitedEdition.Title.v106",
                     tableName: nil,
                     value: "Limited Edition",
                     comment: "In the settings menu, on the Firefox wallpaper customization screen, this is the title of the group of wallpapers that are seasonally available to the user.")
                 public static let IndependentVoicesDescription = MZLocalizedString(
-                    "Settings.Home.Option.Wallpaper.LimitedEdition.IndependentVoices.Description.v106",
+                    key: "Settings.Home.Option.Wallpaper.LimitedEdition.IndependentVoices.Description.v106",
                     tableName: nil,
                     value: "The new Independent Voices collection.",
                     comment: "In the settings menu, on the Firefox wallpaper customization screen, this is the description of the group of wallpapers that are seasonally available to the user.")
                 public static let LimitedEditionDefaultDescription = MZLocalizedString(
-                    "Settings.Home.Option.Wallpaper.LimitedEdition.Default.Description.v106",
+                    key: "Settings.Home.Option.Wallpaper.LimitedEdition.Default.Description.v106",
                     tableName: nil,
                     value: "Try the new collection.",
                     comment: "In the settings menu, on the Firefox wallpaper customization screen, this is the default description of the group of wallpapers that are seasonally available to the user.")
                 public static let LearnMoreButton = MZLocalizedString(
-                    "Settings.Home.Option.Wallpaper.LearnMore.v106",
+                    key: "Settings.Home.Option.Wallpaper.LearnMore.v106",
                     tableName: nil,
                     value: "Learn more",
                     comment: "In the settings menu, on the Firefox wallpaper customization screen, this is the button title of the group of wallpapers that are seasonally available to the user.")
@@ -1236,42 +1236,42 @@ extension String {
                 // Accessibility
                 public struct AccessibilityLabels {
                     public static let FxHomepageWallpaperButton = MZLocalizedString(
-                        "FxHomepage.Wallpaper.ButtonLabel.v99",
+                        key: "FxHomepage.Wallpaper.ButtonLabel.v99",
                         tableName: nil,
                         value: "Firefox logo, change the wallpaper.",
                         comment: "On the firefox homepage, the string read by the voice over prompt for accessibility, for the button which changes the wallpaper")
                     public static let ToggleButton = MZLocalizedString(
-                        "Settings.Home.Option.Wallpaper.Accessibility.ToggleButton",
+                        key: "Settings.Home.Option.Wallpaper.Accessibility.ToggleButton",
                         tableName: nil,
                         value: "Homepage wallpaper cycle toggle",
                         comment: "In the settings menu, on the Firefox wallpaper customization screen, this is the accessibility string of the toggle for turning wallpaper cycling shortcut on or off on the homepage.")
                     public static let DefaultWallpaper = MZLocalizedString(
-                        "Settings.Home.Option.Wallpaper.Accessibility.DefaultWallpaper.v99",
+                        key: "Settings.Home.Option.Wallpaper.Accessibility.DefaultWallpaper.v99",
                         tableName: nil,
                         value: "Default clear wallpaper.",
                         comment: "In the settings menu, on the Firefox wallpaper customization screen, this is the accessibility string for the default wallpaper.")
                     public static let FxAmethystWallpaper = MZLocalizedString(
-                        "Settings.Home.Option.Wallpaper.Accessibility.AmethystWallpaper.v99",
+                        key: "Settings.Home.Option.Wallpaper.Accessibility.AmethystWallpaper.v99",
                         tableName: nil,
                         value: "Firefox wallpaper, amethyst pattern.",
                         comment: "In the settings menu, on the Firefox wallpaper customization screen, this is the accessibility string for the amethyst firefox wallpaper.")
                     public static let FxSunriseWallpaper = MZLocalizedString(
-                        "Settings.Home.Option.Wallpaper.Accessibility.SunriseWallpaper.v99",
+                        key: "Settings.Home.Option.Wallpaper.Accessibility.SunriseWallpaper.v99",
                         tableName: nil,
                         value: "Firefox wallpaper, sunrise pattern.",
                         comment: "In the settings menu, on the Firefox wallpaper customization screen, this is the title accessibility string for the sunrise firefox wallpaper.")
                     public static let FxCeruleanWallpaper = MZLocalizedString(
-                        "Settings.Home.Option.Wallpaper.Accessibility.CeruleanWallpaper.v99",
+                        key: "Settings.Home.Option.Wallpaper.Accessibility.CeruleanWallpaper.v99",
                         tableName: nil,
                         value: "Firefox wallpaper, cerulean pattern.",
                         comment: "In the settings menu, on the Firefox wallpaper customization screen, this is the title accessibility string for the cerulean firefox wallpaper.")
                     public static let FxBeachHillsWallpaper = MZLocalizedString(
-                        "Settings.Home.Option.Wallpaper.Accessibility.BeachHillsWallpaper.v100",
+                        key: "Settings.Home.Option.Wallpaper.Accessibility.BeachHillsWallpaper.v100",
                         tableName: nil,
                         value: "Firefox wallpaper, beach hills pattern.",
                         comment: "In the settings menu, on the Firefox wallpaper customization screen, this is the title accessibility string for the beach hills firefox wallpaper.")
                     public static let FxTwilightHillsWallpaper = MZLocalizedString(
-                        "Settings.Home.Option.Wallpaper.Accessibility.TwilightHillsWallpaper.v100",
+                        key: "Settings.Home.Option.Wallpaper.Accessibility.TwilightHillsWallpaper.v100",
                         tableName: nil,
                         value: "Firefox wallpaper, twilight hills pattern.",
                         comment: "In the settings menu, on the Firefox wallpaper customization screen, this is the title accessibility string for the twilight hills firefox wallpaper.")
@@ -1281,22 +1281,22 @@ extension String {
 
         public struct Tabs {
             public static let TabsSectionTitle = MZLocalizedString(
-                "Settings.Tabs.CustomizeTabsSection.Title",
+                key: "Settings.Tabs.CustomizeTabsSection.Title",
                 tableName: nil,
                 value: "Customize Tab Tray",
                 comment: "In the settings menu, in the Tabs customization section, this is the title for the Tabs Tray customization section. The tabs tray is accessed from firefox hompage")
             public static let InactiveTabs = MZLocalizedString(
-                "Settings.Tabs.CustomizeTabsSection.InactiveTabs",
+                key: "Settings.Tabs.CustomizeTabsSection.InactiveTabs",
                 tableName: nil,
                 value: "Inactive Tabs",
                 comment: "This is the description for the setting that toggles the Inactive Tabs feature in the settings menu under the Tabs customization section. Inactive tabs are a separate section of tabs that appears in the Tab Tray, which can be enabled or not")
             public static let InactiveTabsDescription = MZLocalizedString(
-                "Settings.Tabs.CustomizeTabsSection.InactiveTabsDescription.v101",
+                key: "Settings.Tabs.CustomizeTabsSection.InactiveTabsDescription.v101",
                 tableName: nil,
                 value: "Tabs you haven’t viewed for two weeks get moved to the inactive section.",
                 comment: "This is the description for the setting that toggles the Inactive Tabs feature in the settings menu under the Tabs customization section. Inactive tabs are a separate section of tabs that appears in the Tab Tray, which can be enabled or not")
             public static let TabGroups = MZLocalizedString(
-                "Settings.Tabs.CustomizeTabsSection.TabGroups",
+                key: "Settings.Tabs.CustomizeTabsSection.TabGroups",
                 tableName: nil,
                 value: "Tab Groups",
                 comment: "In the settings menu, in the Tabs customization section, this is the title for the setting that toggles the Tab Groups feature - where tabs from related searches are grouped - on or off")
@@ -1304,49 +1304,49 @@ extension String {
 
         public struct Notifications {
             public static let Title = MZLocalizedString(
-                "Settings.Notifications.Title.v112",
+                key: "Settings.Notifications.Title.v112",
                 tableName: "Settings",
                 value: "Notifications",
                 comment: "In the settings menu, in the Privacy section, this is the title for Notifications customization section."
             )
             public static let SyncNotificationsTitle = MZLocalizedString(
-                "Settings.Notifications.SyncNotificationsTitle.v112",
+                key: "Settings.Notifications.SyncNotificationsTitle.v112",
                 tableName: "Settings",
                 value: "Sync",
                 comment: "This is the title for the setting that toggles Sync related notifications in the settings menu under the Notifications section."
             )
             public static let SyncNotificationsStatus = MZLocalizedString(
-                "Settings.Notifications.SyncNotificationsStatus.v112",
+                key: "Settings.Notifications.SyncNotificationsStatus.v112",
                 tableName: "Settings",
                 value: "This must be turned on to receive tabs and get notified when you sign in on another device.",
                 comment: "This is the description for the setting that toggles Sync related notifications in the settings menu under the Notifications section."
             )
             public static let TipsAndFeaturesNotificationsTitle = MZLocalizedString(
-                "Settings.Notifications.TipsAndFeaturesNotificationsTitle.v112",
+                key: "Settings.Notifications.TipsAndFeaturesNotificationsTitle.v112",
                 tableName: "Settings",
                 value: "Tips and Features",
                 comment: "This is the title for the setting that toggles Tips and Features feature in the settings menu under the Notifications section."
             )
             public static let TipsAndFeaturesNotificationsStatus = MZLocalizedString(
-                "Settings.Notifications.TipsAndFeaturesNotificationsStatus.v112",
+                key: "Settings.Notifications.TipsAndFeaturesNotificationsStatus.v112",
                 tableName: "Settings",
                 value: "Learn about useful features and how to get the most out of %@.",
                 comment: "This is the description for the setting that toggles Tips and Features feature in the settings menu under the Notifications section. The placeholder will be replaced with the app name."
             )
             public static let TurnOnNotificationsTitle = MZLocalizedString(
-                "Settings.Notifications.TurnOnNotificationsTitle.v112",
+                key: "Settings.Notifications.TurnOnNotificationsTitle.v112",
                 tableName: "Settings",
                 value: "Turn on Notifications",
                 comment: "This is the title informing the user needs to turn on notifications in iOS Settings."
             )
             public static let TurnOnNotificationsMessage = MZLocalizedString(
-                "Settings.Notifications.TurnOnNotificationsMessage.v112",
+                key: "Settings.Notifications.TurnOnNotificationsMessage.v112",
                 tableName: "Settings",
                 value: "Go to your device Settings to turn on notifications in %@",
                 comment: "This is the title informing the user needs to turn on notifications in iOS Settings. The placeholder will be replaced with the app name."
             )
             public static let systemNotificationsDisabledMessage = MZLocalizedString(
-                "Settings.Notifications.SystemNotificationsDisabledMessage.v112",
+                key: "Settings.Notifications.SystemNotificationsDisabledMessage.v112",
                 tableName: "Settings",
                 value: "You turned off all %@ notifications. Turn them on by going to device Settings > Notifications > %@",
                 comment: "This is the footer title informing the user needs to turn on notifications in iOS Settings. Both placeholders will be replaced with the app name."
@@ -1355,17 +1355,17 @@ extension String {
 
         public struct Toolbar {
             public static let Toolbar = MZLocalizedString(
-                "Settings.Toolbar.SettingsTitle",
+                key: "Settings.Toolbar.SettingsTitle",
                 tableName: nil,
                 value: "Toolbar",
                 comment: "In the settings menu, this label indicates that there is an option of customizing the Toolbar appearance.")
             public static let Top = MZLocalizedString(
-                "Settings.Toolbar.Top",
+                key: "Settings.Toolbar.Top",
                 tableName: nil,
                 value: "Top",
                 comment: "In the settings menu, in the Toolbar customization section, this label indicates that selecting this will make the toolbar appear at the top of the screen.")
             public static let Bottom = MZLocalizedString(
-                "Settings.Toolbar.Bottom",
+                key: "Settings.Toolbar.Bottom",
                 tableName: nil,
                 value: "Bottom",
                 comment: "In the settings menu, in the Toolbar customization section, this label indicates that selecting this will make the toolbar appear at the bottom of the screen.")
@@ -1373,7 +1373,7 @@ extension String {
 
         public struct Toggle {
             public static let NoImageMode = MZLocalizedString(
-                "Settings.NoImageModeBlockImages.Label.v99",
+                key: "Settings.NoImageModeBlockImages.Label.v99",
                 tableName: nil,
                 value: "Block Images",
                 comment: "Label for the block images toggle displayed in the settings menu. Enabling this toggle will hide images on any webpage the user visits.")
@@ -1381,22 +1381,22 @@ extension String {
 
         public struct Passwords {
             public static let Title = MZLocalizedString(
-                "Settings.Passwords.Title.v103",
+                key: "Settings.Passwords.Title.v103",
                 tableName: nil,
                 value: "Passwords",
                 comment: "Title for the passwords screen.")
             public static let SavePasswords = MZLocalizedString(
-                "Settings.Passwords.SavePasswords.v103",
+                key: "Settings.Passwords.SavePasswords.v103",
                 tableName: nil,
                 value: "Save Passwords",
                 comment: "Setting that appears in the Passwords screen to enable the built-in password manager so users can save their passwords.")
             public static let OnboardingMessage = MZLocalizedString(
-                "Settings.Passwords.OnboardingMessage.v103",
+                key: "Settings.Passwords.OnboardingMessage.v103",
                 tableName: nil,
                 value: "Your passwords are now protected by Face ID, Touch ID or a device passcode.",
                 comment: "Message shown when you enter Passwords screen for the first time. It explains how password are protected in the Firefox for iOS application.")
             public static let FingerPrintReason = MZLocalizedString(
-                "Settings.Passwords.FingerPrintReason.v103",
+                key: "Settings.Passwords.FingerPrintReason.v103",
                 tableName: nil,
                 value: "Use your fingerprint to access passwords now.",
                 comment: "Touch ID prompt subtitle when accessing logins and passwords")
@@ -1404,19 +1404,19 @@ extension String {
 
         public struct Sync {
             public static let ButtonTitle = MZLocalizedString(
-                "Settings.Sync.ButtonTitle.v103",
+                key: "Settings.Sync.ButtonTitle.v103",
                 tableName: nil,
                 value: "Sync and Save Data",
                 comment: "Button label that appears in the settings to prompt the user to sign in to Firefox for iOS sync service to sync and save data.")
             public static let ButtonDescription = MZLocalizedString(
-                "Settings.Sync.ButtonDescription.v103",
+                key: "Settings.Sync.ButtonDescription.v103",
                 tableName: nil,
                 value: "Sign in to sync tabs, bookmarks, passwords, and more.",
                 comment: "Ddescription that appears in the settings screen to explain what Firefox Sync is useful for.")
 
             public struct SignInView {
                 public static let Title = MZLocalizedString(
-                    "Settings.Sync.SignInView.Title.v103",
+                    key: "Settings.Sync.SignInView.Title.v103",
                     tableName: nil,
                     value: "Sync and Save Data",
                     comment: "Title for the page where the user sign in to their Firefox Sync account.")
@@ -1429,12 +1429,12 @@ extension String {
 extension String {
     public struct ShareSheet {
         public static let CopyButtonTitle = MZLocalizedString(
-            "ShareSheet.Copy.Title.v108",
+            key: "ShareSheet.Copy.Title.v108",
             tableName: nil,
             value: "Copy",
             comment: "Button in share sheet to copy the url of the current tab.")
         public static let SendToDeviceButtonTitle = MZLocalizedString(
-            "ShareSheet.SendToDevice.Title.v108",
+            key: "ShareSheet.SendToDevice.Title.v108",
             tableName: nil,
             value: "Send Link to Device",
             comment: "Button in the share sheet to send the current link to another device.")
@@ -1456,17 +1456,17 @@ extension String {
     public struct TabsTray {
         public struct InactiveTabs {
             public static let TabsTrayInactiveTabsSectionClosedAccessibilityTitle = MZLocalizedString(
-                "TabsTray.InactiveTabs.SectionTitle.Closed.Accessibility.v103",
+                key: "TabsTray.InactiveTabs.SectionTitle.Closed.Accessibility.v103",
                 tableName: nil,
                 value: "View Inactive Tabs",
                 comment: "Accessibility title for the inactive tabs section button when section is closed. This section groups all tabs that haven't been used in a while.")
             public static let TabsTrayInactiveTabsSectionOpenedAccessibilityTitle = MZLocalizedString(
-                "TabsTray.InactiveTabs.SectionTitle.Opened.Accessibility.v103",
+                key: "TabsTray.InactiveTabs.SectionTitle.Opened.Accessibility.v103",
                 tableName: nil,
                 value: "Hide Inactive Tabs",
                 comment: "Accessibility title for the inactive tabs section button when section is open. This section groups all tabs that haven't been used in a while.")
             public static let CloseAllInactiveTabsButton = MZLocalizedString(
-                "InactiveTabs.TabTray.CloseButtonTitle",
+                key: "InactiveTabs.TabTray.CloseButtonTitle",
                 tableName: nil,
                 value: "Close All Inactive Tabs",
                 comment: "In the Tabs Tray, in the Inactive Tabs section, this is the button the user must tap in order to close all inactive tabs.")
@@ -1474,17 +1474,17 @@ extension String {
 
         public struct CloseTabsToast {
             public static let Title = MZLocalizedString(
-                "CloseTabsToast.Title.v113",
+                key: "CloseTabsToast.Title.v113",
                 tableName: "TabsTray",
                 value: "Tabs Closed: %d",
                 comment: "When the user closes tabs in the tab tray, a popup will appear informing them how many tabs were closed. This is the text for the popup. The placeholder is the number of tabs")
             public static let SingleTabTitle = MZLocalizedString(
-                "CloseTabsToast.SingleTabTitle.v113",
+                key: "CloseTabsToast.SingleTabTitle.v113",
                 tableName: "TabsTray",
                 value: "Tab Closed",
                 comment: "When the user closes an individual tab in the tab tray, a popup will appear informing them the tab was closed. This is the text for the popup.")
             public static let Action = MZLocalizedString(
-                "CloseTabsToast.Button.v113",
+                key: "CloseTabsToast.Button.v113",
                 tableName: "TabsTray",
                 value: "Undo",
                 comment: "When the user closes tabs in the tab tray, a popup will appear. This is the title for the button to undo the deletion of those tabs")
@@ -1492,7 +1492,7 @@ extension String {
 
         public struct Sync {
             public static let SyncTabs = MZLocalizedString(
-                "TabsTray.SyncTabs.SyncTabsButton.Title.v109",
+                key: "TabsTray.SyncTabs.SyncTabsButton.Title.v109",
                 tableName: "TabsTray",
                 value: "Sync Tabs",
                 comment: "Button label to sync tabs in your Firefox Account")
@@ -1505,7 +1505,7 @@ extension String {
     /// The text for the What's New onboarding card
     public struct WhatsNew {
         public static let RecentButtonTitle = MZLocalizedString(
-            "Onboarding.WhatsNew.Button.Title",
+            key: "Onboarding.WhatsNew.Button.Title",
             tableName: nil,
             value: "Start Browsing",
             comment: "On the onboarding card letting users know what's new in this version of Firefox, this is the title for the button, on the bottom of the card, used to get back to browsing on Firefox by dismissing the onboarding card")
@@ -1522,32 +1522,32 @@ extension String {
 // MARK: - General
 extension String {
     public static let OKString = MZLocalizedString(
-        "OK",
+        key: "OK",
         tableName: nil,
         value: nil,
         comment: "OK button")
     public static let CancelString = MZLocalizedString(
-        "Cancel",
+        key: "Cancel",
         tableName: nil,
         value: nil,
         comment: "Label for Cancel button")
     public static let NotNowString = MZLocalizedString(
-        "Toasts.NotNow",
+        key: "Toasts.NotNow",
         tableName: nil,
         value: "Not Now",
         comment: "label for Not Now button")
     public static let AppStoreString = MZLocalizedString(
-        "Toasts.OpenAppStore",
+        key: "Toasts.OpenAppStore",
         tableName: nil,
         value: "Open App Store",
         comment: "Open App Store button")
     public static let UndoString = MZLocalizedString(
-        "Toasts.Undo",
+        key: "Toasts.Undo",
         tableName: nil,
         value: "Undo",
         comment: "Label for button to undo the action just performed")
     public static let OpenSettingsString = MZLocalizedString(
-        "Open Settings",
+        key: "Open Settings",
         tableName: nil,
         value: nil,
         comment: "See http://mzl.la/1G7uHo7")
@@ -1556,7 +1556,7 @@ extension String {
 // MARK: - Top Sites
 extension String {
     public static let TopSitesRemoveButtonAccessibilityLabel = MZLocalizedString(
-        "TopSites.RemovePage.Button",
+        key: "TopSites.RemovePage.Button",
         tableName: nil,
         value: "Remove page — %@",
         comment: "Button shown in editing mode to remove this site from the top sites panel.")
@@ -1565,17 +1565,17 @@ extension String {
 // MARK: - Activity Stream
 extension String {
     public static let ASShortcutsTitle =  MZLocalizedString(
-        "ActivityStream.Shortcuts.SectionTitle",
+        key: "ActivityStream.Shortcuts.SectionTitle",
         tableName: nil,
         value: "Shortcuts",
         comment: "Section title label for Shortcuts")
     public static let RecentlySavedSectionTitle = MZLocalizedString(
-        "ActivityStream.Library.Title",
+        key: "ActivityStream.Library.Title",
         tableName: nil,
         value: "Recently Saved",
         comment: "A string used to signify the start of the Recently Saved section in Home Screen.")
     public static let RecentlySavedShowAllText = MZLocalizedString(
-        "RecentlySaved.Actions.More",
+        key: "RecentlySaved.Actions.More",
         tableName: nil,
         value: "Show All",
         comment: "More button text for Recently Saved items at the home page.")
@@ -1584,52 +1584,52 @@ extension String {
 // MARK: - Home Panel Context Menu
 extension String {
     public static let OpenInNewTabContextMenuTitle = MZLocalizedString(
-        "HomePanel.ContextMenu.OpenInNewTab",
+        key: "HomePanel.ContextMenu.OpenInNewTab",
         tableName: nil,
         value: "Open in New Tab",
         comment: "The title for the Open in New Tab context menu action for sites in Home Panels")
     public static let OpenInNewPrivateTabContextMenuTitle = MZLocalizedString(
-        "HomePanel.ContextMenu.OpenInNewPrivateTab.v101",
+        key: "HomePanel.ContextMenu.OpenInNewPrivateTab.v101",
         tableName: nil,
         value: "Open in a Private Tab",
         comment: "The title for the Open in New Private Tab context menu action for sites in Home Panels")
     public static let BookmarkContextMenuTitle = MZLocalizedString(
-        "HomePanel.ContextMenu.Bookmark",
+        key: "HomePanel.ContextMenu.Bookmark",
         tableName: nil,
         value: "Bookmark",
         comment: "The title for the Bookmark context menu action for sites in Home Panels")
     public static let RemoveBookmarkContextMenuTitle = MZLocalizedString(
-        "HomePanel.ContextMenu.RemoveBookmark",
+        key: "HomePanel.ContextMenu.RemoveBookmark",
         tableName: nil,
         value: "Remove Bookmark",
         comment: "The title for the Remove Bookmark context menu action for sites in Home Panels")
     public static let DeleteFromHistoryContextMenuTitle = MZLocalizedString(
-        "HomePanel.ContextMenu.DeleteFromHistory",
+        key: "HomePanel.ContextMenu.DeleteFromHistory",
         tableName: nil,
         value: "Delete from History",
         comment: "The title for the Delete from History context menu action for sites in Home Panels")
     public static let ShareContextMenuTitle = MZLocalizedString(
-        "HomePanel.ContextMenu.Share",
+        key: "HomePanel.ContextMenu.Share",
         tableName: nil,
         value: "Share",
         comment: "The title for the Share context menu action for sites in Home Panels")
     public static let RemoveContextMenuTitle = MZLocalizedString(
-        "HomePanel.ContextMenu.Remove",
+        key: "HomePanel.ContextMenu.Remove",
         tableName: nil,
         value: "Remove",
         comment: "The title for the Remove context menu action for sites in Home Panels")
     public static let PinTopsiteActionTitle2 = MZLocalizedString(
-        "ActivityStream.ContextMenu.PinTopsite2",
+        key: "ActivityStream.ContextMenu.PinTopsite2",
         tableName: nil,
         value: "Pin",
         comment: "The title for the pinning a topsite action")
     public static let UnpinTopsiteActionTitle2 = MZLocalizedString(
-        "ActivityStream.ContextMenu.UnpinTopsite",
+        key: "ActivityStream.ContextMenu.UnpinTopsite",
         tableName: nil,
         value: "Unpin",
         comment: "The title for the unpinning a topsite action")
     public static let AddToShortcutsActionTitle = MZLocalizedString(
-        "ActivityStream.ContextMenu.AddToShortcuts",
+        key: "ActivityStream.ContextMenu.AddToShortcuts",
         tableName: nil,
         value: "Add to Shortcuts",
         comment: "The title for the pinning a shortcut action")
@@ -1638,7 +1638,7 @@ extension String {
 // MARK: - PhotonActionSheet String
 extension String {
     public static let CloseButtonTitle = MZLocalizedString(
-        "PhotonMenu.close",
+        key: "PhotonMenu.close",
         tableName: nil,
         value: "Close",
         comment: "Button for closing the menu action sheet")
@@ -1647,27 +1647,27 @@ extension String {
 // MARK: - Home page
 extension String {
     public static let SettingsHomePageSectionName = MZLocalizedString(
-        "Settings.HomePage.SectionName",
+        key: "Settings.HomePage.SectionName",
         tableName: nil,
         value: "Homepage",
         comment: "Label used as an item in Settings. When touched it will open a dialog to configure the home page and its uses.")
     public static let SettingsHomePageURLSectionTitle = MZLocalizedString(
-        "Settings.HomePage.URL.Title",
+        key: "Settings.HomePage.URL.Title",
         tableName: nil,
         value: "Current Homepage",
         comment: "Title of the setting section containing the URL of the current home page.")
     public static let ReopenLastTabAlertTitle = MZLocalizedString(
-        "ReopenAlert.Title",
+        key: "ReopenAlert.Title",
         tableName: nil,
         value: "Reopen Last Closed Tab",
         comment: "Reopen alert title shown at home page.")
     public static let ReopenLastTabButtonText = MZLocalizedString(
-        "ReopenAlert.Actions.Reopen",
+        key: "ReopenAlert.Actions.Reopen",
         tableName: nil,
         value: "Reopen",
         comment: "Reopen button text shown in reopen-alert at home page.")
     public static let ReopenLastTabCancelText = MZLocalizedString(
-        "ReopenAlert.Actions.Cancel",
+        key: "ReopenAlert.Actions.Cancel",
         tableName: nil,
         value: "Cancel",
         comment: "Cancel button text shown in reopen-alert at home page.")
@@ -1676,97 +1676,97 @@ extension String {
 // MARK: - Settings
 extension String {
     public static let SettingsGeneralSectionTitle = MZLocalizedString(
-        "Settings.General.SectionName",
+        key: "Settings.General.SectionName",
         tableName: nil,
         value: "General",
         comment: "General settings section title")
     public static let SettingsClearPrivateDataClearButton = MZLocalizedString(
-        "Settings.ClearPrivateData.Clear.Button",
+        key: "Settings.ClearPrivateData.Clear.Button",
         tableName: nil,
         value: "Clear Private Data",
         comment: "Button in settings that clears private data for the selected items.")
     public static let SettingsClearAllWebsiteDataButton = MZLocalizedString(
-        "Settings.ClearAllWebsiteData.Clear.Button",
+        key: "Settings.ClearAllWebsiteData.Clear.Button",
         tableName: nil,
         value: "Clear All Website Data",
         comment: "Button in Data Management that clears all items.")
     public static let SettingsClearSelectedWebsiteDataButton = MZLocalizedString(
-        "Settings.ClearSelectedWebsiteData.ClearSelected.Button",
+        key: "Settings.ClearSelectedWebsiteData.ClearSelected.Button",
         tableName: nil,
         value: "Clear Items: %1$@",
         comment: "Button in Data Management that clears private data for the selected items. Parameter is the number of items to be cleared")
     public static let SettingsClearPrivateDataSectionName = MZLocalizedString(
-        "Settings.ClearPrivateData.SectionName",
+        key: "Settings.ClearPrivateData.SectionName",
         tableName: nil,
         value: "Clear Private Data",
         comment: "Label used as an item in Settings. When touched it will open a dialog prompting the user to make sure they want to clear all of their private data.")
     public static let SettingsDataManagementSectionName = MZLocalizedString(
-        "Settings.DataManagement.SectionName",
+        key: "Settings.DataManagement.SectionName",
         tableName: nil,
         value: "Data Management",
         comment: "Label used as an item in Settings. When touched it will open a dialog prompting the user to make sure they want to clear all of their private data.")
     public static let SettingsFilterSitesSearchLabel = MZLocalizedString(
-        "Settings.DataManagement.SearchLabel",
+        key: "Settings.DataManagement.SearchLabel",
         tableName: nil,
         value: "Filter Sites",
         comment: "Default text in search bar for Data Management")
     public static let SettingsDataManagementTitle = MZLocalizedString(
-        "Settings.DataManagement.Title",
+        key: "Settings.DataManagement.Title",
         tableName: nil,
         value: "Data Management",
         comment: "Title displayed in header of the setting panel.")
     public static let SettingsWebsiteDataTitle = MZLocalizedString(
-        "Settings.WebsiteData.Title",
+        key: "Settings.WebsiteData.Title",
         tableName: nil,
         value: "Website Data",
         comment: "Title displayed in header of the Data Management panel.")
     public static let SettingsWebsiteDataShowMoreButton = MZLocalizedString(
-        "Settings.WebsiteData.ButtonShowMore",
+        key: "Settings.WebsiteData.ButtonShowMore",
         tableName: nil,
         value: "Show More",
         comment: "Button shows all websites on website data tableview")
     public static let SettingsDisconnectSyncAlertTitle = MZLocalizedString(
-        "Settings.Disconnect.Title",
+        key: "Settings.Disconnect.Title",
         tableName: nil,
         value: "Disconnect Sync?",
         comment: "Title of the alert when prompting the user asking to disconnect.")
     public static let SettingsDisconnectSyncAlertBody = MZLocalizedString(
-        "Settings.Disconnect.Body",
+        key: "Settings.Disconnect.Body",
         tableName: nil,
         value: "Firefox will stop syncing with your account, but won’t delete any of your browsing data on this device.",
         comment: "Body of the alert when prompting the user asking to disconnect.")
     public static let SettingsDisconnectSyncButton = MZLocalizedString(
-        "Settings.Disconnect.Button",
+        key: "Settings.Disconnect.Button",
         tableName: nil,
         value: "Disconnect Sync",
         comment: "Button displayed at the bottom of settings page allowing users to Disconnect from FxA")
     public static let SettingsDisconnectCancelAction = MZLocalizedString(
-        "Settings.Disconnect.CancelButton",
+        key: "Settings.Disconnect.CancelButton",
         tableName: nil,
         value: "Cancel",
         comment: "Cancel action button in alert when user is prompted for disconnect")
     public static let SettingsDisconnectDestructiveAction = MZLocalizedString(
-        "Settings.Disconnect.DestructiveButton",
+        key: "Settings.Disconnect.DestructiveButton",
         tableName: nil,
         value: "Disconnect",
         comment: "Destructive action button in alert when user is prompted for disconnect")
     public static let SettingsSearchDoneButton = MZLocalizedString(
-        "Settings.Search.Done.Button",
+        key: "Settings.Search.Done.Button",
         tableName: nil,
         value: "Done",
         comment: "Button displayed at the top of the search settings.")
     public static let SettingsSearchEditButton = MZLocalizedString(
-        "Settings.Search.Edit.Button",
+        key: "Settings.Search.Edit.Button",
         tableName: nil,
         value: "Edit",
         comment: "Button displayed at the top of the search settings.")
     public static let SettingsCopyAppVersionAlertTitle = MZLocalizedString(
-        "Settings.CopyAppVersion.Title",
+        key: "Settings.CopyAppVersion.Title",
         tableName: nil,
         value: "Copied to clipboard",
         comment: "Copy app version alert shown in settings.")
     public static let SettingsAutofillCreditCard = MZLocalizedString(
-        "Settings.AutofillCreditCard.Title.v112",
+        key: "Settings.AutofillCreditCard.Title.v112",
         tableName: nil,
         value: "Autofill Credit Cards",
         comment: "Label used as an item in Settings screen. When touched, it will take user to credit card settings page to that will allows to add or modify saved credit cards to allow for autofill in a webpage.")
@@ -1775,37 +1775,37 @@ extension String {
 // MARK: - Error pages
 extension String {
     public static let ErrorPagesAdvancedButton = MZLocalizedString(
-        "ErrorPages.Advanced.Button",
+        key: "ErrorPages.Advanced.Button",
         tableName: nil,
         value: "Advanced",
         comment: "Label for button to perform advanced actions on the error page")
     public static let ErrorPagesAdvancedWarning1 = MZLocalizedString(
-        "ErrorPages.AdvancedWarning1.Text",
+        key: "ErrorPages.AdvancedWarning1.Text",
         tableName: nil,
         value: "Warning: we can’t confirm your connection to this website is secure.",
         comment: "Warning text when clicking the Advanced button on error pages")
     public static let ErrorPagesAdvancedWarning2 = MZLocalizedString(
-        "ErrorPages.AdvancedWarning2.Text",
+        key: "ErrorPages.AdvancedWarning2.Text",
         tableName: nil,
         value: "It may be a misconfiguration or tampering by an attacker. Proceed if you accept the potential risk.",
         comment: "Additional warning text when clicking the Advanced button on error pages")
     public static let ErrorPagesCertWarningDescription = MZLocalizedString(
-        "ErrorPages.CertWarning.Description",
+        key: "ErrorPages.CertWarning.Description",
         tableName: nil,
         value: "The owner of %@ has configured their website improperly. To protect your information from being stolen, Firefox has not connected to this website.",
         comment: "Warning text on the certificate error page")
     public static let ErrorPagesCertWarningTitle = MZLocalizedString(
-        "ErrorPages.CertWarning.Title",
+        key: "ErrorPages.CertWarning.Title",
         tableName: nil,
         value: "This Connection is Untrusted",
         comment: "Title on the certificate error page")
     public static let ErrorPagesGoBackButton = MZLocalizedString(
-        "ErrorPages.GoBack.Button",
+        key: "ErrorPages.GoBack.Button",
         tableName: nil,
         value: "Go Back",
         comment: "Label for button to go back from the error page")
     public static let ErrorPagesVisitOnceButton = MZLocalizedString(
-        "ErrorPages.VisitOnce.Button",
+        key: "ErrorPages.VisitOnce.Button",
         tableName: nil,
         value: "Visit site anyway",
         comment: "Button label to temporarily continue to the site from the certificate error page")
@@ -1814,22 +1814,22 @@ extension String {
 // MARK: - Logins Helper
 extension String {
     public static let LoginsHelperSaveLoginButtonTitle = MZLocalizedString(
-        "LoginsHelper.SaveLogin.Button",
+        key: "LoginsHelper.SaveLogin.Button",
         tableName: nil,
         value: "Save Login",
         comment: "Button to save the user's password")
     public static let LoginsHelperDontSaveButtonTitle = MZLocalizedString(
-        "LoginsHelper.DontSave.Button",
+        key: "LoginsHelper.DontSave.Button",
         tableName: nil,
         value: "Don’t Save",
         comment: "Button to not save the user's password")
     public static let LoginsHelperUpdateButtonTitle = MZLocalizedString(
-        "LoginsHelper.Update.Button",
+        key: "LoginsHelper.Update.Button",
         tableName: nil,
         value: "Update",
         comment: "Button to update the user's password")
     public static let LoginsHelperDontUpdateButtonTitle = MZLocalizedString(
-        "LoginsHelper.DontUpdate.Button",
+        key: "LoginsHelper.DontUpdate.Button",
         tableName: nil,
         value: "Don’t Update",
         comment: "Button to not update the user's password")
@@ -1838,17 +1838,17 @@ extension String {
 // MARK: - Downloads Panel
 extension String {
     public static let DownloadsPanelEmptyStateTitle = MZLocalizedString(
-        "DownloadsPanel.EmptyState.Title",
+        key: "DownloadsPanel.EmptyState.Title",
         tableName: nil,
         value: "Downloaded files will show up here.",
         comment: "Title for the Downloads Panel empty state.")
     public static let DownloadsPanelDeleteTitle = MZLocalizedString(
-        "DownloadsPanel.Delete.Title",
+        key: "DownloadsPanel.Delete.Title",
         tableName: nil,
         value: "Delete",
         comment: "Action button for deleting downloaded files in the Downloads panel.")
     public static let DownloadsPanelShareTitle = MZLocalizedString(
-        "DownloadsPanel.Share.Title",
+        key: "DownloadsPanel.Share.Title",
         tableName: nil,
         value: "Share",
         comment: "Action button for sharing downloaded files in the Downloads panel.")
@@ -1857,42 +1857,42 @@ extension String {
 // MARK: - History Panel
 extension String {
     public static let HistoryBackButtonTitle = MZLocalizedString(
-        "HistoryPanel.HistoryBackButton.Title",
+        key: "HistoryPanel.HistoryBackButton.Title",
         tableName: nil,
         value: "History",
         comment: "Title for the Back to History button in the History Panel")
     public static let EmptySyncedTabsPanelStateTitle = MZLocalizedString(
-        "HistoryPanel.EmptySyncedTabsState.Title",
+        key: "HistoryPanel.EmptySyncedTabsState.Title",
         tableName: nil,
         value: "Firefox Sync",
         comment: "Title for the empty synced tabs state in the History Panel")
     public static let EmptySyncedTabsPanelNotSignedInStateDescription = MZLocalizedString(
-        "HistoryPanel.EmptySyncedTabsPanelNotSignedInState.Description",
+        key: "HistoryPanel.EmptySyncedTabsPanelNotSignedInState.Description",
         tableName: nil,
         value: "Sign in to view a list of tabs from your other devices.",
         comment: "Description for the empty synced tabs 'not signed in' state in the History Panel")
     public static let EmptySyncedTabsPanelNullStateDescription = MZLocalizedString(
-        "HistoryPanel.EmptySyncedTabsNullState.Description",
+        key: "HistoryPanel.EmptySyncedTabsNullState.Description",
         tableName: nil,
         value: "Your tabs from other devices show up here.",
         comment: "Description for the empty synced tabs null state in the History Panel")
     public static let HistoryPanelEmptyStateTitle = MZLocalizedString(
-        "HistoryPanel.EmptyState.Title",
+        key: "HistoryPanel.EmptyState.Title",
         tableName: nil,
         value: "Websites you’ve visited recently will show up here.",
         comment: "Title for the History Panel empty state.")
     public static let RecentlyClosedTabsPanelTitle = MZLocalizedString(
-        "RecentlyClosedTabsPanel.Title",
+        key: "RecentlyClosedTabsPanel.Title",
         tableName: nil,
         value: "Recently Closed",
         comment: "Title for the Recently Closed Tabs Panel")
     public static let FirefoxHomePage = MZLocalizedString(
-        "Firefox.HomePage.Title",
+        key: "Firefox.HomePage.Title",
         tableName: nil,
         value: "Firefox Home Page",
         comment: "Title for firefox about:home page in tab history list")
     public static let HistoryPanelDelete = MZLocalizedString(
-        "Delete",
+        key: "Delete",
         tableName: "HistoryPanel",
         value: nil,
         comment: "Action button for deleting history entries in the history panel.")
@@ -1901,22 +1901,22 @@ extension String {
 // MARK: - Clear recent history action menu
 extension String {
     public static let ClearHistoryMenuOptionTheLastHour = MZLocalizedString(
-        "HistoryPanel.ClearHistoryMenuOptionTheLastHour",
+        key: "HistoryPanel.ClearHistoryMenuOptionTheLastHour",
         tableName: nil,
         value: "The Last Hour",
         comment: "Button to perform action to clear history for the last hour")
     public static let ClearHistoryMenuOptionToday = MZLocalizedString(
-        "HistoryPanel.ClearHistoryMenuOptionToday",
+        key: "HistoryPanel.ClearHistoryMenuOptionToday",
         tableName: nil,
         value: "Today",
         comment: "Button to perform action to clear history for today only")
     public static let ClearHistoryMenuOptionTodayAndYesterday = MZLocalizedString(
-        "HistoryPanel.ClearHistoryMenuOptionTodayAndYesterday",
+        key: "HistoryPanel.ClearHistoryMenuOptionTodayAndYesterday",
         tableName: nil,
         value: "Today and Yesterday",
         comment: "Button to perform action to clear history for yesterday and today")
     public static let ClearHistoryMenuOptionEverything = MZLocalizedString(
-        "HistoryPanel.ClearHistoryMenuOptionEverything",
+        key: "HistoryPanel.ClearHistoryMenuOptionEverything",
         tableName: nil,
         value: "Everything",
         comment: "Option title to clear all browsing history.")
@@ -1925,39 +1925,39 @@ extension String {
 // MARK: - Syncing
 extension String {
     public static let SyncingMessageWithEllipsis = MZLocalizedString(
-        "Sync.SyncingEllipsis.Label",
+        key: "Sync.SyncingEllipsis.Label",
         tableName: nil,
         value: "Syncing…",
         comment: "Message displayed when the user's account is syncing with ellipsis at the end")
 
     public static let FirefoxSyncOfflineTitle = MZLocalizedString(
-        "SyncState.Offline.Title",
+        key: "SyncState.Offline.Title",
         tableName: nil,
         value: "Sync is offline",
         comment: "Title for Sync status message when Sync failed due to being offline")
     public static let FirefoxSyncTroubleshootTitle = MZLocalizedString(
-        "Settings.TroubleShootSync.Title",
+        key: "Settings.TroubleShootSync.Title",
         tableName: nil,
         value: "Troubleshoot",
         comment: "Title of link to help page to find out how to solve Sync issues")
 
     public static let FirefoxSyncBookmarksEngine = MZLocalizedString(
-        "Bookmarks",
+        key: "Bookmarks",
         tableName: nil,
         value: nil,
         comment: "Toggle bookmarks syncing setting")
     public static let FirefoxSyncHistoryEngine = MZLocalizedString(
-        "History",
+        key: "History",
         tableName: nil,
         value: nil,
         comment: "Toggle history syncing setting")
     public static let FirefoxSyncTabsEngine = MZLocalizedString(
-        "Open Tabs",
+        key: "Open Tabs",
         tableName: nil,
         value: nil,
         comment: "Toggle tabs syncing setting")
     public static let FirefoxSyncLoginsEngine = MZLocalizedString(
-        "Logins",
+        key: "Logins",
         tableName: nil,
         value: nil,
         comment: "Toggle logins syncing setting")
@@ -1967,92 +1967,92 @@ extension String {
 extension String {
     // Prompts
     public static let SaveLoginUsernamePrompt = MZLocalizedString(
-        "LoginsHelper.PromptSaveLogin.Title",
+        key: "LoginsHelper.PromptSaveLogin.Title",
         tableName: nil,
         value: "Save login %@ for %@?",
         comment: "Prompt for saving a login. The first parameter is the username being saved. The second parameter is the hostname of the site.")
     public static let SaveLoginPrompt = MZLocalizedString(
-        "LoginsHelper.PromptSavePassword.Title",
+        key: "LoginsHelper.PromptSavePassword.Title",
         tableName: nil,
         value: "Save password for %@?",
         comment: "Prompt for saving a password with no username. The parameter is the hostname of the site.")
     public static let UpdateLoginUsernamePrompt = MZLocalizedString(
-        "LoginsHelper.PromptUpdateLogin.Title.TwoArg",
+        key: "LoginsHelper.PromptUpdateLogin.Title.TwoArg",
         tableName: nil,
         value: "Update login %@ for %@?",
         comment: "Prompt for updating a login. The first parameter is the username for which the password will be updated for. The second parameter is the hostname of the site.")
     public static let UpdateLoginPrompt = MZLocalizedString(
-        "LoginsHelper.PromptUpdateLogin.Title.OneArg",
+        key: "LoginsHelper.PromptUpdateLogin.Title.OneArg",
         tableName: nil,
         value: "Update login for %@?",
         comment: "Prompt for updating a login. The first parameter is the hostname for which the password will be updated for.")
 
     // Setting
     public static let SettingToShowLoginsInAppMenu = MZLocalizedString(
-        "Settings.ShowLoginsInAppMenu.Title",
+        key: "Settings.ShowLoginsInAppMenu.Title",
         tableName: nil,
         value: "Show in Application Menu",
         comment: "Setting to show Logins & Passwords quick access in the application menu")
 
     // List view
     public static let LoginsListTitle = MZLocalizedString(
-        "LoginsList.Title",
+        key: "LoginsList.Title",
         tableName: nil,
         value: "SAVED LOGINS",
         comment: "Title for the list of logins")
     public static let LoginsListSearchPlaceholder = MZLocalizedString(
-        "LoginsList.LoginsListSearchPlaceholder",
+        key: "LoginsList.LoginsListSearchPlaceholder",
         tableName: nil,
         value: "Filter",
         comment: "Placeholder test for search box in logins list view.")
 
     // Breach Alerts
     public static let BreachAlertsTitle = MZLocalizedString(
-        "BreachAlerts.Title",
+        key: "BreachAlerts.Title",
         tableName: nil,
         value: "Website Breach",
         comment: "Title for the Breached Login Detail View.")
     public static let BreachAlertsLearnMore = MZLocalizedString(
-        "BreachAlerts.LearnMoreButton",
+        key: "BreachAlerts.LearnMoreButton",
         tableName: nil,
         value: "Learn more",
         comment: "Link to monitor.firefox.com to learn more about breached passwords")
     public static let BreachAlertsBreachDate = MZLocalizedString(
-        "BreachAlerts.BreachDate",
+        key: "BreachAlerts.BreachDate",
         tableName: nil,
         value: "This breach occurred on",
         comment: "Describes the date on which the breach occurred")
     public static let BreachAlertsDescription = MZLocalizedString(
-        "BreachAlerts.Description",
+        key: "BreachAlerts.Description",
         tableName: nil,
         value: "Passwords were leaked or stolen since you last changed your password. To protect this account, log in to the site and change your password.",
         comment: "Description of what a breach is")
     public static let BreachAlertsLink = MZLocalizedString(
-        "BreachAlerts.Link",
+        key: "BreachAlerts.Link",
         tableName: nil,
         value: "Go to",
         comment: "Leads to a link to the breached website")
 
     // For the DevicePasscodeRequiredViewController
     public static let LoginsDevicePasscodeRequiredMessage = MZLocalizedString(
-        "Logins.DevicePasscodeRequired.Message",
+        key: "Logins.DevicePasscodeRequired.Message",
         tableName: nil,
         value: "To save and autofill logins and passwords, enable Face ID, Touch ID or a device passcode.",
         comment: "Message shown when you enter Logins & Passwords without having a device passcode set.")
     public static let LoginsDevicePasscodeRequiredLearnMoreButtonTitle = MZLocalizedString(
-        "Logins.DevicePasscodeRequired.LearnMoreButtonTitle",
+        key: "Logins.DevicePasscodeRequired.LearnMoreButtonTitle",
         tableName: nil,
         value: "Learn More",
         comment: "Title of the Learn More button that links to a support page about device passcode requirements.")
 
     // For the LoginOnboardingViewController
     public static let LoginsOnboardingLearnMoreButtonTitle = MZLocalizedString(
-        "Logins.Onboarding.LearnMoreButtonTitle",
+        key: "Logins.Onboarding.LearnMoreButtonTitle",
         tableName: nil,
         value: "Learn More",
         comment: "Title of the Learn More button that links to a support page about device passcode requirements.")
     public static let LoginsOnboardingContinueButtonTitle = MZLocalizedString(
-        "Logins.Onboarding.ContinueButtonTitle",
+        key: "Logins.Onboarding.ContinueButtonTitle",
         tableName: nil,
         value: "Continue",
         comment: "Title of the Continue button.")
@@ -2062,44 +2062,44 @@ extension String {
 extension String {
     // Settings strings
     public static let FxAFirefoxAccount = MZLocalizedString(
-        "FxA.FirefoxAccount",
+        key: "FxA.FirefoxAccount",
         tableName: nil,
         value: "Firefox Account",
         comment: "Settings section title for Firefox Account")
     public static let FxAManageAccount = MZLocalizedString(
-        "FxA.ManageAccount",
+        key: "FxA.ManageAccount",
         tableName: nil,
         value: "Manage Account & Devices",
         comment: "Button label to go to Firefox Account settings")
     public static let FxASyncNow = MZLocalizedString(
-        "FxA.SyncNow",
+        key: "FxA.SyncNow",
         tableName: nil,
         value: "Sync Now",
         comment: "Button label to Sync your Firefox Account")
     public static let FxANoInternetConnection = MZLocalizedString(
-        "FxA.NoInternetConnection",
+        key: "FxA.NoInternetConnection",
         tableName: nil,
         value: "No Internet Connection",
         comment: "Label when no internet is present")
     public static let FxASettingsTitle = MZLocalizedString(
-        "Settings.FxA.Title",
+        key: "Settings.FxA.Title",
         tableName: nil,
         value: "Firefox Account",
         comment: "Title displayed in header of the FxA settings panel.")
     public static let FxASettingsSyncSettings = MZLocalizedString(
-        "Settings.FxA.Sync.SectionName",
+        key: "Settings.FxA.Sync.SectionName",
         tableName: nil,
         value: "Sync Settings",
         comment: "Label used as a section title in the Firefox Accounts Settings screen.")
     public static let FxASettingsDeviceName = MZLocalizedString(
-        "Settings.FxA.DeviceName",
+        key: "Settings.FxA.DeviceName",
         tableName: nil,
         value: "Device Name",
         comment: "Label used for the device name settings section.")
 
     // Surface error strings
     public static let FxAAccountVerifyPassword = MZLocalizedString(
-        "Enter your password to connect",
+        key: "Enter your password to connect",
         tableName: nil,
         value: nil,
         comment: "Text message in the settings table view")
@@ -2108,43 +2108,43 @@ extension String {
 // MARK: - New tab choice settings
 extension String {
     public static let CustomNewPageURL = MZLocalizedString(
-        "Settings.NewTab.CustomURL",
+        key: "Settings.NewTab.CustomURL",
         tableName: nil,
         value: "Custom URL",
         comment: "Label used to set a custom url as the new tab option (homepage).")
     public static let SettingsNewTabSectionName = MZLocalizedString(
-        "Settings.NewTab.SectionName",
+        key: "Settings.NewTab.SectionName",
         tableName: nil,
         value: "New Tab",
         comment: "Label used as an item in Settings. When touched it will open a dialog to configure the new tab behavior.")
     public static let NewTabSectionName =
     MZLocalizedString(
-        "Settings.NewTab.TopSectionName",
+        key: "Settings.NewTab.TopSectionName",
         tableName: nil,
         value: "Show",
         comment: "Label at the top of the New Tab screen after entering New Tab in settings")
     public static let SettingsNewTabTitle = MZLocalizedString(
-        "Settings.NewTab.Title",
+        key: "Settings.NewTab.Title",
         tableName: nil,
         value: "New Tab",
         comment: "Title displayed in header of the setting panel.")
     public static let NewTabSectionNameFooter = MZLocalizedString(
-        "Settings.NewTab.TopSectionNameFooter",
+        key: "Settings.NewTab.TopSectionNameFooter",
         tableName: nil,
         value: "Choose what to load when opening a new tab",
         comment: "Footer at the bottom of the New Tab screen after entering New Tab in settings")
     public static let SettingsNewTabTopSites = MZLocalizedString(
-        "Settings.NewTab.Option.FirefoxHome",
+        key: "Settings.NewTab.Option.FirefoxHome",
         tableName: nil,
         value: "Firefox Home",
         comment: "Option in settings to show Firefox Home when you open a new tab")
     public static let SettingsNewTabBlankPage = MZLocalizedString(
-        "Settings.NewTab.Option.BlankPage",
+        key: "Settings.NewTab.Option.BlankPage",
         tableName: nil,
         value: "Blank Page",
         comment: "Option in settings to show a blank page when you open a new tab")
     public static let SettingsNewTabCustom = MZLocalizedString(
-        "Settings.NewTab.Option.Custom",
+        key: "Settings.NewTab.Option.Custom",
         tableName: nil,
         value: "Custom",
         comment: "Option in settings to show your homepage when you open a new tab")
@@ -2163,12 +2163,12 @@ extension String {
 // MARK: - Open With Settings
 extension String {
     public static let SettingsOpenWithSectionName = MZLocalizedString(
-        "Settings.OpenWith.SectionName",
+        key: "Settings.OpenWith.SectionName",
         tableName: nil,
         value: "Mail App",
         comment: "Label used as an item in Settings. When touched it will open a dialog to configure the open with (mail links) behavior.")
     public static let SettingsOpenWithPageTitle = MZLocalizedString(
-        "Settings.OpenWith.PageTitle",
+        key: "Settings.OpenWith.PageTitle",
         tableName: nil,
         value: "Open mail links with",
         comment: "Title for Open With Settings")
@@ -2177,57 +2177,57 @@ extension String {
 // MARK: - Third Party Search Engines
 extension String {
     public static let ThirdPartySearchEngineAdded = MZLocalizedString(
-        "Search.ThirdPartyEngines.AddSuccess",
+        key: "Search.ThirdPartyEngines.AddSuccess",
         tableName: nil,
         value: "Added Search engine!",
         comment: "The success message that appears after a user sucessfully adds a new search engine")
     public static let ThirdPartySearchAddTitle = MZLocalizedString(
-        "Search.ThirdPartyEngines.AddTitle",
+        key: "Search.ThirdPartyEngines.AddTitle",
         tableName: nil,
         value: "Add Search Provider?",
         comment: "The title that asks the user to Add the search provider")
     public static let ThirdPartySearchAddMessage = MZLocalizedString(
-        "Search.ThirdPartyEngines.AddMessage",
+        key: "Search.ThirdPartyEngines.AddMessage",
         tableName: nil,
         value: "The new search engine will appear in the quick search bar.",
         comment: "The message that asks the user to Add the search provider explaining where the search engine will appear")
     public static let ThirdPartySearchCancelButton = MZLocalizedString(
-        "Search.ThirdPartyEngines.Cancel",
+        key: "Search.ThirdPartyEngines.Cancel",
         tableName: nil,
         value: "Cancel",
         comment: "The cancel button if you do not want to add a search engine.")
     public static let ThirdPartySearchOkayButton = MZLocalizedString(
-        "Search.ThirdPartyEngines.OK",
+        key: "Search.ThirdPartyEngines.OK",
         tableName: nil,
         value: "OK",
         comment: "The confirmation button")
     public static let ThirdPartySearchFailedTitle = MZLocalizedString(
-        "Search.ThirdPartyEngines.FailedTitle",
+        key: "Search.ThirdPartyEngines.FailedTitle",
         tableName: nil,
         value: "Failed",
         comment: "A title explaining that we failed to add a search engine")
     public static let ThirdPartySearchFailedMessage = MZLocalizedString(
-        "Search.ThirdPartyEngines.FailedMessage",
+        key: "Search.ThirdPartyEngines.FailedMessage",
         tableName: nil,
         value: "The search provider could not be added.",
         comment: "A title explaining that we failed to add a search engine")
     public static let CustomEngineFormErrorTitle = MZLocalizedString(
-        "Search.ThirdPartyEngines.FormErrorTitle",
+        key: "Search.ThirdPartyEngines.FormErrorTitle",
         tableName: nil,
         value: "Failed",
         comment: "A title stating that we failed to add custom search engine.")
     public static let CustomEngineFormErrorMessage = MZLocalizedString(
-        "Search.ThirdPartyEngines.FormErrorMessage",
+        key: "Search.ThirdPartyEngines.FormErrorMessage",
         tableName: nil,
         value: "Please fill all fields correctly.",
         comment: "A message explaining fault in custom search engine form.")
     public static let CustomEngineDuplicateErrorTitle = MZLocalizedString(
-        "Search.ThirdPartyEngines.DuplicateErrorTitle",
+        key: "Search.ThirdPartyEngines.DuplicateErrorTitle",
         tableName: nil,
         value: "Failed",
         comment: "A title stating that we failed to add custom search engine.")
     public static let CustomEngineDuplicateErrorMessage = MZLocalizedString(
-        "Search.ThirdPartyEngines.DuplicateErrorMessage",
+        key: "Search.ThirdPartyEngines.DuplicateErrorMessage",
         tableName: nil,
         value: "A search engine with this title or URL has already been added.",
         comment: "A message explaining fault in custom search engine form.")
@@ -2236,22 +2236,22 @@ extension String {
 // MARK: - Root Bookmarks folders
 extension String {
     public static let BookmarksFolderTitleMobile = MZLocalizedString(
-        "Mobile Bookmarks",
+        key: "Mobile Bookmarks",
         tableName: "Storage",
         value: nil,
         comment: "The title of the folder that contains mobile bookmarks. This should match bookmarks.folder.mobile.label on Android.")
     public static let BookmarksFolderTitleMenu = MZLocalizedString(
-        "Bookmarks Menu",
+        key: "Bookmarks Menu",
         tableName: "Storage",
         value: nil,
         comment: "The name of the folder that contains desktop bookmarks in the menu. This should match bookmarks.folder.menu.label on Android.")
     public static let BookmarksFolderTitleToolbar = MZLocalizedString(
-        "Bookmarks Toolbar",
+        key: "Bookmarks Toolbar",
         tableName: "Storage",
         value: nil,
         comment: "The name of the folder that contains desktop bookmarks in the toolbar. This should match bookmarks.folder.toolbar.label on Android.")
     public static let BookmarksFolderTitleUnsorted = MZLocalizedString(
-        "Unsorted Bookmarks",
+        key: "Unsorted Bookmarks",
         tableName: "Storage",
         value: nil,
         comment: "The name of the folder that contains unsorted desktop bookmarks. This should match bookmarks.folder.unfiled.label on Android.")
@@ -2260,72 +2260,72 @@ extension String {
 // MARK: - Bookmark Management
 extension String {
     public static let BookmarksFolder = MZLocalizedString(
-        "Bookmarks.Folder.Label",
+        key: "Bookmarks.Folder.Label",
         tableName: nil,
         value: "Folder",
         comment: "The label to show the location of the folder where the bookmark is located")
     public static let BookmarksNewBookmark = MZLocalizedString(
-        "Bookmarks.NewBookmark.Label",
+        key: "Bookmarks.NewBookmark.Label",
         tableName: nil,
         value: "New Bookmark",
         comment: "The button to create a new bookmark")
     public static let BookmarksNewFolder = MZLocalizedString(
-        "Bookmarks.NewFolder.Label",
+        key: "Bookmarks.NewFolder.Label",
         tableName: nil,
         value: "New Folder",
         comment: "The button to create a new folder")
     public static let BookmarksNewSeparator = MZLocalizedString(
-        "Bookmarks.NewSeparator.Label",
+        key: "Bookmarks.NewSeparator.Label",
         tableName: nil,
         value: "New Separator",
         comment: "The button to create a new separator")
     public static let BookmarksEditBookmark = MZLocalizedString(
-        "Bookmarks.EditBookmark.Label",
+        key: "Bookmarks.EditBookmark.Label",
         tableName: nil,
         value: "Edit Bookmark",
         comment: "The button to edit a bookmark")
     public static let BookmarksEdit = MZLocalizedString(
-        "Bookmarks.Edit.Button",
+        key: "Bookmarks.Edit.Button",
         tableName: nil,
         value: "Edit",
         comment: "The button on the snackbar to edit a bookmark after adding it.")
     public static let BookmarksEditFolder = MZLocalizedString(
-        "Bookmarks.EditFolder.Label",
+        key: "Bookmarks.EditFolder.Label",
         tableName: nil,
         value: "Edit Folder",
         comment: "The button to edit a folder")
     public static let BookmarksDeleteFolderWarningTitle = MZLocalizedString(
-        "Bookmarks.DeleteFolderWarning.Title",
+        key: "Bookmarks.DeleteFolderWarning.Title",
         tableName: "BookmarkPanelDeleteConfirm",
         value: "This folder isn’t empty.",
         comment: "Title of the confirmation alert when the user tries to delete a folder that still contains bookmarks and/or folders.")
     public static let BookmarksDeleteFolderWarningDescription = MZLocalizedString(
-        "Bookmarks.DeleteFolderWarning.Description",
+        key: "Bookmarks.DeleteFolderWarning.Description",
         tableName: "BookmarkPanelDeleteConfirm",
         value: "Are you sure you want to delete it and its contents?",
         comment: "Main body of the confirmation alert when the user tries to delete a folder that still contains bookmarks and/or folders.")
     public static let BookmarksDeleteFolderCancelButtonLabel = MZLocalizedString(
-        "Bookmarks.DeleteFolderWarning.CancelButton.Label",
+        key: "Bookmarks.DeleteFolderWarning.CancelButton.Label",
         tableName: "BookmarkPanelDeleteConfirm",
         value: "Cancel",
         comment: "Button label to cancel deletion when the user tried to delete a non-empty folder.")
     public static let BookmarksDeleteFolderDeleteButtonLabel = MZLocalizedString(
-        "Bookmarks.DeleteFolderWarning.DeleteButton.Label",
+        key: "Bookmarks.DeleteFolderWarning.DeleteButton.Label",
         tableName: "BookmarkPanelDeleteConfirm",
         value: "Delete",
         comment: "Button label for the button that deletes a folder and all of its children.")
     public static let BookmarksPanelDeleteTableAction = MZLocalizedString(
-        "Delete",
+        key: "Delete",
         tableName: "BookmarkPanel",
         value: nil,
         comment: "Action button for deleting bookmarks in the bookmarks panel.")
     public static let BookmarkDetailFieldTitle = MZLocalizedString(
-        "Bookmark.DetailFieldTitle.Label",
+        key: "Bookmark.DetailFieldTitle.Label",
         tableName: nil,
         value: "Title",
         comment: "The label for the Title field when editing a bookmark")
     public static let BookmarkDetailFieldURL = MZLocalizedString(
-        "Bookmark.DetailFieldURL.Label",
+        key: "Bookmark.DetailFieldURL.Label",
         tableName: nil,
         value: "URL",
         comment: "The label for the URL field when editing a bookmark")
@@ -2334,24 +2334,24 @@ extension String {
 // MARK: - Tab tray (chronological tabs)
 extension String {
     public static let TabTrayV2Title = MZLocalizedString(
-        "TabTray.Title",
+        key: "TabTray.Title",
         tableName: nil,
         value: "Open Tabs",
         comment: "The title for the tab tray")
 
     // Segmented Control tites for iPad
     public static let TabTraySegmentedControlTitlesTabs = MZLocalizedString(
-        "TabTray.SegmentedControlTitles.Tabs",
+        key: "TabTray.SegmentedControlTitles.Tabs",
         tableName: nil,
         value: "Tabs",
         comment: "The title on the button to look at regular tabs.")
     public static let TabTraySegmentedControlTitlesPrivateTabs = MZLocalizedString(
-        "TabTray.SegmentedControlTitles.PrivateTabs",
+        key: "TabTray.SegmentedControlTitles.PrivateTabs",
         tableName: nil,
         value: "Private",
         comment: "The title on the button to look at private tabs.")
     public static let TabTraySegmentedControlTitlesSyncedTabs = MZLocalizedString(
-        "TabTray.SegmentedControlTitles.SyncedTabs",
+        key: "TabTray.SegmentedControlTitles.SyncedTabs",
         tableName: nil,
         value: "Synced",
         comment: "The title on the button to look at synced tabs.")
@@ -2360,23 +2360,23 @@ extension String {
 // MARK: - Clipboard Toast
 extension String {
     public static let GoToCopiedLink = MZLocalizedString(
-        "ClipboardToast.GoToCopiedLink.Title",
+        key: "ClipboardToast.GoToCopiedLink.Title",
         tableName: nil,
         value: "Go to copied link?",
         comment: "Message displayed when the user has a copied link on the clipboard")
     public static let GoButtonTittle = MZLocalizedString(
-        "ClipboardToast.GoToCopiedLink.Button",
+        key: "ClipboardToast.GoToCopiedLink.Button",
         tableName: nil,
         value: "Go",
         comment: "The button to open a new tab with the copied link")
 
     public static let SettingsOfferClipboardBarTitle = MZLocalizedString(
-        "Settings.OfferClipboardBar.Title",
+        key: "Settings.OfferClipboardBar.Title",
         tableName: nil,
         value: "Offer to Open Copied Links",
         comment: "Title of setting to enable the Go to Copied URL feature. See https://bug1223660.bmoattachments.org/attachment.cgi?id=8898349")
     public static let SettingsOfferClipboardBarStatus = MZLocalizedString(
-        "Settings.OfferClipboardBar.Status",
+        key: "Settings.OfferClipboardBar.Status",
         tableName: nil,
         value: "When Opening Firefox",
         comment: "Description displayed under the ”Offer to Open Copied Link” option. See https://bug1223660.bmoattachments.org/attachment.cgi?id=8898349")
@@ -2385,12 +2385,12 @@ extension String {
 // MARK: - Link Previews
 extension String {
     public static let SettingsShowLinkPreviewsTitle = MZLocalizedString(
-        "Settings.ShowLinkPreviews.Title",
+        key: "Settings.ShowLinkPreviews.Title",
         tableName: nil,
         value: "Show Link Previews",
         comment: "Title of setting to enable link previews when long-pressing links.")
     public static let SettingsShowLinkPreviewsStatus = MZLocalizedString(
-        "Settings.ShowLinkPreviews.Status",
+        key: "Settings.ShowLinkPreviews.Status",
         tableName: nil,
         value: "When Long-pressing Links",
         comment: "Description displayed under the ”Show Link Previews” option")
@@ -2399,57 +2399,57 @@ extension String {
 // MARK: - Errors
 extension String {
     public static let UnableToAddPassErrorTitle = MZLocalizedString(
-        "AddPass.Error.Title",
+        key: "AddPass.Error.Title",
         tableName: nil,
         value: "Failed to Add Pass",
         comment: "Title of the 'Add Pass Failed' alert. See https://support.apple.com/HT204003 for context on Wallet.")
     public static let UnableToAddPassErrorMessage = MZLocalizedString(
-        "AddPass.Error.Message",
+        key: "AddPass.Error.Message",
         tableName: nil,
         value: "An error occured while adding the pass to Wallet. Please try again later.",
         comment: "Text of the 'Add Pass Failed' alert.  See https://support.apple.com/HT204003 for context on Wallet.")
     public static let UnableToAddPassErrorDismiss = MZLocalizedString(
-        "AddPass.Error.Dismiss",
+        key: "AddPass.Error.Dismiss",
         tableName: nil,
         value: "OK",
         comment: "Button to dismiss the 'Add Pass Failed' alert.  See https://support.apple.com/HT204003 for context on Wallet.")
     public static let UnableToOpenURLError = MZLocalizedString(
-        "OpenURL.Error.Message",
+        key: "OpenURL.Error.Message",
         tableName: nil,
         value: "Firefox cannot open the page because it has an invalid address.",
         comment: "The message displayed to a user when they try to open a URL that cannot be handled by Firefox, or any external app.")
     public static let UnableToOpenURLErrorTitle = MZLocalizedString(
-        "OpenURL.Error.Title",
+        key: "OpenURL.Error.Title",
         tableName: nil,
         value: "Cannot Open Page",
         comment: "Title of the message shown when the user attempts to navigate to an invalid link.")
     public static let CouldntDownloadWallpaperErrorTitle = MZLocalizedString(
-        "Wallpaper.Download.Error.Title.v106",
+        key: "Wallpaper.Download.Error.Title.v106",
         tableName: nil,
         value: "Couldn’t Download Wallpaper",
         comment: "The title of the error displayed if download fails when changing a wallpaper.")
     public static let CouldntDownloadWallpaperErrorBody = MZLocalizedString(
-        "Wallpaper.Download.Error.Body.v106",
+        key: "Wallpaper.Download.Error.Body.v106",
         tableName: nil,
         value: "Something went wrong with your download.",
         comment: "The message of the error displayed to a user when they try change a wallpaper that failed downloading.")
     public static let CouldntChangeWallpaperErrorTitle = MZLocalizedString(
-        "Wallpaper.Change.Error.Title.v106",
+        key: "Wallpaper.Change.Error.Title.v106",
         tableName: nil,
         value: "Couldn’t Change Wallpaper",
         comment: "The title of the error displayed when changing wallpaper fails.")
     public static let CouldntChangeWallpaperErrorBody = MZLocalizedString(
-        "Wallpaper.Change.Error.Body.v106",
+        key: "Wallpaper.Change.Error.Body.v106",
         tableName: nil,
         value: "Something went wrong with this wallpaper.",
         comment: "The message of the error displayed to a user when they trying to change a wallpaper failed.")
     public static let WallpaperErrorTryAgain = MZLocalizedString(
-        "Wallpaper.Error.TryAgain.v106",
+        key: "Wallpaper.Error.TryAgain.v106",
         tableName: nil,
         value: "Try Again",
         comment: "Action displayed when changing wallpaper fails.")
     public static let WallpaperErrorDismiss = MZLocalizedString(
-        "Wallpaper.Error.Dismiss.v106",
+        key: "Wallpaper.Error.Dismiss.v106",
         tableName: nil,
         value: "Cancel",
         comment: "An action for the error displayed to a user when they trying to change a wallpaper failed.")
@@ -2458,57 +2458,57 @@ extension String {
 // MARK: - Download Helper
 extension String {
     public static let OpenInDownloadHelperAlertDownloadNow = MZLocalizedString(
-        "Downloads.Alert.DownloadNow",
+        key: "Downloads.Alert.DownloadNow",
         tableName: nil,
         value: "Download Now",
         comment: "The label of the button the user will press to start downloading a file")
     public static let DownloadsButtonTitle = MZLocalizedString(
-        "Downloads.Toast.GoToDownloads.Button",
+        key: "Downloads.Toast.GoToDownloads.Button",
         tableName: nil,
         value: "Downloads",
         comment: "The button to open a new tab with the Downloads home panel")
     public static let CancelDownloadDialogTitle = MZLocalizedString(
-        "Downloads.CancelDialog.Title",
+        key: "Downloads.CancelDialog.Title",
         tableName: nil,
         value: "Cancel Download",
         comment: "Alert dialog title when the user taps the cancel download icon.")
     public static let CancelDownloadDialogMessage = MZLocalizedString(
-        "Downloads.CancelDialog.Message",
+        key: "Downloads.CancelDialog.Message",
         tableName: nil,
         value: "Are you sure you want to cancel this download?",
         comment: "Alert dialog body when the user taps the cancel download icon.")
     public static let CancelDownloadDialogResume = MZLocalizedString(
-        "Downloads.CancelDialog.Resume",
+        key: "Downloads.CancelDialog.Resume",
         tableName: nil,
         value: "Resume",
         comment: "Button declining the cancellation of the download.")
     public static let CancelDownloadDialogCancel = MZLocalizedString(
-        "Downloads.CancelDialog.Cancel",
+        key: "Downloads.CancelDialog.Cancel",
         tableName: nil,
         value: "Cancel",
         comment: "Button confirming the cancellation of the download.")
     public static let DownloadCancelledToastLabelText = MZLocalizedString(
-        "Downloads.Toast.Cancelled.LabelText",
+        key: "Downloads.Toast.Cancelled.LabelText",
         tableName: nil,
         value: "Download Cancelled",
         comment: "The label text in the Download Cancelled toast for showing confirmation that the download was cancelled.")
     public static let DownloadFailedToastLabelText = MZLocalizedString(
-        "Downloads.Toast.Failed.LabelText",
+        key: "Downloads.Toast.Failed.LabelText",
         tableName: nil,
         value: "Download Failed",
         comment: "The label text in the Download Failed toast for showing confirmation that the download has failed.")
     public static let DownloadMultipleFilesToastDescriptionText = MZLocalizedString(
-        "Downloads.Toast.MultipleFiles.DescriptionText",
+        key: "Downloads.Toast.MultipleFiles.DescriptionText",
         tableName: nil,
         value: "1 of %d files",
         comment: "The description text in the Download progress toast for showing the number of files when multiple files are downloading.")
     public static let DownloadProgressToastDescriptionText = MZLocalizedString(
-        "Downloads.Toast.Progress.DescriptionText",
+        key: "Downloads.Toast.Progress.DescriptionText",
         tableName: nil,
         value: "%1$@/%2$@",
         comment: "The description text in the Download progress toast for showing the downloaded file size (1$) out of the total expected file size (2$).")
     public static let DownloadMultipleFilesAndProgressToastDescriptionText = MZLocalizedString(
-        "Downloads.Toast.MultipleFilesAndProgress.DescriptionText",
+        key: "Downloads.Toast.MultipleFilesAndProgress.DescriptionText",
         tableName: nil,
         value: "%1$@ %2$@",
         comment: "The description text in the Download progress toast for showing the number of files (1$) and download progress (2$). This string only consists of two placeholders for purposes of displaying two other strings side-by-side where 1$ is Downloads.Toast.MultipleFiles.DescriptionText and 2$ is Downloads.Toast.Progress.DescriptionText. This string should only consist of the two placeholders side-by-side separated by a single space and 1$ should come before 2$ everywhere except for right-to-left locales.")
@@ -2517,37 +2517,37 @@ extension String {
 // MARK: - Add Custom Search Engine
 extension String {
     public static let SettingsAddCustomEngine = MZLocalizedString(
-        "Settings.AddCustomEngine",
+        key: "Settings.AddCustomEngine",
         tableName: nil,
         value: "Add Search Engine",
         comment: "The button text in Search Settings that opens the Custom Search Engine view.")
     public static let SettingsAddCustomEngineTitle = MZLocalizedString(
-        "Settings.AddCustomEngine.Title",
+        key: "Settings.AddCustomEngine.Title",
         tableName: nil,
         value: "Add Search Engine",
         comment: "The title of the  Custom Search Engine view.")
     public static let SettingsAddCustomEngineTitleLabel = MZLocalizedString(
-        "Settings.AddCustomEngine.TitleLabel",
+        key: "Settings.AddCustomEngine.TitleLabel",
         tableName: nil,
         value: "Title",
         comment: "The title for the field which sets the title for a custom search engine.")
     public static let SettingsAddCustomEngineURLLabel = MZLocalizedString(
-        "Settings.AddCustomEngine.URLLabel",
+        key: "Settings.AddCustomEngine.URLLabel",
         tableName: nil,
         value: "URL",
         comment: "The title for URL Field")
     public static let SettingsAddCustomEngineTitlePlaceholder = MZLocalizedString(
-        "Settings.AddCustomEngine.TitlePlaceholder",
+        key: "Settings.AddCustomEngine.TitlePlaceholder",
         tableName: nil,
         value: "Search Engine",
         comment: "The placeholder for Title Field when saving a custom search engine.")
     public static let SettingsAddCustomEngineURLPlaceholder = MZLocalizedString(
-        "Settings.AddCustomEngine.URLPlaceholder",
+        key: "Settings.AddCustomEngine.URLPlaceholder",
         tableName: nil,
         value: "URL (Replace Query with %s)",
         comment: "The placeholder for URL Field when saving a custom search engine")
     public static let SettingsAddCustomEngineSaveButtonText = MZLocalizedString(
-        "Settings.AddCustomEngine.SaveButtonText",
+        key: "Settings.AddCustomEngine.SaveButtonText",
         tableName: nil,
         value: "Save",
         comment: "The text on the Save button when saving a custom search engine")
@@ -2556,17 +2556,17 @@ extension String {
 // MARK: - Context menu ButtonToast instances.
 extension String {
     public static let ContextMenuButtonToastNewTabOpenedLabelText = MZLocalizedString(
-        "ContextMenu.ButtonToast.NewTabOpened.LabelText",
+        key: "ContextMenu.ButtonToast.NewTabOpened.LabelText",
         tableName: nil,
         value: "New Tab opened",
         comment: "The label text in the Button Toast for switching to a fresh New Tab.")
     public static let ContextMenuButtonToastNewTabOpenedButtonText = MZLocalizedString(
-        "ContextMenu.ButtonToast.NewTabOpened.ButtonText",
+        key: "ContextMenu.ButtonToast.NewTabOpened.ButtonText",
         tableName: nil,
         value: "Switch",
         comment: "The button text in the Button Toast for switching to a fresh New Tab.")
     public static let ContextMenuButtonToastNewPrivateTabOpenedLabelText = MZLocalizedString(
-        "ContextMenu.ButtonToast.NewPrivateTabOpened.LabelText.v113",
+        key: "ContextMenu.ButtonToast.NewPrivateTabOpened.LabelText.v113",
         tableName: nil,
         value: "New Private Tab Opened",
         comment: "The label text in the Button Toast for switching to a fresh New Private Tab.")
@@ -2575,48 +2575,48 @@ extension String {
 // MARK: - Page context menu items (i.e. links and images).
 extension String {
     public static let ContextMenuOpenInNewTab = MZLocalizedString(
-        "ContextMenu.OpenInNewTabButtonTitle",
+        key: "ContextMenu.OpenInNewTabButtonTitle",
         tableName: nil,
         value: "Open in New Tab",
         comment: "Context menu item for opening a link in a new tab")
     public static let ContextMenuOpenInNewPrivateTab = MZLocalizedString(
-        "ContextMenu.OpenInNewPrivateTabButtonTitle",
+        key: "ContextMenu.OpenInNewPrivateTabButtonTitle",
         tableName: "PrivateBrowsing",
         value: "Open in New Private Tab",
         comment: "Context menu option for opening a link in a new private tab")
 
     public static let ContextMenuBookmarkLink = MZLocalizedString(
-        "ContextMenu.BookmarkLinkButtonTitle",
+        key: "ContextMenu.BookmarkLinkButtonTitle",
         tableName: nil,
         value: "Bookmark Link",
         comment: "Context menu item for bookmarking a link URL")
     public static let ContextMenuDownloadLink = MZLocalizedString(
-        "ContextMenu.DownloadLinkButtonTitle",
+        key: "ContextMenu.DownloadLinkButtonTitle",
         tableName: nil,
         value: "Download Link",
         comment: "Context menu item for downloading a link URL")
     public static let ContextMenuCopyLink = MZLocalizedString(
-        "ContextMenu.CopyLinkButtonTitle",
+        key: "ContextMenu.CopyLinkButtonTitle",
         tableName: nil,
         value: "Copy Link",
         comment: "Context menu item for copying a link URL to the clipboard")
     public static let ContextMenuShareLink = MZLocalizedString(
-        "ContextMenu.ShareLinkButtonTitle",
+        key: "ContextMenu.ShareLinkButtonTitle",
         tableName: nil,
         value: "Share Link",
         comment: "Context menu item for sharing a link URL")
     public static let ContextMenuSaveImage = MZLocalizedString(
-        "ContextMenu.SaveImageButtonTitle",
+        key: "ContextMenu.SaveImageButtonTitle",
         tableName: nil,
         value: "Save Image",
         comment: "Context menu item for saving an image")
     public static let ContextMenuCopyImage = MZLocalizedString(
-        "ContextMenu.CopyImageButtonTitle",
+        key: "ContextMenu.CopyImageButtonTitle",
         tableName: nil,
         value: "Copy Image",
         comment: "Context menu item for copying an image to the clipboard")
     public static let ContextMenuCopyImageLink = MZLocalizedString(
-        "ContextMenu.CopyImageLinkButtonTitle",
+        key: "ContextMenu.CopyImageLinkButtonTitle",
         tableName: nil,
         value: "Copy Image Link",
         comment: "Context menu item for copying an image URL to the clipboard")
@@ -2625,12 +2625,12 @@ extension String {
 // MARK: - Photo Library access
 extension String {
     public static let PhotoLibraryFirefoxWouldLikeAccessTitle = MZLocalizedString(
-        "PhotoLibrary.FirefoxWouldLikeAccessTitle",
+        key: "PhotoLibrary.FirefoxWouldLikeAccessTitle",
         tableName: nil,
         value: "Firefox would like to access your Photos",
         comment: "See http://mzl.la/1G7uHo7")
     public static let PhotoLibraryFirefoxWouldLikeAccessMessage = MZLocalizedString(
-        "PhotoLibrary.FirefoxWouldLikeAccessMessage",
+        key: "PhotoLibrary.FirefoxWouldLikeAccessMessage",
         tableName: nil,
         value: "This allows you to save the image to your Camera Roll.",
         comment: "See http://mzl.la/1G7uHo7")
@@ -2641,42 +2641,42 @@ extension String {
 extension String {
     // zero tabs
     public static let SentTab_NoTabArrivingNotification_title = MZLocalizedString(
-        "SentTab.NoTabArrivingNotification.title",
+        key: "SentTab.NoTabArrivingNotification.title",
         tableName: nil,
         value: "Firefox Sync",
         comment: "Title of notification received after a spurious message from FxA has been received.")
     public static let SentTab_NoTabArrivingNotification_body =
     MZLocalizedString(
-        "SentTab.NoTabArrivingNotification.body",
+        key: "SentTab.NoTabArrivingNotification.body",
         tableName: nil,
         value: "Tap to begin",
         comment: "Body of notification received after a spurious message from FxA has been received.")
 
     // one or more tabs
     public static let SentTab_TabArrivingNotification_NoDevice_title = MZLocalizedString(
-        "SentTab_TabArrivingNotification_NoDevice_title",
+        key: "SentTab_TabArrivingNotification_NoDevice_title",
         tableName: nil,
         value: "Tab received",
         comment: "Title of notification shown when the device is sent one or more tabs from an unnamed device.")
     public static let SentTab_TabArrivingNotification_NoDevice_body = MZLocalizedString(
-        "SentTab_TabArrivingNotification_NoDevice_body",
+        key: "SentTab_TabArrivingNotification_NoDevice_body",
         tableName: nil,
         value: "New tab arrived from another device.",
         comment: "Body of notification shown when the device is sent one or more tabs from an unnamed device.")
     public static let SentTab_TabArrivingNotification_WithDevice_title = MZLocalizedString(
-        "SentTab_TabArrivingNotification_WithDevice_title",
+        key: "SentTab_TabArrivingNotification_WithDevice_title",
         tableName: nil,
         value: "Tab received from %@",
         comment: "Title of notification shown when the device is sent one or more tabs from the named device. %@ is the placeholder for the device name. This device name will be localized by that device.")
     public static let SentTab_TabArrivingNotification_WithDevice_body = MZLocalizedString(
-        "SentTab_TabArrivingNotification_WithDevice_body",
+        key: "SentTab_TabArrivingNotification_WithDevice_body",
         tableName: nil,
         value: "New tab arrived in %@",
         comment: "Body of notification shown when the device is sent one or more tabs from the named device. %@ is the placeholder for the app name.")
 
     // Notification Actions
     public static let SentTabViewActionTitle = MZLocalizedString(
-        "SentTab.ViewAction.title",
+        key: "SentTab.ViewAction.title",
         tableName: nil,
         value: "View",
         comment: "Label for an action used to view one or more tabs from a notification.")
@@ -2686,12 +2686,12 @@ extension String {
 extension String {
     public struct EngagementNotification {
         public static let Title = MZLocalizedString(
-            "Engagement.Notification.Title.v112",
+            key: "Engagement.Notification.Title.v112",
             tableName: "EngagementNotification",
             value: "Start your first search",
             comment: "Title of notification send to user after inactivity to encourage them to use the search feature.")
         public static let Body = MZLocalizedString(
-            "Engagement.Notification.Body.v112",
+            key: "Engagement.Notification.Body.v112",
             tableName: "EngagementNotification",
             value: "Find something nearby. Or discover something fun.",
             comment: "Body of notification send to user after inactivity to encourage them to use the search feature.")
@@ -2702,7 +2702,7 @@ extension String {
 extension String {
     public struct Notification {
         public static let FallbackTitle = MZLocalizedString(
-            "Notification.Fallback.Title.v113",
+            key: "Notification.Fallback.Title.v113",
             tableName: "Notification",
             value: "%@ Tip",
             comment: "Fallback Title of notification if no notification title was configured. The notification is an advise to the user. The argument is the app name.")
@@ -2712,39 +2712,39 @@ extension String {
 // MARK: - Additional messages sent via Push from FxA
 extension String {
     public static let FxAPush_DeviceDisconnected_ThisDevice_title = MZLocalizedString(
-        "FxAPush_DeviceDisconnected_ThisDevice_title",
+        key: "FxAPush_DeviceDisconnected_ThisDevice_title",
         tableName: nil,
         value: "Sync Disconnected",
         comment: "Title of a notification displayed when this device has been disconnected by another device.")
     public static let FxAPush_DeviceDisconnected_ThisDevice_body = MZLocalizedString(
-        "FxAPush_DeviceDisconnected_ThisDevice_body",
+        key: "FxAPush_DeviceDisconnected_ThisDevice_body",
         tableName: nil,
         value: "This device has been successfully disconnected from Firefox Sync.",
         comment: "Body of a notification displayed when this device has been disconnected from FxA by another device.")
     public static let FxAPush_DeviceDisconnected_title = MZLocalizedString(
-        "FxAPush_DeviceDisconnected_title",
+        key: "FxAPush_DeviceDisconnected_title",
         tableName: nil,
         value: "Sync Disconnected",
         comment: "Title of a notification displayed when named device has been disconnected from FxA.")
     public static let FxAPush_DeviceDisconnected_body = MZLocalizedString(
-        "FxAPush_DeviceDisconnected_body",
+        key: "FxAPush_DeviceDisconnected_body",
         tableName: nil,
         value: "%@ has been successfully disconnected.",
         comment: "Body of a notification displayed when named device has been disconnected from FxA. %@ refers to the name of the disconnected device.")
 
     public static let FxAPush_DeviceDisconnected_UnknownDevice_body = MZLocalizedString(
-        "FxAPush_DeviceDisconnected_UnknownDevice_body",
+        key: "FxAPush_DeviceDisconnected_UnknownDevice_body",
         tableName: nil,
         value: "A device has disconnected from Firefox Sync",
         comment: "Body of a notification displayed when unnamed device has been disconnected from FxA.")
 
     public static let FxAPush_DeviceConnected_title = MZLocalizedString(
-        "FxAPush_DeviceConnected_title",
+        key: "FxAPush_DeviceConnected_title",
         tableName: nil,
         value: "Sync Connected",
         comment: "Title of a notification displayed when another device has connected to FxA.")
     public static let FxAPush_DeviceConnected_body = MZLocalizedString(
-        "FxAPush_DeviceConnected_body",
+        key: "FxAPush_DeviceConnected_body",
         tableName: nil,
         value: "Firefox Sync has connected to %@",
         comment: "Title of a notification displayed when another device has connected to FxA. %@ refers to the name of the newly connected device.")
@@ -2753,12 +2753,12 @@ extension String {
 // MARK: - Reader Mode
 extension String {
     public static let ReaderModeAvailableVoiceOverAnnouncement = MZLocalizedString(
-        "ReaderMode.Available.VoiceOverAnnouncement",
+        key: "ReaderMode.Available.VoiceOverAnnouncement",
         tableName: nil,
         value: "Reader Mode available",
         comment: "Accessibility message e.g. spoken by VoiceOver when Reader Mode becomes available.")
     public static let ReaderModeResetFontSizeAccessibilityLabel = MZLocalizedString(
-        "Reset text size",
+        key: "Reset text size",
         tableName: nil,
         value: nil,
         comment: "Accessibility label for button resetting font size in display settings of reader mode")
@@ -2767,27 +2767,27 @@ extension String {
 // MARK: - QR Code scanner
 extension String {
     public static let ScanQRCodeViewTitle = MZLocalizedString(
-        "ScanQRCode.View.Title",
+        key: "ScanQRCode.View.Title",
         tableName: nil,
         value: "Scan QR Code",
         comment: "Title for the QR code scanner view.")
     public static let ScanQRCodeInstructionsLabel = MZLocalizedString(
-        "ScanQRCode.Instructions.Label",
+        key: "ScanQRCode.Instructions.Label",
         tableName: nil,
         value: "Align QR code within frame to scan",
         comment: "Text for the instructions label, displayed in the QR scanner view")
     public static let ScanQRCodeInvalidDataErrorMessage = MZLocalizedString(
-        "ScanQRCode.InvalidDataError.Message",
+        key: "ScanQRCode.InvalidDataError.Message",
         tableName: nil,
         value: "The data is invalid",
         comment: "Text of the prompt that is shown to the user when the data is invalid")
     public static let ScanQRCodePermissionErrorMessage = MZLocalizedString(
-        "ScanQRCode.PermissionError.Message.v100",
+        key: "ScanQRCode.PermissionError.Message.v100",
         tableName: nil,
         value: "Go to device ‘Settings’ > ‘Firefox’. Allow Firefox to access camera.",
         comment: "Text of the prompt to setup the camera authorization for the Scan QR Code feature.")
     public static let ScanQRCodeErrorOKButton = MZLocalizedString(
-        "ScanQRCode.Error.OK.Button",
+        key: "ScanQRCode.Error.OK.Button",
         tableName: nil,
         value: "OK",
         comment: "OK button to dismiss the error prompt.")
@@ -2798,260 +2798,260 @@ extension String {
     /// Identifiers of all new strings should begin with `Menu.`
     public struct AppMenu {
         public static let AppMenuReportSiteIssueTitleString = MZLocalizedString(
-            "Menu.ReportSiteIssueAction.Title",
+            key: "Menu.ReportSiteIssueAction.Title",
             tableName: "Menu",
             value: "Report Site Issue",
             comment: "Label for the button, displayed in the menu, used to report a compatibility issue with the current page.")
         public static let AppMenuSharePageTitleString = MZLocalizedString(
-            "Menu.SharePageAction.Title",
+            key: "Menu.SharePageAction.Title",
             tableName: "Menu",
             value: "Share Page With…",
             comment: "Label for the button, displayed in the menu, used to open the share dialog.")
         public static let AppMenuCopyLinkTitleString = MZLocalizedString(
-            "Menu.CopyLink.Title",
+            key: "Menu.CopyLink.Title",
             tableName: "Menu",
             value: "Copy Link",
             comment: "Label for the button, displayed in the menu, used to copy the current page link to the clipboard.")
         public static let AppMenuFindInPageTitleString = MZLocalizedString(
-            "Menu.FindInPageAction.Title",
+            key: "Menu.FindInPageAction.Title",
             tableName: "Menu",
             value: "Find in Page",
             comment: "Label for the button, displayed in the menu, used to open the toolbar to search for text within the current page.")
         public static let AppMenuViewDesktopSiteTitleString = MZLocalizedString(
-            "Menu.ViewDekstopSiteAction.Title",
+            key: "Menu.ViewDekstopSiteAction.Title",
             tableName: "Menu",
             value: "Request Desktop Site",
             comment: "Label for the button, displayed in the menu, used to request the desktop version of the current website.")
         public static let AppMenuViewMobileSiteTitleString = MZLocalizedString(
-            "Menu.ViewMobileSiteAction.Title",
+            key: "Menu.ViewMobileSiteAction.Title",
             tableName: "Menu",
             value: "Request Mobile Site",
             comment: "Label for the button, displayed in the menu, used to request the mobile version of the current website.")
         public static let AppMenuSettingsTitleString = MZLocalizedString(
-            "Menu.OpenSettingsAction.Title",
+            key: "Menu.OpenSettingsAction.Title",
             tableName: "Menu",
             value: "Settings",
             comment: "Label for the button, displayed in the menu, used to open the Settings menu.")
         public static let AppMenuCloseAllTabsTitleString = MZLocalizedString(
-            "Menu.CloseAllTabsAction.Title",
+            key: "Menu.CloseAllTabsAction.Title",
             tableName: "Menu",
             value: "Close All Tabs",
             comment: "Label for the button, displayed in the menu, used to close all tabs currently open.")
         public static let AppMenuOpenHomePageTitleString = MZLocalizedString(
-            "SettingsMenu.OpenHomePageAction.Title",
+            key: "SettingsMenu.OpenHomePageAction.Title",
             tableName: "Menu",
             value: "Homepage",
             comment: "Label for the button, displayed in the menu, used to navigate to the home page.")
         public static let AppMenuBookmarksTitleString = MZLocalizedString(
-            "Menu.OpenBookmarksAction.AccessibilityLabel.v2",
+            key: "Menu.OpenBookmarksAction.AccessibilityLabel.v2",
             tableName: "Menu",
             value: "Bookmarks",
             comment: "Accessibility label for the button, displayed in the menu, used to open the Bookmarks home panel. Please keep as short as possible, <15 chars of space available.")
         public static let AppMenuReadingListTitleString = MZLocalizedString(
-            "Menu.OpenReadingListAction.AccessibilityLabel.v2",
+            key: "Menu.OpenReadingListAction.AccessibilityLabel.v2",
             tableName: "Menu",
             value: "Reading List",
             comment: "Accessibility label for the button, displayed in the menu, used to open the Reading list home panel. Please keep as short as possible, <15 chars of space available.")
         public static let AppMenuHistoryTitleString = MZLocalizedString(
-            "Menu.OpenHistoryAction.AccessibilityLabel.v2",
+            key: "Menu.OpenHistoryAction.AccessibilityLabel.v2",
             tableName: "Menu",
             value: "History",
             comment: "Accessibility label for the button, displayed in the menu, used to open the History home panel. Please keep as short as possible, <15 chars of space available.")
         public static let AppMenuDownloadsTitleString = MZLocalizedString(
-            "Menu.OpenDownloadsAction.AccessibilityLabel.v2",
+            key: "Menu.OpenDownloadsAction.AccessibilityLabel.v2",
             tableName: "Menu",
             value: "Downloads",
             comment: "Accessibility label for the button, displayed in the menu, used to open the Downloads home panel. Please keep as short as possible, <15 chars of space available.")
         public static let AppMenuSyncedTabsTitleString = MZLocalizedString(
-            "Menu.OpenSyncedTabsAction.AccessibilityLabel.v2",
+            key: "Menu.OpenSyncedTabsAction.AccessibilityLabel.v2",
             tableName: "Menu",
             value: "Synced Tabs",
             comment: "Accessibility label for the button, displayed in the menu, used to open the Synced Tabs home panel. Please keep as short as possible, <15 chars of space available.")
         public static let AppMenuTurnOnNightMode = MZLocalizedString(
-            "Menu.NightModeTurnOn.Label2",
+            key: "Menu.NightModeTurnOn.Label2",
             tableName: nil,
             value: "Turn on Night Mode",
             comment: "Label for the button, displayed in the menu, turns on night mode.")
         public static let AppMenuTurnOffNightMode = MZLocalizedString(
-            "Menu.NightModeTurnOff.Label2",
+            key: "Menu.NightModeTurnOff.Label2",
             tableName: nil,
             value: "Turn off Night Mode",
             comment: "Label for the button, displayed in the menu, turns off night mode.")
         public static let AppMenuHistory = MZLocalizedString(
-            "Menu.History.Label",
+            key: "Menu.History.Label",
             tableName: nil,
             value: "History",
             comment: "Label for the button, displayed in the menu, takes you to to History screen when pressed.")
         public static let AppMenuDownloads = MZLocalizedString(
-            "Menu.Downloads.Label",
+            key: "Menu.Downloads.Label",
             tableName: nil,
             value: "Downloads",
             comment: "Label for the button, displayed in the menu, takes you to to Downloads screen when pressed.")
         public static let AppMenuPasswords = MZLocalizedString(
-            "Menu.Passwords.Label",
+            key: "Menu.Passwords.Label",
             tableName: nil,
             value: "Passwords",
             comment: "Label for the button, displayed in the menu, takes you to to passwords screen when pressed.")
         public static let AppMenuCopyURLConfirmMessage = MZLocalizedString(
-            "Menu.CopyURL.Confirm",
+            key: "Menu.CopyURL.Confirm",
             tableName: nil,
             value: "URL Copied To Clipboard",
             comment: "Toast displayed to user after copy url pressed.")
         public static let AppMenuTabSentConfirmMessage = MZLocalizedString(
-            "Menu.TabSent.Confirm",
+            key: "Menu.TabSent.Confirm",
             tableName: nil,
             value: "Tab Sent",
             comment: "Toast displayed to the user after a tab has been sent successfully.")
         public static let WhatsNewString = MZLocalizedString(
-            "Menu.WhatsNew.Title",
+            key: "Menu.WhatsNew.Title",
             tableName: nil,
             value: "What’s New",
             comment: "The title for the option to view the What's new page.")
         public static let CustomizeHomePage = MZLocalizedString(
-            "Menu.CustomizeHomePage.v99",
+            key: "Menu.CustomizeHomePage.v99",
             tableName: nil,
             value: "Customize Homepage",
             comment: "Label for the customize homepage button in the menu page. Pressing this button takes users to the settings options, where they can customize the Firefox Home page")
         public static let NewTab = MZLocalizedString(
-            "Menu.NewTab.v99",
+            key: "Menu.NewTab.v99",
             tableName: nil,
             value: "New Tab",
             comment: "Label for the new tab button in the menu page. Pressing this button opens a new tab.")
         public static let Help = MZLocalizedString(
-            "Menu.Help.v99",
+            key: "Menu.Help.v99",
             tableName: nil,
             value: "Help",
             comment: "Label for the help button in the menu page. Pressing this button opens the support page https://support.mozilla.org/en-US/products/ios")
         public static let Share = MZLocalizedString(
-            "Menu.Share.v99",
+            key: "Menu.Share.v99",
             tableName: nil,
             value: "Share",
             comment: "Label for the share button in the menu page. Pressing this button open the share menu to share the current website.")
         public static let SyncAndSaveData = MZLocalizedString(
-            "Menu.SyncAndSaveData.v103",
+            key: "Menu.SyncAndSaveData.v103",
             tableName: nil,
             value: "Sync and Save Data",
             comment: "Label for the Firefox Sync button in the menu page. Pressing this button open the sign in to Firefox page service to sync and save data.")
 
         // Shortcuts
         public static let AddToShortcuts = MZLocalizedString(
-            "Menu.AddToShortcuts.v99",
+            key: "Menu.AddToShortcuts.v99",
             tableName: nil,
             value: "Add to Shortcuts",
             comment: "Label for the add to shortcuts button in the menu. Pressing this button pins the current website as a shortcut on the home page.")
         public static let RemoveFromShortcuts = MZLocalizedString(
-            "Menu.RemovedFromShortcuts.v99",
+            key: "Menu.RemovedFromShortcuts.v99",
             tableName: nil,
             value: "Remove from Shortcuts",
             comment: "Label for the remove from shortcuts button in the menu. Pressing this button removes the current website from the shortcut pins on the home page.")
         public static let AddPinToShortcutsConfirmMessage = MZLocalizedString(
-            "Menu.AddPin.Confirm2",
+            key: "Menu.AddPin.Confirm2",
             tableName: nil,
             value: "Added to Shortcuts",
             comment: "Toast displayed to the user after adding the item to the Shortcuts.")
         public static let RemovePinFromShortcutsConfirmMessage = MZLocalizedString(
-            "Menu.RemovePin.Confirm2.v99",
+            key: "Menu.RemovePin.Confirm2.v99",
             tableName: nil,
             value: "Removed from Shortcuts",
             comment: "Toast displayed to the user after removing the item to the Shortcuts.")
 
         // Bookmarks
         public static let Bookmarks = MZLocalizedString(
-            "Menu.Bookmarks.Label",
+            key: "Menu.Bookmarks.Label",
             tableName: nil,
             value: "Bookmarks",
             comment: "Label for the button, displayed in the menu, takes you to to bookmarks screen when pressed.")
         public static let AddBookmark = MZLocalizedString(
-            "Menu.AddBookmark.Label.v99",
+            key: "Menu.AddBookmark.Label.v99",
             tableName: nil,
             value: "Add",
             comment: "Label for the add bookmark button in the menu. Pressing this button bookmarks the current page. Please keep the text as short as possible for this label.")
         public static let AddBookmarkAlternateTitle = MZLocalizedString(
-            "Menu.AddBookmark.AlternateLabel.v99",
+            key: "Menu.AddBookmark.AlternateLabel.v99",
             tableName: nil,
             value: "Add Bookmark",
             comment: "Long label for the add bookmark button displayed in the menu. Pressing this button bookmarks the current page.")
         public static let AddBookmarkConfirmMessage = MZLocalizedString(
-            "Menu.AddBookmark.Confirm",
+            key: "Menu.AddBookmark.Confirm",
             tableName: nil,
             value: "Bookmark Added",
             comment: "Toast displayed to the user after a bookmark has been added.")
         public static let RemoveBookmark = MZLocalizedString(
-            "Menu.RemoveBookmark.Label.v99",
+            key: "Menu.RemoveBookmark.Label.v99",
             tableName: nil,
             value: "Remove",
             comment: "Label for the remove bookmark button in the menu. Pressing this button remove the current page from the bookmarks. Please keep the text as short as possible for this label.")
         public static let RemoveBookmarkAlternateTitle = MZLocalizedString(
-            "Menu.RemoveBookmark.AlternateLabel.v99",
+            key: "Menu.RemoveBookmark.AlternateLabel.v99",
             tableName: "Menu",
             value: "Remove Bookmark",
             comment: "Long label for the remove bookmark button displayed in the menu. Pressing this button remove the current page from the bookmarks.")
         public static let RemoveBookmarkConfirmMessage = MZLocalizedString(
-            "Menu.RemoveBookmark.Confirm",
+            key: "Menu.RemoveBookmark.Confirm",
             tableName: nil,
             value: "Bookmark Removed",
             comment: "Toast displayed to the user after a bookmark has been removed.")
 
         // Reading list
         public static let ReadingList = MZLocalizedString(
-            "Menu.ReadingList.Label",
+            key: "Menu.ReadingList.Label",
             tableName: nil,
             value: "Reading List",
             comment: "Label for the button, displayed in the menu, takes you to to Reading List screen when pressed.")
         public static let AddReadingList = MZLocalizedString(
-            "Menu.AddReadingList.Label.v99",
+            key: "Menu.AddReadingList.Label.v99",
             tableName: nil,
             value: "Add",
             comment: "Label for the add to reading list button in the menu. Pressing this button adds the current page to the reading list. Please keep the text as short as possible for this label.")
         public static let AddReadingListAlternateTitle = MZLocalizedString(
-            "Menu.AddToReadingList.AlternateLabel.v99",
+            key: "Menu.AddToReadingList.AlternateLabel.v99",
             tableName: "Menu",
             value: "Add to Reading List",
             comment: "Long label for the button displayed in the menu, used to add a page to the reading list.")
         public static let AddToReadingListConfirmMessage = MZLocalizedString(
-            "Menu.AddToReadingList.Confirm",
+            key: "Menu.AddToReadingList.Confirm",
             tableName: nil,
             value: "Added To Reading List",
             comment: "Toast displayed to the user after adding the item to their reading list.")
         public static let RemoveReadingList = MZLocalizedString(
-            "Menu.RemoveReadingList.Label.v99",
+            key: "Menu.RemoveReadingList.Label.v99",
             tableName: nil,
             value: "Remove",
             comment: "Label for the remove from reading list button in the menu. Pressing this button removes the current page from the reading list. Please keep the text as short as possible for this label.")
         public static let RemoveReadingListAlternateTitle = MZLocalizedString(
-            "Menu.RemoveReadingList.AlternateLabel.v99",
+            key: "Menu.RemoveReadingList.AlternateLabel.v99",
             tableName: nil,
             value: "Remove from Reading List",
             comment: "Long label for the remove from reading list button in the menu. Pressing this button removes the current page from the reading list.")
         public static let RemoveFromReadingListConfirmMessage = MZLocalizedString(
-            "Menu.RemoveReadingList.Confirm.v99",
+            key: "Menu.RemoveReadingList.Confirm.v99",
             tableName: nil,
             value: "Removed from Reading List",
             comment: "Toast displayed to confirm to the user that his reading list item was correctly removed.")
 
         // ZoomPageBar
         public static let ZoomPageTitle = MZLocalizedString(
-            "Menu.ZoomPage.Title.v113",
+            key: "Menu.ZoomPage.Title.v113",
             tableName: nil,
             value: "Zoom (%@)",
             comment: "Label for the zoom page button in the menu, used to show the Zoom Page bar. The placeholder shows the current zoom level in percent.")
         public static let ZoomPageCloseAccessibilityLabel = MZLocalizedString(
-            "Menu.ZoomPage.Close.AccessibilityLabel.v113",
+            key: "Menu.ZoomPage.Close.AccessibilityLabel.v113",
             tableName: "ZoomPageBar",
             value: "Close Zoom Panel",
             comment: "Accessibility label for closing the zoom panel in Zoom Page Bar")
         public static let ZoomPageIncreaseZoomAccessibilityLabel = MZLocalizedString(
-            "Menu.ZoomPage.IncreaseZoom.AccessibilityLabel.v113",
+            key: "Menu.ZoomPage.IncreaseZoom.AccessibilityLabel.v113",
             tableName: "ZoomPageBar",
             value: "Increase Zoom Level",
             comment: "Accessibility label for increasing the zoom level in Zoom Page Bar")
         public static let ZoomPageDecreaseZoomAccessibilityLabel = MZLocalizedString(
-            "Menu.ZoomPage.DecreaseZoom.AccessibilityLabel.v113",
+            key: "Menu.ZoomPage.DecreaseZoom.AccessibilityLabel.v113",
             tableName: "ZoomPageBar",
             value: "Decrease Zoom Level",
             comment: "Accessibility label for decreasing the zoom level in Zoom Page Bar")
         public static let ZoomPageCurrentZoomLevelAccessibilityLabel = MZLocalizedString(
-            "Menu.ZoomPage.CurrentZoomLevel.AccessibilityLabel.v113",
+            key: "Menu.ZoomPage.CurrentZoomLevel.AccessibilityLabel.v113",
             tableName: "ZoomPageBar",
             value: "Current Zoom Level: %@",
             comment: "Accessibility label for current zoom level in Zoom Page Bar. The placeholder represents the zoom level")
@@ -3059,22 +3059,22 @@ extension String {
         // Toolbar
         public struct Toolbar {
             public static let MenuButtonAccessibilityLabel = MZLocalizedString(
-                "Toolbar.Menu.AccessibilityLabel",
+                key: "Toolbar.Menu.AccessibilityLabel",
                 tableName: nil,
                 value: "Menu",
                 comment: "Accessibility label for the Menu button.")
             public static let HomeMenuButtonAccessibilityLabel = MZLocalizedString(
-                "Menu.Toolbar.Home.AccessibilityLabel.v99",
+                key: "Menu.Toolbar.Home.AccessibilityLabel.v99",
                 tableName: nil,
                 value: "Home",
                 comment: "Accessibility label for the Home button on the toolbar. Pressing this button brings the user to the home page.")
             public static let BookmarksButtonAccessibilityLabel = MZLocalizedString(
-                "Menu.Toolbar.Bookmarks.AccessibilityLabel.v99",
+                key: "Menu.Toolbar.Bookmarks.AccessibilityLabel.v99",
                 tableName: nil,
                 value: "Bookmarks",
                 comment: "Accessibility label for the Bookmark button on the toolbar. Pressing this button opens the bookmarks menu")
             public static let TabTrayDeleteMenuButtonAccessibilityLabel = MZLocalizedString(
-                "Toolbar.Menu.CloseAllTabs",
+                key: "Toolbar.Menu.CloseAllTabs",
                 tableName: nil,
                 value: "Close All Tabs",
                 comment: "Accessibility label for the Close All Tabs menu button.")
@@ -3083,12 +3083,12 @@ extension String {
         // 3D TouchActions
         public struct TouchActions {
             public static let SendToDeviceTitle = MZLocalizedString(
-                "Send to Device",
+                key: "Send to Device",
                 tableName: "3DTouchActions",
                 value: nil,
                 comment: "Label for preview action on Tab Tray Tab to send the current tab to another device")
             public static let SendLinkToDeviceTitle = MZLocalizedString(
-                "Menu.SendLinkToDevice",
+                key: "Menu.SendLinkToDevice",
                 tableName: "3DTouchActions",
                 value: "Send Link to Device",
                 comment: "Label for preview action on Tab Tray Tab to send the current link to another device")
@@ -3099,12 +3099,12 @@ extension String {
 // MARK: - Snackbar shown when tapping app store link
 extension String {
     public static let ExternalLinkAppStoreConfirmationTitle = MZLocalizedString(
-        "ExternalLink.AppStore.ConfirmationTitle",
+        key: "ExternalLink.AppStore.ConfirmationTitle",
         tableName: nil,
         value: "Open this link in the App Store?",
         comment: "Question shown to user when tapping a link that opens the App Store app")
     public static let ExternalLinkGenericConfirmation = MZLocalizedString(
-        "ExternalLink.AppStore.GenericConfirmationTitle",
+        key: "ExternalLink.AppStore.GenericConfirmationTitle",
         tableName: nil,
         value: "Open this link in external app?",
         comment: "Question shown to user when tapping an SMS or MailTo link that opens the external app for those.")
@@ -3113,70 +3113,70 @@ extension String {
 // MARK: - ContentBlocker/TrackingProtection string
 extension String {
     public static let SettingsTrackingProtectionSectionName = MZLocalizedString(
-        "Settings.TrackingProtection.SectionName",
+        key: "Settings.TrackingProtection.SectionName",
         tableName: nil,
         value: "Tracking Protection",
         comment: "Row in top-level of settings that gets tapped to show the tracking protection settings detail view.")
 
     public static let TrackingProtectionEnableTitle = MZLocalizedString(
-        "Settings.TrackingProtectionOption.NormalBrowsingLabelOn",
+        key: "Settings.TrackingProtectionOption.NormalBrowsingLabelOn",
         tableName: nil,
         value: "Enhanced Tracking Protection",
         comment: "Settings option to specify that Tracking Protection is on")
 
     public static let TrackingProtectionOptionProtectionLevelTitle = MZLocalizedString(
-        "Settings.TrackingProtection.ProtectionLevelTitle",
+        key: "Settings.TrackingProtection.ProtectionLevelTitle",
         tableName: nil,
         value: "Protection Level",
         comment: "Title for tracking protection options section where level can be selected.")
     public static let TrackingProtectionOptionBlockListLevelStandard = MZLocalizedString(
-        "Settings.TrackingProtectionOption.BasicBlockList",
+        key: "Settings.TrackingProtectionOption.BasicBlockList",
         tableName: nil,
         value: "Standard (default)",
         comment: "Tracking protection settings option for using the basic blocklist.")
     public static let TrackingProtectionOptionBlockListLevelStandardStatus = MZLocalizedString(
-        "Settings.TrackingProtectionOption.BasicBlockList.Status",
+        key: "Settings.TrackingProtectionOption.BasicBlockList.Status",
         tableName: nil,
         value: "Standard",
         comment: "Tracking protection settings status showing the current option selected.")
     public static let TrackingProtectionOptionBlockListLevelStrict = MZLocalizedString(
-        "Settings.TrackingProtectionOption.BlockListStrict",
+        key: "Settings.TrackingProtectionOption.BlockListStrict",
         tableName: nil,
         value: "Strict",
         comment: "Tracking protection settings option for using the strict blocklist.")
     public static let TrackingProtectionReloadWithout = MZLocalizedString(
-        "Menu.ReloadWithoutTrackingProtection.Title",
+        key: "Menu.ReloadWithoutTrackingProtection.Title",
         tableName: nil,
         value: "Reload Without Tracking Protection",
         comment: "Label for the button, displayed in the menu, used to reload the current website without Tracking Protection")
     public static let TrackingProtectionReloadWith = MZLocalizedString(
-        "Menu.ReloadWithTrackingProtection.Title",
+        key: "Menu.ReloadWithTrackingProtection.Title",
         tableName: nil,
         value: "Reload With Tracking Protection",
         comment: "Label for the button, displayed in the menu, used to reload the current website with Tracking Protection enabled")
 
     public static let TrackingProtectionCellFooter = MZLocalizedString(
-        "Settings.TrackingProtection.ProtectionCellFooter",
+        key: "Settings.TrackingProtection.ProtectionCellFooter",
         tableName: nil,
         value: "Reduces targeted ads and helps stop advertisers from tracking your browsing.",
         comment: "Additional information about your Enhanced Tracking Protection")
     public static let TrackingProtectionStandardLevelDescription = MZLocalizedString(
-        "Settings.TrackingProtection.ProtectionLevelStandard.Description",
+        key: "Settings.TrackingProtection.ProtectionLevelStandard.Description",
         tableName: nil,
         value: "Allows some ad tracking so websites function properly.",
         comment: "Description for standard level tracker protection")
     public static let TrackingProtectionStrictLevelDescription = MZLocalizedString(
-        "Settings.TrackingProtection.ProtectionLevelStrict.Description",
+        key: "Settings.TrackingProtection.ProtectionLevelStrict.Description",
         tableName: nil,
         value: "Blocks more trackers, ads, and popups. Pages load faster, but some functionality may not work.",
         comment: "Description for strict level tracker protection")
     public static let TrackingProtectionLevelFooter = MZLocalizedString(
-        "Settings.TrackingProtection.ProtectionLevel.Footer.Lock",
+        key: "Settings.TrackingProtection.ProtectionLevel.Footer.Lock",
         tableName: nil,
         value: "If a site doesn’t work as expected, tap the lock in the address bar and turn off Enhanced Tracking Protection for that page.",
         comment: "Footer information for tracker protection level.")
     public static let TrackerProtectionLearnMore = MZLocalizedString(
-        "Settings.TrackingProtection.LearnMore",
+        key: "Settings.TrackingProtection.LearnMore",
         tableName: nil,
         value: "Learn more",
         comment: "'Learn more' info link on the Tracking Protection settings screen.")
@@ -3185,86 +3185,86 @@ extension String {
 // MARK: - Tracking Protection menu
 extension String {
     public static let ETPOn = MZLocalizedString(
-        "Menu.EnhancedTrackingProtectionOn.Title",
+        key: "Menu.EnhancedTrackingProtectionOn.Title",
         tableName: nil,
         value: "Protections are ON for this site",
         comment: "A switch to enable enhanced tracking protection inside the menu.")
     public static let ETPOff = MZLocalizedString(
-        "Menu.EnhancedTrackingProtectionOff.Title",
+        key: "Menu.EnhancedTrackingProtectionOff.Title",
         tableName: nil,
         value: "Protections are OFF for this site",
         comment: "A switch to disable enhanced tracking protection inside the menu.")
 
     public static let TPDetailsVerifiedBy = MZLocalizedString(
-        "Menu.TrackingProtection.Details.Verifier",
+        key: "Menu.TrackingProtection.Details.Verifier",
         tableName: nil,
         value: "Verified by %@",
         comment: "String to let users know the site verifier, where the placeholder represents the SSL certificate signer.")
 
     // Category Titles
     public static let TPCryptominersBlocked = MZLocalizedString(
-        "Menu.TrackingProtectionCryptominersBlocked.Title",
+        key: "Menu.TrackingProtectionCryptominersBlocked.Title",
         tableName: nil,
         value: "Cryptominers",
         comment: "The title that shows the number of cryptomining scripts blocked")
     public static let TPFingerprintersBlocked = MZLocalizedString(
-        "Menu.TrackingProtectionFingerprintersBlocked.Title",
+        key: "Menu.TrackingProtectionFingerprintersBlocked.Title",
         tableName: nil,
         value: "Fingerprinters",
         comment: "The title that shows the number of fingerprinting scripts blocked")
     public static let TPCrossSiteBlocked = MZLocalizedString(
-        "Menu.TrackingProtectionCrossSiteTrackers.Title",
+        key: "Menu.TrackingProtectionCrossSiteTrackers.Title",
         tableName: nil,
         value: "Cross-Site Trackers",
         comment: "The title that shows the number of cross-site URLs blocked")
     public static let TPSocialBlocked = MZLocalizedString(
-        "Menu.TrackingProtectionBlockedSocial.Title",
+        key: "Menu.TrackingProtectionBlockedSocial.Title",
         tableName: nil,
         value: "Social Trackers",
         comment: "The title that shows the number of social URLs blocked")
     public static let TPContentBlocked = MZLocalizedString(
-        "Menu.TrackingProtectionBlockedContent.Title",
+        key: "Menu.TrackingProtectionBlockedContent.Title",
         tableName: nil,
         value: "Tracking content",
         comment: "The title that shows the number of content cookies blocked")
 
     // Shortcut on bottom of TP page menu to get to settings.
     public static let TPProtectionSettings = MZLocalizedString(
-        "Menu.TrackingProtection.ProtectionSettings.Title",
+        key: "Menu.TrackingProtection.ProtectionSettings.Title",
         tableName: nil,
         value: "Protection Settings",
         comment: "The title for tracking protection settings")
 
     // Settings info
     public static let TPAccessoryInfoBlocksTitle = MZLocalizedString(
-        "Settings.TrackingProtection.Info.BlocksTitle",
+        key: "Settings.TrackingProtection.Info.BlocksTitle",
         tableName: nil,
         value: "BLOCKS",
         comment: "The Title on info view which shows a list of all blocked websites")
 
     // Category descriptions
     public static let TPCategoryDescriptionSocial = MZLocalizedString(
-        "Menu.TrackingProtectionDescription.SocialNetworksNew",
+        key: "Menu.TrackingProtectionDescription.SocialNetworksNew",
         tableName: nil,
         value: "Social networks place trackers on other websites to build a more complete and targeted profile of you. Blocking these trackers reduces how much social media companies can see what do you online.",
         comment: "Description of social network trackers.")
     public static let TPCategoryDescriptionCrossSite = MZLocalizedString(
-        "Menu.TrackingProtectionDescription.CrossSiteNew",
+        key: "Menu.TrackingProtectionDescription.CrossSiteNew",
         tableName: nil,
         value: "These cookies follow you from site to site to gather data about what you do online. They are set by third parties such as advertisers and analytics companies.",
         comment: "Description of cross-site trackers.")
     public static let TPCategoryDescriptionCryptominers = MZLocalizedString(
-        "Menu.TrackingProtectionDescription.CryptominersNew",
+        key: "Menu.TrackingProtectionDescription.CryptominersNew",
         tableName: nil,
         value: "Cryptominers secretly use your system’s computing power to mine digital money. Cryptomining scripts drain your battery, slow down your computer, and can increase your energy bill.",
         comment: "Description of cryptominers.")
     public static let TPCategoryDescriptionFingerprinters = MZLocalizedString(
-        "Menu.TrackingProtectionDescription.Fingerprinters",
+        key: "Menu.TrackingProtectionDescription.Fingerprinters",
         tableName: nil,
         value: "The settings on your browser and computer are unique. Fingerprinters collect a variety of these unique settings to create a profile of you, which can be used to track you as you browse.",
         comment: "Description of fingerprinters.")
     public static let TPCategoryDescriptionContentTrackers = MZLocalizedString(
-        "Menu.TrackingProtectionDescription.ContentTrackers",
+        key: "Menu.TrackingProtectionDescription.ContentTrackers",
         tableName: nil,
         value: "Websites may load outside ads, videos, and other content that contains hidden trackers. Blocking this can make websites load faster, but some buttons, forms, and login fields, might not work.",
         comment: "Description of content trackers.")
@@ -3273,17 +3273,17 @@ extension String {
 // MARK: - Location bar long press menu
 extension String {
     public static let PasteAndGoTitle = MZLocalizedString(
-        "Menu.PasteAndGo.Title",
+        key: "Menu.PasteAndGo.Title",
         tableName: nil,
         value: "Paste & Go",
         comment: "The title for the button that lets you paste and go to a URL")
     public static let PasteTitle = MZLocalizedString(
-        "Menu.Paste.Title",
+        key: "Menu.Paste.Title",
         tableName: nil,
         value: "Paste",
         comment: "The title for the button that lets you paste into the location bar")
     public static let CopyAddressTitle = MZLocalizedString(
-        "Menu.Copy.Title",
+        key: "Menu.Copy.Title",
         tableName: nil,
         value: "Copy Address",
         comment: "The title for the button that lets you copy the url from the location bar.")
@@ -3292,32 +3292,32 @@ extension String {
 // MARK: - Settings Home
 extension String {
     public static let SendUsageSettingTitle = MZLocalizedString(
-        "Settings.SendUsage.Title",
+        key: "Settings.SendUsage.Title",
         tableName: nil,
         value: "Send Usage Data",
         comment: "The title for the setting to send usage data.")
     public static let SendUsageSettingLink = MZLocalizedString(
-        "Settings.SendUsage.Link",
+        key: "Settings.SendUsage.Link",
         tableName: nil,
         value: "Learn More.",
         comment: "title for a link that explains how mozilla collects telemetry")
     public static let SendUsageSettingMessage = MZLocalizedString(
-        "Settings.SendUsage.Message",
+        key: "Settings.SendUsage.Message",
         tableName: nil,
         value: "Mozilla strives to only collect what we need to provide and improve Firefox for everyone.",
         comment: "A short description that explains why mozilla collects usage data.")
     public static let SettingsSiriSectionName = MZLocalizedString(
-        "Settings.Siri.SectionName",
+        key: "Settings.Siri.SectionName",
         tableName: nil,
         value: "Siri Shortcuts",
         comment: "The option that takes you to the siri shortcuts settings page")
     public static let SettingsSiriSectionDescription = MZLocalizedString(
-        "Settings.Siri.SectionDescription",
+        key: "Settings.Siri.SectionDescription",
         tableName: nil,
         value: "Use Siri shortcuts to quickly open Firefox via Siri",
         comment: "The description that describes what siri shortcuts are")
     public static let SettingsSiriOpenURL = MZLocalizedString(
-        "Settings.Siri.OpenTabShortcut",
+        key: "Settings.Siri.OpenTabShortcut",
         tableName: nil,
         value: "Open New Tab",
         comment: "The description of the open new tab siri shortcut")
@@ -3326,17 +3326,17 @@ extension String {
 // MARK: - Nimbus settings
 extension String {
     public static let SettingsStudiesToggleTitle = MZLocalizedString(
-        "Settings.Studies.Toggle.Title",
+        key: "Settings.Studies.Toggle.Title",
         tableName: nil,
         value: "Studies",
         comment: "Label used as a toggle item in Settings. When this is off, the user is opting out of all studies.")
     public static let SettingsStudiesToggleLink = MZLocalizedString(
-        "Settings.Studies.Toggle.Link",
+        key: "Settings.Studies.Toggle.Link",
         tableName: nil,
         value: "Learn More.",
         comment: "Title for a link that explains what Mozilla means by Studies")
     public static let SettingsStudiesToggleMessage = MZLocalizedString(
-        "Settings.Studies.Toggle.Message",
+        key: "Settings.Studies.Toggle.Message",
         tableName: nil,
         value: "Firefox may install and run studies from time to time.",
         comment: "A short description that explains that Mozilla is running studies")
@@ -3345,17 +3345,17 @@ extension String {
 // MARK: - Intro Onboarding slides
 extension String {
     public static let CardTitleWelcome = MZLocalizedString(
-        "Intro.Slides.Welcome.Title.v2",
+        key: "Intro.Slides.Welcome.Title.v2",
         tableName: "Intro",
         value: "Welcome to Firefox",
         comment: "Title for the first panel 'Welcome' in the First Run tour.")
     public static let StartBrowsingButtonTitle = MZLocalizedString(
-        "Start Browsing",
+        key: "Start Browsing",
         tableName: "Intro",
         value: nil,
         comment: "See http://mzl.la/1T8gxwo")
     public static let IntroSignInButtonTitle = MZLocalizedString(
-        "Intro.Slides.Button.SignIn",
+        key: "Intro.Slides.Button.SignIn",
         tableName: "Intro",
         value: "Sign In",
         comment: "Sign in to Firefox account button on second intro screen.")
@@ -3364,57 +3364,57 @@ extension String {
 // MARK: - Share extension
 extension String {
     public static let SendToCancelButton = MZLocalizedString(
-        "SendTo.Cancel.Button",
+        key: "SendTo.Cancel.Button",
         tableName: nil,
         value: "Cancel",
         comment: "Button title for cancelling share screen")
     public static let SendToErrorOKButton = MZLocalizedString(
-        "SendTo.Error.OK.Button",
+        key: "SendTo.Error.OK.Button",
         tableName: nil,
         value: "OK",
         comment: "OK button to dismiss the error prompt.")
     public static let SendToErrorTitle = MZLocalizedString(
-        "SendTo.Error.Title",
+        key: "SendTo.Error.Title",
         tableName: nil,
         value: "The link you are trying to share cannot be shared.",
         comment: "Title of error prompt displayed when an invalid URL is shared.")
     public static let SendToErrorMessage = MZLocalizedString(
-        "SendTo.Error.Message",
+        key: "SendTo.Error.Message",
         tableName: nil,
         value: "Only HTTP and HTTPS links can be shared.",
         comment: "Message in error prompt explaining why the URL is invalid.")
     public static let SendToCloseButton = MZLocalizedString(
-        "SendTo.Close.Button",
+        key: "SendTo.Close.Button",
         tableName: nil,
         value: "Close",
         comment: "Close button in top navigation bar")
     public static let SendToNotSignedInText = MZLocalizedString(
-        "SendTo.NotSignedIn.Title",
+        key: "SendTo.NotSignedIn.Title",
         tableName: nil,
         value: "You are not signed in to your Firefox Account.",
         comment: "See http://mzl.la/1ISlXnU")
     public static let SendToNotSignedInMessage = MZLocalizedString(
-        "SendTo.NotSignedIn.Message",
+        key: "SendTo.NotSignedIn.Message",
         tableName: nil,
         value: "Please open Firefox, go to Settings and sign in to continue.",
         comment: "See http://mzl.la/1ISlXnU")
     public static let SendToNoDevicesFound = MZLocalizedString(
-        "SendTo.NoDevicesFound.Message",
+        key: "SendTo.NoDevicesFound.Message",
         tableName: nil,
         value: "You don’t have any other devices connected to this Firefox Account available to sync.",
         comment: "Error message shown in the remote tabs panel")
     public static let SendToTitle = MZLocalizedString(
-        "SendTo.NavBar.Title",
+        key: "SendTo.NavBar.Title",
         tableName: nil,
         value: "Send Tab",
         comment: "Title of the dialog that allows you to send a tab to a different device")
     public static let SendToSendButtonTitle = MZLocalizedString(
-        "SendTo.SendAction.Text",
+        key: "SendTo.SendAction.Text",
         tableName: nil,
         value: "Send",
         comment: "Navigation bar button to Send the current page to a device")
     public static let SendToDevicesListTitle = MZLocalizedString(
-        "SendTo.DeviceList.Text",
+        key: "SendTo.DeviceList.Text",
         tableName: nil,
         value: "Available devices:",
         comment: "Header for the list of devices table")
@@ -3423,44 +3423,44 @@ extension String {
     // The above items are re-used strings from the old extension. New strings below.
 
     public static let ShareAddToReadingList = MZLocalizedString(
-        "ShareExtension.AddToReadingListAction.Title",
+        key: "ShareExtension.AddToReadingListAction.Title",
         tableName: nil,
         value: "Add to Reading List",
         comment: "Action label on share extension to add page to the Firefox reading list.")
     public static let ShareAddToReadingListDone = MZLocalizedString(
-        "ShareExtension.AddToReadingListActionDone.Title",
+        key: "ShareExtension.AddToReadingListActionDone.Title",
         tableName: nil,
         value: "Added to Reading List",
         comment: "Share extension label shown after user has performed 'Add to Reading List' action.")
     public static let ShareBookmarkThisPage = MZLocalizedString(
-        "ShareExtension.BookmarkThisPageAction.Title",
+        key: "ShareExtension.BookmarkThisPageAction.Title",
         tableName: nil,
         value: "Bookmark This Page",
         comment: "Action label on share extension to bookmark the page in Firefox.")
     public static let ShareBookmarkThisPageDone = MZLocalizedString(
-        "ShareExtension.BookmarkThisPageActionDone.Title",
+        key: "ShareExtension.BookmarkThisPageActionDone.Title",
         tableName: nil,
         value: "Bookmarked",
         comment: "Share extension label shown after user has performed 'Bookmark this Page' action.")
 
     public static let ShareOpenInFirefox = MZLocalizedString(
-        "ShareExtension.OpenInFirefoxAction.Title",
+        key: "ShareExtension.OpenInFirefoxAction.Title",
         tableName: nil,
         value: "Open in Firefox",
         comment: "Action label on share extension to immediately open page in Firefox.")
     public static let ShareSearchInFirefox = MZLocalizedString(
-        "ShareExtension.SeachInFirefoxAction.Title",
+        key: "ShareExtension.SeachInFirefoxAction.Title",
         tableName: nil,
         value: "Search in Firefox",
         comment: "Action label on share extension to search for the selected text in Firefox.")
 
     public static let ShareLoadInBackground = MZLocalizedString(
-        "ShareExtension.LoadInBackgroundAction.Title",
+        key: "ShareExtension.LoadInBackgroundAction.Title",
         tableName: nil,
         value: "Load in Background",
         comment: "Action label on share extension to load the page in Firefox when user switches apps to bring it to foreground.")
     public static let ShareLoadInBackgroundDone = MZLocalizedString(
-        "ShareExtension.LoadInBackgroundActionDone.Title",
+        key: "ShareExtension.LoadInBackgroundActionDone.Title",
         tableName: nil,
         value: "Loading in Firefox",
         comment: "Share extension label shown after user has performed 'Load in Background' action.")
@@ -3469,17 +3469,17 @@ extension String {
 // MARK: - Translation bar
 extension String {
     public static let TranslateSnackBarPrompt = MZLocalizedString(
-        "TranslationToastHandler.PromptTranslate.Title",
+        key: "TranslationToastHandler.PromptTranslate.Title",
         tableName: nil,
         value: "This page appears to be in %1$@. Translate to %2$@ with %3$@?",
         comment: "Prompt for translation. The first parameter is the language the page is in. The second parameter is the name of our local language. The third is the name of the service.")
     public static let TranslateSnackBarYes = MZLocalizedString(
-        "TranslationToastHandler.PromptTranslate.OK",
+        key: "TranslationToastHandler.PromptTranslate.OK",
         tableName: nil,
         value: "Yes",
         comment: "Button to allow the page to be translated to the user locale language")
     public static let TranslateSnackBarNo = MZLocalizedString(
-        "TranslationToastHandler.PromptTranslate.Cancel",
+        key: "TranslationToastHandler.PromptTranslate.Cancel",
         tableName: nil,
         value: "No",
         comment: "Button to disallow the page to be translated to the user locale language")
@@ -3488,77 +3488,77 @@ extension String {
 // MARK: - Display Theme
 extension String {
     public static let SettingsDisplayThemeTitle = MZLocalizedString(
-        "Settings.DisplayTheme.Title.v2",
+        key: "Settings.DisplayTheme.Title.v2",
         tableName: nil,
         value: "Theme",
         comment: "Title in main app settings for Theme settings")
     public static let DisplayThemeBrightnessThresholdSectionHeader = MZLocalizedString(
-        "Settings.DisplayTheme.BrightnessThreshold.SectionHeader",
+        key: "Settings.DisplayTheme.BrightnessThreshold.SectionHeader",
         tableName: nil,
         value: "Threshold",
         comment: "Section header for brightness slider.")
     public static let DisplayThemeSectionFooter = MZLocalizedString(
-        "Settings.DisplayTheme.SectionFooter",
+        key: "Settings.DisplayTheme.SectionFooter",
         tableName: nil,
         value: "The theme will automatically change based on your display brightness. You can set the threshold where the theme changes. The circle indicates your display’s current brightness.",
         comment: "Display (theme) settings footer describing how the brightness slider works.")
     public static let SystemThemeSectionHeader = MZLocalizedString(
-        "Settings.DisplayTheme.SystemTheme.SectionHeader",
+        key: "Settings.DisplayTheme.SystemTheme.SectionHeader",
         tableName: nil,
         value: "System Theme",
         comment: "System theme settings section title")
     public static let SystemThemeSectionSwitchTitle = MZLocalizedString(
-        "Settings.DisplayTheme.SystemTheme.SwitchTitle",
+        key: "Settings.DisplayTheme.SystemTheme.SwitchTitle",
         tableName: nil,
         value: "Use System Light/Dark Mode",
         comment: "System theme settings switch to choose whether to use the same theme as the system")
     public static let ThemeSwitchModeSectionHeader = MZLocalizedString(
-        "Settings.DisplayTheme.SwitchMode.SectionHeader",
+        key: "Settings.DisplayTheme.SwitchMode.SectionHeader",
         tableName: nil,
         value: "Switch Mode",
         comment: "Switch mode settings section title")
     public static let ThemePickerSectionHeader = MZLocalizedString(
-        "Settings.DisplayTheme.ThemePicker.SectionHeader",
+        key: "Settings.DisplayTheme.ThemePicker.SectionHeader",
         tableName: nil,
         value: "Theme Picker",
         comment: "Theme picker settings section title")
     public static let DisplayThemeAutomaticSwitchTitle = MZLocalizedString(
-        "Settings.DisplayTheme.SwitchTitle",
+        key: "Settings.DisplayTheme.SwitchTitle",
         tableName: nil,
         value: "Automatically",
         comment: "Display (theme) settings switch to choose whether to set the dark mode manually, or automatically based on the brightness slider.")
     public static let DisplayThemeAutomaticStatusLabel = MZLocalizedString(
-        "Settings.DisplayTheme.StatusTitle",
+        key: "Settings.DisplayTheme.StatusTitle",
         tableName: nil,
         value: "Automatic",
         comment: "Display (theme) settings label to show if automatically switch theme is enabled.")
     public static let DisplayThemeAutomaticSwitchSubtitle = MZLocalizedString(
-        "Settings.DisplayTheme.SwitchSubtitle",
+        key: "Settings.DisplayTheme.SwitchSubtitle",
         tableName: nil,
         value: "Switch automatically based on screen brightness",
         comment: "Display (theme) settings switch subtitle, explaining the title 'Automatically'.")
     public static let DisplayThemeManualSwitchTitle = MZLocalizedString(
-        "Settings.DisplayTheme.Manual.SwitchTitle",
+        key: "Settings.DisplayTheme.Manual.SwitchTitle",
         tableName: nil,
         value: "Manually",
         comment: "Display (theme) setting to choose the theme manually.")
     public static let DisplayThemeManualSwitchSubtitle = MZLocalizedString(
-        "Settings.DisplayTheme.Manual.SwitchSubtitle",
+        key: "Settings.DisplayTheme.Manual.SwitchSubtitle",
         tableName: nil,
         value: "Pick which theme you want",
         comment: "Display (theme) settings switch subtitle, explaining the title 'Manually'.")
     public static let DisplayThemeManualStatusLabel = MZLocalizedString(
-        "Settings.DisplayTheme.Manual.StatusLabel",
+        key: "Settings.DisplayTheme.Manual.StatusLabel",
         tableName: nil,
         value: "Manual",
         comment: "Display (theme) settings label to show if manually switch theme is enabled.")
     public static let DisplayThemeOptionLight = MZLocalizedString(
-        "Settings.DisplayTheme.OptionLight",
+        key: "Settings.DisplayTheme.OptionLight",
         tableName: nil,
         value: "Light",
         comment: "Option choice in display theme settings for light theme")
     public static let DisplayThemeOptionDark = MZLocalizedString(
-        "Settings.DisplayTheme.OptionDark",
+        key: "Settings.DisplayTheme.OptionDark",
         tableName: nil,
         value: "Dark",
         comment: "Option choice in display theme settings for dark theme")
@@ -3566,7 +3566,7 @@ extension String {
 
 extension String {
     public static let AddTabAccessibilityLabel = MZLocalizedString(
-        "TabTray.AddTab.Button",
+        key: "TabTray.AddTab.Button",
         tableName: nil,
         value: "Add Tab",
         comment: "Accessibility label for the Add Tab button in the Tab Tray.")
@@ -3576,17 +3576,17 @@ extension String {
 extension String {
     // ETP Cover Sheet
     public static let CoverSheetETPTitle = MZLocalizedString(
-        "CoverSheet.v24.ETP.Title",
+        key: "CoverSheet.v24.ETP.Title",
         tableName: nil,
         value: "Protection Against Ad Tracking",
         comment: "Title for the new ETP mode i.e. standard vs strict")
     public static let CoverSheetETPDescription = MZLocalizedString(
-        "CoverSheet.v24.ETP.Description",
+        key: "CoverSheet.v24.ETP.Description",
         tableName: nil,
         value: "Built-in Enhanced Tracking Protection helps stop ads from following you around. Turn on Strict to block even more trackers, ads, and popups. ",
         comment: "Description for the new ETP mode i.e. standard vs strict")
     public static let CoverSheetETPSettingsButton = MZLocalizedString(
-        "CoverSheet.v24.ETP.Settings.Button",
+        key: "CoverSheet.v24.ETP.Settings.Button",
         tableName: nil,
         value: "Go to Settings",
         comment: "Text for the new ETP settings button")
@@ -3595,22 +3595,22 @@ extension String {
 // MARK: - FxA Signin screen
 extension String {
     public static let FxASignin_Subtitle = MZLocalizedString(
-        "fxa.signin.camera-signin",
+        key: "fxa.signin.camera-signin",
         tableName: nil,
         value: "Sign In with Your Camera",
         comment: "FxA sign in view subtitle")
     public static let FxASignin_QRInstructions = MZLocalizedString(
-        "fxa.signin.qr-link-instruction",
+        key: "fxa.signin.qr-link-instruction",
         tableName: nil,
         value: "On your computer open Firefox and go to firefox.com/pair",
         comment: "FxA sign in view qr code instructions")
     public static let FxASignin_QRScanSignin = MZLocalizedString(
-        "fxa.signin.ready-to-scan",
+        key: "fxa.signin.ready-to-scan",
         tableName: nil,
         value: "Ready to Scan",
         comment: "FxA sign in view qr code scan button")
     public static let FxASignin_EmailSignin = MZLocalizedString(
-        "fxa.signin.use-email-instead",
+        key: "fxa.signin.use-email-instead",
         tableName: nil,
         value: "Use Email Instead",
         comment: "FxA sign in view email login button")
@@ -3621,106 +3621,106 @@ extension String {
     // Widget - Shared
 
     public static let QuickActionsGalleryTitle = MZLocalizedString(
-        "TodayWidget.QuickActionsGalleryTitle",
+        key: "TodayWidget.QuickActionsGalleryTitle",
         tableName: "Today",
         value: "Quick Actions",
         comment: "Quick Actions title when widget enters edit mode")
     public static let QuickActionsGalleryTitlev2 = MZLocalizedString(
-        "TodayWidget.QuickActionsGalleryTitleV2",
+        key: "TodayWidget.QuickActionsGalleryTitleV2",
         tableName: "Today",
         value: "Firefox Shortcuts",
         comment: "Firefox shortcuts title when widget enters edit mode. Do not translate the word Firefox.")
 
     // Quick Action - Medium Size Quick Action
     public static let GoToCopiedLinkLabel = MZLocalizedString(
-        "TodayWidget.GoToCopiedLinkLabelV1",
+        key: "TodayWidget.GoToCopiedLinkLabelV1",
         tableName: "Today",
         value: "Go to copied link",
         comment: "Go to link pasted on the clipboard")
     public static let GoToCopiedLinkLabelV2 = MZLocalizedString(
-        "TodayWidget.GoToCopiedLinkLabelV2",
+        key: "TodayWidget.GoToCopiedLinkLabelV2",
         tableName: "Today",
         value: "Go to\nCopied Link",
         comment: "Go to copied link")
     public static let ClosePrivateTab = MZLocalizedString(
-        "TodayWidget.ClosePrivateTabsButton",
+        key: "TodayWidget.ClosePrivateTabsButton",
         tableName: "Today",
         value: "Close Private Tabs",
         comment: "Close Private Tabs button label")
 
     // Quick Action - Medium Size - Gallery View
     public static let FirefoxShortcutGalleryDescription = MZLocalizedString(
-        "TodayWidget.FirefoxShortcutGalleryDescription",
+        key: "TodayWidget.FirefoxShortcutGalleryDescription",
         tableName: "Today",
         value: "Add Firefox shortcuts to your Home screen.",
         comment: "Description for medium size widget to add Firefox Shortcut to home screen")
 
     // Quick Action - Small Size Widget
     public static let SearchInPrivateTabLabelV2 = MZLocalizedString(
-        "TodayWidget.SearchInPrivateTabLabelV2",
+        key: "TodayWidget.SearchInPrivateTabLabelV2",
         tableName: "Today",
         value: "Search in\nPrivate Tab",
         comment: "Search in private tab")
     public static let SearchInFirefoxV2 = MZLocalizedString(
-        "TodayWidget.SearchInFirefoxV2",
+        key: "TodayWidget.SearchInFirefoxV2",
         tableName: "Today",
         value: "Search in\nFirefox",
         comment: "Search in Firefox. Do not translate the word Firefox")
     public static let ClosePrivateTabsLabelV2 = MZLocalizedString(
-        "TodayWidget.ClosePrivateTabsLabelV2",
+        key: "TodayWidget.ClosePrivateTabsLabelV2",
         tableName: "Today",
         value: "Close\nPrivate Tabs",
         comment: "Close Private Tabs")
 
     // Quick Action - Small Size - Gallery View
     public static let QuickActionGalleryDescription = MZLocalizedString(
-        "TodayWidget.QuickActionGalleryDescription",
+        key: "TodayWidget.QuickActionGalleryDescription",
         tableName: "Today",
         value: "Add a Firefox shortcut to your Home screen. After adding the widget, touch and hold to edit it and select a different shortcut.",
         comment: "Description for small size widget to add it to home screen")
 
     // Top Sites - Medium Size - Gallery View
     public static let TopSitesGalleryTitle = MZLocalizedString(
-        "TodayWidget.TopSitesGalleryTitle",
+        key: "TodayWidget.TopSitesGalleryTitle",
         tableName: "Today",
         value: "Top Sites",
         comment: "Title for top sites widget to add Firefox top sites shotcuts to home screen")
     public static let TopSitesGalleryTitleV2 = MZLocalizedString(
-        "TodayWidget.TopSitesGalleryTitleV2",
+        key: "TodayWidget.TopSitesGalleryTitleV2",
         tableName: "Today",
         value: "Website Shortcuts",
         comment: "Title for top sites widget to add Firefox top sites shotcuts to home screen")
     public static let TopSitesGalleryDescription = MZLocalizedString(
-        "TodayWidget.TopSitesGalleryDescription",
+        key: "TodayWidget.TopSitesGalleryDescription",
         tableName: "Today",
         value: "Add shortcuts to frequently and recently visited sites.",
         comment: "Description for top sites widget to add Firefox top sites shotcuts to home screen")
 
     // Quick View Open Tabs - Medium Size Widget
     public static let MoreTabsLabel = MZLocalizedString(
-        "TodayWidget.MoreTabsLabel",
+        key: "TodayWidget.MoreTabsLabel",
         tableName: "Today",
         value: "+%d More…",
         comment: "%d represents number and it becomes something like +5 more where 5 is the number of open tabs in tab tray beyond what is displayed in the widget")
     public static let OpenFirefoxLabel = MZLocalizedString(
-        "TodayWidget.OpenFirefoxLabel",
+        key: "TodayWidget.OpenFirefoxLabel",
         tableName: "Today",
         value: "Open Firefox",
         comment: "Open Firefox when there are no tabs opened in tab tray i.e. Empty State")
     public static let NoOpenTabsLabel = MZLocalizedString(
-        "TodayWidget.NoOpenTabsLabel",
+        key: "TodayWidget.NoOpenTabsLabel",
         tableName: "Today",
         value: "No open tabs.",
         comment: "Label that is shown when there are no tabs opened in tab tray i.e. Empty State")
 
     // Quick View Open Tabs - Medium Size - Gallery View
     public static let QuickViewGalleryTitle = MZLocalizedString(
-        "TodayWidget.QuickViewGalleryTitle",
+        key: "TodayWidget.QuickViewGalleryTitle",
         tableName: "Today",
         value: "Quick View",
         comment: "Title for Quick View widget in Gallery View where user can add it to home screen")
     public static let QuickViewGalleryDescriptionV2 = MZLocalizedString(
-        "TodayWidget.QuickViewGalleryDescriptionV2",
+        key: "TodayWidget.QuickViewGalleryDescriptionV2",
         tableName: "Today",
         value: "Add shortcuts to your open tabs.",
         comment: "Description for Quick View widget in Gallery View where user can add it to home screen")
@@ -3729,32 +3729,32 @@ extension String {
 // MARK: - Default Browser
 extension String {
     public static let DefaultBrowserMenuItem = MZLocalizedString(
-        "Settings.DefaultBrowserMenuItem",
+        key: "Settings.DefaultBrowserMenuItem",
         tableName: "Default Browser",
         value: "Set as Default Browser",
         comment: "Menu option for setting Firefox as default browser.")
     public static let DefaultBrowserOnboardingScreenshot = MZLocalizedString(
-        "DefaultBrowserOnboarding.Screenshot",
+        key: "DefaultBrowserOnboarding.Screenshot",
         tableName: "Default Browser",
         value: "Default Browser App",
         comment: "Text for the screenshot of the iOS system settings page for Firefox.")
     public static let DefaultBrowserOnboardingDescriptionStep1 = MZLocalizedString(
-        "DefaultBrowserOnboarding.Description1",
+        key: "DefaultBrowserOnboarding.Description1",
         tableName: "Default Browser",
         value: "1. Go to Settings",
         comment: "Description for default browser onboarding card.")
     public static let DefaultBrowserOnboardingDescriptionStep2 = MZLocalizedString(
-        "DefaultBrowserOnboarding.Description2",
+        key: "DefaultBrowserOnboarding.Description2",
         tableName: "Default Browser",
         value: "2. Tap Default Browser App",
         comment: "Description for default browser onboarding card.")
     public static let DefaultBrowserOnboardingDescriptionStep3 = MZLocalizedString(
-        "DefaultBrowserOnboarding.Description3",
+        key: "DefaultBrowserOnboarding.Description3",
         tableName: "Default Browser",
         value: "3. Select Firefox",
         comment: "Description for default browser onboarding card.")
     public static let DefaultBrowserOnboardingButton = MZLocalizedString(
-        "DefaultBrowserOnboarding.Button",
+        key: "DefaultBrowserOnboarding.Button",
         tableName: "Default Browser",
         value: "Go to Settings",
         comment: "Button string to open settings that allows user to switch their default browser to Firefox.")
@@ -3763,7 +3763,7 @@ extension String {
 // MARK: - FxAWebViewController
 extension String {
     public static let FxAWebContentAccessibilityLabel = MZLocalizedString(
-        "Web content",
+        key: "Web content",
         tableName: nil,
         value: nil,
         comment: "Accessibility label for the main web content view")
@@ -3772,7 +3772,7 @@ extension String {
 // MARK: - QuickActions
 extension String {
     public static let QuickActionsLastBookmarkTitle = MZLocalizedString(
-        "Open Last Bookmark",
+        key: "Open Last Bookmark",
         tableName: "3DTouchActions",
         value: nil,
         comment: "String describing the action of opening the last added bookmark from the home screen Quick Actions via 3D Touch")
@@ -3781,27 +3781,27 @@ extension String {
 // MARK: - CrashOptInAlert
 extension String {
     public static let CrashOptInAlertTitle = MZLocalizedString(
-        "Oops! Firefox crashed",
+        key: "Oops! Firefox crashed",
         tableName: nil,
         value: nil,
         comment: "Title for prompt displayed to user after the app crashes")
     public static let CrashOptInAlertMessage = MZLocalizedString(
-        "Send a crash report so Mozilla can fix the problem?",
+        key: "Send a crash report so Mozilla can fix the problem?",
         tableName: nil,
         value: nil,
         comment: "Message displayed in the crash dialog above the buttons used to select when sending reports")
     public static let CrashOptInAlertSend = MZLocalizedString(
-        "Send Report",
+        key: "Send Report",
         tableName: nil,
         value: nil,
         comment: "Used as a button label for crash dialog prompt")
     public static let CrashOptInAlertAlwaysSend = MZLocalizedString(
-        "Always Send",
+        key: "Always Send",
         tableName: nil,
         value: nil,
         comment: "Used as a button label for crash dialog prompt")
     public static let CrashOptInAlertDontSend = MZLocalizedString(
-        "Don’t Send",
+        key: "Don’t Send",
         tableName: nil,
         value: nil,
         comment: "Used as a button label for crash dialog prompt")
@@ -3810,17 +3810,17 @@ extension String {
 // MARK: - ClearPrivateDataAlert
 extension String {
     public static let ClearPrivateDataAlertMessage = MZLocalizedString(
-        "This action will clear all of your private data. It cannot be undone.",
+        key: "This action will clear all of your private data. It cannot be undone.",
         tableName: "ClearPrivateDataConfirm",
         value: nil,
         comment: "Description of the confirmation dialog shown when a user tries to clear their private data.")
     public static let ClearPrivateDataAlertCancel = MZLocalizedString(
-        "Cancel",
+        key: "Cancel",
         tableName: "ClearPrivateDataConfirm",
         value: nil,
         comment: "The cancel button when confirming clear private data.")
     public static let ClearPrivateDataAlertOk = MZLocalizedString(
-        "OK",
+        key: "OK",
         tableName: "ClearPrivateDataConfirm",
         value: nil,
         comment: "The button that clears private data.")
@@ -3829,23 +3829,23 @@ extension String {
 // MARK: - ClearWebsiteDataAlert
 extension String {
     public static let ClearAllWebsiteDataAlertMessage = MZLocalizedString(
-        "Settings.WebsiteData.ConfirmPrompt",
+        key: "Settings.WebsiteData.ConfirmPrompt",
         tableName: nil,
         value: "This action will clear all of your website data. It cannot be undone.",
         comment: "Description of the confirmation dialog shown when a user tries to clear their private data.")
     public static let ClearSelectedWebsiteDataAlertMessage = MZLocalizedString(
-        "Settings.WebsiteData.SelectedConfirmPrompt",
+        key: "Settings.WebsiteData.SelectedConfirmPrompt",
         tableName: nil,
         value: "This action will clear the selected items. It cannot be undone.",
         comment: "Description of the confirmation dialog shown when a user tries to clear some of their private data.")
     // TODO: these look like the same as in ClearPrivateDataAlert, I think we can remove them
     public static let ClearWebsiteDataAlertCancel = MZLocalizedString(
-        "Cancel",
+        key: "Cancel",
         tableName: "ClearPrivateDataConfirm",
         value: nil,
         comment: "The cancel button when confirming clear private data.")
     public static let ClearWebsiteDataAlertOk = MZLocalizedString(
-        "OK",
+        key: "OK",
         tableName: "ClearPrivateDataConfirm",
         value: nil,
         comment: "The button that clears private data.")
@@ -3854,18 +3854,18 @@ extension String {
 // MARK: - ClearSyncedHistoryAlert
 extension String {
     public static let ClearSyncedHistoryAlertMessage = MZLocalizedString(
-        "This action will clear all of your private data, including history from your synced devices.",
+        key: "This action will clear all of your private data, including history from your synced devices.",
         tableName: "ClearHistoryConfirm",
         value: nil,
         comment: "Description of the confirmation dialog shown when a user tries to clear history that's synced to another device.")
     // TODO: these look like the same as in ClearPrivateDataAlert, I think we can remove them
     public static let ClearSyncedHistoryAlertCancel = MZLocalizedString(
-        "Cancel",
+        key: "Cancel",
         tableName: "ClearHistoryConfirm",
         value: nil,
         comment: "The cancel button when confirming clear history.")
     public static let ClearSyncedHistoryAlertOk = MZLocalizedString(
-        "OK",
+        key: "OK",
         tableName: "ClearHistoryConfirm",
         value: nil,
         comment: "The confirmation button that clears history even when Sync is connected.")
@@ -3874,27 +3874,27 @@ extension String {
 // MARK: - DeleteLoginAlert
 extension String {
     public static let DeleteLoginAlertTitle = MZLocalizedString(
-        "Are you sure?",
+        key: "Are you sure?",
         tableName: "LoginManager",
         value: nil,
         comment: "Prompt title when deleting logins")
     public static let DeleteLoginAlertSyncedMessage = MZLocalizedString(
-        "Logins will be removed from all connected devices.",
+        key: "Logins will be removed from all connected devices.",
         tableName: "LoginManager",
         value: nil,
         comment: "Prompt message warning the user that deleted logins will remove logins from all connected devices")
     public static let DeleteLoginAlertLocalMessage = MZLocalizedString(
-        "Logins will be permanently removed.",
+        key: "Logins will be permanently removed.",
         tableName: "LoginManager",
         value: nil,
         comment: "Prompt message warning the user that deleting non-synced logins will permanently remove them")
     public static let DeleteLoginAlertCancel = MZLocalizedString(
-        "Cancel",
+        key: "Cancel",
         tableName: "LoginManager",
         value: nil,
         comment: "Prompt option for cancelling out of deletion")
     public static let DeleteLoginAlertDelete = MZLocalizedString(
-        "Delete",
+        key: "Delete",
         tableName: "LoginManager",
         value: nil,
         comment: "Label for the button used to delete the current login.")
@@ -3903,37 +3903,37 @@ extension String {
 // MARK: - Authenticator strings
 extension String {
     public static let AuthenticatorCancel = MZLocalizedString(
-        "Cancel",
+        key: "Cancel",
         tableName: nil,
         value: nil,
         comment: "Label for Cancel button")
     public static let AuthenticatorLogin = MZLocalizedString(
-        "Log in",
+        key: "Log in",
         tableName: nil,
         value: nil,
         comment: "Authentication prompt log in button")
     public static let AuthenticatorPromptTitle = MZLocalizedString(
-        "Authentication required",
+        key: "Authentication required",
         tableName: nil,
         value: nil,
         comment: "Authentication prompt title")
     public static let AuthenticatorPromptRealmMessage = MZLocalizedString(
-        "A username and password are being requested by %@. The site says: %@",
+        key: "A username and password are being requested by %@. The site says: %@",
         tableName: nil,
         value: nil,
         comment: "Authentication prompt message with a realm. First parameter is the hostname. Second is the realm string")
     public static let AuthenticatorPromptEmptyRealmMessage = MZLocalizedString(
-        "A username and password are being requested by %@.",
+        key: "A username and password are being requested by %@.",
         tableName: nil,
         value: nil,
         comment: "Authentication prompt message with no realm. Parameter is the hostname of the site")
     public static let AuthenticatorUsernamePlaceholder = MZLocalizedString(
-        "Username",
+        key: "Username",
         tableName: nil,
         value: nil,
         comment: "Username textbox in Authentication prompt")
     public static let AuthenticatorPasswordPlaceholder = MZLocalizedString(
-        "Password",
+        key: "Password",
         tableName: nil,
         value: nil,
         comment: "Password textbox in Authentication prompt")
@@ -3942,22 +3942,22 @@ extension String {
 // MARK: - BrowserViewController
 extension String {
     public static let ReaderModeAddPageGeneralErrorAccessibilityLabel = MZLocalizedString(
-        "Could not add page to Reading list",
+        key: "Could not add page to Reading list",
         tableName: nil,
         value: nil,
         comment: "Accessibility message e.g. spoken by VoiceOver after adding current webpage to the Reading List failed.")
     public static let ReaderModeAddPageSuccessAcessibilityLabel = MZLocalizedString(
-        "Added page to Reading List",
+        key: "Added page to Reading List",
         tableName: nil,
         value: nil,
         comment: "Accessibility message e.g. spoken by VoiceOver after the current page gets added to the Reading List using the Reader View button, e.g. by long-pressing it or by its accessibility custom action.")
     public static let ReaderModeAddPageMaybeExistsErrorAccessibilityLabel = MZLocalizedString(
-        "Could not add page to Reading List. Maybe it’s already there?",
+        key: "Could not add page to Reading List. Maybe it’s already there?",
         tableName: nil,
         value: nil,
         comment: "Accessibility message e.g. spoken by VoiceOver after the user wanted to add current page to the Reading List and this was not done, likely because it already was in the Reading List, but perhaps also because of real failures.")
     public static let WebViewAccessibilityLabel = MZLocalizedString(
-        "Web content",
+        key: "Web content",
         tableName: nil,
         value: nil,
         comment: "Accessibility label for the main web content view")
@@ -3966,17 +3966,17 @@ extension String {
 // MARK: - Find in page
 extension String {
     public static let FindInPagePreviousAccessibilityLabel = MZLocalizedString(
-        "Previous in-page result",
+        key: "Previous in-page result",
         tableName: "FindInPage",
         value: nil,
         comment: "Accessibility label for previous result button in Find in Page Toolbar.")
     public static let FindInPageNextAccessibilityLabel = MZLocalizedString(
-        "Next in-page result",
+        key: "Next in-page result",
         tableName: "FindInPage",
         value: nil,
         comment: "Accessibility label for next result button in Find in Page Toolbar.")
     public static let FindInPageDoneAccessibilityLabel = MZLocalizedString(
-        "Done",
+        key: "Done",
         tableName: "FindInPage",
         value: nil,
         comment: "Done button in Find in Page Toolbar.")
@@ -3985,27 +3985,27 @@ extension String {
 // MARK: - Reader Mode Bar
 extension String {
     public static let ReaderModeBarMarkAsRead = MZLocalizedString(
-        "ReaderModeBar.MarkAsRead.v106",
+        key: "ReaderModeBar.MarkAsRead.v106",
         tableName: nil,
         value: "Mark as Read",
         comment: "Name for Mark as read button in reader mode")
     public static let ReaderModeBarMarkAsUnread = MZLocalizedString(
-        "ReaderModeBar.MarkAsUnread.v106",
+        key: "ReaderModeBar.MarkAsUnread.v106",
         tableName: nil,
         value: "Mark as Unread",
         comment: "Name for Mark as unread button in reader mode")
     public static let ReaderModeBarSettings = MZLocalizedString(
-        "Display Settings",
+        key: "Display Settings",
         tableName: nil,
         value: nil,
         comment: "Name for display settings button in reader mode. Display in the meaning of presentation, not monitor.")
     public static let ReaderModeBarAddToReadingList = MZLocalizedString(
-        "Add to Reading List",
+        key: "Add to Reading List",
         tableName: nil,
         value: nil,
         comment: "Name for button adding current article to reading list in reader mode")
     public static let ReaderModeBarRemoveFromReadingList = MZLocalizedString(
-        "Remove from Reading List",
+        key: "Remove from Reading List",
         tableName: nil,
         value: nil,
         comment: "Name for button removing current article from reading list in reader mode")
@@ -4014,17 +4014,17 @@ extension String {
 // MARK: - SearchViewController
 extension String {
     public static let SearchSettingsAccessibilityLabel = MZLocalizedString(
-        "Search Settings",
+        key: "Search Settings",
         tableName: "Search",
         value: nil,
         comment: "Label for search settings button.")
     public static let SearchSearchEngineAccessibilityLabel = MZLocalizedString(
-        "%@ search",
+        key: "%@ search",
         tableName: "Search",
         value: nil,
         comment: "Label for search engine buttons. The argument corresponds to the name of the search engine.")
     public static let SearchSuggestionCellSwitchToTabLabel = MZLocalizedString(
-        "Search.Awesomebar.SwitchToTab",
+        key: "Search.Awesomebar.SwitchToTab",
         tableName: nil,
         value: "Switch to tab",
         comment: "Search suggestion cell label that allows user to switch to tab which they searched for in url bar")
@@ -4033,27 +4033,27 @@ extension String {
 // MARK: - Tab Location View
 extension String {
     public static let TabLocationURLPlaceholder = MZLocalizedString(
-        "Search or enter address",
+        key: "Search or enter address",
         tableName: nil,
         value: nil,
         comment: "The text shown in the URL bar on about:home")
     public static let TabLocationReaderModeAccessibilityLabel = MZLocalizedString(
-        "Reader View",
+        key: "Reader View",
         tableName: nil,
         value: nil,
         comment: "Accessibility label for the Reader View button")
     public static let TabLocationAddressBarAccessibilityLabel = MZLocalizedString(
-        "Address.Bar.v99",
+        key: "Address.Bar.v99",
         tableName: nil,
         value: "Address Bar",
         comment: "Accessibility label for the Address Bar, where a user can enter the search they wish to make")
     public static let TabLocationReaderModeAddToReadingListAccessibilityLabel = MZLocalizedString(
-        "Address.Bar.ReadingList.v106",
+        key: "Address.Bar.ReadingList.v106",
         tableName: nil,
         value: "Add to Reading List",
         comment: "Accessibility label for action adding current page to reading list.")
     public static let TabLocationReloadAccessibilityLabel = MZLocalizedString(
-        "Reload page",
+        key: "Reload page",
         tableName: nil,
         value: nil,
         comment: "Accessibility label for the reload button")
@@ -4062,22 +4062,22 @@ extension String {
 // MARK: - TabPeekViewController
 extension String {
     public static let TabPeekAddToBookmarks = MZLocalizedString(
-        "Add to Bookmarks",
+        key: "Add to Bookmarks",
         tableName: "3DTouchActions",
         value: nil,
         comment: "Label for preview action on Tab Tray Tab to add current tab to Bookmarks")
     public static let TabPeekCopyUrl = MZLocalizedString(
-        "Copy URL",
+        key: "Copy URL",
         tableName: "3DTouchActions",
         value: nil,
         comment: "Label for preview action on Tab Tray Tab to copy the URL of the current tab to clipboard")
     public static let TabPeekCloseTab = MZLocalizedString(
-        "Close Tab",
+        key: "Close Tab",
         tableName: "3DTouchActions",
         value: nil,
         comment: "Label for preview action on Tab Tray Tab to close the current tab")
     public static let TabPeekPreviewAccessibilityLabel = MZLocalizedString(
-        "Preview of %@",
+        key: "Preview of %@",
         tableName: "3DTouchActions",
         value: nil,
         comment: "Accessibility label, associated to the 3D Touch action on the current tab in the tab tray, used to display a larger preview of the tab.")
@@ -4086,37 +4086,37 @@ extension String {
 // MARK: - Tab Toolbar
 extension String {
     public static let TabToolbarReloadAccessibilityLabel = MZLocalizedString(
-        "Reload",
+        key: "Reload",
         tableName: nil,
         value: nil,
         comment: "Accessibility Label for the tab toolbar Reload button")
     public static let TabToolbarStopAccessibilityLabel = MZLocalizedString(
-        "Stop",
+        key: "Stop",
         tableName: nil,
         value: nil,
         comment: "Accessibility Label for the tab toolbar Stop button")
     public static let TabToolbarSearchAccessibilityLabel = MZLocalizedString(
-        "TabToolbar.Accessibility.Search.v106",
+        key: "TabToolbar.Accessibility.Search.v106",
         tableName: nil,
         value: "Search",
         comment: "Accessibility Label for the tab toolbar Search button")
     public static let TabToolbarBackAccessibilityLabel = MZLocalizedString(
-        "Back",
+        key: "Back",
         tableName: nil,
         value: nil,
         comment: "Accessibility label for the Back button in the tab toolbar.")
     public static let TabToolbarForwardAccessibilityLabel = MZLocalizedString(
-        "Forward",
+        key: "Forward",
         tableName: nil,
         value: nil,
         comment: "Accessibility Label for the tab toolbar Forward button")
     public static let TabToolbarHomeAccessibilityLabel = MZLocalizedString(
-        "Home",
+        key: "Home",
         tableName: nil,
         value: nil,
         comment: "Accessibility label for the tab toolbar indicating the Home button.")
     public static let TabToolbarNavigationToolbarAccessibilityLabel = MZLocalizedString(
-        "Navigation Toolbar",
+        key: "Navigation Toolbar",
         tableName: nil,
         value: nil,
         comment: "Accessibility label for the navigation toolbar displayed at the bottom of the screen.")
@@ -4125,87 +4125,87 @@ extension String {
 // MARK: - Tab Tray v1
 extension String {
     public static let TabTrayToggleAccessibilityLabel = MZLocalizedString(
-        "Private Mode",
+        key: "Private Mode",
         tableName: "PrivateBrowsing",
         value: nil,
         comment: "Accessibility label for toggling on/off private mode")
     public static let TabTrayToggleAccessibilityHint = MZLocalizedString(
-        "Turns private mode on or off",
+        key: "Turns private mode on or off",
         tableName: "PrivateBrowsing",
         value: nil,
         comment: "Accessiblity hint for toggling on/off private mode")
     public static let TabTrayToggleAccessibilityValueOn = MZLocalizedString(
-        "On",
+        key: "On",
         tableName: "PrivateBrowsing",
         value: nil,
         comment: "Toggled ON accessibility value")
     public static let TabTrayToggleAccessibilityValueOff = MZLocalizedString(
-        "Off",
+        key: "Off",
         tableName: "PrivateBrowsing",
         value: nil,
         comment: "Toggled OFF accessibility value")
     public static let TabTrayViewAccessibilityLabel = MZLocalizedString(
-        "Tabs Tray",
+        key: "Tabs Tray",
         tableName: nil,
         value: nil,
         comment: "Accessibility label for the Tabs Tray view.")
     public static let TabTrayNoTabsAccessibilityHint = MZLocalizedString(
-        "No tabs",
+        key: "No tabs",
         tableName: nil,
         value: nil,
         comment: "Message spoken by VoiceOver to indicate that there are no tabs in the Tabs Tray")
     public static let TabTrayVisibleTabRangeAccessibilityHint = MZLocalizedString(
-        "Tab %@ of %@",
+        key: "Tab %@ of %@",
         tableName: nil,
         value: nil,
         comment: "Message spoken by VoiceOver saying the position of the single currently visible tab in Tabs Tray, along with the total number of tabs. E.g. \"Tab 2 of 5\" says that tab 2 is visible (and is the only visible tab), out of 5 tabs total.")
     public static let TabTrayVisiblePartialRangeAccessibilityHint = MZLocalizedString(
-        "Tabs %@ to %@ of %@",
+        key: "Tabs %@ to %@ of %@",
         tableName: nil,
         value: nil,
         comment: "Message spoken by VoiceOver saying the range of tabs that are currently visible in Tabs Tray, along with the total number of tabs. E.g. \"Tabs 8 to 10 of 15\" says tabs 8, 9 and 10 are visible, out of 15 tabs total.")
     public static let TabTrayClosingTabAccessibilityMessage =  MZLocalizedString(
-        "Closing tab",
+        key: "Closing tab",
         tableName: nil,
         value: nil,
         comment: "Accessibility label (used by assistive technology) notifying the user that the tab is being closed.")
     public static let TabTrayCloseAllTabsPromptCancel = MZLocalizedString(
-        "Cancel",
+        key: "Cancel",
         tableName: nil,
         value: nil,
         comment: "Label for Cancel button")
     public static let TabTrayPrivateBrowsingTitle = MZLocalizedString(
-        "Private Browsing",
+        key: "Private Browsing",
         tableName: "PrivateBrowsing",
         value: nil,
         comment: "Title displayed for when there are no open tabs while in private mode")
     public static let TabTrayPrivateBrowsingDescription =  MZLocalizedString(
-        "Firefox won’t remember any of your history or cookies, but new bookmarks will be saved.",
+        key: "Firefox won’t remember any of your history or cookies, but new bookmarks will be saved.",
         tableName: "PrivateBrowsing",
         value: nil,
         comment: "Description text displayed when there are no open tabs while in private mode")
     public static let TabTrayAddTabAccessibilityLabel = MZLocalizedString(
-        "Add Tab",
+        key: "Add Tab",
         tableName: nil,
         value: nil,
         comment: "Accessibility label for the Add Tab button in the Tab Tray.")
     public static let TabTrayCloseAccessibilityCustomAction = MZLocalizedString(
-        "Close",
+        key: "Close",
         tableName: nil,
         value: nil,
         comment: "Accessibility label for action denoting closing a tab in tab list (tray)")
     public static let TabTraySwipeToCloseAccessibilityHint = MZLocalizedString(
-        "Swipe right or left with three fingers to close the tab.",
+        key: "Swipe right or left with three fingers to close the tab.",
         tableName: nil,
         value: nil,
         comment: "Accessibility hint for tab tray's displayed tab.")
     public static let TabTrayCurrentlySelectedTabAccessibilityLabel = MZLocalizedString(
-        "TabTray.CurrentSelectedTab.A11Y",
+        key: "TabTray.CurrentSelectedTab.A11Y",
         tableName: nil,
         value: "Currently selected tab.",
         comment: "Accessibility label for the currently selected tab.")
     public static let TabTrayOtherTabsSectionHeader = MZLocalizedString(
-        "TabTray.Header.FilteredTabs.SectionHeader",
+        key: "TabTray.Header.FilteredTabs.SectionHeader",
         tableName: nil,
         value: "Others",
         comment: "In the tab tray, when tab groups appear and there exist tabs that don't belong to any group, those tabs are listed under this header as \"Others\"")
@@ -4214,7 +4214,7 @@ extension String {
 // MARK: - URL Bar
 extension String {
     public static let URLBarLocationAccessibilityLabel = MZLocalizedString(
-        "Address and Search",
+        key: "Address and Search",
         tableName: nil,
         value: nil,
         comment: "Accessibility label for address and search field, both words (Address, Search) are therefore nouns.")
@@ -4223,12 +4223,12 @@ extension String {
 // MARK: - Error Pages
 extension String {
     public static let ErrorPageTryAgain = MZLocalizedString(
-        "Try again",
+        key: "Try again",
         tableName: "ErrorPages",
         value: nil,
         comment: "Shown in error pages on a button that will try to load the page again")
     public static let ErrorPageOpenInSafari = MZLocalizedString(
-        "Open in Safari",
+        key: "Open in Safari",
         tableName: "ErrorPages",
         value: nil,
         comment: "Shown in error pages for files that can't be shown and need to be downloaded.")
@@ -4237,22 +4237,22 @@ extension String {
 // MARK: - LibraryPanel
 extension String {
     public static let LibraryPanelBookmarksAccessibilityLabel = MZLocalizedString(
-        "LibraryPanel.Accessibility.Bookmarks.v106",
+        key: "LibraryPanel.Accessibility.Bookmarks.v106",
         tableName: nil,
         value: "Bookmarks",
         comment: "Panel accessibility label")
     public static let LibraryPanelHistoryAccessibilityLabel = MZLocalizedString(
-        "LibraryPanel.Accessibility.History.v106",
+        key: "LibraryPanel.Accessibility.History.v106",
         tableName: nil,
         value: "History",
         comment: "Panel accessibility label")
     public static let LibraryPanelReadingListAccessibilityLabel = MZLocalizedString(
-        "Reading list",
+        key: "Reading list",
         tableName: nil,
         value: nil,
         comment: "Panel accessibility label")
     public static let LibraryPanelDownloadsAccessibilityLabel = MZLocalizedString(
-        "Downloads",
+        key: "Downloads",
         tableName: nil,
         value: nil,
         comment: "Panel accessibility label")
@@ -4261,42 +4261,42 @@ extension String {
 // MARK: - ReaderPanel
 extension String {
     public static let ReaderPanelRemove = MZLocalizedString(
-        "Remove",
+        key: "Remove",
         tableName: nil,
         value: nil,
         comment: "Title for the button that removes a reading list item")
     public static let ReaderPanelMarkAsRead = MZLocalizedString(
-        "Mark as Read",
+        key: "Mark as Read",
         tableName: nil,
         value: nil,
         comment: "Title for the button that marks a reading list item as read")
     public static let ReaderPanelMarkAsUnread =  MZLocalizedString(
-        "Mark as Unread",
+        key: "Mark as Unread",
         tableName: nil,
         value: nil,
         comment: "Title for the button that marks a reading list item as unread")
     public static let ReaderPanelUnreadAccessibilityLabel = MZLocalizedString(
-        "unread",
+        key: "unread",
         tableName: nil,
         value: nil,
         comment: "Accessibility label for unread article in reading list. It's a past participle - functions as an adjective.")
     public static let ReaderPanelReadAccessibilityLabel = MZLocalizedString(
-        "read",
+        key: "read",
         tableName: nil,
         value: nil,
         comment: "Accessibility label for read article in reading list. It's a past participle - functions as an adjective.")
     public static let ReaderPanelWelcome = MZLocalizedString(
-        "Welcome to your Reading List",
+        key: "Welcome to your Reading List",
         tableName: nil,
         value: nil,
         comment: "See http://mzl.la/1LXbDOL")
     public static let ReaderPanelReadingModeDescription = MZLocalizedString(
-        "Open articles in Reader View by tapping the book icon when it appears in the title bar.",
+        key: "Open articles in Reader View by tapping the book icon when it appears in the title bar.",
         tableName: nil,
         value: nil,
         comment: "See http://mzl.la/1LXbDOL")
     public static let ReaderPanelReadingListDescription = MZLocalizedString(
-        "Save pages to your Reading List by tapping the book plus icon in the Reader View controls.",
+        key: "Save pages to your Reading List by tapping the book plus icon in the Reader View controls.",
         tableName: nil,
         value: nil,
         comment: "See http://mzl.la/1LXbDOL")
@@ -4305,22 +4305,22 @@ extension String {
 // MARK: - Remote Tabs Panel
 extension String {
     public static let RemoteTabErrorNoTabs = MZLocalizedString(
-        "You don’t have any tabs open in Firefox on your other devices.",
+        key: "You don’t have any tabs open in Firefox on your other devices.",
         tableName: nil,
         value: nil,
         comment: "Error message in the remote tabs panel")
     public static let RemoteTabErrorFailedToSync = MZLocalizedString(
-        "There was a problem accessing tabs from your other devices. Try again in a few moments.",
+        key: "There was a problem accessing tabs from your other devices. Try again in a few moments.",
         tableName: nil,
         value: nil,
         comment: "Error message in the remote tabs panel")
     public static let RemoteTabMobileAccessibilityLabel =  MZLocalizedString(
-        "mobile device",
+        key: "mobile device",
         tableName: nil,
         value: nil,
         comment: "Accessibility label for Mobile Device image in remote tabs list")
     public static let RemoteTabCreateAccount = MZLocalizedString(
-        "Create an account",
+        key: "Create an account",
         tableName: nil,
         value: nil,
         comment: "See http://mzl.la/1Qtkf0j")
@@ -4329,17 +4329,17 @@ extension String {
 // MARK: - Login list
 extension String {
     public static let LoginListDeselctAll = MZLocalizedString(
-        "Deselect All",
+        key: "Deselect All",
         tableName: "LoginManager",
         value: nil,
         comment: "Label for the button used to deselect all logins.")
     public static let LoginListSelctAll = MZLocalizedString(
-        "Select All",
+        key: "Select All",
         tableName: "LoginManager",
         value: nil,
         comment: "Label for the button used to select all logins.")
     public static let LoginListDelete = MZLocalizedString(
-        "Delete",
+        key: "Delete",
         tableName: "LoginManager",
         value: nil,
         comment: "Label for the button used to delete the current login.")
@@ -4348,32 +4348,32 @@ extension String {
 // MARK: - Login Detail
 extension String {
     public static let LoginDetailUsername = MZLocalizedString(
-        "Username",
+        key: "Username",
         tableName: "LoginManager",
         value: nil,
         comment: "Label displayed above the username row in Login Detail View.")
     public static let LoginDetailPassword = MZLocalizedString(
-        "Password",
+        key: "Password",
         tableName: "LoginManager",
         value: nil,
         comment: "Label displayed above the password row in Login Detail View.")
     public static let LoginDetailWebsite = MZLocalizedString(
-        "Website",
+        key: "Website",
         tableName: "LoginManager",
         value: nil,
         comment: "Label displayed above the website row in Login Detail View.")
     public static let LoginDetailCreatedAt =  MZLocalizedString(
-        "Created %@",
+        key: "Created %@",
         tableName: "LoginManager",
         value: nil,
         comment: "Label describing when the current login was created with the timestamp as the parameter.")
     public static let LoginDetailModifiedAt = MZLocalizedString(
-        "Modified %@",
+        key: "Modified %@",
         tableName: "LoginManager",
         value: nil,
         comment: "Label describing when the current login was last modified with the timestamp as the parameter.")
     public static let LoginDetailDelete = MZLocalizedString(
-        "Delete",
+        key: "Delete",
         tableName: "LoginManager",
         value: nil,
         comment: "Label for the button used to delete the current login.")
@@ -4382,7 +4382,7 @@ extension String {
 // MARK: - No Logins View
 extension String {
     public static let NoLoginsFound = MZLocalizedString(
-        "No logins found",
+        key: "No logins found",
         tableName: "LoginManager",
         value: nil,
         comment: "Label displayed when no logins are found after searching.")
@@ -4391,22 +4391,22 @@ extension String {
 // MARK: - Reader Mode Handler
 extension String {
     public static let ReaderModeHandlerLoadingContent = MZLocalizedString(
-        "Loading content…",
+        key: "Loading content…",
         tableName: nil,
         value: nil,
         comment: "Message displayed when the reader mode page is loading. This message will appear only when sharing to Firefox reader mode from another app.")
     public static let ReaderModeHandlerPageCantDisplay = MZLocalizedString(
-        "The page could not be displayed in Reader View.",
+        key: "The page could not be displayed in Reader View.",
         tableName: nil,
         value: nil,
         comment: "Message displayed when the reader mode page could not be loaded. This message will appear only when sharing to Firefox reader mode from another app.")
     public static let ReaderModeHandlerLoadOriginalPage = MZLocalizedString(
-        "Load original page",
+        key: "Load original page",
         tableName: nil,
         value: nil,
         comment: "Link for going to the non-reader page when the reader view could not be loaded. This message will appear only when sharing to Firefox reader mode from another app.")
     public static let ReaderModeHandlerError = MZLocalizedString(
-        "There was an error converting the page",
+        key: "There was an error converting the page",
         tableName: nil,
         value: nil,
         comment: "Error displayed when reader mode cannot be enabled")
@@ -4415,67 +4415,67 @@ extension String {
 // MARK: - ReaderModeStyle
 extension String {
     public static let ReaderModeStyleBrightnessAccessibilityLabel = MZLocalizedString(
-        "Brightness",
+        key: "Brightness",
         tableName: nil,
         value: nil,
         comment: "Accessibility label for brightness adjustment slider in Reader Mode display settings")
     public static let ReaderModeStyleFontTypeAccessibilityLabel = MZLocalizedString(
-        "Changes font type.",
+        key: "Changes font type.",
         tableName: nil,
         value: nil,
         comment: "Accessibility hint for the font type buttons in reader mode display settings")
     public static let ReaderModeStyleSansSerifFontType = MZLocalizedString(
-        "Sans-serif",
+        key: "Sans-serif",
         tableName: nil,
         value: nil,
         comment: "Font type setting in the reading view settings")
     public static let ReaderModeStyleSerifFontType = MZLocalizedString(
-        "Serif",
+        key: "Serif",
         tableName: nil,
         value: nil,
         comment: "Font type setting in the reading view settings")
     public static let ReaderModeStyleSmallerLabel = MZLocalizedString(
-        "-",
+        key: "-",
         tableName: nil,
         value: nil,
         comment: "Button for smaller reader font size. Keep this extremely short! This is shown in the reader mode toolbar.")
     public static let ReaderModeStyleSmallerAccessibilityLabel = MZLocalizedString(
-        "Decrease text size",
+        key: "Decrease text size",
         tableName: nil,
         value: nil,
         comment: "Accessibility label for button decreasing font size in display settings of reader mode")
     public static let ReaderModeStyleLargerLabel = MZLocalizedString(
-        "+",
+        key: "+",
         tableName: nil,
         value: nil,
         comment: "Button for larger reader font size. Keep this extremely short! This is shown in the reader mode toolbar.")
     public static let ReaderModeStyleLargerAccessibilityLabel = MZLocalizedString(
-        "Increase text size",
+        key: "Increase text size",
         tableName: nil,
         value: nil,
         comment: "Accessibility label for button increasing font size in display settings of reader mode")
     public static let ReaderModeStyleFontSize = MZLocalizedString(
-        "Aa",
+        key: "Aa",
         tableName: nil,
         value: nil,
         comment: "Button for reader mode font size. Keep this extremely short! This is shown in the reader mode toolbar.")
     public static let ReaderModeStyleChangeColorSchemeAccessibilityHint = MZLocalizedString(
-        "Changes color theme.",
+        key: "Changes color theme.",
         tableName: nil,
         value: nil,
         comment: "Accessibility hint for the color theme setting buttons in reader mode display settings")
     public static let ReaderModeStyleLightLabel = MZLocalizedString(
-        "Light",
+        key: "Light",
         tableName: nil,
         value: nil,
         comment: "Light theme setting in Reading View settings")
     public static let ReaderModeStyleDarkLabel = MZLocalizedString(
-        "Dark",
+        key: "Dark",
         tableName: nil,
         value: nil,
         comment: "Dark theme setting in Reading View settings")
     public static let ReaderModeStyleSepiaLabel = MZLocalizedString(
-        "Sepia",
+        key: "Sepia",
         tableName: nil,
         value: nil,
         comment: "Sepia theme setting in Reading View settings")
@@ -4484,12 +4484,12 @@ extension String {
 // MARK: - Empty Private tab view
 extension String {
     public static let PrivateBrowsingLearnMore = MZLocalizedString(
-        "Learn More",
+        key: "Learn More",
         tableName: "PrivateBrowsing",
         value: nil,
         comment: "Text button displayed when there are no tabs open while in private mode")
     public static let PrivateBrowsingTitle = MZLocalizedString(
-        "Private Browsing",
+        key: "Private Browsing",
         tableName: "PrivateBrowsing",
         value: nil,
         comment: "Title displayed for when there are no open tabs while in private mode")
@@ -4498,7 +4498,7 @@ extension String {
 // MARK: - Advanced Account Setting
 extension String {
     public static let AdvancedAccountUseStageServer = MZLocalizedString(
-        "Use stage servers",
+        key: "Use stage servers",
         tableName: nil,
         value: nil,
         comment: "Debug option")
@@ -4507,77 +4507,77 @@ extension String {
 // MARK: - App Settings
 extension String {
     public static let AppSettingsLicenses = MZLocalizedString(
-        "Licenses",
+        key: "Licenses",
         tableName: nil,
         value: nil,
         comment: "Settings item that opens a tab containing the licenses. See http://mzl.la/1NSAWCG")
     public static let AppSettingsYourRights = MZLocalizedString(
-        "Your Rights",
+        key: "Your Rights",
         tableName: nil,
         value: nil,
         comment: "Your Rights settings section title")
     public static let AppSettingsShowTour = MZLocalizedString(
-        "Show Tour",
+        key: "Show Tour",
         tableName: nil,
         value: nil,
         comment: "Show the on-boarding screen again from the settings")
     public static let AppSettingsSendFeedback = MZLocalizedString(
-        "Send Feedback",
+        key: "Send Feedback",
         tableName: nil,
         value: nil,
         comment: "Menu item in settings used to open input.mozilla.org where people can submit feedback")
     public static let AppSettingsHelp = MZLocalizedString(
-        "Help",
+        key: "Help",
         tableName: nil,
         value: nil,
         comment: "Show the SUMO support page from the Support section in the settings. see http://mzl.la/1dmM8tZ")
     public static let AppSettingsSearch = MZLocalizedString(
-        "Search",
+        key: "Search",
         tableName: nil,
         value: nil,
         comment: "Open search section of settings")
     public static let AppSettingsPrivacyPolicy = MZLocalizedString(
-        "Privacy Policy",
+        key: "Privacy Policy",
         tableName: nil,
         value: nil,
         comment: "Show Firefox Browser Privacy Policy page from the Privacy section in the settings. See https://www.mozilla.org/privacy/firefox/")
     public static let AppSettingsTitle = MZLocalizedString(
-        "Settings",
+        key: "Settings",
         tableName: nil,
         value: nil,
         comment: "Title in the settings view controller title bar")
     public static let AppSettingsDone = MZLocalizedString(
-        "Done",
+        key: "Done",
         tableName: nil,
         value: nil,
         comment: "Done button on left side of the Settings view controller title bar")
     public static let AppSettingsPrivacyTitle = MZLocalizedString(
-        "Privacy",
+        key: "Privacy",
         tableName: nil,
         value: nil,
         comment: "Privacy section title")
     public static let AppSettingsBlockPopups = MZLocalizedString(
-        "Block Pop-up Windows",
+        key: "Block Pop-up Windows",
         tableName: nil,
         value: nil,
         comment: "Block pop-up windows setting")
     public static let AppSettingsClosePrivateTabsTitle = MZLocalizedString(
-        "Close Private Tabs",
+        key: "Close Private Tabs",
         tableName: "PrivateBrowsing",
         value: nil,
         comment: "Setting for closing private tabs")
     public static let AppSettingsClosePrivateTabsDescription = MZLocalizedString(
-        "When Leaving Private Browsing",
+        key: "When Leaving Private Browsing",
         tableName: "PrivateBrowsing",
         value: nil,
         comment: "Will be displayed in Settings under 'Close Private Tabs'")
     public static let AppSettingsSupport = MZLocalizedString(
-        "Support",
+        key: "Support",
         tableName: nil,
         value: nil,
         comment: "Support section title")
     public static let AppSettingsAbout = MZLocalizedString(
-        "About",
+        key: "About",
         tableName: nil,
         value: nil,
         comment: "About settings section title")
@@ -4587,38 +4587,38 @@ extension String {
 extension String {
     // Removed Clearables as part of Bug 1226654, but keeping the string around.
     private static let removedSavedLoginsLabel = MZLocalizedString(
-        "Saved Logins",
+        key: "Saved Logins",
         tableName: "ClearPrivateData",
         value: nil,
         comment: "Settings item for clearing passwords and login data")
 
     public static let ClearableHistory = MZLocalizedString(
-        "Browsing History",
+        key: "Browsing History",
         tableName: "ClearPrivateData",
         value: nil,
         comment: "Settings item for clearing browsing history")
     public static let ClearableCache = MZLocalizedString(
-        "Cache",
+        key: "Cache",
         tableName: "ClearPrivateData",
         value: nil,
         comment: "Settings item for clearing the cache")
     public static let ClearableOfflineData = MZLocalizedString(
-        "Offline Website Data",
+        key: "Offline Website Data",
         tableName: "ClearPrivateData",
         value: nil,
         comment: "Settings item for clearing website data")
     public static let ClearableCookies = MZLocalizedString(
-        "Cookies",
+        key: "Cookies",
         tableName: "ClearPrivateData",
         value: nil,
         comment: "Settings item for clearing cookies")
     public static let ClearableDownloads = MZLocalizedString(
-        "Downloaded Files",
+        key: "Downloaded Files",
         tableName: "ClearPrivateData",
         value: nil,
         comment: "Settings item for deleting downloaded files")
     public static let ClearableSpotlight = MZLocalizedString(
-        "Spotlight Index",
+        key: "Spotlight Index",
         tableName: "ClearPrivateData",
         value: nil,
         comment: "A settings item that allows a user to use Apple's \"Spotlight Search\" in Data Management's Website Data option to search for and select an item to delete.")
@@ -4627,12 +4627,12 @@ extension String {
 // MARK: - SearchEngine Picker
 extension String {
     public static let SearchEnginePickerTitle = MZLocalizedString(
-        "Default Search Engine",
+        key: "Default Search Engine",
         tableName: nil,
         value: nil,
         comment: "Title for default search engine picker.")
     public static let SearchEnginePickerCancel = MZLocalizedString(
-        "Cancel",
+        key: "Cancel",
         tableName: nil,
         value: nil,
         comment: "Label for Cancel button")
@@ -4641,27 +4641,27 @@ extension String {
 // MARK: - SearchSettings
 extension String {
     public static let SearchSettingsTitle = MZLocalizedString(
-        "SearchSettings.Title.Search.v106",
+        key: "SearchSettings.Title.Search.v106",
         tableName: nil,
         value: "Search",
         comment: "Navigation title for search settings.")
     public static let SearchSettingsDefaultSearchEngineAccessibilityLabel = MZLocalizedString(
-        "SearchSettings.Accessibility.DefaultSearchEngine.v106",
+        key: "SearchSettings.Accessibility.DefaultSearchEngine.v106",
         tableName: nil,
         value: "Default Search Engine",
         comment: "Accessibility label for default search engine setting.")
     public static let SearchSettingsShowSearchSuggestions = MZLocalizedString(
-        "Show Search Suggestions",
+        key: "Show Search Suggestions",
         tableName: nil,
         value: nil,
         comment: "Label for show search suggestions setting.")
     public static let SearchSettingsDefaultSearchEngineTitle = MZLocalizedString(
-        "SearchSettings.Title.DefaultSearchEngine.v106",
+        key: "SearchSettings.Title.DefaultSearchEngine.v106",
         tableName: nil,
         value: "Default Search Engine",
         comment: "Title for default search engine settings section.")
     public static let SearchSettingsQuickSearchEnginesTitle = MZLocalizedString(
-        "Quick-Search Engines",
+        key: "Quick-Search Engines",
         tableName: nil,
         value: nil,
         comment: "Title for quick-search engines settings section.")
@@ -4670,7 +4670,7 @@ extension String {
 // MARK: - SettingsContent
 extension String {
     public static let SettingsContentPageLoadError = MZLocalizedString(
-        "Could not load page.",
+        key: "Could not load page.",
         tableName: nil,
         value: nil,
         comment: "Error message that is shown in settings when there was a problem loading")
@@ -4679,22 +4679,22 @@ extension String {
 // MARK: - SearchInput
 extension String {
     public static let SearchInputAccessibilityLabel = MZLocalizedString(
-        "Search Input Field",
+        key: "Search Input Field",
         tableName: "LoginManager",
         value: nil,
         comment: "Accessibility label for the search input field in the Logins list")
     public static let SearchInputTitle = MZLocalizedString(
-        "SearchInput.Title.Search.v106",
+        key: "SearchInput.Title.Search.v106",
         tableName: "LoginManager",
         value: "Search",
         comment: "Title for the search field at the top of the Logins list screen")
     public static let SearchInputClearAccessibilityLabel = MZLocalizedString(
-        "Clear Search",
+        key: "Clear Search",
         tableName: "LoginManager",
         value: nil,
         comment: "Accessibility message e.g. spoken by VoiceOver after the user taps the close button in the search field to clear the search and exit search mode")
     public static let SearchInputEnterSearchMode = MZLocalizedString(
-        "Enter Search Mode",
+        key: "Enter Search Mode",
         tableName: "LoginManager",
         value: nil,
         comment: "Accessibility label for entering search mode for logins")
@@ -4703,7 +4703,7 @@ extension String {
 // MARK: - TabsButton
 extension String {
     public static let TabsButtonShowTabsAccessibilityLabel = MZLocalizedString(
-        "Show Tabs",
+        key: "Show Tabs",
         tableName: nil,
         value: nil,
         comment: "Accessibility label for the tabs button in the (top) tab toolbar")
@@ -4712,12 +4712,12 @@ extension String {
 // MARK: - TabTrayButtons
 extension String {
     public static let TabTrayButtonNewTabAccessibilityLabel = MZLocalizedString(
-        "New Tab",
+        key: "New Tab",
         tableName: nil,
         value: nil,
         comment: "Accessibility label for the New Tab button in the tab toolbar.")
     public static let TabTrayButtonShowTabsAccessibilityLabel = MZLocalizedString(
-        "TabTrayButtons.Accessibility.ShowTabs.v106",
+        key: "TabTrayButtons.Accessibility.ShowTabs.v106",
         tableName: nil,
         value: "Show Tabs",
         comment: "Accessibility Label for the tabs button in the tab toolbar")
@@ -4726,37 +4726,37 @@ extension String {
 // MARK: - MenuHelper
 extension String {
     public static let MenuHelperPasteAndGo = MZLocalizedString(
-        "UIMenuItem.PasteGo",
+        key: "UIMenuItem.PasteGo",
         tableName: nil,
         value: "Paste & Go",
         comment: "The menu item that pastes the current contents of the clipboard into the URL bar and navigates to the page")
     public static let MenuHelperReveal = MZLocalizedString(
-        "Reveal",
+        key: "Reveal",
         tableName: "LoginManager",
         value: nil,
         comment: "Reveal password text selection menu item")
     public static let MenuHelperHide =  MZLocalizedString(
-        "Hide",
+        key: "Hide",
         tableName: "LoginManager",
         value: nil,
         comment: "Hide password text selection menu item")
     public static let MenuHelperCopy = MZLocalizedString(
-        "Copy",
+        key: "Copy",
         tableName: "LoginManager",
         value: nil,
         comment: "Copy password text selection menu item")
     public static let MenuHelperOpenAndFill = MZLocalizedString(
-        "Open & Fill",
+        key: "Open & Fill",
         tableName: "LoginManager",
         value: nil,
         comment: "Open and Fill website text selection menu item")
     public static let MenuHelperFindInPage = MZLocalizedString(
-        "Find in Page",
+        key: "Find in Page",
         tableName: "FindInPage",
         value: nil,
         comment: "Text selection menu item")
     public static let MenuHelperSearchWithFirefox = MZLocalizedString(
-        "UIMenuItem.SearchWithFirefox",
+        key: "UIMenuItem.SearchWithFirefox",
         tableName: nil,
         value: "Search with Firefox",
         comment: "Search in New Tab Text selection menu item")
@@ -4765,7 +4765,7 @@ extension String {
 // MARK: - DeviceInfo
 extension String {
     public static let DeviceInfoClientNameDescription = MZLocalizedString(
-        "%@ on %@",
+        key: "%@ on %@",
         tableName: "Shared",
         value: nil,
         comment: "A brief descriptive name for this app on this device, used for Send Tab and Synced Tabs. The first argument is the app name. The second argument is the device name.")
@@ -4774,32 +4774,32 @@ extension String {
 // MARK: - TimeConstants
 extension String {
     public static let TimeConstantMoreThanAMonth = MZLocalizedString(
-        "more than a month ago",
+        key: "more than a month ago",
         tableName: nil,
         value: nil,
         comment: "Relative date for dates older than a month and less than two months.")
     public static let TimeConstantMoreThanAWeek = MZLocalizedString(
-        "more than a week ago",
+        key: "more than a week ago",
         tableName: nil,
         value: nil,
         comment: "Description for a date more than a week ago, but less than a month ago.")
     public static let TimeConstantYesterday = MZLocalizedString(
-        "TimeConstants.Yesterday.v106",
+        key: "TimeConstants.Yesterday.v106",
         tableName: nil,
         value: "yesterday",
         comment: "Relative date for yesterday.")
     public static let TimeConstantThisWeek = MZLocalizedString(
-        "this week",
+        key: "this week",
         tableName: nil,
         value: nil,
         comment: "Relative date for date in past week.")
     public static let TimeConstantRelativeToday = MZLocalizedString(
-        "today at %@",
+        key: "today at %@",
         tableName: nil,
         value: nil,
         comment: "Relative date for date older than a minute.")
     public static let TimeConstantJustNow = MZLocalizedString(
-        "just now",
+        key: "just now",
         tableName: nil,
         value: nil,
         comment: "Relative time for a tab that was visited within the last few moments.")
@@ -4808,27 +4808,27 @@ extension String {
 // MARK: - Default Suggested Site
 extension String {
     public static let DefaultSuggestedFacebook = MZLocalizedString(
-        "Facebook",
+        key: "Facebook",
         tableName: nil,
         value: nil,
         comment: "Tile title for Facebook")
     public static let DefaultSuggestedYouTube = MZLocalizedString(
-        "YouTube",
+        key: "YouTube",
         tableName: nil,
         value: nil,
         comment: "Tile title for YouTube")
     public static let DefaultSuggestedAmazon = MZLocalizedString(
-        "Amazon",
+        key: "Amazon",
         tableName: nil,
         value: nil,
         comment: "Tile title for Amazon")
     public static let DefaultSuggestedWikipedia = MZLocalizedString(
-        "Wikipedia",
+        key: "Wikipedia",
         tableName: nil,
         value: nil,
         comment: "Tile title for Wikipedia")
     public static let DefaultSuggestedTwitter = MZLocalizedString(
-        "Twitter",
+        key: "Twitter",
         tableName: nil,
         value: nil,
         comment: "Tile title for Twitter")
@@ -4837,57 +4837,57 @@ extension String {
 // MARK: - Credential Provider
 extension String {
     public static let LoginsWelcomeViewTitle2 = MZLocalizedString(
-        "Logins.WelcomeView.Title2",
+        key: "Logins.WelcomeView.Title2",
         tableName: nil,
         value: "AutoFill Firefox Passwords",
         comment: "Label displaying welcome view title")
     public static let LoginsWelcomeViewTagline = MZLocalizedString(
-        "Logins.WelcomeView.Tagline",
+        key: "Logins.WelcomeView.Tagline",
         tableName: nil,
         value: "Take your passwords everywhere",
         comment: "Label displaying welcome view tagline under the title")
     public static let LoginsWelcomeTurnOnAutoFillButtonTitle = MZLocalizedString(
-        "Logins.WelcomeView.TurnOnAutoFill",
+        key: "Logins.WelcomeView.TurnOnAutoFill",
         tableName: nil,
         value: "Turn on AutoFill",
         comment: "Title of the big blue button to enable AutoFill")
     public static let LoginsListSearchCancel = MZLocalizedString(
-        "LoginsList.Search.Cancel",
+        key: "LoginsList.Search.Cancel",
         tableName: nil,
         value: "Cancel",
         comment: "Title for cancel button for user to stop searching for a particular login")
     public static let LoginsListSearchPlaceholderCredential = MZLocalizedString(
-        "LoginsList.Search.Placeholder",
+        key: "LoginsList.Search.Placeholder",
         tableName: nil,
         value: "Search logins",
         comment: "Placeholder text for search field")
     public static let LoginsListSelectPasswordTitle = MZLocalizedString(
-        "LoginsList.SelectPassword.Title",
+        key: "LoginsList.SelectPassword.Title",
         tableName: nil,
         value: "Select a password to fill",
         comment: "Label displaying select a password to fill instruction")
     public static let LoginsListNoMatchingResultTitle = MZLocalizedString(
-        "LoginsList.NoMatchingResult.Title",
+        key: "LoginsList.NoMatchingResult.Title",
         tableName: nil,
         value: "No matching logins",
         comment: "Label displayed when a user searches and no matches can be found against the search query")
     public static let LoginsListNoMatchingResultSubtitle = MZLocalizedString(
-        "LoginsList.NoMatchingResult.Subtitle",
+        key: "LoginsList.NoMatchingResult.Subtitle",
         tableName: nil,
         value: "There are no results matching your search.",
         comment: "Label that appears after the search if there are no logins matching the search")
     public static let LoginsListNoLoginsFoundTitle = MZLocalizedString(
-        "LoginsList.NoLoginsFound.Title",
+        key: "LoginsList.NoLoginsFound.Title",
         tableName: nil,
         value: "No logins found",
         comment: "Label shown when there are no logins saved")
     public static let LoginsListNoLoginsFoundDescription = MZLocalizedString(
-        "LoginsList.NoLoginsFound.Description",
+        key: "LoginsList.NoLoginsFound.Description",
         tableName: nil,
         value: "Saved logins will show up here. If you saved your logins to Firefox on a different device, sign in to your Firefox Account.",
         comment: "Label shown when there are no logins to list")
     public static let LoginsPasscodeRequirementWarning = MZLocalizedString(
-        "Logins.PasscodeRequirement.Warning",
+        key: "Logins.PasscodeRequirement.Warning",
         tableName: nil,
         value: "To use the AutoFill feature for Firefox, you must have a device passcode enabled.",
         comment: "Warning message shown when you try to enable or use native AutoFill without a device passcode setup")
@@ -4896,12 +4896,12 @@ extension String {
 // MARK: - v35 Strings
 extension String {
     public static let FirefoxHomeJumpBackInSectionTitle = MZLocalizedString(
-        "ActivityStream.JumpBackIn.SectionTitle",
+        key: "ActivityStream.JumpBackIn.SectionTitle",
         tableName: nil,
         value: "Jump Back In",
         comment: "Title for the Jump Back In section. This section allows users to jump back in to a recently viewed tab")
     public static let TabsTrayInactiveTabsSectionTitle = MZLocalizedString(
-        "TabTray.InactiveTabs.SectionTitle",
+        key: "TabTray.InactiveTabs.SectionTitle",
         tableName: nil,
         value: "Inactive Tabs",
         comment: "Title for the inactive tabs section. This section groups all tabs that haven't been used in a while.")
@@ -4910,12 +4910,12 @@ extension String {
 // MARK: - v36 Strings
 extension String {
     public static let ProtectionStatusSecure = MZLocalizedString(
-        "ProtectionStatus.Secure",
+        key: "ProtectionStatus.Secure",
         tableName: nil,
         value: "Connection is secure",
         comment: "This is the value for a label that indicates if a user is on a secure https connection.")
     public static let ProtectionStatusNotSecure = MZLocalizedString(
-        "ProtectionStatus.NotSecure",
+        key: "ProtectionStatus.NotSecure",
         tableName: nil,
         value: "Connection is not secure",
         comment: "This is the value for a label that indicates if a user is on an unencrypted website.")


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6230)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14032)

### Description
Change our strings files, so key name is always specified. This will make it easier for the Danger script to detect Strings issues, and also I prefer having it specified in that case since we have older strings that use the key has value (and making it specific with the parameter name helps visualize that this isn't the proper usage of `MZLocalizedString` we want).

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
