### PR TITLE
Refactor FXIOS-6708 [v116] Clean up theme

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1254,7 +1254,7 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
         // No content is showing in between the bottom search bar and the searchViewController
         if isBottomSearchBar, keyboardBackdrop == nil {
             keyboardBackdrop = UIView()
-            keyboardBackdrop?.backgroundColor = UIColor.legacyTheme.browser.background
+            keyboardBackdrop?.backgroundColor = currentTheme.colors.layer1
             view.insertSubview(keyboardBackdrop!, belowSubview: overKeyboardContainer)
             keyboardBackdrop?.snp.makeConstraints { make in
                 make.edges.equalTo(view)
@@ -1866,6 +1866,31 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
                 }
             }
         }
+    }
+
+    // MARK: Themeable
+    func applyTheme() {
+        let currentTheme = themeManager.currentTheme
+        let hasTopTabs = shouldShowTopTabsForTraitCollection(traitCollection)
+        statusBarOverlay.backgroundColor = hasTopTabs ? currentTheme.colors.layer3 : currentTheme.colors.layer1
+        keyboardBackdrop?.backgroundColor = currentTheme.colors.layer1
+        setNeedsStatusBarAppearanceUpdate()
+
+        // Remove as part of FXIOS-5109
+        (presentedViewController as? LegacyNotificationThemeable)?.applyTheme()
+
+        // Update the `background-color` of any blank webviews.
+        let webViews = tabManager.tabs.compactMap({ $0.webView as? TabWebView })
+        webViews.forEach({ $0.applyTheme() })
+
+        let tabs = tabManager.tabs
+        tabs.forEach {
+            $0.applyTheme()
+            urlBar.locationView.tabDidChangeContentBlocking($0)
+        }
+
+        guard let contentScript = tabManager.selectedTab?.getContentScript(name: ReaderMode.name()) else { return }
+        applyThemeForPreferences(profile.prefs, contentScript: contentScript)
     }
 }
 
@@ -2914,38 +2939,6 @@ extension BrowserViewController: TabTrayDelegate {
         } else {
             showSettingsWithDeeplink(to: .customizeTabs)
         }
-    }
-}
-
-// MARK: Browser Chrome Theming
-extension BrowserViewController: LegacyNotificationThemeable {
-    func applyTheme() {
-        // Clean up with FXIOS-6708
-        let currentTheme = themeManager.currentTheme
-        readerModeBar?.applyTheme(theme: currentTheme)
-        zoomPageBar?.applyTheme(theme: currentTheme)
-        topTabsViewController?.applyTheme()
-
-        let hasTopTabs = shouldShowTopTabsForTraitCollection(traitCollection)
-        statusBarOverlay.backgroundColor = hasTopTabs ? currentTheme.colors.layer3 : currentTheme.colors.layer1
-        keyboardBackdrop?.backgroundColor = currentTheme.colors.layer1
-        setNeedsStatusBarAppearanceUpdate()
-
-        // Remove as part of FXIOS-5109
-        (presentedViewController as? LegacyNotificationThemeable)?.applyTheme()
-
-        // Update the `background-color` of any blank webviews.
-        let webViews = tabManager.tabs.compactMap({ $0.webView as? TabWebView })
-        webViews.forEach({ $0.applyTheme() })
-
-        let tabs = tabManager.tabs
-        tabs.forEach {
-            $0.applyTheme()
-            urlBar.locationView.tabDidChangeContentBlocking($0)
-        }
-
-        guard let contentScript = tabManager.selectedTab?.getContentScript(name: ReaderMode.name()) else { return }
-        applyThemeForPreferences(profile.prefs, contentScript: contentScript)
     }
 }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1254,7 +1254,7 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
         // No content is showing in between the bottom search bar and the searchViewController
         if isBottomSearchBar, keyboardBackdrop == nil {
             keyboardBackdrop = UIView()
-            keyboardBackdrop?.backgroundColor = currentTheme.colors.layer1
+            keyboardBackdrop?.backgroundColor = themeManager.currentTheme.colors.layer1
             view.insertSubview(keyboardBackdrop!, belowSubview: overKeyboardContainer)
             keyboardBackdrop?.snp.makeConstraints { make in
                 make.edges.equalTo(view)
@@ -1886,7 +1886,6 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
         let tabs = tabManager.tabs
         tabs.forEach {
             $0.applyTheme()
-            urlBar.locationView.tabDidChangeContentBlocking($0)
         }
 
         guard let contentScript = tabManager.selectedTab?.getContentScript(name: ReaderMode.name()) else { return }

--- a/Client/Frontend/Library/LibraryPanelHelper.swift
+++ b/Client/Frontend/Library/LibraryPanelHelper.swift
@@ -14,7 +14,7 @@ protocol LibraryPanelDelegate: AnyObject {
     func libraryPanel(didSelectURLString url: String, visitType: VisitType)
 }
 
-protocol LibraryPanel: UIViewController, LegacyNotificationThemeable {
+protocol LibraryPanel: UIViewController {
     var libraryPanelDelegate: LibraryPanelDelegate? { get set }
     var state: LibraryPanelMainState { get set }
     var bottomToolbarItems: [UIBarButtonItem] { get }

--- a/Client/Frontend/Toolbar+URLBar/ReaderModeButton.swift
+++ b/Client/Frontend/Toolbar+URLBar/ReaderModeButton.swift
@@ -70,5 +70,6 @@ extension ReaderModeButton: ThemeApplicable {
     func applyTheme(theme: Theme) {
         selectedTintColor = theme.colors.iconAction
         unselectedTintColor = theme.colors.iconSecondary
+        tintColor = isSelected ? selectedTintColor : unselectedTintColor
     }
 }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6708)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14978)

### Description
- Reader mode, zoom page and top tabs are all `ThemeApplicable` so don't need to manually update those from BVC. They will get theme updates already if they are shown.
- Remove `LegacyNotificationThemeable` from BVC, since it's now `Themeable`
- Each library panel is already `Themeable`, so remove `LegacyNotificationThemeable`
- Location view lock icon updates from the theme changes, no need to do this from BVC anymore
- Fix a `keyboardBackdrop` color
- Fix reader mode button color change on theme change (was keeping the old theme color on theme change).

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
