### PR TITLE
Add FXIOS-6060 [v115] Add support for Safari Web Inspector.

### DIFF
--- a/Client/TabManagement/Tab.swift
+++ b/Client/TabManagement/Tab.swift
@@ -449,6 +449,11 @@ class Tab: NSObject {
             webView.accessibilityLabel = .WebViewAccessibilityLabel
             webView.allowsBackForwardNavigationGestures = true
             webView.allowsLinkPreview = true
+            
+            // Allow Safari Web Inspector (requires toggle in Settings > Safari > Advanced).
+            if #available(iOS 16.4, *) {
+                webView.isInspectable = true
+            }
 
             // Night mode enables this by toggling WKWebView.isOpaque, otherwise this has no effect.
             webView.backgroundColor = .black


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6060)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13726)

### Description
This adds support for Safari Web Inspector. WebKit gates it behind the shared Safari toggle (Settings > Safari > Advanced > Web Inspector), but when that is turned on, tabs in Firefox can be inspected using Safari.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
