### PR TITLE
Refactor FXIOS-5924 [v114] Onboarding data model updates

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2490,11 +2490,15 @@ extension BrowserViewController {
 
     private func showProperIntroVC() {
         let introViewModel = IntroViewModel()
-        let introViewController = IntroViewController(viewModel: introViewModel, profile: profile)
+        let introViewController = IntroViewController(
+            viewModel: introViewModel,
+            profile: profile)
+
         introViewController.didFinishFlow = {
             IntroScreenManager(prefs: self.profile.prefs).didSeeIntroScreen()
             introViewController.dismiss(animated: true)
         }
+        
         self.introVCPresentHelper(introViewController: introViewController)
     }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2498,7 +2498,7 @@ extension BrowserViewController {
             IntroScreenManager(prefs: self.profile.prefs).didSeeIntroScreen()
             introViewController.dismiss(animated: true)
         }
-        
+
         self.introVCPresentHelper(introViewController: introViewController)
     }
 

--- a/Client/Frontend/Onboarding/Models/IntroViewModel.swift
+++ b/Client/Frontend/Onboarding/Models/IntroViewModel.swift
@@ -73,51 +73,48 @@ struct IntroViewModel: OnboardingViewModelProtocol, FeatureFlaggable {
                 name: "welcome",
                 title: String(format: .Onboarding.Welcome.Title),
                 body: String(format: .Onboarding.Welcome.Description, shortName),
-                image: ImageIdentifiers.onboardingWelcomev106,
                 link: OnboardingLinkInfoModel(
                     title: .Onboarding.PrivacyPolicyLinkButtonTitle,
-                    url: "https://macrumors.com"),
-                buttons: [
-                    OnboardingButtonInfoModel(
+                    url: URL(string: "https://macrumors.com")!),
+                buttons: OnboardingButtons(
+                    primary: OnboardingButtonInfoModel(
                         title: .Onboarding.Welcome.GetStartedAction,
-                        action: .nextCard)
-                ],
+                        action: .nextCard)),
                 type: .freshInstall,
-                a11yIdRoot: AccessibilityIdentifiers.Onboarding.welcomeCard)
+                a11yIdRoot: AccessibilityIdentifiers.Onboarding.welcomeCard,
+                imageID: ImageIdentifiers.onboardingWelcomev106)
         case .signSync:
             return OnboardingCardInfoModel(
                 name: "signSync",
                 title: String(format: .Onboarding.Sync.Title),
                 body: String(format: .Onboarding.Sync.Description),
-                image: ImageIdentifiers.onboardingSyncv106,
-                link: nil,,
-                buttons: [
-                    OnboardingButtonInfoModel(
+                link: nil,
+                buttons: OnboardingButtons(
+                    primary: OnboardingButtonInfoModel(
                         title: .Onboarding.Sync.SignInAction,
                         action: .syncSignIn),
-                    OnboardingButtonInfoModel(
+                    secondary: OnboardingButtonInfoModel(
                         title: .Onboarding.Sync.SkipAction,
-                        action: .nextCard)
-                ],
+                        action: .nextCard)),
                 type: .freshInstall,
-                a11yIdRoot: AccessibilityIdentifiers.Onboarding.signSyncCard)
+                a11yIdRoot: AccessibilityIdentifiers.Onboarding.signSyncCard,
+                imageID: ImageIdentifiers.onboardingSyncv106)
         case .notification:
             return OnboardingCardInfoModel(
                 name: "notification",
                 title: String(format: .Onboarding.Notification.Title, shortName),
                 body: String(format: .Onboarding.Notification.Description, shortName),
-                image: ImageIdentifiers.onboardingSyncv106,
-                link: nil,,
-                buttons: [
-                    OnboardingButtonInfoModel(
+                link: nil,
+                buttons: OnboardingButtons(
+                    primary: OnboardingButtonInfoModel(
                         title: .Onboarding.Notification.ContinueAction,
                         action: .requestNotifications),
-                    OnboardingButtonInfoModel(
+                    secondary: OnboardingButtonInfoModel(
                         title: .Onboarding.Notification.SkipAction,
-                        action: .nextCard)
-                ],
+                        action: .nextCard)),
                 type: .freshInstall,
-                a11yIdRoot: AccessibilityIdentifiers.Onboarding.notificationCard)
+                a11yIdRoot: AccessibilityIdentifiers.Onboarding.notificationCard,
+                imageID: ImageIdentifiers.onboardingSyncv106)
         default:
             return nil
         }

--- a/Client/Frontend/Onboarding/Models/IntroViewModel.swift
+++ b/Client/Frontend/Onboarding/Models/IntroViewModel.swift
@@ -64,34 +64,60 @@ struct IntroViewModel: OnboardingViewModelProtocol, FeatureFlaggable {
         }
     }
 
