### PR TITLE
Bugfix FXIOS-6611 [v116] Fix line design on URL bar

### DIFF
--- a/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -22,7 +22,6 @@ private struct URLBarViewUX {
     static let TabsButtonHeight: CGFloat = 18.0
     static let ToolbarButtonInsets = UIEdgeInsets(equalInset: Padding)
     static let urlBarLineHeight = 0.5
-    static let overlayModePadding = 1.5
 }
 
 protocol URLBarDelegate: AnyObject {
@@ -97,7 +96,6 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
     var toolbarIsShowing = false
     var topTabsIsShowing = false
 
-    /// The URL bar text field, when in overlay mode (focused). Has autocomplete text support.
     var locationTextField: ToolbarTextField?
 
     /// Overlay mode is the state where the lock/reader icons are hidden, the home panels are shown,
@@ -106,7 +104,6 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
     /// a panel, the first responder will be resigned, yet the overlay mode UI is still active.
     var inOverlayMode = false
 
-    /// The URL bar text field, when it's not in overlay mode (unfocused)
     lazy var locationView: TabLocationView = {
         let locationView = TabLocationView()
         locationView.layer.cornerRadius = URLBarViewUX.TextFieldCornerRadius
@@ -115,7 +112,6 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
         return locationView
     }()
 
-    /// Enables the URL bar shadow
     lazy var locationContainer: UIView = {
         let locationContainer = TabLocationContainerView()
         locationContainer.translatesAutoresizingMaskIntoConstraints = false
@@ -378,18 +374,14 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
                 make.height.greaterThanOrEqualTo(heightMin)
                 make.trailing.equalTo(self.showQRScannerButton.snp.leading)
                 make.leading.equalTo(self.cancelButton.snp.trailing)
-                make.top.equalTo(self).offset(URLBarViewUX.overlayModePadding)
-                make.bottom.equalTo(self).offset(-URLBarViewUX.overlayModePadding)
+                make.centerY.equalTo(self)
             }
             self.locationView.snp.remakeConstraints { make in
                 make.top.bottom.trailing.equalTo(self.locationContainer).inset(UIEdgeInsets(equalInset: URLBarViewUX.TextFieldBorderWidthSelected))
                 make.leading.equalTo(self.searchIconImageView.snp.trailing)
             }
             self.locationTextField?.snp.remakeConstraints { make in
-                make.edges.equalTo(self.locationView).inset(UIEdgeInsets(top: 0,
-                                                                         left: URLBarViewUX.LocationLeftPadding,
-                                                                         bottom: 0,
-                                                                         right: URLBarViewUX.LocationLeftPadding))
+                make.edges.equalTo(self.locationView).inset(UIEdgeInsets(top: 0, left: URLBarViewUX.LocationLeftPadding, bottom: 0, right: URLBarViewUX.LocationLeftPadding))
             }
         } else {
             searchIconImageView.alpha = 0
@@ -404,10 +396,7 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
                     }
                 } else {
                     // Otherwise, left align the location view
-                    make.leading.trailing.equalTo(self).inset(UIEdgeInsets(top: 0,
-                                                                           left: URLBarViewUX.LocationLeftPadding-1,
-                                                                           bottom: 0,
-                                                                           right: URLBarViewUX.LocationLeftPadding-1))
+                    make.leading.trailing.equalTo(self).inset(UIEdgeInsets(top: 0, left: URLBarViewUX.LocationLeftPadding-1, bottom: 0, right: URLBarViewUX.LocationLeftPadding-1))
                 }
                 make.height.greaterThanOrEqualTo(URLBarViewUX.LocationHeight+2)
                 make.centerY.equalTo(self)

