### PR TITLE
Refactor MTE-904 [v114] Fail build if swiftlint fails

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -119,5 +119,9 @@ excluded: # paths to ignore during linting. Takes precedence over `included`.
   - BrowserKit/Package.swift
   - content-blocker-lib-ios/ContentBlockerGenerator/Package.swift
 
+included:
+  - /Users/vagrant/git
+  - .
+
 # reporter: "json" # reporter type (xcode, json, csv, checkstyle)
 reporter: "xcode" # reporter type (xcode, json, csv, checkstyle)

--- a/Tests/XCUITests/ActivityStreamTest.swift
+++ b/Tests/XCUITests/ActivityStreamTest.swift
@@ -1,6 +1,6 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import XCTest
 

--- a/Tests/XCUITests/ActivityStreamTest.swift
+++ b/Tests/XCUITests/ActivityStreamTest.swift
@@ -1,6 +1,6 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
-//file, You can obtain one at http://mozilla.org/MPL/2.0/
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import XCTest
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -419,20 +419,26 @@ workflows:
             echo "Swiftlint version after mirror swap"
             swiftlint version
 
-            swiftlint --config $BITRISE_SOURCE_DIR/.swiftlint.yml
+            #swiftlint --config $BITRISE_SOURCE_DIR/.swiftlint.yml
     - script@1:
         inputs:
         - content: |-
             ./bootstrap.sh
         title: Run bootstrap
-    #- swiftlint-extended@1:
-    #    inputs:
-    #    - linting_path: "$BITRISE_SOURCE_DIR"
-    #- script@1:
-    #    inputs:
-    #    - content: |-
-    #        swiftlint --path $BITRISE_SOURCE_DIR
-    #    title: Run swiflint via script
+    - swiftlint-extended@1:
+        inputs:
+        - linting_path: "$BITRISE_SOURCE_DIR"
+    - script@1:
+        inputs:
+        - content: |-
+            set -e
+            echo "$SWIFTLINT_REPORT"
+            if [ ! -z "$SWIFTLINT_REPORT" ] ;then
+            # The file is not-empty.
+                echo "Failing build since there are swiftlint errors"
+                exit 1
+            fi
+        title: Fail build if swiftlint fails
     - script@1:
         inputs:
         - content: |-

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -418,6 +418,8 @@ workflows:
             brew upgrade swiftlint
             echo "Swiftlint version after mirror swap"
             swiftlint version
+
+            swiftlint --path $BITRISE_SOURCE_DIR
     - script@1:
         inputs:
         - content: |-
@@ -426,12 +428,11 @@ workflows:
     #- swiftlint-extended@1:
     #    inputs:
     #    - linting_path: "$BITRISE_SOURCE_DIR"
-    - script@1:
-        inputs:
-        - content: |-
-            swiflint --path $BITRISE_SOURCE_DIR
-        title: Run swiflint via script
-
+    #- script@1:
+    #    inputs:
+    #    - content: |-
+    #        swiftlint --path $BITRISE_SOURCE_DIR
+    #    title: Run swiflint via script
     - script@1:
         inputs:
         - content: |-

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -5,7 +5,7 @@ pipelines:
   pipeline_multiple_shards:
     stages:
     - stage_1: {}
-    - stage_2: {}
+    #- stage_2: {}
 stages:
   stage_1:
     workflows:
@@ -423,9 +423,15 @@ workflows:
         - content: |-
             ./bootstrap.sh
         title: Run bootstrap
-    - swiftlint-extended@1:
+    #- swiftlint-extended@1:
+    #    inputs:
+    #    - linting_path: "$BITRISE_SOURCE_DIR"
+    - script@1:
         inputs:
-        - linting_path: "$BITRISE_SOURCE_DIR"
+        - content: |-
+            swiflint --path $BITRISE_SOURCE_DIR
+        title: Run swiflint via script
+
     - script@1:
         inputs:
         - content: |-

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -5,7 +5,7 @@ pipelines:
   pipeline_multiple_shards:
     stages:
     - stage_1: {}
-    #- stage_2: {}
+    - stage_2: {}
 stages:
   stage_1:
     workflows:
@@ -418,8 +418,6 @@ workflows:
             brew upgrade swiftlint
             echo "Swiftlint version after mirror swap"
             swiftlint version
-
-            #swiftlint --config $BITRISE_SOURCE_DIR/.swiftlint.yml
     - script@1:
         inputs:
         - content: |-

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -162,7 +162,7 @@ workflows:
             set -euxo pipefail
             echo "$BITRISE_ARTIFACT_PATHS"
 
-            derived_data=${BITRISE_ARTIFACT_PATHS#*|}
+            derived_data=${BITRISE_ARTIFACT_PATHS##*|}
             echo "$derived_data"
 
             echo "-- unzip -- "

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -419,7 +419,7 @@ workflows:
             echo "Swiftlint version after mirror swap"
             swiftlint version
 
-            swiftlint --path $BITRISE_SOURCE_DIR
+            swiftlint --config .swiftlint.yml
     - script@1:
         inputs:
         - content: |-

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -419,7 +419,7 @@ workflows:
             echo "Swiftlint version after mirror swap"
             swiftlint version
 
-            swiftlint --config .swiftlint.yml
+            swiftlint --config $BITRISE_SOURCE_DIR/.swiftlint.yml
     - script@1:
         inputs:
         - content: |-

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -203,7 +203,7 @@ workflows:
 
             echo "$BITRISE_ARTIFACT_PATHS"
 
-            derived_data=${BITRISE_ARTIFACT_PATHS#*|}
+            derived_data=${BITRISE_ARTIFACT_PATHS##*|}
             echo "$derived_data"
 
             echo "-- unzip -- "
@@ -254,7 +254,7 @@ workflows:
 
             echo "$BITRISE_ARTIFACT_PATHS"
 
-            derived_data=${BITRISE_ARTIFACT_PATHS#*|}
+            derived_data=${BITRISE_ARTIFACT_PATHS##*|}
             echo "$derived_data"
 
             echo "-- unzip -- "
@@ -305,7 +305,7 @@ workflows:
 
             echo "$BITRISE_ARTIFACT_PATHS"
 
-            derived_data=${BITRISE_ARTIFACT_PATHS#*|}
+            derived_data=${BITRISE_ARTIFACT_PATHS##*|}
             echo "$derived_data"
 
             echo "-- unzip -- "

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -428,6 +428,7 @@ workflows:
     - swiftlint-extended@1:
         inputs:
         - linting_path: "$BITRISE_SOURCE_DIR"
+    - deploy-to-bitrise-io@1.9: {}
     - script@1:
         inputs:
         - content: |-


### PR DESCRIPTION
We are using a pre-build step to run swiftlint. This is not maintained by Bitrise and after recent changes, if the swiflint finds an error, we see that in the test result but the build is not failed.
To save time and credits, as soon as the swiftlint fails, the build should stop so that the error is fixed.

In order to do that, we are going to try to change the pre-built step with a custom script.