### PR TITLE
Add FXIOS-6849 [v117] ShareExtensionCoordinator to production code

### DIFF
--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -79,11 +79,13 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
     // MARK: - BrowserDelegate
 
     func showHomepage(inline: Bool,
+                      toastContainer: UIView,
                       homepanelDelegate: HomePanelDelegate,
                       libraryPanelDelegate: LibraryPanelDelegate,
                       sendToDeviceDelegate: HomepageViewController.SendToDeviceDelegate,
                       overlayManager: OverlayModeManager) {
         let homepageController = getHomepage(inline: inline,
+                                             toastContainer: toastContainer,
                                              homepanelDelegate: homepanelDelegate,
                                              libraryPanelDelegate: libraryPanelDelegate,
                                              sendToDeviceDelegate: sendToDeviceDelegate,
@@ -120,6 +122,7 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
     }
 
     private func getHomepage(inline: Bool,
+                             toastContainer: UIView,
                              homepanelDelegate: HomePanelDelegate,
                              libraryPanelDelegate: LibraryPanelDelegate,
                              sendToDeviceDelegate: HomepageViewController.SendToDeviceDelegate,
@@ -130,11 +133,14 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
             let homepageViewController = HomepageViewController(
                 profile: profile,
                 isZeroSearch: inline,
-                overlayManager: overlayManager
-            )
+                toastContainer: toastContainer,
+                overlayManager: overlayManager)
             homepageViewController.homePanelDelegate = homepanelDelegate
             homepageViewController.libraryPanelDelegate = libraryPanelDelegate
             homepageViewController.sendToDeviceDelegate = sendToDeviceDelegate
+            if CoordinatorFlagManager.isShareExtensionCoordinatorEnabled {
+                homepageViewController.browserNavigationHandler = self
+            }
             return homepageViewController
         }
     }

