### PR TITLE
Bugfix FXIOS-6464 [v114] Move restore check to view did load

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -476,6 +476,16 @@ class BrowserViewController: UIViewController {
         SearchBarSettingsViewModel.recordLocationTelemetry(for: isBottomSearchBar ? .bottom : .top)
 
         overlayManager.setURLBar(urlBarView: urlBar)
+
+        if !displayedRestoreTabsAlert && crashedLastLaunch() {
+            logger.log("The application crashed on last session",
+                       level: .info,
+                       category: .lifecycle)
+            displayedRestoreTabsAlert = true
+            showRestoreTabsAlert()
+        } else {
+            tabManager.restoreTabs()
+        }
     }
 
     private func setupAccessibleActions() {
@@ -599,16 +609,6 @@ class BrowserViewController: UIViewController {
             // check of view appearance and the `performSurveySurfaceCheck`, where the
             // alpha will be set to 1.
             self.view.alpha = 0
-        }
-
-        if !displayedRestoreTabsAlert && crashedLastLaunch() {
-            logger.log("The application crashed on last session",
-                       level: .info,
-                       category: .lifecycle)
-            displayedRestoreTabsAlert = true
-            showRestoreTabsAlert()
-        } else {
-            tabManager.restoreTabs()
         }
 
         updateTabCountUsingTabManager(tabManager, animated: false)


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6464)

### Description
Restore tabs should just be called once on app start

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
