### PR TITLE
Bugfix FXIOS-6517 [v115] Fixes device disconnect notification crashing notification service

### DIFF
--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -2873,11 +2873,6 @@ extension String {
         tableName: nil,
         value: "Sync Disconnected",
         comment: "Title of a notification displayed when named device has been disconnected from FxA.")
-    public static let FxAPush_DeviceDisconnected_body = MZLocalizedString(
-        key: "FxAPush_DeviceDisconnected_body",
-        tableName: nil,
-        value: "%@ has been successfully disconnected.",
-        comment: "Body of a notification displayed when named device has been disconnected from FxA. %@ refers to the name of the disconnected device.")
 
     public static let FxAPush_DeviceDisconnected_UnknownDevice_body = MZLocalizedString(
         key: "FxAPush_DeviceDisconnected_UnknownDevice_body",

--- a/Extensions/NotificationService/NotificationService.swift
+++ b/Extensions/NotificationService/NotificationService.swift
@@ -95,8 +95,8 @@ class SyncDataDisplay {
             displayNewSentTabNotification(tab: tab)
         case .deviceConnected(let deviceName):
             displayDeviceConnectedNotification(deviceName)
-        case .deviceDisconnected(let deviceName):
-            displayDeviceDisconnectedNotification(deviceName)
+        case .deviceDisconnected:
+            displayDeviceDisconnectedNotification()
         case .thisDeviceDisconnected:
             displayThisDeviceDisconnectedNotification()
         default:
@@ -111,16 +111,9 @@ class SyncDataDisplay {
                             bodyArg: deviceName)
     }
 
-    func displayDeviceDisconnectedNotification(_ deviceName: String?) {
-        if let deviceName = deviceName {
-            presentNotification(title: .FxAPush_DeviceDisconnected_title,
-                                body: .FxAPush_DeviceDisconnected_body,
-                                bodyArg: deviceName)
-        } else {
-            // We should never see this branch
-            presentNotification(title: .FxAPush_DeviceDisconnected_title,
-                                body: .FxAPush_DeviceDisconnected_UnknownDevice_body)
-        }
+    func displayDeviceDisconnectedNotification() {
+        presentNotification(title: .FxAPush_DeviceDisconnected_title,
+                            body: .FxAPush_DeviceDisconnected_UnknownDevice_body)
     }
 
     func displayThisDeviceDisconnectedNotification() {

--- a/Storage/Rust/RustRemoteTabs.swift
+++ b/Storage/Rust/RustRemoteTabs.swift
@@ -160,8 +160,8 @@ public class RustRemoteTabs {
 
     public func getClient(fxaDeviceId: String) -> Deferred<Maybe<RemoteClient?>> {
         return self.getAll().bind { result in
-            guard result.failureValue == nil else {
-                return deferMaybe(result.failureValue as! String)
+            if let failureValue = result.failureValue {
+                return deferMaybe(failureValue)
             }
 
             guard let records = result.successValue else {
@@ -175,8 +175,8 @@ public class RustRemoteTabs {
 
     public func getClientGUIDs(completion: @escaping (Set<GUID>?, Error?) -> Void) {
         self.getAll().upon { result in
-            guard result.failureValue == nil else {
-                completion(nil, result.failureValue as! String)
+            if let failureValue = result.failureValue {
+                completion(nil, failureValue)
                 return
             }
             guard let records = result.successValue else {
@@ -191,8 +191,8 @@ public class RustRemoteTabs {
 
     public func getRemoteClients(remoteDeviceIds: [String]) -> Deferred<Maybe<[ClientAndTabs]>> {
         return self.getAll().bind { result in
-            guard result.failureValue == nil else {
-                return deferMaybe(result.failureValue!)
+            if let failureValue = result.failureValue {
+                return deferMaybe(failureValue)
             }
             guard let rustClientAndTabs = result.successValue else {
                 return deferMaybe([])


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6517)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14619)

### Description
When the Rust sync manager is ON, the notification service was crashing because of a forced downcast.

The notifications service was attempting to call `RustRemoteTabs.getClient`, when the tabs DB wasn't initialized. This should have returned an error, but instead, it causes the notification service extension to crash and display a generic error notification to the user.

In practice, the name lookup for the device didn't really work (at least for a while, probably since we introduced the Rust tabs syncing last year) because by the time the notification arrives, the device list already doesn't include the disconnected device, and we use the device list to filter the clients list.

Given the above, I removed the code that tries to query the name of the device altogether as it would have always returned nil anyways (verified with v113 on release that the name doesn't show up)

cc @lougeniaC64
### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
