### PR TITLE
Refactor [v116] Handle credit card settings with browser coordinator

### DIFF
--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -419,7 +419,6 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
                 passcodeViewController.profile = profile
                 completion(passcodeViewController)
             }
-            return
 
         default:
             completion(nil)

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -340,36 +340,39 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
         controller.modalPresentationStyle = .formSheet
         router.present(controller)
 
-        guard let viewController = getSettingsViewController(settingsSection: settingsSection) else { return }
-        controller.pushViewController(viewController, animated: true)
+        getSettingsViewController(settingsSection: settingsSection) { viewController in
+            guard let viewController else { return }
+            controller.pushViewController(viewController, animated: true)
+        }
     }
 
     // Will be removed with FXIOS-6529
-    func getSettingsViewController(settingsSection section: Route.SettingsSection) -> UIViewController? {
+    func getSettingsViewController(settingsSection section: Route.SettingsSection,
+                                   completion: @escaping (UIViewController?) -> Void) {
         switch section {
         case .newTab:
             let viewController = NewTabContentSettingsViewController(prefs: profile.prefs)
             viewController.profile = profile
-            return viewController
+            completion(viewController)
 
         case .homePage:
             let viewController = HomePageSettingViewController(prefs: profile.prefs)
             viewController.profile = profile
-            return viewController
+            completion(viewController)
 
         case .mailto:
             let viewController = OpenWithSettingsViewController(prefs: profile.prefs)
-            return viewController
+            completion(viewController)
 
         case .search:
             let viewController = SearchSettingsTableViewController(profile: profile)
-            return viewController
+            completion(viewController)
 
         case .clearPrivateData:
             let viewController = ClearPrivateDataTableViewController()
             viewController.profile = profile
             viewController.tabManager = tabManager
-            return viewController
+            completion(viewController)
 
         case .fxa:
             let fxaParams = FxALaunchParams(entrypoint: .fxaDeepLinkSetting, query: [:])
@@ -379,10 +382,10 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
                 referringPage: .settings,
                 profile: browserViewController.profile
             )
-            return viewController
+            completion(viewController)
 
         case .theme:
-            return ThemeSettingsController()
+            completion(ThemeSettingsController())
 
         case .wallpaper:
             if wallpaperManager.canSettingsBeShown {
@@ -392,13 +395,34 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
                     theme: themeManager.currentTheme
                 )
                 let wallpaperVC = WallpaperSettingsViewController(viewModel: viewModel)
-                return wallpaperVC
+                completion(wallpaperVC)
             } else {
-                return nil
+                completion(nil)
             }
 
+        case .creditCard:
+            let viewModel = CreditCardSettingsViewModel(profile: profile)
+            let viewController = CreditCardSettingsViewController(
+                creditCardViewModel: viewModel)
+            let appAuthenticator = AppAuthenticator()
+            if appAuthenticator.canAuthenticateDeviceOwner {
+                appAuthenticator.authenticateWithDeviceOwnerAuthentication { result in
+                    switch result {
+                    case .success:
+                        completion(viewController)
+                    case .failure:
+                        break
+                    }
+                }
+            } else {
+                let passcodeViewController = DevicePasscodeRequiredViewController()
+                passcodeViewController.profile = profile
+                completion(passcodeViewController)
+            }
+            return
+
         default:
-            return nil
+            completion(nil)
         }
     }
 }

