### PR TITLE
Add FXIOS-6717 [v116] integrate redux in theming settings - Part 1

### DIFF
--- a/.experimenter.yaml
+++ b/.experimenter.yaml
@@ -145,6 +145,14 @@ onboarding-framework-feature:
     dismissable:
       type: boolean
       description: "Whether or not the entire onboarding is dismissable by pressing an X at the top right corner of the screen.\n"
+redux-integration-feature:
+  description: "This feature is for managing the roll out of the Redux integration feature\n"
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "Enables the feature\n"
 rust-sync-manager-component:
   description: The feature that controls whether we use the rust sync manager
   hasExposure: true

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -92,6 +92,10 @@
 		2165B2C42860CB34004C0786 /* MockAdjustTelemetryData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2165B2C32860CB34004C0786 /* MockAdjustTelemetryData.swift */; };
 		2165B2CC28748CD7004C0786 /* LibraryPanelDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2165B2CB28748CD7004C0786 /* LibraryPanelDescriptor.swift */; };
 		216A0D712A40D0FB008077BA /* ReduxFlagManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216A0D702A40D0FB008077BA /* ReduxFlagManager.swift */; };
+		216A0D742A40DD45008077BA /* MainState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216A0D732A40DD45008077BA /* MainState.swift */; };
+		216A0D762A40E7AB008077BA /* Redux in Frameworks */ = {isa = PBXBuildFile; productRef = 216A0D752A40E7AB008077BA /* Redux */; };
+		216A0D792A40E85A008077BA /* ThemeSettingsState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216A0D782A40E85A008077BA /* ThemeSettingsState.swift */; };
+		216A0D7B2A40F08B008077BA /* ThemeSettingsAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216A0D7A2A40F08B008077BA /* ThemeSettingsAction.swift */; };
 		216C133E29DCA8FF0097533B /* TabLayoutDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216C133D29DCA8FF0097533B /* TabLayoutDelegate.swift */; };
 		2173326829CCDA8E007F20C7 /* TabScrollControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2173326629CCD259007F20C7 /* TabScrollControllerTests.swift */; };
 		2173326A29CCF901007F20C7 /* UIPanGestureRecognizerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2173326929CCF901007F20C7 /* UIPanGestureRecognizerMock.swift */; };
@@ -2127,6 +2131,9 @@
 		2165B2C32860CB34004C0786 /* MockAdjustTelemetryData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAdjustTelemetryData.swift; sourceTree = "<group>"; };
 		2165B2CB28748CD7004C0786 /* LibraryPanelDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryPanelDescriptor.swift; sourceTree = "<group>"; };
 		216A0D702A40D0FB008077BA /* ReduxFlagManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReduxFlagManager.swift; sourceTree = "<group>"; };
+		216A0D732A40DD45008077BA /* MainState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainState.swift; sourceTree = "<group>"; };
+		216A0D782A40E85A008077BA /* ThemeSettingsState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeSettingsState.swift; sourceTree = "<group>"; };
+		216A0D7A2A40F08B008077BA /* ThemeSettingsAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeSettingsAction.swift; sourceTree = "<group>"; };
 		216C133D29DCA8FF0097533B /* TabLayoutDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabLayoutDelegate.swift; sourceTree = "<group>"; };
 		2173326629CCD259007F20C7 /* TabScrollControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabScrollControllerTests.swift; sourceTree = "<group>"; };
 		2173326929CCF901007F20C7 /* UIPanGestureRecognizerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIPanGestureRecognizerMock.swift; sourceTree = "<group>"; };
@@ -6781,6 +6788,7 @@
 				435C85F02788F4D00072B526 /* Glean in Frameworks */,
 				433F87CE2788EAB600693368 /* GCDWebServers in Frameworks */,
 				5A06135A29D6052E008F3D38 /* TabDataStore in Frameworks */,
+				216A0D762A40E7AB008077BA /* Redux in Frameworks */,
 				7B8A47F61D01D3B400C07734 /* PassKit.framework in Frameworks */,
 				5A8FD0EC293A7D5E00333AA7 /* SnapKit in Frameworks */,
 			);
