### PR TITLE
Add MTE-1060 [v117] Add History Performance Tests

### DIFF
--- a/test-fixtures/generate-test-db.py
+++ b/test-fixtures/generate-test-db.py
@@ -161,7 +161,9 @@ def create_and_clean_database(db_new_name, db_path):
 
     # Create the full path for the new database
     db_new_path = os.path.join(script_dir, db_new_name)
-
+    print("db_new_name: ", db_new_name)
+    print("db_path: ", db_path)
+    print("db_new_path: ", db_new_path)
     try:
         # Copy the database file
         shutil.copyfile(db_path, db_new_path)
@@ -221,6 +223,9 @@ def read_websites_and_insert_records(db_connection, db_cursor, history_count, bo
                 guid = generate_guid()
                 url = f"https://{row[1]}"
                 title = row[1]
+
+                if history_count == 0 and bookmark_count == 0:
+                    break
 
                 # a record must first be created in moz_places as a parent key before either history or bookmarks
                 insert_into_moz_places(db_cursor, url, title, age_option, guid)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15662)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/MTE-1060)

## :bulb: Description
We need a helper to create and seed test data for our test automation to use during test execution. This will allow us to start data-driving our tests that use any places.db and prepare us for more dynamic test case creation/execution for future tests.

`generate_test_db.py` script has been extended to take arguments for use with test automation while still allowing for ad hoc use without arguments should anyone need to create a stand-in db for local testing.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

