### PR TITLE
Bugfix FXIOS-7013 [v116] Fix url bar height

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -882,7 +882,8 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
         // Make sure that we have a height to actually base our calculations on
         guard urlBar.locationContainer.bounds.height != 0 else { return }
         let locationViewHeight = urlBar.locationView.bounds.height
-        let heightWithPadding = locationViewHeight + 10
+        let padding: CGFloat = CoordinatorFlagManager.isCoordinatorEnabled ? 12 : 10
+        let heightWithPadding = locationViewHeight + padding
 
         // Adjustment for landscape on the urlbar
         // need to account for inset and remove it when keyboard is showing


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7013)

## :bulb: Description
On iPhone with Dynamic island, URL bar height doesn't cover the entire section it should, missing 2 pixels. Since the URL bar is centered constraint, this is the quick fix to the issue. 

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