--- a/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -458,63 +458,63 @@ final class BrowserCoordinatorTests: XCTestCase {
         let route = Route.SettingsSection.newTab
         let subject = createSubject()
 
-        let result = subject.getSettingsViewController(settingsSection: route)
-
-        XCTAssertTrue(result is NewTabContentSettingsViewController)
+        subject.getSettingsViewController(settingsSection: route) { result in
+            XCTAssertTrue(result is NewTabContentSettingsViewController)
+        }
     }
 
     func testHomepageSettingsRoute_returnsHomepageSettingsPage() throws {
         let route = Route.SettingsSection.homePage
         let subject = createSubject()
 
-        let result = subject.getSettingsViewController(settingsSection: route)
-
-        XCTAssertTrue(result is HomePageSettingViewController)
+        subject.getSettingsViewController(settingsSection: route) { result in
+            XCTAssertTrue(result is HomePageSettingViewController)
+        }
     }
 
     func testMailtoSettingsRoute_returnsMailtoSettingsPage() throws {
         let route = Route.SettingsSection.mailto
         let subject = createSubject()
 
-        let result = subject.getSettingsViewController(settingsSection: route)
-
-        XCTAssertTrue(result is OpenWithSettingsViewController)
+        subject.getSettingsViewController(settingsSection: route) { result in
+            XCTAssertTrue(result is OpenWithSettingsViewController)
+        }
     }
 
     func testSearchSettingsRoute_returnsSearchSettingsPage() throws {
         let route = Route.SettingsSection.search
         let subject = createSubject()
 
-        let result = subject.getSettingsViewController(settingsSection: route)
-
-        XCTAssertTrue(result is SearchSettingsTableViewController)
+        subject.getSettingsViewController(settingsSection: route) { result in
+            XCTAssertTrue(result is SearchSettingsTableViewController)
+        }
     }
 
     func testClearPrivateDataSettingsRoute_returnsClearPrivateDataSettingsPage() throws {
         let route = Route.SettingsSection.clearPrivateData
         let subject = createSubject()
 
-        let result = subject.getSettingsViewController(settingsSection: route)
-
-        XCTAssertTrue(result is ClearPrivateDataTableViewController)
+        subject.getSettingsViewController(settingsSection: route) { result in
+            XCTAssertTrue(result is ClearPrivateDataTableViewController)
+        }
     }
 
     func testFxaSettingsRoute_returnsFxaSettingsPage() throws {
         let route = Route.SettingsSection.fxa
         let subject = createSubject()
 
-        let result = subject.getSettingsViewController(settingsSection: route)
-
-        XCTAssertTrue(result is SyncContentSettingsViewController)
+        subject.getSettingsViewController(settingsSection: route) { result in
+            XCTAssertTrue(result is SyncContentSettingsViewController)
+        }
     }
 
     func testThemeSettingsRoute_returnsThemeSettingsPage() throws {
         let route = Route.SettingsSection.theme
         let subject = createSubject()
 
-        let result = subject.getSettingsViewController(settingsSection: route)
-
-        XCTAssertTrue(result is ThemeSettingsController)
+        subject.getSettingsViewController(settingsSection: route) { result in
+            XCTAssertTrue(result is ThemeSettingsController)
+        }
     }
 
     func testWallpaperSettingsRoute_canShow_returnsWallpaperSettingsPage() throws {
@@ -522,9 +522,9 @@ final class BrowserCoordinatorTests: XCTestCase {
         let route = Route.SettingsSection.wallpaper
         let subject = createSubject()
 
-        let result = subject.getSettingsViewController(settingsSection: route)
-
-        XCTAssertTrue(result is WallpaperSettingsViewController)
+        subject.getSettingsViewController(settingsSection: route) { result in
+            XCTAssertTrue(result is WallpaperSettingsViewController)
+        }
     }
 
     func testWallpaperSettingsRoute_cannotShow_returnsWallpaperSettingsPage() throws {
@@ -532,9 +532,9 @@ final class BrowserCoordinatorTests: XCTestCase {
         let route = Route.SettingsSection.wallpaper
         let subject = createSubject()
 
-        let result = subject.getSettingsViewController(settingsSection: route)
-
-        XCTAssertNil(result)
+        subject.getSettingsViewController(settingsSection: route) { result in
+            XCTAssertNil(result)
+        }
     }
 
     func testSettingsRoute_addSettingsCoordinator() {


### PR DESCRIPTION
### Description
This is basically a use case that should happen since whenever `CoordinatorFlagManager.isSettingsCoordinatorEnabled` is false, we'll instead show the settings directly from BVC. But just to be safe let's cover it in the meantime, since we have multiple code paths to support with the refactors.

To test this, you can call `sceneCoordinator?.findAndHandle(route: .settings(section: .creditCard))` from `SceneDelegate.willConnectTo` function

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
