### PR TITLE
Add FXIOS-6464 [v115] Adding log to capture issue

### DIFF
--- a/Client/TabManagement/Tab.swift
+++ b/Client/TabManagement/Tab.swift
@@ -603,8 +603,10 @@ class Tab: NSObject {
                 return webView.loadFileURL(url, allowingReadAccessTo: url)
             }
             return webView.load(request)
+        } else {
+            logger.log("Webview was nil, could not load request", level: .info, category: .webview)
+            return nil
         }
-        return nil
     }
 
     func stop() {

--- a/Tests/ClientTests/TabLocationViewTests.swift
+++ b/Tests/ClientTests/TabLocationViewTests.swift
@@ -2,11 +2,22 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import XCTest
 
 @testable import Client
 
 class TabLocationViewTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        AppContainer.shared.reset()
+    }
+
     func testDelegateMemoryLeak() {
         let tabLocationView = TabLocationView()
         let delegate = MockTabLocationViewDelegate()


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6464)

### Description
Just adding a log here to capture the problem where webview is nil when it shouldn't. Adding a `info` level since it seems this could happen in normal cases as well.

Open as draft since not entirely sure this is something we want? @OrlaM 
 
### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
