### PR TITLE
Bugfix FXIOS-6785 [v116] Status bar overlay adjustments

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -458,6 +458,7 @@ class BrowserViewController: UIViewController,
         overKeyboardContainer.applyTheme(theme: theme)
         bottomContainer.applyTheme(theme: theme)
         bottomContentStackView.applyTheme(theme: theme)
+        statusBarOverlay.hasTopTabs = shouldShowTopTabsForTraitCollection(traitCollection)
         statusBarOverlay.applyTheme(theme: theme)
 
         // Credit card initial setup telemetry

--- a/Client/Frontend/Components/StatusBarOverlay.swift
+++ b/Client/Frontend/Components/StatusBarOverlay.swift
@@ -34,7 +34,8 @@ class StatusBarOverlay: UIView,
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupNotifications(forObserver: self,
-                           observing: [.WallpaperDidChange])
+                           observing: [.WallpaperDidChange,
+                                       .SearchBarPositionDidChange])
     }
 
     required init?(coder: NSCoder) {
@@ -46,7 +47,8 @@ class StatusBarOverlay: UIView,
     }
 
     func resetState() {
-        scrollOffset = WallpaperManager().currentWallpaper.type == .defaultWallpaper ? 1 : 0
+        let needsOpaque = WallpaperManager().currentWallpaper.type == .defaultWallpaper || !isBottomSearchBar
+        scrollOffset = needsOpaque ? 1 : 0
         backgroundColor = savedBackgroundColor?.withAlphaComponent(scrollOffset)
     }
 
@@ -92,7 +94,7 @@ class StatusBarOverlay: UIView,
 
     func handleNotifications(_ notification: Notification) {
         switch notification.name {
-        case .WallpaperDidChange:
+        case .WallpaperDidChange, .SearchBarPositionDidChange:
             ensureMainThread {
                 self.resetState()
             }

--- a/Client/Frontend/Components/StatusBarOverlay.swift
+++ b/Client/Frontend/Components/StatusBarOverlay.swift
@@ -17,9 +17,11 @@ protocol StatusBarScrollDelegate: AnyObject {
 class StatusBarOverlay: UIView,
                         ThemeApplicable,
                         StatusBarScrollDelegate,
-                        SearchBarLocationProvider {
+                        SearchBarLocationProvider,
+                        Notifiable {
     private var savedBackgroundColor: UIColor?
     var hasTopTabs = false
+    var notificationCenter: NotificationProtocol = NotificationCenter.default
 
     /// Returns a value between 0 and 1 which indicates how far the user has scrolled.
     /// This is used as the alpha of the status bar background.
@@ -27,8 +29,24 @@ class StatusBarOverlay: UIView,
     /// 1 = status bar background is opaque
     private var scrollOffset: CGFloat = 0
 
+    // MARK: Initializer
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupNotifications(forObserver: self,
+                           observing: [.WallpaperDidChange])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        notificationCenter.removeObserver(self)
+    }
+
     func resetState() {
-        scrollOffset = 1
+        scrollOffset = WallpaperManager().currentWallpaper.type == .defaultWallpaper ? 1 : 0
         backgroundColor = savedBackgroundColor?.withAlphaComponent(scrollOffset)
     }
 
@@ -68,5 +86,17 @@ class StatusBarOverlay: UIView,
             offset = 0
         }
         scrollOffset = offset
+    }
+
+    // MARK: Notifiable
+
+    func handleNotifications(_ notification: Notification) {
+        switch notification.name {
+        case .WallpaperDidChange:
+            ensureMainThread {
+                self.resetState()
+            }
+        default: break
+        }
     }
 }

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -220,7 +220,9 @@ class HomepageViewController: UIViewController, FeatureFlaggable, Themeable, Con
         view.addSubview(wallpaperView)
 
         // Constraint so wallpaper appears under the status bar
-        let wallpaperTopConstant: CGFloat = statusBarFrame?.height ?? 0
+        let window = UIApplication.shared.windows.first
+        let wallpaperTopConstant: CGFloat = window?.safeAreaInsets.top ?? statusBarFrame?.height ?? 0
+
         NSLayoutConstraint.activate([
             wallpaperView.topAnchor.constraint(equalTo: view.topAnchor, constant: -wallpaperTopConstant),
             wallpaperView.leadingAnchor.constraint(equalTo: view.leadingAnchor),

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -346,9 +346,12 @@ class HomepageViewController: UIViewController, FeatureFlaggable, Themeable, Con
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        statusBarScrollDelegate?.scrollViewDidScroll(scrollView,
-                                                     statusBarFrame: statusBarFrame,
-                                                     theme: themeManager.currentTheme)
+        // We only handle status bar overlay alpha if there's a wallpaper applied on the homepage
+        if WallpaperManager().currentWallpaper.type != .defaultWallpaper {
+            statusBarScrollDelegate?.scrollViewDidScroll(scrollView,
+                                                         statusBarFrame: statusBarFrame,
+                                                         theme: themeManager.currentTheme)
+        }
     }
 
     private func showSiteWithURLHandler(_ url: URL, isGoogleTopSite: Bool = false) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6785)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15116)

## :bulb: Description
- Only apply alpha scroll if wallpaper is present
- Fix the wallpaper height on iPhone 14 pro, as explained from [here](https://developer.apple.com/forums/thread/715417), [here](https://useyourloaf.com/blog/iphone-14-screen-sizes/) and [here](https://developer.apple.com/forums/thread/715451)
- Make sure that changing the wallpaper or the url bar position from settings resets the status bar overlay state properly

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

