### PR TITLE
Bugfix MTE-1120 [v116] Sync Integration Test test_sync_history_from_device

### DIFF
--- a/SyncIntegrationTests/test_history.js
+++ b/SyncIntegrationTests/test_history.js
@@ -15,8 +15,7 @@ var phases = { "phase1": "profile1" };
 var historyExpected = [
     { uri: "http://www.example.com/",
       visits: [
-        { type: 1 },
-        { type: 2 }
+        { type: 1 }
       ]
     }
 ];

--- a/Tests/XCUITests/IntegrationTests.swift
+++ b/Tests/XCUITests/IntegrationTests.swift
@@ -16,7 +16,7 @@ class IntegrationTests: BaseTestCase {
     let testFxAChinaServer = ["testFxASyncPageUsingChinaFxA"]
 
     // This DB contains 1 entry example.com
-    let historyDB = "exampleURLHistoryBookmark.db"
+    let historyDB = "exampleURLHistoryBookmark-places.db"
 
     override func setUp() {
      // Test name looks like: "[Class testFunc]", parse out the function name


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1120)

### Description
`test_sync_history_from_device` has been failing because we need to update the database's name to the new one (`*-place.db`). In addition, the history for the page no longer is `type 2`.

I have run all sync integration tests on MacStadium as well as on my local computer.

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
