### PR TITLE
Bugfix FXIOS-6797 [v116] dismiss the settings screen if biometric auth fails (#15134)

### DIFF
--- a/Client/Frontend/Autofill/CreditCard/ViewComponents/RemoveCardButton.swift
+++ b/Client/Frontend/Autofill/CreditCard/ViewComponents/RemoveCardButton.swift
@@ -62,6 +62,13 @@ struct RemoveCardButton: View {
         .onChange(of: themeVal) { newThemeValue in
             applyTheme(theme: newThemeValue.theme)
         }
+        .onReceive(
+            NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification)) { _ in
+                // part of FXIOS-6797, if the app goes to the background and
+                // then the user fails the biometric authentication this alert
+                // prevents the screen dismissal, hiding it is the simplest way to solve the issue.
+                showAlert = false
+            }
     }
 
     func applyTheme(theme: Theme) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6797)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15134)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Remade the [PR](https://github.com/mozilla-mobile/firefox-ios/pull/15261) after a failed rebase. 
## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and ensured the tests suite is passing
- [ ] Implemented accessibility and tested on UI related work (minimum Dynamic Text and VoiceOver)
- [ ] Updated documentation / comments for complex code and public methods if needed

