### PR TITLE
Add SYNC-3763 [v116] Flip ON autopush feature flag

### DIFF
--- a/nimbus-features/autopushFeature.yaml
+++ b/nimbus-features/autopushFeature.yaml
@@ -5,4 +5,4 @@ features:
       use-new-autopush-client:
         description: If true, the autopush client based on the Rust component will be used
         type: Boolean
-        default: false
+        default: true


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/SYNC-3763)

### Description
Flips the feature flag for the new autopush to true! This concludes the work to integrate the new autopush, only remaining work is to remove dead code once we eventually remove the feature flag.

Is there a policy for when it's usually safe to remove feature flags? The current plan is:
- Let it ride to release
- Observe any bugs
- If anything critical come in, we can flip it OFF using a nimbus rollout
- Once 116 hits release and a couple of weeks pass, we start landing code to remove dead code
    - I have a ticket open for that in https://mozilla-hub.atlassian.net/browse/SYNC-3737, but we're open to a different strategy

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
