### PR TITLE
Bugfix MTE-1157 [v116] Update homepage settings menu item

### DIFF
--- a/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -60,7 +60,7 @@ class HomePageSettingsUITests: BaseTestCase {
         XCTAssertEqual("1", recentlyVisited as? String)
         let recommendedByPocket = app.tables.cells.switches["Recommended by Pocket"].value
         XCTAssertEqual("1", recommendedByPocket as? String)
-        let sponsoredStories = app.tables.cells.switches["Sponsored stories"].value
+        let sponsoredStories = app.tables.cells.switches["Thought-Provoking Stories, Articles powered by Pocket"].value
         XCTAssertEqual("1", sponsoredStories as? String)
 
         // Current Homepage


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1157)

### Description
The settings of the homepage has been updated. The formerly "Sponsored Stories" has been renamed to "Thought-Provoking Stories".

The homepage settings from v115:
![Simulator Screenshot - iPhone 14 - 2023-06-19 at 15 59 36](https://github.com/mozilla-mobile/firefox-ios/assets/1740517/be4c6da5-4eaf-44e7-804e-62b2923fb6ce)

The same page from main:
![Simulator Screenshot - iPhone 14 - 2023-06-19 at 15 54 24](https://github.com/mozilla-mobile/firefox-ios/assets/1740517/e4445265-9a81-4264-ad88-5451acdc9bf6)


### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
