### PR TITLE
Refactor FXIOS-6465 [v115] Consistency use of accessibility identifiers for both iPhone and iPad navigation bar

### DIFF
--- a/Client/Application/AccessibilityIdentifiers.swift
+++ b/Client/Application/AccessibilityIdentifiers.swift
@@ -12,6 +12,8 @@ import Foundation
 /// `.accessibilityIdentifier` identifiers from the client and the tests
 /// should be move here and updated throughout the app.
 public struct AccessibilityIdentifiers {
+    /// Used for toolbar/URL bar buttons since our classes are built that buttons can live in one or the other
+    /// Using only those a11y identifiers for both ensures we have standard way to refer to buttons from iPad to iPhone
     struct Toolbar {
         static let settingsMenuButton = "TabToolbar.menuButton"
         static let homeButton = "TabToolbar.homeButton"
@@ -19,22 +21,24 @@ public struct AccessibilityIdentifiers {
         static let readerModeButton = "TabLocationView.readerModeButton"
         static let reloadButton = "TabLocationView.reloadButton"
         static let shareButton = "TabLocationView.shareButton"
+        static let backButton = "TabToolbar.backButton"
+        static let forwardButton = "TabToolbar.forwardButton"
+        static let tabsButton = "TabToolbar.tabsButton"
+        static let addNewTabButton = "TabToolbar.addNewTabButton"
+        static let searchButton = "TabToolbar.searchButton"
+        static let stopButton = "TabToolbar.stopButton"
+        static let bookmarksButton = "TabToolbar.libraryButton"
     }
 
     struct Browser {
         struct TopTabs {
             static let collectionView = "Top Tabs View"
-            static let tabsButton = "TopTabsViewController.tabsButton"
-            static let newTabButton = "TopTabsViewController.newTabButton"
             static let privateModeButton = "TopTabsViewController.privateModeButton"
         }
 
         struct UrlBar {
             static let scanQRCodeButton = "urlBar-scanQRCode"
             static let cancelButton = "urlBar-cancel"
-            static let tabsButton = "URLBarView.tabsButton"
-            static let backButton = "TabToolbar.backButton"
-            static let forwardButton = "TabToolbar.forwardButton"
             static let searchTextField = "address"
         }
     }

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -56,7 +56,7 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable {
     private lazy var tabsButton: TabsButton = .build { button in
         button.semanticContentAttribute = .forceLeftToRight
         button.addTarget(self, action: #selector(TopTabsViewController.tabsTrayTapped), for: .touchUpInside)
-        button.accessibilityIdentifier = AccessibilityIdentifiers.Browser.TopTabs.tabsButton
+        button.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.tabsButton
         button.inTopTabs = true
     }
 
@@ -64,7 +64,7 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable {
         button.setImage(UIImage.templateImageNamed(ImageIdentifiers.newTab), for: .normal)
         button.semanticContentAttribute = .forceLeftToRight
         button.addTarget(self, action: #selector(TopTabsViewController.newTabTapped), for: .touchUpInside)
-        button.accessibilityIdentifier = AccessibilityIdentifiers.Browser.TopTabs.newTabButton
+        button.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.addNewTabButton
     }
 
     lazy var privateModeButton: PrivateModeButton = {

--- a/Client/Frontend/Toolbar+URLBar/TabToolbar.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabToolbar.swift
@@ -68,11 +68,10 @@ class TabToolbar: UIView {
     }
 
     private func setupAccessibility() {
-        backButton.accessibilityIdentifier = "TabToolbar.backButton"
-        forwardButton.accessibilityIdentifier = "TabToolbar.forwardButton"
-        multiStateButton.accessibilityIdentifier = "TabToolbar.multiStateButton"
-        tabsButton.accessibilityIdentifier = "TabToolbar.tabsButton"
-        addNewTabButton.accessibilityIdentifier = "TabToolbar.addNewTabButton"
+        backButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.backButton
+        forwardButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.forwardButton
+        tabsButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.tabsButton
+        addNewTabButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.addNewTabButton
         appMenuButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.settingsMenuButton
         accessibilityNavigationStyle = .combined
         accessibilityLabel = .TabToolbarNavigationToolbarAccessibilityLabel

--- a/Client/Frontend/Toolbar+URLBar/TabToolbarHelper.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabToolbarHelper.swift
@@ -69,17 +69,21 @@ open class TabToolbarHelper: NSObject {
             middleButtonState = .search
             toolbar.multiStateButton.setImage(ImageSearch, for: .normal)
             toolbar.multiStateButton.accessibilityLabel = .TabToolbarSearchAccessibilityLabel
+            toolbar.multiStateButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.searchButton
         case (.reload, .pad):
             middleButtonState = .reload
             toolbar.multiStateButton.setImage(ImageReload, for: .normal)
             toolbar.multiStateButton.accessibilityLabel = .TabToolbarReloadAccessibilityLabel
+            toolbar.multiStateButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.reloadButton
         case (.stop, .pad):
             middleButtonState = .stop
             toolbar.multiStateButton.setImage(ImageStop, for: .normal)
             toolbar.multiStateButton.accessibilityLabel = .TabToolbarStopAccessibilityLabel
+            toolbar.multiStateButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.stopButton
         default:
             toolbar.multiStateButton.setImage(ImageHome, for: .normal)
             toolbar.multiStateButton.accessibilityLabel = .TabToolbarHomeAccessibilityLabel
+            toolbar.multiStateButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.homeButton
             middleButtonState = .home
         }
     }
@@ -99,12 +103,14 @@ open class TabToolbarHelper: NSObject {
 
         toolbar.backButton.setImage(UIImage.templateImageNamed("nav-back")?.imageFlippedForRightToLeftLayoutDirection(), for: .normal)
         toolbar.backButton.accessibilityLabel = .TabToolbarBackAccessibilityLabel
+        toolbar.backButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.backButton
         let longPressGestureBackButton = UILongPressGestureRecognizer(target: self, action: #selector(didLongPressBack))
         toolbar.backButton.addGestureRecognizer(longPressGestureBackButton)
         toolbar.backButton.addTarget(self, action: #selector(didClickBack), for: .touchUpInside)
 
         toolbar.forwardButton.setImage(UIImage.templateImageNamed("nav-forward")?.imageFlippedForRightToLeftLayoutDirection(), for: .normal)
         toolbar.forwardButton.accessibilityLabel = .TabToolbarForwardAccessibilityLabel
+        toolbar.forwardButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.forwardButton
         let longPressGestureForwardButton = UILongPressGestureRecognizer(target: self, action: #selector(didLongPressForward))
         toolbar.forwardButton.addGestureRecognizer(longPressGestureForwardButton)
         toolbar.forwardButton.addTarget(self, action: #selector(didClickForward), for: .touchUpInside)
@@ -124,11 +130,12 @@ open class TabToolbarHelper: NSObject {
         toolbar.tabsButton.addTarget(self, action: #selector(didClickTabs), for: .touchUpInside)
         let longPressGestureTabsButton = UILongPressGestureRecognizer(target: self, action: #selector(didLongPressTabs))
         toolbar.tabsButton.addGestureRecognizer(longPressGestureTabsButton)
+        toolbar.tabsButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.tabsButton
 
         toolbar.addNewTabButton.setImage(UIImage.templateImageNamed("menu-NewTab"), for: .normal)
         toolbar.addNewTabButton.accessibilityLabel = .AddTabAccessibilityLabel
         toolbar.addNewTabButton.addTarget(self, action: #selector(didClickAddNewTab), for: .touchUpInside)
-        toolbar.addNewTabButton.accessibilityIdentifier = "TabToolbar.addNewTabButton"
+        toolbar.addNewTabButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.addNewTabButton
 
         toolbar.appMenuButton.contentMode = .center
         toolbar.appMenuButton.setImage(UIImage.templateImageNamed("nav-menu"), for: .normal)
@@ -146,7 +153,7 @@ open class TabToolbarHelper: NSObject {
         toolbar.bookmarksButton.setImage(UIImage.templateImageNamed(ImageIdentifiers.bookmarks), for: .normal)
         toolbar.bookmarksButton.accessibilityLabel = .AppMenu.Toolbar.BookmarksButtonAccessibilityLabel
         toolbar.bookmarksButton.addTarget(self, action: #selector(didClickLibrary), for: .touchUpInside)
-        toolbar.bookmarksButton.accessibilityIdentifier = "TabToolbar.libraryButton"
+        toolbar.bookmarksButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.bookmarksButton
         setTheme(forButtons: toolbar.actionButtons)
     }
 

--- a/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -121,7 +121,7 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
 
     lazy var tabsButton: TabsButton = {
         let tabsButton = TabsButton.tabTrayButton()
-        tabsButton.accessibilityIdentifier = AccessibilityIdentifiers.Browser.UrlBar.tabsButton
+        tabsButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.tabsButton
         tabsButton.inTopTabs = false
         return tabsButton
     }()
@@ -183,7 +183,7 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
 
     var backButton: ToolbarButton = {
         let backButton = ToolbarButton()
-        backButton.accessibilityIdentifier = AccessibilityIdentifiers.Browser.UrlBar.backButton
+        backButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.backButton
         return backButton
     }()
 

--- a/Tests/UITests/AuthenticationTests.swift
+++ b/Tests/UITests/AuthenticationTests.swift
@@ -56,11 +56,7 @@ class AuthenticationTests: KIFTestCase {
         tester().waitForWebViewElementWithAccessibilityLabel("logged in")
 
         // Add a private tab.
-        if BrowserUtils.iPad() {
-            tester().tapView(withAccessibilityIdentifier: "TopTabsViewController.tabsButton")
-        } else {
-            tester().tapView(withAccessibilityIdentifier: "TabToolbar.tabsButton")
-        }
+        tester().tapView(withAccessibilityIdentifier: AccessibilityIdentifiers.Toolbar.tabsButton)
         tester().tapView(withAccessibilityLabel: "smallPrivateMask")
         tester().tapView(withAccessibilityIdentifier: AccessibilityIdentifiers.TabTray.newTabButton)
         tester().waitForAnimationsToFinish()

--- a/Tests/UITests/Global.swift
+++ b/Tests/UITests/Global.swift
@@ -223,11 +223,7 @@ class BrowserUtils {
 
 
     class func resetToAboutHomeKIF(_ tester: KIFUITestActor) {
-        if iPad() {
-            tester.tapView(withAccessibilityIdentifier: "TopTabsViewController.tabsButton")
-        } else {
-            tester.tapView(withAccessibilityIdentifier: "TabToolbar.tabsButton")
-        }
+        tester.tapView(withAccessibilityIdentifier: AccessibilityIdentifiers.Toolbar.tabsButton)
         
         // if in private mode, close all tabs
         tester.tapView(withAccessibilityLabel: "smallPrivateMask")
@@ -364,7 +360,7 @@ class BrowserUtils {
 
     class func closeLibraryMenu(_ tester: KIFUITestActor) {
         if iPad() {
-            tester.tapView(withAccessibilityIdentifier: "TabToolbar.libraryButton")
+            tester.tapView(withAccessibilityIdentifier: AccessibilityIdentifiers.Toolbar.bookmarksButton)
         } else {
             // Workaround to be able to swipe the view and close the library panel
             tester.tapView(withAccessibilityLabel: "Done")

--- a/Tests/UITests/LoginManagerTests.swift
+++ b/Tests/UITests/LoginManagerTests.swift
@@ -224,7 +224,7 @@ class LoginManagerTests: KIFTestCase {
         XCTAssertEqual(UIPasteboard.general.string, "http://a0.com")
 
         // Workaround
-        tester().tapView(withAccessibilityIdentifier: "TabToolbar.tabsButton")
+        tester().tapView(withAccessibilityIdentifier: AccessibilityIdentifiers.Toolbar.tabsButton)
         tester().tapView(withAccessibilityIdentifier: AccessibilityIdentifiers.TabTray.closeAllTabsButton)
         tester().tapView(withAccessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCloseAllButton)
         tester().tapView(withAccessibilityIdentifier: "urlBar-cancel")
@@ -249,7 +249,7 @@ class LoginManagerTests: KIFTestCase {
         tester().waitForViewWithAccessibilityValue("a0.com/")
 
         // Workaround
-        tester().tapView(withAccessibilityIdentifier: "TabToolbar.tabsButton")
+        tester().tapView(withAccessibilityIdentifier: AccessibilityIdentifiers.Toolbar.tabsButton)
         tester().tapView(withAccessibilityIdentifier: AccessibilityIdentifiers.TabTray.closeAllTabsButton)
         tester().tapView(withAccessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCloseAllButton)
         tester().tapView(withAccessibilityIdentifier: "urlBar-cancel")

--- a/Tests/UITests/SecurityTests.swift
+++ b/Tests/UITests/SecurityTests.swift
@@ -45,21 +45,14 @@ class SecurityTests: KIFTestCase {
     func testErrorExploit() {
         // We should only have one tab open.
         let tabcount:String?
-        if BrowserUtils.iPad() {
-            tabcount = tester().waitForView(withAccessibilityIdentifier: "TopTabsViewController.tabsButton")?.accessibilityValue
-        } else {
-            tabcount = tester().waitForView(withAccessibilityIdentifier: "TabToolbar.tabsButton")?.accessibilityValue
-        }
+        tabcount = tester().waitForView(withAccessibilityIdentifier: AccessibilityIdentifiers.Toolbar.tabsButton)?.accessibilityValue
 
         // make sure a new tab wasn't opened.
         tester().tapWebViewElementWithAccessibilityLabel("Error exploit")
         tester().wait(forTimeInterval: 1.0)
         let newTabcount:String?
-        if BrowserUtils.iPad() {
-            newTabcount = tester().waitForView(withAccessibilityIdentifier: "TopTabsViewController.tabsButton")?.accessibilityValue
-        } else {
-            newTabcount = tester().waitForView(withAccessibilityIdentifier: "TabToolbar.tabsButton")?.accessibilityValue
-        }
+        newTabcount = tester().waitForView(withAccessibilityIdentifier: AccessibilityIdentifiers.Toolbar.tabsButton)?.accessibilityValue
+
         XCTAssert(tabcount != nil && tabcount == newTabcount)
         }
 
@@ -79,7 +72,7 @@ class SecurityTests: KIFTestCase {
         XCTAssertFalse(tester().viewExistsWithLabel("Local page loaded"))
 
         // Workaround number of tabs not updated
-        tester().tapView(withAccessibilityIdentifier: "TabToolbar.tabsButton")
+        tester().tapView(withAccessibilityIdentifier: AccessibilityIdentifiers.Toolbar.tabsButton)
         tester().tapView(withAccessibilityIdentifier: AccessibilityIdentifiers.TabTray.closeAllTabsButton)
         tester().tapView(withAccessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCloseAllButton)
         tester().tapView(withAccessibilityIdentifier: "urlBar-cancel")
@@ -100,7 +93,7 @@ class SecurityTests: KIFTestCase {
         XCTAssertFalse(tester().viewExistsWithLabel("http://1.2.3.4:1234/"))
 
         // Workaround number of tabs not updated
-        tester().tapView(withAccessibilityIdentifier: "TabToolbar.tabsButton")
+        tester().tapView(withAccessibilityIdentifier: AccessibilityIdentifiers.Toolbar.tabsButton)
         tester().tapView(withAccessibilityIdentifier: AccessibilityIdentifiers.TabTray.closeAllTabsButton)
         tester().tapView(withAccessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCloseAllButton)
         tester().tapView(withAccessibilityIdentifier: "urlBar-cancel")

--- a/Tests/UITests/SessionRestoreTests.swift
+++ b/Tests/UITests/SessionRestoreTests.swift
@@ -37,17 +37,17 @@ class SessionRestoreTests: KIFTestCase {
         tester().wait(forTimeInterval: 3)
         BrowserUtils.enterUrlAddressBar(tester(), typeUrl: restoreURL!.absoluteString)
         tester().waitForWebViewElementWithAccessibilityLabel("Page 2")
-        tester().tapView(withAccessibilityLabel: "Back")
+        tester().tapView(withAccessibilityLabel: AccessibilityIdentifiers.Toolbar.backButton)
 
         tester().waitForWebViewElementWithAccessibilityLabel("Page 1")
-        tester().tapView(withAccessibilityLabel: "Back")
+        tester().tapView(withAccessibilityLabel: AccessibilityIdentifiers.Toolbar.backButton)
 
         tester().tapView(withAccessibilityIdentifier: "urlBar-cancel")
         tester().waitForAnimationsToFinish(withTimeout: 5)
 
         let canGoBack: Bool
         do {
-            try tester().tryFindingTappableView(withAccessibilityLabel: "Back")
+            try tester().tryFindingTappableView(withAccessibilityLabel: AccessibilityIdentifiers.Toolbar.backButton)
             canGoBack = true
         } catch _ {
             canGoBack = false
@@ -55,15 +55,15 @@ class SessionRestoreTests: KIFTestCase {
 
         XCTAssertFalse(canGoBack, "Reached the beginning of browser history")
 
-        tester().tapView(withAccessibilityLabel: "Forward")
-        tester().tapView(withAccessibilityLabel: "Forward")
-        tester().tapView(withAccessibilityLabel: "Forward")
+        tester().tapView(withAccessibilityLabel: AccessibilityIdentifiers.Toolbar.forwardButton)
+        tester().tapView(withAccessibilityLabel: AccessibilityIdentifiers.Toolbar.forwardButton)
+        tester().tapView(withAccessibilityLabel: AccessibilityIdentifiers.Toolbar.forwardButton)
 
         tester().waitForAnimationsToFinish(withTimeout: 5)
         tester().waitForWebViewElementWithAccessibilityLabel("Page 3")
         let canGoForward: Bool
         do {
-            try tester().tryFindingTappableView(withAccessibilityLabel: "Forward")
+            try tester().tryFindingTappableView(withAccessibilityLabel: AccessibilityIdentifiers.Toolbar.forwardButton)
             canGoForward = true
         } catch _ {
             canGoForward = false

--- a/Tests/UITests/TrackingProtectionTests.swift
+++ b/Tests/UITests/TrackingProtectionTests.swift
@@ -131,11 +131,7 @@ class TrackingProtectionTests: KIFTestCase, TabEventHandler {
         tester().tapView(withAccessibilityIdentifier: "prefkey.trackingprotection.normalbrowsing")
         closeTPSetting()
 
-        if BrowserUtils.iPad() {
-            tester().tapView(withAccessibilityIdentifier: "TopTabsViewController.tabsButton")
-        } else {
-            tester().tapView(withAccessibilityIdentifier: "TabToolbar.tabsButton")
-        }
+        tester().tapView(withAccessibilityIdentifier: AccessibilityIdentifiers.Toolbar.tabsButton)
 
         tester().tapView(withAccessibilityIdentifier: AccessibilityIdentifiers.TabTray.newTabButton)
         tester().tapView(withAccessibilityIdentifier: "urlBar-cancel")

--- a/Tests/XCUITests/BaseTestCase.swift
+++ b/Tests/XCUITests/BaseTestCase.swift
@@ -228,14 +228,9 @@ class BaseTestCase: XCTestCase {
 
     func waitForTabsButton() {
         if iPad() {
-        waitForExistence(app.buttons["TopTabsViewController.tabsButton"], timeout: 15)
+            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 15)
         } else {
-            // iPhone sim tabs button is called differently when in portrait or landscape
-            if XCUIDevice.shared.orientation == UIDeviceOrientation.landscapeLeft {
-                waitForExistence(app.buttons["URLBarView.tabsButton"], timeout: 15)
-            } else {
-                waitForExistence(app.buttons["TabToolbar.tabsButton"], timeout: 15)
-            }
+            app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].tap()
         }
     }
 }
@@ -260,7 +255,7 @@ class IphoneOnlyTestCase: BaseTestCase {
 
 extension BaseTestCase {
     func tabTrayButton(forApp app: XCUIApplication) -> XCUIElement {
-        return app.buttons["TopTabsViewController.tabsButton"].exists ? app.buttons["TopTabsViewController.tabsButton"] : app.buttons["TabToolbar.tabsButton"]
+        return app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
     }
 }
 

--- a/Tests/XCUITests/BaseTestCase.swift
+++ b/Tests/XCUITests/BaseTestCase.swift
@@ -227,11 +227,7 @@ class BaseTestCase: XCTestCase {
     }
 
     func waitForTabsButton() {
-        if iPad() {
-            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 15)
-        } else {
-            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 15)
-        }
+        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 15)
     }
 }
 

--- a/Tests/XCUITests/BaseTestCase.swift
+++ b/Tests/XCUITests/BaseTestCase.swift
@@ -230,7 +230,7 @@ class BaseTestCase: XCTestCase {
         if iPad() {
             waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 15)
         } else {
-            app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].tap()
+            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 15)
         }
     }
 }

--- a/Tests/XCUITests/BrowsingPDFTests.swift
+++ b/Tests/XCUITests/BrowsingPDFTests.swift
@@ -42,11 +42,7 @@ class BrowsingPDFTests: BaseTestCase {
         XCTAssertTrue(app.webViews.links["Download Now"].exists)
 
         // Go back to pdf view
-        if iPad() {
-            app.buttons["URLBarView.backButton"].tap()
-        } else {
-            app.buttons["TabToolbar.backButton"].tap()
-        }
+        app.buttons[AccessibilityIdentifiers.Toolbar.backButton].tap()
         waitForValueContains(app.textFields["url"], value: PDF_website["pdfValue"]!)
     }
 

--- a/Tests/XCUITests/DragAndDropTests.swift
+++ b/Tests/XCUITests/DragAndDropTests.swift
@@ -38,11 +38,8 @@ class DragAndDropTests: BaseTestCase {
         openTwoWebsites()
         navigator.goto(TabTray)
         navigator.performAction(Action.OpenNewTabFromTabTray)
-        if iPad() {
-            waitForExistence(app.buttons["TopTabsViewController.tabsButton"])
-        } else {
-            waitForExistence(app.buttons["TabToolbar.tabsButton"], timeout: 10)
-        }
+        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 10)
+
         navigator.openNewURL(urlString: thirdWebsite.url)
         waitUntilPageLoad()
         waitForTabsButton()

--- a/Tests/XCUITests/FxScreenGraph.swift
+++ b/Tests/XCUITests/FxScreenGraph.swift
@@ -155,6 +155,7 @@ class Action {
     static let SelectTopSitesRows = "SelectTopSitesRows"
 
     static let GoToHomePage = "GoToHomePage"
+    static let ClickSearchButton = "ClickSearchButton"
 
     static let OpenSiriFromSettings = "OpenSiriFromSettings"
 
@@ -852,7 +853,11 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
         screenState.tap(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection], to: TrackingProtectionContextMenuDetails)
 
-        screenState.tap(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton], forAction: Action.GoToHomePage) { userState in
+        screenState.tap(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton], forAction: Action.GoToHomePage) {
+            userState in
+        }
+
+        screenState.tap(app.buttons[AccessibilityIdentifiers.Toolbar.searchButton], forAction: Action.ClickSearchButton) { userState in
         }
 
         makeToolBarAvailable(screenState)

--- a/Tests/XCUITests/FxScreenGraph.swift
+++ b/Tests/XCUITests/FxScreenGraph.swift
@@ -298,14 +298,10 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     map.addScreenState(NewTabScreen) { screenState in
         screenState.noop(to: HomePanelsScreen)
         if isTablet {
-            screenState.tap(app.buttons["TopTabsViewController.tabsButton"], to: TabTray)
+            screenState.tap(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], to: TabTray)
         } else {
             screenState.gesture(to: TabTray) {
-                if app.buttons["TabToolbar.tabsButton"].exists {
-                    app.buttons["TabToolbar.tabsButton"].tap()
-                } else {
-                    app.buttons["URLBarView.tabsButton"].tap()
-                }
+                app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].tap()
             }
         }
         makeURLBarAvailable(screenState)
@@ -436,15 +432,10 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
         // Workaround to bug Bug 1417522
         if isTablet {
-            screenState.tap(app.buttons["TopTabsViewController.tabsButton"], to: TabTray)
+            screenState.tap(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], to: TabTray)
         } else {
             screenState.gesture(to: TabTray) {
-                // iPhone sim tabs button is called differently when in portrait or landscape
-                if XCUIDevice.shared.orientation == UIDeviceOrientation.landscapeLeft {
-                    app.buttons["URLBarView.tabsButton"].tap()
-                } else {
-                    app.buttons["TabToolbar.tabsButton"].tap()
-                }
+                app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].tap()
             }
         }
 
@@ -847,14 +838,10 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     func makeToolBarAvailable(_ screenState: MMScreenStateNode<FxUserState>) {
         screenState.tap(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], to: BrowserTabMenu)
         if isTablet {
-            screenState.tap(app.buttons["TopTabsViewController.tabsButton"], to: TabTray)
+            screenState.tap(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], to: TabTray)
         } else {
             screenState.gesture(to: TabTray) {
-                if app.buttons["TabToolbar.tabsButton"].exists {
-                    app.buttons["TabToolbar.tabsButton"].tap()
-                } else {
-                    app.buttons["URLBarView.tabsButton"].tap()
-                }
+                app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].tap()
             }
         }
     }
@@ -886,19 +873,15 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         }
         // For iPad there is no long press on tabs button
         if !isTablet {
-            let tabsButton = app.buttons["TabToolbar.tabsButton"]
+            let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
             screenState.press(tabsButton, to: TabTrayLongPressMenu)
         }
 
         if isTablet {
-            screenState.tap(app.buttons["TopTabsViewController.tabsButton"], to: TabTray)
+            screenState.tap(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], to: TabTray)
         } else {
             screenState.gesture(to: TabTray) {
-                if app.buttons["TabToolbar.tabsButton"].exists {
-                    app.buttons["TabToolbar.tabsButton"].tap()
-                } else {
-                    app.buttons["URLBarView.tabsButton"].tap()
-                }
+                app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].tap()
             }
         }
 
@@ -1025,11 +1008,8 @@ extension MMNavigator where T == FxUserState {
     // Opens a URL in a new tab.
     func openNewURL(urlString: String) {
         let app = XCUIApplication()
-        if isTablet {
-            waitForExistence(app.buttons["TopTabsViewController.tabsButton"], timeout: 15)
-        } else {
-            waitForExistence(app.buttons["TabToolbar.tabsButton"], timeout: 10)
-        }
+        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 10)
+
         self.goto(TabTray)
         createNewTab()
         self.openURL(urlString)
@@ -1047,11 +1027,7 @@ extension MMNavigator where T == FxUserState {
     func createSeveralTabsFromTabTray(numberTabs: Int) {
         let app = XCUIApplication()
         for _ in 1...numberTabs {
-            if isTablet {
-                waitForExistence(app.buttons["TopTabsViewController.tabsButton"], timeout: 5)
-            } else {
-                waitForExistence(app.buttons["TabToolbar.tabsButton"], timeout: 5)
-            }
+            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 5)
             self.goto(TabTray)
             self.goto(HomePanelsScreen)
         }

--- a/Tests/XCUITests/HistoryTests.swift
+++ b/Tests/XCUITests/HistoryTests.swift
@@ -324,8 +324,8 @@ class HistoryTests: BaseTestCase {
     func testTabHistory() {
         navigator.nowAt(NewTabScreen)
         openBookOfMozilla()
-        let urlBarBackButton = app.windows.otherElements.buttons[AccessibilityIdentifiers.Browser.UrlBar.backButton]
-        let urlBarForwardButton = app.windows.otherElements.buttons[AccessibilityIdentifiers.Browser.UrlBar.forwardButton]
+        let urlBarBackButton = app.windows.otherElements.buttons[AccessibilityIdentifiers.Toolbar.backButton]
+        let urlBarForwardButton = app.windows.otherElements.buttons[AccessibilityIdentifiers.Toolbar.forwardButton]
         urlBarBackButton.press(forDuration: 1)
         XCTAssertTrue(app.tables.staticTexts["The Book of Mozilla"].exists)
         app.tables.staticTexts["The Book of Mozilla"].tap()

--- a/Tests/XCUITests/HomeButtonTests.swift
+++ b/Tests/XCUITests/HomeButtonTests.swift
@@ -25,7 +25,7 @@ class HomeButtonTests: BaseTestCase {
         if iPad() {
             XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton].label, "Home")
         } else {
-            XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton].label, "Search")
+            XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.searchButton].label, "Search")
         }
         if iPad() {
             navigator.nowAt(NewTabScreen)

--- a/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -217,7 +217,13 @@ class HomePageSettingsUITests: BaseTestCase {
         waitForTabsButton()
         checkRecentlySaved()
         navigator.performAction(Action.ToggleRecentlySaved)
-        navigator.performAction(Action.GoToHomePage)
+        // On iPad we have the homepage button always present,
+        // on iPhone we have the search button instead when we're on a new tab page
+        if !iPad() {
+            navigator.performAction(Action.ClickSearchButton)
+        } else {
+            navigator.performAction(Action.GoToHomePage)
+        }
         XCTAssertFalse(app.scrollViews.cells[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.recentlySaved].exists)
         if !iPad() {
             waitForExistence(app.buttons["urlBar-cancel"], timeout: 3)
@@ -253,7 +259,15 @@ class HomePageSettingsUITests: BaseTestCase {
         waitForExistence(app.scrollViews.cells[AccessibilityIdentifiers.FirefoxHomepage.HistoryHighlights.itemCell].staticTexts[urlMozillaLabel])
         navigator.goto(HomeSettings)
         navigator.performAction(Action.ToggleRecentlyVisited)
-        navigator.performAction(Action.GoToHomePage)
+
+        // On iPad we have the homepage button always present,
+        // on iPhone we have the search button instead when we're on a new tab page
+        if !iPad() {
+            navigator.performAction(Action.ClickSearchButton)
+        } else {
+            navigator.performAction(Action.GoToHomePage)
+        }
+
         XCTAssertFalse(app.scrollViews.cells[AccessibilityIdentifiers.FirefoxHomepage.HistoryHighlights.itemCell].staticTexts[urlMozillaLabel].exists)
         if !iPad() {
             waitForExistence(app.buttons["urlBar-cancel"], timeout: 3)

--- a/Tests/XCUITests/LibraryTests.swift
+++ b/Tests/XCUITests/LibraryTests.swift
@@ -8,8 +8,8 @@ class LibraryTestsIpad: IpadOnlyTestCase {
     func testLibraryShortcut() {
         if skipPlatform {return}
         // Open Library from shortcut
-        waitForExistence(app.buttons["TabToolbar.libraryButton"])
-        let libraryShorcutButton = app.buttons["TabToolbar.libraryButton"]
+        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.bookmarksButton])
+        let libraryShorcutButton = app.buttons[AccessibilityIdentifiers.Toolbar.bookmarksButton]
         libraryShorcutButton.tap()
         navigator.nowAt(HomePanel_Library)
         waitForExistence(app.tables["Bookmarks List"])

--- a/Tests/XCUITests/NavigationTest.swift
+++ b/Tests/XCUITests/NavigationTest.swift
@@ -22,12 +22,12 @@ class NavigationTest: BaseTestCase {
         // Check the url placeholder text and that the back and forward buttons are disabled
         XCTAssert(urlPlaceholder == defaultValuePlaceholder)
         if iPad() {
-            XCTAssertFalse(app.buttons["URLBarView.backButton"].isEnabled)
-            XCTAssertFalse(app.buttons["Forward"].isEnabled)
+            XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
+            XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
             app.textFields["url"].tap()
         } else {
-            XCTAssertFalse(app.buttons["TabToolbar.backButton"].isEnabled)
-            XCTAssertFalse(app.buttons["TabToolbar.forwardButton"].isEnabled)
+            XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
+            XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
         }
 
         // Once an url has been open, the back button is enabled but not the forward button
@@ -39,11 +39,11 @@ class NavigationTest: BaseTestCase {
         waitUntilPageLoad()
         waitForValueContains(app.textFields["url"], value: "test-example.html")
         if iPad() {
-            XCTAssertTrue(app.buttons["URLBarView.backButton"].isEnabled)
-            XCTAssertFalse(app.buttons["Forward"].isEnabled)
+            XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
+            XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
         } else {
-            XCTAssertTrue(app.buttons["TabToolbar.backButton"].isEnabled)
-            XCTAssertFalse(app.buttons["TabToolbar.forwardButton"].isEnabled)
+            XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
+            XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
         }
 
         // Once a second url is open, back button is enabled but not the forward one till we go back to url_1
@@ -51,25 +51,25 @@ class NavigationTest: BaseTestCase {
         waitUntilPageLoad()
         waitForValueContains(app.textFields["url"], value: "test-mozilla-org.html")
         if iPad() {
-            XCTAssertTrue(app.buttons["URLBarView.backButton"].isEnabled)
-            XCTAssertFalse(app.buttons["Forward"].isEnabled)
+            XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
+            XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
             // Go back to previous visited web site
-            app.buttons["URLBarView.backButton"].tap()
+            app.buttons[AccessibilityIdentifiers.Toolbar.backButton].tap()
         } else {
-            XCTAssertTrue(app.buttons["TabToolbar.backButton"].isEnabled)
-            XCTAssertFalse(app.buttons["TabToolbar.forwardButton"].isEnabled)
+            XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
+            XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
             // Go back to previous visited web site
-            app.buttons["TabToolbar.backButton"].tap()
+            app.buttons[AccessibilityIdentifiers.Toolbar.backButton].tap()
         }
         waitUntilPageLoad()
         waitForValueContains(app.textFields["url"], value: "test-example.html")
 
         if iPad() {
-            app.buttons["Forward"].tap()
+            app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].tap()
         } else {
             // Go forward to next visited web site
-            waitForExistence(app.buttons["TabToolbar.forwardButton"])
-            app.buttons["TabToolbar.forwardButton"].tap()
+            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton])
+            app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].tap()
         }
         waitUntilPageLoad()
         waitForValueContains(app.textFields["url"], value: "test-mozilla-org")
@@ -146,11 +146,7 @@ class NavigationTest: BaseTestCase {
         // Scroll to bottom
         bottomElement.tap()
         waitUntilPageLoad()
-        if iPad() {
-            app.buttons["URLBarView.backButton"].tap()
-        } else {
-            app.buttons["TabToolbar.backButton"].tap()
-        }
+        app.buttons[AccessibilityIdentifiers.Toolbar.backButton].tap()
         waitUntilPageLoad()
 
         // Scroll to top

--- a/Tests/XCUITests/NavigationTest.swift
+++ b/Tests/XCUITests/NavigationTest.swift
@@ -21,46 +21,30 @@ class NavigationTest: BaseTestCase {
 
         // Check the url placeholder text and that the back and forward buttons are disabled
         XCTAssert(urlPlaceholder == defaultValuePlaceholder)
-        if iPad() {
-            XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
-            XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
-            app.textFields["url"].tap()
-        } else {
-            XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
-            XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
-        }
+        XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
+        XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
 
-        // Once an url has been open, the back button is enabled but not the forward button
         if iPad() {
+            app.textFields["url"].tap()
+            // Once an url has been open, the back button is enabled but not the forward button
             navigator.performAction(Action.CloseURLBarOpen)
             navigator.nowAt(NewTabScreen)
         }
         navigator.openURL(path(forTestPage: "test-example.html"))
         waitUntilPageLoad()
         waitForValueContains(app.textFields["url"], value: "test-example.html")
-        if iPad() {
-            XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
-            XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
-        } else {
-            XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
-            XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
-        }
+        XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
+        XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
 
         // Once a second url is open, back button is enabled but not the forward one till we go back to url_1
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
         waitUntilPageLoad()
         waitForValueContains(app.textFields["url"], value: "test-mozilla-org.html")
-        if iPad() {
-            XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
-            XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
-            // Go back to previous visited web site
-            app.buttons[AccessibilityIdentifiers.Toolbar.backButton].tap()
-        } else {
-            XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
-            XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
-            // Go back to previous visited web site
-            app.buttons[AccessibilityIdentifiers.Toolbar.backButton].tap()
-        }
+        XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
+        XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
+        // Go back to previous visited web site
+        app.buttons[AccessibilityIdentifiers.Toolbar.backButton].tap()
+
         waitUntilPageLoad()
         waitForValueContains(app.textFields["url"], value: "test-example.html")
 

--- a/Tests/XCUITests/SearchTest.swift
+++ b/Tests/XCUITests/SearchTest.swift
@@ -225,10 +225,10 @@ class SearchTests: BaseTestCase {
             waitForTabsButton()
 
             // Search icon is displayed.
-            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton])
-            XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton].label, "Search")
-            XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton].exists)
-            app.buttons[AccessibilityIdentifiers.Toolbar.homeButton].tap()
+            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.searchButton])
+            XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.searchButton].label, "Search")
+            XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.searchButton].exists)
+            app.buttons[AccessibilityIdentifiers.Toolbar.searchButton].tap()
 
             let addressBar = app.textFields["address"]
             XCTAssertTrue(addressBar.value(forKey: "hasKeyboardFocus") as? Bool ?? false)
@@ -247,8 +247,8 @@ class SearchTests: BaseTestCase {
             waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton])
             XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton].label, "Home")
             app.buttons[AccessibilityIdentifiers.Toolbar.homeButton].tap()
-            XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton].label, "Search")
-            app.buttons[AccessibilityIdentifiers.Toolbar.homeButton].tap()
+            XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.searchButton].label, "Search")
+            app.buttons[AccessibilityIdentifiers.Toolbar.searchButton].tap()
 
             XCTAssertTrue(addressBar.value(forKey: "hasKeyboardFocus") as? Bool ?? false)
             let keyboardsCount = app.keyboards.count

