### PR TITLE
Bugfix MTE-891 [v116] Enable previously disabled tests due to M1

### DIFF
--- a/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -93,23 +93,19 @@ class HomePageSettingsUITests: BaseTestCase {
         waitForValueContains(app.textFields["url"], value: "example")
     }
 
-    func testClipboard() throws {
-        if processIsTranslatedStr() == m1Rosetta {
-            throw XCTSkip("Copy & paste may not work on M1")
-        } else {
-            navigator.nowAt(NewTabScreen)
-            // Check that what's in clipboard is copied
-            UIPasteboard.general.string = websiteUrl1
-            navigator.goto(HomeSettings)
-            app.textFields["HomeAsCustomURLTextField"].tap()
-            app.textFields["HomeAsCustomURLTextField"].press(forDuration: 3)
-            waitForExistence(app.menuItems["Paste"])
-            app.menuItems["Paste"].tap()
-            waitForValueContains(app.textFields["HomeAsCustomURLTextField"], value: "mozilla")
-            // Check that the webpage has been correctly copied into the correct field
-            let value = app.textFields["HomeAsCustomURLTextField"].value as! String
-            XCTAssertEqual(value, websiteUrl1)
-        }
+    func testClipboard() {
+        navigator.nowAt(NewTabScreen)
+        // Check that what's in clipboard is copied
+        UIPasteboard.general.string = websiteUrl1
+        navigator.goto(HomeSettings)
+        app.textFields["HomeAsCustomURLTextField"].tap()
+        app.textFields["HomeAsCustomURLTextField"].press(forDuration: 3)
+        waitForExistence(app.menuItems["Paste"])
+        app.menuItems["Paste"].tap()
+        waitForValueContains(app.textFields["HomeAsCustomURLTextField"], value: "mozilla")
+        // Check that the webpage has been correctly copied into the correct field
+        let value = app.textFields["HomeAsCustomURLTextField"].value as! String
+        XCTAssertEqual(value, websiteUrl1)
     }
 
     func testSetFirefoxHomeAsHome() {

--- a/Tests/XCUITests/NavigationTest.swift
+++ b/Tests/XCUITests/NavigationTest.swift
@@ -167,39 +167,30 @@ class NavigationTest: BaseTestCase {
         XCTAssertTrue(app.buttons["Download Link"].exists, "The option is not shown")
     }
     // Only testing Share and Copy Link, the other two options are already covered in other tests
-    func testCopyLink() throws {
-        if processIsTranslatedStr() == m1Rosetta {
-            throw XCTSkip("Copy & paste may not work on M1")
-        } else {
-            longPressLinkOptions(optionSelected: "Copy Link")
-            navigator.goto(NewTabScreen)
-            app.textFields["url"].press(forDuration: 2)
+    func testCopyLink() {
+        longPressLinkOptions(optionSelected: "Copy Link")
+        navigator.goto(NewTabScreen)
+        app.textFields["url"].press(forDuration: 2)
 
-            waitForExistence(app.tables["Context Menu"])
-            app.tables.otherElements[ImageIdentifiers.paste].tap()
-            app.buttons["Go"].tap()
-            waitUntilPageLoad()
-            waitForValueContains(app.textFields["url"], value: website_2["moreLinkLongPressInfo"]!)
-        }
+        waitForExistence(app.tables["Context Menu"])
+        app.tables.otherElements[ImageIdentifiers.paste].tap()
+        app.buttons["Go"].tap()
+        waitUntilPageLoad()
+        waitForValueContains(app.textFields["url"], value: website_2["moreLinkLongPressInfo"]!)
     }
 
-    func testCopyLinkPrivateMode() throws {
-        if processIsTranslatedStr() == m1Rosetta {
-            throw XCTSkip("Copy & paste may not work on M1")
-        } else {
-            navigator.performAction(Action.CloseURLBarOpen)
-            navigator.nowAt(NewTabScreen)
-            navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
-            longPressLinkOptions(optionSelected: "Copy Link")
-            navigator.goto(NewTabScreen)
-            waitForExistence(app.textFields["url"])
-            app.textFields["url"].press(forDuration: 2)
+    func testCopyLinkPrivateMode() {
+        navigator.nowAt(NewTabScreen)
+        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
+        longPressLinkOptions(optionSelected: "Copy Link")
+        navigator.goto(NewTabScreen)
+        waitForExistence(app.textFields["url"])
+        app.textFields["url"].press(forDuration: 2)
 
-            app.tables.otherElements[ImageIdentifiers.paste].tap()
-            app.buttons["Go"].tap()
-            waitUntilPageLoad()
-            waitForValueContains(app.textFields["url"], value: website_2["moreLinkLongPressInfo"]!)
-        }
+        app.tables.otherElements[ImageIdentifiers.paste].tap()
+        app.buttons["Go"].tap()
+        waitUntilPageLoad()
+        waitForValueContains(app.textFields["url"], value: website_2["moreLinkLongPressInfo"]!)
     }
 
     func testLongPressOnAddressBar() throws {

--- a/Tests/XCUITests/SearchTest.swift
+++ b/Tests/XCUITests/SearchTest.swift
@@ -121,47 +121,43 @@ class SearchTests: BaseTestCase {
     }
 
     func testCopyPasteComplete() throws {
-        if processIsTranslatedStr() == m1Rosetta {
-            throw XCTSkip("Copy & paste may not work on M1")
-        } else {
-            // Copy, Paste and Go to url
-            navigator.goto(URLBarOpen)
-            typeOnSearchBar(text: "www.mozilla.org")
-            app.textFields["address"].press(forDuration: 5)
-            app.menuItems["Select All"].tap()
-            waitForExistence(app.menuItems["Copy"], timeout: 3)
-            app.menuItems["Copy"].tap()
-            waitForExistence(app.buttons["urlBar-cancel"])
-            app.buttons["urlBar-cancel"].tap()
+        // Copy, Paste and Go to url
+        navigator.goto(URLBarOpen)
+        typeOnSearchBar(text: "www.mozilla.org")
+        app.textFields["address"].press(forDuration: 5)
+        app.menuItems["Select All"].tap()
+        waitForExistence(app.menuItems["Copy"], timeout: 3)
+        app.menuItems["Copy"].tap()
+        waitForExistence(app.buttons["urlBar-cancel"])
+        app.buttons["urlBar-cancel"].tap()
 
-            navigator.nowAt(HomePanelsScreen)
-            waitForExistence(app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell], timeout: 10)
-            waitForExistence(app.textFields["url"], timeout: 3)
-            app.textFields["url"].tap()
-            waitForExistence(app.textFields["address"], timeout: 3)
-            app.textFields["address"].tap()
+        navigator.nowAt(HomePanelsScreen)
+        waitForExistence(app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell], timeout: 10)
+        waitForExistence(app.textFields["url"], timeout: 3)
+        app.textFields["url"].tap()
+        waitForExistence(app.textFields["address"], timeout: 3)
+        app.textFields["address"].tap()
 
-            waitForExistence(app.menuItems["Paste"])
-            app.menuItems["Paste"].tap()
+        waitForExistence(app.menuItems["Paste"])
+        app.menuItems["Paste"].tap()
 
-            // Verify that the Paste shows the search controller with prompt
-            waitForNoExistence(app.staticTexts[LabelPrompt])
-            app.typeText("\r")
-            waitUntilPageLoad()
+        // Verify that the Paste shows the search controller with prompt
+        waitForNoExistence(app.staticTexts[LabelPrompt])
+        app.typeText("\r")
+        waitUntilPageLoad()
 
-            // Check that the website is loaded
-            waitForValueContains(app.textFields["url"], value: "www.mozilla.org")
-            waitUntilPageLoad()
+        // Check that the website is loaded
+        waitForValueContains(app.textFields["url"], value: "www.mozilla.org")
+        waitUntilPageLoad()
 
-            // Go back, write part of moz, check the autocompletion
-            app.buttons[AccessibilityIdentifiers.Toolbar.backButton].tap()
-            navigator.nowAt(HomePanelsScreen)
-            waitForTabsButton()
-            typeOnSearchBar(text: "moz")
-            waitForValueContains(app.textFields["address"], value: "mozilla.org")
-            let value = app.textFields["address"].value
-            XCTAssertEqual(value as? String, "mozilla.org")
-        }
+        // Go back, write part of moz, check the autocompletion
+        app.buttons[AccessibilityIdentifiers.Toolbar.backButton].tap()
+        navigator.nowAt(HomePanelsScreen)
+        waitForTabsButton()
+        typeOnSearchBar(text: "moz")
+        waitForValueContains(app.textFields["address"], value: "mozilla.org")
+        let value = app.textFields["address"].value
+        XCTAssertEqual(value as? String, "mozilla.org")
     }
 
     private func changeSearchEngine(searchEngine: String) {


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-891)

### Description
The following tests have been enabled: `testClipboard`, `testCopyLink`,  `testCopyLinkPrivateMode`, `testCopyPasteComplete`.

`testLongPressOnAddressBar` could be enabled, but I could not get it to pass consistently.

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
