### PR TITLE
Add FXIOS-5960 [v114] Rust Sync Manager tests

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -1379,6 +1379,7 @@
 		F018F84C2719AE8300B9A52D /* ThemedDefaultNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F018F84B2719AE8300B9A52D /* ThemedDefaultNavigationController.swift */; };
 		F35B8D2B1D6380EA008E3D61 /* SessionRestore.html in Resources */ = {isa = PBXBuildFile; fileRef = F35B8D2A1D6380EA008E3D61 /* SessionRestore.html */; };
 		F35B8D2D1D6383E9008E3D61 /* SessionRestoreHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F35B8D2C1D6383E9008E3D61 /* SessionRestoreHelper.swift */; };
+		F80D53CF2A09A3350047ED14 /* RustSyncManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F80D53CD2A09A30F0047ED14 /* RustSyncManagerTests.swift */; };
 		F80DF73F27034F6400E4C37D /* DynamicFontHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65075531E37F6FC006961AC /* DynamicFontHelper.swift */; };
 		F80DF7412703BC8E00E4C37D /* CredentialPasscodeRequirementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F80DF7402703BC8E00E4C37D /* CredentialPasscodeRequirementViewController.swift */; };
 		F80DF74B270CB9CA00E4C37D /* AppAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65D89171C8647420006EA35 /* AppAuthenticator.swift */; };
@@ -6188,6 +6189,7 @@
 		F7AF4A03BEA7A042860317B0 /* ms */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ms; path = ms.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
 		F7C743F899980D164068A607 /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/Shared.strings; sourceTree = "<group>"; };
 		F7F34246B52E8E307FEE81BD /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
+		F80D53CD2A09A30F0047ED14 /* RustSyncManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RustSyncManagerTests.swift; sourceTree = "<group>"; };
 		F80DF7402703BC8E00E4C37D /* CredentialPasscodeRequirementViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialPasscodeRequirementViewController.swift; sourceTree = "<group>"; };
 		F82F4AB9A3C09B181AB61F73 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Shared.strings"; sourceTree = "<group>"; };
 		F8324A052649A188007E4BFA /* CredentialProvider.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = CredentialProvider.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -9765,6 +9767,7 @@
 				03CCC9171AF05E7300DBF30D /* RelativeDatesTests.swift */,
 				8A5C3BC4282ABF8E003A8CCF /* RemoteTabsPanelTests.swift */,
 				28D52E081BCDF44100187A1D /* ResetTests.swift */,
+				F80D53CD2A09A30F0047ED14 /* RustSyncManagerTests.swift */,
 				8AE1E1DA27B1C1320024C45E /* SearchBarSettingsViewModelTests.swift */,
 				8A04136A2825ABEA00D20B10 /* SponsoredTileTelemetryTests.swift */,
 				213B67A727CE721E000542F5 /* StartAtHomeHelperTests.swift */,
@@ -12490,6 +12493,7 @@
 				3B61CD591F2A750800D38DE1 /* PocketFeedTests.swift in Sources */,
 				C8E1BC0A28085AA700C62964 /* NimbusFeatureFlagLayerTests.swift in Sources */,
 				C8D0D6F4281C231200AFAED9 /* FeatureFlagsUserPrefsMigrationUtilityTests.swift in Sources */,
+				F80D53CF2A09A3350047ED14 /* RustSyncManagerTests.swift in Sources */,
 				43446CF02412DDBE00F5C643 /* UpdateViewModelTests.swift in Sources */,
 				8A93F86829D373B0004159D9 /* MockNavigationController.swift in Sources */,
 				8AE1E1D927B1BD380024C45E /* UIStackViewExtensionsTests.swift in Sources */,

