### PR TITLE
Bugfix FXIOS-7005 [v116] Private Tabs persisted despite closing and reopening app through App Switcher

### DIFF
--- a/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -310,7 +310,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         store.preserveTabs(tabs, selectedTab: selectedTab)
     }
 
-    private func shouldClearPrivateTabs() -> Bool {
+    func shouldClearPrivateTabs() -> Bool {
         return profile.prefs.boolForKey("settings.closePrivateTabs") ?? false
     }
 
@@ -370,7 +370,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
 
         // If tabToSelect is nil after restoration, force selection of first tab normal tab
         if tabToSelect == nil {
-            tabToSelect = tabs.first(where: { $0.isPrivate == false })
+            tabToSelect = tabs.first(where: { !$0.isPrivate })
 
             // If tabToSelect is still nil, create a new tab
             if tabToSelect == nil {

--- a/Client/TabManagement/TabManagerImplementation.swift
+++ b/Client/TabManagement/TabManagerImplementation.swift
@@ -107,7 +107,10 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
     /// Creates the webview so needs to live on the main thread
     @MainActor
     private func generateTabs(from windowData: WindowData) async {
-        for tabData in windowData.tabData {
+        let filteredTabs = filterPrivateTabs(from: windowData,
+                                             clearPrivateTabs: shouldClearPrivateTabs())
+
+        for tabData in filteredTabs {
             let newTab = addTab(flushToDisk: false, zombie: true, isPrivate: tabData.isPrivate)
             newTab.url = URL(string: tabData.siteUrl)
             newTab.lastTitle = tabData.title
@@ -130,6 +133,25 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
                 selectTab(newTab)
             }
         }
+
+        // If tabToSelect is nil after restoration, force selection of first tab normal tab
+        if selectedTab == nil {
+            guard let tabToSelect = tabs.first(where: { !$0.isPrivate }) else {
+                selectTab(addTab())
+                return
+            }
+
+            selectTab(tabToSelect)
+        }
+    }
+
+    private func filterPrivateTabs(from windowData: WindowData, clearPrivateTabs: Bool) -> [TabData] {
+        var savedTabs = windowData.tabData
+        if clearPrivateTabs {
+            savedTabs = windowData.tabData.filter { !$0.isPrivate }
+        }
+
+        return savedTabs
     }
 
     /// Creates the webview so needs to live on the main thread


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7005)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15549)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Remove private tabs when restoring the tabs and add logic to select the first normal tab if the previous selected tab was private. This emulates the current process we have on LegacyTabManager.
- Unit test were not added because test involving the restoration process are currently broken I will create a ticket to fix it and add the test in that ticket

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and ensured the tests suite is passing
- [ ] Implemented accessibility and tested on UI related work (minimum Dynamic Text and VoiceOver)
- [x] Updated documentation / comments for complex code and public methods if needed

