### PR TITLE
Bugfix FXIOS-6245 [v114] fix leading and trailing constraints of Customize Homepage button

### DIFF
--- a/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionCell.swift
+++ b/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionCell.swift
@@ -10,7 +10,7 @@ class CustomizeHomepageSectionCell: UICollectionViewCell, ReusableCell {
 
     private struct UX {
         static let buttonFontSize: CGFloat = 15
-        static let buttonTrailingSpace: CGFloat = 12
+        static let buttonTrailingSpace: CGFloat = 18
         static let buttonVerticalInset: CGFloat = 11
         static let buttonCornerRadius: CGFloat = 4
     }
@@ -47,8 +47,8 @@ class CustomizeHomepageSectionCell: UICollectionViewCell, ReusableCell {
         NSLayoutConstraint.activate([
             goToSettingsButton.topAnchor.constraint(equalTo: contentView.topAnchor),
             goToSettingsButton.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-            goToSettingsButton.leftAnchor.constraint(equalTo: contentView.leftAnchor),
-            goToSettingsButton.rightAnchor.constraint(equalTo: contentView.rightAnchor,
+            goToSettingsButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            goToSettingsButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor,
                                                       constant: -UX.buttonTrailingSpace)
         ])
 

--- a/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionCell.swift
+++ b/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionCell.swift
@@ -10,7 +10,7 @@ class CustomizeHomepageSectionCell: UICollectionViewCell, ReusableCell {
 
     private struct UX {
         static let buttonFontSize: CGFloat = 15
-        static let buttonTrailingSpace: CGFloat = 18
+        static let buttonTrailingSpace: CGFloat = 12
         static let buttonVerticalInset: CGFloat = 11
         static let buttonCornerRadius: CGFloat = 4
     }

--- a/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionCell.swift
+++ b/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionCell.swift
@@ -48,8 +48,7 @@ class CustomizeHomepageSectionCell: UICollectionViewCell, ReusableCell {
             goToSettingsButton.topAnchor.constraint(equalTo: contentView.topAnchor),
             goToSettingsButton.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
             goToSettingsButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-            goToSettingsButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor,
-                                                      constant: -UX.buttonTrailingSpace)
+            goToSettingsButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -UX.buttonTrailingSpace)
         ])
 
         goToSettingsButton.setContentHuggingPriority(.required, for: .vertical)


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6245)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14084)

### Description
Changing left and right anchors to leading and trailing to make UI consistent with right-to-left languages and also changing the buttonTrailingSpace value to 18 to make leading and trailing constraints have the same value for a better experience

### Visualizing Code Changes: Screen Shot Provide Clarity on Modifications Made 
<img width="360" alt="after-fix" src="https://user-images.githubusercontent.com/35566553/233790112-241025d1-2616-43f3-a814-7a21e62970a4.png">


### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
