### PR TITLE
Refactor FXIOS-6612 [v116] Handle credit card settings page in coordinator

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -735,6 +735,7 @@
 		8ADC2A1D2A33999800543DAA /* VersionSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADC2A1C2A33999800543DAA /* VersionSetting.swift */; };
 		8ADC2A1F2A3399BD00543DAA /* LicenseAndAcknowledgementsSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADC2A1E2A3399BD00543DAA /* LicenseAndAcknowledgementsSetting.swift */; };
 		8ADC2A212A3399DC00543DAA /* YourRightsSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADC2A202A3399DC00543DAA /* YourRightsSetting.swift */; };
+		8ADEC6832A40F208002D2ED8 /* AppSettingsTableViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADEC6822A40F208002D2ED8 /* AppSettingsTableViewControllerTests.swift */; };
 		8ADED7EC27691351009C19E6 /* CalendarExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADED7EB27691351009C19E6 /* CalendarExtensionsTests.swift */; };
 		8ADED7EE276A7750009C19E6 /* CumulativeDaysOfUseCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADED7ED276A7750009C19E6 /* CumulativeDaysOfUseCounter.swift */; };
 		8ADED7F0276A7788009C19E6 /* CumulativeDaysOfUseCounterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADED7EF276A7788009C19E6 /* CumulativeDaysOfUseCounterTests.swift */; };
@@ -4783,6 +4784,7 @@
 		8ADC2A1C2A33999800543DAA /* VersionSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionSetting.swift; sourceTree = "<group>"; };
 		8ADC2A1E2A3399BD00543DAA /* LicenseAndAcknowledgementsSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LicenseAndAcknowledgementsSetting.swift; sourceTree = "<group>"; };
 		8ADC2A202A3399DC00543DAA /* YourRightsSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YourRightsSetting.swift; sourceTree = "<group>"; };
+		8ADEC6822A40F208002D2ED8 /* AppSettingsTableViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsTableViewControllerTests.swift; sourceTree = "<group>"; };
 		8ADED7EB27691351009C19E6 /* CalendarExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarExtensionsTests.swift; sourceTree = "<group>"; };
 		8ADED7ED276A7750009C19E6 /* CumulativeDaysOfUseCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CumulativeDaysOfUseCounter.swift; sourceTree = "<group>"; };
 		8ADED7EF276A7788009C19E6 /* CumulativeDaysOfUseCounterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CumulativeDaysOfUseCounterTests.swift; sourceTree = "<group>"; };
@@ -8104,6 +8106,7 @@
 			children = (
 				8AE1E1DA27B1C1320024C45E /* SearchBarSettingsViewModelTests.swift */,
 				DACDE995225E537900C8F37F /* VersionSettingTests.swift */,
+				8ADEC6822A40F208002D2ED8 /* AppSettingsTableViewControllerTests.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -13169,6 +13172,7 @@
 				C8699152289177F5007ACC5C /* WallpaperNetworkingTests.swift in Sources */,
 				C818AD452A2100BA007F30BC /* OnboardingNotificationCardHelperTests.swift in Sources */,
 				E1AEC178286E0CF500062E29 /* HomepageViewControllerTests.swift in Sources */,
