### PR TITLE
Refactor FXIOS-6615 [v116] Account settings to use coordinator

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -612,6 +612,8 @@
 		8A635ECD289437A8006378BA /* SyncedTabCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A635ECC289437A8006378BA /* SyncedTabCellTests.swift */; };
 		8A6A796D27F773550022D6C6 /* HomepageContextMenuHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6A796C27F773550022D6C6 /* HomepageContextMenuHelper.swift */; };
 		8A6B77CC2811C468001110D2 /* URLProtocolStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6B77CB2811C468001110D2 /* URLProtocolStub.swift */; };
+		8A720C5E2A4C85DA0003018A /* AccountSettingsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A720C5D2A4C85DA0003018A /* AccountSettingsDelegate.swift */; };
+		8A720C602A4C8B700003018A /* SharedSettingsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A720C5F2A4C8B700003018A /* SharedSettingsDelegate.swift */; };
 		8A7368AD27924AAF005D7704 /* CanRemoveQuickActionBookmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7368AC27924AAF005D7704 /* CanRemoveQuickActionBookmark.swift */; };
 		8A75F1B828B558E20054E34D /* MessageCardDataAdaptorImplementationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A75F1B728B558E20054E34D /* MessageCardDataAdaptorImplementationTests.swift */; };
 		8A7653BD28A2C61D00924ABF /* PocketDataAdaptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7653BC28A2C61D00924ABF /* PocketDataAdaptor.swift */; };
@@ -4545,10 +4547,10 @@
 		8A0621B729428FBD005D1EFD /* OpenTabNotificationObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenTabNotificationObject.swift; sourceTree = "<group>"; };
 		8A07910E278F62F2005529CB /* AdjustHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdjustHelper.swift; sourceTree = "<group>"; };
 		8A08EC6327EBDCAC00E119C7 /* AdServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdServices.framework; path = System/Library/Frameworks/AdServices.framework; sourceTree = SDKROOT; };
-		8A093D822A4B68940099ABA5 /* PrivacySettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacySettingsDelegate.swift; sourceTree = "<group>"; };
 		8A093D7C2A4B3E4F0099ABA5 /* DebugSettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSettingsDelegate.swift; sourceTree = "<group>"; };
 		8A093D7E2A4B3E7D0099ABA5 /* GeneralSettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsDelegate.swift; sourceTree = "<group>"; };
 		8A093D802A4B58330099ABA5 /* MockSettingsFlowDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSettingsFlowDelegate.swift; sourceTree = "<group>"; };
+		8A093D822A4B68940099ABA5 /* PrivacySettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacySettingsDelegate.swift; sourceTree = "<group>"; };
 		8A0F2A7D286DFCC800D84CC6 /* PushRemoteError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushRemoteError.swift; sourceTree = "<group>"; };
 		8A0F2A7F286DFD2B00D84CC6 /* PushClientError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushClientError.swift; sourceTree = "<group>"; };
 		8A0F2A81286DFD9800D84CC6 /* PushRegistrationAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushRegistrationAPI.swift; sourceTree = "<group>"; };
@@ -4644,6 +4646,8 @@
 		8A635ECC289437A8006378BA /* SyncedTabCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncedTabCellTests.swift; sourceTree = "<group>"; };
 		8A6A796C27F773550022D6C6 /* HomepageContextMenuHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageContextMenuHelper.swift; sourceTree = "<group>"; };
 		8A6B77CB2811C468001110D2 /* URLProtocolStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLProtocolStub.swift; sourceTree = "<group>"; };
+		8A720C5D2A4C85DA0003018A /* AccountSettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSettingsDelegate.swift; sourceTree = "<group>"; };
+		8A720C5F2A4C8B700003018A /* SharedSettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedSettingsDelegate.swift; sourceTree = "<group>"; };
 		8A7368AC27924AAF005D7704 /* CanRemoveQuickActionBookmark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanRemoveQuickActionBookmark.swift; sourceTree = "<group>"; };
 		8A75F1B728B558E20054E34D /* MessageCardDataAdaptorImplementationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageCardDataAdaptorImplementationTests.swift; sourceTree = "<group>"; };
 		8A75F1D428B56A2C0054E34D /* af */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = af; path = af.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
