### PR TITLE
Bugfix FXIOS-6033 [v114] did request to open in new tab

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -605,7 +605,7 @@
 		8AA7347B28AEDB3100443D24 /* PocketViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA7347A28AEDB3100443D24 /* PocketViewModelTests.swift */; };
 		8AABBCFC2A0010900089941E /* GleanWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AABBCFB2A0010900089941E /* GleanWrapper.swift */; };
 		8AABBCFF2A0017960089941E /* MockGleanWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AABBCFD2A0017560089941E /* MockGleanWrapper.swift */; };
-		8AABBD052A0041380089941E /* MockBrowserCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AABBD042A0041380089941E /* MockBrowserCoordinator.swift */; };
+		8AABBD052A0041380089941E /* MockCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AABBD042A0041380089941E /* MockCoordinator.swift */; };
 		8AB5958828413F6C0090F4AE /* RecentlySavedCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB5958728413F6C0090F4AE /* RecentlySavedCell.swift */; };
 		8AB5958A284145B30090F4AE /* HomepageSectionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB59589284145B30090F4AE /* HomepageSectionHandler.swift */; };
 		8AB5958C28414DF60090F4AE /* ActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB5958B28414DF60090F4AE /* ActionButton.swift */; };
@@ -4148,7 +4148,7 @@
 		8AA7347A28AEDB3100443D24 /* PocketViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketViewModelTests.swift; sourceTree = "<group>"; };
 		8AABBCFB2A0010900089941E /* GleanWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanWrapper.swift; sourceTree = "<group>"; };
 		8AABBCFD2A0017560089941E /* MockGleanWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGleanWrapper.swift; sourceTree = "<group>"; };
-		8AABBD042A0041380089941E /* MockBrowserCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBrowserCoordinator.swift; sourceTree = "<group>"; };
+		8AABBD042A0041380089941E /* MockCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCoordinator.swift; sourceTree = "<group>"; };
 		8AAD4900BB6F4DF6056B581F /* ml */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ml; path = ml.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		8AB04613B101195AADCC1F1B /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = "cs.lproj/Default Browser.strings"; sourceTree = "<group>"; };
 		8AB5958728413F6C0090F4AE /* RecentlySavedCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentlySavedCell.swift; sourceTree = "<group>"; };
@@ -8192,7 +8192,7 @@
 				8AF99B5329EF2AF100108DEC /* MockLogger.swift */,
 				C8C3FEA029F973C40038E3BA /* MockBrowserViewController.swift */,
 				8AABBCFD2A0017560089941E /* MockGleanWrapper.swift */,
-				8AABBD042A0041380089941E /* MockBrowserCoordinator.swift */,
+				8AABBD042A0041380089941E /* MockCoordinator.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -11980,7 +11980,7 @@
 				21371FA228A6C4A200BC3F37 /* OnboardingCardViewModelTests.swift in Sources */,
 				8A2825352760399B00395E66 /* KeyboardPressesHandlerTests.swift in Sources */,
 				6A5F591D28627C0100FABA92 /* TabManagerNavDelegateTests.swift in Sources */,
-				8AABBD052A0041380089941E /* MockBrowserCoordinator.swift in Sources */,
+				8AABBD052A0041380089941E /* MockCoordinator.swift in Sources */,
 				8AABBCFF2A0017960089941E /* MockGleanWrapper.swift in Sources */,
 				E1D8BC7A21FF7A0000B100BD /* TPStatsBlocklistsTests.swift in Sources */,
 				E571EE7D28756A130051D9AA /* PocketSponsoredStoriesProviderTests.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -605,6 +605,7 @@
 		8AA7347B28AEDB3100443D24 /* PocketViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA7347A28AEDB3100443D24 /* PocketViewModelTests.swift */; };
 		8AABBCFC2A0010900089941E /* GleanWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AABBCFB2A0010900089941E /* GleanWrapper.swift */; };
 		8AABBCFF2A0017960089941E /* MockGleanWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AABBCFD2A0017560089941E /* MockGleanWrapper.swift */; };
+		8AABBD052A0041380089941E /* MockBrowserCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AABBD042A0041380089941E /* MockBrowserCoordinator.swift */; };
 		8AB5958828413F6C0090F4AE /* RecentlySavedCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB5958728413F6C0090F4AE /* RecentlySavedCell.swift */; };
 		8AB5958A284145B30090F4AE /* HomepageSectionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB59589284145B30090F4AE /* HomepageSectionHandler.swift */; };
 		8AB5958C28414DF60090F4AE /* ActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB5958B28414DF60090F4AE /* ActionButton.swift */; };
