### PR TITLE
Bugfix FXIOS-6785 [v116] Page extent and content container

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -524,6 +524,7 @@
 		8A093D7F2A4B3E7D0099ABA5 /* GeneralSettingsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A093D7E2A4B3E7D0099ABA5 /* GeneralSettingsDelegate.swift */; };
 		8A093D812A4B58330099ABA5 /* MockSettingsFlowDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A093D802A4B58330099ABA5 /* MockSettingsFlowDelegate.swift */; };
 		8A093D832A4B68940099ABA5 /* PrivacySettingsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A093D822A4B68940099ABA5 /* PrivacySettingsDelegate.swift */; };
+		8A0D32842A61E1CC007D976D /* StatusBarOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0D32832A61E1CC007D976D /* StatusBarOverlay.swift */; };
 		8A0F2A7E286DFCC800D84CC6 /* PushRemoteError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0F2A7D286DFCC800D84CC6 /* PushRemoteError.swift */; };
 		8A0F2A80286DFD2B00D84CC6 /* PushClientError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0F2A7F286DFD2B00D84CC6 /* PushClientError.swift */; };
 		8A0F2A82286DFD9800D84CC6 /* PushRegistrationAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0F2A81286DFD9800D84CC6 /* PushRegistrationAPI.swift */; };
@@ -4643,6 +4644,7 @@
 		8A093D7E2A4B3E7D0099ABA5 /* GeneralSettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsDelegate.swift; sourceTree = "<group>"; };
 		8A093D802A4B58330099ABA5 /* MockSettingsFlowDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSettingsFlowDelegate.swift; sourceTree = "<group>"; };
 		8A093D822A4B68940099ABA5 /* PrivacySettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacySettingsDelegate.swift; sourceTree = "<group>"; };
+		8A0D32832A61E1CC007D976D /* StatusBarOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarOverlay.swift; sourceTree = "<group>"; };
 		8A0F2A7D286DFCC800D84CC6 /* PushRemoteError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushRemoteError.swift; sourceTree = "<group>"; };
 		8A0F2A7F286DFD2B00D84CC6 /* PushClientError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushClientError.swift; sourceTree = "<group>"; };
 		8A0F2A81286DFD9800D84CC6 /* PushRegistrationAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushRegistrationAPI.swift; sourceTree = "<group>"; };
@@ -8478,6 +8480,7 @@
 				217AEF7728480844004EED37 /* ResizableButton.swift */,
 				8A36BE2829EDBC6900AC1C5C /* ContentContainer.swift */,
 				8ACE9BFA2A54A010001E7A73 /* ExpandButtonState.swift */,
+				8A0D32832A61E1CC007D976D /* StatusBarOverlay.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -12450,6 +12453,7 @@
 				392ED7E61D0AEFEF009D9B62 /* HomePageAccessors.swift in Sources */,
 				8A0017C128A3FF6100FEFC8B /* MessageCardDataAdaptor.swift in Sources */,
 				7BA8D1C71BA037F500C8AE9E /* OpenInHelper.swift in Sources */,
+				8A0D32842A61E1CC007D976D /* StatusBarOverlay.swift in Sources */,
 				8A5D1CA42A30D69A005AD35C /* SearchSetting.swift in Sources */,
 				74BBDF472A17979000D3BEFE /* OnboardingDefaultBrowserModelProtocol.swift in Sources */,
 				8AD40FC727BADC3400672675 /* ToolbarTextField.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -662,6 +662,7 @@
 		8A96C4BB28F9E7B300B75884 /* XCTestCaseRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A96C4BA28F9E7B300B75884 /* XCTestCaseRootViewController.swift */; };
 		8A9AC465276CEC4E0047F5B0 /* JumpBackInCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9AC464276CEC4E0047F5B0 /* JumpBackInCell.swift */; };
 		8A9AC46B276D11280047F5B0 /* PocketViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9AC46A276D11280047F5B0 /* PocketViewModel.swift */; };
+		8A9E46BD2A6599E5003327D4 /* MockStatusBarScrollDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9E46BC2A6599E5003327D4 /* MockStatusBarScrollDelegate.swift */; };
 		8A9F0B5627C595F300FE09AE /* ImageIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9F0B5527C595F300FE09AE /* ImageIdentifiers.swift */; };
 		8A9F0B5727C59E1700FE09AE /* ImageIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9F0B5527C595F300FE09AE /* ImageIdentifiers.swift */; };
 		8A9F0B5827C59E1800FE09AE /* ImageIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9F0B5527C595F300FE09AE /* ImageIdentifiers.swift */; };
