### PR TITLE
Build BUG-1832682 [v115] Move bitrise Taskcluster tasks to GCP

### DIFF
--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -20,7 +20,7 @@ workers:
             provisioner: 'mobile-{level}'
             implementation: docker-worker
             os: linux
-            worker-type: 'bitrise'
+            worker-type: 'bitrise-gcp'
         images:
             provisioner: 'mobile-{level}'
             implementation: docker-worker


### PR DESCRIPTION
[Bug 1832682](https://bugzilla.mozilla.org/show_bug.cgi?id=1832682)

### Description
We're going to be shutting down the AWS account later in the year so all tasks need to be migrated to GCP.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
