### PR TITLE
Refactor MTE-913 [v114] Add treeherder block to perf tests task

### DIFF
--- a/taskcluster/ci/performance/kind.yml
+++ b/taskcluster/ci/performance/kind.yml
@@ -10,7 +10,12 @@ transforms:
     - taskgraph.transforms.job:transforms
     - taskgraph.transforms.task:transforms
 
-
+tasks-default:
+    description: Run the performance tests
+    treeherder:
+        kind: test
+        platform: 'ios-tests'
+        tier: 2
 tasks:
     tests:
         bitrise-workflow: perfherder-test


### PR DESCRIPTION
This work is to follow up on comment added to this PR #14025 so that taskgraph can set the correct route missing now.