### PR TITLE
Bugfix FXIOS-6365 [v113] disk image store crash

### DIFF
--- a/Storage/DiskImageStore.swift
+++ b/Storage/DiskImageStore.swift
@@ -1,6 +1,6 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Shared
 import UIKit
@@ -13,27 +13,31 @@ enum DiskImageStoreErrorCase: Error {
 }
 
 public protocol DiskImageStore {
+    /// Gets an image for the given key if it is in the store.
     func getImageForKey(_ key: String) async throws -> UIImage
+
+    /// Adds an image for the given key.
     func saveImageForKey(_ key: String, image: UIImage) async throws
+
+    /// Clears all images from the cache, excluding the given set of keys.
     func clearAllScreenshotsExcluding(_ keys: Set<String>) async throws
+
+    /// Remove image with provided key
     func deleteImageForKey(_ key: String) async
 }
 
-/**
- * Disk-backed key-value image store.
- */
-open class DefaultDiskImageStore: DiskImageStore {
-    fileprivate let files: FileAccessor
-    fileprivate let filesDir: String
-    fileprivate let queue = DispatchQueue(label: "DiskImageStore")
-    fileprivate let quality: CGFloat
-    fileprivate var keys: Set<String>
+/// Disk-backed key-value image store.
+public actor DefaultDiskImageStore: DiskImageStore {
+    private let files: FileAccessor
+    private let filesDir: String
+    private let quality: CGFloat
+    private var keys: Set<String>
     private var logger: Logger
 
-    required public init(files: FileAccessor,
-                         namespace: String,
-                         quality: Float,
-                         logger: Logger = DefaultLogger.shared) {
+    public init(files: FileAccessor,
+                namespace: String,
+                quality: Float,
+                logger: Logger = DefaultLogger.shared) {
         self.files = files
         self.filesDir = try! files.getAndEnsureDirectory(namespace)
         self.quality = CGFloat(quality)
@@ -49,92 +53,56 @@ open class DefaultDiskImageStore: DiskImageStore {
         self.keys = Set(keys)
     }
 
-    /// Gets an image for the given key if it is in the store.
     public func getImageForKey(_ key: String) async throws -> UIImage {
-        return try await withCheckedThrowingContinuation { continuation in
-            queue.async {
-                if !self.keys.contains(key) {
-                    continuation.resume(throwing: DiskImageStoreErrorCase.notFound(description: "Image key not found"))
-                    return
-                }
+        if !keys.contains(key) {
+            throw DiskImageStoreErrorCase.notFound(description: "Image key not found")
+        }
 
-                let imagePath = URL(fileURLWithPath: self.filesDir).appendingPathComponent(key)
-                do {
-                    let data = try Data(contentsOf: imagePath)
-                    if let image = UIImage.imageFromDataThreadSafe(data) {
-                        continuation.resume(returning: image)
-                    } else {
-                        continuation.resume(throwing: DiskImageStoreErrorCase.invalidImageData(description: "Invalid image data"))
-                    }
-                } catch {
-                    continuation.resume(throwing: error)
-                }
-            }
+        let imagePath = URL(fileURLWithPath: filesDir).appendingPathComponent(key)
+        let data = try Data(contentsOf: imagePath)
+        if let image = UIImage(data: data) {
+            return image
+        } else {
+            throw DiskImageStoreErrorCase.invalidImageData(description: "Invalid image data")
         }
     }
 
-    /// Adds an image for the given key.
-    /// This put is asynchronous; the image is not recorded in the cache until the write completes.
-    /// Does nothing if this key already exists in the store.
     public func saveImageForKey(_ key: String, image: UIImage) async throws {
-        try await withCheckedThrowingContinuation { continuation in
-            queue.async {
-                let size = CGSize(width: image.size.width / 2, height: image.size.height / 2)
+        let size = CGSize(width: image.size.width / 2, height: image.size.height / 2)
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        let renderer = UIGraphicsImageRenderer(size: size, format: format)
+        let scaledImage = renderer.image { _ in
+            image.draw(in: CGRect(origin: .zero, size: size))
+        }
 
-                let format = UIGraphicsImageRendererFormat()
-                format.scale = 1
-                let renderer = UIGraphicsImageRenderer(size: size, format: format)
-                let scaledImage = renderer.image { _ in
-                    image.draw(in: CGRect(origin: .zero, size: size))
-                }
-
-                let imageURL = URL(fileURLWithPath: self.filesDir).appendingPathComponent(key)
-                if let data = scaledImage.jpegData(compressionQuality: self.quality) {
-                    do {
-                        try data.write(to: imageURL, options: .noFileProtection)
-                        self.keys.insert(key)
-                        continuation.resume()
-                    } catch {
-                        continuation.resume(throwing: error)
-                    }
-                } else {
-                    continuation.resume(throwing: DiskImageStoreErrorCase.cannotWrite(description: "Could not write image to file"))
-                }
-            }
+        let imageURL = URL(fileURLWithPath: filesDir).appendingPathComponent(key)
+        if let data = scaledImage.jpegData(compressionQuality: quality) {
+            try data.write(to: imageURL, options: .noFileProtection)
+            keys.insert(key)
+        } else {
+            throw DiskImageStoreErrorCase.cannotWrite(description: "Could not write image to file")
         }
     }
 
-    /// Clears all images from the cache, excluding the given set of keys.
     public func clearAllScreenshotsExcluding(_ keys: Set<String>) async throws {
-        try await withThrowingTaskGroup(of: Void.self) { taskGroup in
-            let keysToDelete = self.keys.subtracting(keys)
+        let keysToDelete = keys.subtracting(keys)
 
-            for key in keysToDelete {
-                taskGroup.addTask {
-                    let url = URL(fileURLWithPath: self.filesDir).appendingPathComponent(key)
-                    try FileManager.default.removeItem(at: url)
-                }
-            }
-
-            try await taskGroup.waitForAll()
-            self.keys = self.keys.intersection(keys)
+        for key in keysToDelete {
+            let url = URL(fileURLWithPath: filesDir).appendingPathComponent(key)
+            try FileManager.default.removeItem(at: url)
         }
+        self.keys = keys.intersection(keys)
     }
 
-    /// Remove image with provided key
     public func deleteImageForKey(_ key: String) async {
-        await withCheckedContinuation { continuation in
-            queue.async {
-                let url = URL(fileURLWithPath: self.filesDir).appendingPathComponent(key)
-                do {
-                    try FileManager.default.removeItem(at: url)
-                } catch {
-                    self.logger.log("Failed to remove DiskImageStore item at \(url.absoluteString): \(error)",
-                                    level: .warning,
-                                    category: .storage)
-                }
-                continuation.resume()
-            }
+        let url = URL(fileURLWithPath: filesDir).appendingPathComponent(key)
+        do {
+            try FileManager.default.removeItem(at: url)
+        } catch {
+            logger.log("Failed to remove DiskImageStore item at \(url.absoluteString): \(error)",
+                       level: .debug,
+                       category: .storage)
         }
     }
 }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6365)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14296)

### Description
This change already exists on main but it's tied to a bunch of other changes so targeting this PR directly at the v113 branch
I found this other Sentry crash with a better stack trace from an older beta build that confirms the theory that it's the disk image store causing the issue https://mozilla.sentry.io/issues/4137637504/events/e5d71c0b6ef74815871ceb66d1b798be/
I cannot repo the crash so I'm not certain these changes will fix the issue

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
