### PR TITLE
Bugfix MTE-927 [v114] Add missing keys for perfherder data object

### DIFF
--- a/test-fixtures/perfTestTransform.py
+++ b/test-fixtures/perfTestTransform.py
@@ -1,6 +1,6 @@
 import json
 
-PERFHERDER_DATA = {"framework": 'mozperftest',
+PERFHERDER_DATA = {"framework": {"name":'mozperftest'},
                    "application": {"name": 'fennec'},
                    "suites": []
                    }
@@ -16,6 +16,7 @@ with open('test.json') as json_file:
                 subtest = {}
                 subtest["name"] = key
                 subtest["replicates"] = [value]
+                subtest["value"] = value
                 suite["subtests"].append(subtest)
         PERFHERDER_DATA["suites"].append(suite)
 

--- a/test-fixtures/perfTestTransform.py
+++ b/test-fixtures/perfTestTransform.py
@@ -1,7 +1,7 @@
 import json
 
-PERFHERDER_DATA = {"framework": {"name":'mozperftest'},
-                   "application": {"name": 'fennec'},
+PERFHERDER_DATA = {"framework": {"name":"mozperftest"},
+                   "application": {"name": "fennec"},
                    "suites": []
                    }
 

--- a/test-fixtures/perfTestTransform.py
+++ b/test-fixtures/perfTestTransform.py
@@ -16,7 +16,7 @@ with open('test.json') as json_file:
                 subtest = {}
                 subtest["name"] = key
                 subtest["replicates"] = [value]
-                subtest["value"] = value
+                subtest["value"] = float(value)
                 suite["subtests"].append(subtest)
         PERFHERDER_DATA["suites"].append(suite)
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-927)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/FXIOS-14222)

### Description
The PERFHERDER_DATA object is missing keys:
- `name` in `framework`
- `value` in `subtests`

These need to be added in to pass data validation.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
