### PR TITLE
Add FXIOS-6087 [v114] Screenshot service with coordinator

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -559,6 +559,7 @@
 		8A7653BF28A2C92600924ABF /* PocketStandardCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7653BE28A2C92600924ABF /* PocketStandardCellViewModel.swift */; };
 		8A7653C228A2E57D00924ABF /* PocketDataAdaptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7653C128A2E57D00924ABF /* PocketDataAdaptorTests.swift */; };
 		8A7653C528A2E69100924ABF /* MockPocketAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7653C328A2E68B00924ABF /* MockPocketAPI.swift */; };
+		8A76B01629F6EB3900A82607 /* ScreenshotService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A76B01529F6EB3900A82607 /* ScreenshotService.swift */; };
 		8A7A26E129D4785900EA76F1 /* MockRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7A26E029D4785900EA76F1 /* MockRouter.swift */; };
 		8A7A26E329D4ACF300EA76F1 /* SceneCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7A26E229D4ACF300EA76F1 /* SceneCoordinatorTests.swift */; };
 		8A7A26E529D4C0A800EA76F1 /* IntroScreenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7A26E429D4C0A800EA76F1 /* IntroScreenManager.swift */; };
@@ -4017,6 +4018,7 @@
 		8A7653BE28A2C92600924ABF /* PocketStandardCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketStandardCellViewModel.swift; sourceTree = "<group>"; };
 		8A7653C128A2E57D00924ABF /* PocketDataAdaptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketDataAdaptorTests.swift; sourceTree = "<group>"; };
 		8A7653C328A2E68B00924ABF /* MockPocketAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPocketAPI.swift; sourceTree = "<group>"; };
+		8A76B01529F6EB3900A82607 /* ScreenshotService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotService.swift; sourceTree = "<group>"; };
 		8A7A26E029D4785900EA76F1 /* MockRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRouter.swift; sourceTree = "<group>"; };
 		8A7A26E229D4ACF300EA76F1 /* SceneCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneCoordinatorTests.swift; sourceTree = "<group>"; };
 		8A7A26E429D4C0A800EA76F1 /* IntroScreenManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroScreenManager.swift; sourceTree = "<group>"; };
@@ -7503,6 +7505,7 @@
 			children = (
 				8A93F86F29D3A597004159D9 /* SceneCoordinator.swift */,
 				8AF10D8E29D774090086351D /* SceneSetupHelper.swift */,
+				8A76B01529F6EB3900A82607 /* ScreenshotService.swift */,
 			);
 			path = Scene;
 			sourceTree = "<group>";
@@ -11143,6 +11146,7 @@
 				CAA3B7E62497DCB60094E3C1 /* LoginDataSource.swift in Sources */,
 				1DFE57FF27BAE3150025DE58 /* HomepageSectionType.swift in Sources */,
 				396E38F11EE0C8EC00CC180F /* FxAPushMessageHandler.swift in Sources */,
+				8A76B01629F6EB3900A82607 /* ScreenshotService.swift in Sources */,
 				E4CD9F6D1A77DD2800318571 /* ReaderModeStyleViewController.swift in Sources */,
 				E1CD81BC290C5C3F00124B27 /* DevicePickerTableViewCell.swift in Sources */,
 				E1FE133129C22726002A65FF /* BackgroundFetchAndProcessingUtility.swift in Sources */,

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -13,11 +13,14 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
 
     private var profile: Profile
     private var logger: Logger
+    private let screenshotService: ScreenshotService
 
     init(router: Router,
+         screenshotService: ScreenshotService,
          profile: Profile = AppContainer.shared.resolve(),
          tabManager: TabManager = AppContainer.shared.resolve(),
          logger: Logger = DefaultLogger.shared) {
+        self.screenshotService = screenshotService
         self.profile = profile
         self.browserViewController = BrowserViewController(profile: profile, tabManager: tabManager)
         self.logger = logger
@@ -77,6 +80,9 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
         }
 
         browserViewController.embedContent(homepage)
+
+        // We currently don't support full page screenshot of the homepage
+        screenshotService.screenshotAbleView = nil
     }
 
     func show(webView: WKWebView?) {
@@ -93,5 +99,7 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
                        level: .fatal,
                        category: .lifecycle)
         }
