### PR TITLE
Remove FXIOS-6427 [v115] Disable DownloadTests

### DIFF
--- a/Tests/SyncTests/DownloadTests.swift
+++ b/Tests/SyncTests/DownloadTests.swift
@@ -17,88 +17,88 @@ class DownloadTests: XCTestCase {
         server.storeRecords(records: [], inCollection: "bookmarks")
     }
 
-    func testBasicDownload() {
-        let server = getServer(preStart: loadEmptyBookmarksIntoServer)
-        server.storeRecords(records: [], inCollection: "bookmarks")
-
-        let storageClient = getClient(server: server)
-        let bookmarksClient = storageClient.clientForCollection("bookmarks", encrypter: getEncrypter())
-
-        let expectation = self.expectation(description: "Waiting for result.")
-        let deferred = bookmarksClient.getSince(0)
-        deferred >>== { response in
-            XCTAssertEqual(response.metadata.status, 200)
-            expectation.fulfill()
-        }
-        waitForExpectations(timeout: 10, handler: nil)
-    }
-
-    func testDownloadBatches() {
-        let guid1: GUID = "abcdefghijkl"
-        let ts1: Timestamp = 1326254123650
-        let rec1 = MockSyncServer.makeValidEnvelope(guid: guid1, modified: ts1)
-
-        let guid2: GUID = "bbcdefghijkl"
-        let ts2: Timestamp = 1326254125650
-        let rec2 = MockSyncServer.makeValidEnvelope(guid: guid2, modified: ts2)
-
-        let server = getServer(preStart: loadEmptyBookmarksIntoServer)
-
-        server.storeRecords(records: [rec1], inCollection: "clients", now: ts1)
-
-        let storageClient = getClient(server: server)
-        let bookmarksClient = storageClient.clientForCollection("clients", encrypter: getEncrypter())
-        let prefs = MockProfilePrefs()
-
-        let batcher = BatchingDownloader(collectionClient: bookmarksClient, basePrefs: prefs, collection: "clients")
-
-        let ic1 = InfoCollections(collections: ["clients": ts1])
-
-        let ex = expectation(description: "batcher")
-        let fetch1 = batcher.go(ic1, limit: 1)
-        fetch1.upon { result in
-            ex.fulfill()
-
-            // We are now off-main, and .value is safe to call from here on
-
-            XCTAssertEqual(result.successValue, DownloadEndState.complete)
-            XCTAssertEqual(0, batcher.baseTimestamp)    // This isn't updated until after success.
-            let records1 = batcher.retrieve()
-            XCTAssertEqual(1, records1.count)
-            XCTAssertEqual(guid1, records1[0].id)
-            batcher.advance()
-            XCTAssertNotEqual(0, batcher.baseTimestamp)
-
-            // Fetching again yields nothing, because the collection hasn't
-            // changed.
-            XCTAssertEqual(batcher.go(ic1, limit: 1).value.successValue, DownloadEndState.noNewData)
-
-            // More records. Start again.
-            _ = batcher.reset().value
-
-            let ic2 = InfoCollections(collections: ["clients": ts2])
-            server.storeRecords(records: [rec2], inCollection: "clients", now: ts2)
-
-            let fetch2 = batcher.go(ic2, limit: 1).value
-            XCTAssertEqual(fetch2.successValue, DownloadEndState.incomplete)
-            let records2 = batcher.retrieve()
-            XCTAssertEqual(1, records2.count)
-            XCTAssertEqual(guid1, records2[0].id)
-            batcher.advance()
-
-            let fetch3 = batcher.go(ic2, limit: 1).value
-            XCTAssertEqual(fetch3.successValue, DownloadEndState.complete)
-            let records3 = batcher.retrieve()
-            XCTAssertEqual(1, records3.count)
-            XCTAssertEqual(guid2, records3[0].id)
-            batcher.advance()
-
-            let fetch4 = batcher.go(ic2, limit: 1).value
-            XCTAssertEqual(fetch4.successValue, DownloadEndState.noNewData)
-            let records4 = batcher.retrieve()
-            XCTAssertEqual(0, records4.count)
-            batcher.advance()
-        }
-        waitForExpectations(timeout: 10)
-    }
+//    func testBasicDownload() {
+//        let server = getServer(preStart: loadEmptyBookmarksIntoServer)
+//        server.storeRecords(records: [], inCollection: "bookmarks")
+//
+//        let storageClient = getClient(server: server)
+//        let bookmarksClient = storageClient.clientForCollection("bookmarks", encrypter: getEncrypter())
+//
+//        let expectation = self.expectation(description: "Waiting for result.")
+//        let deferred = bookmarksClient.getSince(0)
+//        deferred >>== { response in
+//            XCTAssertEqual(response.metadata.status, 200)
+//            expectation.fulfill()
+//        }
+//        waitForExpectations(timeout: 10, handler: nil)
+//    }
+//
+//    func testDownloadBatches() {
+//        let guid1: GUID = "abcdefghijkl"
+//        let ts1: Timestamp = 1326254123650
+//        let rec1 = MockSyncServer.makeValidEnvelope(guid: guid1, modified: ts1)
+//
+//        let guid2: GUID = "bbcdefghijkl"
+//        let ts2: Timestamp = 1326254125650
+//        let rec2 = MockSyncServer.makeValidEnvelope(guid: guid2, modified: ts2)
+//
+//        let server = getServer(preStart: loadEmptyBookmarksIntoServer)
+//
+//        server.storeRecords(records: [rec1], inCollection: "clients", now: ts1)
+//
+//        let storageClient = getClient(server: server)
+//        let bookmarksClient = storageClient.clientForCollection("clients", encrypter: getEncrypter())
+//        let prefs = MockProfilePrefs()
+//
+//        let batcher = BatchingDownloader(collectionClient: bookmarksClient, basePrefs: prefs, collection: "clients")
+//
+//        let ic1 = InfoCollections(collections: ["clients": ts1])
+//
+//        let ex = expectation(description: "batcher")
+//        let fetch1 = batcher.go(ic1, limit: 1)
+//        fetch1.upon { result in
+//            ex.fulfill()
+//
+//            // We are now off-main, and .value is safe to call from here on
+//
+//            XCTAssertEqual(result.successValue, DownloadEndState.complete)
+//            XCTAssertEqual(0, batcher.baseTimestamp)    // This isn't updated until after success.
+//            let records1 = batcher.retrieve()
+//            XCTAssertEqual(1, records1.count)
+//            XCTAssertEqual(guid1, records1[0].id)
+//            batcher.advance()
+//            XCTAssertNotEqual(0, batcher.baseTimestamp)
+//
+//            // Fetching again yields nothing, because the collection hasn't
+//            // changed.
+//            XCTAssertEqual(batcher.go(ic1, limit: 1).value.successValue, DownloadEndState.noNewData)
+//
+//            // More records. Start again.
+//            _ = batcher.reset().value
+//
+//            let ic2 = InfoCollections(collections: ["clients": ts2])
+//            server.storeRecords(records: [rec2], inCollection: "clients", now: ts2)
+//
+//            let fetch2 = batcher.go(ic2, limit: 1).value
+//            XCTAssertEqual(fetch2.successValue, DownloadEndState.incomplete)
+//            let records2 = batcher.retrieve()
+//            XCTAssertEqual(1, records2.count)
+//            XCTAssertEqual(guid1, records2[0].id)
+//            batcher.advance()
+//
+//            let fetch3 = batcher.go(ic2, limit: 1).value
+//            XCTAssertEqual(fetch3.successValue, DownloadEndState.complete)
+//            let records3 = batcher.retrieve()
+//            XCTAssertEqual(1, records3.count)
+//            XCTAssertEqual(guid2, records3[0].id)
+//            batcher.advance()
+//
+//            let fetch4 = batcher.go(ic2, limit: 1).value
+//            XCTAssertEqual(fetch4.successValue, DownloadEndState.noNewData)
+//            let records4 = batcher.retrieve()
+//            XCTAssertEqual(0, records4.count)
+//            batcher.advance()
+//        }
+//        waitForExpectations(timeout: 10)
+//    }
 }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6427)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14446)

### Description
testBasicDownload was flakey but once I removed it testDownloadBatches started failing so I'm disabling both.
For some reason adding them to the skip list in the test plan doesn't work so I commented them out.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
