### PR TITLE
Add FXIOS-6391 [v115] credit card syncing functionality added

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -20,10 +20,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                                                 .rustSyncManagerComponent
                                                 .value()
                                                 .useRustSyncManager
+    private let creditCardAutofillStatus = FxNimbus.shared
+        .features
+        .creditCardAutofill
+        .value()
+        .creditCardAutofillStatus
+
     lazy var profile: Profile = BrowserProfile(
         localName: "profile",
         syncDelegate: UIApplication.shared.syncDelegate,
-        rustSyncManagerEnabled: rustSyncManagerStatus
+        rustSyncManagerEnabled: rustSyncManagerStatus,
+        creditCardAutofillEnabled: creditCardAutofillStatus
     )
     lazy var tabManager: TabManager = TabManagerImplementation(
         profile: profile,

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -235,6 +235,7 @@ open class BrowserProfile: Profile {
     init(localName: String,
          syncDelegate: SyncDelegate? = nil,
          rustSyncManagerEnabled: Bool = false,
+         creditCardAutofillEnabled: Bool = false,
          clear: Bool = false,
          logger: Logger = DefaultLogger.shared) {
         logger.log("Initing profile \(localName) on thread \(Thread.current).",
@@ -323,7 +324,8 @@ open class BrowserProfile: Profile {
             let msg = "Setting `syncManager` property to `RustSyncManager"
             logger.log(msg, level: .debug, category: .sync)
 
-            self.syncManager = RustSyncManager(profile: self)
+            self.syncManager = RustSyncManager(profile: self,
+                                               creditCardAutofillEnabled: creditCardAutofillEnabled)
 
             // Setting this pref to true in the event this is the first time
             // RustSyncManager is being used. If it's been used before setting this pref

--- a/Storage/Rust/RustAutofill.swift
+++ b/Storage/Rust/RustAutofill.swift
@@ -405,6 +405,12 @@ public class RustAutofill {
         }
     }
 
+    public func registerWithSyncManager() {
+        queue.async { [unowned self] in
+            self.storage?.registerWithSyncManager()
+        }
+    }
+
     @discardableResult
     public func getStoredKey() throws -> String {
         let rustKeys = RustAutofillEncryptionKeys()

--- a/Sync/RustSyncManagerAPI.swift
+++ b/Sync/RustSyncManagerAPI.swift
@@ -12,9 +12,14 @@ open class RustSyncManagerAPI {
     let api: SyncManagerComponent
     public typealias MZSyncResult = MozillaAppServices.SyncResult
 
-    public init(logger: Logger = DefaultLogger.shared) {
+    public init(logger: Logger = DefaultLogger.shared,
+                creditCardAutofillEnabled: Bool = false) {
         self.api = SyncManagerComponent()
         self.logger = logger
+
+        if creditCardAutofillEnabled {
+            RustSyncManagerAPI.rustTogglableEngines.append("creditcards")
+        }
     }
 
     public func disconnect() {
@@ -72,6 +77,14 @@ open class RustSyncManagerAPI {
             completion(engines)
         }
     }
+
+    // Names of collections that can be enabled/disabled locally.
+    public static var rustTogglableEngines: [String] = [
+        "tabs",
+        "passwords",
+        "bookmarks",
+        "history",
+    ]
 }
 
 public func toRustSyncReason(reason: OldSyncReason) -> MozillaAppServices.SyncReason {
@@ -88,11 +101,3 @@ public func toRustSyncReason(reason: OldSyncReason) -> MozillaAppServices.SyncRe
         return MozillaAppServices.SyncReason.enabledChange
     }
 }
-
-// Names of collections that can be enabled/disabled locally.
-public let RustTogglableEngines: [String] = [
-    "tabs",
-    "bookmarks",
-    "history",
-    "passwords",
-]

--- a/Tests/ClientTests/RustSyncManagerTests.swift
+++ b/Tests/ClientTests/RustSyncManagerTests.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 @testable import Client
+import Sync
 import Storage
 import XCTest
 
@@ -11,6 +12,8 @@ private typealias MZSyncResult = MozillaAppServices.SyncResult
 class RustSyncManagerTests: XCTestCase {
     let bookmarksStateChangedPrefKey = "sync.engine.bookmarks.enabledStateChanged"
     let bookmarksEnabledPrefKey = "sync.engine.bookmarks.enabled"
+    let creditcardsStateChangedPrefKey = "sync.engine.creditcards.enabledStateChanged"
+    let creditcardsEnabledPrefKey = "sync.engine.creditcards.enabled"
     let historyStateChangedPrefKey = "sync.engine.history.enabledStateChanged"
     let historyEnabledPrefKey = "sync.engine.history.enabled"
     let passwordsStateChangedPrefKey = "sync.engine.passwords.enabledStateChanged"
@@ -24,8 +27,11 @@ class RustSyncManagerTests: XCTestCase {
         super.setUp()
         profile = MockBrowserProfile(localName: "RustSyncManagerTests")
         rustSyncManager = RustSyncManager(profile: profile,
+                                          creditCardAutofillEnabled: true,
                                           logger: MockLogger(),
                                           notificationCenter: MockNotificationCenter())
+        rustSyncManager.syncManagerAPI = RustSyncManagerAPI(creditCardAutofillEnabled: true)
+        profile.syncManager = rustSyncManager
     }
 
     override func tearDown() {
@@ -34,6 +40,8 @@ class RustSyncManagerTests: XCTestCase {
         UserDefaults.standard.removeObject(forKey: "fxa.cwts.declinedSyncEngines")
         profile.prefs.removeObjectForKey(bookmarksStateChangedPrefKey)
         profile.prefs.removeObjectForKey(bookmarksEnabledPrefKey)
+        profile.prefs.removeObjectForKey(creditcardsStateChangedPrefKey)
+        profile.prefs.removeObjectForKey(creditcardsEnabledPrefKey)
         profile.prefs.removeObjectForKey(historyStateChangedPrefKey)
         profile.prefs.removeObjectForKey(historyEnabledPrefKey)
         profile.prefs.removeObjectForKey(passwordsStateChangedPrefKey)
@@ -44,14 +52,19 @@ class RustSyncManagerTests: XCTestCase {
     }
 
     func testGetEnginesAndKeys() {
-        let engines = ["bookmarks", "history", "passwords", "tabs"]
+        let engines = ["bookmarks", "creditcards", "history", "passwords", "tabs"]
         rustSyncManager.getEnginesAndKeys(engines: engines) { (engines, keys) in
-            XCTAssertEqual(engines.count, 4)
+            XCTAssertEqual(engines.count, 5)
+
             XCTAssertTrue(engines.contains("bookmarks"))
             XCTAssertTrue(engines.contains("history"))
             XCTAssertTrue(engines.contains("passwords"))
             XCTAssertTrue(engines.contains("tabs"))
             XCTAssertFalse(keys.isEmpty)
+
+            XCTAssertEqual(keys.count, 2)
+            XCTAssertNotNil(keys["creditcards"])
+            XCTAssertNotNil(keys["passwords"])
         }
     }
 
@@ -64,10 +77,11 @@ class RustSyncManagerTests: XCTestCase {
     }
 
     func testGetEngineEnablementChangesForAccountWithNewAccount() {
-        let declinedEngines = ["tabs"]
+        let declinedEngines = ["tabs", "creditcards"]
         UserDefaults.standard.set(declinedEngines, forKey: "fxa.cwts.declinedSyncEngines")
         let changes = rustSyncManager.getEngineEnablementChangesForAccount()
         XCTAssertFalse(changes["tabs"]!)
+        XCTAssertFalse(changes["creditcards"]!)
     }
 
     func testGetEngineEnablementChangesForAccountWithNoChanges() {
@@ -85,31 +99,38 @@ class RustSyncManagerTests: XCTestCase {
     func testGetEngineEnablementChangesForAccountWithRecentChanges() {
         profile.prefs.setBool(true, forKey: bookmarksStateChangedPrefKey)
         profile.prefs.setBool(true, forKey: bookmarksEnabledPrefKey)
+        profile.prefs.setBool(true, forKey: creditcardsStateChangedPrefKey)
+        profile.prefs.setBool(false, forKey: creditcardsEnabledPrefKey)
 
         let changes = rustSyncManager.getEngineEnablementChangesForAccount()
         XCTAssertTrue(changes["bookmarks"]!)
+        XCTAssertFalse(changes["creditcards"]!)
     }
 
     func testUpdateEnginePrefs() {
         profile.prefs.setBool(true, forKey: bookmarksEnabledPrefKey)
+        profile.prefs.setBool(true, forKey: creditcardsEnabledPrefKey)
         profile.prefs.setBool(true, forKey: historyEnabledPrefKey)
         profile.prefs.setBool(false, forKey: passwordsEnabledPrefKey)
         profile.prefs.setBool(false, forKey: tabsEnabledPrefKey)
 
         profile.prefs.setBool(true, forKey: bookmarksStateChangedPrefKey)
+        profile.prefs.setBool(true, forKey: creditcardsStateChangedPrefKey)
         profile.prefs.setBool(false, forKey: historyStateChangedPrefKey)
         profile.prefs.setBool(false, forKey: passwordsStateChangedPrefKey)
         profile.prefs.setBool(true, forKey: tabsStateChangedPrefKey)
 
-        let declined = ["bookmarks", "passwords"]
+        let declined = ["bookmarks", "creditcards", "passwords"]
         rustSyncManager.updateEnginePrefs(declined: declined)
 
         XCTAssertFalse(profile.prefs.boolForKey(bookmarksEnabledPrefKey)!)
+        XCTAssertFalse(profile.prefs.boolForKey(creditcardsEnabledPrefKey)!)
         XCTAssertTrue(profile.prefs.boolForKey(historyEnabledPrefKey)!)
         XCTAssertFalse(profile.prefs.boolForKey(passwordsEnabledPrefKey)!)
         XCTAssertTrue(profile.prefs.boolForKey(tabsEnabledPrefKey)!)
 
         XCTAssertNil(profile.prefs.boolForKey(bookmarksStateChangedPrefKey))
+        XCTAssertNil(profile.prefs.boolForKey(creditcardsStateChangedPrefKey))
         XCTAssertNil(profile.prefs.boolForKey(historyStateChangedPrefKey))
         XCTAssertNil(profile.prefs.boolForKey(passwordsStateChangedPrefKey))
         XCTAssertNil(profile.prefs.boolForKey(tabsStateChangedPrefKey))


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6391)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14361)

### Description
**NOTE:** This pull request should be reviewed and merged after #14360 as it includes changes from that PR. 

Adding functionality to enable credit card syncing. These changes are behind the `creditCardAutofillStatus` flag and have been added to allow for local testing.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
