### PR TITLE
Add FXIOS-6703 [v116] credit card telemetry events

### DIFF
--- a/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
@@ -255,7 +255,7 @@ class CreditCardBottomSheetViewController: UIViewController, UITableViewDelegate
             item: creditCard,
             isAccessibilityCategory: UIApplication.shared.preferredContentSizeCategory.isAccessibilityCategory,
             shouldShowSeparator: false,
-            addPadding: true,
+            addPadding: numberOfCards > 1,
             didSelectAction: { [weak self] in
                 self?.handleCreditCardSelection(row: indexPath.row)
             })

--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewModel.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewModel.swift
@@ -47,6 +47,16 @@ class CreditCardSettingsViewModel {
             return userDefaults.bool(forKey: key)
         }
         set {
+            // Telemetry for card autofill
+            TelemetryWrapper.recordEvent(
+                category: .action,
+                method: .tap,
+                object: .creditCardAutofillToggle,
+                extras: [
+                    TelemetryWrapper.ExtraKey.isCreditCardAutofillToggleEnabled.rawValue: newValue
+                ]
+            )
+
             UserDefaults.standard.set(newValue, forKey: PrefsKeys.KeyAutofillCreditCardStatus)
         }
     }

--- a/Client/Frontend/Library/HistoryPanel/GeneralizedTableView/SearchGroupedItemsViewController.swift
+++ b/Client/Frontend/Library/HistoryPanel/GeneralizedTableView/SearchGroupedItemsViewController.swift
@@ -130,7 +130,7 @@ class SearchGroupedItemsViewController: UIViewController, UITableViewDelegate, T
                 cell.descriptionLabel.isHidden = false
                 cell.leftImageView.layer.borderWidth = 0.5
                 cell.leftImageView.setFavicon(FaviconImageViewModel(siteURLString: site.url))
-                cell.applyTheme(theme: themeManager.currentTheme)
+                cell.applyTheme(theme: self.themeManager.currentTheme)
 
                 return cell
             }

