### PR TITLE
Bugfix FXIOS-4251 [v117] Sponsored tiles don't show based on defaultSearchEngine

### DIFF
--- a/Client/Frontend/Home/TopSites/DataManagement/SponsoredTileDataUtility.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/SponsoredTileDataUtility.swift
@@ -14,7 +14,7 @@ struct SponsoredTileDataUtility: SponsoredTileDataUtilityInterface {
         guard let defaultSearchEngine = searchEngine,
               let secondLevelDomain = site.secondLevelDomain else { return true }
 
-        let hasMatchedEngine = defaultSearchEngine.shortName.caseInsensitiveCompare(secondLevelDomain) == .orderedSame
+        let hasMatchedEngine = defaultSearchEngine.shortName.localizedCaseInsensitiveContains(secondLevelDomain)
         return !hasMatchedEngine
     }
 }

--- a/Client/Frontend/Home/TopSites/DataManagement/TopSitesDataAdaptor.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/TopSitesDataAdaptor.swift
@@ -39,7 +39,6 @@ class TopSitesDataAdaptorImplementation: TopSitesDataAdaptor, FeatureFlaggable, 
     // Raw data to build top sites with
     private var historySites: [Site] = []
     private var contiles: [Contile] = []
-    private var defaultSearchEngine: OpenSearchEngine?
 
     var notificationCenter: NotificationProtocol
     weak var delegate: TopSitesManagerDelegate?
@@ -54,7 +53,6 @@ class TopSitesDataAdaptorImplementation: TopSitesDataAdaptor, FeatureFlaggable, 
     private static let defaultTopSitesRowCount = 8
 
     init(profile: Profile,
-         defaultSearchEngine: OpenSearchEngine?,
          topSiteHistoryManager: TopSiteHistoryManager,
          googleTopSiteManager: GoogleTopSiteManager,
          contileProvider: ContileProviderInterface = ContileProvider(),
@@ -62,7 +60,6 @@ class TopSitesDataAdaptorImplementation: TopSitesDataAdaptor, FeatureFlaggable, 
          dispatchGroup: DispatchGroupInterface = DispatchGroup()
     ) {
         self.profile = profile
-        self.defaultSearchEngine = defaultSearchEngine
         self.topSiteHistoryManager = topSiteHistoryManager
         self.googleTopSiteManager = googleTopSiteManager
         self.contileProvider = contileProvider
@@ -74,7 +71,8 @@ class TopSitesDataAdaptorImplementation: TopSitesDataAdaptor, FeatureFlaggable, 
                            observing: [.FirefoxAccountChanged,
                                        .PrivateDataClearedHistory,
                                        .ProfileDidFinishSyncing,
-                                       .TopSitesUpdated])
+                                       .TopSitesUpdated,
+                                       .DefaultSearchEngineUpdated])
 
         loadTopSitesData()
     }
@@ -176,7 +174,7 @@ class TopSitesDataAdaptorImplementation: TopSitesDataAdaptor, FeatureFlaggable, 
             sites.addSponsoredTiles(sponsoredTileSpaces: sponsoredTileSpaces,
                                     contiles: contiles,
                                     maxNumberOfSponsoredTile: maxNumberOfTiles,
-                                    defaultSearchEngine: defaultSearchEngine)
+                                    defaultSearchEngine: profile.searchEngines.defaultEngine)
         }
     }
 
