### PR TITLE
Refactor FXIOS-6483 [v116] App settings deeplink option in settings coordinator

### DIFF
--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -121,6 +121,10 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
         }
     }
 
+    func show(settings: Route.SettingsSection) {
+        showSettings(with: settings)
+    }
+
     // MARK: - Route handling
 
     override func handle(route: Route) -> Bool {

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -327,7 +327,6 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
             }
 
         default:
-            // For cases that are not yet handled we show the main settings page, more to come with FXIOS-6274
             return nil
         }
     }

--- a/Client/Coordinators/Browser/BrowserDelegate.swift
+++ b/Client/Coordinators/Browser/BrowserDelegate.swift
@@ -22,4 +22,8 @@ protocol BrowserDelegate: AnyObject {
     /// Show the webview to navigate
     /// - Parameter webView: When nil, will show the already existing webview
     func show(webView: WKWebView)
+
+    /// Asks to show a settings page, can be a general settings page or a child page
+    /// - Parameter settings: The settings route we're trying to get to
+    func show(settings: Route.SettingsSection)
 }

--- a/Client/Coordinators/Router/Route.swift
+++ b/Client/Coordinators/Router/Route.swift
@@ -78,7 +78,6 @@ enum Route: Equatable {
         case mailto
         case newTab = "newtab"
         case search
-        case systemDefaultBrowser = "system-default-browser"
         case tabs
         case theme
         case toolbar

--- a/Client/Coordinators/Router/Route.swift
+++ b/Client/Coordinators/Router/Route.swift
@@ -69,20 +69,21 @@ enum Route: Equatable {
 
     /// An enumeration representing different sections of the settings menu.
     enum SettingsSection: String, CaseIterable, Equatable {
+        case contentBlocker
         case clearPrivateData = "clear-private-data"
-        case newTab = "newtab"
+        case creditCard
+        case fxa
+        case general
         case homePage = "homepage"
         case mailto
+        case newTab = "newtab"
         case search
-        case fxa
         case systemDefaultBrowser = "system-default-browser"
-        case wallpaper
-        case theme
-        case contentBlocker
-        case toolbar
         case tabs
+        case theme
+        case toolbar
         case topSites
-        case general
+        case wallpaper
     }
 
     /// An enumeration representing different actions that can be performed within the application.

--- a/Client/Coordinators/SettingsCoordinator.swift
+++ b/Client/Coordinators/SettingsCoordinator.swift
@@ -87,9 +87,27 @@ class SettingsCoordinator: BaseCoordinator, SettingsDelegate {
                 return nil
             }
 
-        default:
-            // FXIOS-6483: For cases that are not yet handled we show the main settings page
+        case .contentBlocker:
+            let contentBlockerVC = ContentBlockerSettingViewController(prefs: profile.prefs)
+            contentBlockerVC.tabManager = tabManager
+            return contentBlockerVC
+
+        case .creditCard:
+            // FXIOS-6612 Handle credit card settings page in coordinator
             return nil
+
+        case .tabs:
+            return TabsSettingsViewController()
+
+        case .toolbar:
+            let viewModel = SearchBarSettingsViewModel(prefs: profile.prefs)
+            return SearchBarSettingsViewController(viewModel: viewModel)
+
+        case .topSites:
+            return TopSitesSettingsViewController()
+
+        case .general:
+            return nil // Return nil since we're already at the general page
         }
     }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1842,6 +1842,7 @@ class BrowserViewController: UIViewController {
         }
     }
 