--- a/Tests/ClientTests/RustSyncManagerTests.swift
+++ b/Tests/ClientTests/RustSyncManagerTests.swift
@@ -1,0 +1,117 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+import Storage
+import XCTest
+
+private typealias MZSyncResult = MozillaAppServices.SyncResult
+
+class RustSyncManagerTests: XCTestCase {
+    let bookmarksStateChangedPrefKey = "sync.engine.bookmarks.enabledStateChanged"
+    let bookmarksEnabledPrefKey = "sync.engine.bookmarks.enabled"
+    let historyStateChangedPrefKey = "sync.engine.history.enabledStateChanged"
+    let historyEnabledPrefKey = "sync.engine.history.enabled"
+    let passwordsStateChangedPrefKey = "sync.engine.passwords.enabledStateChanged"
+    let passwordsEnabledPrefKey = "sync.engine.passwords.enabled"
+    let tabsStateChangedPrefKey = "sync.engine.tabs.enabledStateChanged"
+    let tabsEnabledPrefKey = "sync.engine.tabs.enabled"
+    var rustSyncManager: RustSyncManager!
+    var profile: MockBrowserProfile!
+
+    override func setUp() {
+        super.setUp()
+        profile = MockBrowserProfile(localName: "RustSyncManagerTests")
+        rustSyncManager = RustSyncManager(profile: profile,
+                                          logger: MockLogger(),
+                                          notificationCenter: MockNotificationCenter())
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        rustSyncManager = nil
+        UserDefaults.standard.removeObject(forKey: "fxa.cwts.declinedSyncEngines")
+        profile.prefs.removeObjectForKey(bookmarksStateChangedPrefKey)
+        profile.prefs.removeObjectForKey(bookmarksEnabledPrefKey)
+        profile.prefs.removeObjectForKey(historyStateChangedPrefKey)
+        profile.prefs.removeObjectForKey(historyEnabledPrefKey)
+        profile.prefs.removeObjectForKey(passwordsStateChangedPrefKey)
+        profile.prefs.removeObjectForKey(passwordsEnabledPrefKey)
+        profile.prefs.removeObjectForKey(tabsStateChangedPrefKey)
+        profile.prefs.removeObjectForKey(tabsEnabledPrefKey)
+        profile = nil
+    }
+
+    func testGetEnginesAndKeys() {
+        let engines = ["bookmarks", "history", "passwords", "tabs"]
+        rustSyncManager.getEnginesAndKeys(engines: engines) { (engines, keys) in
+            XCTAssertEqual(engines.count, 4)
+            XCTAssertTrue(engines.contains("bookmarks"))
+            XCTAssertTrue(engines.contains("history"))
+            XCTAssertTrue(engines.contains("passwords"))
+            XCTAssertTrue(engines.contains("tabs"))
+            XCTAssertFalse(keys.isEmpty)
+        }
+    }
+
+    func testGetEnginesAndKeysWithNoKey() {
+        rustSyncManager.getEnginesAndKeys(engines: ["tabs"]) { (engines, keys) in
+            XCTAssertEqual(engines.count, 1)
+            XCTAssertTrue(engines.contains("tabs"))
+            XCTAssertTrue(keys.isEmpty)
+        }
+    }
+
+    func testGetEngineEnablementChangesForAccountWithNewAccount() {
+        let declinedEngines = ["tabs"]
+        UserDefaults.standard.set(declinedEngines, forKey: "fxa.cwts.declinedSyncEngines")
+        let changes = rustSyncManager.getEngineEnablementChangesForAccount()
+        XCTAssertFalse(changes["tabs"]!)
+    }
+
+    func testGetEngineEnablementChangesForAccountWithNoChanges() {
+        let changes = rustSyncManager.getEngineEnablementChangesForAccount()
+        XCTAssertTrue(changes.isEmpty)
+    }
+
+    func testGetEngineEnablementChangesForAccountWithNoRecentChanges() {
+        profile.prefs.setBool(true, forKey: bookmarksEnabledPrefKey)
+
+        let changes = rustSyncManager.getEngineEnablementChangesForAccount()
+        XCTAssertTrue(changes.isEmpty)
+    }
+
+    func testGetEngineEnablementChangesForAccountWithRecentChanges() {
+        profile.prefs.setBool(true, forKey: bookmarksStateChangedPrefKey)
+        profile.prefs.setBool(true, forKey: bookmarksEnabledPrefKey)
+
+        let changes = rustSyncManager.getEngineEnablementChangesForAccount()
+        XCTAssertTrue(changes["bookmarks"]!)
+    }
+
+    func testUpdateEnginePrefs() {
+        profile.prefs.setBool(true, forKey: bookmarksEnabledPrefKey)
+        profile.prefs.setBool(true, forKey: historyEnabledPrefKey)
+        profile.prefs.setBool(false, forKey: passwordsEnabledPrefKey)
+        profile.prefs.setBool(false, forKey: tabsEnabledPrefKey)
+
+        profile.prefs.setBool(true, forKey: bookmarksStateChangedPrefKey)
+        profile.prefs.setBool(false, forKey: historyStateChangedPrefKey)
+        profile.prefs.setBool(false, forKey: passwordsStateChangedPrefKey)
+        profile.prefs.setBool(true, forKey: tabsStateChangedPrefKey)
+
+        let declined = ["bookmarks", "passwords"]
+        rustSyncManager.updateEnginePrefs(declined: declined)
+
+        XCTAssertFalse(profile.prefs.boolForKey(bookmarksEnabledPrefKey)!)
+        XCTAssertTrue(profile.prefs.boolForKey(historyEnabledPrefKey)!)
+        XCTAssertFalse(profile.prefs.boolForKey(passwordsEnabledPrefKey)!)
+        XCTAssertTrue(profile.prefs.boolForKey(tabsEnabledPrefKey)!)
+
+        XCTAssertNil(profile.prefs.boolForKey(bookmarksStateChangedPrefKey))
+        XCTAssertNil(profile.prefs.boolForKey(historyStateChangedPrefKey))
+        XCTAssertNil(profile.prefs.boolForKey(passwordsStateChangedPrefKey))
+        XCTAssertNil(profile.prefs.boolForKey(tabsStateChangedPrefKey))
+    }
+}


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5960)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13543)

### Description
Adding tests to cover the integral parts of the rust sync manager code. This includes the retrieving and updating of engine enablements and the retrieval of engines to sync and any necessary encryption keys.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
