### PR TITLE
Bugfix FXIOS-6903 [v116] credit card expiration year stored and synced as 2 digit year

### DIFF
--- a/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewModel.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewModel.swift
@@ -191,12 +191,15 @@ class CreditCardBottomSheetViewModel {
             guard !decryptedCreditCardNum.isEmpty else {
                 return nil
             }
-
+            // We need to show only 2 digits but save full year for sync
+            let period = Int64(Date.getCurrentPeriod())
+            let selectedExpYear = selectedCreditCard.ccExpYear
+            let yearVal = selectedExpYear < 1000 ? selectedExpYear + period : selectedExpYear
             let plainTextCard = UnencryptedCreditCardFields(ccName: selectedCreditCard.ccName,
                                                             ccNumber: decryptedCreditCardNum,
                                                             ccNumberLast4: selectedCreditCard.ccNumberLast4,
                                                             ccExpMonth: selectedCreditCard.ccExpMonth,
-                                                            ccExpYear: selectedCreditCard.ccExpYear,
+                                                            ccExpYear: yearVal,
                                                             ccType: selectedCreditCard.ccType)
             return plainTextCard
         }
@@ -261,10 +264,15 @@ class CreditCardBottomSheetViewModel {
         decryptedCreditCardVal.ccExpMonth = isValidMonth ? month : originalCreditCard.ccExpMonth
 
         // Year
-        let yearVal = decryptedCreditCardVal.ccExpYear
+        var decryptedYearVal = decryptedCreditCardVal.ccExpYear
+        var originalYearVal = originalCreditCard.ccExpYear
         let currentYear = Calendar.current.component(.year, from: Date()) % 100
-        let isValidYear = (currentYear...99).contains(Int(yearVal) % 100)
-        decryptedCreditCardVal.ccExpYear = isValidYear ? yearVal : originalCreditCard.ccExpYear
+        let isValidYear = (currentYear...99).contains(Int(decryptedYearVal) % 100)
+        // We need to show only 2 digits but save full year for sync
+        let period = Int64(Date.getCurrentPeriod())
+        decryptedYearVal = decryptedYearVal < 1000 ? decryptedYearVal + period : decryptedYearVal
+        originalYearVal = originalYearVal < 1000 ? originalYearVal + period : originalYearVal
+        decryptedCreditCardVal.ccExpYear = isValidYear ? decryptedYearVal : originalYearVal
 
         return decryptedCreditCardVal
     }

--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputViewModel.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputViewModel.swift
@@ -308,12 +308,16 @@ class CreditCardInputViewModel: ObservableObject {
             return nil
         }
 
+        // We need to show only 2 digits but save full year for sync
+        let period = Int64(Date.getCurrentPeriod())
+        let yearVal = year < 1000 ? year + period : year
+
         let plainCreditCard = UnencryptedCreditCardFields(
                          ccName: nameOnCard,
                          ccNumber: cardNumber,
                          ccNumberLast4: String(cardNumber.suffix(4)),
                          ccExpMonth: month,
-                         ccExpYear: year,
+                         ccExpYear: yearVal,
                          ccType: cardType.rawValue)
 
         return plainCreditCard

--- a/Client/Frontend/TabContentsScripts/CreditCardHelper.swift
+++ b/Client/Frontend/TabContentsScripts/CreditCardHelper.swift
@@ -114,8 +114,7 @@ class CreditCardHelper: TabContentScript {
 
         ccPlainText.ccName = payload.ccName
         ccPlainText.ccExpMonth = Int64(payload.ccExpMonth.filter { $0.isNumber }) ?? 0
-        // Note: we only need the last 2 digits of the ccExpYear
-        ccPlainText.ccExpYear = (Int64(payload.ccExpYear.filter { $0.isNumber }) ?? 0) % 100
+        ccPlainText.ccExpYear = Int64(payload.ccExpYear.filter { $0.isNumber }) ?? 0
         ccPlainText.ccNumber = "\(payload.ccNumber.filter { $0.isNumber })"
         ccPlainText.ccNumberLast4 = ccPlainText.ccNumber.count > 4 ? String(ccPlainText.ccNumber.suffix(4)) : ""
         ccPlainText.ccType = creditCardValidator.cardTypeFor(ccPlainText.ccNumber)?.rawValue ?? ""

--- a/Shared/TimeConstants.swift
+++ b/Shared/TimeConstants.swift
@@ -78,6 +78,11 @@ extension Date {
         return Date(timeIntervalSince1970: Double(microsecondTimestamp) / 1000000)
     }
 
+    public static func getCurrentPeriod() -> Int {
+        let currentYear = Calendar.current.component(.year, from: Date())
+        return Int((currentYear / 1000) * 1000)
+    }
+
     public func toRelativeTimeString(dateStyle: DateFormatter.Style = .short, timeStyle: DateFormatter.Style = .short) -> String {
         let now = Date()
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6903)

## :bulb: Description
For sync we need to store full year hence added a small check with period to ensure we are storing full year in 
- bottom sheet save
- bottom sheet update
- settings save 
- settings update

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and ensured the tests suite is passing
- [ ] Implemented accessibility and tested on UI related work (minimum Dynamic Text and VoiceOver)
- [ ] Updated documentation / comments for complex code and public methods if needed

