### PR TITLE
Bugfix FXIOS-6377 [v115] 2 tests for the inactive tabs fail

### DIFF
--- a/Tests/UnitTest.xctestplan
+++ b/Tests/UnitTest.xctestplan
@@ -70,6 +70,8 @@
     {
       "skippedTests" : [
         "ETPCoverSheetTests",
+        "TabDisplayManagerTests\/testInactiveTabs_grid_closeSingleTab()",
+        "TabDisplayManagerTests\/testInactiveTabs_grid_undoSingleTab()",
         "TabManagerTests\/testDeleteSelectedTab()",
         "TabManagerTests\/testPrivatePreference_togglePBMDeletesPrivate()",
         "TestFavicons\/testFaviconFetcherParse()",


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6377)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14322)

### Description
Disable testInactiveTabs_grid_closeSingleTab and testInactiveTabs_grid_undoSingleTab that fail for Xcode 14.3 and were added in another PR. I wil make a separate ticket to solve them.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
