### PR TITLE
Add FXIOS-6281 support for adding webpage to home screen

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1651,7 +1651,9 @@ class BrowserViewController: UIViewController {
 
     func presentShareSheet(_ url: URL, tab: Tab? = nil, sourceView: UIView?, sourceRect: CGRect, arrowDirection: UIPopoverArrowDirection) {
         let helper = ShareExtensionHelper(url: url, tab: tab)
-        let controller = helper.createActivityViewController({ [unowned self] completed, activityType in
+        let selectedTabWebview = tabManager.selectedTab?.webView
+        let controller = helper.createActivityViewController(selectedTabWebview) {
+            [unowned self] completed, activityType in
             switch activityType {
             case CustomActivityAction.sendToDevice.actionType:
                 self.showSendToDevice()
@@ -1670,7 +1672,7 @@ class BrowserViewController: UIViewController {
             // invoked on iOS 10. See Bug 1297768 for additional details.
             self.displayedPopoverController = nil
             self.updateDisplayedPopoverProperties = nil
-        })
+        }
 
         if let popoverPresentationController = controller.popoverPresentationController {
             popoverPresentationController.sourceView = sourceView

--- a/Client/Frontend/Share/ShareExtensionHelper.swift
+++ b/Client/Frontend/Share/ShareExtensionHelper.swift
@@ -5,6 +5,7 @@
 import Foundation
 import Shared
 import MobileCoreServices
+import WebKit
 
 class ShareExtensionHelper: NSObject, FeatureFlaggable {
     private weak var selectedTab: Tab?
@@ -36,8 +37,15 @@ class ShareExtensionHelper: NSObject, FeatureFlaggable {
         self.selectedTab = tab
     }
 
-    func createActivityViewController(_ completionHandler: @escaping (_ completed: Bool, _ activityType: UIActivity.ActivityType?) -> Void) -> UIActivityViewController {
-        let activityItems = getActivityItems(url: url)
+    func createActivityViewController(
+        _ webView: WKWebView? = nil,
+        completionHandler: @escaping (_ completed: Bool,
+            _ activityType: UIActivity.ActivityType?) -> Void) -> UIActivityViewController {
+        var activityItems = getActivityItems(url: url)
+        // Note: webview is required for adding websites to the iOS home screen
+        if #available(iOS 16.4, *), let webView = webView {
+            activityItems.append(webView)
+        }
         let appActivities = getApplicationActivities()
         let activityViewController = UIActivityViewController(activityItems: activityItems,
                                                               applicationActivities: appActivities)


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6281)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14131)

### Description
Added support allows users to pin a webpage to their home screen. 

https://user-images.githubusercontent.com/8919439/235001163-d5a4be60-4928-4a51-87bf-cb4c14d44d1b.mov

Ref: https://webkit.org/blog/13878/web-push-for-web-apps-on-ios-and-ipados/


### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
~- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)~
~- [ ] Unit tests written and passing~
- [ ] Documentation / comments for complex code and public methods
