### PR TITLE
Bugfix FXIOS-4251 [v116] Sponsored tiles matched against the defaultSearchEngine will stop appearing in topSites

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -773,6 +773,8 @@
 		9609F4CA26B57CE800F81493 /* Calendar+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9609F4C926B57CE800F81493 /* Calendar+Extension.swift */; };
 		9614BF4228A53FDF00D3F7EA /* ContextualHintEligibilityUtilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9614BF4028A53F7C00D3F7EA /* ContextualHintEligibilityUtilityTests.swift */; };
 		9614BF4428AD1C6700D3F7EA /* AccountSyncHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9614BF4328AD1C6700D3F7EA /* AccountSyncHandler.swift */; };
+		961577922A38FDB300391E8D /* TopSitesDataUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961577912A38FDB300391E8D /* TopSitesDataUtility.swift */; };
+		961577942A39008100391E8D /* TopSitesDataUtilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961577932A39008100391E8D /* TopSitesDataUtilityTests.swift */; };
 		961D6B832995AF84001B9CF1 /* GeneralizedImageFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961D6B822995AF84001B9CF1 /* GeneralizedImageFetcherTests.swift */; };
 		962021E128B8078400BDF3D9 /* ContextualHintCopyProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 962021E028B8078400BDF3D9 /* ContextualHintCopyProvider.swift */; };
 		962F394A2672D57A006BDA2A /* RecentItemsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 962F39492672D57A006BDA2A /* RecentItemsHelper.swift */; };
@@ -4885,6 +4887,8 @@
 		9609F4C926B57CE800F81493 /* Calendar+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Calendar+Extension.swift"; sourceTree = "<group>"; };
 		9614BF4028A53F7C00D3F7EA /* ContextualHintEligibilityUtilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualHintEligibilityUtilityTests.swift; sourceTree = "<group>"; };
 		9614BF4328AD1C6700D3F7EA /* AccountSyncHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSyncHandler.swift; sourceTree = "<group>"; };
+		961577912A38FDB300391E8D /* TopSitesDataUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSitesDataUtility.swift; sourceTree = "<group>"; };
+		961577932A39008100391E8D /* TopSitesDataUtilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSitesDataUtilityTests.swift; sourceTree = "<group>"; };
 		961D6B822995AF84001B9CF1 /* GeneralizedImageFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralizedImageFetcherTests.swift; sourceTree = "<group>"; };
 		962021E028B8078400BDF3D9 /* ContextualHintCopyProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualHintCopyProvider.swift; sourceTree = "<group>"; };
 		962A450E9186BF349E535413 /* sat-Olck */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "sat-Olck"; path = "sat-Olck.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
@@ -8220,6 +8224,7 @@
 				8AB8572B27D945FA0075C173 /* TopSitesDataAdaptor.swift */,
 				43AB6F9C25DC53D20016B015 /* GoogleTopSiteManager.swift */,
 				43AB6FA125DC53D30016B015 /* TopSiteHistoryManager.swift */,
+				961577912A38FDB300391E8D /* TopSitesDataUtility.swift */,
 			);
 			path = DataManagement;
 			sourceTree = "<group>";
@@ -8352,6 +8357,7 @@
 				8A33221E27DFE318008F809E /* TopSitesDataAdaptorTests.swift */,
 				3B6F40171DC7849C00656CC6 /* TopSitesViewModelTests.swift */,
 				8AE80BAC2891957C00BC12EA /* TopSitesDimensionTests.swift */,
+				961577932A39008100391E8D /* TopSitesDataUtilityTests.swift */,
 			);
 			path = TopSites;
 			sourceTree = "<group>";
@@ -12754,6 +12760,7 @@
 				8AB8572E27D94A1A0075C173 /* UXSizeClass.swift in Sources */,
 				965C3C8F29313A1B006499ED /* AppSessionManager.swift in Sources */,
 				45D5EDA729269F7500311934 /* DataObserver.swift in Sources */,
