### PR TITLE
Bugfix FXIOS-6342 [v115] Fix warning to start running AVCaptureSession on the main thread

### DIFF
--- a/Client/Frontend/Browser/QRCodeViewController.swift
+++ b/Client/Frontend/Browser/QRCodeViewController.swift
@@ -24,7 +24,7 @@ class QRCodeViewController: UIViewController {
 
     var qrCodeDelegate: QRCodeViewControllerDelegate?
 
-    fileprivate lazy var captureSession: AVCaptureSession = {
+    private lazy var captureSession: AVCaptureSession = {
         let session = AVCaptureSession()
         session.sessionPreset = AVCaptureSession.Preset.high
         return session
@@ -291,7 +291,9 @@ class QRCodeViewController: UIViewController {
         videoPreviewLayer.frame = UIScreen.main.bounds
         view.layer.addSublayer(videoPreviewLayer)
         self.videoPreviewLayer = videoPreviewLayer
-        captureSession.startRunning()
+        DispatchQueue.global(qos: .background).async {
+            self.captureSession.startRunning()
+        }
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {

--- a/Client/Frontend/Browser/QRCodeViewController.swift
+++ b/Client/Frontend/Browser/QRCodeViewController.swift
@@ -291,7 +291,7 @@ class QRCodeViewController: UIViewController {
         videoPreviewLayer.frame = UIScreen.main.bounds
         view.layer.addSublayer(videoPreviewLayer)
         self.videoPreviewLayer = videoPreviewLayer
-        DispatchQueue.global(qos: .background).async {
+        DispatchQueue.global().async {
             self.captureSession.startRunning()
         }
     }

--- a/Client/Frontend/Widgets/TwoLineImageOverlayCell.swift
+++ b/Client/Frontend/Widgets/TwoLineImageOverlayCell.swift
@@ -10,8 +10,8 @@ class TwoLineImageOverlayCell: UITableViewCell,
                                ReusableCell,
                                ThemeApplicable {
     struct UX {
-        static let ImageSize: CGFloat = 29
-        static let BorderViewMargin: CGFloat = 16
+        static let imageSize: CGFloat = 28
+        static let borderViewMargin: CGFloat = 16
         static let iconBorderWidth: CGFloat = 0.5
     }
 
@@ -19,8 +19,7 @@ class TwoLineImageOverlayCell: UITableViewCell,
     static let accessoryUsageReuseIdentifier = "temporary-reuse-identifier"
 
     // Tableview cell items
-    private lazy var selectedView: UIView = .build { view in
-    }
+    private lazy var selectedView: UIView = .build { _ in }
 
     lazy var containerView: UIView = .build { view in
         view.backgroundColor = .clear
@@ -66,7 +65,7 @@ class TwoLineImageOverlayCell: UITableViewCell,
 
     private func setupLayout() {
         separatorInset = UIEdgeInsets(top: 0,
-                                      left: UX.ImageSize + 2 * UX.BorderViewMargin,
+                                      left: UX.imageSize + 2 * UX.borderViewMargin,
                                       bottom: 0,
                                       right: 0)
         selectionStyle = .default
@@ -90,8 +89,8 @@ class TwoLineImageOverlayCell: UITableViewCell,
             leftImageView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor,
                                                    constant: 16),
             leftImageView.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
-            leftImageView.heightAnchor.constraint(equalToConstant: 28),
-            leftImageView.widthAnchor.constraint(equalToConstant: 28),
+            leftImageView.heightAnchor.constraint(equalToConstant: UX.imageSize),
+            leftImageView.widthAnchor.constraint(equalToConstant: UX.imageSize),
             leftImageView.trailingAnchor.constraint(equalTo: stackView.leadingAnchor,
                                                     constant: -16),
 
@@ -126,7 +125,7 @@ class TwoLineImageOverlayCell: UITableViewCell,
 
         selectionStyle = .default
         separatorInset = UIEdgeInsets(top: 0,
-                                      left: UX.ImageSize + 2 * UX.BorderViewMargin,
+                                      left: UX.imageSize + 2 * UX.borderViewMargin,
                                       bottom: 0,
                                       right: 0)
         leftImageView.image = nil


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6342)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14460)

### Description
- Start running the capture video on the background thread to fix the warning
- Minor UX struct fixes

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
