### PR TITLE
Refactor FXIOS-7049 [v116] Add instruction cards per card in onboarding

### DIFF
--- a/.experimenter.yaml
+++ b/.experimenter.yaml
@@ -131,9 +131,6 @@ onboarding-framework-feature:
     dismissable:
       type: boolean
       description: "Whether or not the entire onboarding is dismissable by pressing an X at the top right corner of the screen.\n"
-    instruction-popup:
-      type: json
-      description: "The contents of the instruction popup.\n"
 redux-integration-feature:
   description: "This feature is for managing the roll out of the Redux integration feature\n"
   hasExposure: true

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -481,7 +481,7 @@
 		74821FFE1DB6D3AC00EEEA72 /* MailSchemes.plist in Resources */ = {isa = PBXBuildFile; fileRef = 74821FFD1DB6D3AC00EEEA72 /* MailSchemes.plist */; };
 		7482205C1DBAB56300EEEA72 /* MailProviders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7482205B1DBAB56300EEEA72 /* MailProviders.swift */; };
 		74B195441CF503FC007F36EF /* RecentlyClosedTabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74B195431CF503FC007F36EF /* RecentlyClosedTabs.swift */; };
-		74B420C92A1D0D7A00370E53 /* OnboardingDefaultBrowserInfoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74B420C82A1D0D7A00370E53 /* OnboardingDefaultBrowserInfoModel.swift */; };
+		74B420C92A1D0D7A00370E53 /* OnboardingInstructionsPopupInfoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74B420C82A1D0D7A00370E53 /* OnboardingInstructionsPopupInfoModel.swift */; };
 		74BBDF472A17979000D3BEFE /* OnboardingDefaultBrowserModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74BBDF462A17979000D3BEFE /* OnboardingDefaultBrowserModelProtocol.swift */; };
 		74C027451B2A348C001B1E88 /* LegacySessionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C027441B2A348C001B1E88 /* LegacySessionData.swift */; };
 		74E36D781B71323500D69DA1 /* SettingsContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74E36D771B71323500D69DA1 /* SettingsContentViewController.swift */; };
@@ -4512,7 +4512,7 @@
 		74934281AE0F15BB6EC1E756 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Today.strings; sourceTree = "<group>"; };
 		74A44FBEBA309D6D780BC6F8 /* es-CL */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-CL"; path = "es-CL.lproj/LoginManager.strings"; sourceTree = "<group>"; };
 		74B195431CF503FC007F36EF /* RecentlyClosedTabs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecentlyClosedTabs.swift; sourceTree = "<group>"; };
-		74B420C82A1D0D7A00370E53 /* OnboardingDefaultBrowserInfoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingDefaultBrowserInfoModel.swift; sourceTree = "<group>"; };
+		74B420C82A1D0D7A00370E53 /* OnboardingInstructionsPopupInfoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingInstructionsPopupInfoModel.swift; sourceTree = "<group>"; };
 		74BBDF462A17979000D3BEFE /* OnboardingDefaultBrowserModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingDefaultBrowserModelProtocol.swift; sourceTree = "<group>"; };
 		74C027441B2A348C001B1E88 /* LegacySessionData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacySessionData.swift; sourceTree = "<group>"; };
 		74C14EA28570D995C545434D /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bg; path = bg.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
@@ -9201,7 +9201,7 @@
 				C88E7A5A2A0553510072E638 /* OnboardingLinkInfoModel.swift */,
 				C88E7A542A0553180072E638 /* OnboardingViewModel.swift */,
 				435D660423D794B90046EFA2 /* UpdateViewModel.swift */,
-				74B420C82A1D0D7A00370E53 /* OnboardingDefaultBrowserInfoModel.swift */,
+				74B420C82A1D0D7A00370E53 /* OnboardingInstructionsPopupInfoModel.swift */,
 				C8CD80DB2A1E8C970097C3AE /* OnboardingTelemetryUtility.swift */,
 			);
 			path = Models;
@@ -12505,7 +12505,7 @@
 				C87DF9DB267247190097E707 /* UIConstants+BottomInset.swift in Sources */,
 				8AD08D1527E9198E00B8E907 /* TabsQuantityTelemetry.swift in Sources */,
 				1DA3CE6324EEE83200422BB2 /* LegacySavedTab+ConfigureExtension.swift in Sources */,