+				961577922A38FDB300391E8D /* TopSitesDataUtility.swift in Sources */,
 				D863C8F21F68BFC20058D95F /* GradientProgressBar.swift in Sources */,
 				C8445A14264428DC00B83F53 /* LibraryPanelViewState.swift in Sources */,
 				D5D052D92645ABF400759F85 /* ExperimentsSettingsView.swift in Sources */,
@@ -12887,6 +12894,7 @@
 			files = (
 				E4CD9F1D1A6D9C2800318571 /* WebServerTests.swift in Sources */,
 				C869916528918C8E007ACC5C /* WallpaperURLSessionMock.swift in Sources */,
+				961577942A39008100391E8D /* TopSitesDataUtilityTests.swift in Sources */,
 				431C0D1E25C9DC4D00395CE4 /* DefaultBrowserOnboardingTests.swift in Sources */,
 				213B67A827CE721E000542F5 /* StartAtHomeHelperTests.swift in Sources */,
 				8A7653C228A2E57D00924ABF /* PocketDataAdaptorTests.swift in Sources */,

--- a/Client/Frontend/Home/TopSites/DataManagement/TopSitesDataAdaptor.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/TopSitesDataAdaptor.swift
@@ -39,6 +39,8 @@ class TopSitesDataAdaptorImplementation: TopSitesDataAdaptor, FeatureFlaggable, 
     // Raw data to build top sites with
     private var historySites: [Site] = []
     private var contiles: [Contile] = []
+    private(set) var defaultSearchEngine: OpenSearchEngine?
+    private let topSitesDataUtility = TopSitesDataUtility()
 
     var notificationCenter: NotificationProtocol
     weak var delegate: TopSitesManagerDelegate?
@@ -53,6 +55,7 @@ class TopSitesDataAdaptorImplementation: TopSitesDataAdaptor, FeatureFlaggable, 
     private static let defaultTopSitesRowCount = 8
 
     init(profile: Profile,
+         defaultSearchEngine: OpenSearchEngine?,
          topSiteHistoryManager: TopSiteHistoryManager,
          googleTopSiteManager: GoogleTopSiteManager,
          contileProvider: ContileProviderInterface = ContileProvider(),
@@ -60,6 +63,7 @@ class TopSitesDataAdaptorImplementation: TopSitesDataAdaptor, FeatureFlaggable, 
          dispatchGroup: DispatchGroupInterface = DispatchGroup()
     ) {
         self.profile = profile
+        self.defaultSearchEngine = defaultSearchEngine
         self.topSiteHistoryManager = topSiteHistoryManager
         self.googleTopSiteManager = googleTopSiteManager
         self.contileProvider = contileProvider
@@ -102,6 +106,9 @@ class TopSitesDataAdaptorImplementation: TopSitesDataAdaptor, FeatureFlaggable, 
         }
 
         sites.removeDuplicates()
+
+        // This will prevent any Sponsored tile from appearing if its SLD matches the default search engine.
+        sites = topSitesDataUtility.removeSiteMatching(defaultSearchEngine, from: sites)
 
         topSites = sites.map { TopSite(site: $0) }
     }

--- a/Client/Frontend/Home/TopSites/DataManagement/TopSitesDataAdaptor.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/TopSitesDataAdaptor.swift
@@ -40,7 +40,6 @@ class TopSitesDataAdaptorImplementation: TopSitesDataAdaptor, FeatureFlaggable, 
     private var historySites: [Site] = []
     private var contiles: [Contile] = []
     private(set) var defaultSearchEngine: OpenSearchEngine?
-    private let topSitesDataUtility = TopSitesDataUtility()
 
     var notificationCenter: NotificationProtocol
     weak var delegate: TopSitesManagerDelegate?
@@ -107,8 +106,7 @@ class TopSitesDataAdaptorImplementation: TopSitesDataAdaptor, FeatureFlaggable, 
 
         sites.removeDuplicates()
 
-        // This will prevent any Sponsored tile from appearing if its SLD matches the default search engine.
-        sites = topSitesDataUtility.removeSiteMatching(defaultSearchEngine, from: sites)
+        sites = TopSitesDataUtility().removeSiteMatchingSites(in: defaultSearchEngine, from: sites)
 
         topSites = sites.map { TopSite(site: $0) }
     }

