### PR TITLE
Bugfix FXIOS-6097 [v116] The newly created login is not correctly aligned in RTL locale (ar)

### DIFF
--- a/Client/Frontend/LoginManagement/Cells/LoginListTableViewCell.swift
+++ b/Client/Frontend/LoginManagement/Cells/LoginListTableViewCell.swift
@@ -40,14 +40,12 @@ class LoginListTableViewCell: ThemedTableViewCell {
 
     lazy var hostnameLabel: UILabel = .build { label in
         label.font = UIFont.systemFont(ofSize: 16, weight: .regular)
-        label.textAlignment = .left
         label.numberOfLines = 1
         label.setContentHuggingPriority(.required, for: .vertical)
     }
 
     lazy var usernameLabel: UILabel = .build { label in
         label.font = UIFont.systemFont(ofSize: 14, weight: .regular)
-        label.textAlignment = .left
         label.numberOfLines = 1
     }
 

--- a/Client/Frontend/LoginManagement/Cells/LoginListTableViewCell.swift
+++ b/Client/Frontend/LoginManagement/Cells/LoginListTableViewCell.swift
@@ -95,7 +95,7 @@ class LoginListTableViewCell: ThemedTableViewCell {
             contentStack.topAnchor.constraint(equalTo: contentView.topAnchor),
             contentStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
             contentStack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            contentStack.leftAnchor.constraint(equalTo: contentView.leftAnchor, constant: inset.left),
+            contentStack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: inset.left),
 
             breachAlertImageView.widthAnchor.constraint(equalToConstant: breachAlertSize),
             breachAlertImageView.heightAnchor.constraint(equalToConstant: breachAlertSize),


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6097)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13797)

### Description
This fixes the `textAlignment`, constraint is missing for RTL (ar) Language.


### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
