### PR TITLE
Bugfix FXIOS-6796 [v116] save button is not grayed out in CC section while creating or editing

### DIFF
--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -18,6 +18,7 @@ struct CreditCardInputView: View {
     @State var borderColor: Color = .clear
     @State var textFieldBackgroundColor: Color = .clear
     @State var barButtonColor: Color = .clear
+    @State var saveButtonDisabledColor: Color = .clear
 
     var body: some View {
         NavigationView {
@@ -118,6 +119,7 @@ struct CreditCardInputView: View {
         backgroundColor = Color(color.layer1)
         textFieldBackgroundColor = Color(color.layer2)
         barButtonColor = Color(color.actionPrimary)
+        saveButtonDisabledColor = Color(color.textSecondary)
     }
 
     func rightBarButton() -> some View {
@@ -153,7 +155,7 @@ struct CreditCardInputView: View {
                     }
                 }
             }
-        }
+        }.foregroundColor(viewModel.isRightBarButtonEnabled ? barButtonColor : saveButtonDisabledColor)
     }
 
     func leftBarButton() -> some View {


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15133)

### Description

Bugfix save button is not grayed out in CC section while creating or editing

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
