### PR TITLE
Bugfix MTE-1278 [v117] Fix testLoginsListFromBrowserTabMenu

### DIFF
--- a/Tests/XCUITests/FxScreenGraph.swift
+++ b/Tests/XCUITests/FxScreenGraph.swift
@@ -561,6 +561,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         screenState.gesture(forAction: Action.ToggleNoImageMode) { userState in
             app.otherElements.tables.cells.switches[AccessibilityIdentifiers.Settings.BlockImages.title].tap()
         }
+        screenState.tap(app.buttons["Done"], to: HomePanelsScreen)
 
         screenState.backAction = navigationControllerBackAction
     }
@@ -945,6 +946,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
     map.addScreenState(LoginsSettings) { screenState in
         screenState.backAction = navigationControllerBackAction
+        screenState.tap(app.buttons["Settings"], to: SettingsScreen)
     }
 
     map.addScreenState(BrowserTabMenu) { screenState in

--- a/Tests/XCUITests/SaveLoginsTests.swift
+++ b/Tests/XCUITests/SaveLoginsTests.swift
@@ -59,6 +59,7 @@ class SaveLoginTest: BaseTestCase {
         waitForExistence(app.tables["Login List"])
         XCTAssertTrue(app.searchFields["Filter"].exists)
         XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList)
+        navigator.goto(HomePanelsScreen)
         navigator.performAction(Action.OpenNewTabFromTabTray)
         saveLogin(givenUrl: testLoginPage)
         // Make sure you can access populated Login List from Browser Tab Menu


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1278)

## :bulb: Description
`testLoginsListFromBrowserTabMenu` has been failing since July 11. After I saw this PR (https://github.com/mozilla-mobile/firefox-ios/pull/15551/files) I decided to come up with another solution. We can see if the issue is a legit issue or not.

I have run the changes on the full functional test suite on my computer.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

