### PR TITLE
Refactor FXIOS-5532 [v117] Adjust theme for inactive tabs

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -273,7 +273,7 @@
 		4331A9BB27193DF0005E8080 /* ContextualHintViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4331A9BA27193DEF005E8080 /* ContextualHintViewController.swift */; };
 		4331A9BD271D267E005E8080 /* ContextualHintViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4331A9BC271D267E005E8080 /* ContextualHintViewModel.swift */; };
 		4331D3EF2A059C1C00542BDD /* SyncContentSettingsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4331D3EE2A059C1C00542BDD /* SyncContentSettingsViewControllerTests.swift */; };
-		433396C827ACE92500491049 /* CellWithRoundedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 433396C727ACE92500491049 /* CellWithRoundedButton.swift */; };
+		433396C827ACE92500491049 /* InactiveTabButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 433396C727ACE92500491049 /* InactiveTabButton.swift */; };
 		4336FAD2264B169000A6B076 /* WebcompatAllFramesAtDocumentStart.js in Resources */ = {isa = PBXBuildFile; fileRef = 4336FAD1264B169000A6B076 /* WebcompatAllFramesAtDocumentStart.js */; };
 		433BADA029C8769800E34991 /* BiometricAuthentication.strings in Resources */ = {isa = PBXBuildFile; fileRef = 433BAD9E29C8769800E34991 /* BiometricAuthentication.strings */; };
 		433BADA429C8769800E34991 /* ErrorState.strings in Resources */ = {isa = PBXBuildFile; fileRef = 433BADA229C8769800E34991 /* ErrorState.strings */; };
@@ -698,6 +698,7 @@
 		8AC5D55F28BFE6C8001F6F7F /* Presenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC5D55E28BFE6C8001F6F7F /* Presenter.swift */; };
 		8ACA8F74291987AE00D3075D /* AccountSyncHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACA8F73291987AE00D3075D /* AccountSyncHandlerTests.swift */; };
 		8ACA8F7629198D6400D3075D /* ThrottlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACA8F7529198D6400D3075D /* ThrottlerTests.swift */; };
+		8ACE9BFB2A54A010001E7A73 /* ExpandButtonState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACE9BFA2A54A010001E7A73 /* ExpandButtonState.swift */; };
 		8AD08D1527E9198E00B8E907 /* TabsQuantityTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD08D1427E9198E00B8E907 /* TabsQuantityTelemetry.swift */; };
 		8AD08D1727E91AC800B8E907 /* TabsQuantityTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD08D1627E91AC800B8E907 /* TabsQuantityTelemetryTests.swift */; };
 		8AD1980F27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD1980E27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift */; };
@@ -2814,7 +2815,7 @@
 		4331D3EE2A059C1C00542BDD /* SyncContentSettingsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncContentSettingsViewControllerTests.swift; sourceTree = "<group>"; };
 		4333498629F69D080059610C /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Notification.strings; sourceTree = "<group>"; };
 		4333498729F69D080059610C /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/ZoomPageBar.strings; sourceTree = "<group>"; };
-		433396C727ACE92500491049 /* CellWithRoundedButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellWithRoundedButton.swift; sourceTree = "<group>"; };
+		433396C727ACE92500491049 /* InactiveTabButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InactiveTabButton.swift; sourceTree = "<group>"; };
 		4333FB0129225C4700A3C600 /* pa-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pa-IN"; path = "pa-IN.lproj/SearchHeaderTitle.strings"; sourceTree = "<group>"; };
 		43340F98292B962100CF9ED8 /* rm */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = rm; path = rm.lproj/SearchHeaderTitle.strings; sourceTree = "<group>"; };
 		433429FA29BA6CB1005B05B0 /* zh-TW */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-TW"; path = "zh-TW.lproj/EngagementNotification.strings"; sourceTree = "<group>"; };
