### PR TITLE
Bugfix MTE-1126 [v116] follow-up fix: Add Slack notification for Robo Test

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1421,7 +1421,7 @@ workflows:
                 --results-bucket=firefox_ios_test_artifacts \
                 --no-record-video \
                 --client-details=matrixLabel="Bitrise" \
-                2>&1 | tee /dev/tty)
+                2>&1 | tee /dev/stdout)
             MATRIX_WEBLINK=$(echo "$GCLOUD_OUTPUT" | grep 'https://console.firebase.google.com/project' | awk -F '[][]' '{print $2}' | head -n 1)
             envman add --key MATRIX_WEBLINK --value "$MATRIX_WEBLINK"
     - slack@3.5.0:


### PR DESCRIPTION
https://app.bitrise.io/build/dbf6e2d3-2e0e-4888-a6d9-38117f2d63e6

Fix: `tee: /dev/tty: Device not configured` -> `/dev/stdout` 🤷🏼 