### PR TITLE
Added FXIOS-6239 [v114] Save tab state after webview load

### DIFF
--- a/BrowserKit/Sources/TabDataStore/TabFileManager.swift
+++ b/BrowserKit/Sources/TabDataStore/TabFileManager.swift
@@ -5,7 +5,7 @@
 import Foundation
 import Common
 
-protocol TabFileManager {
+public protocol TabFileManager {
     /// Determines the directory where tabs should be stored
     /// - Returns: the URL that should be used for storing tab data, can be nil
     func tabDataDirectory() -> URL?
@@ -16,16 +16,18 @@ protocol TabFileManager {
     func contentsOfDirectory(at path: URL) -> [URL]
 }
 
-class DefaultTabFileManager: TabFileManager {
+public struct DefaultTabFileManager: TabFileManager {
     let fileManager = FileManager.default
 
-    func tabDataDirectory() -> URL? {
+    public init() {}
+
+    public func tabDataDirectory() -> URL? {
         let path: String = BrowserKitInformation.shared.sharedContainerIdentifier
         let container = fileManager.containerURL(forSecurityApplicationGroupIdentifier: path)
         return container?.appendingPathComponent("tab-data")
     }
 
-    func contentsOfDirectory(at path: URL) -> [URL] {
+    public func contentsOfDirectory(at path: URL) -> [URL] {
         do {
             return try fileManager.contentsOfDirectory(
                     at: path,

--- a/BrowserKit/Sources/TabDataStore/TabSessionStore.swift
+++ b/BrowserKit/Sources/TabDataStore/TabSessionStore.swift
@@ -6,9 +6,6 @@ import Foundation
 import Common
 
 public protocol TabSessionStore {
-    /// The directory the session data should be stored at
-    var filesDirectory: String { get }
-
     /// Saves the session data associated with a tab
     /// - Parameters:
     ///   - tabID: an ID that uniquely identifies the tab
@@ -24,17 +21,17 @@ public protocol TabSessionStore {
     func clearAllData() async
 }
 
-actor DefaultTabSessionStore {
+public actor DefaultTabSessionStore: TabSessionStore {
     let fileManager: TabFileManager
     let logger: Logger
 
-    init(fileManager: TabFileManager = DefaultTabFileManager(),
-         logger: Logger = DefaultLogger.shared) {
+    public init(fileManager: TabFileManager = DefaultTabFileManager(),
+                logger: Logger = DefaultLogger.shared) {
         self.fileManager = fileManager
         self.logger = logger
     }
 
-    func saveTabSession(tabID: UUID, sessionData: Data) async {
+    public func saveTabSession(tabID: UUID, sessionData: Data) async {
         guard let path = fileManager.tabDataDirectory()?.appendingPathComponent(tabID.uuidString) else { return }
         do {
             try sessionData.write(to: path, options: .atomicWrite)
@@ -45,12 +42,12 @@ actor DefaultTabSessionStore {
         }
     }
 
-    func fetchTabSession(tabID: UUID) async -> Data {
+    public func fetchTabSession(tabID: UUID) async -> Data {
         // TODO: FXIOS-5882
         return Data()
     }
 
-    func clearAllData() async {
+    public func clearAllData() async {
         // TODO: FXIOS-6075
     }
 }

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -426,6 +426,7 @@
 		5A9A09D628B01FD500B6F51E /* MockURLBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A9A09D528B01FD500B6F51E /* MockURLBarView.swift */; };
 		5A9A09D828B2E8F000B6F51E /* MockHistoryDeletionProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A9A09D728B2E8F000B6F51E /* MockHistoryDeletionProtocol.swift */; };
 		5A9FF8492942454600DF9FBB /* Common in Frameworks */ = {isa = PBXBuildFile; productRef = 5A9FF8482942454600DF9FBB /* Common */; };
+		5AB0973529F7593B00FBDAFB /* TabStorageFlagManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB0973429F7593B00FBDAFB /* TabStorageFlagManager.swift */; };
 		5AB4237C28A1947A003BC40C /* MockNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB4237B28A1947A003BC40C /* MockNotificationCenter.swift */; };
 		5AB4237E28A2BA9C003BC40C /* HistoryHighlightsDataAdaptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB4237D28A2BA9C003BC40C /* HistoryHighlightsDataAdaptor.swift */; };
 		5AC40329291AFBDB002BF91C /* DispatchQueueHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83821FF1FC7961D00303C12 /* DispatchQueueHelper.swift */; };
@@ -559,8 +560,8 @@
 		8A7653BF28A2C92600924ABF /* PocketStandardCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7653BE28A2C92600924ABF /* PocketStandardCellViewModel.swift */; };
 		8A7653C228A2E57D00924ABF /* PocketDataAdaptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7653C128A2E57D00924ABF /* PocketDataAdaptorTests.swift */; };
 		8A7653C528A2E69100924ABF /* MockPocketAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7653C328A2E68B00924ABF /* MockPocketAPI.swift */; };
-		8A76B01629F6EB3900A82607 /* ScreenshotService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A76B01529F6EB3900A82607 /* ScreenshotService.swift */; };
 		8A76B01429F6E45600A82607 /* CoordinatorFlagManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A76B01329F6E45600A82607 /* CoordinatorFlagManager.swift */; };
+		8A76B01629F6EB3900A82607 /* ScreenshotService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A76B01529F6EB3900A82607 /* ScreenshotService.swift */; };
 		8A7A26E129D4785900EA76F1 /* MockRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7A26E029D4785900EA76F1 /* MockRouter.swift */; };
 		8A7A26E329D4ACF300EA76F1 /* SceneCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7A26E229D4ACF300EA76F1 /* SceneCoordinatorTests.swift */; };
 		8A7A26E529D4C0A800EA76F1 /* IntroScreenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7A26E429D4C0A800EA76F1 /* IntroScreenManager.swift */; };
@@ -3553,6 +3554,7 @@
 		5A9A09D328B01D8700B6F51E /* MockTelemetryWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTelemetryWrapper.swift; sourceTree = "<group>"; };
 		5A9A09D528B01FD500B6F51E /* MockURLBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLBarView.swift; sourceTree = "<group>"; };
 		5A9A09D728B2E8F000B6F51E /* MockHistoryDeletionProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHistoryDeletionProtocol.swift; sourceTree = "<group>"; };
+		5AB0973429F7593B00FBDAFB /* TabStorageFlagManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabStorageFlagManager.swift; sourceTree = "<group>"; };
 		5AB4237B28A1947A003BC40C /* MockNotificationCenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockNotificationCenter.swift; sourceTree = "<group>"; };
 		5AB4237D28A2BA9C003BC40C /* HistoryHighlightsDataAdaptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryHighlightsDataAdaptor.swift; sourceTree = "<group>"; };
 		5ABD40B68B3D03806BC6819C /* es-AR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-AR"; path = "es-AR.lproj/LoginManager.strings"; sourceTree = "<group>"; };
@@ -7205,6 +7207,7 @@
 				D3968F241A38FE8500CEFD3B /* TabManager.swift */,
 				6ACB550B28633860007A6ABD /* TabManagerNavDelegate.swift */,
 				5A8017DF29CE15D90047120D /* TabManagerImplementation.swift */,
+				5AB0973429F7593B00FBDAFB /* TabStorageFlagManager.swift */,
 			);
 			path = TabManagement;
 			sourceTree = "<group>";
