### PR TITLE
Add FXIOS-6577 [v116] Handle middleware in store dispatch

### DIFF
--- a/BrowserKit/Sources/Redux/DispatchStore.swift
+++ b/BrowserKit/Sources/Redux/DispatchStore.swift
@@ -10,10 +10,17 @@ public protocol DispatchStore {
 }
 
 public protocol DefaultDispatchStore: DispatchStore {
-    associatedtype State
+    associatedtype State: StateType
+    /// `ActionCreators` allows  to perform a conditional dispatch to the store.
+    /// An `ActionCreator` takes the current application state and a reference to a store then may return an optional `Action`
+    associatedtype ActionCreator = (_ state: State, _ store: DefaultDispatchStore) -> Action?
 
     var state: State { get }
+    var dispatchFunction: DispatchFunction { get }
 
     func subscribe<S: StoreSubscriber>(_ subscriber: S) where S.SubscriberStateType == State
     func unsubscribe<S: StoreSubscriber>(_ subscriber: S) where S.SubscriberStateType == State
+
+
+    func dispatch(_ actionCreator: ActionCreator)
 }

--- a/BrowserKit/Sources/Redux/DispatchStore.swift
+++ b/BrowserKit/Sources/Redux/DispatchStore.swift
@@ -21,6 +21,5 @@ public protocol DefaultDispatchStore: DispatchStore {
     func subscribe<S: StoreSubscriber>(_ subscriber: S) where S.SubscriberStateType == State
     func unsubscribe<S: StoreSubscriber>(_ subscriber: S) where S.SubscriberStateType == State
 
-
     func dispatch(_ actionCreator: ActionCreator)
 }

--- a/BrowserKit/Sources/Redux/Middleware.swift
+++ b/BrowserKit/Sources/Redux/Middleware.swift
@@ -8,5 +8,5 @@ import Foundation
 /// Middleware produces side effects or uses dependencies and
 /// is the best place to put logger, API calls or access storage.
 public typealias DispatchFunction = (Action) -> Void
