### PR TITLE
Bugfix FXIOS-6436 [v114] Force "en-US" as fallback localization

### DIFF
--- a/Client/Experiments/Experiments.swift
+++ b/Client/Experiments/Experiments.swift
@@ -167,7 +167,7 @@ enum Experiments {
         let bundles = [
             Bundle.main,
             Strings.bundle,
-            Strings.bundle.fallbackTranslationBundle()
+            Strings.bundle.fallbackTranslationBundle(language: "en-US")
         ].compactMap { $0 }
 
         return NimbusBuilder(dbPath: dbPath)


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6436)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14469)

### Description
Localization be darned!

Can't unit test this because the sim locale would have to be changed to test for non-existant strings.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
