### PR TITLE
Bugfix FXIOS-6234 [v115] New Tab always opens a normal mode tab

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1626,9 +1626,9 @@ class BrowserViewController: UIViewController {
         }
     }
 
-    func openNewTabFromMenu(focusLocationField: Bool) {
+    func openNewTabFromMenu(focusLocationField: Bool, isPrivate: Bool) {
         overlayManager.openNewTab(url: nil, newTabSettings: newTabSettings)
-        openBlankNewTab(focusLocationField: focusLocationField)
+        openBlankNewTab(focusLocationField: focusLocationField, isPrivate: isPrivate)
     }
 
     func openBlankNewTab(focusLocationField: Bool, isPrivate: Bool = false, searchFor searchText: String? = nil) {

--- a/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -15,7 +15,7 @@ protocol ToolBarActionMenuDelegate: AnyObject {
     func addBookmark(url: String, title: String?)
 
     func openURLInNewTab(_ url: URL?, isPrivate: Bool)
-    func openNewTabFromMenu(focusLocationField: Bool)
+    func openNewTabFromMenu(focusLocationField: Bool, isPrivate: Bool)
 
     func showLibrary(panel: LibraryPanelType?)
     func showViewController(viewController: UIViewController)
@@ -301,11 +301,12 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
 
     // MARK: - Actions
 
-    private func getNewTabAction() -> PhotonRowActions {
+    private func getNewTabAction() -> PhotonRowActions? {
+        guard let tab = selectedTab else { return nil }
         return SingleActionViewModel(title: .AppMenu.NewTab,
                                      iconString: ImageIdentifiers.newTab) { _ in
             let shouldFocusLocationField = NewTabAccessors.getNewTabPage(self.profile.prefs) != .homePage
-            self.delegate?.openNewTabFromMenu(focusLocationField: shouldFocusLocationField)
+            self.delegate?.openNewTabFromMenu(focusLocationField: shouldFocusLocationField, isPrivate: tab.isPrivate)
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .createNewTab)
         }.items
     }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6234)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14046)

### Description
This PR solves the problem where opening a new tab from the context menu would always open a new normal tab, even if the user is in private browsing mode.

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