@@ -4803,6 +4804,7 @@
 		8A99DB9C27C6DD3E007EA6BD /* is */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = is; path = is.lproj/Localizable.strings; sourceTree = "<group>"; };
 		8A9AC464276CEC4E0047F5B0 /* JumpBackInCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpBackInCell.swift; sourceTree = "<group>"; };
 		8A9AC46A276D11280047F5B0 /* PocketViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketViewModel.swift; sourceTree = "<group>"; };
+		8A9E46BC2A6599E5003327D4 /* MockStatusBarScrollDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStatusBarScrollDelegate.swift; sourceTree = "<group>"; };
 		8A9F0B5527C595F300FE09AE /* ImageIdentifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageIdentifiers.swift; sourceTree = "<group>"; };
 		8AA6ADB42742B567004EEE23 /* TelemetryWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryWrapperTests.swift; sourceTree = "<group>"; };
 		8AA7347A28AEDB3100443D24 /* PocketViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketViewModelTests.swift; sourceTree = "<group>"; };
@@ -9140,6 +9142,7 @@
 				8A5D1C9F2A30C9D7005AD35C /* MockAppSettingsDelegate.swift */,
 				8A093D802A4B58330099ABA5 /* MockSettingsFlowDelegate.swift */,
 				8A5038132A5DFCE000A1B02A /* MockBrowserProfile.swift */,
+				8A9E46BC2A6599E5003327D4 /* MockStatusBarScrollDelegate.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -13002,6 +13005,7 @@
 				8A11C8112731CFD700AC7318 /* ReaderModeStyleTests.swift in Sources */,
 				8ABA9C8E28931288002C0077 /* JumpBackInDataAdaptorTests.swift in Sources */,
 				3943A81D1E9807C700D4F6DC /* FxAPushMessageTest.swift in Sources */,
+				8A9E46BD2A6599E5003327D4 /* MockStatusBarScrollDelegate.swift in Sources */,
 				E1463D0629830E4F0074E16E /* MockUserNotificationCenter.swift in Sources */,
 				439B78182A09721600CAAE37 /* CreditCardHelperTests.swift in Sources */,
 				8ADED7F0276A7788009C19E6 /* CumulativeDaysOfUseCounterTests.swift in Sources */,

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -8,7 +8,14 @@ import WebKit
 import Shared
 import Storage
 
