### PR TITLE
Add FXIOS-7044 [v116] Make onboarding instruction card button experimentable

### DIFF
--- a/.experimenter.yaml
+++ b/.experimenter.yaml
@@ -61,9 +61,6 @@ homescreenFeature:
   hasExposure: true
   exposureDescription: ""
   variables:
-    jump-back-in-synced-tab:
-      type: boolean
-      description: "This property defines whether the synced tab card appears on the homepage in the jump back in section.\n"
     pocket-sponsored-stories:
       type: boolean
       description: "This property defines whether pocket sponsored stories appear on the homepage.\n"

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -475,7 +475,7 @@
 		6ACB550C28633860007A6ABD /* TabManagerNavDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ACB550B28633860007A6ABD /* TabManagerNavDelegate.swift */; };
 		6ADB651B285C03B100947EA4 /* DownloadHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ADB651A285C03B100947EA4 /* DownloadHelperTests.swift */; };
 		742A56391D80B54A00BDB803 /* PhotonActionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742A56381D80B54A00BDB803 /* PhotonActionSheet.swift */; };
-		742BD99E2A13AC9000BA6B15 /* OnboardingDefaultSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742BD99D2A13AC9000BA6B15 /* OnboardingDefaultSettingsViewController.swift */; };
+		742BD99E2A13AC9000BA6B15 /* OnboardingInstructionPopupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742BD99D2A13AC9000BA6B15 /* OnboardingInstructionPopupViewController.swift */; };
 		744B0FFE1B4F172E00100422 /* ToolbarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 744B0FFD1B4F172E00100422 /* ToolbarTests.swift */; };
 		744ED5611DBFEB8D00A2B5BE /* MailtoLinkHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 744ED5601DBFEB8D00A2B5BE /* MailtoLinkHandler.swift */; };
 		745DAB301CDAAFAA00D44181 /* RecentlyClosedTabsPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 745DAB2F1CDAAFAA00D44181 /* RecentlyClosedTabsPanel.swift */; };
@@ -4459,7 +4459,7 @@
 		73AE44D19013492056E1416D /* ms */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ms; path = ms.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		73EC47B2B45CEC067D0CB266 /* es-CL */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-CL"; path = "es-CL.lproj/Shared.strings"; sourceTree = "<group>"; };
 		742A56381D80B54A00BDB803 /* PhotonActionSheet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhotonActionSheet.swift; sourceTree = "<group>"; };
-		742BD99D2A13AC9000BA6B15 /* OnboardingDefaultSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingDefaultSettingsViewController.swift; sourceTree = "<group>"; };
+		742BD99D2A13AC9000BA6B15 /* OnboardingInstructionPopupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingInstructionPopupViewController.swift; sourceTree = "<group>"; };
 		74364B73872F21F4DA1EB543 /* nn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nn; path = nn.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
 		744B0FFD1B4F172E00100422 /* ToolbarTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToolbarTests.swift; sourceTree = "<group>"; };
 		744ED5601DBFEB8D00A2B5BE /* MailtoLinkHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MailtoLinkHandler.swift; sourceTree = "<group>"; };
@@ -9253,7 +9253,7 @@
 				E49943F31AE6879C00BF9DE4 /* FirstInstall */,
 				21A7C44F28353D0E0071D996 /* OnboardingCardViewController.swift */,
 				74F80D332A0A52D700013C3D /* PrivacyPolicyViewController.swift */,
-				742BD99D2A13AC9000BA6B15 /* OnboardingDefaultSettingsViewController.swift */,
+				742BD99D2A13AC9000BA6B15 /* OnboardingInstructionPopupViewController.swift */,
 				43A5643423CD1E1B00B6857D /* Update */,
 			);
 			path = ViewControllers;
@@ -12735,7 +12735,7 @@
 				D3A9949D1A3686BD008AD1AC /* Tab.swift in Sources */,
 				8AD40FD127BADCBA00672675 /* ToolbarButton.swift in Sources */,
 				A93067E81D0FE18E00C49C6E /* NightModeHelper.swift in Sources */,
-				742BD99E2A13AC9000BA6B15 /* OnboardingDefaultSettingsViewController.swift in Sources */,
+				742BD99E2A13AC9000BA6B15 /* OnboardingInstructionPopupViewController.swift in Sources */,
 				9636D92C27F9E50100771F5E /* GleanPlumbMessageStore.swift in Sources */,
 				213B67A627CE682B000542F5 /* StartAtHomeHelper.swift in Sources */,
 				E10A1F752863BC51001EEA80 /* InactiveTabItemCell.swift in Sources */,

