### PR TITLE
Bugfix FXIOS-6777 [v116] save and autofill credit card toggle state check added

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1852,6 +1852,49 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
 
     // MARK: Autofill
 
+    func creditCardAutofillSetup(_ tab: Tab, didCreateWebView webView: WKWebView) {
+        let userDefaults = UserDefaults.standard
+        let keyCreditCardAutofill = PrefsKeys.KeyAutofillCreditCardStatus
+
+        let autofillCreditCardStatus = featureFlags.isFeatureEnabled(
+            .creditCardAutofillStatus, checking: .buildOnly)
+        if autofillCreditCardStatus {
+            let creditCardHelper = CreditCardHelper(tab: tab)
+            tab.addContentScript(creditCardHelper, name: CreditCardHelper.name())
+            creditCardHelper.foundFieldValues = { [weak self] fieldValues, type in
+                guard let tabWebView = tab.webView as? TabWebView,
+                      let type = type,
+                      userDefaults.object(forKey: keyCreditCardAutofill) as? Bool ?? true
+                else { return }
+
+                switch type {
+                case .formInput:
+                    self?.profile.autofill.listCreditCards(completion: { cards, error in
+                        guard let cards = cards, !cards.isEmpty, error == nil
+                        else {
+                            return
+                        }
+                        DispatchQueue.main.async {
+                            tabWebView.accessoryView.reloadViewFor(.creditCard)
+                            tabWebView.reloadInputViews()
+                        }
+                    })
+                case .formSubmit:
+                    self?.showCreditCardAutofillSheet(fieldValues: fieldValues)
+                    break
+                }
+
+                tabWebView.accessoryView.savedCardsClosure = {
+                    DispatchQueue.main.async { [weak self] in
+                        self?.showBottomSheetCardViewController(creditCard: nil,
+                                                                decryptedCard: nil,
+                                                                viewType: .selectSavedCard)
+                    }
+                }
+            }
+        }
+    }
+
     func showCreditCardAutofillSheet(fieldValues: UnencryptedCreditCardFields) {
         self.profile.autofill.checkForCreditCardExistance(cardNumber: fieldValues.ccNumberLast4) {
             existingCard, error in
@@ -2018,46 +2061,8 @@ extension BrowserViewController: LegacyTabDelegate {
             tab.addContentScript(logins, name: LoginsHelper.name())
         }
 
-        let userDefaults = UserDefaults.standard
-        let keyCreditCardAutofill = PrefsKeys.KeyAutofillCreditCardStatus
-
-        let autofillCreditCardStatus = featureFlags.isFeatureEnabled(
-            .creditCardAutofillStatus, checking: .buildOnly)
-        if autofillCreditCardStatus {
-            let creditCardHelper = CreditCardHelper(tab: tab)
-            tab.addContentScript(creditCardHelper, name: CreditCardHelper.name())
-            creditCardHelper.foundFieldValues = { [weak self] fieldValues, type in
-                guard let tabWebView = tab.webView as? TabWebView,
-                      let type = type,
-                      userDefaults.object(forKey: keyCreditCardAutofill) as? Bool ?? true
-                else { return }
-
-                switch type {
-                case .formInput:
-                    self?.profile.autofill.listCreditCards(completion: { cards, error in
-                        guard let cards = cards, !cards.isEmpty, error == nil
-                        else {
-                            return
-                        }
-                        DispatchQueue.main.async {
-                            tabWebView.accessoryView.reloadViewFor(.creditCard)
-                            tabWebView.reloadInputViews()
-                        }
-                    })
-                case .formSubmit:
-                    self?.showCreditCardAutofillSheet(fieldValues: fieldValues)
-                    break
-                }
-
-                tabWebView.accessoryView.savedCardsClosure = {
-                    DispatchQueue.main.async { [weak self] in
-                        self?.showBottomSheetCardViewController(creditCard: nil,
-                                                                decryptedCard: nil,
-                                                                viewType: .selectSavedCard)
-                    }
-                }
-            }
-        }
+        // Credit card autofill setup and callback
+        creditCardAutofillSetup(tab, didCreateWebView: webView)
 
         let contextMenuHelper = ContextMenuHelper(tab: tab)
         contextMenuHelper.delegate = self

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2018,6 +2018,9 @@ extension BrowserViewController: LegacyTabDelegate {
             tab.addContentScript(logins, name: LoginsHelper.name())
         }
 
+        let userDefaults = UserDefaults.standard
+        let keyCreditCardAutofill = PrefsKeys.KeyAutofillCreditCardStatus
+
         let autofillCreditCardStatus = featureFlags.isFeatureEnabled(
             .creditCardAutofillStatus, checking: .buildOnly)
         if autofillCreditCardStatus {
@@ -2025,7 +2028,8 @@ extension BrowserViewController: LegacyTabDelegate {
             tab.addContentScript(creditCardHelper, name: CreditCardHelper.name())
             creditCardHelper.foundFieldValues = { [weak self] fieldValues, type in
                 guard let tabWebView = tab.webView as? TabWebView,
-                      let type = type
+                      let type = type,
+                      userDefaults.object(forKey: keyCreditCardAutofill) as? Bool ?? true
                 else { return }
 
                 switch type {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1852,49 +1852,6 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
 
     // MARK: Autofill
 
-    func creditCardAutofillSetup(_ tab: Tab, didCreateWebView webView: WKWebView) {
-        let userDefaults = UserDefaults.standard
-        let keyCreditCardAutofill = PrefsKeys.KeyAutofillCreditCardStatus
-
-        let autofillCreditCardStatus = featureFlags.isFeatureEnabled(
-            .creditCardAutofillStatus, checking: .buildOnly)
-        if autofillCreditCardStatus {
-            let creditCardHelper = CreditCardHelper(tab: tab)
-            tab.addContentScript(creditCardHelper, name: CreditCardHelper.name())
-            creditCardHelper.foundFieldValues = { [weak self] fieldValues, type in
-                guard let tabWebView = tab.webView as? TabWebView,
-                      let type = type,
-                      userDefaults.object(forKey: keyCreditCardAutofill) as? Bool ?? true
-                else { return }
-
-                switch type {
-                case .formInput:
-                    self?.profile.autofill.listCreditCards(completion: { cards, error in
-                        guard let cards = cards, !cards.isEmpty, error == nil
-                        else {
-                            return
-                        }
-                        DispatchQueue.main.async {
-                            tabWebView.accessoryView.reloadViewFor(.creditCard)
-                            tabWebView.reloadInputViews()
-                        }
-                    })
-                case .formSubmit:
-                    self?.showCreditCardAutofillSheet(fieldValues: fieldValues)
-                    break
-                }
-
-                tabWebView.accessoryView.savedCardsClosure = {
-                    DispatchQueue.main.async { [weak self] in
-                        self?.showBottomSheetCardViewController(creditCard: nil,
-                                                                decryptedCard: nil,
-                                                                viewType: .selectSavedCard)
-                    }
-                }
-            }
-        }
-    }
-
     func showCreditCardAutofillSheet(fieldValues: UnencryptedCreditCardFields) {
         self.profile.autofill.checkForCreditCardExistance(cardNumber: fieldValues.ccNumberLast4) {
             existingCard, error in
@@ -2061,8 +2018,46 @@ extension BrowserViewController: LegacyTabDelegate {
             tab.addContentScript(logins, name: LoginsHelper.name())
         }
 
-        // Credit card autofill setup and callback
-        creditCardAutofillSetup(tab, didCreateWebView: webView)
+        let userDefaults = UserDefaults.standard
+        let keyCreditCardAutofill = PrefsKeys.KeyAutofillCreditCardStatus
+
+        let autofillCreditCardStatus = featureFlags.isFeatureEnabled(
+            .creditCardAutofillStatus, checking: .buildOnly)
+        if autofillCreditCardStatus {
+            let creditCardHelper = CreditCardHelper(tab: tab)
+            tab.addContentScript(creditCardHelper, name: CreditCardHelper.name())
+            creditCardHelper.foundFieldValues = { [weak self] fieldValues, type in
+                guard let tabWebView = tab.webView as? TabWebView,
+                      let type = type,
+                      userDefaults.object(forKey: keyCreditCardAutofill) as? Bool ?? true
+                else { return }
+
+                switch type {
+                case .formInput:
+                    self?.profile.autofill.listCreditCards(completion: { cards, error in
+                        guard let cards = cards, !cards.isEmpty, error == nil
+                        else {
+                            return
+                        }
+                        DispatchQueue.main.async {
+                            tabWebView.accessoryView.reloadViewFor(.creditCard)
+                            tabWebView.reloadInputViews()
+                        }
+                    })
+                case .formSubmit:
+                    self?.showCreditCardAutofillSheet(fieldValues: fieldValues)
+                    break
+                }
+
+                tabWebView.accessoryView.savedCardsClosure = {
+                    DispatchQueue.main.async { [weak self] in
+                        self?.showBottomSheetCardViewController(creditCard: nil,
+                                                                decryptedCard: nil,
+                                                                viewType: .selectSavedCard)
+                    }
+                }
+            }
+        }
 
         let contextMenuHelper = ContextMenuHelper(tab: tab)
         contextMenuHelper.delegate = self


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6777)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15096)

### Description
The toggle wasn't working as we were not checking for our default key if the setting is enabled. Added the key to make sure our settings are enabled for save and autofill. Attached a video to showcase the fix. 

https://github.com/mozilla-mobile/firefox-ios/assets/8919439/225821be-b333-4bc6-8710-119596a3c248

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
