### PR TITLE
Bugfix MTE-1210 [v116] Guarantee that sync is performed at least once

### DIFF
--- a/Tests/XCUITests/IntegrationTests.swift
+++ b/Tests/XCUITests/IntegrationTests.swift
@@ -73,11 +73,11 @@ class IntegrationTests: BaseTestCase {
         waitForExistence(app.staticTexts["FIREFOX ACCOUNT"], timeout: TIMEOUT)
         waitForNoExistence(app.staticTexts["Sync and Save Data"])
         sleep(5)
+        if app.tables.staticTexts["Sync Now"].exists {
+            app.tables.staticTexts["Sync Now"].tap()
+        }
+        waitForNoExistence(app.tables.staticTexts["Syncing…"])
         waitForExistence(app.tables.staticTexts["Sync Now"], timeout: TIMEOUT_LONG)
-        app.tables.staticTexts["Sync Now"].tap()
-        waitForExistence(app.tables.staticTexts["Syncing…"], timeout: TIMEOUT_LONG)
-        waitForExistence(app.tables.staticTexts["Sync Now"], timeout: TIMEOUT_LONG)
-        sleep(3)
     }
 
     func testFxASyncHistory () {


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1210)

### Description
`waitForInitialSyncComplete()` may not detect the sync completion.

After a sync happened recently, pushing "Sync Now" may not change the menu item's label to "Syncing..." for an extended amount of time. The old code assumed that "Syncing..." will happen for at least a few seconds. Recently, "Syncing..." may appear for a split second after a sync has been completed recently. The split second is not enough for `waitForExistence()` to verify that "Syncing..." appeared.

https://storage.googleapis.com/mobile-reports/public/firefox-ios-M1/result_558/SyncIntegrationTests/results/index.html

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
