### PR TITLE
Bugfix FXIOS-6908 [v116] Fixing autocomplete label not being removed

### DIFF
--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -233,6 +233,9 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
         let suggestionText = String(suggestion[suggestion.index(suggestion.startIndex, offsetBy: normalized.count)...])
         let autocompleteText = NSMutableAttributedString(string: suggestionText)
 
+        autocompleteTextLabel = nil
+        autocompleteTextLabel?.removeFromSuperview()
+
         if let theme {
             let color = isPrivateMode ? theme.colors.layerAccentPrivateNonOpaque : theme.colors.layerAccentNonOpaque
             autocompleteText.addAttribute(NSAttributedString.Key.backgroundColor,
@@ -240,8 +243,6 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
                                           range: NSRange(location: 0, length: suggestionText.count))
             autocompleteTextLabel = createAutocompleteLabelWith(autocompleteText)
         }
-
-        autocompleteTextLabel?.removeFromSuperview() // should be nil. But just in case
 
         if let label = autocompleteTextLabel {
             addSubview(label)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6908)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15373)

## :bulb: Description
Fixing autocomplete label not being removed, caused by PR https://github.com/mozilla-mobile/firefox-ios/pull/14977.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and ensured the tests suite is passing
- [ ] Implemented accessibility and tested on UI related work (minimum Dynamic Text and VoiceOver)
- [ ] Updated documentation / comments for complex code and public methods if needed