@@ -4808,6 +4809,7 @@
 		8AC5D55E28BFE6C8001F6F7F /* Presenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Presenter.swift; sourceTree = "<group>"; };
 		8ACA8F73291987AE00D3075D /* AccountSyncHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSyncHandlerTests.swift; sourceTree = "<group>"; };
 		8ACA8F7529198D6400D3075D /* ThrottlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThrottlerTests.swift; sourceTree = "<group>"; };
+		8ACE9BFA2A54A010001E7A73 /* ExpandButtonState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpandButtonState.swift; sourceTree = "<group>"; };
 		8AD08D1427E9198E00B8E907 /* TabsQuantityTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsQuantityTelemetry.swift; sourceTree = "<group>"; };
 		8AD08D1627E91AC800B8E907 /* TabsQuantityTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsQuantityTelemetryTests.swift; sourceTree = "<group>"; };
 		8AD1980E27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotonActionSheetViewModel.swift; sourceTree = "<group>"; };
@@ -7069,6 +7071,7 @@
 		216E9A3829D2119300ABE69B /* InactiveTabs */ = {
 			isa = PBXGroup;
 			children = (
+				433396C727ACE92500491049 /* InactiveTabButton.swift */,
 				437A9B672681256800FB41C1 /* InactiveTabCell.swift */,
 				437A9B692681257F00FB41C1 /* InactiveTabViewModel.swift */,
 				E118B9282862674E00C84831 /* InactiveTabItemCellModel.swift */,
@@ -8451,6 +8454,7 @@
 				43AB6F9E25DC53D20016B015 /* LabelButtonHeaderView.swift */,
 				217AEF7728480844004EED37 /* ResizableButton.swift */,
 				8A36BE2829EDBC6900AC1C5C /* ContentContainer.swift */,
+				8ACE9BFA2A54A010001E7A73 /* ExpandButtonState.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -9459,7 +9463,6 @@
 				EBA3B2CE2268F3E700728BDB /* PhotonActionSheet */,
 				D3FEC38C1AC4B42F00494F45 /* AutocompleteTextField.swift */,
 				EBA3B2D12268F57E00728BDB /* BadgeWithBackdrop.swift */,
-				433396C727ACE92500491049 /* CellWithRoundedButton.swift */,
 				7B844E3C1BBDDB9D00E733A2 /* ChevronView.swift */,
 				D863C8E31F68BFC20058D95F /* GradientProgressBar.swift */,
 				0BF1B7E21AC60DEA00A7B407 /* InsetButton.swift */,
@@ -12654,7 +12657,7 @@
 				C2D71B972A384F40003DEC7A /* ThemedSubtitleTableViewCell.swift in Sources */,
 				8A83B7462A264FA0002FF9AC /* SettingsCoordinator.swift in Sources */,
 				A9072B801D07B34100459960 /* NoImageModeHelper.swift in Sources */,
-				433396C827ACE92500491049 /* CellWithRoundedButton.swift in Sources */,
+				433396C827ACE92500491049 /* InactiveTabButton.swift in Sources */,
 				D8AA923421A602DC002605C0 /* HomePageSettingViewController.swift in Sources */,
 				8A161411282C035D00DDBB02 /* CustomizeHomepageSectionViewModel.swift in Sources */,
 				C8DC90C52A066B6A0008832B /* MarkupTokenizingUtility.swift in Sources */,
@@ -12893,6 +12896,7 @@
 				4390F7FF246DAFBE00570811 /* FirefoxColors.swift in Sources */,
 				E16E1C9828C25F1D00EE2EF5 /* SiteTableViewHeader.swift in Sources */,
 				C8CD80D72A1E2C6E0097C3AE /* NimbusMessagingHelperUtilityProtocol.swift in Sources */,
+				8ACE9BFB2A54A010001E7A73 /* ExpandButtonState.swift in Sources */,
 				8AC5D55F28BFE6C8001F6F7F /* Presenter.swift in Sources */,
 				8AEDB11529F9F00400F2A53B /* SceneContainer.swift in Sources */,
 				AB42CC742A1F5240003C9594 /* CreditCardBottomSheetViewController.swift in Sources */,

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -208,7 +208,7 @@ class TabDisplayManager: NSObject, FeatureFlaggable {
 
         super.init()
         setupNotifications(forObserver: self, observing: [.DidTapUndoCloseAllTabToast])
-        self.inactiveViewModel = InactiveTabViewModel()
+        self.inactiveViewModel = InactiveTabViewModel(theme: theme)
         tabManager.addDelegate(self)
         register(self, forTabEvents: .didChangeURL, .didSetScreenshot)
         self.dataStore.removeAll()
@@ -594,8 +594,8 @@ extension TabDisplayManager: UICollectionViewDataSource {
         switch TabDisplaySection(rawValue: indexPath.section) {
         case .inactiveTabs:
             if let inactiveCell = collectionView.dequeueReusableCell(withReuseIdentifier: InactiveTabCell.cellIdentifier, for: indexPath) as? InactiveTabCell {
-                inactiveCell.applyTheme(theme)
                 inactiveCell.inactiveTabsViewModel = inactiveViewModel
+                inactiveCell.applyTheme(theme: theme)
                 inactiveCell.hasExpanded = isInactiveViewExpanded
                 inactiveCell.delegate = self
                 inactiveCell.tableView.reloadData()

--- a/Client/Frontend/Browser/Tabs/InactiveTabs/InactiveTabButton.swift
+++ b/Client/Frontend/Browser/Tabs/InactiveTabs/InactiveTabButton.swift
@@ -3,26 +3,24 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import Shared
 
-struct CellWithRoundedButtonUX {
-    static let ImageSize: CGFloat = 29
-    static let BorderViewMargin: CGFloat = 16
-    static let ButtonInset: CGFloat = 14
-    static let ButtonImagePadding: CGFloat = 11
-}
+class InactiveTabButton: UITableViewCell, ThemeApplicable, ReusableCell {
+    private struct UX {
+        static let ImageSize: CGFloat = 29
+        static let BorderViewMargin: CGFloat = 16
+        static let ButtonInset: CGFloat = 14
+        static let ButtonImagePadding: CGFloat = 11
+    }
 
-class CellWithRoundedButton: UITableViewCell, LegacyNotificationThemeable, ReusableCell {
     // MARK: - Properties
     var buttonClosure: (() -> Void)?
-
-    let containerView = UIView()
-    var shouldLeftAlignTitle = false
-    var customization: OneLineTableViewCustomization = .regular
+    private let containerView = UIView()
+    private var shouldLeftAlignTitle = false
+    private var customization: OneLineTableViewCustomization = .regular
 
     // MARK: - UI Elements
-    private let selectedView: UIView = .build { view in
-        view.backgroundColor = UIColor.legacyTheme.tableView.selectedBackground
-    }
+    private let selectedView: UIView = .build { _ in }
 
     private lazy var roundedButton: UIButton = {
         let button = UIButton()
@@ -30,10 +28,6 @@ class CellWithRoundedButton: UITableViewCell, LegacyNotificationThemeable, Reusa
             withTextStyle: .body,
             weight: .semibold,
             maxSize: 16)
-        button.setImage(UIImage(named: ImageIdentifiers.Large.delete), for: .normal)
-        button.tintColor = .black
-        button.backgroundColor = .Photon.LightGrey30
-        button.setTitleColor(.black, for: .normal)
         button.setTitle(.TabsTray.InactiveTabs.CloseAllInactiveTabsButton, for: .normal)
         button.titleLabel?.textAlignment = .center
         button.titleLabel?.lineBreakMode = .byTruncatingTail
@@ -62,11 +56,11 @@ class CellWithRoundedButton: UITableViewCell, LegacyNotificationThemeable, Reusa
 
         contentView.addSubview(roundedButton)
 
-        roundedButton.setInsets(forContentPadding: UIEdgeInsets(top: CellWithRoundedButtonUX.ButtonInset,
-                                                                left: CellWithRoundedButtonUX.ButtonInset,
-                                                                bottom: CellWithRoundedButtonUX.ButtonInset,
-                                                                right: CellWithRoundedButtonUX.ButtonInset),
-                                imageTitlePadding: CellWithRoundedButtonUX.ButtonImagePadding)
+        roundedButton.setInsets(forContentPadding: UIEdgeInsets(top: UX.ButtonInset,
+                                                                left: UX.ButtonInset,
+                                                                bottom: UX.ButtonInset,
+                                                                right: UX.ButtonInset),
+                                imageTitlePadding: UX.ButtonImagePadding)
 
         let trailingOffSet: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 100 : 23
         let leadingOffSet: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 100 : 23
@@ -80,23 +74,31 @@ class CellWithRoundedButton: UITableViewCell, LegacyNotificationThemeable, Reusa
         ])
 
         selectedBackgroundView = selectedView
-        applyTheme()
-    }
-
-    func applyTheme() {
-        selectedView.backgroundColor = UIColor.legacyTheme.tableView.selectedBackground
-        self.backgroundColor = .clear
     }
 
     override func prepareForReuse() {
         super.prepareForReuse()
         self.selectionStyle = .default
-        separatorInset = UIEdgeInsets(top: 0, left: CellWithRoundedButtonUX.ImageSize + 2 * CellWithRoundedButtonUX.BorderViewMargin, bottom: 0, right: 0)
-        applyTheme()
+        separatorInset = UIEdgeInsets(top: 0,
+                                      left: UX.ImageSize + 2 * UX.BorderViewMargin,
+                                      bottom: 0,
+                                      right: 0)
     }
 
     @objc
     func buttonPressed() {
         self.buttonClosure?()
+    }
+
+    // MARK: ThemeApplicable
+
+    func applyTheme(theme: Theme) {
+        backgroundColor = .clear
+        selectedView.backgroundColor = theme.colors.layer5Hover
+        roundedButton.setTitleColor(theme.colors.textPrimary, for: .normal)
+        roundedButton.backgroundColor = theme.colors.layer3
+        roundedButton.tintColor = theme.colors.textPrimary
+        let image = UIImage(named: ImageIdentifiers.Large.delete)?.tinted(withColor: theme.colors.iconPrimary)
+        roundedButton.setImage(image, for: .normal)
     }
 }

--- a/Client/Frontend/Browser/Tabs/InactiveTabs/InactiveTabCell.swift
+++ b/Client/Frontend/Browser/Tabs/InactiveTabs/InactiveTabCell.swift
@@ -215,7 +215,7 @@ extension InactiveTabCell: UITableViewDataSource, UITableViewDelegate {
         switch InactiveTabSection(rawValue: section) {
         case .inactive, .none:
             guard let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: InactiveTabHeader.cellIdentifier) as? InactiveTabHeader else { return nil }
-            headerView.state = hasExpanded ? .down : .right
+            headerView.state = hasExpanded ? .down : .trailing
             headerView.title = String.TabsTrayInactiveTabsSectionTitle
             headerView.accessibilityLabel = hasExpanded ?
                 .TabsTray.InactiveTabs.TabsTrayInactiveTabsSectionOpenedAccessibilityTitle :

--- a/Client/Frontend/Browser/Tabs/InactiveTabs/InactiveTabCell.swift
+++ b/Client/Frontend/Browser/Tabs/InactiveTabs/InactiveTabCell.swift
@@ -21,7 +21,7 @@ protocol InactiveTabsDelegate: AnyObject {
     func presentCFR()
 }
 
-class InactiveTabCell: UICollectionViewCell, ReusableCell {
+class InactiveTabCell: UICollectionViewCell, ReusableCell, ThemeApplicable {
     struct UX {
         static let HeaderAndRowHeight: CGFloat = 48
         static let CloseAllTabRowHeight: CGFloat = 88
@@ -39,7 +39,7 @@ class InactiveTabCell: UICollectionViewCell, ReusableCell {
     lazy var tableView: UITableView = {
         let tableView = UITableView(frame: .zero, style: .grouped)
         tableView.register(InactiveTabItemCell.self, forCellReuseIdentifier: InactiveTabItemCell.cellIdentifier)
-        tableView.register(CellWithRoundedButton.self, forCellReuseIdentifier: CellWithRoundedButton.cellIdentifier)
+        tableView.register(InactiveTabButton.self, forCellReuseIdentifier: InactiveTabButton.cellIdentifier)
         tableView.register(InactiveTabHeader.self, forHeaderFooterViewReuseIdentifier: InactiveTabHeader.cellIdentifier)
         tableView.allowsMultipleSelectionDuringEditing = false
         tableView.sectionHeaderHeight = 0
@@ -92,6 +92,15 @@ class InactiveTabCell: UICollectionViewCell, ReusableCell {
 
         self.bringSubviewToFront(tableView)
     }
+
+    // MARK: ThemeApplicable
+
+    func applyTheme(theme: Theme) {
+        inactiveTabsViewModel?.theme = theme
+        backgroundColor = .clear
+        tableView.backgroundColor = .clear
+        containerView.backgroundColor = theme.colors.layer2
+    }
 }
 
 // MARK: - UITableViewDataSource, UITableViewDelegate
@@ -138,11 +147,15 @@ extension InactiveTabCell: UITableViewDataSource, UITableViewDelegate {
             let viewModel = InactiveTabItemCellModel(title: tab.getTabTrayTitle(),
                                                      website: getTabDomainUrl(tab: tab))
             cell.configureCell(viewModel: viewModel)
+            if let theme = inactiveTabsViewModel?.theme {
+                cell.applyTheme(theme: theme)
+            }
+
             return cell
 
         case .closeAllTabsButton:
-            guard let cell = tableView.dequeueReusableCell(withIdentifier: CellWithRoundedButton.cellIdentifier,
-                                                           for: indexPath) as? CellWithRoundedButton
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: InactiveTabButton.cellIdentifier,
+                                                           for: indexPath) as? InactiveTabButton
             else {
                 return UITableViewCell()
             }
@@ -151,6 +164,9 @@ extension InactiveTabCell: UITableViewDataSource, UITableViewDelegate {
                 let inactiveTabsCount = self.inactiveTabsViewModel?.inactiveTabs.count
                 self.delegate?.didTapCloseInactiveTabs(tabsCount: inactiveTabsCount ?? 0)
             }
+            if let theme = inactiveTabsViewModel?.theme {
+                cell.applyTheme(theme: theme)
+            }
 
             return cell
         case .none:
@@ -158,6 +174,9 @@ extension InactiveTabCell: UITableViewDataSource, UITableViewDelegate {
                                                            for: indexPath) as? OneLineTableViewCell
             else {
                 return UITableViewCell()
+            }
+            if let theme = inactiveTabsViewModel?.theme {
+                cell.applyTheme(theme: theme)
             }
             return cell
         }
@@ -285,12 +304,5 @@ extension InactiveTabCell: UITableViewDataSource, UITableViewDelegate {
         guard tab.url != nil else { return tab.sessionData?.urls.last?.domainURL }
 
         return tab.url?.domainURL
-    }
-
-    func applyTheme(_ theme: Theme) {
-        backgroundColor = .clear
-        tableView.backgroundColor = .clear
-        containerView.backgroundColor = theme.colors.layer5
-        tableView.reloadData()
     }
 }

--- a/Client/Frontend/Browser/Tabs/InactiveTabs/InactiveTabHeader.swift
+++ b/Client/Frontend/Browser/Tabs/InactiveTabs/InactiveTabHeader.swift
@@ -3,24 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import Shared
 
-enum ExpandButtonState {
-    case right
-    case down
-
-    var image: UIImage? {
-        switch self {
-        case .right:
-            return UIImage(named: ImageIdentifiers.Large.chevronRight)?
-                .withRenderingMode(.alwaysTemplate)
-                .imageFlippedForRightToLeftLayoutDirection()
-        case .down:
-            return UIImage(named: ImageIdentifiers.Large.chevronDown)?.withRenderingMode(.alwaysTemplate)
-        }
-    }
-}
-
-class InactiveTabHeader: UITableViewHeaderFooterView, LegacyNotificationThemeable, ReusableCell {
+class InactiveTabHeader: UITableViewHeaderFooterView, ReusableCell {
     var state: ExpandButtonState? {
         willSet(state) {
             moreButton.setImage(state?.image, for: .normal)
@@ -29,7 +14,6 @@ class InactiveTabHeader: UITableViewHeaderFooterView, LegacyNotificationThemeabl
 
     lazy var titleLabel: UILabel = .build { titleLabel in
         titleLabel.text = self.title
-        titleLabel.textColor = UIColor.legacyTheme.homePanel.activityStreamHeaderText
         titleLabel.font = DynamicFontHelper.defaultHelper.preferredFont(
             withTextStyle: .headline,
             maxSize: 17)
@@ -53,7 +37,6 @@ class InactiveTabHeader: UITableViewHeaderFooterView, LegacyNotificationThemeabl
 
     override func prepareForReuse() {
         super.prepareForReuse()
-        applyTheme()
         moreButton.setTitle(nil, for: .normal)
         moreButton.accessibilityIdentifier = nil
         titleLabel.text = nil
@@ -81,17 +64,14 @@ class InactiveTabHeader: UITableViewHeaderFooterView, LegacyNotificationThemeabl
             moreButton.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
             moreButton.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -28),
         ])
-
-        applyTheme()
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func applyTheme() {
-        let theme = BuiltinThemeName(rawValue: LegacyThemeManager.instance.current.name) ?? .normal
-        self.titleLabel.textColor = theme == .dark ? .white : .black
-        moreButton.tintColor = theme == .dark ? .white : .black
+    func applyTheme(theme: Theme) {
+        titleLabel.textColor = theme.colors.textPrimary
+        moreButton.tintColor = theme.colors.textPrimary
     }
 }

--- a/Client/Frontend/Browser/Tabs/InactiveTabs/InactiveTabItemCell.swift
+++ b/Client/Frontend/Browser/Tabs/InactiveTabs/InactiveTabItemCell.swift
@@ -4,33 +4,23 @@
 
 import UIKit
 import SiteImageView
+import Shared
 
-class InactiveTabItemCell: UITableViewCell, LegacyNotificationThemeable, ReusableCell {
+class InactiveTabItemCell: UITableViewCell, ReusableCell, ThemeApplicable {
     private var viewModel: InactiveTabItemCellModel?
 
-    private var selectedView: UIView = {
-        let view = UIView()
-        view.backgroundColor = UIColor.legacyTheme.tableView.selectedBackground
-        return view
-    }()
-
+    private lazy var selectedView: UIView = .build { _ in }
     private lazy var leftImageView: FaviconImageView = .build { _ in }
+    private lazy var bottomSeparatorView: UIView = .build { _ in }
+    private lazy var containerView: UIView = .build { _ in }
+    private lazy var midView: UIView = .build { _ in }
+    private var containerViewLeadingConstraint: NSLayoutConstraint!
 
     private lazy var titleLabel: UILabel = .build { label in
-        label.textColor = .black
         label.textAlignment = .natural
         label.numberOfLines = 1
         label.contentMode = .center
     }
-
-    private lazy var bottomSeparatorView: UIView = .build { separatorLine in
-        separatorLine.backgroundColor = UIColor.Photon.LightGrey30
-    }
-
-    private var containerViewLeadingConstraint: NSLayoutConstraint!
-
-    private lazy var containerView: UIView = .build { _ in }
-    private lazy var midView: UIView = .build { _ in }
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -111,24 +101,19 @@ class InactiveTabItemCell: UITableViewCell, LegacyNotificationThemeable, Reusabl
         leftImageView.setContentHuggingPriority(.required, for: .vertical)
 
         selectedBackgroundView = selectedView
-        applyTheme()
-    }
-
-    func applyTheme() {
-        let theme = BuiltinThemeName(rawValue: LegacyThemeManager.instance.current.name) ?? .normal
-        selectedView.backgroundColor = UIColor.legacyTheme.tableView.selectedBackground
-        if theme == .dark {
-            backgroundColor = UIColor.Photon.Grey80
-            titleLabel.textColor = .white
-        } else {
-            backgroundColor = .white
-            titleLabel.textColor = .black
-        }
     }
 
     override func prepareForReuse() {
         super.prepareForReuse()
         selectionStyle = .default
-        applyTheme()
+    }
+
+    // MARK: ThemeApplicable
+
+    func applyTheme(theme: Theme) {
+        selectedView.backgroundColor = theme.colors.layer5Hover
+        titleLabel.textColor = theme.colors.textPrimary
+        backgroundColor = theme.colors.layer2
+        bottomSeparatorView.backgroundColor = theme.colors.borderPrimary
     }
 }

--- a/Client/Frontend/Browser/Tabs/InactiveTabs/InactiveTabViewModel.swift
+++ b/Client/Frontend/Browser/Tabs/InactiveTabs/InactiveTabViewModel.swift
@@ -69,6 +69,7 @@ class InactiveTabViewModel {
     var inactiveTabs = [Tab]()
     var activeTabs = [Tab]()
     var shouldHideInactiveTabs = false
+    var theme: Theme
 
     private var appSessionManager: AppSessionProvider
 
@@ -76,7 +77,9 @@ class InactiveTabViewModel {
         return activeTabs.isEmpty || shouldHideInactiveTabs
     }
 
-    init(appSessionManager: AppSessionProvider = AppContainer.shared.resolve()) {
+    init(theme: Theme,
+         appSessionManager: AppSessionProvider = AppContainer.shared.resolve()) {
+        self.theme = theme
         self.appSessionManager = appSessionManager
     }
 

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsClientAndTabsDataSource.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsClientAndTabsDataSource.swift
@@ -64,7 +64,7 @@ class RemoteTabsClientAndTabsDataSource: NSObject, RemoteTabsPanelDataSource {
         let viewModel = SiteTableViewHeaderModel(title: client.name,
                                                  isCollapsible: true,
                                                  collapsibleState:
-                                                    isCollapsed ? ExpandButtonState.right : ExpandButtonState.down)
+                                                    isCollapsed ? ExpandButtonState.trailing : ExpandButtonState.down)
         headerView.configure(viewModel)
         headerView.showBorder(for: .bottom, true)
         headerView.showBorder(for: .top, section != 0)

--- a/Client/Frontend/Components/ExpandButtonState.swift
+++ b/Client/Frontend/Components/ExpandButtonState.swift
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+enum ExpandButtonState {
+    case right
+    case down
+
+    var image: UIImage? {
+        switch self {
+        case .right:
+            return UIImage(named: ImageIdentifiers.Large.chevronRight)?
+                .withRenderingMode(.alwaysTemplate)
+                .imageFlippedForRightToLeftLayoutDirection()
+        case .down:
+            return UIImage(named: ImageIdentifiers.Large.chevronDown)?.withRenderingMode(.alwaysTemplate)
+        }
+    }
+}

--- a/Client/Frontend/Components/ExpandButtonState.swift
+++ b/Client/Frontend/Components/ExpandButtonState.swift
@@ -5,12 +5,12 @@
 import Foundation
 
 enum ExpandButtonState {
-    case right
+    case trailing
     case down
 
     var image: UIImage? {
         switch self {
-        case .right:
+        case .trailing:
             return UIImage(named: ImageIdentifiers.Large.chevronRight)?
                 .withRenderingMode(.alwaysTemplate)
                 .imageFlippedForRightToLeftLayoutDirection()

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -658,7 +658,7 @@ extension HistoryPanel: UITableViewDelegate {
         let headerViewModel = SiteTableViewHeaderModel(title: actualSection.title ?? "",
                                                        isCollapsible: true,
                                                        collapsibleState:
-                                                        isCollapsed ? ExpandButtonState.right : ExpandButtonState.down)
+                                                        isCollapsed ? ExpandButtonState.trailing : ExpandButtonState.down)
         header.configure(headerViewModel)
         header.applyTheme(theme: themeManager.currentTheme)
 

--- a/Client/Frontend/Theme/LegacyThemeManager/LegacyDarkTheme.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/LegacyDarkTheme.swift
@@ -10,18 +10,12 @@ private class DarkBrowserColor: BrowserColor {
 
 private class DarkTableViewColor: TableViewColor {
     override var rowBackground: UIColor { return UIColor.Photon.Grey70 } // layer2
-    override var selectedBackground: UIColor { return UIColor.Custom.selectedHighlightDark }
     override var rowText: UIColor { return UIColor.Photon.Grey10 } // textPrimary
     override var disabledRowText: UIColor { return UIColor.Photon.Grey40 } // textDisabled
-    override var headerBackground: UIColor { return UIColor.Photon.Grey80 }
 }
 
 private class DarkTabTrayColor: TabTrayColor {
     override var tabTitleBlur: UIBlurEffect.Style { return UIBlurEffect.Style.dark }
-}
-
-private class DarkHomePanelColor: HomePanelColor {
-    override var activityStreamHeaderText: UIColor { return UIColor.Photon.LightGrey05 }
 }
 
 class LegacyDarkTheme: LegacyNormalTheme {
@@ -29,6 +23,5 @@ class LegacyDarkTheme: LegacyNormalTheme {
     override var tableView: TableViewColor { return DarkTableViewColor() }
     override var browser: BrowserColor { return DarkBrowserColor() }
     override var tabTray: TabTrayColor { return DarkTabTrayColor() }
-    override var homePanel: HomePanelColor { return DarkHomePanelColor() }
     override var snackbar: SnackBarColor { return SnackBarColor() }
 }

--- a/Client/Frontend/Theme/LegacyThemeManager/LegacyTheme.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/LegacyTheme.swift
@@ -26,10 +26,8 @@ enum BuiltinThemeName: String {
 
 class TableViewColor {
     var rowBackground: UIColor { return UIColor.Photon.White100 } // layer5
-    var selectedBackground: UIColor { return UIColor.Custom.selectedHighlightLight } // layer5Hover
     var rowText: UIColor { return UIColor.Photon.Grey90 } // textPrimary
     var disabledRowText: UIColor { return UIColor.Photon.Grey40 } // textDisabled
-    var headerBackground: UIColor { return UIColor.Photon.Grey10 } // layer1
 }
 
 class BrowserColor {
@@ -38,10 +36,6 @@ class BrowserColor {
 
 class TabTrayColor {
     var tabTitleBlur: UIBlurEffect.Style { return UIBlurEffect.Style.extraLight }
-}
-
-class HomePanelColor {
-    var activityStreamHeaderText: UIColor { return UIColor.Photon.DarkGrey90 }
 }
 
 class SnackBarColor {
@@ -56,7 +50,6 @@ protocol LegacyTheme {
     var tableView: TableViewColor { get }
     var browser: BrowserColor { get }
     var tabTray: TabTrayColor { get }
-    var homePanel: HomePanelColor { get }
     var snackbar: SnackBarColor { get }
 }
 
@@ -65,6 +58,5 @@ class LegacyNormalTheme: LegacyTheme {
     var tableView: TableViewColor { return TableViewColor() }
     var browser: BrowserColor { return BrowserColor() }
     var tabTray: TabTrayColor { return TabTrayColor() }
-    var homePanel: HomePanelColor { return HomePanelColor() }
     var snackbar: SnackBarColor { return SnackBarColor() }
 }

--- a/Tests/ClientTests/TabDisplayManagerTests.swift
+++ b/Tests/ClientTests/TabDisplayManagerTests.swift
@@ -305,7 +305,7 @@ class TabDisplayManagerTests: XCTestCase {
     func testInactiveTabs_grid_closeTabs() {
         let tabDisplayManager = createTabDisplayManager(useMockDataStore: false)
         tabDisplayManager.tabDisplayType = .TabGrid
-        tabDisplayManager.inactiveViewModel = InactiveTabViewModel()
+        tabDisplayManager.inactiveViewModel = InactiveTabViewModel(theme: LightTheme())
 
         // Add four tabs (2 inactive, 2 active)
         let inactiveTab1 = manager.addTab()
@@ -333,7 +333,7 @@ class TabDisplayManagerTests: XCTestCase {
     func testInactiveTabs_grid_undoSingleTab() {
         let tabDisplayManager = createTabDisplayManager(useMockDataStore: false)
         tabDisplayManager.tabDisplayType = .TabGrid
-        tabDisplayManager.inactiveViewModel = InactiveTabViewModel()
+        tabDisplayManager.inactiveViewModel = InactiveTabViewModel(theme: LightTheme())
 
         // Add three tabs (2 inactive, 1 active)
         let inactiveTab1 = manager.addTab()
@@ -363,7 +363,7 @@ class TabDisplayManagerTests: XCTestCase {
     func testInactiveTabs_grid_closeSingleTab() {
         let tabDisplayManager = createTabDisplayManager(useMockDataStore: false)
         tabDisplayManager.tabDisplayType = .TabGrid
-        tabDisplayManager.inactiveViewModel = InactiveTabViewModel()
+        tabDisplayManager.inactiveViewModel = InactiveTabViewModel(theme: LightTheme())
 
         // Add three tabs (2 inactive, 1 active)
         let inactiveTab1 = manager.addTab()
@@ -396,7 +396,7 @@ class TabDisplayManagerTests: XCTestCase {
     func testInactiveTabs_grid_undoCloseTabs() {
         let tabDisplayManager = createTabDisplayManager(useMockDataStore: false)
         tabDisplayManager.tabDisplayType = .TabGrid
-        tabDisplayManager.inactiveViewModel = InactiveTabViewModel()
+        tabDisplayManager.inactiveViewModel = InactiveTabViewModel(theme: LightTheme())
 
         // Add four tabs (2 inactive, 2 active)
         let inactiveTab1 = manager.addTab()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5532)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/12856)

## :bulb: Description
- Adjust theme for inactive tabs
- Clean up unused legacy colors
- Move `ExpandButtonState` to it's own file
- @cwzilla the "Close All Inactive Tabs" button is currently set as `layer3` since there's equivalent as to what it was before (it was always `LightGrey30` in both light and dark mode).

## Light mode
![Simulator Screenshot - iPhone 14 Plus - 2023-07-04 at 16 02 15](https://github.com/mozilla-mobile/firefox-ios/assets/11338480/ce39f971-7861-43a3-882c-2e244f52e415)
![Simulator Screenshot - iPhone 14 Plus - 2023-07-04 at 16 02 11](https://github.com/mozilla-mobile/firefox-ios/assets/11338480/a3a69084-31b6-4522-9aa6-6aee3e0a8f8d)

## Dark mode
![Simulator Screenshot - iPhone 14 Plus - 2023-07-04 at 15 59 24](https://github.com/mozilla-mobile/firefox-ios/assets/11338480/fc55d30d-1b25-4394-b50c-c0d035bf29be)
![Simulator Screenshot - iPhone 14 Plus - 2023-07-04 at 16 01 54](https://github.com/mozilla-mobile/firefox-ios/assets/11338480/7f4b407b-06c2-460a-a464-8210a34b4819)

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and ensured the tests suite is passing
- [X] Implemented accessibility and tested on UI related work (minimum Dynamic Text and VoiceOver)
- [X] Updated documentation / comments for complex code and public methods if needed

