### PR TITLE
Bugfix MTE-1234 [v117] Remove pocket sponsored stories

### DIFF
--- a/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -60,8 +60,6 @@ class HomePageSettingsUITests: BaseTestCase {
         XCTAssertEqual("1", recentlyVisited as? String)
         let recommendedByPocket = app.tables.cells.switches["Recommended by Pocket"].value
         XCTAssertEqual("1", recommendedByPocket as? String)
-        let sponsoredStories = app.tables.cells.switches["Thought-Provoking Stories, Articles powered by Pocket"].value
-        XCTAssertEqual("1", sponsoredStories as? String)
 
         // Current Homepage
         XCTAssertTrue(app.tables.cells["Firefox Home"].isSelected)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1234) (MTE)
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6696) (FXIOS)

## :bulb: Description
FXIOS-6696 consists of the work to remove pocket sponsored stories from the Homepage settings menu. The menu item “Thought-Provoking Stories, Articles powered by Pocket” is no longer needed.

Here is the current state of the homepage settings:

![Simulator Screenshot - iPhone 14 - 2023-07-06 at 00 36 08](https://github.com/mozilla-mobile/firefox-ios/assets/1740517/d781a962-60c2-48ac-8033-432509a0a415)

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and ensured the tests suite is passing
- [ ] Implemented accessibility and tested on UI related work (minimum Dynamic Text and VoiceOver)
- [ ] Updated documentation / comments for complex code and public methods if needed

