### PR TITLE
Add FXIOS-6018 [v114] Create GleanWrapper and use it to handle route

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -603,6 +603,8 @@
 		8A9F0B5927C5A2AB00FE09AE /* ImageIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9F0B5527C595F300FE09AE /* ImageIdentifiers.swift */; };
 		8AA6ADB52742B567004EEE23 /* TelemetryWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA6ADB42742B567004EEE23 /* TelemetryWrapperTests.swift */; };
 		8AA7347B28AEDB3100443D24 /* PocketViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA7347A28AEDB3100443D24 /* PocketViewModelTests.swift */; };
+		8AABBCFC2A0010900089941E /* GleanWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AABBCFB2A0010900089941E /* GleanWrapper.swift */; };
+		8AABBCFF2A0017960089941E /* MockGleanWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AABBCFD2A0017560089941E /* MockGleanWrapper.swift */; };
 		8AB5958828413F6C0090F4AE /* RecentlySavedCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB5958728413F6C0090F4AE /* RecentlySavedCell.swift */; };
 		8AB5958A284145B30090F4AE /* HomepageSectionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB59589284145B30090F4AE /* HomepageSectionHandler.swift */; };
 		8AB5958C28414DF60090F4AE /* ActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB5958B28414DF60090F4AE /* ActionButton.swift */; };
@@ -4142,6 +4144,8 @@
 		8A9F0B5527C595F300FE09AE /* ImageIdentifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageIdentifiers.swift; sourceTree = "<group>"; };
 		8AA6ADB42742B567004EEE23 /* TelemetryWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryWrapperTests.swift; sourceTree = "<group>"; };
 		8AA7347A28AEDB3100443D24 /* PocketViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketViewModelTests.swift; sourceTree = "<group>"; };
+		8AABBCFB2A0010900089941E /* GleanWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanWrapper.swift; sourceTree = "<group>"; };
+		8AABBCFD2A0017560089941E /* MockGleanWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGleanWrapper.swift; sourceTree = "<group>"; };
 		8AAD4900BB6F4DF6056B581F /* ml */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ml; path = ml.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		8AB04613B101195AADCC1F1B /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = "cs.lproj/Default Browser.strings"; sourceTree = "<group>"; };
 		8AB5958728413F6C0090F4AE /* RecentlySavedCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentlySavedCell.swift; sourceTree = "<group>"; };
@@ -8182,6 +8186,7 @@
 				8AFCE50829DE136300B1B253 /* MockLaunchFinishedLoadingDelegate.swift */,
 				8AF99B5329EF2AF100108DEC /* MockLogger.swift */,
 				C8C3FEA029F973C40038E3BA /* MockBrowserViewController.swift */,
+				8AABBCFD2A0017560089941E /* MockGleanWrapper.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -9037,6 +9042,7 @@
 				8A04136828258DF600D20B10 /* SponsoredTileTelemetry.swift */,
 				EBF47E6F1F7979DF00899189 /* TelemetryWrapper.swift */,
 				8AD08D1427E9198E00B8E907 /* TabsQuantityTelemetry.swift */,
+				8AABBCFB2A0010900089941E /* GleanWrapper.swift */,
 			);
 			path = Telemetry;
 			sourceTree = "<group>";
@@ -11242,6 +11248,7 @@
 				E68E39BE1C46F42000B85F42 /* AppSettingsTableViewController.swift in Sources */,
 				E1A6AB4628CA6A4C00EBEBDD /* String+Extension.swift in Sources */,
 				210887CC293E8800000AB4EE /* RemoteTabsErrorCell.swift in Sources */,
+				8AABBCFC2A0010900089941E /* GleanWrapper.swift in Sources */,
 				F85C7F0F271DD154004BDBA4 /* AppAuthenticator.swift in Sources */,
 				D029A04920A62DB0001DB72F /* TemporaryDocument.swift in Sources */,
 				C8BA0E7627F20B8E00DD8214 /* HistoryDeletionUtility.swift in Sources */,
@@ -11966,6 +11973,7 @@
 				21371FA228A6C4A200BC3F37 /* OnboardingCardViewModelTests.swift in Sources */,
 				8A2825352760399B00395E66 /* KeyboardPressesHandlerTests.swift in Sources */,
 				6A5F591D28627C0100FABA92 /* TabManagerNavDelegateTests.swift in Sources */,
+				8AABBCFF2A0017960089941E /* MockGleanWrapper.swift in Sources */,
 				E1D8BC7A21FF7A0000B100BD /* TPStatsBlocklistsTests.swift in Sources */,
 				E571EE7D28756A130051D9AA /* PocketSponsoredStoriesProviderTests.swift in Sources */,
 				5AF6254328A57A4600A90253 /* HistoryHighlightsDataAdaptorTests.swift in Sources */,

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -5,7 +5,6 @@
 import Common
 import Foundation
 import WebKit
-import Glean
 import Shared
 
 class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDelegate {
@@ -18,19 +17,22 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
     private let themeManager: ThemeManager
     private var logger: Logger
     private let screenshotService: ScreenshotService
+    private let glean: GleanWrapper
 
     init(router: Router,
          screenshotService: ScreenshotService,
          profile: Profile = AppContainer.shared.resolve(),
          tabManager: TabManager = AppContainer.shared.resolve(),
          logger: Logger = DefaultLogger.shared,
-         themeManager: ThemeManager = AppContainer.shared.resolve()) {
+         themeManager: ThemeManager = AppContainer.shared.resolve(),
+         glean: GleanWrapper = DefaultGleanWrapper.shared) {
         self.screenshotService = screenshotService
         self.profile = profile
         self.tabManager = tabManager
         self.themeManager = themeManager
         self.browserViewController = BrowserViewController(profile: profile, tabManager: tabManager)
         self.logger = logger
+        self.glean = glean
         super.init(router: router)
         self.browserViewController.browserDelegate = self
     }
@@ -124,9 +126,9 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
             handle(searchURL: url, tabId: tabId)
             return true
 
-        case .glean:
-            // FXIOS-6018 #13662 - Enable Glean path in BrowserCoordinator
-            return false
+        case let .glean(url):
+            glean.handleDeeplinkUrl(url: url)
+            return true
 
         case let .homepanel(section):
             handle(homepanelSection: section)

--- a/Client/Telemetry/GleanWrapper.swift
+++ b/Client/Telemetry/GleanWrapper.swift
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Glean
+
+protocol GleanWrapper {
+    func handleDeeplinkUrl(url: URL)
+}
+
+/// Glean wrapper to abstract Glean from our application
+struct DefaultGleanWrapper: GleanWrapper {
+    public static let shared = DefaultGleanWrapper()
+
+    func handleDeeplinkUrl(url: URL) {
+        Glean.shared.handleCustomUrl(url: url)
+    }
+}

--- a/Tests/ClientTests/Mocks/MockGleanWrapper.swift
+++ b/Tests/ClientTests/Mocks/MockGleanWrapper.swift
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+@testable import Client
+
+class MockGleanWrapper: GleanWrapper {
+    var handleDeeplinkUrlCalled = 0
+    var savedHandleDeeplinkUrl: URL?
+
+    func handleDeeplinkUrl(url: URL) {
+        handleDeeplinkUrlCalled += 1
+        savedHandleDeeplinkUrl = url
+    }
+}


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6018)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13662)

### Description
- Create `GleanWrapper` to handle the deeplink Glean route. This wrapper will eventually contain more than this function to abstract our application from the Glean dependency. This is a first step in that direction.
- Add unit test for it, adding `MockGleanWrapper`
- Add some `MARK` in test code

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
