### PR TITLE
Refactor FXIOS-6480 [v115] Use wrapper for AdjustTelemetryHelper Glean calls

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -558,6 +558,7 @@
 		8A33222227DFE658008F809E /* NimbusMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A33222127DFE658008F809E /* NimbusMock.swift */; };
 		8A355E5E27D267A400B9AF34 /* RecentItemsHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A355E5D27D267A400B9AF34 /* RecentItemsHelperTests.swift */; };
 		8A359EF32A1FD449004A5BB7 /* AdjustWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A359EF22A1FD449004A5BB7 /* AdjustWrapper.swift */; };
+		8A359EF62A1FE840004A5BB7 /* MockAdjustWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A359EF52A1FE840004A5BB7 /* MockAdjustWrapper.swift */; };
 		8A36AC2C2886F27F00CDC0AD /* MockTabManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A36AC2B2886F27F00CDC0AD /* MockTabManager.swift */; };
 		8A36BE2929EDBC6900AC1C5C /* ContentContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A36BE2829EDBC6900AC1C5C /* ContentContainer.swift */; };
 		8A36BE2C29EDE16C00AC1C5C /* ContentContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A36BE2A29EDE16700AC1C5C /* ContentContainerTests.swift */; };
@@ -4294,6 +4295,7 @@
 		8A33222127DFE658008F809E /* NimbusMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusMock.swift; sourceTree = "<group>"; };
 		8A355E5D27D267A400B9AF34 /* RecentItemsHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentItemsHelperTests.swift; sourceTree = "<group>"; };
 		8A359EF22A1FD449004A5BB7 /* AdjustWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdjustWrapper.swift; sourceTree = "<group>"; };
+		8A359EF52A1FE840004A5BB7 /* MockAdjustWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAdjustWrapper.swift; sourceTree = "<group>"; };
 		8A36AC2B2886F27F00CDC0AD /* MockTabManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTabManager.swift; sourceTree = "<group>"; };
 		8A36BE2829EDBC6900AC1C5C /* ContentContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentContainer.swift; sourceTree = "<group>"; };
 		8A36BE2A29EDE16700AC1C5C /* ContentContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentContainerTests.swift; sourceTree = "<group>"; };
@@ -8590,6 +8592,7 @@
 				8AABBCFD2A0017560089941E /* MockGleanWrapper.swift */,
 				8AABBD022A001CBC0089941E /* MockApplicationHelper.swift */,
 				8AABBD042A0041380089941E /* MockCoordinator.swift */,
+				8A359EF52A1FE840004A5BB7 /* MockAdjustWrapper.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -12417,6 +12420,7 @@
 				C889D7D52858CD8800121E1D /* HistoryHighlightsTestEntryProvider.swift in Sources */,
 				8A171A6329F82B0E0085770E /* SceneDelegateTests.swift in Sources */,
 				E19B38B128A3E69300D8C541 /* WallpaperCollectionAvailabilityTests.swift in Sources */,
+				8A359EF62A1FE840004A5BB7 /* MockAdjustWrapper.swift in Sources */,
 				C8DC90D22A067C6D0008832B /* MarkupAttributionUtilityTests.swift in Sources */,
 				21737FB72878A4BD000A9A92 /* HistoryPanelViewModelTests.swift in Sources */,
 				43B658D929CE251C00C9EF08 /* CreditCardInputViewModelTests.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -557,6 +557,7 @@
 		8A33221F27DFE318008F809E /* TopSitesDataAdaptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A33221E27DFE318008F809E /* TopSitesDataAdaptorTests.swift */; };
 		8A33222227DFE658008F809E /* NimbusMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A33222127DFE658008F809E /* NimbusMock.swift */; };
 		8A355E5E27D267A400B9AF34 /* RecentItemsHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A355E5D27D267A400B9AF34 /* RecentItemsHelperTests.swift */; };
+		8A359EF32A1FD449004A5BB7 /* AdjustWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A359EF22A1FD449004A5BB7 /* AdjustWrapper.swift */; };
 		8A36AC2C2886F27F00CDC0AD /* MockTabManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A36AC2B2886F27F00CDC0AD /* MockTabManager.swift */; };
 		8A36BE2929EDBC6900AC1C5C /* ContentContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A36BE2829EDBC6900AC1C5C /* ContentContainer.swift */; };
 		8A36BE2C29EDE16C00AC1C5C /* ContentContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A36BE2A29EDE16700AC1C5C /* ContentContainerTests.swift */; };
