### PR TITLE
Refactor FXIOS-4762 [v116] Update Pocket branding in settings

### DIFF
--- a/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -123,7 +123,7 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
         let pocketSponsoredSetting = BoolSetting(
             with: .sponsoredPocket,
             titleText: NSAttributedString(string: .Settings.Homepage.CustomizeFirefoxHome.ThoughtProvokingStories),
-            statusText: NSAttributedString(string: .Settings.Homepage.CustomizeFirefoxHome.PoweredByPocket))
+            statusText: NSAttributedString(string: .Settings.Homepage.CustomizeFirefoxHome.ThoughtProvokingStoriesSubtitle))
         // This sets whether the cell is enabled or not, and not the setting itself.
         pocketSponsoredSetting.enabled = featureFlags.isFeatureEnabled(
             .pocket,

--- a/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -122,7 +122,8 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
 
         let pocketSponsoredSetting = BoolSetting(
             with: .sponsoredPocket,
-            titleText: NSAttributedString(string: .Settings.Homepage.CustomizeFirefoxHome.SponsoredPocket))
+            titleText: NSAttributedString(string: .Settings.Homepage.CustomizeFirefoxHome.ThoughtProvokingStories),
+            statusText: NSAttributedString(string: .Settings.Homepage.CustomizeFirefoxHome.PoweredByPocket))
         // This sets whether the cell is enabled or not, and not the setting itself.
         pocketSponsoredSetting.enabled = featureFlags.isFeatureEnabled(
             .pocket,

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -267,12 +267,14 @@ class BoolSetting: Setting, FeatureFlaggable {
     convenience init(
         with featureFlagID: NimbusFeatureFlagID,
         titleText: NSAttributedString,
+        statusText: NSAttributedString? = nil,
         settingDidChange: ((Bool) -> Void)? = nil
     ) {
         self.init(
             prefs: nil,
             defaultValue: nil,
             attributedTitleText: titleText,
+            attributedStatusText: statusText,
             featureFlagName: featureFlagID,
             settingDidChange: settingDidChange)
     }

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -1239,7 +1239,7 @@ extension String {
                     tableName: "CustomizeFirefoxHome",
                     value: "Thought-Provoking Stories",
                     comment: "In the settings menu, in the Firefox homepage customization section, this is the title for the option that allows users to turn the Pocket Recommendations section on the Firefox homepage on or off")
-                public static let PoweredByPocket = MZLocalizedString(
+                public static let ThoughtProvokingStoriesSubtitle = MZLocalizedString(
                     key: "Settings.Home.Option.ThoughtProvokingStories.subtitle.v116",
                     tableName: "CustomizeFirefoxHome",
                     value: "Articles powered by Pocket",

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -1244,11 +1244,6 @@ extension String {
                     tableName: "CustomizeFirefoxHome",
                     value: "Articles powered by Pocket",
                     comment: "In the settings menu, in the Firefox homepage customization section, this is the subtitle for the option that allows users to turn the Pocket Recommendations section on the Firefox homepage on or off")
-                public static let SponsoredPocket = MZLocalizedString(
-                    key: "Settings.Home.Option.SponsoredPocket.v103",
-                    tableName: nil,
-                    value: "Sponsored stories",
-                    comment: "In the settings menu, in the Firefox homepage customization section, this is the title for the option that allows users to turn the Pocket Sponsored Stories on the Firefox homepage on or off")
                 public static let Title = MZLocalizedString(
                     key: "Settings.Home.Option.Title.v101",
                     tableName: nil,

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -1234,6 +1234,16 @@ extension String {
                     tableName: nil,
                     value: "Recommended by Pocket",
                     comment: "In the settings menu, in the Firefox homepage customization section, this is the title for the option that allows users to turn the Pocket Recommendations section on the Firefox homepage on or off")
+                public static let ThoughtProvokingStories = MZLocalizedString(
+                    key: "Settings.Home.Option.ThoughtProvokingStories.v116",
+                    tableName: "CustomizeFirefoxHome",
+                    value: "Thought-Provoking Stories",
+                    comment: "In the settings menu, in the Firefox homepage customization section, this is the title for the option that allows users to turn the Pocket Recommendations section on the Firefox homepage on or off")
+                public static let PoweredByPocket = MZLocalizedString(
+                    key: "Settings.Home.Option.ThoughtProvokingStories.subtitle.v116",
+                    tableName: "CustomizeFirefoxHome",
+                    value: "Articles powered by Pocket",
+                    comment: "In the settings menu, in the Firefox homepage customization section, this is the subtitle for the option that allows users to turn the Pocket Recommendations section on the Firefox homepage on or off")
                 public static let SponsoredPocket = MZLocalizedString(
                     key: "Settings.Home.Option.SponsoredPocket.v103",
                     tableName: nil,


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-4762)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/11599)

### Description
This is updating the strings for the homepage settings for consistent Pocket branding.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