--- a/Client/Coordinators/Browser/BrowserDelegate.swift
+++ b/Client/Coordinators/Browser/BrowserDelegate.swift
@@ -9,11 +9,13 @@ protocol BrowserDelegate: AnyObject {
     /// Show the homepage to the user
     /// - Parameters:
     ///   - inline: See showEmbeddedHomepage function in BVC for description
+    ///   - toastContainer: The container view for alert shown from share extension in the home page context menu
     ///   - homepanelDelegate: The homepanel delegate for the homepage
     ///   - libraryPanelDelegate:  The library panel delegate for the homepage
     ///   - sendToDeviceDelegate: The send to device delegate for the homepage
     ///   - overlayManager: The overlay manager for the homepage
     func showHomepage(inline: Bool,
+                      toastContainer: UIView,
                       homepanelDelegate: HomePanelDelegate,
                       libraryPanelDelegate: LibraryPanelDelegate,
                       sendToDeviceDelegate: HomepageViewController.SendToDeviceDelegate,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1055,6 +1055,7 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
         urlBar.locationView.reloadButton.reloadButtonState = .disabled
 
         browserDelegate?.showHomepage(inline: inline,
+                                      toastContainer: alertContainer,
                                       homepanelDelegate: self,
                                       libraryPanelDelegate: self,
                                       sendToDeviceDelegate: self,
@@ -1118,11 +1119,15 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
     private func createHomepage(inline: Bool) {
         let homepageViewController = HomepageViewController(
             profile: profile,
+            toastContainer: alertContainer,
             tabManager: tabManager,
             overlayManager: overlayManager)
         homepageViewController.homePanelDelegate = self
         homepageViewController.libraryPanelDelegate = self
         homepageViewController.sendToDeviceDelegate = self
+        if CoordinatorFlagManager.isShareExtensionCoordinatorEnabled {
+            homepageViewController.browserNavigationHandler = navigationHandler
+        }
         self.homepageViewController = homepageViewController
         addChild(homepageViewController)
         view.addSubview(homepageViewController.view)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
@@ -86,11 +86,12 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: eventObject)
         let menuHelper = MainMenuActionHelper(profile: profile,
                                               tabManager: tabManager,
-                                              buttonView: button)
+                                              buttonView: button,
+                                              toastContainer: alertContainer)
         menuHelper.delegate = self
         menuHelper.menuActionDelegate = self
         menuHelper.sendToDeviceDelegate = self
-        if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+        if CoordinatorFlagManager.isSettingsCoordinatorEnabled || CoordinatorFlagManager.isShareExtensionCoordinatorEnabled {
             menuHelper.navigationHandler = navigationHandler
         }
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -93,11 +93,19 @@ extension BrowserViewController: URLBarDelegate {
                                      extras: nil)
 
         if let selectedtab = tabManager.selectedTab, let tabUrl = selectedtab.canonicalURL?.displayURL {
-            presentShareSheet(tabUrl,
-                              tab: selectedtab,
-                              sourceView: shareView,
-                              sourceRect: CGRect.null,
-                              arrowDirection: isBottomSearchBar ? .down : .up)
+            if CoordinatorFlagManager.isShareExtensionCoordinatorEnabled {
+                navigationHandler?.showShareExtension(
+                    url: tabUrl,
+                    sourceView: shareView,
+                    toastContainer: alertContainer,
+                    popoverArrowDirection: isBottomSearchBar ? .down : .up)
+            } else {
+                presentShareSheet(tabUrl,
+                                  tab: selectedtab,
+                                  sourceView: shareView,
+                                  sourceRect: CGRect.null,
+                                  arrowDirection: isBottomSearchBar ? .down : .up)
+            }
         }
     }
 

--- a/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -79,7 +79,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     init(profile: Profile,
          tabManager: TabManager,
          buttonView: UIButton,
-         toastContainer: UIView? = nil,
+         toastContainer: UIView,
          themeManager: ThemeManager = AppContainer.shared.resolve(),
          appAuthenticator: AppAuthenticationProtocol = AppAuthenticator()
     ) {
@@ -87,7 +87,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
         self.bookmarksHandler = profile.places
         self.tabManager = tabManager
         self.buttonView = buttonView
-        self.toastContainer = toastContainer ?? UIView()
+        self.toastContainer = toastContainer
         self.appAuthenticator = appAuthenticator
 
         self.selectedTab = tabManager.selectedTab

--- a/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -53,6 +53,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
 
     private let isHomePage: Bool
     private let buttonView: UIButton
+    private let toastContainer: UIView
     private let selectedTab: Tab?
     private let tabUrl: URL?
     private let isFileURL: Bool
@@ -73,10 +74,12 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     ///   - profile: the user's profile
     ///   - tabManager: the tab manager
     ///   - buttonView: the view from which the menu will be shown
+    ///   - toastContainer: the view hosting a toast alert
     ///   - showFXASyncAction: the closure that will be executed for the sync action in the library section
     init(profile: Profile,
          tabManager: TabManager,
          buttonView: UIButton,
+         toastContainer: UIView? = nil,
          themeManager: ThemeManager = AppContainer.shared.resolve(),
          appAuthenticator: AppAuthenticationProtocol = AppAuthenticator()
     ) {
@@ -84,6 +87,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
         self.bookmarksHandler = profile.places
         self.tabManager = tabManager
         self.buttonView = buttonView
+        self.toastContainer = toastContainer ?? UIView()
         self.appAuthenticator = appAuthenticator
 
         self.selectedTab = tabManager.selectedTab
@@ -603,7 +607,15 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .sharePageWith)
 
             guard let temporaryDocument = tab.temporaryDocument else {
-                self.delegate?.showMenuPresenter(url: url, tab: tab, view: self.buttonView)
+                if CoordinatorFlagManager.isShareExtensionCoordinatorEnabled {
+                    self.navigationHandler?.showShareExtension(
+                        url: url,
+                        sourceView: self.buttonView,
+                        toastContainer: self.toastContainer,
+                        popoverArrowDirection: .any)
+                } else {
+                    self.delegate?.showMenuPresenter(url: url, tab: tab, view: self.buttonView)
+                }
                 return
             }
 
@@ -616,7 +628,15 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
                        let presentableVC = self.menuActionDelegate as? PresentableVC {
                         self.share(fileURL: tempDocURL, buttonView: self.buttonView, presentableVC: presentableVC)
                     } else {
-                        self.delegate?.showMenuPresenter(url: url, tab: tab, view: self.buttonView)
+                        if CoordinatorFlagManager.isShareExtensionCoordinatorEnabled {
+                            self.navigationHandler?.showShareExtension(
+                                url: url,
+                                sourceView: self.buttonView,
+                                toastContainer: self.toastContainer,
+                                popoverArrowDirection: .any)
+                        } else {
+                            self.delegate?.showMenuPresenter(url: url, tab: tab, view: self.buttonView)
+                        }
                     }
                 }
             }
