### PR TITLE
Refactor FXIOS-6718 [v116] Use new theming system for base alpha stack view

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -222,11 +222,6 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
         LegacyThemeManager.instance.statusBarStyle
     }
 
-    @objc
-    func displayThemeChanged(notification: Notification) {
-        applyTheme()
-    }
-
     /// If user manually opens the keyboard and presses undo, the app switches to the last
     /// open tab, and because of that we need to leave overlay state
     @objc
@@ -472,6 +467,13 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
         overlayManager.setURLBar(urlBarView: urlBar)
 
         browserDelegate?.browserHasLoaded()
+
+        // Update theme of already existing views
+        let theme = themeManager.currentTheme
+        header.applyTheme(theme: theme)
+        overKeyboardContainer.applyTheme(theme: theme)
+        bottomContainer.applyTheme(theme: theme)
+        bottomContentStackView.applyTheme(theme: theme)
     }
 
     private func setupAccessibleActions() {
@@ -522,11 +524,6 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
             self,
             selector: #selector(appMenuBadgeUpdate),
             name: .FirefoxAccountStateChange,
-            object: nil)
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(displayThemeChanged),
-            name: .DisplayThemeChanged,
             object: nil)
         NotificationCenter.default.addObserver(
             self,

--- a/Client/Frontend/Components/BaseContentStackView.swift
+++ b/Client/Frontend/Components/BaseContentStackView.swift
@@ -4,19 +4,18 @@
 
 import Foundation
 import SnapKit
+import Shared
 
 protocol AlphaDimmable {
     func updateAlphaForSubviews(_ alpha: CGFloat)
 }
 
-class BaseAlphaStackView: UIStackView, AlphaDimmable {
+class BaseAlphaStackView: UIStackView, AlphaDimmable, ThemeApplicable {
     var isClearBackground = false
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        applyTheme()
         setupStyle()
-        setupObservers()
     }
 
     required init(coder: NSCoder) {
@@ -86,25 +85,8 @@ class BaseAlphaStackView: UIStackView, AlphaDimmable {
         self.layoutIfNeeded()
     }
 
-    // MARK: - LegacyNotificationThemeable
-
-    private func setupObservers() {
-        NotificationCenter.default.addObserver(self, selector: #selector(handleNotifications), name: .DisplayThemeChanged, object: nil)
-    }
-
-    @objc
-    private func handleNotifications(_ notification: Notification) {
-        switch notification.name {
-        case .DisplayThemeChanged:
-            applyTheme()
-        default: break
-        }
-    }
-}
-
-extension BaseAlphaStackView: LegacyNotificationThemeable {
-    func applyTheme() {
-        let color = isClearBackground ? .clear : UIColor.legacyTheme.browser.background
+    func applyTheme(theme: Theme) {
+        let color = isClearBackground ? .clear : theme.colors.layer1
         backgroundColor = color
         keyboardSpacer?.backgroundColor = color
         insetSpacer?.backgroundColor = color

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -179,6 +179,9 @@ class HistoryPanel: UIViewController,
         setupLayout()
         configureDataSource()
         applyTheme()
+
+        // Update theme of already existing view
+        bottomStackView.applyTheme(theme: themeManager.currentTheme)
     }
 
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6718)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15007)

### Description
- Use new theming system for base alpha stack view
- Since we create this view on init of the view controllers, we set the theme when the view has loaded
- Remove `displayThemeChanged` from BVC since it's now listening to theme change from the new theming system (through the `Themeable` protocol).

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
