### PR TITLE
Bugfix FXIOS-6250 [v114] Update color of the switches

### DIFF
--- a/Client/Frontend/LoginManagement/LoginListViewController.swift
+++ b/Client/Frontend/LoginManagement/LoginListViewController.swift
@@ -181,6 +181,8 @@ class LoginListViewController: SensitiveViewController, Themeable {
         let theme = themeManager.currentTheme
         viewModel.theme = theme
         loginDataSource.viewModel = viewModel
+        tableView.reloadSections(IndexSet(integer: LoginListViewController.loginsSettingsSection),
+                                 with: .none)
 
         view.backgroundColor = theme.colors.layer1
         tableView.separatorColor = theme.colors.borderPrimary


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6250)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14094)

### Description
Update the color of the switches, in the Passwords Screen, when app theme changes 

| Light  | Dark | 
| ------------- | ------------- |
| ![light](https://user-images.githubusercontent.com/51127880/234029416-9c279c4c-8ca5-4a4e-85d9-ed7b1419e2b9.jpeg) | ![dark](https://user-images.githubusercontent.com/51127880/234029480-7122df2e-748c-4277-b3df-d5c3cc7e31e9.jpeg) |
### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
