### PR TITLE
Bugfix FXIOS-6669 [v117] Fix telemetry expires date

### DIFF
--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -50,7 +50,7 @@ app_icon:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15503
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2023-07-06"
+    expires: "2024-07-06"
 # Accessibility
 accessibility:
   voice_over:
@@ -1090,7 +1090,7 @@ top_sites:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15503
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2023-07-06"
+    expires: "2024-07-06"
 # HomePage
 firefox_home_page:
   open_from_menu_home_button:
@@ -1970,7 +1970,7 @@ pocket:
       - https://github.com/mozilla-mobile/firefox-ios/pull/15503
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2023-07-06"
+    expires: "2024-07-06"
 # Preference metrics
 preferences:
   changed:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6669)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14903)

## :bulb: Description
Fix telemetry expires date from PR https://github.com/mozilla-mobile/firefox-ios/pull/15503. The date was correct for 3 of those new telemetries, but it was set as 2023 which is already expired. Changing that to be in 2024.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and ensured the tests suite is passing
- [ ] Implemented accessibility and tested on UI related work (minimum Dynamic Text and VoiceOver)
- [ ] Updated documentation / comments for complex code and public methods if needed

