### PR TITLE
Refactor FXIOS-6614 [v116] General settings debug

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -517,6 +517,8 @@
 		8A07910F278F62F2005529CB /* AdjustHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A07910E278F62F2005529CB /* AdjustHelper.swift */; };
 		8A08EC6227EBDCA400E119C7 /* iAd.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E4B334871BBF23F3004E2BFF /* iAd.framework */; };
 		8A08EC6427EBDCAD00E119C7 /* AdServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A08EC6327EBDCAC00E119C7 /* AdServices.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		8A093D7D2A4B3E4F0099ABA5 /* DebugSettingsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A093D7C2A4B3E4F0099ABA5 /* DebugSettingsDelegate.swift */; };
+		8A093D7F2A4B3E7D0099ABA5 /* GeneralSettingsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A093D7E2A4B3E7D0099ABA5 /* GeneralSettingsDelegate.swift */; };
 		8A0F2A7E286DFCC800D84CC6 /* PushRemoteError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0F2A7D286DFCC800D84CC6 /* PushRemoteError.swift */; };
 		8A0F2A80286DFD2B00D84CC6 /* PushClientError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0F2A7F286DFD2B00D84CC6 /* PushClientError.swift */; };
 		8A0F2A82286DFD9800D84CC6 /* PushRegistrationAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0F2A81286DFD9800D84CC6 /* PushRegistrationAPI.swift */; };
@@ -1462,8 +1464,8 @@
 		F8AAC1B429663619000BCDEC /* RustAutofill.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AAC1B329663618000BCDEC /* RustAutofill.swift */; };
 		F8AAC1B7296637CE000BCDEC /* RustAutofillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AAC1B5296637B7000BCDEC /* RustAutofillTests.swift */; };
 		F8B18F5529EE01A2008724A8 /* RustSyncManagerAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B18F5429EE01A1008724A8 /* RustSyncManagerAPITests.swift */; };
-		F98CB66E2A4123F1005F38E9 /* EnhancedTrackingProtectionMenuVMTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F98CB66C2A4123E7005F38E9 /* EnhancedTrackingProtectionMenuVMTests.swift */; };
 		F8DEACC52A3D43DA00C3B19D /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = F8DEACC42A3D43DA00C3B19D /* Sentry */; };
+		F98CB66E2A4123F1005F38E9 /* EnhancedTrackingProtectionMenuVMTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F98CB66C2A4123E7005F38E9 /* EnhancedTrackingProtectionMenuVMTests.swift */; };
 		FA6B2AC21D41F02D00429414 /* String+Punycode.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6B2AC11D41F02D00429414 /* String+Punycode.swift */; };
 		FA6B2AC41D41F02D00429414 /* String+Punycode.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6B2AC11D41F02D00429414 /* String+Punycode.swift */; };
 		FA9293D41D6580E100AC8D33 /* QRCodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9293D31D6580E100AC8D33 /* QRCodeViewController.swift */; };
@@ -4541,6 +4543,8 @@
 		8A0621B729428FBD005D1EFD /* OpenTabNotificationObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenTabNotificationObject.swift; sourceTree = "<group>"; };
 		8A07910E278F62F2005529CB /* AdjustHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdjustHelper.swift; sourceTree = "<group>"; };
 		8A08EC6327EBDCAC00E119C7 /* AdServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdServices.framework; path = System/Library/Frameworks/AdServices.framework; sourceTree = SDKROOT; };
+		8A093D7C2A4B3E4F0099ABA5 /* DebugSettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSettingsDelegate.swift; sourceTree = "<group>"; };
+		8A093D7E2A4B3E7D0099ABA5 /* GeneralSettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsDelegate.swift; sourceTree = "<group>"; };
 		8A0F2A7D286DFCC800D84CC6 /* PushRemoteError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushRemoteError.swift; sourceTree = "<group>"; };
 		8A0F2A7F286DFD2B00D84CC6 /* PushClientError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushClientError.swift; sourceTree = "<group>"; };
 		8A0F2A81286DFD9800D84CC6 /* PushRegistrationAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushRegistrationAPI.swift; sourceTree = "<group>"; };
@@ -7966,6 +7970,7 @@
 			children = (
 				8A3EF7FC2A2FCFAC00796E3A /* AppReviewPromptSetting.swift */,
 				8A3EF7FE2A2FCFBB00796E3A /* ChangeToChinaSetting.swift */,
+				8A093D7C2A4B3E4F0099ABA5 /* DebugSettingsDelegate.swift */,
 				8A3EF7F12A2FCF4000796E3A /* DeleteExportedDataSetting.swift */,
 				8A3EF8082A2FD02B00796E3A /* ExperimentsSettings.swift */,
 				8A3EF7F32A2FCF5700796E3A /* ExportBrowserDataSetting.swift */,
