### PR TITLE
Refactor EXP-3614 [v117] Move ArgumentProcessor over from AS to test EXP-3614

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -220,6 +220,7 @@
 		396E38F21EE0C8ED00CC180F /* FxAPushMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3905B4D41E8E7A6B0027D953 /* FxAPushMessageHandler.swift */; };
 		397848DE1ED86605004C0C0B /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 397848DD1ED86605004C0C0B /* NotificationService.swift */; };
 		397848E21ED86605004C0C0B /* NotificationService.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 397848DB1ED86605004C0C0B /* NotificationService.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		399341742A61945C0012EF71 /* ArgumentProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 399341732A61945C0012EF71 /* ArgumentProcessor.swift */; };
 		39A359E41BFCCE94006B9E87 /* UserActivityHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39A359E31BFCCE94006B9E87 /* UserActivityHandler.swift */; };
 		39A35AED1C0662A3006B9E87 /* SpotlightHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = 39A35AEC1C0662A3006B9E87 /* SpotlightHelper.js */; };
 		39AF317429DAE37E00F8E6F7 /* NimbusMessagingMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39AF317329DAE37E00F8E6F7 /* NimbusMessagingMessageTests.swift */; };
@@ -2386,6 +2387,7 @@
 		397848DB1ED86605004C0C0B /* NotificationService.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = NotificationService.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		397848DD1ED86605004C0C0B /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		397848DF1ED86605004C0C0B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		399341732A61945C0012EF71 /* ArgumentProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArgumentProcessor.swift; sourceTree = "<group>"; };
 		39A359E31BFCCE94006B9E87 /* UserActivityHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserActivityHandler.swift; path = Helpers/UserActivityHandler.swift; sourceTree = "<group>"; };
 		39A35AEC1C0662A3006B9E87 /* SpotlightHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = SpotlightHelper.js; sourceTree = "<group>"; };
 		39AD454C88A908D41BA13329 /* te */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = te; path = te.lproj/Today.strings; sourceTree = "<group>"; };
