### PR TITLE
Bugfix FXIOS-6862 [v116] resolve the conflict between the tap and the drag gestures on the CreditCardItemRow (#15292)

### DIFF
--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
@@ -22,9 +22,7 @@ struct CreditCardItemRow: View {
     @State var separatorColor: Color = .clear
     @State var backgroundColor: Color = .clear
     @State var backgroundHoverColor: Color = .clear
-
-    // Vars
-    @GestureState private var isTapped = false
+    @State var isTapping = false
 
     var body: some View {
         VStack(alignment: .center, spacing: 0) {
@@ -78,17 +76,14 @@ struct CreditCardItemRow: View {
             .padding(.trailing, 16)
             .padding(.top, 11)
             .padding(.bottom, 11)
-            .background(isTapped ? backgroundHoverColor : backgroundColor)
-            .gesture(
-                TapGesture()
-                    .onEnded { _ in
-                        didSelectAction?()
-                    }
-                    .simultaneously(with: DragGesture(minimumDistance: 0))
-                    .updating($isTapped) { (_, isTapped, _) in
-                        isTapped = true
-                    }
-            )
+            .background(isTapping ? backgroundHoverColor : backgroundColor)
+            .onTapGesture {
+                isTapping = true
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    isTapping = false
+                    didSelectAction?()
+                }
+            }
             Rectangle()
                 .fill(separatorColor)
                 .frame(maxWidth: .infinity)


### PR DESCRIPTION
… 

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6862)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15292)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
changed the gesture implementation to respond to .onTap instead of .gesture
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and ensured the tests suite is passing
- [ ] Implemented accessibility and tested on UI related work (minimum Dynamic Text and VoiceOver)
- [ ] Updated documentation / comments for complex code and public methods if needed

