### PR TITLE
Bugfix FXIOS-6102 [v114] Tapping menu item crashes the app

### DIFF
--- a/Client/Frontend/LoginManagement/LoginListViewController.swift
+++ b/Client/Frontend/LoginManagement/LoginListViewController.swift
@@ -428,6 +428,8 @@ extension LoginListViewController: UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        // Check that section is > 0, which means that a Login Record is selected, otherwise we do not want to select the row since the returned Login Record is nil and the assertion failure function will cause a crash
+        guard indexPath.section > 0 else { return }
         if tableView.isEditing {
             loginSelectionController.selectIndexPath(indexPath)
             toggleSelectionTitle()

--- a/Client/Frontend/LoginManagement/LoginListViewController.swift
+++ b/Client/Frontend/LoginManagement/LoginListViewController.swift
@@ -427,9 +427,12 @@ extension LoginListViewController: UITableViewDelegate {
         return .none
     }
 
+    func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
+        // Prevent row selection for logins settings section
+        indexPath.section == LoginListViewController.loginsSettingsSection ? nil : indexPath
+    }
+
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        // Check that section is > 0, which means that a Login Record is selected, otherwise we do not want to select the row since the returned Login Record is nil and the assertion failure function will cause a crash
-        guard indexPath.section > 0 else { return }
         if tableView.isEditing {
             loginSelectionController.selectIndexPath(indexPath)
             toggleSelectionTitle()


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6102)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13808)

### Description
Implemented a specific check for section index in order to avoid that func loginAtIndexPath(_ indexPath: [IndexPath]) -> LoginRecord? will return nil and the assertion failure will get called and cause a crash.
Also will preserve the toggle behaviour just by tapping on the toggle not at the row selection.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
