### PR TITLE
Bugfix FXIOS-6451 [v115] ZoomPageBar shadow's overlays UrlBar

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -282,6 +282,7 @@ class BrowserViewController: UIViewController {
         updateHeaderConstraints()
         toolbar.setNeedsDisplay()
         urlBar.updateConstraints()
+        zoomPageBar?.updateConstraints()
     }
 
     func shouldShowToolbarForTraitCollection(_ previousTraitCollection: UITraitCollection) -> Bool {

--- a/Client/Frontend/Browser/TabScrollController.swift
+++ b/Client/Frontend/Browser/TabScrollController.swift
@@ -41,6 +41,16 @@ class TabScrollingController: NSObject, FeatureFlaggable {
     weak var bottomContainer: BaseAlphaStackView?
     weak var delegate: TabScrollingControllerDelegate?
 
+    private var zoomPageBar: ZoomPageBar? {
+        var bar: ZoomPageBar?
+        bottomContainer?.subviews.forEach({
+            if $0 is ZoomPageBar {
+                bar = $0 as! ZoomPageBar
+            }
+        })
+        return bar
+    }
+
     var overKeyboardContainerConstraint: Constraint?
     var bottomContainerConstraint: Constraint?
     var headerTopConstraint: Constraint?
@@ -374,12 +384,20 @@ extension TabScrollingController: UIGestureRecognizerDelegate {
 }
 
 extension TabScrollingController: UIScrollViewDelegate {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        zoomPageBar?.updateGradientViewBottomConstraint(overKeyboardContainerOffset)
+    }
+
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
         guard !tabIsLoading(), !isBouncingAtBottom(), isAbleToScroll else { return }
 
         if decelerate || (toolbarState == .animating && !decelerate) {
             if scrollDirection == .up {
                 showToolbars(animated: true)
+                // Make sure that tool bar is visible to restore the constraint of the zoomBar's gradient view to 0.
+                if toolbarState == .visible {
+                    zoomPageBar?.updateGradientViewBottomConstraint(0)
+                }
             } else if scrollDirection == .down {
                 hideToolbars(animated: true)
             }

--- a/Client/Frontend/Browser/ZoomPageBar.swift
+++ b/Client/Frontend/Browser/ZoomPageBar.swift
@@ -208,6 +208,12 @@ class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable, SearchBarLocationProv
         gradient.frame = gradientView.bounds
     }
 
+    func updateGradientViewBottomConstraint(_ constant: CGFloat) {
+        if searchBarPosition == .bottom && traitCollection.userInterfaceIdiom == .phone {
+            gradientViewBottomConstraint.constant = constant - UIConstants.UrlBarHeight
+        }
+    }
+
     override func updateConstraints() {
         super.updateConstraints()
         if traitCollection.userInterfaceIdiom == .phone {

--- a/Client/Frontend/Browser/ZoomPageBar.swift
+++ b/Client/Frontend/Browser/ZoomPageBar.swift
@@ -11,7 +11,7 @@ protocol ZoomPageBarDelegate: AnyObject {
     func didChangeZoomLevel()
 }
 
-class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
+class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable, SearchBarLocationProvider {
     private struct UX {
         static let leadingTrailingPadding: CGFloat = 20
         static let topBottomPadding: CGFloat = 18
@@ -31,6 +31,7 @@ class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
         static let upperZoomLimit: CGFloat = 2.0
         static let zoomInButtonInsets = UIEdgeInsets(top: 6, left: 0, bottom: 6, right: 12)
         static let zoomOutButtonInsets = UIEdgeInsets(top: 6, left: 12, bottom: 6, right: 0)
+        static let gradientViewBottomAnchorConstant: CGFloat = 0.0
     }
 
     weak var delegate: ZoomPageBarDelegate?
@@ -38,6 +39,7 @@ class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
     private var stepperCompactConstraints = [NSLayoutConstraint]()
     private var stepperDefaultConstraints = [NSLayoutConstraint]()
     private var gradientViewHeightConstraint = NSLayoutConstraint()
+    private var gradientViewBottomConstraint = NSLayoutConstraint()
 
     private let tab: Tab
 
@@ -186,8 +188,14 @@ class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
         if traitCollection.userInterfaceIdiom == .pad {
             gradientView.topAnchor.constraint(equalTo: bottomAnchor).isActive = true
         } else {
-            gradientView.bottomAnchor.constraint(equalTo: topAnchor).isActive = true
+            setupGradientViewBottomConstraintPhoneLayout()
         }
+    }
+
+    private func setupGradientViewBottomConstraintPhoneLayout() {
+        gradientViewBottomConstraint.isActive = false
+        gradientViewBottomConstraint = gradientView.bottomAnchor.constraint(equalTo: topAnchor, constant: isBottomSearchBar ? -UIConstants.UrlBarHeight : UX.gradientViewBottomAnchorConstant)
+        gradientViewBottomConstraint.isActive = true
     }
 
     private func remakeGradientViewHeightConstraint() {
@@ -198,6 +206,13 @@ class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
         gradientViewHeightConstraint = gradientView.heightAnchor.constraint(equalToConstant: viewPortHeight * 0.2)
         gradientViewHeightConstraint.isActive = true
         gradient.frame = gradientView.bounds
+    }
+
+    override func updateConstraints() {
+        super.updateConstraints()
+        if traitCollection.userInterfaceIdiom == .phone {
+            setupGradientViewBottomConstraintPhoneLayout()
+        }
     }
 
     private func updateZoomLabel() {

--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -24,6 +24,7 @@ public struct UIConstants {
     static let TopToolbarHeightMax: CGFloat = 75
     static var ToolbarHeight: CGFloat = 46
     static let ZoomPageBarHeight: CGFloat = 54
+    static let UrlBarHeight: CGFloat = 52
 
     static let SystemBlueColor = UIColor.Photon.Blue40
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6451)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14506)

### Description
Fixed ZoomPageBar shadow's overlays UrlBarView when the position of the UrlBar is set to bottom

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods

### UrlBar position bottom

![Simulator Screenshot - iPhone 14 Pro - 2023-05-30 at 10 27 59](https://github.com/mozilla-mobile/firefox-ios/assets/55580351/b30336aa-43ec-4ebb-96d1-cd298ed16ae7)

### UrlBar position top

![Simulator Screenshot - iPhone 14 Pro - 2023-05-30 at 10 27 29](https://github.com/mozilla-mobile/firefox-ios/assets/55580351/5743cc45-e91b-4990-8e5f-c2e8ef72c51e)
