### PR TITLE
Revert FXIOS-7046 [v117] Revert invalid layout change

### DIFF
--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -301,8 +301,8 @@ class HomepageViewController: UIViewController, FeatureFlaggable, Themeable, Con
 
         // Force the entire collection view to re-layout
         viewModel.refreshData(for: traitCollection, size: newSize)
-        collectionView.collectionViewLayout.invalidateLayout()
         collectionView.reloadData()
+        collectionView.collectionViewLayout.invalidateLayout()
 
         // This pushes a reload to the end of the main queue after all the work associated with
         // rotating has been completed. This is important because some of the cells layout are
@@ -760,8 +760,8 @@ extension HomepageViewController: HomepageViewModelDelegate {
             guard let self = self else { return }
 
             self.viewModel.refreshData(for: self.traitCollection, size: self.view.frame.size)
-            self.collectionView.collectionViewLayout.invalidateLayout()
             self.collectionView.reloadData()
+            self.collectionView.collectionViewLayout.invalidateLayout()
             self.logger.log("Amount of sections shown is \(self.viewModel.shownSections.count)",
                             level: .debug,
                             category: .homepage)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7046)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15666)

## :bulb: Description
Revert some of the changes done in https://github.com/mozilla-mobile/firefox-ios/pull/15566, since turns out this doesn't improve homepage performance.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

