### PR TITLE
Bugfix MTE-1046 [v115] Number of stories from pocket

### DIFF
--- a/Tests/XCUITests/PocketTests.swift
+++ b/Tests/XCUITests/PocketTests.swift
@@ -10,13 +10,10 @@ class PocketTest: BaseTestCase {
         waitForExistence(app.staticTexts[AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.pocket])
         XCTAssertEqual(app.staticTexts[AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.pocket].label, "Thought-Provoking Stories")
 
-        // There should be two stories on iPhone and three on iPad
+        // There should be at least 8 stories on iPhone and three on iPad
         let numPocketStories = app.collectionViews.containing(.cell, identifier: AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell).children(matching: .cell).count-1
-        if iPad() {
-            XCTAssertEqual(numPocketStories, 15)
-        } else {
-            XCTAssertEqual(numPocketStories, 8)
-        }
+        XCTAssertTrue(numPocketStories > 7)
+
         // Disable Pocket
         navigator.performAction(Action.TogglePocketInNewTab)
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1046)

### Description

We get less stories displayed from Pocket on iPad for `testPocketEnabledByDefault`:

https://storage.googleapis.com/mobile-reports/public/firefox-ios-M1/FullFunctionalTests-iPad/result_153/build/reports/tests.html

Let's test for enough (8?) number of stories displayed under Pocket for both iPhone and iPad instead.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
