### PR TITLE
Bugfix FXIOS-6472 [v115] Remove en-US from the privacy link

### DIFF
--- a/nimbus-features/onboardingFrameworkFeature.yaml
+++ b/nimbus-features/onboardingFrameworkFeature.yaml
@@ -37,7 +37,7 @@ features:
               image: welcome-globe
               link:
                 title: Onboarding/Onboarding.Welcome.Link.Action.v114
-                url: "https://www.mozilla.org/en-US/privacy/firefox/"
+                url: "https://www.mozilla.org/privacy/firefox/"
               buttons:
                 primary:
                   title: Onboarding/Onboarding.Welcome.Action.v114


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6472)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14556)

### Description
I removed it!

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
