### PR TITLE
Bugfix FXIOS-6320 [v116] update the value for the private mode #14229

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -290,7 +290,7 @@ extension BrowserViewController: URLBarDelegate {
         } else {
             showSearchController()
         }
-
+        urlBar.locationTextField?.isPrivateMode = tabManager.selectedTab?.isPrivate ?? false
         searchController?.searchQuery = text
         searchLoader?.query = text
     }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -290,7 +290,7 @@ extension BrowserViewController: URLBarDelegate {
         } else {
             showSearchController()
         }
-        urlBar.locationTextField?.isPrivateMode = tabManager.selectedTab?.isPrivate ?? false
+        urlBar.locationTextField?.applyUIMode(isPrivate: tabManager.selectedTab?.isPrivate ?? false, theme: self.themeManager.currentTheme)
         searchController?.searchQuery = text
         searchLoader?.query = text
     }

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -27,7 +27,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     private var hideCursor = false
 
     private let copyShortcutKey = "c"
-    private var isPrivateMode = false
+    public var isPrivateMode = false
     var theme: Theme?
 
     var isSelectionActive: Bool {
@@ -371,7 +371,8 @@ extension AutocompleteTextField: ThemeApplicable, PrivateModeUI {
 
         backgroundColor = theme.colors.layer3
         textColor = theme.colors.textPrimary
-        tintColor = isPrivateMode ? theme.colors.layerAccentPrivateNonOpaque : theme.colors.layerAccentNonOpaque
+        let highlightColor = isPrivateMode ? theme.colors.layerAccentPrivateNonOpaque : theme.colors.layerAccentNonOpaque
+        tintColor = highlightColor
         if autocompleteTextLabel?.attributedText != nil {
             autocompleteTextLabel?.backgroundColor = backgroundColor
             autocompleteTextLabel?.textColor = textColor

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -27,7 +27,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     private var hideCursor = false
 
     private let copyShortcutKey = "c"
-    public var isPrivateMode = false
+    private var isPrivateMode = false
     var theme: Theme?
 
     var isSelectionActive: Bool {
@@ -360,6 +360,12 @@ extension AutocompleteTextField: MenuHelperInterface {
 extension AutocompleteTextField: ThemeApplicable, PrivateModeUI {
     func applyUIMode(isPrivate: Bool, theme: Theme) {
         isPrivateMode = isPrivate
+        let autocompleteText = NSMutableAttributedString(string: self.autocompleteTextLabel?.attributedText?.string ?? "")
+        let color = isPrivateMode ? theme.colors.layerAccentPrivateNonOpaque : theme.colors.layerAccentNonOpaque
+        autocompleteText.addAttribute(NSAttributedString.Key.backgroundColor,
+                                      value: color,
+                                      range: NSRange(location: 0, length: autocompleteText.length))
+        self.autocompleteTextLabel?.attributedText = autocompleteText
         applyTheme(theme: theme)
     }
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6320)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14229)

### Description
Made the property for isPrivateMode public so it can be set before the color of the highlight is determined

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
