### PR TITLE
Add FXIOS-6706 [v116] Screen Time implementation

### DIFF
--- a/Client/Frontend/Browser/WebView/WebviewViewController.swift
+++ b/Client/Frontend/Browser/WebView/WebviewViewController.swift
@@ -5,9 +5,11 @@
 import Foundation
 import Shared
 import WebKit
+import ScreenTime
 
 class WebviewViewController: UIViewController, ContentContainable, ScreenshotableView {
     private var webView: WKWebView
+    private let screenTimeController = STWebpageController()
     var contentType: ContentType = .webview
 
     init(webView: WKWebView) {
@@ -21,10 +23,11 @@ class WebviewViewController: UIViewController, ContentContainable, Screenshotabl
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        setupLayout()
+        setupWebView()
+        setupScreenTimeController()
     }
 
-    private func setupLayout() {
+    private func setupWebView() {
         view.addSubview(webView)
         webView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -35,9 +38,18 @@ class WebviewViewController: UIViewController, ContentContainable, Screenshotabl
         ])
     }
 
+    private func setupScreenTimeController() {
+        addChild(screenTimeController)
+        screenTimeController.view.frame = webView.frame
+        view.addSubview(screenTimeController.view)
+        screenTimeController.didMove(toParent: self)
+        screenTimeController.url = webView.url
+    }
+
     func update(webView: WKWebView) {
         self.webView = webView
-        setupLayout()
+        setupWebView()
+        setupScreenTimeController()
     }
 
     // MARK: - ScreenshotableView

--- a/Client/Frontend/Browser/WebView/WebviewViewController.swift
+++ b/Client/Frontend/Browser/WebView/WebviewViewController.swift
@@ -40,8 +40,14 @@ class WebviewViewController: UIViewController, ContentContainable, Screenshotabl
 
     private func setupScreenTimeController() {
         addChild(screenTimeController)
-        screenTimeController.view.frame = webView.frame
         view.addSubview(screenTimeController.view)
+        screenTimeController.view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            screenTimeController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            screenTimeController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            screenTimeController.view.topAnchor.constraint(equalTo: view.topAnchor),
+            screenTimeController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
         screenTimeController.didMove(toParent: self)
         screenTimeController.url = webView.url
     }

--- a/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -306,7 +306,7 @@ class AppSettingsTableViewController: SettingsTableViewController, AppSettingsSc
             ThemeSetting(settings: self),
             SiriPageSetting(settings: self),
             blockpopUpSetting,
-            NoImageModeSetting(settings: self)
+            NoImageModeSetting(settings: self),
         ]
 
         if isSearchBarLocationFeatureEnabled {


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6706)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14975)

### Description

Added implementation of Screen Time functionalities. To test this implementation use a real device, because on simulator screen time doesn't work. In order to test it, go to `Settings > Screen Time > Content & Privacy Restrictions > Content Restrictions > Web Content` and select `Limit Adult Websites` or `Allowed Websites` then navigate to a restricted page and you should see that the navigation is disabled. 

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
