### PR TITLE
Bugfix FXIOS-6759 [v115] Fix tab screenshot issue on longpress

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1809,6 +1809,9 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
             if tab !== tabManager.selectedTab, let webView = tab.webView {
                 // To Screenshot a tab that is hidden we must add the webView,
                 // then wait enough time for the webview to render.
+                if CoordinatorFlagManager.isCoordinatorEnabled {
+                    webView.frame = contentContainer.frame
+                }
                 view.insertSubview(webView, at: 0)
                 // This is kind of a hacky fix for Bug 1476637 to prevent webpages from focusing the
                 // touch-screen keyboard from the background even though they shouldn't be able to.


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6759)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15044)

### Description
The web view apparently wasn't getting the right size when coordinators are enabled, which prevented the screenshot to be properly loaded. This fixes that. Put the feature flag to ensure we don't affect the other code path.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
