### PR TITLE
Adds SYNC-3736 [v116] Adds Autopush feature flags

### DIFF
--- a/.experimenter.yaml
+++ b/.experimenter.yaml
@@ -1,4 +1,12 @@
 ---
+autopush-feature:
+  description: This property defines the autopush feature configuration
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    use-new-autopush-client:
+      type: boolean
+      description: "If true, the autopush client based on the Rust component will be used"
 contextual-hint-feature:
   description: This set holds all features pertaining to contextual hints.
   hasExposure: true

--- a/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -10,6 +10,7 @@ import UIKit
 /// An enum describing the featureID of all features found in Nimbus.
 /// Please add new features alphabetically.
 enum NimbusFeatureFlagID: String, CaseIterable {
+    case autopushFeature
     case bottomSearchBar
     case contextualHintForJumpBackInSyncedTab
     case contextualHintForToolbar
@@ -63,6 +64,8 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
         typealias FlagKeys = PrefsKeys.FeatureFlags
 
         switch featureID {
+        case .autopushFeature:
+            return FlagKeys.AutopushFeature
         case .bottomSearchBar:
             return FlagKeys.SearchBarPosition
         case .historyHighlights:

--- a/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -11,6 +11,8 @@ final class NimbusFeatureFlagLayer {
                                      from nimbus: FxNimbus = FxNimbus.shared
     ) -> Bool {
         switch featureID {
+        case .autopushFeature:
+            return checkAutopushFeature(from: nimbus)
         case .pullToRefresh,
                 .reportSiteIssue,
                 .shakeToRestore:
@@ -114,6 +116,11 @@ final class NimbusFeatureFlagLayer {
         case .shakeToRestore: return config.shakeToRestore.status
         default: return false
         }
+    }
+
+    private func checkAutopushFeature(from nimbus: FxNimbus) -> Bool {
+        let config = nimbus.features.autopushFeature.value()
+        return config.useNewAutopushClient
     }
 
     private func checkAwesomeBarFeature(for featureID: NimbusFeatureFlagID,

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -74,6 +74,7 @@ public struct PrefsKeys {
     public struct FeatureFlags {
         public static let ASPocketStories = "ASPocketStoriesUserPrefsKey"
         public static let ASSponsoredPocketStories = "ASSponsoredPocketStoriesUserPrefsKey"
+        public static let AutopushFeature = "AutopushFeatureUserPrefKey"
         public static let CustomWallpaper = "CustomWallpaperUserPrefsKey"
         public static let HistoryHighlightsSection = "HistoryHighlightsSectionUserPrefsKey"
         public static let HistoryGroups = "HistoryGroupsUserPrefsKey"

--- a/nimbus-features/autopushFeature.yaml
+++ b/nimbus-features/autopushFeature.yaml
@@ -1,0 +1,8 @@
+features:
+  autopush-feature:
+    description: This property defines the autopush feature configuration
+    variables:
+      use-new-autopush-client:
+        description: If true, the autopush client based on the Rust component will be used
+        type: Boolean
+        default: false

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -13,6 +13,7 @@ channels:
   - beta
   - release
 include:
+  - nimbus-features/autopushFeature.yaml
   - nimbus-features/contextualHintFeature.yaml
   - nimbus-features/coordinatorsRefactorFeature.yaml
   - nimbus-features/creditCardAutofillFeature.yaml


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/SYNC-3736)

### Description
Adds feature flags to protect the new `Autopush`, the feature flag will need to be used both in [`AppDelegate+PushNotifications.swift`](https://github.com/mozilla-mobile/firefox-ios/blob/main/Client/Application/AppDelegate%2BPushNotifications.swift) and in [`NotificationService`](https://github.com/mozilla-mobile/firefox-ios/blob/main/Extensions/NotificationService/NotificationService.swift)

Since the NimbusFeatureFlags can't be accessed in the Notification Service yet, I'll also be using a user pref there that will reflect the state of the nimbus flag



Since this is a tiny PR took at as an opportunity to also add the feature flag I'll use later as I switch up the usage of push

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
