### PR TITLE
Refactor [v115] Update CC_Python_Update.py to tolerate file fetching failures

### DIFF
--- a/Client/Assets/CC_Script/CC_Python_Update.py
+++ b/Client/Assets/CC_Script/CC_Python_Update.py
@@ -19,8 +19,7 @@ FILES_TO_DOWNLOAD = [
     "toolkit/components/formautofill/shared/FormAutofillHandler.sys.mjs",
     "toolkit/components/formautofill/shared/FormAutofillHeuristics.sys.mjs",
     "toolkit/components/formautofill/shared/FormAutofillNameUtils.sys.mjs",
-    "toolkit/components/formautofill/FormAutofillSection.ios.sys.mjs",
-    "toolkit/components/formautofill/FormAutofillSection.sys.mjs",
+    "toolkit/components/formautofill/shared/FormAutofillSection.sys.mjs",
     "toolkit/components/formautofill/shared/FormAutofillUtils.sys.mjs",
     "toolkit/modules/FormLikeFactory.sys.mjs",
     "toolkit/components/formautofill/shared/FormStateManager.sys.mjs",
@@ -101,9 +100,11 @@ def main():
         # download file to compare changes
         downloaded = downloadTemporaryFileToCompare(file_info)
 
+        # This can happen if the file was removed and doesn't exist anymore on central
+        # We don't want to fail if that's the case
         if not downloaded:
             print(f"Skipping file: {file_info['filename']}")
-            return 
+            continue
 
         # move file if it does not exist
         if os.path.exists(file_info["path"]) == False:


### PR DESCRIPTION


### Description
Sometimes we might remove unnecessary files on central. The `CC_Python_Update.py` will fail if a file from the shared list doesn't exist. Ideally we want it to skip it. 

### Pull requests checks where applicable
~~- [ ] Fill in the three TODOs above (tickets number and description of your work)~~
~~- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)~~
~~- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)~~
~~- [ ] Unit tests written and passing~~
~~- [ ] Documentation / comments for complex code and public methods~~
