### PR TITLE
Bugfix FXIOS-6651 [v115] The "expired" event telemetry is registered instead of the "dismissed"

### DIFF
--- a/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
+++ b/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
@@ -207,8 +207,7 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
 
         switch createMessage(messageId: id,
                              message: messageData,
-                             lookupTables: feature,
-                             includeExpired: true) {
+                             lookupTables: feature) {
         case .success(let newMessage): return newMessage
         case .failure: return nil
         }
@@ -243,8 +242,7 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
     private func createMessage(
         messageId: String,
         message: MessageData,
-        lookupTables: Messaging,
-        includeExpired: Bool = false
+        lookupTables: Messaging
     ) -> Result<GleanPlumbMessage, CreateMessageError> {
         // Guard against a message with a blank `text` property.
         guard !message.text.isEmpty else { return .failure(.malformed) }
@@ -268,15 +266,6 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
         }
 
         let messageMetadata = messagingStore.getMessageMetadata(messageId: messageId)
-        if !includeExpired &&
-            (messageMetadata.impressions >= style.maxDisplayCount || messageMetadata.isExpired) {
-            _ = messagingStore.onMessageExpired(
-                messageMetadata,
-                surface: message.surface,
-                shouldReport: true)
-            return .failure(.expired)
-        }
-
         return .success(
             GleanPlumbMessage(id: messageId,
                               data: message,

--- a/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
+++ b/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
@@ -208,7 +208,7 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
         switch createMessage(messageId: id,
                              message: messageData,
                              lookupTables: feature,
-                             ignoreExpiry: true) {
+                             includeExpired: true) {
         case .success(let newMessage): return newMessage
         case .failure: return nil
         }
@@ -244,7 +244,7 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
         messageId: String,
         message: MessageData,
         lookupTables: Messaging,
-        ignoreExpiry: Bool = false
+        includeExpired: Bool = false
     ) -> Result<GleanPlumbMessage, CreateMessageError> {
         // Guard against a message with a blank `text` property.
         guard !message.text.isEmpty else { return .failure(.malformed) }
@@ -268,7 +268,7 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
         }
 
         let messageMetadata = messagingStore.getMessageMetadata(messageId: messageId)
-        if !ignoreExpiry &&
+        if !includeExpired &&
             (messageMetadata.impressions >= style.maxDisplayCount || messageMetadata.isExpired) {
             _ = messagingStore.onMessageExpired(
                 messageMetadata,

--- a/Client/Experiments/Messaging/GleanPlumbMessageStore.swift
+++ b/Client/Experiments/Messaging/GleanPlumbMessageStore.swift
@@ -51,10 +51,10 @@ class GleanPlumbMessageStore: GleanPlumbMessageStoreProtocol {
     func onMessageDisplayed(_ message: GleanPlumbMessage) {
         message.metadata.impressions += 1
 
-        if message.metadata.impressions >= message.style.maxDisplayCount {
+        if message.isExpired {
             onMessageExpired(message.metadata,
                              surface: message.data.surface,
-                             shouldReport: false)
+                             shouldReport: true)
         }
 
         set(key: message.id, metadata: message.metadata)

--- a/Client/Experiments/Messaging/GleanPlumbMessageStore.swift
+++ b/Client/Experiments/Messaging/GleanPlumbMessageStore.swift
@@ -51,6 +51,12 @@ class GleanPlumbMessageStore: GleanPlumbMessageStoreProtocol {
     func onMessageDisplayed(_ message: GleanPlumbMessage) {
         message.metadata.impressions += 1
 
+        if message.metadata.impressions >= message.style.maxDisplayCount {
+            onMessageExpired(message.metadata,
+                             surface: message.data.surface,
+                             shouldReport: false)
+        }
+
         set(key: message.id, metadata: message.metadata)
     }
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6651)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14863)

### Description
We are intermittently reporting the wrong event because once the notification is displayed the impression count is increased and the notification can be retrieved as the impression count is over the limit for notifications. So now we are retrieving expired notifications as well.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
