### PR TITLE
Refactor FXIOS-4762 [v116] Update Pocket branding in settings

### DIFF
--- a/Client/Application/AccessibilityIdentifiers.swift
+++ b/Client/Application/AccessibilityIdentifiers.swift
@@ -207,7 +207,6 @@ public struct AccessibilityIdentifiers {
                 static let jumpBackIn = "Jump Back In"
                 static let recentlySaved = "Recently Saved"
                 static let recentVisited = "Recently Visited"
-                static let recommendedByPocket = "Recommended by Pocket"
                 static let wallpaper = "WallpaperSettings"
             }
         }

--- a/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -115,6 +115,7 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
     private func customizeFirefoxSettingSection() -> SettingSection {
         // Setup
         var sectionItems = [Setting]()
+
         let pocketStatusText = String(
             format: .Settings.Homepage.CustomizeFirefoxHome.ThoughtProvokingStoriesSubtitle,
             PocketAppName.shortName.rawValue)

--- a/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -115,9 +115,13 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
     private func customizeFirefoxSettingSection() -> SettingSection {
         // Setup
         var sectionItems = [Setting]()
+        let pocketStatusText = String(
+            format: .Settings.Homepage.CustomizeFirefoxHome.ThoughtProvokingStoriesSubtitle,
+            PocketAppName.shortName.rawValue)
         let pocketSetting = BoolSetting(
             with: .pocket,
-            titleText: NSAttributedString(string: .Settings.Homepage.CustomizeFirefoxHome.Pocket)) { [weak self] _ in
+            titleText: NSAttributedString(string: .Settings.Homepage.CustomizeFirefoxHome.ThoughtProvokingStories),
+            statusText: NSAttributedString(string: pocketStatusText)) { [weak self] _ in
                 self?.tableView.reloadData()
             }
 

--- a/Tests/XCUITests/FxScreenGraph.swift
+++ b/Tests/XCUITests/FxScreenGraph.swift
@@ -695,7 +695,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
         screenState.gesture(forAction: Action.TogglePocketInNewTab) { userState in
             userState.pocketInNewTab = !userState.pocketInNewTab
-            app.tables.cells.switches["Recommended by Pocket"].tap()
+            app.tables.cells.switches["Thought-Provoking Stories"].tap()
         }
 
         screenState.gesture(forAction: Action.SelectTopSitesRows) { userState in

--- a/Tests/XCUITests/FxScreenGraph.swift
+++ b/Tests/XCUITests/FxScreenGraph.swift
@@ -695,7 +695,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
         screenState.gesture(forAction: Action.TogglePocketInNewTab) { userState in
             userState.pocketInNewTab = !userState.pocketInNewTab
-            app.tables.cells.switches["Thought-Provoking Stories"].tap()
+            app.tables.cells.switches["Thought-Provoking Stories, Articles powered by Pocket"].tap()
         }
 
         screenState.gesture(forAction: Action.SelectTopSitesRows) { userState in

--- a/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -36,6 +36,7 @@ class HomePageSettingsUITests: BaseTestCase {
         }
         super.setUp()
     }
+
     func testCheckHomeSettingsByDefault() {
         navigator.nowAt(NewTabScreen)
         navigator.goto(HomeSettings)
@@ -58,8 +59,6 @@ class HomePageSettingsUITests: BaseTestCase {
         XCTAssertEqual("1", recentlySaved as? String)
         let recentlyVisited = app.tables.cells.switches["Recently Visited"].value
         XCTAssertEqual("1", recentlyVisited as? String)
-        let recommendedByPocket = app.tables.cells.switches["Recommended by Pocket"].value
-        XCTAssertEqual("1", recommendedByPocket as? String)
         let sponsoredStories = app.tables.cells.switches["Thought-Provoking Stories, Articles powered by Pocket"].value
         XCTAssertEqual("1", sponsoredStories as? String)
 

--- a/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -303,6 +303,6 @@ class HomePageSettingsUITests: BaseTestCase {
         // XCTAssertEqual(app.cells.switches[AccessibilityIdentifiers.Settings.Homepage.CustomizeFirefox.jumpBackIn].value as! String, "1")
         // XCTAssertEqual(app.cells.switches[AccessibilityIdentifiers.Settings.Homepage.CustomizeFirefox.recentlySaved].value as! String, "1")
         XCTAssertEqual(app.cells.switches[AccessibilityIdentifiers.Settings.Homepage.CustomizeFirefox.recentVisited].value as! String, "1")
-        XCTAssertEqual(app.cells.switches[AccessibilityIdentifiers.Settings.Homepage.CustomizeFirefox.recommendedByPocket].value as! String, "1")
+        XCTAssertEqual(app.cells.switches["Thought-Provoking Stories, Articles powered by Pocket"].value as! String, "1")
     }
 }

--- a/Tests/XCUITests/PocketTests.swift
+++ b/Tests/XCUITests/PocketTests.swift
@@ -11,7 +11,7 @@ class PocketTest: BaseTestCase {
         XCTAssertEqual(app.staticTexts[AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.pocket].label, "Thought-Provoking Stories")
 
         // There should be at least 8 stories on iPhone and three on iPad
-        let numPocketStories = app.collectionViews.containing(.cell, identifier: AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell).children(matching: .cell).count-1
+        let numPocketStories = app.collectionViews.containing(.cell, identifier: AccessibilityIdentifiers.FirefoxHomepage.Pocket.itemCell).children(matching: .cell).count-1
         XCTAssertTrue(numPocketStories > 7)
 
         // Disable Pocket
@@ -25,7 +25,7 @@ class PocketTest: BaseTestCase {
         waitForExistence(app.staticTexts[AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.pocket])
 
         // Tap on the first Pocket element
-        app.collectionViews.containing(.cell, identifier: AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell).children(matching: .cell).element(boundBy: 1).tap()
+        app.collectionViews.containing(.cell, identifier: AccessibilityIdentifiers.FirefoxHomepage.Pocket.itemCell).children(matching: .cell).element(boundBy: 1).tap()
         waitUntilPageLoad()
         // The url textField is not empty
         XCTAssertNotEqual(app.textFields["url"].value as! String, "", "The url textField is empty")

--- a/Tests/XCUITests/PocketTests.swift
+++ b/Tests/XCUITests/PocketTests.swift
@@ -25,7 +25,7 @@ class PocketTest: BaseTestCase {
         waitForExistence(app.staticTexts[AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.pocket])
 
         // Tap on the first Pocket element
-        app.collectionViews.containing(.cell, identifier: AccessibilityIdentifiers.FirefoxHomepage.Pocket.itemCell).children(matching: .cell).element(boundBy: 1).tap()
+        app.collectionViews.scrollViews.cells[AccessibilityIdentifiers.FirefoxHomepage.Pocket.itemCell].firstMatch.tap()
         waitUntilPageLoad()
         // The url textField is not empty
         XCTAssertNotEqual(app.textFields["url"].value as! String, "", "The url textField is empty")


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-4762)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/11599)

### Description
This is correcting the pocket branding for settings.

### Pull requests checks where applicable
- [x] Fill in the three TODOs above (tickets number and description of your work)
- [x] The PR name follows our [naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Accessibility implemented and tested (minimum Dynamic Text and VoiceOver)
- [ ] Unit tests written and passing
- [ ] Documentation / comments for complex code and public methods
