### PR TITLE
Add FXIOS-6339 [v115] Replace use of DeviceFontLargeBold with preferredBoldFont

### DIFF
--- a/Client/Frontend/LoginManagement/BreachAlertsDetailView.swift
+++ b/Client/Frontend/LoginManagement/BreachAlertsDetailView.swift
@@ -42,7 +42,8 @@ class BreachAlertsDetailView: UIView, ThemeApplicable {
 
     lazy var titleLabel: UILabel = {
         let label = UILabel()
-        label.font = DynamicFontHelper.defaultHelper.DeviceFontLargeBold
+        label.font = DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .headline,
+                                                                       size: 19)
         label.text = .BreachAlertsTitle
         label.sizeToFit()
         label.isAccessibilityElement = true

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetView.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetView.swift
@@ -197,7 +197,13 @@ class PhotonActionSheetView: UIView, UIGestureRecognizerDelegate, ThemeApplicabl
         setupViews()
 
         titleLabel.text = item.currentTitle
-        titleLabel.font = item.bold ? DynamicFontHelper.defaultHelper.DeviceFontLargeBold : DynamicFontHelper.defaultHelper.SemiMediumRegularWeightAS
+
+        if item.bold {
+            titleLabel.font = DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .headline,
+                                                                                size: 19)
+        } else {
+            titleLabel.font = DynamicFontHelper.defaultHelper.SemiMediumRegularWeightAS
+        }
 
         item.customRender?(titleLabel, self)
 

--- a/Client/Helpers/DynamicFontHelper.swift
+++ b/Client/Helpers/DynamicFontHelper.swift
@@ -57,9 +57,6 @@ class DynamicFontHelper: NSObject {
     var DeviceFontExtraLarge: UIFont {
         return UIFont.systemFont(ofSize: deviceFontSize + 4)
     }
-    var DeviceFontLargeBold: UIFont {
-        return UIFont.boldSystemFont(ofSize: deviceFontSize + 2)
-    }
 
     /*
      Activity Stream supports dynamic fonts up to a certain point. Small fonts dont work.


### PR DESCRIPTION
# [FXIOS-6339](https://mozilla-hub.atlassian.net/browse/FXIOS-6339)

### Description
Replaced DeviceFontLargeBold with preferredBoldFont. The size is based on using the normal size.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