@@ -4147,6 +4148,7 @@
 		8AA7347A28AEDB3100443D24 /* PocketViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketViewModelTests.swift; sourceTree = "<group>"; };
 		8AABBCFB2A0010900089941E /* GleanWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanWrapper.swift; sourceTree = "<group>"; };
 		8AABBCFD2A0017560089941E /* MockGleanWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGleanWrapper.swift; sourceTree = "<group>"; };
+		8AABBD042A0041380089941E /* MockBrowserCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBrowserCoordinator.swift; sourceTree = "<group>"; };
 		8AAD4900BB6F4DF6056B581F /* ml */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ml; path = ml.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		8AB04613B101195AADCC1F1B /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = "cs.lproj/Default Browser.strings"; sourceTree = "<group>"; };
 		8AB5958728413F6C0090F4AE /* RecentlySavedCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentlySavedCell.swift; sourceTree = "<group>"; };
@@ -8190,6 +8192,7 @@
 				8AF99B5329EF2AF100108DEC /* MockLogger.swift */,
 				C8C3FEA029F973C40038E3BA /* MockBrowserViewController.swift */,
 				8AABBCFD2A0017560089941E /* MockGleanWrapper.swift */,
+				8AABBD042A0041380089941E /* MockBrowserCoordinator.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -11977,6 +11980,7 @@
 				21371FA228A6C4A200BC3F37 /* OnboardingCardViewModelTests.swift in Sources */,
 				8A2825352760399B00395E66 /* KeyboardPressesHandlerTests.swift in Sources */,
 				6A5F591D28627C0100FABA92 /* TabManagerNavDelegateTests.swift in Sources */,
+				8AABBD052A0041380089941E /* MockBrowserCoordinator.swift in Sources */,
 				8AABBCFF2A0017960089941E /* MockGleanWrapper.swift in Sources */,
 				E1D8BC7A21FF7A0000B100BD /* TPStatsBlocklistsTests.swift in Sources */,
 				E571EE7D28756A130051D9AA /* PocketSponsoredStoriesProviderTests.swift in Sources */,

