### PR TITLE
Refactor FXIOS-6535 [v116] Handle settings presentation from MainMenuActionHelper

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -548,6 +548,7 @@
 		8A161411282C035D00DDBB02 /* CustomizeHomepageSectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A161410282C035D00DDBB02 /* CustomizeHomepageSectionViewModel.swift */; };
 		8A161413282C2F8F00DDBB02 /* NimbusSponsoredTileLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A161412282C2F8F00DDBB02 /* NimbusSponsoredTileLayer.swift */; };
 		8A171A6329F82B0E0085770E /* SceneDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A171A6129F82AE20085770E /* SceneDelegateTests.swift */; };
+		8A19ACAB2A32895E001C2147 /* BrowserNavigationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A19ACAA2A32895E001C2147 /* BrowserNavigationHandler.swift */; };
 		8A1E3BDF28CBA81E003388C4 /* SponsoredContentFilterUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1E3BDE28CBA81E003388C4 /* SponsoredContentFilterUtility.swift */; };
 		8A1E3BE328CBACDD003388C4 /* SponsoredContentFilterUtilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1E3BE128CBACD7003388C4 /* SponsoredContentFilterUtilityTests.swift */; };
 		8A2366FA28A302E500846D1B /* MockSponsoredPocketAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2366F928A302E500846D1B /* MockSponsoredPocketAPI.swift */; };
