### PR TITLE
Bugfix FXIOS-6881 [v116] The main heading of the bottom sheet has touch area that overlaps with the "X" Close for credit card autofill (#15321)

### DIFF
--- a/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetHeaderView.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetHeaderView.swift
@@ -110,6 +110,7 @@ class CreditCardBottomSheetHeaderView: UITableViewHeaderFooterView, ReusableCell
             mainContainerStackView.topAnchor.constraint(equalTo: topAnchor, constant: 0),
             mainContainerStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -UX.bottomSpacing),
         ])
+        titleLabel.accessibilityFrame = titleLabel.frame.updateWidth(byPercentage: 80)
     }
 
     private func setupContent() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6881)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15321)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
set the accessibilityFrame to be smaller than the actual frame so it doesn't overlap with the close button on iPhone anymore
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and ensured the tests suite is passing
- [ ] Implemented accessibility and tested on UI related work (minimum Dynamic Text and VoiceOver)
- [ ] Updated documentation / comments for complex code and public methods if needed