@@ -7005,9 +7013,28 @@
 		216A0D6F2A40D0E4008077BA /* Redux */ = {
 			isa = PBXGroup;
 			children = (
+				216A0D722A40DD34008077BA /* State */,
 				216A0D702A40D0FB008077BA /* ReduxFlagManager.swift */,
 			);
 			path = Redux;
+			sourceTree = "<group>";
+		};
+		216A0D722A40DD34008077BA /* State */ = {
+			isa = PBXGroup;
+			children = (
+				216A0D732A40DD45008077BA /* MainState.swift */,
+			);
+			path = State;
+			sourceTree = "<group>";
+		};
+		216A0D772A40E83F008077BA /* ThemeSettings */ = {
+			isa = PBXGroup;
+			children = (
+				EB9A178D20E525DF00B12184 /* ThemeSettingsController.swift */,
+				216A0D782A40E85A008077BA /* ThemeSettingsState.swift */,
+				216A0D7A2A40F08B008077BA /* ThemeSettingsAction.swift */,
+			);
+			path = ThemeSettings;
 			sourceTree = "<group>";
 		};
 		216E9A3829D2119300ABE69B /* InactiveTabs */ = {
@@ -7245,6 +7272,7 @@
 		2F44FC551A9E83E200FD20CC /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				216A0D772A40E83F008077BA /* ThemeSettings */,
 				8A3EF7ED2A2FCEC900796E3A /* Main */,
 				EBB895322193FFF400EB91A0 /* ContentBlockerSettingViewController.swift */,
 				7B4980A71CE363ED0017547C /* Settings.xcassets */,
@@ -11021,6 +11049,7 @@
 				5A70EF0D295DFCCF00790249 /* Common */,
 				5A37861829A2C337006B3A34 /* Sentry */,
 				5A06135929D6052E008F3D38 /* TabDataStore */,
+				216A0D752A40E7AB008077BA /* Redux */,
 			);
 			productName = Client;
 			productReference = F84B21BE1A090F8100AAB793 /* Client.app */;
@@ -12413,6 +12442,7 @@
 				D0B9483D22A18B78002F4AA1 /* TextFieldTableViewCell.swift in Sources */,
 				8AF99B4F29EF1BA700108DEC /* BrowserDelegate.swift in Sources */,
 				C87D8B802818333F00A6307D /* NimbusManager.swift in Sources */,
+				216A0D742A40DD45008077BA /* MainState.swift in Sources */,
 				8A4AC0EB28C929D700439F83 /* URLSessionDataTaskProtocol.swift in Sources */,
 				C45F44691D087DB600CB7EF0 /* TopTabsViewController.swift in Sources */,
 				8ADC2A212A3399DC00543DAA /* YourRightsSetting.swift in Sources */,
@@ -12598,6 +12628,7 @@
 				964FA97528A1A8F20024BB3B /* ContextualHintEligibilityUtility.swift in Sources */,
 				439C489C29760575007C3DCD /* CreditCardValidator.swift in Sources */,
 				8ADC2A122A3375B900543DAA /* FxAEntryPoint.swift in Sources */,
+				216A0D7B2A40F08B008077BA /* ThemeSettingsAction.swift in Sources */,
 				8A3EF8012A2FCFC900796E3A /* FasterInactiveTabs.swift in Sources */,
 				CA7FC7D324A6A9B70012F347 /* LoginListDataSourceHelper.swift in Sources */,
 				43AB6FA425DC53D30016B015 /* LabelButtonHeaderView.swift in Sources */,
@@ -12691,6 +12722,7 @@
 				E47616C71AB74CA600E7DD25 /* ReaderModeBarView.swift in Sources */,
 				D821E90E2141B71C00452C55 /* SiriSettingsViewController.swift in Sources */,
 				EBB89507219398E500EB91A0 /* ContentBlocker.swift in Sources */,