@@ -8034,15 +8039,16 @@
 		8A5D1CA22A30D661005AD35C /* General */ = {
 			isa = PBXGroup;
 			children = (
-				8A5D1CA32A30D69A005AD35C /* SearchSetting.swift */,
-				8A5D1CA52A30D6BD005AD35C /* NewTabPageSetting.swift */,
+				8A093D7E2A4B3E7D0099ABA5 /* GeneralSettingsDelegate.swift */,
 				8A5D1CA72A30D6D3005AD35C /* HomeSetting.swift */,
-				8A5D1CA92A30D6E2005AD35C /* TabsSetting.swift */,
-				8A5D1CAB2A30D70B005AD35C /* OpenWithSetting.swift */,
-				8A5D1CAD2A30D71A005AD35C /* ThemeSetting.swift */,
-				8A5D1CAF2A30D740005AD35C /* SearchBarSetting.swift */,
-				8A5D1CB12A30D756005AD35C /* SiriPageSetting.swift */,
+				8A5D1CA52A30D6BD005AD35C /* NewTabPageSetting.swift */,
 				8A5D1CB32A30D7D9005AD35C /* NoImageModeSetting.swift */,
+				8A5D1CAB2A30D70B005AD35C /* OpenWithSetting.swift */,
+				8A5D1CAF2A30D740005AD35C /* SearchBarSetting.swift */,
+				8A5D1CA32A30D69A005AD35C /* SearchSetting.swift */,
+				8A5D1CB12A30D756005AD35C /* SiriPageSetting.swift */,
+				8A5D1CA92A30D6E2005AD35C /* TabsSetting.swift */,
+				8A5D1CAD2A30D71A005AD35C /* ThemeSetting.swift */,
 			);
 			path = General;
 			sourceTree = "<group>";
@@ -12412,6 +12418,7 @@
 				8A5D1CB22A30D756005AD35C /* SiriPageSetting.swift in Sources */,
 				39A359E41BFCCE94006B9E87 /* UserActivityHandler.swift in Sources */,
 				4331A9BD271D267E005E8080 /* ContextualHintViewModel.swift in Sources */,
+				8A093D7F2A4B3E7D0099ABA5 /* GeneralSettingsDelegate.swift in Sources */,
 				D88FDAAF1F4E2BA000FD9709 /* PhotonActionSheetAnimator.swift in Sources */,
 				C83432FE26BAD30D00ABAAA6 /* EnhancedTrackingProtectionDetailsVC.swift in Sources */,
 				E698FFDA1B4AADF40001F623 /* TabScrollController.swift in Sources */,
@@ -12479,6 +12486,7 @@
 				962021E128B8078400BDF3D9 /* ContextualHintCopyProvider.swift in Sources */,
 				8AE1E1D227B1ADC40024C45E /* TopBottomInterchangeable.swift in Sources */,
 				8A7653BD28A2C61D00924ABF /* PocketDataAdaptor.swift in Sources */,
+				8A093D7D2A4B3E4F0099ABA5 /* DebugSettingsDelegate.swift in Sources */,
 				96EA9454293655BF00123345 /* AppSession+Enums.swift in Sources */,
 				C8B0F5F4283B7CCE007AE65D /* PocketProvider.swift in Sources */,
 				C8E531C829E5EB6100E03FEF /* RouteBuilder.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -519,6 +519,7 @@
 		8A08EC6427EBDCAD00E119C7 /* AdServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A08EC6327EBDCAC00E119C7 /* AdServices.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		8A093D7D2A4B3E4F0099ABA5 /* DebugSettingsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A093D7C2A4B3E4F0099ABA5 /* DebugSettingsDelegate.swift */; };
 		8A093D7F2A4B3E7D0099ABA5 /* GeneralSettingsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A093D7E2A4B3E7D0099ABA5 /* GeneralSettingsDelegate.swift */; };
+		8A093D812A4B58330099ABA5 /* MockSettingsFlowDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A093D802A4B58330099ABA5 /* MockSettingsFlowDelegate.swift */; };
 		8A0F2A7E286DFCC800D84CC6 /* PushRemoteError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0F2A7D286DFCC800D84CC6 /* PushRemoteError.swift */; };
 		8A0F2A80286DFD2B00D84CC6 /* PushClientError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0F2A7F286DFD2B00D84CC6 /* PushClientError.swift */; };
 		8A0F2A82286DFD9800D84CC6 /* PushRegistrationAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0F2A81286DFD9800D84CC6 /* PushRegistrationAPI.swift */; };
