### PR TITLE
Refactor FXIOS-6455 [v115] Removes deferred from notification service

### DIFF
--- a/Extensions/NotificationService/NotificationService.swift
+++ b/Extensions/NotificationService/NotificationService.swift
@@ -37,9 +37,11 @@ class NotificationService: UNNotificationServiceExtension {
 
         let handler = FxAPushMessageHandler(with: profile)
 
-        handler.handle(userInfo: userInfo).upon { res in
-            guard res.isSuccess, let event = res.successValue else {
-                self.didFinish(nil, with: res.failureValue as? PushMessageError)
+        handler.handle(userInfo: userInfo) { res in
+            guard case .success(let event) = res else {
+                if case .failure(let failure) = res {
+                    self.didFinish(nil, with: failure)
+                }
                 return
             }
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6455)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14518)

### Description
Removes Deferred from Notification Service and FxAPushMessageHandler which is only called from the notification service

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
