### PR TITLE
Revert FXIOS-6330 [v113.1] sync telemetry reporting update

### DIFF
--- a/Providers/RustSyncManager.swift
+++ b/Providers/RustSyncManager.swift
@@ -188,7 +188,8 @@ public class RustSyncManager: NSObject, SyncManager {
         }
 
         if canSendUsageData() {
-            self.syncManagerAPI.reportSyncTelemetry(syncResult: result) {_ in }
+            let gleanHelper = GleanSyncOperationHelper()
+            gleanHelper.reportTelemetry(result)
         } else {
             logger.log("Profile isn't sending usage data. Not sending sync status event.",
                        level: .debug,


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6330)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14242)

### Description
This reverts PR #14019 which updated the metrics used to report sync telemetry. The new metrics, located in a-s, need to be renamed in order to not collide with the old temp metrics located in Firefox iOS. This will be resolved after the sync manager experiment has ended in order to not block that effort.

**Note:** I marked this as a v113.1 change after discussing creating a dot release for these changes with @nbhasin2 .

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
