### PR TITLE
Bugfix [v117] Disable flaky unit tests

### DIFF
--- a/Tests/ClientTests/Frontend/Home/TopSites/ContileProviderTests.swift
+++ b/Tests/ClientTests/Frontend/Home/TopSites/ContileProviderTests.swift
@@ -31,16 +31,17 @@ class ContileProviderTests: XCTestCase {
         }
     }
 
-    func testNilDataResponse_failsWithError() {
-        stubResponse(response: nil, statusCode: 200, error: nil)
-        testProvider { result in
-            switch result {
-            case let .failure(error as ContileProvider.Error):
-                XCTAssertEqual(error, ContileProvider.Error.failure)
-            default:
-                XCTFail("Expected failure, got \(result) instead")
-            }
-        }
+    func testNilDataResponse_failsWithError() throws {
+        throw XCTSkip("Skipping since test is flaky on Bitrise, will be improved with FXIOS-6993")
+//        stubResponse(response: nil, statusCode: 200, error: nil)
+//        testProvider { result in
+//            switch result {
+//            case let .failure(error as ContileProvider.Error):
+//                XCTAssertEqual(error, ContileProvider.Error.failure)
+//            default:
+//                XCTFail("Expected failure, got \(result) instead")
+//            }
+//        }
     }
 
     func testEmptyResponse_failsWithError() {

--- a/Tests/ClientTests/TabManagement/Legacy/LegacyTabManagerStoreTests.swift
+++ b/Tests/ClientTests/TabManagement/Legacy/LegacyTabManagerStoreTests.swift
@@ -40,13 +40,14 @@ class LegacyTabManagerStoreTests: XCTestCase {
 
     // MARK: Preserve
 
-    func testPreserve_withNoTabs() {
-        let manager = createManager()
-        manager.preserveTabs([], selectedTab: nil)
-
-        let retrievedTabs = manager.testTabOnDisk()
-        XCTAssertEqual(retrievedTabs.count, 0, "Expected 0 tabs on disk")
-        XCTAssertFalse(manager.hasTabsToRestoreAtStartup)
+    func testPreserve_withNoTabs() throws {
+        throw XCTSkip("Skipping since test is flaky on Bitrise")
+//        let manager = createManager()
+//        manager.preserveTabs([], selectedTab: nil)
+//
+//        let retrievedTabs = manager.testTabOnDisk()
+//        XCTAssertEqual(retrievedTabs.count, 0, "Expected 0 tabs on disk")
+//        XCTAssertFalse(manager.hasTabsToRestoreAtStartup)
     }
 
     func testPreserveTabs_noSelectedTab() {


### PR DESCRIPTION
## :scroll: Tickets
No ticket

## :bulb: Description
Disable flaky unit tests. For contiles one we have [FXIOS-6993](https://mozilla-hub.atlassian.net/browse/FXIOS-6993) #15512 to improve the tests. For legacy tab manager, we shouldn't touch tab manager legacy since we'll work soon on a new implementation, so I have no tickets planned for that one, since improving the tests means changing the production code.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and ensured the tests suite is passing
- [ ] Implemented accessibility and tested on UI related work (minimum Dynamic Text and VoiceOver)
- [ ] Updated documentation / comments for complex code and public methods if needed

