### PR TITLE
Bugfix FXIOS-6880 [v116]  A11Y - "Save your card information" in for credit card bottom sheet is incorrectly marked as heading (#15322)

### DIFF
--- a/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetHeaderView.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetHeaderView.swift
@@ -44,6 +44,7 @@ class CreditCardBottomSheetHeaderView: UITableViewHeaderFooterView, ReusableCell
             withTextStyle: .headline,
             size: UX.titleLabelFontSize)
         label.adjustsFontForContentSizeCategory = true
+        label.accessibilityTraits = .header
     }
 
     private var headerLabel: UILabel = .build { label in
@@ -57,6 +58,7 @@ class CreditCardBottomSheetHeaderView: UITableViewHeaderFooterView, ReusableCell
             withTextStyle: .body,
             size: UX.headerLabelFontSize)
         label.adjustsFontForContentSizeCategory = true
+        label.accessibilityTraits = .staticText
     }
 
     let mainContainerStackView: UIStackView = .build { stack in


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6880)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15322)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Set the value to the correct ones for the labels in the header view
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and ensured the tests suite is passing
- [ ] Implemented accessibility and tested on UI related work (minimum Dynamic Text and VoiceOver)
- [ ] Updated documentation / comments for complex code and public methods if needed

