### PR TITLE
Add FXIOS-6669 [v117] Implement Privacy Telemetry

### DIFF
--- a/Client/Application/QuickActions.swift
+++ b/Client/Application/QuickActions.swift
@@ -156,6 +156,10 @@ struct QuickActionsImplementation: QuickActions {
         case .newTab:
             handleOpenNewTab(withBrowserViewController: browserViewController, isPrivate: false)
         case .newPrivateTab:
+            TelemetryWrapper.recordEvent(category: .action,
+                                         method: .tap,
+                                         object: .newPrivateTab,
+                                         value: .appIcon)
             handleOpenNewTab(withBrowserViewController: browserViewController, isPrivate: true)
         case .openLastBookmark:
             if let urlToOpen = (userData?[QuickActionInfos.tabURLKey] as? String)?.asURL {

--- a/Client/Coordinators/Router/RouteBuilder.swift
+++ b/Client/Coordinators/Router/RouteBuilder.swift
@@ -157,6 +157,10 @@ final class RouteBuilder {
         case .newTab:
             return .search(url: nil, isPrivate: false, options: options)
         case .newPrivateTab:
+            TelemetryWrapper.recordEvent(category: .action,
+                                         method: .tap,
+                                         object: .newPrivateTab,
+                                         value: .appIcon)
             return .search(url: nil, isPrivate: true, options: options)
         case .openLastBookmark:
             if let urlToOpen = (shortcutItem.userInfo?[QuickActionInfos.tabURLKey] as? String)?.asURL {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
@@ -152,6 +152,7 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
             let shouldFocusLocationField = self.newTabSettings == .blankPage
             self.overlayManager.openNewTab(url: nil, newTabSettings: self.newTabSettings)
             self.openBlankNewTab(focusLocationField: shouldFocusLocationField, isPrivate: true)
+            TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .newPrivateTab, value: .tabTray)
         }.items
 
         let closeTab = SingleActionViewModel(title: .KeyboardShortcuts.CloseCurrentTab,

--- a/Client/Frontend/Browser/Tabs/GridTabViewController.swift
+++ b/Client/Frontend/Browser/Tabs/GridTabViewController.swift
@@ -317,7 +317,13 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate, Themeable {
             let notificationObject = [Tab.privateModeKey: isPrivate]
             NotificationCenter.default.post(name: .TabsPrivacyModeChanged, object: notificationObject)
         }
-
+        if isPrivate {
+            TelemetryWrapper.recordEvent(category: .action,
+                                         method: .tap,
+                                         object: .privateBrowsingIcon,
+                                         value: .tabTray,
+                                         extras: [TelemetryWrapper.EventExtraKey.action.rawValue: "add"] )
+        }
         tabManager.selectTab(tabManager.addTab(request, isPrivate: isPrivate))
     }
 
@@ -350,6 +356,11 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate, Themeable {
                     self.tabManager.cleanupClosedTabs(recentlyClosedTabs,
                                                       previous: previousTab,
                                                       isPrivate: isPrivateState)
+                    TelemetryWrapper.recordEvent(category: .action,
+                                                 method: .tap,
+                                                 object: .privateBrowsingIcon,
+                                                 value: .tabTray,
+                                                 extras: [TelemetryWrapper.EventExtraKey.action.rawValue: "close_all_tabs"] )
                 } else {
                     self.tabManager.makeToastFromRecentlyClosedUrls(recentlyClosedTabs,
                                                                     isPrivate: isPrivateState,

--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -302,6 +302,7 @@ class TabTrayViewController: UIViewController, Themeable {
 
     private func changePanel() {
         let segment = TabTrayViewModel.Segment(rawValue: segmentedControlIphone.selectedSegmentIndex)
+        viewModel.segmentToFocus = segment
         switch segment {
         case .tabs:
             switchBetweenLocalPanels(withPrivateMode: false)
@@ -574,6 +575,13 @@ extension TabTrayViewController {
         // Update Private mode when closing TabTray, if the mode toggle but no tab is pressed with return to previous state
         updatePrivateUIState()
         viewModel.tabTrayView.didTogglePrivateMode(viewModel.tabManager.selectedTab?.isPrivate ?? false)
+        if viewModel.segmentToFocus == .privateTabs {
+            TelemetryWrapper.recordEvent(category: .action,
+                                         method: .tap,
+                                         object: .privateBrowsingIcon,
+                                         value: .tabTray,
+                                         extras: [TelemetryWrapper.EventExtraKey.action.rawValue: "done"] )
+        }
         self.dismiss(animated: true, completion: nil)
     }
 }

--- a/Client/Frontend/Home/HomepageContextMenuHelper.swift
+++ b/Client/Frontend/Home/HomepageContextMenuHelper.swift
@@ -78,10 +78,14 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
 
     // MARK: - Default actions
 
-    func getOpenInNewPrivateTabAction(siteURL: URL) -> PhotonRowActions {
+    func getOpenInNewPrivateTabAction(siteURL: URL, sectionType: HomepageSectionType) -> PhotonRowActions {
         return SingleActionViewModel(title: .OpenInNewPrivateTabContextMenuTitle, iconString: ImageIdentifiers.newPrivateTab) { _ in
             self.delegate?.homePanelDidRequestToOpenInNewTab(siteURL, isPrivate: true)
-            TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .newPrivateTab)
+            if sectionType == .topSites {
+                TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .newPrivateTab, value: .topSite)
+            } else {
+                TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .newPrivateTab, value: .pocketSite)
+            }
         }.items
     }
 
@@ -102,7 +106,7 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
         guard let siteURL = site.url.asURL else { return nil }
 
         let openInNewTabAction = getOpenInNewTabAction(siteURL: siteURL, sectionType: .pocket)
-        let openInNewPrivateTabAction = getOpenInNewPrivateTabAction(siteURL: siteURL)
+        let openInNewPrivateTabAction = getOpenInNewPrivateTabAction(siteURL: siteURL, sectionType: .pocket)
         let shareAction = getShareAction(site: site, sourceView: sourceView)
         let bookmarkAction = getBookmarkAction(site: site)
 
@@ -228,15 +232,15 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
         let topSiteActions: [PhotonRowActions]
         if let site = site as? PinnedSite {
             topSiteActions = [getRemovePinTopSiteAction(site: site),
-                              getOpenInNewPrivateTabAction(siteURL: siteURL),
+                              getOpenInNewPrivateTabAction(siteURL: siteURL, sectionType: .topSites),
                               getRemoveTopSiteAction(site: site)]
         } else if site as? SponsoredTile != nil {
-            topSiteActions = [getOpenInNewPrivateTabAction(siteURL: siteURL),
+            topSiteActions = [getOpenInNewPrivateTabAction(siteURL: siteURL, sectionType: .topSites),
                               getSettingsAction(),
                               getSponsoredContentAction()]
         } else {
             topSiteActions = [getPinTopSiteAction(site: site),
-                              getOpenInNewPrivateTabAction(siteURL: siteURL),
+                              getOpenInNewPrivateTabAction(siteURL: siteURL, sectionType: .topSites),
                               getRemoveTopSiteAction(site: site)]
         }
         return topSiteActions

--- a/Client/Frontend/Home/HomepageContextMenuHelper.swift
+++ b/Client/Frontend/Home/HomepageContextMenuHelper.swift
@@ -81,11 +81,7 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
     func getOpenInNewPrivateTabAction(siteURL: URL, sectionType: HomepageSectionType) -> PhotonRowActions {
         return SingleActionViewModel(title: .OpenInNewPrivateTabContextMenuTitle, iconString: ImageIdentifiers.newPrivateTab) { _ in
             self.delegate?.homePanelDidRequestToOpenInNewTab(siteURL, isPrivate: true)
-            if sectionType == .topSites {
-                TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .newPrivateTab, value: .topSite)
-            } else {
-                TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .newPrivateTab, value: .pocketSite)
-            }
+            sectionType.newPrivateTabActionTelemetry()
         }.items
     }
 

--- a/Client/Frontend/Home/HomepageContextMenuHelper.swift
+++ b/Client/Frontend/Home/HomepageContextMenuHelper.swift
@@ -81,6 +81,7 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
     func getOpenInNewPrivateTabAction(siteURL: URL) -> PhotonRowActions {
         return SingleActionViewModel(title: .OpenInNewPrivateTabContextMenuTitle, iconString: ImageIdentifiers.newPrivateTab) { _ in
             self.delegate?.homePanelDidRequestToOpenInNewTab(siteURL, isPrivate: true)
+            TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .newPrivateTab)
         }.items
     }
 

--- a/Client/Frontend/Home/HomepageSectionType.swift
+++ b/Client/Frontend/Home/HomepageSectionType.swift
@@ -56,4 +56,20 @@ enum HomepageSectionType: Int, CaseIterable {
     init(_ section: Int) {
         self.init(rawValue: section)!
     }
+
+    func newPrivateTabActionTelemetry() {
+        switch self {
+        case .topSites:
+            TelemetryWrapper.recordEvent(category: .action,
+                                         method: .tap,
+                                         object: .newPrivateTab,
+                                         value: .topSite)
+        case .pocket:
+            TelemetryWrapper.recordEvent(category: .action,
+                                         method: .tap,
+                                         object: .newPrivateTab,
+                                         value: .pocketSite)
+        default: return
+        }
+    }
 }

--- a/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -210,6 +210,15 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
 
                     if option == .strict {
                         self.button.isHidden = true
+                        TelemetryWrapper.recordEvent(category: .action,
+                                                     method: .tap,
+                                                     object: .trackingProtectionMenu,
+                                                     extras: [TelemetryWrapper.EventExtraKey.etpSetting.rawValue: option.rawValue])
+                    } else {
+                        TelemetryWrapper.recordEvent(category: .action,
+                                                     method: .tap,
+                                                     object: .trackingProtectionMenu,
+                                                     extras: [TelemetryWrapper.EventExtraKey.etpSetting.rawValue: "standard"])
                     }
             })
 