--- a/Client/Application/SceneDelegate.swift
+++ b/Client/Application/SceneDelegate.swift
@@ -61,17 +61,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
             if let context = connectionOptions.urlContexts.first,
                let route = routeBuilder.makeRoute(url: context.url) {
-                sceneCoordinator?.find(route: route)
+                sceneCoordinator?.findAndHandle(route: route)
             }
 
             if let activity = connectionOptions.userActivities.first,
                let route = routeBuilder.makeRoute(userActivity: activity) {
-                sceneCoordinator?.find(route: route)
+                sceneCoordinator?.findAndHandle(route: route)
             }
 
             if let shortcut = connectionOptions.shortcutItem,
                let route = routeBuilder.makeRoute(shortcutItem: shortcut) {
-                sceneCoordinator?.find(route: route)
+                sceneCoordinator?.findAndHandle(route: route)
             }
         } else {
             let window = configureWindowFor(scene)
@@ -124,7 +124,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         if CoordinatorFlagManager.isCoordinatorEnabled {
             guard let url = URLContexts.first?.url,
                   let route = routeBuilder.makeRoute(url: url) else { return }
-            sceneCoordinator?.find(route: route)
+            sceneCoordinator?.findAndHandle(route: route)
         } else {
             guard let url = URLContexts.first?.url,
                   let routerPath = NavigationPath(url: url) else { return }
@@ -154,7 +154,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
         if CoordinatorFlagManager.isCoordinatorEnabled {
             guard let route = routeBuilder.makeRoute(userActivity: userActivity) else { return }
-            sceneCoordinator?.find(route: route)
+            sceneCoordinator?.findAndHandle(route: route)
         } else {
             if userActivity.activityType == SiriShortcuts.activityType.openURL.rawValue {
                 browserViewController.openBlankNewTab(focusLocationField: false)
@@ -192,7 +192,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     ) {
         if CoordinatorFlagManager.isCoordinatorEnabled {
             guard let route = routeBuilder.makeRoute(shortcutItem: shortcutItem) else { return }
-            sceneCoordinator?.find(route: route)
+            sceneCoordinator?.findAndHandle(route: route)
         } else {
             QuickActionsImplementation().handleShortCutItem(
                 shortcutItem,

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -61,8 +61,9 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
         remove(child: coordinator)
     }
 
-    func didRequestToOpenInNewTab(url: URL, isPrivate: Bool, selectNewTab: Bool) {
-        // FXIOS-6033 #13682 - Enable didRequestToOpenInNewTab in BrowserCoordinator & SceneCoordinator
+    func didRequestToOpenInNewTab(url: URL, isPrivate: Bool) {
+        let route = Route.search(url: url, isPrivate: isPrivate)
+        find(route: route)
     }
 
     // MARK: - BrowserDelegate

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -64,7 +64,9 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
         remove(child: coordinator)
     }
 
-    func didRequestToOpenInNewTab(url: URL, isPrivate: Bool) {
+    func didRequestToOpenInNewTab(from coordinator: LaunchCoordinator, url: URL, isPrivate: Bool) {
+        didFinishLaunch(from: coordinator)
+
         let route = Route.search(url: url, isPrivate: isPrivate)
         findAndHandle(route: route)
     }

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -66,7 +66,7 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
 
     func didRequestToOpenInNewTab(url: URL, isPrivate: Bool) {
         let route = Route.search(url: url, isPrivate: isPrivate)
-        find(route: route)
+        findAndHandle(route: route)
     }
 
     // MARK: - BrowserDelegate

--- a/Client/Coordinators/Coordinator.swift
+++ b/Client/Coordinators/Coordinator.swift
@@ -13,6 +13,9 @@ protocol Coordinator {
     func remove(child coordinator: Coordinator?)
 
     func handle(route: Route) -> Bool
+
+    @discardableResult
+    func find(route: Route) -> Coordinator?
 }
 
 /// An extension on the `Coordinator` class that provides a method to find a coordinator that can handle a given route.

--- a/Client/Coordinators/Coordinator.swift
+++ b/Client/Coordinators/Coordinator.swift
@@ -15,21 +15,18 @@ protocol Coordinator {
     func handle(route: Route) -> Bool
 
     @discardableResult
-    func find(route: Route) -> Coordinator?
+    func findAndHandle(route: Route) -> Coordinator?
 }
 
-/// An extension on the `Coordinator` class that provides a method to find a coordinator that can handle a given route.
 extension Coordinator {
     /// Finds a coordinator that can handle a given route by recursively searching through the current coordinator's child coordinators.
-    ///
-    /// - Parameters:
-    ///     - route: The route to find a matching coordinator for.
-    ///
+    /// - Parameter route: The route to find a matching coordinator for.
     /// - Returns: An optional `Coordinator` instance that can handle the given `route`, or `nil` if no such coordinator was found.
     ///
-    /// - DiscardableResult: The result of this method is marked as `@discardableResult` because the caller may choose not to use the returned `Coordinator` instance, which is safe to do.
+    /// - DiscardableResult: The result of this method is marked as `@discardableResult` because the caller may choose not to use the returned
+    /// `Coordinator` instance, which is safe to do.
     @discardableResult
-    func find(route: Route) -> Coordinator? {
+    func findAndHandle(route: Route) -> Coordinator? {
         // Check if the current coordinator can handle the route.
         if handle(route: route) {
             return self
@@ -37,7 +34,7 @@ extension Coordinator {
 
         // If not, recursively search through child coordinators.
         for childCoordinator in childCoordinators {
-            if let matchingCoordinator = childCoordinator.find(route: route) {
+            if let matchingCoordinator = childCoordinator.findAndHandle(route: route) {
                 return matchingCoordinator
             }
         }

--- a/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -7,7 +7,7 @@ import Foundation
 
 protocol LaunchCoordinatorDelegate: AnyObject {
     func didFinishLaunch(from coordinator: LaunchCoordinator)
-    func didRequestToOpenInNewTab(url: URL, isPrivate: Bool)
+    func didRequestToOpenInNewTab(from coordinator: LaunchCoordinator, url: URL, isPrivate: Bool)
 }
 
 // Manages different types of onboarding that gets shown at the launch of the application
@@ -125,7 +125,6 @@ class LaunchCoordinator: BaseCoordinator, OpenURLDelegate {
     // MARK: OpenURLDelegate
 
     func didRequestToOpenInNewTab(url: URL, isPrivate: Bool) {
-        parentCoordinator?.didFinishLaunch(from: self)
-        parentCoordinator?.didRequestToOpenInNewTab(url: url, isPrivate: isPrivate)
+        parentCoordinator?.didRequestToOpenInNewTab(from: self, url: url, isPrivate: isPrivate)
     }
 }

--- a/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -125,6 +125,7 @@ class LaunchCoordinator: BaseCoordinator, OpenURLDelegate {
     // MARK: OpenURLDelegate
 
     func didRequestToOpenInNewTab(url: URL, isPrivate: Bool) {
+        parentCoordinator?.didFinishLaunch(from: self)
         parentCoordinator?.didRequestToOpenInNewTab(url: url, isPrivate: isPrivate)
     }
 }

--- a/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -7,7 +7,7 @@ import Foundation
 
 protocol LaunchCoordinatorDelegate: AnyObject {
     func didFinishLaunch(from coordinator: LaunchCoordinator)
-    func didRequestToOpenInNewTab(url: URL, isPrivate: Bool, selectNewTab: Bool)
+    func didRequestToOpenInNewTab(url: URL, isPrivate: Bool)
 }
 
 // Manages different types of onboarding that gets shown at the launch of the application
@@ -124,7 +124,7 @@ class LaunchCoordinator: BaseCoordinator, OpenURLDelegate {
 
     // MARK: OpenURLDelegate
 
-    func didRequestToOpenInNewTab(url: URL, isPrivate: Bool, selectNewTab: Bool) {
-        parentCoordinator?.didRequestToOpenInNewTab(url: url, isPrivate: isPrivate, selectNewTab: selectNewTab)
+    func didRequestToOpenInNewTab(url: URL, isPrivate: Bool) {
+        parentCoordinator?.didRequestToOpenInNewTab(url: url, isPrivate: isPrivate)
     }
 }

--- a/Client/Coordinators/Scene/SceneCoordinator.swift
+++ b/Client/Coordinators/Scene/SceneCoordinator.swift
@@ -12,6 +12,9 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
     private let screenshotService: ScreenshotService
     private let sceneContainer: SceneContainer
 
+    // Used in unit tests only
+    var didFinishLaunchCompletion: (() -> Void)?
+
     init(scene: UIScene,
          sceneSetupHelper: SceneSetupHelper = SceneSetupHelper(),
          screenshotService: ScreenshotService = ScreenshotService(),
@@ -81,9 +84,13 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
         router.dismiss(animated: true)
         remove(child: coordinator)
         startBrowser(with: nil)
+
+        didFinishLaunchCompletion?()
     }
 
-    func didRequestToOpenInNewTab(url: URL, isPrivate: Bool) {
+    func didRequestToOpenInNewTab(from coordinator: LaunchCoordinator, url: URL, isPrivate: Bool) {
+        didFinishLaunch(from: coordinator)
+
         let route = Route.search(url: url, isPrivate: isPrivate)
         findAndHandle(route: route)
     }

--- a/Client/Coordinators/Scene/SceneCoordinator.swift
+++ b/Client/Coordinators/Scene/SceneCoordinator.swift
@@ -83,9 +83,8 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
         startBrowser(with: nil)
     }
 
-    // MARK: - LaunchFinishedLoadingDelegate
-
-    func didRequestToOpenInNewTab(url: URL, isPrivate: Bool, selectNewTab: Bool) {
-        // FXIOS-6033 #13682 - Enable didRequestToOpenInNewTab in BrowserCoordinator & SceneCoordinator
+    func didRequestToOpenInNewTab(url: URL, isPrivate: Bool) {
+        let route = Route.search(url: url, isPrivate: isPrivate)
+        find(route: route)
     }
 }

--- a/Client/Coordinators/Scene/SceneCoordinator.swift
+++ b/Client/Coordinators/Scene/SceneCoordinator.swift
@@ -85,6 +85,6 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
 
     func didRequestToOpenInNewTab(url: URL, isPrivate: Bool) {
         let route = Route.search(url: url, isPrivate: isPrivate)
-        find(route: route)
+        findAndHandle(route: route)
     }
 }

--- a/Client/Frontend/SurveySurface/SurveySurfaceManager.swift
+++ b/Client/Frontend/SurveySurface/SurveySurfaceManager.swift
@@ -13,7 +13,7 @@ protocol SurveySurfaceDelegate: AnyObject {
 }
 
 protocol OpenURLDelegate: AnyObject {
-    func didRequestToOpenInNewTab(url: URL, isPrivate: Bool, selectNewTab: Bool)
+    func didRequestToOpenInNewTab(url: URL, isPrivate: Bool)
 }
 
 class SurveySurfaceManager: SurveySurfaceDelegate, GleanPlumbMessagePressedDelegate {
@@ -100,7 +100,7 @@ class SurveySurfaceManager: SurveySurfaceDelegate, GleanPlumbMessagePressedDeleg
         homepanelDelegate?.homePanelDidRequestToOpenInNewTab(url,
                                                              isPrivate: false,
                                                              selectNewTab: true)
-        openURLDelegate?.didRequestToOpenInNewTab(url: url, isPrivate: false, selectNewTab: true)
+        openURLDelegate?.didRequestToOpenInNewTab(url: url, isPrivate: false)
         dismissClosure?()
     }
 }

--- a/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -408,6 +408,20 @@ final class BrowserCoordinatorTests: XCTestCase {
         XCTAssertEqual(mbvc.closePrivateTabsCount, 1)
     }
 
+    // MARK: - DidRequestToOpenInNewTab
+
+    func testDidRequestToOpenInNewTab_findsRoute() {
+        let expectedURL = URL(string: "www.example.com")!
+        let subject = createSubject()
+        let mbvc = MockBrowserViewController(profile: profile, tabManager: tabManager)
+        subject.browserViewController = mbvc
+
+        subject.didRequestToOpenInNewTab(from: LaunchCoordinator(router: mockRouter), url: expectedURL, isPrivate: false)
+
+        XCTAssertEqual(mbvc.switchToTabForURLOrOpenCount, 1)
+        XCTAssertEqual(mbvc.switchToTabForURLOrOpenURL, expectedURL)
+    }
+
     // MARK: - Helpers
     private func createSubject(file: StaticString = #file,
                                line: UInt = #line) -> BrowserCoordinator {

--- a/Tests/ClientTests/Coordinators/CoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/CoordinatorTests.swift
@@ -48,7 +48,8 @@ final class CoordinatorTests: XCTestCase {
         childCoordinator.add(child: grandChildCoordinator)
 
         // When
-        let matchingCoordinator = parentCoordinator.find(route: .search(url: URL(string: "https://www.google.com"), isPrivate: false))
+        let route = Route.search(url: URL(string: "https://www.google.com"), isPrivate: false)
+        let matchingCoordinator = parentCoordinator.findAndHandle(route: route)
 
         // Then
         XCTAssertNotNil(matchingCoordinator)
@@ -65,7 +66,8 @@ final class CoordinatorTests: XCTestCase {
         childCoordinator.add(child: grandChildCoordinator)
 
         // When
-        let matchingCoordinator = parentCoordinator.find(route: .search(url: URL(string: "https://www.google.com"), isPrivate: false))
+        let route = Route.search(url: URL(string: "https://www.google.com"), isPrivate: false)
+        let matchingCoordinator = parentCoordinator.findAndHandle(route: route)
 
         // Then
         XCTAssertNil(matchingCoordinator)

--- a/Tests/ClientTests/Coordinators/Launch/LaunchCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/Launch/LaunchCoordinatorTests.swift
@@ -141,12 +141,10 @@ final class LaunchCoordinatorTests: XCTestCase {
         subject.parentCoordinator = delegate
         let mockURL = URL(string: "www.firefox.com")!
         subject.didRequestToOpenInNewTab(url: mockURL,
-                                         isPrivate: false,
-                                         selectNewTab: false)
+                                         isPrivate: false)
 
         XCTAssertEqual(delegate.savedURL, mockURL)
         XCTAssertEqual(delegate.savedIsPrivate, false)
-        XCTAssertEqual(delegate.savedSelectedNewTab, false)
     }
 
     // MARK: - Helpers

--- a/Tests/ClientTests/Coordinators/SceneCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/SceneCoordinatorTests.swift
@@ -84,6 +84,29 @@ final class SceneCoordinatorTests: XCTestCase {
         XCTAssertNotNil(subject.childCoordinators[0] as? BrowserCoordinator)
     }
 
+    func testDidRequestToOpenInNewTab_hasNoBrowserCoordinator_doesNotFindRoute() {
+        let expectedURL = URL(string: "www.example.com")!
+        let subject = createSubject()
+
+        subject.didRequestToOpenInNewTab(url: expectedURL, isPrivate: false)
+
+        XCTAssertEqual(subject.childCoordinators.count, 1)
+    }
+
+    func testDidRequestToOpenInNewTab_hasBrowserCoordinator_findsRoute() {
+        let expectedURL = URL(string: "www.example.com")!
+        let subject = createSubject()
+
+        let browserCoordinator = MockBrowserCoordinator(router: mockRouter)
+        subject.add(child: browserCoordinator)
+
+        subject.didRequestToOpenInNewTab(url: expectedURL, isPrivate: false)
+
+        XCTAssertEqual(subject.childCoordinators.count, 1)
+        XCTAssertEqual(browserCoordinator.findRouteCalled, 1)
+        XCTAssertEqual(browserCoordinator.savedRoute, .search(url: expectedURL, isPrivate: false))
+    }
+
     // MARK: - Helpers
     private func createSubject(file: StaticString = #file,
                                line: UInt = #line) -> SceneCoordinator {

--- a/Tests/ClientTests/Coordinators/SceneCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/SceneCoordinatorTests.swift
@@ -96,7 +96,7 @@ final class SceneCoordinatorTests: XCTestCase {
     func testDidRequestToOpenInNewTab_hasBrowserCoordinator_findsRoute() {
         let expectedURL = URL(string: "www.example.com")!
         let subject = createSubject()
-        let browserCoordinator = MockBrowserCoordinator(router: mockRouter)
+        let browserCoordinator = MockCoordinator(router: mockRouter)
         subject.add(child: browserCoordinator)
 
         subject.didRequestToOpenInNewTab(url: expectedURL, isPrivate: false)

--- a/Tests/ClientTests/Coordinators/SceneCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/SceneCoordinatorTests.swift
@@ -90,13 +90,12 @@ final class SceneCoordinatorTests: XCTestCase {
 
         subject.didRequestToOpenInNewTab(url: expectedURL, isPrivate: false)
 
-        XCTAssertEqual(subject.childCoordinators.count, 1)
+        XCTAssertEqual(subject.childCoordinators.count, 0)
     }
 
     func testDidRequestToOpenInNewTab_hasBrowserCoordinator_findsRoute() {
         let expectedURL = URL(string: "www.example.com")!
         let subject = createSubject()
-
         let browserCoordinator = MockBrowserCoordinator(router: mockRouter)
         subject.add(child: browserCoordinator)
 
@@ -104,7 +103,7 @@ final class SceneCoordinatorTests: XCTestCase {
 
         XCTAssertEqual(subject.childCoordinators.count, 1)
         XCTAssertEqual(browserCoordinator.findRouteCalled, 1)
-        XCTAssertEqual(browserCoordinator.savedRoute, .search(url: expectedURL, isPrivate: false))
+        XCTAssertEqual(browserCoordinator.savedFindRoute, .search(url: expectedURL, isPrivate: false))
     }
 
     // MARK: - Helpers

--- a/Tests/ClientTests/Mocks/MockBrowserCoordinator.swift
+++ b/Tests/ClientTests/Mocks/MockBrowserCoordinator.swift
@@ -5,13 +5,38 @@
 import UIKit
 @testable import Client
 
-class MockBrowserCoordinator: BaseCoordinator {
-    var findRouteCalled = 0
-    var savedRoute: Route?
+class MockBrowserCoordinator: Coordinator {
+    var id: UUID = UUID()
+    var childCoordinators: [Coordinator] = []
+    var router: Router
 
+    var addChildCalled = 0
+    var removedChildCalled = 0
+    var handleRouteCalled = 0
+    var findRouteCalled = 0
+    var savedFindRoute: Route?
+
+    init(router: MockRouter) {
+        self.router = router
+    }
+
+    func add(child coordinator: Coordinator) {
+        addChildCalled += 1
+    }
+
+    func remove(child coordinator: Coordinator?) {
+        removedChildCalled += 1
+    }
+
+    func handle(route: Route) -> Bool {
+        handleRouteCalled += 1
+        return false
+    }
+
+    @discardableResult
     func find(route: Route) -> Coordinator? {
         findRouteCalled += 1
-        savedRoute = route
+        savedFindRoute = route
         return nil
     }
 }

--- a/Tests/ClientTests/Mocks/MockBrowserCoordinator.swift
+++ b/Tests/ClientTests/Mocks/MockBrowserCoordinator.swift
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+@testable import Client
+
+class MockBrowserCoordinator: BaseCoordinator {
+    var findRouteCalled = 0
+    var savedRoute: Route?
+
+    func find(route: Route) -> Coordinator? {
+        findRouteCalled += 1
+        savedRoute = route
+        return nil
+    }
+}

--- a/Tests/ClientTests/Mocks/MockCoordinator.swift
+++ b/Tests/ClientTests/Mocks/MockCoordinator.swift
@@ -5,8 +5,8 @@
 import UIKit
 @testable import Client
 
-class MockBrowserCoordinator: Coordinator {
-    var id: UUID = UUID()
+class MockCoordinator: Coordinator {
+    var id = UUID()
     var childCoordinators: [Coordinator] = []
     var router: Router
 

--- a/Tests/ClientTests/Mocks/MockCoordinator.swift
+++ b/Tests/ClientTests/Mocks/MockCoordinator.swift
@@ -34,7 +34,7 @@ class MockCoordinator: Coordinator {
     }
 
     @discardableResult
-    func find(route: Route) -> Coordinator? {
+    func findAndHandle(route: Route) -> Coordinator? {
         findRouteCalled += 1
         savedFindRoute = route
         return nil

--- a/Tests/ClientTests/Mocks/MockLaunchCoordinatorDelegate.swift
+++ b/Tests/ClientTests/Mocks/MockLaunchCoordinatorDelegate.swift
@@ -8,16 +8,14 @@ import Foundation
 class MockLaunchCoordinatorDelegate: LaunchCoordinatorDelegate {
     var savedURL: URL?
     var savedIsPrivate: Bool?
-    var savedSelectedNewTab: Bool?
     var savedDidFinishCoordinator: LaunchCoordinator?
 
     func didFinishLaunch(from coordinator: LaunchCoordinator) {
         savedDidFinishCoordinator = coordinator
     }
 
-    func didRequestToOpenInNewTab(url: URL, isPrivate: Bool, selectNewTab: Bool) {
+    func didRequestToOpenInNewTab(url: URL, isPrivate: Bool) {
         savedURL = url
         savedIsPrivate = isPrivate
-        savedSelectedNewTab = selectNewTab
     }
 }

--- a/Tests/ClientTests/Mocks/MockLaunchCoordinatorDelegate.swift
+++ b/Tests/ClientTests/Mocks/MockLaunchCoordinatorDelegate.swift
@@ -14,7 +14,7 @@ class MockLaunchCoordinatorDelegate: LaunchCoordinatorDelegate {
         savedDidFinishCoordinator = coordinator
     }
 
-    func didRequestToOpenInNewTab(url: URL, isPrivate: Bool) {
+    func didRequestToOpenInNewTab(from coordinator: LaunchCoordinator, url: URL, isPrivate: Bool) {
         savedURL = url
         savedIsPrivate = isPrivate
     }

--- a/Tests/ClientTests/Mocks/MockOpenURLDelegate.swift
+++ b/Tests/ClientTests/Mocks/MockOpenURLDelegate.swift
@@ -8,11 +8,9 @@ import UIKit
 class MockOpenURLDelegate: OpenURLDelegate {
     var savedURL: URL?
     var savedIsPrivate: Bool?
-    var savedSelectedNewTab: Bool?
 
-    func didRequestToOpenInNewTab(url: URL, isPrivate: Bool, selectNewTab: Bool) {
+    func didRequestToOpenInNewTab(url: URL, isPrivate: Bool) {
         savedURL = url
         savedIsPrivate = isPrivate
-        savedSelectedNewTab = selectNewTab
     }
 }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6033)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13682)

### Description
- handle `didRequestToOpenInNewTab` that is called from the survey delegate from `LaunchCoordinatorDelegate`. Turns out the `selectNewTab` parameter wasn't needed there since we already select the tab when we use the `Route` path.  
- Add tests for it, creating `MockCoordinator` for this
- Realized I wasn't dismissing the survey from `LaunchCoordinator`, which also makes sure we have a browser coordinator added as a child of the scene coordinator, before we can call this route path.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