--- a/Tests/XCUITests/SearchTest.swift
+++ b/Tests/XCUITests/SearchTest.swift
@@ -142,11 +142,7 @@ class SearchTests: BaseTestCase {
             waitUntilPageLoad()
 
             // Go back, write part of moz, check the autocompletion
-            if iPad() {
-                app.buttons["URLBarView.backButton"].tap()
-            } else {
-                app.buttons["TabToolbar.backButton"].tap()
-            }
+            app.buttons[AccessibilityIdentifiers.Toolbar.backButton].tap()
             navigator.nowAt(HomePanelsScreen)
             waitForTabsButton()
             typeOnSearchBar(text: "moz")
@@ -246,7 +242,7 @@ class SearchTests: BaseTestCase {
             waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton])
             XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton].label, "Home")
             app.buttons[AccessibilityIdentifiers.Toolbar.homeButton].tap()
-            app.buttons["TabToolbar.backButton"].tap()
+            app.buttons[AccessibilityIdentifiers.Toolbar.backButton].tap()
 
             waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton])
             XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton].label, "Home")

--- a/Tests/XCUITests/TabsPerformanceTests.swift
+++ b/Tests/XCUITests/TabsPerformanceTests.swift
@@ -68,8 +68,8 @@ class TabsPerformanceTest: BaseTestCase {
             XCTStorageMetric(), // to measure storage consuming
             XCTMemoryMetric()]) {
             // go to tab tray
-            waitForExistence(app.buttons["TabToolbar.tabsButton"])
-            app.buttons["TabToolbar.tabsButton"].tap()
+            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton])
+            app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].tap()
             waitForExistence(app.buttons[AccessibilityIdentifiers.TabTray.doneButton])
             app.buttons[AccessibilityIdentifiers.TabTray.doneButton].tap()
         }