+				216A0D792A40E85A008077BA /* ThemeSettingsState.swift in Sources */,
 				5A3A2A0D287F742C00B79EAC /* BackgroundSyncUtility.swift in Sources */,
 				23ED80FF25C89C9800D0E9D5 /* DefaultBrowserOnboardingViewController.swift in Sources */,
 				8A3EF80D2A2FD04D00796E3A /* ResetWallpaperOnboardingPage.swift in Sources */,
@@ -19096,6 +19128,10 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 1BDA1F8327113788006B2FAB /* XCRemoteSwiftPackageReference "SwiftyJSON" */;
 			productName = SwiftyJSON;
+		};
+		216A0D752A40E7AB008077BA /* Redux */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Redux;
 		};
 		432BD0232790EBD000A0F3C3 /* Adjust */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		2165B2C22860C2F4004C0786 /* AdjustTelemetryHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2165B2C12860C2F4004C0786 /* AdjustTelemetryHelper.swift */; };
 		2165B2C42860CB34004C0786 /* MockAdjustTelemetryData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2165B2C32860CB34004C0786 /* MockAdjustTelemetryData.swift */; };
 		2165B2CC28748CD7004C0786 /* LibraryPanelDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2165B2CB28748CD7004C0786 /* LibraryPanelDescriptor.swift */; };
+		216A0D712A40D0FB008077BA /* ReduxFlagManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216A0D702A40D0FB008077BA /* ReduxFlagManager.swift */; };
 		216C133E29DCA8FF0097533B /* TabLayoutDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216C133D29DCA8FF0097533B /* TabLayoutDelegate.swift */; };
 		2173326829CCDA8E007F20C7 /* TabScrollControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2173326629CCD259007F20C7 /* TabScrollControllerTests.swift */; };
 		2173326A29CCF901007F20C7 /* UIPanGestureRecognizerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2173326929CCF901007F20C7 /* UIPanGestureRecognizerMock.swift */; };
@@ -2125,6 +2126,7 @@
 		2165B2C12860C2F4004C0786 /* AdjustTelemetryHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdjustTelemetryHelper.swift; sourceTree = "<group>"; };
 		2165B2C32860CB34004C0786 /* MockAdjustTelemetryData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAdjustTelemetryData.swift; sourceTree = "<group>"; };
 		2165B2CB28748CD7004C0786 /* LibraryPanelDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryPanelDescriptor.swift; sourceTree = "<group>"; };
+		216A0D702A40D0FB008077BA /* ReduxFlagManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReduxFlagManager.swift; sourceTree = "<group>"; };
 		216C133D29DCA8FF0097533B /* TabLayoutDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabLayoutDelegate.swift; sourceTree = "<group>"; };
 		2173326629CCD259007F20C7 /* TabScrollControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabScrollControllerTests.swift; sourceTree = "<group>"; };
 		2173326929CCF901007F20C7 /* UIPanGestureRecognizerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIPanGestureRecognizerMock.swift; sourceTree = "<group>"; };
@@ -7000,6 +7002,14 @@
 			path = Downloads;
 			sourceTree = "<group>";
 		};
+		216A0D6F2A40D0E4008077BA /* Redux */ = {
+			isa = PBXGroup;
+			children = (
+				216A0D702A40D0FB008077BA /* ReduxFlagManager.swift */,
+			);
+			path = Redux;
+			sourceTree = "<group>";
+		};
 		216E9A3829D2119300ABE69B /* InactiveTabs */ = {
 			isa = PBXGroup;
 			children = (
@@ -10294,6 +10304,7 @@
 		F84B21C01A090F8100AAB793 /* Client */ = {
 			isa = PBXGroup;
 			children = (
+				216A0D6F2A40D0E4008077BA /* Redux */,
 				8A93F85C29D36D9F004159D9 /* Coordinators */,
 				8A590C6228C13E1D0032F1AA /* TabManagement */,
 				F84B21E41A0910F600AAB793 /* Application */,
@@ -12754,6 +12765,7 @@
 				D3FEC38D1AC4B42F00494F45 /* AutocompleteTextField.swift in Sources */,
 				8A19ACAE2A329058001C2147 /* LoginsSetting.swift in Sources */,
 				8A5D1CB92A30DBDB005AD35C /* ChinaSyncServiceSetting.swift in Sources */,
+				216A0D712A40D0FB008077BA /* ReduxFlagManager.swift in Sources */,
 				C849E46526B9C3DD00260F0B /* SlideoverPresentationController.swift in Sources */,
 				D5D0532E2645B3A700759F85 /* ExperimentsTableView.swift in Sources */,
 				8A832A9029DC96C50025D5DD /* LaunchScreenView.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		215B458027D7FD7D00E5E800 /* LegacyTabGroupData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215B457E27D7FD4B00E5E800 /* LegacyTabGroupData.swift */; };
 		215B458227DA420400E5E800 /* LegacyTabMetadataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215B458127DA420400E5E800 /* LegacyTabMetadataManager.swift */; };
 		215B458427DA87FC00E5E800 /* TabMetadataManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215B458327DA87FC00E5E800 /* TabMetadataManagerTests.swift */; };
+		21618A612A4201E500A5189E /* ThemeSettingsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21618A602A4201E500A5189E /* ThemeSettingsController.swift */; };
 		2165B2C02860BB41004C0786 /* AdjustTelemetryHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2165B2BF2860BB41004C0786 /* AdjustTelemetryHelperTests.swift */; };
 		2165B2C22860C2F4004C0786 /* AdjustTelemetryHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2165B2C12860C2F4004C0786 /* AdjustTelemetryHelper.swift */; };
 		2165B2C42860CB34004C0786 /* MockAdjustTelemetryData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2165B2C32860CB34004C0786 /* MockAdjustTelemetryData.swift */; };
