### PR TITLE
Refactor FXIOS-6386 [v114] Onboarding button handling

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -831,6 +831,8 @@
 		C855728229AE7F1700AF32B0 /* SurveySurfaceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C855728129AE7F1700AF32B0 /* SurveySurfaceManager.swift */; };
 		C855728429AEA3C300AF32B0 /* SurveySurfaceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C855728329AEA3C300AF32B0 /* SurveySurfaceViewModel.swift */; };
 		C855728629AEA3FB00AF32B0 /* SurveySurfaceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C855728529AEA3FB00AF32B0 /* SurveySurfaceViewController.swift */; };
+		C8610DA82A0EBD4100B79FF1 /* OnboardingButtonActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8610DA72A0EBD4100B79FF1 /* OnboardingButtonActionTests.swift */; };
+		C8610DAA2A0EBF7100B79FF1 /* OnboardingCardDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8610DA92A0EBF7100B79FF1 /* OnboardingCardDelegate.swift */; };
 		C8611C8E1F71904C00C3DE7D /* DiskImageStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BF8CBC1B7472FA0007AFE6 /* DiskImageStoreTests.swift */; };
 		C8611CB01F71AEBA00C3DE7D /* NoImageModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8611CA11F71AEB900C3DE7D /* NoImageModeTests.swift */; };
 		C8656D75270F834600E199EA /* FlaggableFeatureOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8656D74270F834600E199EA /* FlaggableFeatureOptions.swift */; };
@@ -5058,6 +5060,8 @@
 		C855728129AE7F1700AF32B0 /* SurveySurfaceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveySurfaceManager.swift; sourceTree = "<group>"; };
 		C855728329AEA3C300AF32B0 /* SurveySurfaceViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveySurfaceViewModel.swift; sourceTree = "<group>"; };
 		C855728529AEA3FB00AF32B0 /* SurveySurfaceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveySurfaceViewController.swift; sourceTree = "<group>"; };
+		C8610DA72A0EBD4100B79FF1 /* OnboardingButtonActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingButtonActionTests.swift; sourceTree = "<group>"; };
+		C8610DA92A0EBF7100B79FF1 /* OnboardingCardDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCardDelegate.swift; sourceTree = "<group>"; };
 		C8611CA11F71AEB900C3DE7D /* NoImageModeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoImageModeTests.swift; sourceTree = "<group>"; };
 		C8656D74270F834600E199EA /* FlaggableFeatureOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlaggableFeatureOptions.swift; sourceTree = "<group>"; };
 		C8656D76270F858900E199EA /* TabsSettingsViewControler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsSettingsViewControler.swift; sourceTree = "<group>"; };
@@ -8564,6 +8568,7 @@
 				C8BD87612A0C257C00CD803A /* OnboardingCardInfoModelProtocol.swift */,
 				2109478828AFD24C00B73D44 /* OnboardingViewControllerProtocol.swift */,
 				21371FA328AA7A8D00BC3F37 /* OnboardingViewModelProtocol.swift */,
+				C8610DA92A0EBF7100B79FF1 /* OnboardingCardDelegate.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -8614,6 +8619,7 @@
 				21371FA128A6C4A200BC3F37 /* OnboardingCardViewModelTests.swift */,
 				C8B41E0D29F034FE00FE218A /* NimbusOnboardingFeatureLayerTests.swift */,
 				C80E2D1A2A0BE55D00144185 /* NimbusOnboardingFeatureLayerDefaultsTests.swift */,
+				C8610DA72A0EBD4100B79FF1 /* OnboardingButtonActionTests.swift */,
 			);
 			path = OnboardingTests;
 			sourceTree = "<group>";