@@ -84,7 +84,7 @@ class TabsPerformanceTest: BaseTestCase {
             XCTStorageMetric(), // to measure storage consuming
             XCTMemoryMetric()]) {
             // go to tab tray
-            app.buttons["TabToolbar.tabsButton"].tap()
+            app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].tap()
             app.buttons[AccessibilityIdentifiers.TabTray.doneButton].tap()
         }
     }

--- a/Tests/XCUITests/ToolbarTest.swift
+++ b/Tests/XCUITests/ToolbarTest.swift
@@ -30,8 +30,8 @@ class ToolbarTests: BaseTestCase {
 
         // Check the url placeholder text and that the back and forward buttons are disabled
         XCTAssertTrue(urlPlaceholder == defaultValuePlaceholder, "The placeholder does not show the correct value")
-        XCTAssertFalse(app.buttons["URLBarView.backButton"].isEnabled)
-        XCTAssertFalse(app.buttons["Forward"].isEnabled)
+        XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
+        XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
 
         // Navigate to two pages and press back once so that all buttons are enabled in landscape mode.
         navigator.openURL(website1["url"]!)
@@ -39,8 +39,8 @@ class ToolbarTests: BaseTestCase {
         waitForExistence(app.webViews.links["Mozilla"], timeout: 10)
         let valueMozilla = app.textFields["url"].value as! String
         XCTAssertEqual(valueMozilla, urlValueLong)
-        XCTAssertTrue(app.buttons["URLBarView.backButton"].isEnabled)
-        XCTAssertFalse(app.buttons["Forward"].isEnabled)
+        XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
+        XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
         if iPad() {
             XCTAssertTrue(app.buttons["Reload"].isEnabled)
         } else {
@@ -50,15 +50,15 @@ class ToolbarTests: BaseTestCase {
         navigator.openURL(website2)
         waitUntilPageLoad()
         waitForValueContains(app.textFields["url"], value: "localhost:\(serverPort)")
-        XCTAssertTrue(app.buttons["URLBarView.backButton"].isEnabled)
-        XCTAssertFalse(app.buttons["Forward"].isEnabled)
+        XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
+        XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
 
-        app.buttons["URLBarView.backButton"].tap()
+        app.buttons[AccessibilityIdentifiers.Toolbar.backButton].tap()
         XCTAssertEqual(valueMozilla, urlValueLong)
 
         waitUntilPageLoad()
-        XCTAssertTrue(app.buttons["URLBarView.backButton"].isEnabled)
-        XCTAssertTrue(app.buttons["Forward"].isEnabled)
+        XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
+        XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
 
         // Open new tab and then go back to previous tab to test navigation buttons.
         waitForTabsButton()
@@ -73,8 +73,8 @@ class ToolbarTests: BaseTestCase {
 
         // Test to see if all the buttons are enabled.
         waitUntilPageLoad()
-        XCTAssertTrue(app.buttons["URLBarView.backButton"].isEnabled)
-        XCTAssertTrue(app.buttons["Forward"].isEnabled)
+        XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
+        XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
     }
 
     func testClearURLTextUsingBackspace() {

--- a/Tests/XCUITests/TopTabsTest.swift
+++ b/Tests/XCUITests/TopTabsTest.swift
@@ -33,8 +33,8 @@ class TopTabsTest: BaseTestCase {
 
         // The tab tray shows the correct tabs
         if iPad() {
-            waitForExistence(app.buttons["TopTabsViewController.tabsButton"], timeout: 15)
-            app.buttons["TopTabsViewController.tabsButton"].tap()
+            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 15)
+            app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].tap()
         } else {
             navigator.goto(TabTray)
         }
@@ -125,13 +125,13 @@ class TopTabsTest: BaseTestCase {
         waitForTabsButton()
         navigator.nowAt(BrowserTab)
         if iPad() {
-            waitForExistence(app.buttons["TopTabsViewController.tabsButton"], timeout: 10)
-            app.buttons["TopTabsViewController.tabsButton"].tap()
+            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 10)
+            app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].tap()
             waitForExistence(app.buttons[AccessibilityIdentifiers.TabTray.newTabButton], timeout: 10)
             app.buttons[AccessibilityIdentifiers.TabTray.newTabButton].tap()
         } else {
             navigator.performAction(Action.OpenNewTabFromTabTray)
-            waitForExistence(app.buttons["TabToolbar.tabsButton"], timeout: 5)
+            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 5)
         }
 
         if iPad() {
@@ -150,7 +150,7 @@ class TopTabsTest: BaseTestCase {
         waitForExistence(app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell], timeout: 5)
         navigator.nowAt(BrowserTab)
         if !iPad() {
-            waitForExistence(app.buttons["TabToolbar.tabsButton"], timeout: 5)
+            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 5)
         }
 
         if iPad() {
@@ -174,13 +174,13 @@ class TopTabsTest: BaseTestCase {
         waitForTabsButton()
 
         if iPad() {
-            waitForExistence(app.buttons["TopTabsViewController.tabsButton"], timeout: 10)
-            app.buttons["TopTabsViewController.tabsButton"].tap()
+            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 10)
+            app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].tap()
             waitForExistence(app.buttons[AccessibilityIdentifiers.TabTray.newTabButton], timeout: 10)
             app.buttons[AccessibilityIdentifiers.TabTray.newTabButton].tap()
         } else {
             navigator.performAction(Action.OpenNewTabFromTabTray)
-            waitForExistence(app.buttons["TabToolbar.tabsButton"], timeout: 5)
+            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 5)
         }
 
         navigator.goto(URLBarOpen)
@@ -207,7 +207,7 @@ class TopTabsTest: BaseTestCase {
         navigator.performAction(Action.OpenNewTabFromTabTray)
         if !iPad() {
             navigator.performAction(Action.CloseURLBarOpen)
-            waitForExistence(app.buttons["TabToolbar.tabsButton"])
+            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton])
         }
         navigator.nowAt(NewTabScreen)
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
@@ -215,7 +215,7 @@ class TopTabsTest: BaseTestCase {
         // Close all tabs and check that the number of tabs is correct
         navigator.performAction(Action.AcceptRemovingAllTabs)
         if !iPad() {
-            waitForExistence(app.buttons["TabToolbar.tabsButton"])
+            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton])
         }
         navigator.nowAt(NewTabScreen)
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
@@ -246,11 +246,11 @@ class TopTabsTest: BaseTestCase {
         XCUIDevice.shared.orientation = .landscapeLeft
         // Verify the '+' icon is shown and open a tab with it
         if iPad() {
-            waitForExistence(app.buttons["TopTabsViewController.newTabButton"])
-            app.buttons["TopTabsViewController.newTabButton"].tap()
+            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton])
+            app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton].tap()
         } else {
-            waitForExistence(app.buttons["TabToolbar.addNewTabButton"], timeout: 15)
-            app.buttons["TabToolbar.addNewTabButton"].tap()
+            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton], timeout: 15)
+            app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton].tap()
         }
         app.typeText("google.com\n")
         waitUntilPageLoad()
