### PR TITLE
Bugfix FXIOS-6751 [v116] Handle telemetry that was missing from Route

### DIFF
--- a/Client/Application/SceneDelegate.swift
+++ b/Client/Application/SceneDelegate.swift
@@ -37,10 +37,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var downloadQueue: DownloadQueue = AppContainer.shared.resolve()
 
     var sceneCoordinator: SceneCoordinator?
-
-    var routeBuilder = RouteBuilder(isPrivate: {
-        UserDefaults.standard.bool(forKey: PrefsKeys.LastSessionWasPrivate)
-    })
+    var routeBuilder = RouteBuilder()
 
     // MARK: - Connecting / Disconnecting Scenes
 
@@ -56,23 +53,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard !AppConstants.isRunningUnitTest else { return }
 
         if CoordinatorFlagManager.isCoordinatorEnabled {
+            routeBuilder.configure(isPrivate: UserDefaults.standard.bool(forKey: PrefsKeys.LastSessionWasPrivate),
+                                   prefs: profile.prefs)
+
             sceneCoordinator = SceneCoordinator(scene: scene)
             sceneCoordinator?.start()
 
-            if let context = connectionOptions.urlContexts.first,
-               let route = routeBuilder.makeRoute(url: context.url) {
-                sceneCoordinator?.findAndHandle(route: route)
-            }
-
-            if let activity = connectionOptions.userActivities.first,
-               let route = routeBuilder.makeRoute(userActivity: activity) {
-                sceneCoordinator?.findAndHandle(route: route)
-            }
-
-            if let shortcut = connectionOptions.shortcutItem,
-               let route = routeBuilder.makeRoute(shortcutItem: shortcut, tabSetting: NewTabAccessors.getNewTabPage(profile.prefs)) {
-                sceneCoordinator?.findAndHandle(route: route)
-            }
+            handle(connectionOptions: connectionOptions)
         } else {
             let window = configureWindowFor(scene)
             let rootVC = configureRootViewController()
@@ -246,6 +233,24 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 withBrowserViewController: browserViewController,
                 completionHandler: { _ in }
             )
+        }
+    }
+
+    private func handle(connectionOptions: UIScene.ConnectionOptions) {
+        if let context = connectionOptions.urlContexts.first,
+           let route = routeBuilder.makeRoute(url: context.url) {
+            sceneCoordinator?.findAndHandle(route: route)
+        }
+
+        if let activity = connectionOptions.userActivities.first,
+           let route = routeBuilder.makeRoute(userActivity: activity) {
+            sceneCoordinator?.findAndHandle(route: route)
+        }
+
+        if let shortcut = connectionOptions.shortcutItem,
+           let route = routeBuilder.makeRoute(shortcutItem: shortcut,
+                                              tabSetting: NewTabAccessors.getNewTabPage(profile.prefs)) {
+            sceneCoordinator?.findAndHandle(route: route)
         }
     }
 }

