### PR TITLE
Bugfix FXIOS-6434 [v115] Fixes send tab broken if user signs in on onboarding

### DIFF
--- a/Client/Application/AppDelegate+PushNotifications.swift
+++ b/Client/Application/AppDelegate+PushNotifications.swift
@@ -118,8 +118,11 @@ extension AppDelegate {
             notificationAllowed = UserDefaults.standard.bool(forKey: PrefsKeys.Notifications.SyncNotifications)
         }
 
-        RustFirefoxAccounts.shared.pushNotifications.didRegister(withDeviceToken: deviceToken,
-                                                                 notificationAllowed: notificationAllowed)
+        if notificationAllowed {
+            RustFirefoxAccounts.shared.pushNotifications.didRegister(withDeviceToken: deviceToken)
+        } else {
+            RustFirefoxAccounts.shared.pushNotifications.disableNotifications()
+        }
     }
 
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {

--- a/Client/Frontend/Settings/NotificationsSettingsViewController.swift
+++ b/Client/Frontend/Settings/NotificationsSettingsViewController.swift
@@ -24,9 +24,6 @@ class NotificationsSettingsViewController: SettingsTableViewController, FeatureF
                 self.syncNotifications.writeBool(self.syncNotifications.control)
 
                 // enable/disable sync notifications
-                MZKeychainWrapper.sharedClientAppContainerKeychain.removeObject(
-                    forKey: KeychainKey.apnsToken,
-                    withAccessibility: MZKeychainItemAccessibility.afterFirstUnlock)
                 NotificationCenter.default.post(name: .RegisterForPushNotifications, object: nil)
             }
         }

--- a/RustFxA/PushNotificationSetup.swift
+++ b/RustFxA/PushNotificationSetup.swift
@@ -14,15 +14,19 @@ open class PushNotificationSetup {
     /// be unsubscribed from receiving notifications.
     /// - Parameters:
     ///   - deviceToken: A token that identifies the device to Apple Push Notification Service (APNS).
-    ///   - notificationAllowed: Indicates if the user allowed sync push notification in the settings.
-    public func didRegister(withDeviceToken deviceToken: Data, notificationAllowed: Bool) {
-        // If we've already registered this push subscription, we don't need to do it again.
+    public func didRegister(withDeviceToken deviceToken: Data) {
         let apnsToken = deviceToken.hexEncodedString
         let keychain = MZKeychainWrapper.sharedClientAppContainerKeychain
-        guard keychain.string(forKey: KeychainKey.apnsToken, withAccessibility: .afterFirstUnlock) != apnsToken
-        else { return }
 
         RustFirefoxAccounts.shared.accountManager.uponQueue(.main) { accountManager in
+            let subscriptionEndpoint = accountManager.deviceConstellation()?.state()?.localDevice?.pushSubscription?.endpoint
+            let persistedApnsToken = keychain.string(forKey: KeychainKey.apnsToken, withAccessibility: .afterFirstUnlock)
+            // The only reason we check the existing subscription endpoint is to recover any old devices
+            // that experienced https://github.com/mozilla-mobile/firefox-ios/issues/14467
+            // checking the APNS token is sufficient otherwise
+            if let subscriptionEndpoint = subscriptionEndpoint, !subscriptionEndpoint.isEmpty, persistedApnsToken == apnsToken {
+                return
+            }
             let config = PushConfigurationLabel(rawValue: AppConstants.scheme)!.toConfiguration()
             self.pushClient = PushClientImplementation(endpointURL: config.endpointURL,
                                                        experimentalMode: false)
@@ -34,9 +38,9 @@ open class PushNotificationSetup {
                 let subscription = pushRegistration.defaultSubscription
 
                 // send empty parameters for push subscription if no notifications should be send to device
-                let endpoint = notificationAllowed ? subscription.endpoint.absoluteString : ""
-                let publicKey = notificationAllowed ? subscription.p256dhPublicKey : ""
-                let authKey = notificationAllowed ? subscription.authKey : ""
+                let endpoint = subscription.endpoint.absoluteString
+                let publicKey = subscription.p256dhPublicKey
+                let authKey = subscription.authKey
 
                 let devicePush = DevicePushSubscription(endpoint: endpoint,
                                                         publicKey: publicKey,
@@ -49,6 +53,22 @@ open class PushNotificationSetup {
                              forKey: KeychainKey.fxaPushRegistration,
                              withAccessibility: .afterFirstUnlock)
             }
+        }
+    }
+
+    /// Disables FxA push notifications for the user
+    public func disableNotifications() {
+        MZKeychainWrapper.sharedClientAppContainerKeychain.removeObject(forKey: KeychainKey.apnsToken, withAccessibility: .afterFirstUnlock)
+        RustFirefoxAccounts.shared.accountManager.uponQueue(.main) { accountManager in
+            let subscriptionEndpoint = accountManager.deviceConstellation()?.state()?.localDevice?.pushSubscription?.endpoint
+            if let subscriptionEndpoint = subscriptionEndpoint, subscriptionEndpoint.isEmpty {
+                // Already disabled, lets quit early
+                return
+            }
+            let devicePush = DevicePushSubscription(endpoint: "",
+                                                    publicKey: "",
+                                                    authKey: "")
+            accountManager.deviceConstellation()?.setDevicePushSubscription(sub: devicePush)
         }
     }
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6434)
fixes [Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14467)

### Description
It was possible for the user signing in through onboarding to have notifications disabled for sync even after opting into notifications in the onboarding menu


cc @dnarcese @nishant2718 we might want to backport this, it's a bug in 113

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
