### PR TITLE
Refactor MTE-876 [v116] Follow up to fix FennecEnterprise archive

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -452,16 +452,6 @@ workflows:
             rm /tmp/tmp.xcconfig
             envman add --key XCODE_XCCONFIG_FILE --value ''
         title: Remove carthage lipo workaround
-    - script@1:
-        title: Add default web browser entitlement for Fennec_Enterprise
-        inputs:
-        - content: |-
-            #/usr/bin/env bash
-            set -x
-
-            echo "Adding com.apple.developer.web-browser to entitlements"
-
-            /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser bool true" Client/Entitlements/FennecEnterpriseApplication.entitlements
   3_provisioning_and_npm_installation:
     steps:
     - script@1.1:


### PR DESCRIPTION
I have seen that if I run the `Add default web browser entitlement for Fennec_Enterprise` script locally, I get the same error. I'm trying removing this step that allows a local build to see if in the same conditions bitrise works.

If not, we will look into the provisioning profiles created.