### PR TITLE
 Add fixes MTE-1219 [116] for navigation on history tests

### DIFF
--- a/Tests/XCUITests/HistoryTests.swift
+++ b/Tests/XCUITests/HistoryTests.swift
@@ -238,6 +238,7 @@ class HistoryTests: BaseTestCase {
         app.tables.otherElements[ImageIdentifiers.Large.plus].tap()
 
         // The page is opened on the new tab
+        navigator.nowAt(NewTabScreen)
         navigator.goto(TabTray)
         if isTablet {
             waitForExistence(app.navigationBars.segmentedControls["navBarTabTray"])
@@ -263,6 +264,7 @@ class HistoryTests: BaseTestCase {
         app.tables.otherElements[ImageIdentifiers.newPrivateTab].tap()
 
         // The page is opened only on the new private tab
+        navigator.nowAt(NewTabScreen)
         navigator.goto(TabTray)
         if isTablet {
             waitForExistence(app.navigationBars.segmentedControls["navBarTabTray"])


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/MTE-1219

According to https://github.com/mozilla-mobile/firefox-ios/issues/15333 the navigation has been changed, so 2 history tests changed to acomodate that. 


