### PR TITLE
Refactor FXIOS-6770 [v116] Improve dependency injection - EnhancedTrackingProtectionMenuVM

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -1492,6 +1492,7 @@
 		F8AAC1B429663619000BCDEC /* RustAutofill.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AAC1B329663618000BCDEC /* RustAutofill.swift */; };
 		F8AAC1B7296637CE000BCDEC /* RustAutofillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AAC1B5296637B7000BCDEC /* RustAutofillTests.swift */; };
 		F8B18F5529EE01A2008724A8 /* RustSyncManagerAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B18F5429EE01A1008724A8 /* RustSyncManagerAPITests.swift */; };
+		F98CB66E2A4123F1005F38E9 /* EnhancedTrackingProtectionMenuVMTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F98CB66C2A4123E7005F38E9 /* EnhancedTrackingProtectionMenuVMTests.swift */; };
 		FA6B2AC21D41F02D00429414 /* String+Punycode.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6B2AC11D41F02D00429414 /* String+Punycode.swift */; };
 		FA6B2AC41D41F02D00429414 /* String+Punycode.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6B2AC11D41F02D00429414 /* String+Punycode.swift */; };
 		FA9293D41D6580E100AC8D33 /* QRCodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9293D31D6580E100AC8D33 /* QRCodeViewController.swift */; };
@@ -6637,6 +6638,7 @@
 		F8DB4306B31FC3DC90685A8C /* af */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = af; path = af.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
 		F8EF4290ACE53B2692EA362F /* hr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hr; path = hr.lproj/LoginManager.strings; sourceTree = "<group>"; };
 		F9564CABB325D696ADAB7E2F /* co */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = co; path = co.lproj/ClearPrivateData.strings; sourceTree = "<group>"; };