--- a/Client/BottomSheet/BottomSheetViewController.swift
+++ b/Client/BottomSheet/BottomSheetViewController.swift
@@ -12,7 +12,11 @@ protocol BottomSheetChild {
     func willDismiss()
 }
 
-class BottomSheetViewController: UIViewController, Themeable {
+protocol BottomSheetDismissProtocol {
+    func dismissSheetViewController()
+}
+
+class BottomSheetViewController: UIViewController, BottomSheetDismissProtocol, Themeable {
     private struct UX {
         static let minVisibleTopSpace: CGFloat = 40
         static let closeButtonWidthHeight: CGFloat = 30
@@ -116,7 +120,7 @@ class BottomSheetViewController: UIViewController, Themeable {
                                                   cornerRadius: viewModel.cornerRadius).cgPath
     }
 
-    public func dismissViewController() {
+    public func dismissSheetViewController() {
         childViewController.willDismiss()
         contentViewBottomConstraint.constant = childViewController.view.frame.height
         UIView.animate(
@@ -240,7 +244,7 @@ private extension BottomSheetViewController {
                     self.sheetView.transform = .identity
                 })
             } else {
-                dismissViewController()
+                dismissSheetViewController()
             }
         default:
             break
@@ -249,7 +253,7 @@ private extension BottomSheetViewController {
 
     @objc
     func closeTapped() {
-        dismissViewController()
+        dismissSheetViewController()
     }
 }
 

--- a/Client/BottomSheet/BottomSheetViewController.swift
+++ b/Client/BottomSheet/BottomSheetViewController.swift
@@ -13,7 +13,7 @@ protocol BottomSheetChild {
 }
 
 protocol BottomSheetDismissProtocol {
-    func dismissSheetViewController()
+    func dismissSheetViewController(completion: (() -> Void)?)
 }
 
 class BottomSheetViewController: UIViewController, BottomSheetDismissProtocol, Themeable {
@@ -120,7 +120,7 @@ class BottomSheetViewController: UIViewController, BottomSheetDismissProtocol, T
                                                   cornerRadius: viewModel.cornerRadius).cgPath
     }
 
-    public func dismissSheetViewController() {
+    public func dismissSheetViewController(completion: (() -> Void)? = nil) {
         childViewController.willDismiss()
         contentViewBottomConstraint.constant = childViewController.view.frame.height
         UIView.animate(
@@ -129,7 +129,7 @@ class BottomSheetViewController: UIViewController, BottomSheetDismissProtocol, T
                 self.view.layoutIfNeeded()
                 self.view.backgroundColor = .clear
             }, completion: { _ in
-                self.dismiss(animated: false, completion: nil)
+                self.dismiss(animated: false, completion: completion)
             })
     }
 

--- a/Client/Frontend/Onboarding/Models/OnboardingDefaultBrowserInfoModel.swift
+++ b/Client/Frontend/Onboarding/Models/OnboardingDefaultBrowserInfoModel.swift
@@ -9,7 +9,7 @@ struct OnboardingDefaultBrowserInfoModel: OnboardingDefaultBrowserModelProtocol 
     var title: String
     var instructionSteps: [String]
     var buttonTitle: String
-    var buttonAction: InstructionCardActions
+    var buttonAction: OnboardingInstructionsPopupActions
     var a11yIdRoot: String
 
     func getAttributedStrings(with font: UIFont) -> [NSAttributedString] {

--- a/Client/Frontend/Onboarding/Models/OnboardingDefaultBrowserInfoModel.swift
+++ b/Client/Frontend/Onboarding/Models/OnboardingDefaultBrowserInfoModel.swift
@@ -9,6 +9,7 @@ struct OnboardingDefaultBrowserInfoModel: OnboardingDefaultBrowserModelProtocol 
     var title: String
     var instructionSteps: [String]
     var buttonTitle: String
+    var buttonAction: InstructionCardActions
     var a11yIdRoot: String
 
     func getAttributedStrings(with font: UIFont) -> [NSAttributedString] {

--- a/Client/Frontend/Onboarding/Protocols/OnboardingCardDelegate.swift
+++ b/Client/Frontend/Onboarding/Protocols/OnboardingCardDelegate.swift
@@ -75,7 +75,7 @@ extension OnboardingCardDelegate where Self: OnboardingViewControllerProtocol,
         from name: String,
         completionIfLastCard: (() -> Void)?
     ) {
-        let viewController = OnboardingDefaultSettingsViewController(
+        let instructionsVC = OnboardingInstructionPopupViewController(
             viewModel: viewModel.infoPopup,
             buttonTappedFinishFlow: {
                 self.showNextPage(
@@ -87,8 +87,10 @@ extension OnboardingCardDelegate where Self: OnboardingViewControllerProtocol,
         bottomSheetViewModel.shouldDismissForTapOutside = true
         let bottomSheetVC = BottomSheetViewController(
             viewModel: bottomSheetViewModel,
-            childViewController: viewController,
+            childViewController: instructionsVC,
             usingDimmedBackground: true)
+
+        instructionsVC.dismissDelegate = bottomSheetVC
 
         self.present(bottomSheetVC, animated: false, completion: nil)
     }

--- a/Client/Frontend/Onboarding/Protocols/OnboardingDefaultBrowserModelProtocol.swift
+++ b/Client/Frontend/Onboarding/Protocols/OnboardingDefaultBrowserModelProtocol.swift
@@ -8,7 +8,7 @@ protocol OnboardingDefaultBrowserModelProtocol {
     var title: String { get set }
     var instructionSteps: [String] { get set }
     var buttonTitle: String { get set }
-    var buttonAction: InstructionCardActions { get set }
+    var buttonAction: OnboardingInstructionsPopupActions { get set }
     var a11yIdRoot: String { get set }
 
     func getAttributedStrings(with font: UIFont) -> [NSAttributedString]

--- a/Client/Frontend/Onboarding/Protocols/OnboardingDefaultBrowserModelProtocol.swift
+++ b/Client/Frontend/Onboarding/Protocols/OnboardingDefaultBrowserModelProtocol.swift
@@ -8,12 +8,8 @@ protocol OnboardingDefaultBrowserModelProtocol {
     var title: String { get set }
     var instructionSteps: [String] { get set }
     var buttonTitle: String { get set }
+    var buttonAction: InstructionCardActions { get set }
     var a11yIdRoot: String { get set }
-
-    init(title: String,
-         instructionSteps: [String],
-         buttonTitle: String,
-         a11yIdRoot: String)
 
     func getAttributedStrings(with font: UIFont) -> [NSAttributedString]
 }

--- a/Client/Frontend/Onboarding/ViewControllers/OnboardingDefaultSettingsViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/OnboardingDefaultSettingsViewController.swift
@@ -200,12 +200,17 @@ class OnboardingDefaultSettingsViewController: UIViewController, Themeable {
     // MARK: - Helper methods
     private func createLabels(from descriptionTexts: [String]) {
         numeratedLabels.removeAll()
-        let attributedStrings = viewModel.getAttributedStrings(with: DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline, size: UX.numeratedTextFontSize))
+        let attributedStrings = viewModel.getAttributedStrings(
+            with: DynamicFontHelper.defaultHelper.preferredFont(
+                withTextStyle: .subheadline,
+                size: UX.numeratedTextFontSize))
         attributedStrings.forEach { attributedText in
             let index = attributedStrings.firstIndex(of: attributedText)! as Int
             let label: UILabel = .build { label in
                 label.textAlignment = .left
-                label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline, size: UX.numeratedTextFontSize)
+                label.font = DynamicFontHelper.defaultHelper.preferredFont(
+                    withTextStyle: .subheadline,
+                    size: UX.numeratedTextFontSize)
                 label.adjustsFontForContentSizeCategory = true
                 label.accessibilityIdentifier = "\(self.viewModel.a11yIdRoot).DefaultBrowserSettings.NumeratedLabel\(index)"
                 label.attributedText = attributedText
@@ -218,16 +223,23 @@ class OnboardingDefaultSettingsViewController: UIViewController, Themeable {
     @objc
     func appDidEnterBackgroundNotification() {
         if didTapButton {
+            dismissWithFinishFlow()
+        }
+    }
+
+    private func dismissWithFinishFlow() {
             dismiss(animated: false)
             buttonTappedFinishFlow?()
-        }
     }
 
     // MARK: - Button actions
     @objc
     func primaryAction() {
         didTapButton = true
-        DefaultApplicationHelper().openSettings()
+        switch viewModel.buttonAction {
+        case .openIosFxSettings: DefaultApplicationHelper().openSettings()
+        case .dismiss: dismissWithFinishFlow()
+        }
     }
 
     // MARK: - Themeable

--- a/Client/Frontend/Onboarding/ViewControllers/OnboardingInstructionPopupViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/OnboardingInstructionPopupViewController.swift
@@ -235,7 +235,7 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
         didTapButton = true
         switch viewModel.buttonAction {
         case .openIosFxSettings: DefaultApplicationHelper().openSettings()
-        case .dismissAndNextCard: dismissDelegate?.dismissSheetViewController()
+        case .dismissAndNextCard: dismissDelegate?.dismissSheetViewController { self.buttonTappedFinishFlow?() }
         }
     }
 

--- a/Client/Frontend/Onboarding/ViewControllers/OnboardingInstructionPopupViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/OnboardingInstructionPopupViewController.swift
@@ -232,10 +232,14 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
     // MARK: - Button actions
     @objc
     func primaryAction() {
-        didTapButton = true
         switch viewModel.buttonAction {
-        case .openIosFxSettings: DefaultApplicationHelper().openSettings()
-        case .dismissAndNextCard: dismissDelegate?.dismissSheetViewController { self.buttonTappedFinishFlow?() }
+        case .openIosFxSettings:
+            didTapButton = true
+            DefaultApplicationHelper().openSettings()
+        case .dismissAndNextCard:
+            dismissDelegate?.dismissSheetViewController { self.buttonTappedFinishFlow?() }
+        case .dismiss:
+            dismissDelegate?.dismissSheetViewController(completion: nil)
         }
     }
 

--- a/Client/Frontend/Onboarding/ViewControllers/OnboardingInstructionPopupViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/OnboardingInstructionPopupViewController.swift
@@ -6,7 +6,7 @@ import Common
 import Shared
 import UIKit
 
-class OnboardingDefaultSettingsViewController: UIViewController, Themeable {
+class OnboardingInstructionPopupViewController: UIViewController, Themeable {
     private enum UX {
         static let contentStackViewSpacing: CGFloat = 40
         static let textStackViewSpacing: CGFloat = 24
@@ -85,6 +85,7 @@ class OnboardingDefaultSettingsViewController: UIViewController, Themeable {
     private var contentViewHeightConstraint: NSLayoutConstraint!
     var didTapButton = false
     var buttonTappedFinishFlow: (() -> Void)?
+    var dismissDelegate: BottomSheetDismissProtocol?
 
     // MARK: - Initializers
     init(viewModel: OnboardingDefaultBrowserModelProtocol,
@@ -223,13 +224,9 @@ class OnboardingDefaultSettingsViewController: UIViewController, Themeable {
     @objc
     func appDidEnterBackgroundNotification() {
         if didTapButton {
-            dismissWithFinishFlow()
-        }
-    }
-
-    private func dismissWithFinishFlow() {
             dismiss(animated: false)
             buttonTappedFinishFlow?()
+        }
     }
 
     // MARK: - Button actions
@@ -238,7 +235,7 @@ class OnboardingDefaultSettingsViewController: UIViewController, Themeable {
         didTapButton = true
         switch viewModel.buttonAction {
         case .openIosFxSettings: DefaultApplicationHelper().openSettings()
-        case .dismiss: dismissWithFinishFlow()
+        case .dismissAndNextCard: dismissDelegate?.dismissSheetViewController()
         }
     }
 
@@ -255,6 +252,6 @@ class OnboardingDefaultSettingsViewController: UIViewController, Themeable {
     }
 }
 
-extension OnboardingDefaultSettingsViewController: BottomSheetChild {
+extension OnboardingInstructionPopupViewController: BottomSheetChild {
     func willDismiss() { }
 }

--- a/Client/Nimbus/OnboardingFeatureLayer/NimbusOnboardingFeatureLayer.swift
+++ b/Client/Nimbus/OnboardingFeatureLayer/NimbusOnboardingFeatureLayer.swift
@@ -196,6 +196,7 @@ class NimbusOnboardingFeatureLayer: NimbusOnboardingFeatureLayerProtocol {
             instructionSteps: data.instructions
                 .map { String(format: $0, AppName.shortName.rawValue)},
             buttonTitle: data.buttonTitle,
+            buttonAction: data.buttonAction,
             a11yIdRoot: a11yID)
     }
 }

--- a/nimbus-features/onboardingFrameworkFeature.yaml
+++ b/nimbus-features/onboardingFrameworkFeature.yaml
@@ -46,7 +46,7 @@ features:
               buttons:
                 primary:
                   title: Onboarding/Onboarding.Welcome.Action.v114
-                  action: open-default-browser-popup
+                  action: next-card
               type: fresh-install
               prerequisites:
                 - ALWAYS
@@ -110,7 +110,7 @@ features:
           instruction-popup:
             title: Onboarding/DefaultBrowserPopup.Title.v114
             button-title: Onboarding/DefaultBrowserPopup.ButtonTitle.v114
-            button-action: dismiss-and-next-card
+            button-action: open-ios-fx-settings
             instructions:
               - Onboarding/DefaultBrowserPopup.FirstLabel.v114
               - Onboarding/DefaultBrowserPopup.SecondLabel.v114
@@ -251,10 +251,11 @@ objects:
           This should never be defaulted.
         default: ""
       button-action:
-        type: InstructionCardActions
+        type: OnboardingInstructionsPopupActions
         description: >
           The action the button should have.
-        default: open-ios-fx-settings
+          Default is `dismiss-and-next-card`
+        default: dismiss-and-next-card
 
 enums:
   OnboardingActions:
@@ -280,7 +281,7 @@ enums:
       read-privacy-policy:
         description: >
           Will open a webview where the user can read the privacy policy
-  InstructionCardActions:
+  OnboardingInstructionsPopupActions:
     description: >
       The identifiers for the different actions available for the
       insturction card in onboarding
@@ -291,7 +292,10 @@ enums:
           in the iOS system settings
       dismiss-and-next-card:
         description: >
-          Will dismiss the card
+          Will dismiss the popup and move to the next card
+      dismiss:
+        description: >
+          Will dismiss the popup
   NimbusOnboardingImages:
     description: >
       The identifiers for the different images available for cards in onboarding

--- a/nimbus-features/onboardingFrameworkFeature.yaml
+++ b/nimbus-features/onboardingFrameworkFeature.yaml
@@ -110,7 +110,7 @@ features:
           instruction-popup:
             title: Onboarding/DefaultBrowserPopup.Title.v114
             button-title: Onboarding/DefaultBrowserPopup.ButtonTitle.v114
-            button-action: dismiss
+            button-action: dismiss-and-next-card
             instructions:
               - Onboarding/DefaultBrowserPopup.FirstLabel.v114
               - Onboarding/DefaultBrowserPopup.SecondLabel.v114
@@ -289,7 +289,7 @@ enums:
         description: >
           Will take the user to the default browser settings
           in the iOS system settings
-      dismiss:
+      dismiss-and-next-card:
         description: >
           Will dismiss the card
   NimbusOnboardingImages:

--- a/nimbus-features/onboardingFrameworkFeature.yaml
+++ b/nimbus-features/onboardingFrameworkFeature.yaml
@@ -46,7 +46,7 @@ features:
               buttons:
                 primary:
                   title: Onboarding/Onboarding.Welcome.Action.v114
-                  action: next-card
+                  action: open-default-browser-popup
               type: fresh-install
               prerequisites:
                 - ALWAYS
@@ -110,6 +110,7 @@ features:
           instruction-popup:
             title: Onboarding/DefaultBrowserPopup.Title.v114
             button-title: Onboarding/DefaultBrowserPopup.ButtonTitle.v114
+            button-action: dismiss
             instructions:
               - Onboarding/DefaultBrowserPopup.FirstLabel.v114
               - Onboarding/DefaultBrowserPopup.SecondLabel.v114
@@ -249,6 +250,11 @@ objects:
           The title the button should have.
           This should never be defaulted.
         default: ""
+      button-action:
+        type: InstructionCardActions
+        description: >
+          The action the button should have.
+        default: open-ios-fx-settings
 
 enums:
   OnboardingActions:
@@ -274,6 +280,18 @@ enums:
       read-privacy-policy:
         description: >
           Will open a webview where the user can read the privacy policy
+  InstructionCardActions:
+    description: >
+      The identifiers for the different actions available for the
+      insturction card in onboarding
+    variants:
+      open-ios-fx-settings:
+        description: >
+          Will take the user to the default browser settings
+          in the iOS system settings
+      dismiss:
+        description: >
+          Will dismiss the card
   NimbusOnboardingImages:
     description: >
       The identifiers for the different images available for cards in onboarding


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7044)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15661)

## :bulb: Description
Um, so. The popup card was exprimentable. But the button action was not.

Well.

Now it is. 

🎉 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

