### PR TITLE
Bugfix FXIOS-6678 [v117] confirm() prompt ignored

### DIFF
--- a/Client/Frontend/Browser/BrowserPrompts.swift
+++ b/Client/Frontend/Browser/BrowserPrompts.swift
@@ -75,6 +75,7 @@ struct TextInputAlert: JSAlertInfo {
     let message: String
     let frame: WKFrameInfo
     let defaultText: String?
+    let completionHandler: (String?) -> Void
 
     var input: UITextField!
 
@@ -87,8 +88,12 @@ struct TextInputAlert: JSAlertInfo {
             input = textField
             input.text = self.defaultText
         })
-        alertController.addAction(UIAlertAction(title: .OKString, style: .default))
-        alertController.addAction(UIAlertAction(title: .CancelString, style: .cancel))
+        alertController.addAction(UIAlertAction(title: .OKString, style: .default) { _ in
+            self.completionHandler(input.text)
+         })
+        alertController.addAction(UIAlertAction(title: .CancelString, style: .cancel) { _ in
+            self.completionHandler(nil)
+         })
         alertController.alertInfo = self
         return alertController
     }

--- a/Client/Frontend/Browser/BrowserPrompts.swift
+++ b/Client/Frontend/Browser/BrowserPrompts.swift
@@ -64,7 +64,7 @@ struct ConfirmPanelAlert: JSAlertInfo {
             self.completionHandler(true)
         })
         alertController.addAction(UIAlertAction(title: .CancelString, style: .cancel) { _ in
-            completionHandler(false)
+            self.completionHandler(false)
         })
         alertController.alertInfo = self
         return alertController

--- a/Client/Frontend/Browser/BrowserPrompts.swift
+++ b/Client/Frontend/Browser/BrowserPrompts.swift
@@ -55,12 +55,17 @@ struct MessageAlert: JSAlertInfo {
 struct ConfirmPanelAlert: JSAlertInfo {
     let message: String
     let frame: WKFrameInfo
+    let completionHandler: (Bool) -> Void
 
     func alertController() -> JSPromptAlertController {
         // Show JavaScript confirm dialogs.
         let alertController = JSPromptAlertController(title: titleForJavaScriptPanelInitiatedByFrame(frame), message: message, preferredStyle: .alert)
-        alertController.addAction(UIAlertAction(title: .OKString, style: .default))
-        alertController.addAction(UIAlertAction(title: .CancelString, style: .cancel))
+        alertController.addAction(UIAlertAction(title: .OKString, style: .default) { _ in
+           self.completionHandler(true)
+        })
+        alertController.addAction(UIAlertAction(title: .CancelString, style: .cancel) { _ in
+            completionHandler(false)
+        })
         alertController.alertInfo = self
         return alertController
     }

--- a/Client/Frontend/Browser/BrowserPrompts.swift
+++ b/Client/Frontend/Browser/BrowserPrompts.swift
@@ -61,7 +61,7 @@ struct ConfirmPanelAlert: JSAlertInfo {
         // Show JavaScript confirm dialogs.
         let alertController = JSPromptAlertController(title: titleForJavaScriptPanelInitiatedByFrame(frame), message: message, preferredStyle: .alert)
         alertController.addAction(UIAlertAction(title: .OKString, style: .default) { _ in
-           self.completionHandler(true)
+            self.completionHandler(true)
         })
         alertController.addAction(UIAlertAction(title: .CancelString, style: .cancel) { _ in
             completionHandler(false)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -64,14 +64,14 @@ extension BrowserViewController: WKUIDelegate {
         initiatedByFrame frame: WKFrameInfo,
         completionHandler: @escaping (Bool) -> Void
     ) {
-        let confirmAlert = ConfirmPanelAlert(message: message, frame: frame)
+        let confirmAlert = ConfirmPanelAlert(message: message,
+                                             frame: frame) { confirm in
+            completionHandler(confirm)
+        }
         if shouldDisplayJSAlertForWebView(webView) {
-            present(confirmAlert.alertController(), animated: true) {
-                completionHandler(true)
-            }
+            present(confirmAlert.alertController(), animated: true)
         } else if let promptingTab = tabManager[webView] {
             promptingTab.queueJavascriptAlertPrompt(confirmAlert)
-            completionHandler(false)
         }
     }
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -84,14 +84,13 @@ extension BrowserViewController: WKUIDelegate {
     ) {
         let textInputAlert = TextInputAlert(message: prompt,
                                             frame: frame,
-                                            defaultText: defaultText)
+                                            defaultText: defaultText) { confirm in
+            completionHandler(confirm)
+        }
         if shouldDisplayJSAlertForWebView(webView) {
-            present(textInputAlert.alertController(), animated: true) {
-                completionHandler(defaultText)
-            }
+            present(textInputAlert.alertController(), animated: true)
         } else if let promptingTab = tabManager[webView] {
             promptingTab.queueJavascriptAlertPrompt(textInputAlert)
-            completionHandler(nil)
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6678)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14909)

## :bulb: Description
Fix callback handling for input and confirm alert making sure callback is called only once to avoid webview crash

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

