### PR TITLE
Bugfix FXIOS-6125 [v114] Update tab preview image scaling

### DIFF
--- a/Client/Frontend/Browser/ScreenshotHelper.swift
+++ b/Client/Frontend/Browser/ScreenshotHelper.swift
@@ -53,6 +53,7 @@ class ScreenshotHelper {
             let configuration = WKSnapshotConfiguration()
             // This is for a bug in certain iOS 13 versions, snapshots cannot be taken correctly without this boolean being set
             configuration.afterScreenUpdates = false
+            configuration.snapshotWidth = 320
 
             webView.takeSnapshot(with: configuration) { image, error in
                 if let image = image {

--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -36,6 +36,6 @@ public struct UIConstants {
     static let PasscodeEntryFont = UIFont.systemFont(ofSize: PasscodeEntryFontSize, weight: UIFont.Weight.bold)
 
     /// JPEG compression quality for persisted screenshots. Must be between 0-1.
-    static let ScreenshotQuality: Float = 0.3
+    static let ScreenshotQuality: Float = 1
     static let ActiveScreenshotQuality: CGFloat = 0.5
 }

--- a/Storage/DiskImageStore.swift
+++ b/Storage/DiskImageStore.swift
@@ -68,16 +68,8 @@ public actor DefaultDiskImageStore: DiskImageStore {
     }
 
     public func saveImageForKey(_ key: String, image: UIImage) async throws {
-        let size = CGSize(width: image.size.width / 2, height: image.size.height / 2)
-        let format = UIGraphicsImageRendererFormat()
-        format.scale = 1
-        let renderer = UIGraphicsImageRenderer(size: size, format: format)
-        let scaledImage = renderer.image { _ in
-            image.draw(in: CGRect(origin: .zero, size: size))
-        }
-
         let imageURL = URL(fileURLWithPath: filesDir).appendingPathComponent(key)
-        if let data = scaledImage.jpegData(compressionQuality: quality) {
+        if let data = image.jpegData(compressionQuality: quality) {
             try data.write(to: imageURL, options: .noFileProtection)
             keys.insert(key)
         } else {

--- a/Tests/StorageTests/DiskImageStoreTests.swift
+++ b/Tests/StorageTests/DiskImageStoreTests.swift
@@ -31,12 +31,12 @@ class DiskImageStoreTests: XCTestCase {
 
         let fetchedImage = try await store.getImageForKey(testKey)
 
-        XCTAssertEqual(testImage.size.width / 2,
+        XCTAssertEqual(testImage.size.width,
                        fetchedImage.size.width,
-                       "Fetched image width should be half the original width")
-        XCTAssertEqual(testImage.size.height / 2,
+                       "Fetched image width should be the same as the original width")
+        XCTAssertEqual(testImage.size.height,
                        fetchedImage.size.height,
-                       "Fetched image height should be half the original height")
+                       "Fetched image height should be the same as the original height")
     }
 
     func testGetImageForKey() async throws {
@@ -51,12 +51,12 @@ class DiskImageStoreTests: XCTestCase {
             let fetchedImage = try await store.getImageForKey(key)
 
             // Then
-            XCTAssertEqual(image.size.width / 2,
+            XCTAssertEqual(image.size.width,
                            fetchedImage.size.width,
-                           "Fetched image width should be half the original width")
-            XCTAssertEqual(image.size.height / 2,
+                           "Fetched image width should be the same as the original width")
+            XCTAssertEqual(image.size.height,
                            fetchedImage.size.height,
-                           "Fetched image height should be half the original height")
+                           "Fetched image height should be the same as the original height")
         }
     }
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6126)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13855)

### Description
Switched the mechanism used to scale the image to use WKSnapshotConfiguration directly, it was previously essentially doubling up on the work being done.
Updated the jpg compression quality, since the image is now smaller the jpg algorithm is not kind to text. This will increase the size on disk slightly, but it should still be a good bit smaller than when this change was originally added when it was a full screen image. And it will continue to have a much smaller footprint in memory.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
