### PR TITLE
Refactor FXIOS-6694 [v116] Theme fix in URL bar

### DIFF
--- a/Client/Application/ImageIdentifiers.swift
+++ b/Client/Application/ImageIdentifiers.swift
@@ -17,6 +17,7 @@ public struct ImageIdentifiers {
     public static let actionRemoveBookmark = "action_bookmark_remove"
     public static let add = "add"
     public static let addShortcut = "action_pin"
+    public static let circleFill = "circle.fill"
     public static let addToBookmark = "menu-Bookmark"
     public static let addToReadingList = "addToReadingList"
     public static let bookmarks = "menu-panel-Bookmarks"

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -307,7 +307,7 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
         if showToolbar {
             toolbar.isHidden = false
             toolbar.tabToolbarDelegate = self
-            toolbar.applyUIMode(isPrivate: tabManager.selectedTab?.isPrivate ?? false)
+            toolbar.applyUIMode(isPrivate: tabManager.selectedTab?.isPrivate ?? false, theme: themeManager.currentTheme)
             toolbar.applyTheme(theme: themeManager.currentTheme)
             toolbar.updateMiddleButtonState(currentMiddleButtonState ?? .search)
             updateTabCountUsingTabManager(self.tabManager)
@@ -1583,7 +1583,7 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
         if let tabTrayController = self.gridTabTrayController, tabTrayController.tabDisplayManager.isPrivate != isPrivate {
             tabTrayController.didTogglePrivateMode(isPrivate)
         }
-        topTabsViewController?.applyUIMode(isPrivate: isPrivate)
+        topTabsViewController?.applyUIMode(isPrivate: isPrivate, theme: themeManager.currentTheme)
     }
 
     func switchToTabForURLOrOpen(_ url: URL, uuid: String? = nil, isPrivate: Bool = false) {
@@ -2310,7 +2310,7 @@ extension BrowserViewController: TabManagerDelegate {
                 applyTheme()
 
                 let ui: [PrivateModeUI?] = [toolbar, topTabsViewController, urlBar]
-                ui.forEach { $0?.applyUIMode(isPrivate: tab.isPrivate) }
+                ui.forEach { $0?.applyUIMode(isPrivate: tab.isPrivate, theme: themeManager.currentTheme) }
             }
 
             readerModeCache = tab.isPrivate ? MemoryReaderModeCache.sharedInstance : DiskReaderModeCache.sharedInstance
@@ -2923,7 +2923,7 @@ extension BrowserViewController: LegacyNotificationThemeable {
         let ui: [ThemeApplicable?] = [urlBar,
                                       toolbar,
                                       readerModeBar]
-        urlBar.applyUIMode(isPrivate: tabManager.selectedTab?.isPrivate ?? false)
+        urlBar.applyUIMode(isPrivate: tabManager.selectedTab?.isPrivate ?? false, theme: currentTheme)
         ui.forEach { $0?.applyTheme(theme: currentTheme) }
         zoomPageBar?.applyTheme(theme: currentTheme)
         topTabsViewController?.applyTheme()

--- a/Client/Frontend/Browser/TabTrayButtonExtensions.swift
+++ b/Client/Frontend/Browser/TabTrayButtonExtensions.swift
@@ -6,9 +6,6 @@ import UIKit
 import Shared
 
 class PrivateModeButton: ToggleButton, PrivateModeUI {
-    var offTint = UIColor.black
-    var onTint = UIColor.black
-
     override init(frame: CGRect) {
         super.init(frame: frame)
         accessibilityLabel = .TabTrayToggleAccessibilityLabel
@@ -21,19 +18,17 @@ class PrivateModeButton: ToggleButton, PrivateModeUI {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func applyUIMode(isPrivate: Bool) {
+    func applyUIMode(isPrivate: Bool, theme: Theme) {
         isSelected = isPrivate
 
-        tintColor = isPrivate ? onTint : offTint
+        tintColor = isPrivate ? theme.colors.iconOnColor : theme.colors.iconPrimary
         imageView?.tintColor = tintColor
 
         accessibilityValue = isSelected ? .TabTrayToggleAccessibilityValueOn : .TabTrayToggleAccessibilityValueOff
     }
 
     func applyTheme(theme: Theme) {
-        onTint = theme.colors.iconOnColor
-        offTint = theme.colors.iconPrimary
-        tintColor = isSelected ? onTint : offTint
+        tintColor = isSelected ? theme.colors.iconOnColor : theme.colors.iconPrimary
         imageView?.tintColor = tintColor
     }
 }

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -150,7 +150,7 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable {
         newTab.addInteraction(dropInteraction)
 
         tabsButton.applyTheme(theme: themeManager.currentTheme)
-        applyUIMode(isPrivate: tabManager.selectedTab?.isPrivate ?? false)
+        applyUIMode(isPrivate: tabManager.selectedTab?.isPrivate ?? false, theme: themeManager.currentTheme)
 
         updateTabCount(topTabDisplayManager.dataStore.count, animated: false)
     }
@@ -313,11 +313,11 @@ extension TopTabsViewController: TopTabCellDelegate {
 }
 
 extension TopTabsViewController: PrivateModeUI {
-    func applyUIMode(isPrivate: Bool) {
+    func applyUIMode(isPrivate: Bool, theme: Theme) {
         topTabDisplayManager.togglePrivateMode(isOn: isPrivate, createTabOnEmptyPrivateMode: true)
 
-        privateModeButton.applyTheme(theme: themeManager.currentTheme)
-        privateModeButton.applyUIMode(isPrivate: topTabDisplayManager.isPrivate)
+        privateModeButton.applyTheme(theme: theme)
+        privateModeButton.applyUIMode(isPrivate: topTabDisplayManager.isPrivate, theme: theme)
     }
 }
 

--- a/Client/Frontend/Theme/LegacyThemeManager/LegacyTheme.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/LegacyTheme.swift
@@ -3,13 +3,14 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import UIKit
+import Shared
 
 protocol LegacyNotificationThemeable: AnyObject {
     func applyTheme()
 }
 
 protocol PrivateModeUI {
-    func applyUIMode(isPrivate: Bool)
+    func applyUIMode(isPrivate: Bool, theme: Theme)
 }
 
 extension UIColor {

--- a/Client/Frontend/Toolbar+URLBar/TabToolbar.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabToolbar.swift
@@ -143,7 +143,7 @@ extension TabToolbar: ThemeApplicable, PrivateModeUI {
         warningMenuBadge.badge.tintBackground(color: theme.colors.layer1)
     }
 
-    func applyUIMode(isPrivate: Bool) {
+    func applyUIMode(isPrivate: Bool, theme: Theme) {
         privateModeBadge(visible: isPrivate)
     }
 }

--- a/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -421,31 +421,21 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
         guard locationTextField == nil else { return }
 
         locationTextField = ToolbarTextField()
-
         guard let locationTextField = locationTextField else { return }
 
-        locationTextField.font = UIFont.preferredFont(forTextStyle: .body)
-        locationTextField.adjustsFontForContentSizeCategory = true
-        locationTextField.clipsToBounds = true
-        locationTextField.translatesAutoresizingMaskIntoConstraints = false
         locationTextField.autocompleteDelegate = self
-        locationTextField.keyboardType = .webSearch
-        locationTextField.autocorrectionType = .no
-        locationTextField.autocapitalizationType = .none
-        locationTextField.returnKeyType = .go
-        locationTextField.clearButtonMode = .whileEditing
-        locationTextField.textAlignment = .left
         locationTextField.accessibilityIdentifier = AccessibilityIdentifiers.Browser.UrlBar.searchTextField
         locationTextField.accessibilityLabel = .URLBarLocationAccessibilityLabel
-        locationTextField.attributedPlaceholder = self.locationView.placeholder
         locationContainer.addSubview(locationTextField)
+
         // Disable dragging urls on iPhones because it conflicts with editing the text
         if UIDevice.current.userInterfaceIdiom != .pad {
             locationTextField.textDragInteraction?.isEnabled = false
         }
-        let isPrivateMode = locationActiveBorderColor == themeManager.currentTheme.colors.layerAccentPrivateNonOpaque
-        locationTextField.applyUIMode(isPrivate: isPrivateMode)
-        locationTextField.applyTheme(theme: themeManager.currentTheme)
+        let theme = themeManager.currentTheme
+        let isPrivateMode = locationActiveBorderColor == theme.colors.layerAccentPrivateNonOpaque
+        locationTextField.applyUIMode(isPrivate: isPrivateMode, theme: theme)
+        locationTextField.applyTheme(theme: theme)
     }
 
     override func becomeFirstResponder() -> Bool {
@@ -867,20 +857,20 @@ extension URLBarView: ThemeApplicable {
 
 // MARK: - PrivateModeUI
 extension URLBarView: PrivateModeUI {
-    func applyUIMode(isPrivate: Bool) {
+    func applyUIMode(isPrivate: Bool, theme: Theme) {
         if UIDevice.current.userInterfaceIdiom != .pad {
             privateModeBadge.show(isPrivate)
         }
-        let currentTheme = themeManager.currentTheme
-        let gradientStartColor = isPrivate ? currentTheme.colors.borderAccentPrivate : currentTheme.colors.borderAccent
-        let gradientMiddleColor = isPrivate ? nil : currentTheme.colors.iconAccentPink
-        let gradientEndColor = isPrivate ? currentTheme.colors.borderAccentPrivate : currentTheme.colors.iconAccentYellow
-        locationActiveBorderColor = isPrivate ? currentTheme.colors.layerAccentPrivateNonOpaque : currentTheme.colors.layerAccentNonOpaque
+
+        let gradientStartColor = isPrivate ? theme.colors.borderAccentPrivate : theme.colors.borderAccent
+        let gradientMiddleColor = isPrivate ? nil : theme.colors.iconAccentPink
+        let gradientEndColor = isPrivate ? theme.colors.borderAccentPrivate : theme.colors.iconAccentYellow
+        locationActiveBorderColor = isPrivate ? theme.colors.layerAccentPrivateNonOpaque : theme.colors.layerAccentNonOpaque
         progressBar.setGradientColors(startColor: gradientStartColor,
                                       middleColor: gradientMiddleColor,
                                       endColor: gradientEndColor)
-        locationTextField?.applyUIMode(isPrivate: isPrivate)
-        locationTextField?.applyTheme(theme: currentTheme)
-        applyTheme(theme: currentTheme)
+        locationTextField?.applyUIMode(isPrivate: isPrivate, theme: theme)
+        locationTextField?.applyTheme(theme: theme)
+        applyTheme(theme: theme)
     }
 }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6694)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14933)

### Description
- Ensure `themeManager` is passed down from theme applicable rather than try to set `themeManager` at init, which then doesn't get updated when there's a theme change
- Make sure we pass down theme when applying new private/normal mode UI (with `applyUIMode` method)
- Ensure tracking protection button updates on theme change (in `TabLocationView`)
- Set `AutocompleteTextField` properties in that class instead of `URLBarView`
- Fix `URLBar` placeholder that wasn't themed on theme change

More URL bar theme updates to come with https://github.com/mozilla-mobile/firefox-ios/issues/14976

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
