### PR TITLE
Bugfix FXIOS-6900 [v116] scheme used for push was incorrect for beta

### DIFF
--- a/Push/PushConfiguration.swift
+++ b/Push/PushConfiguration.swift
@@ -22,14 +22,6 @@ public enum PushConfigurationLabel: String {
     case firefox = "firefox"
 
     static func fromScheme(scheme: String) throws -> PushConfigurationLabel {
-        var scheme = scheme
-        // When running in the NotificationService, the scheme is in the form:
-        // scheme.NotificationService, we strip the suffix out so the scheme is the
-        // same regardless of where the configuration is being evaluated
-        let notificationServiceSuffix = ".NotificationService"
-        if scheme.hasSuffix(notificationServiceSuffix) {
-            scheme = String(scheme.dropLast(notificationServiceSuffix.count))
-        }
         switch scheme {
         case "Fennec": return .fennec
         case "FennecEnterprise": return .fennecEnterprise

--- a/Shared/AppConstants.swift
+++ b/Shared/AppConstants.swift
@@ -59,10 +59,13 @@ public class AppConstants {
         }
 
         let scheme = identifier.replacingOccurrences(of: "org.mozilla.ios.", with: "")
-        if scheme == "FirefoxNightly.enterprise" {
-            return "FirefoxNightly"
+        // We only want to keep the first component past the `org.mozilla.ios`
+        // in practice, that would be "Fennec", "FennecEnterprise", "FirefoxBeta" and "Firefox"
+        guard let firstSchemeComponent = scheme.components(separatedBy: ".").first else {
+            return scheme
         }
-        return scheme
+
+        return firstSchemeComponent
     }()
 
     public static let prefSendUsageData = "settings.sendUsageData"


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6900)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15351)

## :bulb: Description
Improves the parsing of the bundle id into the scheme - the only consumer of this was push. The problem was that in Beta, the suffix component was ".NotificationService2", when the other scheme ended with ".NotificationService".. 

This patch makes it so that the scheme parsing ignores the last component so it would work regardless of the suffix

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and ensured the tests suite is passing
- [x] Implemented accessibility and tested on UI related work (minimum Dynamic Text and VoiceOver)
- [x] Updated documentation / comments for complex code and public methods if needed

