### PR TITLE
Refactor FXIOS-6286 [v114] Add SceneContainer to manage transitions between root view controllers

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -657,6 +657,7 @@
 		8AE80BBE2891C21A00BC12EA /* JumpBackInSyncedTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE80BBD2891C21A00BC12EA /* JumpBackInSyncedTab.swift */; };
 		8AED23C527AC1F9500DE7E97 /* BaseContentStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AED23C427AC1F9500DE7E97 /* BaseContentStackView.swift */; };
 		8AED868328CA3B3400351A50 /* BookmarkPanelViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AED868228CA3B3400351A50 /* BookmarkPanelViewModelTests.swift */; };
+		8AEDB11529F9F00400F2A53B /* SceneContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEDB11429F9F00400F2A53B /* SceneContainer.swift */; };
 		8AEE284B276A973400C7104D /* RatingPromptManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEE284A276A973400C7104D /* RatingPromptManagerTests.swift */; };
 		8AEE62C92756BA34003207D1 /* LoginsHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = 8AEE62C62756BA34003207D1 /* LoginsHelper.js */; };
 		8AEE62CA2756BA34003207D1 /* TrackingProtectionStats.js in Resources */ = {isa = PBXBuildFile; fileRef = 8AEE62C72756BA34003207D1 /* TrackingProtectionStats.js */; };
@@ -4126,6 +4127,7 @@
 		8AE80BBD2891C21A00BC12EA /* JumpBackInSyncedTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpBackInSyncedTab.swift; sourceTree = "<group>"; };
 		8AED23C427AC1F9500DE7E97 /* BaseContentStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseContentStackView.swift; sourceTree = "<group>"; };
 		8AED868228CA3B3400351A50 /* BookmarkPanelViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkPanelViewModelTests.swift; sourceTree = "<group>"; };
+		8AEDB11429F9F00400F2A53B /* SceneContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneContainer.swift; sourceTree = "<group>"; };
 		8AEE284A276A973400C7104D /* RatingPromptManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingPromptManagerTests.swift; sourceTree = "<group>"; };
 		8AEE62C62756BA34003207D1 /* LoginsHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = LoginsHelper.js; path = AllFrames/AtDocumentStart/LoginsHelper.js; sourceTree = "<group>"; };
 		8AEE62C72756BA34003207D1 /* TrackingProtectionStats.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = TrackingProtectionStats.js; path = AllFrames/AtDocumentStart/TrackingProtectionStats.js; sourceTree = "<group>"; };
@@ -7527,6 +7529,7 @@
 				8A93F86F29D3A597004159D9 /* SceneCoordinator.swift */,
 				8AF10D8E29D774090086351D /* SceneSetupHelper.swift */,
 				8A76B01529F6EB3900A82607 /* ScreenshotService.swift */,
+				8AEDB11429F9F00400F2A53B /* SceneContainer.swift */,
 			);
 			path = Scene;
 			sourceTree = "<group>";
@@ -11688,6 +11691,7 @@
 				E16E1C9828C25F1D00EE2EF5 /* SiteTableViewHeader.swift in Sources */,
 				8AC5D55F28BFE6C8001F6F7F /* Presenter.swift in Sources */,
 				C8501F4F2850FB72003B09AB /* LegacyWallpaperMigrationUtility.swift in Sources */,
+				8AEDB11529F9F00400F2A53B /* SceneContainer.swift in Sources */,
 				C8741FE928C4D30F00030029 /* FileManagerInterface.swift in Sources */,
 				8A93F87229D3A5AD004159D9 /* BrowserCoordinator.swift in Sources */,
 				8A3233FE28627446003E1C33 /* LocalDesktopFolder.swift in Sources */,

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -60,7 +60,7 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
     }
 
     func didRequestToOpenInNewTab(url: URL, isPrivate: Bool, selectNewTab: Bool) {
-        // FXIOS-6030: Handle open in new tab route
+        // FXIOS-6033 #13682 - Enable didRequestToOpenInNewTab in BrowserCoordinator & SceneCoordinator
     }
 
     // MARK: - BrowserDelegate
@@ -109,6 +109,8 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
 
         screenshotService.screenshotableView = webviewController
     }