@@ -1431,7 +1432,6 @@
 		EB94075320850C9F00702E05 /* photon-colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C49854D206173C800893DAE /* photon-colors.swift */; };
 		EB9854FF2422686F0040F24B /* AppDelegate+PushNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9854FD2422686F0040F24B /* AppDelegate+PushNotifications.swift */; };
 		EB98550124226EF70040F24B /* AppDelegate+SyncSentTabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB98550024226EF60040F24B /* AppDelegate+SyncSentTabs.swift */; };
-		EB9A178E20E525DF00B12184 /* ThemeSettingsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9A178D20E525DF00B12184 /* ThemeSettingsController.swift */; };
 		EB9A179B20E69A7F00B12184 /* LegacyThemeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9A179820E69A7E00B12184 /* LegacyThemeManager.swift */; };
 		EB9A179C20E69A7F00B12184 /* LegacyDarkTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9A179920E69A7E00B12184 /* LegacyDarkTheme.swift */; };
 		EB9A179D20E69A7F00B12184 /* LegacyTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9A179A20E69A7E00B12184 /* LegacyTheme.swift */; };
@@ -2126,6 +2126,7 @@
 		215B457E27D7FD4B00E5E800 /* LegacyTabGroupData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyTabGroupData.swift; sourceTree = "<group>"; };
 		215B458127DA420400E5E800 /* LegacyTabMetadataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyTabMetadataManager.swift; sourceTree = "<group>"; };
 		215B458327DA87FC00E5E800 /* TabMetadataManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabMetadataManagerTests.swift; sourceTree = "<group>"; };
+		21618A602A4201E500A5189E /* ThemeSettingsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeSettingsController.swift; sourceTree = "<group>"; };
 		2165B2BF2860BB41004C0786 /* AdjustTelemetryHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdjustTelemetryHelperTests.swift; sourceTree = "<group>"; };
 		2165B2C12860C2F4004C0786 /* AdjustTelemetryHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdjustTelemetryHelper.swift; sourceTree = "<group>"; };
 		2165B2C32860CB34004C0786 /* MockAdjustTelemetryData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAdjustTelemetryData.swift; sourceTree = "<group>"; };
@@ -6512,7 +6513,6 @@
 		EB940747208134AF00702E05 /* UXConstants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UXConstants.swift; sourceTree = "<group>"; };
 		EB9854FD2422686F0040F24B /* AppDelegate+PushNotifications.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppDelegate+PushNotifications.swift"; sourceTree = "<group>"; };
 		EB98550024226EF60040F24B /* AppDelegate+SyncSentTabs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppDelegate+SyncSentTabs.swift"; sourceTree = "<group>"; };
-		EB9A178D20E525DF00B12184 /* ThemeSettingsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeSettingsController.swift; sourceTree = "<group>"; };
 		EB9A179820E69A7E00B12184 /* LegacyThemeManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyThemeManager.swift; sourceTree = "<group>"; };
 		EB9A179920E69A7E00B12184 /* LegacyDarkTheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyDarkTheme.swift; sourceTree = "<group>"; };
 		EB9A179A20E69A7E00B12184 /* LegacyTheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyTheme.swift; sourceTree = "<group>"; };
@@ -7030,7 +7030,7 @@
 		216A0D772A40E83F008077BA /* ThemeSettings */ = {
 			isa = PBXGroup;
 			children = (
-				EB9A178D20E525DF00B12184 /* ThemeSettingsController.swift */,
+				21618A602A4201E500A5189E /* ThemeSettingsController.swift */,
 				216A0D782A40E85A008077BA /* ThemeSettingsState.swift */,
 				216A0D7A2A40F08B008077BA /* ThemeSettingsAction.swift */,
 			);
@@ -7294,7 +7294,6 @@
 				D821E9052141B71C00452C55 /* SiriSettingsViewController.swift */,
 				CEFA977D1FAA6B490016F365 /* SyncContentSettingsViewController.swift */,
 				8AE1E1CE27B191160024C45E /* SearchBar */,
-				EB9A178D20E525DF00B12184 /* ThemeSettingsController.swift */,
 				C22753422A3CA25100B9C0D1 /* WebsiteDataManagement */,
 			);
 			path = Settings;
