### PR TITLE
Bugfix FXIOS-6812 [v115] Add a delay prior to performing deeplinks

### DIFF
--- a/Client/Application/SceneDelegate.swift
+++ b/Client/Application/SceneDelegate.swift
@@ -223,16 +223,20 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         with connectionOptions: UIScene.ConnectionOptions,
         on scene: UIScene
     ) {
-        if !connectionOptions.urlContexts.isEmpty {
-            self.scene(scene, openURLContexts: connectionOptions.urlContexts)
-        }
+        // Adding a half second delay to ensure start up actions have resolved prior to attepmting deeplink actions
+        // This is a hacky fix and a long term solution will be add in FXIOS-6828
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            if !connectionOptions.urlContexts.isEmpty {
+                self.scene(scene, openURLContexts: connectionOptions.urlContexts)
+            }
 
-        if let shortcutItem = connectionOptions.shortcutItem {
-            QuickActionsImplementation().handleShortCutItem(
-                shortcutItem,
-                withBrowserViewController: browserViewController,
-                completionHandler: { _ in }
-            )
+            if let shortcutItem = connectionOptions.shortcutItem {
+                QuickActionsImplementation().handleShortCutItem(
+                    shortcutItem,
+                    withBrowserViewController: self.browserViewController,
+                    completionHandler: { _ in }
+                )
+            }
         }
     }
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6812)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15164)

This also fixes #15165 #15166 

### Description
The issue is that with the new tab storage system everything isn't performed on the main thread so there is now a disconnect in timing between the deeplink events triggered by quick actions (and I suspect any deeplinks) and the initial loading of the users tab data. 
This is a hacky fix, it just adds an arbitrary delay that should be long enough in the vast majority of cases to allow time for the tabs to load. 
A proper fix would likely involve building some event management system into the tab manager to hold onto events it can process when it is in an appropriate state to do so. This is a much bigger task and with all of the feature flags active in this area it's tricky and risky to do at this time so I have added a ticket to follow up on it.

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
