### PR TITLE
Bugfix FXIOS-6310 [v114] Fix JumpBackInViewModelTests unit tests for XCode 14.3

### DIFF
--- a/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
@@ -124,9 +124,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let subject = createSubject()
 
         // iPhone layout portrait
-        let trait = MockTraitCollection()
-        trait.overridenHorizontalSizeClass = .compact
-        trait.overridenVerticalSizeClass = .regular
+        let trait = MockTraitCollection(horizontalSizeClass: .compact).getTraitCollection()
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
@@ -144,9 +142,7 @@ class JumpBackInViewModelTests: XCTestCase {
         await adaptor.setSyncedTab(syncedTab: JumpBackInSyncedTab(client: remoteClient, tab: remoteTab))
 
         // iPhone layout portrait
-        let trait = MockTraitCollection()
-        trait.overridenHorizontalSizeClass = .compact
-        trait.overridenVerticalSizeClass = .regular
+        let trait = MockTraitCollection(horizontalSizeClass: .compact).getTraitCollection()
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
@@ -167,9 +163,7 @@ class JumpBackInViewModelTests: XCTestCase {
         await adaptor.setRecentTabs(recentTabs: [tab1])
 
         // iPhone layout portrait
-        let trait = MockTraitCollection()
-        trait.overridenHorizontalSizeClass = .compact
-        trait.overridenVerticalSizeClass = .regular
+        let trait = MockTraitCollection(horizontalSizeClass: .compact).getTraitCollection()
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
@@ -189,9 +183,7 @@ class JumpBackInViewModelTests: XCTestCase {
         await adaptor.setMockHasSyncedTabFeatureEnabled(enabled: false)
 
         // iPhone layout landscape
-        let trait = MockTraitCollection()
-        trait.overridenHorizontalSizeClass = .regular
-        trait.overridenVerticalSizeClass = .compact
+        let trait = MockTraitCollection(verticalSizeClass: .compact).getTraitCollection()
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
@@ -211,9 +203,7 @@ class JumpBackInViewModelTests: XCTestCase {
         await adaptor.setSyncedTab(syncedTab: JumpBackInSyncedTab(client: remoteClient, tab: remoteTab))
 
         // iPhone layout landscape
-        let trait = MockTraitCollection()
-        trait.overridenHorizontalSizeClass = .regular
-        trait.overridenVerticalSizeClass = .compact
+        let trait = MockTraitCollection(verticalSizeClass: .compact).getTraitCollection()
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
@@ -233,9 +223,7 @@ class JumpBackInViewModelTests: XCTestCase {
         await adaptor.setMockHasSyncedTabFeatureEnabled(enabled: false)
 
         // iPad layout portrait
-        let trait = MockTraitCollection()
-        trait.overridenHorizontalSizeClass = .regular
-        trait.overridenVerticalSizeClass = .regular
+        let trait = MockTraitCollection().getTraitCollection()
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
@@ -255,9 +243,7 @@ class JumpBackInViewModelTests: XCTestCase {
         await adaptor.setSyncedTab(syncedTab: JumpBackInSyncedTab(client: remoteClient, tab: remoteTab))
 
         // iPad layout portrait
-        let trait = MockTraitCollection()
-        trait.overridenHorizontalSizeClass = .regular
-        trait.overridenVerticalSizeClass = .regular
+        let trait = MockTraitCollection().getTraitCollection()
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
@@ -277,9 +263,7 @@ class JumpBackInViewModelTests: XCTestCase {
         await adaptor.setMockHasSyncedTabFeatureEnabled(enabled: false)
 
         // iPad layout landscape
-        let trait = MockTraitCollection()
-        trait.overridenHorizontalSizeClass = .regular
-        trait.overridenVerticalSizeClass = .regular
+        let trait = MockTraitCollection().getTraitCollection()
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
@@ -300,10 +284,7 @@ class JumpBackInViewModelTests: XCTestCase {
         await adaptor.setMockHasSyncedTabFeatureEnabled(enabled: false)
 
         // iPhone layout portrait
-        let trait = MockTraitCollection()
-        trait.overridenHorizontalSizeClass = .regular
-        trait.overridenVerticalSizeClass = .compact
-
+        let trait = MockTraitCollection(verticalSizeClass: .compact).getTraitCollection()
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
         subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
@@ -322,9 +303,7 @@ class JumpBackInViewModelTests: XCTestCase {
         await adaptor.setSyncedTab(syncedTab: JumpBackInSyncedTab(client: remoteClient, tab: remoteTab))
 
         // iPad layout landscape
-        let trait = MockTraitCollection()
-        trait.overridenHorizontalSizeClass = .regular
-        trait.overridenVerticalSizeClass = .regular
+        let trait = MockTraitCollection().getTraitCollection()
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
@@ -345,9 +324,7 @@ class JumpBackInViewModelTests: XCTestCase {
         await adaptor.setSyncedTab(syncedTab: JumpBackInSyncedTab(client: remoteClient, tab: remoteTab))
 
         // iPhone layout portrait
-        let trait = MockTraitCollection()
-        trait.overridenHorizontalSizeClass = .regular
-        trait.overridenVerticalSizeClass = .compact
+        let trait = MockTraitCollection(verticalSizeClass: .compact).getTraitCollection()
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
@@ -366,9 +343,7 @@ class JumpBackInViewModelTests: XCTestCase {
         await adaptor.setRecentTabs(recentTabs: [tab1])
 
         // iPhone layout landscape
-        let trait = MockTraitCollection()
-        trait.overridenHorizontalSizeClass = .regular
-        trait.overridenVerticalSizeClass = .compact
+        let trait = MockTraitCollection(verticalSizeClass: .compact).getTraitCollection()
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
@@ -387,9 +362,7 @@ class JumpBackInViewModelTests: XCTestCase {
         await adaptor.setRecentTabs(recentTabs: [tab1])
 
         // iPad layout landscape
-        let trait = MockTraitCollection()
-        trait.overridenHorizontalSizeClass = .regular
-        trait.overridenVerticalSizeClass = .regular
+        let trait = MockTraitCollection().getTraitCollection()
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
@@ -412,17 +385,13 @@ class JumpBackInViewModelTests: XCTestCase {
         try? await Task.sleep(nanoseconds: sleepTime)
 
         // Start in portrait
-        let portraitTrait = MockTraitCollection()
-        portraitTrait.overridenHorizontalSizeClass = .compact
-        portraitTrait.overridenVerticalSizeClass = .regular
+        let portraitTrait = MockTraitCollection(horizontalSizeClass: .compact).getTraitCollection()
 
         subject.refreshData(for: portraitTrait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
         XCTAssertEqual(subject.sectionLayout, .compactJumpBackIn)
 
         // Mock rotation to landscape
-        let landscapeTrait = MockTraitCollection()
-        landscapeTrait.overridenHorizontalSizeClass = .regular
-        landscapeTrait.overridenVerticalSizeClass = .compact
+        let landscapeTrait = MockTraitCollection(verticalSizeClass: .compact).getTraitCollection()
         subject.refreshData(for: landscapeTrait, size: iPhone14ScreenSize, isPortrait: false, device: .phone)
         XCTAssertEqual(subject.sectionLayout, .medium)
 
@@ -457,7 +426,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let subject = createSubject()
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        subject.refreshData(for: MockTraitCollection(), size: iPhone14ScreenSize)
+        subject.refreshData(for: MockTraitCollection().getTraitCollection(), size: iPhone14ScreenSize)
 
         XCTAssertEqual(subject.jumpBackInList.tabs.count, 0)
         XCTAssertNil(subject.mostRecentSyncedTab)
@@ -469,7 +438,7 @@ class JumpBackInViewModelTests: XCTestCase {
         await adaptor.setRecentTabs(recentTabs: [tab1])
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        subject.refreshData(for: MockTraitCollection(), size: iPhone14ScreenSize)
+        subject.refreshData(for: MockTraitCollection().getTraitCollection(), size: iPhone14ScreenSize)
 
         XCTAssertEqual(subject.jumpBackInList.tabs.count, 1)
         XCTAssertNil(subject.mostRecentSyncedTab)
@@ -481,7 +450,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        subject.refreshData(for: MockTraitCollection(), size: iPhone14ScreenSize)
+        subject.refreshData(for: MockTraitCollection().getTraitCollection(), size: iPhone14ScreenSize)
 
         XCTAssertEqual(subject.jumpBackInList.tabs.count, 0)
         XCTAssertNotNil(subject.mostRecentSyncedTab)
@@ -497,9 +466,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let subject = createSubject()
 
         // iPhone layout portrait
-        let trait = MockTraitCollection()
-        trait.overridenHorizontalSizeClass = .compact
-        trait.overridenVerticalSizeClass = .regular
+        let trait = MockTraitCollection(horizontalSizeClass: .compact).getTraitCollection()
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
@@ -519,9 +486,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let subject = createSubject()
 
         // iPhone layout portrait
-        let trait = MockTraitCollection()
-        trait.overridenHorizontalSizeClass = .compact
-        trait.overridenVerticalSizeClass = .regular
+        let trait = MockTraitCollection(horizontalSizeClass: .compact).getTraitCollection()
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
@@ -542,9 +507,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let subject = createSubject()
 
         // iPhone layout portrait
-        let trait = MockTraitCollection()
-        trait.overridenHorizontalSizeClass = .compact
-        trait.overridenVerticalSizeClass = .regular
+        let trait = MockTraitCollection(horizontalSizeClass: .compact).getTraitCollection()
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
@@ -569,9 +532,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let subject = createSubject()
 
         // iPhone layout landscape
-        let trait = MockTraitCollection()
-        trait.overridenHorizontalSizeClass = .regular
-        trait.overridenVerticalSizeClass = .compact
+        let trait = MockTraitCollection(verticalSizeClass: .compact).getTraitCollection()
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
@@ -597,9 +558,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let subject = createSubject()
 
         // iPhone layout landscape
-        let trait = MockTraitCollection()
-        trait.overridenHorizontalSizeClass = .regular
-        trait.overridenVerticalSizeClass = .compact
+        let trait = MockTraitCollection(verticalSizeClass: .compact).getTraitCollection()
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)

--- a/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDimensionTests.swift
+++ b/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDimensionTests.swift
@@ -16,7 +16,7 @@ class TopSitesDimensionTests: XCTestCase {
 
     func testSectionDimension_portraitIphone_defaultRowNumber() {
         let subject = createSubject()
-        let trait = MockTraitCollection()
+        let trait = MockTraitCollection().getTraitCollection()
         let interface = TopSitesUIInterface(isLandscape: false,
                                             interfaceIdiom: .phone,
                                             trait: trait,
@@ -29,7 +29,7 @@ class TopSitesDimensionTests: XCTestCase {
 
     func testSectionDimension_landscapeIphone_defaultRowNumber() {
         let subject = createSubject()
-        let trait = MockTraitCollection()
+        let trait = MockTraitCollection().getTraitCollection()
         let interface = TopSitesUIInterface(isLandscape: true,
                                             interfaceIdiom: .phone,
                                             trait: trait,
@@ -42,7 +42,7 @@ class TopSitesDimensionTests: XCTestCase {
 
     func testSectionDimension_portraitiPadRegular_defaultRowNumber() {
         let subject = createSubject()
-        let trait = MockTraitCollection()
+        let trait = MockTraitCollection().getTraitCollection()
         let interface = TopSitesUIInterface(isLandscape: false,
                                             interfaceIdiom: .pad,
                                             trait: trait,
@@ -55,7 +55,7 @@ class TopSitesDimensionTests: XCTestCase {
 
     func testSectionDimension_landscapeiPadRegular_defaultRowNumber() {
         let subject = createSubject()
-        let trait = MockTraitCollection()
+        let trait = MockTraitCollection().getTraitCollection()
         let interface = TopSitesUIInterface(isLandscape: true,
                                             interfaceIdiom: .pad,
                                             trait: trait,
@@ -68,8 +68,7 @@ class TopSitesDimensionTests: XCTestCase {
 
     func testSectionDimension_portraitiPadCompact_defaultRowNumber() {
         let subject = createSubject()
-        let trait = MockTraitCollection()
-        trait.overridenHorizontalSizeClass = .compact
+        let trait = MockTraitCollection(horizontalSizeClass: .compact).getTraitCollection()
         let interface = TopSitesUIInterface(isLandscape: false,
                                             interfaceIdiom: .pad,
                                             trait: trait,
@@ -82,8 +81,7 @@ class TopSitesDimensionTests: XCTestCase {
 
     func testSectionDimension_landscapeiPadCompact_defaultRowNumber() {
         let subject = createSubject()
-        let trait = MockTraitCollection()
-        trait.overridenHorizontalSizeClass = .compact
+        let trait = MockTraitCollection(horizontalSizeClass: .compact).getTraitCollection()
         let interface = TopSitesUIInterface(isLandscape: true,
                                             interfaceIdiom: .pad,
                                             trait: trait,
@@ -96,8 +94,7 @@ class TopSitesDimensionTests: XCTestCase {
 
     func testSectionDimension_portraitiPadUnspecified_defaultRowNumber() {
         let subject = createSubject()
-        let trait = MockTraitCollection()
-        trait.overridenHorizontalSizeClass = .unspecified
+        let trait = MockTraitCollection(horizontalSizeClass: .unspecified).getTraitCollection()
         let interface = TopSitesUIInterface(isLandscape: false,
                                             interfaceIdiom: .pad,
                                             trait: trait,
@@ -110,8 +107,7 @@ class TopSitesDimensionTests: XCTestCase {
 
     func testSectionDimension_landscapeiPadUnspecified_defaultRowNumber() {
         let subject = createSubject()
-        let trait = MockTraitCollection()
-        trait.overridenHorizontalSizeClass = .unspecified
+        let trait = MockTraitCollection(horizontalSizeClass: .unspecified).getTraitCollection()
         let interface = TopSitesUIInterface(isLandscape: true,
                                             interfaceIdiom: .pad,
                                             trait: trait,
@@ -126,7 +122,7 @@ class TopSitesDimensionTests: XCTestCase {
 
     func testSectionDimension_oneEmptyRow_shouldBeRemoved() {
         let subject = createSubject()
-        let trait = MockTraitCollection()
+        let trait = MockTraitCollection().getTraitCollection()
         let interface = TopSitesUIInterface(isLandscape: false,
                                             interfaceIdiom: .phone,
                                             trait: trait,
@@ -139,7 +135,7 @@ class TopSitesDimensionTests: XCTestCase {
 
     func testSectionDimension_twoEmptyRow_shouldBeRemoved() {
         let subject = createSubject()
-        let trait = MockTraitCollection()
+        let trait = MockTraitCollection().getTraitCollection()
         let interface = TopSitesUIInterface(isLandscape: false,
                                             interfaceIdiom: .phone,
                                             trait: trait,
@@ -152,7 +148,7 @@ class TopSitesDimensionTests: XCTestCase {
 
     func testSectionDimension_noEmptyRow_shouldNotBeRemoved() {
         let subject = createSubject()
-        let trait = MockTraitCollection()
+        let trait = MockTraitCollection().getTraitCollection()
         let interface = TopSitesUIInterface(isLandscape: false,
                                             interfaceIdiom: .phone,
                                             trait: trait,
@@ -165,7 +161,7 @@ class TopSitesDimensionTests: XCTestCase {
 
     func testSectionDimension_halfFilledRow_shouldNotBeRemoved() {
         let subject = createSubject()
-        let trait = MockTraitCollection()
+        let trait = MockTraitCollection().getTraitCollection()
         let interface = TopSitesUIInterface(isLandscape: false,
                                             interfaceIdiom: .phone,
                                             trait: trait,

--- a/Tests/ClientTests/Mocks/MockTraitCollection.swift
+++ b/Tests/ClientTests/Mocks/MockTraitCollection.swift
@@ -4,14 +4,19 @@
 
 import UIKit
 
-class MockTraitCollection: UITraitCollection {
-    var overridenHorizontalSizeClass: UIUserInterfaceSizeClass = .regular
-    override var horizontalSizeClass: UIUserInterfaceSizeClass {
-        return overridenHorizontalSizeClass
+class MockTraitCollection {
+    private var horizontalSizeClass: UIUserInterfaceSizeClass = .regular
+    private var verticalSizeClass: UIUserInterfaceSizeClass = .regular
+
+    init(horizontalSizeClass: UIUserInterfaceSizeClass = .regular,
+         verticalSizeClass: UIUserInterfaceSizeClass = .regular) {
+        self.horizontalSizeClass = horizontalSizeClass
+        self.verticalSizeClass = verticalSizeClass
     }
 
-    var overridenVerticalSizeClass: UIUserInterfaceSizeClass = .regular
-    override var verticalSizeClass: UIUserInterfaceSizeClass {
-        return overridenVerticalSizeClass
+    func getTraitCollection() -> UITraitCollection {
+        let compact = UITraitCollection(horizontalSizeClass: horizontalSizeClass)
+        let regular = UITraitCollection(verticalSizeClass: verticalSizeClass)
+        return UITraitCollection(traitsFrom: [compact, regular])
     }
 }

--- a/Tests/ClientTests/Wallpaper/WallpaperSelectorViewModelTests.swift
+++ b/Tests/ClientTests/Wallpaper/WallpaperSelectorViewModelTests.swift
@@ -35,9 +35,7 @@ class WallpaperSelectorViewModelTests: XCTestCase {
         let subject = createSubject()
         let expectedLayout: WallpaperSelectorViewModel.WallpaperSelectorLayout = .regular
 
-        let landscapeTrait = MockTraitCollection()
-        landscapeTrait.overridenHorizontalSizeClass = .regular
-        landscapeTrait.overridenVerticalSizeClass = .compact
+        let landscapeTrait = MockTraitCollection(verticalSizeClass: .compact).getTraitCollection()
 
         subject.updateSectionLayout(for: landscapeTrait)
 

--- a/Tests/ClientTests/Wallpaper/WallpaperSettingsViewModelTests.swift
+++ b/Tests/ClientTests/Wallpaper/WallpaperSettingsViewModelTests.swift
@@ -35,9 +35,7 @@ class WallpaperSettingsViewModelTests: XCTestCase {
         let subject = createSubject()
         let expectedLayout: WallpaperSettingsViewModel.WallpaperSettingsLayout = .regular
 
-        let landscapeTrait = MockTraitCollection()
-        landscapeTrait.overridenHorizontalSizeClass = .regular
-        landscapeTrait.overridenVerticalSizeClass = .compact
+        let landscapeTrait = MockTraitCollection(verticalSizeClass: .compact).getTraitCollection()
 
         subject.updateSectionLayout(for: landscapeTrait)
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6310)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14192)

### Description
Override properties `horizontalSizeClass` and `verticalSizeClass` changes where not taking effect futhermore the unit test crash when setting the values for the overridden vars. The solution I found is use UITraitCollection(traitsFrom:) where we can create a UITraitCollection merging existing horizontal and vertical classes

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