+				8ADEC6832A40F208002D2ED8 /* AppSettingsTableViewControllerTests.swift in Sources */,
 				5A475E8E29DB89C7009C13FD /* TabManagerTests.swift in Sources */,
 				E16E1C9628BFB2E600EE2EF5 /* WallpaperSettingsViewModelTests.swift in Sources */,
 				E1463D042982D0240074E16E /* NotificationManagerTests.swift in Sources */,

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -246,23 +246,18 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
     }
 
     private func showSettings(with section: Route.SettingsSection) {
-        let settingsVC = AppSettingsTableViewController(
-            with: profile,
-            and: tabManager
-        )
-        let navigationController = ThemedNavigationController(rootViewController: settingsVC)
+        let navigationController = ThemedNavigationController()
         navigationController.modalPresentationStyle = .formSheet
         let settingsRouter = DefaultRouter(navigationController: navigationController)
 
         let settingsCoordinator = SettingsCoordinator(router: settingsRouter)
-        settingsVC.settingsDelegate = settingsCoordinator
         settingsCoordinator.parentCoordinator = self
-
         add(child: settingsCoordinator)
+        settingsCoordinator.start(with: section)
+
         router.present(navigationController) { [weak self] in
             self?.didFinishSettings(from: settingsCoordinator)
         }
-        settingsCoordinator.start(with: section)
     }
 
     private func showLibrary(with homepanelSection: Route.HomepanelSection) {

--- a/Client/Coordinators/LibraryCoordinator.swift
+++ b/Client/Coordinators/LibraryCoordinator.swift
@@ -32,7 +32,7 @@ class LibraryCoordinator: BaseCoordinator, LibraryPanelDelegate {
         libraryViewController.setupOpenPanel(panelType: homepanelSection.libraryPanel)
         libraryViewController.delegate = self
 
-        router.setRootViewController(libraryViewController, hideBar: false, animated: false)
+        router.setRootViewController(libraryViewController)
     }
 
     func libraryPanelDidRequestToSignIn() {

--- a/Client/Coordinators/SettingsCoordinator.swift
+++ b/Client/Coordinators/SettingsCoordinator.swift
@@ -34,6 +34,7 @@ class SettingsCoordinator: BaseCoordinator, SettingsDelegate, SettingsFlowDelega
 
         router.setRootViewController(settingsViewController)
         settingsViewController.settingsDelegate = self
+        settingsViewController.parentCoordinator = self
     }
 
     func start(with settingsSection: Route.SettingsSection) {

--- a/Client/Coordinators/SettingsCoordinator.swift
+++ b/Client/Coordinators/SettingsCoordinator.swift
@@ -12,7 +12,7 @@ protocol SettingsCoordinatorDelegate: AnyObject {
 }
 
 class SettingsCoordinator: BaseCoordinator, SettingsDelegate, SettingsFlowDelegate {
-    private let settingsViewController: AppSettingsTableViewController
+    var settingsViewController: AppSettingsScreen
     private let wallpaperManager: WallpaperManagerInterface
     private let profile: Profile
     private let tabManager: TabManager

--- a/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -800,7 +800,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
                 self.delegate?.openURLInNewTab(url, isPrivate: false)
             }
 
-            if self.appAuthenticator.canAuthenticateDeviceOwner() {
+            if self.appAuthenticator.canAuthenticateDeviceOwner {
                 if LoginOnboarding.shouldShow() {
                     self.showLoginOnboarding(navigationHandler: navigationHandler, navigationController: navigationController)
                 } else {

--- a/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -47,9 +47,16 @@ protocol SettingsFlowDelegate: AnyObject {
     func showCreditCardSettings()
 }
 
+protocol AppSettingsScreen: UIViewController {
+    var settingsDelegate: SettingsDelegate? { get set }
+    var parentCoordinator: SettingsFlowDelegate? { get set }
+
+    func handle(route: Route.SettingsSection)
+}
+
 /// App Settings Screen (triggered by tapping the 'Gear' in the Tab Tray Controller)
-class AppSettingsTableViewController: SettingsTableViewController, FeatureFlaggable, AppSettingsDelegate,
-                                        SearchBarLocationProvider {
+class AppSettingsTableViewController: SettingsTableViewController, AppSettingsScreen,
+                                    FeatureFlaggable, AppSettingsDelegate, SearchBarLocationProvider {
     // MARK: - Properties
     var deeplinkTo: AppSettingsDeeplinkOption? // Will be clean up with FXIOS-6529
     private var showDebugSettings = false

--- a/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -117,7 +117,6 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
         }
     }
 
-    // TODO Laurie - to test this
     private func handleCreditCardAuthenticatinFlow() {
         appAuthenticator.getAuthenticationState { state in
             switch state {

--- a/Client/Frontend/Settings/Main/Privacy/AutofillCreditCardSettings.swift
+++ b/Client/Frontend/Settings/Main/Privacy/AutofillCreditCardSettings.swift
@@ -36,8 +36,8 @@ class AutofillCreditCardSettings: Setting, FeatureFlaggable {
             creditCardViewModel: viewModel)
 
         guard let navController = navigationController else { return }
-        if appAuthenticator.canAuthenticateDeviceOwner() {
-            AppAuthenticator().authenticateWithDeviceOwnerAuthentication { result in
+        if appAuthenticator.canAuthenticateDeviceOwner {
+            appAuthenticator.authenticateWithDeviceOwnerAuthentication { result in
                 switch result {
                 case .success:
                     navController.pushViewController(viewController,

--- a/Client/Frontend/Settings/Main/Privacy/LoginsSetting.swift
+++ b/Client/Frontend/Settings/Main/Privacy/LoginsSetting.swift
@@ -51,7 +51,7 @@ class LoginsSetting: Setting {
             self.delegate?.settingsOpenURLInNewTab(url)
         }
 
-        if appAuthenticator.canAuthenticateDeviceOwner() {
+        if appAuthenticator.canAuthenticateDeviceOwner {
             if LoginOnboarding.shouldShow() {
                 let loginOnboardingViewController = LoginOnboardingViewController(profile: profile, tabManager: tabManager)
 

--- a/Client/Frontend/Settings/SettingsNavigationController.swift
+++ b/Client/Frontend/Settings/SettingsNavigationController.swift
@@ -13,6 +13,13 @@ class ThemedNavigationController: DismissableNavigationViewController, Themeable
 
     var presentingModalViewControllerDelegate: PresentingModalViewControllerDelegate?
 
+    init(themeManager: ThemeManager = AppContainer.shared.resolve(),
+         notificationCenter: NotificationProtocol = NotificationCenter.default) {
+        self.themeManager = themeManager
+        self.notificationCenter = notificationCenter
+        super.init(nibName: nil, bundle: nil)
+    }
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -296,7 +296,7 @@ class TelemetryWrapper: TelemetryWrapperProtocol {
         GleanMetrics.InstalledMozillaProducts.focus.set(UIApplication.shared.canOpenURL(URL(string: "firefox-focus://")!))
         GleanMetrics.InstalledMozillaProducts.klar.set(UIApplication.shared.canOpenURL(URL(string: "firefox-klar://")!))
         // Device Authentication
-        GleanMetrics.Device.authentication.set(AppAuthenticator().canAuthenticateDeviceOwner())
+        GleanMetrics.Device.authentication.set(AppAuthenticator().canAuthenticateDeviceOwner)
 
         // Wallpapers
         let currentWallpaper = WallpaperManager().currentWallpaper

--- a/CredentialProvider/CredentialProviderViewController.swift
+++ b/CredentialProvider/CredentialProviderViewController.swift
@@ -43,7 +43,7 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
     }
 
     override func prepareInterfaceForExtensionConfiguration() {
-        if appAuthenticator.canAuthenticateDeviceOwner() {
+        if appAuthenticator.canAuthenticateDeviceOwner {
             self.presenter?.extensionConfigurationRequested()
         } else {
             self.presenter?.showPasscodeRequirement()
@@ -57,7 +57,7 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
      */
 
     override func prepareCredentialList(for serviceIdentifiers: [ASCredentialServiceIdentifier]) {
-        if appAuthenticator.canAuthenticateDeviceOwner() {
+        if appAuthenticator.canAuthenticateDeviceOwner {
             self.presenter?.credentialList(for: serviceIdentifiers)
         } else {
             self.presenter?.showPasscodeRequirement()
@@ -74,7 +74,7 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
      */
 
     override func provideCredentialWithoutUserInteraction(for credentialIdentity: ASPasswordCredentialIdentity) {
-        if appAuthenticator.canAuthenticateDeviceOwner() {
+        if appAuthenticator.canAuthenticateDeviceOwner {
             self.presenter?.credentialProvisionRequested(for: credentialIdentity)
         } else {
             self.extensionContext.cancelRequest(withError: ASExtensionError(.userInteractionRequired))

--- a/Tests/ClientTests/Coordinators/LibraryCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/LibraryCoordinatorTests.swift
@@ -12,6 +12,7 @@ final class LibraryCoordinatorTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: MockProfile())
         DependencyHelperMock().bootstrapDependencies()
         self.mockRouter = MockRouter(navigationController: MockNavigationController())
         self.delegate = MockLibraryCoordinatorDelegate()

--- a/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
@@ -200,7 +200,6 @@ final class SettingsCoordinatorTests: XCTestCase {
     // MARK: - Settings VC
     func testDelegatesAreSet() {
         let subject = createSubject()
-        subject.settingsViewController = mockSettingsVC
 
         XCTAssertNotNil(subject.settingsViewController.settingsDelegate)
         XCTAssertNotNil(subject.settingsViewController.parentCoordinator)

--- a/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
@@ -10,6 +10,7 @@ final class SettingsCoordinatorTests: XCTestCase {
     private var mockRouter: MockRouter!
     private var wallpaperManager: WallpaperManagerMock!
     private var delegate: MockSettingsCoordinatorDelegate!
+    private var mockSettingsVC: MockAppSettingsScreen!
 
     override func setUp() {
         super.setUp()
@@ -18,6 +19,7 @@ final class SettingsCoordinatorTests: XCTestCase {
         self.mockRouter = MockRouter(navigationController: MockNavigationController())
         self.wallpaperManager = WallpaperManagerMock()
         self.delegate = MockSettingsCoordinatorDelegate()
+        self.mockSettingsVC = MockAppSettingsScreen()
     }
 
     override func tearDown() {
@@ -25,12 +27,16 @@ final class SettingsCoordinatorTests: XCTestCase {
         self.mockRouter = nil
         self.wallpaperManager = nil
         self.delegate = nil
+        self.mockSettingsVC = nil
         DependencyHelperMock().reset()
     }
 
     func testEmptyChilds_whenCreated() {
         let subject = createSubject()
+
         XCTAssertEqual(subject.childCoordinators.count, 0)
+        XCTAssertEqual(mockRouter.setRootViewControllerCalled, 1)
+        XCTAssertNotNil(mockRouter.rootViewController as? AppSettingsTableViewController)
     }
 
     func testGeneralSettingsRoute_showsGeneralSettingsPage() throws {
@@ -191,6 +197,44 @@ final class SettingsCoordinatorTests: XCTestCase {
         XCTAssertEqual(delegate.didFinishSettingsCalled, 1)
     }
 
+    // MARK: - Settings VC
+    func testDelegatesAreSet() {
+        let subject = createSubject()
+        subject.settingsViewController = mockSettingsVC
+
+        XCTAssertNotNil(subject.settingsViewController.settingsDelegate)
+        XCTAssertNotNil(subject.settingsViewController.parentCoordinator)
+    }
+
+    func testHandleRouteCalled_whenCreditCardRouteIsSet() {
+        let subject = createSubject()
+        subject.settingsViewController = mockSettingsVC
+
+        subject.start(with: .creditCard)
+
+        XCTAssertEqual(mockSettingsVC.handleRouteCalled, 1)
+        XCTAssertEqual(mockSettingsVC.savedRoute, .creditCard)
+    }
+
+    // MARK: - SettingsFlowDelegate
+    func testShowDevicePasscode_showDevicePasscodeVC() {
+        let subject = createSubject()
+
+        subject.showDevicePassCode()
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+        XCTAssertTrue(mockRouter.pushedViewController is DevicePasscodeRequiredViewController)
+    }
+
+    func testCreditCardSettings_showsCreditCardVC() {
+        let subject = createSubject()
+
+        subject.showCreditCardSettings()
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+        XCTAssertTrue(mockRouter.pushedViewController is CreditCardSettingsViewController)
+    }
+
     // MARK: - Helper
     func createSubject() -> SettingsCoordinator {
         let subject = SettingsCoordinator(router: mockRouter,
@@ -213,5 +257,19 @@ class MockSettingsCoordinatorDelegate: SettingsCoordinatorDelegate {
 
     func didFinishSettings(from coordinator: SettingsCoordinator) {
         didFinishSettingsCalled += 1
+    }
+}
+
+// MARK: - MockAppSettingsScreen
+class MockAppSettingsScreen: UIViewController, AppSettingsScreen {
+    var settingsDelegate: SettingsDelegate?
+    var parentCoordinator: SettingsFlowDelegate?
+
+    var handleRouteCalled = 0
+    var savedRoute: Route.SettingsSection?
+
+    func handle(route: Route.SettingsSection) {
+        handleRouteCalled += 1
+        savedRoute = route
     }
 }

--- a/Tests/ClientTests/Mocks/MockAppAuthenticator.swift
+++ b/Tests/ClientTests/Mocks/MockAppAuthenticator.swift
@@ -6,12 +6,18 @@ import Foundation
 @testable import Client
 
 class MockAppAuthenticator: AppAuthenticationProtocol {
+    var authenticationState: AuthenticationState = .deviceOwnerAuthenticated
     var shouldAuthenticateDeviceOwner = true
-    func canAuthenticateDeviceOwner() -> Bool {
+    var shouldSucceed = true
+
+    func getAuthenticationState(completion: @escaping (AuthenticationState) -> Void) {
+        completion(authenticationState)
+    }
+
+    var canAuthenticateDeviceOwner: Bool {
         return shouldAuthenticateDeviceOwner
     }
 
-    var shouldSucceed = true
     func authenticateWithDeviceOwnerAuthentication(_ completion: @escaping (Result<Void, AuthenticationError>) -> Void) {
         if shouldSucceed {
             completion(.success(()))

--- a/Tests/ClientTests/Settings/AppSettingsTableViewControllerTests.swift
+++ b/Tests/ClientTests/Settings/AppSettingsTableViewControllerTests.swift
@@ -1,0 +1,93 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Client
+
+class AppSettingsTableViewControllerTests: XCTestCase {
+    private var profile: Profile!
+    private var tabManager: TabManager!
+    private var appAuthenticator: MockAppAuthenticator!
+    private var delegate: MockSettingsFlowDelegate!
+
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+        self.profile = MockProfile()
+        self.tabManager = TabManagerImplementation(profile: profile, imageStore: nil)
+        self.appAuthenticator = MockAppAuthenticator()
+        self.delegate = MockSettingsFlowDelegate()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        DependencyHelperMock().reset()
+        self.profile = nil
+        self.tabManager = nil
+        self.appAuthenticator = nil
+        self.delegate = nil
+    }
+
+    func testRouteNotHandled_delegatesArentCalled() {
+        let subject = createSubject()
+        subject.handle(route: .clearPrivateData)
+
+        XCTAssertEqual(delegate.showCreditCardSettingsCalled, 0)
+        XCTAssertEqual(delegate.showDevicePassCodeCalled, 0)
+    }
+
+    func testCreditCard_whenDeviceOwnerAuthenticated_showCreditCardSettings() {
+        appAuthenticator.authenticationState = .deviceOwnerAuthenticated
+        let subject = createSubject()
+        subject.parentCoordinator = delegate
+
+        subject.handle(route: .creditCard)
+
+        XCTAssertEqual(delegate.showCreditCardSettingsCalled, 1)
+    }
+
+    func testCreditCard_whenPassCodeRequired_showDevicePasscode() {
+        appAuthenticator.authenticationState = .passCodeRequired
+        let subject = createSubject()
+        subject.parentCoordinator = delegate
+
+        subject.handle(route: .creditCard)
+
+        XCTAssertEqual(delegate.showDevicePassCodeCalled, 1)
+    }
+
+    func testCreditCard_whenDeviceOwnerFailed_showNothing() {
+        appAuthenticator.authenticationState = .deviceOwnerFailed
+        let subject = createSubject()
+        subject.parentCoordinator = delegate
+
+        subject.handle(route: .creditCard)
+
+        XCTAssertEqual(delegate.showDevicePassCodeCalled, 0)
+        XCTAssertEqual(delegate.showCreditCardSettingsCalled, 0)
+    }
+
+    // MARK: - Helper
+    private func createSubject() -> AppSettingsTableViewController {
+        let subject = AppSettingsTableViewController(with: profile,
+                                                     and: tabManager,
+                                                     appAuthenticator: appAuthenticator)
+        trackForMemoryLeaks(subject)
+        return subject
+    }
+}
+
+// MARK: - MockSettingsFlowDelegate
+class MockSettingsFlowDelegate: SettingsFlowDelegate {
+    var showDevicePassCodeCalled = 0
+    var showCreditCardSettingsCalled = 0
+
+    func showDevicePassCode() {
+        showDevicePassCodeCalled += 1
+    }
+
+    func showCreditCardSettings() {
+        showCreditCardSettingsCalled += 1
+    }
+}


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6612)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14792)

### Description
- Make canAuthenticateDeviceOwner a variable instead of a func
- Make AppSettingsTableViewController created by SettingsCoordinator instead of BrowserCoordinator
- Handle the authentication flow in VC, then pass the decision on what to show to the coordinator
- Add tests for new code

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
