### PR TITLE
Bugfix MTE-727 [v114] TabCounterTests fail intermittently

### DIFF
--- a/Tests/XCUITests/TabCounterTests.swift
+++ b/Tests/XCUITests/TabCounterTests.swift
@@ -83,6 +83,7 @@ class TabCounterTests: BaseTestCase {
         if !isTablet {
             waitForExistence(app.segmentedControls.firstMatch, timeout: 5)
             let tabsOpenTabTray: String = app.segmentedControls.buttons.firstMatch.label
-            XCTAssertTrue(tabsOpenTabTray.hasSuffix("1"))        }
+            XCTAssertTrue(tabsOpenTabTray.hasSuffix("1"))
+        }
     }
 }

--- a/Tests/XCUITests/TabCounterTests.swift
+++ b/Tests/XCUITests/TabCounterTests.swift
@@ -25,9 +25,11 @@ class TabCounterTests: BaseTestCase {
         // Check only for iPhone, for iPad there is not counter in tab tray
         if !iPad() {
             navigator.goto(TabTray)
-            tabsOpen = app.buttons["2"].label
-            XCTAssertTrue(app.buttons["2"].isSelected)
-            XCTAssertEqual("2", tabsOpen as? String)
+            let navBarTabTrayButton = app.segmentedControls["navBarTabTray"].buttons.firstMatch
+            waitForExistence(navBarTabTrayButton)
+            XCTAssertTrue(navBarTabTrayButton.isSelected)
+            let tabsOpenTabTray: String = navBarTabTrayButton.label
+            XCTAssertTrue(tabsOpenTabTray.hasSuffix("2"))
         }
     }
 
@@ -54,9 +56,11 @@ class TabCounterTests: BaseTestCase {
         if isTablet {
             app.otherElements["Tabs Tray"].collectionViews.cells.element(boundBy: 0).buttons["tab close"].tap()
         } else {
-            tabsOpen = app.segmentedControls.buttons["2"].label
-            XCTAssertTrue(app.buttons["2"].isSelected)
-            XCTAssertEqual("2", tabsOpen as? String)
+            let navBarTabTrayButton = app.segmentedControls["navBarTabTray"].buttons.firstMatch
+            waitForExistence(navBarTabTrayButton)
+            XCTAssertTrue(navBarTabTrayButton.isSelected)
+            let tabsOpenTabTray: String = navBarTabTrayButton.label
+            XCTAssertTrue(tabsOpenTabTray.hasSuffix("2"))
 
             app.otherElements["Tabs Tray"].cells.element(boundBy: 0).buttons["tab close"].tap()
         }
@@ -78,7 +82,7 @@ class TabCounterTests: BaseTestCase {
         XCTAssertTrue(app.segmentedControls.buttons.element(boundBy: 0).isSelected)
         if !isTablet {
             waitForExistence(app.segmentedControls.firstMatch, timeout: 5)
-            XCTAssertEqual("1", tabsOpen as? String)
-        }
+            let tabsOpenTabTray: String = app.segmentedControls.buttons.firstMatch.label
+            XCTAssertTrue(tabsOpenTabTray.hasSuffix("1"))        }
     }
 }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-727)

### Description
`TabCounterTests` fails intermittently at about 5%-10% of the time. The tests from this file fail because the tab's label, which supposes to contain an integer indicating the number of tabs opened, could contain extraneous text in the `debugDescription`. The extraneous text is not visible on the screen. Here's the screen at the time the test failed.

<img width="142" alt="Screenshot 2023-04-26 at 5 17 03 PM" src="https://user-images.githubusercontent.com/1740517/234704965-f69e1840-d089-481c-99c2-3aa69d04ee07.png">

The snippet of `debugDescription` related to the failure is the following. The first `button` supposes to contain `2`, but there is a string proceed the digit intermittently. I have not been able to reliably reproduce the issue.
```
SegmentedControl, 0x7fb9537c89a0, {{16.0, 119.0}, {358.0, 32.0}}, identifier: 'navBarTabTray'
        Button, 0x7fb9537c8ac0, {{16.0, 119.0}, {118.0, 32.0}}, label: 'hbr.org • 8 min, Lendgo, texasmonthly.com • 9 min, Facebook, 2', Selected
        Button, 0x7fb9537c8be0, {{135.0, 119.0}, {119.0, 32.0}}, label: 'smallPrivateMask'
        Button, 0x7fb9537c8d00, {{255.0, 119.0}, {119.0, 32.0}}, label: 'synced devices'
```

As a workaround, the test now check for the existence of the number in the label instead of the label containing only the digit.

I have tested this change on XCode 14.1 and 14.3 running the test 50 times.

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
