### PR TITLE
Add FXIOS-6673 [v117] Tabs count telemetry

### DIFF
--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -234,10 +234,18 @@ class TelemetryWrapper: TelemetryWrapperProtocol {
         let searchEngines = SearchEngines(prefs: profile.prefs, files: profile.files)
         GleanMetrics.Search.defaultEngine.set(searchEngines.defaultEngine?.engineID ?? "custom")
 
-        // Record the open tab count
-        let delegate = UIApplication.shared.delegate as? AppDelegate
-        if let count = delegate?.tabManager.count {
-            GleanMetrics.Tabs.cumulativeCount.add(Int32(count))
+        // Tabs count telemetry
+        if let delegate = UIApplication.shared.delegate as? AppDelegate {
+            let normalTabs = delegate.tabManager.normalTabs
+            let privateTabs = delegate.tabManager.privateTabs
+            let normalAndPrivateTabsCount = normalTabs.count + privateTabs.count
+            let activeTabs = InactiveTabViewModel.getActiveEligibleTabsFrom(normalTabs,
+                                                                            profile: profile)
+
+            GleanMetrics.Tabs.cumulativeCount.add(Int32(normalAndPrivateTabsCount))
+            GleanMetrics.Tabs.normalTabsOpenCount.add(Int32(normalTabs.count))
+            GleanMetrics.Tabs.privateTabsOpenCount.add(Int32(privateTabs.count))
+            GleanMetrics.Tabs.inactiveTabsCount.add(Int32(normalTabs.count - activeTabs.count))
         }
 
         // Record other preference settings.

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -239,13 +239,13 @@ class TelemetryWrapper: TelemetryWrapperProtocol {
             let normalTabs = delegate.tabManager.normalTabs
             let privateTabs = delegate.tabManager.privateTabs
             let normalAndPrivateTabsCount = normalTabs.count + privateTabs.count
-            let activeTabs = InactiveTabViewModel.getActiveEligibleTabsFrom(normalTabs,
-                                                                            profile: profile)
+            let normalActiveTabs = InactiveTabViewModel.getActiveEligibleTabsFrom(normalTabs,
+                                                                                  profile: profile)
 
             GleanMetrics.Tabs.cumulativeCount.add(Int32(normalAndPrivateTabsCount))
-            GleanMetrics.Tabs.normalTabsOpenCount.add(Int32(normalTabs.count))
+            GleanMetrics.Tabs.normalTabsOpenCount.add(Int32(normalActiveTabs.count))
             GleanMetrics.Tabs.privateTabsOpenCount.add(Int32(privateTabs.count))
-            GleanMetrics.Tabs.inactiveTabsCount.add(Int32(normalTabs.count - activeTabs.count))
+            GleanMetrics.Tabs.inactiveTabsCount.add(Int32(normalTabs.count - normalActiveTabs.count))
         }
 
         // Record other preference settings.

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -2552,6 +2552,42 @@ tabs:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2023-12-01"
+  normal_tabs_open_count:
+    type: counter
+    description: |
+      A counter that indicates how many NORMAL tabs a user
+      currently has open.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/14906
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/15341
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2023-12-01"
+  private_tabs_open_count:
+    type: counter
+    description: |
+      A counter that indicates how many PRIVATE tabs a user
+      currently has open.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/14906
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/15341
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2023-12-01"
+  inactive_tabs_count:
+    type: counter
+    description: |
+      A counter that indicates how many INACTIVE tabs a user
+      currently has open.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/14906
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/15341
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2023-12-01"
   open:
     type: labeled_counter
     description: |


### PR DESCRIPTION
## :scroll: Tickets
[FXIOS-6673](https://mozilla-hub.atlassian.net/browse/FXIOS-6673)
https://github.com/mozilla-mobile/firefox-ios/issues/14906

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Tabs quantity telemetry added, following the characteristics described in the JIRA ticket (counter metric type).

One thing to note is that Tabs Quantity telemetry is currently being tracked in a DIFFERENT way. But I assume DS is aware of it and cannot make use of that telemetry collection, so asked for it to be done as described in the JIRA ticket. 

Note the PR and issue of already existing telemetry capture:
- [FXIOS-3514]https://mozilla-hub.atlassian.net/browse/FXIOS-3514
- https://github.com/mozilla-mobile/firefox-ios/issues/9627

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and ensured the tests suite is passing
- [ ] Implemented accessibility and tested on UI related work (minimum Dynamic Text and VoiceOver)
- [ ] Updated documentation / comments for complex code and public methods if needed

