### PR TITLE
Bugfix FXIOS-6366 [v114] Fix issue with tab session reload

### DIFF
--- a/BrowserKit/Sources/TabDataStore/TabDataStore.swift
+++ b/BrowserKit/Sources/TabDataStore/TabDataStore.swift
@@ -31,7 +31,7 @@ public actor DefaultTabDataStore: TabDataStore {
 
     public init(logger: Logger = DefaultLogger.shared,
                 fileManager: TabFileManager = DefaultTabFileManager(),
-                throttleTime: UInt64 = 5 * NSEC_PER_SEC) {
+                throttleTime: UInt64 = 2 * NSEC_PER_SEC) {
         self.logger = logger
         self.fileManager = fileManager
         self.throttleTime = throttleTime

--- a/Client/TabManagement/Tab.swift
+++ b/Client/TabManagement/Tab.swift
@@ -454,7 +454,7 @@ class Tab: NSObject {
             webView.scrollView.layer.masksToBounds = false
             webView.navigationDelegate = navigationDelegate
 
-            restore(webView, sessionData: restoreSessionData)
+            restore(webView, interactionState: restoreSessionData)
 
             self.webView = webView
 
@@ -478,12 +478,17 @@ class Tab: NSObject {
         }
     }
 
-    func restore(_ webView: WKWebView, sessionData: Data? = nil) {
-        // If the session data field is populated it means the new session store is in use and the session data
+    func restore(_ webView: WKWebView, interactionState: Data? = nil) {
+        // If the interactionState field is populated it means the new session store is in use and the session data
         // now comes from a different source than save tab and parsing is managed by the web view itself
-        if #available(iOS 15, *),
-           let url = url {
-            webView.load(PrivilegedRequest(url: url) as URLRequest)
+        if TabStorageFlagManager.isNewTabDataStoreEnabled {
+            if let url = url {
+                webView.load(PrivilegedRequest(url: url) as URLRequest)
+            }
+            if #available(iOS 15, *),
+               let interactionState = interactionState {
+                webView.interactionState = interactionState
+            }
             return
         }
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6366)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14301)

### Description
I renamed the field in the method to interactionState because there is already a sessionData which is confusing. I can rename it back once the deprecated code is removed.
I originally thought I wouldn't directly need the feature flag in the Tab but since during a migration there won't be a interactionState object to retrieve it's not enough to go on. 
I also reduce the throttle time, during testing 5 seconds was often causing me to lose data. 5 seconds is probably fine for a real user but during testing it will get frustrating. 

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
