### PR TITLE
Add FXIOS-6865 [v117] Add empty component library in BrowserKit

### DIFF
--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -19,7 +19,10 @@ let package = Package(
             targets: ["TabDataStore"]),
         .library(
             name: "Redux",
-            targets: ["Redux"])
+            targets: ["Redux"]),
+        .library(
+            name: "ComponentLibrary",
+            targets: ["ComponentLibrary"])
     ],
     dependencies: [
         .package(
@@ -39,6 +42,13 @@ let package = Package(
             exact: "8.8.0"),
     ],
     targets: [
+        .target(
+            name: "ComponentLibrary",
+            dependencies: ["Common"],
+            swiftSettings: [.unsafeFlags(["-enable-testing"])]),
+        .testTarget(
+            name: "ComponentLibraryTests",
+            dependencies: ["ComponentLibrary"]),
         .target(
             name: "SiteImageView",
             dependencies: ["Fuzi", "Kingfisher", "Common"],
@@ -67,6 +77,6 @@ let package = Package(
             swiftSettings: [.unsafeFlags(["-enable-testing"])]),
         .testTarget(
             name: "ReduxTests",
-            dependencies: ["Redux"])
+            dependencies: ["Redux"]),
     ]
 )

--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -77,6 +77,6 @@ let package = Package(
             swiftSettings: [.unsafeFlags(["-enable-testing"])]),
         .testTarget(
             name: "ReduxTests",
-            dependencies: ["Redux"]),
+            dependencies: ["Redux"])
     ]
 )

--- a/BrowserKit/Sources/ComponentLibrary/Dummy.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Dummy.swift
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+// Something needs to be in the target, this will be removed in the next PR
+struct Foo {
+    var bar = 1
+}

--- a/BrowserKit/Sources/ComponentLibrary/Dummy.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Dummy.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-// Something needs to be in the target, this will be removed in the next PR
+// Something needs to be in the target, this will be removed in the rest of FXIOS-6864
 struct Foo {
     var bar = 1
 }

--- a/BrowserKit/Sources/ComponentLibrary/README.md
+++ b/BrowserKit/Sources/ComponentLibrary/README.md
@@ -1,0 +1,3 @@
+# Component Library
+
+A collection of UI components that is used throughout the application. More information available in the  [wiki page](https://github.com/mozilla-mobile/firefox-ios/wiki/UI-Component-Library).

--- a/BrowserKit/Tests/ComponentLibraryTests/FooTests.swift
+++ b/BrowserKit/Tests/ComponentLibraryTests/FooTests.swift
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import ComponentLibrary
+
+final class FooTests: XCTestCase {
+    func testFoo() {
+        let foo = Foo()
+        XCTAssertEqual(foo.bar, 1)
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6865)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15298)

## :bulb: Description
Add empty component library in BrowserKit, setting up an empty class and tests to ensure all works for now.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and ensured the tests suite is passing
- [X] Implemented accessibility and tested on UI related work (minimum Dynamic Text and VoiceOver)
- [X] Updated documentation / comments for complex code and public methods if needed

