### PR TITLE
Add FXIOS-6382 [v114.3] Update Firefox entitlement to support Apple Sign In

### DIFF
--- a/Client/Entitlements/FirefoxApplication.entitlements
+++ b/Client/Entitlements/FirefoxApplication.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
     <key>com.apple.developer.authentication-services.autofill-credential-provider</key>
     <true/>
     <key>com.apple.developer.web-browser</key>


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6382)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14339)

### Description
Update Firefox entitlement to support Apple Sign In

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
