### PR TITLE
Bugfix FXIOS-7028 [v117] memory leak in SensitiveViewController

### DIFF
--- a/Client/Frontend/AuthenticationManager/SensitiveViewController.swift
+++ b/Client/Frontend/AuthenticationManager/SensitiveViewController.swift
@@ -7,7 +7,7 @@ import UIKit
 import Shared
 
 class SensitiveViewController: UIViewController {
-    private var blurredOverlay: UIImageView?
+    private var backgroundBlurView: UIVisualEffectView?
     private var isAuthenticated = false
     private var willEnterForegroundNotificationObserver: NSObjectProtocol?
     private var didEnterBackgroundNotificationObserver: NSObjectProtocol?
@@ -54,31 +54,22 @@ class SensitiveViewController: UIViewController {
 
 extension SensitiveViewController {
     private func installBlurredOverlay() {
-        if blurredOverlay == nil {
-            if let snapshot = view.screenshot() {
-                let blurredSnapshot = snapshot.applyBlur(withRadius: 10,
-                                                         blurType: BOXFILTER,
-                                                         tintColor: UIColor(white: 1, alpha: 0.3),
-                                                         saturationDeltaFactor: 1.8,
-                                                         maskImage: nil)
-                let blurredOverlay: UIImageView = .build { $0.image = blurredSnapshot }
-                self.blurredOverlay = blurredOverlay
-                view.addSubview(blurredOverlay)
-
-                NSLayoutConstraint.activate([
-                    blurredOverlay.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-                    blurredOverlay.topAnchor.constraint(equalTo: view.topAnchor),
-                    blurredOverlay.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-                    blurredOverlay.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-                ])
-
-                view.layoutIfNeeded()
-            }
-        }
+        guard backgroundBlurView == nil else { return }
+        let blur = UIBlurEffect(style: .systemMaterialDark)
+        let backgroundBlurView = IntensityVisualEffectView(effect: blur, intensity: 0.2)
+        view.addSubview(backgroundBlurView)
+        backgroundBlurView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            backgroundBlurView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            backgroundBlurView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            backgroundBlurView.topAnchor.constraint(equalTo: view.topAnchor),
+            backgroundBlurView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+        self.backgroundBlurView = backgroundBlurView
     }
 
     private func removedBlurredOverlay() {
-        blurredOverlay?.removeFromSuperview()
-        blurredOverlay = nil
+        backgroundBlurView?.removeFromSuperview()
+        backgroundBlurView = nil
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7028)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15614)

## :bulb: Description
Bugfix memory leak in `SensitiveViewController` due to the apply of blur to background image view. Initially the background blur was applied by setting a blur image on top of a screenshot of the entire view. Now the screenshot of the view is removed and it's only applied a `UIVisualEffectView` as background with a blur effect.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

https://github.com/mozilla-mobile/firefox-ios/assets/43574230/4e544a76-fe0d-4983-8c6a-cc39c573fcbc

https://github.com/mozilla-mobile/firefox-ios/assets/43574230/dd4b72f5-8c00-42bf-a21b-59a514d56451
