### PR TITLE
Refactor FXIOS-6613 [v116] Debug settings

### DIFF
--- a/Client/Coordinators/SettingsCoordinator.swift
+++ b/Client/Coordinators/SettingsCoordinator.swift
@@ -155,6 +155,11 @@ class SettingsCoordinator: BaseCoordinator, SettingsDelegate, SettingsFlowDelega
         router.push(creditCardViewController)
     }
 
+    func showExperiments() {
+        let experimentsViewController = ExperimentsViewController()
+        router.push(experimentsViewController)
+    }
+
     func didFinishShowingSettings() {
         didFinish()
     }

--- a/Client/Frontend/Settings/Main/About/VersionSetting.swift
+++ b/Client/Frontend/Settings/Main/About/VersionSetting.swift
@@ -8,17 +8,14 @@ import Shared
 
 /// Show the current version of Firefox
 class VersionSetting: Setting {
-    unowned let settings: SettingsTableViewController
-    weak var appSettingsDelegate: AppSettingsDelegate?
+    private weak var settingsDelegate: DebugSettingsDelegate?
 
     override var accessibilityIdentifier: String? {
         return AccessibilityIdentifiers.Settings.Version.title
     }
 
-    init(settings: SettingsTableViewController,
-         appSettingsDelegate: AppSettingsDelegate) {
-        self.settings = settings
-        self.appSettingsDelegate = appSettingsDelegate
+    init(settingsDelegate: DebugSettingsDelegate) {
+        self.settingsDelegate = settingsDelegate
         super.init(title: nil)
     }
 
@@ -32,11 +29,17 @@ class VersionSetting: Setting {
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
-        appSettingsDelegate?.pressedVersion()
+        settingsDelegate?.pressedVersion()
     }
 
     override func onLongPress(_ navigationController: UINavigationController?) {
-        copyAppVersionAndPresentAlert(by: navigationController)
+        if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+            let alertTitle: String = .SettingsCopyAppVersionAlertTitle
+            let alert = AlertController(title: alertTitle, message: nil, preferredStyle: .alert)
+            settingsDelegate?.askedToShow(alert: alert)
+        } else {
+            copyAppVersionAndPresentAlert(by: navigationController)
+        }
     }
 
     func copyAppVersionAndPresentAlert(by navigationController: UINavigationController?) {

--- a/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -62,6 +62,7 @@ protocol DebugSettingsDelegate: AnyObject {
 protocol SettingsFlowDelegate: AnyObject {
     func showDevicePassCode()
     func showCreditCardSettings()
+    func showExperiments()
 
     func didFinishShowingSettings()
 }
@@ -458,8 +459,7 @@ class AppSettingsTableViewController: SettingsTableViewController, AppSettingsSc
     }
 
     func pressedExperiments() {
-        // laurie
-//        pushViewController(ExperimentsViewController(), animated: true)
+        parentCoordinator?.showExperiments()
     }
 
     func askedToShow(alert: AlertController) {

--- a/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -48,10 +48,14 @@ enum AppSettingsDeeplinkOption {
     }
 }
 
-/// Child settings pages action
-protocol AppSettingsDelegate: AnyObject {
+/// Child settings pages debug action
+protocol DebugSettingsDelegate: AnyObject {
     func pressedVersion()
     func pressedShowTour()
+    func pressedExperiments()
+
+    func askedToShow(alert: AlertController)
+    func askedToReload()
 }
 
 /// Supports decision making from VC to parent coordinator
@@ -71,7 +75,7 @@ protocol AppSettingsScreen: UIViewController {
 
 /// App Settings Screen (triggered by tapping the 'Gear' in the Tab Tray Controller)
 class AppSettingsTableViewController: SettingsTableViewController, AppSettingsScreen,
-                                    FeatureFlaggable, AppSettingsDelegate, SearchBarLocationProvider {
+                                    FeatureFlaggable, DebugSettingsDelegate, SearchBarLocationProvider {
     // MARK: - Properties
     var deeplinkTo: AppSettingsDeeplinkOption? // Will be clean up with FXIOS-6529
     private var showDebugSettings = false
@@ -382,7 +386,7 @@ class AppSettingsTableViewController: SettingsTableViewController, AppSettingsSc
 
     private func getSupportSettings() -> [SettingSection] {
         let supportSettings = [
-            ShowIntroductionSetting(settings: self, appSettingsDelegate: self),
+            ShowIntroductionSetting(settings: self, settingsDelegate: self),
             SendFeedbackSetting(),
             SendAnonymousUsageDataSetting(prefs: profile.prefs,
                                           delegate: settingsDelegate,
@@ -401,7 +405,7 @@ class AppSettingsTableViewController: SettingsTableViewController, AppSettingsSc
     private func getAboutSettings() -> [SettingSection] {
         let aboutSettings = [
             AppStoreReviewSetting(),
-            VersionSetting(settings: self, appSettingsDelegate: self),
+            VersionSetting(settingsDelegate: self),
             LicenseAndAcknowledgementsSetting(),
             YourRightsSetting()
         ]
@@ -412,28 +416,28 @@ class AppSettingsTableViewController: SettingsTableViewController, AppSettingsSc
 
     private func getDebugSettings() -> [SettingSection] {
         let hiddenDebugOptions = [
-            ExperimentsSettings(settings: self),
+            ExperimentsSettings(settings: self, settingsDelegate: self),
             ExportLogDataSetting(settings: self),
             ExportBrowserDataSetting(settings: self),
             DeleteExportedDataSetting(settings: self),
             ForceCrashSetting(settings: self),
             ForgetSyncAuthStateDebugSetting(settings: self),
             ChangeToChinaSetting(settings: self),
-            AppReviewPromptSetting(settings: self),
-            TogglePullToRefresh(settings: self),
-            ToggleHistoryGroups(settings: self),
-            ToggleInactiveTabs(settings: self),
+            AppReviewPromptSetting(settings: self, settingsDelegate: self),
+            TogglePullToRefresh(settings: self, settingsDelegate: self),
+            ToggleHistoryGroups(settings: self, settingsDelegate: self),
+            ToggleInactiveTabs(settings: self, settingsDelegate: self),
             ResetContextualHints(settings: self),
-            ResetWallpaperOnboardingPage(settings: self),
-            SentryIDSetting(settings: self),
-            FasterInactiveTabs(settings: self),
+            ResetWallpaperOnboardingPage(settings: self, settingsDelegate: self),
+            SentryIDSetting(settings: self, settingsDelegate: self),
+            FasterInactiveTabs(settings: self, settingsDelegate: self),
             OpenFiftyTabsDebugOption(settings: self),
         ]
 
         return [SettingSection(title: NSAttributedString(string: "Debug"), children: hiddenDebugOptions)]
     }
 
-    // MARK: - AppSettingsDelegate
+    // MARK: - DebugSettingsDelegate
 
     func pressedVersion() {
         debugSettingsClickCount += 1
@@ -451,6 +455,24 @@ class AppSettingsTableViewController: SettingsTableViewController, AppSettingsSc
         let urlString = URL.mozInternalScheme + "://deep-link?url=/action/show-intro-onboarding"
         guard let url = URL(string: urlString) else { return }
         applicationHelper.open(url)
+    }
+
+    func pressedExperiments() {
+        // laurie
+//        pushViewController(ExperimentsViewController(), animated: true)
+    }
+
+    func askedToShow(alert: AlertController) {
+        present(alert, animated: true) {
+            // Dismiss the debug alert briefly after it's shown
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                alert.dismiss(animated: true)
+            }
+        }
+    }
+
+    func askedToReload() {
+        tableView.reloadData()
     }
 
     // MARK: - UITableViewDelegate

--- a/Client/Frontend/Settings/Main/Debug/AppReviewPromptSetting.swift
+++ b/Client/Frontend/Settings/Main/Debug/AppReviewPromptSetting.swift
@@ -6,12 +6,24 @@ import Foundation
 import Shared
 
 class AppReviewPromptSetting: HiddenSetting {
+    private weak var settingsDelegate: DebugSettingsDelegate?
+
+    init(settings: SettingsTableViewController,
+         settingsDelegate: DebugSettingsDelegate) {
+        self.settingsDelegate = settingsDelegate
+        super.init(settings: settings)
+    }
+    
     override var title: NSAttributedString? {
         return NSAttributedString(string: "Toggle App Review (needs tab switch)", attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
         UserDefaults.standard.set(true, forKey: PrefsKeys.ForceShowAppReviewPromptOverride)
-        updateCell(navigationController)
+        if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+            settingsDelegate?.askedToReload()
+        } else {
+            updateCell(navigationController)
+        }
     }
 }

--- a/Client/Frontend/Settings/Main/Debug/AppReviewPromptSetting.swift
+++ b/Client/Frontend/Settings/Main/Debug/AppReviewPromptSetting.swift
@@ -13,7 +13,7 @@ class AppReviewPromptSetting: HiddenSetting {
         self.settingsDelegate = settingsDelegate
         super.init(settings: settings)
     }
-    
+
     override var title: NSAttributedString? {
         return NSAttributedString(string: "Toggle App Review (needs tab switch)", attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }

--- a/Client/Frontend/Settings/Main/Debug/ExperimentsSettings.swift
+++ b/Client/Frontend/Settings/Main/Debug/ExperimentsSettings.swift
@@ -5,9 +5,21 @@
 import Foundation
 
 class ExperimentsSettings: HiddenSetting {
+    private weak var settingsDelegate: DebugSettingsDelegate?
+
     override var title: NSAttributedString? { return NSAttributedString(string: "Experiments")}
 
+    init(settings: SettingsTableViewController,
+         settingsDelegate: DebugSettingsDelegate) {
+        self.settingsDelegate = settingsDelegate
+        super.init(settings: settings)
+    }
+
     override func onClick(_ navigationController: UINavigationController?) {
-        navigationController?.pushViewController(ExperimentsViewController(), animated: true)
+        if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+            settingsDelegate?.pressedExperiments()
+        } else {
+            navigationController?.pushViewController(ExperimentsViewController(), animated: true)
+        }
     }
 }

--- a/Client/Frontend/Settings/Main/Debug/FasterInactiveTabs.swift
+++ b/Client/Frontend/Settings/Main/Debug/FasterInactiveTabs.swift
@@ -6,6 +6,14 @@ import Foundation
 import Shared
 
 class FasterInactiveTabs: HiddenSetting {
+    private weak var settingsDelegate: DebugSettingsDelegate?
+
+    init(settings: SettingsTableViewController,
+         settingsDelegate: DebugSettingsDelegate) {
+        self.settingsDelegate = settingsDelegate
+        super.init(settings: settings)
+    }
+
     override var title: NSAttributedString? {
         let isFasterEnabled = UserDefaults.standard.bool(forKey: PrefsKeys.FasterInactiveTabsOverride)
         let buttonTitle = isFasterEnabled ? "Set Inactive Tab Timeout to Default" : "Set Inactive Tab Timeout to 10s"
@@ -15,6 +23,10 @@ class FasterInactiveTabs: HiddenSetting {
     override func onClick(_ navigationController: UINavigationController?) {
         let isFasterEnabled = UserDefaults.standard.bool(forKey: PrefsKeys.FasterInactiveTabsOverride)
         UserDefaults.standard.set(!isFasterEnabled, forKey: PrefsKeys.FasterInactiveTabsOverride)
-        updateCell(navigationController)
+        if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+            settingsDelegate?.askedToReload()
+        } else {
+            updateCell(navigationController)
+        }
     }
 }

--- a/Client/Frontend/Settings/Main/Debug/ResetWallpaperOnboardingPage.swift
+++ b/Client/Frontend/Settings/Main/Debug/ResetWallpaperOnboardingPage.swift
@@ -13,7 +13,7 @@ class ResetWallpaperOnboardingPage: HiddenSetting, FeatureFlaggable {
         self.settingsDelegate = settingsDelegate
         super.init(settings: settings)
     }
-    
+
     override var title: NSAttributedString? {
         let seenStatus = UserDefaults.standard.bool(forKey: PrefsKeys.Wallpapers.OnboardingSeenKey) ? "seen" : "unseen"
         return NSAttributedString(string: "Reset wallpaper onboarding sheet (\(seenStatus))",

--- a/Client/Frontend/Settings/Main/Debug/ResetWallpaperOnboardingPage.swift
+++ b/Client/Frontend/Settings/Main/Debug/ResetWallpaperOnboardingPage.swift
@@ -6,6 +6,14 @@ import Foundation
 import Shared
 
 class ResetWallpaperOnboardingPage: HiddenSetting, FeatureFlaggable {
+    private weak var settingsDelegate: DebugSettingsDelegate?
+
+    init(settings: SettingsTableViewController,
+         settingsDelegate: DebugSettingsDelegate) {
+        self.settingsDelegate = settingsDelegate
+        super.init(settings: settings)
+    }
+    
     override var title: NSAttributedString? {
         let seenStatus = UserDefaults.standard.bool(forKey: PrefsKeys.Wallpapers.OnboardingSeenKey) ? "seen" : "unseen"
         return NSAttributedString(string: "Reset wallpaper onboarding sheet (\(seenStatus))",
@@ -14,6 +22,10 @@ class ResetWallpaperOnboardingPage: HiddenSetting, FeatureFlaggable {
 
     override func onClick(_ navigationController: UINavigationController?) {
         UserDefaults.standard.set(false, forKey: PrefsKeys.Wallpapers.OnboardingSeenKey)
-        updateCell(navigationController)
+        if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+            settingsDelegate?.askedToReload()
+        } else {
+            updateCell(navigationController)
+        }
     }
 }

--- a/Client/Frontend/Settings/Main/Debug/SentryIDSetting.swift
+++ b/Client/Frontend/Settings/Main/Debug/SentryIDSetting.swift
@@ -7,30 +7,43 @@ import Foundation
 import Shared
 
 class SentryIDSetting: HiddenSetting {
-    let deviceAppHash = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)?.string(forKey: "SentryDeviceAppHash")
+    private weak var settingsDelegate: DebugSettingsDelegate?
+    private let deviceAppHash = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)?.string(forKey: "SentryDeviceAppHash")
+
     override var title: NSAttributedString? {
         return NSAttributedString(
             string: "Sentry ID \(deviceAppHash ?? "(null)")",
             attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }
 
+    init(settings: SettingsTableViewController,
+         settingsDelegate: DebugSettingsDelegate) {
+        self.settingsDelegate = settingsDelegate
+        super.init(settings: settings)
+    }
+
     override func onClick(_ navigationController: UINavigationController?) {
         copyAppDeviceIDAndPresentAlert(by: navigationController)
     }
 
-    func copyAppDeviceIDAndPresentAlert(by navigationController: UINavigationController?) {
+    private func copyAppDeviceIDAndPresentAlert(by navigationController: UINavigationController?) {
+        UIPasteboard.general.string = deviceAppHash
         let alertTitle: String = .SettingsCopyAppVersionAlertTitle
         let alert = AlertController(title: alertTitle, message: nil, preferredStyle: .alert)
-        getSelectedCell(by: navigationController)?.setSelected(false, animated: true)
-        UIPasteboard.general.string = deviceAppHash
-        navigationController?.topViewController?.present(alert, animated: true) {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                alert.dismiss(animated: true)
+
+        if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+            settingsDelegate?.askedToShow(alert: alert)
+        } else {
+            getSelectedCell(by: navigationController)?.setSelected(false, animated: true)
+            navigationController?.topViewController?.present(alert, animated: true) {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    alert.dismiss(animated: true)
+                }
             }
         }
     }
 
-    func getSelectedCell(by navigationController: UINavigationController?) -> UITableViewCell? {
+    private func getSelectedCell(by navigationController: UINavigationController?) -> UITableViewCell? {
         let controller = navigationController?.topViewController
         let tableView = (controller as? AppSettingsTableViewController)?.tableView
         guard let indexPath = tableView?.indexPathForSelectedRow else { return nil }

--- a/Client/Frontend/Settings/Main/Debug/ToggleHistoryGroups.swift
+++ b/Client/Frontend/Settings/Main/Debug/ToggleHistoryGroups.swift
@@ -5,6 +5,14 @@
 import Foundation
 
 class ToggleHistoryGroups: HiddenSetting, FeatureFlaggable {
+    private weak var settingsDelegate: DebugSettingsDelegate?
+
+    init(settings: SettingsTableViewController,
+         settingsDelegate: DebugSettingsDelegate) {
+        self.settingsDelegate = settingsDelegate
+        super.init(settings: settings)
+    }
+    
     override var title: NSAttributedString? {
         let toNewStatus = featureFlags.isFeatureEnabled(.historyGroups, checking: .userOnly) ? "OFF" : "ON"
         return NSAttributedString(
@@ -15,6 +23,10 @@ class ToggleHistoryGroups: HiddenSetting, FeatureFlaggable {
     override func onClick(_ navigationController: UINavigationController?) {
         let newStatus = !featureFlags.isFeatureEnabled(.historyGroups, checking: .userOnly)
         featureFlags.set(feature: .historyGroups, to: newStatus)
-        updateCell(navigationController)
+        if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+            settingsDelegate?.askedToReload()
+        } else {
+            updateCell(navigationController)
+        }
     }
 }

--- a/Client/Frontend/Settings/Main/Debug/ToggleHistoryGroups.swift
+++ b/Client/Frontend/Settings/Main/Debug/ToggleHistoryGroups.swift
@@ -12,7 +12,7 @@ class ToggleHistoryGroups: HiddenSetting, FeatureFlaggable {
         self.settingsDelegate = settingsDelegate
         super.init(settings: settings)
     }
-    
+
     override var title: NSAttributedString? {
         let toNewStatus = featureFlags.isFeatureEnabled(.historyGroups, checking: .userOnly) ? "OFF" : "ON"
         return NSAttributedString(

--- a/Client/Frontend/Settings/Main/Debug/ToggleInactiveTabs.swift
+++ b/Client/Frontend/Settings/Main/Debug/ToggleInactiveTabs.swift
@@ -5,6 +5,14 @@
 import Foundation
 
 class ToggleInactiveTabs: HiddenSetting, FeatureFlaggable {
+    private weak var settingsDelegate: DebugSettingsDelegate?
+
+    init(settings: SettingsTableViewController,
+         settingsDelegate: DebugSettingsDelegate) {
+        self.settingsDelegate = settingsDelegate
+        super.init(settings: settings)
+    }
+    
     override var title: NSAttributedString? {
         let toNewStatus = featureFlags.isFeatureEnabled(.inactiveTabs, checking: .userOnly) ? "OFF" : "ON"
         return NSAttributedString(string: "Toggle inactive tabs \(toNewStatus)",
@@ -15,6 +23,10 @@ class ToggleInactiveTabs: HiddenSetting, FeatureFlaggable {
         let newStatus = !featureFlags.isFeatureEnabled(.inactiveTabs, checking: .userOnly)
         featureFlags.set(feature: .inactiveTabs, to: newStatus)
         InactiveTabModel.hasRunInactiveTabFeatureBefore = false
-        updateCell(navigationController)
+        if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+            settingsDelegate?.askedToReload()
+        } else {
+            updateCell(navigationController)
+        }
     }
 }

--- a/Client/Frontend/Settings/Main/Debug/ToggleInactiveTabs.swift
+++ b/Client/Frontend/Settings/Main/Debug/ToggleInactiveTabs.swift
@@ -12,7 +12,7 @@ class ToggleInactiveTabs: HiddenSetting, FeatureFlaggable {
         self.settingsDelegate = settingsDelegate
         super.init(settings: settings)
     }
-    
+
     override var title: NSAttributedString? {
         let toNewStatus = featureFlags.isFeatureEnabled(.inactiveTabs, checking: .userOnly) ? "OFF" : "ON"
         return NSAttributedString(string: "Toggle inactive tabs \(toNewStatus)",

--- a/Client/Frontend/Settings/Main/Debug/TogglePullToRefresh.swift
+++ b/Client/Frontend/Settings/Main/Debug/TogglePullToRefresh.swift
@@ -5,6 +5,14 @@
 import Foundation
 
 class TogglePullToRefresh: HiddenSetting, FeatureFlaggable {
+    private weak var settingsDelegate: DebugSettingsDelegate?
+
+    init(settings: SettingsTableViewController,
+         settingsDelegate: DebugSettingsDelegate) {
+        self.settingsDelegate = settingsDelegate
+        super.init(settings: settings)
+    }
+
     override var title: NSAttributedString? {
         let toNewStatus = featureFlags.isFeatureEnabled(.pullToRefresh, checking: .userOnly) ? "OFF" : "ON"
         return NSAttributedString(string: "Toggle Pull to Refresh \(toNewStatus)",
@@ -14,6 +22,10 @@ class TogglePullToRefresh: HiddenSetting, FeatureFlaggable {
     override func onClick(_ navigationController: UINavigationController?) {
         let newStatus = !featureFlags.isFeatureEnabled(.pullToRefresh, checking: .userOnly)
         featureFlags.set(feature: .pullToRefresh, to: newStatus)
-        updateCell(navigationController)
+        if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+            settingsDelegate?.askedToReload()
+        } else {
+            updateCell(navigationController)
+        }
     }
 }

--- a/Client/Frontend/Settings/Main/Support/ShowIntroductionSetting.swift
+++ b/Client/Frontend/Settings/Main/Support/ShowIntroductionSetting.swift
@@ -6,14 +6,15 @@ import Foundation
 
 /// Opens the on-boarding screen again
 class ShowIntroductionSetting: Setting {
-    weak var appSettingsDelegate: AppSettingsDelegate?
+    private weak var settingsDelegate: DebugSettingsDelegate?
 
     override var accessibilityIdentifier: String? {
         return AccessibilityIdentifiers.Settings.ShowIntroduction.title
     }
 
-    init(settings: SettingsTableViewController, appSettingsDelegate: AppSettingsDelegate?) {
-        self.appSettingsDelegate = appSettingsDelegate
+    init(settings: SettingsTableViewController,
+         settingsDelegate: DebugSettingsDelegate?) {
+        self.settingsDelegate = settingsDelegate
         let attributes = [NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary]
         super.init(title: NSAttributedString(string: .AppSettingsShowTour,
                                              attributes: attributes))
@@ -27,7 +28,7 @@ class ShowIntroductionSetting: Setting {
         )
 
         if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
-            appSettingsDelegate?.pressedShowTour()
+            settingsDelegate?.pressedShowTour()
         } else {
             navigationController?.dismiss(animated: true) {
                 NotificationCenter.default.post(name: .PresentIntroView, object: self)

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -755,9 +755,6 @@ protocol SettingsDelegate: AnyObject {
 
 // The base settings view controller.
 class SettingsTableViewController: ThemedTableViewController {
-    typealias SettingsGenerator = (SettingsTableViewController, SettingsDelegate?) -> [SettingSection]
-
-    fileprivate let Identifier = "CellIdentifier"
     var settings = [SettingSection]()
 
     weak var settingsDelegate: SettingsDelegate?

--- a/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
@@ -234,6 +234,15 @@ final class SettingsCoordinatorTests: XCTestCase {
         XCTAssertTrue(mockRouter.pushedViewController is CreditCardSettingsViewController)
     }
 
+    func testShowExperimentSettings_showsExperimentVC() {
+        let subject = createSubject()
+
+        subject.showExperiments()
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+        XCTAssertTrue(mockRouter.pushedViewController is ExperimentsViewController)
+    }
+
     func testDidFinishShowingSettings_callsDidFinish() {
         let subject = createSubject()
         subject.parentCoordinator = delegate

--- a/Tests/ClientTests/Mocks/MockAppSettingsDelegate.swift
+++ b/Tests/ClientTests/Mocks/MockAppSettingsDelegate.swift
@@ -3,11 +3,16 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import Shared
+
 @testable import Client
 
-class MockAppSettingsDelegate: AppSettingsDelegate {
+class MockDebugSettingsDelegate: DebugSettingsDelegate {
     var pressedVersionCalled = 0
     var pressedShowTourCalled = 0
+    var pressedExperimentsCalled = 0
+    var askedToShowAlertCalled = 0
+    var askedToReloadCalled = 0
 
     func pressedVersion() {
         pressedVersionCalled += 1
@@ -15,5 +20,17 @@ class MockAppSettingsDelegate: AppSettingsDelegate {
 
     func pressedShowTour() {
         pressedShowTourCalled += 1
+    }
+
+    func pressedExperiments() {
+        pressedExperimentsCalled += 1
+    }
+
+    func askedToShow(alert: AlertController) {
+        askedToShowAlertCalled += 1
+    }
+
+    func askedToReload() {
+        askedToReloadCalled += 1
     }
 }

--- a/Tests/ClientTests/Settings/AppSettingsTableViewControllerTests.swift
+++ b/Tests/ClientTests/Settings/AppSettingsTableViewControllerTests.swift
@@ -82,6 +82,15 @@ class AppSettingsTableViewControllerTests: XCTestCase {
                        URL(string: "fennec://deep-link?url=/action/show-intro-onboarding")!)
     }
 
+    func testShowExperiments_openExperiments() {
+        let subject = createSubject()
+        subject.parentCoordinator = delegate
+
+        subject.pressedExperiments()
+
+        XCTAssertEqual(delegate.showExperimentsCalled, 1)
+    }
+
     // MARK: - Helper
     private func createSubject() -> AppSettingsTableViewController {
         let subject = AppSettingsTableViewController(with: profile,
@@ -98,6 +107,7 @@ class MockSettingsFlowDelegate: SettingsFlowDelegate {
     var showDevicePassCodeCalled = 0
     var showCreditCardSettingsCalled = 0
     var didFinishShowingSettingsCalled = 0
+    var showExperimentsCalled = 0
 
     func showDevicePassCode() {
         showDevicePassCodeCalled += 1
@@ -109,5 +119,9 @@ class MockSettingsFlowDelegate: SettingsFlowDelegate {
 
     func didFinishShowingSettings() {
         didFinishShowingSettingsCalled += 1
+    }
+
+    func showExperiments() {
+        showExperimentsCalled += 1
     }
 }

--- a/Tests/ClientTests/Settings/VersionSettingTests.swift
+++ b/Tests/ClientTests/Settings/VersionSettingTests.swift
@@ -7,12 +7,13 @@ import XCTest
 import Shared
 
 class VersionSettingTests: XCTestCase {
-    private var delegate: MockAppSettingsDelegate!
+    private var delegate: MockDebugSettingsDelegate!
 
     override func setUp() {
         super.setUp()
+        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: MockProfile())
         DependencyHelperMock().bootstrapDependencies()
-        delegate = MockAppSettingsDelegate()
+        delegate = MockDebugSettingsDelegate()
     }
 
     override func tearDown() {
@@ -25,7 +26,7 @@ class VersionSettingTests: XCTestCase {
         // Given
         let settingsTable = SettingsTableViewController(style: .grouped)
         let navigationController = UINavigationController(rootViewController: settingsTable)
-        let versionSetting = VersionSetting(settings: settingsTable, appSettingsDelegate: delegate)
+        let versionSetting = VersionSetting(settingsDelegate: delegate)
         versionSetting.theme = DefaultThemeManager().currentTheme
 
         // When
@@ -42,7 +43,7 @@ class VersionSettingTests: XCTestCase {
         // Given
         let settingsTable = SettingsTableViewController(style: .grouped)
         let navigationController = UINavigationController(rootViewController: settingsTable)
-        let versionSetting = VersionSetting(settings: settingsTable, appSettingsDelegate: delegate)
+        let versionSetting = VersionSetting(settingsDelegate: delegate)
 
         // When
         versionSetting.onClick(navigationController)


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6613)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14793)

### Description
Changing a bit how we handle debug settings, inline with the coordinator pattern where possible. Couple of things:
- I want to remove the `Setting` to know about `SettingsTableViewController`, it should be only the delegate pattern. All Settings need to be adjusted before we can remove that variable thought.
- There's a weird pattern in the settings where we access the `navigationController` to do some actions on it. Sometimes even getting the `tableView` to `reloadData`, or present alerts. This PR changes that to use the delegate instead. We can maybe stop passing the navigation controller to the setting object further down the line when all settings are adjusted.

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
