### PR TITLE
Add EXP-3614 [v117] Add Nimbus tooling to SceneDelegate to be run on app start

### DIFF
--- a/Client/Application/SceneDelegate.swift
+++ b/Client/Application/SceneDelegate.swift
@@ -52,6 +52,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     ) {
         guard !AppConstants.isRunningUnitTest else { return }
 
+        // Add hooks for the nimbus-cli to test experiments on device or involving deeplinks.
+        if let url = connectionOptions.urlContexts.first?.url {
+            Experiments.shared.initializeTooling(url: url)
+        }
+
         if CoordinatorFlagManager.isCoordinatorEnabled {
             routeBuilder.configure(isPrivate: UserDefaults.standard.bool(forKey: PrefsKeys.LastSessionWasPrivate),
                                    prefs: profile.prefs)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/EXP-3614)

## :bulb: Description
This calls from the SceneDelegate to initialize the app's Nimbus SDK– especially at startup— via a deeplink generated by the [`nimbus-cli`](https://experimenter.info/nimbus-cli).

`nimbus-cli` is tooling to start the app with experiments, eliminating the need for special builds of the app. It currently uses `xcrun simctl launch` and `xcrun simctl openurl`– i.e. only works on the simulator.

This allows QA to test experiments on device.

Note this will only build cleanly once https://github.com/mozilla/application-services/pull/5727 is landed, and the upgrade accepted by Firefox for iOS.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