@@ -12776,6 +12775,7 @@
 				8A5D1CAA2A30D6E2005AD35C /* TabsSetting.swift in Sources */,
 				210E0EB8298D9D4500BB4F33 /* DefaultSearchEngineProvider.swift in Sources */,
 				8AE80BBA2891C0C300BC12EA /* JumpBackInSectionLayout.swift in Sources */,
+				21618A612A4201E500A5189E /* ThemeSettingsController.swift in Sources */,
 				21357F2D293FDB60004BF9FD /* RemoteTabsErrorDataSource.swift in Sources */,
 				D34DC8531A16C40C00D49B7B /* Profile.swift in Sources */,
 				DFACDFAA274D489B00A94EEC /* HistoryHighlightsViewModel.swift in Sources */,
@@ -12880,7 +12880,6 @@
 				C8B0F5F5283B7CCE007AE65D /* PocketSponsoredStory.swift in Sources */,
 				8AB8571F27D931B40075C173 /* EmptyTopSiteCell.swift in Sources */,
 				CAC458F1249429C20042561A /* LoginListSelectionHelper.swift in Sources */,
-				EB9A178E20E525DF00B12184 /* ThemeSettingsController.swift in Sources */,
 				C8656D75270F834600E199EA /* FlaggableFeatureOptions.swift in Sources */,
 				C8CD80D82A1E31C20097C3AE /* NimbusOnboardingTestingConfigUtility.swift in Sources */,
 				8AB8573727D951640075C173 /* HomeLogoHeaderViewModel.swift in Sources */,

--- a/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -30,6 +30,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case pocket
     case pullToRefresh
     case recentlySaved
+    case reduxIntegration
     case reportSiteIssue
     case searchHighlights
     case settingsCoordinatorRefactor
@@ -108,6 +109,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .notificationSettings,
                 .onboardingUpgrade,
                 .onboardingFreshInstall,
