### PR TITLE
Bugfix FXIOS-6266 [v114] The Zoom bar is not long enough while in landscape mode on iPhone

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -823,10 +823,15 @@ class BrowserViewController: UIViewController {
     }
 
     private func adjustBottomContentStackView(_ remake: ConstraintMaker) {
-        remake.left.equalTo(view.safeArea.left)
-        remake.right.equalTo(view.safeArea.right)
-        remake.centerX.equalTo(view)
-        remake.width.equalTo(view.safeArea.width)
+        if let zoomPageBar = zoomPageBar,
+           bottomContentStackView.subviews.contains(zoomPageBar) {
+            remake.leading.trailing.equalToSuperview()
+        } else {
+            remake.left.equalTo(view.safeArea.left)
+            remake.right.equalTo(view.safeArea.right)
+            remake.centerX.equalTo(view)
+            remake.width.equalTo(view.safeArea.width)
+        }
 
         // Height is set by content - this removes run time error
         remake.height.greaterThanOrEqualTo(0)


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6266)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14115)

### Description
This PR adjusts the bottom stack view constraints if the Zoom Bar is on the screen

### Screenshot
![screenshot](https://user-images.githubusercontent.com/51127880/236824003-fc894266-49ef-4bc8-92bb-a593cdcb63d7.jpeg)

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