@@ -9052,6 +9054,7 @@
 		C87D8B7E2818331900A6307D /* Nimbus */ = {
 			isa = PBXGroup;
 			children = (
+				399341732A61945C0012EF71 /* ArgumentProcessor.swift */,
 				C87D8B7F2818333F00A6307D /* NimbusManager.swift */,
 				8A161412282C2F8F00DDBB02 /* NimbusSponsoredTileLayer.swift */,
 				C825E9822832A425006CB811 /* NimbusSearchBarLayer.swift */,
@@ -12345,6 +12348,7 @@
 				8A471185287F6E4800F5A6EA /* SeparatorTableViewCell.swift in Sources */,
 				D301AAEE1A3A55B70078DD1D /* GridTabViewController.swift in Sources */,
 				EB9A179B20E69A7F00B12184 /* LegacyThemeManager.swift in Sources */,
+				399341742A61945C0012EF71 /* ArgumentProcessor.swift in Sources */,
 				EBFDB790211C83A5005CCA2F /* BrowserViewController+FindInPage.swift in Sources */,
 				21BFEEF52A040EF40033048D /* TabMigrationUtility.swift in Sources */,
 				C8A012F126AB07D70096A7A7 /* JumpBackInViewModel.swift in Sources */,

--- a/Client/Nimbus/ArgumentProcessor.swift
+++ b/Client/Nimbus/ArgumentProcessor.swift
@@ -1,0 +1,161 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import MozillaAppServices
+
+enum ArgumentProcessor {
+    static func initializeTooling(nimbus: NimbusInterface, args: CliArgs) {
+        if args.resetDatabase {
+            nimbus.resetEnrollmentsDatabase().waitUntilFinished()
+        }
+        if let experiments = args.experiments {
+            nimbus.setExperimentsLocally(experiments)
+            nimbus.applyPendingExperiments().waitUntilFinished()
+            // setExperimentsLocally and applyPendingExperiments run on the
+            // same single threaded dispatch queue, so we can run them in series,
+            // and wait for the apply.
+            nimbus.setFetchEnabled(false)
+        }
+        if args.logState {
+            nimbus.dumpStateToLog()
+        }
+    }
+
+    static func createCommandLineArgs(url: URL) -> CliArgs? {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let scheme = components.scheme,
+              let queryItems = components.queryItems,
+              !["http", "https"].contains(scheme)
+        else {
+            return nil
+        }
+
+        var experiments: String?
+        var resetDatabase = false
+        var logState = false
+        var meantForUs = false
+
+        func flag(_ v: String?) -> Bool {
+            guard let v = v else {
+                return true
+            }
+            return ["1", "true", "yes"].contains(v.lowercased())
+        }
+
+        queryItems.forEach { item in
+            switch item.name {
+            case "--nimbus-cli":
+                meantForUs = flag(item.value)
+            case "--experiments":
+                experiments = item.value?.removingPercentEncoding
+            case "--reset-db":
+                resetDatabase = flag(item.value)
+            case "--log-state":
+                logState = flag(item.value)
+            default:
+                () // NOOP
+            }
+        }
+
+        if !meantForUs {
+            return nil
+        }
+
+        return check(args: CliArgs(resetDatabase: resetDatabase, experiments: experiments, logState: logState))
+    }
+
+    static func createCommandLineArgs(args: [String]?) -> CliArgs? {
+        guard let args = args else {
+            return nil
+        }
+        if !args.contains("--nimbus-cli") {
+            return nil
+        }
+
+        var argMap = [String: String]()
+        var key: String?
+        var resetDatabase = false
+        var logState = false
+
+        args.forEach { arg in
+            var value: String?
+            switch arg {
+            case "--version":
+                key = "version"
+            case "--experiments":
+                key = "experiments"
+            case "--reset-db":
+                resetDatabase = true
+            case "--log-state":
+                logState = true
+            default:
+                value = arg.replacingOccurrences(of: "&apos;", with: "'")
+            }
+
+            if let k = key, let v = value {
+                argMap[k] = v
+                key = nil
+                value = nil
+            }
+        }
+
+        if argMap["version"] != "1" {
+            return nil
+        }
+
+        let experiments = argMap["experiments"]
+
+        return check(args: CliArgs(resetDatabase: resetDatabase, experiments: experiments, logState: logState))
+    }
+
+    static func check(args: CliArgs) -> CliArgs? {
+        if let string = args.experiments {
+            guard let payload = try? Dictionary.parse(jsonString: string),
+                    payload["data"] is [Any]
+            else {
+                return nil
+            }
+        }
+        return args
+    }
+}
+
+struct CliArgs: Equatable {
+    let resetDatabase: Bool
+    let experiments: String?
+    let logState: Bool
+}
+
+public extension NimbusInterface {
+    func initializeTooling(url: URL?) {
+        guard let url = url,
+              let args = ArgumentProcessor.createCommandLineArgs(url: url)
+        else {
+            return
+        }
+        ArgumentProcessor.initializeTooling(nimbus: self, args: args)
+    }
+}
+
+internal extension Dictionary where Key == String, Value == Any {
+    func stringify() throws -> String {
+        let data = try JSONSerialization.data(withJSONObject: self)
+        guard let s = String(data: data, encoding: .utf8) else {
+            throw NimbusError.JsonError(message: "Unable to encode")
+        }
+        return s
+    }
+
+    static func parse(jsonString string: String) throws -> [String: Any] {
+        guard let data = string.data(using: .utf8) else {
+            throw NimbusError.JsonError(message: "Unable to decode string into data")
+        }
+        let obj = try JSONSerialization.jsonObject(with: data)
+        guard let obj = obj as? [String: Any] else {
+            throw NimbusError.JsonError(message: "Unable to cast into JSONObject")
+        }
+        return obj
+    }
+}


### PR DESCRIPTION
This is just for a reviewer to manually test [EXP-3614](https://mozilla-hub.atlassian.net/browse/EXP-3614).

It is essentially https://github.com/mozilla-mobile/firefox-ios/pull/15579 with the iOS parts from https://github.com/mozilla/application-services/pull/5727 so that a reviewer of the latter PR can smoke test it.

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

