### PR TITLE
Bugfix FXIOS-6309 [v115] On opening a new tab the url bar remains populated with the url for the previous tab

### DIFF
--- a/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -507,6 +507,7 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
             locationTextField?.text = location
             return
         }
+
         if search {
             locationTextField?.text = text
             // Not notifying when empty agrees with AutocompleteTextField.textDidChange.
@@ -517,8 +518,6 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
     }
 
     func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool) {
-        guard !inOverlayMode else { return }
-
         createLocationTextField()
 
         // Show the overlay mode UI, which includes hiding the locationView and replacing it
@@ -553,8 +552,6 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
     }
 
     func leaveOverlayMode(didCancel cancel: Bool) {
-        guard inOverlayMode else { return }
-
         locationTextField?.resignFirstResponder()
         animateToOverlayState(overlayMode: false, didCancel: cancel)
         delegate?.urlBarDidLeaveOverlayMode(self)

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -161,7 +161,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     }
 
     /// Commits the completion by setting the text and removing the highlight.
-    fileprivate func applyCompletion() {
+    private func applyCompletion() {
         // Clear the current completion, then set the text without the attributed style.
         let text = (self.text ?? "") + (self.autocompleteTextLabel?.text ?? "")
         let didRemoveCompletion = removeCompletion()
@@ -176,7 +176,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     /// Removes the autocomplete-highlighted. Returns true if a completion was actually removed
     @objc
     @discardableResult
-    fileprivate func removeCompletion() -> Bool {
+    private func removeCompletion() -> Bool {
         let hasActiveCompletion = isSelectionActive
         autocompleteTextLabel?.removeFromSuperview()
         autocompleteTextLabel = nil
@@ -184,7 +184,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     }
 
     @objc
-    fileprivate func clear() {
+    private func clear() {
         text = ""
         removeCompletion()
         autocompleteDelegate?.autocompleteTextField(self, didEnterText: "")

--- a/Tests/XCUITests/BookmarkingTests.swift
+++ b/Tests/XCUITests/BookmarkingTests.swift
@@ -119,8 +119,8 @@ class BookmarkingTests: BaseTestCase {
         waitForExistence(app.tables["SiteTable"])
         waitForExistence(app.tables["SiteTable"].cells.staticTexts["www.google"], timeout: 5)
         XCTAssertTrue(app.tables["SiteTable"].cells.staticTexts["www.google"].exists)
-        typeOnSearchBar(text: ".com")
-        typeOnSearchBar(text: "\r")
+        app.textFields["address"].typeText(".com")
+        app.textFields["address"].typeText("\r")
         navigator.nowAt(BrowserTab)
 
         // Clear text and enter new url
@@ -132,7 +132,7 @@ class BookmarkingTests: BaseTestCase {
         // Site table exists but is empty
         waitForExistence(app.tables["SiteTable"])
         XCTAssertEqual(app.tables["SiteTable"].cells.count, 0)
-        typeOnSearchBar(text: "\r")
+        app.textFields["address"].typeText("\r")
         navigator.nowAt(BrowserTab)
 
         // Add page to bookmarks


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6309)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14190)

### Description
Remove check for inOverlayMode on URLBarView is not related to keyboard

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
