### PR TITLE
Bugfix FXIOS-6876 [v116] - Missing `use saved card option` for credit card autofill when switching between fields on a webpage

### DIFF
--- a/Client/Frontend/TabContentsScripts/CreditCardHelper.swift
+++ b/Client/Frontend/TabContentsScripts/CreditCardHelper.swift
@@ -221,9 +221,9 @@ class CreditCardHelper: TabContentScript {
     static func blurActiveElement(tabWebView: WKWebView,
                                   logger: Logger) {
         let fillCreditCardInfoCallback = "document.activeElement.blur()"
-        tabWebView.evaluateJavascriptInDefaultContentWorld(fillCreditCardInfoCallback) { _, err in
-            guard let err = err else { return }
-            logger.log("Unable to go previous field: \(err)",
+        tabWebView.evaluateJavascriptInDefaultContentWorld(fillCreditCardInfoCallback) { _, error in
+            guard let error = error else { return }
+            logger.log("Unable to go previous field: \(error)",
                        level: .debug,
                        category: .webview)
         }

--- a/Client/Frontend/TabContentsScripts/CreditCardHelper.swift
+++ b/Client/Frontend/TabContentsScripts/CreditCardHelper.swift
@@ -193,9 +193,9 @@ class CreditCardHelper: TabContentScript {
         let fxWindowValExtras = "window.__firefox__.CreditCardExtras"
         let fillCreditCardInfoCallback = "\(fxWindowValExtras).focusNextInputField()"
 
-        tabWebView.evaluateJavascriptInDefaultContentWorld(fillCreditCardInfoCallback) { _, err in
-            guard let err = err else { return }
-            logger.log("Unable to go next field: \(err)",
+        tabWebView.evaluateJavascriptInDefaultContentWorld(fillCreditCardInfoCallback) { _, error in
+            guard let error = error else { return }
+            logger.log("Unable to go next field: \(error)",
                        level: .debug,
                        category: .webview)
         }
@@ -206,9 +206,9 @@ class CreditCardHelper: TabContentScript {
         let fxWindowValExtras = "window.__firefox__.CreditCardExtras"
         let fillCreditCardInfoCallback = "\(fxWindowValExtras).focusPreviousInputField()"
 
-        tabWebView.evaluateJavascriptInDefaultContentWorld(fillCreditCardInfoCallback) { _, err in
-            guard let err = err else { return }
-            logger.log("Unable to go previous field: \(err)",
+        tabWebView.evaluateJavascriptInDefaultContentWorld(fillCreditCardInfoCallback) { _, error in
+            guard let error = error else { return }
+            logger.log("Unable to go previous field: \(error)",
                        level: .debug,
                        category: .webview)
         }

--- a/Client/Frontend/TabContentsScripts/CreditCardHelper.swift
+++ b/Client/Frontend/TabContentsScripts/CreditCardHelper.swift
@@ -213,4 +213,19 @@ class CreditCardHelper: TabContentScript {
                        category: .webview)
         }
     }
+
+    // Note: document.activeElement.blur() is used to remove the focus from the
+    // currently focused element on a web page. When an element is focused,
+    // it typically has a visual indication such as a highlighted border or change in appearance.
+    // The reason we do it is because after pressing done the focus still remains in WKWebview
+    static func blurActiveElement(tabWebView: WKWebView,
+                                  logger: Logger) {
+        let fillCreditCardInfoCallback = "document.activeElement.blur()"
+        tabWebView.evaluateJavascriptInDefaultContentWorld(fillCreditCardInfoCallback) { _, err in
+            guard let err = err else { return }
+            logger.log("Unable to go previous field: \(err)",
+                       level: .debug,
+                       category: .webview)
+        }
+    }
 }

--- a/Client/TabManagement/Tab.swift
+++ b/Client/TabManagement/Tab.swift
@@ -449,9 +449,9 @@ class Tab: NSObject {
             webView.allowsLinkPreview = true
 
             // Allow Safari Web Inspector (requires toggle in Settings > Safari > Advanced).
-//            if #available(iOS 16.4, *) {
-//                webView.isInspectable = true
-//            }
+            if #available(iOS 16.4, *) {
+                webView.isInspectable = true
+            }
 
             // Night mode enables this by toggling WKWebView.isOpaque, otherwise this has no effect.
             webView.backgroundColor = .black
@@ -976,7 +976,10 @@ class TabWebView: WKWebView, MenuHelperInterface {
             CreditCardHelper.focusNextInputField(tabWebView: self,
                                                  logger: self.logger)
         }
-        accessoryView.doneClosure = { self.endEditing(true) }
+
+        accessoryView.doneClosure = {
+            CreditCardHelper.blurActiveElement(tabWebView: self, logger: self.logger)
+            self.endEditing(true) }
     }
 
     required init?(coder: NSCoder) {

--- a/Client/TabManagement/Tab.swift
+++ b/Client/TabManagement/Tab.swift
@@ -979,7 +979,8 @@ class TabWebView: WKWebView, MenuHelperInterface {
 
         accessoryView.doneClosure = {
             CreditCardHelper.blurActiveElement(tabWebView: self, logger: self.logger)
-            self.endEditing(true) }
+            self.endEditing(true)
+        }
     }
 
     required init?(coder: NSCoder) {


### PR DESCRIPTION

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6876)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15317)

## :bulb: Description
Added a fix for missing credit card events when the focus was not being given back to the page by WKWebView.

https://github.com/mozilla-mobile/firefox-ios/assets/8919439/83b5d495-5a6e-44b3-a9dc-543acf4095ab

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and ensured the tests suite is passing
- [ ] Implemented accessibility and tested on UI related work (minimum Dynamic Text and VoiceOver)
- [ ] Updated documentation / comments for complex code and public methods if needed