--- a/Client/Frontend/Home/TopSites/DataManagement/TopSitesDataUtility.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/TopSitesDataUtility.swift
@@ -1,0 +1,26 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Storage
+
+protocol TopSitesDataUtilityInterface {
+    func removeSiteMatching(_ engine: OpenSearchEngine?, from sites: [Site]) -> [Site]
+}
+
+struct TopSitesDataUtility: TopSitesDataUtilityInterface {
+    func removeSiteMatching(_ engine: OpenSearchEngine?, from sites: [Site]) -> [Site] {
+        if let defaultSearchEngine = engine {
+            let filteredSites = sites.filter {
+                guard let secondLevelDomain = $0.secondLevelDomain else { return false }
+                let hasMatchedEngine = defaultSearchEngine.shortName.localizedCaseInsensitiveContains(secondLevelDomain)
+
+                return !hasMatchedEngine
+            }
+            return filteredSites
+        }
+
+        return sites
+    }
+}

--- a/Client/Frontend/Home/TopSites/DataManagement/TopSitesDataUtility.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/TopSitesDataUtility.swift
@@ -6,21 +6,20 @@ import Foundation
 import Storage
 
 protocol TopSitesDataUtilityInterface {
-    func removeSiteMatching(_ engine: OpenSearchEngine?, from sites: [Site]) -> [Site]
+    func removeSiteMatchingSites(in searchEngine: OpenSearchEngine?, from sites: [Site]) -> [Site]
 }
 
 struct TopSitesDataUtility: TopSitesDataUtilityInterface {
-    func removeSiteMatching(_ engine: OpenSearchEngine?, from sites: [Site]) -> [Site] {
-        if let defaultSearchEngine = engine {
-            let filteredSites = sites.filter {
-                guard let secondLevelDomain = $0.secondLevelDomain else { return false }
-                let hasMatchedEngine = defaultSearchEngine.shortName.localizedCaseInsensitiveContains(secondLevelDomain)
+    func removeSiteMatchingSites(in searchEngine: OpenSearchEngine?, from sites: [Site]) -> [Site] {
+        guard let defaultSearchEngine = searchEngine else { return sites }
 
-                return !hasMatchedEngine
-            }
-            return filteredSites
+        let filteredSites = sites.filter {
+            guard let secondLevelDomain = $0.secondLevelDomain else { return false }
+            let hasMatchedEngine = defaultSearchEngine.shortName.localizedCaseInsensitiveContains(secondLevelDomain)
+
+            return !hasMatchedEngine
         }
 
-        return sites
+        return filteredSites
     }
 }

--- a/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -42,6 +42,7 @@ class TopSitesViewModel {
         self.topSiteHistoryManager = TopSiteHistoryManager(profile: profile)
         self.googleTopSiteManager = GoogleTopSiteManager(prefs: profile.prefs)
         let adaptor = TopSitesDataAdaptorImplementation(profile: profile,
+                                                        defaultSearchEngine: profile.searchEngines.defaultEngine,
                                                         topSiteHistoryManager: topSiteHistoryManager,
                                                         googleTopSiteManager: googleTopSiteManager)
         topSitesDataAdaptor = adaptor

--- a/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataAdaptorTests.swift
+++ b/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataAdaptorTests.swift
@@ -412,20 +412,6 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
         XCTAssertTrue(data[2].isPinned)
         XCTAssertEqual(data[2].site.url, "https://www.apinnedurl.com/pinned1")
     }
-
-    func testSearchEngineIsSet() throws {
-        featureFlags.set(feature: .sponsoredTiles, to: true)
-        let expectation = expectation(description: "Search engines should be available by this point.")
-
-        searchEngines.getOrderedEngines { result in
-            XCTAssertEqual(self.searchEngines.orderedEngines.count, 6)
-            expectation.fulfill()
-        }
-        waitForExpectations(timeout: 3)
-
-        let subject = createSubject()
-        XCTAssertNotNil(subject.defaultSearchEngine)
-    }
 }
 
 // MARK: - ContileProviderMock

--- a/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataUtilityTests.swift
+++ b/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataUtilityTests.swift
@@ -30,7 +30,6 @@ class TopSitesDataAdapterTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-
         topSitesDataUtility = TopSitesDataUtility()
     }
 
