### PR TITLE
Bugfix MTE-1173 [v116] testWebSiteDataOptions() test

### DIFF
--- a/Tests/XCUITests/DataManagementTests.swift
+++ b/Tests/XCUITests/DataManagementTests.swift
@@ -25,7 +25,7 @@ class DataManagementTests: BaseTestCase {
         waitForExistence(app.tables.otherElements["Website Data"], timeout: 3)
 
         navigator.performAction(Action.AcceptClearAllWebsiteData)
-        waitForExistence(app.tables.cells["ClearAllWebsiteData"])
+        waitForExistence(app.tables.cells["ClearAllWebsiteData"].staticTexts["Clear All Website Data"])
         let expectedWebsitesCleared = app.tables.cells.count
         XCTAssertEqual(expectedWebsitesCleared, 1)
     }

--- a/Tests/XCUITests/FxScreenGraph.swift
+++ b/Tests/XCUITests/FxScreenGraph.swift
@@ -655,7 +655,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
     map.addScreenState(WebsiteDataSettings) { screenState in
         screenState.gesture(forAction: Action.AcceptClearAllWebsiteData) { userState in
-            app.tables.cells["ClearAllWebsiteData"].tap()
+            app.tables.cells["ClearAllWebsiteData"].staticTexts["Clear All Website Data"].tap()
             app.alerts.buttons["OK"].tap()
         }
         // The swipeDown() is a workaround for an intermittent issue that the search filed is not always in view.


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1173)

### Description
`testWebSiteDataOptions()` fails because there are more than one cell on the "Website Data" page has the label `ClearAllWebsiteData`.

The solution is to use the `staticText` to narrow down the place to tap.

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
