### PR TITLE
Bugfix FXIOS-6753 [v115] Fix black screen when deleting from long press

### DIFF
--- a/Client/TabManagement/TabManagerImplementation.swift
+++ b/Client/TabManagement/TabManagerImplementation.swift
@@ -219,8 +219,6 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
             return
         }
 
-        guard tab.tabUUID != selectedTab?.tabUUID else { return }
-
         // Before moving to a new tab save the current tab session data in order to preseve things like scroll position
         saveCurrentTabSessionData()
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6753)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15029)

### Description
Removed a check to return early if the tab to select is already selected, it seems there is a codepath somewhere when deleting tabs that results in the selected tab being set without firing the codepath to load the webview.
This is a quick fix for the short term, a longer term fix will be part of the tab tray refactor when we clean up how tab selection and deletion is handled.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
