### PR TITLE
Bugfix FXIOS-6322 [v114] Keep webview view controller in memory to avoid black screen

### DIFF
--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -15,7 +15,6 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
     private var profile: Profile
     private let tabManager: TabManager
     private let themeManager: ThemeManager
-    private var logger: Logger
     private let screenshotService: ScreenshotService
     private let glean: GleanWrapper
     private let applicationHelper: ApplicationHelper
@@ -25,7 +24,6 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
          screenshotService: ScreenshotService,
          profile: Profile = AppContainer.shared.resolve(),
          tabManager: TabManager = AppContainer.shared.resolve(),
-         logger: Logger = DefaultLogger.shared,
          themeManager: ThemeManager = AppContainer.shared.resolve(),
          glean: GleanWrapper = DefaultGleanWrapper.shared,
          applicationHelper: ApplicationHelper = DefaultApplicationHelper(),
@@ -35,7 +33,6 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
         self.tabManager = tabManager
         self.themeManager = themeManager
         self.browserViewController = BrowserViewController(profile: profile, tabManager: tabManager)
-        self.logger = logger
         self.applicationHelper = applicationHelper
         self.glean = glean
         self.wallpaperManager = wallpaperManager
@@ -81,9 +78,39 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
                       libraryPanelDelegate: LibraryPanelDelegate,
                       sendToDeviceDelegate: HomepageViewController.SendToDeviceDelegate,
                       overlayManager: OverlayModeManager) {
-        var homepage: HomepageViewController
+        let homepageController = getHomepage(inline: inline,
+                                             homepanelDelegate: homepanelDelegate,
+                                             libraryPanelDelegate: libraryPanelDelegate,
+                                             sendToDeviceDelegate: sendToDeviceDelegate,
+                                             overlayManager: overlayManager)
+
+        browserViewController.embedContent(homepageController)
+        self.homepageViewController = homepageController
+        // We currently don't support full page screenshot of the homepage
+        screenshotService.screenshotableView = nil
+    }
+
+    func show(webView: WKWebView) {
+        // Keep the webviewController in memory, update to newest webview when needed
+        if let webviewController = webviewController {
+            webviewController.update(webView: webView)
+            browserViewController.frontEmbeddedContent(webviewController)
+        } else {
+            let webviewViewController = WebviewViewController(webView: webView)
+            webviewController = webviewViewController
+            browserViewController.embedContent(webviewViewController)
+        }
+
+        screenshotService.screenshotableView = webviewController
+    }
+
+    private func getHomepage(inline: Bool,
+                             homepanelDelegate: HomePanelDelegate,
+                             libraryPanelDelegate: LibraryPanelDelegate,
+                             sendToDeviceDelegate: HomepageViewController.SendToDeviceDelegate,
+                             overlayManager: OverlayModeManager) -> HomepageViewController {
         if let homepageViewController = homepageViewController {
-            homepage = homepageViewController
+            return homepageViewController
         } else {
             let homepageViewController = HomepageViewController(
                 profile: profile,
@@ -93,32 +120,8 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
             homepageViewController.homePanelDelegate = homepanelDelegate
             homepageViewController.libraryPanelDelegate = libraryPanelDelegate
             homepageViewController.sendToDeviceDelegate = sendToDeviceDelegate
-            homepage = homepageViewController
-            self.homepageViewController = homepageViewController
+            return homepageViewController
         }
-
-        browserViewController.embedContent(homepage)
-
-        // We currently don't support full page screenshot of the homepage
-        screenshotService.screenshotableView = nil
-    }
-
-    func show(webView: WKWebView?) {
-        // Navigate with a new webview, or to the existing one
-        if let webView = webView {
-            let webviewViewController = WebviewViewController(webView: webView)
-            webviewController = webviewViewController
-            // Make sure we show the latest webview if we are provided with one
-            browserViewController.embedContent(webviewViewController, forceEmbed: true)
-        } else if let webviewController = webviewController {
-            browserViewController.embedContent(webviewController)
-        } else {
-            logger.log("Webview controller couldn't be shown, this shouldn't happen.",
-                       level: .fatal,
-                       category: .lifecycle)
-        }
-
-        screenshotService.screenshotableView = webviewController
     }
 
     // MARK: - Route handling

--- a/Client/Coordinators/Browser/BrowserDelegate.swift
+++ b/Client/Coordinators/Browser/BrowserDelegate.swift
@@ -21,5 +21,5 @@ protocol BrowserDelegate: AnyObject {
 
     /// Show the webview to navigate
     /// - Parameter webView: When nil, will show the already existing webview
-    func show(webView: WKWebView?)
+    func show(webView: WKWebView)
 }

--- a/Client/Coordinators/CoordinatorFlagManager.swift
+++ b/Client/Coordinators/CoordinatorFlagManager.swift
@@ -9,7 +9,6 @@ import Shared
 /// This will be removed with FXIOS-6036
 struct CoordinatorFlagManager {
     static var isCoordinatorEnabled: Bool {
-        return FeatureFlagsManager.shared.isFeatureEnabled(.coordinatorsRefactor,
-                                                           checking: .buildOnly)
+        return true
     }
 }

--- a/Client/Coordinators/CoordinatorFlagManager.swift
+++ b/Client/Coordinators/CoordinatorFlagManager.swift
@@ -9,6 +9,7 @@ import Shared
 /// This will be removed with FXIOS-6036
 struct CoordinatorFlagManager {
     static var isCoordinatorEnabled: Bool {
-        return true
+        return FeatureFlagsManager.shared.isFeatureEnabled(.coordinatorsRefactor,
+                                                           checking: .buildOnly)
     }
 }

--- a/Client/Frontend/Browser/WebView/WebviewViewController.swift
+++ b/Client/Frontend/Browser/WebView/WebviewViewController.swift
@@ -7,7 +7,7 @@ import Shared
 import WebKit
 
 class WebviewViewController: UIViewController, ContentContainable, ScreenshotableView {
-    private let webView: WKWebView
+    private var webView: WKWebView
     var contentType: ContentType = .webview
 
     init(webView: WKWebView) {
@@ -33,6 +33,11 @@ class WebviewViewController: UIViewController, ContentContainable, Screenshotabl
             view.bottomAnchor.constraint(equalTo: webView.bottomAnchor),
             view.trailingAnchor.constraint(equalTo: webView.trailingAnchor)
         ])
+    }
+
+    func update(webView: WKWebView) {
+        self.webView = webView
+        setupLayout()
     }
 
     // MARK: - ScreenshotableView

