### PR TITLE
Revert "Remove FXIOS-6696 [v116] Remove unused class and tests"

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -1330,6 +1330,8 @@
 		E4E7EB6D1C4AED5E0094275D /* SupportUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E7EB6C1C4AED5E0094275D /* SupportUtilsTests.swift */; };
 		E571EE762875694C0051D9AA /* PocketSponsoredStoriesProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = E571EE732875694C0051D9AA /* PocketSponsoredStoriesProviding.swift */; };
 		E571EE772875694C0051D9AA /* MockPocketSponsoredStoriesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E571EE742875694C0051D9AA /* MockPocketSponsoredStoriesProvider.swift */; };
+		E571EE782875694C0051D9AA /* PocketSponsoredStoriesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E571EE752875694C0051D9AA /* PocketSponsoredStoriesProvider.swift */; };
+		E571EE7D28756A130051D9AA /* PocketSponsoredStoriesProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E571EE7A287569960051D9AA /* PocketSponsoredStoriesProviderTests.swift */; };
 		E571EE7E28756A130051D9AA /* PocketStoryProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E571EE79287569960051D9AA /* PocketStoryProviderTests.swift */; };
 		E58368AA287D632F0087A449 /* StoryProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E58368A9287D632F0087A449 /* StoryProvider.swift */; };
 		E60D03181D511398002FE3F6 /* SyncStatusResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60D03171D511398002FE3F6 /* SyncStatusResolver.swift */; };
@@ -6339,7 +6341,9 @@
 		E56B4867B0EFF2600F5DE8CC /* gl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = gl; path = gl.lproj/ClearPrivateData.strings; sourceTree = "<group>"; };
 		E571EE732875694C0051D9AA /* PocketSponsoredStoriesProviding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PocketSponsoredStoriesProviding.swift; sourceTree = "<group>"; };
 		E571EE742875694C0051D9AA /* MockPocketSponsoredStoriesProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockPocketSponsoredStoriesProvider.swift; sourceTree = "<group>"; };
+		E571EE752875694C0051D9AA /* PocketSponsoredStoriesProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PocketSponsoredStoriesProvider.swift; sourceTree = "<group>"; };
 		E571EE79287569960051D9AA /* PocketStoryProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PocketStoryProviderTests.swift; sourceTree = "<group>"; };
+		E571EE7A287569960051D9AA /* PocketSponsoredStoriesProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PocketSponsoredStoriesProviderTests.swift; sourceTree = "<group>"; };
 		E58368A9287D632F0087A449 /* StoryProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryProvider.swift; sourceTree = "<group>"; };
 		E59A418F9208400903902F07 /* ses */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ses; path = ses.lproj/LoginManager.strings; sourceTree = "<group>"; };
 		E5C24864B9BA6790B352962E /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/Search.strings; sourceTree = "<group>"; };
@@ -8117,6 +8121,7 @@
 			children = (
 				8A7653C128A2E57D00924ABF /* PocketDataAdaptorTests.swift */,
 				3B61CD581F2A750800D38DE1 /* PocketFeedTests.swift */,
+				E571EE7A287569960051D9AA /* PocketSponsoredStoriesProviderTests.swift */,
 				E571EE79287569960051D9AA /* PocketStoryProviderTests.swift */,
 				8AA7347A28AEDB3100443D24 /* PocketViewModelTests.swift */,
 			);