@@ -8631,9 +8637,9 @@
 		C8BD875E2A0C243400CD803A /* ViewControllers */ = {
 			isa = PBXGroup;
 			children = (
-				74F80D332A0A52D700013C3D /* PrivacyPolicyViewController.swift */,
 				E49943F31AE6879C00BF9DE4 /* FirstInstall */,
 				21A7C44F28353D0E0071D996 /* OnboardingCardViewController.swift */,
+				74F80D332A0A52D700013C3D /* PrivacyPolicyViewController.swift */,
 				43A5643423CD1E1B00B6857D /* Update */,
 			);
 			path = ViewControllers;
@@ -11811,6 +11817,7 @@
 				C8DC90C72A06759E0008832B /* MarkupAttributionUtility.swift in Sources */,
 				23D57E6E25ED6F2700883FAD /* SearchViewController.swift in Sources */,
 				C82A94F2269F68ED00624AA7 /* FeatureFlagsManager.swift in Sources */,
+				C8610DAA2A0EBF7100B79FF1 /* OnboardingCardDelegate.swift in Sources */,
 				3BB50E111D6274CD004B33DF /* TopSiteItemCell.swift in Sources */,
 				E127313D28B6AD99006F39D2 /* WallpaperSettingsViewModel.swift in Sources */,
 				8A07910F278F62F2005529CB /* AdjustHelper.swift in Sources */,
@@ -12432,6 +12439,7 @@
 				8AFCE50929DE136300B1B253 /* MockLaunchFinishedLoadingDelegate.swift in Sources */,
 				8AE1E1DB27B1C1320024C45E /* SearchBarSettingsViewModelTests.swift in Sources */,
 				CA24B53924ABFE250093848C /* LoginsListSelectionHelperTests.swift in Sources */,
+				C8610DA82A0EBD4100B79FF1 /* OnboardingButtonActionTests.swift in Sources */,
 				4331D3EF2A059C1C00542BDD /* SyncContentSettingsViewControllerTests.swift in Sources */,
 				39D0DA7629D767DE000760B8 /* NimbusMessagingTriggerTests.swift in Sources */,
 				21B41A1D298B187A008BC0A2 /* MockOverlayModeManager.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -897,6 +897,7 @@
 		C8B0F5F6283B7CCE007AE65D /* PocketStory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B0F5F2283B7CCE007AE65D /* PocketStory.swift */; };
 		C8B0F5F7283B7CCE007AE65D /* PocketFeedStory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B0F5F3283B7CCE007AE65D /* PocketFeedStory.swift */; };
 		C8B0F5F8283B7D38007AE65D /* pocketsponsoredfeed.json in Resources */ = {isa = PBXBuildFile; fileRef = C8B0F5EA283B7BF9007AE65D /* pocketsponsoredfeed.json */; };
+		C8B394362A0ED55D00700E49 /* MockOnboardingCardDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B394352A0ED55D00700E49 /* MockOnboardingCardDelegate.swift */; };
 		C8B41E0A29F0284B00FE218A /* NimbusOnboardingFeatureLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B41E0929F0284B00FE218A /* NimbusOnboardingFeatureLayer.swift */; };
 		C8B41E0F29F0357300FE218A /* NimbusOnboardingFeatureLayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B41E0D29F034FE00FE218A /* NimbusOnboardingFeatureLayerTests.swift */; };
 		C8B509E3293FA39900AC013C /* AppVersionUpdateCheckerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B509E2293FA39900AC013C /* AppVersionUpdateCheckerProtocol.swift */; };
@@ -5126,6 +5127,7 @@
 		C8B0F5F2283B7CCE007AE65D /* PocketStory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PocketStory.swift; sourceTree = "<group>"; };
 		C8B0F5F3283B7CCE007AE65D /* PocketFeedStory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PocketFeedStory.swift; sourceTree = "<group>"; };
 		C8B34CBE911A7211E314D870 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
+		C8B394352A0ED55D00700E49 /* MockOnboardingCardDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOnboardingCardDelegate.swift; sourceTree = "<group>"; };
 		C8B41E0929F0284B00FE218A /* NimbusOnboardingFeatureLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusOnboardingFeatureLayer.swift; sourceTree = "<group>"; };
 		C8B41E0D29F034FE00FE218A /* NimbusOnboardingFeatureLayerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusOnboardingFeatureLayerTests.swift; sourceTree = "<group>"; };
 		C8B509E2293FA39900AC013C /* AppVersionUpdateCheckerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersionUpdateCheckerProtocol.swift; sourceTree = "<group>"; };
@@ -8620,6 +8622,7 @@
 				C8B41E0D29F034FE00FE218A /* NimbusOnboardingFeatureLayerTests.swift */,
 				C80E2D1A2A0BE55D00144185 /* NimbusOnboardingFeatureLayerDefaultsTests.swift */,
 				C8610DA72A0EBD4100B79FF1 /* OnboardingButtonActionTests.swift */,
+				C8B394352A0ED55D00700E49 /* MockOnboardingCardDelegate.swift */,
 			);
 			path = OnboardingTests;
 			sourceTree = "<group>";
