### PR TITLE
Add FXIOS-6670 [v116] FxA telemetry added or adjusted

### DIFF
--- a/Client/Frontend/Settings/Main/Account/ConnectSetting.swift
+++ b/Client/Frontend/Settings/Main/Account/ConnectSetting.swift
@@ -21,7 +21,7 @@ class ConnectSetting: WithoutAccountSetting {
     override func onClick(_ navigationController: UINavigationController?) {
         let fxaParams = FxALaunchParams(entrypoint: .connectSetting, query: [:])
         let viewController = FirefoxAccountSignInViewController(profile: profile, parentType: .settings, deepLinkParams: fxaParams)
-        TelemetryWrapper.recordEvent(category: .firefoxAccount, method: .view, object: .settings)
+        TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .signIntoSync)
         navigationController?.pushViewController(viewController, animated: true)
     }
 

--- a/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -60,7 +60,7 @@ class DisconnectSetting: Setting {
         alertController.addAction(
             UIAlertAction(title: .SettingsDisconnectDestructiveAction, style: .destructive) { (action) in
                 self.profile.removeAccount()
-                TelemetryWrapper.recordEvent(category: .firefoxAccount, method: .settings, object: .accountDisconnected)
+                TelemetryWrapper.recordEvent(category: .firefoxAccount, method: .tap, object: .syncUserLoggedOut)
 
                 // If there is more than one view controller in the navigation controller, we can pop.
                 // Otherwise, assume that we got here directly from the App Menu and dismiss the VC.

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -243,6 +243,8 @@ class TelemetryWrapper: TelemetryWrapperProtocol {
         // If the setting exists at the key location, use that value. Otherwise record the default
         // value for that preference to ensure it makes it into the metrics ping.
         let prefs = profile.prefs
+        // FxA Account Login status
+        GleanMetrics.Preferences.fxaLoggedIn.set(profile.hasSyncableAccount())
         // Record New Tab setting
         if let newTabChoice = prefs.stringForKey(NewTabAccessors.HomePrefKey) {
             GleanMetrics.Preferences.newTabExperience.set(newTabChoice)
@@ -473,6 +475,9 @@ extension TelemetryWrapper {
         case signIntoSync = "sign-into-sync"
         case syncTab = "sync-tab"
         case syncSignIn = "sync-sign-in"
+        case syncSignInUseEmail = "sync-sign-in-use-email"
+        case syncSignInScanQRCode = "sync-sign-in-scan-qr-code"
+        case syncUserLoggedOut = "sync-user-logged-out"
         case syncCreateAccount = "sync-create-account"
         case libraryPanel = "library-panel"
         case navigateToGroupHistory = "navigate-to-group-history"
@@ -1030,6 +1035,12 @@ extension TelemetryWrapper {
             GleanMetrics.Sync.registrationCodeView.record()
         case (.firefoxAccount, .view, .fxaConfirmSignInToken, _, _):
             GleanMetrics.Sync.loginTokenView.record()
+        case (.firefoxAccount, .tap, .syncSignInUseEmail, _, _):
+            GleanMetrics.Sync.useEmail.record()
+        case (.firefoxAccount, .tap, .syncSignInScanQRCode, _, _):
+            GleanMetrics.Sync.paired.record()
+        case (.firefoxAccount, .tap, .syncUserLoggedOut, _, _):
+            GleanMetrics.Sync.disconnect.record()
         // MARK: App cycle
         case(.action, .foreground, .app, _, _):
             GleanMetrics.AppCycle.foreground.record()

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -328,6 +328,7 @@ app_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/9673
       - https://github.com/mozilla-mobile/firefox-ios/pull/12334
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
+      - https://github.com/mozilla-mobile/firefox-ios/pull/15181
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2023-12-01"
@@ -2047,6 +2048,17 @@ preferences:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2023-12-01"
+  fxa_logged_in:
+    type: boolean
+    description: |
+      Measures the state of the fxa login.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/14904
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/15181
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2023-12-01"
   close_private_tabs:
     type: boolean
     description: |
@@ -2450,6 +2462,41 @@ sync:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2023-12-01"
+  use_email:
+    type: event
+    description: |
+      A user chose to use their email to attempt a sign in instead
+      of scanning a QR code, counterpart to "scan_pairing".
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/14904
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/15181
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2023-12-01"
+  paired:
+    type: event
+    description: |
+      A user scanned QR code to attempt to sign in.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/14904
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/15181
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2023-12-01"
+  disconnect:
+    type: event
+    description: |
+      A user tapped disconnect sync in fxa page.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/14904
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/15181
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2023-12-01"
+
 
 # Tab metrics
 tabs:

--- a/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/RustFxA/FirefoxAccountSignInViewController.swift
@@ -255,7 +255,7 @@ class FirefoxAccountSignInViewController: UIViewController, Themeable {
     func scanbuttonTapped(_ sender: UIButton) {
         let qrCodeVC = QRCodeViewController()
         qrCodeVC.qrCodeDelegate = self
-        TelemetryWrapper.recordEvent(category: .firefoxAccount, method: .tap, object: telemetryObject, extras: ["flow_type": "pairing"])
+        TelemetryWrapper.recordEvent(category: .firefoxAccount, method: .tap, object: .syncSignInScanQRCode)
         presentThemedViewController(navItemLocation: .Left, navItemText: .Close, vcBeingPresented: qrCodeVC, topTabsVisible: true)
     }
 
@@ -274,7 +274,7 @@ class FirefoxAccountSignInViewController: UIViewController, Themeable {
             self?.shouldReload?()
             self?.dismissVC()
         }
-        TelemetryWrapper.recordEvent(category: .firefoxAccount, method: .qrPairing, object: telemetryObject, extras: ["flow_type": "email"])
+        TelemetryWrapper.recordEvent(category: .firefoxAccount, method: .tap, object: .syncSignInUseEmail)
         navigationController?.pushViewController(fxaWebVC, animated: true)
     }
 }

--- a/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -375,6 +375,32 @@ class TelemetryWrapperTests: XCTestCase {
         testEventMetricRecordingSuccess(metric: GleanMetrics.SettingsMenu.showTourPressed)
     }
 
+    func test_signIntoSync_GleanIsCalled() {
+        TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .signIntoSync)
+
+        testCounterMetricRecordingSuccess(metric: GleanMetrics.AppMenu.signIntoSync)
+    }
+
+    // MARK: - Sync
+
+    func test_userLoggedOut_GleanIsCalled() {
+        TelemetryWrapper.recordEvent(category: .firefoxAccount, method: .tap, object: .syncUserLoggedOut)
+
+        testEventMetricRecordingSuccess(metric: GleanMetrics.Sync.disconnect)
+    }
+
+    func test_loginWithQRCode_GleanIsCalled() {
+        TelemetryWrapper.recordEvent(category: .firefoxAccount, method: .tap, object: .syncSignInScanQRCode)
+
+        testEventMetricRecordingSuccess(metric: GleanMetrics.Sync.paired)
+    }
+
+    func test_loginWithEmail_GleanIsCalled() {
+        TelemetryWrapper.recordEvent(category: .firefoxAccount, method: .tap, object: .syncSignInUseEmail)
+
+        testEventMetricRecordingSuccess(metric: GleanMetrics.Sync.useEmail)
+    }
+
     // MARK: - Credit card autofill
 
     func test_autofill_credit_card_settings_tapped_GleanIsCalled() {


### PR DESCRIPTION
# [FXIOS-6670](https://mozilla-hub.atlassian.net/browse/FXIOS-6670) | https://github.com/mozilla-mobile/firefox-ios/issues/14904

### Description
Probes for FxA related actions. 

NOTE that `sync.other_external` and `sync.failed` are NOT included in this PR. Those will be investigated and done in a different PR. The reason for this is that `sync.other_external` implies there's a way to get the app to sign into FxA without using any of the known approaches we provide in the app. Android team is reporting this probe. And on an initial look, it doesn't seem like we can report `sync.failed` - need to investigate further and will note in the ticket.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
