### PR TITLE
Refactor FXIOS-6418 [v115] biometrics support for credit card settings view and blur on edit page

### DIFF
--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -9,6 +9,7 @@ import Shared
 
 struct CreditCardInputView: View {
     @ObservedObject var viewModel: CreditCardInputViewModel
+    @State private var isBlurred = false
     var dismiss: ((_ successVal: Bool) -> Void)
 
     // Theming
@@ -90,11 +91,22 @@ struct CreditCardInputView: View {
                 .padding(.top, 0)
                 .background(backgroundColor.edgesIgnoringSafeArea(.bottom))
             }
+            .blur(radius: isBlurred ? 10 : 0)
             .onAppear {
                 applyTheme(theme: themeVal.theme)
             }
             .onChange(of: themeVal) { val in
                 applyTheme(theme: val.theme)
+            }
+            .onReceive(NotificationCenter.default.publisher(
+                for: UIApplication.willResignActiveNotification)
+            ) { _ in
+                isBlurred = true
+            }
+            .onReceive(NotificationCenter.default.publisher(
+                for: UIApplication.didBecomeActiveNotification)
+            ) { _ in
+                isBlurred = false
             }
         }
     }

--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewController.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewController.swift
@@ -8,13 +8,12 @@ import Shared
 import Storage
 import SwiftUI
 
-class CreditCardSettingsViewController: UIViewController, Themeable {
+class CreditCardSettingsViewController: SensitiveViewController, Themeable {
     var viewModel: CreditCardSettingsViewModel
     var themeObserver: NSObjectProtocol?
     var themeManager: ThemeManager
     var notificationCenter: NotificationProtocol
 
-    private let appAuthenticator: AppAuthenticationProtocol
     private let logger: Logger
 
     // MARK: Views
@@ -36,13 +35,11 @@ class CreditCardSettingsViewController: UIViewController, Themeable {
     init(creditCardViewModel: CreditCardSettingsViewModel,
          themeManager: ThemeManager = AppContainer.shared.resolve(),
          notificationCenter: NotificationCenter = NotificationCenter.default,
-         appAuthenticator: AppAuthenticationProtocol = AppAuthenticator(),
          logger: Logger = DefaultLogger.shared
     ) {
         self.viewModel = creditCardViewModel
         self.themeManager = themeManager
         self.notificationCenter = notificationCenter
-        self.appAuthenticator = appAuthenticator
         self.logger = logger
         self.creditCardTableViewController = CreditCardTableViewController(viewModel: viewModel.tableViewModel)
 

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -1067,22 +1067,50 @@ class ClearPrivateDataSetting: Setting {
 
 class AutofillCreditCardSettings: Setting, FeatureFlaggable {
     private let profile: Profile
+    private let appAuthenticator: AppAuthenticationProtocol
+    weak var navigationController: UINavigationController?
+    weak var settings: AppSettingsTableViewController?
     override var accessoryView: UIImageView? { return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme) }
     override var accessibilityIdentifier: String? { return "AutofillCreditCard" }
 
-    init(settings: SettingsTableViewController) {
+    init(settings: SettingsTableViewController,
+         appAuthenticator: AppAuthenticationProtocol = AppAuthenticator()) {
         self.profile = settings.profile
-        let title: String = .SettingsAutofillCreditCard
-        super.init(title: NSAttributedString(string: title, attributes: [NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary]))
+        self.appAuthenticator = appAuthenticator
+        self.navigationController = settings.navigationController
+        self.settings = settings as? AppSettingsTableViewController
+
+        super.init(
+            title: NSAttributedString(
+                string: .SettingsAutofillCreditCard,
+                attributes: [NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary]
+            )
+        )
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
-        // Telemetry
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .creditCardAutofillSettings)
         let viewModel = CreditCardSettingsViewModel(profile: profile)
         let viewController = CreditCardSettingsViewController(
             creditCardViewModel: viewModel)
-        navigationController?.pushViewController(viewController, animated: true)
+
+        guard let navController = navigationController else { return }
+        if appAuthenticator.canAuthenticateDeviceOwner() {
+            AppAuthenticator().authenticateWithDeviceOwnerAuthentication { result in
+                switch result {
+                case .success:
+                    navController.pushViewController(viewController,
+                                                     animated: true)
+                case .failure:
+                    viewController.dismissVC()
+                }
+            }
+        } else {
+            let passcodeViewController = DevicePasscodeRequiredViewController()
+            passcodeViewController.profile = profile
+            navigationController?.pushViewController(passcodeViewController,
+                                                     animated: true)
+        }
     }
 }
 

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -1108,8 +1108,8 @@ class AutofillCreditCardSettings: Setting, FeatureFlaggable {
         } else {
             let passcodeViewController = DevicePasscodeRequiredViewController()
             passcodeViewController.profile = profile
-            navigationController?.pushViewController(passcodeViewController,
-                                                     animated: true)
+            navController.pushViewController(passcodeViewController,
+                                             animated: true)
         }
     }
 }


### PR DESCRIPTION
[FXIOS-6418](https://mozilla-hub.atlassian.net/browse/FXIOS-6418)
[Github issue 14421](https://github.com/mozilla-mobile/firefox-ios/issues/14421)


### Description
We had to remove the biometric support for the edit page due to some complications of it not working as intended. Refactored some of the code to perform the following: 

- Show biometrics check before when a user taps on the credit card autofill on the settings page
- Blur the page when the user background the app 

Older Ticket: https://mozilla-hub.atlassian.net/browse/FXIOS-5552 

No tests as this change is purely for biometrics support.

| Video 1  | Video 2 |
| ------------- | ------------- |
| <video src="https://github.com/mozilla-mobile/firefox-ios/assets/8919439/cc8532eb-5ca4-4353-9b61-1260bbb86241">  | <video src="https://github.com/mozilla-mobile/firefox-ios/assets/8919439/c4c05e9b-88fe-4d9f-88f1-f3cbb677d381">|

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
~- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)~
~- [ ] Unit tests written and passing~
- [ ] Documentation / comments for complex code and public methods
