### PR TITLE
Bugfix FXIOS-5833 [v117] Attempt at Top site and homepage crash

### DIFF
--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -246,6 +246,7 @@ class HomepageViewController: UIViewController, FeatureFlaggable, Themeable, Con
                   let viewModel = self.viewModel.getSectionViewModel(shownSection: sectionIndex),
                   viewModel.shouldShow
             else { return nil }
+            self.logger.log("Section \(viewModel.sectionType) is going to show", level: .debug, category: .homepage)
             return viewModel.section(for: layoutEnvironment.traitCollection, size: self.view.frame.size)
         }
         return layout
@@ -308,8 +309,8 @@ class HomepageViewController: UIViewController, FeatureFlaggable, Themeable, Con
 
         // Force the entire collection view to re-layout
         viewModel.refreshData(for: traitCollection, size: newSize)
-        collectionView.reloadData()
         collectionView.collectionViewLayout.invalidateLayout()
+        collectionView.reloadData()
 
         // This pushes a reload to the end of the main queue after all the work associated with
         // rotating has been completed. This is important because some of the cells layout are
@@ -808,11 +809,11 @@ extension HomepageViewController: HomepageViewModelDelegate {
             guard let self = self else { return }
 
             self.viewModel.refreshData(for: self.traitCollection, size: self.view.frame.size)
+            self.collectionView.collectionViewLayout.invalidateLayout()
             self.collectionView.reloadData()
             self.logger.log("Amount of sections shown is \(self.viewModel.shownSections.count)",
                             level: .debug,
                             category: .homepage)
-            self.collectionView.collectionViewLayout.invalidateLayout()
         }
     }
 }

--- a/Client/Frontend/Home/TopSites/Cell/TopSiteItemCell.swift
+++ b/Client/Frontend/Home/TopSites/Cell/TopSiteItemCell.swift
@@ -259,9 +259,6 @@ extension TopSiteItemCell: ThemeApplicable {
 // MARK: - Blurrable
 extension TopSiteItemCell: Blurrable {
     func adjustBlur(theme: Theme) {
-        rootContainer.setNeedsLayout()
-        rootContainer.layoutIfNeeded()
-
         if shouldApplyWallpaperBlur {
             rootContainer.addBlurEffectWithClearBackgroundAndClipping(using: .systemThickMaterial)
         } else {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5833)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13342)

## :bulb: Description
- Remove layout if needed in adjust blur of top sites cell, seems to be not needed anymore
- Homepage invalidate layout before reloading data, to make sure we return the right number of section in `UICollectionViewCompositionalLayout(sectionProvider:)`
- Adding a log in case this doesn't fix the issue to get more breadcrumbs.
- Tested with and without wallpapers, on iPad and iPhone

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and ensured the tests suite is passing
- [ ] Implemented accessibility and tested on UI related work (minimum Dynamic Text and VoiceOver)
- [ ] Updated documentation / comments for complex code and public methods if needed

