### PR TITLE
Refactor [MTE-446] Backport M1 and XCode 14.3 Upgrade related changes

### DIFF
--- a/Tests/UnitTest.xctestplan
+++ b/Tests/UnitTest.xctestplan
@@ -70,6 +70,8 @@
     {
       "skippedTests" : [
         "ETPCoverSheetTests",
+        "TabDisplayManagerTests\/testInactiveTabs_grid_closeSingleTab()",
+        "TabDisplayManagerTests\/testInactiveTabs_grid_undoSingleTab()",
         "TabManagerTests\/testDeleteSelectedTab()",
         "TabManagerTests\/testPrivatePreference_togglePBMDeletesPrivate()",
         "TestFavicons\/testFaviconFetcherParse()",

--- a/Tests/XCUITests/ClipBoardTests.swift
+++ b/Tests/XCUITests/ClipBoardTests.swift
@@ -73,8 +73,8 @@ class ClipBoardTests: BaseTestCase {
         waitForNoExistence(app.staticTexts["Fennec pasted from XCUITests-Runner"])
         waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.shareButton], timeout: 10)
         app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].tap()
-        waitForExistence(app.buttons["Copy"], timeout: 15)
-        app.buttons["Copy"].tap()
+        waitForExistence(app.cells["Copy"], timeout: 15)
+        app.cells["Copy"].tap()
 
         checkCopiedUrl()
         waitForNoExistence(app.staticTexts["XCUITests-Runner pasted from Fennec"])

--- a/Tests/XCUITests/DownloadFilesTests.swift
+++ b/Tests/XCUITests/DownloadFilesTests.swift
@@ -141,8 +141,7 @@ class DownloadFilesTests: BaseTestCase {
             // Workaround to close the context menu.
             // XCUITest does not allow me to click the greyed out portion of the app.
             app.otherElements["ActivityListView"].cells["XCElementSnapshotPrivilegedValuePlaceholder"].firstMatch.tap()
-            waitForExistence(app.alerts["Unable to Import Clinical Documents"], timeout: TIMEOUT)
-            app.buttons["OK"].tap()
+            app.navigationBars["Add Tag"].buttons["Done"].tap()
         }
      }
 

