### PR TITLE
Add FXIOS-6852 [v117] Update MockSyncManager to adapt for credit card enablements

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -1185,7 +1185,7 @@
 		DDA24A431FD84D630098F159 /* DefaultSearchPrefs.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA24A341FD84D620098F159 /* DefaultSearchPrefs.swift */; };
 		DDA24A451FD84D630098F159 /* DefaultSearchPrefs.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA24A341FD84D620098F159 /* DefaultSearchPrefs.swift */; };
 		DF036E43274FD434002E834E /* HistoryHighlightsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF036E42274FD434002E834E /* HistoryHighlightsCell.swift */; };
-		DF8C6DD72A52EED1007FAAF2 /* MockSyncManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF8C6DD62A52EED1007FAAF2 /* MockSyncManagerTests.swift */; };
+		DF8C6DD72A52EED1007FAAF2 /* ClientSyncManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF8C6DD62A52EED1007FAAF2 /* ClientSyncManagerTests.swift */; };
 		DFA51481275FFEE500266AA0 /* HistoryHighlightsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA51480275FFEE500266AA0 /* HistoryHighlightsManager.swift */; };
 		DFA51484276103A000266AA0 /* HistoryHighlightsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA514822761012D00266AA0 /* HistoryHighlightsManagerTests.swift */; };
 		DFACBF7F277B5F7B003D5F41 /* WallpaperBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFACBF7E277B5F7B003D5F41 /* WallpaperBackgroundView.swift */; };
@@ -6188,7 +6188,7 @@
 		DF46B9A72755297000657F75 /* ne-NP */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ne-NP"; path = "ne-NP.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		DF4A44AB9DB2BE71AD028C35 /* dsb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = dsb; path = dsb.lproj/Today.strings; sourceTree = "<group>"; };
 		DF4B4523B01B0EDC485E3BCB /* hu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
-		DF8C6DD62A52EED1007FAAF2 /* MockSyncManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSyncManagerTests.swift; sourceTree = "<group>"; };
+		DF8C6DD62A52EED1007FAAF2 /* ClientSyncManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientSyncManagerTests.swift; sourceTree = "<group>"; };
 		DFA51480275FFEE500266AA0 /* HistoryHighlightsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryHighlightsManager.swift; sourceTree = "<group>"; };
 		DFA514822761012D00266AA0 /* HistoryHighlightsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryHighlightsManagerTests.swift; sourceTree = "<group>"; };
 		DFACBF7E277B5F7B003D5F41 /* WallpaperBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperBackgroundView.swift; sourceTree = "<group>"; };
@@ -8619,7 +8619,7 @@
 			isa = PBXGroup;
 			children = (
 				C80C11F328B3CD580062922A /* MockUserDefaultsTests.swift */,
-				DF8C6DD62A52EED1007FAAF2 /* MockSyncManagerTests.swift */,
+				DF8C6DD62A52EED1007FAAF2 /* ClientSyncManagerTests.swift */,
 			);
 			path = MockTests;
 			sourceTree = "<group>";
@@ -12913,7 +12913,7 @@
 				E1442FDA294782F7003680B0 /* UIPasteboard+Extension.swift in Sources */,
 				F98CB66E2A4123F1005F38E9 /* EnhancedTrackingProtectionMenuVMTests.swift in Sources */,
 				8A2366FA28A302E500846D1B /* MockSponsoredPocketAPI.swift in Sources */,
-				DF8C6DD72A52EED1007FAAF2 /* MockSyncManagerTests.swift in Sources */,
+				DF8C6DD72A52EED1007FAAF2 /* ClientSyncManagerTests.swift in Sources */,
 				8A8A05E42746ACAC004267A0 /* TabDisplayManagerTests.swift in Sources */,
 				C869916328918C36007ACC5C /* WallpaperNetworkingModuleTests.swift in Sources */,
 				B640467E29B9B58200C5C7B6 /* TabLocationViewTests.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -1185,6 +1185,7 @@
 		DDA24A431FD84D630098F159 /* DefaultSearchPrefs.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA24A341FD84D620098F159 /* DefaultSearchPrefs.swift */; };
 		DDA24A451FD84D630098F159 /* DefaultSearchPrefs.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA24A341FD84D620098F159 /* DefaultSearchPrefs.swift */; };
 		DF036E43274FD434002E834E /* HistoryHighlightsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF036E42274FD434002E834E /* HistoryHighlightsCell.swift */; };
