### PR TITLE
Refactor FXIOS-6710 [v116] RecentlyClosedTabsPanel with Themeable protocol.

### DIFF
--- a/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
+++ b/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
@@ -10,7 +10,6 @@ import Common
 
 private struct RecentlyClosedPanelUX {
     static let IconSize = CGSize(width: 23, height: 23)
-    static let IconBorderColor = UIColor.Photon.Grey30
     static let IconBorderWidth: CGFloat = 0.5
 }
 
@@ -127,10 +126,9 @@ class RecentlyClosedTabsPanelSiteTableViewController: SiteTableViewController {
         twoLineCell.titleLabel.text = tab.title
         twoLineCell.titleLabel.isHidden = tab.title?.isEmpty ?? true ? true : false
         twoLineCell.descriptionLabel.text = displayURL.absoluteDisplayString
-        twoLineCell.leftImageView.layer.borderColor = RecentlyClosedPanelUX.IconBorderColor.cgColor
         twoLineCell.leftImageView.layer.borderWidth = RecentlyClosedPanelUX.IconBorderWidth
         twoLineCell.leftImageView.setFavicon(FaviconImageViewModel(siteURLString: displayURL.absoluteString))
-
+        twoLineCell.applyTheme(theme: themeManager.currentTheme)
         return twoLineCell
     }
 

--- a/Client/Frontend/LoginManagement/LoginListViewController.swift
+++ b/Client/Frontend/LoginManagement/LoginListViewController.swift
@@ -263,7 +263,9 @@ class LoginListViewController: SensitiveViewController, Themeable {
 extension LoginListViewController: UISearchResultsUpdating {
     func updateSearchResults(for searchController: UISearchController) {
         guard let query = searchController.searchBar.text else { return }
-        selectionButton.isHidden = !query.isEmpty
+        if tableView.isEditing {
+            selectionButton.isHidden = !query.isEmpty
+        }
         loadLogins(query)
     }
 }

--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -157,7 +157,7 @@ class SiteTableViewController: UIViewController,
         navigationController?.navigationBar.titleTextAttributes = [.foregroundColor: themeManager.currentTheme.colors.textPrimary]
         setNeedsStatusBarAppearanceUpdate()
 
-        tableView.backgroundColor = themeManager.currentTheme.colors.layer6
+        tableView.backgroundColor = themeManager.currentTheme.colors.layer1
         tableView.separatorColor = themeManager.currentTheme.colors.borderPrimary
         tableView.reloadData()
     }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6710)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14980)

### Description

Refactor `RecentlyClosedTabsPanel` with `Themeable` protocol.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
