### PR TITLE
Bugfix FXIOS-7038 [v116] CreditCardBottomSheetViewController is having the wrong size in multitasking

### DIFF
--- a/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
@@ -132,7 +132,7 @@ class CreditCardBottomSheetViewController: UIViewController, UITableViewDelegate
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        updateHeightConstraints()
+        updateConstraints()
     }
 
     deinit {
@@ -186,17 +186,20 @@ class CreditCardBottomSheetViewController: UIViewController, UITableViewDelegate
         ])
     }
 
-    func updateHeightConstraints() {
+    func updateConstraints() {
         let buttonsHeight = buttonsContainerStackView.frame.height
         let estimatedContentHeight = cardTableView.contentSize.height + buttonsHeight + UX.bottomSpacing
         let aspectRatio = estimatedContentHeight / contentView.bounds.size.height
         contentViewHeightConstraint.constant = contentViewHeightConstraint.constant * aspectRatio
+
+        let contentViewWidth = UX.contentViewWidth > view.frame.size.width ? view.frame.size.width - UX.containerPadding : UX.contentViewWidth
+        contentWidthConstraint.constant = contentViewWidth
     }
 
     // MARK: View Transitions
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        updateHeightConstraints()
+        updateConstraints()
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7038)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15649)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

