### PR TITLE
Refactor FXIOS-6277 [v115] handle settings coordinator existing deeplink

### DIFF
--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -144,7 +144,16 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
 
         case let .settings(section):
             // Note: This will be handled in the settings coordinator when FXIOS-6274 is done
-            handle(settingsSection: section)
+            if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+                let settingsCoordinator = SettingsCoordinator(
+                    router: router,
+                    browserViewController: browserViewController
+                )
+                add(child: settingsCoordinator)
+                settingsCoordinator.start(with: section)
+            } else {
+                handle(settingsSection: section)
+            }
             return true
 
         case let .action(routeAction):
@@ -211,6 +220,11 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
         browserViewController.handle(url: searchURL, tabId: tabId)
     }
 
+    private func handle(fxaParams: FxALaunchParams) {
+        browserViewController.presentSignInViewController(fxaParams)
+    }
+
+    // Will be removed with FXIOS-6529
     private func handle(settingsSection: Route.SettingsSection) {
         let baseSettingsVC = AppSettingsTableViewController(
             with: profile,
@@ -227,6 +241,7 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
         controller.pushViewController(viewController, animated: true)
     }
 
+    // Will be removed with FXIOS-6529
     func getSettingsViewController(settingsSection section: Route.SettingsSection) -> UIViewController? {
         switch section {
         case .newTab:
@@ -283,9 +298,5 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
             // For cases that are not yet handled we show the main settings page, more to come with FXIOS-6274
             return nil
         }
-    }
-
-    private func handle(fxaParams: FxALaunchParams) {
-        browserViewController.presentSignInViewController(fxaParams)
     }
 }

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -143,14 +143,9 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
             return true
 
         case let .settings(section):
-            // Note: This will be handled in the settings coordinator when FXIOS-6274 is done
+            // 'Else' will be removed with FXIOS-6529
             if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
-                let settingsCoordinator = SettingsCoordinator(
-                    router: router,
-                    browserViewController: browserViewController
-                )
-                add(child: settingsCoordinator)
-                settingsCoordinator.start(with: section)
+                showSettings(with: section)
             } else {
                 handle(settingsSection: section)
             }
@@ -222,6 +217,23 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
 
     private func handle(fxaParams: FxALaunchParams) {
         browserViewController.presentSignInViewController(fxaParams)
+    }
+
+    private func showSettings(with section: Route.SettingsSection) {
+        // FXIOS-6556 - Avoid passing whole BVC to settings
+        let baseSettingsVC = AppSettingsTableViewController(
+            with: profile,
+            and: tabManager,
+            delegate: browserViewController
+        )
+        let navigationController = ThemedNavigationController(rootViewController: baseSettingsVC)
+        navigationController.modalPresentationStyle = .formSheet
+        let settingsRouter = DefaultRouter(navigationController: navigationController)
+
+        let settingsCoordinator = SettingsCoordinator(router: settingsRouter)
+        add(child: settingsCoordinator)
+        router.present(navigationController)
+        settingsCoordinator.start(with: section)
     }
 
     // Will be removed with FXIOS-6529

--- a/Client/Coordinators/CoordinatorFlagManager.swift
+++ b/Client/Coordinators/CoordinatorFlagManager.swift
@@ -15,13 +15,15 @@ struct CoordinatorFlagManager {
 
     /// This will be removed with FXIOS-6529
     static var isSettingsCoordinatorEnabled: Bool {
-        return FeatureFlagsManager.shared.isFeatureEnabled(.settingsCoordinatorRefactor,
-                                                           checking: .buildOnly)
+        return CoordinatorFlagManager.isCoordinatorEnabled
+        && FeatureFlagsManager.shared.isFeatureEnabled(.settingsCoordinatorRefactor,
+                                                       checking: .buildOnly)
     }
 
     /// This will be removed with FXIOS-6530
     static var isLibraryCoordinatorEnabled: Bool {
-        return FeatureFlagsManager.shared.isFeatureEnabled(.libraryCoordinatorRefactor,
-                                                           checking: .buildOnly)
+        return CoordinatorFlagManager.isCoordinatorEnabled
+        && FeatureFlagsManager.shared.isFeatureEnabled(.libraryCoordinatorRefactor,
+                                                       checking: .buildOnly)
     }
 }

