### PR TITLE
Bugfix FXIOS-7003 [v117] Fix image loading nil URL

### DIFF
--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -673,8 +673,9 @@ class SearchViewController: SiteTableViewController,
                 twoLineCell.leftOverlayImageView.image = openAndSyncTabBadge
                 twoLineCell.leftImageView.layer.borderColor = SearchViewControllerUX.IconBorderColor.cgColor
                 twoLineCell.leftImageView.layer.borderWidth = SearchViewControllerUX.IconBorderWidth
-                let urlString = openedTab.url?.absoluteString ?? ""
-                twoLineCell.leftImageView.setFavicon(FaviconImageViewModel(siteURLString: urlString))
+                if let urlString = openedTab.url?.absoluteString {
+                    twoLineCell.leftImageView.setFavicon(FaviconImageViewModel(siteURLString: urlString))
+                }
                 twoLineCell.accessoryView = nil
                 cell = twoLineCell
             }

--- a/Client/Frontend/Browser/Tabs/TabCell.swift
+++ b/Client/Frontend/Browser/Tabs/TabCell.swift
@@ -165,8 +165,8 @@ class TabCell: UICollectionViewCell,
         accessibilityHint = .TabTraySwipeToCloseAccessibilityHint
 
         favicon.image = UIImage(named: ImageIdentifiers.Large.globe)
-        if !tab.isFxHomeTab {
-            favicon.setFavicon(FaviconImageViewModel(siteURLString: tab.url?.absoluteString ?? ""))
+        if !tab.isFxHomeTab, let tabURL = tab.url?.absoluteString {
+            favicon.setFavicon(FaviconImageViewModel(siteURLString: tabURL))
         }
 
         if selected {
@@ -198,9 +198,12 @@ class TabCell: UICollectionViewCell,
 
         // Favicon or letter image when tab screenshot isn't available
         } else {
-            smallFaviconView.setFavicon(FaviconImageViewModel(siteURLString: tab.url?.absoluteString ?? ""))
             faviconBG.isHidden = false
             screenshotView.image = nil
+
+            if let tabURL = tab.url?.absoluteString {
+                smallFaviconView.setFavicon(FaviconImageViewModel(siteURLString: tabURL))
+            }
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7003)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15541)

## :bulb: Description
In Sentry we were sometimes seeing a bunch of `"No letter found for site, which should never happen"` logs, which we don’t want to happen since this means the URL to load the image from is nil. Looking at the code, there were indeed some cases where we load images with an empty URL. This fixes that by making sure we have a URL before attempting to load the image.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and ensured the tests suite is passing
- [ ] Implemented accessibility and tested on UI related work (minimum Dynamic Text and VoiceOver)
- [ ] Updated documentation / comments for complex code and public methods if needed