@@ -235,6 +244,10 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
                     item.enabled = enabled
                 }
                 self?.tableView.reloadData()
+                TelemetryWrapper.recordEvent(category: .action,
+                                             method: .tap,
+                                             object: .trackingProtectionMenu,
+                                             extras: [TelemetryWrapper.EventExtraKey.etpEnabled.rawValue: enabled] )
         }
 
         let firstSection = SettingSection(title: nil, footerTitle: NSAttributedString(string: .TrackingProtectionCellFooter), children: [enabledSetting])

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -409,6 +409,7 @@ extension TelemetryWrapper {
         case dismissETPCoverSheetAndStartBrowsing = "dismissed-etp-cover-sheet-and-start-browsing"
         case dismissETPCoverSheetAndGoToSettings = "dismissed-update-cover-sheet-and-go-to-settings"
         case privateBrowsingButton = "private-browsing-button"
+        case privateBrowsingIcon = "private-browsing-icon"
         case startSearchButton = "start-search-button"
         case addNewTabButton = "add-new-tab-button"
         case removeUnVerifiedAccountButton = "remove-unverified-account-button"
@@ -638,6 +639,9 @@ extension TelemetryWrapper {
         var description: String {
             return self.rawValue
         }
+
+        // Tabs Tray
+        case done = "done"
 
         // Inactive Tab
         case inactiveTabsCollapsed = "collapsed"
@@ -1250,6 +1254,14 @@ extension TelemetryWrapper {
         case (.action, .tap, .createNewTab, _, _):
             GleanMetrics.PageActionMenu.createNewTab.add()
 
+        // MARK: Tabs Tray
+        case (.action, .tap, .privateBrowsingIcon, .tabTray, let extras):
+            if let action = extras?[EventExtraKey.action.rawValue] as? String {
+                let actionExtra = GleanMetrics.TabsTray.PrivateBrowsingIconTappedExtra(action: action)
+                GleanMetrics.TabsTray.privateBrowsingIconTapped.record(actionExtra)
+            } else {
+                recordUninstrumentedMetrics(category: category, method: method, object: object, value: value, extras: extras)
+            }
         // MARK: Inactive Tab Tray
         case (.action, .tap, .inactiveTabTray, .openInactiveTab, _):
             GleanMetrics.InactiveTabsTray.openInactiveTab.add()

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -643,7 +643,7 @@ extension TelemetryWrapper {
         var description: String {
             return self.rawValue
         }
-        
+
         // Tracking Protection
         case etpSetting = "etp_setting"
         case etpEnabled = "etp_enabled"

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -579,6 +579,8 @@ extension TelemetryWrapper {
         case historyHighlightsShowAll = "history-highlights-show-all"
         case historyHighlightsItemOpened = "history-highlights-item-opened"
         case historyHighlightsGroupOpen = "history-highlights-group-open"
+        case topSite = "top-site"
+        case pocketSite = "pocket-site"
         case customizeHomepageButton = "customize-homepage-button"
         case wallpaperSelected = "wallpaper-selected"
         case dismissCFRFromButton = "dismiss-cfr-from-button"
@@ -743,7 +745,7 @@ extension TelemetryWrapper {
             } else {
                 recordUninstrumentedMetrics(category: category, method: method, object: object, value: value, extras: extras)
             }
-        case (.action, .tap, .newPrivateTab, _, _):
+        case (.action, .tap, .newPrivateTab, .topSite, _):
             GleanMetrics.TopSites.openInPrivateTab.record()
         // MARK: Preferences
         case (.action, .change, .setting, _, let extras):
@@ -1080,6 +1082,8 @@ extension TelemetryWrapper {
             }
         case (.action, .view, .pocketSectionImpression, _, _):
             GleanMetrics.Pocket.sectionImpressions.add()
+        case (.action, .tap, .newPrivateTab, .pocketSite, _):
+            GleanMetrics.Pocket.openInPrivateTab.record()
 
         // MARK: Library Panel
         case (.action, .tap, .libraryPanel, let type?, _):

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -531,6 +531,7 @@ extension TelemetryWrapper {
 
     public enum EventValue: String {
         case activityStream = "activity-stream"
+        case appIcon = "app-icon"
         case appMenu = "app-menu"
         case browser = "browser"
         case contextMenu = "context-menu"
@@ -1125,6 +1126,9 @@ extension TelemetryWrapper {
             Experiments.shared.recordEvent("app_cycle.foreground")
         case(.action, .background, .app, _, _):
             GleanMetrics.AppCycle.background.record()
+        // MARK: App icon
+        case (.action, .tap, .newPrivateTab, .appIcon, _):
+            GleanMetrics.AppIcon.newPrivateTabTapped.record()
         // MARK: Accessibility
         case(.action, .voiceOver, .app, _, let extras):
             if let isRunning = extras?[EventExtraKey.isVoiceOverRunning.rawValue] as? String {

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -743,7 +743,8 @@ extension TelemetryWrapper {
             } else {
                 recordUninstrumentedMetrics(category: category, method: method, object: object, value: value, extras: extras)
             }
-
+        case (.action, .tap, .newPrivateTab, _, _):
+            GleanMetrics.TopSites.openInPrivateTab.record()
         // MARK: Preferences
         case (.action, .change, .setting, _, let extras):
             if let preference = extras?[EventExtraKey.preference.rawValue] as? String,

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -410,6 +410,7 @@ extension TelemetryWrapper {
         case dismissETPCoverSheetAndGoToSettings = "dismissed-update-cover-sheet-and-go-to-settings"
         case privateBrowsingButton = "private-browsing-button"
         case privateBrowsingIcon = "private-browsing-icon"
+        case newPrivateTab = "new-private-tab"
         case startSearchButton = "start-search-button"
         case addNewTabButton = "add-new-tab-button"
         case removeUnVerifiedAccountButton = "remove-unverified-account-button"
@@ -1262,6 +1263,8 @@ extension TelemetryWrapper {
             } else {
                 recordUninstrumentedMetrics(category: category, method: method, object: object, value: value, extras: extras)
             }
+        case (.action, .tap, .newPrivateTab, .tabTray, _):
+            GleanMetrics.TabsTray.newPrivateTabTapped.record()
         // MARK: Inactive Tab Tray
         case (.action, .tap, .inactiveTabTray, .openInactiveTab, _):
             GleanMetrics.InactiveTabsTray.openInactiveTab.add()

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -643,6 +643,10 @@ extension TelemetryWrapper {
         var description: String {
             return self.rawValue
         }
+        
+        // Tracking Protection
+        case etpSetting = "etp_setting"
+        case etpEnabled = "etp_enabled"
 
         // Tabs Tray
         case done = "done"
@@ -1264,6 +1268,17 @@ extension TelemetryWrapper {
         case (.action, .tap, .createNewTab, _, _):
             GleanMetrics.PageActionMenu.createNewTab.add()
 
+        // MARK: Tracking Protection
+        case (.action, .tap, .trackingProtectionMenu, _, let extras):
+            if let action = extras?[EventExtraKey.etpSetting.rawValue] as? String {
+                let actionExtra = GleanMetrics.TrackingProtection.EtpSettingChangedExtra(etpSetting: action)
+                GleanMetrics.TrackingProtection.etpSettingChanged.record(actionExtra)
+            } else if let action = extras?[EventExtraKey.etpEnabled.rawValue] as? Bool {
+                let actionExtra = GleanMetrics.TrackingProtection.EtpSettingChangedExtra(etpEnabled: action)
+                GleanMetrics.TrackingProtection.etpSettingChanged.record(actionExtra)
+            } else {
+                recordUninstrumentedMetrics(category: category, method: method, object: object, value: value, extras: extras)
+            }
         // MARK: Tabs Tray
         case (.action, .tap, .privateBrowsingIcon, .tabTray, let extras):
             if let action = extras?[EventExtraKey.action.rawValue] as? String {

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -47,7 +47,7 @@ app_icon:
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/14903
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/14903
+      - https://github.com/mozilla-mobile/firefox-ios/pull/15503
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2023-07-06"
@@ -1087,7 +1087,7 @@ top_sites:
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/14903
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/14903
+      - https://github.com/mozilla-mobile/firefox-ios/pull/15503
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2023-07-06"
@@ -1967,7 +1967,7 @@ pocket:
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/14903
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/14903
+      - https://github.com/mozilla-mobile/firefox-ios/pull/15503
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2023-07-06"
@@ -2947,7 +2947,7 @@ tracking_protection:
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/14903
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/14903
+      - https://github.com/mozilla-mobile/firefox-ios/pull/15503
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2024-07-06"
@@ -3193,7 +3193,7 @@ tabs_tray:
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/14903
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/14903
+      - https://github.com/mozilla-mobile/firefox-ios/pull/15503
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2024-07-06"
@@ -3204,7 +3204,7 @@ tabs_tray:
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/14903
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/14903
+      - https://github.com/mozilla-mobile/firefox-ios/pull/15503
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2024-07-06"

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -2928,7 +2928,29 @@ tracking_protection:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2023-12-01"
-
+  etp_setting_changed:
+    type: event
+    description: |
+      A user changed their tracking protection
+      level setting to either strict or standard
+    extra_keys:
+      etp_setting:
+       type: string
+       description: |
+         Records the protection level:
+         standard / strict
+      etp_enabled:
+       type: boolean
+       description: |
+         Records the state
+         true / false
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/14903
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/14903
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2024-07-06"
 # iOS 14 widget metrics
 # m: medium, s: small, l: large
 widget:

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -1080,7 +1080,17 @@ top_sites:
     metadata:
       tags:
         - TopSites
-
+  open_in_private_tab:
+    type: event
+    description: |
+      A user opens a new private tab based on a top site item
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/14903
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/14903
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2023-07-06"
 # HomePage
 firefox_home_page:
   open_from_menu_home_button:

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -38,6 +38,19 @@ app_cycle:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2023-12-01"
+# App icon
+app_icon:
+  new_private_tab_tapped:
+    type: event
+    description: |
+      A user opened a new private tab from long pressing the app icon
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/14903
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/14903
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2023-07-06"
 # Accessibility
 accessibility:
   voice_over:

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -3142,7 +3142,17 @@ tabs_tray:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2024-07-06"
-
+  new_private_tab_tapped:
+    type: event
+    description: |
+      A user opened a new private tab from the tab tray
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/14903
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/14903
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2024-07-06"
 # Inactive Tabs metrics
 inactive_tabs_tray:
   toggle_inactive_tab_tray:

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -1960,7 +1960,17 @@ pocket:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2023-12-01"
-
+  open_in_private_tab:
+    type: event
+    description: |
+      A user opens a new private tab based on a pocket story item
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/14903
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/14903
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2023-07-06"
 # Preference metrics
 preferences:
   changed:

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -3123,6 +3123,26 @@ cfr_analytics:
       - fx-ios-data-stewards@mozilla.com
     expires: "2023-12-01"
 
+# Tabs Tray metrics
+tabs_tray:
+  private_browsing_icon_tapped:
+    type: event
+    description: |
+      A user has tapped on the private browsing icon in tabs tray.
+    extra_keys:
+      action:
+       type: string
+       description: |
+         Records the action:
+         close_all_tabs / add / done
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/14903
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/14903
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2024-07-06"
+
 # Inactive Tabs metrics
 inactive_tabs_tray:
   toggle_inactive_tab_tray:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6669)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14903)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Implement telemetry for:
- tabs_tray.private_browsing_icon_tapped
- tabs_tray.new_private_tab_tapped
- app_icon.new_private_tab_tapped
- top_sites.open_in_private_tab
- pocket.open_in_private_tab
- tracking_protection.etp_setting_changed
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and ensured the tests suite is passing
- [ ] Implemented accessibility and tested on UI related work (minimum Dynamic Text and VoiceOver)
- [ ] Updated documentation / comments for complex code and public methods if needed

