### PR TITLE
Add FXIOS-6298 [v115] sync toggle for credit cards 

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -289,6 +289,7 @@
 		432BD0242790EBD000A0F3C3 /* Adjust in Frameworks */ = {isa = PBXBuildFile; productRef = 432BD0232790EBD000A0F3C3 /* Adjust */; };
 		4331A9BB27193DF0005E8080 /* ContextualHintViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4331A9BA27193DEF005E8080 /* ContextualHintViewController.swift */; };
 		4331A9BD271D267E005E8080 /* ContextualHintViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4331A9BC271D267E005E8080 /* ContextualHintViewModel.swift */; };
+		4331D3EF2A059C1C00542BDD /* SyncContentSettingsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4331D3EE2A059C1C00542BDD /* SyncContentSettingsViewControllerTests.swift */; };
 		433396C827ACE92500491049 /* CellWithRoundedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 433396C727ACE92500491049 /* CellWithRoundedButton.swift */; };
 		4336FAD2264B169000A6B076 /* WebcompatAllFramesAtDocumentStart.js in Resources */ = {isa = PBXBuildFile; fileRef = 4336FAD1264B169000A6B076 /* WebcompatAllFramesAtDocumentStart.js */; };
 		433BADA029C8769800E34991 /* BiometricAuthentication.strings in Resources */ = {isa = PBXBuildFile; fileRef = 433BAD9E29C8769800E34991 /* BiometricAuthentication.strings */; };
@@ -2622,6 +2623,7 @@
 		4331A9BA27193DEF005E8080 /* ContextualHintViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContextualHintViewController.swift; sourceTree = "<group>"; };
 		4331A9BC271D267E005E8080 /* ContextualHintViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualHintViewModel.swift; sourceTree = "<group>"; };
 		4331B5C429E42772003965EA /* ka */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ka; path = "ka.lproj/Edit Card.strings"; sourceTree = "<group>"; };
+		4331D3EE2A059C1C00542BDD /* SyncContentSettingsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncContentSettingsViewControllerTests.swift; sourceTree = "<group>"; };
 		4333498629F69D080059610C /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Notification.strings; sourceTree = "<group>"; };
 		4333498729F69D080059610C /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/ZoomPageBar.strings; sourceTree = "<group>"; };
 		433396C727ACE92500491049 /* CellWithRoundedButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellWithRoundedButton.swift; sourceTree = "<group>"; };
@@ -8708,6 +8710,7 @@
 				9614BF3F28A53F2000D3F7EA /* ContextualHints */,
 				E1AEC16E286E0CF500062E29 /* Home */,
 				8A36BE2A29EDE16700AC1C5C /* ContentContainerTests.swift */,
+				4331D3EE2A059C1C00542BDD /* SyncContentSettingsViewControllerTests.swift */,
 			);
 			path = Frontend;
 			sourceTree = "<group>";
@@ -11947,6 +11950,7 @@
 				8AFCE50929DE136300B1B253 /* MockLaunchFinishedLoadingDelegate.swift in Sources */,
 				8AE1E1DB27B1C1320024C45E /* SearchBarSettingsViewModelTests.swift in Sources */,
 				CA24B53924ABFE250093848C /* LoginsListSelectionHelperTests.swift in Sources */,
