### PR TITLE
Bugfix FXIOS-6882 [v117] poor color contrast for "Yes" button label in remember the card flow for credit card dark mode (#15323)

### DIFF
--- a/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
@@ -326,7 +326,7 @@ class CreditCardBottomSheetViewController: UIViewController, UITableViewDelegate
         let currentTheme = themeManager.currentTheme
         view.backgroundColor = currentTheme.colors.layer1
         yesButton.backgroundColor = currentTheme.colors.actionPrimary
-        yesButton.titleLabel?.textColor = currentTheme.colors.textInverted
+        yesButton.setTitleColor(currentTheme.colors.textInverted, for: .normal)
         cardTableView.reloadData()
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6882)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15323)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
fixed the button label text color for dark mode
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

