### PR TITLE
Bugfix FXIOS-6538 [v115] The url Bar height should not be adjusted

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -891,7 +891,7 @@ class BrowserViewController: UIViewController {
         // need to account for inset and remove it when keyboard is showing
         let showToolBar = shouldShowToolbarForTraitCollection(traitCollection)
         let isKeyboardShowing = keyboardState != nil && keyboardState?.intersectionHeightForView(view) != 0
-        if !showToolBar && isBottomSearchBar && !isKeyboardShowing {
+        if !showToolBar, !isKeyboardShowing, isBottomSearchBar, zoomPageBar == nil {
             overKeyboardContainer.addBottomInsetSpacer(spacerHeight: UIConstants.BottomInset)
         } else {
             overKeyboardContainer.removeBottomInsetSpacer()


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6538)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14651)

### Description
This PR fixes the problem where the url Bar height is adjusted when Zoom Bar is on and the url bar is at the bottom, in landscape mode

### Video

https://github.com/mozilla-mobile/firefox-ios/assets/51127880/d04e4776-8b50-4cbd-83ac-ba54b8e6869e


### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
