### PR TITLE
Bugfix FXIOS-6908 [v116] Make sure autocomplete has text before setting it

### DIFF
--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -361,12 +361,16 @@ extension AutocompleteTextField: MenuHelperInterface {
 extension AutocompleteTextField: ThemeApplicable, PrivateModeUI {
     func applyUIMode(isPrivate: Bool, theme: Theme) {
         isPrivateMode = isPrivate
-        let autocompleteText = NSMutableAttributedString(string: self.autocompleteTextLabel?.attributedText?.string ?? "")
-        let color = isPrivateMode ? theme.colors.layerAccentPrivateNonOpaque : theme.colors.layerAccentNonOpaque
-        autocompleteText.addAttribute(NSAttributedString.Key.backgroundColor,
-                                      value: color,
-                                      range: NSRange(location: 0, length: autocompleteText.length))
-        self.autocompleteTextLabel?.attributedText = autocompleteText
+
+        if autocompleteTextLabel?.attributedText != nil {
+            let autocompleteText = NSMutableAttributedString(string: self.autocompleteTextLabel?.attributedText?.string ?? "")
+            let color = isPrivateMode ? theme.colors.layerAccentPrivateNonOpaque : theme.colors.layerAccentNonOpaque
+            autocompleteText.addAttribute(NSAttributedString.Key.backgroundColor,
+                                          value: color,
+                                          range: NSRange(location: 0, length: autocompleteText.length))
+            self.autocompleteTextLabel?.attributedText = autocompleteText
+        }
+
         applyTheme(theme: theme)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6908)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15373)

## :bulb: Description
Make sure autocomplete has text before setting it, the theory is that this could cause the `autocompleteTextLabel` to be kept in memory and not removed from the view in some occasions. Could not reproduce the issue, so this is the best contender we have so far.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

