### PR TITLE
Bugfix [v114] Fix ActivityStreamTest's mozilla.org label

### DIFF
--- a/Tests/XCUITests/ActivityStreamTest.swift
+++ b/Tests/XCUITests/ActivityStreamTest.swift
@@ -5,7 +5,7 @@
 import XCTest
 
 let defaultTopSite = ["topSiteLabel": "Wikipedia", "bookmarkLabel": "Wikipedia"]
-let newTopSite = ["url": "www.mozilla.org", "topSiteLabel": "Mozilla", "bookmarkLabel": "Internet for people, not profit — Mozilla"]
+let newTopSite = ["url": "www.mozilla.org", "topSiteLabel": "Mozilla", "bookmarkLabel": "Internet for people, not profit — Mozilla (US)"]
 let allDefaultTopSites = ["Facebook", "YouTube", "Amazon", "Wikipedia", "Twitter"]
 
 class ActivityStreamTest: BaseTestCase {

--- a/Tests/XCUITests/ActivityStreamTest.swift
+++ b/Tests/XCUITests/ActivityStreamTest.swift
@@ -136,10 +136,8 @@ class ActivityStreamTest: BaseTestCase {
         waitForExistence(topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!], timeout: TIMEOUT)
         XCTAssertTrue(topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!].exists)
 
-        if !iPad() {
-            waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
-            navigator.performAction(Action.CloseURLBarOpen)
-        }
+        waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
+        navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         navigator.goto(SettingsScreen)
         navigator.goto(ClearPrivateDataSettings)


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

### Description
Similar to #14207, the label for `mozilla.org` has been updated. The string `(US)` should be appended to the website's label.

![Simulator Screenshot - iPhone 14 - 2023-05-02 at 17 29 28](https://user-images.githubusercontent.com/1740517/235790440-b66d91d8-f546-4435-ae84-91ac2b1506b5.png)

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
