### PR TITLE
Refactor FXIOS-6536-6537 [v116] Show settings from keyboard shortcut & ETP menu

### DIFF
--- a/Client/Coordinators/SettingsCoordinator.swift
+++ b/Client/Coordinators/SettingsCoordinator.swift
@@ -89,6 +89,7 @@ class SettingsCoordinator: BaseCoordinator, SettingsDelegate {
 
         case .contentBlocker:
             let contentBlockerVC = ContentBlockerSettingViewController(prefs: profile.prefs)
+            contentBlockerVC.profile = profile
             contentBlockerVC.tabManager = tabManager
             return contentBlockerVC
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1755,17 +1755,6 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider {
         showViewController(viewController: viewController)
     }
 
-    @objc
-    func openSettings() {
-        ensureMainThread { [self] in
-            if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
-                self.navigationHandler?.show(settings: .general)
-            } else {
-                self.legacyShowSettings(deeplink: nil)
-            }
-        }
-    }
-
     fileprivate func postLocationChangeNotificationForTab(_ tab: Tab, navigation: WKNavigation?) {
         let notificationCenter = NotificationCenter.default
         var info = [AnyHashable: Any]()

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1758,18 +1758,11 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider {
     @objc
     func openSettings() {
         ensureMainThread { [self] in
-            if let presentedViewController = self.presentedViewController {
-                presentedViewController.dismiss(animated: true, completion: nil)
+            if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+                self.navigationHandler?.show(settings: .general)
+            } else {
+                self.legacyShowSettings(deeplink: nil)
             }
-
-            let settingsTableViewController = AppSettingsTableViewController(
-                with: profile,
-                and: tabManager,
-                delegate: self)
-
-            let controller = ThemedNavigationController(rootViewController: settingsTableViewController)
-            controller.presentingModalViewControllerDelegate = self
-            self.present(controller, animated: true, completion: nil)
         }
     }
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -11,7 +11,13 @@ extension BrowserViewController {
 
     @objc
     func openSettingsKeyCommand() {
-        openSettings()
+        if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+            self.navigationHandler?.show(settings: .general)
+        } else {
+            ensureMainThread { [self] in
+                self.legacyShowSettings(deeplink: nil)
+            }
+        }
     }
 
     @objc

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -12,7 +12,7 @@ extension BrowserViewController {
     @objc
     func openSettingsKeyCommand() {
         if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
-            self.navigationHandler?.show(settings: .general)
+            navigationHandler?.show(settings: .general)
         } else {
             ensureMainThread { [self] in
                 self.legacyShowSettings(deeplink: nil)


### PR DESCRIPTION
Show from keyboard shortcut ticket
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6536)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14646)

Show from ETP menu ticket
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6537)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14647)

### Description
One PR since it was really small
- Handle showing settings from keyboard shortcut with coordinator
- Handle showing settings from ETP menu with coordinator

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