@@ -4545,6 +4546,7 @@
 		8A08EC6327EBDCAC00E119C7 /* AdServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdServices.framework; path = System/Library/Frameworks/AdServices.framework; sourceTree = SDKROOT; };
 		8A093D7C2A4B3E4F0099ABA5 /* DebugSettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSettingsDelegate.swift; sourceTree = "<group>"; };
 		8A093D7E2A4B3E7D0099ABA5 /* GeneralSettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsDelegate.swift; sourceTree = "<group>"; };
+		8A093D802A4B58330099ABA5 /* MockSettingsFlowDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSettingsFlowDelegate.swift; sourceTree = "<group>"; };
 		8A0F2A7D286DFCC800D84CC6 /* PushRemoteError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushRemoteError.swift; sourceTree = "<group>"; };
 		8A0F2A7F286DFD2B00D84CC6 /* PushClientError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushClientError.swift; sourceTree = "<group>"; };
 		8A0F2A81286DFD9800D84CC6 /* PushRegistrationAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushRegistrationAPI.swift; sourceTree = "<group>"; };
@@ -9021,6 +9023,7 @@
 				8AABBD042A0041380089941E /* MockCoordinator.swift */,
 				8A359EF52A1FE840004A5BB7 /* MockAdjustWrapper.swift */,
 				8A5D1C9F2A30C9D7005AD35C /* MockAppSettingsDelegate.swift */,
+				8A093D802A4B58330099ABA5 /* MockSettingsFlowDelegate.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -12810,6 +12813,7 @@
 				E4CD9F1D1A6D9C2800318571 /* WebServerTests.swift in Sources */,
 				C869916528918C8E007ACC5C /* WallpaperURLSessionMock.swift in Sources */,
 				961577942A39008100391E8D /* SponsoredTileDataUtilityTests.swift in Sources */,
+				8A093D812A4B58330099ABA5 /* MockSettingsFlowDelegate.swift in Sources */,
 				431C0D1E25C9DC4D00395CE4 /* DefaultBrowserOnboardingTests.swift in Sources */,
 				213B67A827CE721E000542F5 /* StartAtHomeHelperTests.swift in Sources */,
 				8A7653C228A2E57D00924ABF /* PocketDataAdaptorTests.swift in Sources */,