@@ -12413,6 +12416,7 @@
 				5A9A09D628B01FD500B6F51E /* MockURLBarView.swift in Sources */,
 				8A33222227DFE658008F809E /* NimbusMock.swift in Sources */,
 				8A8629E72880B7330096DDB1 /* BookmarksPanelTests.swift in Sources */,
+				C8B394362A0ED55D00700E49 /* MockOnboardingCardDelegate.swift in Sources */,
 				8A5604F829DF0D2600035CA3 /* BrowserCoordinatorTests.swift in Sources */,
 				7BBFEE741BB405D900A305AA /* LegacyTabManagerTests.swift in Sources */,
 				39236E721FCC600200A38F1B /* TabEventHandlerTests.swift in Sources */,

--- a/Client/Frontend/Onboarding/Models/IntroViewModel.swift
+++ b/Client/Frontend/Onboarding/Models/IntroViewModel.swift
@@ -114,7 +114,7 @@ struct IntroViewModel: OnboardingViewModelProtocol, FeatureFlaggable {
                         action: .nextCard)),
                 type: .freshInstall,
                 a11yIdRoot: AccessibilityIdentifiers.Onboarding.notificationCard,
-                imageID: ImageIdentifiers.onboardingSyncv106)
+                imageID: ImageIdentifiers.onboardingNotification)
         default:
             return nil
         }

--- a/Client/Frontend/Onboarding/Protocols/OnboardingCardDelegate.swift
+++ b/Client/Frontend/Onboarding/Protocols/OnboardingCardDelegate.swift
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+protocol OnboardingCardDelegate: AnyObject {
+    func handleButtonPress(
+        for action: OnboardingActions,
+        from cardType: IntroViewModel.InformationCards)
+
+    func showPrivacyPolicy(_ cardType: IntroViewModel.InformationCards)
+    func showNextPage(_ cardType: IntroViewModel.InformationCards)
+    func pageChanged(_ cardType: IntroViewModel.InformationCards)
+}

