### PR TITLE
Add FXIOS-3782 [v116] Update empty state message on remoteTabsPanel for disabled sync

### DIFF
--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsErrorDataSource.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsErrorDataSource.swift
@@ -11,6 +11,7 @@ class RemoteTabsErrorDataSource: NSObject, RemoteTabsPanelDataSource, ThemeAppli
         case noClients
         case noTabs
         case failedToSync
+        case syncDisabledByUser
 
         func localizedString() -> String {
             switch self {
@@ -18,6 +19,7 @@ class RemoteTabsErrorDataSource: NSObject, RemoteTabsPanelDataSource, ThemeAppli
             case .noClients: return .EmptySyncedTabsPanelNullStateDescription
             case .noTabs: return .RemoteTabErrorNoTabs
             case .failedToSync: return .RemoteTabErrorFailedToSync
+            case .syncDisabledByUser: return .TabsTray.Sync.SyncTabsDisabled
             }
         }
     }

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanel.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanel.swift
@@ -124,6 +124,14 @@ class RemoteTabsTableViewController: UITableViewController, Themeable {
         return UILongPressGestureRecognizer(target: self, action: #selector(longPress))
     }()
 
+    var isTabSyncEnabled: Bool {
+        guard let isEnabled = profile.prefs.boolForKey(PrefsKeys.tabSyncEnabled) else {
+            return false
+        }
+
+        return isEnabled
+    }
+
     init(profile: Profile,
          themeManager: ThemeManager = AppContainer.shared.resolve(),
          notificationCenter: NotificationProtocol = NotificationCenter.default) {
@@ -225,39 +233,32 @@ class RemoteTabsTableViewController: UITableViewController, Themeable {
         guard let remoteTabsPanel = remoteTabsPanel else { return }
 
         guard !clientAndTabs.isEmpty else {
-            tableViewDelegate = RemoteTabsErrorDataSource(remoteTabsPanel: remoteTabsPanel,
-                                                          error: .noClients,
-                                                          theme: themeManager.currentTheme)
-            tableView.reloadData()
+            showEmptyTabsViewWith(.noClients)
             return
         }
 
         let nonEmptyClientAndTabs = clientAndTabs.filter { !$0.tabs.isEmpty }
-        if nonEmptyClientAndTabs.isEmpty {
-            tableViewDelegate = RemoteTabsErrorDataSource(remoteTabsPanel: remoteTabsPanel,
-                                                          error: .noTabs,
-                                                          theme: themeManager.currentTheme)
-        } else {
-            let tabsPanelDataSource = RemoteTabsClientAndTabsDataSource(remoteTabPanel: remoteTabsPanel,
-                                                                        clientAndTabs: nonEmptyClientAndTabs,
-                                                                        profile: profile,
-                                                                        theme: themeManager.currentTheme)
-            tabsPanelDataSource.collapsibleSectionDelegate = self
-            tableViewDelegate = tabsPanelDataSource
+        guard !nonEmptyClientAndTabs.isEmpty else {
+            showEmptyTabsViewWith(.noTabs)
+            return
         }
+
+        let tabsPanelDataSource = RemoteTabsClientAndTabsDataSource(remoteTabPanel: remoteTabsPanel,
+                                                                    clientAndTabs: nonEmptyClientAndTabs,
+                                                                    profile: profile,
+                                                                    theme: themeManager.currentTheme)
+        tabsPanelDataSource.collapsibleSectionDelegate = self
+        tableViewDelegate = tabsPanelDataSource
+
         tableView.reloadData()
     }
 
     func refreshTabs(updateCache: Bool = false, completion: (() -> Void)? = nil) {
-        guard let remoteTabsPanel = remoteTabsPanel else { return }
-
         ensureMainThread { [self] in
             // Short circuit if the user is not logged in
             guard profile.hasSyncableAccount() else {
                 endRefreshing()
-                tableViewDelegate = RemoteTabsErrorDataSource(remoteTabsPanel: remoteTabsPanel,
-                                                              error: .notLoggedIn,
-                                                              theme: themeManager.currentTheme)
+                showEmptyTabsViewWith(.notLoggedIn)
                 return
             }
 
@@ -265,7 +266,7 @@ class RemoteTabsTableViewController: UITableViewController, Themeable {
             profile.getCachedClientsAndTabs().uponQueue(.main) { [weak self] result in
                 guard let clientAndTabs = result.successValue else {
                     self?.endRefreshing()
-                    self?.showFailedToSync()
+                    self?.showEmptyTabsViewWith(.failedToSync)
                     return
                 }
 
@@ -291,12 +292,18 @@ class RemoteTabsTableViewController: UITableViewController, Themeable {
         }
     }
 
-    private func showFailedToSync() {
+    private func showEmptyTabsViewWith(_ error: RemoteTabsErrorDataSource.ErrorType) {
         guard let remoteTabsPanel = remoteTabsPanel else { return }
+        var errorMessage = error
 
-        self.tableViewDelegate = RemoteTabsErrorDataSource(remoteTabsPanel: remoteTabsPanel,
-                                                           error: .failedToSync,
-                                                           theme: themeManager.currentTheme)
+        if !isTabSyncEnabled { errorMessage = .syncDisabledByUser }
+
+        let remoteTabsErrorView = RemoteTabsErrorDataSource(remoteTabsPanel: remoteTabsPanel,
+                                                            error: errorMessage,
+                                                            theme: themeManager.currentTheme)
+        tableViewDelegate = remoteTabsErrorView
+
+        tableView.reloadData()
     }
 
     @objc

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanel.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanel.swift
@@ -125,7 +125,7 @@ class RemoteTabsTableViewController: UITableViewController, Themeable {
     }()
 
     var isTabSyncEnabled: Bool {
-        guard let isEnabled = profile.prefs.boolForKey(PrefsKeys.tabSyncEnabled) else {
+        guard let isEnabled = profile.prefs.boolForKey(PrefsKeys.TabSyncEnabled) else {
             return false
         }
 

--- a/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -178,7 +178,7 @@ class SyncContentSettingsViewController: SettingsTableViewController, FeatureFla
             settingDidChange: engineSettingChanged("history"))
         let tabs = BoolSetting(
             prefs: profile.prefs,
-            prefKey: PrefsKeys.tabSyncEnabled,
+            prefKey: PrefsKeys.TabSyncEnabled,
             defaultValue: true,
             attributedTitleText: NSAttributedString(string: .FirefoxSyncTabsEngine),
             attributedStatusText: nil,

--- a/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -178,7 +178,7 @@ class SyncContentSettingsViewController: SettingsTableViewController, FeatureFla
             settingDidChange: engineSettingChanged("history"))
         let tabs = BoolSetting(
             prefs: profile.prefs,
-            prefKey: "sync.engine.tabs.enabled",
+            prefKey: PrefsKeys.tabSyncEnabled,
             defaultValue: true,
             attributedTitleText: NSAttributedString(string: .FirefoxSyncTabsEngine),
             attributedStatusText: nil,

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -1648,6 +1648,12 @@ extension String {
                 tableName: "TabsTray",
                 value: "Sync Tabs",
                 comment: "Button label to sync tabs in your Firefox Account")
+
+            public static let SyncTabsDisabled = MZLocalizedString(
+                key: "TabsTray.Sync.SyncTabsDisabled.v116",
+                tableName: "TabsTray",
+                value: "Turn on tab syncing to view a list of tabs from your other devices.",
+                comment: "Users can disable syncing tabs from other devices. In the Sync Tabs panel of the Tab Tray, we inform the user tab syncing can be switched back on to view those tabs.")
         }
     }
 }

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -120,7 +120,7 @@ public struct PrefsKeys {
     public static let KeyInactiveTabsFirstTimeRun = "KeyInactiveTabsFirstTimeRunKey"
     public static let KeyTabDisplayOrder = "KeyTabDisplayOrderKey"
     public static let TabMigrationKey = "TabMigrationKey"
-    public static let tabSyncEnabled = "sync.engine.tabs.enabled"
+    public static let TabSyncEnabled = "sync.engine.tabs.enabled"
 
     // Widgetkit Key
     public static let WidgetKitSimpleTabKey = "WidgetKitSimpleTabKey"

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -120,6 +120,7 @@ public struct PrefsKeys {
     public static let KeyInactiveTabsFirstTimeRun = "KeyInactiveTabsFirstTimeRunKey"
     public static let KeyTabDisplayOrder = "KeyTabDisplayOrderKey"
     public static let TabMigrationKey = "TabMigrationKey"
+    public static let tabSyncEnabled = "sync.engine.tabs.enabled"
 
     // Widgetkit Key
     public static let WidgetKitSimpleTabKey = "WidgetKitSimpleTabKey"

--- a/Tests/ClientTests/RemoteTabsPanelTests.swift
+++ b/Tests/ClientTests/RemoteTabsPanelTests.swift
@@ -4,12 +4,11 @@
 
 import XCTest
 import Storage
+import Shared
 import Common
 @testable import Client
 
 class RemoteTabsPanelTests: XCTestCase {
-    let tabsEnabledPrefKey = "sync.engine.tabs.enabled"
-
     override func setUp() {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
@@ -139,7 +138,7 @@ private extension RemoteTabsPanelTests {
                      file: StaticString = #file,
                      line: UInt = #line) -> RemoteTabsPanel {
         let profile = MockProfile()
-        profile.prefs.setBool(hasSyncEnabled, forKey: tabsEnabledPrefKey)
+        profile.prefs.setBool(hasSyncEnabled, forKey: PrefsKeys.TabSyncEnabled)
         profile.hasSyncableAccountMock = hasAccount
         profile.mockClientAndTabs = clientAndTabs
         let panel = RemoteTabsPanel(profile: profile)

--- a/Tests/ClientTests/RemoteTabsPanelTests.swift
+++ b/Tests/ClientTests/RemoteTabsPanelTests.swift
@@ -8,6 +8,8 @@ import Common
 @testable import Client
 
 class RemoteTabsPanelTests: XCTestCase {
+    let tabsEnabledPrefKey = "sync.engine.tabs.enabled"
+
     override func setUp() {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
@@ -25,6 +27,13 @@ class RemoteTabsPanelTests: XCTestCase {
 
         let dataSource = try XCTUnwrap(panel.tableViewController.tableViewDelegate as? RemoteTabsErrorDataSource)
         XCTAssertEqual(dataSource.error, .notLoggedIn)
+    }
+
+    func testHasNoSync() throws {
+        let panel = createPanel(hasAccount: false, hasSyncEnabled: false)
+
+        let dataSource = try XCTUnwrap(panel.tableViewController.tableViewDelegate as? RemoteTabsErrorDataSource)
+        XCTAssertEqual(dataSource.error, .syncDisabledByUser)
     }
 
     func testHasNoClients() {
@@ -125,10 +134,12 @@ private extension RemoteTabsPanelTests {
     }
 
     func createPanel(hasAccount: Bool = true,
+                     hasSyncEnabled: Bool = true,
                      clientAndTabs: [ClientAndTabs] = [],
                      file: StaticString = #file,
                      line: UInt = #line) -> RemoteTabsPanel {
         let profile = MockProfile()
+        profile.prefs.setBool(hasSyncEnabled, forKey: tabsEnabledPrefKey)
         profile.hasSyncableAccountMock = hasAccount
         profile.mockClientAndTabs = clientAndTabs
         let panel = RemoteTabsPanel(profile: profile)


### PR DESCRIPTION
# [FXIOS-3782](https://mozilla-hub.atlassian.net/browse/FXIOS-3782) | https://github.com/mozilla-mobile/firefox-ios/issues/10049

### Description
If the user has disabled syncing tabs, we show the appropriate message in the RemoteTabsPanel empty view. This PR covers only the case where the user disables syncing. A follow up PR will adjust the message for when an account is not verified. 

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
