### PR TITLE
Bugfix EXP-3715 [v117] Add deprecated message-under-experiment

### DIFF
--- a/.experimenter.yaml
+++ b/.experimenter.yaml
@@ -83,6 +83,9 @@ messaging:
     actions:
       type: json
       description: A growable map of action URLs.
+    message-under-experiment:
+      type: string
+      description: "Deprecated. Please use \"experiment\": \"{experiment}\" instead."
     messages:
       type: json
       description: "A growable collection of messages, where the Key is the message identifier and the value is its associated MessageData.\n"

--- a/nimbus-features/messagingFeature.yaml
+++ b/nimbus-features/messagingFeature.yaml
@@ -41,6 +41,11 @@ features:
         description: What should be displayed when a control message is selected.
         default: show-next-message
 
+      message-under-experiment:
+        type: Option<String>
+        description: 'Deprecated. Please use "experiment": "{experiment}" instead.'
+        default: null
+
     defaults:
       - value:
           # This list of triggers is the same on iOS and Android. Thus,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/EXP-3715)

## :bulb: Description
This adds a no-op `message-under-experiment` to the `messagingFeature`. Currently message senders are not able to send messages to v116 because experimenter checks the `main` branch of firefox-ios for its manifest file, and then complaining when users (who are used to adding a `message-under-experiment` property) add that property.

It is a no-op here because the in v117, the mechanisms of telling what experiment the message is under changed. The message senders from this version on, will be sending `"experiment": "{experiment}"` as part of the message specification.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

