### PR TITLE
Refactor FXIOS-6643-6646 [v116] AddCredentialViewController and ThemeSettingsController with dequeue reusable cell for indexPath

### DIFF
--- a/Client/Frontend/LoginManagement/AddCredentialViewController.swift
+++ b/Client/Frontend/LoginManagement/AddCredentialViewController.swift
@@ -69,6 +69,7 @@ class AddCredentialViewController: UIViewController, Themeable {
         navigationItem.rightBarButtonItem = saveButton
         navigationItem.leftBarButtonItem = cancelButton
 
+        tableView.register(cellType: LoginDetailTableViewCell.self)
         view.addSubview(tableView)
         NSLayoutConstraint.activate([
             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
@@ -134,9 +135,11 @@ class AddCredentialViewController: UIViewController, Themeable {
 // MARK: - UITableViewDataSource
 extension AddCredentialViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let loginCell = cell(forIndexPath: indexPath)
+        loginCell.selectionStyle = .none
+        loginCell.delegate = self
         switch AddCredentialField(rawValue: indexPath.row)! {
         case .usernameItem:
-            let loginCell = cell(forIndexPath: indexPath)
             let cellModel = LoginDetailTableViewCellModel(
                 title: .LoginDetailUsername,
                 keyboardType: .emailAddress,
@@ -149,7 +152,6 @@ extension AddCredentialViewController: UITableViewDataSource {
             return loginCell
 
         case .passwordItem:
-            let loginCell = cell(forIndexPath: indexPath)
             let cellModel = LoginDetailTableViewCellModel(
                 title: .LoginDetailPassword,
                 displayDescriptionAsPassword: true,
@@ -161,7 +163,6 @@ extension AddCredentialViewController: UITableViewDataSource {
             return loginCell
 
         case .websiteItem:
-            let loginCell = cell(forIndexPath: indexPath)
             let cellModel = LoginDetailTableViewCellModel(
                 title: .LoginDetailWebsite,
                 descriptionPlaceholder: "https://www.example.com",
@@ -176,9 +177,10 @@ extension AddCredentialViewController: UITableViewDataSource {
     }
 
     fileprivate func cell(forIndexPath indexPath: IndexPath) -> LoginDetailTableViewCell {
-        let loginCell = LoginDetailTableViewCell()
-        loginCell.selectionStyle = .none
-        loginCell.delegate = self
+        guard let loginCell = tableView.dequeueReusableCell(withIdentifier: LoginDetailTableViewCell.cellIdentifier, for: indexPath) as? LoginDetailTableViewCell
+        else {
+            return LoginDetailTableViewCell()
+        }
         return loginCell
     }
 

--- a/Client/Frontend/LoginManagement/Cells/LoginListTableViewCell.swift
+++ b/Client/Frontend/LoginManagement/Cells/LoginListTableViewCell.swift
@@ -73,7 +73,6 @@ class LoginListTableViewCell: ThemedTableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
 
-        accessoryType = .disclosureIndicator
         contentView.addSubview(contentStack)
         // Need to override the default background multi-select color to support theming
         multipleSelectionBackgroundView = UIView()
@@ -81,6 +80,7 @@ class LoginListTableViewCell: ThemedTableViewCell {
 
     func configure(inset: UIEdgeInsets) {
         self.inset = inset
+        accessoryType = .disclosureIndicator
         setConstraints()
     }
 

--- a/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
+++ b/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
@@ -43,7 +43,7 @@ class ThemeSettingsController: ThemedTableViewController {
         super.viewDidLoad()
         title = .SettingsDisplayThemeTitle
         tableView.accessibilityIdentifier = "DisplayTheme.Setting.Options"
-
+        tableView.register(cellType: ThemedSubtitleTableViewCell.self)
         tableView.register(ThemedTableSectionHeaderFooterView.self,
                            forHeaderFooterViewReuseIdentifier: ThemedTableSectionHeaderFooterView.cellIdentifier)
 
@@ -173,7 +173,7 @@ class ThemeSettingsController: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = ThemedTableViewCell(style: .subtitle, reuseIdentifier: nil)
+        let cell = dequeueCellFor(indexPath: indexPath)
         cell.selectionStyle = .none
         let section = Section(rawValue: indexPath.section) ?? .automaticBrightness
         switch section {
@@ -239,6 +239,14 @@ class ThemeSettingsController: ThemedTableViewController {
         }
         cell.applyTheme(theme: themeManager.currentTheme)
 
+        return cell
+    }
+
+    override func dequeueCellFor(indexPath: IndexPath) -> ThemedTableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: ThemedSubtitleTableViewCell.cellIdentifier, for: indexPath) as? ThemedSubtitleTableViewCell
+        else {
+            return ThemedSubtitleTableViewCell()
+        }
         return cell
     }
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6643)
[Github issue ThemeSettingsController](https://github.com/mozilla-mobile/firefox-ios/issues/14854)

[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6646)
[Github issue AddCredentialViewController](https://github.com/mozilla-mobile/firefox-ios/issues/14855)

### Description
Refactor `AddCredentialViewController` and `ThemeSettingsController` with dequeue reusable cell for indexPath.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
