### PR TITLE
Bugfix FXIOS-6565 [v115] Update credit card logo sizes to 48x48

### DIFF
--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
@@ -28,7 +28,7 @@ struct CreditCardItemRow: View {
                 getImage(creditCard: item)
                     .renderingMode(.original)
                     .resizable()
-                    .frame(width: 24, height: 24)
+                    .frame(width: 48, height: 48)
                     .aspectRatio(contentMode: .fit)
 
                 VStack(spacing: 0) {


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6565)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14693)

### Description

| Small  | Updated 48x48 |
| ------------- | ------------- |
| <img src="https://github.com/mozilla-mobile/firefox-ios/assets/8919439/34358023-42a1-4c3b-a0d0-4c7198f4d4f0">  | <img src="https://github.com/mozilla-mobile/firefox-ios/assets/8919439/4266443d-59b2-4a43-935c-32adb21c8f14">|

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
