### PR TITLE
Bugfix FXIOS-6271 [v114] The Zoom Bar does not disappear when switching tabs

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2847,6 +2847,11 @@ extension BrowserViewController: TopTabsDelegate {
     func topTabsDidChangeTab() {
         // Only for iPad leave overlay mode on tab change
         overlayManager.switchTab(shouldCancelLoading: true)
+        updateZoomPageBarVisibility(visible: false)
+    }
+
+    func topTabsDidPressPrivateMode() {
+        updateZoomPageBarVisibility(visible: false)
     }
 }
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
@@ -44,7 +44,7 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
     }
 
     func tabToolbarDidPressBack(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
-        zoomPageDidPressClose()
+        updateZoomPageBarVisibility(visible: false)
         tabManager.selectedTab?.goBack()
     }
 
@@ -55,7 +55,7 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
     }
 
     func tabToolbarDidPressForward(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
-        zoomPageDidPressClose()
+        updateZoomPageBarVisibility(visible: false)
         tabManager.selectedTab?.goForward()
     }
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -413,7 +413,6 @@ extension BrowserViewController: WKNavigationDelegate {
             decisionHandler(.cancel)
             return
         }
-        zoomPageDidPressClose()
 
         if tab == tabManager.selectedTab,
            navigationAction.navigationType == .linkActivated,

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ZoomPage.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ZoomPage.swift
@@ -10,13 +10,6 @@ extension BrowserViewController {
         toggleZoomPageBar(visible)
     }
 
-    func resetZoomPageBar() {
-        if let zoomPageBar = zoomPageBar {
-            zoomPageBar.resetZoomLevel()
-            removeZoomPageBar(zoomPageBar)
-        }
-    }
-
     private func setupZoomPageBar() {
         guard let tab = tabManager.selectedTab else { return }
 
@@ -34,7 +27,9 @@ extension BrowserViewController {
             })
         }
 
-        zoomPageBar.heightAnchor.constraint(greaterThanOrEqualToConstant: UIConstants.ZoomPageBarHeight).isActive = true
+        zoomPageBar.heightAnchor
+            .constraint(greaterThanOrEqualToConstant: UIConstants.ZoomPageBarHeight)
+            .isActive = true
         zoomPageBar.applyTheme(theme: themeManager.currentTheme)
 
         updateViewConstraints()
@@ -60,12 +55,8 @@ extension BrowserViewController {
             removeZoomPageBar(zoomPageBar)
         }
     }
-}
 
