### PR TITLE
Bugfix FXIOS-6562 [v115] Add title to default/empty state of autofill credit cards settings

### DIFF
--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewController.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewController.swift
@@ -75,6 +75,7 @@ class CreditCardSettingsViewController: SensitiveViewController, Themeable {
         addChild(creditCardTableViewController)
         view.addSubview(emptyCreditCardView)
         view.addSubview(creditCardTableView)
+        self.title = .SettingsAutofillCreditCard
 
         NSLayoutConstraint.activate([
             emptyCreditCardView.leadingAnchor.constraint(equalTo: view.leadingAnchor),


### PR DESCRIPTION

[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6562)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14688)

### Description
Add title to default/empty state of autofill credit cards settings

<img src="https://github.com/mozilla-mobile/firefox-ios/assets/8919439/5beaef66-abe7-451d-975e-76582d9a9efa" width = 400>

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
