### PR TITLE
Bugfix SYNC-3784 [v116] Fixes push for upgrades from v111 or older

### DIFF
--- a/Client/Application/AppDelegate+PushNotifications.swift
+++ b/Client/Application/AppDelegate+PushNotifications.swift
@@ -114,7 +114,8 @@ extension AppDelegate {
     func application(_ application: UIApplication,
                      didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         var notificationAllowed = true
-        if LegacyFeatureFlagsManager.shared.isFeatureEnabled(.notificationSettings, checking: .buildOnly) {
+        if LegacyFeatureFlagsManager.shared.isFeatureEnabled(.notificationSettings, checking: .buildOnly),
+           UserDefaults.standard.object(forKey: PrefsKeys.Notifications.SyncNotifications) != nil {
             notificationAllowed = UserDefaults.standard.bool(forKey: PrefsKeys.Notifications.SyncNotifications)
         }
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/SYNC-3784)


### Description
If any user already had push notifications enabled upgrades form v111 or older, their sync push notifications won't be delivered. This was because we didn't handle the case where the pref was never set, because the user authenticated on an older version of Firefox that didn't have the pref


cc @dnarcese this breaks send tab notifications for a lot of our existing sync users. The users still get the tabs because we poll for them, but the push notifications aren't delivered. We should uplift this but I'm not sure what version this should go into (I imagine 115?)

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
