### PR TITLE
Bugfix MTE-1147 [v116] Enable L10n testIntro() test

### DIFF
--- a/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
@@ -28,22 +28,35 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
     }
 
     func testIntro() {
-        // TODO: https://mozilla-hub.atlassian.net/browse/FXIOS-6433
-//        sleep(3)
-//        waitForExistence(app.scrollViews.staticTexts["WelcomeCardTitleLabel"], timeout: 15)
-//        snapshot("Onboarding-1")
-//
-//        // Swipe to the second screen
-//        app.buttons["\(rootA11yId)PrimaryButton"].tap()
-//        currentScreen += 1
-//        waitForExistence(app.buttons["SignSyncCardPrimaryButton"])
-//        waitForExistence(app.buttons["SignSyncCardSecondaryButton"])
-//        snapshot("Onboarding-2")
-//
-//        // Swipe to the Homescreen
-//        app.buttons["SignSyncCardSecondaryButton"].tap()
-//        currentScreen += 1
-//        snapshot("Homescreen-first-visit")
+        waitForExistence(app.scrollViews.staticTexts["\(rootA11yId)TitleLabel"], timeout: 15)
+        waitForExistence(app.scrollViews.staticTexts["\(rootA11yId)DescriptionLabel"], timeout: 15)
+        snapshot("Onboarding-1")
+
+        // Swipe to the second screen
+        app.buttons["\(rootA11yId)PrimaryButton"].tap()
+        currentScreen += 1
+        waitForExistence(app.scrollViews.staticTexts["\(rootA11yId)TitleLabel"], timeout: 15)
+        waitForExistence(app.scrollViews.staticTexts["\(rootA11yId)DescriptionLabel"], timeout: 15)
+        waitForExistence(app.buttons["\(rootA11yId)PrimaryButton"])
+        waitForExistence(app.buttons["\(rootA11yId)SecondaryButton"])
+        snapshot("Onboarding-2")
+
+        // Swipe to the third screen
+        app.buttons["\(rootA11yId)SecondaryButton"].tap()
+        currentScreen += 1
+        waitForExistence(app.scrollViews.staticTexts["\(rootA11yId)TitleLabel"], timeout: 15)
+        waitForExistence(app.scrollViews.staticTexts["\(rootA11yId)DescriptionLabel"], timeout: 15)
+        waitForExistence(app.buttons["\(rootA11yId)PrimaryButton"])
+        waitForExistence(app.buttons["\(rootA11yId)SecondaryButton"])
+        snapshot("Onboarding-3")
+
+        // Swipe to the Homescreen
+        app.buttons["\(rootA11yId)SecondaryButton"].tap()
+        currentScreen += 1
+        waitForExistence(app.textFields["url"])
+        waitForExistence(app.webViews["contentView"])
+        print(app.debugDescription)
+        snapshot("Homescreen-first-visit")
     }
 
     func testWebViewContextMenu () throws {

--- a/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
@@ -55,7 +55,6 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
         currentScreen += 1
         waitForExistence(app.textFields["url"])
         waitForExistence(app.webViews["contentView"])
-        print(app.debugDescription)
         snapshot("Homescreen-first-visit")
     }
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1147)

### Description
`testIntro()` was disabled because of the new design of the intro screen. The updated intro screen now consists of 3 pages instead of 2.

This PR takes a screenshot for every page from the intro screen.

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
