### PR TITLE
Bump [v114] Update Sentry to version 8.6.0

### DIFF
--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
             exact: "1.9.6"),
         .package(
             url: "https://github.com/getsentry/sentry-cocoa.git",
-            exact: "8.4.0"),
+            exact: "8.6.0"),
     ],
     targets: [
         .target(

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -17427,7 +17427,7 @@
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa.git";
 			requirement = {
 				kind = exactVersion;
-				version = 8.4.0;
+				version = 8.6.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "92a6472efc750a4e18bdee21c204942ab0bc4dcd",
-        "version" : "8.4.0"
+        "revision" : "e6dcfba32f2861438b82c7ad34e058b23c83daf6",
+        "version" : "8.6.0"
       }
     },
     {


### PR DESCRIPTION
Changelogs since previous update:
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.5.0
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.6.0