### PR TITLE
Add FXIOS-5571 [v115] #12908 Auto generate license comment in header for files created in BrowserKit

### DIFF
--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/IDETemplateMacros.plist
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>FILEHEADER</key>
+	<string> This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/</string>
+</dict>
+</plist>


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5571)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/12908)

### Description
Add .plist to generate header for swiftpm
<img width="1121" alt="Screenshot 2023-05-15 at 17 28 23" src="https://github.com/mozilla-mobile/firefox-ios/assets/26011662/d98a1f2c-2e32-4e39-8295-a95e9d0b7c9a">

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
