### PR TITLE
Bump [v116] Upgrades rust-component-swift to 116.0.20230608050307

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -18651,7 +18651,7 @@
 			repositoryURL = "https://github.com/mozilla/rust-components-swift.git";
 			requirement = {
 				kind = exactVersion;
-				version = 115.0.20230604050337;
+				version = 116.0.20230608050307;
 			};
 		};
 		435C85EE2788F4D00072B526 /* XCRemoteSwiftPackageReference "glean-swift" */ = {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla/rust-components-swift.git",
       "state" : {
-        "revision" : "99e7e5dfca9d82ef810c8dc8503dbe5139ac7bc6",
-        "version" : "115.0.20230604050337"
+        "revision" : "242cbbfd94f89ae4715397323bd291f00b896a74",
+        "version" : "116.0.20230608050307"
       }
     },
     {

--- a/nimbus-features/homescreenFeature.yaml
+++ b/nimbus-features/homescreenFeature.yaml
@@ -51,9 +51,6 @@ features:
             "status": true,
             "max-number-of-tiles": 2
           },
-          "wallpaper-feature": {
-            "status": true
-          },
           "pocket-sponsored-stories": true,
           "jump-back-in-synced-tab": true
         }
@@ -69,9 +66,6 @@ features:
           "sponsored-tiles": {
             "status": true,
             "max-number-of-tiles": 1
-          },
-          "wallpaper-feature": {
-            "status": true
           },
           "pocket-sponsored-stories": false,
           "jump-back-in-synced-tab": true


### PR DESCRIPTION
No-ticket bump

### Description
Supersedes #14815 - bumps the rust-components-swift version and deletes the defaults that were causing the breakage.



### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