+
+    // MARK: - Route handling
 
     override func handle(route: Route) -> Bool {
         switch route {

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -36,7 +36,7 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
     }
 
     func start(with launchType: LaunchType?) {
-        router.setRootViewController(browserViewController, hideBar: true)
+        router.push(browserViewController, animated: false)
 
         if let launchType = launchType, launchType.canLaunch(fromType: .BrowserCoordinator) {
             startLaunch(with: launchType)

--- a/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -54,7 +54,7 @@ class LaunchCoordinator: BaseCoordinator, OpenURLDelegate {
 
         if isFullScreen {
             introViewController.modalPresentationStyle = .fullScreen
-            router.setRootViewController(introViewController, hideBar: true, animated: true)
+            router.present(introViewController, animated: false)
         } else {
             introViewController.preferredContentSize = CGSize(
                 width: ViewControllerConsts.PreferredSize.IntroViewController.width,
@@ -75,7 +75,7 @@ class LaunchCoordinator: BaseCoordinator, OpenURLDelegate {
 
         if isFullScreen {
             updateViewController.modalPresentationStyle = .fullScreen
-            router.setRootViewController(updateViewController, hideBar: true, animated: true)
+            router.present(updateViewController, animated: false)
         } else {
             updateViewController.preferredContentSize = CGSize(
                 width: ViewControllerConsts.PreferredSize.UpdateViewController.width,
@@ -119,7 +119,7 @@ class LaunchCoordinator: BaseCoordinator, OpenURLDelegate {
             self.parentCoordinator?.didFinishLaunch(from: self)
         }
 
-        router.setRootViewController(surveySurface, hideBar: true, animated: true)
+        router.present(surveySurface, animated: false)
     }
 
     // MARK: OpenURLDelegate

--- a/Client/Coordinators/Router/DefaultRouter.swift
+++ b/Client/Coordinators/Router/DefaultRouter.swift
@@ -54,12 +54,6 @@ class DefaultRouter: NSObject, Router {
         navigationController.isNavigationBarHidden = hideBar
     }
 
-    func popToRootViewController(animated: Bool = true) {
-        if let controllers = navigationController.popToRootViewController(animated: animated) {
-            controllers.forEach { runCompletion(for: $0) }
-        }
-    }
-
     private func runCompletion(for controller: UIViewController) {
         guard let completion = completions[controller] else { return }
         completion()

--- a/Client/Coordinators/Router/Router.swift
+++ b/Client/Coordinators/Router/Router.swift
@@ -45,10 +45,6 @@ protocol Router: AnyObject, UINavigationControllerDelegate, UIAdaptivePresentati
     ///   - hideBar: Hide the navigation bar or not
     ///   - animated: Animates the transitions or not
     func setRootViewController(_ viewController: UIViewController, hideBar: Bool, animated: Bool)
-
-    /// Pop to the root view controller that was set with `setRootViewController`
-    /// - Parameter animated: true means it will be animated
-    func popToRootViewController(animated: Bool)
 }
 
 /// Adds default parameters on Router protocol
@@ -71,9 +67,5 @@ extension Router {
 
     func setRootViewController(_ viewController: UIViewController, hideBar: Bool = false, animated: Bool = false) {
         setRootViewController(viewController, hideBar: hideBar, animated: animated)
-    }
-
-    func popToRootViewController(animated: Bool = true) {
-        popToRootViewController(animated: animated)
     }
 }

--- a/Client/Coordinators/Scene/SceneContainer.swift
+++ b/Client/Coordinators/Scene/SceneContainer.swift
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+class SceneContainer: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.view.backgroundColor = .red
+    }
+}

--- a/Client/Coordinators/Scene/SceneContainer.swift
+++ b/Client/Coordinators/Scene/SceneContainer.swift
@@ -2,11 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import Foundation
+import UIKit
 
-class SceneContainer: UIViewController {
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        self.view.backgroundColor = .red
-    }
-}
+// The root view controller of the application
+class SceneContainer: UIViewController {}

--- a/Client/Coordinators/Scene/SceneCoordinator.swift
+++ b/Client/Coordinators/Scene/SceneCoordinator.swift
@@ -10,12 +10,15 @@ import Shared
 class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinishedLoadingDelegate {
     var window: UIWindow?
     private let screenshotService: ScreenshotService
+    private let sceneContainer: SceneContainer
 
     init(scene: UIScene,
          sceneSetupHelper: SceneSetupHelper = SceneSetupHelper(),
-         screenshotService: ScreenshotService = ScreenshotService()) {
+         screenshotService: ScreenshotService = ScreenshotService(),
+         sceneContainer: SceneContainer = SceneContainer()) {
         self.window = sceneSetupHelper.configureWindowFor(scene, screenshotServiceDelegate: screenshotService)
         self.screenshotService = screenshotService
+        self.sceneContainer = sceneContainer
         let navigationController = sceneSetupHelper.createNavigationController()
         let router = DefaultRouter(navigationController: navigationController)
         super.init(router: router)
@@ -25,8 +28,10 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
     }
 
     func start() {
+        router.setRootViewController(sceneContainer, hideBar: true)
+
         let launchScreenVC = LaunchScreenViewController(coordinator: self)
-        router.setRootViewController(launchScreenVC, hideBar: true)
+        router.push(launchScreenVC, animated: false)
     }
 
     // MARK: - LaunchFinishedLoadingDelegate
@@ -73,6 +78,7 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
     // MARK: - LaunchCoordinatorDelegate
 
     func didFinishLaunch(from coordinator: LaunchCoordinator) {
+        router.dismiss(animated: true)
         remove(child: coordinator)
         startBrowser(with: nil)
     }

--- a/Client/Coordinators/Scene/SceneCoordinator.swift
+++ b/Client/Coordinators/Scene/SceneCoordinator.swift
@@ -86,6 +86,6 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
     // MARK: - LaunchFinishedLoadingDelegate
 
     func didRequestToOpenInNewTab(url: URL, isPrivate: Bool, selectNewTab: Bool) {
-        // FXIOS-6030: Handle open in new tab route
+        // FXIOS-6033 #13682 - Enable didRequestToOpenInNewTab in BrowserCoordinator & SceneCoordinator
     }
 }

--- a/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
@@ -331,13 +331,6 @@ class BookmarksPanel: SiteTableViewController,
         presentContextMenu(for: indexPath)
     }
 
-    @objc
-    private func didLongPressBackButtonView(_ longPressGestureRecognizer: UILongPressGestureRecognizer) {
-        let generator = UIImpactFeedbackGenerator(style: .heavy)
-        generator.impactOccurred()
-        navigationController?.popToRootViewController(animated: true)
-    }
-
     private func backButtonView() -> UIView? {
         let navigationBarContentView = navigationController?.navigationBar.subviews.find {
             $0.description.starts(with: "<_UINavigationBarContentView:")

--- a/Client/Protocols/NavigationController.swift
+++ b/Client/Protocols/NavigationController.swift
@@ -13,7 +13,6 @@ protocol NavigationController: UIViewController {
 
     func pushViewController(_ viewController: UIViewController, animated: Bool)
     func popViewController(animated: Bool) -> UIViewController?
-    func popToRootViewController(animated: Bool) -> [UIViewController]?
     func setViewControllers(_ viewControllers: [UIViewController], animated: Bool)
 }
 

--- a/RustFxA/FxAWebViewController.swift
+++ b/RustFxA/FxAWebViewController.swift
@@ -104,6 +104,7 @@ class FxAWebViewController: UIViewController {
         } else if dismissType == .popToTabTray {
             shouldDismissFxASignInViewController?()
         } else {
+            // Pop to settings view controller
             navigationController?.popToRootViewController(animated: true)
             completion?()
         }

--- a/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -50,8 +50,8 @@ final class BrowserCoordinatorTests: XCTestCase {
         let subject = createSubject()
         subject.start(with: nil)
 
-        XCTAssertNotNil(mockRouter.rootViewController as? BrowserViewController)
-        XCTAssertEqual(mockRouter.setRootViewControllerCalled, 1)
+        XCTAssertNotNil(mockRouter.pushedViewController as? BrowserViewController)
+        XCTAssertEqual(mockRouter.pushCalled, 1)
         XCTAssertTrue(subject.childCoordinators.isEmpty)
     }
 
@@ -59,8 +59,8 @@ final class BrowserCoordinatorTests: XCTestCase {
         let subject = createSubject()
         subject.start(with: .defaultBrowser)
 
-        XCTAssertNotNil(mockRouter.rootViewController as? BrowserViewController)
-        XCTAssertEqual(mockRouter.setRootViewControllerCalled, 1)
+        XCTAssertNotNil(mockRouter.pushedViewController as? BrowserViewController)
+        XCTAssertEqual(mockRouter.pushCalled, 1)
         XCTAssertEqual(subject.childCoordinators.count, 1)
         XCTAssertNotNil(subject.childCoordinators[0] as? LaunchCoordinator)
     }

--- a/Tests/ClientTests/Coordinators/DefaultRouterTests.swift
+++ b/Tests/ClientTests/Coordinators/DefaultRouterTests.swift
@@ -100,27 +100,6 @@ final class DefaultRouterTests: XCTestCase {
         XCTAssertEqual(navigationController.viewControllers, [viewController])
     }
 
-    func testPopToRootViewController() {
-        let subject = DefaultRouter(navigationController: navigationController)
-        subject.popToRootViewController()
-
-        XCTAssertEqual(navigationController.popToRootCalled, 1)
-    }
-
-    func testPopToRootViewController_withPushedViewController_completionIsCalled() {
-        let subject = DefaultRouter(navigationController: navigationController)
-        let viewController = UIViewController()
-        let expectation = expectation(description: "Completion is called")
-
-        subject.push(viewController) {
-            expectation.fulfill()
-        }
-        subject.popToRootViewController()
-
-        waitForExpectations(timeout: 0.1)
-        XCTAssertEqual(navigationController.popToRootCalled, 1)
-    }
-
     // MARK: - UINavigationControllerDelegate
 
     func testNavigationControllerDelegate_doesntRunCompletionWhenNoFromVC() {

--- a/Tests/ClientTests/Coordinators/Launch/LaunchCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/Launch/LaunchCoordinatorTests.swift
@@ -53,10 +53,10 @@ final class LaunchCoordinatorTests: XCTestCase {
         let subject = createSubject(isIphone: true)
         subject.start(with: .intro(manager: introScreenManager))
 
-        XCTAssertEqual(mockRouter.presentCalled, 0)
-        XCTAssertEqual(mockRouter.setRootViewControllerCalled, 1)
-        let rootViewController = try XCTUnwrap(mockRouter.rootViewController)
-        XCTAssertNotNil(rootViewController as? IntroViewController)
+        XCTAssertEqual(mockRouter.presentCalled, 1)
+        XCTAssertEqual(mockRouter.setRootViewControllerCalled, 0)
+        let pushedVC = try XCTUnwrap(mockRouter.presentedViewController)
+        XCTAssertNotNil(pushedVC as? IntroViewController)
     }
 
     // MARK: - Update
@@ -76,10 +76,10 @@ final class LaunchCoordinatorTests: XCTestCase {
         let subject = createSubject(isIphone: true)
         subject.start(with: .update(viewModel: viewModel))
 
-        XCTAssertEqual(mockRouter.presentCalled, 0)
-        XCTAssertEqual(mockRouter.setRootViewControllerCalled, 1)
-        let rootViewController = try XCTUnwrap(mockRouter.rootViewController)
-        XCTAssertNotNil(rootViewController as? UpdateViewController)
+        XCTAssertEqual(mockRouter.presentCalled, 1)
+        XCTAssertEqual(mockRouter.setRootViewControllerCalled, 0)
+        let pushedVC = try XCTUnwrap(mockRouter.presentedViewController)
+        XCTAssertNotNil(pushedVC as? UpdateViewController)
     }
 
     // MARK: - Default browser
@@ -114,10 +114,10 @@ final class LaunchCoordinatorTests: XCTestCase {
         let subject = createSubject(isIphone: false)
         subject.start(with: .survey(manager: manager))
 
-        XCTAssertEqual(mockRouter.presentCalled, 0)
-        XCTAssertEqual(mockRouter.setRootViewControllerCalled, 1)
-        let rootViewController = try XCTUnwrap(mockRouter.rootViewController)
-        XCTAssertNotNil(rootViewController as? SurveySurfaceViewController)
+        XCTAssertEqual(mockRouter.presentCalled, 1)
+        XCTAssertEqual(mockRouter.setRootViewControllerCalled, 0)
+        let pushedVC = try XCTUnwrap(mockRouter.presentedViewController)
+        XCTAssertNotNil(pushedVC as? SurveySurfaceViewController)
     }
 
     // MARK: - Delegates

--- a/Tests/ClientTests/Coordinators/SceneCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/SceneCoordinatorTests.swift
@@ -32,13 +32,21 @@ final class SceneCoordinatorTests: XCTestCase {
         XCTAssertTrue(subject.childCoordinators.isEmpty)
     }
 
-    func testStart_startsLaunchScreen() {
+    func testStart_rootViewIsSceneContainer() {
         let subject = createSubject()
         subject.start()
 
         XCTAssertNotNil(subject.window)
-        XCTAssertNotNil(mockRouter.rootViewController as? LaunchScreenViewController)
+        XCTAssertNotNil(mockRouter.rootViewController as? SceneContainer)
         XCTAssertEqual(mockRouter.setRootViewControllerCalled, 1)
+    }
+
+    func testStart_startsLaunchScreen() {
+        let subject = createSubject()
+        subject.start()
+
+        XCTAssertNotNil(mockRouter.pushedViewController as? LaunchScreenViewController)
+        XCTAssertEqual(mockRouter.pushCalled, 1)
     }
 
     func testLaunchWithLaunchType_launchFromScene() {

--- a/Tests/ClientTests/Mocks/MockNavigationController.swift
+++ b/Tests/ClientTests/Mocks/MockNavigationController.swift
@@ -16,7 +16,6 @@ class MockNavigationController: UIViewController, NavigationController {
     var dismissCalled = 0
     var pushCalled = 0
     var popViewCalled = 0
-    var popToRootCalled = 0
 
     override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
         presentCalled += 1
@@ -35,15 +34,6 @@ class MockNavigationController: UIViewController, NavigationController {
     func popViewController(animated: Bool) -> UIViewController? {
         popViewCalled += 1
         return topViewController
-    }
-
-    func popToRootViewController(animated: Bool) -> [UIViewController]? {
-        popToRootCalled += 1
-        if let topViewController = topViewController {
-            return [topViewController]
-        } else {
-            return []
-        }
     }
 
     func setViewControllers(_ viewControllers: [UIViewController], animated: Bool) {

--- a/Tests/ClientTests/Mocks/MockRouter.swift
+++ b/Tests/ClientTests/Mocks/MockRouter.swift
@@ -16,7 +16,6 @@ class MockRouter: NSObject, Router {
     var pushCalled = 0
     var popViewControllerCalled = 0
     var setRootViewControllerCalled = 0
-    var popToRootModuleCalled = 0
 
     init(navigationController: NavigationController) {
         self.navigationController = navigationController
@@ -44,9 +43,5 @@ class MockRouter: NSObject, Router {
     func setRootViewController(_ viewController: UIViewController, hideBar: Bool, animated: Bool) {
         rootViewController = viewController
         setRootViewControllerCalled += 1
-    }
-
-    func popToRootViewController(animated: Bool) {
-        popToRootModuleCalled += 1
     }
 }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6286)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14141)

### Description
- Those changes will fix the issue of the transitions for `launchScreen` > `onboarding` (of type intro, update and survey) > to BVC. We currently always show BVC first, but we should see the onboarding after the launch screen on start up of the app. We should also ensure we dismiss the onboarding with a slide out animation.
- Remove `popToRootViewController` since we shouldn't use this method as is with the method.
- Checked that existing `popToRootViewController` usage doesn't have any effect with those changes. We had 1 pop to root that was dead code (`didLongPressBackButtonView`), and the other 1 doesn't have any effect. I added a comment to explain what it does.
- Since we don't use `popToRootViewController` I am not adding the support to do this in this PR. If we need it further down the line then I'll add the possibility.
- Adjust unit tests

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
