### PR TITLE
Add MTE-1258 [116] fix navigation for private mode tests

### DIFF
--- a/Tests/XCUITests/NavigationTest.swift
+++ b/Tests/XCUITests/NavigationTest.swift
@@ -188,6 +188,7 @@ class NavigationTest: BaseTestCase {
         app.textFields["url"].press(forDuration: 2)
 
         app.tables.otherElements[ImageIdentifiers.paste].tap()
+        waitForExistence(app.buttons["Go"])
         app.buttons["Go"].tap()
         waitUntilPageLoad()
         waitForValueContains(app.textFields["url"], value: website_2["moreLinkLongPressInfo"]!)
@@ -256,6 +257,7 @@ class NavigationTest: BaseTestCase {
 
     private func longPressLinkOptions(optionSelected: String) {
         navigator.nowAt(NewTabScreen)
+        app.buttons["Done"].tap()
         navigator.goto(ClearPrivateDataSettings)
         app.cells.switches["Downloaded Files"].tap()
         navigator.performAction(Action.AcceptClearPrivateData)


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/MTE-1258

Due to recent navigation changes, pressing Done is required to exit private mode and reach settings in order to clear the private data.



