### PR TITLE
Bugfix MTE-1057 [v116] Increase testPerfBookmarks1000openMenu timeout

### DIFF
--- a/Tests/XCUITests/PerformanceTests.swift
+++ b/Tests/XCUITests/PerformanceTests.swift
@@ -197,7 +197,7 @@ class PerformanceTests: BaseTestCase {
                 waitForExistence(app.tables["Bookmarks List"], timeout: TIMEOUT_LONG)
                 let loaded = NSPredicate(format: "count == 1001")
                 expectation(for: loaded, evaluatedWith: app.tables["Bookmarks List"].cells, handler: nil)
-                waitForExpectations(timeout: 60, handler: nil)
+                    waitForExpectations(timeout: 120, handler: nil)
         }
     }
 }

--- a/Tests/XCUITests/PerformanceTests.swift
+++ b/Tests/XCUITests/PerformanceTests.swift
@@ -197,7 +197,7 @@ class PerformanceTests: BaseTestCase {
                 waitForExistence(app.tables["Bookmarks List"], timeout: TIMEOUT_LONG)
                 let loaded = NSPredicate(format: "count == 1001")
                 expectation(for: loaded, evaluatedWith: app.tables["Bookmarks List"].cells, handler: nil)
-                    waitForExpectations(timeout: 120, handler: nil)
+                waitForExpectations(timeout: 120, handler: nil)
         }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1057)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/FXIOS-15389

## :bulb: Description
The expectation block exceeds 60 seconds when running in Bitrise, causing a failed test.

We need to increase the timeout to avoid the timeout issue and account for future performance degradation, likely increasing the timeout to 120 secs from 60.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and ensured the tests suite is passing
- [ ] Implemented accessibility and tested on UI related work (minimum Dynamic Text and VoiceOver)
- [ ] Updated documentation / comments for complex code and public methods if needed

