### PR TITLE
Bugfix FXIOS-6853 [v116] don't eval code inside cc json

### DIFF
--- a/Client/Assets/CC_Script/FormAutofillChild.ios.sys.mjs
+++ b/Client/Assets/CC_Script/FormAutofillChild.ios.sys.mjs
@@ -56,9 +56,7 @@ export class FormAutofillChild {
   }
 
   fillFormFields(payload) {
-    this.fieldDetailsManager.activeHandler.autofillFormFields(
-      JSON.parse(payload)
-    );
+    this.fieldDetailsManager.activeHandler.autofillFormFields(payload);
   }
 }
 

--- a/Client/Frontend/TabContentsScripts/CreditCardHelper.swift
+++ b/Client/Frontend/TabContentsScripts/CreditCardHelper.swift
@@ -150,7 +150,7 @@ class CreditCardHelper: TabContentScript {
                 return
             }
 
-            let fillCreditCardInfoCallback = "__firefox__.CreditCardHelper.fillFormFields('\(jsonDataVal)')"
+            let fillCreditCardInfoCallback = "__firefox__.CreditCardHelper.fillFormFields(\(jsonDataVal))"
             webView.evaluateJavascriptInDefaultContentWorld(fillCreditCardInfoCallback, frame) { _, err in
                 guard let err = err else {
                     completion(nil)


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6853)
[Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1840958)

### Description
This PR:
- Removes `''` when concatenating function call and json argument. This essentially allows JS code to be evaluated inside the swift eval function. 
- Since we are not returning JSON anymore we can just skip parsing it in JS side.

Kudos to Serg who asked why we had those quotes in the first place.

### Pull requests checks where applicable
- [ ] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
~~- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)~~
~~- [ ] Unit tests written and passing~~
~~- [ ] Documentation / comments for complex code and public methods~~


https://github.com/mozilla-mobile/firefox-ios/assets/26678795/5830830e-661b-4c9a-81aa-39888358f936