### PR TITLE
Bugfix FXIOS-5550 [v114] Crash  UIKitCore: -[UICollectionView _endItemAnimationsWithInvalidationContext...]

### DIFF
--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -885,16 +885,19 @@ extension TabDisplayManager: UICollectionViewDropDelegate {
             saveRegularOrderedTabs(from: filteredTabs)
         }
 
-        dataStore.removeAll()
-
-        filteredTabs.forEach {
-            dataStore.insert($0)
-        }
-
-        let section = tabDisplayType == .TopTabTray ? 0 : TabDisplaySection.regularTabs.rawValue
-        let start = IndexPath(row: sourceIndex, section: section)
-        let end = IndexPath(row: destinationIndexPath.item, section: section)
+        /// According to Apple's documentation the best place to make the changes to the collectionView and dataStore is
+        /// during the completion call of performBatchUpdates
         updateWith(animationType: .moveTab) { [weak self] in
+            self?.dataStore.removeAll()
+
+            self?.filteredTabs.forEach {
+                self?.dataStore.insert($0)
+            }
+
+            let section = self?.tabDisplayType == .TopTabTray ? 0 : TabDisplaySection.regularTabs.rawValue
+            let start = IndexPath(row: sourceIndex, section: section)
+            let end = IndexPath(row: destinationIndexPath.item, section: section)
+
             self?.collectionView.moveItem(at: start, to: end)
         }
     }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5550)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/12871)

### Description
- Remove unnecessary calls to performBatchUpdate
- Move dataSource and collectionView changes into `updateWith` completion which is called from `performBatchUpdates` update closure as recommended from Apple's doc

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
