### PR TITLE
Bugfix FXIOS-6512 [v116] Make search suggestions scrollable on blank new tab setting

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2952,7 +2952,7 @@ extension BrowserViewController: KeyboardHelperDelegate {
     private func finishEditionMode() {
         // If keyboard is dismiss leave edition mode Homepage case is handled in HomepageVC
         let newTabChoice = NewTabAccessors.getNewTabPage(profile.prefs)
-        if newTabChoice != .topSites {
+        if newTabChoice != .topSites, newTabChoice != .blankPage {
             overlayManager.finishEditing(shouldCancelLoading: false)
         }
     }


### PR DESCRIPTION
# [FXIOS-6512](https://mozilla-hub.atlassian.net/browse/FXIOS-6512) | https://github.com/mozilla-mobile/firefox-ios/issues/14608

### Description
Search suggestions are now scrollable when setting your new tab as blank page. 

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
