### PR TITLE
Refactor FXIOS-6644-6645 [v116] WebsiteDataManagementViewController and WebsiteDataSearchResultViewController with dequeue reusable cell for indexPath.

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -836,6 +836,7 @@
 		BD4B2DE429BB4D9A005FAA50 /* TimerSnackBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4B2DE329BB4D9A005FAA50 /* TimerSnackBar.swift */; };
 		BD57D9A729D4C42B00039394 /* ZoomLevelStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD57D9A629D4C42B00039394 /* ZoomLevelStoreTests.swift */; };
 		BD6CC84229CDDA3400546A5D /* ZoomLevelStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6CC84129CDDA3400546A5D /* ZoomLevelStore.swift */; };
+		C22753402A3C9E1300B9C0D1 /* WebsiteDataManagementViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C227533F2A3C9E1300B9C0D1 /* WebsiteDataManagementViewModel.swift */; };
 		C2D71B952A384F11003DEC7A /* ThemedTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D71B942A384F11003DEC7A /* ThemedTableViewCell.swift */; };
 		C2D71B972A384F40003DEC7A /* ThemedSubtitleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D71B962A384F40003DEC7A /* ThemedSubtitleTableViewCell.swift */; };
 		C2D71B992A384F6A003DEC7A /* ThemedLeftAlignedTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D71B982A384F6A003DEC7A /* ThemedLeftAlignedTableViewCell.swift */; };
@@ -5283,6 +5284,7 @@
 		C1C54E119D804703437D116C /* kab */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kab; path = kab.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
 		C1DF4F71AB33BAB7B199F361 /* si */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = si; path = si.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		C1F24EFFB6E9B114849A4DB3 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
+		C227533F2A3C9E1300B9C0D1 /* WebsiteDataManagementViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebsiteDataManagementViewModel.swift; sourceTree = "<group>"; };
 		C26C4D1F8CFB13730BA74DF5 /* an */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = an; path = an.lproj/FindInPage.strings; sourceTree = "<group>"; };
 		C29B428A81B120AFF0666037 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/Menu.strings; sourceTree = "<group>"; };
 		C2A943CF800ADCD8E96ACA5B /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -7242,8 +7244,7 @@
 				CEFA977D1FAA6B490016F365 /* SyncContentSettingsViewController.swift */,
 				8AE1E1CE27B191160024C45E /* SearchBar */,
 				EB9A178D20E525DF00B12184 /* ThemeSettingsController.swift */,
-				66CE54A720FCF6CF00CC310B /* WebsiteDataManagementViewController.swift */,
-				6669B5E1211418A200CA117B /* WebsiteDataSearchResultsViewController.swift */,
+				C22753422A3CA25100B9C0D1 /* WebsiteDataManagement */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -8615,6 +8616,16 @@
 				ABEF80D42A254185003F52C4 /* CreditCardBottomSheetFooterView.swift */,
 			);
 			path = CreditCardBottomSheet;
