### PR TITLE
Refactor MTE-1128 [v116] For AS Nightly builds notify only on failure…

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -24,6 +24,20 @@ pull_request_rules:
       queue:
         method: rebase
         name: default
+  - name: Rust Component Upgrade - Auto Merge
+    conditions:
+      - author=github-actions[bot]
+      - check-success=Bitrise
+      - -files~=^Client.xcodeproj/project.pbxproj
+      - -files~=^Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+      - head=update-rust-component-version
+    actions:
+      review:
+        type: APPROVE
+        message: Github-action[bot] 💪
+      queue:
+        method: rebase
+        name: default
   - name: L10N - Auto Merge
     conditions:
       - author=github-actions[bot]

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -136,7 +136,7 @@ workflows:
             Mana|https://mana.mozilla.org/wiki/display/MTE/Mobile+Test+Engineering
     - slack@3.1:
         is_always_run: true
-        run_if: '{{getenv "NEW_RC_VERSION" | eq "New_RC_Version"}}'
+        run_if: '{{getenv "NEW_RC_VERSION" | eq "New_RC_Version" | and .IsBuildFailed}}'
         inputs:
         - channel: "#firefox-ios"
         - text: Build status using latest Rust-Component


### PR DESCRIPTION
…, merge on success

As commented on Slack, let's notify about the Application Services Nighly builds integrations only on Failure so that there is not too much noise on the firefox-iOS channel.

Also, let's try to merge on success and see how it goes...