### PR TITLE
Remove FXIOS-6731 [v117] Jump back in sync tab feature flag

### DIFF
--- a/.experimenter.yaml
+++ b/.experimenter.yaml
@@ -46,7 +46,7 @@ fakespot-feature:
   variables:
     config:
       type: json
-      description: "A List of products configurations\n"
+      description: "A Map of website configurations\n"
     status:
       type: boolean
       description: "Whether the Fakespot feature is enabled or disabled\n"

--- a/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -21,7 +21,6 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case historyGroups
     case inactiveTabs
     case jumpBackIn
-    case jumpBackInSyncedTab
     case libraryCoordinatorRefactor
     case notificationSettings
     case onboardingUpgrade
@@ -100,7 +99,6 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .creditCardAutofillStatus,
                 .etpCoordinatorRefactor,
                 .fakespotFeature,
-                .jumpBackInSyncedTab,
                 .libraryCoordinatorRefactor,
                 .notificationSettings,
                 .onboardingUpgrade,

--- a/Client/Frontend/Home/JumpBackIn/Data/JumpBackInDataAdaptor.swift
+++ b/Client/Frontend/Home/JumpBackIn/Data/JumpBackInDataAdaptor.swift
@@ -69,7 +69,7 @@ actor JumpBackInDataAdaptorImplementation: JumpBackInDataAdaptor, FeatureFlaggab
     // MARK: Public interface
 
     func hasSyncedTabFeatureEnabled() -> Bool {
-        return featureFlags.isFeatureEnabled(.jumpBackInSyncedTab, checking: .buildOnly) && hasSyncAccount ?? false
+        return hasSyncAccount ?? false
     }
 
     func getRecentTabData() -> [Tab] {
@@ -149,10 +149,6 @@ actor JumpBackInDataAdaptorImplementation: JumpBackInDataAdaptor, FeatureFlaggab
     // MARK: Synced tab data
 
     private func getHasSyncAccount() async -> Bool {
-        guard featureFlags.isFeatureEnabled(.jumpBackInSyncedTab, checking: .buildOnly) else {
-            return false
-        }
-
         return await withCheckedContinuation { continuation in
             profile.hasSyncAccount { hasSync in
                 continuation.resume(returning: hasSync)

--- a/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -46,9 +46,6 @@ final class NimbusFeatureFlagLayer {
         case .fakespotFeature:
             return checkFakespotFeature(from: nimbus)
 
-        case .jumpBackInSyncedTab:
-            return checkNimbusForJumpBackInSyncedTabFeature(using: nimbus)
-
         case .inactiveTabs:
             return checkTabTrayFeature(for: featureID, from: nimbus)
 
@@ -157,10 +154,6 @@ final class NimbusFeatureFlagLayer {
         guard let status = config.sectionsEnabled[nimbusID] else { return false }
 
         return status
-    }
-
-    private func checkNimbusForJumpBackInSyncedTabFeature(using nimbus: FxNimbus) -> Bool {
-        return nimbus.features.homescreenFeature.value().jumpBackInSyncedTab
     }
 
     private func checkNimbusForContextualHintsFeature(

--- a/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
@@ -138,7 +138,6 @@ class JumpBackInViewModelTests: XCTestCase {
 
     func testMaxJumpBackInItemsToDisplay_compactSyncedTab() async {
         let subject = createSubject()
-        subject.featureFlags.set(feature: .jumpBackInSyncedTab, to: true)
         await adaptor.setSyncedTab(syncedTab: JumpBackInSyncedTab(client: remoteClient, tab: remoteTab))
 
         // iPhone layout portrait
@@ -157,7 +156,6 @@ class JumpBackInViewModelTests: XCTestCase {
 
     func testMaxJumpBackInItemsToDisplay_compactJumpBackInAndSyncedTab() async {
         let subject = createSubject()
-        subject.featureFlags.set(feature: .jumpBackInSyncedTab, to: true)
         await adaptor.setSyncedTab(syncedTab: JumpBackInSyncedTab(client: remoteClient, tab: remoteTab))
         let tab1 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
         await adaptor.setRecentTabs(recentTabs: [tab1])

--- a/nimbus-features/homescreenFeature.yaml
+++ b/nimbus-features/homescreenFeature.yaml
@@ -31,12 +31,6 @@ features:
           stories appear on the homepage.
         type: Boolean
         default: false
-      jump-back-in-synced-tab:
-        description: >
-          This property defines whether the synced tab card
-          appears on the homepage in the jump back in section.
-        type: Boolean
-        default: true
     defaults:
       - channel: developer
         value: {
@@ -51,8 +45,7 @@ features:
             "status": true,
             "max-number-of-tiles": 2
           },
-          "pocket-sponsored-stories": true,
-          "jump-back-in-synced-tab": true
+          "pocket-sponsored-stories": true
         }
       - channel: beta
         value: {
@@ -67,8 +60,7 @@ features:
             "status": true,
             "max-number-of-tiles": 1
           },
-          "pocket-sponsored-stories": false,
-          "jump-back-in-synced-tab": true
+          "pocket-sponsored-stories": false
         }
 
 objects:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6731)

## :bulb: Description
Remove jump back in sync tab feature flag, so the jump back in sync tab will appear for all users with a sync account by default, and is not experimentable anymore.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