+				4331D3EF2A059C1C00542BDD /* SyncContentSettingsViewControllerTests.swift in Sources */,
 				39D0DA7629D767DE000760B8 /* NimbusMessagingTriggerTests.swift in Sources */,
 				21B41A1D298B187A008BC0A2 /* MockOverlayModeManager.swift in Sources */,
 				2FDB10931A9FBEC5006CF312 /* PrefsTests.swift in Sources */,

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -146,7 +146,7 @@ class Setting: NSObject {
 
 // A setting in the sections panel. Contains a sublist of Settings
 class SettingSection: Setting {
-    fileprivate let children: [Setting]
+    let children: [Setting]
 
     init(title: NSAttributedString? = nil, footerTitle: NSAttributedString? = nil, cellHeight: CGFloat? = nil, children: [Setting]) {
         self.children = children

--- a/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -122,7 +122,7 @@ class DeviceNameSetting: StringSetting {
     }
 }
 
-class SyncContentSettingsViewController: SettingsTableViewController {
+class SyncContentSettingsViewController: SettingsTableViewController, FeatureFlaggable {
     fileprivate var enginesToSyncOnExit: Set<String> = Set()
 
     init() {
@@ -191,10 +191,26 @@ class SyncContentSettingsViewController: SettingsTableViewController {
             attributedStatusText: nil,
             settingDidChange: engineSettingChanged("passwords"))
 
+        let creditCards = BoolSetting(
+            prefs: profile.prefs,
+            prefKey: "sync.engine.creditcards.enabled",
+            defaultValue: true,
+            attributedTitleText: NSAttributedString(string: .FirefoxSyncCreditCardsEngine),
+            attributedStatusText: nil,
+            settingDidChange: engineSettingChanged("creditcards"))
+
+        var engineSectionChildren: [Setting] = [bookmarks, history, tabs, passwords]
+
+        if featureFlags.isFeatureEnabled(
+            .creditCardAutofillStatus,
+            checking: .buildOnly) {
+            engineSectionChildren.append(creditCards)
+        }
+
         let enginesSection = SettingSection(
             title: NSAttributedString(string: .FxASettingsSyncSettings),
             footerTitle: nil,
-            children: [bookmarks, history, tabs, passwords])
+            children: engineSectionChildren)
 
         let deviceName = DeviceNameSetting(settings: self)
         let deviceNameSection = SettingSection(

--- a/Tests/ClientTests/Frontend/SyncContentSettingsViewControllerTests.swift
+++ b/Tests/ClientTests/Frontend/SyncContentSettingsViewControllerTests.swift
@@ -1,0 +1,51 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+@testable import Client
+
+import XCTest
+import Common
+
+class SyncContentSettingsViewControllerTests: XCTestCase {
+    var profile: MockProfile!
+    var syncContentSettingsVC: SyncContentSettingsViewController?
+
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+        profile = MockProfile()
+        FeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
+        syncContentSettingsVC = SyncContentSettingsViewController()
+        syncContentSettingsVC?.profile = profile
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        AppContainer.shared.reset()
+        profile = nil
+        syncContentSettingsVC = nil
+    }
+
+    func test_syncContentSettingsViewController_generateSettingsCount() {
+        let settingSections = syncContentSettingsVC?.generateSettings()
+        // Count should be 4 as the sections contains
+        // - manageSection [0]
+        // - enginesSection [1]
+        // - deviceNameSection [2]
+        // - disconnectSection [3]
+        XCTAssertEqual(settingSections?.count, 4)
+    }
+
+    func test_syncContentSettingsViewController_engineSectionForSettings() {
+        let settingSections = syncContentSettingsVC?.generateSettings()
+        let engineSectionChildren = settingSections?[1].children
+        // Count for engine section children should be 5
+        // as the sub engine section contains
+        // bookmarks
+        // history
+        // tabs
+        // passwords
+        // credit cards
+        XCTAssertEqual(engineSectionChildren?.count, 5)
+    }
+}


### PR DESCRIPTION
[Jira ticket - FXIOS-6298](https://mozilla-hub.atlassian.net/browse/FXIOS-6298)
[Github issue - #14173 ](https://github.com/mozilla-mobile/firefox-ios/issues/14173)

### Description
I added view-only portion of the sync toggle. Actual functionality will get added when sync for credit card lands. cc @lougeniaC64 

![image](https://user-images.githubusercontent.com/8919439/236542302-5d3c83b3-f769-4097-8fa4-2db64b6117cf.png)

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
