### PR TITLE
Bugfix FXIOS-5325 [v115] Do not show prompt on homepage

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -335,8 +335,9 @@ extension BrowserViewController: WKUIDelegate {
                  initiatedByFrame frame: WKFrameInfo,
                  type: WKMediaCaptureType,
                  decisionHandler: @escaping (WKPermissionDecision) -> Void) {
-        // If the tab isn't the selected one, do not show the media capture prompt
-        guard tabManager.selectedTab?.webView == webView else {
+        // If the tab isn't the selected one or we're on the homepage, do not show the media capture prompt
+        let hasNoHomepage = CoordinatorFlagManager.isCoordinatorEnabled ? !contentContainer.hasHomepage: homepageViewController?.view.alpha == 0
+        guard tabManager.selectedTab?.webView == webView, hasNoHomepage else {
             decisionHandler(.deny)
             return
         }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5325)

### Description
Following https://github.com/mozilla-mobile/firefox-ios/pull/13363, making sure we're not showing the media prompt on a homepage.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
