### PR TITLE
Refactor FXIOS-6426 [v115] Exclude dependencies from warnings count in CI

### DIFF
--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -49,6 +49,7 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
     }
 
     // MARK: - Helper methods
+
     private func startLaunch(with launchType: LaunchType) {
         let launchCoordinator = LaunchCoordinator(router: router)
         launchCoordinator.parentCoordinator = self
@@ -57,12 +58,14 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
     }
 
     // MARK: - LaunchCoordinatorDelegate
+
     func didFinishLaunch(from coordinator: LaunchCoordinator) {
         router.dismiss(animated: true, completion: nil)
         remove(child: coordinator)
     }
 
     // MARK: - BrowserDelegate
+
     func showHomepage(inline: Bool,
                       homepanelDelegate: HomePanelDelegate,
                       libraryPanelDelegate: LibraryPanelDelegate,
@@ -116,6 +119,7 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
     }
 
     // MARK: - Route handling
+
     override func handle(route: Route) -> Bool {
         switch route {
         case let .searchQuery(query):

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -49,7 +49,6 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
     }
 
     // MARK: - Helper methods
-
     private func startLaunch(with launchType: LaunchType) {
         let launchCoordinator = LaunchCoordinator(router: router)
         launchCoordinator.parentCoordinator = self
@@ -58,14 +57,12 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
     }
 
     // MARK: - LaunchCoordinatorDelegate
-
     func didFinishLaunch(from coordinator: LaunchCoordinator) {
         router.dismiss(animated: true, completion: nil)
         remove(child: coordinator)
     }
 
     // MARK: - BrowserDelegate
-
     func showHomepage(inline: Bool,
                       homepanelDelegate: HomePanelDelegate,
                       libraryPanelDelegate: LibraryPanelDelegate,
@@ -119,7 +116,6 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
     }
 
     // MARK: - Route handling
-
     override func handle(route: Route) -> Bool {
         switch route {
         case let .searchQuery(query):

--- a/test-fixtures/generate-metrics.sh
+++ b/test-fixtures/generate-metrics.sh
@@ -4,10 +4,10 @@ set -e
 
 BUILD_LOG_FILE="$1"
 TYPE_LOG_FILE="$2"
-THRESHOLD_UNIT_TEST=14
-THRESHOLD_XCUITEST=25
+THRESHOLD_UNIT_TEST=4
+THRESHOLD_XCUITEST=4
 
-WARNING_COUNT=`egrep '^(\/.+:[0-9+:[0-9]+:.|warning:|⚠️|ld: warning:|<unknown>:0: warning:|fatal|===)' "$BUILD_LOG_FILE" | uniq | wc -l`
+WARNING_COUNT=`egrep '^(\/(?!.*SourcePackages\/checkouts).+:[0-9+:[0-9]+:.|warning:|⚠️|ld: warning:|<unknown>:0: warning:|fatal|===)' "$BUILD_LOG_FILE" | uniq | wc -l`
 
 if  [ $2 == "unit-test" ]; then
     if [ $WARNING_COUNT -ge $THRESHOLD_UNIT_TEST ]; then

--- a/test-fixtures/generate-metrics.sh
+++ b/test-fixtures/generate-metrics.sh
@@ -4,10 +4,10 @@ set -e
 
 BUILD_LOG_FILE="$1"
 TYPE_LOG_FILE="$2"
-THRESHOLD_UNIT_TEST=4
-THRESHOLD_XCUITEST=4
+THRESHOLD_UNIT_TEST=6
+THRESHOLD_XCUITEST=6
 
-WARNING_COUNT=`egrep '^(\/(?!.*SourcePackages\/checkouts).+:[0-9+:[0-9]+:.|warning:|⚠️|ld: warning:|<unknown>:0: warning:|fatal|===)' "$BUILD_LOG_FILE" | uniq | wc -l`
+WARNING_COUNT=$(grep -E -v "SourcePackages/checkouts" "$BUILD_LOG_FILE" | grep -E "(^|:)[0-9]+:[0-9]+:|warning:|ld: warning:|<unknown>:0: warning:|fatal|===" | uniq | wc -l)
 
 if  [ $2 == "unit-test" ]; then
     if [ $WARNING_COUNT -ge $THRESHOLD_UNIT_TEST ]; then

--- a/test-fixtures/generate-metrics.sh
+++ b/test-fixtures/generate-metrics.sh
@@ -4,8 +4,8 @@ set -e
 
 BUILD_LOG_FILE="$1"
 TYPE_LOG_FILE="$2"
-THRESHOLD_UNIT_TEST=6
-THRESHOLD_XCUITEST=6
+THRESHOLD_UNIT_TEST=4
+THRESHOLD_XCUITEST=4
 
 WARNING_COUNT=`egrep '^(\/(?!.*SourcePackages\/checkouts).+:[0-9+:[0-9]+:.|warning:|⚠️|ld: warning:|<unknown>:0: warning:|fatal|===)' "$BUILD_LOG_FILE" | uniq | wc -l`
 

--- a/test-fixtures/generate-metrics.sh
+++ b/test-fixtures/generate-metrics.sh
@@ -4,8 +4,8 @@ set -e
 
 BUILD_LOG_FILE="$1"
 TYPE_LOG_FILE="$2"
-THRESHOLD_UNIT_TEST=4
-THRESHOLD_XCUITEST=4
+THRESHOLD_UNIT_TEST=6
+THRESHOLD_XCUITEST=6
 
 WARNING_COUNT=`egrep '^(\/(?!.*SourcePackages\/checkouts).+:[0-9+:[0-9]+:.|warning:|⚠️|ld: warning:|<unknown>:0: warning:|fatal|===)' "$BUILD_LOG_FILE" | uniq | wc -l`
 

--- a/test-fixtures/generate-metrics.sh
+++ b/test-fixtures/generate-metrics.sh
@@ -7,7 +7,7 @@ TYPE_LOG_FILE="$2"
 THRESHOLD_UNIT_TEST=6
 THRESHOLD_XCUITEST=6
 
-WARNING_COUNT=`egrep '^(\/(?!.*SourcePackages\/checkouts).+:[0-9+:[0-9]+:.|warning:|⚠️|ld: warning:|<unknown>:0: warning:|fatal|===)' "$BUILD_LOG_FILE" | uniq | wc -l`
+WARNING_COUNT=`egrep '^(?!.*\/SourcePackages\/checkouts)(\/.+:[0-9+:[0-9]+:.|warning:|⚠️|ld: warning:|<unknown>:0: warning:|fatal|===)' "$BUILD_LOG_FILE" | uniq | wc -l`
 
 if  [ $2 == "unit-test" ]; then
     if [ $WARNING_COUNT -ge $THRESHOLD_UNIT_TEST ]; then

--- a/test-fixtures/generate-metrics.sh
+++ b/test-fixtures/generate-metrics.sh
@@ -7,7 +7,7 @@ TYPE_LOG_FILE="$2"
 THRESHOLD_UNIT_TEST=6
 THRESHOLD_XCUITEST=6
 
-WARNING_COUNT=`egrep '^(?!.*\/SourcePackages\/checkouts)(\/.+:[0-9+:[0-9]+:.|warning:|⚠️|ld: warning:|<unknown>:0: warning:|fatal|===)' "$BUILD_LOG_FILE" | uniq | wc -l`
+WARNING_COUNT=`egrep '^(\/(?!.*SourcePackages\/checkouts).+:[0-9+:[0-9]+:.|warning:|⚠️|ld: warning:|<unknown>:0: warning:|fatal|===)' "$BUILD_LOG_FILE" | uniq | wc -l`
 
 if  [ $2 == "unit-test" ]; then
     if [ $WARNING_COUNT -ge $THRESHOLD_UNIT_TEST ]; then


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6426)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14443)

### Description
Adding a check that the pattern "SourcePackages/checkouts" does not appear anywhere in the warning string. If it does, the match will fail and the warning will not be detected.

Example of warnings that should be excluded with this addition:
```
⚠️ /Users/vagrant/git/DerivedData/SourcePackages/checkouts/telemetry-ios/Sources/Telemetry/TelemetryStorage.swift:273:31: 'withUnsafeBytes' is deprecated: use `withUnsafeBytes<R>(_: (UnsafeRawBufferPointer) throws -> R) rethrows -> R` instead

⚠️ /Users/vagrant/git/DerivedData/SourcePackages/checkouts/SwiftyJSON/Source/SwiftyJSON/SwiftyJSON.swift:239:18: type 'Any' is not optional, value can never be nil; this is an error in Swift 6
```

Note, I will run BR only when https://github.com/mozilla-mobile/firefox-ios/pull/14442 is merged, so we get the warnings count adjusted.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
