### PR TITLE
Bugfix FXIOS-6336 [v114] Fix autofill key retrieval logic

### DIFF
--- a/Storage/Rust/RustAutofill.swift
+++ b/Storage/Rust/RustAutofill.swift
@@ -385,7 +385,7 @@ public class RustAutofill {
         let rustKeys = RustAutofillEncryptionKeys()
         let key = rustKeys.keychain.string(forKey: rustKeys.ccKeychainKey)
         let encryptedCanaryPhrase = rustKeys.keychain.string(
-            forKey: rustKeys.canaryPhrase)
+            forKey: rustKeys.ccCanaryPhraseKey)
 
         switch(key, encryptedCanaryPhrase) {
         case (.some(key), .some(encryptedCanaryPhrase)):


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6336)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14256)

### Description
A small bug prevented the canary phrase from being retrieved and caused the autofill key to be regenerated on each startup. This fixes that.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
