### PR TITLE
Bugfix FXIOS-7029 [v117] CC Autofill not working for `nintendo.com`

### DIFF
--- a/Client/Assets/CC_Script/CC_Python_Update.py
+++ b/Client/Assets/CC_Script/CC_Python_Update.py
@@ -12,6 +12,7 @@ FILES_TO_DOWNLOAD = [
     "toolkit/components/formautofill/Constants.ios.mjs",
     "toolkit/modules/CreditCard.sys.mjs",
     "toolkit/components/formautofill/shared/CreditCardRuleset.sys.mjs",
+    "toolkit/components/formautofill/shared/CreditCardRecord.sys.mjs",
     "toolkit/components/formautofill/shared/FieldScanner.sys.mjs",
     "toolkit/components/formautofill/FormAutofill.ios.sys.mjs",
     "toolkit/components/formautofill/FormAutofill.sys.mjs",

--- a/Client/Assets/CC_Script/CreditCardRecord.sys.mjs
+++ b/Client/Assets/CC_Script/CreditCardRecord.sys.mjs
@@ -1,0 +1,71 @@
+/* eslint-disable no-useless-concat */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { CreditCard } from "resource://gre/modules/CreditCard.sys.mjs";
+import { FormAutofillNameUtils } from "resource://gre/modules/shared/FormAutofillNameUtils.sys.mjs";
+
+/**
+ * The CreditCardRecord class serves to handle and normalize internal credit card records.
+ * Unlike the CreditCard class, which represents actual card data, CreditCardRecord is used
+ * for processing and consistent data representation.
+ */
+export class CreditCardRecord {
+  static normalizeFields(creditCard) {
+    this.#normalizeCCNameFields(creditCard);
+    this.#normalizeCCNumberFields(creditCard);
+    this.#normalizeCCExpirationDateFields(creditCard);
+    this.#normalizeCCTypeFields(creditCard);
+  }
+
+  static #normalizeCCNameFields(creditCard) {
+    if (
+      creditCard["cc-given-name"] ||
+      creditCard["cc-additional-name"] ||
+      creditCard["cc-family-name"]
+    ) {
+      if (!creditCard["cc-name"]) {
+        creditCard["cc-name"] = FormAutofillNameUtils.joinNameParts({
+          given: creditCard["cc-given-name"],
+          middle: creditCard["cc-additional-name"],
+          family: creditCard["cc-family-name"],
+        });
+      }
+    }
+    delete creditCard["cc-given-name"];
+    delete creditCard["cc-additional-name"];
+    delete creditCard["cc-family-name"];
+  }
+
+  static #normalizeCCNumberFields(creditCard) {
+    if (!("cc-number" in creditCard)) {
+      return;
+    }
+
+    if (!CreditCard.isValidNumber(creditCard["cc-number"])) {
+      delete creditCard["cc-number"];
+      return;
+    }
+
+    const card = new CreditCard({ number: creditCard["cc-number"] });
+    creditCard["cc-number"] = card.number;
+  }
+
+  static #normalizeCCExpirationDateFields(creditCard) {
+    let normalizedExpiration = CreditCard.normalizeExpiration({
+      expirationMonth: creditCard["cc-exp-month"],
+      expirationYear: creditCard["cc-exp-year"],
+      expirationString: creditCard["cc-exp"],
+    });
+
+    creditCard["cc-exp-month"] = normalizedExpiration.month ?? "";
+    creditCard["cc-exp-year"] = normalizedExpiration.year ?? "";
+    delete creditCard["cc-exp"];
+  }
+
+  static #normalizeCCTypeFields(creditCard) {
+    // Let's overwrite the credit card type with auto-detect algorithm
+    creditCard["cc-type"] = CreditCard.getType(creditCard["cc-number"]) ?? "";
+  }
+}

--- a/Client/Assets/CC_Script/FormAutofillChild.ios.sys.mjs
+++ b/Client/Assets/CC_Script/FormAutofillChild.ios.sys.mjs
@@ -5,6 +5,7 @@
 /* eslint-disable no-undef,mozilla/balanced-listeners */
 import { FormAutofillUtils } from "resource://gre/modules/shared/FormAutofillUtils.sys.mjs";
 import { FormStateManager } from "resource://gre/modules/shared/FormStateManager.sys.mjs";
+import { CreditCardRecord } from "resource://gre/modules/shared/CreditCardRecord.sys.mjs";
 
 export class FormAutofillChild {
   constructor(onSubmitCallback, onAutofillCallback) {
@@ -34,6 +35,9 @@ export class FormAutofillChild {
         }),
         {}
       );
+      // Normalize record format so we always get a consistent
+      // credit card record format: {cc-number, cc-name, cc-exp-month, cc-exp-year}
+      CreditCardRecord.normalizeFields(fieldNamesWithValues);
       this.onAutofillCallback(fieldNamesWithValues);
     }
   }

--- a/Client/Assets/CC_Script/Helpers.ios.mjs
+++ b/Client/Assets/CC_Script/Helpers.ios.mjs
@@ -79,7 +79,7 @@ const internalModuleResolvers = {
 // Define mock for XPCOMUtils
 export const XPCOMUtils = withNotImplementedError({
   defineLazyGetter: (obj, prop, getFn) => {
-    obj[prop] = getFn?.();
+    obj[prop] = getFn?.call(obj);
   },
   defineLazyPreferenceGetter: (
     obj,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7029)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15619)

## :bulb: Description
This PR:
- Adds `CreditCardRecord` file to files pulled from central.
- Pulls changes from central ( mainly:  [D183873](https://phabricator.services.mozilla.com/D183873 ) and [D183952](https://phabricator.services.mozilla.com/D183952) )

### Context

The issue that caused cc autofill to not work for `nintendo.com` has two parts:

- We weren't binding the correct context to the [getter function](https://searchfox.org/mozilla-central/source/toolkit/components/formautofill/Helpers.ios.mjs#82) in the lazy getter mock and this causes an error in [this line](https://searchfox.org/mozilla-central/source/toolkit/modules/FormLikeFactory.sys.mjs#87).
- We were sending an incomplete cc payload to the backend that made ios the parser fail.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
~~- [ ] Wrote unit tests and/or ensured the tests suite is passing~~
~~- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)~~
~~- [ ] If needed I updated documentation / comments for complex code and public methods~~

### Current Behaviour ( It works 🎉 )

https://github.com/mozilla-mobile/firefox-ios/assets/26678795/bc61542f-1168-43fb-a35d-b9f19cbcb5e4