--- a/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -147,7 +147,12 @@ class SyncContentSettingsViewController: SettingsTableViewController, FeatureFla
 
     func engineSettingChanged(_ engineName: String) -> (Bool) -> Void {
         let prefName = "sync.engine.\(engineName).enabledStateChanged"
-        return { enabled in
+        return { [unowned self] enabled in
+            // Credit card sync telemetry
+            if engineName == "creditcards" {
+                self.creditCardSyncEnabledTelemetry(status: enabled)
+            }
+
             if self.profile.prefs.boolForKey(prefName) != nil { // Switch it back to not-changed
                 self.profile.prefs.removeObjectForKey(prefName)
                 self.enginesToSyncOnExit.remove(engineName)
@@ -156,6 +161,17 @@ class SyncContentSettingsViewController: SettingsTableViewController, FeatureFla
                 self.enginesToSyncOnExit.insert(engineName)
             }
         }
+    }
+
+    private func creditCardSyncEnabledTelemetry(status: Bool) {
+        TelemetryWrapper.recordEvent(
+            category: .action,
+            method: .tap,
+            object: .creditCardSyncToggle,
+            extras: [
+                TelemetryWrapper.ExtraKey.isCreditCardSyncToggleEnabled.rawValue: status
+            ]
+        )
     }
 
     override func generateSettings() -> [SettingSection] {

--- a/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -149,6 +149,7 @@ class SyncContentSettingsViewController: SettingsTableViewController, FeatureFla
         let prefName = "sync.engine.\(engineName).enabledStateChanged"
         return { [unowned self] enabled in
             // Credit card sync telemetry
+            // Refactor: FXIOS-6851
             if engineName == "creditcards" {
                 self.creditCardSyncEnabledTelemetry(status: enabled)
             }

--- a/Client/Frontend/TabContentsScripts/CreditCardHelper.swift
+++ b/Client/Frontend/TabContentsScripts/CreditCardHelper.swift
@@ -153,9 +153,15 @@ class CreditCardHelper: TabContentScript {
             let fillCreditCardInfoCallback = "__firefox__.CreditCardHelper.fillFormFields('\(jsonDataVal)')"
             webView.evaluateJavascriptInDefaultContentWorld(fillCreditCardInfoCallback, frame) { _, err in
                 guard let err = err else {
+                    TelemetryWrapper.recordEvent(category: .action,
+                                                 method: .tap,
+                                                 object: .creditCardAutofilled)
                     completion(nil)
                     return
                 }
+                TelemetryWrapper.recordEvent(category: .action,
+                                             method: .tap,
+                                             object: .creditCardAutofillFailed)
                 completion(err)
                 logger.log("Credit card script error \(err)",
                            level: .debug,

--- a/Client/TabManagement/Tab.swift
+++ b/Client/TabManagement/Tab.swift
@@ -449,9 +449,9 @@ class Tab: NSObject {
             webView.allowsLinkPreview = true
 
             // Allow Safari Web Inspector (requires toggle in Settings > Safari > Advanced).
-            if #available(iOS 16.4, *) {
-                webView.isInspectable = true
-            }
+//            if #available(iOS 16.4, *) {
+//                webView.isInspectable = true
+//            }
 
             // Night mode enables this by toggling WKWebView.isOpaque, otherwise this has no effect.
             webView.backgroundColor = .black

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -827,9 +827,6 @@ extension TelemetryWrapper {
             GleanMetrics.CreditCard.autofillFailed.record()
         case(.action, .tap, .creditCardSavePromptCreate, _, _):
             GleanMetrics.CreditCard.savePromptCreate.record()
-//        case creditCardAutofillEnabled = "creditCardAutofillEnabled"
-//        case creditCardSyncEnabled = "creditCardSyncEnabled"
-
         case(.information, .settings, .creditCardAutofillEnabled, _, let extras):
             if let isEnabled = extras?[EventExtraKey.isCreditCardAutofillEnabled.rawValue]
                 as? Bool {

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -209,6 +209,7 @@ class TelemetryWrapper: TelemetryWrapperProtocol {
             GleanMetrics.Deletion.syncDeviceId.set(deviceId)
         }
     }
+
     @objc
     func recordFinishedLaunchingPreferenceMetrics(notification: NSNotification) {
         guard let profile = self.profile else { return }
@@ -426,6 +427,14 @@ extension TelemetryWrapper {
         case creditCardBottomSheetManageCards = "creditCardBottomSheetManageCards"
         case creditCardBottomSheetDismiss = "creditCardBottomSheetDismiss"
         case creditCardAutofillSettings = "creditCardAutofillSettings"
+        case creditCardFormDetected = "creditCardFormDetected"
+        case creditCardAutofilled = "creditCardAutofilled"
+        case creditCardAutofillFailed = "creditCardAutofillFailed"
+        case creditCardSavePromptCreate = "creditCardSavePromptCreate"
+        case creditCardAutofillEnabled = "creditCardAutofillEnabled"
+        case creditCardSyncEnabled = "creditCardSyncEnabled"
+        case creditCardAutofillToggle = "creditCardAutofillToggle"
+        case creditCardSyncToggle = "creditCardSyncToggle"
         case notificationPermission = "notificationPermission"
         case engagementNotification = "engagementNotification"
         // MARK: New Onboarding
@@ -658,6 +667,12 @@ extension TelemetryWrapper {
         case notificationPermissionIsGranted = "is-granted"
         case notificationPermissionStatus = "status"
         case notificationPermissionAlertSetting = "alert-setting"
+
+        // Credit card
+        case isCreditCardAutofillToggleEnabled = "is-credit-card-autofill-toggle-enabled"
+        case isCreditCardSyncToggleEnabled = "is-credit-card-sync-toggle-enabled"
+        case isCreditCardAutofillEnabled = "is-credit-card-autofill-enabled"
+        case isCreditCardSyncEnabled = "is-credit-card-sync-enabled"
     }
 
     func recordEvent(category: EventCategory,
@@ -804,7 +819,67 @@ extension TelemetryWrapper {
         // MARK: Credit Card
         case(.action, .tap, .creditCardAutofillSettings, _, _):
             GleanMetrics.CreditCard.autofillSettingsTapped.record()
+        case(.action, .tap, .creditCardFormDetected, _, _):
+            GleanMetrics.CreditCard.formDetected.record()
+        case(.action, .tap, .creditCardAutofilled, _, _):
+            GleanMetrics.CreditCard.autofilled.record()
+        case(.action, .tap, .creditCardAutofillFailed, _, _):
+            GleanMetrics.CreditCard.autofillFailed.record()
+        case(.action, .tap, .creditCardSavePromptCreate, _, _):
+            GleanMetrics.CreditCard.savePromptCreate.record()
+//        case creditCardAutofillEnabled = "creditCardAutofillEnabled"
+//        case creditCardSyncEnabled = "creditCardSyncEnabled"
 
+        case(.information, .settings, .creditCardAutofillEnabled, _, let extras):
+            if let isEnabled = extras?[EventExtraKey.isCreditCardAutofillEnabled.rawValue]
+                as? Bool {
+                GleanMetrics.CreditCard.autofillEnabled.set(isEnabled)
+            } else {
+                recordUninstrumentedMetrics(
+                    category: category,
+                    method: method,
+                    object: object,
+                    value: value,
+                    extras: extras)
+            }
+        case(.information, .settings, .creditCardSyncEnabled, _, let extras):
+            if let isEnabled = extras?[EventExtraKey.isCreditCardSyncEnabled.rawValue]
+                as? Bool {
+                GleanMetrics.CreditCard.syncEnabled.set(isEnabled)
+            } else {
+                recordUninstrumentedMetrics(
+                    category: category,
+                    method: method,
+                    object: object,
+                    value: value,
+                    extras: extras)
+            }
+        case(.action, .tap, .creditCardAutofillToggle, _, let extras):
+            if let isEnabled = extras?[EventExtraKey.isCreditCardAutofillToggleEnabled.rawValue]
+                as? Bool {
+                let isEnabledExtra = GleanMetrics.CreditCard.AutofillToggleExtra(isEnabled: isEnabled)
+                GleanMetrics.CreditCard.autofillToggle.record(isEnabledExtra)
+            } else {
+                recordUninstrumentedMetrics(
+                    category: category,
+                    method: method,
+                    object: object,
+                    value: value,
+                    extras: extras)
+            }
+        case(.action, .tap, .creditCardSyncToggle, _, let extras):
+            if let isEnabled = extras?[EventExtraKey.isCreditCardSyncToggleEnabled.rawValue]
+                as? Bool {
+                let isEnabledExtra = GleanMetrics.CreditCard.SyncToggleExtra(isEnabled: isEnabled)
+                GleanMetrics.CreditCard.syncToggle.record(isEnabledExtra)
+            } else {
+                recordUninstrumentedMetrics(
+                    category: category,
+                    method: method,
+                    object: object,
+                    value: value,
+                    extras: extras)
+            }
         // MARK: Settings Menu
         case (.action, .open, .settingsMenuSetAsDefaultBrowser, _, _):
             GleanMetrics.SettingsMenu.setAsDefaultBrowserPressed.add()

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -3767,3 +3767,117 @@ credit_card:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2023-12-01"
+  form_detected:
+    type: event
+    description: |
+      Recorded when the user taps on credit card form input
+      and we detect it.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-6703
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/15251
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2023-12-31"
+  autofilled:
+    type: event
+    description: |
+      Recorded when a user taps a card from bottom sheet
+      select a card flow and the credit card does not
+      get autofilled on the webpage page
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-6703
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/15251
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2023-12-31"
+  autofill_failed:
+    type: event
+    description: |
+      Recorded when a user taps a card from bottom sheet
+      select a card flow and the credit card does not
+      get autofilled on the webpage page
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-6703
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/15251
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2023-12-31"
+  save_prompt_create:
+    type: event
+    description: |
+      Recorded when a user saved a credit card using
+      the autofill save prompt.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-6703
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/15251
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2023-12-31"
+  autofill_toggle:
+    type: event
+    description: |
+      Recorded when a user toggles to enable save and autofill
+      cards in autofill settings
+    send_in_pings:
+      - events
+    extra_keys:
+      is_enabled:
+        type: boolean
+        description: |
+          If is enabled or not (true / false)
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-6703
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/15251
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2023-12-31"
+  sync_toggle:
+    type: event
+    description: |
+      Recorded when a user toggles to enable save and autofill
+      cards in sync settings
+    send_in_pings:
+      - events
+    extra_keys:
+      is_enabled:
+        type: boolean
+        description: |
+          If is enabled or not (true / false)
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-6703
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/15251
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2023-12-31"
+  autofill_enabled:
+    type: boolean
+    description: |
+      Recorded on startup to check if credit card
+      autofill settings are enabled
+    lifetime: application
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-6703
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/15251
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2023-12-31"
+  sync_enabled:
+    type: boolean
+    description: |
+      Recorded on startup to check if credit card
+      sync settings are enabled
+    lifetime: application
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-6703
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/15251
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2023-12-31"

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -30,6 +30,7 @@ public protocol SyncManager {
     func endTimedSyncs()
     func applicationDidBecomeActive()
     func applicationDidEnterBackground()
+    func checkCreditCardEngineEnablement() -> Bool
 
     @discardableResult
     func onRemovedAccount() -> Success

--- a/Providers/RustSyncManager.swift
+++ b/Providers/RustSyncManager.swift
@@ -254,7 +254,19 @@ public class RustSyncManager: NSObject, SyncManager {
         return clearPrefs()
     }
 
-    func getEngineEnablementChangesForAccount() -> [String: Bool] {
+    public func checkCreditCardEngineEnablement() -> Bool {
+        let engine = "creditcards"
+        guard let declined = UserDefaults.standard.stringArray(forKey: fxaDeclinedEngines),
+              !declined.isEmpty,
+              declined.contains(engine)
+        else {
+            let engineEnabled = prefsForSync.boolForKey("engine.\(engine).enabled") ?? false
+            return engineEnabled
+        }
+        return false
+    }
+
+    private func getEngineEnablementChangesForAccount() -> [String: Bool] {
         var engineEnablements: [String: Bool] = [:]
         // We just created the account, the user went through the Choose What to Sync
         // screen on FxA.

--- a/Providers/RustSyncManager.swift
+++ b/Providers/RustSyncManager.swift
@@ -266,7 +266,7 @@ public class RustSyncManager: NSObject, SyncManager {
         return false
     }
 
-    private func getEngineEnablementChangesForAccount() -> [String: Bool] {
+    public func getEngineEnablementChangesForAccount() -> [String: Bool] {
         var engineEnablements: [String: Bool] = [:]
         // We just created the account, the user went through the Choose What to Sync
         // screen on FxA.

--- a/Tests/ClientTests/Mocks/MockProfile.swift
+++ b/Tests/ClientTests/Mocks/MockProfile.swift
@@ -48,6 +48,10 @@ open class MockSyncManager: ClientSyncManager {
     open func onRemovedAccount() -> Success {
         return succeed()
     }
+    open func checkCreditCardEngineEnablement() -> Bool {
+        // Refactor: FXIOS-6852
+        return true
+    }
 }
 
 open class MockTabQueue: TabQueue {


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6703)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14963)

### Description

credit_card.form_detected | A credit card form was detected.
-- | --
credit_card.autofilled | User has autofilled a credit card.
credit_card.autofill_failed | User has failed to autofill a credit card.
credit_card.save_prompt_create | User saved a credit card using the autofill save prompt.
credit_card.autofill_enabled | User has ‘save and autofill cards’ enabled in settings [sent on startup, application lifetime]
credit_card.sync_enabled | User has Credit Cards enabled in sync settings [sent on startup, application lifetime]
credit_card.autofill_toggle | User toggles ‘save and autofill cards’ enabled in settings 
credit_card.sync_toggle | User toggles Credit Cards in sync settings 

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [ ] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
