### PR TITLE
Localize FXIOS-6835 [v116] string update for biometrics screen when face id is unavailable

### DIFF
--- a/Client/Frontend/AuthenticationManager/AppAuthenticator.swift
+++ b/Client/Frontend/AuthenticationManager/AppAuthenticator.swift
@@ -48,7 +48,7 @@ class AppAuthenticator: AppAuthenticationProtocol {
 
         // First check if we have the needed hardware support.
         var error: NSError?
-        let localizedErrorMessage = String.Biometry.Screen.UniversalAuthenticationReason
+        let localizedErrorMessage = String.Biometry.Screen.UniversalAuthenticationReasonV2
         if context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) {
             context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: localizedErrorMessage) { success, error in
                 if success {

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -90,6 +90,11 @@ extension String {
                 tableName: "BiometricAuthentication",
                 value: "Authenticate to access passwords.",
                 comment: "Biometric authentication is when the system prompts users for Face ID or fingerprint before accessing protected information. This string asks the user to enter their device passcode to access the protected screen.")
+            public static let UniversalAuthenticationReasonV2 = MZLocalizedString(
+                key: "Biometry.Screen.UniversalAuthenticationReasonV2.v116",
+                tableName: "BiometricAuthentication",
+                value: "Authenticate to access your saved logins and encrypted cards.",
+                comment: "Biometric authentication is when the system prompts users for Face ID or fingerprint before accessing protected information. This string asks the user to enter their device passcode to access the protected screen for logins and encrypted cards.")
         }
     }
 }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6835)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15229)

### Description
Before: Authenticate to access passwords.
After: Authenticate to access your saved logins and encrypted cards.

| Before      | After |
| ----------- | ----------- |
| <img width="276" alt="image" src="https://github.com/mozilla-mobile/firefox-ios/assets/8919439/40c49fc0-3b36-49e0-b3b2-eb3277783990">      | <img width="277" alt="image" src="https://github.com/mozilla-mobile/firefox-ios/assets/8919439/4cb96dc7-7fe9-4033-907d-746f25433f91">       |

------
### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods


