### PR TITLE
Bump [v114] Fixes for new application services nightly process

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -9781,6 +9781,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				459F39E52A031D16008C3411 /* PBXTargetDependency */,
 			);
 			name = RustMozillaAppServices;
 			packageProductDependencies = (
@@ -12134,6 +12135,10 @@
 			isa = PBXTargetDependency;
 			target = F8324A042649A188007E4BFA /* CredentialProvider */;
 			targetProxy = 435A2FF6278F51CD00C94282 /* PBXContainerItemProxy */;
+		};
+		459F39E52A031D16008C3411 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = 459F39E42A031D16008C3411 /* Glean */;
 		};
 		5FA2233727F73E28005B3D87 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -17391,7 +17396,7 @@
 			repositoryURL = "https://github.com/mozilla/rust-components-swift.git";
 			requirement = {
 				kind = exactVersion;
-				version = 97.5.1;
+				version = 114.0.20230504050432;
 			};
 		};
 		435C85EE2788F4D00072B526 /* XCRemoteSwiftPackageReference "glean-swift" */ = {
@@ -17496,6 +17501,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 43C6A47D27A0679300C79856 /* XCRemoteSwiftPackageReference "MappaMundi" */;
 			productName = MappaMundi;
+		};
+		459F39E42A031D16008C3411 /* Glean */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 435C85EE2788F4D00072B526 /* XCRemoteSwiftPackageReference "glean-swift" */;
+			productName = Glean;
 		};
 		5A06135929D6052E008F3D38 /* TabDataStore */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla/rust-components-swift.git",
       "state" : {
-        "revision" : "a04e73953be1f81fa0f2358f36b5255414bbca01",
-        "version" : "97.5.1"
+        "revision" : "91c799f98fe3ac4b5bb26583ff9ebd23328c8737",
+        "version" : "114.0.20230504050432"
       }
     },
     {

--- a/Providers/RustSyncManager.swift
+++ b/Providers/RustSyncManager.swift
@@ -392,8 +392,7 @@ public class RustSyncManager: NSObject, SyncManager {
                             deviceSettings: DeviceSettings(
                                 fxaDeviceId: device.id,
                                 name: device.displayName,
-                                kind: self.toSyncManagerDeviceType(
-                                    deviceType: device.deviceType)))
+                                kind: device.deviceType))
 
                         self.beginSyncing()
                         self.syncManagerAPI.sync(params: params) { syncResult in
@@ -453,23 +452,6 @@ public class RustSyncManager: NSObject, SyncManager {
             }
         }
         return deferred
-    }
-
-    private func toSyncManagerDeviceType(deviceType: DeviceType) -> SyncManagerDeviceType {
-        switch deviceType {
-        case .desktop:
-            return SyncManagerDeviceType.desktop
-        case .mobile:
-            return SyncManagerDeviceType.mobile
-        case .tablet:
-            return SyncManagerDeviceType.tablet
-        case .vr:
-            return SyncManagerDeviceType.vr
-        case .tv:
-            return SyncManagerDeviceType.tv
-        case .unknown:
-            return SyncManagerDeviceType.unknown
-        }
     }
 
     @discardableResult

--- a/bin/nimbus-fml.sh
+++ b/bin/nimbus-fml.sh
@@ -93,7 +93,7 @@ if [ -z "$number_string" ]; then
     fi
 fi
 
-AS_VERSION="v$number_string"
+AS_VERSION=$(echo "$number_string" | sed 's/\.0\./\./g') # rust-component-swift tags have a middle `.0.` to force it to align with spm. We remove it
 FRESHEN_FML=
 NIMBUS_DIR="$SOURCE_ROOT/build/nimbus"
 
@@ -167,11 +167,11 @@ else
     # Otherwise, we should download a pre-built copy from github.com/mozilla/application-services/releases
     FML_DIR="$NIMBUS_DIR/bin"
     export BINARY_PATH="$FML_DIR/nimbus-fml"
-    AS_DOWNLOAD_URL="https://github.com/mozilla/application-services/releases/download/$AS_VERSION"
+    AS_DOWNLOAD_URL="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.v2.nimbus-fml.$AS_VERSION/artifacts/public%2Fbuild%2F"
     # Check whether the cached copy is still the right one to use.
     if [[ -f $FML_DIR/nimbus-fml.sha256 ]]; then
         echo "Checking if we need to redownload the FML"
-        NEW_CHECKSUM=$(curl -L "$AS_DOWNLOAD_URL/nimbus-fml.sha256")
+        NEW_CHECKSUM=$(curl -L "${AS_DOWNLOAD_URL}nimbus-fml.sha256")
         OLD_CHECKSUM=$(cat "$FML_DIR/nimbus-fml.sha256")
         if [ ! "$OLD_CHECKSUM" == "$NEW_CHECKSUM" ]; then
             FRESHEN_FML="true"
@@ -185,9 +185,9 @@ else
     mkdir -p "$FML_DIR"
     if [[ ! -f "$FML_DIR/nimbus-fml.zip" ]] ; then
         # We now download the nimbus-fml from the github release
-        curl -L "$AS_DOWNLOAD_URL/nimbus-fml.zip" --output "$FML_DIR/nimbus-fml.zip"
+        curl -L "${AS_DOWNLOAD_URL}nimbus-fml.zip" --output "$FML_DIR/nimbus-fml.zip"
         # We also download the checksum
-        curl -L "$AS_DOWNLOAD_URL/nimbus-fml.sha256" --output "$FML_DIR/nimbus-fml.sha256"
+        curl -L "${AS_DOWNLOAD_URL}nimbus-fml.sha256" --output "$FML_DIR/nimbus-fml.sha256"
         pushd "${FML_DIR}"
         shasum --check nimbus-fml.sha256
         popd


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/SYNC-3664)



### Description
Application services is moving to Firefox versions. Meaning we would be cutting releases aligning with Firefox, and have built automation to cut nightly releases.

The nightly releases are in the form of `114.XXXXXX` where `XX` is a timestamp. iOS should update on a regular bases when nightly AS releases are available, (preferably automate the merging if CI passes)

As for actual releases, the release will be in the form of `114.0` Firefox iOS should only use release versions of AS on it's release branches. We are going to cut our first release soon for 114, but the nightly process is ready

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
