### PR TITLE
Refactor FXIOS-6995 [v117] Make default browser onboarding VC themeable

### DIFF
--- a/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
+++ b/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
@@ -112,8 +112,7 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
     // MARK: - Inits
 
     init(themeManager: ThemeManager = AppContainer.shared.resolve(),
-         notificationCenter: NotificationProtocol = NotificationCenter.default
-    ) {
+         notificationCenter: NotificationProtocol = NotificationCenter.default) {
         self.themeManager = themeManager
         self.notificationCenter = notificationCenter
         super.init(nibName: nil, bundle: nil)

--- a/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
+++ b/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
@@ -24,15 +24,14 @@ import Shared
  
  */
 
-class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissable {
-    struct UX {
+class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissable, Themeable {
+    private struct UX {
         static let textOffset: CGFloat = 20
         static let textOffsetSmall: CGFloat = 13
         static let titleSize: CGFloat = 28
         static let titleSizeSmall: CGFloat = 24
         static let titleSizeLarge: CGFloat = 34
         static let ctaButtonCornerRadius: CGFloat = 10
-        static let ctaButtonColor = UIColor.Photon.Blue50
         static let ctaButtonWidth: CGFloat = 350
         static let ctaButtonWidthSmall: CGFloat = 300
         static let ctaButtonBottomSpace: CGFloat = 60
@@ -41,11 +40,13 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
     }
 
     // MARK: - Properties
+    var themeManager: ThemeManager
+    var themeObserver: NSObjectProtocol?
+    var notificationCenter: NotificationProtocol
     var onViewDismissed: (() -> Void)?
 
     // Public constants
     let viewModel = DefaultBrowserOnboardingViewModel()
-    let theme = LegacyThemeManager.instance
 
     // Private vars
     private var titleFontSize: CGFloat {
@@ -110,7 +111,11 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
 
     // MARK: - Inits
 
-    init() {
+    init(themeManager: ThemeManager = AppContainer.shared.resolve(),
+         notificationCenter: NotificationProtocol = NotificationCenter.default
+    ) {
+        self.themeManager = themeManager
+        self.notificationCenter = notificationCenter
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -121,7 +126,10 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
     // MARK: - Lifecycles
     override func viewDidLoad() {
         super.viewDidLoad()
+
         initialViewSetup()
+        listenForThemeChange(view)
+        applyTheme()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -154,14 +162,7 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
         closeButton.addTarget(self, action: #selector(dismissAnimated), for: .touchUpInside)
         goToSettingsButton.addTarget(self, action: #selector(goToSettings), for: .touchUpInside)
 
-        updateTheme()
         setupLayout()
-
-        // Theme change notification
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(updateTheme),
-                                               name: .DisplayThemeChanged,
-                                               object: nil)
     }
 
     private func setupLayout() {
@@ -269,25 +270,21 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
         }
     }
 
-    // Theme
-    @objc
-    func updateTheme() {
-        let textColor: UIColor = theme.currentName == .dark ? .white : .black
+    // MARK: Themeable
+    func applyTheme() {
+        let theme = themeManager.currentTheme
 
-        view.backgroundColor = .systemBackground
-        titleLabel.textColor = textColor
+        view.backgroundColor = theme.colors.layer1
+        titleLabel.textColor = theme.colors.textPrimary
 
-        descriptionText.textColor = textColor
-        descriptionLabel1.textColor = textColor
-        descriptionLabel2.textColor = textColor
-        descriptionLabel3.textColor = textColor
+        descriptionText.textColor = theme.colors.textPrimary
+        descriptionLabel1.textColor = theme.colors.textPrimary
+        descriptionLabel2.textColor = theme.colors.textPrimary
+        descriptionLabel3.textColor = theme.colors.textPrimary
 
-        goToSettingsButton.backgroundColor = UX.ctaButtonColor
-        goToSettingsButton.setTitleColor(.white, for: .normal)
-        closeButton.tintColor = .secondaryLabel
-    }
+        goToSettingsButton.backgroundColor = theme.colors.actionPrimary
+        goToSettingsButton.setTitleColor(theme.colors.textInverted, for: .normal)
 
-    deinit {
-        NotificationCenter.default.removeObserver(self)
+        closeButton.tintColor = theme.colors.textSecondary
     }
 }

--- a/Client/Frontend/Theme/LegacyThemeManager/photon-colors.swift
+++ b/Client/Frontend/Theme/LegacyThemeManager/photon-colors.swift
@@ -8,9 +8,7 @@ import UIKit
 
 extension UIColor {
     struct Photon {
-        static let LightGrey05 = UIColor(rgb: 0xfbfbfe)
         static let LightGrey20 = UIColor(rgb: 0xf0f0f4)
-        static let LightGrey30 = UIColor(rgb: 0xe0e0e6)
 
         static let DarkGrey60 = UIColor(rgb: 0x2b2a33)
         static let DarkGrey90 = UIColor(rgb: 0x15141a)
@@ -32,12 +30,6 @@ extension UIColor {
         static let Grey40 = UIColor(rgb: 0xb1b1b3)
         static let Grey50 = UIColor(rgb: 0x737373)
         static let Grey60 = UIColor(rgb: 0x4a4a4f)
-        static let Grey80 = UIColor(rgb: 0x2a2a2e)
         static let Grey90 = UIColor(rgb: 0x0c0c0d)
-    }
-
-    struct Custom {
-        static let selectedHighlightDark = UIColor.Photon.Grey60
-        static let selectedHighlightLight = UIColor.Photon.LightGrey20
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6995)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15519)

## :bulb: Description
- Make the default browser onboarding follow our theming system 
- Remove legacy colors unused anymore.

### Light theme
![Simulator Screenshot - iPhone 14 - 2023-07-17 at 15 51 04](https://github.com/mozilla-mobile/firefox-ios/assets/11338480/05275a30-e181-46b8-ad37-dd6fa837d39b)

### Dark theme
![Simulator Screenshot - iPhone 14 - 2023-07-17 at 15 51 20](https://github.com/mozilla-mobile/firefox-ios/assets/11338480/d33dc51c-e84e-4440-9abb-a182cfb2305c)

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

