### PR TITLE
Add fix MTE-1237 [116] for reader view test

### DIFF
--- a/Tests/XCUITests/ReaderViewUITest.swift
+++ b/Tests/XCUITests/ReaderViewUITest.swift
@@ -189,7 +189,6 @@ class ReaderViewTest: BaseTestCase {
         // Select to open in New Tab
         waitForExistence(app.tables["Context Menu"])
         app.tables.otherElements[ImageIdentifiers.Large.plus].tap()
-        app.buttons["Done"].tap()
         updateScreenGraph()
         // Now there should be two tabs open
         navigator.goto(HomePanelsScreen)


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/MTE-1237

According to https://github.com/mozilla-mobile/firefox-ios/issues/15333 there is a new behaviour in the navigation, so pressing done on history screen in no longer required. 

