### PR TITLE
Bugfix FXIOS-6316 [v114] Internal inconsistency crash

### DIFF
--- a/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
@@ -94,7 +94,7 @@ class HistoryHighlightsViewModel {
     /// Group weight used to create collection view compositional layout
     /// Case 1: For compact and a single column use 0.9 to occupy must of the width of the parent
     /// Case 2: For compact and multiple columns 0.8 to show part of the next column
-    /// Case 3: For ipad and iphone landscape we use 1/3 of the available width
+    /// Case 3: For iPad and iPhone landscape we use 1/3 of the available width
     var groupWidthWeight: NSCollectionLayoutDimension {
         guard !UIDevice().isIphoneLandscape,
               UIDevice.current.userInterfaceIdiom != .pad else {
@@ -444,7 +444,9 @@ extension HistoryHighlightsViewModel: HistoryHighlightsDelegate {
     func didLoadNewData() {
         dispatchQueue.ensureMainThread {
             self.historyItems = self.historyHighlightsDataAdaptor.getHistoryHighlights()
+            print("YRD HistoryHighlights loadd new data and is \(self.isEnabled)")
             guard self.isEnabled else { return }
+            // TODO: Add log here?
             self.delegate?.reloadView()
         }
     }

--- a/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
@@ -71,6 +71,7 @@ class HistoryHighlightsViewModel {
     private var historyHighlightsDataAdaptor: HistoryHighlightsDataAdaptor
     private let dispatchQueue: DispatchQueueInterface
     private let telemetry: TelemetryWrapperProtocol
+    private var logger: Logger
 
     var onTapItem: ((HighlightItem) -> Void)?
     var historyHighlightLongPressHandler: ((HighlightItem, UIView?) -> Void)?
@@ -112,13 +113,15 @@ class HistoryHighlightsViewModel {
          historyHighlightsDataAdaptor: HistoryHighlightsDataAdaptor,
          dispatchQueue: DispatchQueueInterface = DispatchQueue.main,
          telemetry: TelemetryWrapperProtocol = TelemetryWrapper.shared,
-         wallpaperManager: WallpaperManager) {
+         wallpaperManager: WallpaperManager,
+         logger: Logger = DefaultLogger.shared) {
         self.profile = profile
         self.isPrivate = isPrivate
         self.theme = theme
         self.dispatchQueue = dispatchQueue
         self.telemetry = telemetry
         self.wallpaperManager = wallpaperManager
+        self.logger = logger
         self.historyHighlightsDataAdaptor = historyHighlightsDataAdaptor
         self.historyHighlightsDataAdaptor.delegate = self
     }
@@ -444,9 +447,10 @@ extension HistoryHighlightsViewModel: HistoryHighlightsDelegate {
     func didLoadNewData() {
         dispatchQueue.ensureMainThread {
             self.historyItems = self.historyHighlightsDataAdaptor.getHistoryHighlights()
-            print("YRD HistoryHighlights loadd new data and is \(self.isEnabled)")
+            self.logger.log("HistoryHighlights didLoadNewData and section shouldShow \(self.shouldShow)",
+                            level: .debug,
+                            category: .homepage)
             guard self.isEnabled else { return }
-            // TODO: Add log here?
             self.delegate?.reloadView()
         }
     }

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -808,7 +808,7 @@ extension HomepageViewController: HomepageViewModelDelegate {
 
             self.viewModel.refreshData(for: self.traitCollection, size: self.view.frame.size)
             self.collectionView.reloadData()
-            logger.log("Amount of sections shown is \(viewModel.shownSections.count)",
+            logger.log("Amount of sections shown is \(self.viewModel.shownSections.count)",
                        level: .debug,
                        category: .homepage)
             self.collectionView.collectionViewLayout.invalidateLayout()

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -808,6 +808,9 @@ extension HomepageViewController: HomepageViewModelDelegate {
 
             self.viewModel.refreshData(for: self.traitCollection, size: self.view.frame.size)
             self.collectionView.reloadData()
+            logger.log("Amount of sections shown is \(viewModel.shownSections.count)",
+                       level: .debug,
+                       category: .homepage)
             self.collectionView.collectionViewLayout.invalidateLayout()
         }
     }

--- a/Client/Frontend/Home/HomepageViewModel.swift
+++ b/Client/Frontend/Home/HomepageViewModel.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import MozillaAppServices
 import Shared
 
@@ -82,6 +83,7 @@ class HomepageViewModel: FeatureFlaggable {
     var shownSections = [HomepageSectionType]()
     weak var delegate: HomepageViewModelDelegate?
     private var wallpaperManager: WallpaperManager
+    private var logger: Logger
 
     // Child View models
     private var childViewModels: [HomepageViewModelProtocol]
@@ -105,10 +107,12 @@ class HomepageViewModel: FeatureFlaggable {
          nimbus: FxNimbus = FxNimbus.shared,
          isZeroSearch: Bool = false,
          theme: Theme,
-         wallpaperManager: WallpaperManager = WallpaperManager()) {
+         wallpaperManager: WallpaperManager = WallpaperManager(),
+         logger: Logger = DefaultLogger.shared) {
         self.profile = profile
         self.isZeroSearch = isZeroSearch
         self.theme = theme
+        self.logger = logger
 
         self.headerViewModel = HomeLogoHeaderViewModel(profile: profile, theme: theme)
         let messageCardAdaptor = MessageCardDataAdaptorImplementation()
@@ -214,6 +218,9 @@ class HomepageViewModel: FeatureFlaggable {
         childViewModels.forEach {
             if $0.shouldShow { shownSections.append($0.sectionType) }
         }
+        logger.log("Homepage amount of sections shown \(shownSections.count)",
+                   level: .debug,
+                   category: .homepage)
     }
 
     func refreshData(for traitCollection: UITraitCollection, size: CGSize) {

--- a/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -398,6 +398,9 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
                      size: CGSize,
                      isPortrait: Bool = UIWindow.isPortrait,
                      device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
+        updateSectionLayout(for: traitCollection,
+                            isPortrait: isPortrait,
+                            device: device)
         let maxItemsToDisplay = sectionLayout.maxItemsToDisplay(
             hasAccount: isSyncTabFeatureEnabled,
             device: device
@@ -406,9 +409,6 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
         logger.log("JumpBackIn section shouldShow \(shouldShow)",
                    level: .debug,
                    category: .homepage)
-        updateSectionLayout(for: traitCollection,
-                            isPortrait: isPortrait,
-                            device: device)
     }
 
     func updatePrivacyConcernedSection(isPrivate: Bool) {

--- a/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
 import Storage
 import UIKit
@@ -44,6 +45,7 @@ class JumpBackInViewModel: FeatureFlaggable {
     private var hasSentSyncedTabTileEvent = false
     private let tabManager: TabManager
     private var wallpaperManager: WallpaperManager
+    private var logger: Logger
     var sectionLayout: JumpBackInSectionLayout = .compactJumpBackIn // We use the compact layout as default
 
     init(
@@ -53,7 +55,8 @@ class JumpBackInViewModel: FeatureFlaggable {
         theme: Theme,
         tabManager: TabManager,
         adaptor: JumpBackInDataAdaptor,
-        wallpaperManager: WallpaperManager
+        wallpaperManager: WallpaperManager,
+        logger: Logger = DefaultLogger.shared
     ) {
         self.profile = profile
         self.isZeroSearch = isZeroSearch
@@ -62,6 +65,7 @@ class JumpBackInViewModel: FeatureFlaggable {
         self.tabManager = tabManager
         self.jumpBackInDataAdaptor = adaptor
         self.wallpaperManager = wallpaperManager
+        self.logger = logger
     }
 
     func switchTo(group: ASGroup<Tab>) {
@@ -399,6 +403,9 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
             device: device
         )
         refreshData(maxItemsToDisplay: maxItemsToDisplay)
+        logger.log("JumpBackIn section shouldShow \(shouldShow)",
+                   level: .debug,
+                   category: .homepage)
         updateSectionLayout(for: traitCollection,
                             isPortrait: isPortrait,
                             device: device)
@@ -481,7 +488,9 @@ extension JumpBackInViewModel: JumpBackInDelegate {
             self.recentGroups = await self.jumpBackInDataAdaptor.getGroupsData()
             self.recentSyncedTab = await self.jumpBackInDataAdaptor.getSyncedTabData()
             self.isSyncTabFeatureEnabled = await self.jumpBackInDataAdaptor.hasSyncedTabFeatureEnabled()
-            print("YRD JumpBack in loaded new data and is \(self.isEnabled)")
+            logger.log("JumpBack didLoadNewData and section shouldShow \(self.shouldShow)",
+                       level: .debug,
+                       category: .homepage)
             guard self.isEnabled else { return }
 
             self.delegate?.reloadView()

--- a/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -394,14 +394,14 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
                      size: CGSize,
                      isPortrait: Bool = UIWindow.isPortrait,
                      device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
-        updateSectionLayout(for: traitCollection,
-                            isPortrait: isPortrait,
-                            device: device)
         let maxItemsToDisplay = sectionLayout.maxItemsToDisplay(
             hasAccount: isSyncTabFeatureEnabled,
             device: device
         )
         refreshData(maxItemsToDisplay: maxItemsToDisplay)
+        updateSectionLayout(for: traitCollection,
+                            isPortrait: isPortrait,
+                            device: device)
     }
 
     func updatePrivacyConcernedSection(isPrivate: Bool) {
@@ -481,6 +481,7 @@ extension JumpBackInViewModel: JumpBackInDelegate {
             self.recentGroups = await self.jumpBackInDataAdaptor.getGroupsData()
             self.recentSyncedTab = await self.jumpBackInDataAdaptor.getSyncedTabData()
             self.isSyncTabFeatureEnabled = await self.jumpBackInDataAdaptor.hasSyncedTabFeatureEnabled()
+            print("YRD JumpBack in loaded new data and is \(self.isEnabled)")
             guard self.isEnabled else { return }
 
             self.delegate?.reloadView()

--- a/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -205,6 +205,7 @@ extension TopSitesViewModel: TopSitesManagerDelegate {
     func didLoadNewData() {
         ensureMainThread {
             self.topSites = self.topSitesDataAdaptor.getTopSitesData()
+            print("YRD TopSites loadd new data and is enabled \(self.isEnabled)")
             guard self.isEnabled else { return }
             self.delegate?.reloadView()
         }

--- a/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -205,7 +205,6 @@ extension TopSitesViewModel: TopSitesManagerDelegate {
     func didLoadNewData() {
         ensureMainThread {
             self.topSites = self.topSitesDataAdaptor.getTopSitesData()
-            print("YRD TopSites loadd new data and is enabled \(self.isEnabled)")
             guard self.isEnabled else { return }
             self.delegate?.reloadView()
         }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6316)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14217)

### Description
From the logs that we currently have the crash occurs after closing a tab or pressing the back arrow and showing the Homepage as a result 
- Add logs to HomepageViewModel to get the shownSections before the crash
- Add logs to JumpBackIn and HistoryHighlights sections that change the amount of items shown and even if the section is shown when a tab is closed.
- Tagging the PR as v114 to get the logs sonner

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
