### PR TITLE
Bugfix FXIOS-6253 [v113] The keyboard is not raised up when New tab is set as "blank page" and the tab is open from tab tray

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2684,11 +2684,21 @@ extension BrowserViewController: KeyboardHelperDelegate {
             animations: {
                 self.bottomContentStackView.layoutIfNeeded()
             })
+
+        finishEditionMode()
     }
 
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillChangeWithState state: KeyboardState) {
         keyboardState = state
         updateViewConstraints()
+    }
+
+    private func finishEditionMode() {
+        // If keyboard is dismiss leave edition mode Homepage case is handled in HomepageVC
+        let newTabChoice = NewTabAccessors.getNewTabPage(profile.prefs)
+        if newTabChoice != .topSites {
+            overlayManager.finishEditing(shouldCancelLoading: false)
+        }
     }
 }
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
@@ -145,6 +145,7 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
 
         let newPrivateTab = SingleActionViewModel(title: .KeyboardShortcuts.NewPrivateTab, iconString: ImageIdentifiers.newTab, iconType: .Image) { _ in
             let shouldFocusLocationField = self.newTabSettings == .blankPage
+            self.overlayManager.openNewTab(url: nil, newTabSettings: self.newTabSettings)
             self.openBlankNewTab(focusLocationField: shouldFocusLocationField, isPrivate: true)
         }.items
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6253)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14098)

### Description
Leave edit mode when keyboard is dismiss and new tab is not homepage
Also fixed issue for [FXIOS-6254](https://mozilla-hub.atlassian.net/browse/FXIOS-6254), #14099

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
