### PR TITLE
Remove FXIOS-6727 [v117] Contextual hint Jump back in sync tab from Nimbus

### DIFF
--- a/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -12,7 +12,6 @@ import UIKit
 enum NimbusFeatureFlagID: String, CaseIterable {
     case autopushFeature
     case bottomSearchBar
-    case contextualHintForJumpBackInSyncedTab
     case contextualHintForToolbar
     case coordinatorsRefactor
     case creditCardAutofillStatus
@@ -96,8 +95,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
             return FlagKeys.CustomWallpaper
 
         // Cases where users do not have the option to manipulate a setting.
-        case .contextualHintForJumpBackInSyncedTab,
-                .contextualHintForToolbar,
+        case .contextualHintForToolbar,
                 .coordinatorsRefactor,
                 .creditCardAutofillStatus,
                 .engagementNotificationStatus,

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -417,8 +417,7 @@ class HomepageViewController: UIViewController, FeatureFlaggable, Themeable, Con
     }
 
     private func prepareSyncedTabContextualHint(onCell cell: SyncedTabCell) {
-        guard syncTabContextualHintViewController.shouldPresentHint(),
-              featureFlags.isFeatureEnabled(.contextualHintForJumpBackInSyncedTab, checking: .buildOnly)
+        guard syncTabContextualHintViewController.shouldPresentHint()
         else {
             syncTabContextualHintViewController.unconfigure()
             return

--- a/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -29,8 +29,7 @@ final class NimbusFeatureFlagLayer {
                 .topSites:
             return checkHomescreenSectionsFeature(for: featureID, from: nimbus)
 
-        case .contextualHintForToolbar,
-                .contextualHintForJumpBackInSyncedTab:
+        case .contextualHintForToolbar:
             return checkNimbusForContextualHintsFeature(for: featureID, from: nimbus)
 
         case .coordinatorsRefactor:
@@ -172,7 +171,6 @@ final class NimbusFeatureFlagLayer {
         var nimbusID: ContextualHint
 
         switch featureID {
-        case .contextualHintForJumpBackInSyncedTab: nimbusID = ContextualHint.jumpBackInSyncedTabContextualHint
         case .contextualHintForToolbar: nimbusID = ContextualHint.toolbarHint
         default: return false
         }

--- a/nimbus-features/contextualHintFeature.yaml
+++ b/nimbus-features/contextualHintFeature.yaml
@@ -8,25 +8,20 @@ features:
           specific contextual hints are enabled.
         type: Map<ContextualHint, Boolean>
         default:
-           jump-back-in-synced-tab-contextual-hint: true
            toolbar-hint: true
     defaults:
       - channel: developer
         value:
            features-enabled:
-             jump-back-in-synced-tab-contextual-hint : false
              toolbar-hint: true
       - channel: beta
         value:
            features-enabled:
-            jump-back-in-synced-tab-contextual-hint: true
             toolbar-hint: true
 
 enums:
   ContextualHint:
     description: The identifiers for a individual contextual hints.
     variants:
-      jump-back-in-synced-tab-contextual-hint:
-        description: The contextual hint bubble that appears to indicate a synced tab has appeared within the Jump Back In section.
       toolbar-hint:
         description: The contextual hint bubble that appears to provide a hint about the toolbar.


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6727)

## :bulb: Description
Remove contextual hint Jump back in sync tab from Nimbus. This means the Jump back in sync tab contextual hint will show for all users, and isn't experimentable anymore.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and ensured the tests suite is passing
- [ ] Implemented accessibility and tested on UI related work (minimum Dynamic Text and VoiceOver)
- [ ] Updated documentation / comments for complex code and public methods if needed

