### PR TITLE
Bugfix FXIOS-6749 [v114] Deeplink is called when the browser isn't ready

### DIFF
--- a/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
+++ b/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
@@ -8,6 +8,9 @@ import Foundation
 /// Categories are sorted in alphabetical order.
 /// Do not add new categories unless discussing with the team beforehand.
 public enum LoggerCategory: String {
+    /// Related to coordinator navigation
+    case coordinator
+
     /// Related to anything about credit cards.
     case creditcard
 

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -557,6 +557,7 @@
 		8A19ACB82A329128001C2147 /* PrivacyPolicySetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A19ACB72A329128001C2147 /* PrivacyPolicySetting.swift */; };
 		8A1E3BDF28CBA81E003388C4 /* SponsoredContentFilterUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1E3BDE28CBA81E003388C4 /* SponsoredContentFilterUtility.swift */; };
 		8A1E3BE328CBACDD003388C4 /* SponsoredContentFilterUtilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1E3BE128CBACD7003388C4 /* SponsoredContentFilterUtilityTests.swift */; };
+		8A1E93EA2A3CDC6100DD540A /* BaseCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1E93E92A3CDC6100DD540A /* BaseCoordinator.swift */; };
 		8A2366FA28A302E500846D1B /* MockSponsoredPocketAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2366F928A302E500846D1B /* MockSponsoredPocketAPI.swift */; };
 		8A2783F1275FFDC50080D29D /* KeyboardPressesHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2783F0275FFDC50080D29D /* KeyboardPressesHandler.swift */; };
 		8A2825352760399B00395E66 /* KeyboardPressesHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2825342760399B00395E66 /* KeyboardPressesHandlerTests.swift */; };
@@ -663,7 +664,7 @@
 		8A93F86229D36F0F004159D9 /* NavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A93F86129D36F0F004159D9 /* NavigationController.swift */; };
 		8A93F86529D37331004159D9 /* DefaultRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A93F86429D37331004159D9 /* DefaultRouterTests.swift */; };
 		8A93F86829D373B0004159D9 /* MockNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A93F86629D373AC004159D9 /* MockNavigationController.swift */; };
-		8A93F86B29D39BDA004159D9 /* CoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A93F86929D37FC9004159D9 /* CoordinatorTests.swift */; };
+		8A93F86B29D39BDA004159D9 /* BaseCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A93F86929D37FC9004159D9 /* BaseCoordinatorTests.swift */; };
 		8A93F86D29D3A131004159D9 /* DefaultRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A93F86C29D3A131004159D9 /* DefaultRouter.swift */; };
 		8A93F87029D3A597004159D9 /* SceneCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A93F86F29D3A597004159D9 /* SceneCoordinator.swift */; };
 		8A93F87229D3A5AD004159D9 /* BrowserCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A93F87129D3A5AD004159D9 /* BrowserCoordinator.swift */; };
@@ -4575,6 +4576,7 @@
 		8A1E3BDE28CBA81E003388C4 /* SponsoredContentFilterUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SponsoredContentFilterUtility.swift; sourceTree = "<group>"; };
 		8A1E3BE128CBACD7003388C4 /* SponsoredContentFilterUtilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SponsoredContentFilterUtilityTests.swift; sourceTree = "<group>"; };
 		8A1E3BE528CBBF44003388C4 /* OpenSearchEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSearchEngine.swift; sourceTree = "<group>"; };
+		8A1E93E92A3CDC6100DD540A /* BaseCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCoordinator.swift; sourceTree = "<group>"; };
 		8A2366F928A302E500846D1B /* MockSponsoredPocketAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSponsoredPocketAPI.swift; sourceTree = "<group>"; };
 		8A2783F0275FFDC50080D29D /* KeyboardPressesHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardPressesHandler.swift; sourceTree = "<group>"; };
 		8A2825342760399B00395E66 /* KeyboardPressesHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardPressesHandlerTests.swift; sourceTree = "<group>"; };
@@ -4694,7 +4696,7 @@
 		8A93F86129D36F0F004159D9 /* NavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationController.swift; sourceTree = "<group>"; };
 		8A93F86429D37331004159D9 /* DefaultRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultRouterTests.swift; sourceTree = "<group>"; };
 		8A93F86629D373AC004159D9 /* MockNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNavigationController.swift; sourceTree = "<group>"; };
-		8A93F86929D37FC9004159D9 /* CoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatorTests.swift; sourceTree = "<group>"; };
+		8A93F86929D37FC9004159D9 /* BaseCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCoordinatorTests.swift; sourceTree = "<group>"; };
 		8A93F86C29D3A131004159D9 /* DefaultRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultRouter.swift; sourceTree = "<group>"; };
 		8A93F86F29D3A597004159D9 /* SceneCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneCoordinator.swift; sourceTree = "<group>"; };
 		8A93F87129D3A5AD004159D9 /* BrowserCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserCoordinator.swift; sourceTree = "<group>"; };
@@ -8151,6 +8153,7 @@
 				8A832A8E29DC96AD0025D5DD /* Launch */,
 				8AF10D8D29D773FC0086351D /* Scene */,
 				8A93F86E29D3A147004159D9 /* Router */,