-class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDelegate, SettingsCoordinatorDelegate, BrowserNavigationHandler, LibraryCoordinatorDelegate, EnhancedTrackingProtectionCoordinatorDelegate, ParentCoordinatorDelegate {
+class BrowserCoordinator: BaseCoordinator,
+                          LaunchCoordinatorDelegate,
+                          BrowserDelegate,
+                          SettingsCoordinatorDelegate,
+                          BrowserNavigationHandler,
+                          LibraryCoordinatorDelegate,
+                          EnhancedTrackingProtectionCoordinatorDelegate,
+                          ParentCoordinatorDelegate {
     var browserViewController: BrowserViewController
     var webviewController: WebviewViewController?
     var homepageViewController: HomepageViewController?
@@ -83,12 +90,14 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
                       homepanelDelegate: HomePanelDelegate,
                       libraryPanelDelegate: LibraryPanelDelegate,
                       sendToDeviceDelegate: HomepageViewController.SendToDeviceDelegate,
+                      statusBarScrollDelegate: StatusBarScrollDelegate,
                       overlayManager: OverlayModeManager) {
         let homepageController = getHomepage(inline: inline,
                                              toastContainer: toastContainer,
                                              homepanelDelegate: homepanelDelegate,
                                              libraryPanelDelegate: libraryPanelDelegate,
                                              sendToDeviceDelegate: sendToDeviceDelegate,
+                                             statusBarScrollDelegate: statusBarScrollDelegate,
                                              overlayManager: overlayManager)
 
         guard browserViewController.embedContent(homepageController) else { return }
@@ -126,6 +135,7 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
                              homepanelDelegate: HomePanelDelegate,
                              libraryPanelDelegate: LibraryPanelDelegate,
                              sendToDeviceDelegate: HomepageViewController.SendToDeviceDelegate,
+                             statusBarScrollDelegate: StatusBarScrollDelegate,
                              overlayManager: OverlayModeManager) -> HomepageViewController {
         if let homepageViewController = homepageViewController {
             return homepageViewController
@@ -138,6 +148,7 @@ class BrowserCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, BrowserDel
             homepageViewController.homePanelDelegate = homepanelDelegate
             homepageViewController.libraryPanelDelegate = libraryPanelDelegate
             homepageViewController.sendToDeviceDelegate = sendToDeviceDelegate
+            homepageViewController.statusBarScrollDelegate = statusBarScrollDelegate
             if CoordinatorFlagManager.isShareExtensionCoordinatorEnabled {
                 homepageViewController.browserNavigationHandler = self
             }

--- a/Client/Coordinators/Browser/BrowserDelegate.swift
+++ b/Client/Coordinators/Browser/BrowserDelegate.swift
@@ -13,12 +13,14 @@ protocol BrowserDelegate: AnyObject {
     ///   - homepanelDelegate: The homepanel delegate for the homepage
     ///   - libraryPanelDelegate:  The library panel delegate for the homepage
     ///   - sendToDeviceDelegate: The send to device delegate for the homepage
+    ///   - statusBarScrollDelegate: The delegate that takes care of the status bar overlay scroll
     ///   - overlayManager: The overlay manager for the homepage
     func showHomepage(inline: Bool,
                       toastContainer: UIView,
                       homepanelDelegate: HomePanelDelegate,
                       libraryPanelDelegate: LibraryPanelDelegate,
                       sendToDeviceDelegate: HomepageViewController.SendToDeviceDelegate,
+                      statusBarScrollDelegate: StatusBarScrollDelegate,
                       overlayManager: OverlayModeManager)
 
     /// Show the webview to navigate

--- a/Client/Extensions/UIViewController+Extension.swift
+++ b/Client/Extensions/UIViewController+Extension.swift
@@ -33,6 +33,12 @@ struct ViewControllerConsts {
 }
 
 extension UIViewController {
+    var statusBarFrame: CGRect? {
+        guard let keyWindow = UIWindow.keyWindow else { return nil }
+
+        return keyWindow.windowScene?.statusBarManager?.statusBarFrame
+    }
+    
     /// Determines whether, based on size class, the particular view controller should
     /// use iPad setup, as defined by design requirements. All iPad devices use a
     /// combination of either (.compact, .regular) or (.regular, .regular) size class

--- a/Client/Extensions/UIViewController+Extension.swift
+++ b/Client/Extensions/UIViewController+Extension.swift
@@ -33,12 +33,6 @@ struct ViewControllerConsts {
 }
 
 extension UIViewController {
-    var statusBarFrame: CGRect? {
-        guard let keyWindow = UIWindow.keyWindow else { return nil }
-
-        return keyWindow.windowScene?.statusBarManager?.statusBarFrame
-    }
-    
     /// Determines whether, based on size class, the particular view controller should
     /// use iPad setup, as defined by design requirements. All iPad devices use a
     /// combination of either (.compact, .regular) or (.regular, .regular) size class

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -14,7 +14,10 @@ import MobileCoreServices
 import Telemetry
 import Common
 
-class BrowserViewController: UIViewController, SearchBarLocationProvider, Themeable, LibraryPanelDelegate {
+class BrowserViewController: UIViewController,
+                             SearchBarLocationProvider,
+                             Themeable,
+                             LibraryPanelDelegate {
     private enum UX {
         static let ShowHeaderTapAreaHeight: CGFloat = 32
         static let ActionSheetTitleMaxLength = 120
@@ -41,7 +44,7 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
     var clipboardBarDisplayHandler: ClipboardBarDisplayHandler?
     var readerModeBar: ReaderModeBarView?
     var readerModeCache: ReaderModeCache
-    var statusBarOverlay = UIView()
+    var statusBarOverlay: StatusBarOverlay = .build { _ in }
     var searchController: SearchViewController?
     var screenshotHelper: ScreenshotHelper!
     var searchTelemetry: SearchTelemetry?
@@ -52,7 +55,6 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
     var urlFromAnotherApp: UrlToOpenModel?
     var isCrashAlertShowing = false
     var currentMiddleButtonState: MiddleButtonState?
-    private var customSearchBarButton: UIBarButtonItem?
     var openedUrlFromExternalSource = false
     var passBookHelper: OpenPassBookHelper?
     var overlayManager: OverlayModeManager
@@ -473,6 +475,7 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
         overKeyboardContainer.applyTheme(theme: theme)
         bottomContainer.applyTheme(theme: theme)
         bottomContentStackView.applyTheme(theme: theme)
+        statusBarOverlay.applyTheme(theme: theme)
 
         // Credit card initial setup telemetry
         creditCardInitialSetupTelemetry()
@@ -570,7 +573,6 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
         view.addSubview(topTouchArea)
 
         // Work around for covering the non-clipped web view content
-        statusBarOverlay = UIView()
         view.addSubview(statusBarOverlay)
 
         // Setup the URL bar, wrapped in a view to get transparency effect
@@ -742,8 +744,7 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
 
         if CoordinatorFlagManager.isCoordinatorEnabled {
             NSLayoutConstraint.activate([
-                contentContainer.topAnchor.constraint(equalTo: statusBarOverlay.bottomAnchor, priority: .init(998)),
-                contentContainer.topAnchor.constraint(equalTo: header.bottomAnchor, priority: .init(999)),
+                contentContainer.topAnchor.constraint(equalTo: header.bottomAnchor),
                 contentContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor),
                 contentContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor),
                 contentContainer.bottomAnchor.constraint(equalTo: overKeyboardContainer.topAnchor),
@@ -756,7 +757,8 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
     private func updateHeaderConstraints() {
         header.snp.remakeConstraints { make in
             if isBottomSearchBar {
-                make.left.right.top.equalTo(view)
+                make.left.right.equalTo(view)
+                make.top.equalTo(view.safeArea.top)
                 if CoordinatorFlagManager.isCoordinatorEnabled {
                     // The status bar is covered by the statusBarOverlay,
                     // if we don't have the URL bar at the top then header height is 0
@@ -1010,15 +1012,13 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
         [header, overKeyboardContainer].forEach { view in
             view?.transform = .identity
         }
-
-        statusBarOverlay.isHidden = false
     }
 
     // MARK: - Manage embedded content
 
     func frontEmbeddedContent(_ viewController: ContentContainable) {
         contentContainer.update(content: viewController)
-        manageStatusBarEmbedded()
+        statusBarOverlay.resetState()
     }
 
     /// Embed a ContentContainable inside the content container
@@ -1030,19 +1030,10 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
         addChild(viewController)
         contentContainer.add(content: viewController)
         viewController.didMove(toParent: self)
-        manageStatusBarEmbedded()
+        statusBarOverlay.resetState()
 
         UIAccessibility.post(notification: UIAccessibility.Notification.screenChanged, argument: nil)
         return true
-    }
-
-    /// Status bar overlay needs to be at the back for some content type that need extended content
-    private func manageStatusBarEmbedded() {
-        if let type = contentContainer.type, type.needTopContentExtended {
-            view.sendSubviewToBack(statusBarOverlay)
-        } else {
-            view.bringSubviewToFront(statusBarOverlay)
-        }
     }
 
     /// Show the home page embedded in the contentContainer
@@ -1060,6 +1051,7 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
                                       homepanelDelegate: self,
                                       libraryPanelDelegate: self,
                                       sendToDeviceDelegate: self,
+                                      statusBarScrollDelegate: statusBarOverlay,
                                       overlayManager: overlayManager)
     }
 
@@ -1988,8 +1980,7 @@ class BrowserViewController: UIViewController, SearchBarLocationProvider, Themea
     // MARK: Themeable
     func applyTheme() {
         let currentTheme = themeManager.currentTheme
-        let hasTopTabs = shouldShowTopTabsForTraitCollection(traitCollection)
-        statusBarOverlay.backgroundColor = hasTopTabs ? currentTheme.colors.layer3 : currentTheme.colors.layer1
+        statusBarOverlay.hasTopTabs = shouldShowTopTabsForTraitCollection(traitCollection)
         keyboardBackdrop?.backgroundColor = currentTheme.colors.layer1
         setNeedsStatusBarAppearanceUpdate()
 

--- a/Client/Frontend/Components/ContentContainer.swift
+++ b/Client/Frontend/Components/ContentContainer.swift
@@ -7,16 +7,6 @@ import UIKit
 enum ContentType {
     case webview
     case homepage
-
-    /// Homepage wallpaper with bottom URL bar can be seen under the status bar, this means we need extended content at the top (unclipped)
-    var needTopContentExtended: Bool {
-        switch self {
-        case .homepage:
-            return true
-        default:
-            return false
-        }
-    }
 }
 
 protocol ContentContainable: UIViewController {

--- a/Client/Frontend/Components/StatusBarOverlay.swift
+++ b/Client/Frontend/Components/StatusBarOverlay.swift
@@ -1,0 +1,63 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+
+/// laurie - add comment
+class StatusBarOverlay: UIView,
+                        ThemeApplicable,
+                        StatusBarScrollDelegate,
+                        SearchBarLocationProvider {
+    // Returns a value between 0 and 1 which indicates how far the user has scrolled.
+    // This is used as the alpha of the status bar background.
+    // 0 = no status bar background shown
+    // 1 = status bar background is opaque
+    private var scrollOffset: CGFloat = 0
+    private var savedBackgroundColor: UIColor?
+    var hasTopTabs = false
+
+    private func setScrollOffset(scrollView: UIScrollView,
+                                 statusBarFrame: CGRect?) {
+        // Status bar height can be 0 on iPhone in landscape mode.
+        guard isBottomSearchBar,
+              let statusBarHeight: CGFloat = statusBarFrame?.height,
+              statusBarHeight > 0
+        else {
+            scrollOffset = 1
+            return
+        }
+
+        // The scrollview content offset is automatically adjusted to account for the status bar.
+        // We want to start showing the status bar background as soon as the user scrolls.
+        var offset: CGFloat
+        offset = scrollView.contentOffset.y / statusBarHeight
+
+        if offset > 1 {
+            offset = 1
+        } else if offset < 0 {
+            offset = 0
+        }
+        scrollOffset = offset
+    }
+
+    func resetState() {
+        scrollOffset = 1
+        backgroundColor = savedBackgroundColor?.withAlphaComponent(scrollOffset)
+    }
+
+    // MARK: - ThemeApplicable
+
+    func applyTheme(theme: Theme) {
+        savedBackgroundColor = hasTopTabs ? theme.colors.layer3 : theme.colors.layer1
+        backgroundColor = savedBackgroundColor?.withAlphaComponent(scrollOffset)
+    }
+
+    // MARK: - StatusBarScrollDelegate
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView, statusBarFrame: CGRect?, theme: Theme) {
+        setScrollOffset(scrollView: scrollView, statusBarFrame: statusBarFrame)
+        applyTheme(theme: theme)
+    }
+}

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -8,13 +8,6 @@ import Storage
 import MozillaAppServices
 import Common
 
-// laurie - put this in its own file/place
-protocol StatusBarScrollDelegate: AnyObject {
-    func scrollViewDidScroll(_ scrollView: UIScrollView,
-                             statusBarFrame: CGRect?,
-                             theme: Theme)
-}
-
 class HomepageViewController: UIViewController, FeatureFlaggable, Themeable, ContentContainable,
                                 SearchBarLocationProvider {
     // MARK: - Typealiases

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -748,6 +748,12 @@ extension HomepageViewController: HomepageContextMenuHelperDelegate {
 // MARK: - Status Bar Background
 
 extension HomepageViewController {
+    var statusBarFrame: CGRect? {
+        guard let keyWindow = UIWindow.keyWindow else { return nil }
+
+        return keyWindow.windowScene?.statusBarManager?.statusBarFrame
+    }
+
     // Returns a value between 0 and 1 which indicates how far the user has scrolled.
     // This is used as the alpha of the status bar background.
     // 0 = no status bar background shown

--- a/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -17,6 +17,7 @@ final class BrowserCoordinatorTests: XCTestCase {
     private var applicationHelper: MockApplicationHelper!
     private var glean: MockGleanWrapper!
     private var wallpaperManager: WallpaperManagerMock!
+    private var scrollDelegate: MockStatusBarScrollDelegate!
 
     override func setUp() {
         super.setUp()
@@ -31,6 +32,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         self.applicationHelper = MockApplicationHelper()
         self.glean = MockGleanWrapper()
         self.wallpaperManager = WallpaperManagerMock()
+        self.scrollDelegate = MockStatusBarScrollDelegate()
     }
 
     override func tearDown() {
@@ -44,6 +46,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         self.applicationHelper = nil
         self.glean = nil
         self.wallpaperManager = nil
+        self.scrollDelegate = nil
         AppContainer.shared.reset()
     }
 
@@ -94,6 +97,7 @@ final class BrowserCoordinatorTests: XCTestCase {
                              homepanelDelegate: subject.browserViewController,
                              libraryPanelDelegate: subject.browserViewController,
                              sendToDeviceDelegate: subject.browserViewController,
+                             statusBarScrollDelegate: scrollDelegate,
                              overlayManager: overlayModeManager)
 
         let secondHomepage = HomepageViewController(profile: profile, toastContainer: UIView(), overlayManager: overlayModeManager)
@@ -109,6 +113,7 @@ final class BrowserCoordinatorTests: XCTestCase {
                              homepanelDelegate: subject.browserViewController,
                              libraryPanelDelegate: subject.browserViewController,
                              sendToDeviceDelegate: subject.browserViewController,
+                             statusBarScrollDelegate: scrollDelegate,
                              overlayManager: overlayModeManager)
         let firstHomepage = subject.homepageViewController
         XCTAssertNotNil(subject.homepageViewController)
@@ -118,6 +123,7 @@ final class BrowserCoordinatorTests: XCTestCase {
                              homepanelDelegate: subject.browserViewController,
                              libraryPanelDelegate: subject.browserViewController,
                              sendToDeviceDelegate: subject.browserViewController,
+                             statusBarScrollDelegate: scrollDelegate,
                              overlayManager: overlayModeManager)
         let secondHomepage = subject.homepageViewController
         XCTAssertEqual(firstHomepage, secondHomepage)

--- a/Tests/ClientTests/Frontend/ContentContainerTests.swift
+++ b/Tests/ClientTests/Frontend/ContentContainerTests.swift
@@ -95,26 +95,6 @@ final class ContentContainerTests: XCTestCase {
         XCTAssertNotNil(subject.contentView)
     }
 
-    func testContentType_needTopContentExtended_trueWithHomepage() {
-        let subject = ContentContainer(frame: .zero)
-        let homepage = createHomepage()
-        subject.add(content: homepage)
-        XCTAssertTrue(subject.type!.needTopContentExtended)
-    }
-
-    func testContentType_needTopContentExtended_hasNotTypeWhenNil() {
-        let subject = ContentContainer(frame: .zero)
-        XCTAssertNil(subject.type)
-    }
-
-    func testContentType_needTopContentExtended_falseWithWebview() {
-        let subject = ContentContainer(frame: .zero)
-        let webview = WebviewViewController(webView: WKWebView())
-        subject.add(content: webview)
-
-        XCTAssertFalse(subject.type!.needTopContentExtended)
-    }
-
     private func createHomepage() -> HomepageViewController {
         return HomepageViewController(profile: profile, toastContainer: UIView(), overlayManager: overlayModeManager)
     }

--- a/Tests/ClientTests/Mocks/MockStatusBarScrollDelegate.swift
+++ b/Tests/ClientTests/Mocks/MockStatusBarScrollDelegate.swift
@@ -1,0 +1,20 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+
+@testable import Client
+
+class MockStatusBarScrollDelegate: StatusBarScrollDelegate {
+    var savedScrollView: UIScrollView?
+    var savedStatusBarFrame: CGRect?
+    var savedTheme: Theme?
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView, statusBarFrame: CGRect?, theme: Theme) {
+        savedScrollView = scrollView
+        savedStatusBarFrame = statusBarFrame
+        savedTheme = theme
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6785)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15116)

## :bulb: Description
This issue originated when we moved to have one content container for the homepage and web view. Where before the homepage and web view had different set of constraints, we now have one solution for both. This required a bit of tweaking let's say, and was attempted to be fixed differently which resulted in the current problem.

To add a little more detail, bottom constraint of the `contentContainer` is always the top of the `overKeyboardContainer`. Top constraint of the `contentContainer` was sometimes the bottom of the URL bar (header) or the bottom of the `statusBarOverlay`. This PR changes that so the top constraint of the `contentContainer` is always the bottom of the header stack view.

For this to work, the homepage cannot manage its own status bar overlay anymore. There's a new `StatusBarOverlay` class introduced here, that will handle the status bar for us. Homepage has a delegate to tell when it scrolls, so the status bar can be adjusted in the needed case of bottom URL bar on homepage. In all other cases, the status bar overlay is opaque.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

