### PR TITLE
Add MTE-1126 [v116] Add Slack notification for Robo test

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1419,14 +1419,38 @@ workflows:
             curl -o /tmp/key-file.json $BITRISEIO_GOOGLE_APPLICATION_CREDENTIALS_URL 
             $HOME/google-cloud-sdk/bin/gcloud version
             $HOME/google-cloud-sdk/bin/gcloud auth activate-service-account -q --key-file /tmp/key-file.json
-            $HOME/google-cloud-sdk/bin/gcloud config set project moz-firefox-ios-230118
-            $HOME/google-cloud-sdk/bin/gcloud beta firebase test ios run \
-            --type robo \
-            --app "$BITRISE_IPA_PATH" \
-            --device=model=iphone13pro,version=15.7 \
-            --results-bucket=firefox_ios_test_artifacts \
-            --no-record-video \
-            --client-details=matrixLabel="Bitrise"
+            $HOME/google-cloud-sdk/bin/gcloud config set project "$GOOGLE_CLOUD_PROJECT"
+            GCLOUD_OUTPUT=$($HOME/google-cloud-sdk/bin/gcloud beta firebase test ios run \
+                --type robo \
+                --app "$BITRISE_IPA_PATH" \
+                --device=model=iphone13pro,version=15.7 \
+                --results-bucket=firefox_ios_test_artifacts \
+                --no-record-video \
+                --client-details=matrixLabel="Bitrise" \
+                2>&1 | tee /dev/tty)
+            MATRIX_WEBLINK=$(echo "$GCLOUD_OUTPUT" | grep 'https://console.firebase.google.com/project' | awk -F '[][]' '{print $2}' | head -n 1)
+            envman add --key MATRIX_WEBLINK --value "$MATRIX_WEBLINK"
+    - slack@3.5.0:
+        is_always_run: true
+        inputs:
+        - title: ''
+        - author_name: ''
+        - webhook_url: "$WEBHOOK_SLACK_TOKEN"
+        - footer_icon: https://emoji.slack-edge.com/T027LFU12/testops-notify/d350cecb43e9e630.png
+        - footer: Created by Mobile Test Engineering
+        - pretext_on_error: "*Firefox-iOS* :firefox: *Archive/Robo Test* :x:"
+        - pretext: "*Firefox-iOS* :firefox: *Archive/Robo Test* :white_check_mark:"
+        - timestamp: 'no'
+        - fields: |
+            Task | ${BITRISE_BUILD_URL}
+            Commit | ${GIT_CLONE_COMMIT_MESSAGE_SUBJECT}
+            Source-Workflow | ${BITRISE_TRIGGERED_WORKFLOW_TITLE}
+            Branch | ${BITRISE_GIT_BRANCH}
+            Result | ${MATRIX_WEBLINK}
+        - buttons: |
+            App|${BITRISE_APP_URL}
+            #mobile-testeng|https://mozilla.slack.com/archives/C02KDDS9QM9
+            Mana|https://mana.mozilla.org/wiki/display/MTE/Mobile+Test+Engineering
 
 app:
   envs:


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/jira/software/c/projects/MTE/boards/546

* Adds a Slack notification step
* Use secret for project set

Follow-up: I'd like to see how we can pull the web-link to a matrix exposed as part of the notification. From a notification, to getting a web-link will require many clicks.

Opening as a draft to check with @isabelrios to see if we only want notifications on failure (like Android), as well as which `fields:` we need.