@@ -625,16 +645,24 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
 
     // Main menu option Share page with when opening a file
     private func share(fileURL: URL, buttonView: UIView, presentableVC: PresentableVC) {
-        let helper = ShareExtensionHelper(url: fileURL, tab: selectedTab)
-        let controller = helper.createActivityViewController { _, _ in }
+        if CoordinatorFlagManager.isShareExtensionCoordinatorEnabled {
+            navigationHandler?.showShareExtension(
+                url: fileURL,
+                sourceView: buttonView,
+                toastContainer: toastContainer,
+                popoverArrowDirection: .any)
+        } else {
+            let helper = ShareExtensionHelper(url: fileURL, tab: selectedTab)
+            let controller = helper.createActivityViewController { _, _ in }
 
-        if let popoverPresentationController = controller.popoverPresentationController {
-            popoverPresentationController.sourceView = buttonView
-            popoverPresentationController.sourceRect = buttonView.bounds
-            popoverPresentationController.permittedArrowDirections = .up
+            if let popoverPresentationController = controller.popoverPresentationController {
+                popoverPresentationController.sourceView = buttonView
+                popoverPresentationController.sourceRect = buttonView.bounds
+                popoverPresentationController.permittedArrowDirections = .up
+            }
+            TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .sharePageWith)
+            delegate?.showViewController(viewController: controller)
         }
-        TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .sharePageWith)
-        delegate?.showViewController(viewController: controller)
     }
 
     // MARK: Reading list

--- a/Client/Frontend/Home/HomepageContextMenuHelper.swift
+++ b/Client/Frontend/Home/HomepageContextMenuHelper.swift
@@ -33,10 +33,10 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
 
     init(
         viewModel: HomepageViewModel,
-        toastContainer: UIView? = nil
+        toastContainer: UIView
     ) {
         self.viewModel = viewModel
-        self.toastContainer = toastContainer ?? UIView()
+        self.toastContainer = toastContainer
     }
 
     func presentContextMenu(for site: Site,

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -22,7 +22,11 @@ class HomepageViewController: UIViewController, FeatureFlaggable, Themeable, Con
             contextMenuHelper.sendToDeviceDelegate = sendToDeviceDelegate
         }
     }
-
+    weak var browserNavigationHandler: BrowserNavigationHandler? {
+        didSet {
+            contextMenuHelper.browserNavigationHandler = browserNavigationHandler
+        }
+    }
     private var viewModel: HomepageViewModel
     private var contextMenuHelper: HomepageContextMenuHelper
     private var tabManager: TabManager
