### PR TITLE
Bugfix FXIOS-6982 [v117] Fix nimbus fml local script with clean build

### DIFF
--- a/bin/nimbus-fml.sh
+++ b/bin/nimbus-fml.sh
@@ -84,7 +84,7 @@ if [ -z "$number_string" ]; then
     # We try to resolve that, and find the version from the Package.swift file in that local directory.
     # https://github.com/mozilla-mobile/firefox-ios/issues/12243
     rust_components_path=$(grep -A 3 $'XCRemoteSwiftPackageReference "rust-components-swift"' "$SOURCE_ROOT/$PROJECT.xcodeproj/project.pbxproj" | grep 'repositoryURL = "file://' | grep -o -E '/\w[^"]+')
-    number_string=$(grep 'let version =' "$rust_components_path/Package.swift" | grep -E -o "\d+\.\d+" | sed 's/\./\.0\./g')
+    number_string=$(grep 'let version =' "$rust_components_path/Package.swift" | grep -E -o "\d+\.0.\d+")
 
     if [ -z "$number_string" ]; then
         echo "Error: No https://github.com/mozilla/rust-components-swift package was detected."


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6982)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15500)

## :bulb: Description
Locally building rust-component-swift on a clean repo fails to build due to version parsing being incorrect, the versions in rust-component-swift include three components

This is only to build against a local branch of rust-component-swift and has no impact on non-local builds

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and ensured the tests suite is passing
- [x] Implemented accessibility and tested on UI related work (minimum Dynamic Text and VoiceOver)
- [x] Updated documentation / comments for complex code and public methods if needed

