### PR TITLE
Refactor FXIOS-6637/8/9 [v116] TPAccessoryInfo ClearPrivateDataTableViewController OpenWithSettingsViewController with dequeue reusable cell

### DIFF
--- a/Client/Frontend/Browser/OpenWithSettingsViewController.swift
+++ b/Client/Frontend/Browser/OpenWithSettingsViewController.swift
@@ -100,7 +100,7 @@ class OpenWithSettingsViewController: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = ThemedTableViewCell()
+        let cell = dequeueCellFor(indexPath: indexPath)
         let option = mailProviderSource[indexPath.row]
 
         cell.applyTheme(theme: themeManager.currentTheme)

--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -86,7 +86,7 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = ThemedTableViewCell()
+        let cell = dequeueCellFor(indexPath: indexPath)
         cell.applyTheme(theme: themeManager.currentTheme)
 
         if indexPath.section == SectionArrow {

--- a/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -50,8 +50,7 @@ class TPAccessoryInfo: ThemedTableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        tableView.dataSource = self
-        tableView.delegate = self
+        tableView.register(cellType: ThemedSubtitleTableViewCell.self)
         tableView.estimatedRowHeight = 130
         tableView.rowHeight = UITableView.automaticDimension
         tableView.separatorStyle = .none
@@ -109,7 +108,7 @@ class TPAccessoryInfo: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = ThemedTableViewCell(style: .subtitle, reuseIdentifier: nil)
+        let cell = dequeueCellFor(indexPath: indexPath)
         cell.applyTheme(theme: themeManager.currentTheme)
         if indexPath.section == 0 {
             if indexPath.row == 0 {
@@ -151,6 +150,14 @@ class TPAccessoryInfo: ThemedTableViewController {
         cell.backgroundColor = .clear
         cell.textLabel?.textColor = themeManager.currentTheme.colors.textPrimary
         cell.selectionStyle = .none
+        return cell
+    }
+
+    override func dequeueCellFor(indexPath: IndexPath) -> ThemedTableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: ThemedSubtitleTableViewCell.cellIdentifier, for: indexPath) as? ThemedSubtitleTableViewCell
+        else {
+            return ThemedSubtitleTableViewCell()
+        }
         return cell
     }
 }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6637)
[Github issue OpenWithSettingsViewController](https://github.com/mozilla-mobile/firefox-ios/issues/14848)

[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6638)
[Github issue TPAccessoryInfo](https://github.com/mozilla-mobile/firefox-ios/issues/14847)

[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6639)
[Github issue ClearPrivateDataTableViewController](https://github.com/mozilla-mobile/firefox-ios/issues/14846)

### Description

Refactor `TPAccessoryInfo` `ClearPrivateDataTableViewController` `OpenWithSettingsViewController` with dequeue reusable cell.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