+
+        screenshotService.screenshotAbleView = webviewController
     }
 }

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -82,7 +82,7 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
         browserViewController.embedContent(homepage)
 
         // We currently don't support full page screenshot of the homepage
-        screenshotService.screenshotAbleView = nil
+        screenshotService.screenshotableView = nil
     }
 
     func show(webView: WKWebView?) {
@@ -100,6 +100,6 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
                        category: .lifecycle)
         }
 
-        screenshotService.screenshotAbleView = webviewController
+        screenshotService.screenshotableView = webviewController
     }
 }

--- a/Client/Coordinators/Scene/SceneCoordinator.swift
+++ b/Client/Coordinators/Scene/SceneCoordinator.swift
@@ -9,7 +9,7 @@ import Shared
 /// Each scene has it's own scene coordinator, which is the root coordinator for a scene.
 class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinishedLoadingDelegate {
     var window: UIWindow?
-    let screenshotService = ScreenShotService()
+    private let screenshotService = ScreenshotService()
 
     init(scene: UIScene,
          sceneSetupHelper: SceneSetupHelper = SceneSetupHelper()) {
@@ -62,7 +62,8 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
     }
 
     private func startBrowser(with launchType: LaunchType?) {
-        let browserCoordinator = BrowserCoordinator(router: router)
+        let browserCoordinator = BrowserCoordinator(router: router,
+                                                    screenshotService: screenshotService)
         add(child: browserCoordinator)
         browserCoordinator.start(with: launchType)
     }

--- a/Client/Coordinators/Scene/SceneCoordinator.swift
+++ b/Client/Coordinators/Scene/SceneCoordinator.swift
@@ -9,10 +9,11 @@ import Shared
 /// Each scene has it's own scene coordinator, which is the root coordinator for a scene.
 class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinishedLoadingDelegate {
     var window: UIWindow?
+    let screenshotService = ScreenShotService()
 
     init(scene: UIScene,
          sceneSetupHelper: SceneSetupHelper = SceneSetupHelper()) {
-        self.window = sceneSetupHelper.configureWindowFor(scene, screenshotServiceDelegate: nil)
+        self.window = sceneSetupHelper.configureWindowFor(scene, screenshotServiceDelegate: screenshotService)
         let navigationController = sceneSetupHelper.createNavigationController()
         let router = DefaultRouter(navigationController: navigationController)
         super.init(router: router)
@@ -37,16 +38,18 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
         startLaunch(with: launchType)
     }
 
+    func launchBrowser() {
+        startBrowser(with: nil)
+    }
+
+    // MARK: - Route handling
+
     /// Handles the specified route.
     ///
     /// - Parameter route: The route to handle.
     ///
     func handle(route: Route) {
         // TODO: Implement this function.
-    }
-
-    func launchBrowser() {
-        startBrowser(with: nil)
     }
 
     // MARK: - Helper methods

--- a/Client/Coordinators/Scene/SceneSetupHelper.swift
+++ b/Client/Coordinators/Scene/SceneSetupHelper.swift
@@ -8,12 +8,11 @@ import Shared
 
 struct SceneSetupHelper {
     func configureWindowFor(_ scene: UIScene,
-                            screenshotServiceDelegate: UIScreenshotServiceDelegate?) -> UIWindow {
+                            screenshotServiceDelegate: UIScreenshotServiceDelegate) -> UIWindow {
         guard let windowScene = (scene as? UIWindowScene) else {
             return UIWindow(frame: UIScreen.main.bounds)
         }
 
-        // FXIOS-6087: Create screenshot service delegate, currently nil
         windowScene.screenshotService?.delegate = screenshotServiceDelegate
 
         let window = UIWindow(windowScene: windowScene)

--- a/Client/Coordinators/Scene/ScreenshotService.swift
+++ b/Client/Coordinators/Scene/ScreenshotService.swift
@@ -4,30 +4,36 @@
 
 import Foundation
 
-struct ScreenShotData {
+struct ScreenshotData {
     var pdfData: Data
     var rect: CGRect
 }
 
-protocol ScreenShotAbleView: UIViewController {
-    func getScreenshotData() -> ScreenShotData?
+/// A protocol to get PDF data for the fullscreen screenshot feature
+protocol ScreenshotAbleView: UIViewController {
+    func getScreenshotData(completionHandler: @escaping (ScreenshotData?) -> Void)
 }
 
-class ScreenShotService: NSObject, UIScreenshotServiceDelegate {
-    var screenshotAbleView: ScreenShotAbleView?
+class ScreenshotService: NSObject, UIScreenshotServiceDelegate {
+    var screenshotAbleView: ScreenshotAbleView?
 
     func screenshotService(
         _ screenshotService: UIScreenshotService,
         generatePDFRepresentationWithCompletion completionHandler: @escaping (Data?, Int, CGRect) -> Void
     ) {
-
-        guard let screenShotAbleView = screenshotAbleView,
-              screenShotAbleView.presentedViewController == nil,
-              let screenshotData = screenShotAbleView.getScreenshotData() else {
+        guard let screenshotAbleView = screenshotAbleView,
+              screenshotAbleView.presentedViewController == nil else {
             completionHandler(nil, 0, .zero)
             return
         }
 
-        completionHandler(screenshotData.pdfData, 0, screenshotData.rect)
+        screenshotAbleView.getScreenshotData { screenshotData in
+            guard let screenshotData = screenshotData else {
+                completionHandler(nil, 0, .zero)
+                return
+            }
+
+            completionHandler(screenshotData.pdfData, 0, screenshotData.rect)
+        }
     }
 }

--- a/Client/Coordinators/Scene/ScreenshotService.swift
+++ b/Client/Coordinators/Scene/ScreenshotService.swift
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+struct ScreenShotData {
+    var pdfData: Data
+    var rect: CGRect
+}
+
+protocol ScreenShotAbleView: UIViewController {
+    func getScreenshotData() -> ScreenShotData?
+}
+
+class ScreenShotService: NSObject, UIScreenshotServiceDelegate {
+    var screenshotAbleView: ScreenShotAbleView?
+
+    func screenshotService(
+        _ screenshotService: UIScreenshotService,
+        generatePDFRepresentationWithCompletion completionHandler: @escaping (Data?, Int, CGRect) -> Void
+    ) {
+
+        guard let screenShotAbleView = screenshotAbleView,
+              screenShotAbleView.presentedViewController == nil,
+              let screenshotData = screenShotAbleView.getScreenshotData() else {
+            completionHandler(nil, 0, .zero)
+            return
+        }
+
+        completionHandler(screenshotData.pdfData, 0, screenshotData.rect)
+    }
+}

--- a/Client/Coordinators/Scene/ScreenshotService.swift
+++ b/Client/Coordinators/Scene/ScreenshotService.swift
@@ -10,24 +10,24 @@ struct ScreenshotData {
 }
 
 /// A protocol to get PDF data for the fullscreen screenshot feature
-protocol ScreenshotAbleView: UIViewController {
+protocol ScreenshotableView: UIViewController {
     func getScreenshotData(completionHandler: @escaping (ScreenshotData?) -> Void)
 }
 
 class ScreenshotService: NSObject, UIScreenshotServiceDelegate {
-    var screenshotAbleView: ScreenshotAbleView?
+    var screenshotableView: ScreenshotableView?
 
     func screenshotService(
         _ screenshotService: UIScreenshotService,
         generatePDFRepresentationWithCompletion completionHandler: @escaping (Data?, Int, CGRect) -> Void
     ) {
-        guard let screenshotAbleView = screenshotAbleView,
-              screenshotAbleView.presentedViewController == nil else {
+        guard let screenshotableView = screenshotableView,
+              screenshotableView.presentedViewController == nil else {
             completionHandler(nil, 0, .zero)
             return
         }
 
-        screenshotAbleView.getScreenshotData { screenshotData in
+        screenshotableView.getScreenshotData { screenshotData in
             guard let screenshotData = screenshotData else {
                 completionHandler(nil, 0, .zero)
                 return

--- a/Client/Frontend/Browser/WebView/WebviewViewController.swift
+++ b/Client/Frontend/Browser/WebView/WebviewViewController.swift
@@ -6,7 +6,7 @@ import Foundation
 import Shared
 import WebKit
 
-class WebviewViewController: UIViewController, ContentContainable, ScreenshotAbleView {
+class WebviewViewController: UIViewController, ContentContainable, ScreenshotableView {
     private let webView: WKWebView
     var contentType: ContentType = .webview
 
@@ -35,7 +35,7 @@ class WebviewViewController: UIViewController, ContentContainable, ScreenshotAbl
         ])
     }
 
-    // MARK: - ScreenshotAbleView
+    // MARK: - ScreenshotableView
 
     func getScreenshotData(completionHandler: @escaping (ScreenshotData?) -> Void) {
         guard let url = webView.url,

--- a/Client/Frontend/Browser/WebView/WebviewViewController.swift
+++ b/Client/Frontend/Browser/WebView/WebviewViewController.swift
@@ -3,9 +3,10 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import Shared
 import WebKit
 
-class WebviewViewController: UIViewController, ContentContainable {
+class WebviewViewController: UIViewController, ContentContainable, ScreenshotAbleView {
     private let webView: WKWebView
     var contentType: ContentType = .webview
 
@@ -32,5 +33,28 @@ class WebviewViewController: UIViewController, ContentContainable {
             view.bottomAnchor.constraint(equalTo: webView.bottomAnchor),
             view.trailingAnchor.constraint(equalTo: webView.trailingAnchor)
         ])
+    }
+
+    // MARK: - ScreenshotAbleView
+
+    func getScreenshotData(completionHandler: @escaping (ScreenshotData?) -> Void) {
+        guard let url = webView.url,
+              InternalURL(url) == nil else {
+            completionHandler(nil)
+            return
+        }
+
+        var rect = webView.scrollView.frame
+        rect.origin.x = webView.scrollView.contentOffset.x
+        rect.origin.y = webView.scrollView.contentSize.height - rect.height - webView.scrollView.contentOffset.y
+
+        webView.createPDF { result in
+            switch result {
+            case .success(let data):
+                completionHandler(ScreenshotData(pdfData: data, rect: rect))
+            case .failure:
+                completionHandler(nil)
+            }
+        }
     }
 }

--- a/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -12,6 +12,7 @@ final class BrowserCoordinatorTests: XCTestCase {
     private var profile: MockProfile!
     private var overlayModeManager: MockOverlayModeManager!
     private var logger: MockLogger!
+    private var screenshotService: ScreenshotService!
 
     override func setUp() {
         super.setUp()
@@ -21,6 +22,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         self.profile = MockProfile()
         self.overlayModeManager = MockOverlayModeManager()
         self.logger = MockLogger()
+        self.screenshotService = ScreenshotService()
     }
 
     override func tearDown() {
@@ -29,6 +31,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         self.profile = nil
         self.overlayModeManager = nil
         self.logger = nil
+        self.screenshotService = nil
         AppContainer.shared.reset()
     }
 
@@ -134,10 +137,21 @@ final class BrowserCoordinatorTests: XCTestCase {
         XCTAssertEqual(firstWebview, secondWebview)
     }
 
+    func testShowWebview_setsScreenshotService() {
+        let webview = WKWebView()
+        let subject = createSubject()
+        subject.show(webView: webview)
+
+        XCTAssertNotNil(screenshotService.screenshotableView)
+    }
+
     // MARK: - Helpers
     private func createSubject(file: StaticString = #file,
                                line: UInt = #line) -> BrowserCoordinator {
-        let subject = BrowserCoordinator(router: mockRouter, profile: profile, logger: logger)
+        let subject = BrowserCoordinator(router: mockRouter,
+                                         screenshotService: screenshotService,
+                                         profile: profile,
+                                         logger: logger)
         trackForMemoryLeaks(subject, file: file, line: line)
         return subject
     }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6087)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13775)

### Description
- Add a screenshot service since the current implementation relies on taking the webview screenshot from SceneDelegate
- BrowserCoordinator sets the `screenshotAbleView` when embedding the `webviewController`. There's the possibility in the future if we wish we could make the homepage follow the `screenshotAbleView` protocol so we can take full page homepage screenshot too.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
