### PR TITLE
Bugfix FXIOS-6323 [v114] Status bar appears on second launch screen

### DIFF
--- a/Client/Coordinators/LaunchView/LaunchScreenViewController.swift
+++ b/Client/Coordinators/LaunchView/LaunchScreenViewController.swift
@@ -21,6 +21,10 @@ class LaunchScreenViewController: UIViewController, LaunchFinishedLoadingDelegat
         viewModel.delegate = self
     }
 
+    override var prefersStatusBarHidden: Bool {
+        return true
+    }
+
     required init?(coder: NSCoder) {
         fatalError()
     }

--- a/Client/Coordinators/Scene/SceneContainer.swift
+++ b/Client/Coordinators/Scene/SceneContainer.swift
@@ -5,4 +5,8 @@
 import UIKit
 
 // The root view controller of the application
-class SceneContainer: UIViewController {}
+class SceneContainer: UIViewController {
+//    override var prefersStatusBarHidden: Bool {
+//        return true
+//    }
+}

--- a/Client/Coordinators/Scene/SceneContainer.swift
+++ b/Client/Coordinators/Scene/SceneContainer.swift
@@ -5,8 +5,4 @@
 import UIKit
 
 // The root view controller of the application
-class SceneContainer: UIViewController {
-//    override var prefersStatusBarHidden: Bool {
-//        return true
-//    }
-}
+class SceneContainer: UIViewController {}


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6323)

### Description
Hide status bar

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