--- a/Client/Coordinators/CoordinatorFlagManager.swift
+++ b/Client/Coordinators/CoordinatorFlagManager.swift
@@ -24,5 +24,4 @@ struct CoordinatorFlagManager {
         return FeatureFlagsManager.shared.isFeatureEnabled(.libraryCoordinatorRefactor,
                                                            checking: .buildOnly)
     }
-
 }

--- a/Client/Coordinators/CoordinatorFlagManager.swift
+++ b/Client/Coordinators/CoordinatorFlagManager.swift
@@ -5,11 +5,24 @@
 import Foundation
 import Shared
 
-/// This is a temporary struct made to manage the feature flag for conveniance
-/// This will be removed with FXIOS-6036
+/// This is a temporary struct made to manage the coordinator multiple feature flag for conveniance
 struct CoordinatorFlagManager {
+    /// This will be removed with FXIOS-6036
     static var isCoordinatorEnabled: Bool {
         return FeatureFlagsManager.shared.isFeatureEnabled(.coordinatorsRefactor,
                                                            checking: .buildOnly)
     }
+
+    /// This will be removed with FXIOS-6529
+    static var isSettingsCoordinatorEnabled: Bool {
+        return FeatureFlagsManager.shared.isFeatureEnabled(.settingsCoordinatorRefactor,
+                                                           checking: .buildOnly)
+    }
+
+    /// This will be removed with FXIOS-6530
+    static var isLibraryCoordinatorEnabled: Bool {
+        return FeatureFlagsManager.shared.isFeatureEnabled(.libraryCoordinatorRefactor,
+                                                           checking: .buildOnly)
+    }
+
 }

