### PR TITLE
Bugfix FXIOS-7100 [v117] Fix some leaks in grid tab view controller

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -615,6 +615,7 @@
 		8A635ECD289437A8006378BA /* SyncedTabCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A635ECC289437A8006378BA /* SyncedTabCellTests.swift */; };
 		8A6A796D27F773550022D6C6 /* HomepageContextMenuHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6A796C27F773550022D6C6 /* HomepageContextMenuHelper.swift */; };
 		8A6B77CC2811C468001110D2 /* URLProtocolStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6B77CB2811C468001110D2 /* URLProtocolStub.swift */; };
+		8A6E139E2A71C78A00A88FA8 /* GridTabViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6E139D2A71C78A00A88FA8 /* GridTabViewControllerTests.swift */; };
 		8A720C5E2A4C85DA0003018A /* AccountSettingsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A720C5D2A4C85DA0003018A /* AccountSettingsDelegate.swift */; };
 		8A720C602A4C8B700003018A /* SharedSettingsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A720C5F2A4C8B700003018A /* SharedSettingsDelegate.swift */; };
 		8A720C622A4CBB370003018A /* SupportSettingsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A720C612A4CBB370003018A /* SupportSettingsDelegate.swift */; };
@@ -4807,6 +4808,7 @@
 		8A635ECC289437A8006378BA /* SyncedTabCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncedTabCellTests.swift; sourceTree = "<group>"; };
 		8A6A796C27F773550022D6C6 /* HomepageContextMenuHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageContextMenuHelper.swift; sourceTree = "<group>"; };
 		8A6B77CB2811C468001110D2 /* URLProtocolStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLProtocolStub.swift; sourceTree = "<group>"; };
+		8A6E139D2A71C78A00A88FA8 /* GridTabViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridTabViewControllerTests.swift; sourceTree = "<group>"; };
 		8A720C5D2A4C85DA0003018A /* AccountSettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSettingsDelegate.swift; sourceTree = "<group>"; };
 		8A720C5F2A4C8B700003018A /* SharedSettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedSettingsDelegate.swift; sourceTree = "<group>"; };
 		8A720C612A4CBB370003018A /* SupportSettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportSettingsDelegate.swift; sourceTree = "<group>"; };
@@ -10477,6 +10479,7 @@
 				8A96C4BA28F9E7B300B75884 /* XCTestCaseRootViewController.swift */,
 				8A4190D02A6B0843001E8401 /* StatusBarOverlayTests.swift */,
 				8C6DA7D02A6FE78F00DE264F /* ShoppingProductTests.swift */,
+				8A6E139D2A71C78A00A88FA8 /* GridTabViewControllerTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -13100,6 +13103,7 @@
 				2173326A29CCF901007F20C7 /* UIPanGestureRecognizerMock.swift in Sources */,
 				5A9A09D628B01FD500B6F51E /* MockURLBarView.swift in Sources */,
 				8A33222227DFE658008F809E /* NimbusMock.swift in Sources */,
+				8A6E139E2A71C78A00A88FA8 /* GridTabViewControllerTests.swift in Sources */,
 				8A8629E72880B7330096DDB1 /* BookmarksPanelTests.swift in Sources */,
 				C8B394362A0ED55D00700E49 /* MockOnboardingCardDelegate.swift in Sources */,
 				8A5604F829DF0D2600035CA3 /* BrowserCoordinatorTests.swift in Sources */,

