### PR TITLE
Bugfix FXIOS-6600 [v116] There is a gap between the gradient shadow and the urlBar

### DIFF
--- a/Client/Frontend/Browser/ZoomPageBar.swift
+++ b/Client/Frontend/Browser/ZoomPageBar.swift
@@ -120,6 +120,7 @@ class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
         super.layoutSubviews()
         remakeGradientViewHeightConstraint()
         updateStepperConstraintsBasedOnSizeClass()
+        layoutIfNeeded()
     }
 
     private func setupViews() {


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6600)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14774)

### Description
- Call layoutIfNeeded in layoutSubviews to force a layout update

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
