### PR TITLE
Refactor FXIOS-6700 [v116] update SwiftUI CC strings to be only localized when required

### DIFF
--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
@@ -44,7 +44,7 @@ struct CreditCardItemRow: View {
                         Text(item.ccType)
                             .font(.body)
                             .foregroundColor(titleTextColor)
-                        Text("••••\(item.ccNumberLast4)")
+                        Text(verbatim: "••••\(item.ccNumberLast4)")
                             .font(.subheadline)
                             .foregroundColor(subTextColor)
                     }
@@ -59,7 +59,7 @@ struct CreditCardItemRow: View {
                         Text(String.CreditCard.DisplayCard.ExpiresLabel)
                             .font(.body)
                             .foregroundColor(subTextColor)
-                        Text("\(item.ccExpMonth)/\(item.ccExpYear)")
+                        Text(verbatim: "\(item.ccExpMonth)/\(item.ccExpYear)")
                             .font(.subheadline)
                             .foregroundColor(subTextColor)
                     }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6700)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14946)


### Description
Using `Text(verbatim:` instead of `Text(` for SwiftUI as the strings were getting localized which we don't want for the following strings.

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