@@ -7966,6 +7970,7 @@
 				8A19ACAC2A329036001C2147 /* Privacy */,
 				8A5D1CC02A30DCA4005AD35C /* SettingDisclosureUtility.swift */,
 				8ADAE41C2A33A0D3007BF926 /* Support */,
+				8A720C5F2A4C8B700003018A /* SharedSettingsDelegate.swift */,
 			);
 			path = Main;
 			sourceTree = "<group>";
@@ -8066,6 +8071,7 @@
 				8A3EF8162A2FD2B900796E3A /* AdvancedAccountSettings.swift */,
 				8A5D1CBC2A30DC4E005AD35C /* AccountStatusSetting.swift */,
 				8A5D1CBE2A30DC75005AD35C /* SyncNowSetting.swift */,
+				8A720C5D2A4C85DA0003018A /* AccountSettingsDelegate.swift */,
 			);
 			path = Account;
 			sourceTree = "<group>";
@@ -12377,6 +12383,7 @@
 				8A5D1CA42A30D69A005AD35C /* SearchSetting.swift in Sources */,
 				74BBDF472A17979000D3BEFE /* OnboardingDefaultBrowserModelProtocol.swift in Sources */,
 				8AD40FC727BADC3400672675 /* ToolbarTextField.swift in Sources */,
+				8A720C5E2A4C85DA0003018A /* AccountSettingsDelegate.swift in Sources */,
 				CA90753824929B22005B794D /* NoLoginsView.swift in Sources */,
 				E4B423BE1AB9FE6A007E66C8 /* ReaderModeCache.swift in Sources */,
 				396CDB55203C5B870034A3A3 /* TabTrayController+KeyCommands.swift in Sources */,
@@ -12677,6 +12684,7 @@
 				8AFA263227B6E9AB00D0C33B /* ToolbarBadge.swift in Sources */,
 				43D16B7A29831C7F009F8279 /* CreditCardAutofillToggle.swift in Sources */,
 				8AD40FCD27BADC5C00672675 /* TabLocationContainerView.swift in Sources */,
+				8A720C602A4C8B700003018A /* SharedSettingsDelegate.swift in Sources */,
 				E18EA57128AD46D3003F97FC /* WallpaperCollectionType.swift in Sources */,
 				C84655E42887394B00861B4A /* WallpaperMetadata.swift in Sources */,
 				8AB8572E27D94A1A0075C173 /* UXSizeClass.swift in Sources */,

--- a/Client/Application/AccessibilityIdentifiers.swift
+++ b/Client/Application/AccessibilityIdentifiers.swift
@@ -231,6 +231,10 @@ public struct AccessibilityIdentifiers {
             static let deleteButton = "Delete"
         }
 
+        struct AdvancedAccountSettings {
+            static let title = "AdvancedAccount.Setting"
+        }
+
         struct Logins {
             static let title = "Logins"
         }