+				8A1E93E92A3CDC6100DD540A /* BaseCoordinator.swift */,
 				8A93F85D29D36DA9004159D9 /* Coordinator.swift */,
 				8A76B01329F6E45600A82607 /* CoordinatorFlagManager.swift */,
 				8A83B7452A264FA0002FF9AC /* SettingsCoordinator.swift */,
@@ -8165,7 +8168,7 @@
 				8AFCE50329DDCD3F00B1B253 /* LaunchView */,
 				8AF10D8829D713E70086351D /* Launch */,
 				8A93F86429D37331004159D9 /* DefaultRouterTests.swift */,
-				8A93F86929D37FC9004159D9 /* CoordinatorTests.swift */,
+				8A93F86929D37FC9004159D9 /* BaseCoordinatorTests.swift */,
 				C8EDDBEF29DD83FC003A4C07 /* RouteTests.swift */,
 				C8E531CB29E72A2F00E03FEF /* ShortcutRouteTests.swift */,
 				C8E531C929E5F7D300E03FEF /* URLScannerTests.swift */,
@@ -12712,6 +12715,7 @@
 				D34DC8531A16C40C00D49B7B /* Profile.swift in Sources */,
 				DFACDFAA274D489B00A94EEC /* HistoryHighlightsViewModel.swift in Sources */,
 				C84655FF2887A06B00861B4A /* WallpaperFilePathProvider.swift in Sources */,
+				8A1E93EA2A3CDC6100DD540A /* BaseCoordinator.swift in Sources */,
 				E1442FD6294782D9003680B0 /* UIView+Extension.swift in Sources */,
 				74F80D342A0A52D700013C3D /* PrivacyPolicyViewController.swift in Sources */,
 				274A36CE239EB9EC00A21587 /* LibraryViewController+LibraryPanelDelegate.swift in Sources */,
@@ -13040,7 +13044,7 @@
 				C83DE54729DF35EE006E1B69 /* GleanPlumbMessageTests.swift in Sources */,
 				C8C3FE9D29F907B30038E3BA /* MockSearchHandlerRouteCoordinator.swift in Sources */,
 				C8C3FEA129F973C40038E3BA /* MockBrowserViewController.swift in Sources */,
-				8A93F86B29D39BDA004159D9 /* CoordinatorTests.swift in Sources */,
+				8A93F86B29D39BDA004159D9 /* BaseCoordinatorTests.swift in Sources */,
 				967EDABD29D705300089208D /* CreditCardValidatorTests.swift in Sources */,
 				D815A3A824A53F3200AAB221 /* TabToolbarHelperTests.swift in Sources */,
 				967EDABF29D769A10089208D /* CreditCardInputFieldTests.swift in Sources */,

--- a/Client/Coordinators/BaseCoordinator.swift
+++ b/Client/Coordinators/BaseCoordinator.swift
@@ -52,6 +52,7 @@ open class BaseCoordinator: Coordinator {
 
         // If no matching coordinator is found, return nil and save the Route to be passed along when it next navigates
         savedRoute = route
+        logger.log("Saved a route", level: .info, category: .coordinator)
         return nil
     }
 }

--- a/Client/Coordinators/BaseCoordinator.swift
+++ b/Client/Coordinators/BaseCoordinator.swift
@@ -1,0 +1,57 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+
+open class BaseCoordinator: Coordinator {
+    var savedRoute: Route?
+    var id = UUID()
+    var childCoordinators: [Coordinator] = []
+    var router: Router
+    var logger: Logger
+
+    init(router: Router,
+         logger: Logger = DefaultLogger.shared) {
+        self.router = router
+        self.logger = logger
+    }
+
+    func add(child coordinator: Coordinator) {
+        childCoordinators.append(coordinator)
+    }
+
+    func remove(child coordinator: Coordinator?) {
+        guard let coordinator = coordinator,
+              let index = childCoordinators.firstIndex(where: { $0.id == coordinator.id })
+        else { return }
+
+        childCoordinators.remove(at: index)
+    }
+
+    func handle(route: Route) -> Bool {
+        return false
+    }
+
+    @discardableResult
+    func findAndHandle(route: Route) -> Coordinator? {
+        // Check if the current coordinator can handle the route.
+        if handle(route: route) {
+            savedRoute = nil
+            return self
+        }
+
+        // If not, recursively search through child coordinators.
+        for childCoordinator in childCoordinators {
+            if let matchingCoordinator = childCoordinator.findAndHandle(route: route) {
+                savedRoute = nil
+                return matchingCoordinator
+            }
+        }
+
+        // If no matching coordinator is found, return nil and save the Route to be passed along when it next navigates
+        savedRoute = route
+        return nil
+    }
+}

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -20,7 +20,7 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
     private let applicationHelper: ApplicationHelper
     private let wallpaperManager: WallpaperManagerInterface
     private let isSettingsCoordinatorEnabled: Bool
