### PR TITLE
Refactor FXIOS-6944 [v116] Credit card logo on the dark mode for empty state in settings does not match theme

### DIFF
--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsEmptyView.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsEmptyView.swift
@@ -13,6 +13,7 @@ struct CreditCardSettingsEmptyView: View {
     @State var titleTextColor: Color = .clear
     @State var subTextColor: Color = .clear
     @State var toggleTextColor: Color = .clear
+    @State var imageColor: Color = .clear
 
     @ObservedObject var toggleModel: ToggleModel
 
@@ -31,6 +32,8 @@ struct CreditCardSettingsEmptyView: View {
                         Spacer()
                         Image(ImageIdentifiers.Large.creditCard)
                             .resizable()
+                            .renderingMode(.template)
+                            .foregroundColor(imageColor)
                             .frame(width: 200, height: 200)
                             .aspectRatio(contentMode: .fit)
                             .fixedSize()
@@ -70,6 +73,7 @@ struct CreditCardSettingsEmptyView: View {
         titleTextColor = Color(color.textPrimary)
         subTextColor = Color(color.textSecondary)
         toggleTextColor = Color(color.textPrimary)
+        imageColor = Color(color.iconSecondary)
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6944)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15426)

## :bulb: Description
Updates credit card color based on theme.
![Simulator Screenshot - iPhone 14 Pro - 2023-07-07 at 17 58 58](https://github.com/mozilla-mobile/firefox-ios/assets/4530/a1033090-0bf0-4859-b83a-886d376fbc35)
![Simulator Screenshot - iPhone 14 Pro - 2023-07-07 at 17 58 44](https://github.com/mozilla-mobile/firefox-ios/assets/4530/c4d72048-7dac-4d35-9802-6352b44825e5)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and ensured the tests suite is passing
- [ ] Implemented accessibility and tested on UI related work (minimum Dynamic Text and VoiceOver)
- [ ] Updated documentation / comments for complex code and public methods if needed

