### PR TITLE
Bugfix FXIOS-6789 [v116] enable scrolling for multiple cards in the saved cards screen

### DIFF
--- a/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
@@ -172,6 +172,7 @@ class CreditCardBottomSheetViewController: UIViewController, UITableViewDelegate
         let contentViewWidth = UX.contentViewWidth > view.frame.width ? view.frame.width - UX.containerPadding : UX.contentViewWidth
         contentWidthConstraint = contentView.widthAnchor.constraint(equalToConstant: contentViewWidth)
         contentWidthConstraint.priority = UILayoutPriority(999)
+        cardTableView.isScrollEnabled = viewModel.creditCards?.count ?? 0 > 6
 
         NSLayoutConstraint.activate([
             contentView.topAnchor.constraint(equalTo: view.topAnchor),

--- a/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
@@ -108,6 +108,7 @@ class CreditCardBottomSheetViewController: UIViewController, UITableViewDelegate
 
         self.viewModel.didUpdateCreditCard = { [weak self] in
             self?.cardTableView.reloadData()
+            self?.cardTableView.isScrollEnabled = self?.cardTableView.contentSize.height ?? 0 > self?.view.frame.height ?? 0
         }
 
         // Only allow selection when we are in selectSavedCard state
@@ -172,7 +173,6 @@ class CreditCardBottomSheetViewController: UIViewController, UITableViewDelegate
         let contentViewWidth = UX.contentViewWidth > view.frame.width ? view.frame.width - UX.containerPadding : UX.contentViewWidth
         contentWidthConstraint = contentView.widthAnchor.constraint(equalToConstant: contentViewWidth)
         contentWidthConstraint.priority = UILayoutPriority(999)
-        cardTableView.isScrollEnabled = viewModel.creditCards?.count ?? 0 > 6
 
         NSLayoutConstraint.activate([
             contentView.topAnchor.constraint(equalTo: view.topAnchor),


### PR DESCRIPTION


[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6789)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15126)

### Description
Made the tableView scrollable when there are more than 6 saved cards

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