--- a/Tests/XCUITests/JumpBackInTests.swift
+++ b/Tests/XCUITests/JumpBackInTests.swift
@@ -6,13 +6,14 @@ import XCTest
 
 class JumpBackInTests: BaseTestCase {
     func closeKeyboard() {
+        waitForExistence(app.buttons["urlBar-cancel"])
+        navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
     }
 
     func scrollDown() {
         if !isTablet {
-            app.collectionViews["FxCollectionView"].swipeUp()
             while app.staticTexts["Switch Your Default Browser"].exists || app.buttons["Learn How"].exists {
                 app.collectionViews["FxCollectionView"].swipeUp()
             }
@@ -21,8 +22,6 @@ class JumpBackInTests: BaseTestCase {
 
     override func setUp() {
         super.setUp()
-
-        closeKeyboard()
 
         // "Jump Back In" is enabled by default. See Settings -> Homepage
         navigator.goto(HomeSettings)

--- a/Tests/XCUITests/NavigationTest.swift
+++ b/Tests/XCUITests/NavigationTest.swift
@@ -311,16 +311,16 @@ class NavigationTest: BaseTestCase {
 
     func testShareLink() {
         longPressLinkOptions(optionSelected: "Share Link")
-        waitForExistence(app.buttons["Copy"], timeout: TIMEOUT)
-        XCTAssertTrue(app.buttons["Copy"].exists, "The share menu is not shown")
+        waitForExistence(app.cells["Copy"], timeout: TIMEOUT)
+        XCTAssertTrue(app.cells["Copy"].exists, "The share menu is not shown")
     }
 
     func testShareLinkPrivateMode() {
         navigator.nowAt(NewTabScreen)
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         longPressLinkOptions(optionSelected: "Share Link")
-        waitForExistence(app.buttons["Copy"], timeout: TIMEOUT)
-        XCTAssertTrue(app.buttons["Copy"].exists, "The share menu is not shown")
+        waitForExistence(app.cells["Copy"], timeout: TIMEOUT)
+        XCTAssertTrue(app.cells["Copy"].exists, "The share menu is not shown")
     }
 
     // Smoketest

--- a/Tests/XCUITests/PhotonActionSheetTest.swift
+++ b/Tests/XCUITests/PhotonActionSheetTest.swift
@@ -36,7 +36,7 @@ class PhotonActionSheetTest: BaseTestCase {
         app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].tap()
 
         // Wait to see the Share options sheet
-        waitForExistence(app.buttons["Copy"], timeout: 10)
+        waitForExistence(app.cells["Copy"], timeout: 10)
     }
 
     // Smoketest
@@ -48,7 +48,7 @@ class PhotonActionSheetTest: BaseTestCase {
 
         // Wait to see the Share options sheet
         if iPad() {
-            waitForExistence(app.buttons["Copy"], timeout: 15)
+            waitForExistence(app.cells["Copy"], timeout: 15)
         } else {
             waitForExistence(app.buttons["Close"], timeout: 15)
         }
@@ -60,8 +60,8 @@ class PhotonActionSheetTest: BaseTestCase {
         waitUntilPageLoad()
         waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.shareButton], timeout: 10)
         app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].tap()
-        waitForExistence(app.buttons["Send Link to Device"], timeout: 10)
-        app.buttons["Send Link to Device"].tap()
+        waitForExistence(app.cells["Send Link to Device"], timeout: 10)
+        app.cells["Send Link to Device"].tap()
         waitForExistence(app.buttons[AccessibilityIdentifiers.ShareTo.HelpView.doneButton])
         XCTAssertTrue(app.staticTexts["You are not signed in to your Firefox Account."].exists)
     }
@@ -99,7 +99,7 @@ class PhotonActionSheetTest: BaseTestCase {
 
         // This is not ideal but only way to get the element on iPhone 8
         // for iPhone 11, that would be boundBy: 2
-        waitForExistence(app.collectionViews.buttons["Copy"], timeout: TIMEOUT)
+        waitForExistence(app.collectionViews.cells["Copy"], timeout: TIMEOUT)
         waitForExistence(app.collectionViews.scrollViews.cells["XCElementSnapshotPrivilegedValuePlaceholder"].firstMatch, timeout: TIMEOUT)
         var  fennecElement = app.collectionViews.scrollViews.cells.element(boundBy: 2)
         if iPad() {

--- a/Tests/XCUITests/PocketTests.swift
+++ b/Tests/XCUITests/PocketTests.swift
@@ -12,7 +12,11 @@ class PocketTest: BaseTestCase {
 
         // There should be two stories on iPhone and three on iPad
         let numPocketStories = app.collectionViews.containing(.cell, identifier: AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell).children(matching: .cell).count-1
-        XCTAssertEqual(numPocketStories, 8)
+         if iPad() {
+            XCTAssertEqual(numPocketStories, 15)
+        } else {
+            XCTAssertEqual(numPocketStories, 8)
+        }
         // Disable Pocket
         navigator.performAction(Action.TogglePocketInNewTab)
 

--- a/Tests/XCUITests/SaveLoginsTests.swift
+++ b/Tests/XCUITests/SaveLoginsTests.swift
@@ -90,15 +90,11 @@ class SaveLoginTest: BaseTestCase {
         waitForExistence(app.tables["Login List"])
         XCTAssertTrue(app.staticTexts[domain].exists)
         // XCTAssertTrue(app.staticTexts[domainSecondLogin].exists)
-        if processIsTranslatedStr() == m1Rosetta {
-            XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList + 2)
+       // Workaround for Bitrise specific issue. "vagrant" user is used in Bitrise.
+        if (ProcessInfo.processInfo.environment["HOME"]!).contains(String("vagrant")) {
+            XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList + 1)
         } else {
-            // Change to 3 entries for iPhone since the hostname is not saved and only one entry appears
-            if iPad() {
-                XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList + 2)
-            } else {
-                XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList + 1)
-            }
+            XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList + 2)
         }
     }
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -44,13 +44,13 @@ workflows:
             echo "-- build-for-testing --"
             mkdir DerivedData
             xcodebuild -resolvePackageDependencies -onlyUsePackageVersionsFromResolvedFile
-            xcodebuild "-project" "/Users/vagrant/git/Client.xcodeproj" "-scheme" "Fennec" -configuration "Fennec" "CODE_SIGNING_ALLOWED=NO" -sdk "iphonesimulator" "-destination" "platform=iOS Simulator,name=iPhone 14,OS=latest" "COMPILER_INDEX_STORE_ENABLE=NO" "build-for-testing" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" -derivedDataPath "/Users/vagrant/git/DerivedData" | xcpretty | tee xcodebuild_fennec.log
+            xcodebuild "-project" "/Users/vagrant/git/Client.xcodeproj" "-scheme" "Fennec" -configuration "Fennec" "CODE_SIGNING_ALLOWED=NO" -sdk "iphonesimulator" "-destination" "platform=iOS Simulator,name=iPhone 14,OS=16.4" "COMPILER_INDEX_STORE_ENABLE=NO" "build-for-testing" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" -derivedDataPath "/Users/vagrant/git/DerivedData" | xcpretty | tee xcodebuild_fennec.log
     - xcode-test-without-building@0:
         inputs:
-        - destination: platform=iOS Simulator,name=iPhone 14 Plus,OS=latest
+        - destination: platform=iOS Simulator,name=iPhone 14 Plus,OS=16.4
         - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO"
             "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
-        - xctestrun: "/Users/vagrant/git/DerivedData/Build/Products/Fennec_UnitTest_iphonesimulator16.1-x86_64.xctestrun"
+        - xctestrun: "/Users/vagrant/git/DerivedData/Build/Products/Fennec_UnitTest_iphonesimulator16.4-x86_64.xctestrun"
         - maximum_test_repetitions: 2
     - script@1.1:
         title: Compress Derived Data
@@ -69,10 +69,10 @@ workflows:
             "$BITRISE_SOURCE_DIR/Tests/Smoketest3.xctestplan" \
             "$BITRISE_SOURCE_DIR/Tests/Smoketest4.xctestplan" \
             "$BITRISE_SOURCE_DIR/xcodebuild.log" \
-            "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Fennec_SmokeXCUITests_iphonesimulator16.1-x86_64.xctestrun" \
-            "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Fennec_Smoketest2_iphonesimulator16.1-x86_64.xctestrun" \
-            "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Fennec_Smoketest3_iphonesimulator16.1-x86_64.xctestrun" \
-            "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Fennec_Smoketest4_iphonesimulator16.1-x86_64.xctestrun" \
+            "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Fennec_SmokeXCUITests_iphonesimulator16.4-x86_64.xctestrun" \
+            "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Fennec_Smoketest2_iphonesimulator16.4-x86_64.xctestrun" \
+            "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Fennec_Smoketest3_iphonesimulator16.4-x86_64.xctestrun" \
+            "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Fennec_Smoketest4_iphonesimulator16.4-x86_64.xctestrun" \
             "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Fennec-iphonesimulator/" \
             "$BITRISE_SOURCE_DIR/Tests/UnitTest.xctestplan" \
             "$BITRISE_SOURCE_DIR/Client/" \
@@ -141,8 +141,8 @@ workflows:
         - webhook_url: $WEBHOOK_SLACK_TOKEN_2
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x-ventura
-        machine_type_id: g2.8core
+        stack: osx-xcode-14.3.x-ventura
+        machine_type_id: g2-m1.8core
   build_and_test_1_SmokeTest2:
     before_run:
     - 1_git_clone_and_post_clone
@@ -171,18 +171,18 @@ workflows:
         run_if: '{{getenv "RUN_UI_TESTS" | eq "Run_UI_Tests"}}'
         title: UI Smoketest2
         inputs:
-        - destination: platform=iOS Simulator,name=iPhone 14 Plus,OS=latest
+        - destination: platform=iOS Simulator,name=iPhone 14 Plus,OS=16.4
         - xcodebuild_options: '"-derivedDataPath" "/Users/vagrant/git/DerivedData" "COMPILER_INDEX_STORE_ENABLE=NO"
             "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
-        - xctestrun: "Users/vagrant/git/DerivedData/Build/Products/Fennec_Smoketest2_iphonesimulator16.1-x86_64.xctestrun"
+        - xctestrun: "Users/vagrant/git/DerivedData/Build/Products/Fennec_Smoketest2_iphonesimulator16.4-x86_64.xctestrun"
     - deploy-to-bitrise-io@2.1.1:
         run_if: '{{getenv "RUN_UI_TESTS" | eq "Run_UI_Tests"}}'
         inputs:
         - pipeline_intermediate_files: '$BITRISE_XCRESULT_PATH:BITRISE_UITESTS_2_XCRESULT_PATH'
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x-ventura
-        machine_type_id: g2.4core
+        stack: osx-xcode-14.3.x-ventura
+        machine_type_id: g2-m1.8core
   build_and_test_2_SmokeTest:
     before_run:
     - 1_git_clone_and_post_clone
@@ -222,7 +222,7 @@ workflows:
             mv ./Users/vagrant/git/DerivedData .
             ls -la
             echo "-- test-without-building --"
-            xcodebuild -resultBundlePath "xcodebuild.xcresult" -derivedDataPath "/Users/vagrant/git/DerivedData" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" test-without-building -xctestrun "/Users/vagrant/git/DerivedData/Build/Products/Fennec_SmokeXCUITests_iphonesimulator16.1-x86_64.xctestrun"
+            xcodebuild -resultBundlePath "xcodebuild.xcresult" -derivedDataPath "/Users/vagrant/git/DerivedData" -destination "platform=iOS Simulator,name=iPhone 14,OS=16.4" test-without-building -xctestrun "/Users/vagrant/git/DerivedData/Build/Products/Fennec_SmokeXCUITests_iphonesimulator16.4-x86_64.xctestrun"
     - custom-test-results-export@0:
         run_if: '{{getenv "RUN_UI_TESTS" | eq "Run_UI_Tests"}}'
         inputs:
@@ -232,8 +232,8 @@ workflows:
         run_if: '{{getenv "RUN_UI_TESTS" | eq "Run_UI_Tests"}}'
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x-ventura
-        machine_type_id: g2.4core
+        stack: osx-xcode-14.3.x-ventura
+        machine_type_id: g2-m1.8core
   build_and_test_3_SmokeTest3:
     before_run:
     - 1_git_clone_and_post_clone
@@ -273,7 +273,7 @@ workflows:
             mv ./Users/vagrant/git/DerivedData .
             ls -la
             echo "-- test-without-building --"
-            xcodebuild -resultBundlePath "xcodebuild.xcresult" -derivedDataPath "/Users/vagrant/git/DerivedData" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" test-without-building -xctestrun "/Users/vagrant/git/DerivedData/Build/Products/Fennec_Smoketest3_iphonesimulator16.1-x86_64.xctestrun"
+            xcodebuild -resultBundlePath "xcodebuild.xcresult" -derivedDataPath "/Users/vagrant/git/DerivedData" -destination "platform=iOS Simulator,name=iPhone 14,OS=16.4" test-without-building -xctestrun "/Users/vagrant/git/DerivedData/Build/Products/Fennec_Smoketest3_iphonesimulator16.4-x86_64.xctestrun"
     - custom-test-results-export@0:
         run_if: '{{getenv "RUN_UI_TESTS" | eq "Run_UI_Tests"}}'
         inputs:
@@ -283,8 +283,8 @@ workflows:
         run_if: '{{getenv "RUN_UI_TESTS" | eq "Run_UI_Tests"}}'
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x-ventura
-        machine_type_id: g2.4core
+        stack: osx-xcode-14.3.x-ventura
+        machine_type_id: g2-m1.8core
   build_and_test_4_SmokeTest4:
     before_run:
     - 1_git_clone_and_post_clone
@@ -316,18 +316,18 @@ workflows:
         run_if: '{{getenv "RUN_UI_TESTS" | eq "Run_UI_Tests"}}'
         title: UI Smoketest4
         inputs:
-        - destination: platform=iOS Simulator,name=iPhone 14 Plus,OS=latest
+        - destination: platform=iOS Simulator,name=iPhone 14 Plus,OS=16.4
         - xcodebuild_options: '"-derivedDataPath" "/Users/vagrant/git/DerivedData" "COMPILER_INDEX_STORE_ENABLE=NO"
             "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
-        - xctestrun: "Users/vagrant/git/DerivedData/Build/Products/Fennec_Smoketest4_iphonesimulator16.1-x86_64.xctestrun"
+        - xctestrun: "Users/vagrant/git/DerivedData/Build/Products/Fennec_Smoketest4_iphonesimulator16.4-x86_64.xctestrun"
     - deploy-to-bitrise-io@2:
         run_if: '{{getenv "RUN_UI_TESTS" | eq "Run_UI_Tests"}}'
         inputs:
         - pipeline_intermediate_files: '$BITRISE_XCRESULT_PATH:BITRISE_UITESTS_4_XCRESULT_PATH'
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x-ventura
-        machine_type_id: g2.4core
+        stack: osx-xcode-14.3.x-ventura
+        machine_type_id: g2-m1.8core
   send_slack_notification:
     steps:
     - slack@3.1:
@@ -740,7 +740,7 @@ workflows:
         run_if: '{{getenv "NEW_XCODE_VERSION" | eq "New_Version_Found" | or (getenv "RUN_ALL_STEPS" | eq "Run_All_Steps")}}'
         inputs:
         - scheme: Fennec
-        - destination: platform=iOS Simulator,name=iPhone 14,OS=latest
+        - destination: platform=iOS Simulator,name=iPhone 14,OS=16.4
     - deploy-to-bitrise-io@1.9: {}
     - cache-push@2.4: {}
     - slack@3.1:
@@ -753,8 +753,8 @@ workflows:
     description: This Workflow is to build the app using latest xcode available in Bitrise
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x-ventura
-        machine_type_id: g2.4core
+        stack: osx-xcode-14.3.x-ventura
+        machine_type_id: g2-m1.8core
   RunAllXCUITests:
     steps: []
     after_run:
@@ -765,8 +765,8 @@ workflows:
     - 5_deploy_and_slack
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x-ventura
-        machine_type_id: g2.4core
+        stack: osx-xcode-14.3.x-ventura
+        machine_type_id: g2-m1.8core
   RunSmokeXCUITestsiPad:
     steps:
     - xcode-build-for-simulator@0.12:
@@ -778,21 +778,21 @@ workflows:
         inputs:
         - scheme: Fennec_Enterprise_XCUITests
         - test_plan: "SmokeXCUITests"
-        - destination: platform=iOS Simulator,name=iPad Pro (12.9-inch) (5th generation),OS=latest
+        - destination: platform=iOS Simulator,name=iPad Pro (12.9-inch) (5th generation),OS=16.4
         description: This Workflow is to run SmokeTest on iPad simulator device
     - xcode-test@4.5:
         is_always_run: true
         inputs:
         - scheme: Fennec_Enterprise_XCUITests
         - test_plan: "Smoketest2"
-        - destination: platform=iOS Simulator,name=iPad Pro (12.9-inch) (5th generation),OS=latest
+        - destination: platform=iOS Simulator,name=iPad Pro (12.9-inch) (5th generation),OS=16.4
         description: This Workflow is to run SmokeTest on iPad simulator device Smoketest2
     - xcode-test@4.5:
         is_always_run: true
         inputs:
         - scheme: Fennec_Enterprise_XCUITests
         - test_plan: "Smoketest3"
-        - destination: platform=iOS Simulator,name=iPad Pro (12.9-inch) (5th generation),OS=latest
+        - destination: platform=iOS Simulator,name=iPad Pro (12.9-inch) (5th generation),OS=16.4
         description: This Workflow is to run SmokeTest on iPad simulator device Smoketest3
     - xcode-test@4.5:
         is_always_run: true
@@ -803,8 +803,8 @@ workflows:
         description: This Workflow is to run SmokeTest on iPad simulator device Smoketest4
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x-ventura
-        machine_type_id: g2.4core
+        stack: osx-xcode-14.3.x-ventura
+        machine_type_id: g2-m1.8core
     before_run:
     - 1_git_clone_and_post_clone
     - 2_certificate_and_profile
@@ -826,8 +826,8 @@ workflows:
         is_always_run: true
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x-ventura
-        machine_type_id: g2.4core
+        stack: osx-xcode-14.3.x-ventura
+        machine_type_id: g2-m1.8core
     before_run:
     - 1_git_clone_and_post_clone
     - 2_certificate_and_profile
@@ -931,8 +931,8 @@ workflows:
       This Workflow is to run L10n tests in one locale and then share the bundle with the rest of the builds
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x-ventura
-        machine_type_id: g2.4core
+        stack: osx-xcode-14.3.x-ventura
+        machine_type_id: g2-m1.8core
 
   L10nScreenshotsTests:
     steps:
@@ -993,8 +993,8 @@ workflows:
       This Workflow is to run L10n tests for all locales
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x-ventura
-        machine_type_id: g2.4core
+        stack: osx-xcode-14.3.x-ventura
+        machine_type_id: g2-m1.8core
 
   RunUnitTests:
     steps:
@@ -1032,8 +1032,8 @@ workflows:
       in master
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x-ventura
-        machine_type_id: g2.8core
+        stack: osx-xcode-14.3.x-ventura
+        machine_type_id: g2-m1.8core
     before_run:
     - 1_git_clone_and_post_clone
     - 2_certificate_and_profile
@@ -1058,8 +1058,8 @@ workflows:
     description: This Workflow is to run tests UI TESTS
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x-ventura
-        machine_type_id: g2.8core
+        stack: osx-xcode-14.3.x-ventura
+        machine_type_id: g2-m1.8core
   SPM_Deploy_Prod_Beta:
     steps:
     - activate-ssh-key@4.1:
@@ -1184,8 +1184,8 @@ workflows:
     description: This step is to build, archive and upload Firefox Release and Beta
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x-ventura
-        machine_type_id: g2.8core
+        stack: osx-xcode-14.3.x-ventura
+        machine_type_id: g2-m1.8core
   SPM_Deploy_Beta_Only:
     steps:
     - activate-ssh-key@4.1:
@@ -1281,8 +1281,8 @@ workflows:
     description: This step is to build, archive and upload Firefox Release and Beta
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x-ventura
-        machine_type_id: g2.8core
+        stack: osx-xcode-14.3.x-ventura
+        machine_type_id: g2-m1.8core
   SPM_Nightly_Beta_Only:
     steps:
     - activate-ssh-key@4.1:
@@ -1379,8 +1379,8 @@ workflows:
     description: This step is to build, archive and upload Firefox Release and Beta
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x-ventura
-        machine_type_id: g2.8core
+        stack: osx-xcode-14.3.x-ventura
+        machine_type_id: g2-m1.8core
   perfherder-test:
     steps:
     - cache-pull@2.1:
@@ -1431,8 +1431,8 @@ workflows:
     - deploy-to-bitrise-io@1.9: {}
     meta:
       bitrise.io:
-        stack: osx-xcode-14.1.x-ventura
-        machine_type_id: g2.4core
+        stack: osx-xcode-14.3.x-ventura
+        machine_type_id: g2-m1.8core
     before_run:
     - 1_git_clone_and_post_clone
     - 2_certificate_and_profile
@@ -1458,7 +1458,7 @@ app:
 meta:
   bitrise.io:
     stack: osx-xcode-14.1.x-ventura
-    machine_type_id: g2.4core
+    machine_type_id: g2-m1.8core
 
 trigger_map:
 - push_branch: main

--- a/test-fixtures/generate-metrics.sh
+++ b/test-fixtures/generate-metrics.sh
@@ -5,7 +5,7 @@ set -e
 BUILD_LOG_FILE="$1"
 TYPE_LOG_FILE="$2"
 THRESHOLD_UNIT_TEST=14
-THRESHOLD_XCUITEST=25
+THRESHOLD_XCUITEST=28
 
 WARNING_COUNT=`egrep '^(\/.+:[0-9+:[0-9]+:.|warning:|⚠️|ld: warning:|<unknown>:0: warning:|fatal|===)' "$BUILD_LOG_FILE" | uniq | wc -l`
 

--- a/test-fixtures/generate-metrics.sh
+++ b/test-fixtures/generate-metrics.sh
@@ -5,7 +5,7 @@ set -e
 BUILD_LOG_FILE="$1"
 TYPE_LOG_FILE="$2"
 THRESHOLD_UNIT_TEST=14
-THRESHOLD_XCUITEST=14
+THRESHOLD_XCUITEST=25
 
 WARNING_COUNT=`egrep '^(\/.+:[0-9+:[0-9]+:.|warning:|⚠️|ld: warning:|<unknown>:0: warning:|fatal|===)' "$BUILD_LOG_FILE" | uniq | wc -l`
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-446)

### Description
We may need the `release/v114` branch to run after the Intel based Bitrise stacks are deprecated. Let me backport the changes related to XCode 14.3 and M1 in this PR.

This PR contains the cherry pick from MTE-446 and MTE-968. The parallel testing is not enable here yet.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
