### PR TITLE
Refactor FXIOS-6381 [v115] Turn off Glean internal logs in our console

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -17974,7 +17974,7 @@
 			repositoryURL = "https://github.com/mozilla/glean-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 52.5.0;
+				version = 52.7.0;
 			};
 		};
 		4368F83B279669690013419B /* XCRemoteSwiftPackageReference "SnapKit" */ = {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla/glean-swift",
       "state" : {
-        "revision" : "a3fb726ae0c4c10c1a1b7314b21d0a845107bb10",
-        "version" : "52.5.0"
+        "revision" : "dd626f0fb051ffc70179846a0b75a04f997b63b7",
+        "version" : "52.7.0"
       }
     },
     {

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -167,7 +167,10 @@ class TelemetryWrapper: TelemetryWrapperProtocol {
         }
 
         // Initialize Glean telemetry
-        glean.initialize(uploadEnabled: sendUsageData, configuration: Configuration(channel: AppConstants.buildChannel.rawValue), buildInfo: GleanMetrics.GleanBuild.info)
+        let gleanConfig = Configuration(channel: AppConstants.buildChannel.rawValue, logLevel: .off)
+        glean.initialize(uploadEnabled: sendUsageData,
+                         configuration: gleanConfig,
+                         buildInfo: GleanMetrics.GleanBuild.info)
 
         // Save the profile so we can record settings from it when the notification below fires.
         self.profile = profile


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6381)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14336)

### Description
It's now possible with Glean release [52.7.0](https://github.com/mozilla/glean/releases/tag/v52.7.0) to turn off the Glean internal logging in the Xcode console. Those logs don't get pipped into our own logger so never get to our debug file, and we rarely (IMO) use them locally to debug Glean. It's possible to change the log level locally, but by default I would turn them off. The end goal is to reduce noise in our console so we don't miss any important issues while developing.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
