### PR TITLE
Bump [v114] Upgrades appservices to 114.0

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -17550,7 +17550,7 @@
 			repositoryURL = "https://github.com/mozilla/rust-components-swift.git";
 			requirement = {
 				kind = exactVersion;
-				version = 114.0.20230504050432;
+				version = 114.0.0;
 			};
 		};
 		435C85EE2788F4D00072B526 /* XCRemoteSwiftPackageReference "glean-swift" */ = {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla/rust-components-swift.git",
       "state" : {
-        "revision" : "91c799f98fe3ac4b5bb26583ff9ebd23328c8737",
-        "version" : "114.0.20230504050432"
+        "revision" : "674bf7ba63f79769f1bfbef011bb4365d6f79e2d",
+        "version" : "114.0.0"
       }
     },
     {

--- a/bin/nimbus-fml.sh
+++ b/bin/nimbus-fml.sh
@@ -93,7 +93,7 @@ if [ -z "$number_string" ]; then
     fi
 fi
 
-AS_VERSION=$(echo "$number_string" | sed 's/\.0\./\./g') # rust-component-swift tags have a middle `.0.` to force it to align with spm. We remove it
+AS_VERSION=$(echo "v$number_string" | sed 's/\.0\./\./g') # rust-component-swift tags have a middle `.0.` to force it to align with spm. We remove it
 FRESHEN_FML=
 NIMBUS_DIR="$SOURCE_ROOT/build/nimbus"
 
@@ -167,11 +167,11 @@ else
     # Otherwise, we should download a pre-built copy from github.com/mozilla/application-services/releases
     FML_DIR="$NIMBUS_DIR/bin"
     export BINARY_PATH="$FML_DIR/nimbus-fml"
-    AS_DOWNLOAD_URL="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.v2.nimbus-fml.$AS_VERSION/artifacts/public%2Fbuild%2F"
+    AS_DOWNLOAD_URL="https://github.com/mozilla/application-services/releases/download/$AS_VERSION"
     # Check whether the cached copy is still the right one to use.
     if [[ -f $FML_DIR/nimbus-fml.sha256 ]]; then
         echo "Checking if we need to redownload the FML"
-        NEW_CHECKSUM=$(curl -L "${AS_DOWNLOAD_URL}nimbus-fml.sha256")
+        NEW_CHECKSUM=$(curl -L "$AS_DOWNLOAD_URL/nimbus-fml.sha256")
         OLD_CHECKSUM=$(cat "$FML_DIR/nimbus-fml.sha256")
         if [ ! "$OLD_CHECKSUM" == "$NEW_CHECKSUM" ]; then
             FRESHEN_FML="true"
@@ -185,9 +185,9 @@ else
     mkdir -p "$FML_DIR"
     if [[ ! -f "$FML_DIR/nimbus-fml.zip" ]] ; then
         # We now download the nimbus-fml from the github release
-        curl -L "${AS_DOWNLOAD_URL}nimbus-fml.zip" --output "$FML_DIR/nimbus-fml.zip"
+        curl -L "$AS_DOWNLOAD_URL/nimbus-fml.zip" --output "$FML_DIR/nimbus-fml.zip"
         # We also download the checksum
-        curl -L "${AS_DOWNLOAD_URL}nimbus-fml.sha256" --output "$FML_DIR/nimbus-fml.sha256"
+        curl -L "$AS_DOWNLOAD_URL/nimbus-fml.sha256" --output "$FML_DIR/nimbus-fml.sha256"
         pushd "${FML_DIR}"
         shasum --check nimbus-fml.sha256
         popd


### PR DESCRIPTION
No Jira Ticket, this is a simple bump. There should be no changes from the nightly before this, but this is a stable release.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
