### PR TITLE
Refactor FXIOS-6203 [v117] Clean up homepage view cycles

### DIFF
--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -138,6 +138,7 @@ class BrowserCoordinator: BaseCoordinator,
                              statusBarScrollDelegate: StatusBarScrollDelegate,
                              overlayManager: OverlayModeManager) -> HomepageViewController {
         if let homepageViewController = homepageViewController {
+            homepageViewController.configure(isZeroSearch: inline)
             return homepageViewController
         } else {
             let homepageViewController = HomepageViewController(

--- a/Client/Frontend/Fakespot/Components/CardContainer.swift
+++ b/Client/Frontend/Fakespot/Components/CardContainer.swift
@@ -44,7 +44,7 @@ class CardContainer: UIView, ThemeApplicable {
     }
 
     func configure(_ view: UIView) {
-        rootView.subviews.map { $0.removeFromSuperview() }
+        rootView.subviews.forEach { $0.removeFromSuperview() }
         rootView.addSubview(view)
 
         NSLayoutConstraint.activate([


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6203)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13982)

## :bulb: Description
- Clean up homepage view cycles since we now use coordinators, those fake view cycles methods aren't needed anymore.
- Made sure `isZeroSearch` is configured correctly with coordinators

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

