### PR TITLE
Added FXIOS-6704 [v115] Enable tabs refactor feature by default

### DIFF
--- a/nimbus-features/tabStorageRefactorFeature.yaml
+++ b/nimbus-features/tabStorageRefactorFeature.yaml
@@ -8,11 +8,11 @@ features:
         description: >
           Enables the feature
         type: Boolean
-        default: false
+        default: true
     defaults:
       - channel: beta
         value:
-          enabled: false
+          enabled: true
       - channel: developer
         value:
           enabled: true


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6704)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14964)

### Description
This PR is to enable the tabs refactor project by default. Seeing as the plan is to rollout this feature in v114, it probably makes sense to have it enabled by default in v115 so that QA can test it in the state that is most likely to be released in.

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