--- a/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -21,6 +21,7 @@ private struct URLBarViewUX {
     static let TabsButtonRotationOffset: CGFloat = 1.5
     static let TabsButtonHeight: CGFloat = 18.0
     static let ToolbarButtonInsets = UIEdgeInsets(equalInset: Padding)
+    static let urlBarLineHeight = 0.5
 }
 
 protocol URLBarDelegate: AnyObject {
@@ -344,13 +345,13 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
 
         line.snp.remakeConstraints { make in
             if isBottomSearchBar {
-                make.top.equalTo(self).offset(0)
+                make.top.equalTo(self)
             } else {
-                make.bottom.equalTo(self)
+                make.bottom.equalTo(self).offset(URLBarViewUX.urlBarLineHeight)
             }
 
             make.leading.trailing.equalTo(self)
-            make.height.equalTo(0.5)
+            make.height.equalTo(URLBarViewUX.urlBarLineHeight)
         }
 
         progressBar.snp.remakeConstraints { make in

--- a/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -22,6 +22,7 @@ private struct URLBarViewUX {
     static let TabsButtonHeight: CGFloat = 18.0
     static let ToolbarButtonInsets = UIEdgeInsets(equalInset: Padding)
     static let urlBarLineHeight = 0.5
+    static let overlayModePadding = 1.5
 }
 
 protocol URLBarDelegate: AnyObject {
@@ -96,6 +97,7 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
     var toolbarIsShowing = false
     var topTabsIsShowing = false
 
+    /// The URL bar text field, when in overlay mode (focused). Has autocomplete text support.
     var locationTextField: ToolbarTextField?
 
     /// Overlay mode is the state where the lock/reader icons are hidden, the home panels are shown,
@@ -104,6 +106,7 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
     /// a panel, the first responder will be resigned, yet the overlay mode UI is still active.
     var inOverlayMode = false
 
+    /// The URL bar text field, when it's not in overlay mode (unfocused)
     lazy var locationView: TabLocationView = {
         let locationView = TabLocationView()
         locationView.layer.cornerRadius = URLBarViewUX.TextFieldCornerRadius
@@ -112,6 +115,7 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
         return locationView
     }()
 
+    /// Enables the URL bar shadow
     lazy var locationContainer: UIView = {
         let locationContainer = TabLocationContainerView()
         locationContainer.translatesAutoresizingMaskIntoConstraints = false
@@ -374,14 +378,18 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
                 make.height.greaterThanOrEqualTo(heightMin)
                 make.trailing.equalTo(self.showQRScannerButton.snp.leading)
                 make.leading.equalTo(self.cancelButton.snp.trailing)
-                make.centerY.equalTo(self)
+                make.top.equalTo(self).offset(URLBarViewUX.overlayModePadding)
+                make.bottom.equalTo(self).offset(-URLBarViewUX.overlayModePadding)
             }
             self.locationView.snp.remakeConstraints { make in
                 make.top.bottom.trailing.equalTo(self.locationContainer).inset(UIEdgeInsets(equalInset: URLBarViewUX.TextFieldBorderWidthSelected))
                 make.leading.equalTo(self.searchIconImageView.snp.trailing)
             }
             self.locationTextField?.snp.remakeConstraints { make in
-                make.edges.equalTo(self.locationView).inset(UIEdgeInsets(top: 0, left: URLBarViewUX.LocationLeftPadding, bottom: 0, right: URLBarViewUX.LocationLeftPadding))
+                make.edges.equalTo(self.locationView).inset(UIEdgeInsets(top: 0,
+                                                                         left: URLBarViewUX.LocationLeftPadding,
+                                                                         bottom: 0,
+                                                                         right: URLBarViewUX.LocationLeftPadding))
             }
         } else {
             searchIconImageView.alpha = 0
@@ -396,7 +404,10 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
                     }
                 } else {
                     // Otherwise, left align the location view
-                    make.leading.trailing.equalTo(self).inset(UIEdgeInsets(top: 0, left: URLBarViewUX.LocationLeftPadding-1, bottom: 0, right: URLBarViewUX.LocationLeftPadding-1))
+                    make.leading.trailing.equalTo(self).inset(UIEdgeInsets(top: 0,
+                                                                           left: URLBarViewUX.LocationLeftPadding-1,
+                                                                           bottom: 0,
+                                                                           right: URLBarViewUX.LocationLeftPadding-1))
                 }
                 make.height.greaterThanOrEqualTo(URLBarViewUX.LocationHeight+2)
                 make.centerY.equalTo(self)

--- a/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -118,7 +118,7 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
         return locationContainer
     }()
 
-    let line = UIView()
+    private let line = UIView()
 
     lazy var tabsButton: TabsButton = {
         let tabsButton = TabsButton()
@@ -205,11 +205,6 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
 
         set(newURL) {
             locationView.url = newURL
-            if let url = newURL, InternalURL(url)?.isAboutHomeURL ?? false {
-                line.isHidden = true
-            } else {
-                line.isHidden = false
-            }
         }
     }
 
@@ -355,7 +350,7 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
             }
 
             make.leading.trailing.equalTo(self)
-            make.height.equalTo(1)
+            make.height.equalTo(0.5)
         }
 
         progressBar.snp.remakeConstraints { make in
@@ -594,7 +589,6 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
         locationContainer.layer.borderColor = borderColor.cgColor
 
         if inOverlayMode {
-            line.isHidden = inOverlayMode
             // Make the editable text field span the entire URL bar, covering the lock and reader icons.
             locationTextField?.snp.remakeConstraints { make in
                 make.edges.equalTo(self.locationView)


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6611)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14788)

### Description
Fix line height (was 1 pixel instead of 0.5) and fix that it was disappearing.

#### Dark mode top and bottom
![Screenshot 2023-06-13 at 2 36 12 PM](https://github.com/mozilla-mobile/firefox-ios/assets/11338480/52a290a3-30d4-4b07-b8cd-727cadc73cb2)

![Screenshot 2023-06-13 at 1 49 41 PM](https://github.com/mozilla-mobile/firefox-ios/assets/11338480/53d25341-5fa1-4cc5-bcd3-cf14eb426820)

#### Dark mode overlay mode, top and bottom
![Screenshot 2023-06-13 at 2 36 20 PM](https://github.com/mozilla-mobile/firefox-ios/assets/11338480/0275fe26-9a20-4d9b-9476-951df57d9af8)


![Screenshot 2023-06-13 at 2 02 16 PM](https://github.com/mozilla-mobile/firefox-ios/assets/11338480/03a8a0ed-f397-4121-a74b-8305dd1852e6)

#### Light mode top and bottom
![Screenshot 2023-06-13 at 2 37 30 PM](https://github.com/mozilla-mobile/firefox-ios/assets/11338480/9dbf1883-e47c-4fe1-a71f-e526895a4db5)

![Screenshot 2023-06-13 at 2 19 03 PM](https://github.com/mozilla-mobile/firefox-ios/assets/11338480/5148d395-d88e-4d9e-82df-44fbd2196ecb)

#### Light mode overlay mode, top and bottom
![Screenshot 2023-06-13 at 2 37 34 PM](https://github.com/mozilla-mobile/firefox-ios/assets/11338480/fef407a6-c865-46d2-9d80-e5013ae98004)

![Screenshot 2023-06-13 at 2 19 07 PM](https://github.com/mozilla-mobile/firefox-ios/assets/11338480/e5b07e0c-7951-4030-b8be-878fa5c5188c)

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
