### PR TITLE
Bugfix FXIOS-6947 [v116] Fix guard for password flow

### DIFF
--- a/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -800,7 +800,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
                                      iconString: ImageIdentifiers.Large.login,
                                      iconType: .Image,
                                      iconAlignment: .left) { _ in
-            guard CoordinatorFlagManager.isSettingsCoordinatorEnabled else {
+            if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
                 self.navigationHandler?.show(settings: .password)
                 return
             }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6947)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15438)

## :bulb: Description
So interestingly, the UI tests [failed](https://github.com/mozilla-mobile/firefox-ios/pull/15445) on v116 branch since another bugfix was not backported yet there. Which made me realized I inverted the guard I added for that bugfix. I'll use an `if` instead, like we did in the other places using that flag.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and ensured the tests suite is passing
- [ ] Implemented accessibility and tested on UI related work (minimum Dynamic Text and VoiceOver)
- [ ] Updated documentation / comments for complex code and public methods if needed

