### PR TITLE
Refactor MTE-999 [v115] Run smoke tests in parallel

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -223,19 +223,16 @@ workflows:
             exec unzip "$derived_data"
             echo "show dir"
             ls
-    - script@1.1:
+    - xcode-test-without-building@0:
         run_if: '{{getenv "RUN_UI_TESTS" | eq "Run_UI_Tests"}}'
         title: UI Smoketest
         inputs:
-        - content: |
-            #!/usr/bin/env bash
-            set -ex
-            ls ./Users/vagrant/git/Tests/
-            cp -r ./Users/vagrant/git/Tests/* .
-            mv ./Users/vagrant/git/DerivedData .
-            ls -la
-            echo "-- test-without-building --"
-            xcodebuild -resultBundlePath "xcodebuild.xcresult" -derivedDataPath "/Users/vagrant/git/DerivedData" -destination "platform=iOS Simulator,name=iPhone 14,OS=16.4" test-without-building -xctestrun "/Users/vagrant/git/DerivedData/Build/Products/Fennec_SmokeXCUITests_iphonesimulator16.4-x86_64.xctestrun"
+        - destination: platform=iOS Simulator,name=iPhone 14 Plus,OS=16.4
+        - xcodebuild_options: '"-derivedDataPath" "/Users/vagrant/git/DerivedData"
+            "-parallel-testing-enabled" "YES" "-parallel-testing-worker-count" "2"
+            "COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" 
+            "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
+        - xctestrun: "Users/vagrant/git/DerivedData/Build/Products/Fennec_SmokeXCUITests_iphonesimulator16.4-x86_64.xctestrun"
     - custom-test-results-export@0:
         run_if: '{{getenv "RUN_UI_TESTS" | eq "Run_UI_Tests"}}'
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -183,8 +183,10 @@ workflows:
         title: UI Smoketest2
         inputs:
         - destination: platform=iOS Simulator,name=iPhone 14 Plus,OS=16.4
-        - xcodebuild_options: '"-derivedDataPath" "/Users/vagrant/git/DerivedData" "COMPILER_INDEX_STORE_ENABLE=NO"
-            "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
+        - xcodebuild_options: '"-derivedDataPath" "/Users/vagrant/git/DerivedData"
+            "-parallel-testing-enabled" "YES" "-parallel-testing-worker-count" "2"
+            "COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" 
+            "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
         - xctestrun: "Users/vagrant/git/DerivedData/Build/Products/Fennec_Smoketest2_iphonesimulator16.4-x86_64.xctestrun"
     - deploy-to-bitrise-io@2.1.1:
         run_if: '{{getenv "RUN_UI_TESTS" | eq "Run_UI_Tests"}}'
@@ -272,19 +274,16 @@ workflows:
             exec unzip "$derived_data"
             echo "show dir"
             ls
-    - script@1.1:
+    - xcode-test-without-building@0:
         run_if: '{{getenv "RUN_UI_TESTS" | eq "Run_UI_Tests"}}'
         title: UI Smoketest3
         inputs:
-        - content: |
-            #!/usr/bin/env bash
-            set -ex
-            ls ./Users/vagrant/git/Tests/
-            cp -r ./Users/vagrant/git/Tests/* .
-            mv ./Users/vagrant/git/DerivedData .
-            ls -la
-            echo "-- test-without-building --"
-            xcodebuild -resultBundlePath "xcodebuild.xcresult" -derivedDataPath "/Users/vagrant/git/DerivedData" -destination "platform=iOS Simulator,name=iPhone 14,OS=16.4" test-without-building -xctestrun "/Users/vagrant/git/DerivedData/Build/Products/Fennec_Smoketest3_iphonesimulator16.4-x86_64.xctestrun"
+        - destination: platform=iOS Simulator,name=iPhone 14 Plus,OS=16.4
+        - xcodebuild_options: '"-derivedDataPath" "/Users/vagrant/git/DerivedData"
+            "-parallel-testing-enabled" "YES" "-parallel-testing-worker-count" "2"
+            "COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" 
+            "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
+        - xctestrun: "Users/vagrant/git/DerivedData/Build/Products/Fennec_Smoketest3_iphonesimulator16.4-x86_64.xctestrun"
     - custom-test-results-export@0:
         run_if: '{{getenv "RUN_UI_TESTS" | eq "Run_UI_Tests"}}'
         inputs:
@@ -328,8 +327,10 @@ workflows:
         title: UI Smoketest4
         inputs:
         - destination: platform=iOS Simulator,name=iPhone 14 Plus,OS=16.4
-        - xcodebuild_options: '"-derivedDataPath" "/Users/vagrant/git/DerivedData" "COMPILER_INDEX_STORE_ENABLE=NO"
-            "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
+        - xcodebuild_options: '"-derivedDataPath" "/Users/vagrant/git/DerivedData"
+            "-parallel-testing-enabled" "YES" "-parallel-testing-worker-count" "2"
+            "COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" 
+            "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
         - xctestrun: "Users/vagrant/git/DerivedData/Build/Products/Fennec_Smoketest4_iphonesimulator16.4-x86_64.xctestrun"
     - deploy-to-bitrise-io@2:
         run_if: '{{getenv "RUN_UI_TESTS" | eq "Run_UI_Tests"}}'


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-999)

### Description
We would like to take advantage of the multiple cores from the Bitrise M1 stack by running the smoke tests in parallel on Bitrise. I have confirmed on my local M1 computer that the smoke tests can be run in parallel. Let's put it on Bitrise and see how much time and credits can be saved.

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
