### PR TITLE
Remove FXIOS-7015 [v117] obsolete places reset functions

### DIFF
--- a/Storage/Rust/RustPlaces.swift
+++ b/Storage/Rust/RustPlaces.swift
@@ -295,46 +295,6 @@ public class RustPlaces: BookmarksHandler, HistoryMetadataObserver {
         }
     }
 
-    public func resetBookmarksMetadata() -> Success {
-        let deferred = Success()
-
-        writerQueue.async {
-            guard self.isOpen else {
-                deferred.fill(Maybe(failure: PlacesConnectionError.connUseAfterApiClosed as MaybeErrorType))
-                return
-            }
-
-            do {
-                try self.api?.resetBookmarkSyncMetadata()
-                deferred.fill(Maybe(success: ()))
-            } catch let error {
-                deferred.fill(Maybe(failure: error as MaybeErrorType))
-            }
-        }
-
-        return deferred
-    }
-
-    public func resetHistoryMetadata() -> Success {
-         let deferred = Success()
-
-         writerQueue.async {
-             guard self.isOpen else {
-                 deferred.fill(Maybe(failure: PlacesConnectionError.connUseAfterApiClosed as MaybeErrorType))
-                 return
-             }
-
-             do {
-                 try self.api?.resetHistorySyncMetadata()
-                 deferred.fill(Maybe(success: ()))
-             } catch let error {
-                 deferred.fill(Maybe(failure: error as MaybeErrorType))
-             }
-         }
-
-         return deferred
-     }
-
     public func getHistoryMetadataSince(since: Int64) -> Deferred<Maybe<[HistoryMetadata]>> {
         return withReader { connection in
             return try connection.getHistoryMetadataSince(since: since)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7015)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15571)

## :bulb: Description
I missed a couple of spots when I was removing the obsolete sync code. Removing the `resetBookmarksMetadata` and `resetHistoryMetadata` as they are not being called.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and ensured the tests suite is passing
- [ ] Implemented accessibility and tested on UI related work (minimum Dynamic Text and VoiceOver)
- [ ] Updated documentation / comments for complex code and public methods if needed