@@ -259,7 +259,7 @@ class TopTabsTest: BaseTestCase {
         XCUIDevice.shared.orientation = .portrait
         // Verify that the '+' is not displayed
         if !iPad() {
-            waitForNoExistence(app.buttons["TabToolbar.addNewTabButton"])
+            waitForNoExistence(app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton])
         }
     }
 
@@ -452,9 +452,9 @@ class TopTabsTestIpad: IpadOnlyTestCase {
     func testUpdateTabCounter() {
         if skipPlatform { return }
         // Open three tabs by tapping on '+' button
-        app.buttons["TopTabsViewController.newTabButton"].tap()
-        app.buttons["TopTabsViewController.newTabButton"].tap()
-        waitForExistence(app.buttons["TopTabsViewController.tabsButton"])
+        app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton].tap()
+        app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton].tap()
+        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton])
         let numTab = app.buttons["Show Tabs"].value as? String
         XCTAssertEqual("3", numTab)
         // Remove one tab by tapping on 'x' button


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6465)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14539)

### Description
Making sure we're consistent on a11y identifiers between iPad and iPhone.
- The back button was called `"URLBarView.backButton"` or `"TabToolbar.backButton"`. Now we always refer to it as `"TabToolbar.backButton"`
- The tabs button was called `"URLBarView.tabsButton"`, `"TopTabsViewController.tabsButton"` or `"TabToolbar.tabsButton"`. Now we always refer to it as `"TabToolbar.tabsButton"`
- The new tab button was called `"TopTabsViewController.newTabButton"`, `"TabToolbar.addNewTabButton"` or `"newTabButtonTabTray"`. Now we always refer to it as `"TabToolbar.addNewTabButton"`
- Made sure all toolbar/url bar have their a11y identifiers.
- Made sure the multistate button is properly identified with the purpose it has.
- Adjusted the UI tests where needed. Hopefully I didn't miss any, I have trouble running UITests locally (but can run XCUITests normally).

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
