### PR TITLE
Refactor FXIOS-6484 [v116] support showing settings subpage when settings already exists

### DIFF
--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -320,11 +320,12 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
     private func handle(settingsSection: Route.SettingsSection) {
         // Temporary bugfix for #14954, real fix is with settings coordinator
         if let subNavigationController = router.navigationController.presentedViewController as? ThemedNavigationController,
-           let settings = subNavigationController.viewControllers.first as? AppSettingsTableViewController,
-           let deeplinkTo = settingsSection.getSettingsRoute() {
+           let settings = subNavigationController.viewControllers.first as? AppSettingsTableViewController {
             // Showing settings already, pass the deeplink down
-            settings.deeplinkTo = deeplinkTo
-            settings.checkForDeeplinkSetting()
+            if let deeplinkTo = settingsSection.getSettingsRoute() {
+                settings.deeplinkTo = deeplinkTo
+                settings.checkForDeeplinkSetting()
+            }
             return
         }
 

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -171,11 +171,11 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
         case let .settings(section):
             // 'Else' case will be removed with FXIOS-6529
             if isSettingsCoordinatorEnabled {
-                showSettings(with: section)
+                return handleSettings(with: section)
             } else {
                 handle(settingsSection: section)
+                return true
             }
-            return true
 
         case let .action(routeAction):
             switch routeAction {
@@ -254,7 +254,11 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
         browserViewController.presentSignInViewController(fxaParams)
     }
 
-    private func showSettings(with section: Route.SettingsSection) {
+    private func handleSettings(with section: Route.SettingsSection) -> Bool {
+        guard !childCoordinators.contains(where: { $0 is SettingsCoordinator}) else {
+            return false // route is handled with existing child coordinator
+        }
+
         let navigationController = ThemedNavigationController()
         navigationController.modalPresentationStyle = .formSheet
         let settingsRouter = DefaultRouter(navigationController: navigationController)
@@ -267,6 +271,7 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
         router.present(navigationController) { [weak self] in
             self?.didFinishSettings(from: settingsCoordinator)
         }
+        return true
     }
 
     private func showLibrary(with homepanelSection: Route.HomepanelSection) {
@@ -304,7 +309,7 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
     // MARK: - BrowserNavigationHandler
 
     func show(settings: Route.SettingsSection) {
-        showSettings(with: settings)
+        _ = handleSettings(with: settings)
     }
 
     func show(homepanelSection: Route.HomepanelSection) {
@@ -313,6 +318,16 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
 
     // MARK: - To be removed with FXIOS-6529
     private func handle(settingsSection: Route.SettingsSection) {
+        // Temporary bugfix for #14954, real fix is with settings coordinator
+        if let subNavigationController = router.navigationController.presentedViewController as? ThemedNavigationController,
+           let settings = subNavigationController.viewControllers.first as? AppSettingsTableViewController,
+           let deeplinkTo = settingsSection.getSettingsRoute() {
+            // Showing settings already, pass the deeplink down
+            settings.deeplinkTo = deeplinkTo
+            settings.checkForDeeplinkSetting()
+            return
+        }
+
         let baseSettingsVC = AppSettingsTableViewController(
             with: profile,
             and: tabManager,

--- a/Client/Coordinators/Router/Route.swift
+++ b/Client/Coordinators/Router/Route.swift
@@ -93,6 +93,28 @@ enum Route: Equatable {
         case toolbar
         case topSites
         case wallpaper
+
+        // Will be clean up with FXIOS-6529
+        func getSettingsRoute() -> AppSettingsDeeplinkOption? {
+            switch self {
+            case .contentBlocker:
+                return .contentBlocker
+            case .homePage:
+                return .customizeHomepage
+            case .tabs:
+                return .customizeTabs
+            case .toolbar:
+                return .customizeToolbar
+            case .topSites:
+                return .customizeTopSites
+            case .wallpaper:
+                return .wallpaper
+            case .creditCard:
+                return .creditCard
+            default:
+                return nil // not all cases supported for AppSettingsDeeplinkOption
+            }
+        }
     }
 
     /// An enumeration representing different actions that can be performed within the application.

--- a/Client/Coordinators/Router/Route.swift
+++ b/Client/Coordinators/Router/Route.swift
@@ -111,8 +111,16 @@ enum Route: Equatable {
                 return .wallpaper
             case .creditCard:
                 return .creditCard
-            default:
-                return nil // not all cases supported for AppSettingsDeeplinkOption
+            case .fxa:
+                return .fxa
+            case .mailto:
+                return .mailto
+            case .newTab:
+                return .newTab
+            case .search:
+                return .search
+            case .clearPrivateData, .general, .theme:
+                return nil // not handling those since not needed to temporary fix #14954
             }
         }
     }

--- a/Client/Coordinators/SettingsCoordinator.swift
+++ b/Client/Coordinators/SettingsCoordinator.swift
@@ -47,6 +47,16 @@ class SettingsCoordinator: BaseCoordinator, SettingsDelegate, SettingsFlowDelega
         }
     }
 
+    override func handle(route: Route) -> Bool {
+        switch route {
+        case let .settings(section):
+            start(with: section)
+            return true
+        default:
+            return false
+        }
+    }
+
     private func getSettingsViewController(settingsSection section: Route.SettingsSection) -> UIViewController? {
         switch section {
         case .newTab:

--- a/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -15,6 +15,10 @@ enum AppSettingsDeeplinkOption {
     case customizeTopSites
     case wallpaper
     case creditCard
+    case fxa
+    case mailto
+    case newTab
+    case search
 
     func getSettingsRoute() -> Route.SettingsSection {
         switch self {
@@ -32,6 +36,14 @@ enum AppSettingsDeeplinkOption {
             return .wallpaper
         case .creditCard:
             return .creditCard
+        case .fxa:
+            return .fxa
+        case .mailto:
+            return .mailto
+        case .newTab:
+            return .newTab
+        case .search:
+            return .search
         }
     }
 }
@@ -198,6 +210,27 @@ class AppSettingsTableViewController: SettingsTableViewController, AppSettingsSc
             return
         case .customizeTopSites:
             viewController = TopSitesSettingsViewController()
+        case .fxa:
+            let fxaParams = FxALaunchParams(entrypoint: .fxaDeepLinkSetting, query: [:])
+            let viewController = FirefoxAccountSignInViewController.getSignInOrFxASettingsVC(
+                fxaParams,
+                flowType: .emailLoginFlow,
+                referringPage: .settings,
+                profile: profile
+            )
+            navigationController?.pushViewController(viewController, animated: true)
+            return
+        case .mailto:
+            let viewController = OpenWithSettingsViewController(prefs: profile.prefs)
+            navigationController?.pushViewController(viewController, animated: true)
+            return
+        case .newTab:
+            viewController = NewTabContentSettingsViewController(prefs: profile.prefs)
+            viewController.profile = profile
+        case .search:
+            let viewController = SearchSettingsTableViewController(profile: profile)
+            navigationController?.pushViewController(viewController, animated: true)
+            return
         }
 
         viewController.profile = profile

--- a/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -144,7 +144,7 @@ class AppSettingsTableViewController: SettingsTableViewController, AppSettingsSc
     }
 
     // Will be removed with FXIOS-6529
-    private func checkForDeeplinkSetting() {
+    func checkForDeeplinkSetting() {
         guard let deeplink = deeplinkTo else { return }
         var viewController: SettingsTableViewController
 

--- a/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -548,6 +548,19 @@ final class BrowserCoordinatorTests: XCTestCase {
         XCTAssertNotNil(subject.childCoordinators[0] as? SettingsCoordinator)
     }
 
+    func testSettingsRoute_addSettingsCoordinatorOnlyOnce() {
+        let subject = createSubject(isSettingsCoordinatorEnabled: true)
+        subject.browserHasLoaded()
+
+        let result1 = subject.handle(route: .settings(section: .general))
+        let result2 = subject.handle(route: .settings(section: .general))
+
+        XCTAssertTrue(result1)
+        XCTAssertEqual(subject.childCoordinators.count, 1)
+        XCTAssertNotNil(subject.childCoordinators[0] as? SettingsCoordinator)
+        XCTAssertFalse(result2)
+    }
+
     func testPresentedCompletion_callsDidFinishSettings_removesChild() {
         let subject = createSubject(isSettingsCoordinatorEnabled: true)
         subject.browserHasLoaded()

--- a/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
@@ -243,6 +243,23 @@ final class SettingsCoordinatorTests: XCTestCase {
         XCTAssertEqual(delegate.didFinishSettingsCalled, 1)
     }
 
+    // MARK: - Handle route
+    func testHandleRouteSettings_generalIsHandled() {
+        let subject = createSubject()
+
+        let result = subject.handle(route: .settings(section: .general))
+
+        XCTAssertTrue(result)
+    }
+
+    func testHandleRouteOther_notHandled() {
+        let subject = createSubject()
+
+        let result = subject.handle(route: .homepanel(section: .downloads))
+
+        XCTAssertFalse(result)
+    }
+
     // MARK: - Helper
     func createSubject() -> SettingsCoordinator {
         let subject = SettingsCoordinator(router: mockRouter,


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6484)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14572)

### Description
Support navigating to sub-page of the settings when the settings is already showing. There is two use case to handle since settings coordinator aren't released yet. Since we'll remove shortly the code path without settings coordinator, the solution is a less elegant. This is also explained that without coordinators, this is use cases harder to support. This will fix https://github.com/mozilla-mobile/firefox-ios/issues/14954 as long as coordinators are used.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