-extension BrowserViewController: ZoomPageBarDelegate {
-    func zoomPageDidPressClose() {
-        guard zoomPageBar != nil else { return }
-        updateZoomPageBarVisibility(visible: false)
+    private func saveZoomLevel() {
         guard let tab = tabManager.selectedTab else { return }
         guard let host = tab.url?.host else { return }
         let domainZoomLevel = DomainZoomLevel(host: host, zoomLevel: tab.pageZoom)
@@ -74,12 +65,23 @@ extension BrowserViewController: ZoomPageBarDelegate {
 
     func zoomPageHandleEnterReaderMode() {
         guard let tab = tabManager.selectedTab else { return }
-        zoomPageDidPressClose()
+        updateZoomPageBarVisibility(visible: false)
         tab.resetZoom()
     }
 
     func zoomPageHandleExitReaderMode() {
         guard let tab = tabManager.selectedTab else { return }
         tab.setZoomLevelforDomain()
+    }
+}
+
+extension BrowserViewController: ZoomPageBarDelegate {
+    func didChangeZoomLevel() {
+        saveZoomLevel()
+    }
+
+    func zoomPageDidPressClose() {
+        updateZoomPageBarVisibility(visible: false)
+        saveZoomLevel()
     }
 }

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -25,6 +25,7 @@ protocol TopTabsDelegate: AnyObject {
     func topTabsDidPressTabs()
     func topTabsDidPressNewTab(_ isPrivate: Bool)
     func topTabsDidChangeTab()
+    func topTabsDidPressPrivateMode()
 }
 
 class TopTabsViewController: UIViewController, Themeable, Notifiable {
@@ -179,6 +180,7 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable {
 
     @objc
     func togglePrivateModeTapped() {
+        delegate?.topTabsDidPressPrivateMode()
         topTabDisplayManager.togglePrivateMode(isOn: !topTabDisplayManager.isPrivate,
                                                createTabOnEmptyPrivateMode: true,
                                                shouldSelectMostRecentTab: true)

--- a/Client/Frontend/Browser/ZoomPageBar.swift
+++ b/Client/Frontend/Browser/ZoomPageBar.swift
@@ -8,6 +8,7 @@ import Shared
 
 protocol ZoomPageBarDelegate: AnyObject {
     func zoomPageDidPressClose()
+    func didChangeZoomLevel()
 }
 
 class ZoomPageBar: UIView, ThemeApplicable {
@@ -96,7 +97,6 @@ class ZoomPageBar: UIView, ThemeApplicable {
         self.tab = tab
 
         super.init(frame: .zero)
-        self.tab.urlHostDelegate = self
 
         setupViews()
         setupLayout()
@@ -158,11 +158,6 @@ class ZoomPageBar: UIView, ThemeApplicable {
             closeButton.trailingAnchor.constraint(equalTo: trailingAnchor,
                                                   constant: -UX.leadingTrailingPadding),
         ])
-    }
-
-    func resetZoomLevel() {
-        tab.resetZoom()
-        checkPageZoomLimits()
     }
 
     private func setupSeparator(_ separator: UIView) {
@@ -239,7 +234,7 @@ class ZoomPageBar: UIView, ThemeApplicable {
     private func didPressZoomIn(_ sender: UIButton) {
         tab.zoomIn()
         updateZoomLabel()
-
+        delegate?.didChangeZoomLevel()
         zoomOutButton.isEnabled = true
         if tab.pageZoom >= UX.upperZoomLimit {
             zoomInButton.isEnabled = false
@@ -250,7 +245,7 @@ class ZoomPageBar: UIView, ThemeApplicable {
     private func didPressZoomOut(_ sender: UIButton) {
         tab.zoomOut()
         updateZoomLabel()
-
+        delegate?.didChangeZoomLevel()
         zoomInButton.isEnabled = true
         if tab.pageZoom <= UX.lowerZoomLimit {
             zoomOutButton.isEnabled = false
@@ -262,6 +257,7 @@ class ZoomPageBar: UIView, ThemeApplicable {
         if recognizer.state == .ended {
             tab.resetZoom()
             updateZoomLabel()
+            delegate?.didChangeZoomLevel()
             enableZoomButtons()
         }
     }
@@ -291,12 +287,5 @@ class ZoomPageBar: UIView, ThemeApplicable {
         gradient.colors = traitCollection.userInterfaceIdiom == .pad ?
         theme.colors.layerGradientOverlay.cgColors.reversed() :
         theme.colors.layerGradientOverlay.cgColors
-    }
-}
-
-extension ZoomPageBar: URLHostDelegate {
-    func hostDidSet() {
-        updateZoomLabel()
-        checkPageZoomLimits()
     }
 }

--- a/Client/TabManagement/Tab.swift
+++ b/Client/TabManagement/Tab.swift
@@ -41,10 +41,6 @@ protocol URLChangeDelegate {
     func tab(_ tab: Tab, urlDidChangeTo url: URL)
 }
 
-protocol URLHostDelegate: AnyObject {
-    func hostDidSet()
-}
-
 struct TabState {
     var isPrivate = false
     var url: URL?
@@ -241,7 +237,6 @@ class Tab: NSObject {
     var webView: WKWebView?
     var tabDelegate: LegacyTabDelegate?
     weak var urlDidChangeDelegate: URLChangeDelegate?     // TODO: generalize this.
-    weak var urlHostDelegate: URLHostDelegate?
     var bars = [SnackBar]()
     var lastExecutedTime: Timestamp?
     var firstCreatedTime: Timestamp?
@@ -260,7 +255,7 @@ class Tab: NSObject {
         didSet {
             if let _url = url, let internalUrl = InternalURL(_url), internalUrl.isAuthorized {
                 url = URL(string: internalUrl.stripAuthorization)
-            } else { setZoomLevelforDomain() }
+            }
         }
     }
     var lastKnownUrl: URL? {
@@ -284,6 +279,7 @@ class Tab: NSObject {
             return true
         }
 
+        setZoomLevelforDomain()
         return false
     }
 
@@ -695,7 +691,6 @@ class Tab: NSObject {
         if let host = url?.host,
            let domainZoomLevel = ZoomLevelStore.shared.findZoomLevel(forDomain: host) {
             pageZoom = domainZoomLevel.zoomLevel
-            urlHostDelegate?.hostDidSet()
         } else { resetZoom() }
     }
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6271)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14120)

### Description
This fix addresses the issue of the Zoom Bar not disappearing when switching tabs or entering private browsing mode

### Video

https://user-images.githubusercontent.com/51127880/236641464-26b39fa7-75a9-4b0c-a560-885fadbca06a.mp4

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
