### PR TITLE
Refactor FXIOS-7007 [v117] Add a11y id to "Sync and Save Data" button in synced tabs view

### DIFF
--- a/Client/Application/AccessibilityIdentifiers.swift
+++ b/Client/Application/AccessibilityIdentifiers.swift
@@ -126,6 +126,7 @@ public struct AccessibilityIdentifiers {
         static let doneButton = "doneButtonTabTray"
         static let syncTabsButton = "syncTabsButtonTabTray"
         static let navBarSegmentedControl = "navBarTabTray"
+        static let syncDataButton = "syncDataButton"
     }
 
     struct LibraryPanels {

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsErrorCell.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsErrorCell.swift
@@ -60,6 +60,7 @@ class RemoteTabsErrorCell: UITableViewCell, ReusableCell, ThemeApplicable {
                                                 left: UX.buttonVerticalInset,
                                                 bottom: UX.buttonVerticalInset,
                                                 right: UX.buttonVerticalInset)
+        button.accessibilityIdentifier = AccessibilityIdentifiers.TabTray.syncDataButton
     }
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {

--- a/Tests/XCUITests/NavigationTest.swift
+++ b/Tests/XCUITests/NavigationTest.swift
@@ -107,8 +107,8 @@ class NavigationTest: BaseTestCase {
         navigator.performAction(Action.ToggleSyncMode)
 
         app.tables.buttons[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaSettingsButton].tap()
-        waitForExistence(app.buttons["EmailSignIn.button"], timeout: TIMEOUT)
-        app.buttons["EmailSignIn.button"].tap()
+        waitForExistence(app.buttons[AccessibilityIdentifiers.TabTray.syncDataButton], timeout: TIMEOUT)
+        app.buttons[AccessibilityIdentifiers.TabTray.syncDataButton].tap()
         checkFirefoxSyncScreenShown()
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7007)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15556)

## :bulb: Description
Adds a11y id and fixes failing UITest.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and ensured the tests suite is passing
- [ ] Implemented accessibility and tested on UI related work (minimum Dynamic Text and VoiceOver)
- [ ] Updated documentation / comments for complex code and public methods if needed