--- a/Extensions/ShareTo/ShareViewController.swift
+++ b/Extensions/ShareTo/ShareViewController.swift
@@ -400,7 +400,7 @@ extension ShareViewController {
         let profile = BrowserProfile(localName: "profile")
         profile.prefs.setBool(true, forKey: PrefsKeys.AppExtensionTelemetryOpenUrl)
 
-       func firefoxUrl(_ url: String) -> String {
+        func firefoxUrl(_ url: String) -> String {
             let encoded = url.addingPercentEncoding(withAllowedCharacters: NSCharacterSet.alphanumerics) ?? ""
             if isSearch {
                 return "firefox://open-text?text=\(encoded)"

--- a/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -22,9 +22,9 @@ final class BrowserCoordinatorTests: XCTestCase {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: AppContainer.shared.resolve())
-        self.routeBuilder = RouteBuilder { false }
         self.mockRouter = MockRouter(navigationController: MockNavigationController())
         self.profile = MockProfile()
+        self.routeBuilder = RouteBuilder()
         self.overlayModeManager = MockOverlayModeManager()
         self.screenshotService = ScreenshotService()
         self.tabManager = MockTabManager()
@@ -678,6 +678,7 @@ final class BrowserCoordinatorTests: XCTestCase {
     private func createSubject(isSettingsCoordinatorEnabled: Bool = false,
                                file: StaticString = #file,
                                line: UInt = #line) -> BrowserCoordinator {
+        routeBuilder.configure(isPrivate: false, prefs: profile.prefs)
         let subject = BrowserCoordinator(router: mockRouter,
                                          screenshotService: screenshotService,
                                          profile: profile,

--- a/Tests/ClientTests/Coordinators/RouteTests.swift
+++ b/Tests/ClientTests/Coordinators/RouteTests.swift
@@ -6,215 +6,313 @@ import XCTest
 @testable import Client
 
 class RouteTests: XCTestCase {
-    var routeBuilder: RouteBuilder!
-
-    override func setUp() {
-        super.setUp()
-        self.routeBuilder = RouteBuilder { false }
-    }
-
-    override func tearDown() {
-        super.tearDown()
-        routeBuilder = nil
-    }
-
     func testSearchRouteWithUrl() {
+        let subject = createSubject()
         let url = URL(string: "http://google.com?a=1&b=2&c=foo%20bar")!
-        let route = routeBuilder.makeRoute(url: url)
+
+        let route = subject.makeRoute(url: url)
+
         XCTAssertEqual(route, .search(url: URL(string: "http://google.com?a=1&b=2&c=foo%20bar")!, isPrivate: false, options: [.focusLocationField]))
     }
 
     func testSearchRouteWithEncodedUrl() {
+        let subject = createSubject()
         let url = URL(string: "firefox://open-url?url=http%3A%2F%2Fgoogle.com%3Fa%3D1%26b%3D2%26c%3Dfoo%2520bar")!
-        let route = routeBuilder.makeRoute(url: url)
+
+        let route = subject.makeRoute(url: url)
+
         XCTAssertEqual(route, .search(url: URL(string: "http://google.com?a=1&b=2&c=foo%20bar"), isPrivate: false))
     }
 
     func testSearchRouteWithPrivateFlag() {
+        let subject = createSubject()
         let url = URL(string: "firefox://open-url?private=true")!
-        let route = routeBuilder.makeRoute(url: url)
+
+        let route = subject.makeRoute(url: url)
+
         XCTAssertEqual(route, .search(url: nil, isPrivate: true))
     }
 
     func testSettingsRouteWithClearPrivateData() {
+        let subject = createSubject()
         let url = URL(string: "firefox://deep-link?url=/settings/clear-private-data")!
-        let route = routeBuilder.makeRoute(url: url)
+
+        let route = subject.makeRoute(url: url)
+
         XCTAssertEqual(route, .settings(section: .clearPrivateData))
     }
 
     func testSettingsRouteWithNewTab() {
+        let subject = createSubject()
         let url = URL(string: "firefox://deep-link?url=/settings/newTab")!
-        let route = routeBuilder.makeRoute(url: url)
+
+        let route = subject.makeRoute(url: url)
+
         XCTAssertEqual(route, .settings(section: .newTab))
     }
 
     func testSettingsRouteWithNewTabTrailingSlash() {
+        let subject = createSubject()
         let url = URL(string: "firefox://deep-link?url=/settings/newTab/")!
-        let route = routeBuilder.makeRoute(url: url)
+
+        let route = subject.makeRoute(url: url)
+
         XCTAssertEqual(route, .settings(section: .newTab))
     }
 
     func testSettingsRouteWithHomePage() {
+        let subject = createSubject()
         let url = URL(string: "firefox://deep-link?url=/settings/homePage")!
-        let route = routeBuilder.makeRoute(url: url)
+
+        let route = subject.makeRoute(url: url)
+
         XCTAssertEqual(route, .settings(section: .homePage))
     }
 
     func testSettingsRouteWithMailto() {
+        let subject = createSubject()
         let url = URL(string: "firefox://deep-link?url=/settings/mailto")!
-        let route = routeBuilder.makeRoute(url: url)
+
+        let route = subject.makeRoute(url: url)
+
         XCTAssertEqual(route, .settings(section: .mailto))
     }
 
     func testSettingsRouteWithSearch() {
+        let subject = createSubject()
         let url = URL(string: "firefox://deep-link?url=/settings/search")!
-        let route = routeBuilder.makeRoute(url: url)
+
+        let route = subject.makeRoute(url: url)
+
         XCTAssertEqual(route, .settings(section: .search))
     }
 
     func testSettingsRouteWithFxa() {
+        let subject = createSubject()
         let url = URL(string: "firefox://deep-link?url=/settings/fxa")!
-        let route = routeBuilder.makeRoute(url: url)
+
+        let route = subject.makeRoute(url: url)
+
         XCTAssertEqual(route, .settings(section: .fxa))
     }
 
     func testHomepanelRouteWithBookmarks() {
+        let subject = createSubject()
         let url = URL(string: "firefox://deep-link?url=/homepanel/bookmarks")!
-        let route = routeBuilder.makeRoute(url: url)
+
+        let route = subject.makeRoute(url: url)
+
         XCTAssertEqual(route, .homepanel(section: .bookmarks))
     }
 
     func testHomepanelRouteWithTopSites() {
+        let subject = createSubject()
         let url = URL(string: "firefox://deep-link?url=/homepanel/top-sites")!
-        let route = routeBuilder.makeRoute(url: url)
+
+        let route = subject.makeRoute(url: url)
+
         XCTAssertEqual(route, .homepanel(section: .topSites))
     }
 
     func testHomepanelRouteWithHistory() {
+        let subject = createSubject()
         let url = URL(string: "firefox://deep-link?url=/homepanel/history")!
-        let route = routeBuilder.makeRoute(url: url)
+
+        let route = subject.makeRoute(url: url)
+
         XCTAssertEqual(route, .homepanel(section: .history))
     }
 
     func testHomepanelRouteWithReadingList() {
+        let subject = createSubject()
         let url = URL(string: "firefox://deep-link?url=/homepanel/reading-list")!
-        let route = routeBuilder.makeRoute(url: url)
+
+        let route = subject.makeRoute(url: url)
+
         XCTAssertEqual(route, .homepanel(section: .readingList))
     }
 
     func testDefaultBrowserRouteWithTutorial() {
+        let subject = createSubject()
         let url = URL(string: "firefox://deep-link?url=/default-browser/tutorial")!
-        let route = routeBuilder.makeRoute(url: url)
+
+        let route = subject.makeRoute(url: url)
+
         XCTAssertEqual(route, .defaultBrowser(section: .tutorial))
     }
 
     func testDefaultBrowserRouteWithSystemSettings() {
+        let subject = createSubject()
         let url = URL(string: "firefox://deep-link?url=/default-browser/system-settings")!
-        let route = routeBuilder.makeRoute(url: url)
+
+        let route = subject.makeRoute(url: url)
+
         XCTAssertEqual(route, .defaultBrowser(section: .systemSettings))
     }
 
     func testInvalidRouteWithBadPath() {
+        let subject = createSubject()
         let url = URL(string: "firefox://deep-link?url=/homepanel/badbad")!
-        let route = routeBuilder.makeRoute(url: url)
+
+        let route = subject.makeRoute(url: url)
+
         XCTAssertNil(route)
     }
 
     func testFxaSignInrouteBuilderRoute() {
+        let subject = createSubject()
         let url = URL(string: "firefox://fxa-signin?signin=coolcodes&user=foo&email=bar")!
-        let route = routeBuilder.makeRoute(url: url)
-        XCTAssertEqual(route, .fxaSignIn(params: FxALaunchParams(entrypoint: .fxaDeepLinkNavigation, query: ["signin": "coolcodes", "user": "foo", "email": "bar"])))
+
+        let route = subject.makeRoute(url: url)
+
+        let expectedQuery = ["signin": "coolcodes", "user": "foo", "email": "bar"]
+        XCTAssertEqual(route, .fxaSignIn(params: FxALaunchParams(entrypoint: .fxaDeepLinkNavigation,
+                                                                 query: expectedQuery)))
     }
 
     func testInvalidScheme() {
+        let subject = createSubject()
         let url = URL(string: "focus://deep-link?url=/settings/newTab")!
-        let route = routeBuilder.makeRoute(url: url)
+
+        let route = subject.makeRoute(url: url)
+
         XCTAssertNil(route)
     }
 
     func testInvalidDeepLink() {
+        let subject = createSubject()
         let url = URL(string: "firefox://deep-links-are-fun?url=/settings/newTab/")!
-        let route = routeBuilder.makeRoute(url: url)
+
+        let route = subject.makeRoute(url: url)
+
         XCTAssertNil(route)
     }
 
     func testWidgetMediumTopSitesOpenUrl() {
+        let subject = createSubject()
         let url = URL(string: "firefox://widget-medium-topsites-open-url?url=https://google.com")!
-        let route = routeBuilder.makeRoute(url: url)
+
+        let route = subject.makeRoute(url: url)
+
         XCTAssertEqual(route, .search(url: URL(string: "https://google.com"), isPrivate: false))
     }
 
     func testWidgetSmallQuicklinkOpenUrlWithPrivateFlag() {
+        let subject = createSubject()
         let url = URL(string: "firefox://widget-small-quicklink-open-url?private=true&url=https://google.com")!
-        let route = routeBuilder.makeRoute(url: url)
+
+        let route = subject.makeRoute(url: url)
+
         XCTAssertEqual(route, .search(url: URL(string: "https://google.com"), isPrivate: true))
     }
 
     func testWidgetMediumQuicklinkOpenUrlWithoutPrivateFlag() {
+        let subject = createSubject()
         let url = URL(string: "firefox://widget-medium-quicklink-open-url?url=https://google.com")!
-        let route = routeBuilder.makeRoute(url: url)
+
+        let route = subject.makeRoute(url: url)
+
         XCTAssertEqual(route, .search(url: URL(string: "https://google.com"), isPrivate: false))
     }
 
     func testWidgetSmallQuicklinkOpenCopied() {
+        let subject = createSubject()
         UIPasteboard.general.string = "test search text"
         let url = URL(string: "firefox://widget-small-quicklink-open-copied")!
-        let route = routeBuilder.makeRoute(url: url)
+
+        let route = subject.makeRoute(url: url)
+
         XCTAssertEqual(route, .searchQuery(query: "test search text"))
     }
 
     func testWidgetSmallQuicklinkOpenCopiedWithUrl() {
+        let subject = createSubject()
         UIPasteboard.general.url = URL(string: "https://google.com")
         let url = URL(string: "firefox://widget-small-quicklink-open-copied")!
-        let route = routeBuilder.makeRoute(url: url)
+
+        let route = subject.makeRoute(url: url)
+
         XCTAssertEqual(route, .search(url: URL(string: "https://google.com"), isPrivate: false))
     }
 
     func testWidgetSmallQuicklinkClosePrivateTabs() {
+        let subject = createSubject()
         let url = URL(string: "firefox://widget-small-quicklink-close-private-tabs")!
-        let route = routeBuilder.makeRoute(url: url)
+
+        let route = subject.makeRoute(url: url)
+
         XCTAssertEqual(route, .action(action: .closePrivateTabs))
     }
 
     func testWidgetMediumQuicklinkClosePrivateTabs() {
+        let subject = createSubject()
         let url = URL(string: "firefox://widget-medium-quicklink-close-private-tabs")!
-        let route = routeBuilder.makeRoute(url: url)
+
+        let route = subject.makeRoute(url: url)
+
         XCTAssertEqual(route, .action(action: .closePrivateTabs))
     }
 
     func testUnsupportedScheme() {
+        let subject = createSubject()
         let url = URL(string: "chrome://example.com")!
-        let route = routeBuilder.makeRoute(url: url)
+
+        let route = subject.makeRoute(url: url)
+
         XCTAssertNil(route)
     }
 
     func testInvalidHost() {
+        let subject = createSubject()
         let url = URL(string: "firefox://")!
-        let route = routeBuilder.makeRoute(url: url)
+
+        let route = subject.makeRoute(url: url)
+
         XCTAssertNil(route)
     }
 
     func testInvalidDeepLinking() {
+        let subject = createSubject()
         let url = URL(string: "firefox://deep-link?url=/invalid-path")!
-        let route = routeBuilder.makeRoute(url: url)
+
+        let route = subject.makeRoute(url: url)
+
         XCTAssertNil(route)
     }
 
     func testInvalidWidgetTabUuid() {
+        let subject = createSubject()
         let url = URL(string: "firefox://widget-tabs-medium-open-url?uuid=invalid")!
-        let route = routeBuilder.makeRoute(url: url)
+
+        let route = subject.makeRoute(url: url)
+
         XCTAssertEqual(route, .search(url: nil, isPrivate: false))
     }
 
     func testInvalidFxaSignIn() {
+        let subject = createSubject()
         let url = URL(string: "firefox://fxa-signin")!
-        let route = routeBuilder.makeRoute(url: url)
+
+        let route = subject.makeRoute(url: url)
+
         XCTAssertNil(route)
     }
 
     func testOpenText() {
+        let subject = createSubject()
         let url = URL(string: "firefox://open-text?text=google")!
-        let route = routeBuilder.makeRoute(url: url)
+
+        let route = subject.makeRoute(url: url)
+
         XCTAssertEqual(route, .searchQuery(query: "google"))
+    }
+
+    // MARK: - Helper
+
+    func createSubject() -> RouteBuilder {
+        let subject = RouteBuilder()
+        subject.configure(isPrivate: false, prefs: MockProfile().prefs)
+        trackForMemoryLeaks(subject)
+        return subject
     }
 }

--- a/Tests/ClientTests/Coordinators/ShortcutRouteTests.swift
+++ b/Tests/ClientTests/Coordinators/ShortcutRouteTests.swift
@@ -6,53 +6,80 @@ import XCTest
 @testable import Client
 
 final class ShortcutRouteTests: XCTestCase {
-    var routeBuilder: RouteBuilder!
-
-    override func setUp() {
-        super.setUp()
-        self.routeBuilder = RouteBuilder { false }
-    }
-
-    override func tearDown() {
-        super.tearDown()
-        routeBuilder = nil
-    }
-
     func testNewTabShortcut() {
-        let shortcutItem = UIApplicationShortcutItem(type: "com.example.app.NewTab", localizedTitle: "New Tab")
-        let route = routeBuilder.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
+        let subject = createSubject()
+        let shortcutItem = UIApplicationShortcutItem(type: "com.example.app.NewTab",
+                                                     localizedTitle: "New Tab")
+
+        let route = subject.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
+
         XCTAssertEqual(route, .search(url: nil, isPrivate: false, options: [.focusLocationField]))
     }
 
     func testNewPrivateTabShortcut() {
-        let shortcutItem = UIApplicationShortcutItem(type: "com.example.app.NewPrivateTab", localizedTitle: "New Private Tab")
-        let route = routeBuilder.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
+        let subject = createSubject()
+        let shortcutItem = UIApplicationShortcutItem(type: "com.example.app.NewPrivateTab",
+                                                     localizedTitle: "New Private Tab")
+
+        let route = subject.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
+
         XCTAssertEqual(route, .search(url: nil, isPrivate: true, options: [.focusLocationField]))
     }
 
     func testOpenLastBookmarkShortcutWithValidUrl() {
+        let subject = createSubject()
         let userInfo = [QuickActionInfos.tabURLKey: "https://www.example.com" as NSSecureCoding]
-        let shortcutItem = UIApplicationShortcutItem(type: "com.example.app.OpenLastBookmark", localizedTitle: "Open Last Bookmark", localizedSubtitle: nil, icon: nil, userInfo: userInfo)
-        let route = routeBuilder.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
-        XCTAssertEqual(route, .search(url: URL(string: "https://www.example.com"), isPrivate: false, options: [.switchToNormalMode]))
+        let shortcutItem = UIApplicationShortcutItem(type: "com.example.app.OpenLastBookmark",
+                                                     localizedTitle: "Open Last Bookmark",
+                                                     localizedSubtitle: nil,
+                                                     icon: nil,
+                                                     userInfo: userInfo)
+
+        let route = subject.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
+
+        XCTAssertEqual(route, .search(url: URL(string: "https://www.example.com"),
+                                      isPrivate: false,
+                                      options: [.switchToNormalMode]))
     }
 
     func testOpenLastBookmarkShortcutWithInvalidUrl() {
+        let subject = createSubject()
         let userInfo = [QuickActionInfos.tabURLKey: "not a url" as NSSecureCoding]
-        let shortcutItem = UIApplicationShortcutItem(type: "com.example.app.OpenLastBookmark", localizedTitle: "Open Last Bookmark", localizedSubtitle: nil, icon: nil, userInfo: userInfo)
-        let route = routeBuilder.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
+        let shortcutItem = UIApplicationShortcutItem(type: "com.example.app.OpenLastBookmark",
+                                                     localizedTitle: "Open Last Bookmark",
+                                                     localizedSubtitle: nil,
+                                                     icon: nil,
+                                                     userInfo: userInfo)
+
+        let route = subject.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
+
         XCTAssertNil(route)
     }
 
     func testQRCodeShortcut() {
-        let shortcutItem = UIApplicationShortcutItem(type: "com.example.app.QRCode", localizedTitle: "QR Code")
-        let route = routeBuilder.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
+        let subject = createSubject()
+        let shortcutItem = UIApplicationShortcutItem(type: "com.example.app.QRCode",
+                                                     localizedTitle: "QR Code")
+        let route = subject.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
         XCTAssertEqual(route, .action(action: .showQRCode))
     }
 
     func testInvalidShortcut() {
-        let shortcutItem = UIApplicationShortcutItem(type: "invalid shortcut", localizedTitle: "Invalid Shortcut")
-        let route = routeBuilder.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
+        let subject = createSubject()
+        let shortcutItem = UIApplicationShortcutItem(type: "invalid shortcut",
+                                                     localizedTitle: "Invalid Shortcut")
+
+        let route = subject.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
+
         XCTAssertNil(route)
+    }
+
+    // MARK: - Helper
+
+    func createSubject() -> RouteBuilder {
+        let subject = RouteBuilder()
+        subject.configure(isPrivate: false, prefs: MockProfile().prefs)
+        trackForMemoryLeaks(subject)
+        return subject
     }
 }

--- a/Tests/ClientTests/Coordinators/UserActivityRouteTests.swift
+++ b/Tests/ClientTests/Coordinators/UserActivityRouteTests.swift
@@ -8,45 +8,54 @@ import CoreSpotlight
 @testable import Client
 
 class UserActivityRouteTests: XCTestCase {
-    var routeBuilder: RouteBuilder!
-
-    override func setUp() {
-        super.setUp()
-        self.routeBuilder = RouteBuilder { false }
-    }
-
-    override func tearDown() {
-        super.tearDown()
-        self.routeBuilder = nil
-    }
-
     // Test the Route initializer with a Siri shortcut user activity.
     func testSiriShortcutUserActivity() {
+        let subject = createSubject()
         let userActivity = NSUserActivity(activityType: SiriShortcuts.activityType.openURL.rawValue)
-        let route = routeBuilder.makeRoute(userActivity: userActivity)
+
+        let route = subject.makeRoute(userActivity: userActivity)
+
         XCTAssertEqual(route, .search(url: nil, isPrivate: false))
     }
 
     // Test the Route initializer with a deep link user activity.
     func testDeepLinkUserActivity() {
+        let subject = createSubject()
         let userActivity = NSUserActivity(activityType: NSUserActivityTypeBrowsingWeb)
         userActivity.webpageURL = URL(string: "https://www.example.com")
-        let route = routeBuilder.makeRoute(userActivity: userActivity)
+
+        let route = subject.makeRoute(userActivity: userActivity)
+
         XCTAssertEqual(route, .search(url: URL(string: "https://www.example.com"), isPrivate: false))
     }
 
     // Test the Route initializer with a CoreSpotlight user activity.
     func testCoreSpotlightUserActivity() {
+        let subject = createSubject()
         let userActivity = NSUserActivity(activityType: CSSearchableItemActionType)
         userActivity.userInfo = [CSSearchableItemActivityIdentifier: "https://www.example.com"]
-        let route = routeBuilder.makeRoute(userActivity: userActivity)
+
+        let route = subject.makeRoute(userActivity: userActivity)
+
         XCTAssertEqual(route, .search(url: URL(string: "https://www.example.com"), isPrivate: false))
     }
 
     // Test the Route initializer with an unsupported user activity.
     func testUnsupportedUserActivity() {
+        let subject = createSubject()
         let userActivity = NSUserActivity(activityType: "unsupported.activity.type")
-        let route = routeBuilder.makeRoute(userActivity: userActivity)
+
+        let route = subject.makeRoute(userActivity: userActivity)
+
         XCTAssertNil(route)
+    }
+
+    // MARK: - Helper
+
+    func createSubject() -> RouteBuilder {
+        let subject = RouteBuilder()
+        subject.configure(isPrivate: false, prefs: MockProfile().prefs)
+        trackForMemoryLeaks(subject)
+        return subject
     }
 }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6751)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15026)

### Description
Realized we weren't handling some telemetry with coordinator in the case of the app extension. This fixes that.
- Pass `prefs` to `RouteBuilder`, change how it's configured
- Add a new `handle(connectionOptions:)` method in scene delegate
- Make sure unit tests use `createSubject` method + indent code
- Fix indentation in `ShareViewController`

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