+		DF8C6DD72A52EED1007FAAF2 /* MockSyncManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF8C6DD62A52EED1007FAAF2 /* MockSyncManagerTests.swift */; };
 		DFA51481275FFEE500266AA0 /* HistoryHighlightsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA51480275FFEE500266AA0 /* HistoryHighlightsManager.swift */; };
 		DFA51484276103A000266AA0 /* HistoryHighlightsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA514822761012D00266AA0 /* HistoryHighlightsManagerTests.swift */; };
 		DFACBF7F277B5F7B003D5F41 /* WallpaperBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFACBF7E277B5F7B003D5F41 /* WallpaperBackgroundView.swift */; };
@@ -6187,6 +6188,7 @@
 		DF46B9A72755297000657F75 /* ne-NP */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ne-NP"; path = "ne-NP.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		DF4A44AB9DB2BE71AD028C35 /* dsb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = dsb; path = dsb.lproj/Today.strings; sourceTree = "<group>"; };
 		DF4B4523B01B0EDC485E3BCB /* hu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
+		DF8C6DD62A52EED1007FAAF2 /* MockSyncManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSyncManagerTests.swift; sourceTree = "<group>"; };
 		DFA51480275FFEE500266AA0 /* HistoryHighlightsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryHighlightsManager.swift; sourceTree = "<group>"; };
 		DFA514822761012D00266AA0 /* HistoryHighlightsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryHighlightsManagerTests.swift; sourceTree = "<group>"; };
 		DFACBF7E277B5F7B003D5F41 /* WallpaperBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperBackgroundView.swift; sourceTree = "<group>"; };
@@ -8617,6 +8619,7 @@
 			isa = PBXGroup;
 			children = (
 				C80C11F328B3CD580062922A /* MockUserDefaultsTests.swift */,
+				DF8C6DD62A52EED1007FAAF2 /* MockSyncManagerTests.swift */,
 			);
 			path = MockTests;
 			sourceTree = "<group>";
@@ -12910,6 +12913,7 @@
 				E1442FDA294782F7003680B0 /* UIPasteboard+Extension.swift in Sources */,
 				F98CB66E2A4123F1005F38E9 /* EnhancedTrackingProtectionMenuVMTests.swift in Sources */,
 				8A2366FA28A302E500846D1B /* MockSponsoredPocketAPI.swift in Sources */,
+				DF8C6DD72A52EED1007FAAF2 /* MockSyncManagerTests.swift in Sources */,
 				8A8A05E42746ACAC004267A0 /* TabDisplayManagerTests.swift in Sources */,
 				C869916328918C36007ACC5C /* WallpaperNetworkingModuleTests.swift in Sources */,
 				B640467E29B9B58200C5C7B6 /* TabLocationViewTests.swift in Sources */,

