### PR TITLE
Bugfix FXIOS-6807 [v116] UX updates and removed horizontal line from bottom sheet save / update card modal

### DIFF
--- a/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
@@ -33,10 +33,18 @@ class CreditCardBottomSheetViewController: UIViewController, UITableViewDelegate
     var themeObserver: NSObjectProtocol?
     private var viewModel: CreditCardBottomSheetViewModel
 
-    var didTapNotNowClosure: (() -> Void)?
     var didTapYesClosure: ((Error?) -> Void)?
     var didTapManageCardsClosure: (() -> Void)?
     var didSelectCreditCardToFill: ((UnencryptedCreditCardFields) -> Void)?
+
+    private var numberOfCards: Int {
+        switch viewModel.state {
+        case .save, .update:
+            return 1
+        case .selectSavedCard:
+            return viewModel.creditCards?.count ?? 1
+        }
+    }
 
     // MARK: Views
     private lazy var contentView: UIView = .build { _ in }
@@ -47,7 +55,7 @@ class CreditCardBottomSheetViewController: UIViewController, UITableViewDelegate
         cardTableView.backgroundColor = .clear
         cardTableView.dataSource = self
         cardTableView.delegate = self
-        cardTableView.allowsSelection = true
+        cardTableView.allowsSelection = false
         cardTableView.separatorColor = .clear
         cardTableView.separatorStyle = .none
         cardTableView.isScrollEnabled = false
@@ -81,17 +89,6 @@ class CreditCardBottomSheetViewController: UIViewController, UITableViewDelegate
         button.layer.cornerRadius = UX.yesButtonCornerRadius
         button.titleLabel?.adjustsFontForContentSizeCategory = true
         button.accessibilityIdentifier = AccessibilityIdentifiers.RememberCreditCard.yesButton
-    }
-
-    private lazy var notNowButton: ResizableButton = .build { button in
-        button.titleLabel?.font = DynamicFontHelper.defaultHelper.preferredFont(
-            withTextStyle: .headline,
-            size: UX.yesButtonFontSize)
-        button.titleLabel?.adjustsFontForContentSizeCategory = true
-        button.accessibilityIdentifier = AccessibilityIdentifiers.RememberCreditCard.notNowButton
-        button.addTarget(self, action: #selector(CreditCardBottomSheetViewController.didTapNotNow), for: .touchUpInside)
-        button.setTitle(.CreditCard.RememberCreditCard.SecondaryButtonTitle, for: .normal)
-        button.layer.cornerRadius = UX.yesButtonCornerRadius
     }
 
     private var contentViewHeightConstraint: NSLayoutConstraint!
@@ -143,13 +140,8 @@ class CreditCardBottomSheetViewController: UIViewController, UITableViewDelegate
 
     // MARK: View Setup
     func addSubviews() {
-        let isIpad = UIDevice.current.userInterfaceIdiom == .pad
-
         if viewModel.state != .selectSavedCard {
             buttonsContainerStackView.addArrangedSubview(yesButton)
-        }
-        if isIpad {
-            buttonsContainerStackView.addArrangedSubview(notNowButton)
         }
         contentView.addSubviews(cardTableView, buttonsContainerStackView)
         view.addSubview(contentView)
@@ -188,7 +180,6 @@ class CreditCardBottomSheetViewController: UIViewController, UITableViewDelegate
             buttonsContainerStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -UX.tableMargin),
 
             yesButton.heightAnchor.constraint(greaterThanOrEqualToConstant: UX.yesButtonHeight),
-            notNowButton.heightAnchor.constraint(greaterThanOrEqualToConstant: UX.yesButtonHeight),
             contentWidthConstraint,
             contentViewHeightConstraint
         ])
@@ -229,13 +220,6 @@ class CreditCardBottomSheetViewController: UIViewController, UITableViewDelegate
     }
 
     @objc
-    private func didTapNotNow() {
-        TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .creditCardBottomSheetDismiss)
-        dismissVC()
-        didTapNotNowClosure?()
-    }
-
-    @objc
     private func didTapManageCards() {
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .creditCardBottomSheetManageCards)
         didTapManageCardsClosure?()
@@ -248,12 +232,7 @@ class CreditCardBottomSheetViewController: UIViewController, UITableViewDelegate
 
     // MARK: UITableViewDelegate
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        switch viewModel.state {
-        case .save, .update:
-            return 1
-        case .selectSavedCard:
-            return viewModel.creditCards?.count ?? 1
-        }
+        return numberOfCards
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -274,9 +253,16 @@ class CreditCardBottomSheetViewController: UIViewController, UITableViewDelegate
 
         let creditCardRow = CreditCardItemRow(
             item: creditCard,
-            isAccessibilityCategory: UIApplication.shared.preferredContentSizeCategory.isAccessibilityCategory)
+            isAccessibilityCategory: UIApplication.shared.preferredContentSizeCategory.isAccessibilityCategory,
+            shouldShowSeparator: false,
+            addPadding: true,
+            didSelectAction: { [weak self] in
+                self?.handleCreditCardSelection(row: indexPath.row)
+            })
         hostingCell.host(creditCardRow, parentController: self)
