### PR TITLE
Bump [v116] Update Sentry to version 8.8.0

### DIFF
--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
             exact: "2.0.0"),
         .package(
             url: "https://github.com/getsentry/sentry-cocoa.git",
-            exact: "8.6.0"),
+            exact: "8.8.0"),
     ],
     targets: [
         .target(

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -18923,7 +18923,7 @@
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa.git";
 			requirement = {
 				kind = exactVersion;
-				version = 8.6.0;
+				version = 8.8.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "e6dcfba32f2861438b82c7ad34e058b23c83daf6",
-        "version" : "8.6.0"
+        "revision" : "d277532e1c8af813981ba01f591b15bbdd735615",
+        "version" : "8.8.0"
       }
     },
     {


### PR DESCRIPTION
Changelogs since the previous update:
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.7.0
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.7.1
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.7.2
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.7.3
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.7.4
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.8.0

To whomever ends up reviewing this, if you could kindly do the same for the accompanying Focus PR (https://github.com/mozilla-mobile/focus-ios/pull/3796), I would be most appreciative!