### PR TITLE
Add MTE-1287 [117] fix for navigation tests

### DIFF
--- a/Tests/XCUITests/NavigationTest.swift
+++ b/Tests/XCUITests/NavigationTest.swift
@@ -257,7 +257,9 @@ class NavigationTest: BaseTestCase {
 
     private func longPressLinkOptions(optionSelected: String) {
         navigator.nowAt(NewTabScreen)
-        app.buttons["Done"].tap()
+        if app.buttons["Done"].exists {
+            app.buttons["Done"].tap()
+        }
         navigator.goto(ClearPrivateDataSettings)
         app.cells.switches["Downloaded Files"].tap()
         navigator.performAction(Action.AcceptClearPrivateData)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1287)

## :bulb: Description
A previous fix of mine on this area caused other tests to fail. Added the check if only the button is available to be selected because not all the tests have the same starting point.


