### PR TITLE
Add FXIOS-6458 [v115] Add logic for removal of credit card with / without sync

### DIFF
--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -127,25 +127,25 @@ struct CreditCardInputView: View {
                 if viewModel.state == .edit {
                     viewModel.updateCreditCard { _, error in
                         guard let error = error else {
-                            viewModel.dismiss?(true)
+                            viewModel.dismiss?(.updatedCard, true)
                             return
                         }
                         viewModel.logger?.log("Unable to update card with error: \(error)",
                                               level: .fatal,
                                               category: .creditcard)
-                        viewModel.dismiss?(false)
+                        viewModel.dismiss?(.none, false)
                     }
                 } else {
                     // Save new card
                     viewModel.saveCreditCard { _, error in
                         guard let error = error else {
-                            viewModel.dismiss?(true)
+                            viewModel.dismiss?(.savedCard, true)
                             return
                         }
                         viewModel.logger?.log("Unable to save credit card with error: \(error)",
                                               level: .fatal,
                                               category: .creditcard)
-                        viewModel.dismiss?(false)
+                        viewModel.dismiss?(.savedCard, false)
                     }
                 }
             }
@@ -159,7 +159,7 @@ struct CreditCardInputView: View {
             case .cancel:
                 viewModel.updateState(state: .view)
             case.close:
-                viewModel.dismiss?(false)
+                viewModel.dismiss?(.none, false)
             }
         }
     }

--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -10,7 +10,6 @@ import Shared
 struct CreditCardInputView: View {
     @ObservedObject var viewModel: CreditCardInputViewModel
     @State private var isBlurred = false
-    var dismiss: ((_ successVal: Bool) -> Void)
 
     // Theming
     @Environment(\.themeType)
@@ -128,25 +127,25 @@ struct CreditCardInputView: View {
                 if viewModel.state == .edit {
                     viewModel.updateCreditCard { _, error in
                         guard let error = error else {
-                            dismiss(true)
+                            viewModel.dismiss?(true)
                             return
                         }
                         viewModel.logger?.log("Unable to update card with error: \(error)",
                                               level: .fatal,
                                               category: .creditcard)
-                        dismiss(false)
+                        viewModel.dismiss?(false)
                     }
                 } else {
                     // Save new card
                     viewModel.saveCreditCard { _, error in
                         guard let error = error else {
-                            dismiss(true)
+                            viewModel.dismiss?(true)
                             return
                         }
                         viewModel.logger?.log("Unable to save credit card with error: \(error)",
                                               level: .fatal,
                                               category: .creditcard)
-                        dismiss(false)
+                        viewModel.dismiss?(false)
                     }
                 }
             }
@@ -160,7 +159,7 @@ struct CreditCardInputView: View {
             case .cancel:
                 viewModel.updateState(state: .view)
             case.close:
-                dismiss(false)
+                viewModel.dismiss?(false)
             }
         }
     }
@@ -187,10 +186,6 @@ struct CreditCardEditView_Previews: PreviewProvider {
                                                  creditCard: sampleCreditCard,
                                                  state: .view)
 
-        return CreditCardInputView(
-            viewModel: viewModel,
-            dismiss: { successVal in
-            // dismiss view
-        })
+        return CreditCardInputView(viewModel: viewModel)
     }
 }

--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputViewModel.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputViewModel.swift
@@ -75,6 +75,22 @@ enum InputVMError: Error {
     case unableToUpdateCC
 }
 
