### PR TITLE
Refactor FXIOS-6871 [v117] Create Standard Image identifiers

### DIFF
--- a/BrowserKit/Sources/Common/Constants/StandardImageIndentifiers.swift
+++ b/BrowserKit/Sources/Common/Constants/StandardImageIndentifiers.swift
@@ -1,0 +1,54 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// This struct defines all the standard image identifiers of icons and images used in the app.
+/// When adding new identifiers, please respect alphabetical order.
+/// Sing the song if you must.
+public struct StandardImageIdentifiers {
+    public struct Medium {
+        public static let cross = "crossMedium"
+    }
+
+    public struct Large {
+        public static let appendUp = "appendUpLarge"
+        public static let appMenu = "appMenuLarge"
+        public static let avatarCircle = "avatarCircleLarge"
+        public static let back = "backLarge"
+        public static let bookmark = "bookmarkLarge"
+        public static let bookmarkFill = "bookmarkFillLarge"
+        public static let bookmarkSlash = "bookmarkSlashLarge"
+        public static let bookmarkTrayFill = "bookmarkTrayFillLarge"
+        public static let checkmark = "checkmarkLarge"
+        public static let chevronDown = "chevronDownLarge"
+        public static let chevronLeft = "chevronLeftLarge"
+        public static let chevronRight = "chevronRightLarge"
+        public static let chevronUp = "chevronUpLarge"
+        public static let clipboard = "clipboardLarge"
+        public static let creditCard = "creditCardLarge"
+        public static let cross = "crossLarge"
+        public static let delete = "deleteLarge"
+        public static let deviceDesktop = "deviceDesktopLarge"
+        public static let deviceDesktopSend = "deviceDesktopSendLarge"
+        public static let deviceMobile = "deviceMobileLarge"
+        public static let download = "downloadLarge"
+        public static let edit = "editLarge"
+        public static let folder = "folderLarge"
+        public static let forward = "forwardLarge"
+        public static let globe = "globeLarge"
+        public static let helpCircle = "helpCircleLarge"
+        public static let history = "historyLarge"
+        public static let home = "homeLarge"
+        public static let lock = "lockLarge"
+        public static let logoFirefox = "logoFirefoxLarge"
+        public static let lightbulb = "lightbulbLarge"
+        public static let link = "linkLarge"
+        public static let login = "loginLarge"
+        public static let plus = "plusLarge"
+        public static let privateMode = "privateModeLarge"
+        public static let qrCode = "qrCodeLarge"
+        public static let tabTray = "tabTrayLarge"
+    }
+}

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -516,6 +516,7 @@
 		8A04136928258DF600D20B10 /* SponsoredTileTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A04136828258DF600D20B10 /* SponsoredTileTelemetry.swift */; };
 		8A04136B2825ABEA00D20B10 /* SponsoredTileTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A04136A2825ABEA00D20B10 /* SponsoredTileTelemetryTests.swift */; };
 		8A05B0052A69A0C40011B622 /* Common in Frameworks */ = {isa = PBXBuildFile; productRef = 8A05B0042A69A0C40011B622 /* Common */; };
+		8A05B0072A69A25C0011B622 /* Common in Frameworks */ = {isa = PBXBuildFile; productRef = 8A05B0062A69A25C0011B622 /* Common */; };
 		8A0621B829428FBD005D1EFD /* OpenTabNotificationObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0621B729428FBD005D1EFD /* OpenTabNotificationObject.swift */; };
 		8A07910F278F62F2005529CB /* AdjustHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A07910E278F62F2005529CB /* AdjustHelper.swift */; };
 		8A08EC6227EBDCA400E119C7 /* iAd.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E4B334871BBF23F3004E2BFF /* iAd.framework */; };
@@ -6971,6 +6972,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8A05B0072A69A25C0011B622 /* Common in Frameworks */,
 				E6231C071B90A712005ABB0D /* libz.tbd in Frameworks */,
 				433F87D52788F01500693368 /* KIF in Frameworks */,
 				D36998891AD70A0A00650C6C /* IOKit.framework in Frameworks */,
@@ -10908,6 +10910,7 @@
 			name = UITests;
 			packageProductDependencies = (
 				433F87D42788F01500693368 /* KIF */,
+				8A05B0062A69A25C0011B622 /* Common */,
 			);
 			productName = UITests;
 			productReference = D39FA15F1A83E0EC00EE869C /* UITests.xctest */;
@@ -19284,6 +19287,10 @@
 			productName = Glean;
 		};
 		8A05B0042A69A0C40011B622 /* Common */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Common;
+		};
+		8A05B0062A69A25C0011B622 /* Common */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Common;
 		};

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -515,6 +515,7 @@
 		8A03309828C2691800286539 /* LegacyTabFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A03309428C2653600286539 /* LegacyTabFileManager.swift */; };
 		8A04136928258DF600D20B10 /* SponsoredTileTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A04136828258DF600D20B10 /* SponsoredTileTelemetry.swift */; };
 		8A04136B2825ABEA00D20B10 /* SponsoredTileTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A04136A2825ABEA00D20B10 /* SponsoredTileTelemetryTests.swift */; };
+		8A05B0052A69A0C40011B622 /* Common in Frameworks */ = {isa = PBXBuildFile; productRef = 8A05B0042A69A0C40011B622 /* Common */; };
 		8A0621B829428FBD005D1EFD /* OpenTabNotificationObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0621B729428FBD005D1EFD /* OpenTabNotificationObject.swift */; };
 		8A07910F278F62F2005529CB /* AdjustHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A07910E278F62F2005529CB /* AdjustHelper.swift */; };
 		8A08EC6227EBDCA400E119C7 /* iAd.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E4B334871BBF23F3004E2BFF /* iAd.framework */; };
@@ -6930,6 +6931,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				43C6A47F27A0679300C79856 /* MappaMundi in Frameworks */,
+				8A05B0052A69A0C40011B622 /* Common in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -10828,6 +10830,7 @@
 			name = XCUITests;
 			packageProductDependencies = (
 				43C6A47E27A0679300C79856 /* MappaMundi */,
+				8A05B0042A69A0C40011B622 /* Common */,
 			);
 			productName = XCUITests;
 			productReference = 3BFE4B071D342FB800DDF53F /* XCUITests.xctest */;
@@ -19279,6 +19282,10 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 435C85EE2788F4D00072B526 /* XCRemoteSwiftPackageReference "glean-swift" */;
 			productName = Glean;
+		};
+		8A05B0042A69A0C40011B622 /* Common */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Common;
 		};
 		8AF2D0FB2A5F272A00C7DD69 /* ComponentLibrary */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Client/AccessoryViewProvider.swift
