### PR TITLE
Refactor FXIOS-6548 [v115] Clean up legacy theme colors that aren't used anymore

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2844,7 +2844,7 @@ extension BrowserViewController: TabTrayDelegate {
 }
 
 // MARK: Browser Chrome Theming
-extension BrowserViewController: NotificationThemeable {
+extension BrowserViewController: LegacyNotificationThemeable {
     func applyTheme() {
         guard self.isViewLoaded else { return }
         // TODO: Clean up after FXIOS-5109
@@ -2860,7 +2860,7 @@ extension BrowserViewController: NotificationThemeable {
         keyboardBackdrop?.backgroundColor = UIColor.legacyTheme.browser.background
         setNeedsStatusBarAppearanceUpdate()
 
-        (presentedViewController as? NotificationThemeable)?.applyTheme()
+        (presentedViewController as? LegacyNotificationThemeable)?.applyTheme()
 
         // Update the `background-color` of any blank webviews.
         let webViews = tabManager.tabs.compactMap({ $0.webView as? TabWebView })

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
@@ -194,7 +194,7 @@ extension BrowserViewController: ReaderModeBarViewDelegate {
                 let arrowDirection: UIPopoverArrowDirection = isBottomSearchBar ? .down : .up
                 let ySpacing = isBottomSearchBar ? -1 : UIConstants.ToolbarHeight
 
-                popoverPresentationController.backgroundColor = UIColor.Photon.White100
+                popoverPresentationController.backgroundColor = .white
                 popoverPresentationController.delegate = self
                 popoverPresentationController.sourceView = readerModeBar
                 popoverPresentationController.sourceRect = CGRect(

--- a/Client/Frontend/Browser/Tabs/InactiveTabs/InactiveTabHeader.swift
+++ b/Client/Frontend/Browser/Tabs/InactiveTabs/InactiveTabHeader.swift
@@ -18,7 +18,7 @@ enum ExpandButtonState {
     }
 }
 
-class InactiveTabHeader: UITableViewHeaderFooterView, NotificationThemeable, ReusableCell {
+class InactiveTabHeader: UITableViewHeaderFooterView, LegacyNotificationThemeable, ReusableCell {
     var state: ExpandButtonState? {
         willSet(state) {
             moreButton.setImage(state?.image, for: .normal)

--- a/Client/Frontend/Browser/Tabs/InactiveTabs/InactiveTabItemCell.swift
+++ b/Client/Frontend/Browser/Tabs/InactiveTabs/InactiveTabItemCell.swift
@@ -5,7 +5,7 @@
 import UIKit
 import SiteImageView
 
-class InactiveTabItemCell: UITableViewCell, NotificationThemeable, ReusableCell {
+class InactiveTabItemCell: UITableViewCell, LegacyNotificationThemeable, ReusableCell {
     private var viewModel: InactiveTabItemCellModel?
 
     private var selectedView: UIView = {

--- a/Client/Frontend/Browser/Tabs/TabTableViewHeader.swift
+++ b/Client/Frontend/Browser/Tabs/TabTableViewHeader.swift
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-class TabTableViewHeader: UITableViewHeaderFooterView, NotificationThemeable {
+class TabTableViewHeader: UITableViewHeaderFooterView, LegacyNotificationThemeable {
     private struct UX {
         static let titleHorizontalPadding: CGFloat = 15
         static let titleVerticalPadding: CGFloat = 6

--- a/Client/Frontend/Components/BaseContentStackView.swift
+++ b/Client/Frontend/Components/BaseContentStackView.swift
@@ -86,7 +86,7 @@ class BaseAlphaStackView: UIStackView, AlphaDimmable {
         self.layoutIfNeeded()
     }
 
-    // MARK: - NotificationThemeable
+    // MARK: - LegacyNotificationThemeable
 
     private func setupObservers() {
         NotificationCenter.default.addObserver(self, selector: #selector(handleNotifications), name: .DisplayThemeChanged, object: nil)
@@ -102,7 +102,7 @@ class BaseAlphaStackView: UIStackView, AlphaDimmable {
     }
 }
 
-extension BaseAlphaStackView: NotificationThemeable {
+extension BaseAlphaStackView: LegacyNotificationThemeable {
     func applyTheme() {
         let color = isClearBackground ? .clear : UIColor.legacyTheme.browser.background
         backgroundColor = color

--- a/Client/Frontend/Home/HomePanelType.swift
+++ b/Client/Frontend/Home/HomePanelType.swift
@@ -5,7 +5,7 @@
 import Foundation
 import Shared
 
-protocol HomePanel: NotificationThemeable {
+protocol HomePanel: LegacyNotificationThemeable {
     var homePanelDelegate: HomePanelDelegate? { get set }
 }
 

--- a/Client/Frontend/Library/HistoryPanel/GeneralizedTableView/SearchGroupedItemsViewController.swift
+++ b/Client/Frontend/Library/HistoryPanel/GeneralizedTableView/SearchGroupedItemsViewController.swift
@@ -200,7 +200,7 @@ extension SearchGroupedItemsViewController: UITableViewDelegate {
     }
 }
 
-extension SearchGroupedItemsViewController: NotificationThemeable {
+extension SearchGroupedItemsViewController: LegacyNotificationThemeable {
     func applyTheme() {
         let theme = BuiltinThemeName(rawValue: LegacyThemeManager.instance.current.name) ?? .normal
         if theme == .dark {

--- a/Client/Frontend/Library/LibraryPanelHelper.swift
+++ b/Client/Frontend/Library/LibraryPanelHelper.swift
@@ -14,7 +14,7 @@ protocol LibraryPanelDelegate: AnyObject {
     func libraryPanel(didSelectURLString url: String, visitType: VisitType)
 }
 
-protocol LibraryPanel: UIViewController, NotificationThemeable {
+protocol LibraryPanel: UIViewController, LegacyNotificationThemeable {
     var libraryPanelDelegate: LibraryPanelDelegate? { get set }
     var state: LibraryPanelMainState { get set }
     var bottomToolbarItems: [UIBarButtonItem] { get }

--- a/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
+++ b/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
@@ -174,7 +174,7 @@ extension RecentlyClosedTabsPanelSiteTableViewController: LibraryPanelContextMen
     }
 }
 
-extension RecentlyClosedTabsPanel: NotificationThemeable {
+extension RecentlyClosedTabsPanel: LegacyNotificationThemeable {
     func applyTheme() {
         tableViewController.tableView.reloadData()
     }

--- a/Client/Frontend/Theme/LegacyThemeManager/LegacyDarkTheme.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/LegacyDarkTheme.swift
@@ -4,191 +4,42 @@
 
 import UIKit
 
-// Convenience reference to these normal mode colors which are used in a few color classes.
-private let defaultBackground = UIColor.Photon.DarkGrey60
-private let defaultSeparator = UIColor.Photon.Grey60
-private let defaultTextAndTint = UIColor.Photon.Grey10
+private class DarkBrowserColor: BrowserColor {
+    override var background: UIColor { return UIColor.Photon.DarkGrey60 }
+}
 
 private class DarkTableViewColor: TableViewColor {
     override var rowBackground: UIColor { return UIColor.Photon.Grey70 } // layer2
-    override var rowText: UIColor { return defaultTextAndTint } // textPrimary
-    override var rowDetailText: UIColor { return UIColor.Photon.Grey30 }
-    override var disabledRowText: UIColor { return UIColor.Photon.Grey40 } // textDisabled
-    override var separator: UIColor { return UIColor.Photon.Grey60 }
-    override var headerBackground: UIColor { return UIColor.Photon.Grey80 }
-    override var headerTextLight: UIColor { return UIColor.Photon.Grey30 } // textSecondary
     override var headerTextDark: UIColor { return UIColor.Photon.Grey30 }
-    override var syncText: UIColor { return defaultTextAndTint }
-    override var accessoryViewTint: UIColor { return UIColor.Photon.Grey40 } // actionSecondary
     override var selectedBackground: UIColor { return UIColor.Custom.selectedHighlightDark }
+    override var rowText: UIColor { return UIColor.Photon.Grey10 } // textPrimary
+    override var disabledRowText: UIColor { return UIColor.Photon.Grey40 } // textDisabled
+    override var headerBackground: UIColor { return UIColor.Photon.Grey80 }
 }
-
-private class DarkActionMenuColor: ActionMenuColor {
-    override var foreground: UIColor { return UIColor.Photon.White100 }
-    override var iPhoneBackgroundBlurStyle: UIBlurEffect.Style { return UIBlurEffect.Style.dark }
-    override var iPhoneBackground: UIColor { return defaultBackground.withAlphaComponent(0.9) }
-    override var closeButtonBackground: UIColor { return defaultBackground }
-}
-
-private class DarkURLBarColor: URLBarColor {
-    override func textSelectionHighlight(_ isPrivate: Bool) -> TextSelectionHighlight {
-        let color = isPrivate ? UIColor.Defaults.MobilePrivatePurple : UIColor(rgb: 0x3d89cc)
-        return (labelMode: color.withAlphaComponent(0.25), textFieldMode: color)
-    }
-
-    override func activeBorder(_ isPrivate: Bool) -> UIColor {
-        return !isPrivate ? UIColor.Photon.Blue20A40 : UIColor.Defaults.MobilePrivatePurple
-    }
-}
-
-private class DarkBrowserColor: BrowserColor {
-    override var background: UIColor { return defaultBackground }
-    override var tint: UIColor { return defaultTextAndTint }
-}
-
-// The back/forward/refresh/menu button (bottom toolbar)
-private class DarkToolbarButtonColor: ToolbarButtonColor { }
 
 private class DarkTabTrayColor: TabTrayColor {
-    override var tabTitleText: UIColor { return defaultTextAndTint }
     override var tabTitleBlur: UIBlurEffect.Style { return UIBlurEffect.Style.dark }
-    override var background: UIColor { return UIColor.Photon.DarkGrey80 }
-    override var screenshotBackground: UIColor { return UIColor.Photon.DarkGrey30 }
-    override var cellBackground: UIColor { return defaultBackground }
-    override var toolbar: UIColor { return UIColor.Photon.Grey80 }
-    override var toolbarButtonTint: UIColor { return defaultTextAndTint }
-    override var cellCloseButton: UIColor { return defaultTextAndTint }
-    override var cellTitleBackground: UIColor { return UIColor.Photon.Grey70 }
-    override var faviconTint: UIColor { return UIColor.Photon.White100 }
-    override var searchBackground: UIColor { return UIColor.Photon.Grey60 }
-}
-
-private class DarkEnhancedTrackingProtectionMenuColor: EnhancedTrackingProtectionMenuColor {
-    override var defaultImageTints: UIColor { return defaultTextAndTint }
-    override var background: UIColor { return UIColor.Photon.DarkGrey80 }
-    override var sectionColor: UIColor { return UIColor.Photon.DarkGrey65 }
-    override var switchAndButtonTint: UIColor { return UIColor.Photon.Blue20 }
-    override var subtextColor: UIColor { return UIColor.Photon.LightGrey05 }
-    override var closeButtonColor: UIColor { return UIColor.Photon.DarkGrey65 }
 }
 
 private class DarkTopTabsColor: TopTabsColor {
     override var background: UIColor { UIColor.Photon.DarkGrey80 }
-    override var tabBackgroundSelected: UIColor { return UIColor.Photon.DarkGrey30 }
-    override var tabBackgroundUnselected: UIColor { return UIColor.Photon.Grey80 }
-    override var tabForegroundSelected: UIColor { return UIColor.Photon.Grey10 }
-    override var tabForegroundUnselected: UIColor { return UIColor.Photon.Grey40 }
-    override var closeButtonSelectedTab: UIColor { return tabForegroundSelected }
-    override var closeButtonUnselectedTab: UIColor { return tabForegroundUnselected }
-    override var separator: UIColor { return UIColor.Photon.Grey50 }
-    override var buttonTint: UIColor { return UIColor.Photon.Grey10 }
-}
-
-private class DarkTextFieldColor: TextFieldColor {
-    override var background: UIColor { return UIColor.Photon.DarkGrey80 }
-    override var backgroundInOverlay: UIColor { return self.background }
-
-    override var textAndTint: UIColor { return defaultTextAndTint }
-    override var separator: UIColor { return super.separator.withAlphaComponent(0.3) }
 }
 
 private class DarkHomePanelColor: HomePanelColor {
-    override var toolbarBackground: UIColor { return defaultBackground }
-    override var toolbarHighlight: UIColor { return UIColor.Photon.Blue20 }
-    override var toolbarTint: UIColor { return UIColor.Photon.Grey30 }
-    override var topSiteHeaderTitle: UIColor { return UIColor.Photon.White100 }
     override var panelBackground: UIColor { return UIColor.Photon.Grey80 }
-    override var separator: UIColor { return defaultSeparator }
-    override var border: UIColor { return UIColor.Photon.Grey60 }
-    override var buttonContainerBorder: UIColor { return separator }
-
-    override var welcomeScreenText: UIColor { return UIColor.Photon.Grey30 }
-    override var bookmarkIconBorder: UIColor { return UIColor.Photon.Grey30 }
-    override var bookmarkFolderBackground: UIColor { return UIColor.Photon.Grey80 }
-    override var bookmarkFolderText: UIColor { return UIColor.Photon.White100 }
-    override var bookmarkCurrentFolderText: UIColor { return UIColor.Photon.White100 }
-    override var bookmarkBackNavCellBackground: UIColor { return UIColor.Photon.Grey70 }
-
     override var activityStreamHeaderText: UIColor { return UIColor.Photon.LightGrey05 }
-    override var activityStreamHeaderButton: UIColor { return UIColor.Photon.Blue20 }
-    override var activityStreamCellTitle: UIColor { return UIColor.Photon.LightGrey05 }
-    override var activityStreamCellDescription: UIColor { return UIColor.Photon.LightGrey50 }
-
-    override var topSiteDomain: UIColor { return UIColor.Photon.LightGrey05 }
-    override var topSitePin: UIColor { return UIColor.Photon.LightGrey05 }
-    override var topSitesBackground: UIColor { return UIColor.Photon.DarkGrey60 }
-    override var topSitesContainerView: UIColor { return UIColor.Photon.DarkGrey40 }
-    override var emptyTopSitesBorder: UIColor { return .white }
-
-    override var shortcutBackground: UIColor { return UIColor.Photon.DarkGrey30 }
-    override var shortcutShadowColor: CGColor { return UIColor(red: 0.11, green: 0.11, blue: 0.13, alpha: 1.0).cgColor }
-
-    override var recentlySavedBookmarkCellBackground: UIColor { return UIColor.Photon.DarkGrey40 }
-    override var recentlySavedBookmarkImageBackground: UIColor { return UIColor.Photon.DarkGrey60 }
-    override var recentlySavedBookmarkTitle: UIColor { return UIColor.Photon.LightGrey10 }
-
-    override var recentlyVisitedCellGroupImage: UIColor { return .white }
-
-    override var downloadedFileIcon: UIColor { return UIColor.Photon.Grey30 }
-
-    override var historyHeaderIconsBackground: UIColor { return UIColor.clear }
-
-    override var readingListActive: UIColor { return UIColor.Photon.Grey10 }
-    override var readingListDimmed: UIColor { return UIColor.Photon.Grey40 }
-
-    override var searchSuggestionPillBackground: UIColor { return UIColor.Photon.Grey70 }
-    override var searchSuggestionPillForeground: UIColor { return defaultTextAndTint }
-
-    override var customizeHomepageButtonBackground: UIColor { return UIColor.Photon.DarkGrey50 }
-    override var customizeHomepageButtonText: UIColor { return UIColor.Photon.LightGrey10 }
-
-    override var sponsored: UIColor { return UIColor.Photon.LightGrey40 }
 }
 
 private class DarkSnackBarColor: SnackBarColor {
 // Use defaults
 }
 
-private class DarkGeneralColor: GeneralColor {
-    override var settingsTextPlaceholder: UIColor { return UIColor.Photon.Grey40 }
-    override var faviconBackground: UIColor { return UIColor.Photon.White100 }
-    override var passcodeDot: UIColor { return UIColor.Photon.Grey40 }
-    override var switchToggle: UIColor { return UIColor.Photon.Grey40 }
-}
-
-class DarkHomeTabBannerColor: HomeTabBannerColor {
-    override var backgroundColor: UIColor { return UIColor.Photon.DarkGrey40 }
-    override var textColor: UIColor { return UIColor.white }
-    override var closeButtonBackground: UIColor { return UIColor.Photon.Grey80 }
-    override var closeButton: UIColor { return UIColor.Photon.Grey20 }
-}
-
-class DarkOnboardingColor: OnboardingColor {
-    override var backgroundColor: UIColor { return UIColor.Photon.DarkGrey40 }
-    override var etpBackgroundColor: UIColor { return UIColor.Photon.DarkGrey40 }
-    override var etpTextColor: UIColor { return UIColor.white }
-    override var etpButtonColor: UIColor { return UIColor.Photon.Blue20 }
-}
-
-class DarkRemoteTabTrayColor: RemoteTabTrayColor {
-    override var background: UIColor { return UIColor.Photon.Grey70 }
-}
-
 class LegacyDarkTheme: LegacyNormalTheme {
     override var name: String { return BuiltinThemeName.dark.rawValue }
     override var tableView: TableViewColor { return DarkTableViewColor() }
-    override var urlbar: URLBarColor { return DarkURLBarColor() }
     override var browser: BrowserColor { return DarkBrowserColor() }
-    override var toolbarButton: ToolbarButtonColor { return DarkToolbarButtonColor() }
     override var tabTray: TabTrayColor { return DarkTabTrayColor() }
-    override var etpMenu: EnhancedTrackingProtectionMenuColor { return DarkEnhancedTrackingProtectionMenuColor() }
     override var topTabs: TopTabsColor { return DarkTopTabsColor() }
-    override var textField: TextFieldColor { return DarkTextFieldColor() }
     override var homePanel: HomePanelColor { return DarkHomePanelColor() }
     override var snackbar: SnackBarColor { return DarkSnackBarColor() }
-    override var general: GeneralColor { return DarkGeneralColor() }
-    override var actionMenu: ActionMenuColor { return DarkActionMenuColor() }
-    override var homeTabBanner: HomeTabBannerColor { return DarkHomeTabBannerColor() }
-    override var onboarding: OnboardingColor { return DarkOnboardingColor() }
-    override var remotePanel: RemoteTabTrayColor { return DarkRemoteTabTrayColor() }
 }

--- a/Client/Frontend/Theme/LegacyThemeManager/LegacyTheme.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/LegacyTheme.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-protocol NotificationThemeable: AnyObject {
+protocol LegacyNotificationThemeable: AnyObject {
     func applyTheme()
 }
 
@@ -23,120 +23,21 @@ enum BuiltinThemeName: String {
     case dark
 }
 
-// Convenience reference to these normal mode colors which are used in a few color classes.
-private let defaultBackground = UIColor.Photon.Grey10 // layer1 in new system
-private let defaultSeparator = UIColor.Photon.Grey30 // layerLightGray30
-private let defaultTextAndTint = UIColor.Photon.Grey80 // textPrimary in new system
-
 class TableViewColor {
     var rowBackground: UIColor { return UIColor.Photon.White100 } // layer5
-    var rowText: UIColor { return UIColor.Photon.Grey90 } // textPrimary
-    var rowDetailText: UIColor { return UIColor.Photon.Grey60 } // textSecondary
-    var disabledRowText: UIColor { return UIColor.Photon.Grey40 } // textDisabled
-    var separator: UIColor { return defaultSeparator } // layer4
-    var headerBackground: UIColor { return defaultBackground } // layer1
-    // Used for table headers in Settings and Photon menus
-    var headerTextLight: UIColor { return UIColor.Photon.Grey50 } // textSecondary
-    // Used for table headers in home panel tables
     var headerTextDark: UIColor { return UIColor.Photon.Grey90 }
-    var rowActionAccessory: UIColor { return UIColor.Photon.Blue40 } // actionPrimary
-    var controlTint: UIColor { return rowActionAccessory } // actionPrimary
-    var syncText: UIColor { return defaultTextAndTint } // textPrimary
-    var errorText: UIColor { return UIColor.Photon.Red50 } // textWarning
-    var warningText: UIColor { return UIColor.Photon.Orange50 } // textWarning
-    var accessoryViewTint: UIColor { return UIColor.Photon.Grey40 } // iconSecondary
     var selectedBackground: UIColor { return UIColor.Custom.selectedHighlightLight } // layer5Hover
-}
-
-class ActionMenuColor {
-    var foreground: UIColor { return defaultTextAndTint }
-    var iPhoneBackgroundBlurStyle: UIBlurEffect.Style { return UIBlurEffect.Style.light }
-    var iPhoneBackground: UIColor { return defaultBackground.withAlphaComponent(0.9) }
-    var closeButtonBackground: UIColor { return defaultBackground }
-}
-
-class URLBarColor {
-    var border: UIColor { return UIColor.Photon.Grey90A10 }
-    func activeBorder(_ isPrivate: Bool) -> UIColor {
-        return !isPrivate ? UIColor.Photon.Blue20A40 : UIColor.Defaults.MobilePrivatePurple
-    }
-    var tint: UIColor { return UIColor.Photon.Blue40A30 }
-
-    // This text selection color is used in two ways:
-    // 1) <UILabel>.background = textSelectionHighlight.withAlphaComponent(textSelectionHighlightAlpha)
-    // To simulate text highlighting when the URL bar is tapped once, this is a background
-    // color to create a simulated selected text effect. The color will have an alpha
-    // applied when assigning it to the background.
-    // 2) <UITextField>.tintColor = textSelectionHighlight.
-    // When the text is in edit mode (tapping URL bar second time), this is assigned to the to set the selection (and cursor) color. The color is assigned directly to the tintColor.
-    typealias TextSelectionHighlight = (labelMode: UIColor, textFieldMode: UIColor?)
-    func textSelectionHighlight(_ isPrivate: Bool) -> TextSelectionHighlight {
-        if isPrivate {
-            let color = UIColor.Defaults.MobilePrivatePurple
-            return (labelMode: color.withAlphaComponent(0.25), textFieldMode: color)
-        } else {
-            return (labelMode: UIColor.Defaults.iOSTextHighlightBlue, textFieldMode: nil)
-        }
-    }
-
-    var readerModeButtonSelected: UIColor { return UIColor.Photon.Blue40 }
-    var readerModeButtonUnselected: UIColor { return UIColor.Photon.Grey50 }
-    var pageOptionsSelected: UIColor { return readerModeButtonSelected }
-    var pageOptionsUnselected: UIColor { return UIColor.legacyTheme.browser.tint }
+    var rowText: UIColor { return UIColor.Photon.Grey90 } // textPrimary
+    var disabledRowText: UIColor { return UIColor.Photon.Grey40 } // textDisabled
+    var headerBackground: UIColor { return UIColor.Photon.Grey10 } // layer1
 }
 
 class BrowserColor {
-    var background: UIColor { return defaultBackground }
-    var urlBarDivider: UIColor { return UIColor.Photon.Grey90A10 }
-    var tint: UIColor { return defaultTextAndTint }
-}
-
-// The back/forward/refresh/menu button (bottom toolbar)
-class ToolbarButtonColor {
-    var selectedTint: UIColor { return UIColor.Photon.Blue40 }
-    var disabledTint: UIColor { return UIColor.Photon.Grey30 }
-}
-
-class LoadingBarColor {
-    func start(_ isPrivate: Bool) -> UIColor {
-        return !isPrivate ? UIColor.Photon.Violet50 : UIColor.Photon.Magenta60A30
-    }
-    // Adds middle color for loadingBar only in public browsing
-    func middle(_ isPrivate: Bool) -> UIColor? {
-        return !isPrivate ? UIColor.Photon.Pink40 : nil
-    }
-
-    func end(_ isPrivate: Bool) -> UIColor {
-        return !isPrivate ? UIColor.Photon.Yellow40 : UIColor.Photon.Purple60
-    }
+    var background: UIColor { return UIColor.Photon.Grey10 } // layer1
 }
 
 class TabTrayColor {
-    var tabTitleText: UIColor { return UIColor.black }
     var tabTitleBlur: UIBlurEffect.Style { return UIBlurEffect.Style.extraLight }
-    var background: UIColor { return UIColor.Photon.LightGrey30 }
-    var screenshotBackground: UIColor { return UIColor.Photon.Grey10 }
-    var cellBackground: UIColor { return defaultBackground }
-    var toolbar: UIColor { return defaultBackground }
-    var toolbarButtonTint: UIColor { return defaultTextAndTint }
-    var privateModeLearnMore: UIColor { return UIColor.Photon.Purple60 }
-    var privateModePurple: UIColor { return UIColor.Photon.Purple60 }
-    var privateModeButtonOffTint: UIColor { return toolbarButtonTint }
-    var privateModeButtonOnTint: UIColor { return UIColor.Photon.Grey10 }
-    var cellCloseButton: UIColor { return UIColor.Photon.Grey50 }
-    var cellTitleBackground: UIColor { return UIColor.clear }
-    var faviconTint: UIColor { return UIColor.black }
-    var searchBackground: UIColor { return UIColor.Photon.Grey30 }
-}
-
-class EnhancedTrackingProtectionMenuColor {
-    var defaultImageTints: UIColor { return defaultTextAndTint }
-    var background: UIColor { return UIColor.Photon.Grey12 }
-    var horizontalLine: UIColor { return UIColor.Photon.Grey75A39 }
-    var sectionColor: UIColor { return .white }
-    var switchAndButtonTint: UIColor { return UIColor.Photon.Blue50 }
-    var subtextColor: UIColor { return UIColor.Photon.Grey75A60}
-    var closeButtonColor: UIColor { return UIColor.Photon.LightGrey30 }
 }
 
 class TopTabsColor {
@@ -156,93 +57,16 @@ class TopTabsColor {
     var separator: UIColor { return UIColor.Photon.Grey70 }
 }
 
-class TextFieldColor {
-    var background: UIColor { return UIColor.Photon.LightGrey20 }
-    var backgroundInOverlay: UIColor { return UIColor.Photon.LightGrey20 }
-    var textAndTint: UIColor { return defaultTextAndTint }
-    var separator: UIColor { return .white }
-}
-
 class HomePanelColor {
-    var toolbarBackground: UIColor { return defaultBackground }
-    var toolbarHighlight: UIColor { return UIColor.Photon.Blue40 }
-    var toolbarTint: UIColor { return UIColor.Photon.Grey50 }
-    var topSiteHeaderTitle: UIColor { return .black }
     var panelBackground: UIColor { return UIColor.Photon.White100 }
-
-    var separator: UIColor { return defaultSeparator }
-    var border: UIColor { return UIColor.Photon.Grey60 }
-    var buttonContainerBorder: UIColor { return separator }
-
-    var welcomeScreenText: UIColor { return UIColor.Photon.Grey50 }
-    var bookmarkIconBorder: UIColor { return UIColor.Photon.Grey30 }
-    var bookmarkFolderBackground: UIColor { return UIColor.Photon.Grey10.withAlphaComponent(0.3) }
-    var bookmarkFolderText: UIColor { return UIColor.Photon.Grey80 }
-    var bookmarkCurrentFolderText: UIColor { return UIColor.Photon.Blue40 }
-    var bookmarkBackNavCellBackground: UIColor { return UIColor.clear }
-
-    var siteTableHeaderBorder: UIColor { return UIColor.Photon.Grey30.withAlphaComponent(0.8) }
-
-    var topSitesBackground: UIColor { return UIColor.Photon.LightGrey10 }  // layer2
-    var topSiteDomain: UIColor { return UIColor.Photon.DarkGrey90 }
-    var topSitePin: UIColor { return UIColor.Photon.DarkGrey05 }
-    var topSitesContainerView: UIColor { return .white }
-    var emptyTopSitesBorder: UIColor { return UIColor.Photon.DarkGrey40 }
-
-    var shortcutBackground: UIColor { return .white }
-    var shortcutShadowColor: CGColor { return UIColor(red: 0.23, green: 0.22, blue: 0.27, alpha: 1.0).cgColor }
-
-    var recentlySavedBookmarkCellBackground: UIColor { return .white }
-    var recentlySavedBookmarkImageBackground: UIColor { return UIColor.Photon.LightGrey10 }
-    var recentlySavedBookmarkTitle: UIColor { return UIColor.Photon.DarkGrey90 }
-
-    var recentlyVisitedCellGroupImage: UIColor { return UIColor.Photon.DarkGrey90 }
-    var recentlyVisitedCellBottomLine: UIColor { return UIColor.Photon.LightGrey40 }
-
     var activityStreamHeaderText: UIColor { return UIColor.Photon.DarkGrey90 }
-    var activityStreamHeaderButton: UIColor { return UIColor.Photon.Blue50 }
-    var activityStreamCellTitle: UIColor { return UIColor.Photon.DarkGrey90 }
-    var activityStreamCellDescription: UIColor { return UIColor.Photon.DarkGrey05 }
-
-    var readingListActive: UIColor { return defaultTextAndTint }
-    var readingListDimmed: UIColor { return UIColor.Photon.Grey40 }
-
-    var downloadedFileIcon: UIColor { return UIColor.Photon.Grey60 }
-
-    var historyHeaderIconsBackground: UIColor { return UIColor.Photon.White100 }
-
-    var searchSuggestionPillBackground: UIColor { return UIColor.Photon.White100 }
-    var searchSuggestionPillForeground: UIColor { return UIColor.Photon.Blue40 }
-
-    var customizeHomepageButtonBackground: UIColor { return UIColor.Photon.LightGrey30 }
-    var customizeHomepageButtonText: UIColor { return UIColor.Photon.DarkGrey90 }
-
-    var sponsored: UIColor { return UIColor.Photon.DarkGrey05 }
 }
 
 class SnackBarColor {
-    var highlight: UIColor { return UIColor.Defaults.iOSTextHighlightBlue.withAlphaComponent(0.9) }
+    var highlight: UIColor { return UIColor.LegacyDefaults.iOSTextHighlightBlue.withAlphaComponent(0.9) }
     var highlightText: UIColor { return UIColor.Photon.Blue40 }
     var border: UIColor { return UIColor.Photon.Grey30 }
     var title: UIColor { return UIColor.Photon.Blue40 }
-}
-
-class GeneralColor {
-    var faviconBackground: UIColor { return UIColor.clear }
-    var passcodeDot: UIColor { return UIColor.Photon.Grey60 }
-    var highlightBlue: UIColor { return UIColor.Photon.Blue40 } // actionPrimary
-    var destructiveRed: UIColor { return UIColor.Photon.Red50 } // textWarning
-    var separator: UIColor { return defaultSeparator }
-    var settingsTextPlaceholder: UIColor { return UIColor.Photon.Grey40 } // textDisabled? asked Crystal
-    var controlTint: UIColor { return UIColor.Photon.Blue40 } // actionPrimary
-    var switchToggle: UIColor { return UIColor.Photon.Grey90A40 }
-}
-
-class HomeTabBannerColor {
-    var backgroundColor: UIColor { return UIColor.white }
-    var textColor: UIColor { return UIColor.black }
-    var closeButtonBackground: UIColor { return UIColor.Photon.Grey20 }
-    var closeButton: UIColor { return UIColor.Photon.Grey80 }
 }
 
 class OnboardingColor {
@@ -259,41 +83,19 @@ class RemoteTabTrayColor {
 protocol LegacyTheme {
     var name: String { get }
     var tableView: TableViewColor { get }
-    var urlbar: URLBarColor { get }
-    var browser: BrowserColor { get }
-    var toolbarButton: ToolbarButtonColor { get }
-    var loadingBar: LoadingBarColor { get }
-    var tabTray: TabTrayColor { get }
-    var etpMenu: EnhancedTrackingProtectionMenuColor { get }
     var topTabs: TopTabsColor { get }
-    var textField: TextFieldColor { get }
+    var browser: BrowserColor { get }
+    var tabTray: TabTrayColor { get }
     var homePanel: HomePanelColor { get }
     var snackbar: SnackBarColor { get }
-    var general: GeneralColor { get }
-    var actionMenu: ActionMenuColor { get }
-    var switchToggleTheme: GeneralColor { get }
-    var homeTabBanner: HomeTabBannerColor { get }
-    var onboarding: OnboardingColor { get }
-    var remotePanel: RemoteTabTrayColor { get }
 }
 
 class LegacyNormalTheme: LegacyTheme {
     var name: String { return BuiltinThemeName.normal.rawValue }
     var tableView: TableViewColor { return TableViewColor() }
-    var urlbar: URLBarColor { return URLBarColor() }
     var browser: BrowserColor { return BrowserColor() }
-    var toolbarButton: ToolbarButtonColor { return ToolbarButtonColor() }
-    var loadingBar: LoadingBarColor { return LoadingBarColor() }
     var tabTray: TabTrayColor { return TabTrayColor() }
     var topTabs: TopTabsColor { return TopTabsColor() }
-    var etpMenu: EnhancedTrackingProtectionMenuColor { return EnhancedTrackingProtectionMenuColor() }
-    var textField: TextFieldColor { return TextFieldColor() }
     var homePanel: HomePanelColor { return HomePanelColor() }
     var snackbar: SnackBarColor { return SnackBarColor() }
-    var general: GeneralColor { return GeneralColor() }
-    var actionMenu: ActionMenuColor { return ActionMenuColor() }
-    var switchToggleTheme: GeneralColor { return GeneralColor() }
-    var homeTabBanner: HomeTabBannerColor { return HomeTabBannerColor() }
-    var onboarding: OnboardingColor { return OnboardingColor() }
-    var remotePanel: RemoteTabTrayColor { return RemoteTabTrayColor() }
 }

--- a/Client/Frontend/Toolbar+URLBar/TabToolbar.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabToolbar.swift
@@ -20,7 +20,7 @@ class TabToolbar: UIView {
     let actionButtons: [ThemeApplicable & UIButton]
 
     private let privateModeBadge = BadgeWithBackdrop(imageName: ImageIdentifiers.privateModeBadge,
-                                                     backdropCircleColor: UIColor.Defaults.MobilePrivatePurple)
+                                                     backdropCircleColor: UIColor.LegacyDefaults.MobilePrivatePurple)
     private let appMenuBadge = BadgeWithBackdrop(imageName: ImageIdentifiers.menuBadge)
     private let warningMenuBadge = BadgeWithBackdrop(imageName: ImageIdentifiers.menuWarning,
                                                      imageMask: ImageIdentifiers.menuWarningMask)

--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -6,14 +6,11 @@ import UIKit
 import Shared
 
 extension UIColor {
-    // These are defaults from http://design.firefox.com/photon/visuals/color.html
-    struct Defaults {
-        static let MobileGreyF = UIColor(rgb: 0x636369)
+    // These are colors which we shouldn't use anymore - we'll migrate to use the new theming system
+    struct LegacyDefaults {
         static let iOSTextHighlightBlue = UIColor(rgb: 0xccdded) // This color should exactly match the ios text highlight
-        static let Purple60A30 = UIColor(rgba: 0x8000d74c)
         static let MobilePrivatePurple = UIColor.Photon.Purple60
-        // Reader Mode Sepia
-        static let LightBeige = UIColor(rgb: 0xf0e6dc)
+        static let SystemBlueColor = UIColor.Photon.Blue40
     }
 }
 
@@ -24,8 +21,6 @@ public struct UIConstants {
     static let TopToolbarHeightMax: CGFloat = 75
     static var ToolbarHeight: CGFloat = 46
     static let ZoomPageBarHeight: CGFloat = 54
-
-    static let SystemBlueColor = UIColor.Photon.Blue40
 
     // Static fonts
     static let DefaultChromeSize: CGFloat = 16

--- a/Client/Frontend/Widgets/CellWithRoundedButton.swift
+++ b/Client/Frontend/Widgets/CellWithRoundedButton.swift
@@ -11,7 +11,7 @@ struct CellWithRoundedButtonUX {
     static let ButtonImagePadding: CGFloat = 11
 }
 
-class CellWithRoundedButton: UITableViewCell, NotificationThemeable, ReusableCell {
+class CellWithRoundedButton: UITableViewCell, LegacyNotificationThemeable, ReusableCell {
     // MARK: - Properties
     var buttonClosure: (() -> Void)?
 

--- a/Client/Frontend/Widgets/SearchInputView.swift
+++ b/Client/Frontend/Widgets/SearchInputView.swift
@@ -21,7 +21,7 @@ protocol SearchInputViewDelegate: AnyObject {
     func searchInputViewFinishedEditing(_ searchView: SearchInputView)
 }
 
-class SearchInputView: UIView, NotificationThemeable {
+class SearchInputView: UIView, LegacyNotificationThemeable {
     weak var delegate: SearchInputViewDelegate?
 
     var showBottomBorder = true {

--- a/Client/Frontend/Widgets/TextFieldTableViewCell.swift
+++ b/Client/Frontend/Widgets/TextFieldTableViewCell.swift
@@ -8,7 +8,7 @@ struct TextFieldTableViewCellUX {
     static let HorizontalMargin: CGFloat = 16
     static let VerticalMargin: CGFloat = 10
     static let TitleLabelFont = UIFont.systemFont(ofSize: 12)
-    static let TitleLabelTextColor = UIConstants.SystemBlueColor
+    static let TitleLabelTextColor = UIColor.LegacyDefaults.SystemBlueColor
     static let TextFieldFont = UIFont.systemFont(ofSize: 16)
 }
 
@@ -16,7 +16,7 @@ protocol TextFieldTableViewCellDelegate: AnyObject {
     func textFieldTableViewCell(_ textFieldTableViewCell: TextFieldTableViewCell, didChangeText text: String)
 }
 
-class TextFieldTableViewCell: UITableViewCell, NotificationThemeable {
+class TextFieldTableViewCell: UITableViewCell, LegacyNotificationThemeable {
     let titleLabel: UILabel
     let textField: UITextField
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6548)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14662)

### Description
- Make the NotificationThemable have the legacy in it so it’s clear we shouldn’t use it anymore
- Clean up colors we don’t use anymore in legacy theming, clearer to see what’s left todo
- Didn't change any colors, just renamed and clean up

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
