### PR TITLE
Refactor MTE-932 [v114] Fix l10n-screenshots taskcluster task

### DIFF
--- a/Tests/SmokeXCUITests.xctestplan
+++ b/Tests/SmokeXCUITests.xctestplan
@@ -74,6 +74,7 @@
         "FindInPageTests\/testFindInPageTwoWordsSearch()",
         "FindInPageTests\/testFindInPageTwoWordsSearchLargeDoc()",
         "FindInPageTests\/testQueryWithNoMatches()",
+        "FirstRunTourTests\/testFirstRunTour()",
         "FirstRunTourTests\/testStartBrowsingFromSecondScreen()",
         "FxScreenGraphTests",
         "HistoryTests",

--- a/Tests/XCUITests/FirstRunTourTests.swift
+++ b/Tests/XCUITests/FirstRunTourTests.swift
@@ -19,6 +19,7 @@ class FirstRunTourTests: BaseTestCase {
     }
 
     // Smoketest
+    // Temporary disabled as changes in PR #14231  modifies its behaviour
     func testFirstRunTour() {
         // Complete the First run from first screen to the latest one
         // Check that the first's tour screen is shown as well as all the elements in there

--- a/taskcluster/ffios_taskgraph/loader/screenshots_locales.py
+++ b/taskcluster/ffios_taskgraph/loader/screenshots_locales.py
@@ -26,7 +26,7 @@ def loader(kind, path, config, params, loaded_tasks):
     # Taskcluster sorts task names alphabetically, we need numbers to be zero-padded.
     max_number_of_digits = _get_number_of_digits(chunks)
 
-    jobs = {
+    tasks = {
         str(this_chunk).zfill(max_number_of_digits): {
             "attributes": {
                 "chunk_locales": chunkify(filtered_locales, this_chunk, chunks),
@@ -37,7 +37,7 @@ def loader(kind, path, config, params, loaded_tasks):
         for this_chunk in range(1, chunks + 1)
     }
 
-    config["jobs"] = jobs
+    config["tasks"] = tasks
 
     return base_loader(kind, path, config, params, loaded_tasks)
 

--- a/taskcluster/ffios_taskgraph/transforms/bitrise.py
+++ b/taskcluster/ffios_taskgraph/transforms/bitrise.py
@@ -58,7 +58,7 @@ def set_worker_config(config, tasks):
             "path": f"{_ARTIFACTS_DIRECTORY}/bitrise.log",
         })
 
-        for locale in task.get("atributes", {}).get("chunk_locales", []):
+        for locale in task.get("attributes", {}).get("chunk_locales", []):
             artifacts.append({
                 "type": "file",
                 "name": f"public/screenshots/{locale}.zip",
@@ -89,7 +89,7 @@ def add_bitrise_command(config, tasks):
             "--artifacts-directory", _ARTIFACTS_DIRECTORY
         ]
 
-        for locale in task.get("atributes", {}).get("chunk_locales", []):
+        for locale in task.get("attributes", {}).get("chunk_locales", []):
             command.extend(["--importLocales", locale])
 
         derived_data_path = task.pop("build-derived-data-path", "")


### PR DESCRIPTION
This PR fixes a regression that broke the l10n-screenshot task on taskcluster when I bumped the taskcluster version from 1.2 to 3.x.
See the [PR](https://github.com/mozilla-mobile/firefox-ios/pull/13517) that broke this task and the [changes needed](https://github.com/taskcluster/taskgraph/blob/main/docs/reference/migrations.rst#1x---2x)to bump the taskcluster version.