--- a/Client/Frontend/Onboarding/ViewControllers/FirstInstall/IntroViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/FirstInstall/IntroViewController.swift
@@ -169,6 +169,23 @@ extension IntroViewController: UIPageViewControllerDataSource, UIPageViewControl
 }
 
 extension IntroViewController: OnboardingCardDelegate {
+    func handlePrimaryButtonPress(
+        for action: OnboardingActions,
+        from cardType: IntroViewModel.InformationCards
+    ) {
+        switch action {
+        case .requestNotifications:
+            askForNotificationPermission()
+        case .nextCard:
+            showNextPage(cardType)
+        case .syncSignIn:
+            let fxaPrams = FxALaunchParams(entrypoint: .introOnboarding, query: [:])
+            presentSignToSync(fxaPrams)
+        case .setDefaultBrowser:
+            DefaultApplicationHelper().openSettings()
+        }
+    }
+
     func showNextPage(_ cardType: IntroViewModel.InformationCards) {
         guard cardType != viewModel.enabledCards.last else {
             viewModel.saveHasSeenOnboarding()
@@ -177,20 +194,6 @@ extension IntroViewController: OnboardingCardDelegate {
         }
 
         moveToNextPage(cardType: cardType)
-    }
-
-    func primaryAction(_ cardType: IntroViewModel.InformationCards) {
-        switch cardType {
-        case .welcome:
-            moveToNextPage(cardType: cardType)
-        case .signSync:
-            let fxaPrams = FxALaunchParams(entrypoint: .introOnboarding, query: [:])
-            presentSignToSync(fxaPrams)
-        case .notification:
-            askForNotificationPermission()
-        default:
-            break
-        }
     }
 
     func privacyPolicyLinkAction(_ cardType: IntroViewModel.InformationCards) {

--- a/Client/Frontend/Onboarding/ViewControllers/FirstInstall/IntroViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/FirstInstall/IntroViewController.swift
@@ -169,7 +169,7 @@ extension IntroViewController: UIPageViewControllerDataSource, UIPageViewControl
 }
 
 extension IntroViewController: OnboardingCardDelegate {
-    func handlePrimaryButtonPress(
+    func handleButtonPress(
         for action: OnboardingActions,
         from cardType: IntroViewModel.InformationCards
     ) {
@@ -183,6 +183,8 @@ extension IntroViewController: OnboardingCardDelegate {
             presentSignToSync(fxaPrams)
         case .setDefaultBrowser:
             DefaultApplicationHelper().openSettings()
+        case .readPrivacyPolicy:
+            showPrivacyPolicy(cardType)
         }
     }
 
@@ -196,7 +198,7 @@ extension IntroViewController: OnboardingCardDelegate {
         moveToNextPage(cardType: cardType)
     }
 
-    func privacyPolicyLinkAction(_ cardType: IntroViewModel.InformationCards) {
+    func showPrivacyPolicy(_ cardType: IntroViewModel.InformationCards) {
         guard let infoModel = viewModel.getInfoModel(cardType: cardType),
               let url = infoModel.link?.url
         else { return }

--- a/Client/Frontend/Onboarding/ViewControllers/OnboardingCardViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/OnboardingCardViewController.swift
@@ -7,10 +7,13 @@ import Common
 import Shared
 
 protocol OnboardingCardDelegate: AnyObject {
-    func showNextPage(_ cardType: IntroViewModel.InformationCards)
-    func primaryAction(_ cardType: IntroViewModel.InformationCards)
-    func pageChanged(_ cardType: IntroViewModel.InformationCards)
+    func handlePrimaryButtonPress(
+        for action: OnboardingActions,
+        from cardType: IntroViewModel.InformationCards)
     func privacyPolicyLinkAction(_ cardType: IntroViewModel.InformationCards)
+
+    func showNextPage(_ cardType: IntroViewModel.InformationCards)
+    func pageChanged(_ cardType: IntroViewModel.InformationCards)
 }
 
 class OnboardingCardViewController: UIViewController, Themeable {
@@ -45,6 +48,7 @@ class OnboardingCardViewController: UIViewController, Themeable {
         static let tinyImageViewSize = CGSize(width: 144, height: 180)
     }
 
+    // MARK: - Properties
     var viewModel: OnboardingCardProtocol
     weak var delegate: OnboardingCardDelegate?
     var notificationCenter: NotificationProtocol
@@ -185,6 +189,7 @@ class OnboardingCardViewController: UIViewController, Themeable {
         }
     }
 
+    // MARK: - Initializers
     init(viewModel: OnboardingCardProtocol,
          delegate: OnboardingCardDelegate?,
          themeManager: ThemeManager = AppContainer.shared.resolve(),
@@ -201,6 +206,7 @@ class OnboardingCardViewController: UIViewController, Themeable {
         fatalError("init(coder:) has not been implemented")
     }
 
+    // MARK: - View lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -217,24 +223,11 @@ class OnboardingCardViewController: UIViewController, Themeable {
         viewModel.sendCardViewTelemetry()
     }
 
+    // MARK: - View setup
     func setupView() {
         view.backgroundColor = .clear
 
-        topStackView.addArrangedSubview(imageView)
-        topStackView.addArrangedSubview(titleLabel)
-        topStackView.addArrangedSubview(descriptionBoldLabel)
-        topStackView.addArrangedSubview(descriptionLabel)
-        contentStackView.addArrangedSubview(topStackView)
-        contentStackView.addArrangedSubview(linkButton)
-
-        buttonStackView.addArrangedSubview(primaryButton)
-        buttonStackView.addArrangedSubview(secondaryButton)
-        contentStackView.addArrangedSubview(buttonStackView)
-
-        contentContainerView.addSubview(contentStackView)
-        containerView.addSubviews(contentContainerView)
-        scrollView.addSubviews(containerView)
-        view.addSubview(scrollView)
+        addViewsToView()
 
         // Adapt layout for smaller screens
         var scrollViewVerticalPadding = UX.scrollViewVerticalPadding
@@ -317,6 +310,24 @@ class OnboardingCardViewController: UIViewController, Themeable {
         ])
     }
 
+    private func addViewsToView() {
+        topStackView.addArrangedSubview(imageView)
+        topStackView.addArrangedSubview(titleLabel)
+        topStackView.addArrangedSubview(descriptionBoldLabel)
+        topStackView.addArrangedSubview(descriptionLabel)
+        contentStackView.addArrangedSubview(topStackView)
+        contentStackView.addArrangedSubview(linkButton)
+
+        buttonStackView.addArrangedSubview(primaryButton)
+        buttonStackView.addArrangedSubview(secondaryButton)
+        contentStackView.addArrangedSubview(buttonStackView)
+
+        contentContainerView.addSubview(contentStackView)
+        containerView.addSubviews(contentContainerView)
+        scrollView.addSubviews(containerView)
+        view.addSubview(scrollView)
+    }
+
     private func updateLayout() {
         titleLabel.text = viewModel.infoModel.title
         descriptionBoldLabel.isHidden = !viewModel.shouldShowDescriptionBold
@@ -350,16 +361,22 @@ class OnboardingCardViewController: UIViewController, Themeable {
         linkButton.setTitle(buttonTitle, for: .normal)
     }
 
+    // MARK: - Button Actions
     @objc
     func primaryAction() {
         viewModel.sendTelemetryButton(isPrimaryAction: true)
-        delegate?.primaryAction(viewModel.cardType)
+        delegate?.handlePrimaryButtonPress(
+            for: viewModel.infoModel.buttons.primary.action,
+            from: viewModel.cardType)
     }
 
     @objc
     func secondaryAction() {
+        guard let buttonAction = viewModel.infoModel.buttons.secondary?.action else { return }
         viewModel.sendTelemetryButton(isPrimaryAction: false)
-        delegate?.showNextPage(viewModel.cardType)
+        delegate?.handlePrimaryButtonPress(
+            for: buttonAction,
+            from: viewModel.cardType)
     }
 
     @objc

--- a/Client/Frontend/Onboarding/ViewControllers/OnboardingCardViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/OnboardingCardViewController.swift
@@ -6,16 +6,6 @@ import UIKit
 import Common
 import Shared
 
-protocol OnboardingCardDelegate: AnyObject {
-    func handlePrimaryButtonPress(
-        for action: OnboardingActions,
-        from cardType: IntroViewModel.InformationCards)
-    func privacyPolicyLinkAction(_ cardType: IntroViewModel.InformationCards)
-
-    func showNextPage(_ cardType: IntroViewModel.InformationCards)
-    func pageChanged(_ cardType: IntroViewModel.InformationCards)
-}
-
 class OnboardingCardViewController: UIViewController, Themeable {
     struct UX {
         static let stackViewSpacing: CGFloat = 24
@@ -365,7 +355,7 @@ class OnboardingCardViewController: UIViewController, Themeable {
     @objc
     func primaryAction() {
         viewModel.sendTelemetryButton(isPrimaryAction: true)
-        delegate?.handlePrimaryButtonPress(
+        delegate?.handleButtonPress(
             for: viewModel.infoModel.buttons.primary.action,
             from: viewModel.cardType)
     }
@@ -373,15 +363,16 @@ class OnboardingCardViewController: UIViewController, Themeable {
     @objc
     func secondaryAction() {
         guard let buttonAction = viewModel.infoModel.buttons.secondary?.action else { return }
+
         viewModel.sendTelemetryButton(isPrimaryAction: false)
-        delegate?.handlePrimaryButtonPress(
+        delegate?.handleButtonPress(
             for: buttonAction,
             from: viewModel.cardType)
     }
 
     @objc
     func linkButtonAction() {
-        delegate?.privacyPolicyLinkAction(viewModel.cardType)
+        delegate?.handleButtonPress(for: .readPrivacyPolicy, from: viewModel.cardType)
     }
 
     // MARK: - Themeable

--- a/Client/Frontend/Onboarding/ViewControllers/Update/UpdateViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/Update/UpdateViewController.swift
@@ -245,7 +245,7 @@ extension UpdateViewController: UIPageViewControllerDataSource, UIPageViewContro
 }
 
 extension UpdateViewController: OnboardingCardDelegate {
-    func handlePrimaryButtonPress(
+    func handleButtonPress(
         for action: OnboardingActions,
         from cardType: IntroViewModel.InformationCards
     ) {
@@ -255,6 +255,8 @@ extension UpdateViewController: OnboardingCardDelegate {
         case .syncSignIn:
             let fxaParams = FxALaunchParams(entrypoint: .updateOnboarding, query: [:])
             presentSignToSync(fxaParams)
+        case .readPrivacyPolicy:
+            showPrivacyPolicy(cardType)
         default:
             break
         }
@@ -269,7 +271,7 @@ extension UpdateViewController: OnboardingCardDelegate {
         moveToNextPage(cardType: cardType)
     }
 
-    func privacyPolicyLinkAction(_ cardType: IntroViewModel.InformationCards) {
+    func showPrivacyPolicy(_ cardType: IntroViewModel.InformationCards) {
         guard let infoModel = viewModel.getInfoModel(cardType: cardType),
               let url = infoModel.link?.url
         else { return }

--- a/Client/Frontend/Onboarding/ViewControllers/Update/UpdateViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/Update/UpdateViewController.swift
@@ -245,6 +245,21 @@ extension UpdateViewController: UIPageViewControllerDataSource, UIPageViewContro
 }
 
 extension UpdateViewController: OnboardingCardDelegate {
+    func handlePrimaryButtonPress(
+        for action: OnboardingActions,
+        from cardType: IntroViewModel.InformationCards
+    ) {
+        switch action {
+        case .nextCard:
+            showNextPage(cardType)
+        case .syncSignIn:
+            let fxaParams = FxALaunchParams(entrypoint: .updateOnboarding, query: [:])
+            presentSignToSync(fxaParams)
+        default:
+            break
+        }
+    }
+
     func showNextPage(_ cardType: IntroViewModel.InformationCards) {
         guard cardType != viewModel.enabledCards.last else {
             self.didFinishFlow?()
@@ -252,18 +267,6 @@ extension UpdateViewController: OnboardingCardDelegate {
         }
 
         moveToNextPage(cardType: cardType)
-    }
-
-    func primaryAction(_ cardType: IntroViewModel.InformationCards) {
-        switch cardType {
-        case .updateWelcome:
-            showNextPage(cardType)
-        case .updateSignSync:
-            let fxaParams = FxALaunchParams(entrypoint: .updateOnboarding, query: [:])
-            presentSignToSync(fxaParams)
-        default:
-            break
-        }
     }
 
     func privacyPolicyLinkAction(_ cardType: IntroViewModel.InformationCards) {

--- a/Tests/ClientTests/OnboardingTests/MockOnboardingCardDelegate.swift
+++ b/Tests/ClientTests/OnboardingTests/MockOnboardingCardDelegate.swift
@@ -35,4 +35,3 @@ class MockIntroViewController: OnboardingCardDelegate {
 
     func pageChanged(_ cardType: IntroViewModel.InformationCards) { }
 }
-

--- a/Tests/ClientTests/OnboardingTests/MockOnboardingCardDelegate.swift
+++ b/Tests/ClientTests/OnboardingTests/MockOnboardingCardDelegate.swift
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+class MockIntroViewController: OnboardingCardDelegate {
+    var action: OnboardingActions?
+
+    func handleButtonPress(
+        for action: OnboardingActions,
+        from cardType: IntroViewModel.InformationCards
+    ) {
+        switch action {
+        case .syncSignIn:
+            self.action = .syncSignIn
+        case .requestNotifications:
+            self.action = .requestNotifications
+        case .nextCard:
+            showNextPage(cardType)
+        case .setDefaultBrowser:
+            self.action = .setDefaultBrowser
+        case .readPrivacyPolicy:
+            showPrivacyPolicy(.welcome)
+        }
+    }
+
+    func showPrivacyPolicy(_ cardType: IntroViewModel.InformationCards) {
+        action = .readPrivacyPolicy
+    }
+
+    func showNextPage(_ cardType: IntroViewModel.InformationCards) {
+        action = .nextCard
+    }
+
+    func pageChanged(_ cardType: IntroViewModel.InformationCards) { }
+}
+

--- a/Tests/ClientTests/OnboardingTests/OnboardingButtonActionTests.swift
+++ b/Tests/ClientTests/OnboardingTests/OnboardingButtonActionTests.swift
@@ -1,0 +1,150 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+@testable import Client
+
+class MockIntroViewController: OnboardingCardDelegate {
+    var action: OnboardingActions?
+
+    func handleButtonPress(
+        for action: OnboardingActions,
+        from cardType: IntroViewModel.InformationCards
+    ) {
+        switch action {
+        case .syncSignIn:
+            self.action = .syncSignIn
+        case .requestNotifications:
+            self.action = .requestNotifications
+        case .nextCard:
+            showNextPage(cardType)
+        case .setDefaultBrowser:
+            self.action = .setDefaultBrowser
+        case .readPrivacyPolicy:
+            showPrivacyPolicy(.welcome)
+        }
+    }
+
+    func showPrivacyPolicy(_ cardType: IntroViewModel.InformationCards) {
+        action = .readPrivacyPolicy
+    }
+
+    func showNextPage(_ cardType: IntroViewModel.InformationCards) {
+        action = .nextCard
+    }
+
+    func pageChanged(_ cardType: IntroViewModel.InformationCards) { }
+}
+
+class OnboardingButtonActionTests: XCTestCase {
+    var subject: OnboardingCardViewController!
+    var mockDelegate: MockIntroViewController!
+
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        subject = nil
+        mockDelegate = nil
+    }
+
+    func testMockDelegate_whenInitialized_actionIsNil() {
+        setSubjecUpWith(firstAction: .nextCard)
+
+        XCTAssertNil(mockDelegate.action)
+    }
+
+    func testsubject_whenOnlyOneButtonExists_secondaryButtonIsHidden() {
+        setSubjecUpWith(firstAction: .nextCard, twoButtons: false)
+
+        subject.secondaryAction()
+
+        XCTAssertNil(mockDelegate.action)
+    }
+
+    func testsubject_primaryAction_returnsNextCardAction() {
+        setSubjecUpWith(firstAction: .nextCard)
+
+        subject.primaryAction()
+
+        XCTAssertEqual(mockDelegate.action, OnboardingActions.nextCard)
+    }
+
+    func testsubject_buttonAction_returnsPrivacyPolicyAction() {
+        setSubjecUpWith(firstAction: .readPrivacyPolicy)
+
+        subject.linkButtonAction()
+
+        XCTAssertEqual(mockDelegate.action, OnboardingActions.readPrivacyPolicy)
+    }
+
+    func testsubject_buttonAction_returnsNotifiactionsAction() {
+        setSubjecUpWith(firstAction: .requestNotifications)
+
+        subject.primaryAction()
+
+        XCTAssertEqual(mockDelegate.action, OnboardingActions.requestNotifications)
+    }
+    func testsubject_buttonAction_returnsSyncAction() {
+        setSubjecUpWith(firstAction: .syncSignIn)
+
+        subject.primaryAction()
+
+        XCTAssertEqual(mockDelegate.action, OnboardingActions.syncSignIn)
+    }
+
+    func testsubject_buttonAction_returnsSetAsDefaultAction() {
+        setSubjecUpWith(firstAction: .setDefaultBrowser)
+
+        subject.primaryAction()
+
+        XCTAssertEqual(mockDelegate.action, OnboardingActions.setDefaultBrowser)
+    }
+
+    // MARK: - Helpers
+    func setSubjecUpWith(
+        firstAction: OnboardingActions,
+        twoButtons: Bool = true
+    ) {
+        var buttons: OnboardingButtons
+        if twoButtons {
+            buttons = OnboardingButtons(
+                primary: OnboardingButtonInfoModel(
+                    title: .Onboarding.Sync.SignInAction,
+                    action: firstAction),
+                secondary: OnboardingButtonInfoModel(
+                    title: .Onboarding.Sync.SkipAction,
+                    action: .nextCard))
+        } else {
+            buttons = OnboardingButtons(
+                primary: OnboardingButtonInfoModel(
+                    title: .Onboarding.Sync.SignInAction,
+                    action: firstAction))
+        }
+
+        let mockInfoModel = OnboardingCardInfoModel(
+            name: "signSync",
+            title: String(format: .Onboarding.Sync.Title),
+            body: String(format: .Onboarding.Sync.Description),
+            link: nil,
+            buttons: buttons,
+            type: .freshInstall,
+            a11yIdRoot: AccessibilityIdentifiers.Onboarding.signSyncCard,
+            imageID: ImageIdentifiers.onboardingSyncv106)
+        let mockCardViewModel = LegacyOnboardingCardViewModel(
+            cardType: .welcome,
+            infoModel: mockInfoModel,
+            isFeatureEnabled: true)
+
+        mockDelegate = MockIntroViewController()
+        subject = OnboardingCardViewController(
+            viewModel: mockCardViewModel,
+            delegate: mockDelegate)
+        subject.viewDidLoad()
+    }
+}

--- a/Tests/ClientTests/OnboardingTests/OnboardingButtonActionTests.swift
+++ b/Tests/ClientTests/OnboardingTests/OnboardingButtonActionTests.swift
@@ -44,7 +44,7 @@ class OnboardingButtonActionTests: XCTestCase {
     }
 
     func testsubject_buttonAction_returnsPrivacyPolicyAction() {
-        setSubjecUpWith(firstAction: .readPrivacyPolicy)
+        setSubjectUpWith(firstAction: .readPrivacyPolicy)
 
         subject.linkButtonAction()
 

--- a/Tests/ClientTests/OnboardingTests/OnboardingButtonActionTests.swift
+++ b/Tests/ClientTests/OnboardingTests/OnboardingButtonActionTests.swift
@@ -6,38 +6,6 @@ import XCTest
 
 @testable import Client
 
-class MockIntroViewController: OnboardingCardDelegate {
-    var action: OnboardingActions?
-
-    func handleButtonPress(
-        for action: OnboardingActions,
-        from cardType: IntroViewModel.InformationCards
-    ) {
-        switch action {
-        case .syncSignIn:
-            self.action = .syncSignIn
-        case .requestNotifications:
-            self.action = .requestNotifications
-        case .nextCard:
-            showNextPage(cardType)
-        case .setDefaultBrowser:
-            self.action = .setDefaultBrowser
-        case .readPrivacyPolicy:
-            showPrivacyPolicy(.welcome)
-        }
-    }
-
-    func showPrivacyPolicy(_ cardType: IntroViewModel.InformationCards) {
-        action = .readPrivacyPolicy
-    }
-
-    func showNextPage(_ cardType: IntroViewModel.InformationCards) {
-        action = .nextCard
-    }
-
-    func pageChanged(_ cardType: IntroViewModel.InformationCards) { }
-}
-
 class OnboardingButtonActionTests: XCTestCase {
     var subject: OnboardingCardViewController!
     var mockDelegate: MockIntroViewController!
@@ -54,13 +22,13 @@ class OnboardingButtonActionTests: XCTestCase {
     }
 
     func testMockDelegate_whenInitialized_actionIsNil() {
-        setSubjecUpWith(firstAction: .nextCard)
+        setSubjectUpWith(firstAction: .nextCard)
 
         XCTAssertNil(mockDelegate.action)
     }
 
     func testsubject_whenOnlyOneButtonExists_secondaryButtonIsHidden() {
-        setSubjecUpWith(firstAction: .nextCard, twoButtons: false)
+        setSubjectUpWith(firstAction: .nextCard, twoButtons: false)
 
         subject.secondaryAction()
 
@@ -68,7 +36,7 @@ class OnboardingButtonActionTests: XCTestCase {
     }
 
     func testsubject_primaryAction_returnsNextCardAction() {
-        setSubjecUpWith(firstAction: .nextCard)
+        setSubjectUpWith(firstAction: .nextCard)
 
         subject.primaryAction()
 
@@ -84,14 +52,14 @@ class OnboardingButtonActionTests: XCTestCase {
     }
 
     func testsubject_buttonAction_returnsNotifiactionsAction() {
-        setSubjecUpWith(firstAction: .requestNotifications)
+        setSubjectUpWith(firstAction: .requestNotifications)
 
         subject.primaryAction()
 
         XCTAssertEqual(mockDelegate.action, OnboardingActions.requestNotifications)
     }
     func testsubject_buttonAction_returnsSyncAction() {
-        setSubjecUpWith(firstAction: .syncSignIn)
+        setSubjectUpWith(firstAction: .syncSignIn)
 
         subject.primaryAction()
 
@@ -99,7 +67,7 @@ class OnboardingButtonActionTests: XCTestCase {
     }
 
     func testsubject_buttonAction_returnsSetAsDefaultAction() {
-        setSubjecUpWith(firstAction: .setDefaultBrowser)
+        setSubjectUpWith(firstAction: .setDefaultBrowser)
 
         subject.primaryAction()
 
@@ -107,7 +75,7 @@ class OnboardingButtonActionTests: XCTestCase {
     }
 
     // MARK: - Helpers
-    func setSubjecUpWith(
+    func setSubjectUpWith(
         firstAction: OnboardingActions,
         twoButtons: Bool = true
     ) {
@@ -145,6 +113,8 @@ class OnboardingButtonActionTests: XCTestCase {
         subject = OnboardingCardViewController(
             viewModel: mockCardViewModel,
             delegate: mockDelegate)
+        trackForMemoryLeaks(subject)
+
         subject.viewDidLoad()
     }
 }

--- a/nimbus-features/onboardingFrameworkFeature.yaml
+++ b/nimbus-features/onboardingFrameworkFeature.yaml
@@ -214,6 +214,9 @@ enums:
       set-default-browser:
         description: >
           Will send the user to settings to set Firefox as their default browser
+      read-privacy-policy:
+        description: >
+          Will open a webview where the user can read the privacy policy
   NimbusOnboardingImages:
     description: >
       The identifiers for the different images available for cards in onboarding


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-3686)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14354)

### Description
Updates how buttons are handled. Now moved into one handler, with secondary helper methods.
More updates will be done once data sources are moved over, but I wanted this to be in place so things are handled gracefully as we move over.

Also adds an action for setting browser as defualt. I followed the same template as the settings/homepage do for that.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
