### PR TITLE
Bug MTE-1119 [v115] Disable UI Test Decision for Merge from Release Branch

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -585,15 +585,20 @@ workflows:
             #!/usr/bin/env bash
             set -ex
 
-            # Manual triggers leave empty commits. 
-            # Check for empty commit/PR and exit blacklist check if found to avoid erroring out.
-
+            # We need to check both PRs and MERGE for release and epic branches so an error isn't
+            # created when trying to find a diff on a commit that doesn't exist on origin/main
+            # First check destination branch for PRs and then check $BITRISE_GIT_BRANCH for
+            # merges to main since the destination branch changes back to origin/main
             if [[ $BITRISEIO_GIT_BRANCH_DEST = release* ]] || [[ $BITRISEIO_GIT_BRANCH_DEST = epic* ]]; then
                 FILES_CHANGED=$(git diff --name-only $BITRISEIO_GIT_BRANCH_DEST..."$BITRISE_GIT_COMMIT")
+            elif [[ $BITRISE_GIT_BRANCH = release* ]] || [[ $BITRISE_GIT_BRANCH = epic* ]]; then
+                FILES_CHANGED=$(git diff --name-only $BITRISE_GIT_BRANCH..."$BITRISE_GIT_COMMIT")
             else
                 FILES_CHANGED=$(git diff --name-only origin/main..."$BITRISE_GIT_COMMIT")
             fi
 
+            # Manual triggers leave empty commits. 
+            # Check for empty commit/PR and exit blacklist check if found to avoid erroring out.
             echo "Files changed in commit/PR: $FILES_CHANGED"
             if [[ -z "$FILES_CHANGED" ]]; then
                 echo "No files changed in commit/PR. Skipping Blacklist check..."

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -585,10 +585,10 @@ workflows:
             #!/usr/bin/env bash
             set -ex
 
-            # We need to check both PRs and MERGE for release and epic branches so an error isn't
+            # We need to check both PRs and MERGEs for release and epic branches so an error isn't
             # created when trying to find a diff on a commit that doesn't exist on origin/main
             # First check destination branch for PRs and then check $BITRISE_GIT_BRANCH for
-            # merges to main since the destination branch changes back to origin/main
+            # merges to origin/main since the destination branch changes back to origin/main
             if [[ $BITRISEIO_GIT_BRANCH_DEST = release* ]] || [[ $BITRISEIO_GIT_BRANCH_DEST = epic* ]]; then
                 FILES_CHANGED=$(git diff --name-only $BITRISEIO_GIT_BRANCH_DEST..."$BITRISE_GIT_COMMIT")
             elif [[ $BITRISE_GIT_BRANCH = release* ]] || [[ $BITRISE_GIT_BRANCH = epic* ]]; then

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -592,6 +592,8 @@ workflows:
             if [[ $BITRISEIO_GIT_BRANCH_DEST = release* ]] || [[ $BITRISEIO_GIT_BRANCH_DEST = epic* ]]; then
                 FILES_CHANGED=$(git diff --name-only $BITRISEIO_GIT_BRANCH_DEST..."$BITRISE_GIT_COMMIT")
             elif [[ $BITRISE_GIT_BRANCH = release* ]] || [[ $BITRISE_GIT_BRANCH = epic* ]]; then
+                echo "Skipping Blacklist check for Merging into $BITRISE_BIT_BRANCH..."
+                exit 0
                 FILES_CHANGED=$(git diff --name-only $BITRISE_GIT_BRANCH..."$BITRISE_GIT_COMMIT")
             else
                 FILES_CHANGED=$(git diff --name-only origin/main..."$BITRISE_GIT_COMMIT")


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1119)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

### Description
We need to temporarily disable the `Decision_to_run_UI_Tests` for merges into release branches while we figure out an apparent bug in Bitrise.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