-
+        hostingCell.backgroundColor = .clear
+        hostingCell.contentView.backgroundColor = .clear
+        hostingCell.selectionStyle = .none
         hostingCell.isAccessibilityElement = true
         return hostingCell
     }
@@ -322,10 +308,10 @@ class CreditCardBottomSheetViewController: UIViewController, UITableViewDelegate
         return UITableView.automaticDimension
     }
 
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    func handleCreditCardSelection(row: Int) {
         guard let plainTextCreditCard = viewModel.getPlainCreditCardValues(
             bottomSheetState: .selectSavedCard,
-            row: indexPath.row
+            row: row
         ) else {
             return
         }
@@ -337,13 +323,8 @@ class CreditCardBottomSheetViewController: UIViewController, UITableViewDelegate
     func applyTheme() {
         let currentTheme = themeManager.currentTheme
         view.backgroundColor = currentTheme.colors.layer1
-        contentView.backgroundColor = currentTheme.colors.layer1
         yesButton.backgroundColor = currentTheme.colors.actionPrimary
         yesButton.titleLabel?.textColor = currentTheme.colors.textInverted
-
-        notNowButton.backgroundColor = currentTheme.colors.actionSecondary
-        notNowButton.titleLabel?.textColor = currentTheme.colors.textPrimary
-
         cardTableView.reloadData()
     }
 }

--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
@@ -97,7 +97,7 @@ struct CreditCardItemRow: View {
                 .padding(.trailing, 10)
                 .opacity(shouldShowSeparator ? 1 : 0)
         }
-        .background(BackgroundCleanerView())
+        .background(Color.clear)
         .padding(.vertical, addPadding ? 8 : 0)
         .onAppear {
             applyTheme(theme: themeVal.theme)

--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
@@ -97,7 +97,7 @@ struct CreditCardItemRow: View {
                 .padding(.trailing, 10)
                 .opacity(shouldShowSeparator ? 1 : 0)
         }
-        .background(Color.clear)
+        .background(ClearBackgroundView())
         .padding(.vertical, addPadding ? 8 : 0)
         .onAppear {
             applyTheme(theme: themeVal.theme)
@@ -163,7 +163,10 @@ struct CreditCardItemRow_Previews: PreviewProvider {
     }
 }
 
-struct BackgroundCleanerView: UIViewRepresentable {
+// Note: We use a clear view because Color.clear doesn't work
+// well if we embed a SwiftUI View inside a UIHostingController
+// and it displays black instead of clear color
+struct ClearBackgroundView: UIViewRepresentable {
     func makeUIView(context: Context) -> UIView {
         let view = UIView()
         DispatchQueue.main.async {

--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
@@ -10,6 +10,9 @@ import Shared
 struct CreditCardItemRow: View {
     let item: CreditCard
     let isAccessibilityCategory: Bool
+    let shouldShowSeparator: Bool
+    var addPadding: Bool
+    var didSelectAction: (() -> Void)?
 
     // Theming
     @Environment(\.themeType)
@@ -18,6 +21,10 @@ struct CreditCardItemRow: View {
     @State var subTextColor: Color = .clear
     @State var separatorColor: Color = .clear
     @State var backgroundColor: Color = .clear
+    @State var backgroundHoverColor: Color = .clear
+
+    // Vars
+    @GestureState private var isTapped = false
 
     var body: some View {
         VStack(alignment: .center, spacing: 0) {
@@ -71,15 +78,27 @@ struct CreditCardItemRow: View {
             .padding(.trailing, 16)
             .padding(.top, 11)
             .padding(.bottom, 11)
-
+            .background(isTapped ? backgroundHoverColor : backgroundColor)
+            .gesture(
+                TapGesture()
+                    .onEnded { _ in
+                        didSelectAction?()
+                    }
+                    .simultaneously(with: DragGesture(minimumDistance: 0))
+                    .updating($isTapped) { (_, isTapped, _) in
+                        isTapped = true
+                    }
+            )
             Rectangle()
                 .fill(separatorColor)
                 .frame(maxWidth: .infinity)
                 .frame(height: 0.7)
                 .padding(.leading, 10)
                 .padding(.trailing, 10)
+                .opacity(shouldShowSeparator ? 1 : 0)
         }
-        .background(backgroundColor)
+        .background(BackgroundCleanerView())
+        .padding(.vertical, addPadding ? 8 : 0)
         .onAppear {
             applyTheme(theme: themeVal.theme)
         }
@@ -105,6 +124,7 @@ struct CreditCardItemRow: View {
         subTextColor = Color(color.textSecondary)
         separatorColor = Color(color.borderPrimary)
         backgroundColor = Color(color.layer5)
+        backgroundHoverColor = Color(color.layer5Hover)
     }
 }
 
@@ -123,16 +143,34 @@ struct CreditCardItemRow_Previews: PreviewProvider {
                                     timesUsed: 123123)
 
         CreditCardItemRow(item: creditCard,
-                          isAccessibilityCategory: false)
+                          isAccessibilityCategory: false,
+                          shouldShowSeparator: true,
+                          addPadding: true)
 
         CreditCardItemRow(item: creditCard,
-                          isAccessibilityCategory: true)
+                          isAccessibilityCategory: true,
+                          shouldShowSeparator: true,
+                          addPadding: true)
             .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
             .previewDisplayName("Large")
 
         CreditCardItemRow(item: creditCard,
-                          isAccessibilityCategory: false)
+                          isAccessibilityCategory: false,
+                          shouldShowSeparator: true,
+                          addPadding: true)
             .environment(\.sizeCategory, .extraSmall)
             .previewDisplayName("Small")
     }
+}
+
+struct BackgroundCleanerView: UIViewRepresentable {
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView()
+        DispatchQueue.main.async {
+            view.superview?.superview?.backgroundColor = .clear
+        }
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {}
 }

--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardTableViewController.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardTableViewController.swift
@@ -197,5 +197,3 @@ extension CreditCardTableViewController: UITableViewDelegate,
         return hostingCell
     }
 }
-
-

--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardTableViewController.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardTableViewController.swift
@@ -159,11 +159,6 @@ extension CreditCardTableViewController: UITableViewDelegate,
         }
     }
 
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        didSelectCardAtIndex?(viewModel.creditCards[indexPath.row])
-        tableView.deselectRow(at: indexPath, animated: true)
-    }
-
     // MARK: - Private
     private func toggleCell() -> UITableViewCell {
         guard let hostingCell = tableView.dequeueReusableCell(
@@ -183,14 +178,24 @@ extension CreditCardTableViewController: UITableViewDelegate,
             withIdentifier: HostingTableViewCell<CreditCardItemRow>.cellIdentifier) as? HostingTableViewCell<CreditCardItemRow> else {
             return UITableViewCell()
         }
-
+        let creditCardCount = viewModel.creditCards.count
         let creditCard = viewModel.creditCards[indexPath.row]
         let creditCardRow = CreditCardItemRow(
             item: creditCard,
-            isAccessibilityCategory: UIApplication.shared.preferredContentSizeCategory.isAccessibilityCategory)
+            isAccessibilityCategory: UIApplication.shared.preferredContentSizeCategory.isAccessibilityCategory,
+            shouldShowSeparator: indexPath.row < creditCardCount - 1 && creditCardCount > 1,
+            addPadding: false,
+            didSelectAction: { [weak self] in
+                self?.didSelectCardAtIndex?(creditCard)
+            })
         hostingCell.host(creditCardRow, parentController: self)
         hostingCell.accessibilityAttributedLabel = viewModel.a11yLabel(for: indexPath)