-    private var browserIsReady: Bool = false
+    private var browserIsReady = false
 
     init(router: Router,
          screenshotService: ScreenshotService,
@@ -146,7 +146,7 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
             return false
         }
 
-        logger.log("Handling Route \(route)", level: .info, category: .coordinator)
+        logger.log("Handling a route", level: .info, category: .coordinator)
         switch route {
         case let .searchQuery(query):
             handle(query: query)

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -20,6 +20,7 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
     private let applicationHelper: ApplicationHelper
     private let wallpaperManager: WallpaperManagerInterface
     private let isSettingsCoordinatorEnabled: Bool
+    private var browserIsReady: Bool = false
 
     init(router: Router,
          screenshotService: ScreenshotService,
@@ -67,6 +68,11 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
     func didFinishLaunch(from coordinator: LaunchCoordinator) {
         router.dismiss(animated: true, completion: nil)
         remove(child: coordinator)
+
+        // Once launch is done, we check for any saved Route
+        if let savedRoute {
+            findAndHandle(route: savedRoute)
+        }
     }
 
     // MARK: - BrowserDelegate
@@ -103,6 +109,15 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
         screenshotService.screenshotableView = webviewController
     }
 
+    func browserHasLoaded() {
+        browserIsReady = true
+        logger.log("Browser has loaded", level: .info, category: .coordinator)
+
+        if let savedRoute {
+            findAndHandle(route: savedRoute)
+        }
+    }
+
     private func getHomepage(inline: Bool,
                              homepanelDelegate: HomePanelDelegate,
                              libraryPanelDelegate: LibraryPanelDelegate,
@@ -126,6 +141,12 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
     // MARK: - Route handling
 
     override func handle(route: Route) -> Bool {
+        guard browserIsReady else {
+            logger.log("Could not handle route, wasn't ready", level: .info, category: .coordinator)
+            return false
+        }
+
+        logger.log("Handling Route \(route)", level: .info, category: .coordinator)
         switch route {
         case let .searchQuery(query):
             handle(query: query)

--- a/Client/Coordinators/Browser/BrowserDelegate.swift
+++ b/Client/Coordinators/Browser/BrowserDelegate.swift
@@ -22,4 +22,7 @@ protocol BrowserDelegate: AnyObject {
     /// Show the webview to navigate
     /// - Parameter webView: When nil, will show the already existing webview
     func show(webView: WKWebView)
+
+    /// This is called the browser is ready to start navigating, ensuring we are in the required state to perform deeplinks
+    func browserHasLoaded()
 }

--- a/Client/Coordinators/Coordinator.swift
+++ b/Client/Coordinators/Coordinator.swift
@@ -2,23 +2,24 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
 
-protocol Coordinator {
+protocol Coordinator: AnyObject {
     var id: UUID { get }
     var childCoordinators: [Coordinator] { get }
     var router: Router { get }
+    var logger: Logger { get }
 
-    func add(child coordinator: Coordinator)
-    func remove(child coordinator: Coordinator?)
+    /// Will hold the Route the coordinator was asked to navigate to in case the path could not be handled yet.
+    var savedRoute: Route? { get set }
 
+    /// Handle the Route, this is implemented by each coordinator for Route they will handle.
+    /// When the coordinator cannot handle this particular Route, it returns false.
+    /// - Parameter route: The Route to navigate to
+    /// - Returns: True when the Route was handled
     func handle(route: Route) -> Bool
 
-    @discardableResult
-    func findAndHandle(route: Route) -> Coordinator?
-}
-
-extension Coordinator {
     /// Finds a coordinator that can handle a given route by recursively searching through the current coordinator's child coordinators.
     /// - Parameter route: The route to find a matching coordinator for.
     /// - Returns: An optional `Coordinator` instance that can handle the given `route`, or `nil` if no such coordinator was found.
@@ -26,46 +27,8 @@ extension Coordinator {
     /// - DiscardableResult: The result of this method is marked as `@discardableResult` because the caller may choose not to use the returned
     /// `Coordinator` instance, which is safe to do.
     @discardableResult
-    func findAndHandle(route: Route) -> Coordinator? {
-        // Check if the current coordinator can handle the route.
-        if handle(route: route) {
-            return self
-        }
+    func findAndHandle(route: Route) -> Coordinator?
 
-        // If not, recursively search through child coordinators.
-        for childCoordinator in childCoordinators {
-            if let matchingCoordinator = childCoordinator.findAndHandle(route: route) {
-                return matchingCoordinator
-            }
-        }
-
-        // If no matching coordinator is found, return nil.
-        return nil
-    }
-}
-
-open class BaseCoordinator: Coordinator {
-    var id = UUID()
-    var childCoordinators: [Coordinator] = []
-    var router: Router
-
-    init(router: Router) {
-        self.router = router
-    }
-
-    func add(child coordinator: Coordinator) {
-        childCoordinators.append(coordinator)
-    }
-
-    func remove(child coordinator: Coordinator?) {
-        guard let coordinator = coordinator,
-              let index = childCoordinators.firstIndex(where: { $0.id == coordinator.id })
-        else { return }
-
-        childCoordinators.remove(at: index)
-    }
-
-    func handle(route: Route) -> Bool {
-        return false
-    }
+    func add(child coordinator: Coordinator)
+    func remove(child coordinator: Coordinator?)
 }

--- a/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -12,16 +12,13 @@ protocol LaunchCoordinatorDelegate: AnyObject {
 // Manages different types of onboarding that gets shown at the launch of the application
 class LaunchCoordinator: BaseCoordinator, SurveySurfaceViewControllerDelegate {
     private let profile: Profile
-    private let logger: Logger
     private let isIphone: Bool
     weak var parentCoordinator: LaunchCoordinatorDelegate?
 
     init(router: Router,
          profile: Profile = AppContainer.shared.resolve(),
-         isIphone: Bool = UIDevice.current.userInterfaceIdiom == .phone,
-         logger: Logger = DefaultLogger.shared) {
+         isIphone: Bool = UIDevice.current.userInterfaceIdiom == .phone) {
         self.profile = profile
-        self.logger = logger
         self.isIphone = isIphone
         super.init(router: router)
     }

--- a/Client/Coordinators/Scene/SceneCoordinator.swift
+++ b/Client/Coordinators/Scene/SceneCoordinator.swift
@@ -49,19 +49,13 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
         startBrowser(with: nil)
     }
 
-    // MARK: - Route handling
-
-    /// Handles the specified route.
-    ///
-    /// - Parameter route: The route to handle.
-    ///
-    override func handle(route: Route) -> Bool {
-        return false
-    }
-
     // MARK: - Helper methods
 
     private func startLaunch(with launchType: LaunchType) {
+        logger.log("Launching with launchtype \(launchType)",
+                   level: .info,
+                   category: .coordinator)
+
         let launchCoordinator = LaunchCoordinator(router: router)
         launchCoordinator.parentCoordinator = self
         add(child: launchCoordinator)
@@ -69,10 +63,18 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
     }
 
     private func startBrowser(with launchType: LaunchType?) {
+        logger.log("Starting browser with launchtype \(String(describing: launchType))",
+                   level: .info,
+                   category: .coordinator)
+
         let browserCoordinator = BrowserCoordinator(router: router,
                                                     screenshotService: screenshotService)
         add(child: browserCoordinator)
         browserCoordinator.start(with: launchType)
+
+        if let savedRoute {
+            browserCoordinator.findAndHandle(route: savedRoute)
+        }
     }
 
     // MARK: - LaunchCoordinatorDelegate

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -470,6 +470,8 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
         SearchBarSettingsViewModel.recordLocationTelemetry(for: isBottomSearchBar ? .bottom : .top)
 
         overlayManager.setURLBar(urlBarView: urlBar)
+
+        browserDelegate?.browserHasLoaded()
     }
 
     private func setupAccessibleActions() {

--- a/Tests/ClientTests/Coordinators/BaseCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/BaseCoordinatorTests.swift
@@ -40,36 +40,38 @@ final class BaseCoordinatorTests: XCTestCase {
 
     func testFindMatchingCoordinator() {
         // Given
-        let parentCoordinator = BaseCoordinator(router: router)
+        let subject = BaseCoordinator(router: router)
         let childCoordinator = BaseCoordinator(router: router)
         let grandChildCoordinator = MockSearchHandlerRouteCoordinator(router: router)
 
-        parentCoordinator.add(child: childCoordinator)
+        subject.add(child: childCoordinator)
         childCoordinator.add(child: grandChildCoordinator)
 
         // When
         let route = Route.search(url: URL(string: "https://www.google.com"), isPrivate: false)
-        let matchingCoordinator = parentCoordinator.findAndHandle(route: route)
+        let matchingCoordinator = subject.findAndHandle(route: route)
 
         // Then
         XCTAssertNotNil(matchingCoordinator)
         XCTAssertEqual(matchingCoordinator?.id, grandChildCoordinator.id)
+        XCTAssertNil(subject.savedRoute)
     }
 
     func testFindNoMatchingCoordinator() {
         // Given
-        let parentCoordinator = BaseCoordinator(router: router)
+        let subject = BaseCoordinator(router: router)
         let childCoordinator = BaseCoordinator(router: router)
         let grandChildCoordinator = BaseCoordinator(router: router)
 
-        parentCoordinator.add(child: childCoordinator)
+        subject.add(child: childCoordinator)
         childCoordinator.add(child: grandChildCoordinator)
 
         // When
         let route = Route.search(url: URL(string: "https://www.google.com"), isPrivate: false)
-        let matchingCoordinator = parentCoordinator.findAndHandle(route: route)
+        let matchingCoordinator = subject.findAndHandle(route: route)
 
         // Then
         XCTAssertNil(matchingCoordinator)
+        XCTAssertNotNil(subject.savedRoute)
     }
 }

--- a/Tests/ClientTests/Coordinators/BaseCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/BaseCoordinatorTests.swift
@@ -5,7 +5,7 @@
 import XCTest
 @testable import Client
 
-final class CoordinatorTests: XCTestCase {
+final class BaseCoordinatorTests: XCTestCase {
     var navigationController: NavigationController!
     var router: MockRouter!
 

--- a/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -192,7 +192,10 @@ final class BrowserCoordinatorTests: XCTestCase {
         let subject = createSubject()
         let mbvc = MockBrowserViewController(profile: profile, tabManager: tabManager)
         subject.browserViewController = mbvc
+        subject.browserHasLoaded()
+
         let result = subject.handle(route: .searchQuery(query: query))
+
         XCTAssertTrue(result)
         XCTAssertTrue(mbvc.handleQueryCalled)
         XCTAssertEqual(mbvc.handleQuery, query)
@@ -203,7 +206,12 @@ final class BrowserCoordinatorTests: XCTestCase {
         let subject = createSubject()
         let mbvc = MockBrowserViewController(profile: profile, tabManager: tabManager)
         subject.browserViewController = mbvc
-        let result = subject.handle(route: .search(url: URL(string: "https://example.com")!, isPrivate: false, options: nil))
+        subject.browserHasLoaded()
+
+        let result = subject.handle(route: .search(url: URL(string: "https://example.com")!,
+                                                   isPrivate: false,
+                                                   options: nil))
+
         XCTAssertTrue(result)
         XCTAssertTrue(mbvc.switchToTabForURLOrOpenCalled)
         XCTAssertEqual(mbvc.switchToTabForURLOrOpenURL, URL(string: "https://example.com")!)
@@ -214,7 +222,12 @@ final class BrowserCoordinatorTests: XCTestCase {
         let subject = createSubject()
         let mbvc = MockBrowserViewController(profile: profile, tabManager: tabManager)
         subject.browserViewController = mbvc
-        let result = subject.handle(route: .search(url: URL(string: "https://example.com")!, isPrivate: false, options: [.switchToNormalMode]))
+        subject.browserHasLoaded()
+
+        let result = subject.handle(route: .search(url: URL(string: "https://example.com")!,
+                                                   isPrivate: false,
+                                                   options: [.switchToNormalMode]))
+
         XCTAssertTrue(result)
         XCTAssertTrue(mbvc.switchToPrivacyModeCalled)
         XCTAssertFalse(mbvc.switchToPrivacyModeIsPrivate)
@@ -227,7 +240,10 @@ final class BrowserCoordinatorTests: XCTestCase {
         let subject = createSubject()
         let mbvc = MockBrowserViewController(profile: profile, tabManager: tabManager)
         subject.browserViewController = mbvc
+        subject.browserHasLoaded()
+
         let result = subject.handle(route: .search(url: nil, isPrivate: false))
+
         XCTAssertTrue(result)
         XCTAssertTrue(mbvc.openBlankNewTabCalled)
         XCTAssertFalse(mbvc.openBlankNewTabIsPrivate)
@@ -238,7 +254,10 @@ final class BrowserCoordinatorTests: XCTestCase {
         let subject = createSubject()
         let mbvc = MockBrowserViewController(profile: profile, tabManager: tabManager)
         subject.browserViewController = mbvc
+        subject.browserHasLoaded()
+
         let result = subject.handle(route: .searchURL(url: URL(string: "https://example.com")!, tabId: "1234"))
+
         XCTAssertTrue(result)
         XCTAssertTrue(mbvc.switchToTabForURLOrOpenCalled)
         XCTAssertEqual(mbvc.switchToTabForURLOrOpenURL, URL(string: "https://example.com")!)
@@ -249,7 +268,10 @@ final class BrowserCoordinatorTests: XCTestCase {
         let subject = createSubject()
         let mbvc = MockBrowserViewController(profile: profile, tabManager: tabManager)
         subject.browserViewController = mbvc
+        subject.browserHasLoaded()
+
         let result = subject.handle(route: .searchURL(url: nil, tabId: "1234"))
+
         XCTAssertTrue(result)
         XCTAssertTrue(mbvc.openBlankNewTabCalled)
         XCTAssertFalse(mbvc.openBlankNewTabIsPrivate)
@@ -262,8 +284,11 @@ final class BrowserCoordinatorTests: XCTestCase {
         let subject = createSubject()
         let mbvc = MockBrowserViewController(profile: profile, tabManager: tabManager)
         subject.browserViewController = mbvc
+        subject.browserHasLoaded()
+
         let route = routeBuilder.makeRoute(url: URL(string: "firefox://deep-link?url=/homepanel/bookmarks")!)
         let result = subject.handle(route: route!)
+
         XCTAssertTrue(result)
         XCTAssertTrue(mbvc.showLibraryCalled)
         XCTAssertEqual(mbvc.showLibraryPanel, .bookmarks)
@@ -274,8 +299,11 @@ final class BrowserCoordinatorTests: XCTestCase {
         let subject = createSubject()
         let mbvc = MockBrowserViewController(profile: profile, tabManager: tabManager)
         subject.browserViewController = mbvc
+        subject.browserHasLoaded()
+
         let route = routeBuilder.makeRoute(url: URL(string: "firefox://deep-link?url=/homepanel/history")!)
         let result = subject.handle(route: route!)
+
         XCTAssertTrue(result)
         XCTAssertTrue(mbvc.showLibraryCalled)
         XCTAssertEqual(mbvc.showLibraryPanel, .history)
@@ -286,8 +314,11 @@ final class BrowserCoordinatorTests: XCTestCase {
         let subject = createSubject()
         let mbvc = MockBrowserViewController(profile: profile, tabManager: tabManager)
         subject.browserViewController = mbvc
+        subject.browserHasLoaded()
+
         let route = routeBuilder.makeRoute(url: URL(string: "firefox://deep-link?url=/homepanel/reading-list")!)
         let result = subject.handle(route: route!)
+
         XCTAssertTrue(result)
         XCTAssertTrue(mbvc.showLibraryCalled)
         XCTAssertEqual(mbvc.showLibraryPanel, .readingList)
@@ -298,8 +329,11 @@ final class BrowserCoordinatorTests: XCTestCase {
         let subject = createSubject()
         let mbvc = MockBrowserViewController(profile: profile, tabManager: tabManager)
         subject.browserViewController = mbvc
+        subject.browserHasLoaded()
+
         let route = routeBuilder.makeRoute(url: URL(string: "firefox://deep-link?url=/homepanel/downloads")!)
         let result = subject.handle(route: route!)
+
         XCTAssertTrue(result)
         XCTAssertTrue(mbvc.showLibraryCalled)
         XCTAssertEqual(mbvc.showLibraryPanel, .downloads)
@@ -312,6 +346,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         let subject = createSubject()
         let mbvc = MockBrowserViewController(profile: profile, tabManager: tabManager)
         subject.browserViewController = mbvc
+        subject.browserHasLoaded()
 
         // When
         let route = routeBuilder.makeRoute(url: topSitesURL)
@@ -330,6 +365,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         let subject = createSubject()
         let mbvc = MockBrowserViewController(profile: profile, tabManager: tabManager)
         subject.browserViewController = mbvc
+        subject.browserHasLoaded()
 
         // When
         let route = routeBuilder.makeRoute(url: newPrivateTabURL)
@@ -348,6 +384,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         let subject = createSubject()
         let mbvc = MockBrowserViewController(profile: profile, tabManager: tabManager)
         subject.browserViewController = mbvc
+        subject.browserHasLoaded()
 
         // When
         let route = routeBuilder.makeRoute(url: newTabURL)
@@ -365,6 +402,7 @@ final class BrowserCoordinatorTests: XCTestCase {
     func testDefaultBrowser_systemSettings_handlesRoute() {
         let route = Route.defaultBrowser(section: .systemSettings)
         let subject = createSubject()
+        subject.browserHasLoaded()
 
         let result = subject.handle(route: route)
 
@@ -375,6 +413,7 @@ final class BrowserCoordinatorTests: XCTestCase {
     func testDefaultBrowser_tutorial_handlesRoute() {
         let route = Route.defaultBrowser(section: .tutorial)
         let subject = createSubject()
+        subject.browserHasLoaded()
 
         let result = subject.handle(route: route)
 
@@ -391,6 +430,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         let expectedURL = URL(string: "www.example.com")!
         let route = Route.glean(url: expectedURL)
         let subject = createSubject()
+        subject.browserHasLoaded()
 
         let result = subject.handle(route: route)
 
@@ -404,6 +444,7 @@ final class BrowserCoordinatorTests: XCTestCase {
     func testGeneralSettingsRoute_showsGeneralSettingsPage() throws {
         let route = Route.settings(section: .general)
         let subject = createSubject()
+        subject.browserHasLoaded()
 
         let result = subject.handle(route: route)
 
@@ -498,6 +539,7 @@ final class BrowserCoordinatorTests: XCTestCase {
 
     func testSettingsRoute_addSettingsCoordinator() {
         let subject = createSubject(isSettingsCoordinatorEnabled: true)
+        subject.browserHasLoaded()
 
         let result = subject.handle(route: .settings(section: .general))
 
@@ -508,6 +550,7 @@ final class BrowserCoordinatorTests: XCTestCase {
 
     func testPresentedCompletion_callsDidFinishSettings_removesChild() {
         let subject = createSubject(isSettingsCoordinatorEnabled: true)
+        subject.browserHasLoaded()
 
         let result = subject.handle(route: .settings(section: .general))
         mockRouter.savedCompletion?()
@@ -531,6 +574,7 @@ final class BrowserCoordinatorTests: XCTestCase {
 
     func testSettingsCoordinatorDelegate_didFinishSettings_removesChild() {
         let subject = createSubject(isSettingsCoordinatorEnabled: true)
+        subject.browserHasLoaded()
 
         let result = subject.handle(route: .settings(section: .general))
         let settingsCoordinator = subject.childCoordinators[0] as! SettingsCoordinator
@@ -548,6 +592,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         let subject = createSubject()
         let mbvc = MockBrowserViewController(profile: profile, tabManager: tabManager)
         subject.browserViewController = mbvc
+        subject.browserHasLoaded()
 
         // When
         let route = routeBuilder.makeRoute(url: URL(string: "firefox://fxa-signin?signin=coolcodes&user=foo&email=bar")!)
@@ -566,10 +611,10 @@ final class BrowserCoordinatorTests: XCTestCase {
     func testHandleHandleQRCode_returnsTrue() {
         // Given
         let shortcutItem = UIApplicationShortcutItem(type: "com.example.app.QRCode", localizedTitle: "QR Code")
-
         let subject = createSubject()
         let mbvc = MockBrowserViewController(profile: profile, tabManager: tabManager)
         subject.browserViewController = mbvc
+        subject.browserHasLoaded()
 
         // When
         let route = routeBuilder.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
@@ -586,6 +631,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         let subject = createSubject()
         let mbvc = MockBrowserViewController(profile: profile, tabManager: tabManager)
         subject.browserViewController = mbvc
+        subject.browserHasLoaded()
 
         // When
         let route = routeBuilder.makeRoute(url: url)
@@ -594,6 +640,38 @@ final class BrowserCoordinatorTests: XCTestCase {
         // Then
         XCTAssertTrue(result)
         XCTAssertEqual(mbvc.closePrivateTabsCount, 1)
+    }
+
+    // MARK: - Saved route
+
+    func testSavesRoute_whenLaunchFinished() throws {
+        let subject = createSubject()
+        subject.findAndHandle(route: .defaultBrowser(section: .tutorial))
+        subject.start(with: nil)
+
+        subject.didFinishLaunch(from: LaunchCoordinator(router: mockRouter))
+
+        XCTAssertNotNil(subject.savedRoute)
+    }
+
+    func testSavedRouteCalled_whenBrowserHasLoaded() throws {
+        let subject = createSubject()
+        subject.findAndHandle(route: .defaultBrowser(section: .tutorial))
+        subject.start(with: nil)
+
+        subject.browserHasLoaded()
+
+        XCTAssertNotNil(mockRouter.presentedViewController as? DefaultBrowserOnboardingViewController)
+        XCTAssertEqual(mockRouter.presentCalled, 1)
+    }
+
+    func testSavesRoute_whenBrowserNotLoaded() {
+        let subject = createSubject()
+
+        let coordinator = subject.findAndHandle(route: .defaultBrowser(section: .tutorial))
+
+        XCTAssertNotNil(subject.savedRoute)
+        XCTAssertNil(coordinator)
     }
 
     // MARK: - Helpers

--- a/Tests/ClientTests/Coordinators/SceneCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/SceneCoordinatorTests.swift
@@ -84,6 +84,27 @@ final class SceneCoordinatorTests: XCTestCase {
         XCTAssertNotNil(subject.childCoordinators[0] as? BrowserCoordinator)
     }
 
+    func testHandleRoute_launchNotFinished() {
+        let subject = createSubject()
+        subject.start()
+        let coordinator = subject.findAndHandle(route: .search(url: URL(string: "www.mozilla.com")!,
+                                                               isPrivate: false))
+
+        // laurie - we should store and navigate to when launch is done
+        XCTAssertNil(coordinator)
+    }
+
+    func testHandleRoute_launchFinished() {
+        let subject = createSubject()
+        subject.start()
+        subject.launchBrowser()
+        let coordinator = subject.findAndHandle(route: .search(url: URL(string: "www.mozilla.com")!,
+                                                               isPrivate: false))
+
+        // laurie - we should navigate when BVC is ready
+        XCTAssertNotNil(coordinator)
+    }
+
     // MARK: - Helpers
     private func createSubject(file: StaticString = #file,
                                line: UInt = #line) -> SceneCoordinator {

--- a/Tests/ClientTests/Coordinators/SceneCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/SceneCoordinatorTests.swift
@@ -84,25 +84,40 @@ final class SceneCoordinatorTests: XCTestCase {
         XCTAssertNotNil(subject.childCoordinators[0] as? BrowserCoordinator)
     }
 
-    func testHandleRoute_launchNotFinished() {
+    func testHandleRoute_launchNotFinished_routeSaved() {
         let subject = createSubject()
-        subject.start()
-        let coordinator = subject.findAndHandle(route: .search(url: URL(string: "www.mozilla.com")!,
-                                                               isPrivate: false))
 
-        // laurie - we should store and navigate to when launch is done
+        subject.start()
+        let coordinator = subject.findAndHandle(route: .defaultBrowser(section: .tutorial))
+
         XCTAssertNil(coordinator)
+        XCTAssertNotNil(subject.savedRoute)
     }
 
-    func testHandleRoute_launchFinished() {
+    func testHandleRoute_launchFinishedAndBrowserNotReady_routeSaved() throws {
         let subject = createSubject()
+
         subject.start()
         subject.launchBrowser()
-        let coordinator = subject.findAndHandle(route: .search(url: URL(string: "www.mozilla.com")!,
-                                                               isPrivate: false))
+        let coordinator = subject.findAndHandle(route: .defaultBrowser(section: .tutorial))
 
-        // laurie - we should navigate when BVC is ready
+        XCTAssertNil(coordinator)
+        XCTAssertNotNil(subject.savedRoute)
+        let browserCoordinator = try XCTUnwrap(subject.childCoordinators[0] as? BrowserCoordinator)
+        XCTAssertNotNil(browserCoordinator.savedRoute)
+    }
+
+    func testHandleRoute_launchFinishedAndBrowserReady_routeSavedCalled() throws {
+        let subject = createSubject()
+
+        subject.start()
+        subject.launchBrowser()
+        let browserCoordinator = try XCTUnwrap(subject.childCoordinators[0] as? BrowserCoordinator)
+        browserCoordinator.browserHasLoaded()
+        let coordinator = subject.findAndHandle(route: .defaultBrowser(section: .tutorial))
+
         XCTAssertNotNil(coordinator)
+        XCTAssertNil(subject.savedRoute)
     }
 
     // MARK: - Helpers

--- a/Tests/ClientTests/Mocks/MockCoordinator.swift
+++ b/Tests/ClientTests/Mocks/MockCoordinator.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import UIKit
 @testable import Client
 
@@ -9,12 +10,13 @@ class MockCoordinator: Coordinator {
     var id = UUID()
     var childCoordinators: [Coordinator] = []
     var router: Router
+    var savedRoute: Route?
+    var logger: Logger = MockLogger()
 
     var addChildCalled = 0
     var removedChildCalled = 0
     var handleRouteCalled = 0
     var findRouteCalled = 0
-    var savedFindRoute: Route?
 
     init(router: MockRouter) {
         self.router = router
@@ -36,7 +38,7 @@ class MockCoordinator: Coordinator {
     @discardableResult
     func findAndHandle(route: Route) -> Coordinator? {
         findRouteCalled += 1
-        savedFindRoute = route
+        savedRoute = route
         return nil
     }
 }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6749)

### Description
- Ensure we save the Route when we can't navigate to it with coordinators yet
- Separate `BaseCoordinator` into it's own file
- Add logs to ensure we track down the issue if it's not solved
- Add method to know when browser has loaded, then check to navigate to `Route`
- Add check when we finished Launch (survey, onboarding, update views) to navigate to `Route` when those are done showing
- Logger is now part of the `BaseCoordinator`
- Add unit tests + tested manually as well

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
