### PR TITLE
Bugfix FXIOS-6006 [v115] wrong text displayed in Touch ID Biometrics

### DIFF
--- a/Client/Frontend/AuthenticationManager/AppAuthenticator.swift
+++ b/Client/Frontend/AuthenticationManager/AppAuthenticator.swift
@@ -25,7 +25,7 @@ class AppAuthenticator: AppAuthenticationProtocol {
 
         // First check if we have the needed hardware support.
         var error: NSError?
-        let localizedErrorMessage = AppAuthenticator.getDefaultErrorMessageForContext(context: context)
+        let localizedErrorMessage = String.Biometry.Screen.UniversalAuthenticationReason
         if context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) {
             context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: localizedErrorMessage) { success, error in
                 if success {
@@ -47,16 +47,5 @@ class AppAuthenticator: AppAuthenticationProtocol {
 
     func canAuthenticateDeviceOwner() -> Bool {
         return LAContext().canEvaluatePolicy(.deviceOwnerAuthentication, error: nil)
-    }
-
-    static func getDefaultErrorMessageForContext(context: LAContext) -> String {
-        var localizedErrorMessage = String.Biometry.Screen.UniversalAuthenticationReason
-        if context.biometryType == .touchID {
-            localizedErrorMessage = .Biometry.Screen.FingerprintAuthenticationReason
-        } else if context.biometryType == .faceID {
-            localizedErrorMessage = .Biometry.Screen.FaceIDAuthenticationReason
-        }
-
-        return localizedErrorMessage
     }
 }

--- a/Client/Frontend/AuthenticationManager/AppAuthenticator.swift
+++ b/Client/Frontend/AuthenticationManager/AppAuthenticator.swift
@@ -25,8 +25,9 @@ class AppAuthenticator: AppAuthenticationProtocol {
 
         // First check if we have the needed hardware support.
         var error: NSError?
+        let localizedErrorMessage = AppAuthenticator.getDefaultErrorMessageForContext(context: context)
         if context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) {
-            context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: .Biometry.Screen.UniversalAuthenticationReason) { success, error in
+            context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: localizedErrorMessage) { success, error in
                 if success {
                     DispatchQueue.main.async {
                         completion(.success(()))
@@ -46,5 +47,16 @@ class AppAuthenticator: AppAuthenticationProtocol {
 
     func canAuthenticateDeviceOwner() -> Bool {
         return LAContext().canEvaluatePolicy(.deviceOwnerAuthentication, error: nil)
+    }
+
+    static func getDefaultErrorMessageForContext(context: LAContext) -> String {
+        var localizedErrorMessage = String.Biometry.Screen.UniversalAuthenticationReason
+        if context.biometryType == .touchID {
+            localizedErrorMessage = .Biometry.Screen.FingerprintAuthenticationReason
+        } else if context.biometryType == .faceID {
+            localizedErrorMessage = .Biometry.Screen.FaceIDAuthenticationReason
+        }
+
+        return localizedErrorMessage
     }
 }

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -86,7 +86,7 @@ extension String {
     public struct Biometry {
         public struct Screen {
             public static let UniversalAuthenticationReason = MZLocalizedString(
-                key: "Biometry.Screen.UniversalAuthenticationReason.v113",
+                key: "Biometry.Screen.UniversalAuthenticationReason.v115",
                 tableName: "BiometricAuthentication",
                 value: "Authenticate to access passwords.",
                 comment: "Biometric authentication is when the system prompts users for Face ID or fingerprint before accessing protected information. This string asks the user to enter their device passcode to access the protected screen.")

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -88,17 +88,7 @@ extension String {
             public static let UniversalAuthenticationReason = MZLocalizedString(
                 key: "Biometry.Screen.UniversalAuthenticationReason.v113",
                 tableName: "BiometricAuthentication",
-                value: "Enter your device passcode",
-                comment: "Biometric authentication is when the system prompts users for Face ID or fingerprint before accessing protected information. This string asks the user to enter their device passcode to access the protected screen.")
-            public static let FingerprintAuthenticationReason = MZLocalizedString(
-                key: "Biometry.Screen.FingerprintAuthenticationReason.v114",
-                tableName: "BiometricAuthentication",
-                value: "Use your fingerprint to access passwords.",
-                comment: "Biometric authentication is when the system prompts users for Face ID or fingerprint before accessing protected information. This string asks the user to enter their device passcode to access the protected screen.")
-            public static let FaceIDAuthenticationReason = MZLocalizedString(
-                key: "Biometry.Screen.FaceIDAuthenticationReason.v114",
-                tableName: "BiometricAuthentication",
-                value: "Use Face ID to access passwords.",
+                value: "Authenticate to access passwords.",
                 comment: "Biometric authentication is when the system prompts users for Face ID or fingerprint before accessing protected information. This string asks the user to enter their device passcode to access the protected screen.")
         }
     }

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -90,6 +90,16 @@ extension String {
                 tableName: "BiometricAuthentication",
                 value: "Enter your device passcode",
                 comment: "Biometric authentication is when the system prompts users for Face ID or fingerprint before accessing protected information. This string asks the user to enter their device passcode to access the protected screen.")
+            public static let FingerprintAuthenticationReason = MZLocalizedString(
+                key: "Biometry.Screen.FingerprintAuthenticationReason.v114",
+                tableName: "BiometricAuthentication",
+                value: "Use your fingerprint to access passwords.",
+                comment: "Biometric authentication is when the system prompts users for Face ID or fingerprint before accessing protected information. This string asks the user to enter their device passcode to access the protected screen.")
+            public static let FaceIDAuthenticationReason = MZLocalizedString(
+                key: "Biometry.Screen.FaceIDAuthenticationReason.v114",
+                tableName: "BiometricAuthentication",
+                value: "Use Face ID to access passwords.",
+                comment: "Biometric authentication is when the system prompts users for Face ID or fingerprint before accessing protected information. This string asks the user to enter their device passcode to access the protected screen.")
         }
     }
 }


### PR DESCRIPTION
#13636

[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6006)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13636)

### Description
Added the text for Fingerprint and FaceID biometric authentication errors

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
