### PR TITLE
Add FXIOS-6359 [v115] Set default browser instruction flow

### DIFF
--- a/Client/Frontend/Onboarding/Protocols/OnboardingCardDelegate.swift
+++ b/Client/Frontend/Onboarding/Protocols/OnboardingCardDelegate.swift
@@ -73,7 +73,11 @@ extension OnboardingCardDelegate where Self: OnboardingViewControllerProtocol,
     func presentDefaultBrowserPopup() {
         guard let a11yIdRoot = viewModel.availableCards.first?.viewModel.a11yIdRoot else { return }
         let infoModel = OnboardingDefaultBrowserInfoModel(a11yIdRoot: a11yIdRoot)
-        let viewController = OnboardingDefaultSettingsViewController(viewModel: infoModel)
+        let viewController = OnboardingDefaultSettingsViewController(
+            viewModel: infoModel,
+            buttonTappedFinishFlow: { showNextPage(from: <#T##String#>, completionIfLastCard: <#T##() -> Void#>)
+            }
+        )
         var bottomSheetViewModel = BottomSheetViewModel()
         bottomSheetViewModel.shouldDismissForTapOutside = true
         let bottomSheetVC = BottomSheetViewController(

--- a/Client/Frontend/Onboarding/Protocols/OnboardingCardDelegate.swift
+++ b/Client/Frontend/Onboarding/Protocols/OnboardingCardDelegate.swift
@@ -25,7 +25,7 @@ protocol OnboardingCardDelegate: AnyObject {
                               selector: Selector?,
                               completion: (() -> Void)?,
                               referringPage: ReferringPage)
-    func presentDefaultBrowserPopup()
+    func presentDefaultBrowserPopup(from name: String)
 
     func presentSignToSync(
         with fxaOptions: FxALaunchParams,
@@ -34,7 +34,7 @@ protocol OnboardingCardDelegate: AnyObject {
         flowType: FxAPageType,
         referringPage: ReferringPage)
 
-    func showNextPage(from cardNamed: String, completionIfLastCard completion: () -> Void)
+    func showNextPage(from cardNamed: String, completionIfLastCard completion: (() -> Void)?)
     func pageChanged(from cardName: String)
 }
 
@@ -69,14 +69,12 @@ extension OnboardingCardDelegate where Self: OnboardingViewControllerProtocol,
     }
 
     // MARK: - Default Browser Popup
-    // TODO: https://mozilla-hub.atlassian.net/browse/FXIOS-6359
-    func presentDefaultBrowserPopup() {
+    func presentDefaultBrowserPopup(from name: String) {
         guard let a11yIdRoot = viewModel.availableCards.first?.viewModel.a11yIdRoot else { return }
         let infoModel = OnboardingDefaultBrowserInfoModel(a11yIdRoot: a11yIdRoot)
         let viewController = OnboardingDefaultSettingsViewController(
             viewModel: infoModel,
-            buttonTappedFinishFlow: { showNextPage(from: <#T##String#>, completionIfLastCard: <#T##() -> Void#>)
-            }
+            buttonTappedFinishFlow: { self.showNextPage(from: name, completionIfLastCard: nil) }
         )
         var bottomSheetViewModel = BottomSheetViewModel()
         bottomSheetViewModel.shouldDismissForTapOutside = true
@@ -117,10 +115,10 @@ extension OnboardingCardDelegate where Self: OnboardingViewControllerProtocol,
     // MARK: - Page helpers
     func showNextPage(
         from cardName: String,
-        completionIfLastCard completion: () -> Void
+        completionIfLastCard completion: (() -> Void)?
     ) {
         guard cardName != viewModel.availableCards.last?.viewModel.name else {
-            completion()
+            completion?()
             return
         }
 

--- a/Client/Frontend/Onboarding/ViewControllers/FirstInstall/IntroViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/FirstInstall/IntroViewController.swift
@@ -195,7 +195,7 @@ extension IntroViewController: OnboardingCardDelegate {
             askForNotificationPermission(from: cardName)
         case .nextCard:
             showNextPage(from: cardName) {
-                showNextPageCompletionForLastCard()
+                self.showNextPageCompletionForLastCard()
             }
         case .syncSignIn:
             let fxaPrams = FxALaunchParams(entrypoint: .introOnboarding, query: [:])
@@ -210,8 +210,7 @@ extension IntroViewController: OnboardingCardDelegate {
         case .setDefaultBrowser:
             DefaultApplicationHelper().openSettings()
         case .openDefaultBrowserPopup:
-            // TODO: https://mozilla-hub.atlassian.net/browse/FXIOS-5922
-            presentDefaultBrowserPopup()
+            presentDefaultBrowserPopup(from: cardName)
         case .readPrivacyPolicy:
             presentPrivacyPolicy(
                 from: cardName,

--- a/Client/Frontend/Onboarding/ViewControllers/OnboardingDefaultSettingsViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/OnboardingDefaultSettingsViewController.swift
@@ -83,12 +83,16 @@ class OnboardingDefaultSettingsViewController: UIViewController, Themeable {
     var themeManager: ThemeManager
     var themeObserver: NSObjectProtocol?
     private var contentViewHeightConstraint: NSLayoutConstraint!
+    var didTapButton: Bool = false
+    var buttonTappedFinishFlow: (() -> Void)?
 
     // MARK: - Initializers
     init(viewModel: OnboardingDefaultBrowserModelProtocol,
+         buttonTappedFinishFlow: (() -> Void)?,
          themeManager: ThemeManager = AppContainer.shared.resolve(),
          notificationCenter: NotificationProtocol = NotificationCenter.default) {
         self.viewModel = viewModel
+        self.buttonTappedFinishFlow = buttonTappedFinishFlow
         self.themeManager = themeManager
         self.notificationCenter = notificationCenter
 
@@ -104,6 +108,7 @@ class OnboardingDefaultSettingsViewController: UIViewController, Themeable {
         super.viewDidLoad()
 
         listenForThemeChange(view)
+        setupNotifications()
         setupView()
         updateLayout()
         applyTheme()
@@ -112,6 +117,10 @@ class OnboardingDefaultSettingsViewController: UIViewController, Themeable {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         applyTheme()
+    }
+
+    deinit {
+        notificationCenter.removeObserver(self)
     }
 
     func setupView() {
@@ -161,6 +170,14 @@ class OnboardingDefaultSettingsViewController: UIViewController, Themeable {
         ])
     }
 
+    private func setupNotifications() {
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(appDidBecomeActiveNotification),
+            name: UIApplication.didEnterBackgroundNotification,
+            object: nil)
+    }
+
     private func updateLayout() {
         titleLabel.text = viewModel.title
         primaryButton.setTitle(viewModel.buttonTitle, for: .normal)
@@ -198,9 +215,17 @@ class OnboardingDefaultSettingsViewController: UIViewController, Themeable {
         }
     }
 
+    @objc
+    func appDidBecomeActiveNotification() {
+        if didTapButton {
+            dismiss(animated: false)
+        }
+    }
+
     // MARK: - Button actions
     @objc
     func primaryAction() {
+        didTapButton = true
         DefaultApplicationHelper().openSettings()
     }
 

--- a/Client/Frontend/Onboarding/ViewControllers/OnboardingDefaultSettingsViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/OnboardingDefaultSettingsViewController.swift
@@ -32,6 +32,7 @@ class OnboardingDefaultSettingsViewController: UIViewController, Themeable {
         static let bottomPaddingPad: CGFloat = 60
     }
 
+    // MARK: - Properties
     lazy var contentContainerView: UIView = .build { stack in
         stack.backgroundColor = .clear
     }
@@ -83,6 +84,7 @@ class OnboardingDefaultSettingsViewController: UIViewController, Themeable {
     var themeObserver: NSObjectProtocol?
     private var contentViewHeightConstraint: NSLayoutConstraint!
 
+    // MARK: - Initializers
     init(viewModel: OnboardingDefaultBrowserModelProtocol,
          themeManager: ThemeManager = AppContainer.shared.resolve(),
          notificationCenter: NotificationProtocol = NotificationCenter.default) {
@@ -97,17 +99,18 @@ class OnboardingDefaultSettingsViewController: UIViewController, Themeable {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        applyTheme()
-    }
-
+    // MARK: - View lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
 
         listenForThemeChange(view)
         setupView()
         updateLayout()
+        applyTheme()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         applyTheme()
     }
 
@@ -177,6 +180,7 @@ class OnboardingDefaultSettingsViewController: UIViewController, Themeable {
         view.backgroundColor = .white
     }
 
+    // MARK: - Helper methods
     private func createLabels(from descriptionTexts: [String]) {
         numeratedLabels.removeAll()
         let attributedStrings = viewModel.getAttributedStrings(with: DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline, size: UX.numeratedTextFontSize))
@@ -194,11 +198,13 @@ class OnboardingDefaultSettingsViewController: UIViewController, Themeable {
         }
     }
 
+    // MARK: - Button actions
     @objc
     func primaryAction() {
         DefaultApplicationHelper().openSettings()
     }
 
+    // MARK: - Themeable
     func applyTheme() {
         let theme = themeManager.currentTheme
         titleLabel.textColor = theme.colors.textPrimary

--- a/Client/Frontend/Onboarding/ViewControllers/OnboardingDefaultSettingsViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/OnboardingDefaultSettingsViewController.swift
@@ -83,7 +83,7 @@ class OnboardingDefaultSettingsViewController: UIViewController, Themeable {
     var themeManager: ThemeManager
     var themeObserver: NSObjectProtocol?
     private var contentViewHeightConstraint: NSLayoutConstraint!
-    var didTapButton: Bool = false
+    var didTapButton = false
     var buttonTappedFinishFlow: (() -> Void)?
 
     // MARK: - Initializers
@@ -173,7 +173,7 @@ class OnboardingDefaultSettingsViewController: UIViewController, Themeable {
     private func setupNotifications() {
         notificationCenter.addObserver(
             self,
-            selector: #selector(appDidBecomeActiveNotification),
+            selector: #selector(appDidEnterBackgroundNotification),
             name: UIApplication.didEnterBackgroundNotification,
             object: nil)
     }
@@ -216,9 +216,10 @@ class OnboardingDefaultSettingsViewController: UIViewController, Themeable {
     }
 
     @objc
-    func appDidBecomeActiveNotification() {
+    func appDidEnterBackgroundNotification() {
         if didTapButton {
             dismiss(animated: false)
+            buttonTappedFinishFlow?()
         }
     }
 

--- a/Client/Frontend/Onboarding/ViewControllers/Update/UpdateViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/Update/UpdateViewController.swift
@@ -222,7 +222,7 @@ extension UpdateViewController: OnboardingCardDelegate {
                 from: cardName,
                 selector: #selector(dismissPrivacyPolicyViewController))
         case .openDefaultBrowserPopup:
-            presentDefaultBrowserPopup()
+            presentDefaultBrowserPopup(from: cardName)
         default:
             break
         }

--- a/nimbus-features/onboardingFrameworkFeature.yaml
+++ b/nimbus-features/onboardingFrameworkFeature.yaml
@@ -41,7 +41,7 @@ features:
               buttons:
                 primary:
                   title: Onboarding/Onboarding.Welcome.Action.v114
-                  action: open-default-browser-popup
+                  action: next-card
               type: fresh-install
               prerequisites:
                 - ALWAYS

--- a/nimbus-features/onboardingFrameworkFeature.yaml
+++ b/nimbus-features/onboardingFrameworkFeature.yaml
@@ -41,7 +41,7 @@ features:
               buttons:
                 primary:
                   title: Onboarding/Onboarding.Welcome.Action.v114
-                  action: next-card
+                  action: open-default-browser-popup
               type: fresh-install
               prerequisites:
                 - ALWAYS


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6359)

### Description
If the action is `open-default-browser-popup`, and the user opens the popup and taps the button to go to settings, the app will close the popup and go to the next page in the background.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