+enum CreditCardModifiedStatus {
+    case savedCard
+    case updatedCard
+    case removedCard
+    case none
+
+    var message: String {
+        switch self {
+        case .savedCard: return String.CreditCard.SnackBar.SavedCardLabel
+        case .updatedCard: return String.CreditCard.SnackBar.UpdatedCardLabel
+        case .removedCard: return String.CreditCard.SnackBar.RemovedCardLabel
+        default: return ""
+        }
+    }
+}
+
 class CreditCardInputViewModel: ObservableObject {
     typealias CreditCardText = String.CreditCard.Alert
     var logger: Logger?
@@ -93,7 +109,8 @@ class CreditCardInputViewModel: ObservableObject {
 
     // MARK: View
 
-    var dismiss: ((_ successVal: Bool) -> Void)?
+    var dismiss: ((_ modifiedStatus: CreditCardModifiedStatus,
+                   _ successVal: Bool) -> Void)?
 
     @Published var state: CreditCardEditState
     @Published var errorState: String = ""
@@ -244,7 +261,7 @@ class CreditCardInputViewModel: ObservableObject {
         autofill.deleteCreditCard(id: currentCreditCard.guid) {
             status, error in
             guard let error = error, status == true else {
-                self.dismiss?(true)
+                self.dismiss?(.removedCard, true)
                 return
             }
             self.logger?.log("Unable to remove credit card: \(error)",

--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputViewModel.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputViewModel.swift
@@ -267,7 +267,7 @@ class CreditCardInputViewModel: ObservableObject {
 
         autofill.deleteCreditCard(id: currentCreditCard.guid) {
             status, error in
-            guard let error = error, status == true else {
+            guard let error = error, status else {
                 completion(.removedCard, true)
                 return
             }

--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputViewModel.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputViewModel.swift
@@ -163,7 +163,9 @@ class CreditCardInputViewModel: ObservableObject {
             alertBody: Text(CreditCardText.RemoveCardSublabel),
             primaryButtonStyleAndText: .destructive(Text(CreditCardText.RemovedCardLabel)) {
                 [self] in
-                self.dismissAndRemoveCreditCard()
+                self.removeCreditCard(creditCard: creditCard) { status, successVal in
+                    self.dismiss?(status, successVal)
+                }
             },
             secondaryButtonStyleAndText: .cancel(),
             primaryButtonAction: {},
@@ -176,7 +178,9 @@ class CreditCardInputViewModel: ObservableObject {
             alertBody: nil,
             primaryButtonStyleAndText: .destructive(Text(CreditCardText.RemovedCardLabel)) {
                 [self] in
-                self.dismissAndRemoveCreditCard()
+                self.removeCreditCard(creditCard: creditCard) { status, successVal in
+                    self.dismiss?(status, successVal)
+                }
             },
             secondaryButtonStyleAndText: .cancel(),
             primaryButtonAction: {},
@@ -253,20 +257,24 @@ class CreditCardInputViewModel: ObservableObject {
                                   completion: completion)
     }
 
-    private func dismissAndRemoveCreditCard() {
+    func removeCreditCard(creditCard: CreditCard?,
+                          completion: @escaping (CreditCardModifiedStatus, Bool) -> Void) {
         guard let currentCreditCard = creditCard,
               !currentCreditCard.guid.isEmpty else {
+            completion(.none, false)
             return
         }
+
         autofill.deleteCreditCard(id: currentCreditCard.guid) {
             status, error in
             guard let error = error, status == true else {
-                self.dismiss?(.removedCard, true)
+                completion(.removedCard, true)
                 return
             }
             self.logger?.log("Unable to remove credit card: \(error)",
                              level: .warning,
                              category: .storage)
+            completion(.none, false)
         }
     }
 

--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputViewModel.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputViewModel.swift
@@ -161,9 +161,9 @@ class CreditCardInputViewModel: ObservableObject {
         return RemoveCardButton.AlertDetails(
             alertTitle: Text(CreditCardText.RemoveCardTitle),
             alertBody: Text(CreditCardText.RemoveCardSublabel),
-            primaryButtonStyleAndText: .destructive(Text(CreditCardText.RemovedCardLabel)) { [self] in
-                guard let creditCard = creditCard else { return }
-                dismissAndRemoveCreditCard()
+            primaryButtonStyleAndText: .destructive(Text(CreditCardText.RemovedCardLabel)) {
+                [self] in
+                self.dismissAndRemoveCreditCard()
             },
             secondaryButtonStyleAndText: .cancel(),
             primaryButtonAction: {},
@@ -174,9 +174,9 @@ class CreditCardInputViewModel: ObservableObject {
         return RemoveCardButton.AlertDetails(
             alertTitle: Text(CreditCardText.RemoveCardTitle),
             alertBody: nil,
-            primaryButtonStyleAndText: .destructive(Text(CreditCardText.RemovedCardLabel)) { [self] in
-                guard let creditCard = creditCard else { return }
-                dismissAndRemoveCreditCard()
+            primaryButtonStyleAndText: .destructive(Text(CreditCardText.RemovedCardLabel)) {
+                [self] in
+                self.dismissAndRemoveCreditCard()
             },
             secondaryButtonStyleAndText: .cancel(),
             primaryButtonAction: {},

--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputViewModel.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputViewModel.swift
@@ -162,7 +162,7 @@ class CreditCardInputViewModel: ObservableObject {
             alertTitle: Text(CreditCardText.RemoveCardTitle),
             alertBody: Text(CreditCardText.RemoveCardSublabel),
             primaryButtonStyleAndText: .destructive(Text(CreditCardText.RemovedCardLabel)) {
-                [self] in
+                [unowned self] in
                 self.removeCreditCard(creditCard: creditCard) { status, successVal in
                     self.dismiss?(status, successVal)
                 }
@@ -177,7 +177,7 @@ class CreditCardInputViewModel: ObservableObject {
             alertTitle: Text(CreditCardText.RemoveCardTitle),
             alertBody: nil,
             primaryButtonStyleAndText: .destructive(Text(CreditCardText.RemovedCardLabel)) {
-                [self] in
+                [unowned self] in
                 self.removeCreditCard(creditCard: creditCard) { status, successVal in
                     self.dismiss?(status, successVal)
                 }

--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewController.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewController.swift
@@ -149,11 +149,14 @@ class CreditCardSettingsViewController: SensitiveViewController, Themeable {
         viewModel.cardInputViewModel.updateState(state: editState)
         creditCardEditView = CreditCardInputView(viewModel: viewModel.cardInputViewModel)
         viewModel.cardInputViewModel.dismiss = {
-            [weak self] successVal in
+            [weak self] status, successVal in
             DispatchQueue.main.async {
+                self?.showToast(status: status)
+
                 if successVal {
                     self?.updateCreditCardList()
                 }
+
                 self?.creditCardAddEditView?.dismiss(animated: true)
                 self?.viewModel.cardInputViewModel.clearValues()
             }
@@ -165,6 +168,13 @@ class CreditCardSettingsViewController: SensitiveViewController, Themeable {
         creditCardAddEditView.view.backgroundColor = .clear
         creditCardAddEditView.modalPresentationStyle = .formSheet
         present(creditCardAddEditView, animated: true, completion: nil)
+    }
+
+    private func showToast(status: CreditCardModifiedStatus) {
+        SimpleToast().showAlertWithText(status.message,
+                                        bottomContainer: view,
+                                        theme: themeManager.currentTheme,
+                                        bottomConstraintPadding: 0)
     }
 
     @objc

--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewController.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewController.swift
@@ -147,17 +147,17 @@ class CreditCardSettingsViewController: SensitiveViewController, Themeable {
             viewModel.cardInputViewModel.creditCard = creditCard
         }
         viewModel.cardInputViewModel.updateState(state: editState)
-        creditCardEditView = CreditCardInputView(
-            viewModel: self.viewModel.cardInputViewModel,
-            dismiss: { [weak self] successVal in
-                DispatchQueue.main.async {
-                    if successVal {
-                        self?.updateCreditCardList()
-                    }
-                    self?.creditCardAddEditView?.dismiss(animated: true)
-                    self?.viewModel.cardInputViewModel.clearValues()
+        creditCardEditView = CreditCardInputView(viewModel: viewModel.cardInputViewModel)
+        viewModel.cardInputViewModel.dismiss = {
+            [weak self] successVal in
+            DispatchQueue.main.async {
+                if successVal {
+                    self?.updateCreditCardList()
                 }
-        })
+                self?.creditCardAddEditView?.dismiss(animated: true)
+                self?.viewModel.cardInputViewModel.clearValues()
+            }
+        }
 
         guard let creditCardEditView = creditCardEditView else { return }
         creditCardAddEditView = UIHostingController(rootView: creditCardEditView)

--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewController.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewController.swift
@@ -149,10 +149,8 @@ class CreditCardSettingsViewController: SensitiveViewController, Themeable {
         viewModel.cardInputViewModel.updateState(state: editState)
         creditCardEditView = CreditCardInputView(viewModel: viewModel.cardInputViewModel)
         viewModel.cardInputViewModel.dismiss = {
-            [weak self] status, successVal in
+            [weak self] _, successVal in
             DispatchQueue.main.async {
-                self?.showToast(status: status)
-
                 if successVal {
                     self?.updateCreditCardList()
                 }
@@ -168,13 +166,6 @@ class CreditCardSettingsViewController: SensitiveViewController, Themeable {
         creditCardAddEditView.view.backgroundColor = .clear
         creditCardAddEditView.modalPresentationStyle = .formSheet
         present(creditCardAddEditView, animated: true, completion: nil)
-    }
-
-    private func showToast(status: CreditCardModifiedStatus) {
-        SimpleToast().showAlertWithText(status.message,
-                                        bottomContainer: view,
-                                        theme: themeManager.currentTheme,
-                                        bottomConstraintPadding: 0)
     }
 
     @objc

--- a/Client/Frontend/Autofill/CreditCard/ViewComponents/ToastView.swift
+++ b/Client/Frontend/Autofill/CreditCard/ViewComponents/ToastView.swift
@@ -6,23 +6,9 @@ import Foundation
 import SwiftUI
 
 struct ToastView: View {
-    enum MessageType {
-        case savedCard
-        case updatedCard
-        case removedCard
-
-        var message: String {
-            switch self {
-            case .savedCard: return String.CreditCard.SnackBar.SavedCardLabel
-            case .updatedCard: return String.CreditCard.SnackBar.UpdatedCardLabel
-            case .removedCard: return String.CreditCard.SnackBar.RemovedCardLabel
-            }
-        }
-    }
-
     var textColor: Color = .white
     var backgroundColor: Color = .blue
-    var messageType: MessageType
+    var messageType: CreditCardModifiedStatus
     @State var isShowing = false
 
     var toast: some View {

--- a/Tests/ClientTests/CreditCard/CreditCardInputViewModelTests.swift
+++ b/Tests/ClientTests/CreditCard/CreditCardInputViewModelTests.swift
@@ -224,13 +224,6 @@ class CreditCardInputViewModelTests: XCTestCase {
     }
 
     func testFailureToRemoveCreditCard() {
-        let unencryptedCreditCard = UnencryptedCreditCardFields(ccName: "Allen Burges",
-                                                                ccNumber: "4539185806954013",
-                                                                ccNumberLast4: "4013",
-                                                                ccExpMonth: 08,
-                                                                ccExpYear: 2055,
-                                                                ccType: "VISA")
-
         let expectation = expectation(description: "wait for credit card to be removed")
 
         self.viewModel.removeCreditCard(creditCard: nil) {

--- a/Tests/ClientTests/CreditCard/CreditCardInputViewModelTests.swift
+++ b/Tests/ClientTests/CreditCard/CreditCardInputViewModelTests.swift
@@ -235,7 +235,7 @@ class CreditCardInputViewModelTests: XCTestCase {
     }
 
     func testUpdateCreditCard() {
-        let expectation = expectation(description: "wait for credit card to be removed")
+        let expectation = expectation(description: "wait for credit card to be updated")
         // Add sample card
         viewModel.autofill.addCreditCard(creditCard: samplePlainTextCard) {
             ccCard, error in

--- a/Tests/ClientTests/CreditCard/CreditCardInputViewModelTests.swift
+++ b/Tests/ClientTests/CreditCard/CreditCardInputViewModelTests.swift
@@ -249,8 +249,6 @@ class CreditCardInputViewModelTests: XCTestCase {
                 // Update name and expiration
                 self.viewModel.nameOnCard = "Mickey Mouse"
                 self.viewModel.expirationDate = "0256"
-                // Note: We do not test encrypted card number
-                // but is required to update card
                 self.viewModel.cardNumber = "5427754897487332"
                 // Update card with new values
                 self.viewModel.updateCreditCard { success, error in
@@ -261,10 +259,12 @@ class CreditCardInputViewModelTests: XCTestCase {
                         ccUpdatedCard, error in
                         XCTAssertNil(error)
                         XCTAssertNotNil(ccUpdatedCard)
-
                         XCTAssertEqual(ccUpdatedCard?.ccName, "Mickey Mouse")
                         XCTAssertEqual(ccUpdatedCard?.ccExpYear, 56)
                         XCTAssertEqual(ccUpdatedCard?.ccExpMonth, 02)
+                        // Note: We do not test encrypted card number
+                        // but the last 4 digits
+                        XCTAssertNotNil(ccUpdatedCard?.ccNumberLast4, "7332")
                         expectation.fulfill()
                     }
                 }

--- a/Tests/ClientTests/CreditCard/CreditCardInputViewModelTests.swift
+++ b/Tests/ClientTests/CreditCard/CreditCardInputViewModelTests.swift
@@ -193,6 +193,56 @@ class CreditCardInputViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.creditCard)
     }
 
+    func testSuccessRemoveCreditCard() {
+        let unencryptedCreditCard = UnencryptedCreditCardFields(ccName: "Allen Burges",
+                                                                ccNumber: "4539185806954013",
+                                                                ccNumberLast4: "4013",
+                                                                ccExpMonth: 08,
+                                                                ccExpYear: 2055,
+                                                                ccType: "VISA")
+
+        let expectation = expectation(description: "wait for credit card to be removed")
+
+        viewModel.autofill.addCreditCard(creditCard: unencryptedCreditCard) {
+            ccCard, error in
+            guard let ccCard = ccCard else {
+                XCTFail("no credit card saved to be tested")
+                return
+            }
+            guard let error = error else {
+                self.viewModel.removeCreditCard(creditCard: ccCard) {
+                    status, success in
+                    XCTAssertEqual(status, .removedCard)
+                    XCTAssertTrue(success)
+                    expectation.fulfill()
+                }
+                return
+            }
+            XCTFail("Error removing credit card \(error)")
+        }
+        waitForExpectations(timeout: 1.0)
+    }
+
+    func testFailureToRemoveCreditCard() {
+        let unencryptedCreditCard = UnencryptedCreditCardFields(ccName: "Allen Burges",
+                                                                ccNumber: "4539185806954013",
+                                                                ccNumberLast4: "4013",
+                                                                ccExpMonth: 08,
+                                                                ccExpYear: 2055,
+                                                                ccType: "VISA")
+
+        let expectation = expectation(description: "wait for credit card to be removed")
+
+        self.viewModel.removeCreditCard(creditCard: nil) {
+            status, success in
+            XCTAssertEqual(status, .none)
+            XCTAssertFalse(success)
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 1.0)
+    }
+
     // MARK: Helpers
 
     func rightBarButtonDisabled_Empty_CardName(


### PR DESCRIPTION
[Jira ticket - 6458](https://mozilla-hub.atlassian.net/browse/FXIOS-6458)
[Github issue - 14524](https://github.com/mozilla-mobile/firefox-ios/issues/14524)

### Description

This PR is to add logic to actually remove the credit card data if there is sync involved and update the list.

Original ticket that shows the credit card remove confirmation. 

**Note**: No unit tests as it's mostly adding existing functionality but if you find any area then do let me know.

https://mozilla-hub.atlassian.net/browse/FXIOS-5721

| Sync  | Without Sync |
| ------------- | ------------- |
| <video src="https://github.com/mozilla-mobile/firefox-ios/assets/8919439/52b08e58-c21c-4d72-a374-3393d3ea0c72">  | <video src="https://github.com/mozilla-mobile/firefox-ios/assets/8919439/aa369cf9-ecb8-46a1-838a-ede0cd962f65">|

### Pull requests checks where applicable
~- [ ] Fill in the three TODOs above (tickets number and description of your work)~
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
~- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)~
~- [ ] Unit tests written and passing~
- [ ] Documentation / comments for complex code and public methods
