### PR TITLE
Bugfix FXIOS-5870 [v114] Custom web page is not loaded correctly when opening a new tab

### DIFF
--- a/Client/Application/NavigationRouter.swift
+++ b/Client/Application/NavigationRouter.swift
@@ -307,7 +307,8 @@ enum NavigationPath {
         if let newURL = url {
             bvc.switchToTabForURLOrOpen(newURL, isPrivate: isPrivate)
         } else {
-            bvc.openBlankNewTab(focusLocationField: true, isPrivate: isPrivate)
+            let shouldFocus = bvc.newTabSettings != .homePage
+            bvc.openBlankNewTab(focusLocationField: shouldFocus, isPrivate: isPrivate)
             bvc.overlayManager.openNewTab(url: nil,
                                           newTabSettings: bvc.newTabSettings)
         }

--- a/Tests/ClientTests/TabTrayViewControllerTests.swift
+++ b/Tests/ClientTests/TabTrayViewControllerTests.swift
@@ -25,7 +25,6 @@ class TabTrayViewControllerTests: XCTestCase {
         profile = TabManagerMockProfile()
         manager = LegacyTabManager(profile: profile, imageStore: nil)
         urlBar = MockURLBarView()
-        urlBar = MockURLBarView()
         overlayManager = MockOverlayModeManager()
         overlayManager.setURLBar(urlBarView: urlBar)
         tabTray = TabTrayViewController(tabTrayDelegate: nil,


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5870)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13392)

### Description
Remove focus from textfiel when New tab settings is set to CustomURL

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