+                .reduxIntegration,
                 .reportSiteIssue,
                 .searchHighlights,
                 .settingsCoordinatorRefactor,

--- a/Client/Frontend/Settings/ThemeSettings/ThemeSettingsAction.swift
+++ b/Client/Frontend/Settings/ThemeSettings/ThemeSettingsAction.swift
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Redux
+
+enum ThemeSettingsAction: Action {
+    case enableSystemAppearance(Bool)
+    case toggleSwitchMode(SwitchMode)
+    case brightnessValueChanged(Float)
+    case updateUserBrightnessThreshold(Float)
+}

--- a/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
+++ b/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
@@ -47,7 +47,10 @@ class ThemeSettingsController: ThemedTableViewController {
         tableView.register(ThemedTableSectionHeaderFooterView.self,
                            forHeaderFooterViewReuseIdentifier: ThemedTableSectionHeaderFooterView.cellIdentifier)
 
-        NotificationCenter.default.addObserver(self, selector: #selector(brightnessChanged), name: UIScreen.brightnessDidChangeNotification, object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(brightnessChanged),
+                                               name: UIScreen.brightnessDidChangeNotification,
+                                               object: nil)
     }
 
     @objc

--- a/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
+++ b/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
@@ -1,0 +1,50 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Redux
+
+enum ThemePicker: Equatable {
+    case light
+    case dark
+}
+
+enum SwitchMode: Equatable {
+    case manual(ThemePicker)
+    case automatic(Float)
+}
+
+struct ThemeSettingsState: Equatable {
+    // Use system Light/Dark mode
+    var useSystemAppearance: Bool
+    var switchMode: SwitchMode
+    var systemBrightnessValue: Float
+    var userBrightnessThreshold: Float
+
+    static let reducer: Reducer<Self> = { state, action in
+        guard let action = action as? ThemeSettingsAction else { return state }
+
+        switch action {
+        case .enableSystemAppearance(let isEnabled):
+            return ThemeSettingsState(useSystemAppearance: isEnabled,
+                                      switchMode: state.switchMode,
+                                      systemBrightnessValue: state.systemBrightnessValue,
+                                      userBrightnessThreshold: state.userBrightnessThreshold)
+        case .toggleSwitchMode(let switchMode):
+            return ThemeSettingsState(useSystemAppearance: state.useSystemAppearance,
+                                      switchMode: switchMode,
+                                      systemBrightnessValue: state.systemBrightnessValue,
+                                      userBrightnessThreshold: state.userBrightnessThreshold)
+        case .brightnessValueChanged(let systemValue):
+            return ThemeSettingsState(useSystemAppearance: state.useSystemAppearance,
+                                      switchMode: state.switchMode,
+                                      systemBrightnessValue: systemValue,
+                                      userBrightnessThreshold: state.userBrightnessThreshold)
+        case .updateUserBrightnessThreshold(let userValue):
+            return ThemeSettingsState(useSystemAppearance: state.useSystemAppearance,
+                                      switchMode: state.switchMode,
+                                      systemBrightnessValue: state.systemBrightnessValue,
+                                      userBrightnessThreshold: userValue)
+        }
+    }
+}

--- a/Client/Frontend/Settings/ThemeSettingsController.swift
+++ b/Client/Frontend/Settings/ThemeSettingsController.swift
@@ -31,8 +31,6 @@ class ThemeSettingsController: ThemedTableViewController {
         return LegacyThemeManager.instance.systemThemeIsOn
     }
 
-    private var shouldHideSystemThemeSection = false
-
     init() {
         super.init(style: .grouped)
     }
