### PR TITLE
Bugfix MTE-725 [v117] Disable parallel testing on Bitrise

### DIFF
--- a/Tests/XCUITests/JumpBackInTests.swift
+++ b/Tests/XCUITests/JumpBackInTests.swift
@@ -142,7 +142,7 @@ class JumpBackInTests: BaseTestCase {
 
         // The view is switched to the twitter tab
         let url = app.textFields["url"].value as! String
-        XCTAssertEqual(url, "twitter.com/i/flow/login")
+        XCTAssertEqual(url, "twitter.com/i/flow/login?redirect_after_login=%2F")
 
         // Open a new tab in normal browsing
         navigator.goto(TabTray)

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -176,7 +176,7 @@ workflows:
         inputs:
         - destination: platform=iOS Simulator,name=iPhone 14 Plus,OS=16.4
         - xcodebuild_options: '"-derivedDataPath" "/Users/vagrant/git/DerivedData"
-            "-parallel-testing-enabled" "YES" "-parallel-testing-worker-count" "2"
+            "-parallel-testing-enabled" "NO" "-parallel-testing-worker-count" "2"
             "COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" 
             "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
         - xctestrun: "Users/vagrant/git/DerivedData/Build/Products/Fennec_Smoketest2_iphonesimulator16.4-x86_64.xctestrun"
@@ -222,7 +222,7 @@ workflows:
         inputs:
         - destination: platform=iOS Simulator,name=iPhone 14 Plus,OS=16.4
         - xcodebuild_options: '"-derivedDataPath" "/Users/vagrant/git/DerivedData"
-            "-parallel-testing-enabled" "YES" "-parallel-testing-worker-count" "2"
+            "-parallel-testing-enabled" "NO" "-parallel-testing-worker-count" "2"
             "COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" 
             "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
         - xctestrun: "Users/vagrant/git/DerivedData/Build/Products/Fennec_SmokeXCUITests_iphonesimulator16.4-x86_64.xctestrun"
@@ -268,7 +268,7 @@ workflows:
         inputs:
         - destination: platform=iOS Simulator,name=iPhone 14 Plus,OS=16.4
         - xcodebuild_options: '"-derivedDataPath" "/Users/vagrant/git/DerivedData"
-            "-parallel-testing-enabled" "YES" "-parallel-testing-worker-count" "2"
+            "-parallel-testing-enabled" "NO" "-parallel-testing-worker-count" "2"
             "COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" 
             "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
         - xctestrun: "Users/vagrant/git/DerivedData/Build/Products/Fennec_Smoketest3_iphonesimulator16.4-x86_64.xctestrun"
@@ -314,7 +314,7 @@ workflows:
         inputs:
         - destination: platform=iOS Simulator,name=iPhone 14 Plus,OS=16.4
         - xcodebuild_options: '"-derivedDataPath" "/Users/vagrant/git/DerivedData"
-            "-parallel-testing-enabled" "YES" "-parallel-testing-worker-count" "2"
+            "-parallel-testing-enabled" "NO" "-parallel-testing-worker-count" "2"
             "COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" 
             "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
         - xctestrun: "Users/vagrant/git/DerivedData/Build/Products/Fennec_Smoketest4_iphonesimulator16.4-x86_64.xctestrun"


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-725)

## :bulb: Description
The smoke tests time out sporadically on Bitrise. Let us disable parallel testing for now while we are working with the developers on any potential build issue.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and ensured the tests suite is passing
- [ ] Implemented accessibility and tested on UI related work (minimum Dynamic Text and VoiceOver)
- [ ] Updated documentation / comments for complex code and public methods if needed

