### PR TITLE
Build [v115] update build config for cc scripts

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -73,7 +73,13 @@ module.exports = {
     path: path.resolve(__dirname, "Client/Assets"),
   },
   module: {
-    rules: [],
+    rules: [
+      {
+        test: /\.mjs$/,
+        include: [path.resolve(__dirname, "Client/Assets/CC_Script/")],
+        type: "javascript/auto",
+      },
+    ],
   },
   plugins: [CustomResourceURIWebpackPlugin],
   resolve: {


### PR DESCRIPTION
### Description
This PR updates:
- Webpack config to treat all `.mjs` files inside `CC_Scprit` as JS modules (i.e. can use both `import` and `require` syntax at the same time).
- Update python script to skip file creation if request errors out (for instance file doesn't exist upstream anymore ).

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