@@ -89,28 +87,21 @@ class ThemeSettingsController: ThemedTableViewController {
         let label: UILabel = .build { label in
             label.text = .DisplayThemeSectionFooter
             label.numberOfLines = 0
-            label.font = UIFont.systemFont(ofSize: UX.footerFontSize)
+            label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .footnote,
+                                                                       size: UX.footerFontSize)
             label.textColor = self.themeManager.currentTheme.colors.textSecondary
         }
         footer.addSubview(label)
         NSLayoutConstraint.activate([
             label.topAnchor.constraint(equalTo: footer.topAnchor, constant: 4),
-            label.leadingAnchor.constraint(equalTo: footer.leadingAnchor, constant: 16),
-            label.trailingAnchor.constraint(equalTo: footer.trailingAnchor, constant: -16),
+            label.leadingAnchor.constraint(equalTo: footer.leadingAnchor, constant: UX.sliderLeftRightInset),
+            label.trailingAnchor.constraint(equalTo: footer.trailingAnchor, constant: -UX.sliderLeftRightInset),
         ])
         return footer
     }
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        guard section == Section.systemTheme.rawValue else {
-            return UITableView.automaticDimension
-        }
-
-        if shouldHideSystemThemeSection {
-            return CGFloat.leastNonzeroMagnitude
-        } else {
-            return UITableView.automaticDimension
-        }
+        return UITableView.automaticDimension
     }
 
     override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
@@ -134,7 +125,11 @@ class ThemeSettingsController: ThemedTableViewController {
         } else if LegacyThemeManager.instance.automaticBrightnessIsOn {
             LegacyThemeManager.instance.updateCurrentThemeBasedOnScreenBrightness()
         }
-        TelemetryWrapper.recordEvent(category: .action, method: .press, object: .setting, value: .systemThemeSwitch, extras: ["to": control.isOn])
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .press,
+                                     object: .setting,
+                                     value: .systemThemeSwitch,
+                                     extras: ["to": control.isOn])
 
         // Switch animation must begin prior to scheduling table view update animation
         // (or the switch will be auto-synchronized to the slower tableview animation
