### PR TITLE
Bugfix FXIOS-6904 [v116] Keep old behavior of removing the onboarding VC from the stack

### DIFF
--- a/Client/Coordinators/PasswordManagerCoordinator.swift
+++ b/Client/Coordinators/PasswordManagerCoordinator.swift
@@ -53,6 +53,12 @@ class PasswordManagerCoordinator: BaseCoordinator,
 
     func continueFromOnboarding() {
         showPasswordManager()
+
+        // Remove the onboarding from the navigation stack so that we go straight back to settings
+        guard let navigationController = router.navigationController as? UINavigationController else { return }
+        navigationController.viewControllers.removeAll(where: { viewController in
+            type(of: viewController) == PasswordManagerOnboardingViewController.self
+        })
     }
 
     func pressedPasswordDetail(model: PasswordDetailViewControllerModel) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6904)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15361)

## :bulb: Description
[Keep old behavior](https://github.com/mozilla-mobile/firefox-ios/blob/dc09dc42d1829101aba5d8ac9885e102d051ee5a/Client/Frontend/Settings/Main/Privacy/PasswordManagerSetting.swift#L82-L85) of removing the onboarding VC from the stack, so we remove the password onboarding from the stack adn go back to settings.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and ensured the tests suite is passing
- [ ] Implemented accessibility and tested on UI related work (minimum Dynamic Text and VoiceOver)
- [ ] Updated documentation / comments for complex code and public methods if needed

