### PR TITLE
Bugfix FXIOS-5908 [v115] The data in Passwords section can be seen

### DIFF
--- a/Client/Frontend/AuthenticationManager/SensitiveViewController.swift
+++ b/Client/Frontend/AuthenticationManager/SensitiveViewController.swift
@@ -56,8 +56,12 @@ extension SensitiveViewController {
     private func installBlurredOverlay() {
         if blurredOverlay == nil {
             if let snapshot = view.screenshot() {
-                let blurredSnapshot = snapshot.applyBlur(withRadius: 10, blurType: BOXFILTER, tintColor: UIColor(white: 1, alpha: 0.3), saturationDeltaFactor: 1.8, maskImage: nil)
-                let blurredOverlay = UIImageView(image: blurredSnapshot)
+                let blurredSnapshot = snapshot.applyBlur(withRadius: 10,
+                                                         blurType: BOXFILTER,
+                                                         tintColor: UIColor(white: 1, alpha: 0.3),
+                                                         saturationDeltaFactor: 1.8,
+                                                         maskImage: nil)
+                let blurredOverlay: UIImageView = .build { $0.image = blurredSnapshot }
                 self.blurredOverlay = blurredOverlay
                 view.addSubview(blurredOverlay)
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5908)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13448)

### Description
This PR solve the problem where the data in the Passwords section can be seen without unlocking the phone 
(with Face ID)

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