+        hostingCell.backgroundColor = .clear
+        hostingCell.contentView.backgroundColor = .clear
+        hostingCell.selectionStyle = .none
         hostingCell.isAccessibilityElement = true
         return hostingCell
     }
 }
+
+

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1852,7 +1852,7 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
     // MARK: Autofill
 
     private func creditCardAutofillSetup(_ tab: Tab, didCreateWebView webView: WKWebView) {
-         let userDefaults = UserDefaults.standard
+        let userDefaults = UserDefaults.standard
         let keyCreditCardAutofill = PrefsKeys.KeyAutofillCreditCardStatus
 
         let autofillCreditCardStatus = featureFlags.isFeatureEnabled(

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1852,7 +1852,7 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
     // MARK: Autofill
 
     private func creditCardAutofillSetup(_ tab: Tab, didCreateWebView webView: WKWebView) {
-        let userDefaults = UserDefaults.standard
+         let userDefaults = UserDefaults.standard
         let keyCreditCardAutofill = PrefsKeys.KeyAutofillCreditCardStatus
 
         let autofillCreditCardStatus = featureFlags.isFeatureEnabled(
@@ -2695,10 +2695,6 @@ extension BrowserViewController {
                                                 bottomContainer: self.alertContainer,
                                                 theme: self.themeManager.currentTheme)
             }
-        }
-
-        viewController.didTapNotNowClosure = {
-            viewController.dismissVC()
         }
 
         viewController.didTapManageCardsClosure = {

--- a/Client/Frontend/HostingTableViewCell.swift
+++ b/Client/Frontend/HostingTableViewCell.swift
@@ -9,7 +9,6 @@ final class HostingTableViewCell<Content: View>: UITableViewCell, ReusableCell {
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        hostingController.view.backgroundColor = .clear
     }
 
     private func removeHostingControllerFromParent() {


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6807)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15157)

### Description
1. Fixed the proper background for bottom sheet 
2. Added padding for multiple cards in bottom sheet 
3. Refactored code to not use `didSelect` in table and added a closure instead inside SwiftUI for more control
4. Removed horizontal line in bottom sheet (save / update / select) card but kept it for settings list cards for more than one card

| Background Bottom Sheet  | Card list with separator |
| ----------- |  ----------- | 
| ![Screen Recording 2023-06-27 at 5 28 54 PM](https://github.com/mozilla-mobile/firefox-ios/assets/8919439/f404e002-4f73-454b-bb57-cec72c200809) | <img width="250" alt="image" src="https://github.com/mozilla-mobile/firefox-ios/assets/8919439/1e949efe-13c3-4a14-90bd-5947abee3f54"> |



### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
