### PR TITLE
Bugfix [v114] Fix UI tests failure on recently visited

### DIFF
--- a/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -9,7 +9,7 @@ let websiteUrl2 = "developer.mozilla.org"
 let invalidUrl = "1-2-3"
 let exampleUrl = "test-example.html"
 let urlExampleLabel = "Example Domain"
-let urlMozillaLabel = "Internet for people, not profit — Mozilla"
+let urlMozillaLabel = "Internet for people, not profit — Mozilla (US)"
 
 class HomePageSettingsUITests: BaseTestCase {
     private func enterWebPageAsHomepage(text: String) {


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

### Description
The description changed and now contains `(US)`. Since we check for exact text, the test is failing. I am making this quick fix to unblock main.
![Screenshot 2023-05-02 at 1 43 32 PM](https://user-images.githubusercontent.com/11338480/235743825-db441bd0-8933-46e3-8b16-2baee0975cff.png)

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