--- a/Client/Application/AccessibilityIdentifiers.swift
+++ b/Client/Application/AccessibilityIdentifiers.swift
@@ -224,6 +224,7 @@ public struct AccessibilityIdentifiers {
         }
 
         struct Search {
+            static let title = "Search"
             static let customEngineViewButton = "customEngineViewButton"
             static let searchNavigationBar = "Search"
             static let deleteMozillaEngine = "Delete Mozilla Engine"
@@ -250,6 +251,18 @@ public struct AccessibilityIdentifiers {
             static let title = "TrackingProtection"
         }
 
+        struct NewTab {
+            static let title = "NewTab"
+        }
+
+        struct NoImageMode {
+            static let title = "NoImageMode"
+        }
+
+        struct OpenWithMail {
+            static let title = "OpenWith.Setting"
+        }
+
         struct SearchBar {
             static let searchBarSetting = "SearchBarSetting"
             static let topSetting = "TopSearchBar"
@@ -264,8 +277,20 @@ public struct AccessibilityIdentifiers {
             static let title = "ShowTour"
         }
 
+        struct Siri {
+            static let title = "SiriSettings"
+        }
+
         struct StudiesToggle {
             static let title = "StudiesToggle"
+        }
+
+        struct Tabs {
+            static let title = "TabsSetting"
+        }
+
+        struct Theme {
+            static let title = "DisplayThemeOption"
         }
 
         struct BlockImages {

--- a/Client/Coordinators/SettingsCoordinator.swift
+++ b/Client/Coordinators/SettingsCoordinator.swift
@@ -11,7 +11,7 @@ protocol SettingsCoordinatorDelegate: AnyObject {
     func didFinishSettings(from coordinator: SettingsCoordinator)
 }
 
-class SettingsCoordinator: BaseCoordinator, SettingsDelegate, SettingsFlowDelegate {
+class SettingsCoordinator: BaseCoordinator, SettingsDelegate, SettingsFlowDelegate, GeneralSettingsDelegate {
     var settingsViewController: AppSettingsScreen
     private let wallpaperManager: WallpaperManagerInterface
     private let profile: Profile
@@ -194,5 +194,50 @@ class SettingsCoordinator: BaseCoordinator, SettingsDelegate, SettingsFlowDelega
 
     func goToPasswordManager() {
         settingsViewController.handle(route: .password)
+    }
+
+    // MARK: GeneralSettingsDelegate
+
+    func pressedHome() {
+        let viewController = HomePageSettingViewController(prefs: profile.prefs)
+        viewController.profile = profile
+        router.push(viewController)
+    }
+
+    func pressedMailApp() {
+        let viewController = OpenWithSettingsViewController(prefs: profile.prefs)
+        router.push(viewController)
+    }
+
+    func pressedNewTab() {
+        let viewController = NewTabContentSettingsViewController(prefs: profile.prefs)
+        viewController.profile = profile
+        router.push(viewController)
+    }
+
+    func pressedSearchEngine() {
+        let viewController = SearchSettingsTableViewController(profile: profile)
+        router.push(viewController)
+    }
+
+    func pressedSiri() {
+        let viewController = SiriSettingsViewController(prefs: profile.prefs)
+        viewController.profile = profile
+        router.push(viewController)
+    }
+
+    func pressedToolbar() {
+        let viewModel = SearchBarSettingsViewModel(prefs: profile.prefs)
+        let viewController = SearchBarSettingsViewController(viewModel: viewModel)
+        router.push(viewController)
+    }
+
+    func pressedTabs() {
+        let viewController = TabsSettingsViewController()
+        router.push(viewController)
+    }
+
+    func pressedTheme() {
+        router.push(ThemeSettingsController())
     }
 }

--- a/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -48,18 +48,8 @@ enum AppSettingsDeeplinkOption {
     }
 }
 
-/// Child settings pages debug action
-protocol DebugSettingsDelegate: AnyObject {
-    func pressedVersion()
-    func pressedShowTour()
-    func pressedExperiments()
-
-    func askedToShow(alert: AlertController)
-    func askedToReload()
-}
-
 /// Supports decision making from VC to parent coordinator
-protocol SettingsFlowDelegate: AnyObject {
+protocol SettingsFlowDelegate: AnyObject, GeneralSettingsDelegate {
     func showDevicePassCode()
     func showCreditCardSettings()
     func showExperiments()
@@ -324,24 +314,24 @@ class AppSettingsTableViewController: SettingsTableViewController, AppSettingsSc
         )
 
         var generalSettings: [Setting] = [
-            SearchSetting(settings: self),
-            NewTabPageSetting(settings: self),
-            HomeSetting(settings: self),
-            OpenWithSetting(settings: self),
-            ThemeSetting(settings: self),
-            SiriPageSetting(settings: self),
+            SearchSetting(settings: self, settingsDelegate: parentCoordinator),
+            NewTabPageSetting(settings: self, settingsDelegate: parentCoordinator),
+            HomeSetting(settings: self, settingsDelegate: parentCoordinator),
+            OpenWithSetting(settings: self, settingsDelegate: parentCoordinator),
+            ThemeSetting(settings: self, settingsDelegate: parentCoordinator),
+            SiriPageSetting(settings: self, settingsDelegate: parentCoordinator),
             blockpopUpSetting,
             NoImageModeSetting(settings: self),
         ]
 
         if isSearchBarLocationFeatureEnabled {
-            generalSettings.insert(SearchBarSetting(settings: self), at: 5)
+            generalSettings.insert(SearchBarSetting(settings: self, settingsDelegate: parentCoordinator), at: 5)
         }
 
         let tabTrayGroupsAreBuildActive = featureFlags.isFeatureEnabled(.tabTrayGroups, checking: .buildOnly)
         let inactiveTabsAreBuildActive = featureFlags.isFeatureEnabled(.inactiveTabs, checking: .buildOnly)
         if tabTrayGroupsAreBuildActive || inactiveTabsAreBuildActive {
-            generalSettings.insert(TabsSetting(theme: themeManager.currentTheme), at: 3)
+            generalSettings.insert(TabsSetting(theme: themeManager.currentTheme, settingsDelegate: parentCoordinator), at: 3)
         }
 
         let offerToOpenCopiedLinksSettings = BoolSetting(

--- a/Client/Frontend/Settings/Main/Debug/DebugSettingsDelegate.swift
+++ b/Client/Frontend/Settings/Main/Debug/DebugSettingsDelegate.swift
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Shared
+
+/// Child settings pages debug actions
+protocol DebugSettingsDelegate: AnyObject {
+    func pressedVersion()
+    func pressedShowTour()
+    func pressedExperiments()
+
+    func askedToShow(alert: AlertController)
+    func askedToReload()
+}

--- a/Client/Frontend/Settings/Main/Debug/ResetWallpaperOnboardingPage.swift
+++ b/Client/Frontend/Settings/Main/Debug/ResetWallpaperOnboardingPage.swift
@@ -5,7 +5,7 @@
 import Foundation
 import Shared
 
-class ResetWallpaperOnboardingPage: HiddenSetting, FeatureFlaggable {
+class ResetWallpaperOnboardingPage: HiddenSetting {
     private weak var settingsDelegate: DebugSettingsDelegate?
 
     init(settings: SettingsTableViewController,

--- a/Client/Frontend/Settings/Main/General/GeneralSettingsDelegate.swift
+++ b/Client/Frontend/Settings/Main/General/GeneralSettingsDelegate.swift
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// Child settings pages general actions
+protocol GeneralSettingsDelegate: AnyObject {
+    func pressedHome()
+    func pressedMailApp()
+    func pressedNewTab()
+    func pressedSearchEngine()
+    func pressedSiri()
+    func pressedToolbar()
+    func pressedTabs()
+    func pressedTheme()
+}

--- a/Client/Frontend/Settings/Main/General/HomeSetting.swift
+++ b/Client/Frontend/Settings/Main/General/HomeSetting.swift
@@ -5,11 +5,16 @@
 import Foundation
 
 class HomeSetting: Setting {
-    let profile: Profile
+    private weak var settingsDelegate: GeneralSettingsDelegate?
+    private let profile: Profile
 
-    override var accessoryView: UIImageView? { return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme) }
+    override var accessoryView: UIImageView? {
+        return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme)
+    }
 
-    override var accessibilityIdentifier: String? { return "Home" }
+    override var accessibilityIdentifier: String? {
+        return AccessibilityIdentifiers.Settings.Homepage.homeSettings
+    }
 
     override var status: NSAttributedString {
         return NSAttributedString(string: NewTabAccessors.getHomePage(self.profile.prefs).settingTitle)
@@ -17,15 +22,21 @@ class HomeSetting: Setting {
 
     override var style: UITableViewCell.CellStyle { return .value1 }
 
-    init(settings: SettingsTableViewController) {
+    init(settings: SettingsTableViewController,
+         settingsDelegate: GeneralSettingsDelegate?) {
         self.profile = settings.profile
+        self.settingsDelegate = settingsDelegate
         super.init(title: NSAttributedString(string: .SettingsHomePageSectionName,
                                              attributes: [NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
-        let viewController = HomePageSettingViewController(prefs: profile.prefs)
-        viewController.profile = profile
-        navigationController?.pushViewController(viewController, animated: true)
+        if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+            settingsDelegate?.pressedHome()
+        } else {
+            let viewController = HomePageSettingViewController(prefs: profile.prefs)
+            viewController.profile = profile
+            navigationController?.pushViewController(viewController, animated: true)
+        }
     }
 }

--- a/Client/Frontend/Settings/Main/General/NewTabPageSetting.swift
+++ b/Client/Frontend/Settings/Main/General/NewTabPageSetting.swift
@@ -5,13 +5,16 @@
 import Foundation
 
 class NewTabPageSetting: Setting {
-    let profile: Profile
+    private let profile: Profile
+    private weak var settingsDelegate: GeneralSettingsDelegate?
 
     override var accessoryView: UIImageView? {
         return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme)
     }
 
-    override var accessibilityIdentifier: String? { return "NewTab" }
+    override var accessibilityIdentifier: String? {
+        return AccessibilityIdentifiers.Settings.NewTab.title
+    }
 
     override var status: NSAttributedString {
         return NSAttributedString(string: NewTabAccessors.getNewTabPage(self.profile.prefs).settingTitle)
@@ -19,15 +22,21 @@ class NewTabPageSetting: Setting {
 
     override var style: UITableViewCell.CellStyle { return .value1 }
 
-    init(settings: SettingsTableViewController) {
+    init(settings: SettingsTableViewController,
+         settingsDelegate: GeneralSettingsDelegate?) {
         self.profile = settings.profile
+        self.settingsDelegate = settingsDelegate
         super.init(title: NSAttributedString(string: .SettingsNewTabSectionName,
                                              attributes: [NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
-        let viewController = NewTabContentSettingsViewController(prefs: profile.prefs)
-        viewController.profile = profile
-        navigationController?.pushViewController(viewController, animated: true)
+        if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+            settingsDelegate?.pressedNewTab()
+        } else {
+            let viewController = NewTabContentSettingsViewController(prefs: profile.prefs)
+            viewController.profile = profile
+            navigationController?.pushViewController(viewController, animated: true)
+        }
     }
 }

--- a/Client/Frontend/Settings/Main/General/NoImageModeSetting.swift
+++ b/Client/Frontend/Settings/Main/General/NoImageModeSetting.swift
@@ -25,5 +25,7 @@ class NoImageModeSetting: BoolSetting {
         )
     }
 
-    override var accessibilityIdentifier: String? { return "NoImageMode" }
+    override var accessibilityIdentifier: String? {
+        return AccessibilityIdentifiers.Settings.NoImageMode.title
+    }
 }

--- a/Client/Frontend/Settings/Main/General/OpenWithSetting.swift
+++ b/Client/Frontend/Settings/Main/General/OpenWithSetting.swift
@@ -6,13 +6,16 @@ import Foundation
 import Shared
 
 class OpenWithSetting: Setting {
-    let profile: Profile
+    private weak var settingsDelegate: GeneralSettingsDelegate?
+    private let profile: Profile
 
     override var accessoryView: UIImageView? {
         return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme)
     }
 
-    override var accessibilityIdentifier: String? { return "OpenWith.Setting" }
+    override var accessibilityIdentifier: String? {
+        return AccessibilityIdentifiers.Settings.OpenWithMail.title
+    }
 
     override var status: NSAttributedString {
         guard let provider = self.profile.prefs.stringForKey(PrefsKeys.KeyMailToOption) else {
@@ -30,15 +33,21 @@ class OpenWithSetting: Setting {
 
     override var style: UITableViewCell.CellStyle { return .value1 }
 
-    init(settings: SettingsTableViewController) {
+    init(settings: SettingsTableViewController,
+         settingsDelegate: GeneralSettingsDelegate?) {
         self.profile = settings.profile
+        self.settingsDelegate = settingsDelegate
 
         super.init(title: NSAttributedString(string: .SettingsOpenWithSectionName,
                                              attributes: [NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
-        let viewController = OpenWithSettingsViewController(prefs: profile.prefs)
-        navigationController?.pushViewController(viewController, animated: true)
+        if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+            settingsDelegate?.pressedMailApp()
+        } else {
+            let viewController = OpenWithSettingsViewController(prefs: profile.prefs)
+            navigationController?.pushViewController(viewController, animated: true)
+        }
     }
 }

--- a/Client/Frontend/Settings/Main/General/SearchBarSetting.swift
+++ b/Client/Frontend/Settings/Main/General/SearchBarSetting.swift
@@ -5,11 +5,16 @@
 import Foundation
 
 class SearchBarSetting: Setting {
-    let viewModel: SearchBarSettingsViewModel
+    private let viewModel: SearchBarSettingsViewModel
+    private weak var settingsDelegate: GeneralSettingsDelegate?
 
-    override var accessoryView: UIImageView? { return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme) }
+    override var accessoryView: UIImageView? {
+        return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme)
+    }
 
-    override var accessibilityIdentifier: String? { return AccessibilityIdentifiers.Settings.SearchBar.searchBarSetting }
+    override var accessibilityIdentifier: String? {
+        return AccessibilityIdentifiers.Settings.SearchBar.searchBarSetting
+    }
 
     override var status: NSAttributedString {
         return NSAttributedString(string: viewModel.searchBarTitle )
@@ -17,14 +22,20 @@ class SearchBarSetting: Setting {
 
     override var style: UITableViewCell.CellStyle { return .value1 }
 
-    init(settings: SettingsTableViewController) {
+    init(settings: SettingsTableViewController,
+         settingsDelegate: GeneralSettingsDelegate?) {
         self.viewModel = SearchBarSettingsViewModel(prefs: settings.profile.prefs)
+        self.settingsDelegate = settingsDelegate
         super.init(title: NSAttributedString(string: viewModel.title,
                                              attributes: [NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
-        let viewController = SearchBarSettingsViewController(viewModel: viewModel)
-        navigationController?.pushViewController(viewController, animated: true)
+        if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+            settingsDelegate?.pressedToolbar()
+        } else {
+            let viewController = SearchBarSettingsViewController(viewModel: viewModel)
+            navigationController?.pushViewController(viewController, animated: true)
+        }
     }
 }

--- a/Client/Frontend/Settings/Main/General/SearchSetting.swift
+++ b/Client/Frontend/Settings/Main/General/SearchSetting.swift
@@ -5,7 +5,8 @@
 import Foundation
 
 class SearchSetting: Setting {
-    let profile: Profile
+    private let profile: Profile
+    private weak var settingsDelegate: GeneralSettingsDelegate?
 
     override var accessoryView: UIImageView? {
         return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme)
@@ -15,17 +16,24 @@ class SearchSetting: Setting {
 
     override var status: NSAttributedString { return NSAttributedString(string: profile.searchEngines.defaultEngine?.shortName ?? "") }
 
-    override var accessibilityIdentifier: String? { return "Search" }
+    override var accessibilityIdentifier: String? {
+        return AccessibilityIdentifiers.Settings.Search.title
+    }
 
-    init(settings: SettingsTableViewController) {
+    init(settings: SettingsTableViewController,
+         settingsDelegate: GeneralSettingsDelegate?) {
         self.profile = settings.profile
+        self.settingsDelegate = settingsDelegate
         super.init(title: NSAttributedString(string: .AppSettingsSearch,
                                              attributes: [NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
-        let viewController = SearchSettingsTableViewController(profile: profile)
-
-        navigationController?.pushViewController(viewController, animated: true)
+        if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+            settingsDelegate?.pressedSearchEngine()
+        } else {
+            let viewController = SearchSettingsTableViewController(profile: profile)
+            navigationController?.pushViewController(viewController, animated: true)
+        }
     }
 }

--- a/Client/Frontend/Settings/Main/General/SiriPageSetting.swift
+++ b/Client/Frontend/Settings/Main/General/SiriPageSetting.swift
@@ -5,24 +5,33 @@
 import Foundation
 
 class SiriPageSetting: Setting {
-    let profile: Profile
+    private weak var settingsDelegate: GeneralSettingsDelegate?
+    private let profile: Profile
 
     override var accessoryView: UIImageView? {
         return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme)
     }
 
-    override var accessibilityIdentifier: String? { return "SiriSettings" }
+    override var accessibilityIdentifier: String? {
+        return AccessibilityIdentifiers.Settings.Siri.title
+    }
 
-    init(settings: SettingsTableViewController) {
+    init(settings: SettingsTableViewController,
+         settingsDelegate: GeneralSettingsDelegate?) {
         self.profile = settings.profile
+        self.settingsDelegate = settingsDelegate
 
         super.init(title: NSAttributedString(string: .SettingsSiriSectionName,
                                              attributes: [NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
-        let viewController = SiriSettingsViewController(prefs: profile.prefs)
-        viewController.profile = profile
-        navigationController?.pushViewController(viewController, animated: true)
+        if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+            settingsDelegate?.pressedSiri()
+        } else {
+            let viewController = SiriSettingsViewController(prefs: profile.prefs)
+            viewController.profile = profile
+            navigationController?.pushViewController(viewController, animated: true)
+        }
     }
 }

--- a/Client/Frontend/Settings/Main/General/TabsSetting.swift
+++ b/Client/Frontend/Settings/Main/General/TabsSetting.swift
@@ -6,17 +6,27 @@ import Foundation
 import Shared
 
 class TabsSetting: Setting {
+    private weak var settingsDelegate: GeneralSettingsDelegate?
+
     override var accessoryView: UIImageView? { return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme) }
 
-    override var accessibilityIdentifier: String? { return "TabsSetting" }
+    override var accessibilityIdentifier: String? {
+        return AccessibilityIdentifiers.Settings.Tabs.title
+    }
 
-    init(theme: Theme) {
+    init(theme: Theme,
+         settingsDelegate: GeneralSettingsDelegate?) {
+        self.settingsDelegate = settingsDelegate
         super.init(title: NSAttributedString(string: .Settings.SectionTitles.TabsTitle,
                                              attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
-        let viewController = TabsSettingsViewController()
-        navigationController?.pushViewController(viewController, animated: true)
+        if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+            settingsDelegate?.pressedTabs()
+        } else {
+            let viewController = TabsSettingsViewController()
+            navigationController?.pushViewController(viewController, animated: true)
+        }
     }
 }

--- a/Client/Frontend/Settings/Main/General/ThemeSetting.swift
+++ b/Client/Frontend/Settings/Main/General/ThemeSetting.swift
@@ -5,12 +5,17 @@
 import Foundation
 
 class ThemeSetting: Setting {
-    let profile: Profile
+    private weak var settingsDelegate: GeneralSettingsDelegate?
+    private let profile: Profile
+
     override var accessoryView: UIImageView? {
         return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme)
     }
     override var style: UITableViewCell.CellStyle { return .value1 }
-    override var accessibilityIdentifier: String? { return "DisplayThemeOption" }
+
+    override var accessibilityIdentifier: String? {
+        return AccessibilityIdentifiers.Settings.Theme.title
+    }
 
     override var status: NSAttributedString {
         if LegacyThemeManager.instance.systemThemeIsOn {
@@ -23,13 +28,19 @@ class ThemeSetting: Setting {
         return NSAttributedString(string: "")
     }
 
-    init(settings: SettingsTableViewController) {
+    init(settings: SettingsTableViewController,
+         settingsDelegate: GeneralSettingsDelegate?) {
         self.profile = settings.profile
+        self.settingsDelegate = settingsDelegate
         super.init(title: NSAttributedString(string: .SettingsDisplayThemeTitle,
                                              attributes: [NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary]))
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
-        navigationController?.pushViewController(ThemeSettingsController(), animated: true)
+        if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+            settingsDelegate?.pressedTheme()
+        } else {
+            navigationController?.pushViewController(ThemeSettingsController(), animated: true)
+        }
     }
 }

--- a/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
@@ -297,6 +297,80 @@ final class SettingsCoordinatorTests: XCTestCase {
         XCTAssertFalse(result)
     }
 
+    // MARK: - GeneralSettingsDelegate
+
+    func testGeneralSettingsDelegate_pushedHome() {
+        let subject = createSubject()
+
+        subject.pressedHome()
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+        XCTAssertTrue(mockRouter.pushedViewController is HomePageSettingViewController)
+    }
+
+    func testGeneralSettingsDelegate_pushedMailApp() {
+        let subject = createSubject()
+
+        subject.pressedMailApp()
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+        XCTAssertTrue(mockRouter.pushedViewController is OpenWithSettingsViewController)
+    }
+
+    func testGeneralSettingsDelegate_pushedNewTab() {
+        let subject = createSubject()
+
+        subject.pressedNewTab()
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+        XCTAssertTrue(mockRouter.pushedViewController is NewTabContentSettingsViewController)
+    }
+
+    func testGeneralSettingsDelegate_pushedSearchEngine() {
+        let subject = createSubject()
+
+        subject.pressedSearchEngine()
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+        XCTAssertTrue(mockRouter.pushedViewController is SearchSettingsTableViewController)
+    }
+
+    func testGeneralSettingsDelegate_pushedSiri() {
+        let subject = createSubject()
+
+        subject.pressedSiri()
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+        XCTAssertTrue(mockRouter.pushedViewController is SiriSettingsViewController)
+    }
+
+    func testGeneralSettingsDelegate_pushedToolbar() {
+        let subject = createSubject()
+
+        subject.pressedToolbar()
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+        XCTAssertTrue(mockRouter.pushedViewController is SearchBarSettingsViewController)
+    }
+
+    func testGeneralSettingsDelegate_pushedTabs() {
+        let subject = createSubject()
+
+        subject.pressedTabs()
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+        XCTAssertTrue(mockRouter.pushedViewController is TabsSettingsViewController)
+    }
+
+    func testGeneralSettingsDelegate_pushedTheme() {
+        let subject = createSubject()
+
+        subject.pressedTheme()
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+        XCTAssertTrue(mockRouter.pushedViewController is ThemeSettingsController)
+    }
+
     // MARK: - Helper
     func createSubject() -> SettingsCoordinator {
         let subject = SettingsCoordinator(router: mockRouter,

--- a/Tests/ClientTests/Mocks/MockSettingsFlowDelegate.swift
+++ b/Tests/ClientTests/Mocks/MockSettingsFlowDelegate.swift
@@ -11,8 +11,8 @@ class MockSettingsFlowDelegate: SettingsFlowDelegate, GeneralSettingsDelegate {
     var showCreditCardSettingsCalled = 0
     var didFinishShowingSettingsCalled = 0
     var showExperimentsCalled = 0
-
-    // MARK: SettingsFlowDelegate
+    var showPasswordListCalled = 0
+    var showPasswordOnboardingCalled = 0
 
     func showDevicePassCode() {
         showDevicePassCodeCalled += 1
@@ -28,6 +28,14 @@ class MockSettingsFlowDelegate: SettingsFlowDelegate, GeneralSettingsDelegate {
 
     func showExperiments() {
         showExperimentsCalled += 1
+    }
+
+    func showPasswordList() {
+        showPasswordListCalled += 1
+    }
+
+    func showPasswordOnboarding() {
+        showPasswordOnboardingCalled += 1
     }
 
     // MARK: GeneralSettingsDelegate

--- a/Tests/ClientTests/Mocks/MockSettingsFlowDelegate.swift
+++ b/Tests/ClientTests/Mocks/MockSettingsFlowDelegate.swift
@@ -1,0 +1,50 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+@testable import Client
+
+class MockSettingsFlowDelegate: SettingsFlowDelegate, GeneralSettingsDelegate {
+    var showDevicePassCodeCalled = 0
+    var showCreditCardSettingsCalled = 0
+    var didFinishShowingSettingsCalled = 0
+    var showExperimentsCalled = 0
+
+    // MARK: SettingsFlowDelegate
+
+    func showDevicePassCode() {
+        showDevicePassCodeCalled += 1
+    }
+
+    func showCreditCardSettings() {
+        showCreditCardSettingsCalled += 1
+    }
+
+    func didFinishShowingSettings() {
+        didFinishShowingSettingsCalled += 1
+    }
+
+    func showExperiments() {
+        showExperimentsCalled += 1
+    }
+
+    // MARK: GeneralSettingsDelegate
+
+    func pressedHome() {}
+
+    func pressedMailApp() {}
+
+    func pressedNewTab() {}
+
+    func pressedSearchEngine() {}
+
+    func pressedSiri() {}
+
+    func pressedToolbar() {}
+
+    func pressedTabs() {}
+
+    func pressedTheme() {}
+}

--- a/Tests/ClientTests/Settings/AppSettingsTableViewControllerTests.swift
+++ b/Tests/ClientTests/Settings/AppSettingsTableViewControllerTests.swift
@@ -101,37 +101,3 @@ class AppSettingsTableViewControllerTests: XCTestCase {
         return subject
     }
 }
-
-// MARK: - MockSettingsFlowDelegate
-class MockSettingsFlowDelegate: SettingsFlowDelegate {
-    var showDevicePassCodeCalled = 0
-    var showCreditCardSettingsCalled = 0
-    var didFinishShowingSettingsCalled = 0
-    var showExperimentsCalled = 0
-    var showPasswordListCalled = 0
-    var showPasswordOnboardingCalled = 0
-
-    func showDevicePassCode() {
-        showDevicePassCodeCalled += 1
-    }
-
-    func showCreditCardSettings() {
-        showCreditCardSettingsCalled += 1
-    }
-
-    func didFinishShowingSettings() {
-        didFinishShowingSettingsCalled += 1
-    }
-
-    func showExperiments() {
-        showExperimentsCalled += 1
-    }
-
-    func showPasswordList() {
-        showPasswordListCalled += 1
-    }
-
-    func showPasswordOnboarding() {
-        showPasswordOnboardingCalled += 1
-    }
-}


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6614)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14794)

### Description
General settings debug using settings coordinator to push views instead of being pushed from the Settings NSObject class by passing the navigation controller on click. 
- Protected behind feature flag.
- Put `DebugSettingsDelegate` in its own file
- Made sure to fix a11y identifiers for those general settings

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
