### PR TITLE
Bugfix MTE-1045 [v115] Forward button for both iPhone and iPad

### DIFF
--- a/Tests/XCUITests/HistoryTests.swift
+++ b/Tests/XCUITests/HistoryTests.swift
@@ -338,7 +338,11 @@ class HistoryTests: BaseTestCase {
         app.tables.staticTexts["The Book of Mozilla"].tap()
         urlBarBackButton.tap()
         XCTAssertFalse(urlBarBackButton.isEnabled)
-        urlBarForwardButton.press(forDuration: 1)
+        if iPad() {
+            app.windows.otherElements.buttons["Forward"].press(forDuration: 1)
+        } else {
+            urlBarForwardButton.press(forDuration: 1)
+        }
         XCTAssertTrue(app.tables.staticTexts["The Book of Mozilla"].exists)
         app.tables.staticTexts["The Book of Mozilla"].tap()
         waitForValueContains(app.textFields["url"], value: "test-fixture/test-mozilla-book.html")

--- a/Tests/XCUITests/NavigationTest.swift
+++ b/Tests/XCUITests/NavigationTest.swift
@@ -22,7 +22,8 @@ class NavigationTest: BaseTestCase {
         // Check the url placeholder text and that the back and forward buttons are disabled
         XCTAssert(urlPlaceholder == defaultValuePlaceholder)
         if iPad() {
-            XCTAssertFalse(app.buttons["URLBarView.backButton"].isEnabled)
+            print(app.debugDescription)
+            XCTAssertFalse(app.buttons["TabToolbar.backButton"].isEnabled)
             XCTAssertFalse(app.buttons["Forward"].isEnabled)
             app.textFields["url"].tap()
         } else {
@@ -39,7 +40,7 @@ class NavigationTest: BaseTestCase {
         waitUntilPageLoad()
         waitForValueContains(app.textFields["url"], value: "test-example.html")
         if iPad() {
-            XCTAssertTrue(app.buttons["URLBarView.backButton"].isEnabled)
+            XCTAssertTrue(app.buttons["TabToolbar.backButton"].isEnabled)
             XCTAssertFalse(app.buttons["Forward"].isEnabled)
         } else {
             XCTAssertTrue(app.buttons["TabToolbar.backButton"].isEnabled)
@@ -51,10 +52,10 @@ class NavigationTest: BaseTestCase {
         waitUntilPageLoad()
         waitForValueContains(app.textFields["url"], value: "test-mozilla-org.html")
         if iPad() {
-            XCTAssertTrue(app.buttons["URLBarView.backButton"].isEnabled)
+            XCTAssertTrue(app.buttons["TabToolbar.backButton"].isEnabled)
             XCTAssertFalse(app.buttons["Forward"].isEnabled)
             // Go back to previous visited web site
-            app.buttons["URLBarView.backButton"].tap()
+            app.buttons["TabToolbar.backButton"].tap()
         } else {
             XCTAssertTrue(app.buttons["TabToolbar.backButton"].isEnabled)
             XCTAssertFalse(app.buttons["TabToolbar.forwardButton"].isEnabled)

--- a/Tests/XCUITests/NavigationTest.swift
+++ b/Tests/XCUITests/NavigationTest.swift
@@ -22,7 +22,6 @@ class NavigationTest: BaseTestCase {
         // Check the url placeholder text and that the back and forward buttons are disabled
         XCTAssert(urlPlaceholder == defaultValuePlaceholder)
         if iPad() {
-            print(app.debugDescription)
             XCTAssertFalse(app.buttons["TabToolbar.backButton"].isEnabled)
             XCTAssertFalse(app.buttons["Forward"].isEnabled)
             app.textFields["url"].tap()

--- a/Tests/XCUITests/ToolbarTest.swift
+++ b/Tests/XCUITests/ToolbarTest.swift
@@ -30,7 +30,7 @@ class ToolbarTests: BaseTestCase {
 
         // Check the url placeholder text and that the back and forward buttons are disabled
         XCTAssertTrue(urlPlaceholder == defaultValuePlaceholder, "The placeholder does not show the correct value")
-        XCTAssertFalse(app.buttons["URLBarView.backButton"].isEnabled)
+        XCTAssertFalse(app.buttons["TabToolbar.backButton"].isEnabled)
         XCTAssertFalse(app.buttons["Forward"].isEnabled)
 
         // Navigate to two pages and press back once so that all buttons are enabled in landscape mode.
@@ -39,7 +39,7 @@ class ToolbarTests: BaseTestCase {
         waitForExistence(app.webViews.links["Mozilla"], timeout: 10)
         let valueMozilla = app.textFields["url"].value as! String
         XCTAssertEqual(valueMozilla, urlValueLong)
-        XCTAssertTrue(app.buttons["URLBarView.backButton"].isEnabled)
+        XCTAssertTrue(app.buttons["TabToolbar.backButton"].isEnabled)
         XCTAssertFalse(app.buttons["Forward"].isEnabled)
         if iPad() {
             XCTAssertTrue(app.buttons["Reload"].isEnabled)
@@ -50,14 +50,14 @@ class ToolbarTests: BaseTestCase {
         navigator.openURL(website2)
         waitUntilPageLoad()
         waitForValueContains(app.textFields["url"], value: "localhost:\(serverPort)")
-        XCTAssertTrue(app.buttons["URLBarView.backButton"].isEnabled)
+        XCTAssertTrue(app.buttons["TabToolbar.backButton"].isEnabled)
         XCTAssertFalse(app.buttons["Forward"].isEnabled)
 
-        app.buttons["URLBarView.backButton"].tap()
+        app.buttons["TabToolbar.backButton"].tap()
         XCTAssertEqual(valueMozilla, urlValueLong)
 
         waitUntilPageLoad()
-        XCTAssertTrue(app.buttons["URLBarView.backButton"].isEnabled)
+        XCTAssertTrue(app.buttons["TabToolbar.backButton"].isEnabled)
         XCTAssertTrue(app.buttons["Forward"].isEnabled)
 
         // Open new tab and then go back to previous tab to test navigation buttons.
@@ -73,7 +73,7 @@ class ToolbarTests: BaseTestCase {
 
         // Test to see if all the buttons are enabled.
         waitUntilPageLoad()
-        XCTAssertTrue(app.buttons["URLBarView.backButton"].isEnabled)
+        XCTAssertTrue(app.buttons["TabToolbar.backButton"].isEnabled)
         XCTAssertTrue(app.buttons["Forward"].isEnabled)
     }
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1045)

### Description
Some accessibility identifiers are applied inconsistently between iPhone and iPad: https://github.com/mozilla-mobile/firefox-ios/issues/14539. The issue on the "Foward" ➡️ button causes some tests to fail on iPad or on both platforms (`testTabHistory`, `testNavigation` and `testLandscapeNavigationWithTabSwitch`). Since the tests are unable to locate the button, the tests fail.

This PR is to apply the label/identifier that works for the current state of the app to rule out legitimate test failures in the near future.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