@@ -60,6 +64,7 @@ class HomepageViewController: UIViewController, FeatureFlaggable, Themeable, Con
     // MARK: - Initializers
     init(profile: Profile,
          isZeroSearch: Bool = false,
+         toastContainer: UIView? = nil,
          tabManager: TabManager = AppContainer.shared.resolve(),
          overlayManager: OverlayModeManager,
          userDefaults: UserDefaultsInterface = UserDefaults.standard,
@@ -82,7 +87,7 @@ class HomepageViewController: UIViewController, FeatureFlaggable, Themeable, Con
         let syncTabContextualViewModel = ContextualHintViewModel(forHintType: .jumpBackInSyncedTab,
                                                                  with: viewModel.profile)
         self.syncTabContextualHintViewController = ContextualHintViewController(with: syncTabContextualViewModel)
-        self.contextMenuHelper = HomepageContextMenuHelper(viewModel: viewModel)
+        self.contextMenuHelper = HomepageContextMenuHelper(viewModel: viewModel, toastContainer: toastContainer)
 
         self.themeManager = themeManager
         self.notificationCenter = notificationCenter

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -22,11 +22,13 @@ class HomepageViewController: UIViewController, FeatureFlaggable, Themeable, Con
             contextMenuHelper.sendToDeviceDelegate = sendToDeviceDelegate
         }
     }
+
     weak var browserNavigationHandler: BrowserNavigationHandler? {
         didSet {
             contextMenuHelper.browserNavigationHandler = browserNavigationHandler
         }
     }
+
     private var viewModel: HomepageViewModel
     private var contextMenuHelper: HomepageContextMenuHelper
     private var tabManager: TabManager
