### PR TITLE
Remove FXIOS-6844 [v117] Remove old FxA migration code

### DIFF
--- a/RustFxA/FxAWebViewModel.swift
+++ b/RustFxA/FxAWebViewModel.swift
@@ -70,10 +70,6 @@ class FxAWebViewModel {
         self.deepLinkParams = deepLinkParams
         self.shouldAskForNotificationPermission = shouldAskForNotificationPermission
         self.logger = logger
-
-        // If accountMigrationFailed then the app menu has a caution icon,
-        // and at this point the user has taken sufficient action to clear the caution.
-        profile.rustFxA.accountMigrationFailed = false
     }
 
     var onDismissController: (() -> Void)?


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6844)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15258)

## :bulb: Description
Unfortunately a recent app-services push of mine, which *tried* to be non-breaking for iOS, failed to be non-breaking, causing #15280 to fail. My understanding is that @bendk [reverted my app-services change, but only on the 117 branch](https://github.com/mozilla/application-services/pull/5703), meaning it will again be breaking next time you try and take app-services `main`.

This PR just removes all the migration code, so should be safe to use with an app-services on both the 117 branch and `main`, and also fixes #15258.

cc @tarikeshaq, @lmarceau 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and ensured the tests suite is passing
- [x] Implemented accessibility and tested on UI related work (minimum Dynamic Text and VoiceOver)
- [x] Updated documentation / comments for complex code and public methods if needed