@@ -11177,6 +11180,7 @@
 				6ACB550C28633860007A6ABD /* TabManagerNavDelegate.swift in Sources */,
 				E18259DF29B25E4F00E6BE76 /* UserNotificationCenterProtocol.swift in Sources */,
 				435D660523D794B90046EFA2 /* UpdateViewModel.swift in Sources */,
+				5AB0973529F7593B00FBDAFB /* TabStorageFlagManager.swift in Sources */,
 				215B457F27D7FD4B00E5E800 /* LegacyTabGroupData.swift in Sources */,
 				E12BD0B028AC3A7E0029AAF0 /* UIEdgeInsets+Extension.swift in Sources */,
 				C8BE692729BA2FBB0015C4A2 /* SurveySurfaceInfoModel.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -430,6 +430,7 @@
 		5AB4237C28A1947A003BC40C /* MockNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB4237B28A1947A003BC40C /* MockNotificationCenter.swift */; };
 		5AB4237E28A2BA9C003BC40C /* HistoryHighlightsDataAdaptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB4237D28A2BA9C003BC40C /* HistoryHighlightsDataAdaptor.swift */; };
 		5AC40329291AFBDB002BF91C /* DispatchQueueHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83821FF1FC7961D00303C12 /* DispatchQueueHelper.swift */; };
+		5AC7110729F822E60011ED11 /* MockTabSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AC7110629F822E60011ED11 /* MockTabSessionStore.swift */; };
 		5AEF388E299BD74300537C1B /* RustMozillaAppServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43BE578A278BA4D900491291 /* RustMozillaAppServices.framework */; };
 		5AF6254328A57A4600A90253 /* HistoryHighlightsDataAdaptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF6254228A57A4600A90253 /* HistoryHighlightsDataAdaptorTests.swift */; };
 		5AF6254528A57B6700A90253 /* MockHistoryHighlightsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF6254428A57B6700A90253 /* MockHistoryHighlightsManager.swift */; };
