### PR TITLE
Bugfix FXIOS-6631 [v114.2] [Experiment] The "Firefox" string from the iOS Re-engagement Notifications is wrongly displayed as "%@"

### DIFF
--- a/Client/Frontend/NotificationSurface/NotificationSurfaceManager.swift
+++ b/Client/Frontend/NotificationSurface/NotificationSurfaceManager.swift
@@ -88,8 +88,9 @@ class NotificationSurfaceManager: NotificationSurfaceDelegate {
     private func scheduleNotification(message: GleanPlumbMessage, notificationId: String) {
         let userInfo = [Constant.messageIdKey: message.id]
         let fallbackTitle = String(format: .Notification.FallbackTitle, AppInfo.displayName)
+        let body = String(format: message.data.text, AppInfo.displayName)
         notificationManager.schedule(title: message.data.title ?? fallbackTitle,
-                                     body: message.data.text,
+                                     body: body,
                                      id: notificationId,
                                      userInfo: userInfo,
                                      categoryIdentifier: Constant.notificationCategoryId,


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6631)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14839)

### Description
This fixes the placeholders not being replaced by the app name for notifications.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
