### PR TITLE
Refactor FXIOS-6689 [v115] Revert implementation of focusing on a tab in tab tray

### DIFF
--- a/Client/Frontend/Browser/Tabs/GridTabViewController.swift
+++ b/Client/Frontend/Browser/Tabs/GridTabViewController.swift
@@ -187,6 +187,13 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate, Themeable {
         ])
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        DispatchQueue.main.async {
+            self.focusItem()
+        }
+    }
+
     private func setupView() {
         // TODO: Remove SNAPKIT - this will require some work as the layouts
         // are using other snapkit constraints and this will require modification
@@ -219,15 +226,6 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate, Themeable {
         super.viewWillLayoutSubviews()
         guard let flowlayout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout else { return }
         flowlayout.invalidateLayout()
-    }
-
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        // Temporary solution using asyncAfter for fixing https://mozilla-hub.atlassian.net/browse/FXIOS-5711
-        // Will be changed once the TabTray logic will be reimplemented
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            self.focusItem()
-        }
     }
 
     private func tabManagerTeardown() {


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6689)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14923)

### Description
Revert the implementation of focusing on a tab in tab tray

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