+		F98CB66C2A4123E7005F38E9 /* EnhancedTrackingProtectionMenuVMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnhancedTrackingProtectionMenuVMTests.swift; sourceTree = "<group>"; };
 		F991462C8BE57AF0DA53AF95 /* zh-TW */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-TW"; path = "zh-TW.lproj/PrivateBrowsing.strings"; sourceTree = "<group>"; };
 		F9F7412B87BA08E6FB185446 /* uz */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uz; path = uz.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		F9F94CED8452BC964CABDEE2 /* sk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sk; path = sk.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
@@ -9715,6 +9717,7 @@
 		E1AEC173286E0CF500062E29 /* Browser */ = {
 			isa = PBXGroup;
 			children = (
+				F98CB66B2A4123B5005F38E9 /* EnhancedTrackingProtection */,
 				8A1E3BE828CBC57E003388C4 /* SearchEngines */,
 				E1AEC174286E0CF500062E29 /* WebView */,
 				8A5BD9582878871B000FE773 /* TopSitesHelperTests.swift */,
@@ -10530,6 +10533,14 @@
 				F8708D291A0970990051AB07 /* ShareViewController.swift */,
 			);
 			path = ShareTo;
+			sourceTree = "<group>";
+		};
+		F98CB66B2A4123B5005F38E9 /* EnhancedTrackingProtection */ = {
+			isa = PBXGroup;
+			children = (
+				F98CB66C2A4123E7005F38E9 /* EnhancedTrackingProtectionMenuVMTests.swift */,
+			);
+			path = EnhancedTrackingProtection;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -12976,6 +12987,7 @@
 				C8501F5128510DA1003B09AB /* WallpaperMigrationUtilityTests.swift in Sources */,
 				5A70EF1D295E3C3500790249 /* TestSetup.swift in Sources */,
 				E1442FDA294782F7003680B0 /* UIPasteboard+Extension.swift in Sources */,
+				F98CB66E2A4123F1005F38E9 /* EnhancedTrackingProtectionMenuVMTests.swift in Sources */,
 				8A2366FA28A302E500846D1B /* MockSponsoredPocketAPI.swift in Sources */,
 				8A8A05E42746ACAC004267A0 /* TabDisplayManagerTests.swift in Sources */,
 				C869916328918C36007ACC5C /* WallpaperNetworkingModuleTests.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -117,8 +117,8 @@ extension BrowserViewController: URLBarDelegate {
                 url: url,
                 displayTitle: tab.displayTitle,
                 connectionSecure: webView.hasOnlySecureContent,
-                contentBlocker: contentBlocker,
-                profile: profile)
+                globalETPIsEnabled: FirefoxTabContentBlocker.isTrackingProtectionEnabled(prefs: profile.prefs),
+                contentBlockerStatus: contentBlocker.status)
             etpViewModel.onOpenSettingsTapped = {
                 if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
                     // Wait to show settings in async dispatch since hamburger menu is still showing at that time

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -109,8 +109,16 @@ extension BrowserViewController: URLBarDelegate {
     }
 
     func urlBarDidTapShield(_ urlBar: URLBarView) {
-        if let tab = self.tabManager.selectedTab {
-            let etpViewModel = EnhancedTrackingProtectionMenuVM(tab: tab, profile: profile)
+        if let tab = self.tabManager.selectedTab,
+            let url = tab.url,
+            let contentBlocker = tab.contentBlocker,
+            let webView = tab.webView {
+            let etpViewModel = EnhancedTrackingProtectionMenuVM(
+                url: url,
+                displayTitle: tab.displayTitle,
+                connectionSecure: webView.hasOnlySecureContent,
+                contentBlocker: contentBlocker,
+                profile: profile)
             etpViewModel.onOpenSettingsTapped = {
                 if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
                     // Wait to show settings in async dispatch since hamburger menu is still showing at that time
@@ -121,6 +129,7 @@ extension BrowserViewController: URLBarDelegate {
                     self.legacyShowSettings(deeplink: .contentBlocker)
                 }
             }
+            etpViewModel.onToggleSiteSafelistStatus = { tab.reload() }
 
             let etpVC = EnhancedTrackingProtectionMenuVC(viewModel: etpViewModel)
             if UIDevice.current.userInterfaceIdiom == .phone {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -109,43 +109,43 @@ extension BrowserViewController: URLBarDelegate {
     }
 
     func urlBarDidTapShield(_ urlBar: URLBarView) {
-        if let tab = self.tabManager.selectedTab,
-            let url = tab.url,
-            let contentBlocker = tab.contentBlocker,
-            let webView = tab.webView {
-            let etpViewModel = EnhancedTrackingProtectionMenuVM(
-                url: url,
-                displayTitle: tab.displayTitle,
-                connectionSecure: webView.hasOnlySecureContent,
-                globalETPIsEnabled: FirefoxTabContentBlocker.isTrackingProtectionEnabled(prefs: profile.prefs),
-                contentBlockerStatus: contentBlocker.status)
-            etpViewModel.onOpenSettingsTapped = {
-                if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
-                    // Wait to show settings in async dispatch since hamburger menu is still showing at that time
-                    DispatchQueue.main.async {
-                        self.navigationHandler?.show(settings: .contentBlocker)
-                    }
-                } else {
-                    self.legacyShowSettings(deeplink: .contentBlocker)
+        guard let tab = self.tabManager.selectedTab,
+              let url = tab.url,
+              let contentBlocker = tab.contentBlocker,
+              let webView = tab.webView else { return }
+
+        let etpViewModel = EnhancedTrackingProtectionMenuVM(
+            url: url,
+            displayTitle: tab.displayTitle,
+            connectionSecure: webView.hasOnlySecureContent,
+            globalETPIsEnabled: FirefoxTabContentBlocker.isTrackingProtectionEnabled(prefs: profile.prefs),
+            contentBlockerStatus: contentBlocker.status)
+        etpViewModel.onOpenSettingsTapped = {
+            if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+                // Wait to show settings in async dispatch since hamburger menu is still showing at that time
+                DispatchQueue.main.async {
+                    self.navigationHandler?.show(settings: .contentBlocker)
                 }
-            }
-            etpViewModel.onToggleSiteSafelistStatus = { tab.reload() }
-
-            let etpVC = EnhancedTrackingProtectionMenuVC(viewModel: etpViewModel)
-            if UIDevice.current.userInterfaceIdiom == .phone {
-                etpVC.modalPresentationStyle = .custom
-                etpVC.transitioningDelegate = self
             } else {
-                etpVC.asPopover = true
-                etpVC.modalPresentationStyle = .popover
-                etpVC.popoverPresentationController?.sourceView = urlBar.locationView.trackingProtectionButton
-                etpVC.popoverPresentationController?.permittedArrowDirections = .up
-                etpVC.popoverPresentationController?.delegate = self
+                self.legacyShowSettings(deeplink: .contentBlocker)
             }
-
-            TelemetryWrapper.recordEvent(category: .action, method: .press, object: .trackingProtectionMenu)
-            self.present(etpVC, animated: true, completion: nil)
         }
+        etpViewModel.onToggleSiteSafelistStatus = { tab.reload() }
+
+        let etpVC = EnhancedTrackingProtectionMenuVC(viewModel: etpViewModel)
+        if UIDevice.current.userInterfaceIdiom == .phone {
+            etpVC.modalPresentationStyle = .custom
+            etpVC.transitioningDelegate = self
+        } else {
+            etpVC.asPopover = true
+            etpVC.modalPresentationStyle = .popover
+            etpVC.popoverPresentationController?.sourceView = urlBar.locationView.trackingProtectionButton
+            etpVC.popoverPresentationController?.permittedArrowDirections = .up
+            etpVC.popoverPresentationController?.delegate = self
+        }
+
+        TelemetryWrapper.recordEvent(category: .action, method: .press, object: .trackingProtectionMenu)
+        self.present(etpVC, animated: true, completion: nil)
     }
 
     // Will be removed with FXIOS-6529

--- a/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVC.swift
+++ b/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVC.swift
@@ -336,10 +336,8 @@ class EnhancedTrackingProtectionMenuVC: UIViewController, Themeable {
     }
 
     private func updateViewDetails() {
-        if let urlString = viewModel.tab.url?.absoluteString {
-            favicon.setFavicon(FaviconImageViewModel(siteURLString: urlString,
-                                                     faviconCornerRadius: ETPMenuUX.UX.faviconCornerRadius))
-        }
+        favicon.setFavicon(FaviconImageViewModel(siteURLString: viewModel.url.absoluteString,
+                                                 faviconCornerRadius: ETPMenuUX.UX.faviconCornerRadius))
 
         siteDomainLabel.text = viewModel.websiteTitle
         connectionLabel.text = viewModel.connectionStatusString

--- a/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVM.swift
+++ b/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVM.swift
@@ -7,17 +7,16 @@ import Storage
 
 class EnhancedTrackingProtectionMenuVM {
     // MARK: - Variables
-    var profile: Profile
     var onOpenSettingsTapped: (() -> Void)?
     var onToggleSiteSafelistStatus: (() -> Void)?
     var heroImage: UIImage?
 
-    ///
-    let contentBlocker: FirefoxTabContentBlocker
+    // MARK: - Constants
+    let contentBlockerStatus: BlockerStatus
     let url: URL
     let displayTitle: String
     let connectionSecure: Bool
-    ///
+    let globalETPIsEnabled: Bool
 
     var websiteTitle: String {
         return url.baseDomain ?? ""
@@ -37,24 +36,24 @@ class EnhancedTrackingProtectionMenuVM {
     }
 
     var isSiteETPEnabled: Bool {
-        switch contentBlocker.status {
+        switch contentBlockerStatus {
         case .noBlockedURLs, .blocking, .disabled: return true
         case .safelisted: return false
         }
     }
 
-    var globalETPIsEnabled: Bool {
-        return FirefoxTabContentBlocker.isTrackingProtectionEnabled(prefs: profile.prefs)
-    }
-
     // MARK: - Initializers
 
-    init(url: URL, displayTitle: String, connectionSecure: Bool, contentBlocker: FirefoxTabContentBlocker, profile: Profile) {
+    init(url: URL,
+         displayTitle: String,
+         connectionSecure: Bool,
+         globalETPIsEnabled: Bool,
+         contentBlockerStatus: BlockerStatus) {
         self.url = url
         self.displayTitle = displayTitle
         self.connectionSecure = connectionSecure
-        self.contentBlocker = contentBlocker
-        self.profile = profile
+        self.globalETPIsEnabled = globalETPIsEnabled
+        self.contentBlockerStatus = contentBlockerStatus
     }
 
     // MARK: - Functions
@@ -70,7 +69,7 @@ class EnhancedTrackingProtectionMenuVM {
 
     func toggleSiteSafelistStatus() {
         TelemetryWrapper.recordEvent(category: .action, method: .add, object: .trackingProtectionSafelist)
-        ContentBlocker.shared.safelist(enable: contentBlocker.status != .safelisted, url: url) { [weak self] in
+        ContentBlocker.shared.safelist(enable: contentBlockerStatus != .safelisted, url: url) { [weak self] in
             self?.onToggleSiteSafelistStatus?()
         }
     }

--- a/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVM.swift
+++ b/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVM.swift
@@ -26,15 +26,6 @@ class EnhancedTrackingProtectionMenuVM {
         return connectionSecure ? .ProtectionStatusSecure : .ProtectionStatusNotSecure
     }
 
-    func getConnectionStatusImage(themeType: ThemeType) -> UIImage {
-        let insecureImageName = themeType.getThemedImageName(name: ImageIdentifiers.lockBlocked)
-        if connectionSecure {
-            return UIImage(imageLiteralResourceName: ImageIdentifiers.lockVerifed).withRenderingMode(.alwaysTemplate)
-        } else {
-            return UIImage(imageLiteralResourceName: insecureImageName)
-        }
-    }
-
     var isSiteETPEnabled: Bool {
         switch contentBlockerStatus {
         case .noBlockedURLs, .blocking, .disabled: return true
@@ -57,6 +48,15 @@ class EnhancedTrackingProtectionMenuVM {
     }
 
     // MARK: - Functions
+
+    func getConnectionStatusImage(themeType: ThemeType) -> UIImage {
+        let insecureImageName = themeType.getThemedImageName(name: ImageIdentifiers.lockBlocked)
+        if connectionSecure {
+            return UIImage(imageLiteralResourceName: ImageIdentifiers.lockVerifed).withRenderingMode(.alwaysTemplate)
+        } else {
+            return UIImage(imageLiteralResourceName: insecureImageName)
+        }
+    }
 
     func getDetailsViewModel() -> EnhancedTrackingProtectionDetailsVM {
         return EnhancedTrackingProtectionDetailsVM(topLevelDomain: websiteTitle,

--- a/Tests/ClientTests/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionMenuVMTests.swift
+++ b/Tests/ClientTests/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionMenuVMTests.swift
@@ -8,56 +8,42 @@ import XCTest
 
 class EnhancedTrackingProtectionMenuVMTests: XCTestCase {
     func test_websiteTitle_whenURLHasBaseDomainDeliversCorrectTitle() {
-        let sut = EnhancedTrackingProtectionMenuVM(
-            url: URL(string: "https://firefox.com")!,
-            displayTitle: "any",
-            connectionSecure: true,
-            globalETPIsEnabled: true,
-            contentBlockerStatus: anyContentBlockerStatus())
+        let sut = makeSUT(url: URL(string: "https://firefox.com")!)
 
         XCTAssertEqual(sut.websiteTitle, "firefox.com")
     }
 
     func test_websiteTitle_whenURLDoesNotHaveBaseDomainDeliversEmptyTitle() {
-        let sut = EnhancedTrackingProtectionMenuVM(
-            url: URL(string: "https://192.168.0.1:8080/path/to/resource")!,
-            displayTitle: "any",
-            connectionSecure: true,
-            globalETPIsEnabled: true,
-            contentBlockerStatus: anyContentBlockerStatus())
+        let sut = makeSUT(url: URL(string: "https://192.168.0.1:8080/path/to/resource")!)
 
         XCTAssertEqual(sut.websiteTitle, "")
     }
 
     func test_connectionStatusString_whenConnectionIsSecureDeliversCorrectStatus() {
-        let sut = EnhancedTrackingProtectionMenuVM(
-            url: anyURL(),
-            displayTitle: "any",
-            connectionSecure: true,
-            globalETPIsEnabled: true,
-            contentBlockerStatus: anyContentBlockerStatus())
+        let sut = makeSUT(connectionSecure: true)
 
         XCTAssertEqual(sut.connectionStatusString, .ProtectionStatusSecure)
     }
 
     func test_connectionStatusString_whenConnectionIsNotSecureDeliversCorrectStatus() {
-        let sut = EnhancedTrackingProtectionMenuVM(
-            url: anyURL(),
-            displayTitle: "any",
-            connectionSecure: false,
-            globalETPIsEnabled: true,
-            contentBlockerStatus: anyContentBlockerStatus())
+        let sut = makeSUT(connectionSecure: false)
 
         XCTAssertEqual(sut.connectionStatusString, .ProtectionStatusNotSecure)
     }
 
     // MARK: Helpers
 
-    private func anyURL() -> URL {
-        URL(string: "https://any-url.com")!
-    }
-
-    private func anyContentBlockerStatus() -> BlockerStatus {
-        .blocking
+    private func makeSUT(
+        url: URL = URL(string: "https://any-url.com")!,
+        displayTitle: String = "any",
+        connectionSecure: Bool = true,
+        globalETPIsEnabled: Bool = true,
+        contentBlockerStatus: BlockerStatus = .blocking) -> EnhancedTrackingProtectionMenuVM {
+        EnhancedTrackingProtectionMenuVM(
+            url: url,
+            displayTitle: displayTitle,
+            connectionSecure: connectionSecure,
+            globalETPIsEnabled: globalETPIsEnabled,
+            contentBlockerStatus: contentBlockerStatus)
     }
 }

--- a/Tests/ClientTests/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionMenuVMTests.swift
+++ b/Tests/ClientTests/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionMenuVMTests.swift
@@ -31,6 +31,30 @@ class EnhancedTrackingProtectionMenuVMTests: XCTestCase {
         XCTAssertEqual(sut.connectionStatusString, .ProtectionStatusNotSecure)
     }
 
+    func test_isSiteETPEnabled_whenStatusIsNoBlockerURLsDeliversCorrectResult() {
+        let sut = makeSUT(contentBlockerStatus: .noBlockedURLs)
+
+        XCTAssertTrue(sut.isSiteETPEnabled)
+    }
+
+    func test_isSiteETPEnabled_whenStatusIsBlockingDeliversCorrectResult() {
+        let sut = makeSUT(contentBlockerStatus: .blocking)
+
+        XCTAssertTrue(sut.isSiteETPEnabled)
+    }
+
+    func test_isSiteETPEnabled_whenStatusIsDisabledDeliversCorrectResult() {
+        let sut = makeSUT(contentBlockerStatus: .disabled)
+
+        XCTAssertTrue(sut.isSiteETPEnabled)
+    }
+
+    func test_isSiteETPEnabled_whenStatusIsSafelistedDeliversCorrectResult() {
+        let sut = makeSUT(contentBlockerStatus: .safelisted)
+
+        XCTAssertFalse(sut.isSiteETPEnabled)
+    }
+
     // MARK: Helpers
 
     private func makeSUT(

--- a/Tests/ClientTests/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionMenuVMTests.swift
+++ b/Tests/ClientTests/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionMenuVMTests.swift
@@ -55,22 +55,6 @@ class EnhancedTrackingProtectionMenuVMTests: XCTestCase {
         XCTAssertFalse(sut.isSiteETPEnabled)
     }
 
-    func test_getConnectionStatusImage_whenConnectionIsSecureDeliversCorrectImage() {
-        let sut = makeSUT(connectionSecure: true)
-
-        let image = sut.getConnectionStatusImage(themeType: .light)
-
-        XCTAssertEqual(image.accessibilityIdentifier, "lock_verified")
-    }
-
-    func test_getConnectionStatusImage_whenConnectionIsNotSecureDeliversCorrectImage() {
-        let sut = makeSUT(connectionSecure: false)
-
-        let image = sut.getConnectionStatusImage(themeType: .light)
-
-        XCTAssertEqual(image.accessibilityIdentifier, "lock_blocked")
-    }
-
     func test_getDetailsViewModel_deliversCorrectResult() {
         let sut = makeSUT(url: URL(string: "https://firefox.com")!,
                           displayTitle: "Firefox",

--- a/Tests/ClientTests/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionMenuVMTests.swift
+++ b/Tests/ClientTests/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionMenuVMTests.swift
@@ -55,6 +55,22 @@ class EnhancedTrackingProtectionMenuVMTests: XCTestCase {
         XCTAssertFalse(sut.isSiteETPEnabled)
     }
 
+    func test_getConnectionStatusImage_whenConnectionIsSecureDeliversCorrectImage() {
+        let sut = makeSUT(connectionSecure: true)
+
+        let image = sut.getConnectionStatusImage(themeType: .light)
+
+        XCTAssertEqual(image.accessibilityIdentifier, "lock_verified")
+    }
+
+    func test_getConnectionStatusImage_whenConnectionIsNotSecureDeliversCorrectImage() {
+        let sut = makeSUT(connectionSecure: false)
+
+        let image = sut.getConnectionStatusImage(themeType: .light)
+
+        XCTAssertEqual(image.accessibilityIdentifier, "lock_blocked")
+    }
+
     // MARK: Helpers
 
     private func makeSUT(

--- a/Tests/ClientTests/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionMenuVMTests.swift
+++ b/Tests/ClientTests/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionMenuVMTests.swift
@@ -7,6 +7,28 @@ import XCTest
 @testable import Client
 
 class EnhancedTrackingProtectionMenuVMTests: XCTestCase {
+    func test_websiteTitle_whenURLHasBaseDomainDeliversCorrectTitle() {
+        let sut = EnhancedTrackingProtectionMenuVM(
+            url: URL(string: "https://firefox.com")!,
+            displayTitle: "any",
+            connectionSecure: true,
+            globalETPIsEnabled: true,
+            contentBlockerStatus: anyContentBlockerStatus())
+
+        XCTAssertEqual(sut.websiteTitle, "firefox.com")
+    }
+
+    func test_websiteTitle_whenURLDoesNotHaveBaseDomainDeliversEmptyTitle() {
+        let sut = EnhancedTrackingProtectionMenuVM(
+            url: URL(string: "https://192.168.0.1:8080/path/to/resource")!,
+            displayTitle: "any",
+            connectionSecure: true,
+            globalETPIsEnabled: true,
+            contentBlockerStatus: anyContentBlockerStatus())
+
+        XCTAssertEqual(sut.websiteTitle, "")
+    }
+
     func test_connectionStatusString_whenConnectionIsSecureDeliversCorrectStatus() {
         let sut = EnhancedTrackingProtectionMenuVM(
             url: anyURL(),

--- a/Tests/ClientTests/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionMenuVMTests.swift
+++ b/Tests/ClientTests/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionMenuVMTests.swift
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import XCTest
+@testable import Client
+
+class EnhancedTrackingProtectionMenuVMTests: XCTestCase {
+    func test_connectionStatusString_whenConnectionIsSecureDeliversCorrectStatus() {
+        let sut = EnhancedTrackingProtectionMenuVM(
+            url: anyURL(),
+            displayTitle: "any",
+            connectionSecure: true,
+            globalETPIsEnabled: true,
+            contentBlockerStatus: anyContentBlockerStatus())
+
+        XCTAssertEqual(sut.connectionStatusString, .ProtectionStatusSecure)
+    }
+
+    func test_connectionStatusString_whenConnectionIsNotSecureDeliversCorrectStatus() {
+        let sut = EnhancedTrackingProtectionMenuVM(
+            url: anyURL(),
+            displayTitle: "any",
+            connectionSecure: false,
+            globalETPIsEnabled: true,
+            contentBlockerStatus: anyContentBlockerStatus())
+
+        XCTAssertEqual(sut.connectionStatusString, .ProtectionStatusNotSecure)
+    }
+
+    // MARK: Helpers
+
+    private func anyURL() -> URL {
+        URL(string: "https://any-url.com")!
+    }
+
+    private func anyContentBlockerStatus() -> BlockerStatus {
+        .blocking
+    }
+}

--- a/Tests/ClientTests/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionMenuVMTests.swift
+++ b/Tests/ClientTests/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionMenuVMTests.swift
@@ -71,6 +71,20 @@ class EnhancedTrackingProtectionMenuVMTests: XCTestCase {
         XCTAssertEqual(image.accessibilityIdentifier, "lock_blocked")
     }
 
+    func test_getDetailsViewModel_deliversCorrectResult() {
+        let sut = makeSUT(url: URL(string: "https://firefox.com")!,
+                          displayTitle: "Firefox",
+                          connectionSecure: true)
+
+        let detailsVM = sut.getDetailsViewModel()
+
+        XCTAssertEqual(detailsVM.topLevelDomain, "firefox.com")
+        XCTAssertEqual(detailsVM.title, "Firefox")
+        XCTAssertEqual(detailsVM.URL, "https://firefox.com")
+        XCTAssertEqual(detailsVM.connectionStatusMessage, .ProtectionStatusSecure)
+        XCTAssertTrue(detailsVM.connectionSecure)
+    }
+
     // MARK: Helpers
 
     private func makeSUT(


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6770)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15069)

### Description
- Decouple the `Tab` dependency from EnhancedTrackingProtectionMenuVM and inject the URL, displayTitle and BlockerStatus instead.
- Decouple the `Profile` dependency and inject only the boolean that we need for `globalETPIsEnabled`. 
- Create new closure `onToggleSiteSafelistStatus` to be called inside the function `toggleSiteSafelistStatus`, that way this class doesn't need to reload the `Tab` and delegates back to BrowserViewController.
- Create unit tests for EnhancedTrackingProtectionMenuVM. 

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
