### PR TITLE
Add FXIOS-6508 [v117] ShareExtensionCoordinator flag feature.

### DIFF
--- a/.experimenter.yaml
+++ b/.experimenter.yaml
@@ -180,6 +180,14 @@ settings-coordinator-refactor:
     enabled:
       type: boolean
       description: "Enables the feature\n"
+share-extension-coordinator-refactor:
+  description: "This feature is for managing the roll out of the share extension coordinator as part of the changes to the navigation in the app\n"
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "Enables the feature\n"
 share-sheet:
   description: This feature define the redesign of the share sheet
   hasExposure: true

--- a/Client/Coordinators/CoordinatorFlagManager.swift
+++ b/Client/Coordinators/CoordinatorFlagManager.swift
@@ -27,6 +27,10 @@ struct CoordinatorFlagManager {
                                                              checking: .buildOnly)
     }
 
+    static var isShareExtensionCoordinatorEnabled: Bool {
+        isCoordinatorEnabled && NimbusManager.shared.featureFlagLayer.checkNimbusConfigFor(.shareExtensionCoordinatorRefactor)
+    }
+
     static var isEtpCoordinatorEnabled: Bool {
         return CoordinatorFlagManager.isSettingsCoordinatorEnabled
         && LegacyFeatureFlagsManager.shared.isFeatureEnabled(.etpCoordinatorRefactor,

--- a/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -35,6 +35,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case searchHighlights
     case settingsCoordinatorRefactor
     case shakeToRestore
+    case shareExtensionCoordinatorRefactor
     case shareSheetChanges
     case shareToolbarChanges
     case sponsoredTiles
@@ -111,6 +112,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .searchHighlights,
                 .settingsCoordinatorRefactor,
                 .shakeToRestore,
+                .shareExtensionCoordinatorRefactor,
                 .shareSheetChanges,
                 .shareToolbarChanges,
                 .tabStorageRefactor,

--- a/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -61,6 +61,9 @@ final class NimbusFeatureFlagLayer {
         case .reduxIntegration:
             return checkReduxIntegrationFeature(from: nimbus)
 
+        case .shareExtensionCoordinatorRefactor:
+            return checkShareExtensionCoordinatorRefactorFeature(from: nimbus)
+
         case .shareSheetChanges,
                 .shareToolbarChanges:
             return checkNimbusForShareSheet(for: featureID, from: nimbus)
@@ -190,6 +193,11 @@ final class NimbusFeatureFlagLayer {
 
     private func checkSettingsCoordinatorRefactorFeature(from nimbus: FxNimbus) -> Bool {
         let config = nimbus.features.settingsCoordinatorRefactor.value()
+        return config.enabled
+    }
+
+    private func checkShareExtensionCoordinatorRefactorFeature(from nimbus: FxNimbus) -> Bool {
+        let config = nimbus.features.shareExtensionCoordinatorRefactor.value()
         return config.enabled
     }
 

--- a/nimbus-features/shareExtensionCoordinatorRefactor.yaml
+++ b/nimbus-features/shareExtensionCoordinatorRefactor.yaml
@@ -15,5 +15,5 @@ features:
           enabled: false
       - channel: developer
         value:
-          enabled: true
+          enabled: false
 

--- a/nimbus-features/shareExtensionCoordinatorRefactor.yaml
+++ b/nimbus-features/shareExtensionCoordinatorRefactor.yaml
@@ -1,0 +1,19 @@
+# The configuration for the shareExtensionCoordinatorRefactor feature
+features:
+  share-extension-coordinator-refactor:
+    description: >
+      This feature is for managing the roll out of the share extension coordinator as part of the changes to the navigation in the app
+    variables:
+      enabled:
+        description: >
+          Enables the feature
+        type: Boolean
+        default: false
+    defaults:
+      - channel: beta
+        value:
+          enabled: false
+      - channel: developer
+        value:
+          enabled: true
+

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -30,6 +30,7 @@ include:
   - nimbus-features/searchFeature.yaml
   - nimbus-features/searchTermGroupsFeature.yaml
   - nimbus-features/settingsCoordinatorRefactor.yaml
+  - nimbus-features/shareExtensionCoordinatorRefactor.yaml
   - nimbus-features/shareSheetFeature.yaml
   - nimbus-features/spotlightSearchFeature.yaml
   - nimbus-features/startAtHomeFeature.yaml


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6508)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14602)

### Description

Add ShareExtensionCoordinator flag feature to Nimbus.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [x] Documentation / comments for complex code and public methods
