### PR TITLE
Bugfix FXIOS-6334 [v114] session save fix

### DIFF
--- a/BrowserKit/Sources/TabDataStore/TabDataStore.swift
+++ b/BrowserKit/Sources/TabDataStore/TabDataStore.swift
@@ -6,8 +6,15 @@ import Foundation
 import Common
 
 public protocol TabDataStore {
+    /// Fetches the previously saved window data (this contains the list of tabs) from disk, if it exists
+    /// - Returns: The window data object if one was previously saved
     func fetchWindowData() async -> WindowData?
+
+    /// Saves the window data (contains the list of tabs) to disk
+    /// - Parameter window: the window data object to be saved
     func saveWindowData(window: WindowData) async
+
+    /// Erases all window data on disk
     func clearAllWindowsData() async
 }
 

--- a/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -975,6 +975,10 @@ extension LegacyTabManager: WKNavigationDelegate {
                 return
             }
 
+            if let title = webView.title {
+                selectedTab?.lastTitle = title
+            }
+
             storeChanges()
         }
     }

--- a/Client/TabManagement/TabManagerImplementation.swift
+++ b/Client/TabManagement/TabManagerImplementation.swift
@@ -30,7 +30,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
         super.init(profile: profile, imageStore: imageStore)
 
         setupNotifications(forObserver: self,
-                           observing: [UIApplication.didEnterBackgroundNotification])
+                           observing: [UIApplication.willResignActiveNotification])
     }
 
     // MARK: - Restore tabs
@@ -249,7 +249,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
 
     func handleNotifications(_ notification: Notification) {
         switch notification.name {
-        case UIApplication.didEnterBackgroundNotification:
+        case UIApplication.willResignActiveNotification:
             saveCurrentTabSessionData()
         default:
             break

--- a/Client/TabManagement/TabManagerImplementation.swift
+++ b/Client/TabManagement/TabManagerImplementation.swift
@@ -132,7 +132,7 @@ class TabManagerImplementation: LegacyTabManager {
                                          nextUrl: oldTabGroupData?.tabAssociatedNextUrl,
                                          tabHistoryCurrentState: state)
             return TabData(id: UUID(uuidString: tab.tabUUID) ?? UUID(),
-                           title: tab.title ?? tab.lastTitle,
+                           title: tab.lastTitle,
                            siteUrl: tab.url?.absoluteString ?? "",
                            faviconURL: tab.faviconURL,
                            isPrivate: tab.isPrivate,

--- a/Client/TabManagement/TabManagerImplementation.swift
+++ b/Client/TabManagement/TabManagerImplementation.swift
@@ -10,21 +10,27 @@ import Shared
 
 // This class subclasses the legacy tab manager temporarily so we can
 // gradually migrate to the new system
-class TabManagerImplementation: LegacyTabManager {
-    let tabDataStore: TabDataStore
-    let tabSessionStore: TabSessionStore
-    let imageStore: DiskImageStore?
+class TabManagerImplementation: LegacyTabManager, Notifiable {
+    private let tabDataStore: TabDataStore
+    private let tabSessionStore: TabSessionStore
+    private let imageStore: DiskImageStore?
+    var notificationCenter: NotificationProtocol
     lazy var isNewTabStoreEnabled: Bool = TabStorageFlagManager.isNewTabDataStoreEnabled
 
     init(profile: Profile,
          imageStore: DiskImageStore?,
          logger: Logger = DefaultLogger.shared,
          tabDataStore: TabDataStore = DefaultTabDataStore(),
-         tabSessionStore: TabSessionStore = DefaultTabSessionStore()) {
+         tabSessionStore: TabSessionStore = DefaultTabSessionStore(),
+         notificationCenter: NotificationProtocol = NotificationCenter.default) {
         self.tabDataStore = tabDataStore
         self.tabSessionStore = tabSessionStore
         self.imageStore = imageStore
+        self.notificationCenter = notificationCenter
         super.init(profile: profile, imageStore: imageStore)
+
+        setupNotifications(forObserver: self,
+                           observing: [UIApplication.didEnterBackgroundNotification])
     }
 
     // MARK: - Restore tabs
@@ -153,10 +159,10 @@ class TabManagerImplementation: LegacyTabManager {
 
         saveTabs(toProfile: profile, normalTabs)
         preserveTabs()
-        saveIndividualTabSessionData()
+        saveCurrentTabSessionData()
     }
 
-    private func saveIndividualTabSessionData() {
+    private func saveCurrentTabSessionData() {
         guard #available(iOS 15.0, *),
               let selectedTab = self.selectedTab,
               let tabSession = selectedTab.webView?.interactionState as? Data,
@@ -179,6 +185,9 @@ class TabManagerImplementation: LegacyTabManager {
         }
 
         guard tab.tabUUID != selectedTab?.tabUUID else { return }
+
+        // Before moving to a new tab save the current tab session data in order to preseve things like scroll position
+        saveCurrentTabSessionData()
 
         Task {
             let sessionData = await tabSessionStore.fetchTabSession(tabID: tabUUID)
@@ -233,6 +242,17 @@ class TabManagerImplementation: LegacyTabManager {
 
         Task {
             await imageStore?.deleteImageForKey(tab.tabUUID)
+        }
+    }
+
+    // MARK: - Notifiable
+
+    func handleNotifications(_ notification: Notification) {
+        switch notification.name {
+        case UIApplication.didEnterBackgroundNotification:
+            saveCurrentTabSessionData()
+        default:
+            break
         }
     }
 }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6334)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14251)

### Description
Save the tab session data when leaving a tab or back grounding the app
This allows us to keep track of the scroll position on the webview when restoring

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
