### PR TITLE
Bugfix FXIOS-6648 [v115] Fix url bar color on selection

### DIFF
--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -351,7 +351,7 @@ extension AutocompleteTextField: ThemeApplicable, PrivateModeUI {
     func applyTheme(theme: Theme) {
         backgroundColor = theme.colors.layer3
         textColor = theme.colors.textPrimary
-        tintColor = theme.colors.actionPrimary
+        tintColor = isPrivateMode ? theme.colors.layerAccentPrivateNonOpaque : theme.colors.layerAccentNonOpaque
         if autocompleteTextLabel?.attributedText != nil {
             autocompleteTextLabel?.backgroundColor = backgroundColor
             autocompleteTextLabel?.textColor = textColor


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6648)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14857)

### Description
Fix the URL bar text color when selected. The color used is the same as the one we use for suggestions in the textbox.

#### Private mode
![Screenshot 2023-06-12 at 3 09 53 PM](https://github.com/mozilla-mobile/firefox-ios/assets/11338480/7f84b4b6-2d32-40d1-8bdb-0c8d244e05c9)
![Screenshot 2023-06-12 at 3 10 09 PM](https://github.com/mozilla-mobile/firefox-ios/assets/11338480/4daa16a9-5323-4ceb-a760-3898b1272428)

#### Normal mode
![Screenshot 2023-06-12 at 3 09 44 PM](https://github.com/mozilla-mobile/firefox-ios/assets/11338480/a4839d90-87aa-444d-a587-22d1949aee9a)
![Screenshot 2023-06-12 at 3 10 15 PM](https://github.com/mozilla-mobile/firefox-ios/assets/11338480/25a92be9-effd-4945-b385-d10d513fce8f)

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