--- a/Tests/ClientTests/Helpers/AccountSyncHandlerTests.swift
+++ b/Tests/ClientTests/Helpers/AccountSyncHandlerTests.swift
@@ -9,13 +9,13 @@ import WebKit
 
 class AccountSyncHandlerTests: XCTestCase {
     private var profile: MockProfile!
-    private var syncManager: MockSyncManager!
+    private var syncManager: ClientSyncManagerSpy!
     private var queue: MockDispatchQueue!
 
     override func setUp() {
         super.setUp()
         self.profile = MockProfile()
-        self.syncManager = profile.syncManager as? MockSyncManager
+        self.syncManager = profile.syncManager as? ClientSyncManagerSpy
         self.queue = MockDispatchQueue()
     }
 

--- a/Tests/ClientTests/Mocks/MockProfile.swift
+++ b/Tests/ClientTests/Mocks/MockProfile.swift
@@ -16,6 +16,9 @@ open class MockSyncManager: ClientSyncManager {
     open var isSyncing = false
     open var lastSyncFinishTime: Timestamp?
     open var syncDisplayState: SyncDisplayState?
+
+    private var mockDeclinedEngines: [String]?
+    private var mockEngineEnabled = false
     private var emptySyncResult = deferMaybe(SyncResult(status: .ok,
                                                         successful: [],
                                                         failures: [:],
@@ -49,8 +52,20 @@ open class MockSyncManager: ClientSyncManager {
         return succeed()
     }
     open func checkCreditCardEngineEnablement() -> Bool {
-        // Refactor: FXIOS-6852
-        return true
+        guard let mockDeclinedEngines = mockDeclinedEngines,
+              !mockDeclinedEngines.isEmpty,
+              mockDeclinedEngines.contains("creditcards") else {
+            return mockEngineEnabled
+        }
+        return false
+    }
+
+    func setMockDeclinedEngines(_ engines: [String]?) {
+        mockDeclinedEngines = engines
+    }
+
+    func setMockEngineEnabled(_ enabled: Bool) {
+        mockEngineEnabled = enabled
     }
 }
 

--- a/Tests/ClientTests/Mocks/MockProfile.swift
+++ b/Tests/ClientTests/Mocks/MockProfile.swift
@@ -12,7 +12,7 @@ import XCTest
 
 public typealias ClientSyncManager = Client.SyncManager
 
-open class MockSyncManager: ClientSyncManager {
+open class ClientSyncManagerSpy: ClientSyncManager {
     open var isSyncing = false
     open var lastSyncFinishTime: Timestamp?
     open var syncDisplayState: SyncDisplayState?
@@ -113,7 +113,7 @@ open class MockProfile: Client.Profile {
 
     init(databasePrefix: String = "mock") {
         files = MockFiles()
-        syncManager = MockSyncManager()
+        syncManager = ClientSyncManagerSpy()
 
         let oldLoginsDatabasePath = URL(fileURLWithPath: (try! files.getAndEnsureDirectory()), isDirectory: true).appendingPathComponent("\(databasePrefix)_logins.db").path
         try? files.remove("\(databasePrefix)_logins.db")

--- a/Tests/ClientTests/Mocks/MockTests/ClientSyncManagerTests.swift
+++ b/Tests/ClientTests/Mocks/MockTests/ClientSyncManagerTests.swift
@@ -7,13 +7,13 @@ import Foundation
 
 @testable import Client
 
-final class MockSyncManagerTests: XCTestCase {
-    private var sut: MockSyncManager!
+final class ClientSyncManagerTests: XCTestCase {
+    private var sut: ClientSyncManagerSpy!
     private let engine = "creditcards"
 
     override func setUp() {
         super.setUp()
-        sut = MockSyncManager()
+        sut = ClientSyncManagerSpy()
     }
 
     override func tearDown() {

--- a/Tests/ClientTests/Mocks/MockTests/MockSyncManagerTests.swift
+++ b/Tests/ClientTests/Mocks/MockTests/MockSyncManagerTests.swift
@@ -1,0 +1,65 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import Foundation
+
+@testable import Client
+
+final class MockSyncManagerTests: XCTestCase {
+    private var sut: MockSyncManager!
+    private let engine = "creditcards"
+
+    override func setUp() {
+        super.setUp()
+        sut = MockSyncManager()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        sut = nil
+    }
+
+    func testCheckCreditCardEngineEnablement_WhenMockDeclinedEnginesIsNilAndMockEngineEnabledIsFalse() {
+        sut.setMockDeclinedEngines(nil)
+        sut.setMockEngineEnabled(false)
+        let result = sut.checkCreditCardEngineEnablement()
+        XCTAssertEqual(result, false)
+    }
+
+    func testCheckCreditCardEngineEnablement_WhenMockDeclinedEnginesIsEmptyAndMockEngineEnabledIsFalse() {
+        sut.setMockDeclinedEngines([])
+        sut.setMockEngineEnabled(false)
+        let result = sut.checkCreditCardEngineEnablement()
+        XCTAssertEqual(result, false)
+    }
+
+    func testCheckCreditCardEngineEnablement_WhenMockDeclinedEnginesContainsCreditCardsAndMockEngineEnabledIsFalse() {
+        sut.setMockDeclinedEngines([engine])
+        sut.setMockEngineEnabled(false)
+        let result = sut.checkCreditCardEngineEnablement()
+        XCTAssertEqual(result, false)
+    }
+
+    func testCheckCreditCardEngineEnablement_WhenMockDeclinedEnginesContainsCreditCardsAndMockEngineEnabledIsTrue() {
+        sut.setMockDeclinedEngines([engine])
+        sut.setMockEngineEnabled(true)
+        let result = sut.checkCreditCardEngineEnablement()
+        XCTAssertEqual(result, false)
+    }
+
+    func testCheckCreditCardEngineEnablement_WhenMockDeclinedEnginesDoesNotContainCreditCardsAndMockEngineEnabledIsTrue() {
+        sut.setMockDeclinedEngines(["someengine"])
+        sut.setMockEngineEnabled(true)
+        let result = sut.checkCreditCardEngineEnablement()
+        XCTAssertEqual(result, true)
+    }
+
+    func testCheckCreditCardEngineEnablement_WhenMockDeclinedEnginesDoesNotContainCreditCardsAndMockEngineEnabledIsFalse() {
+        sut.setMockDeclinedEngines(["someengine"])
+        sut.setMockEngineEnabled(false)
+        let result = sut.checkCreditCardEngineEnablement()
+        XCTAssertEqual(result, false)
+    }
+}


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6852)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15273)

### Description
- Implement the checkCreditCardEngineEnablement method from ClientSyncManagerSpy
- Write tests for it

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [x] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
