### PR TITLE
Add MTE-1304 [v117] Add iPhone8 iOS 16.5 to the robo tests

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1422,6 +1422,7 @@ workflows:
                 --type robo \
                 --app "$BITRISE_IPA_PATH" \
                 --device=model=iphone13pro,version=15.7 \
+                --device=model=iphone8,version=16.5 \
                 --results-bucket=firefox_ios_test_artifacts \
                 --no-record-video \
                 --client-details=matrixLabel="Bitrise" \


### PR DESCRIPTION
We have the robo tests running on an older OS version: 15.7, it should be good to have these tests running also in the latest version available, in this case 16.5.
