### PR TITLE
Bugfix FXIOS-6683 [v116] Add Search Engine is not correctly aligned in RTL locale

### DIFF
--- a/Client/Frontend/Settings/CustomSearchViewController.swift
+++ b/Client/Frontend/Settings/CustomSearchViewController.swift
@@ -243,7 +243,6 @@ class CustomSearchEngineTextView: Setting, UITextViewDelegate {
         placeholderLabel.textColor = theme.colors.textSecondary
         placeholderLabel.text = placeholder
         placeholderLabel.isHidden = !textField.text.isEmpty
-        placeholderLabel.frame = CGRect(width: TextLabelWidth, height: TextLabelHeight)
         textField.font = placeholderLabel.font
 
         textField.textContainer.lineFragmentPadding = 0
@@ -265,6 +264,8 @@ class CustomSearchEngineTextView: Setting, UITextViewDelegate {
             make.top.bottom.equalTo(0).inset(Padding / 2)
             make.left.right.equalTo(cell.contentView).inset(Padding)
         }
+        textField.layoutIfNeeded()
+        placeholderLabel.frame = CGRect(width: TextLabelWidth, height: TextLabelHeight)
     }
 
     override func onClick(_ navigationController: UINavigationController?) {


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6683)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14917)

### Description
Root cause:

just from the code, seems that placeholder width wants to be aligned with the textField's width, and only fallback to magic number 360. However, when that compute property is called, textField is just added constraint and not yet triggered a layout till next render loop, therefore caused for rtl scenario, the placeholder is not aligned to the right side.

Fix idea is also just followed this idea, but just manually trigger a layout update before configure the placeholder's width so it will match with the real width of textField. Maybe this part code needs refactor later when considering rtl.

After fix screenshot:
ar language
![Simulator Screenshot - iPhone 14 Pro - 2023-06-21 at 21 46 25](https://github.com/mozilla-mobile/firefox-ios/assets/9611782/20ff4dd7-ca8e-4837-9b33-d391b5255c3b)
en language
![Simulator Screenshot - iPhone 14 Pro - 2023-06-21 at 21 52 13](https://github.com/mozilla-mobile/firefox-ios/assets/9611782/54bb36ae-d33a-47f5-91fe-c51cf7cc64e4)
