### PR TITLE
Refactor FXIOS-6781 [v115] Ensure browserHasLoaded gets called once tabs have restored in viewWillAppear

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -466,8 +466,6 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
 
         overlayManager.setURLBar(urlBarView: urlBar)
 
-        browserDelegate?.browserHasLoaded()
-
         // Update theme of already existing views
         let theme = themeManager.currentTheme
         header.applyTheme(theme: theme)
@@ -616,6 +614,8 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
         }
 
         urlBar.searchEnginesDidUpdate()
+
+        browserDelegate?.browserHasLoaded()
     }
 
     override func viewDidAppear(_ animated: Bool) {


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6781)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15103)

### Description
Ensure browserHasLoaded gets called once tabs have restored in viewWillAppear, otherwise the deeplink creates a new tab when called from widget and puts the tab restore aside.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
