### PR TITLE
Remove FXIOS-6739 [v117] Remove shake to restore

### DIFF
--- a/.experimenter.yaml
+++ b/.experimenter.yaml
@@ -53,17 +53,11 @@ general-app-features:
     report-site-issue:
       type: json
       description: This property defines whether or not the feature is enabled
-    shake-to-restore:
-      type: json
-      description: This property defines whether or not the feature is enabled
 homescreenFeature:
   description: The homescreen that the user goes to when they press home or new tab.
   hasExposure: true
   exposureDescription: ""
   variables:
-    jump-back-in-synced-tab:
-      type: boolean
-      description: "This property defines whether the synced tab card appears on the homepage in the jump back in section.\n"
     pocket-sponsored-stories:
       type: boolean
       description: "This property defines whether pocket sponsored stories appear on the homepage.\n"

--- a/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -31,7 +31,6 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case reportSiteIssue
     case searchHighlights
     case settingsCoordinatorRefactor
-    case shakeToRestore
     case shareExtensionCoordinatorRefactor
     case shareSheetChanges
     case shareToolbarChanges
@@ -105,7 +104,6 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .reportSiteIssue,
                 .searchHighlights,
                 .settingsCoordinatorRefactor,
-                .shakeToRestore,
                 .shareExtensionCoordinatorRefactor,
                 .shareSheetChanges,
                 .shareToolbarChanges,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2788,41 +2788,6 @@ extension BrowserViewController: DevicePickerViewControllerDelegate, Instruction
     }
 }
 
-// MARK: - Reopen last closed tab
-
-extension BrowserViewController: FeatureFlaggable {
-    override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
-        if featureFlags.isFeatureEnabled(.shakeToRestore, checking: .buildOnly) {
-            homePanelDidRequestToRestoreClosedTab(motion)
-        }
-    }
-
-    func homePanelDidRequestToRestoreClosedTab(_ motion: UIEvent.EventSubtype) {
-        guard motion == .motionShake,
-              !topTabsVisible,
-              !urlBar.inOverlayMode,
-              let lastClosedURL = profile.recentlyClosedTabs.tabs.first?.url,
-              let selectedTab = tabManager.selectedTab
-        else { return }
-
-        let alertTitleText: String = .ReopenLastTabAlertTitle
-        let reopenButtonText: String = .ReopenLastTabButtonText
-        let cancelButtonText: String = .ReopenLastTabCancelText
-
-        func reopenLastTab(_ action: UIAlertAction) {
-            let request = URLRequest(url: lastClosedURL)
-            let closedTab = tabManager.addTab(request, afterTab: selectedTab, isPrivate: false)
-            tabManager.selectTab(closedTab)
-        }
-
-        let alert = AlertController(title: alertTitleText, message: "", preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: reopenButtonText, style: .default, handler: reopenLastTab), accessibilityIdentifier: "BrowserViewController.ReopenLastTabAlert.ReopenButton")
-        alert.addAction(UIAlertAction(title: cancelButtonText, style: .cancel, handler: nil), accessibilityIdentifier: "BrowserViewController.ReopenLastTabAlert.CancelButton")
-
-        self.present(alert, animated: true, completion: nil)
-    }
-}
-
 extension BrowserViewController {
     /// This method now returns the BrowserViewController associated with the scene.
     /// We currently have a single scene app setup, so this will change as we introduce support for multiple scenes.

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -1838,21 +1838,6 @@ extension String {
         tableName: nil,
         value: "Current Homepage",
         comment: "Title of the setting section containing the URL of the current home page.")
-    public static let ReopenLastTabAlertTitle = MZLocalizedString(
-        key: "ReopenAlert.Title",
-        tableName: nil,
-        value: "Reopen Last Closed Tab",
-        comment: "Reopen alert title shown at home page.")
-    public static let ReopenLastTabButtonText = MZLocalizedString(
-        key: "ReopenAlert.Actions.Reopen",
-        tableName: nil,
-        value: "Reopen",
-        comment: "Reopen button text shown in reopen-alert at home page.")
-    public static let ReopenLastTabCancelText = MZLocalizedString(
-        key: "ReopenAlert.Actions.Cancel",
-        tableName: nil,
-        value: "Cancel",
-        comment: "Cancel button text shown in reopen-alert at home page.")
 }
 
 // MARK: - Settings

--- a/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -14,8 +14,7 @@ final class NimbusFeatureFlagLayer {
         case .autopushFeature:
             return checkAutopushFeature(from: nimbus)
         case .pullToRefresh,
-                .reportSiteIssue,
-                .shakeToRestore:
+                .reportSiteIssue:
             return checkGeneralFeature(for: featureID, from: nimbus)
 
         case .bottomSearchBar,
@@ -112,7 +111,6 @@ final class NimbusFeatureFlagLayer {
         switch featureID {
         case .pullToRefresh: return config.pullToRefresh.status
         case .reportSiteIssue: return config.reportSiteIssue.status
-        case .shakeToRestore: return config.shakeToRestore.status
         default: return false
         }
     }

--- a/Tests/ClientTests/FeatureFlagManagerTests.swift
+++ b/Tests/ClientTests/FeatureFlagManagerTests.swift
@@ -54,8 +54,6 @@ class FeatureFlagManagerTests: XCTestCase, FeatureFlaggable {
         XCTAssertTrue(featureFlags.isFeatureEnabled(.recentlySaved, checking: .userOnly))
         XCTAssertTrue(featureFlags.isFeatureEnabled(.reportSiteIssue, checking: .buildOnly))
         XCTAssertTrue(featureFlags.isFeatureEnabled(.reportSiteIssue, checking: .userOnly))
-        XCTAssertTrue(featureFlags.isFeatureEnabled(.shakeToRestore, checking: .buildOnly))
-        XCTAssertTrue(featureFlags.isFeatureEnabled(.shakeToRestore, checking: .userOnly))
         XCTAssertTrue(featureFlags.isFeatureEnabled(.sponsoredTiles, checking: .buildOnly))
         XCTAssertTrue(featureFlags.isFeatureEnabled(.sponsoredTiles, checking: .userOnly))
         XCTAssertTrue(featureFlags.isFeatureEnabled(.startAtHome, checking: .buildOnly))

--- a/nimbus-features/generalFeatures.yaml
+++ b/nimbus-features/generalFeatures.yaml
@@ -16,13 +16,6 @@ features:
           {
             "status": false
           }
-      shake-to-restore:
-        description: "This property defines whether or not the feature is enabled"
-        type: GeneralFeature
-        default:
-          {
-            "status": false
-          }
     defaults:
       - channel: beta
         value: {
@@ -30,9 +23,6 @@ features:
             "status": true
           },
           "report-site-issue": {
-            "status": true
-          },
-          "shake-to-restore": {
             "status": true
           }
         }
@@ -42,9 +32,6 @@ features:
             "status": true
           },
           "report-site-issue": {
-            "status": true
-          },
-          "shake-to-restore": {
             "status": true
           }
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6739)

## :bulb: Description
Remove shake to restore. This was enabled in Beta, but never in Production. This PR removes this feature entirely.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

