### PR TITLE
Add FXIOS-6547 [v116] Update strings based on l10n feedback

### DIFF
--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -328,7 +328,7 @@ extension String {
             public static let ToggleToAllowAutofillTitle = MZLocalizedString(
                 key: "CreditCard.EditCard.ToggleToAllowAutofillTitle.v112",
                 tableName: "EditCard",
-                value: "Save and autofill cards",
+                value: "Save and Autofill Cards",
                 comment: "Title label for user to use the toggle settings to allow saving and autofilling of credit cards for webpages.")
             public static let SavedCardListTitle = MZLocalizedString(
                 key: "CreditCard.EditCard.SavedCardListTitle.v112",
@@ -438,17 +438,17 @@ extension String {
             public static let SavedCardLabel = MZLocalizedString(
                 key: "CreditCard.SnackBar.SavedCardLabel.v112",
                 tableName: "SnackBar",
-                value: "New card saved",
+                value: "New Card Saved",
                 comment: "Label text that gets presented as a confirmation at the bottom of screen when credit card information gets saved successfully")
             public static let UpdatedCardLabel = MZLocalizedString(
                 key: "CreditCard.SnackBar.UpdatedCardLabel.v112",
                 tableName: "SnackBar",
-                value: "Card information updated",
+                value: "Card Information updated",
                 comment: "Label text that gets presented as a confirmation at the bottom of screen when credit card information gets updated successfully")
             public static let RemovedCardLabel = MZLocalizedString(
                 key: "CreditCard.SnackBar.RemovedCardLabel.v112",
                 tableName: "SnackBar",
-                value: "Card removed",
+                value: "Card Removed",
                 comment: "Label text that gets presented as a confirmation at the bottom of screen when the credit card is successfully removed.")
         }
 

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -326,9 +326,9 @@ extension String {
                 value: "Remove Card",
                 comment: "Title label for button that allows user to remove their saved credit card.")
             public static let ToggleToAllowAutofillTitle = MZLocalizedString(
-                key: "CreditCard.EditCard.ToggleToAllowAutofillTitle.v116",
+                key: "CreditCard.EditCard.ToggleToAllowAutofillTitle.v112",
                 tableName: "EditCard",
-                value: "Save and Autofill Cards",
+                value: "Save and autofill cards",
                 comment: "Title label for user to use the toggle settings to allow saving and autofilling of credit cards for webpages.")
             public static let SavedCardListTitle = MZLocalizedString(
                 key: "CreditCard.EditCard.SavedCardListTitle.v112",
@@ -436,19 +436,19 @@ extension String {
         // Snackbar / toast
         public struct SnackBar {
             public static let SavedCardLabel = MZLocalizedString(
-                key: "CreditCard.SnackBar.SavedCardLabel.v116",
+                key: "CreditCard.SnackBar.SavedCardLabel.v112",
                 tableName: "SnackBar",
-                value: "New Card Saved",
+                value: "New card saved",
                 comment: "Label text that gets presented as a confirmation at the bottom of screen when credit card information gets saved successfully")
             public static let UpdatedCardLabel = MZLocalizedString(
-                key: "CreditCard.SnackBar.UpdatedCardLabel.v116",
+                key: "CreditCard.SnackBar.UpdatedCardLabel.v112",
                 tableName: "SnackBar",
-                value: "Card Information updated",
+                value: "Card information updated",
                 comment: "Label text that gets presented as a confirmation at the bottom of screen when credit card information gets updated successfully")
             public static let RemovedCardLabel = MZLocalizedString(
-                key: "CreditCard.SnackBar.RemovedCardLabel.v116",
+                key: "CreditCard.SnackBar.RemovedCardLabel.v112",
                 tableName: "SnackBar",
-                value: "Card Removed",
+                value: "Card removed",
                 comment: "Label text that gets presented as a confirmation at the bottom of screen when the credit card is successfully removed.")
         }
 


### PR DESCRIPTION
# [FXIOS-6547](https://mozilla-hub.atlassian.net/browse/FXIOS-6547) | https://github.com/mozilla-mobile/firefox-ios/issues/14661

### Description
Updating strings based on L10n team feedback. Strings that were previously translated should not be changed if the only change is capitalization, because capitalization varies depending on the language. We lose the old translation if we allow these changes.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
