### PR TITLE
Revert FXIOS-6461 [v115] Revert truncating cell

### DIFF
--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -37,13 +37,6 @@ extension UILabel {
             context: nil)
         return boundingRect.height
     }
-
-    func truncateLabelText(to limit: Int) {
-        if let labelText = self.text {
-            let attributedString = labelText.prefix(min(labelText.count, limit))
-            self.attributedText = NSAttributedString(string: String(attributedString))
-        }
-    }
 }
 
 // A base setting class that shows a title. You probably want to subclass this, not use it directly.
@@ -854,7 +847,6 @@ class SettingsTableViewController: ThemedTableViewController {
             let cell = ThemedTableViewCell(style: setting.style, reuseIdentifier: nil)
             setting.onConfigureCell(cell, theme: themeManager.currentTheme)
             cell.applyTheme(theme: themeManager.currentTheme)
-            cell.detailTextLabel?.truncateLabelText(to: 28)
             return cell
         }
         return super.tableView(tableView, cellForRowAt: indexPath)


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6461)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14532)

### Description
Revert truncating cell, so settings cell height adjust automatically to the content lenght.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