@@ -4491,6 +4492,7 @@
 		8A161410282C035D00DDBB02 /* CustomizeHomepageSectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomizeHomepageSectionViewModel.swift; sourceTree = "<group>"; };
 		8A161412282C2F8F00DDBB02 /* NimbusSponsoredTileLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusSponsoredTileLayer.swift; sourceTree = "<group>"; };
 		8A171A6129F82AE20085770E /* SceneDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegateTests.swift; sourceTree = "<group>"; };
+		8A19ACAA2A32895E001C2147 /* BrowserNavigationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserNavigationHandler.swift; sourceTree = "<group>"; };
 		8A1E3BDE28CBA81E003388C4 /* SponsoredContentFilterUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SponsoredContentFilterUtility.swift; sourceTree = "<group>"; };
 		8A1E3BE128CBACD7003388C4 /* SponsoredContentFilterUtilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SponsoredContentFilterUtilityTests.swift; sourceTree = "<group>"; };
 		8A1E3BE528CBBF44003388C4 /* OpenSearchEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSearchEngine.swift; sourceTree = "<group>"; };
@@ -8318,6 +8320,7 @@
 		8AF99B5029EF1BB600108DEC /* Browser */ = {
 			isa = PBXGroup;
 			children = (
+				8A19ACAA2A32895E001C2147 /* BrowserNavigationHandler.swift */,
 				8A93F87129D3A5AD004159D9 /* BrowserCoordinator.swift */,
 				8AF99B4E29EF1BA700108DEC /* BrowserDelegate.swift */,
 			);
@@ -12392,6 +12395,7 @@
 				CA520E7A24913C1B00CCAB48 /* LoginListViewModel.swift in Sources */,
 				8AE1E1CD27B191110024C45E /* SearchBarSettingsViewModel.swift in Sources */,
 				43D16B8529831EA5009F8279 /* Style.swift in Sources */,
+				8A19ACAB2A32895E001C2147 /* BrowserNavigationHandler.swift in Sources */,
 				8AE80BB82891BE0700BC12EA /* JumpBackInDataAdaptor.swift in Sources */,
 				8A01891C275E9C2A00923EFE /* ClearHistorySheetProvider.swift in Sources */,
 				C88E7A572A0553360072E638 /* OnboardingButtonInfoModel.swift in Sources */,

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -7,7 +7,7 @@ import Foundation
 import WebKit
 import Shared
 
-class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDelegate, SettingsCoordinatorDelegate {
+class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDelegate, SettingsCoordinatorDelegate, BrowserNavigationHandler {
     var browserViewController: BrowserViewController
     var webviewController: WebviewViewController?
     var homepageViewController: HomepageViewController?
@@ -40,7 +40,9 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
         self.wallpaperManager = wallpaperManager
         self.isSettingsCoordinatorEnabled = isSettingsCoordinatorEnabled
         super.init(router: router)
-        self.browserViewController.browserDelegate = self
+
+        browserViewController.browserDelegate = self
+        browserViewController.navigationHandler = self
     }
 
     func start(with launchType: LaunchType?) {
@@ -119,10 +121,6 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
             homepageViewController.sendToDeviceDelegate = sendToDeviceDelegate
             return homepageViewController
         }
-    }
-
-    func show(settings: Route.SettingsSection) {
-        showSettings(with: settings)
     }
 
     // MARK: - Route handling
@@ -254,6 +252,12 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
     func didFinishSettings(from coordinator: SettingsCoordinator) {
         router.dismiss(animated: true, completion: nil)
         remove(child: coordinator)
+    }
+
+    // MARK: - BrowserNavigationHandler
+
+    func show(settings: Route.SettingsSection) {
+        showSettings(with: settings)
     }
 
     // MARK: - To be removed with FXIOS-6529

--- a/Client/Coordinators/Browser/BrowserDelegate.swift
+++ b/Client/Coordinators/Browser/BrowserDelegate.swift
@@ -22,8 +22,4 @@ protocol BrowserDelegate: AnyObject {
     /// Show the webview to navigate
     /// - Parameter webView: When nil, will show the already existing webview
     func show(webView: WKWebView)
-
-    /// Asks to show a settings page, can be a general settings page or a child page
-    /// - Parameter settings: The settings route we're trying to get to
-    func show(settings: Route.SettingsSection)
 }

--- a/Client/Coordinators/Browser/BrowserNavigationHandler.swift
+++ b/Client/Coordinators/Browser/BrowserNavigationHandler.swift
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+protocol BrowserNavigationHandler: AnyObject {
+    /// Asks to show a settings page, can be a general settings page or a child page
+    /// - Parameter settings: The settings route we're trying to get to
+    func show(settings: Route.SettingsSection)
+}

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -44,6 +44,8 @@ class BrowserViewController: UIViewController {
     ]
 
     weak var browserDelegate: BrowserDelegate?
+    weak var navigationHandler: BrowserNavigationHandler?
+
     var homepageViewController: HomepageViewController?
     var libraryViewController: LibraryViewController?
     var webViewContainer: UIView!
@@ -2198,7 +2200,7 @@ extension BrowserViewController: HomePanelDelegate {
     func homePanelDidRequestToOpenSettings(at settingsPage: AppSettingsDeeplinkOption) {
         if CoordinatorFlagManager.isCoordinatorEnabled {
             let route = settingsPage.getSettingsRoute()
-            browserDelegate?.show(settings: route)
+            navigationHandler?.show(settings: route)
         } else {
             showSettingsWithDeeplink(to: settingsPage)
         }
@@ -2859,7 +2861,7 @@ extension BrowserViewController: TabTrayDelegate {
 
     func tabTrayDidRequestTabsSettings() {
         if CoordinatorFlagManager.isCoordinatorEnabled {
-            browserDelegate?.show(settings: .tabs)
+            navigationHandler?.show(settings: .tabs)
         } else {
             showSettingsWithDeeplink(to: .customizeTabs)
         }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
@@ -91,6 +91,9 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
         menuHelper.delegate = self
         menuHelper.menuActionDelegate = self
         menuHelper.sendToDeviceDelegate = self
+        if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+            menuHelper.navigationHandler = navigationHandler
+        }
 
         updateZoomPageBarVisibility(visible: false)
         menuHelper.getToolbarActions(navigationController: navigationController) { actions in
@@ -232,7 +235,7 @@ extension BrowserViewController: ToolBarActionMenuDelegate {
 
     func showCustomizeHomePage() {
         if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
-            browserDelegate?.show(settings: .homePage)
+            navigationHandler?.show(settings: .homePage)
         } else {
             showSettingsWithDeeplink(to: .customizeHomepage)
         }
@@ -240,7 +243,7 @@ extension BrowserViewController: ToolBarActionMenuDelegate {
 
     func showWallpaperSettings() {
         if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
-            browserDelegate?.show(settings: .wallpaper)
+            navigationHandler?.show(settings: .wallpaper)
         } else {
             showSettingsWithDeeplink(to: .wallpaper)
         }
@@ -248,7 +251,7 @@ extension BrowserViewController: ToolBarActionMenuDelegate {
 
     func showCreditCardSettings() {
         if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
-            browserDelegate?.show(settings: .creditCard)
+            navigationHandler?.show(settings: .creditCard)
         } else {
             showSettingsWithDeeplink(to: .creditCard)
         }

--- a/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -70,6 +70,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     weak var delegate: ToolBarActionMenuDelegate?
     weak var menuActionDelegate: MenuActionsDelegate?
     weak var sendToDeviceDelegate: SendToDeviceDelegate?
+    weak var navigationHandler: BrowserNavigationHandler?
 
     /// MainMenuActionHelper init
     /// - Parameters:
@@ -443,31 +444,42 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     }
 
     private func getSettingsAction() -> PhotonRowActions {
-        let title = String.AppMenu.AppMenuSettingsTitleString
-        let icon = ImageIdentifiers.settings
+        let openSettings = SingleActionViewModel(title: .AppMenu.AppMenuSettingsTitleString,
+                                                 iconString: ImageIdentifiers.settings) { _ in
+            if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+                TelemetryWrapper.recordEvent(category: .action, method: .open, object: .settings)
 
-        let openSettings = SingleActionViewModel(title: title,
-                                                 iconString: icon) { _ in
-            let settingsTableViewController = AppSettingsTableViewController(
-                with: self.profile,
-                and: self.tabManager,
-                delegate: self.menuActionDelegate)
-
-            let controller = ThemedNavigationController(rootViewController: settingsTableViewController)
-            // On iPhone iOS13 the WKWebview crashes while presenting file picker if its not full screen. Ref #6232
-            if UIDevice.current.userInterfaceIdiom == .phone {
-                controller.modalPresentationStyle = .fullScreen
-            }
-            controller.presentingModalViewControllerDelegate = self.menuActionDelegate
-            TelemetryWrapper.recordEvent(category: .action, method: .open, object: .settings)
-
-            // Wait to present VC in an async dispatch queue to prevent a case where dismissal
-            // of this popover on iPad seems to block the presentation of the modal VC.
-            DispatchQueue.main.async {
-                self.delegate?.showViewController(viewController: controller)
+                // Wait to show settings in async dispatch since hamburger menu is still showing at that time
+                DispatchQueue.main.async {
+                    self.navigationHandler?.show(settings: .general)
+                }
+            } else {
+                self.legacyShowSettings()
             }
         }.items
         return openSettings
+    }
+
+    // Will be removed with FXIOS-6529
+    private func legacyShowSettings() {
+        let settingsTableViewController = AppSettingsTableViewController(
+            with: self.profile,
+            and: self.tabManager,
+            delegate: self.menuActionDelegate)
+
+        let controller = ThemedNavigationController(rootViewController: settingsTableViewController)
+        // On iPhone iOS13 the WKWebview crashes while presenting file picker if its not full screen. Ref #6232
+        if UIDevice.current.userInterfaceIdiom == .phone {
+            controller.modalPresentationStyle = .fullScreen
+        }
+        controller.presentingModalViewControllerDelegate = self.menuActionDelegate
+        TelemetryWrapper.recordEvent(category: .action, method: .open, object: .settings)
+
+        // Wait to present VC in an async dispatch queue to prevent a case where dismissal
+        // of this popover on iPad seems to block the presentation of the modal VC.
+        DispatchQueue.main.async {
+            self.delegate?.showViewController(viewController: controller)
+        }
     }
 
     private func getNightModeAction() -> [PhotonRowActions] {

--- a/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -161,7 +161,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         XCTAssertNotNil(screenshotService.screenshotableView)
     }
 
-    // MARK: - Show settings
+    // MARK: - BrowserNavigationHandler
 
     func testShowSettings() throws {
         let subject = createSubject()


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6535)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14645)

### Description
- Create `BrowserNavigationHandler` to handle show settings navigation
- Make sure this handler handles the case from our main menu
- Remove show settings from `BrowserDelegate`, so it's the navigation handler instead that takes care of this case. This will be used elsewhere as well.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