@@ -245,6 +249,10 @@ public struct AccessibilityIdentifiers {
 
         struct CreditCard {
             static let title = "AutofillCreditCard"
+        }
+
+        struct ConnectSetting {
+            static let title = "SignInToSync"
         }
 
         struct ContentBlocker {

--- a/Client/Coordinators/SettingsCoordinator.swift
+++ b/Client/Coordinators/SettingsCoordinator.swift
@@ -12,7 +12,7 @@ protocol SettingsCoordinatorDelegate: AnyObject {
 }
 
 class SettingsCoordinator: BaseCoordinator, SettingsDelegate, SettingsFlowDelegate, GeneralSettingsDelegate,
-                           PrivacySettingsDelegate {
+                           PrivacySettingsDelegate, AccountSettingsDelegate {
     var settingsViewController: AppSettingsScreen
     private let wallpaperManager: WallpaperManagerInterface
     private let profile: Profile
@@ -292,9 +292,17 @@ class SettingsCoordinator: BaseCoordinator, SettingsDelegate, SettingsFlowDelega
         router.push(viewController)
     }
 
-    func pressedAccountStatusSetting() {
+    func pressedToShowSyncContent() {
         let viewController = SyncContentSettingsViewController()
         viewController.profile = profile
+        router.push(viewController)
+    }
+
+    func pressedToShowFirefoxAccount() {
+        let fxaParams = FxALaunchParams(entrypoint: .accountStatusSettingReauth, query: [:])
+        let viewController = FirefoxAccountSignInViewController(profile: profile,
+                                                                parentType: .settings,
+                                                                deepLinkParams: fxaParams)
         router.push(viewController)
     }
 }

--- a/Client/Coordinators/SettingsCoordinator.swift
+++ b/Client/Coordinators/SettingsCoordinator.swift
@@ -12,7 +12,7 @@ protocol SettingsCoordinatorDelegate: AnyObject {
 }
 
 class SettingsCoordinator: BaseCoordinator, SettingsDelegate, SettingsFlowDelegate, GeneralSettingsDelegate,
-                            PrivacySettingsDelegate {
+                           PrivacySettingsDelegate {
     var settingsViewController: AppSettingsScreen
     private let wallpaperManager: WallpaperManagerInterface
     private let profile: Profile
@@ -274,5 +274,19 @@ class SettingsCoordinator: BaseCoordinator, SettingsDelegate, SettingsFlowDelega
 
     func pressedTheme() {
         router.push(ThemeSettingsController())
+    }
+
+    // MARK: PrivacySettingsDelegate
+
+    func pressedConnectSetting() {
+        // TODO: Laurie
+    }
+
+    func pressedAdvancedAccountSetting() {
+        // TODO: Laurie
+    }
+
+    func pressedAccountStatusSetting() {
+        // TODO: Laurie
     }
 }

--- a/Client/Coordinators/SettingsCoordinator.swift
+++ b/Client/Coordinators/SettingsCoordinator.swift
@@ -276,17 +276,25 @@ class SettingsCoordinator: BaseCoordinator, SettingsDelegate, SettingsFlowDelega
         router.push(ThemeSettingsController())
     }
 
-    // MARK: PrivacySettingsDelegate
+    // MARK: AccountSettingsDelegate
 
     func pressedConnectSetting() {
-        // TODO: Laurie
+        let fxaParams = FxALaunchParams(entrypoint: .connectSetting, query: [:])
+        let viewController = FirefoxAccountSignInViewController(profile: profile,
+                                                                parentType: .settings,
+                                                                deepLinkParams: fxaParams)
+        router.push(viewController)
     }
 
     func pressedAdvancedAccountSetting() {
-        // TODO: Laurie
+        let viewController = AdvancedAccountSettingViewController()
+        viewController.profile = profile
+        router.push(viewController)
     }
 
     func pressedAccountStatusSetting() {
-        // TODO: Laurie
+        let viewController = SyncContentSettingsViewController()
+        viewController.profile = profile
+        router.push(viewController)
     }
 }

--- a/Client/Frontend/Settings/Main/About/VersionSetting.swift
+++ b/Client/Frontend/Settings/Main/About/VersionSetting.swift
@@ -42,7 +42,7 @@ class VersionSetting: Setting {
         }
     }
 
-    func copyAppVersionAndPresentAlert(by navigationController: UINavigationController?) {
+    private func copyAppVersionAndPresentAlert(by navigationController: UINavigationController?) {
         let alertTitle: String = .SettingsCopyAppVersionAlertTitle
         let alert = AlertController(title: alertTitle, message: nil, preferredStyle: .alert)
         getSelectedCell(by: navigationController)?.setSelected(false, animated: true)
@@ -54,7 +54,7 @@ class VersionSetting: Setting {
         }
     }
 
-    func getSelectedCell(by navigationController: UINavigationController?) -> UITableViewCell? {
+    private func getSelectedCell(by navigationController: UINavigationController?) -> UITableViewCell? {
         let controller = navigationController?.topViewController
         let tableView = (controller as? AppSettingsTableViewController)?.tableView
         guard let indexPath = tableView?.indexPathForSelectedRow else { return nil }

--- a/Client/Frontend/Settings/Main/Account/AccountSettingsDelegate.swift
+++ b/Client/Frontend/Settings/Main/Account/AccountSettingsDelegate.swift
@@ -8,6 +8,7 @@ import Foundation
 protocol AccountSettingsDelegate: AnyObject {
     func pressedConnectSetting()
     func pressedAdvancedAccountSetting()
-    func pressedAccountStatusSetting()
+    func pressedToShowSyncContent()
+    func pressedToShowFirefoxAccount()
     func askedToOpen(url: URL?, withTitle title: NSAttributedString?)
 }

--- a/Client/Frontend/Settings/Main/Account/AccountSettingsDelegate.swift
+++ b/Client/Frontend/Settings/Main/Account/AccountSettingsDelegate.swift
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// Child settings pages account actions
+protocol AccountSettingsDelegate: AnyObject {
+    func pressedConnectSetting()
+    func pressedAdvancedAccountSetting()
+    func pressedAccountStatusSetting()
+    func askedToOpen(url: URL?, withTitle title: NSAttributedString?)
+}

--- a/Client/Frontend/Settings/Main/Account/AccountStatusSetting.swift
+++ b/Client/Frontend/Settings/Main/Account/AccountStatusSetting.swift
@@ -75,15 +75,21 @@ class AccountStatusSetting: WithAccountSetting {
 
     override func onClick(_ navigationController: UINavigationController?) {
         guard !profile.rustFxA.accountNeedsReauth() else {
+            TelemetryWrapper.recordEvent(category: .firefoxAccount, method: .view, object: .settings)
+
+            if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+                settingsDelegate?.pressedToShowFirefoxAccount()
+                return
+            }
+
             let fxaParams = FxALaunchParams(entrypoint: .accountStatusSettingReauth, query: [:])
             let controller = FirefoxAccountSignInViewController(profile: profile, parentType: .settings, deepLinkParams: fxaParams)
-            TelemetryWrapper.recordEvent(category: .firefoxAccount, method: .view, object: .settings)
             navigationController?.pushViewController(controller, animated: true)
             return
         }
 
         if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
-            settingsDelegate?.pressedAccountStatusSetting()
+            settingsDelegate?.pressedToShowSyncContent()
             return
         }
 

--- a/Client/Frontend/Settings/Main/Account/AccountStatusSetting.swift
+++ b/Client/Frontend/Settings/Main/Account/AccountStatusSetting.swift
@@ -3,14 +3,30 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Account
+import Common
 import Foundation
 import Shared
 
 // Sync setting that shows the current Firefox Account status.
 class AccountStatusSetting: WithAccountSetting {
-    override init(settings: SettingsTableViewController) {
+    private weak var settingsDelegate: AccountSettingsDelegate?
+    private var notificationCenter: NotificationProtocol
+
+    init(settings: SettingsTableViewController,
+         settingsDelegate: AccountSettingsDelegate?,
+         notificationCenter: NotificationProtocol = NotificationCenter.default) {
+        self.notificationCenter = notificationCenter
+        self.settingsDelegate = settingsDelegate
         super.init(settings: settings)
-        NotificationCenter.default.addObserver(self, selector: #selector(updateAccount), name: .FirefoxAccountProfileChanged, object: nil)
+
+        notificationCenter.addObserver(self,
+                                       selector: #selector(updateAccount),
+                                       name: .FirefoxAccountProfileChanged,
+                                       object: nil)
+    }
+
+    deinit {
+        notificationCenter.removeObserver(self)
     }
 
     @objc
@@ -63,6 +79,11 @@ class AccountStatusSetting: WithAccountSetting {
             let controller = FirefoxAccountSignInViewController(profile: profile, parentType: .settings, deepLinkParams: fxaParams)
             TelemetryWrapper.recordEvent(category: .firefoxAccount, method: .view, object: .settings)
             navigationController?.pushViewController(controller, animated: true)
+            return
+        }
+
+        if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+            settingsDelegate?.pressedAccountStatusSetting()
             return
         }
 

--- a/Client/Frontend/Settings/Main/Account/AdvancedAccountSettings.swift
+++ b/Client/Frontend/Settings/Main/Account/AdvancedAccountSettings.swift
@@ -6,24 +6,37 @@ import Foundation
 
 // Shown only when debug menu is active
 class AdvancedAccountSetting: HiddenSetting {
-    let profile: Profile
+    private weak var settingsDelegate: AccountSettingsDelegate?
+    private let profile: Profile
     private let isHidden: Bool
 
-    override var accessoryView: UIImageView? { return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme) }
+    override var accessoryView: UIImageView? {
+        return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme)
+    }
 
-    override var accessibilityIdentifier: String? { return "AdvancedAccount.Setting" }
+    override var accessibilityIdentifier: String? {
+        return AccessibilityIdentifiers.Settings.AdvancedAccountSettings.title
+    }
 
     override var title: NSAttributedString? {
         return NSAttributedString(string: .SettingsAdvancedAccountTitle, attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }
 
-    init(settings: SettingsTableViewController, isHidden: Bool) {
+    init(settings: SettingsTableViewController,
+         isHidden: Bool,
+         settingsDelegate: AccountSettingsDelegate?) {
         self.profile = settings.profile
         self.isHidden = isHidden
+        self.settingsDelegate = settingsDelegate
         super.init(settings: settings)
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
+        if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+            settingsDelegate?.pressedAdvancedAccountSetting()
+            return
+        }
+
         let viewController = AdvancedAccountSettingViewController()
         viewController.profile = profile
         navigationController?.pushViewController(viewController, animated: true)

--- a/Client/Frontend/Settings/Main/Account/ConnectSetting.swift
+++ b/Client/Frontend/Settings/Main/Account/ConnectSetting.swift
@@ -29,6 +29,7 @@ class ConnectSetting: WithoutAccountSetting {
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
+        TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .signIntoSync)
         if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
             settingsDelegate?.pressedConnectSetting()
             return
@@ -36,7 +37,6 @@ class ConnectSetting: WithoutAccountSetting {
 
         let fxaParams = FxALaunchParams(entrypoint: .connectSetting, query: [:])
         let viewController = FirefoxAccountSignInViewController(profile: profile, parentType: .settings, deepLinkParams: fxaParams)
-        TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .signIntoSync)
         navigationController?.pushViewController(viewController, animated: true)
     }
 

--- a/Client/Frontend/Settings/Main/Account/ConnectSetting.swift
+++ b/Client/Frontend/Settings/Main/Account/ConnectSetting.swift
@@ -7,6 +7,8 @@ import Shared
 
 // Sync setting for connecting a Firefox Account. Shown when we don't have an account.
 class ConnectSetting: WithoutAccountSetting {
+    private weak var settingsDelegate: AccountSettingsDelegate?
+
     override var accessoryView: UIImageView? {
         return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme)
     }
@@ -16,9 +18,22 @@ class ConnectSetting: WithoutAccountSetting {
                                   attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }
 
-    override var accessibilityIdentifier: String? { return "SignInToSync" }
+    override var accessibilityIdentifier: String? {
+        return AccessibilityIdentifiers.Settings.ConnectSetting.title
+    }
+
+    init(settings: SettingsTableViewController,
+         settingsDelegate: AccountSettingsDelegate?) {
+        self.settingsDelegate = settingsDelegate
+        super.init(settings: settings)
+    }
 
     override func onClick(_ navigationController: UINavigationController?) {
+        if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+            settingsDelegate?.pressedConnectSetting()
+            return
+        }
+
         let fxaParams = FxALaunchParams(entrypoint: .connectSetting, query: [:])
         let viewController = FirefoxAccountSignInViewController(profile: profile, parentType: .settings, deepLinkParams: fxaParams)
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .signIntoSync)

--- a/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -49,7 +49,7 @@ enum AppSettingsDeeplinkOption {
 }
 
 /// Supports decision making from VC to parent coordinator
-protocol SettingsFlowDelegate: AnyObject, GeneralSettingsDelegate, PrivacySettingsDelegate {
+protocol SettingsFlowDelegate: AnyObject, GeneralSettingsDelegate, PrivacySettingsDelegate, AccountSettingsDelegate {
     func showDevicePassCode()
     func showCreditCardSettings()
     func showExperiments()
@@ -68,7 +68,8 @@ protocol AppSettingsScreen: UIViewController {
 
 /// App Settings Screen (triggered by tapping the 'Gear' in the Tab Tray Controller)
 class AppSettingsTableViewController: SettingsTableViewController, AppSettingsScreen,
-                                    FeatureFlaggable, DebugSettingsDelegate, SearchBarLocationProvider {
+                                    FeatureFlaggable, DebugSettingsDelegate, SearchBarLocationProvider,
+                                        SharedSettingsDelegate {
     // MARK: - Properties
     var deeplinkTo: AppSettingsDeeplinkOption? // Will be clean up with FXIOS-6529
     private var showDebugSettings = false
@@ -287,7 +288,7 @@ class AppSettingsTableViewController: SettingsTableViewController, AppSettingsSc
         } else {
             accountChinaSyncSetting = [
                 // Show China sync service setting:
-                ChinaSyncServiceSetting(settings: self)
+                ChinaSyncServiceSetting(settings: self, settingsDelegate: self)
             ]
         }
 
@@ -296,11 +297,11 @@ class AppSettingsTableViewController: SettingsTableViewController, AppSettingsSc
         let accountFooterText = !profile.hasAccount() ? NSAttributedString(string: .Settings.Sync.ButtonDescription) : nil
         return [SettingSection(title: accountSectionTitle, footerTitle: accountFooterText, children: [
             // Without a Firefox Account:
-            ConnectSetting(settings: self),
-            AdvancedAccountSetting(settings: self, isHidden: showDebugSettings),
+            ConnectSetting(settings: self, settingsDelegate: parentCoordinator),
+            AdvancedAccountSetting(settings: self, isHidden: showDebugSettings, settingsDelegate: parentCoordinator),
             // With a Firefox Account:
-            AccountStatusSetting(settings: self),
-            SyncNowSetting(settings: self)
+            AccountStatusSetting(settings: self, settingsDelegate: parentCoordinator),
+            SyncNowSetting(settings: self, settingsDelegate: parentCoordinator)
         ] + accountChinaSyncSetting)]
     }
 

--- a/Client/Frontend/Settings/Main/Debug/SentryIDSetting.swift
+++ b/Client/Frontend/Settings/Main/Debug/SentryIDSetting.swift
@@ -7,7 +7,7 @@ import Foundation
 import Shared
 
 class SentryIDSetting: HiddenSetting {
-    private weak var settingsDelegate: DebugSettingsDelegate?
+    private weak var settingsDelegate: SharedSettingsDelegate?
     private let deviceAppHash = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)?.string(forKey: "SentryDeviceAppHash")
 
     override var title: NSAttributedString? {
@@ -17,7 +17,7 @@ class SentryIDSetting: HiddenSetting {
     }
 
     init(settings: SettingsTableViewController,
-         settingsDelegate: DebugSettingsDelegate) {
+         settingsDelegate: SharedSettingsDelegate) {
         self.settingsDelegate = settingsDelegate
         super.init(settings: settings)
     }

--- a/Client/Frontend/Settings/Main/Debug/ToggleInactiveTabs.swift
+++ b/Client/Frontend/Settings/Main/Debug/ToggleInactiveTabs.swift
@@ -5,10 +5,10 @@
 import Foundation
 
 class ToggleInactiveTabs: HiddenSetting, FeatureFlaggable {
-    private weak var settingsDelegate: DebugSettingsDelegate?
+    private weak var settingsDelegate: SharedSettingsDelegate?
 
     init(settings: SettingsTableViewController,
-         settingsDelegate: DebugSettingsDelegate) {
+         settingsDelegate: SharedSettingsDelegate) {
         self.settingsDelegate = settingsDelegate
         super.init(settings: settings)
     }

--- a/Client/Frontend/Settings/Main/SharedSettingsDelegate.swift
+++ b/Client/Frontend/Settings/Main/SharedSettingsDelegate.swift
@@ -5,9 +5,8 @@
 import Foundation
 import Shared
 
-/// Child settings pages debug actions
-protocol DebugSettingsDelegate: AnyObject, SharedSettingsDelegate {
-    func pressedVersion()
-    func pressedShowTour()
-    func pressedExperiments()
+/// The actions used by multiple child settings
+protocol SharedSettingsDelegate: AnyObject {
+    func askedToReload()
+    func askedToShow(alert: AlertController)
 }

--- a/Shared/NotificationConstants.swift
+++ b/Shared/NotificationConstants.swift
@@ -46,8 +46,6 @@ extension Notification.Name {
 
     public static let DynamicFontChanged = Notification.Name("DynamicFontChanged")
 
-    public static let UserInitiatedSyncManually = Notification.Name("UserInitiatedSyncManually")
-
     public static let FaviconDidLoad = Notification.Name("FaviconDidLoad")
 
     public static let ReachabilityStatusChanged = Notification.Name("ReachabilityStatusChanged")

--- a/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
@@ -429,6 +429,35 @@ final class SettingsCoordinatorTests: XCTestCase {
         XCTAssertTrue(mockRouter.pushedViewController is SettingsContentViewController)
     }
 
+    // MARK: AccountSettingsDelegate
+
+    func testAccountSettingsDelegate_pushedConnectSetting() {
+        let subject = createSubject()
+
+        subject.pressedConnectSetting()
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+        XCTAssertTrue(mockRouter.pushedViewController is FirefoxAccountSignInViewController)
+    }
+
+    func testAccountSettingsDelegate_pushedAdvancedAccountSetting() {
+        let subject = createSubject()
+
+        subject.pressedAdvancedAccountSetting()
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+        XCTAssertTrue(mockRouter.pushedViewController is AdvancedAccountSettingViewController)
+    }
+
+    func testAccountSettingsDelegate_pushedAccountStatusSetting() {
+        let subject = createSubject()
+
+        subject.pressedAccountStatusSetting()
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+        XCTAssertTrue(mockRouter.pushedViewController is SyncContentSettingsViewController)
+    }
+
     // MARK: - Helper
     func createSubject() -> SettingsCoordinator {
         let subject = SettingsCoordinator(router: mockRouter,

--- a/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
@@ -449,13 +449,22 @@ final class SettingsCoordinatorTests: XCTestCase {
         XCTAssertTrue(mockRouter.pushedViewController is AdvancedAccountSettingViewController)
     }
 
-    func testAccountSettingsDelegate_pushedAccountStatusSetting() {
+    func testAccountSettingsDelegate_pushedToShowSyncContent() {
         let subject = createSubject()
 
-        subject.pressedAccountStatusSetting()
+        subject.pressedToShowSyncContent()
 
         XCTAssertEqual(mockRouter.pushCalled, 1)
         XCTAssertTrue(mockRouter.pushedViewController is SyncContentSettingsViewController)
+    }
+
+    func testAccountSettingsDelegate_pushedToShowFirefoxAccount() {
+        let subject = createSubject()
+
+        subject.pressedToShowFirefoxAccount()
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+        XCTAssertTrue(mockRouter.pushedViewController is FirefoxAccountSignInViewController)
     }
 
     // MARK: - Helper

--- a/Tests/ClientTests/Mocks/MockSettingsFlowDelegate.swift
+++ b/Tests/ClientTests/Mocks/MockSettingsFlowDelegate.swift
@@ -6,7 +6,8 @@ import Foundation
 
 @testable import Client
 
-class MockSettingsFlowDelegate: SettingsFlowDelegate, GeneralSettingsDelegate, PrivacySettingsDelegate {
+class MockSettingsFlowDelegate: SettingsFlowDelegate, GeneralSettingsDelegate, PrivacySettingsDelegate,
+                                AccountSettingsDelegate {
     var showDevicePassCodeCalled = 0
     var showCreditCardSettingsCalled = 0
     var didFinishShowingSettingsCalled = 0
@@ -69,4 +70,14 @@ class MockSettingsFlowDelegate: SettingsFlowDelegate, GeneralSettingsDelegate, P
     func pressedNotifications() {}
 
     func askedToOpen(url: URL?, withTitle title: NSAttributedString?) {}
+
+    // MARK: AccountSettingsDelegate
+
+    func pressedConnectSetting() {}
+
+    func pressedAdvancedAccountSetting() {}
+
+    func pressedToShowSyncContent() {}
+
+    func pressedToShowFirefoxAccount() {}
 }


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6615)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14795)

### Description
Account settings now use settings coordinator to push views instead of being pushed from the Settings NSObject class by passing the navigation controller on click.
- Remove UserInitiatedSyncManually notification since it's sent but never used anywhere
- Create SharedSettingsDelegate since some actions are shared between settings sections
- Make sure a11y identifiers are set properly on account sections

### Pull requests checks where applicable
- [X] Fill in the three TODOs above (tickets number and description of your work)
- [X] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [X] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
