### PR TITLE
Add SYNC-3764 [v116] Adds unsubscribe using new Autopush

### DIFF
--- a/RustFxA/RustFirefoxAccounts.swift
+++ b/RustFxA/RustFirefoxAccounts.swift
@@ -5,7 +5,6 @@
 import Common
 import UIKit
 import Shared
-import Common
 import MozillaAppServices
 
 let PendingAccountDisconnectedKey = "PendingAccountDisconnect"
@@ -302,7 +301,7 @@ open class RustFirefoxAccounts {
         return cachedUserProfile
     }
 
-    public func disconnect() {
+    public func disconnect(useNewAutopush: Bool) {
         guard let accountManager = accountManager.peek() else { return }
         accountManager.logout { _ in }
         let prefs = RustFirefoxAccounts.prefs
@@ -311,7 +310,9 @@ open class RustFirefoxAccounts {
         prefs?.removeObjectForKey(PendingAccountDisconnectedKey)
         self.syncAuthState.invalidate()
         cachedUserProfile = nil
-        pushNotifications.unregister()
+        if !useNewAutopush {
+            pushNotifications.unregister()
+        }
         MZKeychainWrapper.sharedClientAppContainerKeychain.removeObject(forKey: KeychainKey.apnsToken, withAccessibility: .afterFirstUnlock)
     }
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/SYNC-3764)

### Description
Adds unsubscribing from the new autopush client when an account is disconnected

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