+++ b/Client/AccessoryViewProvider.swift
@@ -69,7 +69,7 @@ class AccessoryViewProvider: UIView, Themeable {
     private let trailingFixedSpacer: UIView = .build()
 
     lazy private var cardImageView: UIImageView = .build { imageView in
-        imageView.image = UIImage(named: ImageIdentifiers.Large.creditCard)?.withRenderingMode(.alwaysTemplate)
+        imageView.image = UIImage(named: StandardImageIdentifiers.Large.creditCard)?.withRenderingMode(.alwaysTemplate)
         imageView.contentMode = .scaleAspectFit
         imageView.accessibilityElementsHidden = true
 

--- a/Client/Application/ImageIdentifiers.swift
+++ b/Client/Application/ImageIdentifiers.swift
@@ -4,54 +4,11 @@
 
 import Foundation
 
-/// This struct defines all the image identifiers of icons and images used in the app.
+/// This struct defines all the non-standard image identifiers of icons and images used in the app.
+/// Please see `StandardImageIdentifiers` for th standard ones.
 /// When adding new identifiers, please respect alphabetical order.
 /// Sing the song if you must.
 public struct ImageIdentifiers {
-    public struct Medium {
-        public static let cross = "crossMedium"
-    }
-
-    public struct Large {
-        public static let appendUp = "appendUpLarge"
-        public static let appMenu = "appMenuLarge"
-        public static let avatarCircle = "avatarCircleLarge"
-        public static let back = "backLarge"
-        public static let bookmark = "bookmarkLarge"
-        public static let bookmarkFill = "bookmarkFillLarge"
-        public static let bookmarkSlash = "bookmarkSlashLarge"
-        public static let bookmarkTrayFill = "bookmarkTrayFillLarge"
-        public static let checkmark = "checkmarkLarge"
-        public static let chevronDown = "chevronDownLarge"
-        public static let chevronLeft = "chevronLeftLarge"
-        public static let chevronRight = "chevronRightLarge"
-        public static let chevronUp = "chevronUpLarge"
-        public static let clipboard = "clipboardLarge"
-        public static let creditCard = "creditCardLarge"
-        public static let cross = "crossLarge"
-        public static let delete = "deleteLarge"
-        public static let deviceDesktop = "deviceDesktopLarge"
-        public static let deviceDesktopSend = "deviceDesktopSendLarge"
-        public static let deviceMobile = "deviceMobileLarge"
-        public static let download = "downloadLarge"
-        public static let edit = "editLarge"
-        public static let folder = "folderLarge"
-        public static let forward = "forwardLarge"
-        public static let globe = "globeLarge"
-        public static let helpCircle = "helpCircleLarge"
-        public static let history = "historyLarge"
-        public static let home = "homeLarge"
-        public static let lock = "lockLarge"
-        public static let logoFirefox = "logoFirefoxLarge"
-        public static let lightbulb = "lightbulbLarge"
-        public static let link = "linkLarge"
-        public static let login = "loginLarge"
-        public static let plus = "plusLarge"
-        public static let privateMode = "privateModeLarge"
-        public static let qrCode = "qrCodeLarge"
-        public static let tabTray = "tabTrayLarge"
-    }
-
     public static let addShortcut = "action_pin"
     public static let addToReadingList = "addToReadingList"
     public static let badgeMask = "badge-mask"

--- a/Client/Application/QuickActions.swift
+++ b/Client/Application/QuickActions.swift
@@ -98,7 +98,7 @@ struct QuickActionsImplementation: QuickActions {
                 type: ShortcutType.openLastBookmark.type,
                 localizedTitle: .QuickActionsLastBookmarkTitle,
                 localizedSubtitle: userData[QuickActionInfos.tabTitleKey],
-                icon: UIApplicationShortcutIcon(templateImageName: ImageIdentifiers.Large.bookmarkFill),
+                icon: UIApplicationShortcutIcon(templateImageName: StandardImageIdentifiers.Large.bookmarkFill),
                 userInfo: userData as [String: NSSecureCoding]
             )
 

--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
@@ -104,7 +104,7 @@ struct CreditCardItemRow: View {
     }
 
     func getImage(creditCard: CreditCard) -> Image {
-        let defaultImage = Image(ImageIdentifiers.Large.creditCard)
+        let defaultImage = Image(StandardImageIdentifiers.Large.creditCard)
 
         guard let type = CreditCardType(rawValue: creditCard.ccType.uppercased()),
               let image = type.image else {

--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsEmptyView.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsEmptyView.swift
@@ -31,7 +31,7 @@ struct CreditCardSettingsEmptyView: View {
                         .background(Color.white)
                         .padding(.top, 25)
                         Spacer()
-                        Image(ImageIdentifiers.Large.creditCard)
+                        Image(StandardImageIdentifiers.Large.creditCard)
                             .resizable()
                             .renderingMode(.template)
                             .foregroundColor(imageColor)

--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewController.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewController.swift
@@ -25,7 +25,7 @@ class CreditCardSettingsViewController: SensitiveViewController, Themeable {
     var creditCardTableViewController: CreditCardTableViewController
 
     private lazy var addCreditCardButton: UIBarButtonItem = {
-        return UIBarButtonItem(image: UIImage.templateImageNamed(ImageIdentifiers.Large.plus),
+        return UIBarButtonItem(image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.plus),
                                style: .plain,
                                target: self,
                                action: #selector(addCreditCard))

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+DownloadQueueDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+DownloadQueueDelegate.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
 import Shared
 
@@ -50,7 +51,7 @@ extension BrowserViewController: DownloadQueueDelegate {
 
             if error == nil {
                 let viewModel = ButtonToastViewModel(labelText: download.filename,
-                                                     imageName: ImageIdentifiers.Large.checkmark,
+                                                     imageName: StandardImageIdentifiers.Large.checkmark,
                                                      buttonText: .DownloadsButtonTitle)
                 let downloadCompleteToast = ButtonToast(viewModel: viewModel,
                                                         theme: self.themeManager.currentTheme,

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Shared
 import UIKit
 
@@ -143,13 +144,17 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
     }
 
     func getMoreTabToolbarLongPressActions() -> [PhotonRowActions] {
-        let newTab = SingleActionViewModel(title: .KeyboardShortcuts.NewTab, iconString: ImageIdentifiers.Large.plus, iconType: .Image) { _ in
+        let newTab = SingleActionViewModel(title: .KeyboardShortcuts.NewTab,
+                                           iconString: StandardImageIdentifiers.Large.plus,
+                                           iconType: .Image) { _ in
             let shouldFocusLocationField = self.newTabSettings == .blankPage
             self.overlayManager.openNewTab(url: nil, newTabSettings: self.newTabSettings)
             self.openBlankNewTab(focusLocationField: shouldFocusLocationField, isPrivate: false)
         }.items
 
-        let newPrivateTab = SingleActionViewModel(title: .KeyboardShortcuts.NewPrivateTab, iconString: ImageIdentifiers.Large.plus, iconType: .Image) { _ in
+        let newPrivateTab = SingleActionViewModel(title: .KeyboardShortcuts.NewPrivateTab,
+                                                  iconString: StandardImageIdentifiers.Large.plus,
+                                                  iconType: .Image) { _ in
             let shouldFocusLocationField = self.newTabSettings == .blankPage
             self.overlayManager.openNewTab(url: nil, newTabSettings: self.newTabSettings)
             self.openBlankNewTab(focusLocationField: shouldFocusLocationField, isPrivate: true)
@@ -157,7 +162,7 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
         }.items
 
         let closeTab = SingleActionViewModel(title: .KeyboardShortcuts.CloseCurrentTab,
-                                             iconString: ImageIdentifiers.Large.cross,
+                                             iconString: StandardImageIdentifiers.Large.cross,
                                              iconType: .Image) { _ in
             if let tab = self.tabManager.selectedTab {
                 self.tabManager.removeTab(tab)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -209,7 +209,7 @@ extension BrowserViewController: WKUIDelegate {
                     actions.append(
                         UIAction(
                             title: .ContextMenuOpenInNewTab,
-                            image: UIImage.templateImageNamed(ImageIdentifiers.Large.plus),
+                            image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.plus),
                             identifier: UIAction.Identifier(rawValue: "linkContextMenu.openInNewTab")
                         ) { _ in
                             addTab(url, false)
@@ -219,7 +219,7 @@ extension BrowserViewController: WKUIDelegate {
                 actions.append(
                     UIAction(
                         title: .ContextMenuOpenInNewPrivateTab,
-                        image: UIImage.templateImageNamed(ImageIdentifiers.Large.privateMode),
+                        image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.privateMode),
                         identifier: UIAction.Identifier("linkContextMenu.openInNewPrivateTab")
                     ) { _ in
                         addTab(url, true)
@@ -227,7 +227,7 @@ extension BrowserViewController: WKUIDelegate {
 
                 let addBookmarkAction = UIAction(
                     title: .ContextMenuBookmarkLink,
-                    image: UIImage.templateImageNamed(ImageIdentifiers.Large.bookmark),
+                    image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.bookmark),
                     identifier: UIAction.Identifier("linkContextMenu.bookmarkLink")
                 ) { _ in
                     self.addBookmark(url: url.absoluteString, title: elements.title)
@@ -239,7 +239,7 @@ extension BrowserViewController: WKUIDelegate {
 
                 let removeAction = UIAction(
                     title: .RemoveBookmarkContextMenuTitle,
-                    image: UIImage.templateImageNamed(ImageIdentifiers.Large.cross),
+                    image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross),
                     identifier: UIAction.Identifier("linkContextMenu.removeBookmarkLink")
                 ) { _ in
                     self.removeBookmark(url: url.absoluteString)
@@ -252,7 +252,7 @@ extension BrowserViewController: WKUIDelegate {
                 let isBookmarkedSite = profile.places.isBookmarked(url: url.absoluteString).value.successValue ?? false
                 actions.append(isBookmarkedSite ? removeAction : addBookmarkAction)
 
-                actions.append(UIAction(title: .ContextMenuDownloadLink, image: UIImage.templateImageNamed(ImageIdentifiers.Large.download), identifier: UIAction.Identifier("linkContextMenu.download")) { _ in
+                actions.append(UIAction(title: .ContextMenuDownloadLink, image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.download), identifier: UIAction.Identifier("linkContextMenu.download")) { _ in
                     // This checks if download is a blob, if yes, begin blob download process
                     if !DownloadContentScript.requestBlobDownload(url: url, tab: currentTab) {
                         // if not a blob, set pendingDownloadWebView and load the request in
@@ -266,7 +266,7 @@ extension BrowserViewController: WKUIDelegate {
 
                 actions.append(UIAction(
                     title: .ContextMenuCopyLink,
-                    image: UIImage.templateImageNamed(ImageIdentifiers.Large.link),
+                    image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.link),
                     identifier: UIAction.Identifier("linkContextMenu.copyLink")
                 ) { _ in
                     UIPasteboard.general.url = url

--- a/Client/Frontend/Browser/DownloadToast.swift
+++ b/Client/Frontend/Browser/DownloadToast.swift
@@ -21,7 +21,7 @@ class DownloadToast: Toast {
     }
 
     private var imageView: UIImageView = .build { imageView in
-        imageView.image = UIImage.templateImageNamed(ImageIdentifiers.Large.download)
+        imageView.image = UIImage.templateImageNamed(StandardImageIdentifiers.Large.download)
     }
 
     private var labelStackView: UIStackView = .build { stackView in
@@ -43,7 +43,7 @@ class DownloadToast: Toast {
     }
 
     private lazy var closeButton: UIButton = .build { button in
-        button.setImage(UIImage.templateImageNamed(ImageIdentifiers.Medium.cross), for: [])
+        button.setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Medium.cross), for: [])
         button.addTarget(self, action: #selector(self.buttonPressed), for: .touchUpInside)
     }
 

--- a/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVC.swift
+++ b/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVC.swift
@@ -65,7 +65,7 @@ class EnhancedTrackingProtectionMenuVC: UIViewController, Themeable {
     }
 
     private var favicon: FaviconImageView = .build { favicon in
-        favicon.image = UIImage(named: ImageIdentifiers.Large.globe)?.withRenderingMode(.alwaysTemplate)
+        favicon.image = UIImage(named: StandardImageIdentifiers.Large.globe)?.withRenderingMode(.alwaysTemplate)
     }
 
     private let siteDomainLabel: UILabel = .build { label in
@@ -97,7 +97,7 @@ class EnhancedTrackingProtectionMenuVC: UIViewController, Themeable {
     }
 
     private let connectionDetailArrow: UIImageView = .build { image in
-        image.image = UIImage(imageLiteralResourceName: ImageIdentifiers.Large.chevronLeft).withRenderingMode(.alwaysTemplate).imageFlippedForRightToLeftLayoutDirection()
+        image.image = UIImage(imageLiteralResourceName: StandardImageIdentifiers.Large.chevronLeft).withRenderingMode(.alwaysTemplate).imageFlippedForRightToLeftLayoutDirection()
         image.transform = CGAffineTransform(rotationAngle: .pi)
     }
 
@@ -443,7 +443,7 @@ extension EnhancedTrackingProtectionMenuVC {
         overrideUserInterfaceStyle = theme.type.getInterfaceStyle()
         view.backgroundColor = theme.colors.layer1
         closeButton.backgroundColor = theme.colors.layer2
-        let buttonImage = UIImage(named: ImageIdentifiers.Medium.cross)?
+        let buttonImage = UIImage(named: StandardImageIdentifiers.Medium.cross)?
             .tinted(withColor: theme.colors.iconSecondary)
         closeButton.setImage(buttonImage, for: .normal)
         connectionView.backgroundColor = theme.colors.layer2

--- a/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVM.swift
+++ b/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVM.swift
@@ -53,7 +53,7 @@ class EnhancedTrackingProtectionMenuVM {
     func getConnectionStatusImage(themeType: ThemeType) -> UIImage {
         let insecureImageName = themeType.getThemedImageName(name: ImageIdentifiers.lockBlocked)
         if connectionSecure {
-            return UIImage(imageLiteralResourceName: ImageIdentifiers.Large.lock).withRenderingMode(.alwaysTemplate)
+            return UIImage(imageLiteralResourceName: StandardImageIdentifiers.Large.lock).withRenderingMode(.alwaysTemplate)
         } else {
             return UIImage(imageLiteralResourceName: insecureImageName)
         }

--- a/Client/Frontend/Browser/FindInPageBar.swift
+++ b/Client/Frontend/Browser/FindInPageBar.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import UIKit
 import Shared
 
@@ -87,14 +88,14 @@ class FindInPageBar: UIView {
         matchCountView.accessibilityIdentifier = "FindInPage.matchCount"
         addSubview(matchCountView)
 
-        previousButton.setImage(UIImage(named: ImageIdentifiers.Large.chevronUp), for: .normal)
+        previousButton.setImage(UIImage(named: StandardImageIdentifiers.Large.chevronUp), for: .normal)
         previousButton.setTitleColor(FindInPageUX.ButtonColor, for: .normal)
         previousButton.accessibilityLabel = .FindInPagePreviousAccessibilityLabel
         previousButton.addTarget(self, action: #selector(didFindPrevious), for: .touchUpInside)
         previousButton.accessibilityIdentifier = AccessibilityIdentifiers.FindInPage.findPreviousButton
         addSubview(previousButton)
 
-        nextButton.setImage(UIImage(named: ImageIdentifiers.Large.chevronDown), for: .normal)
+        nextButton.setImage(UIImage(named: StandardImageIdentifiers.Large.chevronDown), for: .normal)
         nextButton.setTitleColor(FindInPageUX.ButtonColor, for: .normal)
         nextButton.accessibilityLabel = .FindInPageNextAccessibilityLabel
         nextButton.addTarget(self, action: #selector(didFindNext), for: .touchUpInside)
@@ -102,7 +103,7 @@ class FindInPageBar: UIView {
         addSubview(nextButton)
 
         let closeButton = UIButton()
-        closeButton.setImage(UIImage(named: ImageIdentifiers.Medium.cross), for: .normal)
+        closeButton.setImage(UIImage(named: StandardImageIdentifiers.Medium.cross), for: .normal)
         closeButton.setTitleColor(FindInPageUX.ButtonColor, for: .normal)
         closeButton.accessibilityLabel = .FindInPageDoneAccessibilityLabel
         closeButton.addTarget(self, action: #selector(didPressClose), for: .touchUpInside)

--- a/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -305,7 +305,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     private func getNewTabAction() -> PhotonRowActions? {
         guard let tab = selectedTab else { return nil }
         return SingleActionViewModel(title: .AppMenu.NewTab,
-                                     iconString: ImageIdentifiers.Large.plus) { _ in
+                                     iconString: StandardImageIdentifiers.Large.plus) { _ in
             let shouldFocusLocationField = NewTabAccessors.getNewTabPage(self.profile.prefs) != .homePage
             self.delegate?.openNewTabFromMenu(focusLocationField: shouldFocusLocationField, isPrivate: tab.isPrivate)
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .createNewTab)
@@ -314,7 +314,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
 
     private func getHistoryLibraryAction() -> PhotonRowActions {
         return SingleActionViewModel(title: .AppMenu.AppMenuHistory,
-                                     iconString: ImageIdentifiers.Large.history) { _ in
+                                     iconString: StandardImageIdentifiers.Large.history) { _ in
             self.delegate?.showLibrary(panel: .history)
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .viewHistoryPanel)
         }.items
@@ -322,7 +322,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
 
     private func getDownloadsLibraryAction() -> PhotonRowActions {
         return SingleActionViewModel(title: .AppMenu.AppMenuDownloads,
-                                     iconString: ImageIdentifiers.Large.download) { _ in
+                                     iconString: StandardImageIdentifiers.Large.download) { _ in
             self.delegate?.showLibrary(panel: .downloads)
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .viewDownloadsPanel)
         }.items
@@ -358,11 +358,11 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
         let siteTypeTelemetryObject: TelemetryWrapper.EventObject
         if defaultUAisDesktop {
             toggleActionTitle = tab.changedUserAgent ? .AppMenu.AppMenuViewDesktopSiteTitleString : .AppMenu.AppMenuViewMobileSiteTitleString
-            toggleActionIcon = tab.changedUserAgent ? ImageIdentifiers.Large.deviceDesktop : ImageIdentifiers.Large.deviceMobile
+            toggleActionIcon = tab.changedUserAgent ? StandardImageIdentifiers.Large.deviceDesktop : StandardImageIdentifiers.Large.deviceMobile
             siteTypeTelemetryObject = .requestDesktopSite
         } else {
             toggleActionTitle = tab.changedUserAgent ? .AppMenu.AppMenuViewMobileSiteTitleString : .AppMenu.AppMenuViewDesktopSiteTitleString
-            toggleActionIcon = tab.changedUserAgent ? ImageIdentifiers.Large.deviceMobile : ImageIdentifiers.Large.deviceDesktop
+            toggleActionIcon = tab.changedUserAgent ? StandardImageIdentifiers.Large.deviceMobile : StandardImageIdentifiers.Large.deviceDesktop
             siteTypeTelemetryObject = .requestMobileSite
         }
 
@@ -378,7 +378,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
 
     private func getCopyAction() -> PhotonRowActions? {
         return SingleActionViewModel(title: .AppMenu.AppMenuCopyLinkTitleString,
-                                     iconString: ImageIdentifiers.Large.link) { _ in
+                                     iconString: StandardImageIdentifiers.Large.link) { _ in
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .copyAddress)
             if let url = self.selectedTab?.canonicalURL?.displayURL {
                 UIPasteboard.general.url = url
@@ -389,7 +389,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
 
     private func getSendToDevice() -> PhotonRowActions {
         return SingleActionViewModel(title: .AppMenu.TouchActions.SendLinkToDeviceTitle,
-                                     iconString: ImageIdentifiers.Large.deviceDesktopSend) { _ in
+                                     iconString: StandardImageIdentifiers.Large.deviceDesktopSend) { _ in
             guard let delegate = self.sendToDeviceDelegate,
                   let selectedTab = self.selectedTab,
                   let url = selectedTab.canonicalURL?.displayURL
@@ -416,7 +416,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
         guard featureFlags.isFeatureEnabled(.reportSiteIssue, checking: .buildOnly) else { return nil }
 
         return SingleActionViewModel(title: .AppMenu.AppMenuReportSiteIssueTitleString,
-                                     iconString: ImageIdentifiers.Large.lightbulb) { _ in
+                                     iconString: StandardImageIdentifiers.Large.lightbulb) { _ in
             guard let tabURL = self.selectedTab?.url?.absoluteString else { return }
             self.delegate?.openURLInNewTab(SupportUtils.URLForReportSiteIssue(tabURL), isPrivate: false)
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .reportSiteIssue)
@@ -425,7 +425,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
 
     private func getHelpAction() -> PhotonRowActions {
         return SingleActionViewModel(title: .AppMenu.Help,
-                                     iconString: ImageIdentifiers.Large.helpCircle) { _ in
+                                     iconString: StandardImageIdentifiers.Large.helpCircle) { _ in
             if let url = URL(string: "https://support.mozilla.org/products/ios") {
                 self.delegate?.openURLInNewTab(url, isPrivate: false)
             }
@@ -435,7 +435,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
 
     private func getCustomizeHomePageAction() -> PhotonRowActions? {
         return SingleActionViewModel(title: .AppMenu.CustomizeHomePage,
-                                     iconString: ImageIdentifiers.Large.edit) { _ in
+                                     iconString: StandardImageIdentifiers.Large.edit) { _ in
             self.delegate?.showCustomizeHomePage()
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .customizeHomePage)
         }.items
@@ -541,7 +541,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
             return userProfile.displayName ?? userProfile.email
         }()
 
-        let iconString = needsReAuth ? ImageIdentifiers.warning : ImageIdentifiers.Large.avatarCircle
+        let iconString = needsReAuth ? ImageIdentifiers.warning : StandardImageIdentifiers.Large.avatarCircle
 
         var iconURL: URL?
         if let str = rustAccount.userProfile?.avatarUrl, let url = URL(string: str) {
@@ -709,7 +709,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     private func getRemoveReadingListAction() -> SingleActionViewModel {
         return SingleActionViewModel(title: .AppMenu.RemoveReadingList,
                                      alternateTitle: .AppMenu.RemoveReadingListAlternateTitle,
-                                     iconString: ImageIdentifiers.Large.delete) { _ in
+                                     iconString: StandardImageIdentifiers.Large.delete) { _ in
             guard let url = self.tabUrl?.displayURL?.absoluteString,
                   let record = self.profile.readingList.getRecordWithURL(url).value.successValue
             else { return }
@@ -741,7 +741,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
 
     private func getBookmarkLibraryAction() -> SingleActionViewModel {
         return SingleActionViewModel(title: .AppMenu.Bookmarks,
-                                     iconString: ImageIdentifiers.Large.bookmarkTrayFill) { _ in
+                                     iconString: StandardImageIdentifiers.Large.bookmarkTrayFill) { _ in
             self.delegate?.showLibrary(panel: .bookmarks)
         }
     }
@@ -753,7 +753,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     private func getAddBookmarkAction() -> SingleActionViewModel {
         return SingleActionViewModel(title: .AppMenu.AddBookmark,
                                      alternateTitle: .AppMenu.AddBookmarkAlternateTitle,
-                                     iconString: ImageIdentifiers.Large.bookmark) { _ in
+                                     iconString: StandardImageIdentifiers.Large.bookmark) { _ in
             guard let tab = self.selectedTab,
                   let url = tab.canonicalURL?.displayURL
             else { return }
@@ -767,7 +767,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     private func getRemoveBookmarkAction() -> SingleActionViewModel {
         return SingleActionViewModel(title: .AppMenu.RemoveBookmark,
                                      alternateTitle: .AppMenu.RemoveBookmarkAlternateTitle,
-                                     iconString: ImageIdentifiers.Large.bookmarkSlash) { _ in
+                                     iconString: StandardImageIdentifiers.Large.bookmarkSlash) { _ in
             guard let url = self.tabUrl?.displayURL else { return }
 
             self.profile.places.deleteBookmarksWithURL(url: url.absoluteString).uponQueue(.main) { result in
@@ -825,7 +825,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
         else { return nil }
 
         return SingleActionViewModel(title: .AppMenu.AppMenuPasswords,
-                                     iconString: ImageIdentifiers.Large.login,
+                                     iconString: StandardImageIdentifiers.Large.login,
                                      iconType: .Image,
                                      iconAlignment: .left) { _ in
             if CoordinatorFlagManager.isSettingsCoordinatorEnabled {

--- a/Client/Frontend/Browser/OpenInHelper/OpenInHelper.swift
+++ b/Client/Frontend/Browser/OpenInHelper/OpenInHelper.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
 import MobileCoreServices
 import WebKit
@@ -125,7 +126,7 @@ class DownloadHelper: NSObject {
         }
 
         let downloadFileItem = SingleActionViewModel(title: .OpenInDownloadHelperAlertDownloadNow,
-                                                     iconString: ImageIdentifiers.Large.download) { _ in
+                                                     iconString: StandardImageIdentifiers.Large.download) { _ in
             okAction(download)
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .downloadNowButton)
         }

--- a/Client/Frontend/Browser/QRCodeViewController.swift
+++ b/Client/Frontend/Browser/QRCodeViewController.swift
@@ -98,7 +98,7 @@ class QRCodeViewController: UIViewController {
 
         // Setup the NavigationItem
         navigationItem.leftBarButtonItem = UIBarButtonItem(
-            image: UIImage(named: ImageIdentifiers.Large.chevronLeft)?.imageFlippedForRightToLeftLayoutDirection(),
+            image: UIImage(named: StandardImageIdentifiers.Large.chevronLeft)?.imageFlippedForRightToLeftLayoutDirection(),
             style: .plain,
             target: self,
             action: #selector(goBack))

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -749,7 +749,7 @@ class SearchViewController: SiteTableViewController,
     }
 
     private var searchAppendImage: UIImage? {
-        var searchAppendImage = UIImage(named: ImageIdentifiers.Large.appendUp)
+        var searchAppendImage = UIImage(named: StandardImageIdentifiers.Large.appendUp)
 
         if viewModel.isBottomSearchBar, let image = searchAppendImage, let cgImage = image.cgImage {
             searchAppendImage = UIImage(

--- a/Client/Frontend/Browser/TabPeekViewController.swift
+++ b/Client/Frontend/Browser/TabPeekViewController.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import UIKit
 import Shared
 import Storage
@@ -78,7 +79,7 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
         if !self.ignoreURL && !urlIsTooLongToSave {
             if !self.isBookmarked && !isHomeTab {
                 actions.append(UIAction(title: .TabPeekAddToBookmarks,
-                                        image: UIImage.templateImageNamed(ImageIdentifiers.Large.bookmark),
+                                        image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.bookmark),
                                         identifier: nil) { [weak self] _ in
                     guard let wself = self, let tab = wself.tab else { return }
                     wself.delegate?.tabPeekDidAddBookmark(tab)
@@ -91,7 +92,7 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
                 })
             }
             actions.append(UIAction(title: .TabPeekCopyUrl,
-                                    image: UIImage.templateImageNamed(ImageIdentifiers.Large.link),
+                                    image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.link),
                                     identifier: nil) { [weak self] _ in
                 guard let wself = self, let url = wself.tab?.canonicalURL else { return }
 
@@ -100,7 +101,7 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
             })
         }
         actions.append(UIAction(title: .TabPeekCloseTab,
-                                image: UIImage.templateImageNamed(ImageIdentifiers.Large.cross),
+                                image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross),
                                 identifier: nil) { [weak self] _ in
             guard let wself = self, let tab = wself.tab else { return }
             wself.delegate?.tabPeekDidCloseTab(tab)

--- a/Client/Frontend/Browser/TabTrayButtonExtensions.swift
+++ b/Client/Frontend/Browser/TabTrayButtonExtensions.swift
@@ -11,7 +11,7 @@ class PrivateModeButton: ToggleButton, PrivateModeUI {
         super.init(frame: frame)
         accessibilityLabel = .TabTrayToggleAccessibilityLabel
         accessibilityHint = .TabTrayToggleAccessibilityHint
-        let maskImage = UIImage(named: ImageIdentifiers.Large.privateMode)?.withRenderingMode(.alwaysTemplate)
+        let maskImage = UIImage(named: StandardImageIdentifiers.Large.privateMode)?.withRenderingMode(.alwaysTemplate)
         setImage(maskImage, for: [])
     }
 

--- a/Client/Frontend/Browser/Tabs/EmptyPrivateTabsView.swift
+++ b/Client/Frontend/Browser/Tabs/EmptyPrivateTabsView.swift
@@ -53,7 +53,7 @@ class EmptyPrivateTabsView: UIView {
     }
 
     private let iconImageView: UIImageView = .build { imageView in
-        imageView.image = UIImage.templateImageNamed(ImageIdentifiers.Large.privateMode)
+        imageView.image = UIImage.templateImageNamed(StandardImageIdentifiers.Large.privateMode)
     }
 
     // MARK: - Inits

--- a/Client/Frontend/Browser/Tabs/InactiveTabs/InactiveTabButton.swift
+++ b/Client/Frontend/Browser/Tabs/InactiveTabs/InactiveTabButton.swift
@@ -99,7 +99,7 @@ class InactiveTabButton: UITableViewCell, ThemeApplicable, ReusableCell {
         roundedButton.setTitleColor(theme.colors.textPrimary, for: .normal)
         roundedButton.backgroundColor = theme.colors.layer3
         roundedButton.tintColor = theme.colors.textPrimary
-        let image = UIImage(named: ImageIdentifiers.Large.delete)?.tinted(withColor: theme.colors.iconPrimary)
+        let image = UIImage(named: StandardImageIdentifiers.Large.delete)?.tinted(withColor: theme.colors.iconPrimary)
         roundedButton.setImage(image, for: .normal)
     }
 }

--- a/Client/Frontend/Browser/Tabs/TabCell.swift
+++ b/Client/Frontend/Browser/Tabs/TabCell.swift
@@ -63,7 +63,7 @@ class TabCell: UICollectionViewCell,
     lazy var favicon: FaviconImageView = .build { _ in }
 
     lazy var closeButton: UIButton = .build { button in
-        button.setImage(UIImage.templateImageNamed(ImageIdentifiers.Large.cross), for: [])
+        button.setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross), for: [])
         button.imageView?.contentMode = .scaleAspectFit
         button.contentMode = .center
         button.imageEdgeInsets = UIEdgeInsets(equalInset: GridTabViewController.UX.closeButtonEdgeInset)
@@ -165,7 +165,7 @@ class TabCell: UICollectionViewCell,
         isAccessibilityElement = true
         accessibilityHint = .TabTraySwipeToCloseAccessibilityHint
 
-        favicon.image = UIImage(named: ImageIdentifiers.Large.globe)
+        favicon.image = UIImage(named: StandardImageIdentifiers.Large.globe)
         if !tab.isFxHomeTab, let tabURL = tab.url?.absoluteString {
             favicon.setFavicon(FaviconImageViewModel(siteURLString: tabURL))
         }
@@ -189,7 +189,7 @@ class TabCell: UICollectionViewCell,
         // Favicon or letter image when home screenshot is present for a regular (non-internal) url
         } else if let url = tab.url, (!url.absoluteString.starts(with: "internal") &&
             tab.hasHomeScreenshot) {
-            smallFaviconView.image = UIImage(named: ImageIdentifiers.Large.globe)
+            smallFaviconView.image = UIImage(named: StandardImageIdentifiers.Large.globe)
             faviconBG.isHidden = false
             screenshotView.image = nil
 

--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -45,28 +45,28 @@ class TabTrayViewController: UIViewController, Themeable {
 
     // Buttons & Menus
     private lazy var deleteButtonIpad: UIBarButtonItem = {
-        return createButtonItem(imageName: ImageIdentifiers.Large.delete,
+        return createButtonItem(imageName: StandardImageIdentifiers.Large.delete,
                                 action: #selector(didTapDeleteTabs(_:)),
                                 a11yId: AccessibilityIdentifiers.TabTray.closeAllTabsButton,
                                 a11yLabel: .AppMenu.Toolbar.TabTrayDeleteMenuButtonAccessibilityLabel)
     }()
 
     private lazy var newTabButtonIpad: UIBarButtonItem = {
-        return createButtonItem(imageName: ImageIdentifiers.Large.plus,
+        return createButtonItem(imageName: StandardImageIdentifiers.Large.plus,
                                 action: #selector(didTapAddTab(_:)),
                                 a11yId: AccessibilityIdentifiers.TabTray.newTabButton,
                                 a11yLabel: .TabTrayAddTabAccessibilityLabel)
     }()
 
     private lazy var deleteButtonIphone: UIBarButtonItem = {
-        return createButtonItem(imageName: ImageIdentifiers.Large.delete,
+        return createButtonItem(imageName: StandardImageIdentifiers.Large.delete,
                                 action: #selector(didTapDeleteTabs(_:)),
                                 a11yId: AccessibilityIdentifiers.TabTray.closeAllTabsButton,
                                 a11yLabel: .AppMenu.Toolbar.TabTrayDeleteMenuButtonAccessibilityLabel)
     }()
 
     private lazy var newTabButtonIphone: UIBarButtonItem = {
-        return createButtonItem(imageName: ImageIdentifiers.Large.plus,
+        return createButtonItem(imageName: StandardImageIdentifiers.Large.plus,
                                 action: #selector(didTapAddTab(_:)),
                                 a11yId: AccessibilityIdentifiers.TabTray.newTabButton,
                                 a11yLabel: .TabTrayAddTabAccessibilityLabel)

--- a/Client/Frontend/Browser/Tabs/TabTrayViewModel.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewModel.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Shared
 import Storage
 
@@ -38,7 +39,7 @@ class TabTrayViewModel {
             case .tabs:
                 return UIImage(named: ImageIdentifiers.navTabCounter)
             case .privateTabs:
-                return UIImage(named: ImageIdentifiers.Large.privateMode)
+                return UIImage(named: StandardImageIdentifiers.Large.privateMode)
             case .syncedTabs:
                 return UIImage(named: ImageIdentifiers.syncedDevicesIcon)
             }

--- a/Client/Frontend/Browser/TopTabCell.swift
+++ b/Client/Frontend/Browser/TopTabCell.swift
@@ -43,7 +43,7 @@ class TopTabCell: UICollectionViewCell, ThemeApplicable, TabTrayCell, ReusableCe
     let favicon: FaviconImageView = .build { _ in }
 
     let closeButton: UIButton = .build { button in
-        button.setImage(UIImage.templateImageNamed(ImageIdentifiers.Large.cross), for: [])
+        button.setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross), for: [])
         button.imageEdgeInsets = UIEdgeInsets(top: 15,
                                               left: UX.tabTitlePadding,
                                               bottom: 15,
@@ -73,7 +73,7 @@ class TopTabCell: UICollectionViewCell, ThemeApplicable, TabTrayCell, ReusableCe
         let hideCloseButton = frame.width < 148 && !selected
         closeButton.isHidden = hideCloseButton
 
-        favicon.image = UIImage(named: ImageIdentifiers.Large.globe)?.withRenderingMode(.alwaysTemplate)
+        favicon.image = UIImage(named: StandardImageIdentifiers.Large.globe)?.withRenderingMode(.alwaysTemplate)
         favicon.backgroundColor = .clear
 
         if let siteURL = tab.url?.absoluteString, !tab.isFxHomeTab {

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -60,7 +60,7 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable {
     }
 
     private lazy var newTab: UIButton = .build { button in
-        button.setImage(UIImage.templateImageNamed(ImageIdentifiers.Large.plus), for: .normal)
+        button.setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Large.plus), for: .normal)
         button.semanticContentAttribute = .forceLeftToRight
         button.addTarget(self, action: #selector(TopTabsViewController.newTabTapped), for: .touchUpInside)
         button.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.addNewTabButton

--- a/Client/Frontend/Browser/ZoomPageBar.swift
+++ b/Client/Frontend/Browser/ZoomPageBar.swift
@@ -78,7 +78,7 @@ class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
     }
 
     private let zoomInButton: UIButton = .build { button in
-        button.setImage(UIImage.templateImageNamed(ImageIdentifiers.Large.plus), for: [])
+        button.setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Large.plus), for: [])
         button.accessibilityLabel = .AppMenu.ZoomPageIncreaseZoomAccessibilityLabel
         button.accessibilityIdentifier = AccessibilityIdentifiers.ZoomPageBar.zoomPageZoomInButton
         button.setContentHuggingPriority(.required, for: .horizontal)
@@ -87,7 +87,7 @@ class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
     }
 
     private let closeButton: UIButton = .build { button in
-        button.setImage(UIImage.templateImageNamed(ImageIdentifiers.Large.cross), for: [])
+        button.setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross), for: [])
         button.accessibilityLabel = .AppMenu.ZoomPageCloseAccessibilityLabel
         button.accessibilityIdentifier = AccessibilityIdentifiers.FindInPage.findInPageCloseButton
         button.setContentCompressionResistancePriority(.required, for: .horizontal)

--- a/Client/Frontend/Components/ExpandButtonState.swift
+++ b/Client/Frontend/Components/ExpandButtonState.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
 
 enum ExpandButtonState {
@@ -11,11 +12,11 @@ enum ExpandButtonState {
     var image: UIImage? {
         switch self {
         case .trailing:
-            return UIImage(named: ImageIdentifiers.Large.chevronRight)?
+            return UIImage(named: StandardImageIdentifiers.Large.chevronRight)?
                 .withRenderingMode(.alwaysTemplate)
                 .imageFlippedForRightToLeftLayoutDirection()
         case .down:
-            return UIImage(named: ImageIdentifiers.Large.chevronDown)?.withRenderingMode(.alwaysTemplate)
+            return UIImage(named: StandardImageIdentifiers.Large.chevronDown)?.withRenderingMode(.alwaysTemplate)
         }
     }
 }

--- a/Client/Frontend/ContextualHint/ContextualHintViewController.swift
+++ b/Client/Frontend/ContextualHint/ContextualHintViewController.swift
@@ -26,7 +26,7 @@ class ContextualHintViewController: UIViewController, OnViewDismissable, Themeab
     }
 
     private lazy var closeButton: UIButton = .build { [weak self] button in
-        button.setImage(UIImage(named: ImageIdentifiers.Medium.cross)?.withRenderingMode(.alwaysTemplate),
+        button.setImage(UIImage(named: StandardImageIdentifiers.Medium.cross)?.withRenderingMode(.alwaysTemplate),
                         for: .normal)
         button.addTarget(self,
                          action: #selector(self?.dismissAnimated),

--- a/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsCell.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsCell.swift
@@ -88,7 +88,7 @@ class HistoryHighlightsCell: UICollectionViewCell, ReusableCell {
             let faviconViewModel = FaviconImageViewModel(siteURLString: url)
             imageView.setFavicon(faviconViewModel)
         } else {
-            imageView.image = UIImage.templateImageNamed(ImageIdentifiers.Large.tabTray)
+            imageView.image = UIImage.templateImageNamed(StandardImageIdentifiers.Large.tabTray)
         }
 
         applyTheme(theme: theme)

--- a/Client/Frontend/Home/HomepageContextMenuHelper.swift
+++ b/Client/Frontend/Home/HomepageContextMenuHelper.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
 import Shared
 import Storage
@@ -84,7 +85,7 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
     // MARK: - Default actions
 
     func getOpenInNewPrivateTabAction(siteURL: URL, sectionType: HomepageSectionType) -> PhotonRowActions {
-        return SingleActionViewModel(title: .OpenInNewPrivateTabContextMenuTitle, iconString: ImageIdentifiers.Large.privateMode) { _ in
+        return SingleActionViewModel(title: .OpenInNewPrivateTabContextMenuTitle, iconString: StandardImageIdentifiers.Large.privateMode) { _ in
             self.delegate?.homePanelDidRequestToOpenInNewTab(siteURL, isPrivate: true)
             sectionType.newPrivateTabActionTelemetry()
         }.items
@@ -94,7 +95,7 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
 
     private func getHistoryHighlightsActions(for highlightItem: HighlightItem) -> [PhotonRowActions]? {
         return [SingleActionViewModel(title: .RemoveContextMenuTitle,
-                                      iconString: ImageIdentifiers.Large.cross,
+                                      iconString: StandardImageIdentifiers.Large.cross,
                                       tapHandler: { _ in
             self.viewModel.historyHighlightsViewModel.delete(highlightItem)
             self.sendHistoryHighlightContextualTelemetry(type: .remove)
@@ -115,7 +116,7 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
     }
 
     private func getOpenInNewTabAction(siteURL: URL, sectionType: HomepageSectionType) -> PhotonRowActions {
-        return SingleActionViewModel(title: .OpenInNewTabContextMenuTitle, iconString: ImageIdentifiers.Large.plus) { _ in
+        return SingleActionViewModel(title: .OpenInNewTabContextMenuTitle, iconString: StandardImageIdentifiers.Large.plus) { _ in
             self.delegate?.homePanelDidRequestToOpenInNewTab(siteURL, isPrivate: false)
 
             if sectionType == .pocket {
@@ -140,7 +141,7 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
 
     private func getRemoveBookmarkAction(site: Site) -> SingleActionViewModel {
         return SingleActionViewModel(title: .RemoveBookmarkContextMenuTitle,
-                                     iconString: ImageIdentifiers.Large.bookmarkSlash,
+                                     iconString: StandardImageIdentifiers.Large.bookmarkSlash,
                                      tapHandler: { _ in
             self.viewModel.profile.places.deleteBookmarksWithURL(url: site.url) >>== {
                 site.setBookmarked(false)
@@ -152,7 +153,7 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
 
     private func getAddBookmarkAction(site: Site) -> SingleActionViewModel {
         return SingleActionViewModel(title: .BookmarkContextMenuTitle,
-                                     iconString: ImageIdentifiers.Large.bookmark,
+                                     iconString: StandardImageIdentifiers.Large.bookmark,
                                      tapHandler: { _ in
             let shareItem = ShareItem(url: site.url, title: site.title)
             // Add new mobile bookmark at the top of the list
@@ -258,7 +259,7 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
     // Removes the site out of the top sites. If site is pinned it removes it from pinned and remove
     private func getRemoveTopSiteAction(site: Site) -> PhotonRowActions {
         return SingleActionViewModel(title: .RemoveContextMenuTitle,
-                                     iconString: ImageIdentifiers.Large.cross,
+                                     iconString: StandardImageIdentifiers.Large.cross,
                                      tapHandler: { _ in
             self.viewModel.topSiteViewModel.removePinTopSite(site)
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
@@ -297,7 +298,7 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
 
     private func getSponsoredContentAction() -> PhotonRowActions {
         return SingleActionViewModel(title: .FirefoxHomepage.ContextualMenu.SponsoredContent,
-                                     iconString: ImageIdentifiers.Large.helpCircle,
+                                     iconString: StandardImageIdentifiers.Large.helpCircle,
                                      tapHandler: { _ in
             guard let url = SupportUtils.URLForTopic("sponsor-privacy") else { return }
             self.delegate?.homePanelDidRequestToOpenInNewTab(url, isPrivate: false, selectNewTab: true)

--- a/Client/Frontend/Home/MessageCard/HomepageMessageCard.swift
+++ b/Client/Frontend/Home/MessageCard/HomepageMessageCard.swift
@@ -76,7 +76,7 @@ class HomepageMessageCardCell: UICollectionViewCell, ReusableCell {
     }
 
     private lazy var dismissButton: UIButton = .build { [weak self] button in
-        button.setImage(UIImage(named: ImageIdentifiers.Large.cross)?.withRenderingMode(.alwaysTemplate), for: .normal)
+        button.setImage(UIImage(named: StandardImageIdentifiers.Large.cross)?.withRenderingMode(.alwaysTemplate), for: .normal)
         button.addTarget(self, action: #selector(self?.dismissCard), for: .touchUpInside)
         button.accessibilityLabel = BannerCopy.HomeTabBannerCloseAccessibility
     }

--- a/Client/Frontend/Library/Bookmarks/BookmarkDetailPanel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarkDetailPanel.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import UIKit
 import Storage
 import Shared
@@ -79,7 +80,7 @@ class BookmarkDetailPanel: SiteTableViewController {
     }()
 
     fileprivate lazy var topLeftButton: UIBarButtonItem =  {
-        let button = UIBarButtonItem(image: UIImage.templateImageNamed(ImageIdentifiers.Large.cross), style: .done, target: self, action: #selector(topLeftButtonAction))
+        let button = UIBarButtonItem(image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross), style: .done, target: self, action: #selector(topLeftButtonAction))
         return button
     }()
 
@@ -362,7 +363,7 @@ class BookmarkDetailPanel: SiteTableViewController {
                 cell.isUserInteractionEnabled = true
             }
 
-            cell.leftImageView.image = UIImage(named: ImageIdentifiers.Large.folder)
+            cell.leftImageView.image = UIImage(named: StandardImageIdentifiers.Large.folder)
             cell.leftImageView.contentMode = .center
             cell.indentationWidth = BookmarkDetailPanelUX.IndentationWidth
 

--- a/Client/Frontend/Library/Bookmarks/BookmarksFolderCell.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarksFolderCell.swift
@@ -91,16 +91,16 @@ extension FxBookmarkNode {
     }
 
     var chevronImage: UIImage? {
-        return UIImage(named: ImageIdentifiers.Large.chevronRight)?.withRenderingMode(.alwaysTemplate)
+        return UIImage(named: StandardImageIdentifiers.Large.chevronRight)?.withRenderingMode(.alwaysTemplate)
     }
 
     private var bookmarkFolderIconNormal: UIImage? {
-        return UIImage(named: ImageIdentifiers.Large.folder)?
+        return UIImage(named: StandardImageIdentifiers.Large.folder)?
             .tinted(withColor: UIColor.Photon.Grey90)
     }
 
     private var bookmarkFolderIconDark: UIImage? {
-        return UIImage(named: ImageIdentifiers.Large.folder)?
+        return UIImage(named: StandardImageIdentifiers.Large.folder)?
             .tinted(withColor: UIColor.Photon.Grey10)
     }
 }

--- a/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
@@ -63,7 +63,7 @@ class BookmarksPanel: SiteTableViewController,
     }
 
     private lazy var bottomLeftButton: UIBarButtonItem = {
-        let button = UIBarButtonItem(image: UIImage.templateImageNamed(ImageIdentifiers.Large.plus),
+        let button = UIBarButtonItem(image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.plus),
                                      style: .plain,
                                      target: self,
                                      action: #selector(bottomLeftButtonAction))
@@ -148,7 +148,7 @@ class BookmarksPanel: SiteTableViewController,
 
     private func getNewBookmarkAction() -> PhotonRowActions {
         return SingleActionViewModel(title: .BookmarksNewBookmark,
-                                     iconString: ImageIdentifiers.Large.bookmark,
+                                     iconString: StandardImageIdentifiers.Large.bookmark,
                                      tapHandler: { _ in
             guard let bookmarkFolder = self.viewModel.bookmarkFolder else { return }
 
@@ -165,7 +165,7 @@ class BookmarksPanel: SiteTableViewController,
 
     private func getNewFolderAction() -> PhotonRowActions {
         return SingleActionViewModel(title: .BookmarksNewFolder,
-                                     iconString: ImageIdentifiers.Large.folder,
+                                     iconString: StandardImageIdentifiers.Large.folder,
                                      tapHandler: { _ in
             guard let bookmarkFolder = self.viewModel.bookmarkFolder else { return }
 
@@ -179,7 +179,7 @@ class BookmarksPanel: SiteTableViewController,
 
     private func getNewSeparatorAction() -> PhotonRowActions {
         return SingleActionViewModel(title: .BookmarksNewSeparator,
-                                     iconString: ImageIdentifiers.Large.appMenu,
+                                     iconString: StandardImageIdentifiers.Large.appMenu,
                                      tapHandler: { _ in
             let centerVisibleRow = self.centerVisibleRow()
 
@@ -521,7 +521,7 @@ extension BookmarksPanel: LibraryPanelContextMenu {
         actions.append(pinTopSite)
 
         let removeAction = SingleActionViewModel(title: .RemoveBookmarkContextMenuTitle,
-                                                 iconString: ImageIdentifiers.Large.bookmarkSlash,
+                                                 iconString: StandardImageIdentifiers.Large.bookmarkSlash,
                                                  tapHandler: { _ in
             self.deleteBookmarkNodeAtIndexPath(indexPath)
             TelemetryWrapper.recordEvent(category: .action,

--- a/Client/Frontend/Library/Downloads/DownloadsPanel.swift
+++ b/Client/Frontend/Library/Downloads/DownloadsPanel.swift
@@ -223,7 +223,7 @@ class DownloadsPanel: UIViewController,
             view.translatesAutoresizingMaskIntoConstraints = false
         }
         let logoImageView: UIImageView = .build { imageView in
-            imageView.image = UIImage.templateImageNamed(ImageIdentifiers.Large.download)?
+            imageView.image = UIImage.templateImageNamed(StandardImageIdentifiers.Large.download)?
                 .withRenderingMode(.alwaysTemplate)
             imageView.tintColor = self.themeManager.currentTheme.colors.iconSecondary
         }

--- a/Client/Frontend/Library/HistoryPanel/HistoryActionables.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryActionables.swift
@@ -42,11 +42,11 @@ struct HistoryActionablesModel: Hashable {
     // As this section evolves (or we experiment with it), we may need to replace items within.
     // Let's keep separate stashes of ALL and ACTIVE items.
     static let allActionables = [
-        HistoryActionablesModel(imageName: ImageIdentifiers.Large.delete,
+        HistoryActionablesModel(imageName: StandardImageIdentifiers.Large.delete,
                                 title: History.HistoryPanelClearHistoryButtonTitle,
                                 a11yId: a11y.clearHistoryCell,
                                 itemIdentity: .clearHistory),
-        HistoryActionablesModel(imageName: ImageIdentifiers.Large.tabTray,
+        HistoryActionablesModel(imageName: StandardImageIdentifiers.Large.tabTray,
                                 title: History.RecentlyClosedTabsButtonTitle,
                                 a11yId: a11y.recentlyClosedCell,
                                 itemIdentity: .recentlyClosed),
@@ -57,7 +57,7 @@ struct HistoryActionablesModel: Hashable {
     ]
 
     static let activeActionables = [
-        HistoryActionablesModel(imageName: ImageIdentifiers.Large.tabTray,
+        HistoryActionablesModel(imageName: StandardImageIdentifiers.Large.tabTray,
                                 title: History.RecentlyClosedTabsButtonTitle,
                                 a11yId: a11y.recentlyClosedCell,
                                 itemIdentity: .recentlyClosed)

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanel+ContextMenuExtensions.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanel+ContextMenuExtensions.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import UIKit
 import Storage
 
@@ -20,7 +21,7 @@ extension HistoryPanel: LibraryPanelContextMenu {
         guard var actions = getDefaultContextMenuActions(for: site, libraryPanelDelegate: libraryPanelDelegate) else { return nil }
 
         let removeAction = SingleActionViewModel(title: .DeleteFromHistoryContextMenuTitle,
-                                                 iconString: ImageIdentifiers.Large.delete,
+                                                 iconString: StandardImageIdentifiers.Large.delete,
                                                  tapHandler: { _ in
             self.removeHistoryItem(at: indexPath)
         })

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -38,7 +38,7 @@ class HistoryPanel: UIViewController,
     let viewModel: HistoryPanelViewModel
     private let clearHistoryHelper: ClearHistorySheetProvider
     var keyboardState: KeyboardState?
-    var chevronImage = UIImage(named: ImageIdentifiers.Large.chevronRight)?.withRenderingMode(.alwaysTemplate)
+    var chevronImage = UIImage(named: StandardImageIdentifiers.Large.chevronRight)?.withRenderingMode(.alwaysTemplate)
     var themeManager: ThemeManager
     var themeObserver: NSObjectProtocol?
     var notificationCenter: NotificationProtocol
@@ -89,7 +89,7 @@ class HistoryPanel: UIViewController,
     }()
 
     private lazy var bottomDeleteButton: UIBarButtonItem = {
-        let button = UIBarButtonItem(image: UIImage.templateImageNamed(ImageIdentifiers.Large.delete),
+        let button = UIBarButtonItem(image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.delete),
                                      style: .plain,
                                      target: self,
                                      action: #selector(bottomDeleteButtonAction))
@@ -418,7 +418,7 @@ class HistoryPanel: UIViewController,
         cell.titleLabel.text = asGroup.displayTitle
         let imageView = UIImageView(image: chevronImage)
         cell.accessoryView = imageView
-        cell.leftImageView.image = UIImage(named: ImageIdentifiers.Large.tabTray)?.withTintColor(themeManager.currentTheme.colors.iconSecondary)
+        cell.leftImageView.image = UIImage(named: StandardImageIdentifiers.Large.tabTray)?.withTintColor(themeManager.currentTheme.colors.iconSecondary)
         cell.leftImageView.backgroundColor = themeManager.currentTheme.colors.layer5
         cell.applyTheme(theme: themeManager.currentTheme)
         return cell
@@ -552,7 +552,7 @@ class HistoryPanel: UIViewController,
         tableView.backgroundColor = themeManager.currentTheme.colors.layer6
         searchbar.backgroundColor = themeManager.currentTheme.colors.layer3
         let tintColor = themeManager.currentTheme.colors.textPrimary
-        let searchBarImage = UIImage(named: ImageIdentifiers.Large.history)?
+        let searchBarImage = UIImage(named: StandardImageIdentifiers.Large.history)?
             .withRenderingMode(.alwaysTemplate)
             .tinted(withColor: tintColor)
         searchbar.setImage(searchBarImage, for: .search, state: .normal)

--- a/Client/Frontend/Library/LibraryPanelContextMenu.swift
+++ b/Client/Frontend/Library/LibraryPanelContextMenu.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Storage
 import Shared
 
@@ -37,11 +38,11 @@ extension LibraryPanelContextMenu {
     func getRecentlyClosedTabContexMenuActions(for site: Site, recentlyClosedPanelDelegate: RecentlyClosedPanelDelegate?) -> [PhotonRowActions]? {
         guard let siteURL = URL(string: site.url) else { return nil }
 
-        let openInNewTabAction = SingleActionViewModel(title: .OpenInNewTabContextMenuTitle, iconString: ImageIdentifiers.Large.plus) { _ in
+        let openInNewTabAction = SingleActionViewModel(title: .OpenInNewTabContextMenuTitle, iconString: StandardImageIdentifiers.Large.plus) { _ in
             recentlyClosedPanelDelegate?.openRecentlyClosedSiteInNewTab(siteURL, isPrivate: false)
         }
 
-        let openInNewPrivateTabAction = SingleActionViewModel(title: .OpenInNewPrivateTabContextMenuTitle, iconString: ImageIdentifiers.Large.privateMode) { _ in
+        let openInNewPrivateTabAction = SingleActionViewModel(title: .OpenInNewPrivateTabContextMenuTitle, iconString: StandardImageIdentifiers.Large.privateMode) { _ in
             recentlyClosedPanelDelegate?.openRecentlyClosedSiteInNewTab(siteURL, isPrivate: true)
         }
 
@@ -51,11 +52,11 @@ extension LibraryPanelContextMenu {
     func getRemoteTabContextMenuActions(for site: Site, remotePanelDelegate: RemotePanelDelegate?) -> [PhotonRowActions]? {
         guard let siteURL = URL(string: site.url) else { return nil }
 
-        let openInNewTabAction = SingleActionViewModel(title: .OpenInNewTabContextMenuTitle, iconString: ImageIdentifiers.Large.plus) { _ in
+        let openInNewTabAction = SingleActionViewModel(title: .OpenInNewTabContextMenuTitle, iconString: StandardImageIdentifiers.Large.plus) { _ in
             remotePanelDelegate?.remotePanelDidRequestToOpenInNewTab(siteURL, isPrivate: false)
         }
 
-        let openInNewPrivateTabAction = SingleActionViewModel(title: .OpenInNewPrivateTabContextMenuTitle, iconString: ImageIdentifiers.Large.privateMode) { _ in
+        let openInNewPrivateTabAction = SingleActionViewModel(title: .OpenInNewPrivateTabContextMenuTitle, iconString: StandardImageIdentifiers.Large.privateMode) { _ in
             remotePanelDelegate?.remotePanelDidRequestToOpenInNewTab(siteURL, isPrivate: true)
         }
 
@@ -66,12 +67,12 @@ extension LibraryPanelContextMenu {
         guard let siteURL = URL(string: site.url) else { return nil }
 
         let openInNewTabAction = SingleActionViewModel(title: .OpenInNewTabContextMenuTitle,
-                                                       iconString: ImageIdentifiers.Large.plus) { _ in
+                                                       iconString: StandardImageIdentifiers.Large.plus) { _ in
             libraryPanelDelegate?.libraryPanelDidRequestToOpenInNewTab(siteURL, isPrivate: false)
         }.items
 
         let openInNewPrivateTabAction = SingleActionViewModel(title: .OpenInNewPrivateTabContextMenuTitle,
-                                                              iconString: ImageIdentifiers.Large.privateMode) { _ in
+                                                              iconString: StandardImageIdentifiers.Large.privateMode) { _ in
             libraryPanelDelegate?.libraryPanelDidRequestToOpenInNewTab(siteURL, isPrivate: true)
         }.items
 

--- a/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -51,7 +51,7 @@ class LibraryViewController: UIViewController, Themeable {
 
     private lazy var topLeftButton: UIBarButtonItem =  {
         let button = UIBarButtonItem(
-            image: UIImage.templateImageNamed(ImageIdentifiers.Large.chevronLeft)?.imageFlippedForRightToLeftLayoutDirection(),
+            image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.chevronLeft)?.imageFlippedForRightToLeftLayoutDirection(),
             style: .plain,
             target: self,
             action: #selector(topLeftButtonAction))
@@ -255,10 +255,10 @@ class LibraryViewController: UIViewController, Themeable {
         switch viewModel.currentPanelState {
         case .bookmarks(state: .inFolder),
              .history(state: .inFolder):
-            topLeftButton.image = UIImage.templateImageNamed(ImageIdentifiers.Large.chevronLeft)?.imageFlippedForRightToLeftLayoutDirection()
+            topLeftButton.image = UIImage.templateImageNamed(StandardImageIdentifiers.Large.chevronLeft)?.imageFlippedForRightToLeftLayoutDirection()
             navigationItem.leftBarButtonItem = topLeftButton
         case .bookmarks(state: .itemEditMode), .bookmarks(state: .itemEditModeInvalidField):
-            topLeftButton.image = UIImage.templateImageNamed(ImageIdentifiers.Large.cross)
+            topLeftButton.image = UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross)
             navigationItem.leftBarButtonItem = topLeftButton
         default:
             navigationItem.leftBarButtonItem = nil

--- a/Client/Frontend/Library/LibraryViewController/LibraryViewModel.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryViewModel.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
 
 class LibraryViewModel {
@@ -25,9 +26,9 @@ class LibraryViewModel {
     }
 
     var segmentedControlItems: [UIImage] {
-        [UIImage(named: ImageIdentifiers.Large.bookmarkTrayFill) ?? UIImage(),
-         UIImage(named: ImageIdentifiers.Large.history) ?? UIImage(),
-         UIImage(named: ImageIdentifiers.Large.download) ?? UIImage(),
+        [UIImage(named: StandardImageIdentifiers.Large.bookmarkTrayFill) ?? UIImage(),
+         UIImage(named: StandardImageIdentifiers.Large.history) ?? UIImage(),
+         UIImage(named: StandardImageIdentifiers.Large.download) ?? UIImage(),
          UIImage(named: ImageIdentifiers.libraryReadingList) ?? UIImage()]
     }
 

--- a/Client/Frontend/Library/ReaderPanel.swift
+++ b/Client/Frontend/Library/ReaderPanel.swift
@@ -439,7 +439,7 @@ extension ReadingListPanel: LibraryPanelContextMenu {
         guard var actions = getDefaultContextMenuActions(for: site, libraryPanelDelegate: libraryPanelDelegate) else { return nil }
 
         let removeAction = SingleActionViewModel(title: .RemoveContextMenuTitle,
-                                                 iconString: ImageIdentifiers.Large.cross,
+                                                 iconString: StandardImageIdentifiers.Large.cross,
                                                  tapHandler: { _ in
             self.deleteItem(atIndex: indexPath)
         }).items

--- a/Client/Frontend/Reader/View/ReaderModeBarView.swift
+++ b/Client/Frontend/Reader/View/ReaderModeBarView.swift
@@ -29,7 +29,7 @@ enum ReaderModeBarButtonType {
         case .markAsUnread: return "MarkAsUnread"
         case .settings: return "SettingsSerif"
         case .addToReadingList: return ImageIdentifiers.addToReadingList
-        case .removeFromReadingList: return ImageIdentifiers.Large.delete
+        case .removeFromReadingList: return StandardImageIdentifiers.Large.delete
         }
     }
 

--- a/Client/Frontend/Settings/Main/Account/AccountStatusSetting.swift
+++ b/Client/Frontend/Settings/Main/Account/AccountStatusSetting.swift
@@ -106,7 +106,7 @@ class AccountStatusSetting: WithAccountSetting {
             imageView.layer.cornerRadius = (imageView.frame.height) / 2
             imageView.layer.masksToBounds = true
 
-            imageView.image = UIImage(named: ImageIdentifiers.Large.avatarCircle)?
+            imageView.image = UIImage(named: StandardImageIdentifiers.Large.avatarCircle)?
                 .createScaled(CGSize(width: 30, height: 30))
                 .tinted(withColor: theme.colors.iconPrimary)
 

--- a/Client/Frontend/Settings/Main/Account/ConnectSetting.swift
+++ b/Client/Frontend/Settings/Main/Account/ConnectSetting.swift
@@ -43,7 +43,7 @@ class ConnectSetting: WithoutAccountSetting {
 
     override func onConfigureCell(_ cell: UITableViewCell, theme: Theme) {
         super.onConfigureCell(cell, theme: theme)
-        cell.imageView?.image = UIImage.templateImageNamed(ImageIdentifiers.Large.logoFirefox)
+        cell.imageView?.image = UIImage.templateImageNamed(StandardImageIdentifiers.Large.logoFirefox)
         cell.imageView?.tintColor = theme.colors.textDisabled
         cell.imageView?.layer.cornerRadius = (cell.imageView?.frame.size.width)! / 2
         cell.imageView?.layer.masksToBounds = true

--- a/Client/Frontend/Settings/Main/SettingDisclosureUtility.swift
+++ b/Client/Frontend/Settings/Main/SettingDisclosureUtility.swift
@@ -9,7 +9,7 @@ import Shared
 struct SettingDisclosureUtility {
     static func buildDisclosureIndicator(theme: Theme) -> UIImageView {
         let disclosureIndicator = UIImageView()
-        disclosureIndicator.image = UIImage(named: ImageIdentifiers.Large.chevronRight)?.withRenderingMode(.alwaysTemplate).imageFlippedForRightToLeftLayoutDirection()
+        disclosureIndicator.image = UIImage(named: StandardImageIdentifiers.Large.chevronRight)?.withRenderingMode(.alwaysTemplate).imageFlippedForRightToLeftLayoutDirection()
         disclosureIndicator.tintColor = theme.colors.actionSecondary
         disclosureIndicator.sizeToFit()
         return disclosureIndicator

--- a/Client/Frontend/Share/CustomAppActivity.swift
+++ b/Client/Frontend/Share/CustomAppActivity.swift
@@ -23,9 +23,9 @@ enum CustomActivityAction {
     var image: UIImage? {
         switch self {
         case .sendToDevice:
-            return UIImage(named: ImageIdentifiers.Large.deviceDesktopSend)
+            return UIImage(named: StandardImageIdentifiers.Large.deviceDesktopSend)
         case .copyLink:
-            return UIImage(named: ImageIdentifiers.Large.link)
+            return UIImage(named: StandardImageIdentifiers.Large.link)
         }
     }
 

--- a/Client/Frontend/TabContentsScripts/LoginsHelper.swift
+++ b/Client/Frontend/TabContentsScripts/LoginsHelper.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
 import Shared
 import Storage
@@ -172,7 +173,7 @@ class LoginsHelper: TabContentScript {
             tab?.removeSnackbar(existingPrompt)
         }
 
-        snackBar = TimerSnackBar(text: promptMessage, img: UIImage(named: ImageIdentifiers.Large.login))
+        snackBar = TimerSnackBar(text: promptMessage, img: UIImage(named: StandardImageIdentifiers.Large.login))
         let dontSave = SnackButton(title: .LoginsHelperDontSaveButtonTitle, accessibilityIdentifier: "SaveLoginPrompt.dontSaveButton", bold: false) { bar in
             self.tab?.removeSnackbar(bar)
             self.snackBar = nil
@@ -203,7 +204,7 @@ class LoginsHelper: TabContentScript {
             tab?.removeSnackbar(existingPrompt)
         }
 
-        snackBar = TimerSnackBar(text: formatted, img: UIImage(named: ImageIdentifiers.Large.login))
+        snackBar = TimerSnackBar(text: formatted, img: UIImage(named: StandardImageIdentifiers.Large.login))
         let dontSave = SnackButton(title: .LoginsHelperDontUpdateButtonTitle, accessibilityIdentifier: "UpdateLoginPrompt.donttUpdateButton", bold: false) { bar in
             self.tab?.removeSnackbar(bar)
             self.snackBar = nil

--- a/Client/Frontend/Toolbar+URLBar/LockButton.swift
+++ b/Client/Frontend/Toolbar+URLBar/LockButton.swift
@@ -37,7 +37,7 @@ class LockButton: UIButton {
         super.init(frame: frame)
 
         clipsToBounds = false
-        setImage(UIImage.templateImageNamed(ImageIdentifiers.Large.lock), for: .normal)
+        setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Large.lock), for: .normal)
         imageView?.contentMode = .scaleAspectFill
         adjustsImageWhenHighlighted = false
     }

--- a/Client/Frontend/Toolbar+URLBar/StatefulButton.swift
+++ b/Client/Frontend/Toolbar+URLBar/StatefulButton.swift
@@ -41,7 +41,7 @@ class StatefulButton: UIButton {
             case .reload:
                 setImage(UIImage.templateImageNamed("nav-refresh"), for: .normal)
             case .stop:
-                setImage(UIImage.templateImageNamed(ImageIdentifiers.Large.cross), for: .normal)
+                setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross), for: .normal)
             case .disabled:
                 self.isHidden = true
             }

--- a/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -276,7 +276,7 @@ class TabLocationView: UIView, FeatureFlaggable {
             let imageID = theme.type.getThemedImageName(name: ImageIdentifiers.lockBlocked)
             lockImage = UIImage(imageLiteralResourceName: imageID)
         } else if let tintColor = trackingProtectionButton.tintColor {
-            lockImage = UIImage(imageLiteralResourceName: ImageIdentifiers.Large.lock)
+            lockImage = UIImage(imageLiteralResourceName: StandardImageIdentifiers.Large.lock)
                 .withTintColor(tintColor, renderingMode: .alwaysTemplate)
         }
 

--- a/Client/Frontend/Toolbar+URLBar/TabToolbarHelper.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabToolbarHelper.swift
@@ -56,10 +56,10 @@ enum MiddleButtonState {
 open class TabToolbarHelper: NSObject {
     let toolbar: TabToolbarProtocol
     let ImageReload = UIImage.templateImageNamed("nav-refresh")
-    let ImageStop = UIImage.templateImageNamed(ImageIdentifiers.Large.cross)
+    let ImageStop = UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross)
     let ImageSearch = UIImage.templateImageNamed("search")
-    let ImageNewTab = UIImage.templateImageNamed(ImageIdentifiers.Large.plus)
-    let ImageHome = UIImage.templateImageNamed(ImageIdentifiers.Large.home)
+    let ImageNewTab = UIImage.templateImageNamed(StandardImageIdentifiers.Large.plus)
+    let ImageHome = UIImage.templateImageNamed(StandardImageIdentifiers.Large.home)
 
     func setMiddleButtonState(_ state: MiddleButtonState) {
         let device = UIDevice.current.userInterfaceIdiom
@@ -94,7 +94,7 @@ open class TabToolbarHelper: NSObject {
         self.toolbar = toolbar
         super.init()
 
-        toolbar.backButton.setImage(UIImage.templateImageNamed(ImageIdentifiers.Large.back)?.imageFlippedForRightToLeftLayoutDirection(), for: .normal)
+        toolbar.backButton.setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Large.back)?.imageFlippedForRightToLeftLayoutDirection(), for: .normal)
         toolbar.backButton.accessibilityLabel = .TabToolbarBackAccessibilityLabel
         toolbar.backButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.backButton
         let longPressGestureBackButton = UILongPressGestureRecognizer(target: self, action: #selector(didLongPressBack))
@@ -102,7 +102,7 @@ open class TabToolbarHelper: NSObject {
         toolbar.backButton.addTarget(self, action: #selector(didClickBack), for: .touchUpInside)
 
         toolbar.forwardButton.setImage(
-            UIImage.templateImageNamed(ImageIdentifiers.Large.forward)?.imageFlippedForRightToLeftLayoutDirection(),
+            UIImage.templateImageNamed(StandardImageIdentifiers.Large.forward)?.imageFlippedForRightToLeftLayoutDirection(),
             for: .normal)
         toolbar.forwardButton.accessibilityLabel = .TabToolbarForwardAccessibilityLabel
         toolbar.forwardButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.forwardButton
@@ -111,7 +111,7 @@ open class TabToolbarHelper: NSObject {
         toolbar.forwardButton.addTarget(self, action: #selector(didClickForward), for: .touchUpInside)
 
         if UIDevice.current.userInterfaceIdiom == .phone {
-            toolbar.multiStateButton.setImage(UIImage.templateImageNamed(ImageIdentifiers.Large.home), for: .normal)
+            toolbar.multiStateButton.setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Large.home), for: .normal)
         } else {
             toolbar.multiStateButton.setImage(UIImage.templateImageNamed("nav-refresh"), for: .normal)
         }
@@ -127,25 +127,25 @@ open class TabToolbarHelper: NSObject {
         toolbar.tabsButton.addGestureRecognizer(longPressGestureTabsButton)
         toolbar.tabsButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.tabsButton
 
-        toolbar.addNewTabButton.setImage(UIImage.templateImageNamed(ImageIdentifiers.Large.plus), for: .normal)
+        toolbar.addNewTabButton.setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Large.plus), for: .normal)
         toolbar.addNewTabButton.accessibilityLabel = .AddTabAccessibilityLabel
         toolbar.addNewTabButton.addTarget(self, action: #selector(didClickAddNewTab), for: .touchUpInside)
         toolbar.addNewTabButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.addNewTabButton
 
         toolbar.appMenuButton.contentMode = .center
-        toolbar.appMenuButton.setImage(UIImage.templateImageNamed(ImageIdentifiers.Large.appMenu), for: .normal)
+        toolbar.appMenuButton.setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Large.appMenu), for: .normal)
         toolbar.appMenuButton.accessibilityLabel = .AppMenu.Toolbar.MenuButtonAccessibilityLabel
         toolbar.appMenuButton.addTarget(self, action: #selector(didClickMenu), for: .touchUpInside)
         toolbar.appMenuButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.settingsMenuButton
 
         toolbar.homeButton.contentMode = .center
-        toolbar.homeButton.setImage(UIImage.templateImageNamed(ImageIdentifiers.Large.home), for: .normal)
+        toolbar.homeButton.setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Large.home), for: .normal)
         toolbar.homeButton.accessibilityLabel = .AppMenu.Toolbar.HomeMenuButtonAccessibilityLabel
         toolbar.homeButton.addTarget(self, action: #selector(didClickHome), for: .touchUpInside)
         toolbar.homeButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.homeButton
 
         toolbar.bookmarksButton.contentMode = .center
-        toolbar.bookmarksButton.setImage(UIImage.templateImageNamed(ImageIdentifiers.Large.bookmarkTrayFill),
+        toolbar.bookmarksButton.setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Large.bookmarkTrayFill),
                                          for: .normal)
         toolbar.bookmarksButton.accessibilityLabel = .AppMenu.Toolbar.BookmarksButtonAccessibilityLabel
         toolbar.bookmarksButton.addTarget(self, action: #selector(didClickLibrary), for: .touchUpInside)

--- a/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -137,7 +137,7 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
     fileprivate lazy var cancelButton: UIButton = {
         let cancelButton = InsetButton()
         cancelButton.setImage(
-            UIImage.templateImageNamed(ImageIdentifiers.Large.chevronLeft)?.imageFlippedForRightToLeftLayoutDirection(),
+            UIImage.templateImageNamed(StandardImageIdentifiers.Large.chevronLeft)?.imageFlippedForRightToLeftLayoutDirection(),
             for: .normal)
         cancelButton.accessibilityIdentifier = AccessibilityIdentifiers.Browser.UrlBar.cancelButton
         cancelButton.accessibilityLabel = AccessibilityIdentifiers.GeneralizedIdentifiers.back
@@ -148,7 +148,7 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
 
     fileprivate lazy var showQRScannerButton: InsetButton = {
         let button = InsetButton()
-        button.setImage(UIImage.templateImageNamed(ImageIdentifiers.Large.qrCode), for: .normal)
+        button.setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Large.qrCode), for: .normal)
         button.accessibilityIdentifier = AccessibilityIdentifiers.Browser.UrlBar.scanQRCodeButton
         button.accessibilityLabel = .ScanQRCodeViewTitle
         button.clipsToBounds = false

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
@@ -42,7 +42,7 @@ extension PhotonActionSheetProtocol {
 
     func getLongPressLocationBarActions(with urlBar: URLBarView, alertContainer: UIView) -> [PhotonRowActions] {
         let pasteGoAction = SingleActionViewModel(title: .PasteAndGoTitle,
-                                                  iconString: ImageIdentifiers.Large.clipboard) { _ in
+                                                  iconString: StandardImageIdentifiers.Large.clipboard) { _ in
             if let pasteboardContents = UIPasteboard.general.string {
                 urlBar.delegate?.urlBar(urlBar, didSubmitText: pasteboardContents)
             }
@@ -50,7 +50,7 @@ extension PhotonActionSheetProtocol {
         pasteGoAction.accessibilityId = AccessibilityIdentifiers.Photon.pasteAndGoAction
 
         let pasteAction = SingleActionViewModel(title: .PasteTitle,
-                                                iconString: ImageIdentifiers.Large.clipboard) { _ in
+                                                iconString: StandardImageIdentifiers.Large.clipboard) { _ in
             if let pasteboardContents = UIPasteboard.general.string {
                 urlBar.enterOverlayMode(pasteboardContents, pasted: true, search: true)
             }
@@ -58,7 +58,7 @@ extension PhotonActionSheetProtocol {
         pasteAction.accessibilityId = AccessibilityIdentifiers.Photon.pasteAction
 
         let copyAddressAction = SingleActionViewModel(title: .CopyAddressTitle,
-                                                      iconString: ImageIdentifiers.Large.link) { _ in
+                                                      iconString: StandardImageIdentifiers.Large.link) { _ in
             if let url = tabManager.selectedTab?.canonicalURL?.displayURL ?? urlBar.currentURL {
                 UIPasteboard.general.url = url
                 SimpleToast().showAlertWithText(.AppMenu.AppMenuCopyURLConfirmMessage,
@@ -86,7 +86,8 @@ extension PhotonActionSheetProtocol {
         } else {
             toggleActionTitle = tab.changedUserAgent ? .AppMenu.AppMenuViewMobileSiteTitleString : .AppMenu.AppMenuViewDesktopSiteTitleString
         }
-        let toggleDesktopSite = SingleActionViewModel(title: toggleActionTitle, iconString: ImageIdentifiers.Large.deviceDesktop) { _ in
+        let toggleDesktopSite = SingleActionViewModel(title: toggleActionTitle,
+                                                      iconString: StandardImageIdentifiers.Large.deviceDesktop) { _ in
             if let url = tab.url {
                 tab.toggleChangeUserAgent()
                 Tab.ChangeUserAgent.updateDomainList(forUrl: url, isChangedUA: tab.changedUserAgent, isPrivate: tab.isPrivate)

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetView.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetView.swift
@@ -87,7 +87,7 @@ class PhotonActionSheetView: UIView, UIGestureRecognizerDelegate, ThemeApplicabl
 
     private lazy var disclosureIndicator: UIImageView = {
         let disclosureIndicator = createIconImageView()
-        disclosureIndicator.image = UIImage(named: ImageIdentifiers.Large.chevronRight)?.withRenderingMode(.alwaysTemplate)
+        disclosureIndicator.image = UIImage(named: StandardImageIdentifiers.Large.chevronRight)?.withRenderingMode(.alwaysTemplate)
         return disclosureIndicator
     }()
 

--- a/Client/Frontend/Widgets/SnackBar.swift
+++ b/Client/Frontend/Widgets/SnackBar.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
 import Shared
 
@@ -50,7 +51,7 @@ class SnackBar: UIView {
     init(text: String, img: UIImage?, snackbarClassIdentifier: String? = nil) {
         self.snackbarClassIdentifier = snackbarClassIdentifier ?? text
         super.init(frame: .zero)
-        imageView.image = img ?? UIImage(named: ImageIdentifiers.Large.globe)?.withRenderingMode(.alwaysOriginal)
+        imageView.image = img ?? UIImage(named: StandardImageIdentifiers.Large.globe)?.withRenderingMode(.alwaysOriginal)
         textLabel.text = text
         setupLayout()
         setupUI()

--- a/Client/Frontend/Widgets/TimerSnackBar.swift
+++ b/Client/Frontend/Widgets/TimerSnackBar.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
 
 /**
@@ -25,7 +26,7 @@ class TimerSnackBar: SnackBar {
     static func showAppStoreConfirmationBar(forTab tab: Tab, appStoreURL: URL, completion: @escaping (Bool) -> Void) {
         let bar = TimerSnackBar(
             text: .ExternalLinkAppStoreConfirmationTitle,
-            img: UIImage(named: ImageIdentifiers.Large.globe)?.withRenderingMode(.alwaysOriginal))
+            img: UIImage(named: StandardImageIdentifiers.Large.globe)?.withRenderingMode(.alwaysOriginal))
         let openAppStore = SnackButton(title: .AppStoreString, accessibilityIdentifier: "ConfirmOpenInAppStore", bold: true) { bar in
             tab.removeSnackbar(bar)
             UIApplication.shared.open(appStoreURL, options: [:])

--- a/RustFxA/Avatar.swift
+++ b/RustFxA/Avatar.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import UIKit
 import Shared
 
@@ -14,7 +15,7 @@ open class Avatar {
 
         downloadAvatar(url: url) { image in
             guard let avatarImage = image else {
-                self.image = UIImage(named: ImageIdentifiers.Large.avatarCircle)
+                self.image = UIImage(named: StandardImageIdentifiers.Large.avatarCircle)
                 NotificationCenter.default.post(name: .FirefoxAccountProfileChanged, object: self)
                 return
             }

--- a/Tests/ClientTests/TabToolbarHelperTests.swift
+++ b/Tests/ClientTests/TabToolbarHelperTests.swift
@@ -13,12 +13,12 @@ class TabToolbarHelperTests: XCTestCase {
     var subject: TabToolbarHelper!
     var mockToolbar: MockTabToolbar!
 
-    let backButtonImage = UIImage.templateImageNamed(ImageIdentifiers.Large.back)?.imageFlippedForRightToLeftLayoutDirection()
-    let forwardButtonImage = UIImage.templateImageNamed(ImageIdentifiers.Large.forward)?.imageFlippedForRightToLeftLayoutDirection()
-    let menuButtonImage = UIImage.templateImageNamed(ImageIdentifiers.Large.appMenu)
+    let backButtonImage = UIImage.templateImageNamed(StandardImageIdentifiers.Large.back)?.imageFlippedForRightToLeftLayoutDirection()
+    let forwardButtonImage = UIImage.templateImageNamed(StandardImageIdentifiers.Large.forward)?.imageFlippedForRightToLeftLayoutDirection()
+    let menuButtonImage = UIImage.templateImageNamed(StandardImageIdentifiers.Large.appMenu)
     let searchButtonImage = UIImage.templateImageNamed("search")
-    let imageNewTab = UIImage.templateImageNamed(ImageIdentifiers.Large.plus)
-    let imageHome = UIImage.templateImageNamed(ImageIdentifiers.Large.home)
+    let imageNewTab = UIImage.templateImageNamed(StandardImageIdentifiers.Large.plus)
+    let imageHome = UIImage.templateImageNamed(StandardImageIdentifiers.Large.home)
 
     override func setUp() {
         super.setUp()

--- a/Tests/UITests/AuthenticationTests.swift
+++ b/Tests/UITests/AuthenticationTests.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
 
 class AuthenticationTests: KIFTestCase {
@@ -57,7 +58,7 @@ class AuthenticationTests: KIFTestCase {
 
         // Add a private tab.
         tester().tapView(withAccessibilityIdentifier: AccessibilityIdentifiers.Toolbar.tabsButton)
-        tester().tapView(withAccessibilityLabel: ImageIdentifiers.Large.privateMode)
+        tester().tapView(withAccessibilityLabel: StandardImageIdentifiers.Large.privateMode)
         tester().tapView(withAccessibilityIdentifier: AccessibilityIdentifiers.TabTray.newTabButton)
         tester().waitForAnimationsToFinish()
         tester().tapView(withAccessibilityIdentifier: "urlBar-cancel")

--- a/Tests/UITests/ClearPrivateDataTests.swift
+++ b/Tests/UITests/ClearPrivateDataTests.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Shared
 import WebKit
 import UIKit
@@ -75,7 +76,7 @@ class ClearPrivateDataTests: KIFTestCase, UITextFieldDelegate {
         tester().wait(forTimeInterval: 10)
         BrowserUtils.openLibraryMenu(tester())
         // Open History Panel
-        tester().tapView(withAccessibilityIdentifier: ImageIdentifiers.Large.history)
+        tester().tapView(withAccessibilityIdentifier: StandardImageIdentifiers.Large.history)
         tester().waitForView(withAccessibilityLabel: url1)
         tester().waitForView(withAccessibilityLabel: url2)
 
@@ -86,7 +87,7 @@ class ClearPrivateDataTests: KIFTestCase, UITextFieldDelegate {
         BrowserUtils.closeClearPrivateDataDialog(tester())
 
         BrowserUtils.openLibraryMenu(tester())
-        tester().tapView(withAccessibilityIdentifier: ImageIdentifiers.Large.history)
+        tester().tapView(withAccessibilityIdentifier: StandardImageIdentifiers.Large.history)
 
         // Open History Panel
         tester().waitForAbsenceOfView(withAccessibilityLabel: url1)
@@ -114,7 +115,7 @@ class ClearPrivateDataTests: KIFTestCase, UITextFieldDelegate {
         tester().waitForAnimationsToFinish()
         BrowserUtils.openLibraryMenu(tester())
         // Open History Panel
-        tester().tapView(withAccessibilityIdentifier: ImageIdentifiers.Large.history)
+        tester().tapView(withAccessibilityIdentifier: StandardImageIdentifiers.Large.history)
         tester().waitForAnimationsToFinish()
 
         tester().waitForView(withAccessibilityLabel: url1)

--- a/Tests/UITests/Global.swift
+++ b/Tests/UITests/Global.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
 import GCDWebServers
 import Storage
@@ -226,7 +227,7 @@ class BrowserUtils {
         tester.tapView(withAccessibilityIdentifier: AccessibilityIdentifiers.Toolbar.tabsButton)
         
         // if in private mode, close all tabs
-        tester.tapView(withAccessibilityLabel: ImageIdentifiers.Large.privateMode)
+        tester.tapView(withAccessibilityLabel: StandardImageIdentifiers.Large.privateMode)
 
         tester.tapView(withAccessibilityIdentifier: AccessibilityIdentifiers.TabTray.closeAllTabsButton)
         tester.tapView(withAccessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCloseAllButton)

--- a/Tests/UITests/HistoryTests.swift
+++ b/Tests/UITests/HistoryTests.swift
@@ -42,7 +42,7 @@ class HistoryTests: KIFTestCase {
 
         // Check that both appear in the history home panel
         BrowserUtils.openLibraryMenu(tester())
-        tester().tapView(withAccessibilityIdentifier: ImageIdentifiers.Large.history)
+        tester().tapView(withAccessibilityIdentifier: StandardImageIdentifiers.Large.history)
 
         // Wait until the dialog shows up
         tester().waitForAnimationsToFinish()
@@ -70,8 +70,8 @@ class HistoryTests: KIFTestCase {
         tester().waitForAnimationsToFinish()
         BrowserUtils.openLibraryMenu(tester())
         tester().waitForAnimationsToFinish(withTimeout: 10)
-        tester().waitForView(withAccessibilityIdentifier: ImageIdentifiers.Large.history)
-        tester().tapView(withAccessibilityIdentifier: ImageIdentifiers.Large.history)
+        tester().waitForView(withAccessibilityIdentifier: StandardImageIdentifiers.Large.history)
+        tester().tapView(withAccessibilityIdentifier: StandardImageIdentifiers.Large.history)
         tester().waitForAnimationsToFinish(withTimeout: 10)
         tester().waitForView(withAccessibilityLabel: "Page 102")
 

--- a/Tests/XCUITests/BaseTestCase.swift
+++ b/Tests/XCUITests/BaseTestCase.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import MappaMundi
 import XCTest
 
@@ -135,15 +136,15 @@ class BaseTestCase: XCTestCase {
     func bookmark() {
         waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection], timeout: TIMEOUT)
         navigator.goto(BrowserTabMenu)
-        waitForExistence(app.tables.otherElements[ImageIdentifiers.Large.bookmark], timeout: TIMEOUT_LONG)
-        app.tables.otherElements[ImageIdentifiers.Large.bookmark].tap()
+        waitForExistence(app.tables.otherElements[StandardImageIdentifiers.Large.bookmark], timeout: TIMEOUT_LONG)
+        app.tables.otherElements[StandardImageIdentifiers.Large.bookmark].tap()
         navigator.nowAt(BrowserTab)
     }
 
     func unbookmark() {
         navigator.goto(BrowserTabMenu)
-        waitForExistence(app.tables.otherElements[ImageIdentifiers.Large.bookmarkSlash])
-        app.otherElements[ImageIdentifiers.Large.bookmarkSlash].tap()
+        waitForExistence(app.tables.otherElements[StandardImageIdentifiers.Large.bookmarkSlash])
+        app.otherElements[StandardImageIdentifiers.Large.bookmarkSlash].tap()
         navigator.nowAt(BrowserTab)
     }
 

--- a/Tests/XCUITests/BookmarkingTests.swift
+++ b/Tests/XCUITests/BookmarkingTests.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import XCTest
 
 let url_1 = "test-example.html"
@@ -14,7 +15,7 @@ let url_4 = "test-password-2.html"
 class BookmarkingTests: BaseTestCase {
     private func checkBookmarked() {
         navigator.goto(BrowserTabMenu)
-        waitForExistence(app.tables.otherElements[ImageIdentifiers.Large.bookmarkSlash])
+        waitForExistence(app.tables.otherElements[StandardImageIdentifiers.Large.bookmarkSlash])
         if iPad() {
             app.otherElements["PopoverDismissRegion"].tap()
             navigator.nowAt(BrowserTab)
@@ -25,8 +26,8 @@ class BookmarkingTests: BaseTestCase {
 
     private func undoBookmarkRemoval() {
         navigator.goto(BrowserTabMenu)
-        waitForExistence(app.tables.otherElements[ImageIdentifiers.Large.bookmarkSlash])
-        app.otherElements[ImageIdentifiers.Large.bookmarkSlash].tap()
+        waitForExistence(app.tables.otherElements[StandardImageIdentifiers.Large.bookmarkSlash])
+        app.otherElements[StandardImageIdentifiers.Large.bookmarkSlash].tap()
         navigator.nowAt(BrowserTab)
         waitForExistence(app.buttons["Undo"], timeout: 3)
         app.buttons["Undo"].tap()
@@ -34,7 +35,7 @@ class BookmarkingTests: BaseTestCase {
 
     private func checkUnbookmarked() {
         navigator.goto(BrowserTabMenu)
-        waitForExistence(app.tables.otherElements[ImageIdentifiers.Large.bookmark])
+        waitForExistence(app.tables.otherElements[StandardImageIdentifiers.Large.bookmark])
         if iPad() {
             app.otherElements["PopoverDismissRegion"].tap()
             navigator.nowAt(BrowserTab)
@@ -171,7 +172,7 @@ class BookmarkingTests: BaseTestCase {
         navigator.nowAt(MobileBookmarks)
         // Now remove the folder
         navigator.performAction(Action.RemoveItemMobileBookmarks)
-        waitForExistence(app.buttons[ImageIdentifiers.Large.delete])
+        waitForExistence(app.buttons[StandardImageIdentifiers.Large.delete])
         navigator.performAction(Action.ConfirmRemoveItemMobileBookmarks)
         checkItemsInBookmarksList(items: 0)
     }
@@ -186,7 +187,7 @@ class BookmarkingTests: BaseTestCase {
         // Remove it
         navigator.nowAt(MobileBookmarks)
         navigator.performAction(Action.RemoveItemMobileBookmarks)
-        waitForExistence(app.buttons[ImageIdentifiers.Large.delete])
+        waitForExistence(app.buttons[StandardImageIdentifiers.Large.delete])
         navigator.performAction(Action.ConfirmRemoveItemMobileBookmarks)
         checkItemsInBookmarksList(items: 0)
     }
@@ -195,7 +196,7 @@ class BookmarkingTests: BaseTestCase {
         addNewBookmark()
         // Remove by swiping
         app.tables["Bookmarks List"].staticTexts["BBC"].swipeLeft()
-        app.buttons[ImageIdentifiers.Large.delete].tap()
+        app.buttons[StandardImageIdentifiers.Large.delete].tap()
         checkItemsInBookmarksList(items: 0)
     }
 
@@ -204,7 +205,7 @@ class BookmarkingTests: BaseTestCase {
         // Remove by long press and select option from context menu
         app.tables.staticTexts.element(boundBy: 0).press(forDuration: 1)
         waitForExistence(app.tables["Context Menu"])
-        app.tables["Context Menu"].cells[ImageIdentifiers.Large.bookmarkSlash].tap()
+        app.tables["Context Menu"].cells[StandardImageIdentifiers.Large.bookmarkSlash].tap()
         checkItemsInBookmarksList(items: 0)
     }*/
 
@@ -276,7 +277,7 @@ class BookmarkingTests: BaseTestCase {
             app.tables.otherElements["Remove Bookmark"].tap()
         } else {
             app.tables["Bookmarks List"].cells.staticTexts["Example Domain"].swipeLeft()
-            app.buttons[ImageIdentifiers.Large.delete].tap()
+            app.buttons[StandardImageIdentifiers.Large.delete].tap()
         }
         waitForNoExistence(app.tables["Bookmarks List"].cells.staticTexts["Example Domain"], timeoutValue: 10)
         XCTAssertFalse(app.tables["Bookmarks List"].cells.staticTexts["Example Domain"].exists, "Bookmark not removed successfully")

--- a/Tests/XCUITests/DesktopModeTests.swift
+++ b/Tests/XCUITests/DesktopModeTests.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import XCTest
 
 // swiftlint:disable empty_count
@@ -97,14 +98,14 @@ class DesktopModeTestsIphone: IphoneOnlyTestCase {
         XCTAssert(app.webViews.staticTexts.matching(identifier: "MOBILE_UA").count > 0)
         waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton])
         navigator.goto(BrowserTabMenu)
-        waitForExistence(app.tables["Context Menu"].otherElements[ImageIdentifiers.Large.deviceDesktop])
+        waitForExistence(app.tables["Context Menu"].otherElements[StandardImageIdentifiers.Large.deviceDesktop])
         navigator.goto(RequestDesktopSite)
         waitUntilPageLoad()
         XCTAssert(app.webViews.staticTexts.matching(identifier: "DESKTOP_UA").count > 0)
 
         navigator.nowAt(BrowserTab)
         navigator.goto(BrowserTabMenu)
-        waitForExistence(app.tables["Context Menu"].otherElements[ImageIdentifiers.Large.deviceMobile])
+        waitForExistence(app.tables["Context Menu"].otherElements[StandardImageIdentifiers.Large.deviceMobile])
         // Select Mobile site here, the identifier is the same but the Text is not
         navigator.goto(RequestMobileSite)
         waitUntilPageLoad()

--- a/Tests/XCUITests/DownloadFilesTests.swift
+++ b/Tests/XCUITests/DownloadFilesTests.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import XCTest
 
 let testFileName = "Download smallZip.zip"
@@ -29,8 +30,8 @@ class DownloadFilesTests: BaseTestCase {
                 for _ in 0...list-1 {
                     waitForExistence(app.tables["DownloadsTable"].cells.element(boundBy: 0))
                     app.tables["DownloadsTable"].cells.element(boundBy: 0).swipeLeft()
-                    waitForExistence(app.tables.cells.buttons[ImageIdentifiers.Large.delete])
-                    app.tables.cells.buttons[ImageIdentifiers.Large.delete].tap()
+                    waitForExistence(app.tables.cells.buttons[StandardImageIdentifiers.Large.delete])
+                    app.tables.cells.buttons[StandardImageIdentifiers.Large.delete].tap()
                 }
             }
         }
@@ -39,8 +40,8 @@ class DownloadFilesTests: BaseTestCase {
 
     private func deleteItem(itemName: String) {
         app.tables.cells.staticTexts[itemName].swipeLeft()
-        waitForExistence(app.tables.cells.buttons[ImageIdentifiers.Large.delete], timeout: TIMEOUT)
-        app.tables.cells.buttons[ImageIdentifiers.Large.delete].tap()
+        waitForExistence(app.tables.cells.buttons[StandardImageIdentifiers.Large.delete], timeout: TIMEOUT)
+        app.tables.cells.buttons[StandardImageIdentifiers.Large.delete].tap()
     }
 
     func testDownloadFilesAppMenuFirstTime() {
@@ -65,7 +66,7 @@ class DownloadFilesTests: BaseTestCase {
 
         waitForExistence(app.tables["Context Menu"], timeout: TIMEOUT)
         XCTAssertTrue(app.tables["Context Menu"].staticTexts[testFileNameDownloadPanel].exists)
-        XCTAssertTrue(app.tables["Context Menu"].otherElements[ImageIdentifiers.Large.download].exists)
+        XCTAssertTrue(app.tables["Context Menu"].otherElements[StandardImageIdentifiers.Large.download].exists)
         app.buttons["Cancel"].tap()
         navigator.goto(BrowserTabMenu)
         navigator.goto(LibraryPanel_Downloads)
@@ -122,7 +123,7 @@ class DownloadFilesTests: BaseTestCase {
         } else {
             app.tables.cells.staticTexts[testFileNameDownloadPanel].swipeLeft()
             XCTAssertTrue(app.tables.buttons.staticTexts["Share"].exists)
-            XCTAssertTrue(app.tables.buttons.staticTexts[ImageIdentifiers.Large.delete].exists)
+            XCTAssertTrue(app.tables.buttons.staticTexts[StandardImageIdentifiers.Large.delete].exists)
         }
     }
 
@@ -154,8 +155,8 @@ class DownloadFilesTests: BaseTestCase {
 
             app.webViews.links[testFileName].firstMatch.tap()
 
-            waitForExistence(app.tables["Context Menu"].otherElements[ImageIdentifiers.Large.download], timeout: TIMEOUT)
-            app.tables["Context Menu"].otherElements[ImageIdentifiers.Large.download].tap()
+            waitForExistence(app.tables["Context Menu"].otherElements[StandardImageIdentifiers.Large.download], timeout: TIMEOUT)
+            app.tables["Context Menu"].otherElements[StandardImageIdentifiers.Large.download].tap()
         }
     }
 

--- a/Tests/XCUITests/FxScreenGraph.swift
+++ b/Tests/XCUITests/FxScreenGraph.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
 import MappaMundi
 import XCTest
@@ -469,13 +470,13 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
             app.tables["Bookmarks List"].buttons.element(boundBy: 0).tap()
         }
         screenState.gesture(forAction: Action.ConfirmRemoveItemMobileBookmarks) { userState in
-            app.buttons[ImageIdentifiers.Large.delete].tap()
+            app.buttons[StandardImageIdentifiers.Large.delete].tap()
         }
     }
 
     map.addScreenState(MobileBookmarksAdd) { screenState in
         screenState.gesture(forAction: Action.AddNewBookmark, transitionTo: EnterNewBookmarkTitleAndUrl) { userState in
-            app.tables.cells[ImageIdentifiers.Large.bookmark].tap()
+            app.tables.cells[StandardImageIdentifiers.Large.bookmark].tap()
         }
         screenState.gesture(forAction: Action.AddNewFolder) { userState in
             app.tables.cells["bookmarkFolder"].tap()
@@ -815,8 +816,8 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     if !isTablet {
         map.addScreenState(TabTrayLongPressMenu) { screenState in
             screenState.dismissOnUse = true
-            screenState.tap(app.otherElements[ImageIdentifiers.Large.plus], forAction: Action.OpenNewTabLongPressTabsButton, transitionTo: NewTabScreen)
-            screenState.tap(app.otherElements[ImageIdentifiers.Large.cross], forAction: Action.CloseTabFromTabTrayLongPressMenu, Action.CloseTab, transitionTo: HomePanelsScreen)
+            screenState.tap(app.otherElements[StandardImageIdentifiers.Large.plus], forAction: Action.OpenNewTabLongPressTabsButton, transitionTo: NewTabScreen)
+            screenState.tap(app.otherElements[StandardImageIdentifiers.Large.cross], forAction: Action.CloseTabFromTabTrayLongPressMenu, Action.CloseTab, transitionTo: HomePanelsScreen)
             screenState.tap(app.otherElements["nav-tabcounter"], forAction: Action.OpenPrivateTabLongPressTabsButton, transitionTo: NewTabScreen) { userState in
                 userState.isPrivate = !userState.isPrivate
             }
@@ -950,12 +951,12 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     map.addScreenState(BrowserTabMenu) { screenState in
         screenState.tap(app.tables.otherElements[ImageIdentifiers.settings], to: SettingsScreen)
         screenState.tap(app.tables.otherElements[ImageIdentifiers.sync], to: Intro_FxASignin, if: "fxaUsername == nil")
-        screenState.tap(app.tables.otherElements[ImageIdentifiers.Large.login], to: LoginsSettings)
-        screenState.tap(app.tables.otherElements[ImageIdentifiers.Large.bookmarkTrayFill], to: LibraryPanel_Bookmarks)
-        screenState.tap(app.tables.otherElements[ImageIdentifiers.Large.history], to: LibraryPanel_History)
-        screenState.tap(app.tables.otherElements[ImageIdentifiers.Large.download], to: LibraryPanel_Downloads)
+        screenState.tap(app.tables.otherElements[StandardImageIdentifiers.Large.login], to: LoginsSettings)
+        screenState.tap(app.tables.otherElements[StandardImageIdentifiers.Large.bookmarkTrayFill], to: LibraryPanel_Bookmarks)
+        screenState.tap(app.tables.otherElements[StandardImageIdentifiers.Large.history], to: LibraryPanel_History)
+        screenState.tap(app.tables.otherElements[StandardImageIdentifiers.Large.download], to: LibraryPanel_Downloads)
         screenState.tap(app.tables.otherElements[ImageIdentifiers.readingList], to: LibraryPanel_ReadingList)
-        screenState.tap(app.tables.otherElements[ImageIdentifiers.Large.avatarCircle], to: FxAccountManagementPage)
+        screenState.tap(app.tables.otherElements[StandardImageIdentifiers.Large.avatarCircle], to: FxAccountManagementPage)
 
         screenState.tap(app.tables.otherElements[ImageIdentifiers.nightMode], forAction: Action.ToggleNightMode, transitionTo: BrowserTabMenu) { userState in
             userState.nightMode = !userState.nightMode
@@ -963,23 +964,23 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
         screenState.tap(app.tables.otherElements[ImageIdentifiers.whatsNew], forAction: Action.OpenWhatsNewPage) { userState in
         }
-        screenState.tap(app.tables.otherElements[ImageIdentifiers.Large.deviceDesktopSend], forAction: Action.SentToDevice) { userState in
+        screenState.tap(app.tables.otherElements[StandardImageIdentifiers.Large.deviceDesktopSend], forAction: Action.SentToDevice) { userState in
         }
 
         screenState.tap(app.tables.otherElements[ImageIdentifiers.share], forAction: Action.ShareBrowserTabMenuOption) {
             userState in
         }
 
-        screenState.tap(app.tables.otherElements[ImageIdentifiers.Large.deviceDesktop], to: RequestDesktopSite)
-        screenState.tap(app.tables.otherElements[ImageIdentifiers.Large.deviceMobile], to: RequestMobileSite)
+        screenState.tap(app.tables.otherElements[StandardImageIdentifiers.Large.deviceDesktop], to: RequestDesktopSite)
+        screenState.tap(app.tables.otherElements[StandardImageIdentifiers.Large.deviceMobile], to: RequestMobileSite)
         screenState.tap(app.tables.otherElements[ImageIdentifiers.findInPage], to: FindInPage)
         // TODO: Add new state
-        // screenState.tap(app.tables["Context Menu"].otherElements[ImageIdentifiers.Large.lightbulb], to: ReportSiteIssue)
+        // screenState.tap(app.tables["Context Menu"].otherElements[StandardImageIdentifiers.Large.lightbulb], to: ReportSiteIssue)
 
         screenState.tap(app.tables.otherElements[ImageIdentifiers.addShortcut], forAction: Action.PinToTopSitesPAM)
-        screenState.tap(app.tables.otherElements[ImageIdentifiers.Large.link], forAction: Action.CopyAddressPAM)
+        screenState.tap(app.tables.otherElements[StandardImageIdentifiers.Large.link], forAction: Action.CopyAddressPAM)
 
-        screenState.tap(app.tables.otherElements[ImageIdentifiers.Large.bookmark], forAction: Action.BookmarkThreeDots, Action.Bookmark)
+        screenState.tap(app.tables.otherElements[StandardImageIdentifiers.Large.bookmark], forAction: Action.BookmarkThreeDots, Action.Bookmark)
         screenState.tap(app.tables.otherElements[ImageIdentifiers.addToReadingList], forAction: Action.AddToReadingListBrowserTabMenu)
 
         screenState.dismissOnUse = true

--- a/Tests/XCUITests/HistoryTests.swift
+++ b/Tests/XCUITests/HistoryTests.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import XCTest
 
 let webpage = ["url": "www.mozilla.org", "label": "Internet for people, not profit — Mozilla", "value": "mozilla.org"]
@@ -218,8 +219,8 @@ class HistoryTests: BaseTestCase {
         XCTAssertTrue(app.tables.cells.staticTexts[bookOfMozilla["label"]!].exists)
         app.tables.cells.staticTexts[bookOfMozilla["label"]!].press(forDuration: 1)
         waitForExistence(app.tables["Context Menu"])
-        XCTAssertTrue(app.tables.otherElements[ImageIdentifiers.Large.plus].exists)
-        XCTAssertTrue(app.tables.otherElements[ImageIdentifiers.Large.privateMode].exists)
+        XCTAssertTrue(app.tables.otherElements[StandardImageIdentifiers.Large.plus].exists)
+        XCTAssertTrue(app.tables.otherElements[StandardImageIdentifiers.Large.privateMode].exists)
     }
 
     func testOpenInNewTabRecentlyClosedItem() {
@@ -235,7 +236,7 @@ class HistoryTests: BaseTestCase {
         XCTAssertEqual(userState.numTabs, 1)
         app.tables.cells.staticTexts[bookOfMozilla["label"]!].press(forDuration: 1)
         waitForExistence(app.tables["Context Menu"])
-        app.tables.otherElements[ImageIdentifiers.Large.plus].tap()
+        app.tables.otherElements[StandardImageIdentifiers.Large.plus].tap()
 
         // The page is opened on the new tab
         navigator.nowAt(NewTabScreen)
@@ -261,7 +262,7 @@ class HistoryTests: BaseTestCase {
         XCTAssertTrue(app.tables.cells.staticTexts[bookOfMozilla["label"]!].exists)
         app.tables.cells.staticTexts[bookOfMozilla["label"]!].press(forDuration: 1)
         waitForExistence(app.tables["Context Menu"])
-        app.tables.otherElements[ImageIdentifiers.Large.privateMode].tap()
+        app.tables.otherElements[StandardImageIdentifiers.Large.privateMode].tap()
 
         // The page is opened only on the new private tab
         navigator.nowAt(NewTabScreen)
@@ -381,10 +382,10 @@ class HistoryTests: BaseTestCase {
         waitForTabsButton()
         navigator.goto(TabTray)
         if isTablet {
-            app.otherElements["Tabs Tray"].collectionViews.cells.element(boundBy: 0).buttons[ImageIdentifiers.Large.cross].tap()
+            app.otherElements["Tabs Tray"].collectionViews.cells.element(boundBy: 0).buttons[StandardImageIdentifiers.Large.cross].tap()
         } else {
-            app.cells.buttons[ImageIdentifiers.Large.cross].firstMatch.tap()
-            // app.otherElements.cells.element(boundBy: 0).buttons[ImageIdentifiers.Large.cross].tap()
+            app.cells.buttons[StandardImageIdentifiers.Large.cross].firstMatch.tap()
+            // app.otherElements.cells.element(boundBy: 0).buttons[StandardImageIdentifiers.Large.cross].tap()
         }
     }
 
@@ -448,8 +449,8 @@ class HistoryTests: BaseTestCase {
             navigator.goto(LibraryPanel_History)
             waitForExistence(app.cells.staticTexts["http://example.com/"], timeout: TIMEOUT)
             app.cells.staticTexts["http://example.com/"].firstMatch.swipeLeft()
-            waitForExistence(app.buttons[ImageIdentifiers.Large.delete], timeout: TIMEOUT)
-            app.buttons[ImageIdentifiers.Large.delete].tap()
+            waitForExistence(app.buttons[StandardImageIdentifiers.Large.delete], timeout: TIMEOUT)
+            app.buttons[StandardImageIdentifiers.Large.delete].tap()
             waitForNoExistence(app.staticTexts["http://example.com"])
         }
     }

--- a/Tests/XCUITests/IntegrationTests.swift
+++ b/Tests/XCUITests/IntegrationTests.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import XCTest
 
 private let testingURL = "example.com"
@@ -109,8 +110,8 @@ class IntegrationTests: BaseTestCase {
         navigator.openURL("example.com")
         waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection], timeout: 5)
         navigator.goto(BrowserTabMenu)
-        waitForExistence(app.tables.otherElements[ImageIdentifiers.Large.bookmark], timeout: 15)
-        app.tables.otherElements[ImageIdentifiers.Large.bookmark].tap()
+        waitForExistence(app.tables.otherElements[StandardImageIdentifiers.Large.bookmark], timeout: 15)
+        app.tables.otherElements[StandardImageIdentifiers.Large.bookmark].tap()
         navigator.nowAt(BrowserTab)
         signInFxAccounts()
 

--- a/Tests/XCUITests/JumpBackInTests.swift
+++ b/Tests/XCUITests/JumpBackInTests.swift
@@ -165,7 +165,7 @@ class JumpBackInTests: BaseTestCase {
 //        } else {
 //            waitForExistence(app.navigationBars.staticTexts["Open Tabs"])
 //        }
-//        app.cells["Amazon.com. Spend less. Smile more."].buttons[ImageIdentifiers.Large.cross].tap()
+//        app.cells["Amazon.com. Spend less. Smile more."].buttons[StandardImageIdentifiers.Large.cross].tap()
 //
 //        // Revisit the "Jump Back In" section
 //        waitForExistence(app.buttons[AccessibilityIdentifiers.TabTray.newTabButton], timeout: TIMEOUT)

--- a/Tests/XCUITests/NavigationTest.swift
+++ b/Tests/XCUITests/NavigationTest.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import XCTest
 
 let website_1 = ["url": "www.mozilla.org", "label": "Internet for people, not profit — Mozilla", "value": "mozilla.org"]
@@ -232,7 +233,7 @@ class NavigationTest: BaseTestCase {
             waitForNoExistence(app.staticTexts["XCUITests-Runner pasted from Fennec"])
 
             app.textFields["url"].press(forDuration: 3)
-            app.tables.otherElements[ImageIdentifiers.Large.link].tap()
+            app.tables.otherElements[StandardImageIdentifiers.Large.link].tap()
 
             sleep(2)
             app.textFields["url"].tap()
@@ -274,8 +275,8 @@ class NavigationTest: BaseTestCase {
     func testDownloadLink() {
         longPressLinkOptions(optionSelected: "Download Link")
         waitForExistence(app.tables["Context Menu"])
-        XCTAssertTrue(app.tables["Context Menu"].otherElements[ImageIdentifiers.Large.download].exists)
-        app.tables["Context Menu"].otherElements[ImageIdentifiers.Large.download].tap()
+        XCTAssertTrue(app.tables["Context Menu"].otherElements[StandardImageIdentifiers.Large.download].exists)
+        app.tables["Context Menu"].otherElements[StandardImageIdentifiers.Large.download].tap()
         navigator.goto(BrowserTabMenu)
         navigator.goto(LibraryPanel_Downloads)
         waitForExistence(app.tables["DownloadsTable"])
@@ -378,11 +379,11 @@ class NavigationTest: BaseTestCase {
         navigator.goto(BrowserTabMenu)
         waitForExistence(app.tables["Context Menu"])
 
-        XCTAssertTrue(app.tables.otherElements[ImageIdentifiers.Large.bookmarkTrayFill].exists)
-        XCTAssertTrue(app.tables.otherElements[ImageIdentifiers.Large.history].exists)
-        XCTAssertTrue(app.tables.otherElements[ImageIdentifiers.Large.download].exists)
+        XCTAssertTrue(app.tables.otherElements[StandardImageIdentifiers.Large.bookmarkTrayFill].exists)
+        XCTAssertTrue(app.tables.otherElements[StandardImageIdentifiers.Large.history].exists)
+        XCTAssertTrue(app.tables.otherElements[StandardImageIdentifiers.Large.download].exists)
         XCTAssertTrue(app.tables.otherElements[ImageIdentifiers.readingList].exists)
-        XCTAssertTrue(app.tables.otherElements[ImageIdentifiers.Large.login].exists)
+        XCTAssertTrue(app.tables.otherElements[StandardImageIdentifiers.Large.login].exists)
         XCTAssertTrue(app.tables.otherElements[ImageIdentifiers.sync].exists)
         XCTAssertTrue(app.tables.otherElements[ImageIdentifiers.nightMode].exists)
         XCTAssertTrue(app.tables.otherElements[ImageIdentifiers.whatsNew].exists)

--- a/Tests/XCUITests/ReaderViewUITest.swift
+++ b/Tests/XCUITests/ReaderViewUITest.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import XCTest
 
 class ReaderViewTest: BaseTestCase {
@@ -188,7 +189,7 @@ class ReaderViewTest: BaseTestCase {
 
         // Select to open in New Tab
         waitForExistence(app.tables["Context Menu"])
-        app.tables.otherElements[ImageIdentifiers.Large.plus].tap()
+        app.tables.otherElements[StandardImageIdentifiers.Large.plus].tap()
         updateScreenGraph()
         // Now there should be two tabs open
         navigator.goto(HomePanelsScreen)
@@ -206,7 +207,7 @@ class ReaderViewTest: BaseTestCase {
         waitForExistence(savedToReadingList)
         savedToReadingList.press(forDuration: 1)
         waitForExistence(app.tables["Context Menu"])
-        app.tables.otherElements[ImageIdentifiers.Large.cross].tap()
+        app.tables.otherElements[StandardImageIdentifiers.Large.cross].tap()
 
         // Verify the item has been removed
         waitForNoExistence(app.tables["ReadingTable"].cells.staticTexts["The Book of Mozilla"])

--- a/Tests/XCUITests/TabCounterTests.swift
+++ b/Tests/XCUITests/TabCounterTests.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import XCTest
 
 class TabCounterTests: BaseTestCase {
@@ -54,7 +55,7 @@ class TabCounterTests: BaseTestCase {
         navigator.goto(TabTray)
 
         if isTablet {
-            app.otherElements["Tabs Tray"].collectionViews.cells.element(boundBy: 0).buttons[ImageIdentifiers.Large.cross].tap()
+            app.otherElements["Tabs Tray"].collectionViews.cells.element(boundBy: 0).buttons[StandardImageIdentifiers.Large.cross].tap()
         } else {
             let navBarTabTrayButton = app.segmentedControls["navBarTabTray"].buttons.firstMatch
             waitForExistence(navBarTabTrayButton)
@@ -62,7 +63,7 @@ class TabCounterTests: BaseTestCase {
             let tabsOpenTabTray: String = navBarTabTrayButton.label
             XCTAssertTrue(tabsOpenTabTray.hasSuffix("2"))
 
-            app.otherElements["Tabs Tray"].cells.element(boundBy: 0).buttons[ImageIdentifiers.Large.cross].tap()
+            app.otherElements["Tabs Tray"].cells.element(boundBy: 0).buttons[StandardImageIdentifiers.Large.cross].tap()
         }
 
         app.otherElements["Tabs Tray"].cells.element(boundBy: 0).tap()

--- a/Tests/XCUITests/TopTabsTest.swift
+++ b/Tests/XCUITests/TopTabsTest.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import XCTest
 
 let url = "www.mozilla.org"
@@ -100,9 +101,9 @@ class TopTabsTest: BaseTestCase {
         waitForExistence(app.cells.staticTexts[urlLabel])
         // Close the tab using 'x' button
         if iPad() {
-            app.cells.buttons[ImageIdentifiers.Large.cross].tap()
+            app.cells.buttons[StandardImageIdentifiers.Large.cross].tap()
         } else {
-            app.otherElements.cells.buttons[ImageIdentifiers.Large.cross].tap()
+            app.otherElements.cells.buttons[StandardImageIdentifiers.Large.cross].tap()
         }
 
         // After removing only one tab it automatically goes to HomepanelView
@@ -270,12 +271,12 @@ class TopTabsTest: BaseTestCase {
             navigator.nowAt(NewTabScreen)
             waitForExistence(app.buttons["Show Tabs"], timeout: 10)
             app.buttons["Show Tabs"].press(forDuration: 1)
-            waitForExistence(app.cells.otherElements[ImageIdentifiers.Large.plus])
-            XCTAssertTrue(app.cells.otherElements[ImageIdentifiers.Large.plus].exists)
-            XCTAssertTrue(app.cells.otherElements[ImageIdentifiers.Large.cross].exists)
+            waitForExistence(app.cells.otherElements[StandardImageIdentifiers.Large.plus])
+            XCTAssertTrue(app.cells.otherElements[StandardImageIdentifiers.Large.plus].exists)
+            XCTAssertTrue(app.cells.otherElements[StandardImageIdentifiers.Large.cross].exists)
 
             // Open New Tab
-            app.cells.otherElements[ImageIdentifiers.Large.plus].tap()
+            app.cells.otherElements[StandardImageIdentifiers.Large.plus].tap()
             navigator.performAction(Action.CloseURLBarOpen)
 
             waitForTabsButton()
@@ -290,8 +291,8 @@ class TopTabsTest: BaseTestCase {
 
             waitForExistence(app.buttons["Show Tabs"])
             app.buttons["Show Tabs"].press(forDuration: 1)
-            waitForExistence(app.tables.cells.otherElements[ImageIdentifiers.Large.plus])
-            app.tables.cells.otherElements[ImageIdentifiers.Large.cross].tap()
+            waitForExistence(app.tables.cells.otherElements[StandardImageIdentifiers.Large.plus])
+            app.tables.cells.otherElements[StandardImageIdentifiers.Large.cross].tap()
             navigator.nowAt(NewTabScreen)
             checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
 
@@ -376,8 +377,8 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
         navigator.goto(URLBarOpen)
         navigator.back()
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
-        waitForExistence(app.buttons[ImageIdentifiers.Large.privateMode])
-        XCTAssertTrue(app.buttons[ImageIdentifiers.Large.privateMode].isEnabled)
+        waitForExistence(app.buttons[StandardImageIdentifiers.Large.privateMode])
+        XCTAssertTrue(app.buttons[StandardImageIdentifiers.Large.privateMode].isEnabled)
         XCTAssertTrue(userState.isPrivate)
     }
 
@@ -443,7 +444,7 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
         waitForExistence(app.textFields["url"], timeout: 5)
         waitForValueContains(app.textFields["url"], value: "iana")
         navigator.goto(TabTray)
-        XCTAssertTrue(app.buttons[ImageIdentifiers.Large.privateMode].isEnabled)
+        XCTAssertTrue(app.buttons[StandardImageIdentifiers.Large.privateMode].isEnabled)
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6871)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15304)

## :bulb: Description
Create Standard Image identifiers, and use those in the needed places in the app. This way we can have the standard images used in library components.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

