### PR TITLE
Add MTE-876 [v115] Adjust Fennec_Enterprise browser entitlement step for archiving

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -380,16 +380,6 @@ workflows:
             echo "Adding com.apple.developer.web-browser to entitlements"
 
             /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser bool true" Client/Entitlements/FennecApplication.entitlements
-    - script@1:
-        title: Add default web browser entitlement for Fennec_Enterprise
-        inputs:
-        - content: |-
-            #/usr/bin/env bash
-            set -x
-
-            echo "Adding com.apple.developer.web-browser to entitlements"
-
-            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser bool true" Client/Entitlements/FennecEnterpriseApplication.entitlements
     - cache-pull@2.1: {}
   2_certificate_and_profile:
     steps:
@@ -466,6 +456,16 @@ workflows:
             rm /tmp/tmp.xcconfig
             envman add --key XCODE_XCCONFIG_FILE --value ''
         title: Remove carthage lipo workaround
+    - script@1:
+        title: Add default web browser entitlement for Fennec_Enterprise
+        inputs:
+        - content: |-
+            #/usr/bin/env bash
+            set -x
+
+            echo "Adding com.apple.developer.web-browser to entitlements"
+
+            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser bool true" Client/Entitlements/FennecEnterpriseApplication.entitlements
   3_provisioning_and_npm_installation:
     steps:
     - script@1.1:


### PR DESCRIPTION
Speculative fix as suggested by @isabelrios, this matches the order in `Focus`. 

As found in: https://app.bitrise.io/build/80dd3631-2882-4df1-b545-844331efb18d

Perhaps we need to move the com.apple.developer.web-browser entitlement for Fennec_Enterprise to happen after certs and profile setup.