### PR TITLE
Refactor FXIOS-5736 [v116] quality of life ux improvements for credit card settings

### DIFF
--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -17,6 +17,7 @@ struct CreditCardInputView: View {
     @State var backgroundColor: Color = .clear
     @State var borderColor: Color = .clear
     @State var textFieldBackgroundColor: Color = .clear
+    @State var barButtonColor: Color = .clear
 
     var body: some View {
         NavigationView {
@@ -82,9 +83,11 @@ struct CreditCardInputView: View {
                     ToolbarItem(placement: .navigationBarTrailing) {
                         rightBarButton()
                             .disabled(!viewModel.isRightBarButtonEnabled)
+                            .foregroundColor(barButtonColor)
                     }
                     ToolbarItem(placement: .navigationBarLeading) {
                         leftBarButton()
+                            .foregroundColor(barButtonColor)
                     }
                 }
                 .padding(.top, 0)
@@ -114,6 +117,7 @@ struct CreditCardInputView: View {
         let color = theme.colors
         backgroundColor = Color(color.layer1)
         textFieldBackgroundColor = Color(color.layer2)
+        barButtonColor = Color(color.actionPrimary)
     }
 
     func rightBarButton() -> some View {

--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
@@ -44,7 +44,7 @@ struct CreditCardItemRow: View {
                         Text(item.ccType)
                             .font(.body)
                             .foregroundColor(titleTextColor)
-                        Text(item.ccNumberLast4)
+                        Text("••••\(item.ccNumberLast4)")
                             .font(.subheadline)
                             .foregroundColor(subTextColor)
                     }
@@ -59,7 +59,7 @@ struct CreditCardItemRow: View {
                         Text(String.CreditCard.DisplayCard.ExpiresLabel)
                             .font(.body)
                             .foregroundColor(subTextColor)
-                        Text(String(item.ccExpYear))
+                        Text("\(item.ccExpMonth)/\(item.ccExpYear)")
                             .font(.subheadline)
                             .foregroundColor(subTextColor)
                     }

--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewController.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewController.swift
@@ -171,6 +171,7 @@ class CreditCardSettingsViewController: SensitiveViewController, Themeable {
     }
 
     private func showToast(status: CreditCardModifiedStatus) {
+        guard status != .none else { return }
         SimpleToast().showAlertWithText(status.message,
                                         bottomContainer: view,
                                         theme: themeManager.currentTheme)

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -182,11 +182,11 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
         var privacySettings = [Setting]()
         privacySettings.append(LoginsSetting(settings: self, delegate: settingsDelegate))
 
-        privacySettings.append(ClearPrivateDataSetting(settings: self))
-
         if autofillCreditCardStatus {
             privacySettings.append(AutofillCreditCardSettings(settings: self))
         }
+
+        privacySettings.append(ClearPrivateDataSetting(settings: self))
 
         privacySettings += [
             BoolSetting(prefs: prefs,


### PR DESCRIPTION
This was made before the tickets but here are the tickets associated with the PR

Github
[Incorrect Settings Position](https://github.com/mozilla-mobile/firefox-ios/issues/14686)
[Incorrect Blank toast appears](https://github.com/mozilla-mobile/firefox-ios/issues/14690)
[Incorrect Expiration date format](https://github.com/mozilla-mobile/firefox-ios/issues/14692)
[Dark mode theme udpate](https://github.com/mozilla-mobile/firefox-ios/issues/14694)

Jira:
[Incorrect Settings Position](https://mozilla-hub.atlassian.net/browse/FXIOS-6559)
[Incorrect Blank toast appears](https://mozilla-hub.atlassian.net/browse/FXIOS-6563)
[Incorrect Expiration date format](https://mozilla-hub.atlassian.net/browse/FXIOS-6566)
[Dark mode theme udpate](https://mozilla-hub.atlassian.net/browse/FXIOS-6567)

### Description
These are mostly quality of life changes for the credit card settings screen related to UX. 

| Button Swapped | Color Changes |
| ------------- | ------------- | 
| ![2 1](https://github.com/mozilla-mobile/firefox-ios/assets/8919439/eeaac790-ca81-4463-9541-9722a43cc0e8)| ![4 1](https://github.com/mozilla-mobile/firefox-ios/assets/8919439/5c1dee2c-78f5-40ed-8a24-656daa79c184) |

---

| No toast when cancelling (Fixed)| Text for expiry and visa number updated |
| ------------- | ------------- | 
| <video src="https://github.com/mozilla-mobile/firefox-ios/assets/8919439/ac9d6959-d921-4740-abb7-c0681bddabdf"> |<img src="https://github.com/mozilla-mobile/firefox-ios/assets/8919439/0afd1b07-a2d1-43a6-a468-b71cb1fa9a0f" width="280">|



### Pull requests checks where applicable

- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
