### PR TITLE
Bugfix FXIOS-6385 [v114] Websites cannot be accessed from the home screen after restoring `inactive tabs`

### DIFF
--- a/Client/Frontend/Browser/Tabs/GridTabViewController.swift
+++ b/Client/Frontend/Browser/Tabs/GridTabViewController.swift
@@ -72,6 +72,7 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate, Themeable {
     var contextualHintViewController: ContextualHintViewController
     var themeManager: ThemeManager
     var themeObserver: NSObjectProtocol?
+    var shownToast: Toast?
 
     var toolbarHeight: CGFloat {
         return !shouldUseiPadSetup() ? view.safeAreaInsets.bottom : 0
@@ -432,6 +433,10 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate, Themeable {
 
     private func presentUndoToast(toastType: UndoToastType,
                                   completion: @escaping (Bool) -> Void) {
+        if let currentToast = shownToast {
+            currentToast.dismiss(false)
+        }
+
         let viewModel = ButtonToastViewModel(
             labelText: toastType.title,
             buttonText: toastType.buttonText)
@@ -451,6 +456,7 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate, Themeable {
                                               constant: -self.toolbarHeight)
             ]
         }
+        shownToast = toast
     }
 }
 

--- a/Client/Frontend/Browser/Toast.swift
+++ b/Client/Frontend/Browser/Toast.swift
@@ -21,7 +21,7 @@ class Toast: UIView, ThemeApplicable {
 
     weak var viewController: UIViewController?
 
-    private static var currentToast: Toast?
+    var dismissed = false
 
     lazy var gestureRecognizer: UITapGestureRecognizer = {
         let gestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTap))
@@ -45,10 +45,6 @@ class Toast: UIView, ThemeApplicable {
         translatesAutoresizingMaskIntoConstraints = false
 
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-            if let currentToast = Toast.currentToast {
-                currentToast.dismiss(false)
-            }
-
             viewController?.view.addSubview(self)
             guard viewController != nil else { return }
 
@@ -67,11 +63,13 @@ class Toast: UIView, ThemeApplicable {
                         }
                     }
                 }
-            Toast.currentToast = self
         }
     }
 
     func dismiss(_ buttonPressed: Bool) {
+        guard !dismissed else { return }
+
+        dismissed = true
         superview?.removeGestureRecognizer(gestureRecognizer)
 
         UIView.animate(


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6385)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14351)

### Description
Revert changes to dismiss previous shown Toast at the Toast class and move logic to dismiss the Toast when the next one is going to be presented

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
