### PR TITLE
Bugfix FXIOS-6499 [v115] Fix firefox icon on backforward list

### DIFF
--- a/Client/Frontend/Browser/BackForwardTableViewCell.swift
+++ b/Client/Frontend/Browser/BackForwardTableViewCell.swift
@@ -108,9 +108,8 @@ class BackForwardTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
         self.viewModel = viewModel
 
         if let url = URL(string: viewModel.site.url),
-            InternalURL(url)?.isAboutHomeURL == true {
-            faviconView.image = UIImage(named: ImageIdentifiers.defaultFavicon)?.withRenderingMode(.alwaysTemplate)
-            faviconView.backgroundColor = .clear
+           InternalURL(url)?.isAboutHomeURL == true {
+            faviconView.image = UIImage(named: ImageIdentifiers.firefoxFavicon)
         } else {
             faviconView.setFavicon(FaviconImageViewModel(siteURLString: viewModel.site.url,
                                                          faviconCornerRadius: UX.faviconCornerRadius))


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6499)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## The bug
The Firefox homepage has the default browser logo. I remember we had the Firefox logo before.

![IMG_1185](https://github.com/mozilla-mobile/firefox-ios/assets/11338480/1136c3c7-1213-4dfd-9f29-a1b0a3ffe350)

## The proposed fix
Set the Firefox logo in the backforward list.

![Screenshot 2023-05-26 at 11 30 11 AM](https://github.com/mozilla-mobile/firefox-ios/assets/11338480/d768784a-d94f-405c-b1dd-4f4989e45d3c)

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
