### PR TITLE
Add FXIOS-5866 [v115] debug option for rating prompt

### DIFF
--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -497,6 +497,17 @@ class ForceCrashSetting: HiddenSetting {
     }
 }
 
+class AppReviewPromptSetting: HiddenSetting {
+    override var title: NSAttributedString? {
+        return NSAttributedString(string: "⭐️ Debug: App Review (needs tab switch)", attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
+    }
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        UserDefaults.standard.set(true, forKey: PrefsKeys.ForceShowAppReviewPromptOverride)
+        updateCell(navigationController)
+    }
+}
+
 class ChangeToChinaSetting: HiddenSetting {
     override var title: NSAttributedString? {
         return NSAttributedString(string: "Debug: toggle China version (needs restart)", attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -237,6 +237,7 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
                 OpenFiftyTabsDebugOption(settings: self),
                 ExperimentsSettings(settings: self),
                 FasterInactiveTabs(settings: self)
+                AppReviewPromptSetting(settings: self)
             ])]
 
         return settings

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -236,7 +236,7 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
                 ResetContextualHints(settings: self),
                 OpenFiftyTabsDebugOption(settings: self),
                 ExperimentsSettings(settings: self),
-                FasterInactiveTabs(settings: self)
+                FasterInactiveTabs(settings: self),
                 AppReviewPromptSetting(settings: self)
             ])]
 

--- a/Client/RatingPromptManager.swift
+++ b/Client/RatingPromptManager.swift
@@ -47,6 +47,7 @@ final class RatingPromptManager {
     func showRatingPromptIfNeeded(at date: Date = Date()) {
         if shouldShowPrompt {
             requestRatingPrompt(at: date)
+            UserDefaults.standard.set(false, forKey: PrefsKeys.ForceShowAppReviewPromptOverride)
         }
     }
 
@@ -95,6 +96,10 @@ final class RatingPromptManager {
     // MARK: Private
 
     private var shouldShowPrompt: Bool {
+        if UserDefaults.standard.bool(forKey: PrefsKeys.ForceShowAppReviewPromptOverride) {
+            return true
+        }
+        
         // Required: 5th launch or more
         let currentSessionCount = profile.prefs.intForKey(PrefsKeys.Session.Count) ?? 0
         guard currentSessionCount >= 5 else { return false }

--- a/Client/RatingPromptManager.swift
+++ b/Client/RatingPromptManager.swift
@@ -99,7 +99,7 @@ final class RatingPromptManager {
         if UserDefaults.standard.bool(forKey: PrefsKeys.ForceShowAppReviewPromptOverride) {
             return true
         }
-        
+
         // Required: 5th launch or more
         let currentSessionCount = profile.prefs.intForKey(PrefsKeys.Session.Count) ?? 0
         guard currentSessionCount >= 5 else { return false }

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -166,7 +166,7 @@ public struct PrefsKeys {
 
     // Only used to force faster transition of tabs to the inactive state (10 seconds)
     public static let FasterInactiveTabsOverride = "FasterInactiveTabsOverride"
-    
+
     // Only used to force showing the App Store review dialog for debugging purposes
     public static let ForceShowAppReviewPromptOverride = "ForceShowAppReviewPromptOverride"
 }

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -166,6 +166,9 @@ public struct PrefsKeys {
 
     // Only used to force faster transition of tabs to the inactive state (10 seconds)
     public static let FasterInactiveTabsOverride = "FasterInactiveTabsOverride"
+    
+    // Only used to force showing the App Store review dialog for debugging purposes
+    public static let ForceShowAppReviewPromptOverride = "ForceShowAppReviewPromptOverride"
 }
 
 public struct PrefsDefaults {


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5866)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13385)

### Description
Adding a debug option to force show the App Store review prompt on the next tab switch.
![Simulator Screenshot - iPhone 14 Pro - 2023-05-23 at 02 02 20](https://github.com/mozilla-mobile/firefox-ios/assets/10427842/938be92e-32af-4033-af23-4f33d1efd5e4)
![Simulator Screenshot - iPhone 14 Pro - 2023-05-23 at 02 02 35](https://github.com/mozilla-mobile/firefox-ios/assets/10427842/eefb83f0-07b3-436f-8a49-d2bf183e5da3)

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
