### PR TITLE
Bugfix FXIOS-7034 [v117] Fix clearables not saved when clicking the toggles

### DIFF
--- a/Client/Application/AccessibilityIdentifiers.swift
+++ b/Client/Application/AccessibilityIdentifiers.swift
@@ -241,6 +241,8 @@ public struct AccessibilityIdentifiers {
 
         struct ClearData {
             static let title = "ClearPrivateData"
+            static let websiteDataSection = "WebsiteData"
+            static let clearPrivateDataSection = "ClearPrivateData"
         }
 
         struct Notifications {

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -450,9 +450,7 @@ class BrowserCoordinator: BaseCoordinator,
             completion(viewController)
 
         case .clearPrivateData:
-            let viewController = ClearPrivateDataTableViewController()
-            viewController.profile = profile
-            viewController.tabManager = tabManager
+            let viewController = ClearPrivateDataTableViewController(profile: profile, tabManager: tabManager)
             completion(viewController)
 
         case .fxa:

--- a/Client/Coordinators/SettingsCoordinator.swift
+++ b/Client/Coordinators/SettingsCoordinator.swift
@@ -85,9 +85,7 @@ class SettingsCoordinator: BaseCoordinator,
             return viewController
 
         case .clearPrivateData:
-            let viewController = ClearPrivateDataTableViewController()
-            viewController.profile = profile
-            viewController.tabManager = tabManager
+            let viewController = ClearPrivateDataTableViewController(profile: profile, tabManager: tabManager)
             return viewController
 
         case .fxa:
@@ -188,9 +186,7 @@ class SettingsCoordinator: BaseCoordinator,
     }
 
     func pressedClearPrivateData() {
-        let viewController = ClearPrivateDataTableViewController()
-        viewController.profile = profile
-        viewController.tabManager = tabManager
+        let viewController = ClearPrivateDataTableViewController(profile: profile, tabManager: tabManager)
         router.push(viewController)
     }
 

--- a/Client/Extensions/UIAlertController+Extension.swift
+++ b/Client/Extensions/UIAlertController+Extension.swift
@@ -88,30 +88,6 @@ extension UIAlertController {
         return alert
     }
 
-    class func clearPrivateDataAlert(okayCallback: @escaping (UIAlertAction) -> Void) -> UIAlertController {
-        let alert = UIAlertController(
-            title: "",
-            message: .ClearPrivateDataAlertMessage,
-            preferredStyle: .alert
-        )
-
-        let noOption = UIAlertAction(
-            title: .ClearPrivateDataAlertCancel,
-            style: .cancel,
-            handler: nil
-        )
-
-        let okayOption = UIAlertAction(
-            title: .ClearPrivateDataAlertOk,
-            style: .destructive,
-            handler: okayCallback
-        )
-
-        alert.addAction(okayOption)
-        alert.addAction(noOption)
-        return alert
-    }
-
     class func clearSelectedWebsiteDataAlert(okayCallback: @escaping (UIAlertAction) -> Void) -> UIAlertController {
         let alert = UIAlertController(
             title: "",
@@ -151,38 +127,6 @@ extension UIAlertController {
 
         let okayOption = UIAlertAction(
             title: .ClearWebsiteDataAlertOk,
-            style: .destructive,
-            handler: okayCallback
-        )
-
-        alert.addAction(okayOption)
-        alert.addAction(noOption)
-        return alert
-    }
-
-    /**
-     Builds the Alert view that asks if the users wants to also delete history stored on their other devices.
-
-     - parameter okayCallback: Okay option handler.
-
-     - returns: UIAlertController for asking the user to restore tabs after a crash
-     */
-
-    class func clearSyncedHistoryAlert(okayCallback: @escaping (UIAlertAction) -> Void) -> UIAlertController {
-        let alert = UIAlertController(
-            title: "",
-            message: .ClearSyncedHistoryAlertMessage,
-            preferredStyle: .alert
-        )
-
-        let noOption = UIAlertAction(
-            title: .ClearSyncedHistoryAlertCancel,
-            style: .cancel,
-            handler: nil
-        )
-
-        let okayOption = UIAlertAction(
-            title: .ClearSyncedHistoryAlertOk,
             style: .destructive,
             handler: okayCallback
         )

--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -6,28 +6,25 @@ import UIKit
 import Shared
 import Common
 
-private let SectionArrow = 0
-private let SectionToggles = 1
-private let SectionButton = 2
-private let NumberOfSections = 3
-private let TogglesPrefKey = "clearprivatedata.toggles"
-
-private let HistoryClearableIndex = 0
-
 class ClearPrivateDataTableViewController: ThemedTableViewController {
-    fileprivate var clearButton: UITableViewCell?
+    private var clearButton: UITableViewCell?
 
-    var profile: Profile!
-    var tabManager: TabManager!
-    private let logger: Logger
+    private let sectionArrow = 0
+    private let sectionToggles = 1
+    private let sectionButton = 2
+    private let numberOfSections = 3
+    private let historyClearableIndex = 0
 
-    fileprivate typealias DefaultCheckedState = Bool
+    private enum Keys: String {
+        case keyTogglesPref = "clearprivatedata.toggles"
+    }
 
-    // TODO: The next person to add a new clearable in the UI here needs to
-    // refactor how we store the saved values. We currently save an array of
-    // `Bool`s which is highly insufficient.
-    // Bug 1445687 -- https://bugzilla.mozilla.org/show_bug.cgi?id=1445687
-    fileprivate lazy var clearables: [(clearable: Clearable, checked: DefaultCheckedState)] = {
+    private var profile: Profile
+    private var tabManager: TabManager
+
+    private typealias DefaultCheckedState = Bool
+
+    private lazy var clearables: [(clearable: Clearable, checked: DefaultCheckedState)] = {
         var items: [(clearable: Clearable, checked: DefaultCheckedState)] = [
             (HistoryClearable(profile: profile, tabManager: tabManager), true),
             (CacheClearable(), true),
@@ -45,24 +42,27 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
         return items
     }()
 
-    fileprivate lazy var toggles: [Bool] = {
+    private lazy var toggles: [Bool] = {
         // If the number of saved toggles doesn't match the number of clearables, just reset
         // and return the default values for the clearables.
-        if let savedToggles = self.profile.prefs.arrayForKey(TogglesPrefKey) as? [Bool], savedToggles.count == self.clearables.count {
+        if let savedToggles = self.profile.prefs.arrayForKey(Keys.keyTogglesPref.rawValue) as? [Bool],
+            savedToggles.count == self.clearables.count {
             return savedToggles
         }
 
         return self.clearables.map { $0.checked }
     }()
 
-    fileprivate var clearButtonEnabled = true {
+    private var clearButtonEnabled = true {
         didSet {
             clearButton?.textLabel?.textColor = clearButtonEnabled ? themeManager.currentTheme.colors.textWarning : themeManager.currentTheme.colors.textDisabled
         }
     }
 
-    init(logger: Logger = DefaultLogger.shared) {
-        self.logger = logger
+    init(profile: Profile,
+         tabManager: TabManager) {
+        self.profile = profile
+        self.tabManager = tabManager
 
         super.init()
     }
@@ -89,12 +89,12 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
         let cell = dequeueCellFor(indexPath: indexPath)
         cell.applyTheme(theme: themeManager.currentTheme)
 
-        if indexPath.section == SectionArrow {
+        if indexPath.section == sectionArrow {
             cell.accessoryType = .disclosureIndicator
             cell.textLabel?.text = .SettingsWebsiteDataTitle
-            cell.accessibilityIdentifier = "WebsiteData"
+            cell.accessibilityIdentifier = AccessibilityIdentifiers.Settings.ClearData.websiteDataSection
             clearButton = cell
-        } else if indexPath.section == SectionToggles {
+        } else if indexPath.section == sectionToggles {
             cell.textLabel?.text = clearables[indexPath.item].clearable.label
             cell.textLabel?.numberOfLines = 0
             let control = UISwitch()
@@ -105,14 +105,11 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
             cell.selectionStyle = .none
             control.tag = indexPath.item
         } else {
-            assert(indexPath.section == SectionButton)
-            logger.log("We had to fallback to this setup!", level: .warning, category: .unlabeled)
-
             cell.textLabel?.text = .SettingsClearPrivateDataClearButton
             cell.textLabel?.textAlignment = .center
             cell.textLabel?.textColor = themeManager.currentTheme.colors.textWarning
             cell.accessibilityTraits = UIAccessibilityTraits.button
-            cell.accessibilityIdentifier = "ClearPrivateData"
+            cell.accessibilityIdentifier = AccessibilityIdentifiers.Settings.ClearData.clearPrivateDataSection
             clearButton = cell
         }
 
@@ -120,83 +117,69 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
     }
 
     override func numberOfSections(in tableView: UITableView) -> Int {
-        return NumberOfSections
+        return numberOfSections
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        if section == SectionArrow {
+        if section == sectionArrow {
             return 1
-        } else if section == SectionToggles {
+        } else if section == sectionToggles {
             return clearables.count
-        }
-
-        assert(section == SectionButton)
-        if section != SectionButton {
-            logger.log("We've hit a case where the section isn't supported.",
-                       level: .warning,
-                       category: .unlabeled)
         }
 
         return 1
     }
 
     override func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
-        if indexPath.section == SectionButton {
+        if indexPath.section == sectionButton {
             // Highlight the button only if it's enabled.
             return clearButtonEnabled
-        }
-        if indexPath.section == SectionArrow {
+        } else if indexPath.section == sectionArrow {
             return true
         }
         return false
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        if indexPath.section == SectionArrow {
+        if indexPath.section == sectionArrow {
             let view = WebsiteDataManagementViewController()
             navigationController?.pushViewController(view, animated: true)
-        } else if indexPath.section == SectionButton {
-            // We have been asked to clear history and we have an account.
-            // (Whether or not it's in a good state is irrelevant.)
-            func clearPrivateData(_ action: UIAlertAction) {
-                let toggles = self.toggles
-                self.clearables
-                    .enumerated()
-                    .compactMap { (i, pair) in
-                        guard toggles[i] else { return nil }
-                        return pair.clearable.clear()
-                    }
-                    .allSucceed()
-                    .uponQueue(.main) { result in
-                        guard result.isSuccess else {
-                            DefaultLogger.shared.log("Private data was not cleared.", level: .debug, category: .storage)
-                            return
-                        }
-
-                        self.profile.prefs.setObject(self.toggles, forKey: TogglesPrefKey)
-
-                        // Disable the Clear Private Data button after it's clicked.
-                        self.clearButtonEnabled = false
-                        self.tableView.deselectRow(at: indexPath, animated: true)
-                }
-            }
-
+        } else if indexPath.section == sectionButton {
             let alert: UIAlertController
-            if self.toggles[HistoryClearableIndex] && profile.hasAccount() {
-                alert = UIAlertController.clearSyncedHistoryAlert(okayCallback: clearPrivateData)
+            if self.toggles[historyClearableIndex] && profile.hasAccount() {
+                alert = clearSyncedHistoryAlert(okayCallback: clearPrivateData)
             } else {
-                alert = UIAlertController.clearPrivateDataAlert(okayCallback: clearPrivateData)
+                alert = clearPrivateDataAlert(okayCallback: clearPrivateData)
             }
-            self.present(alert, animated: true, completion: nil)
+            present(alert, animated: true, completion: nil)
         }
         tableView.deselectRow(at: indexPath, animated: false)
     }
 
+    private func clearPrivateData(_ action: UIAlertAction) {
+        let toggles = self.toggles
+        self.clearables
+            .enumerated()
+            .compactMap { (i, pair) in
+                guard toggles[i] else { return nil }
+                return pair.clearable.clear()
+            }
+            .allSucceed()
+            .uponQueue(.main) { result in
+                self.profile.prefs.setObject(self.toggles, forKey: Keys.keyTogglesPref.rawValue)
+
+                // Disable the Clear Private Data button after it's clicked.
+                self.clearButtonEnabled = false
+            }
+    }
+
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        guard let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: ThemedTableSectionHeaderFooterView.cellIdentifier) as? ThemedTableSectionHeaderFooterView else { return nil }
+        guard let headerView = tableView
+            .dequeueReusableHeaderFooterView(withIdentifier: ThemedTableSectionHeaderFooterView.cellIdentifier) as? ThemedTableSectionHeaderFooterView
+        else { return nil }
 
         var sectionTitle: String?
-        if section == SectionToggles {
+        if section == sectionToggles {
             sectionTitle = .SettingsClearPrivateDataSectionName
         } else {
             sectionTitle = nil
@@ -210,10 +193,60 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
     }
 
     @objc
-    func switchValueChanged(_ toggle: UISwitch) {
+    private func switchValueChanged(_ toggle: UISwitch) {
         toggles[toggle.tag] = toggle.isOn
 
         // Dim the clear button if no clearables are selected.
         clearButtonEnabled = toggles.contains(true)
+
+        profile.prefs.setObject(toggles, forKey: Keys.keyTogglesPref.rawValue)
+    }
+
+    private func clearPrivateDataAlert(okayCallback: @escaping (UIAlertAction) -> Void) -> UIAlertController {
+        let alert = UIAlertController(
+            title: "",
+            message: .ClearPrivateDataAlertMessage,
+            preferredStyle: .alert
+        )
+
+        let noOption = UIAlertAction(
+            title: .ClearPrivateDataAlertCancel,
+            style: .cancel,
+            handler: nil
+        )
+
+        let okayOption = UIAlertAction(
+            title: .ClearPrivateDataAlertOk,
+            style: .destructive,
+            handler: okayCallback
+        )
+
+        alert.addAction(okayOption)
+        alert.addAction(noOption)
+        return alert
+    }
+
+    private func clearSyncedHistoryAlert(okayCallback: @escaping (UIAlertAction) -> Void) -> UIAlertController {
+        let alert = UIAlertController(
+            title: "",
+            message: .ClearSyncedHistoryAlertMessage,
+            preferredStyle: .alert
+        )
+
+        let noOption = UIAlertAction(
+            title: .ClearSyncedHistoryAlertCancel,
+            style: .cancel,
+            handler: nil
+        )
+
+        let okayOption = UIAlertAction(
+            title: .ClearSyncedHistoryAlertOk,
+            style: .destructive,
+            handler: okayCallback
+        )
+
+        alert.addAction(okayOption)
+        alert.addAction(noOption)
+        return alert
     }
 }

--- a/Client/Frontend/Settings/Main/Privacy/ClearPrivateDataSetting.swift
+++ b/Client/Frontend/Settings/Main/Privacy/ClearPrivateDataSetting.swift
@@ -32,9 +32,7 @@ class ClearPrivateDataSetting: Setting {
             return
         }
 
-        let viewController = ClearPrivateDataTableViewController()
-        viewController.profile = profile
-        viewController.tabManager = tabManager
+        let viewController = ClearPrivateDataTableViewController(profile: profile, tabManager: tabManager)
         navigationController?.pushViewController(viewController, animated: true)
     }
 }

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -4008,7 +4008,6 @@ extension String {
         tableName: nil,
         value: "This action will clear the selected items. It cannot be undone.",
         comment: "Description of the confirmation dialog shown when a user tries to clear some of their private data.")
-    // TODO: these look like the same as in ClearPrivateDataAlert, I think we can remove them
     public static let ClearWebsiteDataAlertCancel = MZLocalizedString(
         key: "Cancel",
         tableName: "ClearPrivateDataConfirm",
@@ -4028,7 +4027,6 @@ extension String {
         tableName: "ClearHistoryConfirm",
         value: nil,
         comment: "Description of the confirmation dialog shown when a user tries to clear history that's synced to another device.")
-    // TODO: these look like the same as in ClearPrivateDataAlert, I think we can remove them
     public static let ClearSyncedHistoryAlertCancel = MZLocalizedString(
         key: "Cancel",
         tableName: "ClearHistoryConfirm",

--- a/Tests/XCUITests/FxScreenGraph.swift
+++ b/Tests/XCUITests/FxScreenGraph.swift
@@ -726,7 +726,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     }
 
     map.addScreenState(ClearPrivateDataSettings) { screenState in
-        screenState.tap(app.cells["WebsiteData"], to: WebsiteDataSettings)
+        screenState.tap(app.cells[AccessibilityIdentifiers.Settings.ClearData.websiteDataSection], to: WebsiteDataSettings)
         screenState.gesture(forAction: Action.AcceptClearPrivateData) { userState in
             app.tables.cells["ClearPrivateData"].tap()
             app.alerts.buttons["OK"].tap()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7034)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15645)

## :bulb: Description
- Fix clearables not saved when clicking the toggles
- Cleaned up the class a bit, removed some logs since they were logging some cases that happens when it's normal (or guarding for success when we still want to save and react even with failure of the clearables).
- Adding accessibility identifiers for some of the cases we have here + adjusting the UI test for it
- Removed the `UIAlertController` from the extension, since those `class func` were literally used for this one case only, so doesn't make sense to be in an extension.
- Removed some TODOs which we either won't do or don't care doing them. 

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

