### PR TITLE
Bugfix FXIOS-6805 [v116] Update padding and corners on 'Use saved card' button

### DIFF
--- a/Client/AccessoryViewProvider.swift
+++ b/Client/AccessoryViewProvider.swift
@@ -14,6 +14,11 @@ class AccessoryViewProvider: UIView, Themeable {
     private struct UX {
         static let toolbarHeight: CGFloat = 50
         static let cornerRadius: CGFloat = 4
+        static let cardImageViewSize: CGFloat = 24
+        static let fixedSpacerHeight: CGFloat = 30
+        static let fixedLeadingSpacerWidth: CGFloat = 2
+        static let fixedTrailingSpacerWidth: CGFloat = 3
+        static let cardButtonStackViewSpacing: CGFloat = 2
     }
 
     var themeManager: ThemeManager
@@ -69,8 +74,8 @@ class AccessoryViewProvider: UIView, Themeable {
         imageView.accessibilityElementsHidden = true
 
         NSLayoutConstraint.activate([
-            imageView.widthAnchor.constraint(equalToConstant: 24),
-            imageView.heightAnchor.constraint(equalToConstant: 24)
+            imageView.widthAnchor.constraint(equalToConstant: UX.cardImageViewSize),
+            imageView.heightAnchor.constraint(equalToConstant: UX.cardImageViewSize)
         ])
     }
 
@@ -90,7 +95,7 @@ class AccessoryViewProvider: UIView, Themeable {
         stackView.addArrangedSubview(self.cardImageView)
         stackView.addArrangedSubview(self.useCardTextLabel)
         stackView.addArrangedSubview(self.trailingFixedSpacer)
-        stackView.spacing = 2
+        stackView.spacing = UX.cardButtonStackViewSpacing
         stackView.distribution = .equalCentering
         stackView.layer.cornerRadius = UX.cornerRadius
         stackView.addGestureRecognizer(stackViewTapped)
@@ -139,18 +144,18 @@ class AccessoryViewProvider: UIView, Themeable {
         layoutIfNeeded()
     }
 
-    private func setupSpacer(_ spacer: UIView, width: CGFloat = 0) {
+    private func setupSpacer(_ spacer: UIView, width: CGFloat) {
         NSLayoutConstraint.activate([
             spacer.widthAnchor.constraint(equalToConstant: width),
-            spacer.heightAnchor.constraint(equalToConstant: 30)
+            spacer.heightAnchor.constraint(equalToConstant: UX.fixedSpacerHeight)
         ])
         spacer.accessibilityElementsHidden = true
     }
 
     private func setupLayout() {
         translatesAutoresizingMaskIntoConstraints = false
-        setupSpacer(leadingFixedSpacer, width: 2)
-        setupSpacer(trailingFixedSpacer, width: 3)
+        setupSpacer(leadingFixedSpacer, width: UX.fixedLeadingSpacerWidth)
+        setupSpacer(trailingFixedSpacer, width: UX.fixedTrailingSpacerWidth)
 
         if showCreditCard {
             let cardStackViewForBarButton = UIBarButtonItem(customView: cardButtonStackView)

--- a/Client/AccessoryViewProvider.swift
+++ b/Client/AccessoryViewProvider.swift
@@ -139,9 +139,9 @@ class AccessoryViewProvider: UIView, Themeable {
         layoutIfNeeded()
     }
 
-    private func setupSpacer(_ spacer: UIView) {
+    private func setupSpacer(_ spacer: UIView, width: CGFloat = 0) {
         NSLayoutConstraint.activate([
-            spacer.widthAnchor.constraint(equalToConstant: 2),
+            spacer.widthAnchor.constraint(equalToConstant: width),
             spacer.heightAnchor.constraint(equalToConstant: 30)
         ])
         spacer.accessibilityElementsHidden = true
@@ -149,8 +149,8 @@ class AccessoryViewProvider: UIView, Themeable {
 
     private func setupLayout() {
         translatesAutoresizingMaskIntoConstraints = false
-        setupSpacer(leadingFixedSpacer)
-        setupSpacer(trailingFixedSpacer)
+        setupSpacer(leadingFixedSpacer, width: 2)
+        setupSpacer(trailingFixedSpacer, width: 3)
 
         if showCreditCard {
             let cardStackViewForBarButton = UIBarButtonItem(customView: cardButtonStackView)

--- a/Client/AccessoryViewProvider.swift
+++ b/Client/AccessoryViewProvider.swift
@@ -11,8 +11,9 @@ enum AccessoryType {
 }
 
 class AccessoryViewProvider: UIView, Themeable {
-    private struct AccessoryViewUX {
+    private struct UX {
         static let toolbarHeight: CGFloat = 50
+        static let cornerRadius: CGFloat = 4
     }
 
     var themeManager: ThemeManager
@@ -59,14 +60,8 @@ class AccessoryViewProvider: UIView, Themeable {
 
     private let flexibleSpacer = UIBarButtonItem(systemItem: .flexibleSpace)
 
-    private let fixedSpacer: UIView = .build { view in
-        NSLayoutConstraint.activate([
-            view.widthAnchor.constraint(equalToConstant: 2),
-            view.heightAnchor.constraint(equalToConstant: 30)
-        ])
-
-        view.accessibilityElementsHidden = true
-    }
+    private let leadingFixedSpacer: UIView = .build()
+    private let trailingFixedSpacer: UIView = .build()
 
     lazy private var cardImageView: UIImageView = .build { imageView in
         imageView.image = UIImage(named: ImageIdentifiers.Large.creditCard)?.withRenderingMode(.alwaysTemplate)
@@ -91,12 +86,13 @@ class AccessoryViewProvider: UIView, Themeable {
         let stackViewTapped = UITapGestureRecognizer(target: self, action: #selector(self.tappedCardButton))
 
         stackView.isUserInteractionEnabled = true
-        stackView.addArrangedSubview(self.fixedSpacer)
+        stackView.addArrangedSubview(self.leadingFixedSpacer)
         stackView.addArrangedSubview(self.cardImageView)
         stackView.addArrangedSubview(self.useCardTextLabel)
-        stackView.addArrangedSubview(self.fixedSpacer)
+        stackView.addArrangedSubview(self.trailingFixedSpacer)
         stackView.spacing = 2
         stackView.distribution = .equalCentering
+        stackView.layer.cornerRadius = UX.cornerRadius
         stackView.addGestureRecognizer(stackViewTapped)
     }
 
@@ -108,7 +104,7 @@ class AccessoryViewProvider: UIView, Themeable {
         self.notificationCenter = notificationCenter
 
         super.init(frame: CGRect(width: UIScreen.main.bounds.width,
-                                 height: AccessoryViewUX.toolbarHeight))
+                                 height: UX.toolbarHeight))
 
         listenForThemeChange(self)
         setupLayout()
@@ -143,8 +139,18 @@ class AccessoryViewProvider: UIView, Themeable {
         layoutIfNeeded()
     }
 
+    private func setupSpacer(_ spacer: UIView) {
+        NSLayoutConstraint.activate([
+            spacer.widthAnchor.constraint(equalToConstant: 2),
+            spacer.heightAnchor.constraint(equalToConstant: 30)
+        ])
+        spacer.accessibilityElementsHidden = true
+    }
+
     private func setupLayout() {
         translatesAutoresizingMaskIntoConstraints = false
+        setupSpacer(leadingFixedSpacer)
+        setupSpacer(trailingFixedSpacer)
 
         if showCreditCard {
             let cardStackViewForBarButton = UIBarButtonItem(customView: cardButtonStackView)
@@ -157,7 +163,7 @@ class AccessoryViewProvider: UIView, Themeable {
 
         NSLayoutConstraint.activate([
             toolbar.widthAnchor.constraint(equalTo: super.widthAnchor),
-            toolbar.heightAnchor.constraint(equalToConstant: AccessoryViewUX.toolbarHeight)
+            toolbar.heightAnchor.constraint(equalToConstant: UX.toolbarHeight)
         ])
     }
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6805)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15155)

### Description
Update padding and add corner radius to the Use saved card accessory view

![screenshot](https://github.com/mozilla-mobile/firefox-ios/assets/51127880/2f37a6ae-f901-4f54-8132-fad9b7ec9053)

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
