### PR TITLE
Bugfix [v117] Fix warning

### DIFF
--- a/Tests/ClientTests/Messaging/GleanPlumbMessageManagerTests.swift
+++ b/Tests/ClientTests/Messaging/GleanPlumbMessageManagerTests.swift
@@ -156,7 +156,6 @@ class GleanPlumbMessageManagerTests: XCTestCase {
         XCTAssertEqual(messagingStore.getMessageMetadata(messageId: "control").impressions, 0)
 
         let expectedId = "infoCard"
-        let experiment = "my-experiment"
         let messages = [
             createMessage(messageId: "control", surface: .newTabCard, isControl: true),
             createMessage(messageId: expectedId, surface: .newTabCard)


### PR DESCRIPTION
## :scroll: Tickets
No ticket

## :bulb: Description
Fix new warning in main introduced in https://github.com/mozilla-mobile/firefox-ios/pull/15580. Build was green, so not sure why it wasn't catched here again.
```
⚠️  /Users/vagrant/git/Tests/ClientTests/Messaging/GleanPlumbMessageManagerTests.swift:159:13: initialization of immutable value 'experiment' was never used; consider replacing with assignment to '_' or removing it
        let experiment = "my-experiment"
```

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