-    func getInfoModel(cardType: IntroViewModel.InformationCards) -> LegacyOnboardingModelProtocol? {
+    func getInfoModel(cardType: IntroViewModel.InformationCards) -> OnboardingCardInfoModelProtocol? {
         let shortName = AppName.shortName.rawValue
 
         switch cardType {
         case .welcome:
-            return LegacyOnboardingInfoModel(image: UIImage(named: ImageIdentifiers.onboardingWelcomev106),
-                                             title: String(format: .Onboarding.Welcome.Title, shortName),
-                                             description: String(format: .Onboarding.Welcome.Description, shortName),
-                                             linkButtonTitle: .Onboarding.PrivacyPolicyLinkButtonTitle,
-                                             primaryAction: .Onboarding.Welcome.GetStartedAction,
-                                             secondaryAction: nil,
-                                             a11yIdRoot: AccessibilityIdentifiers.Onboarding.welcomeCard)
+            return OnboardingCardInfoModel(
+                name: "welcome",
+                title: String(format: .Onboarding.Welcome.Title),
+                body: String(format: .Onboarding.Welcome.Description, shortName),
+                image: ImageIdentifiers.onboardingWelcomev106,
+                link: OnboardingLinkInfoModel(
+                    title: .Onboarding.PrivacyPolicyLinkButtonTitle,
+                    url: "https://macrumors.com"),
+                buttons: [
+                    OnboardingButtonInfoModel(
+                        title: .Onboarding.Welcome.GetStartedAction,
+                        action: .nextCard)
+                ],
+                type: .freshInstall,
+                a11yIdRoot: AccessibilityIdentifiers.Onboarding.welcomeCard)
         case .signSync:
-            return LegacyOnboardingInfoModel(image: UIImage(named: ImageIdentifiers.onboardingSyncv106),
-                                             title: .Onboarding.Sync.Title,
-                                             description: .Onboarding.Sync.Description,
-                                             linkButtonTitle: nil,
-                                             primaryAction: .Onboarding.Sync.SignInAction,
-                                             secondaryAction: .Onboarding.Sync.SkipAction,
-                                             a11yIdRoot: AccessibilityIdentifiers.Onboarding.signSyncCard)
+            return OnboardingCardInfoModel(
+                name: "signSync",
+                title: String(format: .Onboarding.Sync.Title),
+                body: String(format: .Onboarding.Sync.Description),
+                image: ImageIdentifiers.onboardingSyncv106,
+                link: nil,,
+                buttons: [
+                    OnboardingButtonInfoModel(
+                        title: .Onboarding.Sync.SignInAction,
+                        action: .syncSignIn),
+                    OnboardingButtonInfoModel(
+                        title: .Onboarding.Sync.SkipAction,
+                        action: .nextCard)
+                ],
+                type: .freshInstall,
+                a11yIdRoot: AccessibilityIdentifiers.Onboarding.signSyncCard)
         case .notification:
-            return LegacyOnboardingInfoModel(image: UIImage(named: ImageIdentifiers.onboardingNotification),
-                                             title: String(format: .Onboarding.Notification.Title, shortName),
-                                             description: String(format: .Onboarding.Notification.Description, shortName),
-                                             linkButtonTitle: nil,
-                                             primaryAction: .Onboarding.Notification.ContinueAction,
-                                             secondaryAction: .Onboarding.Notification.SkipAction,
-                                             a11yIdRoot: AccessibilityIdentifiers.Onboarding.notificationCard)
+            return OnboardingCardInfoModel(
+                name: "notification",
+                title: String(format: .Onboarding.Notification.Title, shortName),
+                body: String(format: .Onboarding.Notification.Description, shortName),
+                image: ImageIdentifiers.onboardingSyncv106,
+                link: nil,,
+                buttons: [
+                    OnboardingButtonInfoModel(
+                        title: .Onboarding.Notification.ContinueAction,
+                        action: .requestNotifications),
+                    OnboardingButtonInfoModel(
+                        title: .Onboarding.Notification.SkipAction,
+                        action: .nextCard)
+                ],
+                type: .freshInstall,
+                a11yIdRoot: AccessibilityIdentifiers.Onboarding.notificationCard)
         default:
             return nil
         }

--- a/Client/Frontend/Onboarding/Models/LegacyOnboardingCardViewModel.swift
+++ b/Client/Frontend/Onboarding/Models/LegacyOnboardingCardViewModel.swift
@@ -6,7 +6,7 @@ import Foundation
 
 protocol OnboardingCardProtocol {
     var cardType: IntroViewModel.InformationCards { get set }
-    var infoModel: LegacyOnboardingModelProtocol { get }
+    var infoModel: OnboardingCardInfoModelProtocol { get }
     var shouldShowDescriptionBold: Bool { get }
 
     func sendCardViewTelemetry()
@@ -15,12 +15,14 @@ protocol OnboardingCardProtocol {
 
 struct LegacyOnboardingCardViewModel: OnboardingCardProtocol {
     var cardType: IntroViewModel.InformationCards
-    var infoModel: LegacyOnboardingModelProtocol
+    var infoModel: OnboardingCardInfoModelProtocol
     var shouldShowDescriptionBold: Bool
 
-    init(cardType: IntroViewModel.InformationCards,
-         infoModel: LegacyOnboardingModelProtocol,
-         isFeatureEnabled: Bool) {
+    init(
+        cardType: IntroViewModel.InformationCards,
+        infoModel: OnboardingCardInfoModelProtocol,
+        isFeatureEnabled: Bool
+    ) {
         self.cardType = cardType
         self.infoModel = infoModel
         self.shouldShowDescriptionBold = cardType == .welcome && !isFeatureEnabled

--- a/Client/Frontend/Onboarding/Models/OnboardingButtonInfoModel.swift
+++ b/Client/Frontend/Onboarding/Models/OnboardingButtonInfoModel.swift
@@ -4,6 +4,19 @@
 
 import Foundation
 
+struct OnboardingButtons {
+    let primary: OnboardingButtonInfoModel
+    let secondary: OnboardingButtonInfoModel?
+
+    init(
+        primary: OnboardingButtonInfoModel,
+        secondary: OnboardingButtonInfoModel? = nil
+    ) {
+        self.primary = primary
+        self.secondary = secondary
+    }
+}
+
 struct OnboardingButtonInfoModel {
     let title: String
     let action: OnboardingActions

--- a/Client/Frontend/Onboarding/Models/OnboardingCardInfoModel.swift
+++ b/Client/Frontend/Onboarding/Models/OnboardingCardInfoModel.swift
@@ -33,7 +33,7 @@ struct OnboardingCardInfoModel: OnboardingCardInfoModelProtocol {
     var title: String
     var body: String
     var link: OnboardingLinkInfoModel?
-    var buttons: OnboardingButtons,
+    var buttons: OnboardingButtons
     var type: OnboardingType
     var a11yIdRoot: String
 

--- a/Client/Frontend/Onboarding/Models/OnboardingCardInfoModel.swift
+++ b/Client/Frontend/Onboarding/Models/OnboardingCardInfoModel.swift
@@ -4,12 +4,62 @@
 
 import Foundation
 
-struct OnboardingCardInfoModel {
-    let name: String
-    let title: String
-    let body: String
-    let image: String
-    let link: OnboardingLinkInfoModel?
-    let buttons: [OnboardingButtonInfoModel]
-    let type: OnboardingType
+protocol OnboardingCardInfoModelProtocol {
+    var name: String { get set }
+    var title: String { get set }
+    var body: String { get set }
+    var link: OnboardingLinkInfoModel? { get set }
+    var buttons: OnboardingButtons { get set }
+    var type: OnboardingType { get set }
+    var a11yIdRoot: String { get set }
+    var imageID: String { get set }
+
+    var image: UIImage? { get }
+
+    init(
+        name: String,
+        title: String,
+        body: String,
+        link: OnboardingLinkInfoModel?,
+        buttons: OnboardingButtons,
+        type: OnboardingType,
+        a11yIdRoot: String,
+        imageID: String
+    )
+}
+
+struct OnboardingCardInfoModel: OnboardingCardInfoModelProtocol {
+    var name: String
+    var title: String
+    var body: String
+    var link: OnboardingLinkInfoModel?
+    var buttons: OnboardingButtons,
+    var type: OnboardingType
+    var a11yIdRoot: String
+
+    var imageID: String
+
+    var image: UIImage? {
+        return UIImage(named: imageID)
+    }
+
+    init(
+        name: String,
+        title: String,
+        body: String,
+        link: OnboardingLinkInfoModel?,
+        buttons: OnboardingButtons,
+        type: OnboardingType,
+        a11yIdRoot: String,
+        imageID: String
+    ) {
+        self.name = name
+        self.title = title
+        self.body = body
+        self.imageID = imageID
+        self.link = link
+        self.buttons = buttons
+        self.type = type
+        self.a11yIdRoot = a11yIdRoot
+    }
 }

--- a/Client/Frontend/Onboarding/Protocols/OnboardingViewModelProtocol.swift
+++ b/Client/Frontend/Onboarding/Protocols/OnboardingViewModelProtocol.swift
@@ -8,8 +8,8 @@ protocol OnboardingViewModelProtocol {
     var enabledCards: [IntroViewModel.InformationCards] { get }
     var isFeatureEnabled: Bool { get }
 
+    func getInfoModel(cardType: IntroViewModel.InformationCards) -> OnboardingCardInfoModelProtocol?
     func getCardViewModel(cardType: IntroViewModel.InformationCards) -> OnboardingCardProtocol?
-    func getInfoModel(cardType: IntroViewModel.InformationCards) -> LegacyOnboardingModelProtocol?
 }
 
 extension OnboardingViewModelProtocol {

--- a/Client/Frontend/Onboarding/ViewControllers/OnboardingCardViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/OnboardingCardViewController.swift
@@ -323,14 +323,15 @@ class OnboardingCardViewController: UIViewController, Themeable {
         descriptionLabel.text = viewModel.infoModel.body
 
         imageView.image = viewModel.infoModel.image
-        primaryButton.setTitle(viewModel.infoModel.primaryAction, for: .normal)
+        primaryButton.setTitle(viewModel.infoModel.buttons.primary.title,
+                               for: .normal)
         handleSecondaryButton()
     }
 
     private func handleSecondaryButton() {
         // To keep Title, Description aligned between cards we don't hide the button
         // we clear the background and make disabled
-        guard let buttonTitle = viewModel.infoModel.secondaryAction else {
+        guard let buttonTitle = viewModel.infoModel.buttons.secondary?.title else {
             secondaryButton.isUserInteractionEnabled = false
             secondaryButton.backgroundColor = .clear
             return
@@ -340,7 +341,7 @@ class OnboardingCardViewController: UIViewController, Themeable {
     }
 
     private func handleLinkButton() {
-        guard let buttonTitle = viewModel.infoModel.linkButtonTitle else {
+        guard let buttonTitle = viewModel.infoModel.link?.title else {
             linkButton.isUserInteractionEnabled = false
             linkButton.isHidden = true
             return

--- a/Client/Frontend/Onboarding/ViewControllers/OnboardingCardViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/OnboardingCardViewController.swift
@@ -320,8 +320,7 @@ class OnboardingCardViewController: UIViewController, Themeable {
         titleLabel.text = viewModel.infoModel.title
         descriptionBoldLabel.isHidden = !viewModel.shouldShowDescriptionBold
         descriptionBoldLabel.text = .Onboarding.Intro.DescriptionPart1
-        descriptionLabel.isHidden = viewModel.infoModel.description?.isEmpty ?? true
-        descriptionLabel.text = viewModel.infoModel.description
+        descriptionLabel.text = viewModel.infoModel.body
 
         imageView.image = viewModel.infoModel.image
         primaryButton.setTitle(viewModel.infoModel.primaryAction, for: .normal)

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -1021,36 +1021,41 @@ extension String {
 // MARK: - Upgrade CoverSheet
 extension String {
     public struct Upgrade {
-        public static let WelcomeTitle = MZLocalizedString(
-            key: "Upgrade.Welcome.Title.v114",
-            tableName: "Upgrade",
-            value: "Welcome to a more personal internet",
-            comment: "Title string used to welcome back users in the Upgrade screens. This screen is shown after user upgrades Firefox version.")
-        public static let WelcomeDescription = MZLocalizedString(
-            key: "Upgrade.Welcome.Description.v114",
-            tableName: "Upgrade",
-            value: "New colors. New convenience. Same commitment to people over profits.",
-            comment: "Description string used to welcome back users in the Upgrade screens. This screen is shown after user upgrades Firefox version.")
-        public static let WelcomeAction = MZLocalizedString(
-            key: "Upgrade.Welcome.Action.v114",
-            tableName: "Upgrade",
-            value: "Set as Default Browser",
-            comment: "Describes the action on the first upgrade page in the Upgrade screen. This string will be on a button so user can continue the Upgrade.")
-        public static let SyncSignTitle = MZLocalizedString(
-            key: "Upgrade.SyncSign.Title.v114",
-            tableName: "Upgrade",
-            value: "Switching screens is easier than ever",
-            comment: "Title string used to sign in to sync in the Upgrade screens. This screen is shown after user upgrades Firefox version.")
-        public static let SyncSignDescription = MZLocalizedString(
-            key: "Upgrade.SyncSign.Description.v114",
-            tableName: "Upgrade",
-            value: "Pick up where you left off with tabs from other devices now on your homepage.",
-            comment: "Description string used to to sign in to sync in the Upgrade screens. This screen is shown after user upgrades Firefox version.")
-        public static let SyncAction = MZLocalizedString(
-            key: "Upgrade.SyncSign.Action.v114",
-            tableName: "Upgrade",
-            value: "Sign In",
-            comment: "Describes an action on the sync upgrade page in our Upgrade screens. This string will be on a button so user can sign up or login directly in the upgrade.")
+        public struct Welcome {
+            public static let Title = MZLocalizedString(
+                key: "Upgrade.Welcome.Title.v114",
+                tableName: "Upgrade",
+                value: "Welcome to a more personal internet",
+                comment: "Title string used to welcome back users in the Upgrade screens. This screen is shown after user upgrades Firefox version.")
+            public static let Description = MZLocalizedString(
+                key: "Upgrade.Welcome.Description.v114",
+                tableName: "Upgrade",
+                value: "New colors. New convenience. Same commitment to people over profits.",
+                comment: "Description string used to welcome back users in the Upgrade screens. This screen is shown after user upgrades Firefox version.")
+            public static let Action = MZLocalizedString(
+                key: "Upgrade.Welcome.Action.v114",
+                tableName: "Upgrade",
+                value: "Set as Default Browser",
+                comment: "Describes the action on the first upgrade page in the Upgrade screen. This string will be on a button so user can continue the Upgrade.")
+        }
+
+        public struct Sync {
+            public static let Title = MZLocalizedString(
+                key: "Upgrade.SyncSign.Title.v114",
+                tableName: "Upgrade",
+                value: "Switching screens is easier than ever",
+                comment: "Title string used to sign in to sync in the Upgrade screens. This screen is shown after user upgrades Firefox version.")
+            public static let Description = MZLocalizedString(
+                key: "Upgrade.SyncSign.Description.v114",
+                tableName: "Upgrade",
+                value: "Pick up where you left off with tabs from other devices now on your homepage.",
+                comment: "Description string used to to sign in to sync in the Upgrade screens. This screen is shown after user upgrades Firefox version.")
+            public static let Action = MZLocalizedString(
+                key: "Upgrade.SyncSign.Action.v114",
+                tableName: "Upgrade",
+                value: "Sign In",
+                comment: "Describes an action on the sync upgrade page in our Upgrade screens. This string will be on a button so user can sign up or login directly in the upgrade.")
+        }
     }
 }
 

--- a/Client/Frontend/Update/UpdateViewModel.swift
+++ b/Client/Frontend/Update/UpdateViewModel.swift
@@ -98,28 +98,49 @@ class UpdateViewModel: OnboardingViewModelProtocol,
                                      extras: extra)
     }
 
-    func getInfoModel(cardType: IntroViewModel.InformationCards) -> LegacyOnboardingModelProtocol? {
+    func getInfoModel(cardType: IntroViewModel.InformationCards) -> OnboardingCardInfoModelProtocol? {
         switch cardType {
         case .updateWelcome:
-            return LegacyOnboardingInfoModel(image: UIImage(named: ImageIdentifiers.onboardingWelcomev106),
-                                             title: .Upgrade.WelcomeTitle,
-                                             description: .Upgrade.WelcomeDescription,
-                                             linkButtonTitle: nil,
-                                             primaryAction: .Upgrade.WelcomeAction,
-                                             secondaryAction: nil,
-                                             a11yIdRoot: AccessibilityIdentifiers.Upgrade.welcomeCard)
+            return OnboardingCardInfoModel(
+                name: "upgrade1",
+                title: .Upgrade.Welcome.Title,
+                body: .Upgrade.Welcome.Description,
+                link: nil,
+                buttons: OnboardingButtons(
+                    primary: OnboardingButtonInfoModel(
+                        title: .Upgrade.Welcome.Action,
+                        action: .nextCard)),
+                type: .update,
+                a11yIdRoot: AccessibilityIdentifiers.Upgrade.welcomeCard,
+                imageID: ImageIdentifiers.onboardingWelcomev106)
         case .updateSignSync:
-            return LegacyOnboardingInfoModel(image: UIImage(named: ImageIdentifiers.onboardingSyncv106),
-                                             title: .Upgrade.SyncSignTitle,
-                                             description: .Upgrade.SyncSignDescription,
-                                             linkButtonTitle: nil,
-                                             primaryAction: .Upgrade.SyncAction,
-                                             secondaryAction: .Onboarding.LaterAction,
-                                             a11yIdRoot: AccessibilityIdentifiers.Upgrade.signSyncCard)
+            return OnboardingCardInfoModel(
+                name: "upgrade2",
+                title: .Upgrade.Sync.Title,
+                body: .Upgrade.Sync.Description,
+                link: nil,
+                buttons: OnboardingButtons(
+                    primary: OnboardingButtonInfoModel(
+                        title: .Upgrade.Sync.Action,
+                        action: .syncSignIn),
+                    secondary: OnboardingButtonInfoModel(
+                        title: .Onboarding.LaterAction,
+                        action: .nextCard)),
+                type: .update,
+                a11yIdRoot: AccessibilityIdentifiers.Upgrade.signSyncCard,
+                imageID: ImageIdentifiers.onboardingSyncv106)
         case .welcome, .signSync, .notification:
             // Cases not supported by the upgrade screen
             return nil
         }
+    }
+
+    func getCardViewModel(cardType: IntroViewModel.InformationCards) -> OnboardingCardProtocol? {
+        guard let infoModel = getInfoModel(cardType: cardType) else { return nil }
+
+        return LegacyOnboardingCardViewModel(cardType: cardType,
+                                             infoModel: infoModel,
+                                             isFeatureEnabled: isFeatureEnabled)
     }
 
     private func saveAppVersion(for appVersion: String) {

--- a/Client/Nimbus/OnboardingFeatureLayer/NimbusOnboardingFeatureLayer.swift
+++ b/Client/Nimbus/OnboardingFeatureLayer/NimbusOnboardingFeatureLayer.swift
@@ -69,10 +69,20 @@ class NimbusOnboardingFeatureLayer: NimbusOnboardingFeatureLayerProtocol {
 
     /// Returns an optional array of ``OnboardingButtonInfoModel`` given the data.
     /// A card is not viable without buttons.
-    private func getOnboardingCardButtons(from cardButtons: [NimbusOnboardingButton]) -> [OnboardingButtonInfoModel]? {
-        if cardButtons.isEmpty { return nil }
+    private func getOnboardingCardButtons(from cardButtons: [NimbusOnboardingButton]) -> OnboardingButtons {
+        if cardButtons.isEmpty {
+            return OnboardingButtons(
+                primary: OnboardingButtonInfoModel(
+                    title: .Onboarding.Welcome.Skip,
+                    action: .nextCard))
+        }
 
-        return cardButtons.map { OnboardingButtonInfoModel(title: $0.title, action: $0.action) }
+        let buttons = cardButtons.map { OnboardingButtonInfoModel(title: $0.title, action: $0.action) }
+
+        if cardButtons.count == 1 {
+            return OnboardingButtons(
+                primary: OnboardingButtonInfoModel(title: buttons[0].title,
+                                                   action: buttons[0].))
     }
 
     /// Returns an optional ``OnboardingLinkInfoModel``, if one is provided. This will be

--- a/Client/Nimbus/OnboardingFeatureLayer/NimbusOnboardingFeatureLayer.swift
+++ b/Client/Nimbus/OnboardingFeatureLayer/NimbusOnboardingFeatureLayer.swift
@@ -52,37 +52,32 @@ class NimbusOnboardingFeatureLayer: NimbusOnboardingFeatureLayerProtocol {
     /// - Returns: An array of viable ``OnboardingCardInfoModel``
     private func getOnboardingCards(from cardData: [NimbusOnboardingCardData]) -> [OnboardingCardInfoModel] {
         return cardData.compactMap { card in
-            let image = getOnboardingImageID(from: card.image)
-            guard let buttons = getOnboardingCardButtons(from: card.buttons),
-                  !buttons.isEmpty
-            else { return nil }
-
-            return OnboardingCardInfoModel(name: card.name,
-                                           title: card.title,
-                                           body: card.body,
-                                           image: image,
-                                           link: getOnboardingLink(from: card.link),
-                                           buttons: buttons,
-                                           type: card.type)
+            return OnboardingCardInfoModel(
+                name: card.name,
+                title: card.title,
+                body: card.body,
+                link: getOnboardingLink(from: card.link),
+                buttons: getOnboardingCardButtons(from: card.buttons),
+                type: card.type,
+                a11yIdRoot: "test",
+                imageID: getOnboardingImageID(from: card.image))
         }
     }
 
     /// Returns an optional array of ``OnboardingButtonInfoModel`` given the data.
     /// A card is not viable without buttons.
-    private func getOnboardingCardButtons(from cardButtons: [NimbusOnboardingButton]) -> OnboardingButtons {
-        if cardButtons.isEmpty {
-            return OnboardingButtons(
-                primary: OnboardingButtonInfoModel(
-                    title: .Onboarding.Welcome.Skip,
-                    action: .nextCard))
+    private func getOnboardingCardButtons(from cardButtons: NimbusOnboardingButtons) -> OnboardingButtons {
+        var secondButton: OnboardingButtonInfoModel?
+        if let secondary = cardButtons.secondary {
+            secondButton = OnboardingButtonInfoModel(title: secondary.title,
+                                                     action: secondary.action)
         }
 
-        let buttons = cardButtons.map { OnboardingButtonInfoModel(title: $0.title, action: $0.action) }
-
-        if cardButtons.count == 1 {
-            return OnboardingButtons(
-                primary: OnboardingButtonInfoModel(title: buttons[0].title,
-                                                   action: buttons[0].))
+        return OnboardingButtons(
+            primary: OnboardingButtonInfoModel(
+                title: cardButtons.primary.title,
+                action: cardButtons.primary.action),
+            secondary: secondButton)
     }
 
     /// Returns an optional ``OnboardingLinkInfoModel``, if one is provided. This will be

--- a/Tests/ClientTests/OnboardingTests/NimbusOnboardingFeatureLayerTests.swift
+++ b/Tests/ClientTests/OnboardingTests/NimbusOnboardingFeatureLayerTests.swift
@@ -14,6 +14,7 @@ class NimbusOnboardingFeatureLayerTests: XCTestCase {
         static let name = "Name"
         static let title = "Title"
         static let body = "Body"
+        static let a11yID = "A11yId"
         static let linkTitle = "MacRumors"
         static let linkURL = "https://macrumors.com"
         static let primaryButtonTitle = "Primary Button"
@@ -63,28 +64,32 @@ class NimbusOnboardingFeatureLayerTests: XCTestCase {
             name: CardElementNames.name + " 1",
             title: CardElementNames.title + " 1",
             body: CardElementNames.body + " 1",
-            image: ImageIdentifiers.onboardingWelcomev106,
             link: OnboardingLinkInfoModel(title: CardElementNames.linkTitle + " 1",
                                           url: URL(string: CardElementNames.linkURL)!),
-            buttons: [
-                OnboardingButtonInfoModel(title: CardElementNames.primaryButtonTitle + " 1",
-                                          action: .nextCard),
-                OnboardingButtonInfoModel(title: CardElementNames.secondaryButtonTitle + " 1",
-                                          action: .nextCard)
-            ],
-            type: .freshInstall)
+            buttons: OnboardingButtons(
+                primary: OnboardingButtonInfoModel(
+                    title: CardElementNames.primaryButtonTitle,
+                    action: .nextCard),
+                secondary: OnboardingButtonInfoModel(
+                    title: CardElementNames.secondaryButtonTitle,
+                    action: .nextCard)),
+            type: .freshInstall,
+            a11yIdRoot: CardElementNames.a11yID,
+            imageID: ImageIdentifiers.onboardingWelcomev106)
 
         XCTAssertEqual(subject.name, expectedCard.name)
         XCTAssertEqual(subject.title, expectedCard.title)
         XCTAssertEqual(subject.body, expectedCard.body)
-        XCTAssertEqual(subject.image, expectedCard.image)
         XCTAssertEqual(subject.type, expectedCard.type)
+        XCTAssertEqual(subject.image, UIImage(named: ImageIdentifiers.onboardingWelcomev106))
         XCTAssertEqual(subject.link?.title, expectedCard.link?.title)
         XCTAssertEqual(subject.link?.url, expectedCard.link?.url)
-        XCTAssertEqual(subject.buttons[0].title, expectedCard.buttons[0].title)
-        XCTAssertEqual(subject.buttons[0].action, expectedCard.buttons[0].action)
-        XCTAssertEqual(subject.buttons[1].title, expectedCard.buttons[1].title)
-        XCTAssertEqual(subject.buttons[1].action, expectedCard.buttons[1].action)
+        XCTAssertEqual(subject.buttons.primary.title, expectedCard.buttons.primary.title)
+        XCTAssertEqual(subject.buttons.primary.action, expectedCard.buttons.primary.action)
+        // Make sure a second button exists
+        XCTAssertNotNil(subject.buttons.secondary)
+        XCTAssertEqual(subject.buttons.secondary!.title, expectedCard.buttons.secondary!.title)
+        XCTAssertEqual(subject.buttons.secondary!.action, expectedCard.buttons.secondary!.action)
     }
 
     func testLayer_cardsAreReturned_ThreeCardsReturned() {
@@ -164,7 +169,7 @@ class NimbusOnboardingFeatureLayerTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(subject.image, ImageIdentifiers.onboardingWelcomev106)
+        XCTAssertEqual(subject.imageID, ImageIdentifiers.onboardingWelcomev106)
     }
 
     func testLayer_cardIsReturned_WithNotificationImageIdenfier() {
@@ -180,7 +185,7 @@ class NimbusOnboardingFeatureLayerTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(subject.image, ImageIdentifiers.onboardingNotification)
+        XCTAssertEqual(subject.image, UIImage(named: ImageIdentifiers.onboardingNotification))
     }
 
     func testLayer_cardIsReturned_WithSyncImageIdenfier() {
@@ -196,7 +201,7 @@ class NimbusOnboardingFeatureLayerTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(subject.image, ImageIdentifiers.onboardingSyncv106)
+        XCTAssertEqual(subject.image, UIImage(named: ImageIdentifiers.onboardingSyncv106))
     }
 
     func testLayer_cardIsReturnedWithDefaultIMageID_IfBadImageID() {
@@ -212,7 +217,7 @@ class NimbusOnboardingFeatureLayerTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(subject.image, ImageIdentifiers.onboardingWelcomev106)
+        XCTAssertEqual(subject.image, UIImage(named: ImageIdentifiers.onboardingWelcomev106))
     }
 
     // MARK: - Test install types
@@ -280,11 +285,12 @@ class NimbusOnboardingFeatureLayerTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(subject.buttons.count, expectedNumberOfButtons)
+        XCTAssertNotNil(subject.buttons.primary)
+        XCTAssertNil(subject.buttons.secondary)
     }
 
-    func testLayer_cardIsNotReturned_IfNoButtons() {
-        let expectedNumberOfButtons = 0
+    func testLayer_cardIsReturned_WithTwoButtons() {
+        let expectedNumberOfButtons = 2
         setupNimbusWith(
           cards: 1,
           cardOrdering: ["\(CardElementNames.name) 1"],
@@ -292,7 +298,24 @@ class NimbusOnboardingFeatureLayerTests: XCTestCase {
         )
         let layer = NimbusOnboardingFeatureLayer()
 
-        XCTAssertNil(layer.getOnboardingModel().cards?.first)
+        guard let subject = layer.getOnboardingModel().cards?.first else {
+            XCTFail("Expected a card, and got none.")
+            return
+        }
+
+        XCTAssertNotNil(subject.buttons.primary)
+        XCTAssertNotNil(subject.buttons.secondary)
+    }
+
+    func testLayer_cardIsReturnedWithDefaultPrimaryButton_IfNoButtonsSpecified() {
+        setupNimbusWith(
+          cards: 1,
+          cardOrdering: ["\(CardElementNames.name) 1"],
+          numberOfButtons: 0
+        )
+        let layer = NimbusOnboardingFeatureLayer()
+
+        XCTAssertNotNil(layer.getOnboardingModel().cards?.first)
     }
 
     // MARK: - Test button actions
@@ -310,7 +333,7 @@ class NimbusOnboardingFeatureLayerTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(subject.buttons[0].action, .nextCard)
+        XCTAssertEqual(subject.buttons.primary.action, .nextCard)
     }
 
     func testLayer_cardIsReturned_WithDefaultBrowserButton() {
@@ -327,7 +350,7 @@ class NimbusOnboardingFeatureLayerTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(subject.buttons[0].action, .setDefaultBrowser)
+        XCTAssertEqual(subject.buttons.primary.action, .setDefaultBrowser)
     }
 
     func testLayer_cardIsReturned_WithSyncSignInButton() {
@@ -344,7 +367,7 @@ class NimbusOnboardingFeatureLayerTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(subject.buttons[0].action, .syncSignIn)
+        XCTAssertEqual(subject.buttons.primary.action, .syncSignIn)
     }
 
     func testLayer_cardIsReturned_WithRequestNotificationsButton() {
@@ -361,7 +384,7 @@ class NimbusOnboardingFeatureLayerTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(subject.buttons[0].action, .requestNotifications)
+        XCTAssertEqual(subject.buttons.primary.action, .requestNotifications)
     }
 
     // MARK: - Helpers
@@ -445,8 +468,7 @@ class NimbusOnboardingFeatureLayerTests: XCTestCase {
                                                    type: type))
         string.append(contentsOf: addLink(number: number,
                                           shouldAddLink: shouldAddLink))
-        string.append(contentsOf: addButtons(number: number,
-                                             numberOfButtons: numberOfButtons,
+        string.append(contentsOf: addButtons(numberOfButtons: numberOfButtons,
                                              buttonActions: buttonActions))
         string.append(contentsOf: "}")
 
@@ -482,23 +504,30 @@ class NimbusOnboardingFeatureLayerTests: XCTestCase {
     }
 
     private func addButtons(
-        number: Int,
         numberOfButtons: Int,
         buttonActions: OnboardingActions
     ) -> String {
-        let buttonInfo = [CardElementNames.primaryButtonTitle, CardElementNames.secondaryButtonTitle]
-        var string = "\"buttons\": ["
+        var string = "\"buttons\": {"
 
-        for x in 0..<numberOfButtons {
+        if numberOfButtons > 0 {
             string.append(contentsOf: """
-    {
-      "title": "\(buttonInfo[x]) \(number)",
+    "primary": {
+      "title": "\(CardElementNames.primaryButtonTitle)",
       "action": "\(buttonActions.rawValue)",
     },
 """)
         }
 
-        string.append(contentsOf: "],")
+        if numberOfButtons > 1 {
+            string.append(contentsOf: """
+    "secondary": {
+      "title": "\(CardElementNames.secondaryButtonTitle)",
+      "action": "\(buttonActions.rawValue)",
+    },
+""")
+        }
+
+        string.append(contentsOf: "},")
         return string
     }
 }

--- a/Tests/ClientTests/OnboardingTests/OnboardingCardViewModelTests.swift
+++ b/Tests/ClientTests/OnboardingTests/OnboardingCardViewModelTests.swift
@@ -114,13 +114,19 @@ class OnboardingCardViewModelTests: XCTestCase {
     }
 
     // MARK: Private
-    private func createInfoModel() -> LegacyOnboardingModelProtocol {
-        return LegacyOnboardingInfoModel(image: nil,
-                                         title: "Title",
-                                         description: "Description",
-                                         linkButtonTitle: "Link",
-                                         primaryAction: "Button1",
-                                         secondaryAction: "Button2",
-                                         a11yIdRoot: "A11yId")
+    private func createInfoModel() -> OnboardingCardInfoModelProtocol {
+        return OnboardingCardInfoModel(
+            name: "name",
+            title: "Title",
+            body: "Description",
+            link: OnboardingLinkInfoModel(
+                title: "Link",
+                url: URL(string: "https://macrumors.com")!),
+            buttons: OnboardingButtons(
+                primary: OnboardingButtonInfoModel(title: "Button1", action: .nextCard),
+                secondary: OnboardingButtonInfoModel(title: "Button2", action: .nextCard)),
+            type: .freshInstall,
+            a11yIdRoot: "A11yId",
+            imageID: "image")
     }
 }

--- a/nimbus-features/onboardingFrameworkFeature.yaml
+++ b/nimbus-features/onboardingFrameworkFeature.yaml
@@ -36,10 +36,12 @@ features:
               title: "First title"
               body: "Some body text that's rather longer than a title 1"
               buttons:
-                - title: "Primary Button 1"
-                  action: sync-sign-in
-                - title: "Secondary Button 1"
+                primary:
+                  title: "Primary Button 2"
                   action: request-notifications
+                secondary:
+                  title: "Secondary Button 2"
+                  action: next-card
               type: fresh-install
             - name: "Test 2"
               title: "Second title"
@@ -48,9 +50,11 @@ features:
                 title: "Hello, senator"
                 url: "https://macrumors.com"
               buttons:
-                - title: "Primary Button 2"
+                primary:
+                  title: "Primary Button 2"
                   action: sync-sign-in
-                - title: "Secondary Button 2"
+                secondary:
+                  title: "Secondary Button 2"
                   action: next-card
               type: update
           card-ordering:
@@ -94,12 +98,14 @@ objects:
           If left empty, the card will have no link.
         default: null
       buttons:
-        type: List<NimbusOnboardingButton>
+        type: NimbusOnboardingButtons
         description: >
-          A list of buttons associated with the card.
-          Based on the number of buttons in this list, the card will
-          display only one or, at maximum, two buttons.
-        default: []
+          The set of buttons associated with the card.
+        default:
+          primary:
+            title: "Primary Button"
+            action: next-card
+          secondary: null
       type:
         type: OnboardingType
         description: >
@@ -122,6 +128,23 @@ objects:
         description: >
           The url that the link will lead to.
         default: "https://macrumors.com"
+  NimbusOnboardingButtons:
+    description: >
+      A set of buttons for the card. There can be up to two, but
+      there must be at least one.
+    fields:
+      primary:
+        type: NimbusOnboardingButton
+        description: >
+          The primary button for the card. This must exist.
+        default:
+          title: "Primary Button"
+          action: next-card
+      secondary:
+        type: Option<NimbusOnboardingButton>
+        description: >
+          A secondary, optional, button for the card.
+        default: null
   NimbusOnboardingButton:
     description: >
       A group of properties describing the attributes of a card.


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5924)

### Description
This simply changes views to use the new data models.

There's a minor adjustment to the nimbus onboarding framework: the original plan was to have buttons as an array, but the presents a problem: how do we know which is the primary action for the card? Instead of having all sorts of logic to determine that, the onus is put on the user to assign buttons.

NOTE: There are some random strings & URL's in the data models are currently hardcoded in some places. This cannot cause a production issue as these URL's aren't currently being used. This will change and the hardcoded flags will be removed with this [ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6375). But for now, it hardcoding expedites work without any risks. As for the strings, these aren't currently being used either, and will be removed once the data comes from nimbus, rather than these hardcoded models.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