+    // Will be clean up with FXIOS-6529
     func showSettingsWithDeeplink(to destination: AppSettingsDeeplinkOption) {
         let settingsTableViewController = AppSettingsTableViewController(
             with: profile,
@@ -2195,7 +2196,12 @@ extension BrowserViewController: HomePanelDelegate {
     }
 
     func homePanelDidRequestToOpenSettings(at settingsPage: AppSettingsDeeplinkOption) {
-        showSettingsWithDeeplink(to: settingsPage)
+        if CoordinatorFlagManager.isCoordinatorEnabled {
+            let route = settingsPage.getSettingsRoute()
+            browserDelegate?.show(settings: route)
+        } else {
+            showSettingsWithDeeplink(to: settingsPage)
+        }
     }
 }
 
@@ -2852,7 +2858,11 @@ extension BrowserViewController: TabTrayDelegate {
     }
 
     func tabTrayDidRequestTabsSettings() {
-        showSettingsWithDeeplink(to: .customizeTabs)
+        if CoordinatorFlagManager.isCoordinatorEnabled {
+            browserDelegate?.show(settings: .tabs)
+        } else {
+            showSettingsWithDeeplink(to: .customizeTabs)
+        }
     }
 }
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
@@ -231,15 +231,27 @@ extension BrowserViewController: ToolBarActionMenuDelegate {
     }
 
     func showCustomizeHomePage() {
-        showSettingsWithDeeplink(to: .customizeHomepage)
+        if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+            browserDelegate?.show(settings: .homePage)
+        } else {
+            showSettingsWithDeeplink(to: .customizeHomepage)
+        }
     }
 
     func showWallpaperSettings() {
-        showSettingsWithDeeplink(to: .wallpaper)
+        if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+            browserDelegate?.show(settings: .wallpaper)
+        } else {
+            showSettingsWithDeeplink(to: .wallpaper)
+        }
     }
 
     func showCreditCardSettings() {
-        showSettingsWithDeeplink(to: .creditCard)
+        if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+            browserDelegate?.show(settings: .creditCard)
+        } else {
+            showSettingsWithDeeplink(to: .creditCard)
+        }
     }
 
     func showZoomPage(tab: Tab) {

--- a/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -6,6 +6,7 @@ import Common
 import UIKit
 import Shared
 
+// Will be clean up with FXIOS-6529
 enum AppSettingsDeeplinkOption {
     case contentBlocker
     case customizeHomepage
@@ -14,6 +15,25 @@ enum AppSettingsDeeplinkOption {
     case customizeTopSites
     case wallpaper
     case creditCard
+
+    func getSettingsRoute() -> Route.SettingsSection {
+        switch self {
+        case .contentBlocker:
+            return .contentBlocker
+        case .customizeHomepage:
+            return .homePage
+        case .customizeTabs:
+            return .tabs
+        case .customizeToolbar:
+            return .toolbar
+        case .customizeTopSites:
+            return .topSites
+        case .wallpaper:
+            return .wallpaper
+        case .creditCard:
+            return .creditCard
+        }
+    }
 }
 
 protocol AppSettingsDelegate: AnyObject {
@@ -23,7 +43,7 @@ protocol AppSettingsDelegate: AnyObject {
 /// App Settings Screen (triggered by tapping the 'Gear' in the Tab Tray Controller)
 class AppSettingsTableViewController: SettingsTableViewController, FeatureFlaggable, AppSettingsDelegate {
     // MARK: - Properties
-    var deeplinkTo: AppSettingsDeeplinkOption?
+    var deeplinkTo: AppSettingsDeeplinkOption? // Will be clean up with FXIOS-6529
     private var showDebugSettings = false
     private var debugSettingsClickCount: Int = 0
     private var appAuthenticator: AppAuthenticationProtocol
@@ -77,6 +97,7 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
         settingsDelegate?.didFinish()
     }
 
+    // Will be clean up with FXIOS-6529
     private func checkForDeeplinkSetting() {
         guard let deeplink = deeplinkTo else { return }
         var viewController: SettingsTableViewController

--- a/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -161,6 +161,19 @@ final class BrowserCoordinatorTests: XCTestCase {
         XCTAssertNotNil(screenshotService.screenshotableView)
     }
 
+    // MARK: - Show settings
+
+    func testShowSettings() throws {
+        let subject = createSubject()
+        subject.show(settings: .general)
+
+        XCTAssertEqual(subject.childCoordinators.count, 1)
+        XCTAssertNotNil(subject.childCoordinators[0] as? SettingsCoordinator)
+        let presentedVC = try XCTUnwrap(mockRouter.presentedViewController as? ThemedNavigationController)
+        XCTAssertEqual(mockRouter.presentCalled, 1)
+        XCTAssertTrue(presentedVC.topViewController is AppSettingsTableViewController)
+    }
+
     // MARK: - Search route
 
     func testHandleSearchQuery_returnsTrue() {

--- a/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
@@ -125,6 +125,51 @@ final class SettingsCoordinatorTests: XCTestCase {
         XCTAssertTrue(mockRouter.pushedViewController is WallpaperSettingsViewController)
     }
 
+    func testContentBlockerSettingsRoute_showsContentBlockerSettingsPage() throws {
+        let subject = createSubject()
+
+        subject.start(with: .contentBlocker)
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+        XCTAssertTrue(mockRouter.pushedViewController is ContentBlockerSettingViewController)
+    }
+
+    func testTabsSettingsRoute_showsTabsSettingsPage() throws {
+        let subject = createSubject()
+
+        subject.start(with: .tabs)
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+        XCTAssertTrue(mockRouter.pushedViewController is TabsSettingsViewController)
+    }
+
+    func testToolbarSettingsRoute_showsToolbarSettingsPage() throws {
+        let subject = createSubject()
+
+        subject.start(with: .toolbar)
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+        XCTAssertTrue(mockRouter.pushedViewController is SearchBarSettingsViewController)
+    }
+
+    func testTopSitesSettingsRoute_showsTopSitesSettingsPage() throws {
+        let subject = createSubject()
+
+        subject.start(with: .topSites)
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+        XCTAssertTrue(mockRouter.pushedViewController is TopSitesSettingsViewController)
+    }
+
+    func testCreditCardSettingsRoute_showsGeneralSettingsPageForNow() throws {
+        let subject = createSubject()
+
+        subject.start(with: .creditCard)
+
+        XCTAssertEqual(mockRouter.pushCalled, 0)
+        XCTAssertNil(mockRouter.pushedViewController)
+    }
+
     // MARK: - Delegate
     func testParentCoordinatorDelegate_calledWithURL() {
         let subject = createSubject()


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6483)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13813)

### Description
- Add a function to `func show(settings:)` in `BrowserDelegate`. So BVC tells `BrowserCoordinator` it wants to open a settings page. `BrowserCoordinator` then creates the `SettingsCoordinator` which will handle the settings page for us.
- Handling new cases in `SettingsCoordinator` - One thing I would like to improve is that since this is enum based, this will be a gigantic enum soon since we have more settings pages coming. Any ideas on how to improve that @OrlaM?
- Removed `Route.SettingsSection` case with ` case systemDefaultBrowser = "system-default-browser"` since it will not be used (this isn't a settings page, it's an action to open the real iOS settings which is covered with `Route.DefaultBrowserSection.systemSettings`)
- Add unit tests in `SettingsCoordinator` and `BrowserCoordinator`

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
