### PR TITLE
Bugfix FXIOS-6520 [v115] Keyboard is not raised when opening a new tab from app QuickAction when Coordinator feature flag is enabled

### DIFF
--- a/Client/Application/SceneDelegate.swift
+++ b/Client/Application/SceneDelegate.swift
@@ -70,7 +70,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             }
 
             if let shortcut = connectionOptions.shortcutItem,
-               let route = routeBuilder.makeRoute(shortcutItem: shortcut) {
+               let route = routeBuilder.makeRoute(shortcutItem: shortcut, tabSetting: NewTabAccessors.getNewTabPage(profile.prefs)) {
                 sceneCoordinator?.findAndHandle(route: route)
             }
         } else {
@@ -191,7 +191,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         completionHandler: @escaping (Bool) -> Void
     ) {
         if CoordinatorFlagManager.isCoordinatorEnabled {
-            guard let route = routeBuilder.makeRoute(shortcutItem: shortcutItem) else { return }
+            guard let route = routeBuilder.makeRoute(shortcutItem: shortcutItem, tabSetting: NewTabAccessors.getNewTabPage(profile.prefs)) else { return }
             sceneCoordinator?.findAndHandle(route: route)
         } else {
             QuickActionsImplementation().handleShortCutItem(

--- a/Client/Coordinators/Router/RouteBuilder.swift
+++ b/Client/Coordinators/Router/RouteBuilder.swift
@@ -165,16 +165,18 @@ struct RouteBuilder {
         return nil
     }
 
-    func makeRoute(shortcutItem: UIApplicationShortcutItem) -> Route? {
+    func makeRoute(shortcutItem: UIApplicationShortcutItem, tabSetting: NewTabPage) -> Route? {
         guard let shortcutTypeRaw = shortcutItem.type.components(separatedBy: ".").last,
               let shortcutType = DeeplinkInput.Shortcut(rawValue: shortcutTypeRaw)
         else { return nil }
 
+        let options: Set<Route.SearchOptions> = tabSetting != .homePage ? [.focusLocationField] : []
+
         switch shortcutType {
         case .newTab:
-            return .search(url: nil, isPrivate: false, options: [.focusLocationField])
+            return .search(url: nil, isPrivate: false, options: options)
         case .newPrivateTab:
-            return .search(url: nil, isPrivate: true, options: [.focusLocationField])
+            return .search(url: nil, isPrivate: true, options: options)
         case .openLastBookmark:
             if let urlToOpen = (shortcutItem.userInfo?[QuickActionInfos.tabURLKey] as? String)?.asURL {
                 return .search(url: urlToOpen, isPrivate: false, options: [.switchToNormalMode])

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1607,7 +1607,8 @@ class BrowserViewController: UIViewController {
         }
     }
 
-    func openURLInNewTab(_ url: URL?, isPrivate: Bool = false) {
+    @discardableResult
+    func openURLInNewTab(_ url: URL?, isPrivate: Bool = false) -> Tab {
         if let selectedTab = tabManager.selectedTab {
             screenshotHelper.takeScreenshot(selectedTab)
         }
@@ -1619,7 +1620,9 @@ class BrowserViewController: UIViewController {
         }
 
         switchToPrivacyMode(isPrivate: isPrivate)
-        tabManager.selectTab(tabManager.addTab(request, isPrivate: isPrivate))
+        let tab = tabManager.addTab(request, isPrivate: isPrivate)
+        tabManager.selectTab(tab)
+        return tab
     }
 
     func focusLocationTextField(forTab tab: Tab?, setSearchText searchText: String? = nil) {
@@ -1649,9 +1652,8 @@ class BrowserViewController: UIViewController {
         }
         openedUrlFromExternalSource = true
 
-        openURLInNewTab(nil, isPrivate: isPrivate)
-        let freshTab = tabManager.selectedTab
-        freshTab?.metadataManager?.updateTimerAndObserving(state: .newTab, isPrivate: freshTab?.isPrivate ?? false)
+        let freshTab = openURLInNewTab(nil, isPrivate: isPrivate)
+        freshTab.metadataManager?.updateTimerAndObserving(state: .newTab, isPrivate: freshTab.isPrivate)
         if focusLocationField {
             focusLocationTextField(forTab: freshTab, setSearchText: searchText)
         }

--- a/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -14,7 +14,8 @@ protocol ToolBarActionMenuDelegate: AnyObject {
     func updateToolbarState()
     func addBookmark(url: String, title: String?)
 
-    func openURLInNewTab(_ url: URL?, isPrivate: Bool)
+    @discardableResult
+    func openURLInNewTab(_ url: URL?, isPrivate: Bool) -> Tab
     func openNewTabFromMenu(focusLocationField: Bool, isPrivate: Bool)
 
     func showLibrary(panel: LibraryPanelType?)

--- a/Client/TabManagement/Tab.swift
+++ b/Client/TabManagement/Tab.swift
@@ -447,7 +447,6 @@ class Tab: NSObject {
             webView.accessibilityLabel = .WebViewAccessibilityLabel
             webView.allowsBackForwardNavigationGestures = true
             webView.allowsLinkPreview = true
-            
             // Allow Safari Web Inspector (requires toggle in Settings > Safari > Advanced).
             if #available(iOS 16.4, *) {
                 webView.isInspectable = true

--- a/Client/TabManagement/Tab.swift
+++ b/Client/TabManagement/Tab.swift
@@ -447,7 +447,6 @@ class Tab: NSObject {
             webView.accessibilityLabel = .WebViewAccessibilityLabel
             webView.allowsBackForwardNavigationGestures = true
             webView.allowsLinkPreview = true
-
             // Night mode enables this by toggling WKWebView.isOpaque, otherwise this has no effect.
             webView.backgroundColor = .black
 

--- a/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -503,7 +503,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         subject.browserViewController = mbvc
 
         // When
-        let route = routeBuilder.makeRoute(shortcutItem: shortcutItem)
+        let route = routeBuilder.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
         let result = subject.handle(route: route!)
 
         // Then

--- a/Tests/ClientTests/Coordinators/ShortcutRouteTests.swift
+++ b/Tests/ClientTests/Coordinators/ShortcutRouteTests.swift
@@ -20,39 +20,39 @@ final class ShortcutRouteTests: XCTestCase {
 
     func testNewTabShortcut() {
         let shortcutItem = UIApplicationShortcutItem(type: "com.example.app.NewTab", localizedTitle: "New Tab")
-        let route = routeBuilder.makeRoute(shortcutItem: shortcutItem)
+        let route = routeBuilder.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
         XCTAssertEqual(route, .search(url: nil, isPrivate: false, options: [.focusLocationField]))
     }
 
     func testNewPrivateTabShortcut() {
         let shortcutItem = UIApplicationShortcutItem(type: "com.example.app.NewPrivateTab", localizedTitle: "New Private Tab")
-        let route = routeBuilder.makeRoute(shortcutItem: shortcutItem)
+        let route = routeBuilder.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
         XCTAssertEqual(route, .search(url: nil, isPrivate: true, options: [.focusLocationField]))
     }
 
     func testOpenLastBookmarkShortcutWithValidUrl() {
         let userInfo = [QuickActionInfos.tabURLKey: "https://www.example.com" as NSSecureCoding]
         let shortcutItem = UIApplicationShortcutItem(type: "com.example.app.OpenLastBookmark", localizedTitle: "Open Last Bookmark", localizedSubtitle: nil, icon: nil, userInfo: userInfo)
-        let route = routeBuilder.makeRoute(shortcutItem: shortcutItem)
+        let route = routeBuilder.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
         XCTAssertEqual(route, .search(url: URL(string: "https://www.example.com"), isPrivate: false, options: [.switchToNormalMode]))
     }
 
     func testOpenLastBookmarkShortcutWithInvalidUrl() {
         let userInfo = [QuickActionInfos.tabURLKey: "not a url" as NSSecureCoding]
         let shortcutItem = UIApplicationShortcutItem(type: "com.example.app.OpenLastBookmark", localizedTitle: "Open Last Bookmark", localizedSubtitle: nil, icon: nil, userInfo: userInfo)
-        let route = routeBuilder.makeRoute(shortcutItem: shortcutItem)
+        let route = routeBuilder.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
         XCTAssertNil(route)
     }
 
     func testQRCodeShortcut() {
         let shortcutItem = UIApplicationShortcutItem(type: "com.example.app.QRCode", localizedTitle: "QR Code")
-        let route = routeBuilder.makeRoute(shortcutItem: shortcutItem)
+        let route = routeBuilder.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
         XCTAssertEqual(route, .action(action: .showQRCode))
     }
 
     func testInvalidShortcut() {
         let shortcutItem = UIApplicationShortcutItem(type: "invalid shortcut", localizedTitle: "Invalid Shortcut")
-        let route = routeBuilder.makeRoute(shortcutItem: shortcutItem)
+        let route = routeBuilder.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
         XCTAssertNil(route)
     }
 }

--- a/Tests/ClientTests/Mocks/MockBrowserViewController.swift
+++ b/Tests/ClientTests/Mocks/MockBrowserViewController.swift
@@ -80,11 +80,12 @@ class MockBrowserViewController: BrowserViewController {
         showLibraryCount += 1
     }
 
-    override func openURLInNewTab(_ url: URL?, isPrivate: Bool) {
+    override func openURLInNewTab(_ url: URL?, isPrivate: Bool) -> Tab {
         openURLInNewTabCalled = true
         openURLInNewTabURL = url
         openURLInNewTabIsPrivate = isPrivate
         openURLInNewTabCount += 1
+        return Tab(profile: MockProfile(), configuration: .init())
     }
 
     override func handleQRCode() {


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6520)

### Description
Creating and then selecting the tab is done async and it takes a split second to complete. Because we immediately access the selected tab, we end up with an older tab which cannot be focused. By passing the tab reference that was created we can be sure it's the exact tab that we want to focus.

Note: it's an intermediate fix until we can move the tab method to be fully async.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