@@ -166,8 +161,8 @@ class ThemeSettingsController: ThemedTableViewController {
         parent.addSubview(slider)
 
         NSLayoutConstraint.activate([
-            slider.topAnchor.constraint(equalTo: parent.topAnchor),
-            slider.bottomAnchor.constraint(equalTo: parent.bottomAnchor),
+            slider.topAnchor.constraint(equalTo: parent.topAnchor, constant: 4),
+            slider.bottomAnchor.constraint(equalTo: parent.bottomAnchor, constant: -4),
             slider.leadingAnchor.constraint(equalTo: parent.leadingAnchor, constant: UX.sliderLeftRightInset),
             slider.trailingAnchor.constraint(equalTo: parent.trailingAnchor, constant: -UX.sliderLeftRightInset),
         ])
@@ -245,11 +240,7 @@ class ThemeSettingsController: ThemedTableViewController {
     }
 
     override func numberOfSections(in tableView: UITableView) -> Int {
-        if shouldHideSystemThemeSection {
-            return 3
-        } else {
-            return isSystemThemeOn ? 1 : 3
-        }
+        return isSystemThemeOn ? 1 : 3
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/Client/Frontend/Theme/ThemedTableSectionHeaderFooterView.swift
+++ b/Client/Frontend/Theme/ThemedTableSectionHeaderFooterView.swift
@@ -46,7 +46,7 @@ class ThemedTableSectionHeaderFooterView: UITableViewHeaderFooterView, ReusableC
         label.numberOfLines = 0
     }
 
-    fileprivate lazy var bordersHelper = ThemedHeaderFooterViewBordersHelper()
+    private lazy var bordersHelper = ThemedHeaderFooterViewBordersHelper()
     private var titleTopConstraint: NSLayoutConstraint!
     private var titleBottomConstraint: NSLayoutConstraint!
 

--- a/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -61,6 +61,9 @@ final class NimbusFeatureFlagLayer {
                 .onboardingFreshInstall:
             return checkNimbusForOnboardingFeature(for: featureID, from: nimbus)
 
+        case .reduxIntegration:
+            return checkReduxIntegrationFeature(from: nimbus)
+
         case .shareSheetChanges,
                 .shareToolbarChanges:
             return checkNimbusForShareSheet(for: featureID, from: nimbus)
@@ -192,6 +195,7 @@ final class NimbusFeatureFlagLayer {
         let config = nimbus.features.settingsCoordinatorRefactor.value()
         return config.enabled
     }
+
     private func checkEtpCoordinatorRefactorFeature(from nimbus: FxNimbus) -> Bool {
         let config = nimbus.features.etpCoordinatorRefactor.value()
         return config.enabled
@@ -220,6 +224,11 @@ final class NimbusFeatureFlagLayer {
     private func checkSponsoredTilesFeature(from nimbus: FxNimbus) -> Bool {
         let config = nimbus.features.homescreenFeature.value()
         return config.sponsoredTiles.status
+    }
+
+    private func checkReduxIntegrationFeature(from nimbus: FxNimbus) -> Bool {
+        let config = nimbus.features.reduxIntegrationFeature.value()
+        return config.enabled
     }
 
     private func checkTabStorageRefactorFeature(from nimbus: FxNimbus) -> Bool {

--- a/Client/Redux/ReduxFlagManager.swift
+++ b/Client/Redux/ReduxFlagManager.swift
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// This is a temporary struct made to manage the feature flag for convenience
+struct ReduxFlagManager {
+    static var isReduxEnabled: Bool {
+        return LegacyFeatureFlagsManager.shared.isFeatureEnabled(.tabStorageRefactor,
+                                                                 checking: .buildOnly)
+    }
+}

--- a/Client/Redux/ReduxFlagManager.swift
+++ b/Client/Redux/ReduxFlagManager.swift
@@ -7,7 +7,7 @@ import Foundation
 /// This is a temporary struct made to manage the feature flag for convenience
 struct ReduxFlagManager {
     static var isReduxEnabled: Bool {
-        return LegacyFeatureFlagsManager.shared.isFeatureEnabled(.tabStorageRefactor,
+        return LegacyFeatureFlagsManager.shared.isFeatureEnabled(.reduxIntegration,
                                                                  checking: .buildOnly)
     }
 }

--- a/Client/Redux/State/MainState.swift
+++ b/Client/Redux/State/MainState.swift
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Redux
+
+struct MainState: StateType {
+    var themeSettings: ThemeSettingsState
+
+    static let reducer: Reducer<Self> = { state, action in
+        MainState(
+            themeSettings: ThemeSettingsState.reducer(state.themeSettings, action)
+        )
+    }
+}

--- a/nimbus-features/reduxIntegrationFeature.yaml
+++ b/nimbus-features/reduxIntegrationFeature.yaml
@@ -1,0 +1,18 @@
+# The configuration for the tabStorageRefactorFeature feature
+features:
+  redux-integration-feature:
+    description: >
+      This feature is for managing the roll out of the Redux integration feature
+    variables:
+      enabled:
+        description: >
+          Enables the feature
+        type: Boolean
+        default: false
+    defaults:
+      - channel: beta
+        value:
+          enabled: false
+      - channel: developer
+        value:
+          enabled: true

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -26,6 +26,7 @@ include:
   - nimbus-features/notificationSettingsFeature.yaml
   - nimbus-features/onboardingFeature.yaml
   - nimbus-features/onboardingFrameworkFeature.yaml
+  - nimbus-features/reduxIntegrationFeature.yaml
   - nimbus-features/rustSyncManagerFeature.yaml
   - nimbus-features/searchFeature.yaml
   - nimbus-features/searchTermGroupsFeature.yaml


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6717)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15006)

### Description
Breaking down into two PRs before it gets more challenging to review, this first part includes:
- ThemeSettingsController clean up ex: Add missing dynamic text in the footer, remove an unused flag 
- Add Redux integration feature flag (unused ATM)
- Create a `MainState` app and reducer 
- Create `ThemeSettingsState`, `ThemeSettingsAction` and reducer

Next step: 
- Use feature flag
- Create a store and subscribe ThemeSettingsController to receive newState
- Dispatch actions to the store
- Analyze how to handle theme changes probably through Middleware so create ThemeMiddleware

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
