### PR TITLE
Bugfix MTE-1171 [v116] Long press from BrowsingPDFTests

### DIFF
--- a/Tests/XCUITests/BrowsingPDFTests.swift
+++ b/Tests/XCUITests/BrowsingPDFTests.swift
@@ -36,7 +36,7 @@ class BrowsingPDFTests: BaseTestCase {
         navigator.openURL(PDF_website["url"]!)
         waitUntilPageLoad()
         // Long press on a link on the pdf and check the options shown
-        app.webViews.links.element(boundBy: 0).pressAtPoint(CGPoint(x: 0, y: 0), forDuration: 3)
+        app.webViews.links.element(boundBy: 0).pressAtPoint(CGPoint(x: 10, y: 0), forDuration: 3)
 
         waitForExistence(app.staticTexts[PDF_website["longUrlValue"]!])
         waitForExistence(app.buttons["Open"])
@@ -49,7 +49,7 @@ class BrowsingPDFTests: BaseTestCase {
         navigator.openURL(PDF_website["url"]!)
         waitUntilPageLoad()
         // Long press on a link on the pdf and check the options shown
-        app.webViews.links.element(boundBy: 0).pressAtPoint(CGPoint(x: 0, y: 0), forDuration: 3)
+        app.webViews.links.element(boundBy: 0).pressAtPoint(CGPoint(x: 10, y: 0), forDuration: 3)
 
         waitForExistence(app.staticTexts[PDF_website["longUrlValue"]!])
         app.buttons["Add to Reading List"].tap()


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1171)

### Description
`testLongPressOnPDFLink` and `testLongPressOnPDFLinkToAddToReadingList` fail on iPhone 14 simulator. Let's long press somewhere in the middle of the link to ensure that the context menu is launched.

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