@@ -9105,6 +9110,7 @@
 			isa = PBXGroup;
 			children = (
 				E571EE742875694C0051D9AA /* MockPocketSponsoredStoriesProvider.swift */,
+				E571EE752875694C0051D9AA /* PocketSponsoredStoriesProvider.swift */,
 				E571EE732875694C0051D9AA /* PocketSponsoredStoriesProviding.swift */,
 				C8B0F5F0283B7CCE007AE65D /* Model */,
 				C8B0F5EF283B7CCE007AE65D /* PocketProvider.swift */,
@@ -12455,6 +12461,7 @@
 				E650755C1E37F747006961AC /* Swizzling.m in Sources */,
 				74821FC51DB56A2500EEEA72 /* OpenWithSettingsViewController.swift in Sources */,
 				C84656012887A0F700861B4A /* WallpaperMetadataUtility.swift in Sources */,
+				E571EE782875694C0051D9AA /* PocketSponsoredStoriesProvider.swift in Sources */,
 				E1B04A9D28E20A8300670E54 /* InstructionsView.swift in Sources */,
 				D3B6923D1B9F9444004B87A4 /* FindInPageBar.swift in Sources */,
 				2F44FC721A9E840300FD20CC /* SettingsNavigationController.swift in Sources */,
@@ -13105,6 +13112,7 @@
 				8AABBD052A0041380089941E /* MockCoordinator.swift in Sources */,
 				8AABBCFF2A0017960089941E /* MockGleanWrapper.swift in Sources */,
 				E1D8BC7A21FF7A0000B100BD /* TPStatsBlocklistsTests.swift in Sources */,
+				E571EE7D28756A130051D9AA /* PocketSponsoredStoriesProviderTests.swift in Sources */,
 				5AF6254328A57A4600A90253 /* HistoryHighlightsDataAdaptorTests.swift in Sources */,
 				8AE80BAD2891957C00BC12EA /* TopSitesDimensionTests.swift in Sources */,
 				D82ED2641FEB3C420059570B /* DefaultSearchPrefsTests.swift in Sources */,

--- a/Providers/Pocket/PocketSponsoredStoriesProvider.swift
+++ b/Providers/Pocket/PocketSponsoredStoriesProvider.swift
@@ -1,0 +1,145 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Shared
+
+class PocketSponsoredStoriesProvider: PocketSponsoredStoriesProviding, FeatureFlaggable, URLCaching {
+    private var logger: Logger
+
+    init(logger: Logger = DefaultLogger.shared) {
+        self.logger = logger
+    }
+
+    var endpoint: URL {
+        if featureFlags.isCoreFeatureEnabled(.useStagingSponsoredPocketStoriesAPI) {
+            return PocketSponsoredConstants.staging
+        } else {
+            return PocketSponsoredConstants.prod
+        }
+    }
+
+    lazy var urlSession: URLSession = makeURLSession(userAgent: UserAgent.defaultClientUserAgent, configuration: URLSessionConfiguration.default)
+
+    private lazy var pocketKey: String = {
+        return Bundle.main.object(forInfoDictionaryKey: PocketSponsoredConstants.pocketEnvAPIKey) as? String ?? ""
+    }()
+
+    lazy var urlCache: URLCache = {
+        return URLCache.shared
+    }()
+
+    private lazy var pocketId: String = {
+        if let pocketId = UserDefaults.standard.object(forKey: PocketSponsoredConstants.pocketId) as? String {
+            return pocketId
+        } else {
+            let uuid = UUID()
+            UserDefaults.standard.setValue(uuid.uuidString, forKey: PocketSponsoredConstants.pocketId)
+            return uuid.uuidString
+        }
+    }()
+
+    private var sponsoredFeedRequest: URLRequest? {
+        var request = Locale
+            .current
+            .regionCode?
+            .map { URLQueryItem(name: .country, value: $0) }
+            .map { endpoint.withQueryParams([$0]) }
+            .map {
+                URLRequest(
+                    url: $0,
+                    cachePolicy: .reloadIgnoringCacheData,
+                    timeoutInterval: 5
+                )
+            }
+
+        let body: [String: Any] = [
+            .version: 2,
+            .consumerKey: pocketKey,
+            .pocketId: pocketId
+        ]
+
+        let bodyData = try? JSONSerialization.data(withJSONObject: body)
+        request?.httpBody = bodyData
+        request?.httpMethod = .post
+
+        return request
+    }
+
+    func fetchSponsoredStories(timestamp: Timestamp = Date.now(), completion: @escaping (SponsoredStoryResult) -> Void) {
+        guard let request = sponsoredFeedRequest else {
+            completion(.failure(Error.requestCreationFailure))
+            return
+        }
+
+        if let cachedData = findCachedData(for: request, timestamp: timestamp) {
+            decode(data: cachedData, completion: completion)
+        } else {
+            fetchSponsoredStories(request: request, completion: completion)
+        }
+    }
+
+    func fetchSponsoredStories(request: URLRequest, completion: @escaping (SponsoredStoryResult) -> Void) {
+        urlSession.dataTask(with: request) { [weak self] (data, response, error) in
+            guard let self = self else { return }
+            if let error = error {
+                self.logger.log("An error occurred while fetching data: \(error)",
+                                level: .debug,
+                                category: .homepage)
+                completion(.failure(Error.failure))
+                return
+            }
+
+            guard let response = validatedHTTPResponse(response, statusCode: 200..<300),
+                       let data = data,
+                       !data.isEmpty
+            else {
+                self.logger.log("Response isn't proper",
+                                level: .debug,
+                                category: .homepage)
+                completion(.failure(Error.invalidHTTPResponse))
+                return
+            }
+
+            self.cache(response: response, for: request, with: data)
+            self.decode(data: data, completion: completion)
+        }.resume()
+    }
+
+    private func decode(data: Data, completion: @escaping (SponsoredStoryResult) -> Void) {
+        do {
+            let decodedResponse = try JSONDecoder().decode(PocketSponsoredRequest.self, from: data)
+            completion(.success(decodedResponse.spocs))
+        } catch {
+            logger.log("Unable to parse with error: \(error)",
+                       level: .warning,
+                       category: .homepage)
+            completion(.failure(Error.decodingFailure))
+        }
+    }
+}
+
+extension PocketSponsoredStoriesProvider {
+    enum Error: Swift.Error {
+        case failure
+        case decodingFailure
+        case requestCreationFailure
+        case invalidHTTPResponse
+    }
+}
+
+enum PocketSponsoredConstants {
+    static let pocketEnvAPIKey = "PocketEnvironmentAPIKey"
+    static let pocketId = "PocketID"
+    static let staging = URL(string: "https://spocs.getpocket.dev/spocs")!
+    static let prod = URL(string: "https://spocs.getpocket.com/spocs")!
+}
+
+fileprivate extension String {
+    static let country = "country"
+    static let version = "version"
+    static let consumerKey = "consumer_key"
+    static let pocketId = "pocket_id"
+    static let post = "POST"
+}

--- a/Tests/ClientTests/Frontend/Home/Pocket/PocketSponsoredStoriesProviderTests.swift
+++ b/Tests/ClientTests/Frontend/Home/Pocket/PocketSponsoredStoriesProviderTests.swift
@@ -1,0 +1,304 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Client
+
+class PocketSponsoredStoriesProviderTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        clearState()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        clearState()
+    }
+
+    func testErrorResponse_failsWithError() {
+        stubResponse(response: nil, statusCode: 200, error: anError)
+        testProvider { result in
+            switch result {
+            case let .failure(error as PocketSponsoredStoriesProvider.Error):
+                XCTAssertEqual(error, PocketSponsoredStoriesProvider.Error.failure)
+            default:
+                XCTFail("Expected failure, got \(result) instead")
+            }
+        }
+    }
+
+    func testNilDataResponse_failsWithError() {
+        stubResponse(response: nil, statusCode: 200, error: nil)
+        testProvider { result in
+            switch result {
+            case let .failure(error as PocketSponsoredStoriesProvider.Error):
+                XCTAssertEqual(error, PocketSponsoredStoriesProvider.Error.invalidHTTPResponse)
+            default:
+                XCTFail("Expected failure, got \(result) instead")
+            }
+        }
+    }
+
+    func testEmptyResponse_failsWithError() {
+        stubResponse(response: emptyResponse, statusCode: 200, error: nil)
+        testProvider { result in
+            switch result {
+            case let .failure(error as PocketSponsoredStoriesProvider.Error):
+                XCTAssertEqual(error, PocketSponsoredStoriesProvider.Error.decodingFailure)
+            default:
+                XCTFail("Expected failure, got \(result) instead")
+            }
+        }
+    }
+
+    func testAuthStatusCodeResponse_failsWithError() {
+        stubResponse(response: nil, statusCode: 403, error: nil)
+        testProvider { result in
+            switch result {
+            case let .failure(error as PocketSponsoredStoriesProvider.Error):
+                XCTAssertEqual(error, PocketSponsoredStoriesProvider.Error.invalidHTTPResponse)
+            default:
+                XCTFail("Expected failure, got \(result) instead")
+            }
+        }
+    }
+
+    func testWrongResponse_failsWithError() {
+        stubResponse(response: emptyWrongResponse, statusCode: 200, error: nil)
+        testProvider { result in
+            switch result {
+            case let .failure(error as PocketSponsoredStoriesProvider.Error):
+                XCTAssertEqual(error, PocketSponsoredStoriesProvider.Error.decodingFailure)
+            default:
+                XCTFail("Expected failure, got \(result) instead")
+            }
+        }
+    }
+
+    func testEmptyArrayResponse_succeedsWithEmptyArray() {
+        stubResponse(response: emptyArrayResponse, statusCode: 200, error: nil)
+        testProvider { result in
+            switch result {
+            case let .success(stories):
+                XCTAssertEqual(stories, [])
+            default:
+                XCTFail("Expected success, got \(result) instead")
+            }
+        }
+    }
+
+    func testValidResponse_succeedsWithValidSponsoredStories() {
+        stubResponse(response: validSpocResponse, statusCode: 200, error: nil)
+        testProvider { result in
+            switch result {
+            case let .success(stories):
+                XCTAssertEqual(stories.count, 2)
+            default:
+                XCTFail("Expected success, got \(result) instead")
+            }
+        }
+    }
+
+    func testCachingExpires_failsIfCacheIsTooOld() {
+        stubResponse(response: validSpocResponse, statusCode: 200, error: nil)
+        let provider = getProvider()
+        let expectation = expectation(description: "Wait for completion")
+        provider.fetchSponsoredStories { result in
+            self.stubResponse(response: nil, statusCode: 403, error: nil)
+            provider.fetchSponsoredStories(timestamp: Date.tomorrow.toTimestamp()) { result in
+                switch result {
+                case let .failure(error as PocketSponsoredStoriesProvider.Error):
+                    XCTAssertEqual(error, PocketSponsoredStoriesProvider.Error.invalidHTTPResponse)
+                default:
+                    XCTFail("Expected failure, got \(result) instead")
+                }
+                expectation.fulfill()
+            }
+        }
+
+        waitForExpectations(timeout: 1.0, handler: nil)
+    }
+
+    func testCachingExpires_failsIfCacheIsNewerThanCurrentDate() {
+        stubResponse(response: validSpocResponse, statusCode: 200, error: nil)
+        let provider = getProvider()
+        let expectation = expectation(description: "Wait for completion")
+        provider.fetchSponsoredStories { result in
+            self.stubResponse(response: nil, statusCode: 403, error: nil)
+            provider.fetchSponsoredStories(timestamp: Date.yesterday.toTimestamp()) { result in
+                switch result {
+                case let .failure(error as PocketSponsoredStoriesProvider.Error):
+                    XCTAssertEqual(error, PocketSponsoredStoriesProvider.Error.invalidHTTPResponse)
+                default:
+                    XCTFail("Expected failure, got \(result) instead")
+                }
+                expectation.fulfill()
+            }
+        }
+
+        waitForExpectations(timeout: 1.0, handler: nil)
+    }
+
+    func testNoStubbing_doesntComplete() {
+        let provider = getProvider()
+        let expectation = expectation(description: "Wait for completion")
+        expectation.isInverted = true
+        provider.fetchSponsoredStories { result in
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 1.0, handler: nil)
+    }
+}
+
+// MARK: - Helper functions
+
+private extension PocketSponsoredStoriesProviderTests {
+    func getProvider(file: StaticString = #filePath, line: UInt = #line) -> PocketSponsoredStoriesProviding {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [URLProtocolStub.self]
+        let session = URLSession(configuration: configuration)
+        let cache = URLCache(memoryCapacity: 100000, diskCapacity: 1000, directory: URL(string: "/dev/null"))
+
+        let provider = PocketSponsoredStoriesProvider()
+        provider.urlSession = session
+        provider.urlCache = cache
+
+        trackForMemoryLeaks(provider, file: file, line: line)
+        trackForMemoryLeaks(cache, file: file, line: line)
+
+        return provider
+    }
+
+    func testProvider(completion: @escaping (Result<[PocketSponsoredStory], Error>) -> Void) {
+        let provider = getProvider()
+        let expectation = expectation(description: "Wait for completion")
+        provider.fetchSponsoredStories { result in
+            completion(result)
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 1.0, handler: nil)
+    }
+
+    func stubResponse(response: String?, statusCode: Int, error: Error?) {
+        let mockJSONData = response?.data(using: .utf8)
+        let response = HTTPURLResponse(url: PocketSponsoredConstants.staging,
+                                       statusCode: statusCode,
+                                       httpVersion: nil,
+                                       headerFields: nil)!
+        URLProtocolStub.stub(data: mockJSONData, response: response, error: error)
+    }
+
+    func clearState() {
+        URLProtocolStub.removeStub()
+    }
+
+    // MARK: - Mock responses
+
+    var emptyArrayResponse: String {
+        """
+        {
+        "spocs": []
+        }
+        """
+    }
+
+    var emptyWrongResponse: String {
+        """
+        {
+            "bad": []
+        }
+        """
+    }
+
+    var emptyResponse: String {
+        return "{}"
+    }
+
+    var validSpocResponse: String {
+        """
+        {
+            "spocs": [
+                \(spoc1),
+                \(spoc2)
+            ]
+        }
+        """
+    }
+
+    var spoc1: String {
+        """
+        {
+            "id" : 1,
+            "flight_id" : 1,
+            "campaign_id" : 1,
+            "title" : "test",
+            "domain" : "test",
+            "excerpt" : "test",
+            "priority" : 2,
+            "context" : "test",
+            "raw_image_src" : "www.google.com",
+            "image_src" : "www.google.com",
+            "sponsor" : "test",
+            "caps": {
+                "lifetime": 50,
+                "campaign": {
+                    "count": 10,
+                    "period": 86400
+                },
+                "flight": {
+                    "count": 10,
+                    "period": 86400
+                }
+            },
+             "shim": {
+                 "click": "test",
+                 "impression": "test",
+                 "delete": "test",
+                 "save": "test"
+             }
+        }
+        """
+    }
+
+    var spoc2: String {
+        """
+        {
+            "id" : 1,
+            "flight_id" : 1,
+            "campaign_id" : 1,
+            "title" : "test",
+            "domain" : "test",
+            "excerpt" : "test",
+            "priority" : 2,
+            "context" : "test",
+            "raw_image_src" : "www.google.com",
+            "image_src" : "www.google.com",
+            "sponsor" : "test",
+            "caps": {
+                "lifetime": 50,
+                "campaign": {
+                    "count": 10,
+                    "period": 86400
+                },
+                "flight": {
+                    "count": 10,
+                    "period": 86400
+                }
+            },
+             "shim": {
+                 "click": "test",
+                 "impression": "test",
+                 "delete": "test",
+                 "save": "test"
+             }
+        }
+        """
+    }
+
+    var anError: NSError {
+        return NSError(domain: "test error", code: 0)
+    }
+}


### PR DESCRIPTION
Reverts mozilla-mobile/firefox-ios#14938

Based on Laurie's comment in the PR it seems this was to be used for the sponsored stories for pocket feature that was never finished. That project is not being picked up in the foreseeable future but product do want to do it eventually so we should still remove it but I will put all code associated with it into one PR so that it at least it can easily be referenced down the road if the feature ever does get picked up again.