### PR TITLE
Refactor FXIOS-6534 [v116] Settings coordinator deinit

### DIFF
--- a/Client/Application/AccessibilityIdentifiers.swift
+++ b/Client/Application/AccessibilityIdentifiers.swift
@@ -179,6 +179,7 @@ public struct AccessibilityIdentifiers {
 
     struct Settings {
         static let tableViewController = "AppSettingsTableViewController.tableView"
+        static let navigationBarItem = "AppSettingsTableViewController.navigationItem.rightBarButtonItem"
 
         struct Homepage {
             static let homeSettings = "Home"

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -19,6 +19,7 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
     private let glean: GleanWrapper
     private let applicationHelper: ApplicationHelper
     private let wallpaperManager: WallpaperManagerInterface
+    private let isSettingsCoordinatorEnabled: Bool
 
     init(router: Router,
          screenshotService: ScreenshotService,
@@ -27,7 +28,8 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
          themeManager: ThemeManager = AppContainer.shared.resolve(),
          glean: GleanWrapper = DefaultGleanWrapper.shared,
          applicationHelper: ApplicationHelper = DefaultApplicationHelper(),
-         wallpaperManager: WallpaperManagerInterface = WallpaperManager()) {
+         wallpaperManager: WallpaperManagerInterface = WallpaperManager(),
+         isSettingsCoordinatorEnabled: Bool = CoordinatorFlagManager.isSettingsCoordinatorEnabled) {
         self.screenshotService = screenshotService
         self.profile = profile
         self.tabManager = tabManager
@@ -36,6 +38,7 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
         self.applicationHelper = applicationHelper
         self.glean = glean
         self.wallpaperManager = wallpaperManager
+        self.isSettingsCoordinatorEnabled = isSettingsCoordinatorEnabled
         super.init(router: router)
         self.browserViewController.browserDelegate = self
     }
@@ -143,8 +146,8 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
             return true
 
         case let .settings(section):
-            // 'Else' will be removed with FXIOS-6529
-            if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+            // 'Else' case will be removed with FXIOS-6529
+            if isSettingsCoordinatorEnabled {
                 showSettings(with: section)
             } else {
                 handle(settingsSection: section)

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -233,7 +233,9 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
         settingsCoordinator.parentCoordinator = self
 
         add(child: settingsCoordinator)
-        router.present(navigationController)
+        router.present(navigationController) { [weak self] in
+            self?.didFinishSettings(from: settingsCoordinator)
+        }
         settingsCoordinator.start(with: section)
     }
 
@@ -242,7 +244,12 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
         browserViewController.openURLInNewTab(url)
     }
 
-    // Will be removed with FXIOS-6529
+    func didFinishSettings(from coordinator: SettingsCoordinator) {
+        router.dismiss(animated: true, completion: nil)
+        remove(child: coordinator)
+    }
+
+    // MARK: - To be removed with FXIOS-6529
     private func handle(settingsSection: Route.SettingsSection) {
         let baseSettingsVC = AppSettingsTableViewController(
             with: profile,

--- a/Client/Coordinators/Router/DefaultRouter.swift
+++ b/Client/Coordinators/Router/DefaultRouter.swift
@@ -5,7 +5,7 @@
 import UIKit
 
 class DefaultRouter: NSObject, Router {
-    private var completions: [UIViewController: () -> Void]
+    var completions: [UIViewController: () -> Void]
 
     var rootViewController: UIViewController? {
         return navigationController.viewControllers.first
@@ -30,8 +30,8 @@ class DefaultRouter: NSObject, Router {
     }
 
     func dismiss(animated: Bool = true, completion: (() -> Void)? = nil) {
-        // Make sure we remove reference to presentedViewController completions
-        if let topController = navigationController.presentedViewController {
+        // Make sure we remove reference to the topViewController completions
+        if let topController = navigationController.topPresentedViewController {
             completions.removeValue(forKey: topController)
         }
         navigationController.dismiss(animated: animated, completion: completion)

--- a/Client/Coordinators/Router/DefaultRouter.swift
+++ b/Client/Coordinators/Router/DefaultRouter.swift
@@ -30,6 +30,10 @@ class DefaultRouter: NSObject, Router {
     }
 
     func dismiss(animated: Bool = true, completion: (() -> Void)? = nil) {
+        // Make sure we remove reference to presentedViewController completions
+        if let topController = navigationController.presentedViewController {
+            completions.removeValue(forKey: topController)
+        }
         navigationController.dismiss(animated: animated, completion: completion)
     }
 

--- a/Client/Coordinators/Router/DefaultRouter.swift
+++ b/Client/Coordinators/Router/DefaultRouter.swift
@@ -11,7 +11,7 @@ class DefaultRouter: NSObject, Router {
         return navigationController.viewControllers.first
     }
 
-    let navigationController: NavigationController
+    var navigationController: NavigationController
 
     init(navigationController: NavigationController) {
         self.navigationController = navigationController
@@ -30,8 +30,8 @@ class DefaultRouter: NSObject, Router {
     }
 
     func dismiss(animated: Bool = true, completion: (() -> Void)? = nil) {
-        // Make sure we remove reference to the topViewController completions
-        if let topController = navigationController.topPresentedViewController {
+        // Make sure we remove reference to the presentedViewController completions
+        if let topController = navigationController.presentedViewController {
             completions.removeValue(forKey: topController)
         }
         navigationController.dismiss(animated: animated, completion: completion)

--- a/Client/Coordinators/SettingsCoordinator.swift
+++ b/Client/Coordinators/SettingsCoordinator.swift
@@ -8,6 +8,7 @@ import Shared
 
 protocol SettingsCoordinatorDelegate: AnyObject {
     func openURLinNewTab(_ url: URL)
+    func didFinishSettings(from coordinator: SettingsCoordinator)
 }
 
 class SettingsCoordinator: BaseCoordinator, SettingsDelegate {
@@ -27,10 +28,6 @@ class SettingsCoordinator: BaseCoordinator, SettingsDelegate {
         self.tabManager = tabManager
         self.themeManager = themeManager
         super.init(router: router)
-    }
-
-    deinit {
-        // FXIOS-6534: Make sure SettingsCoordinator is deinit/removed as child once done with it
     }
 
     func start(with settingsSection: Route.SettingsSection) {
@@ -99,5 +96,9 @@ class SettingsCoordinator: BaseCoordinator, SettingsDelegate {
     // MARK: - SettingsDelegate
     func settingsOpenURLInNewTab(_ url: URL) {
         parentCoordinator?.openURLinNewTab(url)
+    }
+
+    func didFinish() {
+        parentCoordinator?.didFinishSettings(from: self)
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1910,6 +1910,11 @@ extension BrowserViewController: SettingsDelegate {
         let isPrivate = tabManager.selectedTab?.isPrivate ?? false
         self.openURLInNewTab(url, isPrivate: isPrivate)
     }
+
+    func didFinish() {
+        // Does nothing since this is used by Coordinators
+        // BVC will stop being a SettingsDelegate after FXIOS-6529
+    }
 }
 
 extension BrowserViewController: PresentingModalViewControllerDelegate {

--- a/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVC.swift
+++ b/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVC.swift
@@ -421,13 +421,6 @@ class EnhancedTrackingProtectionMenuVC: UIViewController, Themeable {
     }
 }
 
-// MARK: - PresentingModalViewControllerDelegate
-extension EnhancedTrackingProtectionMenuVC: PresentingModalViewControllerDelegate {
-    func dismissPresentedModalViewController(_ modalViewController: UIViewController, animated: Bool) {
-        self.dismiss(animated: true, completion: nil)
-    }
-}
-
 // MARK: - Themable
 extension EnhancedTrackingProtectionMenuVC {
     func applyTheme() {

--- a/Client/Frontend/Browser/Tabs/GridTabViewController.swift
+++ b/Client/Frontend/Browser/Tabs/GridTabViewController.swift
@@ -713,13 +713,6 @@ extension GridTabViewController: UIAdaptivePresentationControllerDelegate, UIPop
     }
 }
 
-// MARK: - PresentingModalViewControllerDelegate
-extension GridTabViewController: PresentingModalViewControllerDelegate {
-    func dismissPresentedModalViewController(_ modalViewController: UIViewController, animated: Bool) {
-        dismiss(animated: animated, completion: { self.collectionView.reloadData() })
-    }
-}
-
 // MARK: - Notifiable
 extension GridTabViewController: Notifiable {
     func handleNotifications(_ notification: Notification) {

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -42,20 +42,29 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
         super.viewDidLoad()
 
         navigationItem.title = String.AppSettingsTitle
-        navigationItem.rightBarButtonItem = UIBarButtonItem(
-            title: .AppSettingsDone,
-            style: .done,
-            target: navigationController,
-            action: #selector((navigationController as! ThemedNavigationController).done))
-        navigationItem.rightBarButtonItem?.accessibilityIdentifier = "AppSettingsTableViewController.navigationItem.leftBarButtonItem"
+        if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+            navigationItem.rightBarButtonItem = UIBarButtonItem(
+                title: .AppSettingsDone,
+                style: .done,
+                target: self,
+                action: #selector(done))
+        } else {
+            navigationItem.rightBarButtonItem = UIBarButtonItem(
+                title: .AppSettingsDone,
+                style: .done,
+                target: navigationController,
+                action: #selector((navigationController as! ThemedNavigationController).done))
+        }
 
-        tableView.accessibilityIdentifier = "AppSettingsTableViewController.tableView"
-
-        // Refresh the user's FxA profile upon viewing settings. This will update their avatar,
-        // display name, etc.
-        // profile.rustAccount.refreshProfile()
+        navigationItem.rightBarButtonItem?.accessibilityIdentifier = AccessibilityIdentifiers.Settings.navigationBarItem
+        tableView.accessibilityIdentifier = AccessibilityIdentifiers.Settings.tableViewController
 
         checkForDeeplinkSetting()
+    }
+
+    @objc
+    private func done() {
+        settingsDelegate?.didFinish()
     }
 
     private func checkForDeeplinkSetting() {

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -748,6 +748,7 @@ class WithoutAccountSetting: AccountSetting {
 @objc
 protocol SettingsDelegate: AnyObject {
     func settingsOpenURLInNewTab(_ url: URL)
+    func didFinish()
 }
 
 // The base settings view controller.

--- a/Client/Protocols/NavigationController.swift
+++ b/Client/Protocols/NavigationController.swift
@@ -10,6 +10,7 @@ protocol NavigationController: UIViewController {
     var isNavigationBarHidden: Bool { get set }
     var transitionCoordinator: UIViewControllerTransitionCoordinator? { get }
     var fromViewController: UIViewController? { get }
+    var topPresentedViewController: UIViewController? { get }
 
     func pushViewController(_ viewController: UIViewController, animated: Bool)
     func popViewController(animated: Bool) -> UIViewController?
@@ -19,5 +20,9 @@ protocol NavigationController: UIViewController {
 extension UINavigationController: NavigationController {
     var fromViewController: UIViewController? {
         return transitionCoordinator?.viewController(forKey: .from)
+    }
+
+    var topPresentedViewController: UIViewController? {
+        return presentedViewController
     }
 }

--- a/Client/Protocols/NavigationController.swift
+++ b/Client/Protocols/NavigationController.swift
@@ -4,14 +4,16 @@
 
 import Foundation
 
-protocol NavigationController: UIViewController {
+protocol NavigationController {
     var viewControllers: [UIViewController] { get }
     var delegate: UINavigationControllerDelegate? { get set }
     var isNavigationBarHidden: Bool { get set }
     var transitionCoordinator: UIViewControllerTransitionCoordinator? { get }
     var fromViewController: UIViewController? { get }
-    var topPresentedViewController: UIViewController? { get }
+    var presentedViewController: UIViewController? { get }
 
+    func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)?)
+    func dismiss(animated flag: Bool, completion: (() -> Void)?)
     func pushViewController(_ viewController: UIViewController, animated: Bool)
     func popViewController(animated: Bool) -> UIViewController?
     func setViewControllers(_ viewControllers: [UIViewController], animated: Bool)
@@ -20,9 +22,5 @@ protocol NavigationController: UIViewController {
 extension UINavigationController: NavigationController {
     var fromViewController: UIViewController? {
         return transitionCoordinator?.viewController(forKey: .from)
-    }
-
-    var topPresentedViewController: UIViewController? {
-        return presentedViewController
     }
 }

--- a/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -378,7 +378,6 @@ final class BrowserCoordinatorTests: XCTestCase {
     // MARK: - Settings route
 
     func testGeneralSettingsRoute_showsGeneralSettingsPage() throws {
-        guard !CoordinatorFlagManager.isSettingsCoordinatorEnabled else { return }
         let route = Route.settings(section: .general)
         let subject = createSubject()
 
@@ -391,7 +390,6 @@ final class BrowserCoordinatorTests: XCTestCase {
     }
 
     func testNewTabSettingsRoute_returnsNewTabSettingsPage() throws {
-        guard !CoordinatorFlagManager.isSettingsCoordinatorEnabled else { return }
         let route = Route.SettingsSection.newTab
         let subject = createSubject()
 
@@ -401,7 +399,6 @@ final class BrowserCoordinatorTests: XCTestCase {
     }
 
     func testHomepageSettingsRoute_returnsHomepageSettingsPage() throws {
-        guard !CoordinatorFlagManager.isSettingsCoordinatorEnabled else { return }
         let route = Route.SettingsSection.homePage
         let subject = createSubject()
 
@@ -411,7 +408,6 @@ final class BrowserCoordinatorTests: XCTestCase {
     }
 
     func testMailtoSettingsRoute_returnsMailtoSettingsPage() throws {
-        guard !CoordinatorFlagManager.isSettingsCoordinatorEnabled else { return }
         let route = Route.SettingsSection.mailto
         let subject = createSubject()
 
@@ -421,7 +417,6 @@ final class BrowserCoordinatorTests: XCTestCase {
     }
 
     func testSearchSettingsRoute_returnsSearchSettingsPage() throws {
-        guard !CoordinatorFlagManager.isSettingsCoordinatorEnabled else { return }
         let route = Route.SettingsSection.search
         let subject = createSubject()
 
@@ -431,7 +426,6 @@ final class BrowserCoordinatorTests: XCTestCase {
     }
 
     func testClearPrivateDataSettingsRoute_returnsClearPrivateDataSettingsPage() throws {
-        guard !CoordinatorFlagManager.isSettingsCoordinatorEnabled else { return }
         let route = Route.SettingsSection.clearPrivateData
         let subject = createSubject()
 
@@ -441,7 +435,6 @@ final class BrowserCoordinatorTests: XCTestCase {
     }
 
     func testFxaSettingsRoute_returnsFxaSettingsPage() throws {
-        guard !CoordinatorFlagManager.isSettingsCoordinatorEnabled else { return }
         let route = Route.SettingsSection.fxa
         let subject = createSubject()
 
@@ -451,7 +444,6 @@ final class BrowserCoordinatorTests: XCTestCase {
     }
 
     func testThemeSettingsRoute_returnsThemeSettingsPage() throws {
-        guard !CoordinatorFlagManager.isSettingsCoordinatorEnabled else { return }
         let route = Route.SettingsSection.theme
         let subject = createSubject()
 
@@ -461,7 +453,6 @@ final class BrowserCoordinatorTests: XCTestCase {
     }
 
     func testWallpaperSettingsRoute_canShow_returnsWallpaperSettingsPage() throws {
-        guard !CoordinatorFlagManager.isSettingsCoordinatorEnabled else { return }
         wallpaperManager.canSettingsBeShown = true
         let route = Route.SettingsSection.wallpaper
         let subject = createSubject()
@@ -472,7 +463,6 @@ final class BrowserCoordinatorTests: XCTestCase {
     }
 
     func testWallpaperSettingsRoute_cannotShow_returnsWallpaperSettingsPage() throws {
-        guard !CoordinatorFlagManager.isSettingsCoordinatorEnabled else { return }
         wallpaperManager.canSettingsBeShown = false
         let route = Route.SettingsSection.wallpaper
         let subject = createSubject()
@@ -483,8 +473,7 @@ final class BrowserCoordinatorTests: XCTestCase {
     }
 
     func testSettingsRoute_addSettingsCoordinator() {
-        guard CoordinatorFlagManager.isSettingsCoordinatorEnabled else { return }
-        let subject = createSubject()
+        let subject = createSubject(isSettingsCoordinatorEnabled: true)
 
         let result = subject.handle(route: .settings(section: .general))
 
@@ -494,7 +483,7 @@ final class BrowserCoordinatorTests: XCTestCase {
     }
 
     func testPresentedCompletion_callsDidFinishSettings_removesChild() {
-        let subject = createSubject()
+        let subject = createSubject(isSettingsCoordinatorEnabled: true)
 
         let result = subject.handle(route: .settings(section: .general))
         mockRouter.savedCompletion?()
@@ -517,8 +506,7 @@ final class BrowserCoordinatorTests: XCTestCase {
     }
 
     func testSettingsCoordinatorDelegate_didFinishSettings_removesChild() {
-        guard CoordinatorFlagManager.isSettingsCoordinatorEnabled else { return }
-        let subject = createSubject()
+        let subject = createSubject(isSettingsCoordinatorEnabled: true)
 
         let result = subject.handle(route: .settings(section: .general))
         let settingsCoordinator = subject.childCoordinators[0] as! SettingsCoordinator
@@ -585,14 +573,16 @@ final class BrowserCoordinatorTests: XCTestCase {
     }
 
     // MARK: - Helpers
-    private func createSubject(file: StaticString = #file,
+    private func createSubject(isSettingsCoordinatorEnabled: Bool = false,
+                               file: StaticString = #file,
                                line: UInt = #line) -> BrowserCoordinator {
         let subject = BrowserCoordinator(router: mockRouter,
                                          screenshotService: screenshotService,
                                          profile: profile,
                                          glean: glean,
                                          applicationHelper: applicationHelper,
-                                         wallpaperManager: wallpaperManager)
+                                         wallpaperManager: wallpaperManager,
+                                         isSettingsCoordinatorEnabled: isSettingsCoordinatorEnabled)
 
         trackForMemoryLeaks(subject, file: file, line: line)
         return subject

--- a/Tests/ClientTests/Coordinators/DefaultRouterTests.swift
+++ b/Tests/ClientTests/Coordinators/DefaultRouterTests.swift
@@ -22,7 +22,7 @@ final class DefaultRouterTests: XCTestCase {
         let subject = DefaultRouter(navigationController: navigationController)
 
         XCTAssertNil(subject.rootViewController)
-        XCTAssertEqual(subject.navigationController, navigationController)
+        XCTAssertEqual(subject.navigationController.viewControllers, navigationController.viewControllers)
         XCTAssertEqual(subject.completions.count, 0)
     }
 
@@ -32,7 +32,7 @@ final class DefaultRouterTests: XCTestCase {
         subject.present(viewController, completion: {})
 
         XCTAssertEqual(navigationController.presentCalled, 1)
-        XCTAssertEqual(navigationController.topPresentedViewController, viewController)
+        XCTAssertEqual(navigationController.presentedViewController, viewController)
         XCTAssertEqual(subject.completions.count, 1)
     }
 
@@ -82,7 +82,7 @@ final class DefaultRouterTests: XCTestCase {
         subject.push(viewController, completion: {})
 
         XCTAssertEqual(navigationController.pushCalled, 1)
-        XCTAssertEqual(navigationController.topPresentedViewController, viewController)
+        XCTAssertEqual(navigationController.presentedViewController, viewController)
         XCTAssertEqual(subject.completions.count, 1)
     }
 

--- a/Tests/ClientTests/Coordinators/DefaultRouterTests.swift
+++ b/Tests/ClientTests/Coordinators/DefaultRouterTests.swift
@@ -23,15 +23,17 @@ final class DefaultRouterTests: XCTestCase {
 
         XCTAssertNil(subject.rootViewController)
         XCTAssertEqual(subject.navigationController, navigationController)
+        XCTAssertEqual(subject.completions.count, 0)
     }
 
     func testPresentViewController_presentCalled() {
         let subject = DefaultRouter(navigationController: navigationController)
         let viewController = UIViewController()
-        subject.present(viewController)
+        subject.present(viewController, completion: {})
 
         XCTAssertEqual(navigationController.presentCalled, 1)
-        XCTAssertEqual(navigationController.topViewController, viewController)
+        XCTAssertEqual(navigationController.topPresentedViewController, viewController)
+        XCTAssertEqual(subject.completions.count, 1)
     }
 
     func testPresentViewController_dismissModalCompletionCalled() {
@@ -47,6 +49,15 @@ final class DefaultRouterTests: XCTestCase {
         waitForExpectations(timeout: 0.1)
     }
 
+    func testRunCompletion_DoesNotRunForNonExistingCompletion() {
+        let subject = DefaultRouter(navigationController: navigationController)
+
+        let viewController = UIViewController()
+        subject.presentationControllerDidDismiss(viewController.presentationController!)
+
+        XCTAssertEqual(subject.completions.count, 0)
+    }
+
     func testDismissModule() {
         let subject = DefaultRouter(navigationController: navigationController)
         subject.dismiss()
@@ -54,13 +65,25 @@ final class DefaultRouterTests: XCTestCase {
         XCTAssertEqual(navigationController.dismissCalled, 1)
     }
 
+    func testPresentThenDismiss_removesCompletion() {
+        let subject = DefaultRouter(navigationController: navigationController)
+        let viewController = UIViewController()
+
+        subject.present(viewController, completion: {})
+        XCTAssertEqual(subject.completions.count, 1)
+
+        subject.dismiss()
+        XCTAssertEqual(subject.completions.count, 0)
+    }
+
     func testPushModule_pushViewController() {
         let subject = DefaultRouter(navigationController: navigationController)
         let viewController = UIViewController()
-        subject.push(viewController)
+        subject.push(viewController, completion: {})
 
         XCTAssertEqual(navigationController.pushCalled, 1)
-        XCTAssertEqual(navigationController.topViewController, viewController)
+        XCTAssertEqual(navigationController.topPresentedViewController, viewController)
+        XCTAssertEqual(subject.completions.count, 1)
     }
 
     func testPopViewController() {

--- a/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
@@ -137,6 +137,15 @@ final class SettingsCoordinatorTests: XCTestCase {
         XCTAssertEqual(delegate.savedURL, expectedURL)
     }
 
+    func testParentCoordinatorDelegate_calledDidFinish() {
+        let subject = createSubject()
+        subject.parentCoordinator = delegate
+
+        subject.didFinish()
+
+        XCTAssertEqual(delegate.didFinishSettingsCalled, 1)
+    }
+
     // MARK: - Helper
     func createSubject() -> SettingsCoordinator {
         let subject = SettingsCoordinator(router: mockRouter,

--- a/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
@@ -150,9 +150,14 @@ final class SettingsCoordinatorTests: XCTestCase {
 class MockSettingsCoordinatorDelegate: SettingsCoordinatorDelegate {
     var savedURL: URL?
     var openURLinNewTabCalled = 0
+    var didFinishSettingsCalled = 0
 
     func openURLinNewTab(_ url: URL) {
         savedURL = url
         openURLinNewTabCalled += 1
+    }
+
+    func didFinishSettings(from coordinator: SettingsCoordinator) {
+        didFinishSettingsCalled += 1
     }
 }

--- a/Tests/ClientTests/Mocks/MockNavigationController.swift
+++ b/Tests/ClientTests/Mocks/MockNavigationController.swift
@@ -5,11 +5,12 @@
 import UIKit
 @testable import Client
 
-class MockNavigationController: UIViewController, NavigationController {
+class MockNavigationController: NavigationController {
+    var transitionCoordinator: UIViewControllerTransitionCoordinator?
+    var presentedViewController: UIViewController?
     var viewControllers: [UIViewController] = []
     var delegate: UINavigationControllerDelegate?
     var isNavigationBarHidden = false
-    var topPresentedViewController: UIViewController?
     var fromViewController: UIViewController?
 
     var presentCalled = 0
@@ -17,23 +18,23 @@ class MockNavigationController: UIViewController, NavigationController {
     var pushCalled = 0
     var popViewCalled = 0
 
-    override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
+    func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
         presentCalled += 1
-        topPresentedViewController = viewControllerToPresent
+        presentedViewController = viewControllerToPresent
     }
 
-    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+    func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
         dismissCalled += 1
     }
 
     func pushViewController(_ viewController: UIViewController, animated: Bool) {
         pushCalled += 1
-        topPresentedViewController = viewController
+        presentedViewController = viewController
     }
 
     func popViewController(animated: Bool) -> UIViewController? {
         popViewCalled += 1
-        return topPresentedViewController
+        return presentedViewController
     }
 
     func setViewControllers(_ viewControllers: [UIViewController], animated: Bool) {

--- a/Tests/ClientTests/Mocks/MockNavigationController.swift
+++ b/Tests/ClientTests/Mocks/MockNavigationController.swift
@@ -9,7 +9,7 @@ class MockNavigationController: UIViewController, NavigationController {
     var viewControllers: [UIViewController] = []
     var delegate: UINavigationControllerDelegate?
     var isNavigationBarHidden = false
-    var topViewController: UIViewController?
+    var topPresentedViewController: UIViewController?
     var fromViewController: UIViewController?
 
     var presentCalled = 0
@@ -19,7 +19,7 @@ class MockNavigationController: UIViewController, NavigationController {
 
     override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
         presentCalled += 1
-        topViewController = viewControllerToPresent
+        topPresentedViewController = viewControllerToPresent
     }
 
     override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
@@ -28,12 +28,12 @@ class MockNavigationController: UIViewController, NavigationController {
 
     func pushViewController(_ viewController: UIViewController, animated: Bool) {
         pushCalled += 1
-        topViewController = viewController
+        topPresentedViewController = viewController
     }
 
     func popViewController(animated: Bool) -> UIViewController? {
         popViewCalled += 1
-        return topViewController
+        return topPresentedViewController
     }
 
     func setViewControllers(_ viewControllers: [UIViewController], animated: Bool) {

--- a/Tests/ClientTests/Mocks/MockRouter.swift
+++ b/Tests/ClientTests/Mocks/MockRouter.swift
@@ -16,6 +16,7 @@ class MockRouter: NSObject, Router {
     var pushCalled = 0
     var popViewControllerCalled = 0
     var setRootViewControllerCalled = 0
+    var savedCompletion: (() -> Void)?
 
     init(navigationController: NavigationController) {
         self.navigationController = navigationController
@@ -23,15 +24,18 @@ class MockRouter: NSObject, Router {
     }
 
     func present(_ viewController: UIViewController, animated: Bool, completion: (() -> Void)?) {
+        savedCompletion = completion
         presentedViewController = viewController
         presentCalled += 1
     }
 
     func dismiss(animated: Bool, completion: (() -> Void)?) {
+        savedCompletion = completion
         dismissCalled += 1
     }
 
     func push(_ viewController: UIViewController, animated: Bool, completion: (() -> Void)?) {
+        savedCompletion = completion
         pushedViewController = viewController
         pushCalled += 1
     }

--- a/Tests/UITests/Global.swift
+++ b/Tests/UITests/Global.swift
@@ -287,7 +287,7 @@ class BrowserUtils {
 
     class func closeClearPrivateDataDialog(_ tester: KIFUITestActor) {
         tester.tapView(withAccessibilityLabel: "Settings")
-        tester.tapView(withAccessibilityIdentifier: "AppSettingsTableViewController.navigationItem.leftBarButtonItem")
+        tester.tapView(withAccessibilityIdentifier: AccessibilityIdentifiers.Settings.navigationBarItem)
     }
 
     class func acceptClearPrivateData(_ tester: KIFUITestActor) {

--- a/Tests/UITests/LoginManagerTests.swift
+++ b/Tests/UITests/LoginManagerTests.swift
@@ -31,9 +31,9 @@ class LoginManagerTests: KIFTestCase {
         tester().tapView(withAccessibilityLabel: "Settings")
 
         let firstIndexPath = IndexPath(row: 0, section: 1)
-        let list = tester().waitForView(withAccessibilityIdentifier: "AppSettingsTableViewController.tableView") as? UITableView
+        let list = tester().waitForView(withAccessibilityIdentifier: AccessibilityIdentifiers.Settings.tableViewController) as? UITableView
                
-        let row = tester().waitForCell(at: firstIndexPath, inTableViewWithAccessibilityIdentifier: "AppSettingsTableViewController.tableView")
+        let row = tester().waitForCell(at: firstIndexPath, inTableViewWithAccessibilityIdentifier: AccessibilityIdentifiers.Settings.tableViewController)
         tester().swipeView(withAccessibilityLabel: row?.accessibilityLabel, value: row?.accessibilityValue, in: KIFSwipeDirection.down)
 
         tester().tapView(withAccessibilityIdentifier: "Logins")
@@ -43,7 +43,7 @@ class LoginManagerTests: KIFTestCase {
         tester().waitForAnimationsToFinish(withTimeout: 5)
         tester().tapView(withAccessibilityLabel: "Settings")
 
-        tester().tapView(withAccessibilityIdentifier: "AppSettingsTableViewController.navigationItem.leftBarButtonItem")
+        tester().tapView(withAccessibilityIdentifier: AccessibilityIdentifiers.Settings.navigationBarItem)
    }
 
     fileprivate func generateLogins() {

--- a/Tests/XCUITests/NavigationTest.swift
+++ b/Tests/XCUITests/NavigationTest.swift
@@ -310,7 +310,7 @@ class NavigationTest: BaseTestCase {
 //        navigator.nowAt(BrowserTab)
 //        waitForExistence(app.buttons["TabToolbar.menuButton"], timeout: TIMEOUT)
 //        navigator.goto(SettingsScreen)
-//        waitForExistence(app.tables["AppSettingsTableViewController.tableView"])
+//        waitForExistence(app.tables[AccessibilityIdentifiers.Settings.tableViewController])
 //        let switchBlockPopUps = app.tables.cells.switches["blockPopups"]
 //        let switchValue = switchBlockPopUps.value!
 //        XCTAssertEqual(switchValue as? String, "1")
@@ -358,7 +358,7 @@ class NavigationTest: BaseTestCase {
         waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.goto(SettingsScreen)
-        waitForExistence(app.tables["AppSettingsTableViewController.tableView"])
+        waitForExistence(app.tables[AccessibilityIdentifiers.Settings.tableViewController])
         let switchBlockPopUps = app.tables.cells.switches["blockPopups"]
         switchBlockPopUps.tap()
         let switchValueAfter = switchBlockPopUps.value!

--- a/Tests/XCUITests/PrivateBrowsingTest.swift
+++ b/Tests/XCUITests/PrivateBrowsingTest.swift
@@ -201,7 +201,7 @@ fileprivate extension BaseTestCase {
 
     func enableClosePrivateBrowsingOptionWhenLeaving() {
         navigator.goto(SettingsScreen)
-        let settingsTableView = app.tables["AppSettingsTableViewController.tableView"]
+        let settingsTableView = app.tables[AccessibilityIdentifiers.Settings.tableViewController]
 
         while settingsTableView.staticTexts["Close Private Tabs"].exists == false {
             settingsTableView.swipeUp()

--- a/Tests/XCUITests/SearchTest.swift
+++ b/Tests/XCUITests/SearchTest.swift
@@ -25,7 +25,7 @@ class SearchTests: BaseTestCase {
         navigator.goto(SearchSettings)
         app.tables.switches["Show Search Suggestions"].tap()
         app.navigationBars["Search"].buttons["Settings"].tap()
-        app.navigationBars["Settings"].buttons["AppSettingsTableViewController.navigationItem.leftBarButtonItem"].tap()
+        app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].tap()
     }
 
     func testPromptPresence() {

--- a/Tests/XCUITests/SettingsTest.swift
+++ b/Tests/XCUITests/SettingsTest.swift
@@ -53,7 +53,7 @@ class SettingsTest: BaseTestCase {
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         navigator.goto(SettingsScreen)
-        let settingsTableView = app.tables["AppSettingsTableViewController.tableView"]
+        let settingsTableView = app.tables[AccessibilityIdentifiers.Settings.tableViewController]
         let defaultBrowserButton = settingsTableView.cells["Set as Default Browser"]
         defaultBrowserButton.tap()
 

--- a/Tests/XCUITests/ThirdPartySearchTest.swift
+++ b/Tests/XCUITests/ThirdPartySearchTest.swift
@@ -16,7 +16,7 @@ class ThirdPartySearchTest: BaseTestCase {
 
         waitForExistence(app.navigationBars["Search"].buttons["Settings"], timeout: 3)
         app.navigationBars["Search"].buttons["Settings"].tap()
-        app.navigationBars["Settings"].buttons["AppSettingsTableViewController.navigationItem.leftBarButtonItem"].tap()
+        app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].tap()
 
         // Perform a search using a custom search engine
         app.textFields["url"].tap()
@@ -73,7 +73,7 @@ class ThirdPartySearchTest: BaseTestCase {
         waitForExistence(app.navigationBars["Search"].buttons["Settings"], timeout: 3)
 
         app.navigationBars["Search"].buttons["Settings"].tap()
-        app.navigationBars["Settings"].buttons["AppSettingsTableViewController.navigationItem.leftBarButtonItem"].tap()
+        app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].tap()
         app.textFields["url"].tap()
         waitForExistence(app.buttons["urlBar-cancel"])
         if processIsTranslatedStr() == m1Rosetta {
@@ -124,7 +124,7 @@ class ThirdPartySearchTest: BaseTestCase {
     private func dismissSearchScreen() {
         waitForExistence(app.navigationBars["Search"].buttons["Settings"])
         app.navigationBars["Search"].buttons["Settings"].tap()
-        app.navigationBars["Settings"].buttons["AppSettingsTableViewController.navigationItem.leftBarButtonItem"].tap()
+        app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].tap()
     }
 
     func testCustomEngineFromIncorrectTemplate() {

--- a/Tests/XCUITests/TrackingProtectionTests.swift
+++ b/Tests/XCUITests/TrackingProtectionTests.swift
@@ -93,7 +93,7 @@ class TrackingProtectionTests: BaseTestCase {
         XCTAssertEqual(switchSettingsValue as! String, "1")
         app.switches["prefkey.trackingprotection.normalbrowsing"].tap()
         // Disable ETP from setting and check that it applies to the site
-        app.buttons["AppSettingsTableViewController.navigationItem.leftBarButtonItem"].tap()
+        app.buttons[AccessibilityIdentifiers.Settings.navigationBarItem].tap()
         navigator.nowAt(BrowserTab)
         navigator.goto(TrackingProtectionContextMenuDetails)
         waitForNoExistence(app.switches.firstMatch)


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6534)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14644)

### Description
- Make sure we deinit properly `SettingsCoordinator` both when swipping out the settings page and clicking the `done` button
- `Done` button action is handled by the view controller `AppSettingsTableViewController` instead of the `ThemedNavigationController`.
- Had to make sure we remove the saved completion in our Router when we dismiss the view controller, otherwise coordinator couldn't be deinit
- Make sure to update accessibility identifiers for related area in `AppSettingsTableViewController`
- Clean up unused conformance to protocol `PresentingModalViewControllerDelegate`
- Made sure to check for flag in unit tests, since the settings coordinator flag depends on the first coordinator flag. We'll be able to adjust those tests easily when the time comes to remove the code from `BrowserCoordinator`.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
