### PR TITLE
Bugfix FXIOS-7022 [v116] Customize homepage using settings coordinator when it shouldn't

### DIFF
--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -191,7 +191,7 @@ class BrowserCoordinator: BaseCoordinator,
             if isSettingsCoordinatorEnabled {
                 return handleSettings(with: section)
             } else {
-                handle(settingsSection: section)
+                legacyHandle(settingsSection: section)
                 return true
             }
 
@@ -358,7 +358,11 @@ class BrowserCoordinator: BaseCoordinator,
 
     func show(settings: Route.SettingsSection) {
         presentWithModalDismissIfNeeded {
-            _ = self.handleSettings(with: settings)
+            if self.isSettingsCoordinatorEnabled {
+                _ = self.handleSettings(with: settings)
+            } else {
+                self.legacyHandle(settingsSection: settings)
+            }
         }
     }
 
@@ -394,7 +398,7 @@ class BrowserCoordinator: BaseCoordinator,
     }
 
     // MARK: - To be removed with FXIOS-6529
-    private func handle(settingsSection: Route.SettingsSection) {
+    private func legacyHandle(settingsSection: Route.SettingsSection) {
         // Temporary bugfix for #14954, real fix is with settings coordinator
         if let subNavigationController = router.navigationController.presentedViewController as? ThemedNavigationController,
            let settings = subNavigationController.viewControllers.first as? AppSettingsTableViewController {
@@ -417,15 +421,15 @@ class BrowserCoordinator: BaseCoordinator,
         controller.modalPresentationStyle = .formSheet
         router.present(controller)
 
-        getSettingsViewController(settingsSection: settingsSection) { viewController in
+        legacyGetSettingsViewController(settingsSection: settingsSection) { viewController in
             guard let viewController else { return }
             controller.pushViewController(viewController, animated: true)
         }
     }
 
     // Will be removed with FXIOS-6529
-    func getSettingsViewController(settingsSection section: Route.SettingsSection,
-                                   completion: @escaping (UIViewController?) -> Void) {
+    func legacyGetSettingsViewController(settingsSection section: Route.SettingsSection,
+                                         completion: @escaping (UIViewController?) -> Void) {
         switch section {
         case .newTab:
             let viewController = NewTabContentSettingsViewController(prefs: profile.prefs)

--- a/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -504,7 +504,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         let route = Route.SettingsSection.newTab
         let subject = createSubject()
 
-        subject.getSettingsViewController(settingsSection: route) { result in
+        subject.legacyGetSettingsViewController(settingsSection: route) { result in
             XCTAssertTrue(result is NewTabContentSettingsViewController)
         }
     }
@@ -513,7 +513,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         let route = Route.SettingsSection.homePage
         let subject = createSubject()
 
-        subject.getSettingsViewController(settingsSection: route) { result in
+        subject.legacyGetSettingsViewController(settingsSection: route) { result in
             XCTAssertTrue(result is HomePageSettingViewController)
         }
     }
@@ -522,7 +522,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         let route = Route.SettingsSection.mailto
         let subject = createSubject()
 
-        subject.getSettingsViewController(settingsSection: route) { result in
+        subject.legacyGetSettingsViewController(settingsSection: route) { result in
             XCTAssertTrue(result is OpenWithSettingsViewController)
         }
     }
@@ -531,7 +531,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         let route = Route.SettingsSection.search
         let subject = createSubject()
 
-        subject.getSettingsViewController(settingsSection: route) { result in
+        subject.legacyGetSettingsViewController(settingsSection: route) { result in
             XCTAssertTrue(result is SearchSettingsTableViewController)
         }
     }
@@ -540,7 +540,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         let route = Route.SettingsSection.clearPrivateData
         let subject = createSubject()
 
-        subject.getSettingsViewController(settingsSection: route) { result in
+        subject.legacyGetSettingsViewController(settingsSection: route) { result in
             XCTAssertTrue(result is ClearPrivateDataTableViewController)
         }
     }
@@ -549,7 +549,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         let route = Route.SettingsSection.fxa
         let subject = createSubject()
 
-        subject.getSettingsViewController(settingsSection: route) { result in
+        subject.legacyGetSettingsViewController(settingsSection: route) { result in
             XCTAssertTrue(result is SyncContentSettingsViewController)
         }
     }
@@ -558,7 +558,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         let route = Route.SettingsSection.theme
         let subject = createSubject()
 
-        subject.getSettingsViewController(settingsSection: route) { result in
+        subject.legacyGetSettingsViewController(settingsSection: route) { result in
             XCTAssertTrue(result is ThemeSettingsController)
         }
     }
@@ -568,7 +568,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         let route = Route.SettingsSection.wallpaper
         let subject = createSubject()
 
-        subject.getSettingsViewController(settingsSection: route) { result in
+        subject.legacyGetSettingsViewController(settingsSection: route) { result in
             XCTAssertTrue(result is WallpaperSettingsViewController)
         }
     }
@@ -578,7 +578,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         let route = Route.SettingsSection.wallpaper
         let subject = createSubject()
 
-        subject.getSettingsViewController(settingsSection: route) { result in
+        subject.legacyGetSettingsViewController(settingsSection: route) { result in
             XCTAssertNil(result)
         }
     }

--- a/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -173,7 +173,7 @@ final class BrowserCoordinatorTests: XCTestCase {
     // MARK: - BrowserNavigationHandler
 
     func testShowSettings() throws {
-        let subject = createSubject()
+        let subject = createSubject(isSettingsCoordinatorEnabled: true)
         subject.show(settings: .general)
 
         XCTAssertEqual(subject.childCoordinators.count, 1)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7022)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15603)

## :bulb: Description
Fix customize homepage going into the case with settings coordinator when it shouldn't. Renamed functions to legacy to make this more implicit.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