--- a/Client/Coordinators/SettingsCoordinator.swift
+++ b/Client/Coordinators/SettingsCoordinator.swift
@@ -7,19 +7,16 @@ import Foundation
 import Shared
 
 class SettingsCoordinator: BaseCoordinator {
-    private let browserViewController: BrowserViewController
     private let wallpaperManager: WallpaperManagerInterface
     private let profile: Profile
     private let tabManager: TabManager
     private let themeManager: ThemeManager
 
     init(router: Router,
-         browserViewController: BrowserViewController,
          wallpaperManager: WallpaperManagerInterface = WallpaperManager(),
          profile: Profile = AppContainer.shared.resolve(),
          tabManager: TabManager = AppContainer.shared.resolve(),
          themeManager: ThemeManager = AppContainer.shared.resolve()) {
-        self.browserViewController = browserViewController
         self.wallpaperManager = wallpaperManager
         self.profile = profile
         self.tabManager = tabManager
@@ -32,22 +29,11 @@ class SettingsCoordinator: BaseCoordinator {
     }
 
     func start(with settingsSection: Route.SettingsSection) {
-        let baseSettingsVC = AppSettingsTableViewController(
-            with: profile,
-            and: tabManager,
-            delegate: browserViewController
-        )
-
-        let controller = ThemedNavigationController(rootViewController: baseSettingsVC)
-        controller.presentingModalViewControllerDelegate = browserViewController
-        controller.modalPresentationStyle = .formSheet
-        router.present(controller)
-
         guard let viewController = getSettingsViewController(settingsSection: settingsSection) else { return }
-        controller.pushViewController(viewController, animated: true)
+        router.push(viewController)
     }
 
-    func getSettingsViewController(settingsSection section: Route.SettingsSection) -> UIViewController? {
+    private func getSettingsViewController(settingsSection section: Route.SettingsSection) -> UIViewController? {
         switch section {
         case .newTab:
             let viewController = NewTabContentSettingsViewController(prefs: profile.prefs)
@@ -79,7 +65,7 @@ class SettingsCoordinator: BaseCoordinator {
                 fxaParams,
                 flowType: .emailLoginFlow,
                 referringPage: .settings,
-                profile: browserViewController.profile
+                profile: profile
             )
             return viewController
 

--- a/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
@@ -8,15 +8,21 @@ import XCTest
 
 final class SettingsCoordinatorTests: XCTestCase {
     private var mockRouter: MockRouter!
+    private var wallpaperManager: WallpaperManagerMock!
 
     override func setUp() {
         super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+        FeatureFlagsManager.shared.initializeDeveloperFeatures(with: MockProfile())
         self.mockRouter = MockRouter(navigationController: MockNavigationController())
+        self.wallpaperManager = WallpaperManagerMock()
     }
 
     override func tearDown() {
         super.tearDown()
-        mockRouter = nil
+        self.mockRouter = nil
+        self.wallpaperManager = nil
+        DependencyHelperMock().reset()
     }
 
     func testEmptyChilds_whenCreated() {
@@ -24,8 +30,102 @@ final class SettingsCoordinatorTests: XCTestCase {
         XCTAssertEqual(subject.childCoordinators.count, 0)
     }
 
+    func testGeneralSettingsRoute_showsGeneralSettingsPage() throws {
+        let subject = createSubject()
+
+        subject.start(with: .general)
+
+        XCTAssertEqual(mockRouter.pushCalled, 0)
+        XCTAssertNil(mockRouter.pushedViewController)
+    }
+
+    func testNewTabSettingsRoute_showsNewTabSettingsPage() throws {
+        let subject = createSubject()
+
+        subject.start(with: .newTab)
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+        XCTAssertTrue(mockRouter.pushedViewController is NewTabContentSettingsViewController)
+    }
+
+    func testHomepageSettingsRoute_showsHomepageSettingsPage() throws {
+        let subject = createSubject()
+
+        subject.start(with: .homePage)
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+        XCTAssertTrue(mockRouter.pushedViewController is HomePageSettingViewController)
+    }
+
+    func testMailtoSettingsRoute_showsMailtoSettingsPage() throws {
+        let subject = createSubject()
+
+        subject.start(with: .mailto)
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+        XCTAssertTrue(mockRouter.pushedViewController is OpenWithSettingsViewController)
+    }
+
+    func testSearchSettingsRoute_showsSearchSettingsPage() throws {
+        let subject = createSubject()
+
+        subject.start(with: .search)
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+        XCTAssertTrue(mockRouter.pushedViewController is SearchSettingsTableViewController)
+    }
+
+    func testClearPrivateDataSettingsRoute_showsClearPrivateDataSettingsPage() throws {
+        let subject = createSubject()
+
+        subject.start(with: .clearPrivateData)
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+        XCTAssertTrue(mockRouter.pushedViewController is ClearPrivateDataTableViewController)
+    }
+
+    func testFxaSettingsRoute_showsFxaSettingsPage() throws {
+        let subject = createSubject()
+
+        subject.start(with: .fxa)
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+        XCTAssertTrue(mockRouter.pushedViewController is FirefoxAccountSignInViewController)
+    }
+
+    func testThemeSettingsRoute_showsThemeSettingsPage() throws {
+        let subject = createSubject()
+
+        subject.start(with: .theme)
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+        XCTAssertTrue(mockRouter.pushedViewController is ThemeSettingsController)
+    }
+
+    func testWallpaperSettingsRoute_cannotBeShown_showsWallpaperSettingsPage() throws {
+        wallpaperManager.canSettingsBeShown = false
+        let subject = createSubject()
+
+        subject.start(with: .wallpaper)
+
+        XCTAssertEqual(mockRouter.pushCalled, 0)
+        XCTAssertNil(mockRouter.pushedViewController)
+    }
+
+    func testWallpaperSettingsRoute_canBeShown_showsWallpaperSettingsPage() throws {
+        wallpaperManager.canSettingsBeShown = true
+        let subject = createSubject()
+
+        subject.start(with: .wallpaper)
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+        XCTAssertTrue(mockRouter.pushedViewController is WallpaperSettingsViewController)
+    }
+
+    // MARK: - Helper
     func createSubject() -> SettingsCoordinator {
-        let subject = SettingsCoordinator(router: mockRouter)
+        let subject = SettingsCoordinator(router: mockRouter,
+                                          wallpaperManager: wallpaperManager)
         trackForMemoryLeaks(subject)
         return subject
     }

--- a/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
+++ b/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
@@ -40,4 +40,8 @@ class DependencyHelperMock {
         // Tell the container we are done registering
         AppContainer.shared.bootstrap()
     }
+
+    func reset() {
+        AppContainer.shared.reset()
+    }
 }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6277)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14126)

### Description
- Move code from browser coordinator to settings coordinator (not really moving, but only duplicating for now since we're using a feature flag).
- Use the new nimbus flag for settings coordinator
- Make sure to use the right navigation controller in settings coordinator router
- Add tests

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
