### PR TITLE
Localize FXIOS-6284 [v114] Done string added for CC accessory view

### DIFF
--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -236,7 +236,7 @@ extension String {
                 "CreditCards.Settings.Done.v114",
                 tableName: "Settings",
                 value: "Done",
-                comment: "When a user is in the process of making a purchase and has at least one saved card, a view above the keyboard shows actions a user can take. When tapping this label, the keyboard will dismiss from view.")
+                comment: "When a user is in the process of making a purchase and has at least one saved credit card, a view above the keyboard shows actions a user can take. When tapping this label, the keyboard will dismiss from view.")
             public static let ListItemA11y = MZLocalizedString(
                 "CreditCard.Settings.ListItemA11y.v112",
                 tableName: "Settings",

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -232,6 +232,11 @@ extension String {
                 tableName: "Settings",
                 value: "Use saved card",
                 comment: "When a user is in the process of making a purchase, and has at least one saved card, we show this label inside the keyboard hint. This indicates to the user that there are stored cards available for use on this pending purchase.")
+            public static let Done = MZLocalizedString(
+                "CreditCards.Settings.Done.v114",
+                tableName: "Settings",
+                value: "Done",
+                comment: "When a user is in the process of making a purchase and has at least one saved card, a view above the keyboard shows actions a user can take. When tapping this label, the keyboard will dismiss from view.")
             public static let ListItemA11y = MZLocalizedString(
                 "CreditCard.Settings.ListItemA11y.v112",
                 tableName: "Settings",


### PR DESCRIPTION
# [FXIOS-6284](https://mozilla-hub.atlassian.net/browse/FXIOS-6284)

### Description
The "Done" string was added to use for CC items - specifically for the keyboard input accessory view used in the TabWebView.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
