### PR TITLE
Bugfix MTE-991 [v115] URL label for PrivateBrowsingTest

### DIFF
--- a/Tests/XCUITests/PrivateBrowsingTest.swift
+++ b/Tests/XCUITests/PrivateBrowsingTest.swift
@@ -10,7 +10,7 @@ let url3 = path(forTestPage: "test-example.html")
 let urlIndexedDB = path(forTestPage: "test-indexeddb-private.html")
 
 let url1And3Label = "Example Domain"
-let url2Label = "Internet for people, not profit — Mozilla (US)"
+let url2Label = "Internet for people, not profit — Mozilla"
 
 class PrivateBrowsingTest: BaseTestCase {
     typealias HistoryPanelA11y = AccessibilityIdentifiers.LibraryPanels.HistoryPanel
@@ -72,7 +72,8 @@ class PrivateBrowsingTest: BaseTestCase {
         // Go back to regular mode and check the total number of tabs
         navigator.toggleOff(userState.isPrivate, withAction: Action.ToggleRegularMode)
 
-        waitForExistence(app.otherElements["Tabs Tray"].collectionViews.cells.staticTexts[url2Label])
+        waitForExistence(app.otherElements["Tabs Tray"])
+        XCTAssertNotNil(app.otherElements["Tabs Tray"].collectionViews.cells.staticTexts.element(boundBy: 1).label.range(of: url2Label))
         waitForNoExistence(app.otherElements["Tabs Tray"].collectionViews.cells.staticTexts[url1And3Label])
         let numRegularTabs = app.otherElements["Tabs Tray"].cells.count
         XCTAssertEqual(numRegularTabs, 2, "The number of regular tabs is not correct")
@@ -104,7 +105,8 @@ class PrivateBrowsingTest: BaseTestCase {
 
         // Go back to private browsing and check that the tab has not been closed
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
-        waitForExistence(app.cells.staticTexts[url2Label], timeout: TIMEOUT)
+        waitForExistence(app.otherElements["Tabs Tray"])
+        XCTAssertNotNil(app.otherElements["Tabs Tray"].collectionViews.cells.staticTexts.element(boundBy: 0).label.range(of: url2Label))
         checkOpenTabsBeforeClosingPrivateMode()
 
         // Now the enable the Close Private Tabs when closing the Private Browsing Button

--- a/Tests/XCUITests/PrivateBrowsingTest.swift
+++ b/Tests/XCUITests/PrivateBrowsingTest.swift
@@ -269,8 +269,8 @@ class PrivateBrowsingTestIpad: IpadOnlyTestCase {
         // History without counting Clear Recent History, Recently Closed
         let history = app.tables[HistoryPanelA11y.tableView].cells.count - 1
         XCTAssertEqual(history, 1, "There should be one entry in History")
-        let savedToHistory = app.tables[HistoryPanelA11y.tableView].cells.staticTexts[url2Label]
+        let savedToHistory = app.tables[HistoryPanelA11y.tableView].cells.element(boundBy: 1).staticTexts.element(boundBy: 1)
         waitForExistence(savedToHistory)
-        XCTAssertTrue(savedToHistory.exists)
+        XCTAssertNotNil(savedToHistory.label.range(of: url2Label))
     }
 }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-991)

### Description
testClosePrivateTabsOptionClosesPrivateTabs and testTabCountShowsOnlyNormalOrPrivateTabCount could fail intermittently because of the Suggest API returns a website label with the locale (`(US)`). This PR is to harden the tests so that the presence of the locale does not make the tests to fail.

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
