### PR TITLE
Refactor [v115] `recordTelemetry` function within `FxAWebViewTelemetry` class.

### DIFF
--- a/RustFxA/FxAWebViewTelemetry.swift
+++ b/RustFxA/FxAWebViewTelemetry.swift
@@ -57,44 +57,35 @@ class FxAWebViewTelemetry {
     }
 
     func recordTelemetry(for flow: FxAFlow) {
+        let eventObject: TelemetryWrapper.EventObject
+        
         switch flow {
         case .completed:
-            if validStartedFlow == .signinStarted {
-                TelemetryWrapper.recordEvent(
-                    category: .firefoxAccount,
-                    method: .view,
-                    object: .fxaLoginCompleteWebpage)
-            } else if validStartedFlow == .signupStarted {
-                TelemetryWrapper.recordEvent(
-                    category: .firefoxAccount,
-                    method: .view,
-                    object: .fxaRegistrationCompletedWebpage)
+            switch validStartedFlow {
+            case .signinStarted:
+                eventObject = .fxaLoginCompleteWebpage
+            case .signupStarted:
+                eventObject = .fxaRegistrationCompletedWebpage
+            default: return
             }
         case .startedFlow(let type):
             switch type {
             case .signinStarted:
                 validStartedFlow = type
-                TelemetryWrapper.recordEvent(
-                    category: .firefoxAccount,
-                    method: .view,
-                    object: .fxaLoginWebpage)
+                eventObject = .fxaLoginWebpage
             case .signupStarted:
                 validStartedFlow = type
-                TelemetryWrapper.recordEvent(
-                    category: .firefoxAccount,
-                    method: .view,
-                    object: .fxaRegistrationWebpage)
+                eventObject = .fxaRegistrationWebpage
             case .confirmSignupCode:
-                TelemetryWrapper.recordEvent(
-                    category: .firefoxAccount,
-                    method: .view,
-                    object: .fxaConfirmSignUpCode)
+                eventObject = .fxaConfirmSignUpCode
             case .signinTokenCode:
-                TelemetryWrapper.recordEvent(
-                    category: .firefoxAccount,
-                    method: .view,
-                    object: .fxaConfirmSignInToken)
+                eventObject = .fxaConfirmSignInToken
             }
         }
+        
+        TelemetryWrapper.recordEvent(
+            category: .firefoxAccount,
+            method: .view,
+            object: eventObject)
     }
 }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

### Description
- This PR improves the existing implementation of `recordTelemetry` function within `FxAWebViewTelemetry` class.
- Instead of duplicating the `TelemetryWrapper.recordEvent` multiple times we can create the params of the function based on various conditions and call that once. 

- I am using `let` ,instead of `var` for param creation  for `TelemetryWrapper.recordEvent`(in this case EventObject). This approach ensures that for every conditional path the eventObject is initialised and initialised only once. This minimises the bugs and guarantees compile time safety for initialisation of `eventObject` param.

- Added comment for this function as well.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods

## Note

- Please let me know if there are any feedbacks or if we can improve further. Thanks.
