### PR TITLE
Refactor FXIOS-XXX [v116] controllers with dequeue reusable cell for indexPath

### DIFF
--- a/Client/Frontend/Browser/OpenWithSettingsViewController.swift
+++ b/Client/Frontend/Browser/OpenWithSettingsViewController.swift
@@ -31,6 +31,7 @@ class OpenWithSettingsViewController: ThemedTableViewController {
         title = .SettingsOpenWithSectionName
 
         tableView.accessibilityIdentifier = "OpenWithPage.Setting.Options"
+        tableView.register(cellType: ThemedTableViewCell.self)
         tableView.register(ThemedTableSectionHeaderFooterView.self,
                            forHeaderFooterViewReuseIdentifier: ThemedTableSectionHeaderFooterView.cellIdentifier)
 
@@ -100,7 +101,7 @@ class OpenWithSettingsViewController: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = ThemedTableViewCell()
+        let cell = tableView.dequeueReusableCell(withIdentifier: ThemedTableViewCell.cellIdentifier, for: indexPath) as! ThemedTableViewCell
         let option = mailProviderSource[indexPath.row]
 
         cell.applyTheme(theme: themeManager.currentTheme)

--- a/Client/Frontend/LoginManagement/AddCredentialViewController.swift
+++ b/Client/Frontend/LoginManagement/AddCredentialViewController.swift
@@ -69,13 +69,7 @@ class AddCredentialViewController: UIViewController, Themeable {
         navigationItem.rightBarButtonItem = saveButton
         navigationItem.leftBarButtonItem = cancelButton
 
-        view.addSubview(tableView)
-        NSLayoutConstraint.activate([
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-        ])
+        setupTableView()
 
         applyTheme()
         listenForThemeChange(view)
@@ -87,6 +81,17 @@ class AddCredentialViewController: UIViewController, Themeable {
         // Normally UITableViewControllers handle responding to content inset changes from keyboard events when editing
         // but since we don't use the tableView's editing flag for editing we handle this ourselves.
         KeyboardHelper.defaultHelper.addDelegate(self)
+    }
+
+    private func setupTableView() {
+        tableView.register(cellType: LoginDetailTableViewCell.self)
+        view.addSubview(tableView)
+        NSLayoutConstraint.activate([
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.topAnchor.constraint(equalTo: view.topAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
     }
 
     @objc
@@ -134,9 +139,9 @@ class AddCredentialViewController: UIViewController, Themeable {
 // MARK: - UITableViewDataSource
 extension AddCredentialViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let loginCell = cell(forIndexPath: indexPath)
         switch AddCredentialField(rawValue: indexPath.row)! {
         case .usernameItem:
-            let loginCell = cell(forIndexPath: indexPath)
             let cellModel = LoginDetailTableViewCellModel(
                 title: .LoginDetailUsername,
                 keyboardType: .emailAddress,
@@ -149,7 +154,6 @@ extension AddCredentialViewController: UITableViewDataSource {
             return loginCell
 
         case .passwordItem:
-            let loginCell = cell(forIndexPath: indexPath)
             let cellModel = LoginDetailTableViewCellModel(
                 title: .LoginDetailPassword,
                 displayDescriptionAsPassword: true,
@@ -161,7 +165,6 @@ extension AddCredentialViewController: UITableViewDataSource {
             return loginCell
 
         case .websiteItem:
-            let loginCell = cell(forIndexPath: indexPath)
             let cellModel = LoginDetailTableViewCellModel(
                 title: .LoginDetailWebsite,
                 descriptionPlaceholder: "https://www.example.com",
@@ -176,7 +179,7 @@ extension AddCredentialViewController: UITableViewDataSource {
     }
 
     fileprivate func cell(forIndexPath indexPath: IndexPath) -> LoginDetailTableViewCell {
-        let loginCell = LoginDetailTableViewCell()
+        let loginCell = tableView.dequeueReusableCell(withIdentifier: LoginDetailTableViewCell.cellIdentifier, for: indexPath) as! LoginDetailTableViewCell
         loginCell.selectionStyle = .none
         loginCell.delegate = self
         return loginCell

--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -76,6 +76,7 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
 
         title = .SettingsDataManagementTitle
 
+        tableView.register(cellType: ThemedTableViewCell.self)
         tableView.register(ThemedTableSectionHeaderFooterView.self,
                            forHeaderFooterViewReuseIdentifier: ThemedTableSectionHeaderFooterView.cellIdentifier)
 
@@ -86,16 +87,19 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = ThemedTableViewCell()
+        let cell = tableView.dequeueReusableCell(withIdentifier: ThemedTableViewCell.cellIdentifier, for: indexPath) as! ThemedTableViewCell
+        cell.restoreToInitialState()
         cell.applyTheme(theme: themeManager.currentTheme)
 
         if indexPath.section == SectionArrow {
             cell.accessoryType = .disclosureIndicator
+            cell.textLabel?.textAlignment = .natural
             cell.textLabel?.text = .SettingsWebsiteDataTitle
             cell.accessibilityIdentifier = "WebsiteData"
             clearButton = cell
         } else if indexPath.section == SectionToggles {
             cell.textLabel?.text = clearables[indexPath.item].clearable.label
+            cell.textLabel?.textAlignment = .natural
             cell.textLabel?.numberOfLines = 0
             let control = UISwitch()
             control.onTintColor = themeManager.currentTheme.colors.actionPrimary

--- a/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -50,6 +50,7 @@ class TPAccessoryInfo: ThemedTableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        tableView.register(cellType: ThemedSubtitleTableViewCell.self)
         tableView.dataSource = self
         tableView.delegate = self
         tableView.estimatedRowHeight = 130
@@ -109,7 +110,8 @@ class TPAccessoryInfo: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = ThemedTableViewCell(style: .subtitle, reuseIdentifier: nil)
+        let cell = tableView.dequeueReusableCell(withIdentifier: ThemedSubtitleTableViewCell.cellIdentifier, for: indexPath) as! ThemedSubtitleTableViewCell
+        cell.restoreToInitialState()
         cell.applyTheme(theme: themeManager.currentTheme)
         if indexPath.section == 0 {
             if indexPath.row == 0 {

--- a/Client/Frontend/Settings/SearchEnginePicker.swift
+++ b/Client/Frontend/Settings/SearchEnginePicker.swift
@@ -12,6 +12,7 @@ class SearchEnginePicker: ThemedTableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        tableView.register(cellType: ThemedTableViewCell.self)
         navigationItem.title = .SearchEnginePickerTitle
         navigationItem.leftBarButtonItem = UIBarButtonItem(title: .SearchEnginePickerCancel, style: .plain, target: self, action: #selector(cancel))
     }
@@ -22,7 +23,7 @@ class SearchEnginePicker: ThemedTableViewController {
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let engine = engines[indexPath.item]
-        let cell = ThemedTableViewCell()
+        let cell = tableView.dequeueReusableCell(withIdentifier: ThemedTableViewCell.cellIdentifier, for: indexPath) as! ThemedTableViewCell
         cell.applyTheme(theme: themeManager.currentTheme)
         cell.textLabel?.text = engine.shortName
         let size = CGSize(width: OpenSearchEngine.UX.preferredIconSize,

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -55,7 +55,7 @@ class SearchSettingsTableViewController: ThemedTableViewController {
         tableView.isEditing = true
         // So that we push the default search engine controller on selection.
         tableView.allowsSelectionDuringEditing = true
-
+        tableView.register(cellType: ThemedTableViewCell.self)
         tableView.register(ThemedTableSectionHeaderFooterView.self,
                            forHeaderFooterViewReuseIdentifier: ThemedTableSectionHeaderFooterView.cellIdentifier)
 
@@ -86,7 +86,8 @@ class SearchSettingsTableViewController: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = ThemedTableViewCell()
+        let cell = tableView.dequeueReusableCell(withIdentifier: ThemedTableViewCell.cellIdentifier, for: indexPath) as! ThemedTableViewCell
+        cell.restoreToInitialState()
         cell.applyTheme(theme: themeManager.currentTheme)
         var engine: OpenSearchEngine!
 

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -766,7 +766,9 @@ class SettingsTableViewController: ThemedTableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        tableView.register(UITableViewCell.self, forCellReuseIdentifier: Identifier)
+        tableView.register(cellType: ThemedTableViewCell.self)
+        tableView.register(cellType: ThemedValue1TableViewCell.self)
+        tableView.register(cellType: ThemedSubtitleTableViewCell.self)
         tableView.register(ThemedTableSectionHeaderFooterView.self,
                            forHeaderFooterViewReuseIdentifier: ThemedTableSectionHeaderFooterView.cellIdentifier)
         tableView.tableFooterView = UIView(frame: CGRect(width: view.frame.width, height: 30))
@@ -845,7 +847,14 @@ class SettingsTableViewController: ThemedTableViewController {
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let section = settings[indexPath.section]
         if let setting = section[indexPath.row] {
-            let cell = ThemedTableViewCell(style: setting.style, reuseIdentifier: nil)
+            var cell = tableView.dequeueReusableCell(withIdentifier: ThemedTableViewCell.cellIdentifier, for: indexPath) as! ThemedTableViewCell
+            if setting.style == .value1 {
+                cell = tableView.dequeueReusableCell(withIdentifier: ThemedValue1TableViewCell.cellIdentifier, for: indexPath) as! ThemedValue1TableViewCell
+            }
+            if setting.style == .subtitle {
+                cell = tableView.dequeueReusableCell(withIdentifier: ThemedSubtitleTableViewCell.cellIdentifier, for: indexPath) as! ThemedSubtitleTableViewCell
+            }
+            cell.restoreToInitialState()
             setting.onConfigureCell(cell, theme: themeManager.currentTheme)
             cell.applyTheme(theme: themeManager.currentTheme)
             return cell

--- a/Client/Frontend/Settings/ThemeSettingsController.swift
+++ b/Client/Frontend/Settings/ThemeSettingsController.swift
@@ -20,9 +20,6 @@ class ThemeSettingsController: ThemedTableViewController {
         case lightDarkPicker
     }
 
-    // A non-interactable slider is underlaid to show the current screen brightness indicator
-    private var slider: (control: UISlider, deviceBrightnessIndicator: UISlider)?
-
     var isAutoBrightnessOn: Bool {
         return LegacyThemeManager.instance.automaticBrightnessIsOn
     }
@@ -48,6 +45,8 @@ class ThemeSettingsController: ThemedTableViewController {
 
         tableView.register(ThemedTableSectionHeaderFooterView.self,
                            forHeaderFooterViewReuseIdentifier: ThemedTableSectionHeaderFooterView.cellIdentifier)
+        tableView.register(cellType: ThemedTableViewCell.self)
+        tableView.register(cellType: ThemedSubtitleTableViewCell.self)
 
         NotificationCenter.default.addObserver(self, selector: #selector(brightnessChanged), name: UIScreen.brightnessDidChangeNotification, object: nil)
     }
@@ -176,9 +175,11 @@ class ThemeSettingsController: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = ThemedTableViewCell(style: .subtitle, reuseIdentifier: nil)
+        var cell = tableView.dequeueReusableCell(withIdentifier: ThemedTableViewCell.cellIdentifier, for: indexPath) as! ThemedTableViewCell
+        cell.restoreToInitialState()
         cell.selectionStyle = .none
         let section = Section(rawValue: indexPath.section) ?? .automaticBrightness
+        print(section)
         switch section {
         case .systemTheme:
             cell.textLabel?.text = .SystemThemeSectionSwitchTitle
@@ -193,6 +194,8 @@ class ThemeSettingsController: ThemedTableViewController {
 
             cell.accessoryView = control
         case .automaticBrightness:
+            cell = tableView.dequeueReusableCell(withIdentifier: ThemedSubtitleTableViewCell.cellIdentifier, for: indexPath) as! ThemedSubtitleTableViewCell
+            cell.selectionStyle = .none
             if indexPath.row == 0 {
                 cell.textLabel?.text = .DisplayThemeManualSwitchTitle
                 cell.detailTextLabel?.text = .DisplayThemeManualSwitchSubtitle
@@ -210,7 +213,6 @@ class ThemeSettingsController: ThemedTableViewController {
             } else {
                 cell.accessoryType = .none
             }
-
         case .lightDarkPicker:
             if isAutoBrightnessOn {
                 let deviceBrightnessIndicator = makeSlider(parent: cell.contentView)
@@ -222,7 +224,6 @@ class ThemeSettingsController: ThemedTableViewController {
                 deviceBrightnessIndicator.minimumTrackTintColor = .clear
                 deviceBrightnessIndicator.maximumTrackTintColor = .clear
                 deviceBrightnessIndicator.thumbTintColor = themeManager.currentTheme.colors.formKnob
-                self.slider = (slider, deviceBrightnessIndicator)
             } else {
                 if indexPath.row == 0 {
                     cell.textLabel?.text = .DisplayThemeOptionLight
@@ -241,7 +242,6 @@ class ThemeSettingsController: ThemedTableViewController {
             }
         }
         cell.applyTheme(theme: themeManager.currentTheme)
-
         return cell
     }
 

--- a/Client/Frontend/Settings/WebsiteDataManagementViewController.swift
+++ b/Client/Frontend/Settings/WebsiteDataManagementViewController.swift
@@ -138,7 +138,7 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
         tableView.allowsSelectionDuringEditing = true
         tableView.register(ThemedTableSectionHeaderFooterView.self,
                            forHeaderFooterViewReuseIdentifier: ThemedTableSectionHeaderFooterView.cellIdentifier)
-
+        tableView.register(cellType: ThemedTableViewCell.self)
         let footer = ThemedTableSectionHeaderFooterView(frame: CGRect(width: tableView.bounds.width,
                                                                       height: SettingsUX.TableViewHeaderFooterHeight))
         footer.applyTheme(theme: themeManager.currentTheme)
@@ -198,17 +198,20 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = ThemedTableViewCell(style: .default, reuseIdentifier: nil)
+        let cell = tableView.dequeueReusableCell(withIdentifier: ThemedTableViewCell.cellIdentifier, for: indexPath) as! ThemedTableViewCell
         let section = Section(rawValue: indexPath.section)!
         switch section {
         case .sites:
             if let record = viewModel.siteRecords[safe: indexPath.row] {
+                cell.textLabel?.textAlignment = .natural
                 cell.textLabel?.text = record.displayName
                 if viewModel.selectedRecords.contains(record) {
                     tableView.selectRow(at: indexPath, animated: false, scrollPosition: .none)
                 } else {
                     tableView.deselectRow(at: indexPath, animated: false)
                 }
+                let cellViewModel = ThemedTableViewCellViewModel(theme: themeManager.currentTheme, type: .standard)
+                cell.configure(viewModel: cellViewModel)
             }
         case .showMore:
             let cellType: ThemedTableViewCellType = showMoreButtonEnabled ? .actionPrimary : .disabled

--- a/Client/Frontend/Settings/WebsiteDataSearchResultsViewController.swift
+++ b/Client/Frontend/Settings/WebsiteDataSearchResultsViewController.swift
@@ -48,7 +48,7 @@ class WebsiteDataSearchResultsViewController: UIViewController, UITableViewDataS
 
         tableView.isEditing = true
         tableView.allowsMultipleSelectionDuringEditing = true
-        tableView.register(ThemedTableViewCell.self, forCellReuseIdentifier: "Cell")
+        tableView.register(cellType: ThemedTableViewCell.self)
         tableView.register(ThemedTableSectionHeaderFooterView.self,
                            forHeaderFooterViewReuseIdentifier: ThemedTableSectionHeaderFooterView.cellIdentifier)
         view.addSubview(tableView)
@@ -87,13 +87,14 @@ class WebsiteDataSearchResultsViewController: UIViewController, UITableViewDataS
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = ThemedTableViewCell(style: .default, reuseIdentifier: nil)
+        let cell = tableView.dequeueReusableCell(withIdentifier: ThemedTableViewCell.cellIdentifier, for: indexPath) as! ThemedTableViewCell
         cell.applyTheme(theme: themeManager.currentTheme)
         let section = Section(rawValue: indexPath.section)!
         switch section {
         case .sites:
             if let record = filteredSiteRecords[safe: indexPath.row] {
                 cell.textLabel?.text = record.displayName
+                cell.textLabel?.textAlignment = .natural
                 if viewModel.selectedRecords.contains(record) {
                     tableView.selectRow(at: indexPath, animated: false, scrollPosition: .none)
                 } else {

--- a/Client/Frontend/Theme/LegacyThemeManager/ThemedWidgets.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/ThemedWidgets.swift
@@ -93,6 +93,45 @@ class ThemedTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
     func configure(viewModel: ThemedTableViewCellViewModel) {
         self.viewModel = viewModel
     }
+
+    func restoreToInitialState() {
+        textLabel?.text = nil
+        textLabel?.font = DynamicFontHelper.defaultHelper.DefaultStandardFont
+        detailTextLabel?.text = nil
+        accessoryView = nil
+        accessoryType = .none
+        editingAccessoryView = nil
+        editingAccessoryType = .none
+        imageView?.image = nil
+        contentView.subviews.forEach {
+            $0.removeFromSuperview()
+        }
+        subviews.forEach {
+            $0.alpha = 1.0
+        }
+    }
+}
+
+/// Themed Table View Cell with cell style type subtitle
+class ThemedSubtitleTableViewCell: ThemedTableViewCell {
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: .subtitle, reuseIdentifier: reuseIdentifier)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+/// Themed Table View Cell with cell style type value1
+class ThemedValue1TableViewCell: ThemedTableViewCell {
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: .value1, reuseIdentifier: reuseIdentifier)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 }
 
 class ThemedTableViewController: UITableViewController, Themeable {
@@ -113,11 +152,12 @@ class ThemedTableViewController: UITableViewController, Themeable {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        return ThemedTableViewCell(style: .subtitle, reuseIdentifier: nil)
+        tableView.dequeueReusableCell(withIdentifier: ThemedSubtitleTableViewCell.cellIdentifier, for: indexPath)
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        tableView.register(cellType: ThemedSubtitleTableViewCell.self)
         applyTheme()
         listenForThemeChange(view)
     }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue AddCredentialViewController](https://github.com/mozilla-mobile/firefox-ios/issues/14855)
[Github issue ThemeSettingsController](https://github.com/mozilla-mobile/firefox-ios/issues/14854)
[Github issue WebsiteDataManagementViewController](https://github.com/mozilla-mobile/firefox-ios/issues/14853)
[Github issue WebsiteDataSearchResultsViewController](https://github.com/mozilla-mobile/firefox-ios/issues/14852)
[Github issue SettingsTableViewController](https://github.com/mozilla-mobile/firefox-ios/issues/14851)
[Github issue SearchEngiinePicker](https://github.com/mozilla-mobile/firefox-ios/issues/14850)
[Github issue SearchSettingsTableViewController](https://github.com/mozilla-mobile/firefox-ios/issues/14849)
[Github issue OpenWithSettingsViewController](https://github.com/mozilla-mobile/firefox-ios/issues/14848)
[Github issue TPAccessoryInfo](https://github.com/mozilla-mobile/firefox-ios/issues/14847)
[Github issue ClearPrivateDataTableViewController](https://github.com/mozilla-mobile/firefox-ios/issues/14846)
[Github issue ThemedTableViewController](https://github.com/mozilla-mobile/firefox-ios/issues/14845)

### Description

Refactor Controllers with dequeue reusable cell for item at indexPath. 
I had to create other two subclass of `ThemedTableViewCell` because with dequeuing it's not possible to instantiate directly the cells and pass the correct `UITableViewCell.CellStyle`, instead you need to register it via `tableView.register(cellClass:)`. I honestly found only this solution in order to support different cell styles, if you have other better ideas, please suggests them so i can refactor the code. I had also to introduce a new method for `ThemedTableViewCell` or `restoreToInitialState()` that was needed in order to restore the state of the cell after a table view reload, that because without it the cells were behaving in a weird way, not rendering in the correct way, caused by the dequeuing of the cells after the reload. The same applies for this solution, if you have a better one it's very welcomed to have.   

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