+			sourceTree = "<group>";
+		};
+		C22753422A3CA25100B9C0D1 /* WebsiteDataManagement */ = {
+			isa = PBXGroup;
+			children = (
+				66CE54A720FCF6CF00CC310B /* WebsiteDataManagementViewController.swift */,
+				C227533F2A3C9E1300B9C0D1 /* WebsiteDataManagementViewModel.swift */,
+				6669B5E1211418A200CA117B /* WebsiteDataSearchResultsViewController.swift */,
+			);
+			path = WebsiteDataManagement;
 			sourceTree = "<group>";
 		};
 		C2D71B932A384EF6003DEC7A /* ThemedTableViewCells */ = {
@@ -12537,6 +12548,7 @@
 				E63ED8E11BFD25580097D08E /* LoginListViewController.swift in Sources */,
 				8ADC2A162A33765E00543DAA /* UrlToOpenModel.swift in Sources */,
 				D0625CA8208FC47A0081F3B2 /* BrowserViewController+DownloadQueueDelegate.swift in Sources */,
+				C22753402A3C9E1300B9C0D1 /* WebsiteDataManagementViewModel.swift in Sources */,
 				8A56955227C68AE00077A89E /* UILabel+Extension.swift in Sources */,
 				2F44FCC71A9E8CF500FD20CC /* SearchSettingsTableViewController.swift in Sources */,
 				8AD3271527E3B45D00EAF033 /* SponsoredTile.swift in Sources */,

--- a/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewModel.swift
+++ b/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewModel.swift
@@ -1,0 +1,85 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import WebKit
+
+class WebsiteDataManagementViewModel {
+    enum State {
+        case loading
+        case displayInitial
+        case displayAll
+    }
+
+    private(set) var state: State = .loading
+    private(set) var siteRecords: [WKWebsiteDataRecord] = []
+    private(set) var selectedRecords: Set<WKWebsiteDataRecord> = []
+    var onViewModelChanged: () -> Void = {}
+
+    var clearButtonTitle: String {
+        switch selectedRecords.count {
+        case 0: return .SettingsClearAllWebsiteDataButton
+        default: return String(format: .SettingsClearSelectedWebsiteDataButton, "\(selectedRecords.count)")
+        }
+    }
+
+    func loadAllWebsiteData() {
+        state = .loading
+
+        let types = WKWebsiteDataStore.allWebsiteDataTypes()
+        WKWebsiteDataStore.default().fetchDataRecords(ofTypes: types) { [weak self] records in
+            self?.siteRecords = records.sorted { $0.displayName < $1.displayName }
+            self?.state = .displayInitial
+            self?.onViewModelChanged()
+        }
+
+        self.onViewModelChanged()
+    }
+
+    func selectItem(_ item: WKWebsiteDataRecord) {
+        selectedRecords.insert(item)
+        onViewModelChanged()
+    }
+
+    func deselectItem(_ item: WKWebsiteDataRecord) {
+        selectedRecords.remove(item)
+        onViewModelChanged()
+    }
+
+    func createAlertToRemove() -> UIAlertController {
+        if selectedRecords.isEmpty {
+            return UIAlertController.clearAllWebsiteDataAlert { _ in self.removeAllRecords() }
+        } else {
+            return UIAlertController.clearSelectedWebsiteDataAlert { _ in self.removeSelectedRecords() }
+        }
+    }
+
+    private func removeSelectedRecords() {
+        let previousState = state
+        state = .loading
+        onViewModelChanged()
+
+        let types = WKWebsiteDataStore.allWebsiteDataTypes()
+        WKWebsiteDataStore.default().removeData(ofTypes: types, for: Array(selectedRecords)) { [weak self] in
+            self?.state = previousState
+            self?.siteRecords.removeAll { self?.selectedRecords.contains($0) ?? false }
+            self?.selectedRecords = []
+            self?.onViewModelChanged()
+        }
+    }
+
+    private func removeAllRecords() {
+        let previousState = state
+        state = .loading
+        onViewModelChanged()
+
+        let types = WKWebsiteDataStore.allWebsiteDataTypes()
+        WKWebsiteDataStore.default().removeData(ofTypes: types, modifiedSince: .distantPast) { [weak self] in
+            self?.siteRecords = []
+            self?.selectedRecords = []
+            self?.state = previousState
+            self?.onViewModelChanged()
+        }
+    }
+}

--- a/Client/Frontend/Theme/ThemedTableViewCells/ThemedTableViewCell.swift
+++ b/Client/Frontend/Theme/ThemedTableViewCells/ThemedTableViewCell.swift
@@ -49,6 +49,7 @@ class ThemedTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
     override func prepareForReuse() {
         super.prepareForReuse()
         textLabel?.text = nil
+        textLabel?.textAlignment = .natural
         textLabel?.font = DynamicFontHelper.defaultHelper.DefaultStandardFont
         detailTextLabel?.text = nil
         accessoryView = nil


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6644)
[Github issue WebsiteDataManagementViewController](https://github.com/mozilla-mobile/firefox-ios/issues/14853)

[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6645)
[Github issue WebsiteDataSearchResultViewController](https://github.com/mozilla-mobile/firefox-ios/issues/14852)

### Description

Refactor `WebsiteDataSearchResultViewController` with `ThemedTableViewController`, refactor WebsiteData Controllers with dequeue reusable cell for indexPath. 

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
