### PR TITLE
Bugfix FXIOS-6695 [v115] Fix show tour to appear under debug menu

### DIFF
--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -791,16 +791,20 @@ class YourRightsSetting: Setting {
 }
 
 // Opens the on-boarding screen again
-class ShowIntroductionSetting: Setting {
+class ShowIntroductionSetting: HiddenSetting {
     let profile: Profile
 
     override var accessibilityIdentifier: String? { return "ShowTour" }
 
-    init(settings: SettingsTableViewController) {
-        self.profile = settings.profile
+    override var title: NSAttributedString? {
         let attributes = [NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary]
-        super.init(title: NSAttributedString(string: .AppSettingsShowTour,
-                                             attributes: attributes))
+        return NSAttributedString(string: .AppSettingsShowTour,
+                                  attributes: attributes)
+    }
+
+    override init(settings: SettingsTableViewController) {
+        self.profile = settings.profile
+        super.init(settings: settings)
     }
 
     override func onClick(_ navigationController: UINavigationController?) {

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -218,9 +218,9 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
             SettingSection(title: NSAttributedString(string: .AppSettingsAbout), children: [
                 AppStoreReviewSetting(),
                 VersionSetting(settings: self),
-                ShowIntroductionSetting(settings: self),
                 LicenseAndAcknowledgementsSetting(),
                 YourRightsSetting(),
+                ShowIntroductionSetting(settings: self),
                 ExportBrowserDataSetting(settings: self),
                 ExportLogDataSetting(settings: self),
                 DeleteExportedDataSetting(settings: self),


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6695)

### Description
This is done following https://github.com/mozilla-mobile/firefox-ios/pull/14936 to make sure the show tour appears only when we click 5 times on the version to see the debug menu. This is on v115 only as explained in other PR.

#### Without seeing debug
![Simulator Screenshot - iPhone 14 - 2023-06-13 at 17 44 08](https://github.com/mozilla-mobile/firefox-ios/assets/11338480/38a2b503-b73b-4322-9335-470cdd431b5c)

#### When seeing debug
![Simulator Screenshot - iPhone 14 - 2023-06-13 at 17 44 18](https://github.com/mozilla-mobile/firefox-ios/assets/11338480/170cb0c9-c49a-4175-9b8c-a4f7f3032446)


### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
