### PR TITLE
Refactor FXIOS-6716 [v116] Update Pocket branding on homepage

### DIFF
--- a/Client/Frontend/Home/PocketFooterView.swift
+++ b/Client/Frontend/Home/PocketFooterView.swift
@@ -88,7 +88,7 @@ class PocketFooterView: UICollectionReusableView, ReusableCell, ThemeApplicable 
 
     func applyTheme(theme: Theme) {
         let colors = theme.colors
-        titleLabel.textColor = colors.textSecondary
+        titleLabel.textColor = colors.textPrimary
         learnMoreLabel.textColor = colors.textAccent
     }
 }

--- a/Client/Frontend/Home/PocketFooterView.swift
+++ b/Client/Frontend/Home/PocketFooterView.swift
@@ -11,7 +11,7 @@ class PocketFooterView: UICollectionReusableView, ReusableCell, FeatureFlaggable
         static let mainContainerSpacing: CGFloat = 8
     }
 
-    private let wallpaperManager: WallpaperManager
+    private let wallpaperManager: WallpaperManagerInterface
     var onTapLearnMore: (() -> Void)?
 
     private let pocketImageView: UIImageView = .build { imageView in

--- a/Client/Frontend/Home/PocketFooterView.swift
+++ b/Client/Frontend/Home/PocketFooterView.swift
@@ -20,15 +20,8 @@ class PocketFooterView: UICollectionReusableView, ReusableCell, ThemeApplicable 
     }
 
     private let titleLabel: UILabel = .build { label in
-        label.text = String(format: String.FirefoxHomepage.Pocket.Footer.Title, PocketAppName.shortName.rawValue)
-        label.numberOfLines = 0
-        label.adjustsFontForContentSizeCategory = true
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption1,
-                                                                   size: UX.fontSize)
-    }
-
-    private let subtitleLabel: UILabel = .build { label in
-        label.text = String(format: .FirefoxHomepage.Pocket.Footer.Subtitle,
+        label.text = String(format: .FirefoxHomepage.Pocket.Footer.Title,
+                            PocketAppName.shortName.rawValue,
                             AppName.shortName.rawValue)
         label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
@@ -73,7 +66,7 @@ class PocketFooterView: UICollectionReusableView, ReusableCell, ThemeApplicable 
                                                 action: #selector(didTapLearnMore))
         learnMoreLabel.addGestureRecognizer(tapGesture)
 
-        [titleLabel, subtitleLabel, learnMoreLabel].forEach(labelsContainer.addArrangedSubview)
+        [titleLabel, learnMoreLabel].forEach(labelsContainer.addArrangedSubview)
         [pocketImageView, labelsContainer].forEach(mainContainer.addArrangedSubview)
 
         addSubview(mainContainer)
@@ -96,7 +89,6 @@ class PocketFooterView: UICollectionReusableView, ReusableCell, ThemeApplicable 
     func applyTheme(theme: Theme) {
         let colors = theme.colors
         titleLabel.textColor = colors.textSecondary
-        subtitleLabel.textColor = colors.textSecondary
         learnMoreLabel.textColor = colors.textAccent
     }
 }

--- a/Client/Frontend/Home/PocketFooterView.swift
+++ b/Client/Frontend/Home/PocketFooterView.swift
@@ -5,13 +5,13 @@
 import UIKit
 import Shared
 
-class PocketFooterView: UICollectionReusableView, ReusableCell, FeatureFlaggable, ThemeApplicable {
+class PocketFooterView: UICollectionReusableView, ReusableCell,, ThemeApplicable {
     private struct UX {
         static let fontSize: CGFloat = 12
         static let mainContainerSpacing: CGFloat = 8
     }
 
-    private let wallpaperManager: WallpaperManagerInterface
+    private let wallpaperManager: WallpaperManager
     var onTapLearnMore: (() -> Void)?
 
     private let pocketImageView: UIImageView = .build { imageView in

--- a/Client/Frontend/Home/PocketFooterView.swift
+++ b/Client/Frontend/Home/PocketFooterView.swift
@@ -5,12 +5,13 @@
 import UIKit
 import Shared
 
-class PocketFooterView: UICollectionReusableView, ReusableCell, ThemeApplicable {
+class PocketFooterView: UICollectionReusableView, ReusableCell, FeatureFlaggable, ThemeApplicable {
     private struct UX {
         static let fontSize: CGFloat = 12
         static let mainContainerSpacing: CGFloat = 8
     }
 
+    private let wallpaperManager: WallpaperManager
     var onTapLearnMore: (() -> Void)?
 
     private let pocketImageView: UIImageView = .build { imageView in
@@ -52,6 +53,7 @@ class PocketFooterView: UICollectionReusableView, ReusableCell, ThemeApplicable 
     }
 
     override init(frame: CGRect) {
+        wallpaperManager = WallpaperManager()
         super.init(frame: frame)
         setupViews()
         setupLayout()
@@ -88,7 +90,8 @@ class PocketFooterView: UICollectionReusableView, ReusableCell, ThemeApplicable 
 
     func applyTheme(theme: Theme) {
         let colors = theme.colors
-        titleLabel.textColor = colors.textPrimary
+        titleLabel.textColor = wallpaperManager.featureAvailable ?
+        wallpaperManager.currentWallpaper.textColor : colors.textPrimary
         learnMoreLabel.textColor = colors.textAccent
     }
 }

--- a/Client/Frontend/Home/PocketFooterView.swift
+++ b/Client/Frontend/Home/PocketFooterView.swift
@@ -5,7 +5,7 @@
 import UIKit
 import Shared
 
-class PocketFooterView: UICollectionReusableView, ReusableCell,, ThemeApplicable {
+class PocketFooterView: UICollectionReusableView, ReusableCell, ThemeApplicable {
     private struct UX {
         static let fontSize: CGFloat = 12
         static let mainContainerSpacing: CGFloat = 8

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -600,13 +600,8 @@ extension String {
                 public static let Title = MZLocalizedString(
                     key: "FirefoxHomepage.Pocket.Footer.Title.v115",
                     tableName: "Footer",
-                    value: "Powered by %@.",
-                    comment: "This is the title of the Pocket footer on Firefox Homepage. placeholder will be for App Name")
-                public static let Subtitle = MZLocalizedString(
-                    key: "FirefoxHomepage.Pocket.Footer.Subtitle.v115",
-                    tableName: "Footer",
-                    value: "Part of the %@ family.",
-                    comment: "This is the subtitle of the Pocket footer on Firefox Homepage. The placeholder is the app name.")
+                    value: "Powered by %@. Part of the %@ family.",
+                    comment: "This is the title of the Pocket footer on Firefox Homepage. The first placeholder is for the Pocket app name and the second placeholder for the app name")
                 public static let LearnMore = MZLocalizedString(
                     key: "FirefoxHomepage.Pocket.Footer.LearnMore.v115",
                     tableName: "Footer",

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -598,7 +598,7 @@ extension String {
                 comment: "This string will show under the description on pocket story, indicating that the story is sponsored.")
             public struct Footer {
                 public static let Title = MZLocalizedString(
-                    key: "FirefoxHomepage.Pocket.Footer.Title.v115",
+                    key: "FirefoxHomepage.Pocket.Footer.Title.v116",
                     tableName: "Footer",
                     value: "Powered by %@. Part of the %@ family.",
                     comment: "This is the title of the Pocket footer on Firefox Homepage. The first placeholder is for the Pocket app name and the second placeholder for the app name")


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6716)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15005)

### Description
Delete the subtitle label and move the text on the same line as the title

| iPhone SE  | iPhone 13 | 
| ------------- | ------------- |
| ![iPhone SE](https://github.com/mozilla-mobile/firefox-ios/assets/51127880/9991f0bc-25e2-4782-a502-dfe67a1a3fd0)|![iPhone13](https://github.com/mozilla-mobile/firefox-ios/assets/51127880/987a1bc5-9b31-4735-8a26-a7589b2e664c) |

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
