### PR TITLE
Bugfix FXIOS-6260 [v113] iPad - The keyboard is not raised up when New tab is set as "Firefox Home" and the new tab is opened from tab tray

### DIFF
--- a/Client/Application/NavigationRouter.swift
+++ b/Client/Application/NavigationRouter.swift
@@ -308,6 +308,8 @@ enum NavigationPath {
             bvc.switchToTabForURLOrOpen(newURL, isPrivate: isPrivate)
         } else {
             bvc.openBlankNewTab(focusLocationField: true, isPrivate: isPrivate)
+            bvc.overlayManager.openNewTab(url: nil,
+                                          newTabSettings: bvc.newTabSettings)
         }
     }
 

--- a/Client/Application/QuickActions.swift
+++ b/Client/Application/QuickActions.swift
@@ -168,7 +168,11 @@ struct QuickActionsImplementation: QuickActions {
 
     private func handleOpenNewTab(withBrowserViewController bvc: BrowserViewController,
                                   isPrivate: Bool) {
-        bvc.openBlankNewTab(focusLocationField: true, isPrivate: isPrivate)
+        // Should not focus if New tab settings is Custom URL
+        let shouldFocus = bvc.newTabSettings != .homePage
+        bvc.openBlankNewTab(focusLocationField: shouldFocus, isPrivate: isPrivate)
+        bvc.overlayManager.openNewTab(url: nil,
+                                      newTabSettings: bvc.newTabSettings)
     }
 
     private func handleOpenURL(withBrowserViewController bvc: BrowserViewController,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1564,6 +1564,11 @@ class BrowserViewController: UIViewController {
         }
     }
 
+    func openNewTabFromMenu(focusLocationField: Bool) {
+        overlayManager.openNewTab(url: nil, newTabSettings: newTabSettings)
+        openBlankNewTab(focusLocationField: focusLocationField)
+    }
+
     func openBlankNewTab(focusLocationField: Bool, isPrivate: Bool = false, searchFor searchText: String? = nil) {
         popToBVC()
         guard !isShowingJSPromptAlert() else {

--- a/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -15,7 +15,7 @@ protocol ToolBarActionMenuDelegate: AnyObject {
     func addBookmark(url: String, title: String?)
 
     func openURLInNewTab(_ url: URL?, isPrivate: Bool)
-    func openBlankNewTab(focusLocationField: Bool, isPrivate: Bool, searchFor searchText: String?)
+    func openNewTabFromMenu(focusLocationField: Bool)
 
     func showLibrary(panel: LibraryPanelType?)
     func showViewController(viewController: UIViewController)
@@ -300,8 +300,8 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     private func getNewTabAction() -> PhotonRowActions {
         return SingleActionViewModel(title: .AppMenu.NewTab,
                                      iconString: ImageIdentifiers.newTab) { _ in
-            let shouldFocusLocationField = NewTabAccessors.getNewTabPage(self.profile.prefs) == .blankPage
-            self.delegate?.openBlankNewTab(focusLocationField: shouldFocusLocationField, isPrivate: false, searchFor: nil)
+            let shouldFocusLocationField = NewTabAccessors.getNewTabPage(self.profile.prefs) != .homePage
+            self.delegate?.openNewTabFromMenu(focusLocationField: shouldFocusLocationField)
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .createNewTab)
         }.items
     }

--- a/Client/Frontend/Browser/Tabs/TabTrayViewModel.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewModel.swift
@@ -105,9 +105,9 @@ extension TabTrayViewModel {
 
     @objc
     func didTapAddTab(_ sender: UIBarButtonItem) {
+        tabTrayView.performToolbarAction(.addTab, sender: sender)
         overlayManager.openNewTab(url: nil,
                                   newTabSettings: NewTabAccessors.getNewTabPage(profile.prefs))
-        tabTrayView.performToolbarAction(.addTab, sender: sender)
     }
 
     @objc

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -174,18 +174,18 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable {
     }
 
     func updateTabCount(_ count: Int, animated: Bool = true) {
-        self.tabsButton.updateTabCount(count, animated: animated)
+        tabsButton.updateTabCount(count, animated: animated)
     }
 
     @objc
     func tabsTrayTapped() {
-        self.topTabDisplayManager.refreshStore(evenIfHidden: true)
+        topTabDisplayManager.refreshStore(evenIfHidden: true)
         delegate?.topTabsDidPressTabs()
     }
 
     @objc
     func newTabTapped() {
-        self.delegate?.topTabsDidPressNewTab(self.topTabDisplayManager.isPrivate)
+        delegate?.topTabsDidPressNewTab(self.topTabDisplayManager.isPrivate)
     }
 
     @objc

--- a/Tests/ClientTests/NavigationRouterTests.swift
+++ b/Tests/ClientTests/NavigationRouterTests.swift
@@ -140,6 +140,12 @@ class NavigationRouterTests: XCTestCase {
         XCTAssertEqual(path, NavigationPath.closePrivateTabs)
     }
 
+    func testNavigationPath_OverlayMode_handleBlankURL() throws {
+        NavigationPath.handle(nav: .url(webURL: nil, isPrivate: false), with: browserViewController)
+
+        XCTAssertTrue(browserViewController.overlayManager.inOverlayMode, "Expected to be in Overlay mode when opening a new blank page")
+    }
+
     func testNavigationPath_handleNormalTab_isExternalSourceTrue() throws {
         throw XCTSkip("Need to fix that tabs aren't properly closed during test, which creates leaks")
 //        let path = buildNavigationPath(url: "widget-medium-quicklink-open-url?private=false")

--- a/Tests/ClientTests/TabTrayViewControllerTests.swift
+++ b/Tests/ClientTests/TabTrayViewControllerTests.swift
@@ -25,6 +25,7 @@ class TabTrayViewControllerTests: XCTestCase {
         profile = TabManagerMockProfile()
         manager = LegacyTabManager(profile: profile, imageStore: nil)
         urlBar = MockURLBarView()
+        urlBar = MockURLBarView()
         overlayManager = MockOverlayModeManager()
         overlayManager.setURLBar(urlBarView: urlBar)
         tabTray = TabTrayViewController(tabTrayDelegate: nil,
@@ -87,5 +88,14 @@ class TabTrayViewControllerTests: XCTestCase {
 
         let privateState = UserDefaults.standard.bool(forKey: PrefsKeys.LastSessionWasPrivate)
         XCTAssertFalse(privateState)
+    }
+
+    func testInOverlayMode_ForHomepageNewTabSettings() {
+        tabTray.viewModel.segmentToFocus = TabTrayViewModel.Segment.privateTabs
+        tabTray.viewDidLoad()
+        profile.prefs.setString(NewTabPage.topSites.rawValue, forKey: NewTabAccessors.NewTabPrefKey)
+        tabTray.viewModel.didTapAddTab(UIBarButtonItem())
+
+        XCTAssertTrue(tabTray.viewModel.overlayManager.inOverlayMode)
     }
 }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6260)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14108)

### Description
Add openNewTab call for Widget and Quick actions
Unit test will be updated in final PR

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