@@ -4292,6 +4293,7 @@
 		8A33221E27DFE318008F809E /* TopSitesDataAdaptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSitesDataAdaptorTests.swift; sourceTree = "<group>"; };
 		8A33222127DFE658008F809E /* NimbusMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusMock.swift; sourceTree = "<group>"; };
 		8A355E5D27D267A400B9AF34 /* RecentItemsHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentItemsHelperTests.swift; sourceTree = "<group>"; };
+		8A359EF22A1FD449004A5BB7 /* AdjustWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdjustWrapper.swift; sourceTree = "<group>"; };
 		8A36AC2B2886F27F00CDC0AD /* MockTabManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTabManager.swift; sourceTree = "<group>"; };
 		8A36BE2829EDBC6900AC1C5C /* ContentContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentContainer.swift; sourceTree = "<group>"; };
 		8A36BE2A29EDE16700AC1C5C /* ContentContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentContainerTests.swift; sourceTree = "<group>"; };
@@ -7623,6 +7625,14 @@
 			path = TestingHelperClasses;
 			sourceTree = "<group>";
 		};
+		8A359EF42A1FD4CF004A5BB7 /* Wrapper */ = {
+			isa = PBXGroup;
+			children = (
+				8A359EF22A1FD449004A5BB7 /* AdjustWrapper.swift */,
+			);
+			path = Wrapper;
+			sourceTree = "<group>";
+		};
 		8A4AC0ED28C929DD00439F83 /* URLSession */ = {
 			isa = PBXGroup;
 			children = (
@@ -9546,12 +9556,13 @@
 		E69DB0B91E97E301008A67E6 /* Telemetry */ = {
 			isa = PBXGroup;
 			children = (
+				8A359EF42A1FD4CF004A5BB7 /* Wrapper */,
 				43175DB726B87D2C00C41C31 /* AdsTelemetryHelper.swift */,
+				8AABBCFB2A0010900089941E /* GleanWrapper.swift */,
 				43F7952425795F69005AEE40 /* SearchTelemetry.swift */,
 				8A04136828258DF600D20B10 /* SponsoredTileTelemetry.swift */,
-				EBF47E6F1F7979DF00899189 /* TelemetryWrapper.swift */,
 				8AD08D1427E9198E00B8E907 /* TabsQuantityTelemetry.swift */,
-				8AABBCFB2A0010900089941E /* GleanWrapper.swift */,
+				EBF47E6F1F7979DF00899189 /* TelemetryWrapper.swift */,
 			);
 			path = Telemetry;
 			sourceTree = "<group>";
@@ -12006,6 +12017,7 @@
 				D88FDAAF1F4E2BA000FD9709 /* PhotonActionSheetAnimator.swift in Sources */,
 				C83432FE26BAD30D00ABAAA6 /* EnhancedTrackingProtectionDetailsVC.swift in Sources */,
 				E698FFDA1B4AADF40001F623 /* TabScrollController.swift in Sources */,
+				8A359EF32A1FD449004A5BB7 /* AdjustWrapper.swift in Sources */,
 				D34510881ACF415700EC27F0 /* SearchLoader.swift in Sources */,
 				E17496402994302D0096900A /* PreferredFont.swift in Sources */,
 				E1442FD4294782D9003680B0 /* URL+Mail.swift in Sources */,

--- a/Client/AdjustHelper.swift
+++ b/Client/AdjustHelper.swift
@@ -6,7 +6,6 @@ import Common
 import Foundation
 import Adjust
 import Shared
-import Glean
 
 final class AdjustHelper: NSObject, FeatureFlaggable {
     private static let adjustAppTokenKey = "AdjustAppToken"

--- a/Client/AdjustTelemetryHelper.swift
+++ b/Client/AdjustTelemetryHelper.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import Adjust
-import Glean
 
 protocol AdjustTelemetryData {
     var campaign: String? { get set }
@@ -22,30 +21,38 @@ protocol AdjustTelemetryProtocol {
 }
 
 class AdjustTelemetryHelper: AdjustTelemetryProtocol {
+    var gleanWrapper: GleanWrapper
+    var telemetry: AdjustWrapper
+
+    init(gleanWrapper: GleanWrapper = DefaultGleanWrapper(),
+         telemetry: AdjustWrapper = DefaultAdjustWrapper()) {
+        self.gleanWrapper = gleanWrapper
+        self.telemetry = telemetry
+    }
+
     func sendDeeplinkTelemetry(url: URL, attribution: AdjustTelemetryData?) {
-        let extra = GleanMetrics.Adjust.DeeplinkReceivedExtra(receivedUrl: url.absoluteString)
-        GleanMetrics.Adjust.deeplinkReceived.record(extra)
+        telemetry.recordDeeplink(url: url)
 
         setAttributionData(attribution)
     }
 
     func setAttributionData(_ attribution: AdjustTelemetryData?) {
         if let campaign = attribution?.campaign {
-            GleanMetrics.Adjust.campaign.set(campaign)
+            telemetry.record(campaign: campaign)
         }
 
         if let adgroup = attribution?.adgroup {
-            GleanMetrics.Adjust.adGroup.set(adgroup)
+            telemetry.record(adgroup: adgroup)
         }
 
         if let creative = attribution?.creative {
-            GleanMetrics.Adjust.creative.set(creative)
+            telemetry.record(creative: creative)
         }
 
         if let network = attribution?.network {
-            GleanMetrics.Adjust.network.set(network)
+            telemetry.record(network: network)
         }
 
-        GleanMetrics.Pings.shared.firstSession.submit()
+        gleanWrapper.submitPing()
     }
 }

--- a/Client/Telemetry/GleanWrapper.swift
+++ b/Client/Telemetry/GleanWrapper.swift
@@ -7,6 +7,7 @@ import Glean
 
 protocol GleanWrapper {
     func handleDeeplinkUrl(url: URL)
+    func submitPing()
 }
 
 /// Glean wrapper to abstract Glean from our application
@@ -15,5 +16,9 @@ struct DefaultGleanWrapper: GleanWrapper {
 
     func handleDeeplinkUrl(url: URL) {
         Glean.shared.handleCustomUrl(url: url)
+    }
+
+    func submitPing() {
+        GleanMetrics.Pings.shared.firstSession.submit()
     }
 }

--- a/Client/Telemetry/Wrapper/AdjustWrapper.swift
+++ b/Client/Telemetry/Wrapper/AdjustWrapper.swift
@@ -1,0 +1,37 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Glean
+
+protocol AdjustWrapper {
+    func recordDeeplink(url: URL)
+    func record(campaign: String)
+    func record(adgroup: String)
+    func record(creative: String)
+    func record(network: String)
+}
+
+struct DefaultAdjustWrapper: AdjustWrapper {
+    func recordDeeplink(url: URL) {
+        let extra = GleanMetrics.Adjust.DeeplinkReceivedExtra(receivedUrl: url.absoluteString)
+        GleanMetrics.Adjust.deeplinkReceived.record(extra)
+    }
+
+    func record(campaign: String) {
+        GleanMetrics.Adjust.campaign.set(campaign)
+    }
+
+    func record(adgroup: String) {
+        GleanMetrics.Adjust.adGroup.set(adgroup)
+    }
+
+    func record(creative: String) {
+        GleanMetrics.Adjust.creative.set(creative)
+    }
+
+    func record(network: String) {
+        GleanMetrics.Adjust.network.set(network)
+    }
+}

--- a/Storage/SQL/SQLitePinnedSites.swift
+++ b/Storage/SQL/SQLitePinnedSites.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import Shared
-import Glean
 
 private var ignoredSchemes = ["about"]
 

--- a/Tests/ClientTests/Mocks/MockAdjustWrapper.swift
+++ b/Tests/ClientTests/Mocks/MockAdjustWrapper.swift
@@ -1,0 +1,44 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+
+class MockAdjustWrapper: AdjustWrapper {
+    var recordDeeplinkCalled = 0
+    var recordCampaignCalled = 0
+    var recordAdGroupCalled = 0
+    var recordCreativeCalled = 0
+    var recordNetworkCalled = 0
+
+    var savedDeeplink: URL?
+    var savedCampaign: String?
+    var savedAdGroup: String?
+    var savedCreative: String?
+    var savedNetwork: String?
+
+    func recordDeeplink(url: URL) {
+        recordDeeplinkCalled += 1
+        savedDeeplink = url
+    }
+
+    func record(campaign: String) {
+        recordCampaignCalled += 1
+        savedCampaign = campaign
+    }
+
+    func record(adgroup: String) {
+        recordAdGroupCalled += 1
+        savedAdGroup = adgroup
+    }
+
+    func record(creative: String) {
+        recordCreativeCalled += 1
+        savedCreative = creative
+    }
+
+    func record(network: String) {
+        recordNetworkCalled += 1
+        savedNetwork = network
+    }
+}

--- a/Tests/ClientTests/Mocks/MockGleanWrapper.swift
+++ b/Tests/ClientTests/Mocks/MockGleanWrapper.swift
@@ -7,10 +7,16 @@ import UIKit
 
 class MockGleanWrapper: GleanWrapper {
     var handleDeeplinkUrlCalled = 0
+    var submitPingCalled = 0
+
     var savedHandleDeeplinkUrl: URL?
 
     func handleDeeplinkUrl(url: URL) {
         handleDeeplinkUrlCalled += 1
         savedHandleDeeplinkUrl = url
+    }
+
+    func submitPing() {
+        submitPingCalled += 1
     }
 }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6480)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14568)

### Description
Use wrapper for AdjustTelemetryHelper Glean calls, so we don't use Glean directly in our tests.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