@@ -294,7 +292,8 @@ extension TopSitesDataAdaptorImplementation: Notifiable {
         case .ProfileDidFinishSyncing,
                 .PrivateDataClearedHistory,
                 .FirefoxAccountChanged,
-                .TopSitesUpdated:
+                .TopSitesUpdated,
+                .DefaultSearchEngineUpdated:
             self.didInvalidateDataSource(forceRefresh: true)
         default:
             break

--- a/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -42,7 +42,6 @@ class TopSitesViewModel {
         self.topSiteHistoryManager = TopSiteHistoryManager(profile: profile)
         self.googleTopSiteManager = GoogleTopSiteManager(prefs: profile.prefs)
         let adaptor = TopSitesDataAdaptorImplementation(profile: profile,
-                                                        defaultSearchEngine: profile.searchEngines.defaultEngine,
                                                         topSiteHistoryManager: topSiteHistoryManager,
                                                         googleTopSiteManager: googleTopSiteManager)
         topSitesDataAdaptor = adaptor

--- a/Client/Frontend/Settings/SearchEnginePicker.swift
+++ b/Client/Frontend/Settings/SearchEnginePicker.swift
@@ -38,6 +38,8 @@ class SearchEnginePicker: ThemedTableViewController {
         let engine = engines[indexPath.item]
         delegate?.searchEnginePicker(self, didSelectSearchEngine: engine)
         tableView.cellForRow(at: indexPath)?.accessoryType = .checkmark
+
+        NotificationCenter.default.post(name: .DefaultSearchEngineUpdated, object: self)
     }
 
     override func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {

--- a/Shared/NotificationConstants.swift
+++ b/Shared/NotificationConstants.swift
@@ -98,6 +98,7 @@ extension Notification.Name {
     public static let ReadingListUpdated = Notification.Name("ReadingListUpdated")
     public static let TopSitesUpdated = Notification.Name("TopSitesUpdated")
     public static let HistoryUpdated = Notification.Name("HistoryUpdated")
+    public static let DefaultSearchEngineUpdated = Notification.Name("DefaultSearchEngineUpdated")
 
     public static let PresentIntroView = Notification.Name("PresentIntroView")
 }

--- a/Tests/ClientTests/Frontend/Home/TopSites/SponsoredTileDataUtilityTests.swift
+++ b/Tests/ClientTests/Frontend/Home/TopSites/SponsoredTileDataUtilityTests.swift
@@ -23,6 +23,12 @@ class SponsoredTileDataUtilityTests: XCTestCase {
                                                        searchTemplate: "http://firefox.com/find?q={searchTerm}",
                                                        suggestTemplate: nil,
                                                        isCustomEngine: false)
+    let tldIncludedSearchEngine = OpenSearchEngine(engineID: "Test.com",
+                                                   shortName: "Test.com",
+                                                   image: UIImage(),
+                                                   searchTemplate: "http://firefox.com/find?q={searchTerm}",
+                                                   suggestTemplate: nil,
+                                                   isCustomEngine: false)
 
     override func setUp() {
         super.setUp()
@@ -50,6 +56,12 @@ class SponsoredTileDataUtilityTests: XCTestCase {
     func testShouldAdd_filterSite_whenCaseInsentiveIsUsed() {
         let siteToFilter = Site(url: "https://www.test.com", title: "test", bookmarked: false, guid: nil)
         let shouldAdd = subject.shouldAdd(site: siteToFilter, with: caseInsensitiveSearchEngine)
+        XCTAssertFalse(shouldAdd)
+    }
+
+    func testShouldAdd_filterSite_whenTldIsIncluded() {
+        let siteToFilter = Site(url: "https://www.test.com", title: "test", bookmarked: false, guid: nil)
+        let shouldAdd = subject.shouldAdd(site: siteToFilter, with: tldIncludedSearchEngine)
         XCTAssertFalse(shouldAdd)
     }
 }

--- a/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataAdaptorTests.swift
+++ b/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataAdaptorTests.swift
@@ -12,8 +12,6 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
     private var profile: MockProfile!
     private var contileProviderMock: ContileProviderMock!
     private var notificationCenter: MockNotificationCenter!
-    private var searchEngines: SearchEngines!
-    private var mockSearchEngineProvider: MockSearchEngineProvider!
 
     override func setUp() {
         super.setUp()
@@ -35,8 +33,6 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
         profile.prefs.clearAll()
         profile.shutdown()
         profile = nil
-        mockSearchEngineProvider = nil
-        searchEngines = nil
     }
 
     func testData_whenNotLoaded() {

--- a/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataAdaptorTests.swift
+++ b/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataAdaptorTests.swift
@@ -580,9 +580,7 @@ extension TopSitesDataAdaptorTests {
         let googleManager = GoogleTopSiteManager(prefs: profile.prefs)
         let dispatchGroup = MockDispatchGroup()
 
-        let defaultEngine = searchEngines != nil ? searchEngines.defaultEngine: nil
         let subject = TopSitesDataAdaptorImplementation(profile: profile,
-                                                        defaultSearchEngine: defaultEngine,
                                                         topSiteHistoryManager: historyStub,
                                                         googleTopSiteManager: googleManager,
                                                         contileProvider: contileProviderMock,
@@ -598,11 +596,7 @@ extension TopSitesDataAdaptorTests {
     }
 
     func add(searchEngine: OpenSearchEngine) {
-        mockSearchEngineProvider = MockSearchEngineProvider()
-        mockSearchEngineProvider.mockEngines.insert(searchEngine, at: 0)
-        searchEngines = SearchEngines(prefs: profile.prefs,
-                                      files: profile.files,
-                                      engineProvider: mockSearchEngineProvider)
+        profile.searchEngines.defaultEngine = searchEngine
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[FXIOS-4251](https://mozilla-hub.atlassian.net/browse/FXIOS-4251)
https://github.com/mozilla-mobile/firefox-ios/issues/10773

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

Sponsored tiles don't show in TopSites section if it matches the default search engine. 
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and ensured the tests suite is passing
- [ ] Implemented accessibility and tested on UI related work (minimum Dynamic Text and VoiceOver)
- [ ] Updated documentation / comments for complex code and public methods if needed

