### PR TITLE
Added FXIOS-6207 [v114] Add throttle to window data save

### DIFF
--- a/BrowserKit/Sources/TabDataStore/TabDataStore.swift
+++ b/BrowserKit/Sources/TabDataStore/TabDataStore.swift
@@ -195,7 +195,9 @@ public actor DefaultTabDataStore: TabDataStore {
         do {
             try FileManager.default.copyItem(at: windowSavingPath, to: backupWindowSavingPath)
         } catch {
-            self.logger.log("Failed to create window data backup: \(error)", level: .debug, category: .tabs)
+            self.logger.log("Failed to create window data backup: \(error)",
+                            level: .debug,
+                            category: .tabs)
         }
     }
 
@@ -208,7 +210,7 @@ public actor DefaultTabDataStore: TabDataStore {
         // Ignore the request because a save is already scheduled to happen
         guard !nextSaveIsScheduled else { return }
 
-        // Set the guard bool to true so no new saves can be initialted while waiting
+        // Set the guard bool to true so no new saves can be initiated while waiting
         nextSaveIsScheduled = true
 
         // Dispatch to a task so as not to block the caller

--- a/BrowserKit/Sources/TabDataStore/TabDataStore.swift
+++ b/BrowserKit/Sources/TabDataStore/TabDataStore.swift
@@ -22,10 +22,16 @@ public actor DefaultTabDataStore: TabDataStore {
     static let profilePath = "profile.profile"
     static let backupPath = "profile.backup"
     private var logger: Logger = DefaultLogger.shared
+    private var windowDataToSave: WindowData?
+    private var nextSaveIsScheduled = false
+    private let throttleTime: UInt64
 
-    public init() {}
+    public init(throttleTime: UInt64 = 5_000_000_000) {
+        self.throttleTime = throttleTime
+    }
 
-    // MARK: URL Utils
+    // MARK: - URL Utils
+
     private var windowDataDirectoryURL: URL? {
         FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: browserKitInfo.sharedContainerIdentifier)?
             .appendingPathComponent(DefaultTabDataStore.profilePath)
@@ -46,6 +52,7 @@ public actor DefaultTabDataStore: TabDataStore {
     }
 
     // MARK: Fetching Window Data
+
     public func fetchWindowData() async -> WindowData {
         return WindowData(id: UUID(), isPrimary: true, activeTabId: UUID(), tabData: [])
     }
@@ -158,34 +165,71 @@ public actor DefaultTabDataStore: TabDataStore {
         }
     }
 
-    // MARK: Saving Data
+    // MARK: - Saving Data
+
     public func saveWindowData(window: WindowData) async {
-        guard let windowSavingPath = self.windowURLPath(for: window.id, isBackup: false) else {
+        guard let windowSavingPath = self.windowURLPath(for: window.id, isBackup: false)
+        else {
             return
         }
+
+        if checkIfFileExistsAtPath(path: windowSavingPath) {
+            createWindowDataBackup(window: window, windowSavingPath: windowSavingPath)
+        } else {
+            if let windowDataDirectoryURL = windowDataDirectoryURL,
+               !self.checkIfFileExistsAtPath(path: windowDataDirectoryURL) {
+                self.createDirectoryAtPath(path: windowDataDirectoryURL)
+            }
+        }
+        await writeWindowDataToFileWithThrottle(window: window, path: windowSavingPath)
+    }
+
+    private func createWindowDataBackup(window: WindowData, windowSavingPath: URL) {
+        guard let backupWindowSavingPath = self.windowURLPath(for: window.id, isBackup: true),
+              let backupDirectoryPath = self.windowDataBackupDirectoryURL else {
+            return
+        }
+        if !self.checkIfFileExistsAtPath(path: backupDirectoryPath) {
+            self.createDirectoryAtPath(path: backupDirectoryPath)
+        }
         do {
-            if self.checkIfFileExistsAtPath(path: windowSavingPath) {
-                guard let backupWindowSavingPath = self.windowURLPath(for: window.id, isBackup: true), let backupDirectoryPath = self.windowDataBackupDirectoryURL else {
+            try FileManager.default.copyItem(at: windowSavingPath, to: backupWindowSavingPath)
+        } catch {
+            self.logger.log("Failed to create window data backup: \(error)", level: .debug, category: .tabs)
+        }
+    }
+
+    // Throttles the saving of the data so that it happens every 'throttleTime' nanoseconds
+    // as long as their is new data to be saved
+    private func writeWindowDataToFileWithThrottle(window: WindowData, path: URL) async {
+        // Hold onto a copy of the latest window data so whenever the save happens it is using the latest
+        windowDataToSave = window
+
+        // Ignore the request because a save is already scheduled to happen
+        guard !nextSaveIsScheduled else { return }
+
+        // Set the guard bool to true so no new saves can be initialted while waiting
+        nextSaveIsScheduled = true
+
+        // Dispatch to a task so as not to block the caller
+        Task {
+            // Once the throttle time has passed initiate the save and reset the bool
+            try? await Task.sleep(nanoseconds: throttleTime)
+            nextSaveIsScheduled = false
+
+            do {
+                guard let windowDataToSave = windowDataToSave else {
+                    logger.log("Tried to save window data but found nil",
+                               level: .fatal,
+                               category: .tabs)
                     return
                 }
-                if !self.checkIfFileExistsAtPath(path: backupDirectoryPath) {
-                    self.createDirectoryAtPath(path: backupDirectoryPath)
-                }
-                do {
-                    try FileManager.default.copyItem(at: windowSavingPath, to: backupWindowSavingPath)
-                } catch {
-                    self.logger.log("Failed to create window data backup: \(error)", level: .debug, category: .tabs)
-                }
-            } else {
-                if let mainDirectoryPath = windowDataDirectoryURL {
-                    if !self.checkIfFileExistsAtPath(path: mainDirectoryPath) {
-                        self.createDirectoryAtPath(path: mainDirectoryPath)
-                    }
-                }
+                try await self.writeWindowData(windowData: windowDataToSave, to: path)
+            } catch {
+                logger.log("Failed to save window data: \(error)",
+                           level: .debug,
+                           category: .tabs)
             }
-            try await self.writeWindowData(windowData: window, to: windowSavingPath)
-        } catch {
-            self.logger.log("Failed to save window data: \(error)", level: .debug, category: .tabs)
         }
     }
 
@@ -202,15 +246,12 @@ public actor DefaultTabDataStore: TabDataStore {
     }
 
     private func writeWindowData(windowData: WindowData, to url: URL) async throws {
-        do {
-            let data = try JSONEncoder().encode(windowData)
-            try data.write(to: url, options: .atomicWrite)
-        } catch {
-            throw error
-        }
+        let data = try JSONEncoder().encode(windowData)
+        try data.write(to: url, options: .atomicWrite)
     }
 
-    // MARK: Deleting Window Data
+    // MARK: - Deleting Window Data
+
     public func clearWindowData(for id: UUID) async {
         guard let profileURL = self.windowURLPath(for: id, isBackup: false) else {
             return

--- a/BrowserKit/Tests/TabDataStoreTests/TabDataStoreTests.swift
+++ b/BrowserKit/Tests/TabDataStoreTests/TabDataStoreTests.swift
@@ -8,10 +8,11 @@ import Common
 
 final class TabDataStoreTests: XCTestCase {
     private var tabDataStore: DefaultTabDataStore!
+    private let sleepTime: UInt64 = 1_000_000
 
     override func setUp() {
         super.setUp()
-        tabDataStore = DefaultTabDataStore()
+        tabDataStore = DefaultTabDataStore(throttleTime: 100)
         BrowserKitInformation.shared.configure(buildChannel: .other,
                                                nightlyAppVersion: "",
                                                sharedContainerIdentifier: "group.org.mozilla.ios.Fennec.Test")
@@ -25,6 +26,7 @@ final class TabDataStoreTests: XCTestCase {
     func testSaveTabData() async throws {
         let windowData = self.createMockWindow()
         await tabDataStore.saveWindowData(window: windowData)
+        try await Task.sleep(nanoseconds: sleepTime)
         let fetchedWindowData = await tabDataStore.fetchWindowData(withID: windowData.id)
         XCTAssertEqual(fetchedWindowData?.id, windowData.id)
         XCTAssertEqual(fetchedWindowData?.isPrimary, windowData.isPrimary)
@@ -36,7 +38,9 @@ final class TabDataStoreTests: XCTestCase {
         let windowData = self.createMockWindow()
         let windowID = windowData.id
         await tabDataStore.saveWindowData(window: windowData)
+        try await Task.sleep(nanoseconds: sleepTime)
         await tabDataStore.saveWindowData(window: windowData)
+        try await Task.sleep(nanoseconds: sleepTime)
         let browserKitInfo = BrowserKitInformation.shared
         let baseURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: browserKitInfo.sharedContainerIdentifier)?
             .appendingPathComponent("profile.backup")
@@ -53,7 +57,9 @@ final class TabDataStoreTests: XCTestCase {
         let windowData = self.createMockWindow()
         let windowID = windowData.id
         await tabDataStore.saveWindowData(window: windowData)
+        try await Task.sleep(nanoseconds: sleepTime)
         await tabDataStore.saveWindowData(window: windowData)
+        try await Task.sleep(nanoseconds: sleepTime)
         let browserKitInfo = BrowserKitInformation.shared
         let baseURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: browserKitInfo.sharedContainerIdentifier)?
             .appendingPathComponent("profile.backup")
@@ -77,7 +83,9 @@ final class TabDataStoreTests: XCTestCase {
         let windowData1 = self.createMockWindow()
         let windowData2 = self.createMockWindow()
         await tabDataStore.saveWindowData(window: windowData1)
+        try await Task.sleep(nanoseconds: sleepTime)
         await tabDataStore.saveWindowData(window: windowData2)
+        try await Task.sleep(nanoseconds: sleepTime)
         let fetchedWindowsData = await tabDataStore.fetchAllWindowsData()
         XCTAssertEqual(fetchedWindowsData.count, 2)
         XCTAssertTrue(fetchedWindowsData.contains(where: { $0.id == windowData1.id }))
@@ -89,6 +97,7 @@ final class TabDataStoreTests: XCTestCase {
         let fetchedNonExistingData = await tabDataStore.fetchWindowData(withID: UUID())
         XCTAssertNil(fetchedNonExistingData)
         await tabDataStore.saveWindowData(window: windowData)
+        try await Task.sleep(nanoseconds: sleepTime)
         let fetchedWindowData = await tabDataStore.fetchWindowData(withID: windowData.id)
         XCTAssertNotNil(fetchedWindowData)
         XCTAssertEqual(fetchedWindowData?.id, windowData.id)
@@ -101,6 +110,7 @@ final class TabDataStoreTests: XCTestCase {
     func testClearAllTabData() async throws {
         let windowData = self.createMockWindow()
         await tabDataStore.saveWindowData(window: windowData)
+        try await Task.sleep(nanoseconds: sleepTime)
         await tabDataStore.clearAllWindowsData()
         let fetchedWindowData = await tabDataStore.fetchAllWindowsData()
         XCTAssertTrue(fetchedWindowData.isEmpty)


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6207)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13990)

### Description
Added a very basic throttle to the logic that writes the window to disk
Ideally we could use [swift async algorithms](https://github.com/apple/swift-async-algorithms) for this but it uses API's that are only available in iOS 16 so will need to make do for now.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