@@ -3560,6 +3561,7 @@
 		5ABD40B68B3D03806BC6819C /* es-AR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-AR"; path = "es-AR.lproj/LoginManager.strings"; sourceTree = "<group>"; };
 		5AC24B85BF0D2FCC2F1EB6D3 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/LoginManager.strings; sourceTree = "<group>"; };
 		5AC549C0BA565EB2B08B87EC /* hr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hr; path = hr.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
+		5AC7110629F822E60011ED11 /* MockTabSessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTabSessionStore.swift; sourceTree = "<group>"; };
 		5AF6254228A57A4600A90253 /* HistoryHighlightsDataAdaptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryHighlightsDataAdaptorTests.swift; sourceTree = "<group>"; };
 		5AF6254428A57B6700A90253 /* MockHistoryHighlightsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHistoryHighlightsManager.swift; sourceTree = "<group>"; };
 		5AF6254628A58AC100A90253 /* MockHistoryHighlightsDataAdaptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHistoryHighlightsDataAdaptor.swift; sourceTree = "<group>"; };
@@ -6960,6 +6962,7 @@
 			children = (
 				5A475E8C29DB888E009C13FD /* MockTabDataStore.swift */,
 				5A475E9029DB8AA7009C13FD /* MockDiskImageStore.swift */,
+				5AC7110629F822E60011ED11 /* MockTabSessionStore.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -11722,6 +11725,7 @@
 				3B39EDBA1E16E18900EF029F /* CustomSearchEnginesTest.swift in Sources */,
 				C80C11EE28B3C8B80062922A /* WallpaperMetadataTrackerTests.swift in Sources */,
 				C8E531CA29E5F7D300E03FEF /* URLScannerTests.swift in Sources */,
+				5AC7110729F822E60011ED11 /* MockTabSessionStore.swift in Sources */,
 				8AEE284B276A973400C7104D /* RatingPromptManagerTests.swift in Sources */,
 				8AF10D9129D7761A0086351D /* MockLaunchScreenManager.swift in Sources */,
 				5A9A09D828B2E8F000B6F51E /* MockHistoryDeletionProtocol.swift in Sources */,

--- a/Client/TabManagement/TabStorageFlagManager.swift
+++ b/Client/TabManagement/TabStorageFlagManager.swift
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Shared
+
+/// This is a temporary struct made to manage the feature flag for conveniance
+struct TabStorageFlagManager {
+    static var isNewTabDataStoreEnabled: Bool {
+        return FeatureFlagsManager.shared.isFeatureEnabled(.tabStorageRefactor,
+                                                           checking: .buildOnly)
+    }
+}

--- a/Shared/AppConstants.swift
+++ b/Shared/AppConstants.swift
@@ -101,8 +101,4 @@ public class AppConstants {
 
     /// Fixed short version for nightly builds
     public static let nightlyAppVersion = "9000"
-
-    /// A hard coded flag to enable the refactored tab data store
-    /// FXIOS-5885 This will be replaced with a nimbus flag when the feature is ready
-    public static var useNewTabDataStore = false
 }

--- a/Tests/ClientTests/TabManagement/Mocks/MockTabSessionStore.swift
+++ b/Tests/ClientTests/TabManagement/Mocks/MockTabSessionStore.swift
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import TabDataStore
+
+class MockTabSessionStore: TabSessionStore {
+    var saveTabSessionCallCount = 0
+    var tabID: UUID?
+    var sessionData: Data?
+
+    func saveTabSession(tabID: UUID, sessionData: Data) async {
+        saveTabSessionCallCount += 1
+        self.tabID = tabID
+        self.sessionData = sessionData
+    }
+
+    func fetchTabSession(tabID: UUID) async -> Data {
+        return Data()
+    }
+
+    func clearAllData() async {}
+}

--- a/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -16,15 +16,16 @@ class TabManagerTests: XCTestCase {
     var mockDiskImageStore: MockDiskImageStore!
     let webViewConfig = WKWebViewConfiguration()
     let sleepTime: UInt64 = 1_000_000_000
+
     override func setUp() {
         super.setUp()
-        AppConstants.useNewTabDataStore = true
         mockProfile = MockProfile()
         mockDiskImageStore = MockDiskImageStore()
         mockTabStore = MockTabDataStore()
         subject = TabManagerImplementation(profile: mockProfile,
                                            imageStore: mockDiskImageStore,
                                            tabDataStore: mockTabStore)
+        subject.isNewTabStoreEnabled = true
     }
 
     override func tearDown() {

--- a/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -92,20 +92,6 @@ class TabManagerTests: XCTestCase {
         XCTAssertEqual(subject.tabs.count, 5)
     }
 
-    // MARK: - Store changes
-
-    func testStoreTabs() async throws {
-        addTabs(count: 5)
-        subject.selectTab(subject.tabs.first)
-        let tabID = subject.tabs.first?.tabUUID
-        subject.storeChanges()
-
-        XCTAssertEqual(mockTabStore.saveTabDataCalledCount, 1)
-        XCTAssertEqual(subject.tabs.count, 5)
-        XCTAssertEqual(mockSessionStore.saveTabSessionCallCount, 1)
-        XCTAssertEqual(mockSessionStore.tabID?.uuidString, tabID)
-    }
-
     // MARK: - Helper methods
 
     private func addTabs(count: Int) {


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6239)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14071)

### Description
Call the tab session store anytime the webview loads

I tried to get testings running for the storeChanges function but there is a lot of technical debt in both the Tab object and in the LegacyTabManager that would require too many changes to overcome 😞 

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
