### PR TITLE
Refactor MTE-876 [v116] Followup add Bitrise matrix label

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1425,7 +1425,8 @@ workflows:
             --app "$BITRISE_IPA_PATH" \
             --device=model=iphone13pro,version=15.7 \
             --results-bucket=firefox_ios_test_artifacts \
-            --no-record-video
+            --no-record-video \
+            --client-details=matrixLabel="Bitrise"
 
 app:
   envs:


### PR DESCRIPTION
This adds a label to the matrices that indicates it started on Bitrise.
![Screenshot 2023-06-08 at 10 23 40 AM](https://github.com/mozilla-mobile/firefox-ios/assets/102331/046becbc-bb70-495f-8e56-41e0b0d1ff66)

[1] https://cloud.google.com/sdk/gcloud/reference/firebase/test/android/run#--client-details