### PR TITLE
Bugfix FXIOS-6788 [v115] Put browserHasLoaded even later so we're ready for deeplinks

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -614,8 +614,6 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
         }
 
         urlBar.searchEnginesDidUpdate()
-
-        browserDelegate?.browserHasLoaded()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -634,6 +632,8 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
         showQueuedAlertIfAvailable()
 
         prepareURLOnboardingContextualHint()
+
+        browserDelegate?.browserHasLoaded()
     }
 
     private func prepareURLOnboardingContextualHint() {


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6788)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15122)

### Description
Third time will be the good one! Ensures we're truly ready before handling any deep links, otherwise `selectTab` cannot be done (the tab is just not selected, probably a timing issue with the tab restore happening at the same time?). This was happening in the case of survey, where we load BVC after the "take survey" button is clicked. We then try to navigate to the survey in a new tab, but we weren't navigating to it.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