-public typealias Middleware<State> = (_ inputAction: @escaping DispatchFunction,
+public typealias Middleware<State> = (_ dispatch: @escaping DispatchFunction,
                                       _ getState: @escaping () -> State?) -> (@escaping DispatchFunction) -> DispatchFunction

--- a/BrowserKit/Sources/Redux/Middleware.swift
+++ b/BrowserKit/Sources/Redux/Middleware.swift
@@ -8,5 +8,5 @@ import Foundation
 /// Middleware produces side effects or uses dependencies and
 /// is the best place to put logger, API calls or access storage.
 public typealias DispatchFunction = (Action) -> Void
-public typealias Middleware<State> = (@escaping DispatchFunction,
-                                      @escaping () -> State?) -> (@escaping DispatchFunction) -> DispatchFunction
+public typealias Middleware<State> = (_ inputAction: @escaping DispatchFunction,
+                                      _ getState: @escaping () -> State?) -> (@escaping DispatchFunction) -> DispatchFunction

--- a/BrowserKit/Sources/Redux/Store.swift
+++ b/BrowserKit/Sources/Redux/Store.swift
@@ -31,7 +31,7 @@ public class Store<State: StateType>: DefaultDispatchStore {
             .reversed()
             .reduce(
                 { [unowned self] action in
-                    self.dispatch(action)
+                    self.handleReducer(action)
                 },
                 { dispatchFunction, middleware in
                     let dispatch: (Action) -> Void = { [weak self] in self?.dispatch($0)
@@ -62,14 +62,11 @@ public class Store<State: StateType>: DefaultDispatchStore {
     }
 
     public func dispatch(_ action: Action) {
-        dispatch(state, action)
+        dispatchFunction(action)
     }
 
-    private func dispatch(_ currentState: State, _ action: Action) {
-        let newState = reducer(currentState, action)
-
-        dispatchFunction(action)
-
+    private func handleReducer(_ action: Action) {
+        let newState = reducer(state, action)
         state = newState
     }
 

--- a/BrowserKit/Sources/Redux/Store.swift
+++ b/BrowserKit/Sources/Redux/Store.swift
@@ -29,11 +29,9 @@ public class Store<State: StateType>: DefaultDispatchStore {
     lazy public var dispatchFunction: DispatchFunction = {
         let dispatchFunc = middlewares
             .reversed()
-            .reduce(
-                { [unowned self] action in
+            .reduce({ [unowned self] action in
                     self.handleReducer(action)
-                },
-                { dispatchFunction, middleware in
+                }, { dispatchFunction, middleware in
                     let dispatch: (Action) -> Void = { [weak self] in self?.dispatch($0)
                     }
                     let getState = { [weak self] in self?.state }

--- a/BrowserKit/Sources/Redux/Store.swift
+++ b/BrowserKit/Sources/Redux/Store.swift
@@ -26,7 +26,7 @@ public class Store<State: StateType>: DefaultDispatchStore {
     private var reducer: Reducer<State>
     private var middlewares: [Middleware<State>]
     private var subscriptions: Set<SubscriptionType> = []
-    public var dispatchFunction: DispatchFunction {
+    lazy public var dispatchFunction: DispatchFunction = {
         let dispatchFunc = middlewares
             .reversed()
             .reduce(
@@ -40,7 +40,7 @@ public class Store<State: StateType>: DefaultDispatchStore {
                     return middleware(dispatch, getState)(dispatchFunction)
             })
         return dispatchFunc
-    }
+    }()
 
     public init(state: State,
                 reducer: @escaping Reducer<State>,

--- a/BrowserKit/Sources/Redux/Store.swift
+++ b/BrowserKit/Sources/Redux/Store.swift
@@ -25,8 +25,8 @@ public class Store<State: StateType>: DefaultDispatchStore {
 
     private var reducer: Reducer<State>
     private var middlewares: [Middleware<State>]
-
-    var subscriptions: Set<SubscriptionType> = []
+    private var subscriptions: Set<SubscriptionType> = []
+    public var dispatchFunction: DispatchFunction!
 
     public init(state: State,
                 reducer: @escaping Reducer<State>,
@@ -53,6 +53,20 @@ public class Store<State: StateType>: DefaultDispatchStore {
 
     private func dispatch(_ currentState: State, _ action: Action) {
         let newState = reducer(currentState, action)
+
+        self.dispatchFunction = middlewares
+            .reversed()
+            .reduce(
+                { [unowned self] action in
+                    self.dispatch(action)
+                },
+                { dispatchFunction, middleware in
+                    let dispatch: (Action) -> Void = { [weak self] in self?.dispatch($0)
+                    }
+                    let getState = { [weak self] in self?.state }
+                    return middleware(dispatch, getState)(dispatchFunction)
+            })
+
         state = newState
     }
 

--- a/BrowserKit/Sources/Redux/Thunk.swift
+++ b/BrowserKit/Sources/Redux/Thunk.swift
@@ -28,5 +28,3 @@ public struct Thunk<State>: Action {
         }
     }
 }
-
-

--- a/BrowserKit/Sources/Redux/Thunk.swift
+++ b/BrowserKit/Sources/Redux/Thunk.swift
@@ -12,19 +12,21 @@ public struct Thunk<State>: Action {
                                  _ getState: @escaping () -> State?) -> Void) {
         self.body = body
     }
-}
 
-public func createThunkMiddleware<State>() -> Middleware<State> {
-    return { dispatch, getState in
-        return { next in
-            return { action in
-                switch action {
-                case let thunk as Thunk<State>:
-                    thunk.body(dispatch, getState)
-                default:
-                    next(action)
+    public func createThunkMiddleware<State>() -> Middleware<State> {
+        return { dispatch, getState in
+            return { next in
+                return { action in
+                    switch action {
+                    case let thunk as Thunk<State>:
+                        thunk.body(dispatch, getState)
+                    default:
+                        next(action)
+                    }
                 }
             }
         }
     }
 }
+
+

--- a/BrowserKit/Sources/Redux/Thunk.swift
+++ b/BrowserKit/Sources/Redux/Thunk.swift
@@ -1,0 +1,30 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+public struct Thunk<State>: Action {
+    let body: (_ dispatch: @escaping DispatchFunction,
+               _ getState: @escaping () -> State?) -> Void
+
+    public init(body: @escaping (_ dispatch: @escaping DispatchFunction,
+                                 _ getState: @escaping () -> State?) -> Void) {
+        self.body = body
+    }
+}
+
+public func createThunkMiddleware<State>() -> Middleware<State> {
+    return { dispatch, getState in
+        return { next in
+            return { action in
+                switch action {
+                case let thunk as Thunk<State>:
+                    thunk.body(dispatch, getState)
+                default:
+                    next(action)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6577)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14722)

### Description
Handle Middleware logic in the store in the dispatch action function. The middleware initialized in the `Store` with intercept the action if any `Middleware` can handle it will produce side effects and dispatch a new action to the store which can be handled by other `Middleware` or by the `Reducers`

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
