### PR TITLE
Bugfix FXIOS-6785 [v115] fix contentContainer constraint

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -738,7 +738,8 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
 
         if CoordinatorFlagManager.isCoordinatorEnabled {
             NSLayoutConstraint.activate([
-                contentContainer.topAnchor.constraint(equalTo: header.bottomAnchor),
+                contentContainer.topAnchor.constraint(equalTo: statusBarOverlay.bottomAnchor, priority: .init(998)),
+                contentContainer.topAnchor.constraint(equalTo: header.bottomAnchor, priority: .init(999)),
                 contentContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor),
                 contentContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor),
                 contentContainer.bottomAnchor.constraint(equalTo: overKeyboardContainer.topAnchor),


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6785)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15116)

### Description
Fix `contentContainer` constraint. We weren't adjusting when `header` was empty with a bottom toolbar, but the status bar overlay is appearing on top and content was appearing below that status bar overlay.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