@@ -40,7 +39,6 @@ class TopSitesDataAdapterTests: XCTestCase {
     }
 
     // MARK: Tests
-
     func testSitesNotFiltered() {
         let sites = topSitesDataUtility.removeSiteMatching(searchEngine, from: nonFilterableSites)
         XCTAssertEqual(sites.count, 3)

--- a/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataUtilityTests.swift
+++ b/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataUtilityTests.swift
@@ -40,12 +40,12 @@ class TopSitesDataAdapterTests: XCTestCase {
 
     // MARK: Tests
     func testSitesNotFiltered() {
-        let sites = topSitesDataUtility.removeSiteMatching(searchEngine, from: nonFilterableSites)
+        let sites = topSitesDataUtility.removeSiteMatchingSites(in: searchEngine, from: nonFilterableSites)
         XCTAssertEqual(sites.count, 3)
     }
 
     func testSitesAreFiltered() {
-        let sites = topSitesDataUtility.removeSiteMatching(searchEngine, from: filterableSites)
+        let sites = topSitesDataUtility.removeSiteMatchingSites(in: searchEngine, from: filterableSites)
         XCTAssertEqual(sites.count, 2)
     }
 }

--- a/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataUtilityTests.swift
+++ b/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataUtilityTests.swift
@@ -7,7 +7,7 @@ import XCTest
 import Storage
 @testable import Client
 
-class TopSitesDataAdapterTests: XCTestCase {
+class TopSitesDataUtilityTests: XCTestCase {
     var topSitesDataUtility: TopSitesDataUtilityInterface!
 
     // MARK: Stubs

--- a/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataUtilityTests.swift
+++ b/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataUtilityTests.swift
@@ -1,0 +1,53 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import XCTest
+import Storage
+@testable import Client
+
+class TopSitesDataAdapterTests: XCTestCase {
+    var topSitesDataUtility: TopSitesDataUtilityInterface!
+
+    // MARK: Stubs
+    let nonFilterableSites: [Site] = [
+        Site(url: "https://www.hello.com", title: "hello", bookmarked: false, guid: nil),
+        Site(url: "https://www.another.com", title: "another", bookmarked: false, guid: nil),
+        Site(url: "https://www.site.com", title: "site", bookmarked: false, guid: nil),
+    ]
+    let filterableSites: [Site] = [
+        Site(url: "https://www.test.com", title: "test", bookmarked: false, guid: nil),
+        Site(url: "https://www.another.com", title: "another", bookmarked: false, guid: nil),
+        Site(url: "https://www.site.com", title: "site", bookmarked: false, guid: nil),
+    ]
+    let searchEngine = OpenSearchEngine(engineID: "test",
+                                        shortName: "test",
+                                        image: UIImage(),
+                                        searchTemplate: "http://firefox.com/find?q={searchTerm}",
+                                        suggestTemplate: nil,
+                                        isCustomEngine: false)
+
+    override func setUp() {
+        super.setUp()
+
+        topSitesDataUtility = TopSitesDataUtility()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        topSitesDataUtility = nil
+    }
+
+    // MARK: Tests
+
+    func testSitesNotFiltered() {
+        let sites = topSitesDataUtility.removeSiteMatching(searchEngine, from: nonFilterableSites)
+        XCTAssertEqual(sites.count, 3)
+    }
+
+    func testSitesAreFiltered() {
+        let sites = topSitesDataUtility.removeSiteMatching(searchEngine, from: filterableSites)
+        XCTAssertEqual(sites.count, 2)
+    }
+}


### PR DESCRIPTION
# [FXIOS-4251](https://mozilla-hub.atlassian.net/browse/FXIOS-4251) | https://github.com/mozilla-mobile/firefox-ios/issues/10773

### Description
Sponsored tiles that are matched against the default search engine will now stop appearing in top sites.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
