### PR TITLE
Bugfix MTE-1194 [v117] Adjust exit status check in bitrise.yml

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1426,7 +1426,7 @@ workflows:
                 --no-record-video \
                 --client-details=matrixLabel="Bitrise" \
                 2>&1 | tee /dev/stdout)
-            envman add --key GCLOUD_EXIT_CODE --value $?
+            envman add --key GCLOUD_EXIT_CODE --value ${PIPESTATUS[0]}
             MATRIX_WEBLINK=$(echo "$GCLOUD_OUTPUT" | grep 'https://console.firebase.google.com/project' | awk -F '[][]' '{print $2}' | head -n 1)
             envman add --key MATRIX_WEBLINK --value "$MATRIX_WEBLINK"
     - script@1:


### PR DESCRIPTION
The `PIPESTATUS` array in bash holds the exit status of each command in a pipeline. The indexes represent the order of the commands in the pipeline. So, in this case, `PIPESTATUS[0]` would hold the exit status of the `gcloud` command which is what we want. `$?` would be holding the status of the `tee`.