### PR TITLE
Refactor FXIOS-6851 [v116] Refactor RustSyncManagerAPI so that we don't hardcode string value

### DIFF
--- a/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -145,21 +145,19 @@ class SyncContentSettingsViewController: SettingsTableViewController, FeatureFla
         super.viewWillDisappear(animated)
     }
 
-    func engineSettingChanged(_ engineName: String) -> (Bool) -> Void {
-        let prefName = "sync.engine.\(engineName).enabledStateChanged"
+    func engineSettingChanged(_ engineName: RustSyncManagerAPI.TogglableEngine) -> (Bool) -> Void {
+        let prefName = "sync.engine.\(engineName.rawValue).enabledStateChanged"
         return { [unowned self] enabled in
-            // Credit card sync telemetry
-            // Refactor: FXIOS-6851
-            if engineName == "creditcards" {
+            if engineName == .creditcards {
                 self.creditCardSyncEnabledTelemetry(status: enabled)
             }
 
             if self.profile.prefs.boolForKey(prefName) != nil { // Switch it back to not-changed
                 self.profile.prefs.removeObjectForKey(prefName)
-                self.enginesToSyncOnExit.remove(engineName)
+                self.enginesToSyncOnExit.remove(engineName.rawValue)
             } else {
                 self.profile.prefs.setBool(true, forKey: prefName)
-                self.enginesToSyncOnExit.insert(engineName)
+                self.enginesToSyncOnExit.insert(engineName.rawValue)
             }
         }
     }
@@ -185,28 +183,28 @@ class SyncContentSettingsViewController: SettingsTableViewController, FeatureFla
             defaultValue: true,
             attributedTitleText: NSAttributedString(string: .FirefoxSyncBookmarksEngine),
             attributedStatusText: nil,
-            settingDidChange: engineSettingChanged("bookmarks"))
+            settingDidChange: engineSettingChanged(.bookmarks))
         let history = BoolSetting(
             prefs: profile.prefs,
             prefKey: "sync.engine.history.enabled",
             defaultValue: true,
             attributedTitleText: NSAttributedString(string: .FirefoxSyncHistoryEngine),
             attributedStatusText: nil,
-            settingDidChange: engineSettingChanged("history"))
+            settingDidChange: engineSettingChanged(.history))
         let tabs = BoolSetting(
             prefs: profile.prefs,
             prefKey: PrefsKeys.TabSyncEnabled,
             defaultValue: true,
             attributedTitleText: NSAttributedString(string: .FirefoxSyncTabsEngine),
             attributedStatusText: nil,
-            settingDidChange: engineSettingChanged("tabs"))
+            settingDidChange: engineSettingChanged(.tabs))
         let passwords = BoolSetting(
             prefs: profile.prefs,
             prefKey: "sync.engine.passwords.enabled",
             defaultValue: true,
             attributedTitleText: NSAttributedString(string: .FirefoxSyncLoginsEngine),
             attributedStatusText: nil,
-            settingDidChange: engineSettingChanged("passwords"))
+            settingDidChange: engineSettingChanged(.passwords))
 
         let creditCards = BoolSetting(
             prefs: profile.prefs,
@@ -214,7 +212,7 @@ class SyncContentSettingsViewController: SettingsTableViewController, FeatureFla
             defaultValue: true,
             attributedTitleText: NSAttributedString(string: .FirefoxSyncCreditCardsEngine),
             attributedStatusText: nil,
-            settingDidChange: engineSettingChanged("creditcards"))
+            settingDidChange: engineSettingChanged(.creditcards))
 
         var engineSectionChildren: [Setting] = [bookmarks, history, tabs, passwords]
 

--- a/Sync/RustSyncManagerAPI.swift
+++ b/Sync/RustSyncManagerAPI.swift
@@ -12,20 +12,22 @@ open class RustSyncManagerAPI {
     let api: SyncManagerComponent
 
     // Names of collections that can be enabled/disabled locally.
-    public var rustTogglableEngines: [String] = [
-        "tabs",
-        "passwords",
-        "bookmarks",
-        "history",
-    ]
+    public enum TogglableEngine: String, CaseIterable {
+        case tabs
+        case passwords
+        case bookmarks
+        case history
+        case creditcards
+    }
 
+    public var rustTogglableEngines: [TogglableEngine] = [.tabs, .passwords, .bookmarks, .history]
     public init(logger: Logger = DefaultLogger.shared,
                 creditCardAutofillEnabled: Bool = false) {
         self.api = SyncManagerComponent()
         self.logger = logger
 
         if creditCardAutofillEnabled {
-            self.rustTogglableEngines.append("creditcards")
+            self.rustTogglableEngines.append(.creditcards)
         }
     }
 

--- a/Tests/ClientTests/RustSyncManagerTests.swift
+++ b/Tests/ClientTests/RustSyncManagerTests.swift
@@ -52,7 +52,7 @@ class RustSyncManagerTests: XCTestCase {
     }
 
     func testGetEnginesAndKeys() {
-        let engines = ["bookmarks", "creditcards", "history", "passwords", "tabs"]
+        let engines: [RustSyncManagerAPI.TogglableEngine] = [.bookmarks, .creditcards, .history, .passwords, .tabs]
         rustSyncManager.getEnginesAndKeys(engines: engines) { (engines, keys) in
             XCTAssertEqual(engines.count, 5)
 
@@ -69,7 +69,7 @@ class RustSyncManagerTests: XCTestCase {
     }
 
     func testGetEnginesAndKeysWithNoKey() {
-        rustSyncManager.getEnginesAndKeys(engines: ["tabs"]) { (engines, keys) in
+        rustSyncManager.getEnginesAndKeys(engines: [.tabs]) { (engines, keys) in
             XCTAssertEqual(engines.count, 1)
             XCTAssertTrue(engines.contains("tabs"))
             XCTAssertTrue(keys.isEmpty)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6851)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15272)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Replace rustTogglableEngines array of strings with enum values
- Update some tests
## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and ensured the tests suite is passing
- [ ] Implemented accessibility and tested on UI related work (minimum Dynamic Text and VoiceOver)
- [ ] Updated documentation / comments for complex code and public methods if needed

