### PR TITLE
Bugfix FXIOS-6388 [v114] Move zoom level file

### DIFF
--- a/Storage/ZoomLevelStore.swift
+++ b/Storage/ZoomLevelStore.swift
@@ -26,7 +26,7 @@ public class ZoomLevelStore {
     private static let pathExtension = "json"
 
     private let url = URL(fileURLWithPath: fileName,
-                          relativeTo: FileManager.documentsDirectoryURL).appendingPathExtension(pathExtension)
+                          relativeTo: FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first)
 
     private init(logger: Logger = DefaultLogger.shared) {
         self.logger = logger

--- a/Storage/ZoomLevelStore.swift
+++ b/Storage/ZoomLevelStore.swift
@@ -23,7 +23,6 @@ public class ZoomLevelStore {
     private var logger: Logger
 
     private static let fileName = "domain-zoom-levels"
-    private static let pathExtension = "json"
 
     private let url = URL(fileURLWithPath: fileName,
                           relativeTo: FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first)

--- a/Tests/StorageTests/ZoomLevelStoreTests.swift
+++ b/Tests/StorageTests/ZoomLevelStoreTests.swift
@@ -27,7 +27,7 @@ class ZoomLevelStoreTests: XCTestCase {
 
     private func cleanUp() {
         let url = URL(fileURLWithPath: "domain-zoom-levels",
-                      relativeTo: FileManager.documentsDirectoryURL).appendingPathExtension("json")
+                      relativeTo: FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first)
         if FileManager.default.fileExists(atPath: url.path) {
             do {
                 try FileManager.default.removeItem(at: url)


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6388)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14357)

### Description
Move the file that stores the domain zoom level into the cache directory instead of documents

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
