### PR TITLE
Bugfix FXIOS-6602 [v116] "Added to shortcuts" toast message not visible

### DIFF
--- a/Client/Frontend/Browser/SimpleToast.swift
+++ b/Client/Frontend/Browser/SimpleToast.swift
@@ -13,6 +13,13 @@ struct SimpleToast: ThemeApplicable {
         label.textAlignment = .center
     }
 
+    private let heightConstraint: NSLayoutConstraint
+
+    init() {
+        heightConstraint = toastLabel.heightAnchor
+            .constraint(equalToConstant: Toast.UX.toastHeight)
+    }
+
     func showAlertWithText(_ text: String,
                            bottomContainer: UIView,
                            theme: Theme,
@@ -20,10 +27,11 @@ struct SimpleToast: ThemeApplicable {
         toastLabel.text = text
         bottomContainer.addSubview(toastLabel)
         NSLayoutConstraint.activate([
+            heightConstraint,
             toastLabel.widthAnchor.constraint(equalTo: bottomContainer.widthAnchor),
             toastLabel.leadingAnchor.constraint(equalTo: bottomContainer.leadingAnchor),
-            toastLabel.bottomAnchor.constraint(equalTo: bottomContainer.bottomAnchor, constant: bottomConstraintPadding),
-            toastLabel.heightAnchor.constraint(equalToConstant: Toast.UX.toastHeight),
+            toastLabel.bottomAnchor.constraint(equalTo: bottomContainer.safeAreaLayoutGuide.bottomAnchor,
+                                               constant: bottomConstraintPadding)
         ])
         applyTheme(theme: theme)
         animate(toastLabel)
@@ -38,10 +46,8 @@ struct SimpleToast: ThemeApplicable {
         UIView.animate(
             withDuration: Toast.UX.toastAnimationDuration,
             animations: {
-                var frame = toast.frame
-                frame.origin.y = frame.origin.y + Toast.UX.toastHeight
-                frame.size.height = 0
-                toast.frame = frame
+                heightConstraint.constant = 0
+                toast.superview?.layoutIfNeeded()
             },
             completion: { finished in
                 toast.removeFromSuperview()


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6602)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14776)

### Description
- Fix the Simple Toast that was not appearing when adding a shortcut from Bookmarks or History
- Fix animation when dismissing the Simple Toast

| Before  | After | 
| ------------- | ------------- |
| https://github.com/mozilla-mobile/firefox-ios/assets/51127880/f8f2064c-5b32-42c4-b04a-5dac1308c23c| https://github.com/mozilla-mobile/firefox-ios/assets/51127880/2b896cb4-33d6-42ef-9845-91fa00b342ef|
### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
