### PR TITLE
Bugfix FXIOS-6690 [v114] crash deleting last inactive tabs

### DIFF
--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -688,7 +688,8 @@ extension TabDisplayManager: InactiveTabsDelegate {
         let generator = UIImpactFeedbackGenerator(style: .light)
         generator.impactOccurred()
 
-        // Reload Inactive Tabs section for user feedback
+        // Hide inactive tabs and reload section to "simulate" deletion
+        inactiveViewModel?.shouldHideInactiveTabs = true
         collectionView.reloadSections(IndexSet(integer: TabDisplaySection.inactiveTabs.rawValue))
 
         cfrDelegate?.presentUndoToast(tabsCount: tabsCount,

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -668,7 +668,7 @@ extension TabDisplayManager: GroupedTabDelegate {
 extension TabDisplayManager: InactiveTabsDelegate {
     func closeInactiveTab(_ tab: Tab, index: Int) {
         tabManager.backupCloseTab = BackupCloseTab(tab: tab, restorePosition: index)
-        removeInactiveTabAndReloadView(tabs: [tab])
+        removeSingleInactiveTab(tab)
 
         cfrDelegate?.presentUndoSingleToast { undoButtonPressed in
             guard undoButtonPressed, let closedTab = self.tabManager.backupCloseTab else {
@@ -695,11 +695,11 @@ extension TabDisplayManager: InactiveTabsDelegate {
                                       completion: { undoButtonPressed in
             undoButtonPressed ?
             self.undoInactiveTabsClose() :
-            self.closeInactiveTabs()
+            self.closeAllInactiveTabs()
         })
     }
 
-    private func closeInactiveTabs() {
+    private func closeAllInactiveTabs() {
         guard let inactiveTabs = inactiveViewModel?.inactiveTabs,
               !inactiveTabs.isEmpty else { return }
 
@@ -732,6 +732,11 @@ extension TabDisplayManager: InactiveTabsDelegate {
         }
 
         collectionView.reloadItems(at: [indexPath])
+    }
+
+    private func removeSingleInactiveTab(_ tab: Tab) {
+        tabManager.removeTab(tab)
+        collectionView.reloadSections(IndexSet(integer: TabDisplaySection.inactiveTabs.rawValue))
     }
 
     private func undoDeleteInactiveTab(_ tab: Tab, at index: Int) {

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -713,8 +713,12 @@ extension TabDisplayManager: InactiveTabsDelegate {
 
     private func removeInactiveTabAndReloadView(tabs: [Tab]) {
         // Remove inactive tabs from tab manager
-        tabManager.removeTabs(tabs)
-        tabManager.selectTab(mostRecentTab(inTabs: tabManager.normalTabs) ?? tabManager.normalTabs.last)
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(50)) {
+            self.tabManager.removeTabs(tabs)
+            let mostRecentTab = mostRecentTab(inTabs: self.tabManager.normalTabs) ?? self.tabManager.normalTabs.last
+            self.tabManager.selectTab(mostRecentTab)
+        }
+
         let allTabs = isPrivate ? tabManager.privateTabs : tabManager.normalTabs
         inactiveViewModel?.updateInactiveTabs(with: tabManager.selectedTab, tabs: allTabs)
         let indexPath = IndexPath(row: 0, section: TabDisplaySection.inactiveTabs.rawValue)

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -1101,17 +1101,13 @@ extension TabDisplayManager: TabManagerDelegate {
         /// collectionView is not visible the dataSource section/items differs from the actions to be perform
         /// which causes the crash
         collectionView.numberOfItems(inSection: 0)
-        /// Add temporary hack to delay the `collectionView.performBatchUpdates`
-        /// to fix crash caused by race condition where the dataSource hasn't finish loading causing Internal inconsistency crash
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200)) {
-            self.collectionView.performBatchUpdates({
-                operation()
-            }, completion: { [weak self] (done) in
-                self?.performingChainedOperations = false
-                self?.tabDisplayCompletionDelegate?.completedAnimation(for: type)
-                self?.performChainedOperations()
-            })
-        }
+        collectionView.performBatchUpdates({
+            operation()
+        }, completion: { [weak self] (done) in
+            self?.performingChainedOperations = false
+            self?.tabDisplayCompletionDelegate?.completedAnimation(for: type)
+            self?.performChainedOperations()
+        })
     }
 
     private func updateWith(animationType: TabAnimationType,

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -711,7 +711,6 @@ extension TabDisplayManager: InactiveTabsDelegate {
                                      extras: nil)
     }
 
-    // Note: This is a helper method for shouldCloseInactiveTab and didTapCloseAllTabs
     private func removeInactiveTabAndReloadView(tabs: [Tab]) {
         // Remove inactive tabs from tab manager
         tabManager.removeTabs(tabs)

--- a/Client/Frontend/Browser/Tabs/InactiveTabs/InactiveTabCell.swift
+++ b/Client/Frontend/Browser/Tabs/InactiveTabs/InactiveTabCell.swift
@@ -148,7 +148,6 @@ extension InactiveTabCell: UITableViewDataSource, UITableViewDelegate {
             }
 
             cell.buttonClosure = {
-                self.inactiveTabsViewModel?.shouldHideInactiveTabs = true
                 let inactiveTabsCount = self.inactiveTabsViewModel?.inactiveTabs.count
                 self.delegate?.didTapCloseInactiveTabs(tabsCount: inactiveTabsCount ?? 0)
             }

--- a/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -864,20 +864,23 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     }
 
     func undoCloseTab(tab: Tab, position: Int?) {
-        let tabToSelect = selectedTab
         if let index = position {
             tabs.insert(tab, at: index)
         } else {
             tabs.append(tab)
         }
 
-        // Select previous selected tab
-        if let tabToSelect = tabToSelect {
-            selectTab(tabToSelect, previous: nil)
-        }
-
         delegates.forEach { $0.get()?.tabManagerUpdateCount() }
         storeChanges()
+
+        // Select previous selected tab
+        let tabUUID = selectedTab?.tabUUID
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(50)) {
+            if let tabUUID = tabUUID,
+               let tabToSelect = self.tabs.first(where: { $0.tabUUID == tabUUID }) {
+                self.selectTab(tabToSelect)
+            }
+        }
     }
 
     // Select the most recently visited tab, IFF it is also the parent tab of the closed tab.

--- a/Tests/ClientTests/TabDisplayManagerTests.swift
+++ b/Tests/ClientTests/TabDisplayManagerTests.swift
@@ -353,8 +353,10 @@ class TabDisplayManagerTests: XCTestCase {
         tabDisplayManager.closeInactiveTab(inactiveTab1, index: 0)
 
         let expectation = self.expectation(description: "TabDisplayManagerTests")
-        XCTAssertEqual(tabDisplayManager.inactiveViewModel?.inactiveTabs.count, 2, "Expected 2 inactive tabs after undo")
-        expectation.fulfill()
+        tabDisplayManager.refreshStore {
+            XCTAssertEqual(tabDisplayManager.inactiveViewModel?.inactiveTabs.count, 2, "Expected 2 inactive tabs after undo")
+            expectation.fulfill()
+        }
         waitForExpectations(timeout: 5)
     }
 
@@ -381,8 +383,13 @@ class TabDisplayManagerTests: XCTestCase {
         tabDisplayManager.closeInactiveTab(inactiveTab1, index: 0)
 
         let expectation = self.expectation(description: "TabDisplayManagerTests")
-        XCTAssertEqual(tabDisplayManager.inactiveViewModel?.inactiveTabs.count, 1, "Expected 1 inactive tab after deletion")
-        expectation.fulfill()
+        // Add delay so the tab removal finishes and the refreshStore gets the right tabs data
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) {
+            tabDisplayManager.refreshStore {
+                XCTAssertEqual(tabDisplayManager.inactiveViewModel?.inactiveTabs.count, 1, "Expected 1 inactive tab after deletion")
+                expectation.fulfill()
+            }
+        }
         waitForExpectations(timeout: 5)
     }
 

--- a/Tests/ClientTests/TabDisplayManagerTests.swift
+++ b/Tests/ClientTests/TabDisplayManagerTests.swift
@@ -320,18 +320,14 @@ class TabDisplayManagerTests: XCTestCase {
                                                              inactiveTab2]
 
         // Force collectionView reload section to avoid crash
-        collectionView.reloadSections(IndexSet(integer: 0))
         cfrDelegate.isUndoButtonPressed = false
         // Force collectionView reload to avoid crash
         collectionView.reloadSections(IndexSet(integer: 0))
         tabDisplayManager.didTapCloseInactiveTabs(tabsCount: 2)
 
-        let expectation = self.expectation(description: "TabDisplayManagerTests")
-        tabDisplayManager.refreshStore {
-            XCTAssertTrue(tabDisplayManager.inactiveViewModel?.inactiveTabs.isEmpty ?? false, "Inactive tabs should be empty after closing")
-            expectation.fulfill()
-        }
-        waitForExpectations(timeout: 5)
+        // For delete all inactive tabs we don't actually delete the tabs we collapse
+        // the section and delete after toast delay
+        XCTAssertTrue(tabDisplayManager.inactiveViewModel?.shouldHideInactiveTabs ?? false, "Inactive tabs should be empty after closing")
     }
 
     func testInactiveTabs_grid_undoSingleTab() {


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6690)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14955)

### Description
- Add temporary delay to performBatchUpdate to fix race condition where the dataSource hasn't finished loading and provokes CollectionView internal inconsistency crash.
- Add logic to reload and open Inactive Tabs section if the user undo the last tab closed
- Remove force unwrap and default to 0 position

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
