### PR TITLE
Refactor FXIOS-6556 [v115] Delegate is settings coordinator instead of BVC

### DIFF
--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -220,16 +220,16 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
     }
 
     private func showSettings(with section: Route.SettingsSection) {
-        let baseSettingsVC = AppSettingsTableViewController(
+        let settingsVC = AppSettingsTableViewController(
             with: profile,
             and: tabManager
         )
-        let navigationController = ThemedNavigationController(rootViewController: baseSettingsVC)
+        let navigationController = ThemedNavigationController(rootViewController: settingsVC)
         navigationController.modalPresentationStyle = .formSheet
         let settingsRouter = DefaultRouter(navigationController: navigationController)
 
         let settingsCoordinator = SettingsCoordinator(router: settingsRouter)
-        baseSettingsVC.settingsDelegate = settingsCoordinator
+        settingsVC.settingsDelegate = settingsCoordinator
         settingsCoordinator.parentCoordinator = self
 
         add(child: settingsCoordinator)

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -7,7 +7,7 @@ import Foundation
 import WebKit
 import Shared
 
-class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDelegate {
+class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDelegate, SettingsCoordinatorDelegate {
     var browserViewController: BrowserViewController
     var webviewController: WebviewViewController?
     var homepageViewController: HomepageViewController?
@@ -220,20 +220,26 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
     }
 
     private func showSettings(with section: Route.SettingsSection) {
-        // FXIOS-6556 - Avoid passing whole BVC to settings
         let baseSettingsVC = AppSettingsTableViewController(
             with: profile,
-            and: tabManager,
-            delegate: browserViewController
+            and: tabManager
         )
         let navigationController = ThemedNavigationController(rootViewController: baseSettingsVC)
         navigationController.modalPresentationStyle = .formSheet
         let settingsRouter = DefaultRouter(navigationController: navigationController)
 
         let settingsCoordinator = SettingsCoordinator(router: settingsRouter)
+        baseSettingsVC.settingsDelegate = settingsCoordinator
+        settingsCoordinator.parentCoordinator = self
+
         add(child: settingsCoordinator)
         router.present(navigationController)
         settingsCoordinator.start(with: section)
+    }
+
+    // MARK: - SettingsCoordinatorDelegate
+    func openURLinNewTab(_ url: URL) {
+        browserViewController.openURLInNewTab(url)
     }
 
     // Will be removed with FXIOS-6529

--- a/Client/Coordinators/SettingsCoordinator.swift
+++ b/Client/Coordinators/SettingsCoordinator.swift
@@ -6,11 +6,16 @@ import Common
 import Foundation
 import Shared
 
-class SettingsCoordinator: BaseCoordinator {
+protocol SettingsCoordinatorDelegate: AnyObject {
+    func openURLinNewTab(_ url: URL)
+}
+
+class SettingsCoordinator: BaseCoordinator, SettingsDelegate {
     private let wallpaperManager: WallpaperManagerInterface
     private let profile: Profile
     private let tabManager: TabManager
     private let themeManager: ThemeManager
+    weak var parentCoordinator: SettingsCoordinatorDelegate?
 
     init(router: Router,
          wallpaperManager: WallpaperManagerInterface = WallpaperManager(),
@@ -89,5 +94,10 @@ class SettingsCoordinator: BaseCoordinator {
             // FXIOS-6483: For cases that are not yet handled we show the main settings page
             return nil
         }
+    }
+
+    // MARK: - SettingsDelegate
+    func settingsOpenURLInNewTab(_ url: URL) {
+        parentCoordinator?.openURLinNewTab(url)
     }
 }

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -23,7 +23,7 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
     // MARK: - Initializers
     init(with profile: Profile,
          and tabManager: TabManager,
-         delegate: SettingsDelegate?,
+         delegate: SettingsDelegate? = nil,
          deeplinkingTo destination: AppSettingsDeeplinkOption? = nil) {
         self.deeplinkTo = destination
 

--- a/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
@@ -9,6 +9,7 @@ import XCTest
 final class SettingsCoordinatorTests: XCTestCase {
     private var mockRouter: MockRouter!
     private var wallpaperManager: WallpaperManagerMock!
+    private var delegate: MockSettingsCoordinatorDelegate!
 
     override func setUp() {
         super.setUp()
@@ -16,12 +17,14 @@ final class SettingsCoordinatorTests: XCTestCase {
         FeatureFlagsManager.shared.initializeDeveloperFeatures(with: MockProfile())
         self.mockRouter = MockRouter(navigationController: MockNavigationController())
         self.wallpaperManager = WallpaperManagerMock()
+        self.delegate = MockSettingsCoordinatorDelegate()
     }
 
     override func tearDown() {
         super.tearDown()
         self.mockRouter = nil
         self.wallpaperManager = nil
+        self.delegate = nil
         DependencyHelperMock().reset()
     }
 
@@ -122,11 +125,34 @@ final class SettingsCoordinatorTests: XCTestCase {
         XCTAssertTrue(mockRouter.pushedViewController is WallpaperSettingsViewController)
     }
 
+    // MARK: - Delegate
+    func testParentCoordinatorDelegate_calledWithURL() {
+        let subject = createSubject()
+        subject.parentCoordinator = delegate
+
+        let expectedURL = URL(string: "www.mozilla.com")!
+        subject.settingsOpenURLInNewTab(expectedURL)
+
+        XCTAssertEqual(delegate.openURLinNewTabCalled, 1)
+        XCTAssertEqual(delegate.savedURL, expectedURL)
+    }
+
     // MARK: - Helper
     func createSubject() -> SettingsCoordinator {
         let subject = SettingsCoordinator(router: mockRouter,
                                           wallpaperManager: wallpaperManager)
         trackForMemoryLeaks(subject)
         return subject
+    }
+}
+
+// MARK: - MockSettingsCoordinatorDelegate
+class MockSettingsCoordinatorDelegate: SettingsCoordinatorDelegate {
+    var savedURL: URL?
+    var openURLinNewTabCalled = 0
+
+    func openURLinNewTab(_ url: URL) {
+        savedURL = url
+        openURLinNewTabCalled += 1
     }
 }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6556)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14680)

### Description
Delegate is the settings coordinator instead of BVC for `AppSettingsTableViewController`

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
