### PR TITLE
Bugfix FXIOS-6627 [v114] Add second parameter for app name

### DIFF
--- a/Client/Nimbus/OnboardingFeatureLayer/NimbusOnboardingFeatureLayer.swift
+++ b/Client/Nimbus/OnboardingFeatureLayer/NimbusOnboardingFeatureLayer.swift
@@ -94,7 +94,7 @@ class NimbusOnboardingFeatureLayer: NimbusOnboardingFeatureLayerProtocol {
                 return OnboardingCardInfoModel(
                     name: card.name,
                     title: String(format: card.title, AppName.shortName.rawValue),
-                    body: String(format: card.body, AppName.shortName.rawValue),
+                    body: String(format: card.body, AppName.shortName.rawValue, AppName.shortName.rawValue),
                     link: getOnboardingLink(from: card.link),
                     buttons: getOnboardingCardButtons(from: card.buttons),
                     type: card.type,


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6627)

### Description
Turkish has two placeholders, which is causing a crash. This fixes it.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
