### PR TITLE
Localize FXIOS-6804 [v116] credit card string updates

### DIFF
--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -291,9 +291,9 @@ extension String {
                 value: "Cancel",
                 comment: "Button label for cancelling editing of the credit card details shown in the form")
             public static let ViewCreditCardTitle = MZLocalizedString(
-                key: "CreditCard.EditCard.ViewCreditCardTitle.v113",
+                key: "CreditCard.EditCard.ViewCreditCardTitle.v116",
                 tableName: "EditCard",
-                value: "View Credit Card",
+                value: "View Card",
                 comment: "Title label for the view where user can view their credit card info")
             public static let AddCreditCardTitle = MZLocalizedString(
                 key: "CreditCard.EditCard.AddCreditCardTitle.v113",
@@ -436,19 +436,19 @@ extension String {
         // Snackbar / toast
         public struct SnackBar {
             public static let SavedCardLabel = MZLocalizedString(
-                key: "CreditCard.SnackBar.SavedCardLabel.v112",
+                key: "CreditCard.SnackBar.SavedCardLabel.v116",
                 tableName: "SnackBar",
-                value: "New card saved",
+                value: "New Card Saved",
                 comment: "Label text that gets presented as a confirmation at the bottom of screen when credit card information gets saved successfully")
             public static let UpdatedCardLabel = MZLocalizedString(
-                key: "CreditCard.SnackBar.UpdatedCardLabel.v112",
+                key: "CreditCard.SnackBar.UpdatedCardLabel.v116",
                 tableName: "SnackBar",
-                value: "Card information updated",
+                value: "Card Information updated",
                 comment: "Label text that gets presented as a confirmation at the bottom of screen when credit card information gets updated successfully")
             public static let RemovedCardLabel = MZLocalizedString(
-                key: "CreditCard.SnackBar.RemovedCardLabel.v112",
+                key: "CreditCard.SnackBar.RemovedCardLabel.v116",
                 tableName: "SnackBar",
-                value: "Card removed",
+                value: "Card Removed",
                 comment: "Label text that gets presented as a confirmation at the bottom of screen when the credit card is successfully removed.")
         }
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15154)

### Description
Updated the following, the rest needs confirmation (point 2 and 5)
```
1. Confirmation toast for updating a card should say “Card Information Updated” instead of “Card information updated” - Needs to be title case
3.  Update the title ‘View Credit Card’ to ‘View Card’ 
4. Need to use title case on 3 toasts. They should be: 
New Card Saved
Card Information Updated
Card Removed
```

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
