### PR TITLE
Bug MTE-1119 [v115] Bitrise workflow breaks on MERGE from release/epic branches

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -585,15 +585,20 @@ workflows:
             #!/usr/bin/env bash
             set -ex
 
-            # Manual triggers leave empty commits. 
-            # Check for empty commit/PR and exit blacklist check if found to avoid erroring out.
-
+            # We need to check both PRs and MERGE for release and epic branches so an error isn't
+            # created when trying to find a diff on a commit that doesn't exist on origin/main
+            # First check destination branch for PRs and then check $BITRISE_GIT_BRANCH for
+            # merges to main since the destination branch changes back to origin/main
             if [[ $BITRISEIO_GIT_BRANCH_DEST = release* ]] || [[ $BITRISEIO_GIT_BRANCH_DEST = epic* ]]; then
                 FILES_CHANGED=$(git diff --name-only $BITRISEIO_GIT_BRANCH_DEST..."$BITRISE_GIT_COMMIT")
+            elif [[ $BITRISE_GIT_BRANCH = release* ]] || [[ $BITRISE_GIT_BRANCH = epic* ]]; then
+                FILES_CHANGED=$(git diff --name-only $BITRISE_GIT_BRANCH..."$BITRISE_GIT_COMMIT")
             else
                 FILES_CHANGED=$(git diff --name-only origin/main..."$BITRISE_GIT_COMMIT")
             fi
 
+            # Manual triggers leave empty commits. 
+            # Check for empty commit/PR and exit blacklist check if found to avoid erroring out.
             echo "Files changed in commit/PR: $FILES_CHANGED"
             if [[ -z "$FILES_CHANGED" ]]; then
                 echo "No files changed in commit/PR. Skipping Blacklist check..."

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -585,10 +585,10 @@ workflows:
             #!/usr/bin/env bash
             set -ex
 
-            # We need to check both PRs and MERGE for release and epic branches so an error isn't
+            # We need to check both PRs and MERGEs for release and epic branches so an error isn't
             # created when trying to find a diff on a commit that doesn't exist on origin/main
             # First check destination branch for PRs and then check $BITRISE_GIT_BRANCH for
-            # merges to main since the destination branch changes back to origin/main
+            # merges to origin/main since the destination branch changes back to origin/main
             if [[ $BITRISEIO_GIT_BRANCH_DEST = release* ]] || [[ $BITRISEIO_GIT_BRANCH_DEST = epic* ]]; then
                 FILES_CHANGED=$(git diff --name-only $BITRISEIO_GIT_BRANCH_DEST..."$BITRISE_GIT_COMMIT")
             elif [[ $BITRISE_GIT_BRANCH = release* ]] || [[ $BITRISE_GIT_BRANCH = epic* ]]; then


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1119)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

### Description
The step that checks which files have been changed to decide if ui tests should be run currently doesn’t account for PRs and MERGES to/from any branches that aren’t origin/main.

Right now, the branches where PRs are opened against origin/release or origin/epic cause a failure because the diff is checking for the commit hash against origin/main, but the commit hash doesn’t exist there, which causes a git error fatal: ambiguous argument 'origin/main...3bc28fdcb55145609547ec387fe87bec326aff9a': unknown revision or path not in the working tree.

With that fixed, there’s still issues on MERGE that cause the same issue because the bitrise env var being used $BITRISEIO_GIT_BRANCH_DEST now becomes origin/main again.

We need to add an additional check to cover the use case of MERGEs on origin/main from these different branches.

The current solution proposal is to check if the $BITRISEIO_GIT_BRANCH_DEST is either release or epic, then run the diff using $BITRISEIO_GIT_BRANCH_DEST..."$BITRISE_GIT_COMMIT to cover the usecase for PRs followed by doing the same check but with $BITRISE_GIT_BRANCH by assigning $FILES_CHANGED to git diff --name-only $BITRISEIO_GIT_BRANCH..."$BITRISE_GIT_COMMIT".

We should consider updating the script at some point to allow for any non-`origin/main` destination branch and avoid using if-else to handle our login since context can be lost between the checks that implies the decision making, but doesn’t explicitly state that decision making, which will make future debugging more difficult, should this solution not account for all use cases.

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
