### PR TITLE
Bugfix FXIOS-6709 [v116] Search group items theming

### DIFF
--- a/Client/Frontend/Library/HistoryPanel/GeneralizedTableView/SearchGroupedItemsViewModel.swift
+++ b/Client/Frontend/Library/HistoryPanel/GeneralizedTableView/SearchGroupedItemsViewModel.swift
@@ -2,8 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-/// Although it's bare bones now, we should keep this in place for when we generalize this VM and VC later.
-
 import Foundation
 import Storage
 
@@ -13,14 +11,11 @@ class SearchGroupedItemsViewModel {
     var asGroup: ASGroup<Site>
     var presenter: Presenter
 
-    /// There are two entry points into this VC. We will track the presenters without Coordinators for now.
+    /// There are two entry points into this VC
     enum Presenter {
         case historyPanel
         case recentlyVisited
     }
-
-    // UI
-    let notifications = [Notification.Name.DisplayThemeChanged]
 
     // MARK: - Inits
 
@@ -28,9 +23,4 @@ class SearchGroupedItemsViewModel {
         self.asGroup = asGroup
         self.presenter = presenter
     }
-
-    // MARK: - Lifecycles
-
-    // MARK: - Misc helpers
-
 }

--- a/Client/Frontend/Theme/LegacyThemeManager/LegacyDarkTheme.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/LegacyDarkTheme.swift
@@ -10,7 +10,6 @@ private class DarkBrowserColor: BrowserColor {
 
 private class DarkTableViewColor: TableViewColor {
     override var rowBackground: UIColor { return UIColor.Photon.Grey70 } // layer2
-    override var headerTextDark: UIColor { return UIColor.Photon.Grey30 }
     override var selectedBackground: UIColor { return UIColor.Custom.selectedHighlightDark }
     override var rowText: UIColor { return UIColor.Photon.Grey10 } // textPrimary
     override var disabledRowText: UIColor { return UIColor.Photon.Grey40 } // textDisabled
@@ -30,7 +29,6 @@ class LegacyDarkTheme: LegacyNormalTheme {
     override var tableView: TableViewColor { return DarkTableViewColor() }
     override var browser: BrowserColor { return DarkBrowserColor() }
     override var tabTray: TabTrayColor { return DarkTabTrayColor() }
-    override var topTabs: TopTabsColor { return TopTabsColor() }
     override var homePanel: HomePanelColor { return DarkHomePanelColor() }
     override var snackbar: SnackBarColor { return SnackBarColor() }
 }

--- a/Client/Frontend/Theme/LegacyThemeManager/LegacyDarkTheme.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/LegacyDarkTheme.swift
@@ -22,7 +22,6 @@ private class DarkTabTrayColor: TabTrayColor {
 }
 
 private class DarkHomePanelColor: HomePanelColor {
-    override var panelBackground: UIColor { return UIColor.Photon.Grey80 }
     override var activityStreamHeaderText: UIColor { return UIColor.Photon.LightGrey05 }
 }
 

--- a/Client/Frontend/Theme/LegacyThemeManager/LegacyTheme.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/LegacyTheme.swift
@@ -26,7 +26,6 @@ enum BuiltinThemeName: String {
 
 class TableViewColor {
     var rowBackground: UIColor { return UIColor.Photon.White100 } // layer5
-    var headerTextDark: UIColor { return UIColor.Photon.Grey90 }
     var selectedBackground: UIColor { return UIColor.Custom.selectedHighlightLight } // layer5Hover
     var rowText: UIColor { return UIColor.Photon.Grey90 } // textPrimary
     var disabledRowText: UIColor { return UIColor.Photon.Grey40 } // textDisabled
@@ -41,22 +40,6 @@ class TabTrayColor {
     var tabTitleBlur: UIBlurEffect.Style { return UIBlurEffect.Style.extraLight }
 }
 
-class TopTabsColor {
-    var tabBackgroundSelected: UIColor { return UIColor.Photon.Grey10 }
-    var tabBackgroundUnselected: UIColor { return UIColor.Photon.Grey80 }
-    var tabForegroundSelected: UIColor { return UIColor.Photon.Grey90 }
-    var tabForegroundUnselected: UIColor { return UIColor.Photon.Grey40 }
-    func tabSelectedIndicatorBar(_ isPrivate: Bool) -> UIColor {
-        return !isPrivate ? UIColor.Photon.Blue40 : UIColor.Photon.Purple60
-    }
-    var buttonTint: UIColor { return UIColor.Photon.Grey80 }
-    var privateModeButtonOffTint: UIColor { return buttonTint }
-    var privateModeButtonOnTint: UIColor { return UIColor.Photon.Grey10 }
-    var closeButtonSelectedTab: UIColor { return tabBackgroundUnselected }
-    var closeButtonUnselectedTab: UIColor { return tabBackgroundSelected }
-    var separator: UIColor { return UIColor.Photon.Grey70 }
-}
-
 class HomePanelColor {
     var activityStreamHeaderText: UIColor { return UIColor.Photon.DarkGrey90 }
 }
@@ -68,21 +51,9 @@ class SnackBarColor {
     var title: UIColor { return UIColor.Photon.Blue40 }
 }
 
-class OnboardingColor {
-    var backgroundColor: UIColor { return UIColor.white }
-    var etpBackgroundColor: UIColor { return UIColor.white }
-    var etpTextColor: UIColor { return UIColor.black }
-    var etpButtonColor: UIColor { return UIColor.Photon.Blue50 }
-}
-
-class RemoteTabTrayColor {
-    var background: UIColor { return UIColor.white }
-}
-
 protocol LegacyTheme {
     var name: String { get }
     var tableView: TableViewColor { get }
-    var topTabs: TopTabsColor { get }
     var browser: BrowserColor { get }
     var tabTray: TabTrayColor { get }
     var homePanel: HomePanelColor { get }
@@ -94,7 +65,6 @@ class LegacyNormalTheme: LegacyTheme {
     var tableView: TableViewColor { return TableViewColor() }
     var browser: BrowserColor { return BrowserColor() }
     var tabTray: TabTrayColor { return TabTrayColor() }
-    var topTabs: TopTabsColor { return TopTabsColor() }
     var homePanel: HomePanelColor { return HomePanelColor() }
     var snackbar: SnackBarColor { return SnackBarColor() }
 }

--- a/Client/Frontend/Theme/LegacyThemeManager/LegacyTheme.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/LegacyTheme.swift
@@ -58,7 +58,6 @@ class TopTabsColor {
 }
 
 class HomePanelColor {
-    var panelBackground: UIColor { return UIColor.Photon.White100 }
     var activityStreamHeaderText: UIColor { return UIColor.Photon.DarkGrey90 }
 }
 

--- a/Client/Frontend/Widgets/SiteTableViewHeader.swift
+++ b/Client/Frontend/Widgets/SiteTableViewHeader.swift
@@ -23,7 +23,6 @@ class SiteTableViewHeader: UITableViewHeaderFooterView, ThemeApplicable, Reusabl
     var collapsibleState: ExpandButtonState?
 
     private let titleLabel: UILabel = .build { label in
-        label.textColor = UIColor.legacyTheme.tableView.headerTextDark
         label.numberOfLines = 0
         label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .headline,
                                                                    size: 16)


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6709)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14979)

### Description
- Fix search group items theming
- Clean up unused legacy colors, 
- Could remove `label.textColor = UIColor.legacyTheme.tableView.headerTextDark` in `SiteTableViewHeader` since the color is already properly set through the new theming system with `ThemeApplicable`. Was forgotten it seems when work was done in that area.

#### Dark mode
![Simulator Screenshot - iPhone 14 - 2023-06-20 at 14 29 33](https://github.com/mozilla-mobile/firefox-ios/assets/11338480/a66ee3db-a417-4a17-a1fc-f90cef29cf8f)

#### Light mode
![Simulator Screenshot - iPhone 14 - 2023-06-20 at 14 29 47](https://github.com/mozilla-mobile/firefox-ios/assets/11338480/2553bc61-3c32-4cac-9e00-417d7126cd94)

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
