### PR TITLE
Bugfix FXIOS-6322 [v114] Turns out not needed, we pass the webview and constraint it

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1920,8 +1920,6 @@ extension BrowserViewController: LegacyTabDelegate {
     func tab(_ tab: Tab, didCreateWebView webView: WKWebView) {
         if !CoordinatorFlagManager.isCoordinatorEnabled {
             webView.frame = webViewContainer.frame
-        } else {
-            browserDelegate?.show(webView: webView)
         }
         // Observers that live as long as the tab. Make sure these are all cleared in willDeleteWebView below!
         KVOs.forEach { webView.addObserver(self, forKeyPath: $0.rawValue, options: .new, context: nil) }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6322)

### Description
- Sometimes we shouldn't show the webview right away after its creation. The webview is constrained when we switch to that tab. So that call was actually superfluous. 
- With this change we should be able to turn on the coordinators in main, since this was breaking some UI tests in https://github.com/mozilla-mobile/firefox-ios/pull/14202

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
