### PR TITLE
Refactor MTE-967 [v115] Use M1 stack to build and run unit tests

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -148,7 +148,7 @@ workflows:
     meta:
       bitrise.io:
         stack: osx-xcode-14.3.x-ventura
-        machine_type_id: g2-m1.4core
+        machine_type_id: g2-m1.8core
   build_and_test_1_SmokeTest2:
     before_run:
     - 1_git_clone_and_post_clone

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -13,9 +13,9 @@ stages:
   stage_2:
     workflows:
     - build_and_test_1_SmokeTest2: {}
-    - build_and_test_2_SmokeTest: {}
-    - build_and_test_3_SmokeTest3: {}
-    - build_and_test_4_SmokeTest4: {}
+    # - build_and_test_2_SmokeTest: {}
+    # - build_and_test_3_SmokeTest3: {}
+    # - build_and_test_4_SmokeTest4: {}
 workflows:
   configure_build_fennec:
     before_run:
@@ -148,7 +148,7 @@ workflows:
     meta:
       bitrise.io:
         stack: osx-xcode-14.3.x-ventura
-        machine_type_id: g2.8core
+        machine_type_id: g2-m1.4core
   build_and_test_1_SmokeTest2:
     before_run:
     - 1_git_clone_and_post_clone
@@ -188,7 +188,7 @@ workflows:
     meta:
       bitrise.io:
         stack: osx-xcode-14.3.x-ventura
-        machine_type_id: g2.4core
+        machine_type_id: g2-m1.4core
   build_and_test_2_SmokeTest:
     before_run:
     - 1_git_clone_and_post_clone

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -188,7 +188,7 @@ workflows:
     meta:
       bitrise.io:
         stack: osx-xcode-14.3.x-ventura
-        machine_type_id: g2-m1.4core
+        machine_type_id: g2-m1.8core
   build_and_test_2_SmokeTest:
     before_run:
     - 1_git_clone_and_post_clone


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-967)

### Description

Intel Bitrise stacks will be deprecated in a month. We need to ensure that we can use Bitrise's M1 stack to carry on our work.

This PR is to show that we can use the M1 stack to build and run unit tests.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
