### PR TITLE
Bugfix MTE-990 [v115] Update testTopSitesOpenInNewPrivateTab for iPad

### DIFF
--- a/Tests/XCUITests/ActivityStreamTest.swift
+++ b/Tests/XCUITests/ActivityStreamTest.swift
@@ -188,8 +188,8 @@ class ActivityStreamTest: BaseTestCase {
         waitForExistence(app.cells.staticTexts.element(boundBy: 0), timeout: 10)
 
         navigator.nowAt(TabTray)
-        waitForExistence(app/*@START_MENU_TOKEN@*/.otherElements["Tabs Tray"].collectionViews/*[[".otherElements[\"Tabs Tray\"].collectionViews",".collectionViews"],[[[-1,1],[-1,0]]],[1]]@END_MENU_TOKEN@*/.cells["Wikipedia"], timeout: TIMEOUT)
-        app/*@START_MENU_TOKEN@*/.otherElements["Tabs Tray"].collectionViews/*[[".otherElements[\"Tabs Tray\"].collectionViews",".collectionViews"],[[[-1,1],[-1,0]]],[1]]@END_MENU_TOKEN@*/.cells["Wikipedia"].tap()
+        waitForExistence(app.otherElements["Tabs Tray"].collectionViews.cells["Wikipedia"], timeout: TIMEOUT)
+        app.otherElements["Tabs Tray"].collectionViews.cells["Wikipedia"].tap()
 
         // The website is open
         XCTAssertFalse(TopSiteCellgroup.exists)

--- a/Tests/XCUITests/ActivityStreamTest.swift
+++ b/Tests/XCUITests/ActivityStreamTest.swift
@@ -188,13 +188,8 @@ class ActivityStreamTest: BaseTestCase {
         waitForExistence(app.cells.staticTexts.element(boundBy: 0), timeout: 10)
 
         navigator.nowAt(TabTray)
-        if iPad() {
-            waitForExistence(app.collectionViews.element(boundBy: 1).cells.staticTexts["Wikipedia"], timeout: TIMEOUT)
-            app/*@START_MENU_TOKEN@*/.otherElements["Tabs Tray"].collectionViews/*[[".otherElements[\"Tabs Tray\"].collectionViews",".collectionViews"],[[[-1,1],[-1,0]]],[1]]@END_MENU_TOKEN@*/.cells["Wikipedia"].tap()
-        } else {
-            waitForExistence(app.collectionViews.cells.staticTexts["Wikipedia"], timeout: TIMEOUT)
-            app.collectionViews.element(boundBy: 1).cells.staticTexts["Wikipedia"].tap()
-        }
+        waitForExistence(app/*@START_MENU_TOKEN@*/.otherElements["Tabs Tray"].collectionViews/*[[".otherElements[\"Tabs Tray\"].collectionViews",".collectionViews"],[[[-1,1],[-1,0]]],[1]]@END_MENU_TOKEN@*/.cells["Wikipedia"], timeout: TIMEOUT)
+        app/*@START_MENU_TOKEN@*/.otherElements["Tabs Tray"].collectionViews/*[[".otherElements[\"Tabs Tray\"].collectionViews",".collectionViews"],[[[-1,1],[-1,0]]],[1]]@END_MENU_TOKEN@*/.cells["Wikipedia"].tap()
 
         // The website is open
         XCTAssertFalse(TopSiteCellgroup.exists)


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-990)

### Description
The underlying structure of the tab tray has been updated. Now we can use the same code for both iPhone and iPad.

I confirm that the test pass on both iPhone and iPad.

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