-				74B420C92A1D0D7A00370E53 /* OnboardingDefaultBrowserInfoModel.swift in Sources */,
+				74B420C92A1D0D7A00370E53 /* OnboardingInstructionsPopupInfoModel.swift in Sources */,
 				E15DE7C4293A7B0F00B32667 /* PhotonActionSheetTitleHeaderView.swift in Sources */,
 				392ED7E61D0AEFEF009D9B62 /* HomePageAccessors.swift in Sources */,
 				8A0017C128A3FF6100FEFC8B /* MessageCardDataAdaptor.swift in Sources */,

--- a/Client/Frontend/Onboarding/Models/IntroViewModel.swift
+++ b/Client/Frontend/Onboarding/Models/IntroViewModel.swift
@@ -11,7 +11,6 @@ class IntroViewModel: OnboardingViewModelProtocol, FeatureFlaggable {
     var introScreenManager: IntroScreenManager?
 
     var availableCards: [OnboardingCardViewController]
-    var infoPopup: OnboardingDefaultBrowserModelProtocol
     var isDismissable: Bool
     var profile: Profile
     var telemetryUtility: OnboardingTelemetryProtocol
@@ -29,7 +28,6 @@ class IntroViewModel: OnboardingViewModelProtocol, FeatureFlaggable {
         self.telemetryUtility = telemetryUtility
         self.cardModels = model.cards
         self.isDismissable = model.isDismissable
-        self.infoPopup = model.infoPopupModel
         self.availableCards = []
     }
 

--- a/Client/Frontend/Onboarding/Models/OnboardingCardInfoModel.swift
+++ b/Client/Frontend/Onboarding/Models/OnboardingCardInfoModel.swift
@@ -9,6 +9,7 @@ struct OnboardingCardInfoModel: OnboardingCardInfoModelProtocol {
     var order: Int
     var title: String
     var body: String
+    var instructionsPopup: OnboardingInstructionsPopupInfoModel?
     var link: OnboardingLinkInfoModel?
     var buttons: OnboardingButtons
     var type: OnboardingType
@@ -29,7 +30,8 @@ struct OnboardingCardInfoModel: OnboardingCardInfoModelProtocol {
         buttons: OnboardingButtons,
         type: OnboardingType,
         a11yIdRoot: String,
-        imageID: String
+        imageID: String,
+        instructionsPopup: OnboardingInstructionsPopupInfoModel?
     ) {
         self.name = name
         self.order = order
@@ -40,5 +42,6 @@ struct OnboardingCardInfoModel: OnboardingCardInfoModelProtocol {
         self.buttons = buttons
         self.type = type
         self.a11yIdRoot = a11yIdRoot
+        self.instructionsPopup = instructionsPopup
     }
 }

--- a/Client/Frontend/Onboarding/Models/OnboardingInstructionsPopupInfoModel.swift
+++ b/Client/Frontend/Onboarding/Models/OnboardingInstructionsPopupInfoModel.swift
@@ -5,7 +5,7 @@
 import Foundation
 import Shared
 
-struct OnboardingDefaultBrowserInfoModel: OnboardingDefaultBrowserModelProtocol {
+struct OnboardingInstructionsPopupInfoModel: OnboardingDefaultBrowserModelProtocol {
     var title: String
     var instructionSteps: [String]
     var buttonTitle: String

--- a/Client/Frontend/Onboarding/Models/OnboardingViewModel.swift
+++ b/Client/Frontend/Onboarding/Models/OnboardingViewModel.swift
@@ -6,6 +6,5 @@ import Foundation
 
 struct OnboardingViewModel {
     let cards: [OnboardingCardInfoModel]
-    let infoPopupModel: OnboardingDefaultBrowserInfoModel
     let isDismissable: Bool
 }

--- a/Client/Frontend/Onboarding/Models/UpdateViewModel.swift
+++ b/Client/Frontend/Onboarding/Models/UpdateViewModel.swift
@@ -13,7 +13,6 @@ class UpdateViewModel: OnboardingViewModelProtocol,
     var profile: Profile
     var hasSyncableAccount: Bool?
     var availableCards: [OnboardingCardViewController]
-    var infoPopup: OnboardingDefaultBrowserModelProtocol
     var isDismissable: Bool
     var telemetryUtility: OnboardingTelemetryProtocol
     private var cardModels: [OnboardingCardInfoModelProtocol]
@@ -40,7 +39,6 @@ class UpdateViewModel: OnboardingViewModelProtocol,
         self.profile = profile
         self.telemetryUtility = telemetryUtility
         self.cardModels = model.cards
-        self.infoPopup = model.infoPopupModel
         self.isDismissable = model.isDismissable
         self.availableCards = []
     }

--- a/Client/Frontend/Onboarding/Protocols/OnboardingCardDelegate.swift
+++ b/Client/Frontend/Onboarding/Protocols/OnboardingCardDelegate.swift
@@ -75,8 +75,15 @@ extension OnboardingCardDelegate where Self: OnboardingViewControllerProtocol,
         from name: String,
         completionIfLastCard: (() -> Void)?
     ) {
+        guard let popupViewModel = viewModel
+            .availableCards
+            .first(where: { $0.viewModel.name == name })?
+            .viewModel
+            .instructionsPopup
+        else { return }
+
         let instructionsVC = OnboardingInstructionPopupViewController(
-            viewModel: viewModel.infoPopup,
+            viewModel: popupViewModel,
             buttonTappedFinishFlow: {
                 self.showNextPage(
                     from: name,

--- a/Client/Frontend/Onboarding/Protocols/OnboardingCardInfoModelProtocol.swift
+++ b/Client/Frontend/Onboarding/Protocols/OnboardingCardInfoModelProtocol.swift
@@ -9,6 +9,7 @@ protocol OnboardingCardInfoModelProtocol {
     var order: Int { get set }
     var title: String { get set }
     var body: String { get set }
+    var instructionsPopup: OnboardingInstructionsPopupInfoModel? { get set }
     var link: OnboardingLinkInfoModel? { get set }
     var buttons: OnboardingButtons { get set }
     var type: OnboardingType { get set }
@@ -26,6 +27,7 @@ protocol OnboardingCardInfoModelProtocol {
         buttons: OnboardingButtons,
         type: OnboardingType,
         a11yIdRoot: String,
-        imageID: String
+        imageID: String,
+        instructionsPopup: OnboardingInstructionsPopupInfoModel?
     )
 }

--- a/Client/Frontend/Onboarding/Protocols/OnboardingViewModelProtocol.swift
+++ b/Client/Frontend/Onboarding/Protocols/OnboardingViewModelProtocol.swift
@@ -6,7 +6,6 @@ import Foundation
 
 protocol OnboardingViewModelProtocol {
     var availableCards: [OnboardingCardViewController] { get }
-    var infoPopup: OnboardingDefaultBrowserModelProtocol { get }
     var isDismissable: Bool { get }
     var profile: Profile { get }
     var telemetryUtility: OnboardingTelemetryProtocol { get }

--- a/Client/Frontend/Onboarding/ViewControllers/FirstInstall/IntroViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/FirstInstall/IntroViewController.swift
@@ -245,7 +245,7 @@ extension IntroViewController: OnboardingCardDelegate {
         case .setDefaultBrowser:
             registerForNotification()
             DefaultApplicationHelper().openSettings()
-        case .openDefaultBrowserPopup:
+        case .openInstructionsPopup:
             presentDefaultBrowserPopup(
                 from: cardName,
                 completionIfLastCard: { self.showNextPageCompletionForLastCard() })

--- a/Client/Frontend/Onboarding/ViewControllers/Update/UpdateViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/Update/UpdateViewController.swift
@@ -221,7 +221,7 @@ extension UpdateViewController: OnboardingCardDelegate {
             presentPrivacyPolicy(
                 from: cardName,
                 selector: #selector(dismissPrivacyPolicyViewController))
-        case .openDefaultBrowserPopup:
+        case .openInstructionsPopup:
             presentDefaultBrowserPopup(
                 from: cardName,
                 completionIfLastCard: { self.closeUpdate() })

--- a/Client/Nimbus/OnboardingFeatureLayer/NimbusOnboardingFeatureLayer.swift
+++ b/Client/Nimbus/OnboardingFeatureLayer/NimbusOnboardingFeatureLayer.swift
@@ -31,9 +31,6 @@ class NimbusOnboardingFeatureLayer: NimbusOnboardingFeatureLayerProtocol {
 
         return OnboardingViewModel(
             cards: cards,
-            infoPopupModel: getPopupInfoModel(
-                from: framework.instructionPopup,
-                withA11yID: cards.first?.a11yIdRoot ?? "noID"),
             isDismissable: framework.dismissable)
     }
 
@@ -62,7 +59,8 @@ class NimbusOnboardingFeatureLayer: NimbusOnboardingFeatureLayerProtocol {
                 buttons: card.buttons,
                 type: card.type,
                 a11yIdRoot: "\(card.a11yIdRoot)\(index)",
-                imageID: card.imageID)
+                imageID: card.imageID,
+                instructionsPopup: card.instructionsPopup)
         }
     }
 
@@ -92,13 +90,22 @@ class NimbusOnboardingFeatureLayer: NimbusOnboardingFeatureLayerProtocol {
                 return OnboardingCardInfoModel(
                     name: cardName,
                     order: cardData.order,
-                    title: String(format: cardData.title, AppName.shortName.rawValue),
-                    body: String(format: cardData.body, AppName.shortName.rawValue, AppName.shortName.rawValue),
+                    title: String(
+                        format: cardData.title,
+                        AppName.shortName.rawValue),
+                    body: String(
+                        format: cardData.body,
+                        AppName.shortName.rawValue,
+                        AppName.shortName.rawValue),
                     link: getOnboardingLink(from: cardData.link),
                     buttons: getOnboardingCardButtons(from: cardData.buttons),
                     type: cardData.type,
                     a11yIdRoot: cardData.type == .freshInstall ? a11yOnboarding : a11yUpgrade,
-                    imageID: getOnboardingImageID(from: cardData.image))
+                    imageID: getOnboardingImageID(from: cardData.image),
+                    instructionsPopup: getPopupInfoModel(
+                        from: cardData.instructionsPopup,
+                        withA11yID: "")
+                )
             }
 
             return nil
@@ -188,10 +195,12 @@ class NimbusOnboardingFeatureLayer: NimbusOnboardingFeatureLayerProtocol {
     }
 
     private func getPopupInfoModel(
-        from data: NimbusInstructionPopup,
+        from data: NimbusInstructionPopup?,
         withA11yID a11yID: String
-    ) -> OnboardingDefaultBrowserInfoModel {
-        return OnboardingDefaultBrowserInfoModel(
+    ) -> OnboardingInstructionsPopupInfoModel? {
+        guard let data else { return nil }
+
+        return OnboardingInstructionsPopupInfoModel(
             title: data.title,
             instructionSteps: data.instructions
                 .map { String(format: $0, AppName.shortName.rawValue)},

--- a/Tests/ClientTests/OnboardingTests/Helpers/NimbusOnboardingTestingConfigUtility.swift
+++ b/Tests/ClientTests/OnboardingTests/Helpers/NimbusOnboardingTestingConfigUtility.swift
@@ -49,8 +49,7 @@ struct NimbusOnboardingTestingConfigUtility {
         FxNimbus.shared.features.onboardingFrameworkFeature.with(initializer: { _ in
             OnboardingFrameworkFeature(
                 cards: dictionary,
-                dismissable: true,
-                instructionPopup: buildInfoPopup())
+                dismissable: true)
         })
     }
 
@@ -78,8 +77,7 @@ struct NimbusOnboardingTestingConfigUtility {
         FxNimbus.shared.features.onboardingFrameworkFeature.with(initializer: { _ in
             OnboardingFrameworkFeature(
                 cards: cards,
-                dismissable: dismissable,
-                instructionPopup: buildInfoPopup())
+                dismissable: dismissable)
         })
     }
 
@@ -104,6 +102,7 @@ struct NimbusOnboardingTestingConfigUtility {
                     andSecondaryButton: withSecondaryButton),
                 disqualifiers: disqualifiers,
                 image: image,
+                instructionsPopup: buildInfoPopup(),
                 link: shouldAddLink ? buildLink() : nil,
                 order: number,
                 prerequisites: prerequisites,
@@ -133,6 +132,7 @@ struct NimbusOnboardingTestingConfigUtility {
             buttons: createButtons(for: id),
             disqualifiers: ["NEVER"],
             image: image,
+            instructionsPopup: buildInfoPopup(),
             link: shouldAddLink.contains(where: { $0 == id }) ? buildLink() : nil,
             order: order,
             prerequisites: ["ALWAYS"],
@@ -197,6 +197,7 @@ struct NimbusOnboardingTestingConfigUtility {
 
     private func buildInfoPopup() -> NimbusInstructionPopup {
         return NimbusInstructionPopup(
+            buttonAction: .dismiss,
             buttonTitle: CardElementNames.popupButtonTitle,
             instructions: [
                 CardElementNames.popupFirstInstruction,

--- a/Tests/ClientTests/OnboardingTests/Mocks/MockOnboardingCardDelegate.swift
+++ b/Tests/ClientTests/OnboardingTests/Mocks/MockOnboardingCardDelegate.swift
@@ -40,7 +40,7 @@ class MockOnboardinCardDelegateController: UIViewController, OnboardingCardDeleg
             showNextPage(from: cardName, completionIfLastCard: {})
         case .setDefaultBrowser:
             self.action = .setDefaultBrowser
-        case .openDefaultBrowserPopup:
+        case .openInstructionsPopup:
             presentDefaultBrowserPopup()
         case .readPrivacyPolicy:
             presentPrivacyPolicy(from: cardName,
@@ -61,7 +61,7 @@ class MockOnboardinCardDelegateController: UIViewController, OnboardingCardDeleg
     }
 
     func presentDefaultBrowserPopup() {
-        action = .openDefaultBrowserPopup
+        action = .openInstructionsPopup
     }
 
     func presentSignToSync(

--- a/Tests/ClientTests/OnboardingTests/NimbusOnboardingFeatureLayerTests.swift
+++ b/Tests/ClientTests/OnboardingTests/NimbusOnboardingFeatureLayerTests.swift
@@ -109,7 +109,8 @@ class NimbusOnboardingFeatureLayerTests: XCTestCase {
                     action: .nextCard)),
             type: .freshInstall,
             a11yIdRoot: CardElementNames.a11yIDOnboarding,
-            imageID: ImageIdentifiers.onboardingWelcomev106)
+            imageID: ImageIdentifiers.onboardingWelcomev106,
+            instructionsPopup: nil)
 
         XCTAssertEqual(subject.name, expectedCard.name)
         XCTAssertEqual(subject.title, expectedCard.title)
@@ -244,14 +245,17 @@ class NimbusOnboardingFeatureLayerTests: XCTestCase {
     }
 
     // MARK: - Test Info Popup
-    func testLayer_infoPopupReturnsExpectedValues() {
+    func testLayer_infoPopupReturnsExpectedValues() throws {
         configUtility.setupNimbusWith()
         let layer = NimbusOnboardingFeatureLayer(with: MockNimbusMessagingHelperUtility())
 
-        let subject = layer.getOnboardingModel(for: .freshInstall).infoPopupModel
+        let subject = try XCTUnwrap(
+            layer.getOnboardingModel(for: .freshInstall).cards.first?.instructionsPopup,
+            "Failed to get instructions popup")
 
         XCTAssertEqual(subject.title, CardElementNames.popupTitle)
         XCTAssertEqual(subject.buttonTitle, CardElementNames.popupButtonTitle)
+        XCTAssertEqual(subject.buttonAction, OnboardingInstructionsPopupActions.dismiss)
         XCTAssertEqual(
             subject.instructionSteps,
             [

--- a/Tests/ClientTests/OnboardingTests/OnboardingButtonActionTests.swift
+++ b/Tests/ClientTests/OnboardingTests/OnboardingButtonActionTests.swift
@@ -73,11 +73,11 @@ class OnboardingButtonActionTests: XCTestCase {
     }
 
     func testsubject_buttonAction_returnsOpenPopupAction() {
-        let subject = setSubjectUpWith(firstAction: .openDefaultBrowserPopup)
+        let subject = setSubjectUpWith(firstAction: .openInstructionsPopup)
 
         subject.primaryAction()
 
-        XCTAssertEqual(mockDelegate.action, OnboardingActions.openDefaultBrowserPopup)
+        XCTAssertEqual(mockDelegate.action, OnboardingActions.openInstructionsPopup)
     }
 
     // MARK: - Helpers
@@ -112,7 +112,8 @@ class OnboardingButtonActionTests: XCTestCase {
             buttons: buttons,
             type: .freshInstall,
             a11yIdRoot: AccessibilityIdentifiers.Onboarding.onboarding,
-            imageID: ImageIdentifiers.onboardingSyncv106)
+            imageID: ImageIdentifiers.onboardingSyncv106,
+            instructionsPopup: nil)
 
         mockDelegate = MockOnboardinCardDelegateController()
         let subject = OnboardingCardViewController(

--- a/nimbus-features/onboardingFrameworkFeature.yaml
+++ b/nimbus-features/onboardingFrameworkFeature.yaml
@@ -42,14 +42,6 @@ features:
                 primary:
                   title: Onboarding/Onboarding.Welcome.Action.v114
                   action: next-card
-              instructions-popup:
-                title: Onboarding/DefaultBrowserPopup.Title.v114
-                button-title: Onboarding/DefaultBrowserPopup.ButtonTitle.v114
-                button-action: open-ios-fx-settings
-                instructions:
-                  - Onboarding/DefaultBrowserPopup.FirstLabel.v114
-                  - Onboarding/DefaultBrowserPopup.SecondLabel.v114
-                  - Onboarding/DefaultBrowserPopup.ThirdLabel.v114
               type: fresh-install
               prerequisites:
                 - ALWAYS

--- a/nimbus-features/onboardingFrameworkFeature.yaml
+++ b/nimbus-features/onboardingFrameworkFeature.yaml
@@ -17,11 +17,6 @@ features:
           The list of available cards for onboarding.
         type: Map<String, NimbusOnboardingCardData>
         default: {}
-      instruction-popup:
-        description: >
-          The contents of the instruction popup.
-        type: NimbusInstructionPopup
-        default: {}
       dismissable:
         description: >
           Whether or not the entire onboarding is dismissable
@@ -47,6 +42,14 @@ features:
                 primary:
                   title: Onboarding/Onboarding.Welcome.Action.v114
                   action: next-card
+              instructions-popup:
+                title: Onboarding/DefaultBrowserPopup.Title.v114
+                button-title: Onboarding/DefaultBrowserPopup.ButtonTitle.v114
+                button-action: open-ios-fx-settings
+                instructions:
+                  - Onboarding/DefaultBrowserPopup.FirstLabel.v114
+                  - Onboarding/DefaultBrowserPopup.SecondLabel.v114
+                  - Onboarding/DefaultBrowserPopup.ThirdLabel.v114
               type: fresh-install
               prerequisites:
                 - ALWAYS
@@ -107,14 +110,6 @@ features:
               type: upgrade
               prerequisites:
                 - ALWAYS
-          instruction-popup:
-            title: Onboarding/DefaultBrowserPopup.Title.v114
-            button-title: Onboarding/DefaultBrowserPopup.ButtonTitle.v114
-            button-action: open-ios-fx-settings
-            instructions:
-              - Onboarding/DefaultBrowserPopup.FirstLabel.v114
-              - Onboarding/DefaultBrowserPopup.SecondLabel.v114
-              - Onboarding/DefaultBrowserPopup.ThirdLabel.v114
           dismissable: true
 
 objects:
@@ -160,6 +155,14 @@ objects:
             title: Onboarding/Onboarding.Sync.Skip.Action.v114
             action: next-card
           secondary: null
+      instructions-popup:
+        type: Option<NimbusInstructionPopup>
+        description: >
+          The object describing the specific instruction popup
+          button for a card.
+          If left empty, the card will have no instruction
+          popup information
+        default: null
       prerequisites:
         type: List<String>
         description: >
@@ -274,10 +277,9 @@ enums:
       set-default-browser:
         description: >
           Will send the user to settings to set Firefox as their default browser
-      open-default-browser-popup:
+      open-instructions-popup:
         description: >
-          Will open up a popup with instructions for setting
-          Firefox as their default browser.
+          Will open up a popup with instructions for something
       read-privacy-policy:
         description: >
           Will open a webview where the user can read the privacy policy


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7049)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15674)

## :bulb: Description
Moved from one generic instruction popup card to a popup card per onboarding card, as optional, and `null` by default.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