@@ -64,7 +66,7 @@ class HomepageViewController: UIViewController, FeatureFlaggable, Themeable, Con
     // MARK: - Initializers
     init(profile: Profile,
          isZeroSearch: Bool = false,
-         toastContainer: UIView? = nil,
+         toastContainer: UIView,
          tabManager: TabManager = AppContainer.shared.resolve(),
          overlayManager: OverlayModeManager,
          userDefaults: UserDefaultsInterface = UserDefaults.standard,

--- a/Tests/ClientTests/ContextMenuHelperTests.swift
+++ b/Tests/ClientTests/ContextMenuHelperTests.swift
@@ -31,7 +31,7 @@ class ContextMenuHelperTests: XCTestCase {
                                           isPrivate: false,
                                           tabManager: MockTabManager(),
                                           theme: LightTheme())
-        let helper = HomepageContextMenuHelper(viewModel: viewModel)
+        let helper = HomepageContextMenuHelper(viewModel: viewModel, toastContainer: UIView())
 
         helper.sendHistoryHighlightContextualTelemetry(type: .remove)
 

--- a/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -90,6 +90,7 @@ final class BrowserCoordinatorTests: XCTestCase {
     func testShowHomepage_addsOneHomepageOnly() {
         let subject = createSubject()
         subject.showHomepage(inline: true,
+                             toastContainer: UIView(),
                              homepanelDelegate: subject.browserViewController,
                              libraryPanelDelegate: subject.browserViewController,
                              sendToDeviceDelegate: subject.browserViewController,
@@ -104,6 +105,7 @@ final class BrowserCoordinatorTests: XCTestCase {
     func testShowHomepage_reuseExistingHomepage() {
         let subject = createSubject()
         subject.showHomepage(inline: true,
+                             toastContainer: UIView(),
                              homepanelDelegate: subject.browserViewController,
                              libraryPanelDelegate: subject.browserViewController,
                              sendToDeviceDelegate: subject.browserViewController,
@@ -112,6 +114,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         XCTAssertNotNil(subject.homepageViewController)
 
         subject.showHomepage(inline: true,
+                             toastContainer: UIView(),
                              homepanelDelegate: subject.browserViewController,
                              libraryPanelDelegate: subject.browserViewController,
                              sendToDeviceDelegate: subject.browserViewController,

--- a/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -96,7 +96,7 @@ final class BrowserCoordinatorTests: XCTestCase {
                              sendToDeviceDelegate: subject.browserViewController,
                              overlayManager: overlayModeManager)
 
-        let secondHomepage = HomepageViewController(profile: profile, overlayManager: overlayModeManager)
+        let secondHomepage = HomepageViewController(profile: profile, toastContainer: UIView(), overlayManager: overlayModeManager)
         XCTAssertFalse(subject.browserViewController.contentContainer.canAdd(content: secondHomepage))
         XCTAssertNotNil(subject.homepageViewController)
         XCTAssertNil(subject.webviewController)

--- a/Tests/ClientTests/Frontend/ContentContainerTests.swift
+++ b/Tests/ClientTests/Frontend/ContentContainerTests.swift
@@ -116,6 +116,6 @@ final class ContentContainerTests: XCTestCase {
     }
 
     private func createHomepage() -> HomepageViewController {
-        HomepageViewController(profile: profile, toastContainer: UIView(), overlayManager: overlayModeManager)
+        return HomepageViewController(profile: profile, toastContainer: UIView(), overlayManager: overlayModeManager)
     }
 }

--- a/Tests/ClientTests/Frontend/ContentContainerTests.swift
+++ b/Tests/ClientTests/Frontend/ContentContainerTests.swift
@@ -30,14 +30,14 @@ final class ContentContainerTests: XCTestCase {
 
     func testCanAddHomepage() {
         let subject = ContentContainer(frame: .zero)
-        let homepage = HomepageViewController(profile: profile, overlayManager: overlayModeManager)
+        let homepage = createHomepage()
 
         XCTAssertTrue(subject.canAdd(content: homepage))
     }
 
     func testCanAddHomepageOnceOnly() {
         let subject = ContentContainer(frame: .zero)
-        let homepage = HomepageViewController(profile: profile, overlayManager: overlayModeManager)
+        let homepage = createHomepage()
 
         subject.add(content: homepage)
         XCTAssertFalse(subject.canAdd(content: homepage))
@@ -62,7 +62,7 @@ final class ContentContainerTests: XCTestCase {
 
     func testHasHomepage_trueWhenHomepage() {
         let subject = ContentContainer(frame: .zero)
-        let homepage = HomepageViewController(profile: profile, overlayManager: overlayModeManager)
+        let homepage = createHomepage()
         subject.add(content: homepage)
 
         XCTAssertTrue(subject.hasHomepage)
@@ -90,14 +90,14 @@ final class ContentContainerTests: XCTestCase {
 
     func testContentView_hasContentHomepage_viewIsNotNil() {
         let subject = ContentContainer(frame: .zero)
-        let homepage = HomepageViewController(profile: profile, overlayManager: overlayModeManager)
+        let homepage = createHomepage()
         subject.add(content: homepage)
         XCTAssertNotNil(subject.contentView)
     }
 
     func testContentType_needTopContentExtended_trueWithHomepage() {
         let subject = ContentContainer(frame: .zero)
-        let homepage = HomepageViewController(profile: profile, overlayManager: overlayModeManager)
+        let homepage = createHomepage()
         subject.add(content: homepage)
         XCTAssertTrue(subject.type!.needTopContentExtended)
     }
@@ -113,5 +113,9 @@ final class ContentContainerTests: XCTestCase {
         subject.add(content: webview)
 
         XCTAssertFalse(subject.type!.needTopContentExtended)
+    }
+
+    private func createHomepage() -> HomepageViewController {
+        HomepageViewController(profile: profile, toastContainer: UIView(), overlayManager: overlayModeManager)
     }
 }

--- a/Tests/ClientTests/Frontend/Home/HomepageViewControllerTests.swift
+++ b/Tests/ClientTests/Frontend/Home/HomepageViewControllerTests.swift
@@ -57,6 +57,7 @@ class HomepageViewControllerTests: XCTestCase {
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
 
         let firefoxHomeViewController = HomepageViewController(profile: profile,
+                                                               toastContainer: UIView(),
                                                                tabManager: tabManager,
                                                                overlayManager: overlayManager)
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6849)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15265)

## :bulb: Description
Add `ShareExtensionCoordinator` to production code protected with `CoordinatorFlagManager`.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and ensured the tests suite is passing
- [ ] Implemented accessibility and tested on UI related work (minimum Dynamic Text and VoiceOver)
- [x] Updated documentation / comments for complex code and public methods if needed