--- a/Client/Frontend/Components/ContentContainer.swift
+++ b/Client/Frontend/Components/ContentContainer.swift
@@ -52,16 +52,26 @@ class ContentContainer: UIView {
     }
 
     /// Add content view controller to the container, we remove the previous content if present before adding new one
-    /// - Parameter viewController: The view controller to add
+    /// - Parameter content: The view controller to add
     func add(content: ContentContainable) {
         removePreviousContent()
         saveContentType(content: content)
         addToView(content: content)
     }
 
+    /// Update content in the container. This is used in the case of the webview since it's not removed, we don't need to add it back again.
+    /// - Parameter content: The content to update
+    func update(content: ContentContainable) {
+        removePreviousContent()
+        saveContentType(content: content)
+    }
+
     // MARK: - Private
 
     private func removePreviousContent() {
+        // Only remove previous content when it's the homepage. We're not remving the webview controller for now
+        // since if it's not loaded, the webview doesn't layout it's WKCompositingView which result in black screen
+        guard type == .homepage else { return }
         contentController?.willMove(toParent: nil)
         contentController?.view.removeFromSuperview()
         contentController?.removeFromParent()

--- a/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -11,7 +11,6 @@ final class BrowserCoordinatorTests: XCTestCase {
     private var mockRouter: MockRouter!
     private var profile: MockProfile!
     private var overlayModeManager: MockOverlayModeManager!
-    private var logger: MockLogger!
     private var screenshotService: ScreenshotService!
     private var routeBuilder: RouteBuilder!
     private var tabManager: MockTabManager!
@@ -27,7 +26,6 @@ final class BrowserCoordinatorTests: XCTestCase {
         self.mockRouter = MockRouter(navigationController: MockNavigationController())
         self.profile = MockProfile()
         self.overlayModeManager = MockOverlayModeManager()
-        self.logger = MockLogger()
         self.screenshotService = ScreenshotService()
         self.tabManager = MockTabManager()
         self.applicationHelper = MockApplicationHelper()
@@ -41,7 +39,6 @@ final class BrowserCoordinatorTests: XCTestCase {
         self.mockRouter = nil
         self.profile = nil
         self.overlayModeManager = nil
-        self.logger = nil
         self.screenshotService = nil
         self.tabManager = nil
         self.applicationHelper = nil
@@ -125,35 +122,35 @@ final class BrowserCoordinatorTests: XCTestCase {
 
     // MARK: - Show webview
 
-    func testShowWebview_withoutPreviousSendsFatal() {
-        let subject = createSubject()
-        subject.show(webView: nil)
-        XCTAssertEqual(logger.savedMessage, "Webview controller couldn't be shown, this shouldn't happen.")
-        XCTAssertEqual(logger.savedLevel, .fatal)
-
-        XCTAssertNil(subject.homepageViewController)
-        XCTAssertNil(subject.webviewController)
-    }
-
     func testShowWebview_embedNewWebview() {
         let webview = WKWebView()
         let subject = createSubject()
+        let mbvc = MockBrowserViewController(profile: profile, tabManager: tabManager)
+        subject.browserViewController = mbvc
         subject.show(webView: webview)
 
         XCTAssertNil(subject.homepageViewController)
         XCTAssertNotNil(subject.webviewController)
+        XCTAssertEqual(mbvc.embedContentCalled, 1)
+        XCTAssertEqual(mbvc.saveEmbeddedContent?.contentType, .webview)
     }
 
     func testShowWebview_reuseExistingWebview() {
         let webview = WKWebView()
         let subject = createSubject()
+        let mbvc = MockBrowserViewController(profile: profile, tabManager: tabManager)
+        subject.browserViewController = mbvc
         subject.show(webView: webview)
         let firstWebview = subject.webviewController
         XCTAssertNotNil(firstWebview)
 
-        subject.show(webView: nil)
+        subject.show(webView: webview)
         let secondWebview = subject.webviewController
+
         XCTAssertEqual(firstWebview, secondWebview)
+        XCTAssertEqual(mbvc.embedContentCalled, 1)
+        XCTAssertEqual(mbvc.frontEmbeddedContentCalled, 1)
+        XCTAssertEqual(mbvc.saveEmbeddedContent?.contentType, .webview)
     }
 
     func testShowWebview_setsScreenshotService() {
@@ -550,7 +547,6 @@ final class BrowserCoordinatorTests: XCTestCase {
         let subject = BrowserCoordinator(router: mockRouter,
                                          screenshotService: screenshotService,
                                          profile: profile,
-                                         logger: logger,
                                          glean: glean,
                                          applicationHelper: applicationHelper,
                                          wallpaperManager: wallpaperManager)

--- a/Tests/ClientTests/Mocks/MockBrowserViewController.swift
+++ b/Tests/ClientTests/Mocks/MockBrowserViewController.swift
@@ -45,7 +45,7 @@ class MockBrowserViewController: BrowserViewController {
     var embedContentCalled = 0
     var frontEmbeddedContentCalled = 0
     var saveEmbeddedContent: ContentContainable?
-    
+
     override func switchToPrivacyMode(isPrivate: Bool) {
         switchToPrivacyModeCalled = true
         switchToPrivacyModeIsPrivate = isPrivate

--- a/Tests/ClientTests/Mocks/MockBrowserViewController.swift
+++ b/Tests/ClientTests/Mocks/MockBrowserViewController.swift
@@ -42,6 +42,10 @@ class MockBrowserViewController: BrowserViewController {
     var qrCodeCount = 0
     var closePrivateTabsCount = 0
 
+    var embedContentCalled = 0
+    var frontEmbeddedContentCalled = 0
+    var saveEmbeddedContent: ContentContainable?
+    
     override func switchToPrivacyMode(isPrivate: Bool) {
         switchToPrivacyModeCalled = true
         switchToPrivacyModeIsPrivate = isPrivate
@@ -96,5 +100,15 @@ class MockBrowserViewController: BrowserViewController {
         presentSignInFlowType = flowType
         presentSignInReferringPage = referringPage
         presentSignInCount += 1
+    }
+
+    override func embedContent(_ viewController: ContentContainable) {
+        embedContentCalled += 1
+        saveEmbeddedContent = viewController
+    }
+
+    override func frontEmbeddedContent(_ viewController: ContentContainable) {
+        frontEmbeddedContentCalled += 1
+        saveEmbeddedContent = viewController
     }
 }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6322)

### Description
Since we were re-adding the webview controller each time to the stack view, the webview `WKCompositingView` wasn't created by the time we where ready to show the webview (removing the homepage). This meant we were seeing a black screen instead (which happens to be the `WKContentView`). Since we have no control over the `WKCompositingView`, and it's a high risk change to reassess how the webview is showing, we're keeping the webview controller in memory for now until we'll rework the webview management.

Also, needed to remove the optional on the `func show(webView: WKWebView)` method, since on some occasion the webview was nil. I am now passing the webview from the selected tab in that case, where previously we where only hiding the homepage. This means I update the webview into the existing webview controller.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
