### PR TITLE
Bugfix FXIOS-6295 [v114] update nimbus experiments job for output changes

### DIFF
--- a/.github/workflows/update-nimbus-experiments.yml
+++ b/.github/workflows/update-nimbus-experiments.yml
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 name: "Update Nimbus Experiments"
 
 on:
@@ -28,7 +32,7 @@ jobs:
       - name: Create Pull Request
         id: create-pull-request
         uses: peter-evans/create-pull-request@v4
-        if: steps.update-experiments-json.outputs.changed == 1 && steps.update-experiments-json.outputs.changed-branch == 1
+        if: steps.update-experiments-json.outputs.changed == 1 && steps.update-experiments-json.outputs.changed-branch >= 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           path: firefox-ios


### PR DESCRIPTION
[JIRA issue](https://mozilla-hub.atlassian.net/browse/FXIOS-6295)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14167)

### Description
Updates the job output check to be `>=` instead of `==`.

See here: https://github.com/mozilla-mobile/firefox-android/blob/main/.github/workflows/fenix-update-nimbus-experiments.yml#L34

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
