### PR TITLE
Bugfix FXIOS-6333 [v114] Fix survey following delegate changes

### DIFF
--- a/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -10,7 +10,7 @@ protocol LaunchCoordinatorDelegate: AnyObject {
 }
 
 // Manages different types of onboarding that gets shown at the launch of the application
-class LaunchCoordinator: BaseCoordinator {
+class LaunchCoordinator: BaseCoordinator, SurveySurfaceViewControllerDelegate {
     private let profile: Profile
     private let logger: Logger
     private let isIphone: Bool
@@ -112,11 +112,13 @@ class LaunchCoordinator: BaseCoordinator {
             return
         }
         surveySurface.modalPresentationStyle = .fullScreen
-        manager.dismissClosure = { [weak self] in
-            guard let self = self else { return }
-            self.parentCoordinator?.didFinishLaunch(from: self)
-        }
-
+        surveySurface.delegate = self
         router.present(surveySurface, animated: false)
+    }
+
+    // MARK: - SurveySurfaceViewControllerDelegate
+
+    func didFinish() {
+        parentCoordinator?.didFinishLaunch(from: self)
     }
 }

--- a/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -117,7 +117,6 @@ class LaunchCoordinator: BaseCoordinator, SurveySurfaceViewControllerDelegate {
     }
 
     // MARK: - SurveySurfaceViewControllerDelegate
-
     func didFinish() {
         parentCoordinator?.didFinishLaunch(from: self)
     }

--- a/Client/Frontend/SurveySurface/SurveySurfaceManager.swift
+++ b/Client/Frontend/SurveySurface/SurveySurfaceManager.swift
@@ -84,6 +84,9 @@ class SurveySurfaceManager: SurveySurfaceDelegate {
 
     func didTapDismissSurvey() {
         message.map(messagingManager.onMessageDismissed)
-        dismissClosure?()
+        // FXIOS-6036 - Remove the dismissClosure, we dismiss using delegate instead of closure
+        if !CoordinatorFlagManager.isCoordinatorEnabled {
+            dismissClosure?()
+        }
     }
 }

--- a/Client/Frontend/SurveySurface/SurveySurfaceViewController.swift
+++ b/Client/Frontend/SurveySurface/SurveySurfaceViewController.swift
@@ -7,6 +7,10 @@ import Foundation
 import Shared
 import UIKit
 
+protocol SurveySurfaceViewControllerDelegate: AnyObject {
+    func didFinish()
+}
+
 class SurveySurfaceViewController: UIViewController, Themeable {
     struct UX {
         static let buttonCornerRadius: CGFloat = 13
@@ -29,6 +33,7 @@ class SurveySurfaceViewController: UIViewController, Themeable {
     }
 
     // MARK: - Variables
+    weak var delegate: SurveySurfaceViewControllerDelegate?
     var viewModel: SurveySurfaceViewModel
     var notificationCenter: NotificationProtocol
     var themeManager: ThemeManager
@@ -216,13 +221,21 @@ class SurveySurfaceViewController: UIViewController, Themeable {
     @objc
     func takeSurveyAction() {
         viewModel.didTapTakeSurvey()
-        dismiss(animated: true)
+        if CoordinatorFlagManager.isCoordinatorEnabled {
+            delegate?.didFinish()
+        } else {
+            dismiss(animated: true)
+        }
     }
 
     @objc
     func dismissAction() {
         viewModel.didTapDismissSurvey()
-        dismiss(animated: true)
+        if CoordinatorFlagManager.isCoordinatorEnabled {
+            delegate?.didFinish()
+        } else {
+            dismiss(animated: true)
+        }
     }
 
     // MARK: - Themable

--- a/Tests/ClientTests/Coordinators/Launch/LaunchCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/Launch/LaunchCoordinatorTests.swift
@@ -121,7 +121,7 @@ final class LaunchCoordinatorTests: XCTestCase {
     }
 
     // MARK: - Delegates
-    func testStart_surveySetsDelegate() {
+    func testStart_surveySetsDelegate() throws {
         let messageManager = MockGleanPlumbMessageManagerProtocol()
         let message = createMessage(isExpired: false)
         messageManager.message = message
@@ -131,7 +131,8 @@ final class LaunchCoordinatorTests: XCTestCase {
         let subject = createSubject(isIphone: false)
         subject.start(with: .survey(manager: manager))
 
-        XCTAssertNotNil(manager.dismissClosure)
+        let presentedVC = try XCTUnwrap(mockRouter.presentedViewController as? SurveySurfaceViewController)
+        XCTAssertNotNil(presentedVC.delegate)
     }
 
     // MARK: - Helpers

--- a/Tests/ClientTests/Coordinators/Launch/LaunchCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/Launch/LaunchCoordinatorTests.swift
@@ -135,6 +135,15 @@ final class LaunchCoordinatorTests: XCTestCase {
         XCTAssertNotNil(presentedVC.delegate)
     }
 
+    func testDidFinish_fromSurveySurfaceViewControllerDelegate() {
+        let subject = createSubject(isIphone: false)
+        subject.parentCoordinator = delegate
+        subject.didFinish()
+
+        XCTAssertEqual(delegate.didFinishCalledCount, 1)
+        XCTAssertEqual(delegate.savedDidFinishCoordinator?.id, subject.id)
+    }
+
     // MARK: - Helpers
     private func createSubject(isIphone: Bool,
                                file: StaticString = #file,

--- a/Tests/ClientTests/Mocks/MockLaunchCoordinatorDelegate.swift
+++ b/Tests/ClientTests/Mocks/MockLaunchCoordinatorDelegate.swift
@@ -6,11 +6,11 @@ import Foundation
 @testable import Client
 
 class MockLaunchCoordinatorDelegate: LaunchCoordinatorDelegate {
-    var savedURL: URL?
-    var savedIsPrivate: Bool?
-    var savedDidFinishCoordinator: LaunchCoordinator?
+    var didFinishCalledCount = 0
+    weak var savedDidFinishCoordinator: LaunchCoordinator?
 
     func didFinishLaunch(from coordinator: LaunchCoordinator) {
+        didFinishCalledCount += 1
         savedDidFinishCoordinator = coordinator
     }
 }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6333)

### Description
The pressed delegate was removed with [this PR](https://github.com/mozilla-mobile/firefox-ios/pull/14234/files#diff-82aa043eab5a39cadd6055d8fa2bae01a85769f43b9223e3b16e9aa2291d8f27). The survey now uses a deep link to navigate (with open URL). The `launchCoordinator` was not `deinit` and the `browserCoordinator` wasn't yet ready to handle the said deep link. This fixes that by ensuring we tell the `launchCoordinator` it's done.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
