### PR TITLE
Bugfix MTE-1104 [v115] Enable SPM Bitrise workflows to use M1-based stacks.

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -971,71 +971,6 @@ workflows:
       bitrise.io:
         stack: osx-xcode-14.3.x-ventura
         machine_type_id: g2-m1.8core
-
-  RunUnitTests:
-    steps:
-    - script@1.1:
-        title: Detect number of warnings
-        inputs:
-        - content: |-
-            #!/usr/bin/env bash
-            # fail if any commands fails
-            set -e
-            # debug log
-            set -x
-
-            TEST_LOG_PATH=$BITRISE_XCODEBUILD_TEST_LOG_PATH
-
-            COUNT=$(./test-fixtures/generate-metrics.sh $TEST_LOG_PATH unit-test)
-            envman add --key SHOW_WARNING_COUNT --value "$COUNT"
-            envman add --key SHOW_WARNING_IN_SLACK --value Show_Warnings
-
-            STR=$COUNT
-            SUB='greater'
-            if [[ "$STR" == *"$SUB"* ]]; then
-                echo "Failure, the number of warnings increased"
-                exit 1
-            fi
-        is_always_run: true
-    - slack@3.1:
-        run_if: '{{getenv "NEW_RC_VERSION" | eq "New_RC_Version"}}'
-        inputs:
-        - channel: "#firefox-ios"
-        - text: Build status using latest Rust-Component
-        - webhook_url: $WEBHOOK_SLACK_TOKEN_2
-    description: >-
-      This Workflow is to run tests (currently SmokeTest) when there is a merge
-      in master
-    meta:
-      bitrise.io:
-        stack: osx-xcode-14.3.x-ventura
-        machine_type_id: g2.8core
-    before_run:
-    - 1_git_clone_and_post_clone
-    - 2_certificate_and_profile
-    - 3_provisioning_and_npm_installation
-    - 4_A_xcode_build_and_test_Fennec
-    after_run:
-    - RunSmokeXCUITests
-    - Detect_warnings
-    - 5_deploy_and_slack
-  RunSmokeXCUITests:
-    steps:
-    - cache-pull@2.1:
-        is_always_run: true
-    - xcode-test@4.5:
-        inputs:
-        - scheme: Fennec_Enterprise_XCUITests
-        - xcodebuild_test_options: "-testPlan SmokeXCUITests"
-        - simulator_device: iPhone 11
-        is_always_run: true
-    - deploy-to-bitrise-io@1.9: {}
-    - cache-push@2.2: {}
-    description: This Workflow is to run tests UI TESTS
-    meta:
-      bitrise.io:
-        stack: osx-xcode-14.3.x-ventura
-        machine_type_id: g2.8core
   SPM_Deploy_Prod_Beta:
     steps:
     - activate-ssh-key@4.1:
@@ -1161,7 +1096,7 @@ workflows:
     meta:
       bitrise.io:
         stack: osx-xcode-14.3.x-ventura
-        machine_type_id: g2.8core
+        machine_type_id: g2-m1.8core
   SPM_Deploy_Beta_Only:
     steps:
     - activate-ssh-key@4.1:
@@ -1258,7 +1193,7 @@ workflows:
     meta:
       bitrise.io:
         stack: osx-xcode-14.3.x-ventura
-        machine_type_id: g2.8core
+        machine_type_id: g2-m1.8core
   SPM_Nightly_Beta_Only:
     steps:
     - activate-ssh-key@4.1:
@@ -1356,7 +1291,7 @@ workflows:
     meta:
       bitrise.io:
         stack: osx-xcode-14.3.x-ventura
-        machine_type_id: g2.8core
+        machine_type_id: g2-m1.8core
   perfherder-test:
     steps:
     - cache-pull@2.1:


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1104)

### Description
The 3 `SPM_*` workflows are still using the Intel-based Bitrise stack. They are run daily and are still needed after the Intel stack becomes deprecated.

The workflows `RunUniTests` and `RunSmokeXCUITests` are no longer needed after the Monorepo work and can be removed safely.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