--- a/Client/AccessoryViewProvider.swift
+++ b/Client/AccessoryViewProvider.swift
@@ -24,7 +24,7 @@ class AccessoryViewProvider: UIView, Themeable {
     var themeManager: ThemeManager
     var themeObserver: NSObjectProtocol?
     var notificationCenter: NotificationProtocol
-    private(set) var showCreditCard = false
+    private var showCreditCard = false
 
     // stubs - these closures will be given as selectors in a future task
     var previousClosure: (() -> Void)?
@@ -36,7 +36,7 @@ class AccessoryViewProvider: UIView, Themeable {
         toolbar.sizeToFit()
     }
 
-    lazy private var previousButton: UIBarButtonItem = {
+    private lazy var previousButton: UIBarButtonItem = {
         let button = UIBarButtonItem(image: UIImage(systemName: "chevron.up"),
                                      style: .plain,
                                      target: self,
@@ -45,7 +45,7 @@ class AccessoryViewProvider: UIView, Themeable {
         return button
     }()
 
-    lazy private var nextButton: UIBarButtonItem = {
+    private lazy var nextButton: UIBarButtonItem = {
         let button = UIBarButtonItem(image: UIImage(systemName: "chevron.down"),
                                      style: .plain,
                                      target: self,
@@ -54,7 +54,7 @@ class AccessoryViewProvider: UIView, Themeable {
         return button
     }()
 
-    lazy private var doneButton: UIBarButtonItem = {
+    private lazy var doneButton: UIBarButtonItem = {
         let button = UIBarButtonItem(title: .CreditCard.Settings.Done,
                                      style: .done,
                                      target: self,
@@ -68,7 +68,7 @@ class AccessoryViewProvider: UIView, Themeable {
     private let leadingFixedSpacer: UIView = .build()
     private let trailingFixedSpacer: UIView = .build()
 
-    lazy private var cardImageView: UIImageView = .build { imageView in
+    private lazy  var cardImageView: UIImageView = .build { imageView in
         imageView.image = UIImage(named: StandardImageIdentifiers.Large.creditCard)?.withRenderingMode(.alwaysTemplate)
         imageView.contentMode = .scaleAspectFit
         imageView.accessibilityElementsHidden = true
@@ -79,7 +79,7 @@ class AccessoryViewProvider: UIView, Themeable {
         ])
     }
 
-    lazy private var useCardTextLabel: UILabel = .build { label in
+    private lazy  var useCardTextLabel: UILabel = .build { label in
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .title3, size: 16, weight: .medium)
         label.text = .CreditCard.Settings.UseSavedCardFromKeyboard
         label.numberOfLines = 0

--- a/Client/AccessoryViewProvider.swift
+++ b/Client/AccessoryViewProvider.swift
@@ -68,7 +68,7 @@ class AccessoryViewProvider: UIView, Themeable {
     private let leadingFixedSpacer: UIView = .build()
     private let trailingFixedSpacer: UIView = .build()
 
-    private lazy  var cardImageView: UIImageView = .build { imageView in
+    private lazy var cardImageView: UIImageView = .build { imageView in
         imageView.image = UIImage(named: StandardImageIdentifiers.Large.creditCard)?.withRenderingMode(.alwaysTemplate)
         imageView.contentMode = .scaleAspectFit
         imageView.accessibilityElementsHidden = true
@@ -79,7 +79,7 @@ class AccessoryViewProvider: UIView, Themeable {
         ])
     }
 
-    private lazy  var useCardTextLabel: UILabel = .build { label in
+    private lazy var useCardTextLabel: UILabel = .build { label in
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .title3, size: 16, weight: .medium)
         label.text = .CreditCard.Settings.UseSavedCardFromKeyboard
         label.numberOfLines = 0

--- a/Client/Frontend/Browser/Tabs/GridTabViewController.swift
+++ b/Client/Frontend/Browser/Tabs/GridTabViewController.swift
@@ -62,7 +62,7 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate, Themeable {
     let profile: Profile
     weak var delegate: TabTrayDelegate?
     var tabDisplayManager: TabDisplayManager!
-    var tabCellIdentifier: TabDisplayer.TabCellIdentifier = TabCell.cellIdentifier
+    var tabCellIdentifier: TabDisplayerDelegate.TabCellIdentifier = TabCell.cellIdentifier
     static let independentTabsHeaderIdentifier = "IndependentTabs"
     var otherBrowsingModeOffset = CGPoint.zero
     // Backdrop used for displaying greyed background for private tabs
@@ -470,7 +470,7 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate, Themeable {
 }
 
 // MARK: - TabDisplayer
-extension GridTabViewController: TabDisplayer {
+extension GridTabViewController: TabDisplayerDelegate {
     func focusSelectedTab() {
         self.focusItem()
     }

--- a/Client/Frontend/Browser/Tabs/InactiveTabs/InactiveTabViewModel.swift
+++ b/Client/Frontend/Browser/Tabs/InactiveTabs/InactiveTabViewModel.swift
@@ -7,7 +7,7 @@ import Storage
 import Shared
 import Common
 
-protocol InactiveTabsCFRProtocol {
+protocol InactiveTabsCFRProtocol: AnyObject {
     func setupCFR(with view: UILabel)
     func presentCFR()
     func presentUndoToast(tabsCount: Int, completion: @escaping (Bool) -> Void)

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -33,7 +33,7 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable {
     let tabManager: TabManager
     weak var delegate: TopTabsDelegate?
     private var topTabDisplayManager: TabDisplayManager!
-    var tabCellIdentifier: TabDisplayer.TabCellIdentifier = TopTabCell.cellIdentifier
+    var tabCellIdentifier: TabDisplayerDelegate.TabCellIdentifier = TopTabCell.cellIdentifier
     var profile: Profile
     var themeManager: ThemeManager
     var themeObserver: NSObjectProtocol?
@@ -285,7 +285,7 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable {
     }
 }
 
-extension TopTabsViewController: TabDisplayer {
+extension TopTabsViewController: TabDisplayerDelegate {
     func focusSelectedTab() {
         self.scrollToCurrentTab(true)
         self.handleFadeOutAfterTabSelection()

--- a/Tests/ClientTests/GridTabViewControllerTests.swift
+++ b/Tests/ClientTests/GridTabViewControllerTests.swift
@@ -1,0 +1,30 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Client
+
+final class GridTabViewControllerTests: XCTestCase {
+    private var manager: TabManager!
+    private var profile: MockProfile!
+
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+        profile = MockProfile()
+        manager = TabManagerImplementation(profile: profile, imageStore: nil)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        DependencyHelperMock().reset()
+        profile = nil
+        manager = nil
+    }
+
+    func testGridTabViewControllerDeinit() {
+        let subject = GridTabViewController(tabManager: manager, profile: profile)
+        trackForMemoryLeaks(subject)
+    }
+}

--- a/Tests/ClientTests/HistoryHighlights/HistoryHighlightsManagerTests.swift
+++ b/Tests/ClientTests/HistoryHighlights/HistoryHighlightsManagerTests.swift
@@ -18,6 +18,8 @@ class HistoryHighlightsTests: XCTestCase {
 
         manager = HistoryHighlightsManager()
         profile = MockProfile(databasePrefix: "historyHighlights_tests")
+        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
+        DependencyHelperMock().bootstrapDependencies()
         profile.reopen()
         let tabManager = LegacyTabManager(profile: profile, imageStore: nil)
         entryProvider = HistoryHighlightsTestEntryProvider(with: profile, and: tabManager)
@@ -30,6 +32,7 @@ class HistoryHighlightsTests: XCTestCase {
         profile.shutdown()
         profile = nil
         entryProvider = nil
+        DependencyHelperMock().reset()
     }
 
     func testEmptyRead() {

--- a/Tests/ClientTests/TabDisplayManagerTests.swift
+++ b/Tests/ClientTests/TabDisplayManagerTests.swift
@@ -10,7 +10,7 @@ import XCTest
 import Common
 
 class TabDisplayManagerTests: XCTestCase {
-    var tabCellIdentifier: TabDisplayer.TabCellIdentifier = TopTabCell.cellIdentifier
+    var tabCellIdentifier: TabDisplayerDelegate.TabCellIdentifier = TopTabCell.cellIdentifier
 
     var mockDataStore: WeakListMock<Tab>!
     var dataStore: WeakList<Tab>!
@@ -541,7 +541,7 @@ extension TabDisplayManagerTests {
     }
 }
 
-extension TabDisplayManagerTests: TabDisplayer {
+extension TabDisplayManagerTests: TabDisplayerDelegate {
     func focusSelectedTab() {}
 
     func cellFactory(for cell: UICollectionViewCell, using tab: Tab) -> UICollectionViewCell {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7100)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15774)

## :bulb: Description
Fix some leaks in grid tab view controller. This doesn't fix the issue that at run time that object doesn't get deinit, so there's still other problems.
- Cleaned up some code at the same time
- Renamed `TabDisplayer` to `TabDisplayerDelegate` to make this clearer this is a delegate and needs to be weak

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

