### PR TITLE
Bugfix FXIOS-6561 [v115] Centering of credit card icon & text on default empty state too low

### DIFF
--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsEmptyView.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsEmptyView.swift
@@ -51,6 +51,7 @@ struct CreditCardSettingsEmptyView: View {
                             .padding(.trailing, 10)
                             .padding([.top], -5)
                         Spacer()
+                        Spacer()
                     }
                     .frame(minHeight: proxy.size.height)
                 }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6561)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14689)

### Description
| Before  | After (Updated) |
| ------------- | ------------- |
| <img src="https://github.com/mozilla-mobile/firefox-ios/assets/8919439/f9fca4ba-5fb2-4e82-87ba-52ea4735d49d" width = 300>  | <img src="https://github.com/mozilla-mobile/firefox-ios/assets/8919439/b8263ffe-a5d8-44df-a55a-072add3d05fb" width = 300>|

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
