### PR TITLE
Bugfix FXIOS-6407 [v116] Graphic inconsistency in tabs tray when switching tabs

### DIFF
--- a/Client/Frontend/Browser/Tabs/TabCell.swift
+++ b/Client/Frontend/Browser/Tabs/TabCell.swift
@@ -35,7 +35,7 @@ class TabCell: UICollectionViewCell,
 
     // MARK: - UI Vars
     lazy var backgroundHolder: UIView = .build { view in
-        view.layer.cornerRadius = GridTabViewController.UX.cornerRadius
+        view.layer.cornerRadius = GridTabViewController.UX.cornerRadius + TabCell.borderWidth
         view.clipsToBounds = true
     }
 

--- a/Client/Frontend/Browser/Tabs/TabCell.swift
+++ b/Client/Frontend/Browser/Tabs/TabCell.swift
@@ -73,8 +73,6 @@ class TabCell: UICollectionViewCell,
     var animator: SwipeAnimator?
     var isSelectedTab = false
 
-    private var initialFrame = CGRect()
-
     weak var delegate: TabCellDelegate?
 
     // Changes depending on whether we're full-screen or not.
@@ -83,7 +81,6 @@ class TabCell: UICollectionViewCell,
     // MARK: - Initializer
     override init(frame: CGRect) {
         super.init(frame: frame)
-        initialFrame = frame
         self.animator = SwipeAnimator(animatingView: self)
         self.closeButton.addTarget(self, action: #selector(close), for: .touchUpInside)
 
@@ -175,8 +172,6 @@ class TabCell: UICollectionViewCell,
         if selected {
             setTabSelected(tab.isPrivate, theme: theme)
         } else {
-            frame.size.width = initialFrame.width
-            frame.size.height = initialFrame.height
             layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
             layer.borderColor = UIColor.clear.cgColor
             layer.borderWidth = 0
@@ -251,9 +246,6 @@ class TabCell: UICollectionViewCell,
     }
 
     private func setTabSelected(_ isPrivate: Bool, theme: Theme) {
-        // This creates a border around a tabcell. Using edge insets is created a border _outside_ of the tab frame.
-        frame.size.height = initialFrame.height + TabCell.borderWidth
-        frame.size.width = initialFrame.width + TabCell.borderWidth
         layoutMargins = UIEdgeInsets(top: TabCell.borderWidth, left: TabCell.borderWidth, bottom: TabCell.borderWidth, right: TabCell.borderWidth)
         layer.borderColor = (isPrivate ? theme.colors.borderAccentPrivate : theme.colors.borderAccent).cgColor
         layer.borderWidth = TabCell.borderWidth


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6407)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14409)

### Description
Remove the initialFrame variable from TabCell, as it was causing problems in the tab tray and not getting along with auto layout.
- The problem was occuring when opening the tab tray and then changing to private tabs tray and switching orientation
of the device. The initialFrame starts fighting with the auto layout and wins the battle.
### Video with the Problem

https://github.com/mozilla-mobile/firefox-ios/assets/51127880/ec96179c-c492-4729-942a-32563e410251

### Video after removing initialFrame var

https://github.com/mozilla-mobile/firefox-ios/assets/51127880/b6b8e1ab-01b5-4510-baae-561f4ff6bad1


### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
