### PR TITLE
Build MTE-925 [v114] Add Taskcluster logging for Bitrise Perfherder Data

### DIFF
--- a/taskcluster/scripts/bitrise-schedule.py
+++ b/taskcluster/scripts/bitrise-schedule.py
@@ -234,5 +234,4 @@ async def print_bitrise_perfherder_data(file_destination):
                 print(line, end='')
 
 
-
 __name__ == "__main__" and sync_main()

--- a/taskcluster/scripts/bitrise-schedule.py
+++ b/taskcluster/scripts/bitrise-schedule.py
@@ -98,6 +98,7 @@ async def async_main(token, branch, commit, workflow, artifacts_directory, local
         finally:
             log.info("Retrieving bitrise log...")
             await download_log(client, build_slug, artifacts_directory)
+            await print_bitrise_perfherder_data(os.path.join(artifacts_directory, "bitrise.log"))
 
 
 async def schedule_build(client, branch, commit, workflow, locales=None, derived_data_path=None):
@@ -224,6 +225,13 @@ async def do_http_request_json(client, url, method="get", **kwargs):
     log.debug(f"{method_and_url} returned JSON {response}")
 
     return response
+
+
+async def print_bitrise_perfherder_data(file_destination):
+    with open(file_destination, 'r') as f:
+        for line in f:
+            if line.startswith('PERFHERDER_DATA'):
+                print(line, end='')
 
 
 __name__ == "__main__" and sync_main()

--- a/taskcluster/scripts/bitrise-schedule.py
+++ b/taskcluster/scripts/bitrise-schedule.py
@@ -228,10 +228,16 @@ async def do_http_request_json(client, url, method="get", **kwargs):
 
 
 async def log_bitrise_perfherder_data(file_destination):
-    with open(file_destination, 'r') as f:
-        for line in f:
-            if line.startswith('PERFHERDER_DATA'):
-                log.info(line)
+    if not os.path.isfile(file_destination):
+        raise Exception(f"Bitrise.log not found at {file_destination}")
+    
+    try:
+        with open(file_destination, 'r') as f:
+            for line in f:
+                if line.startswith('PERFHERDER_DATA'):
+                    log.info(line)
+    except Exception as e:
+        log.error(f"Error reading Bitrise.log: {e}")
 
 
 __name__ == "__main__" and sync_main()

--- a/taskcluster/scripts/bitrise-schedule.py
+++ b/taskcluster/scripts/bitrise-schedule.py
@@ -234,4 +234,5 @@ async def print_bitrise_perfherder_data(file_destination):
                 print(line, end='')
 
 
+
 __name__ == "__main__" and sync_main()

--- a/taskcluster/scripts/bitrise-schedule.py
+++ b/taskcluster/scripts/bitrise-schedule.py
@@ -98,7 +98,7 @@ async def async_main(token, branch, commit, workflow, artifacts_directory, local
         finally:
             log.info("Retrieving bitrise log...")
             await download_log(client, build_slug, artifacts_directory)
-            await print_bitrise_perfherder_data(os.path.join(artifacts_directory, "bitrise.log"))
+            await log_bitrise_perfherder_data(os.path.join(artifacts_directory, "bitrise.log"))
 
 
 async def schedule_build(client, branch, commit, workflow, locales=None, derived_data_path=None):
@@ -227,11 +227,11 @@ async def do_http_request_json(client, url, method="get", **kwargs):
     return response
 
 
-async def print_bitrise_perfherder_data(file_destination):
+async def log_bitrise_perfherder_data(file_destination):
     with open(file_destination, 'r') as f:
         for line in f:
             if line.startswith('PERFHERDER_DATA'):
-                print(line, end='')
+                log.info(line)
 
 
 __name__ == "__main__" and sync_main()


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-925)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/FXIOS-14205)

### Description
In order to expose the `bitrise.log` `PERFHERDER_DATA` object to the taskcluster `live.log` for ingest, we need to add logging in the taskcluster script scope.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
