### PR TITLE
Refactor FXIOS-6150 [v114]  Update toast messages to be displayed in pascal case

### DIFF
--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -2561,7 +2561,7 @@ extension String {
 // MARK: - Context menu ButtonToast instances.
 extension String {
     public static let ContextMenuButtonToastNewTabOpenedLabelText = MZLocalizedString(
-        "ContextMenu.ButtonToast.NewTabOpened.LabelText.v114",
+        key: "ContextMenu.ButtonToast.NewTabOpened.LabelText.v114",
         tableName: nil,
         value: "New Tab Opened",
         comment: "The label text in the Button Toast for switching to a fresh New Tab.")

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -2556,7 +2556,7 @@ extension String {
 // MARK: - Context menu ButtonToast instances.
 extension String {
     public static let ContextMenuButtonToastNewTabOpenedLabelText = MZLocalizedString(
-        "ContextMenu.ButtonToast.NewTabOpened.LabelText",
+        "ContextMenu.ButtonToast.NewTabOpened.LabelText.v114",
         tableName: nil,
         value: "New Tab Opened",
         comment: "The label text in the Button Toast for switching to a fresh New Tab.")

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -2558,7 +2558,7 @@ extension String {
     public static let ContextMenuButtonToastNewTabOpenedLabelText = MZLocalizedString(
         "ContextMenu.ButtonToast.NewTabOpened.LabelText",
         tableName: nil,
-        value: "New Tab opened",
+        value: "New Tab Opened",
         comment: "The label text in the Button Toast for switching to a fresh New Tab.")
     public static let ContextMenuButtonToastNewTabOpenedButtonText = MZLocalizedString(
         "ContextMenu.ButtonToast.NewTabOpened.ButtonText",


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6150)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13891)

### Description
Update localized string ContextMenuButtonToastNewTabOpenedLabelText to "New Tab Opened"

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
