### PR TITLE
Bump [v117] Update Sentry to version 8.9.3

### DIFF
--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
             exact: "2.0.0"),
         .package(
             url: "https://github.com/getsentry/sentry-cocoa.git",
-            exact: "8.8.0"),
+            exact: "8.9.3"),
     ],
     targets: [
         .target(

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -19221,7 +19221,7 @@
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa.git";
 			requirement = {
 				kind = exactVersion;
-				version = 8.8.0;
+				version = 8.9.3;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "d277532e1c8af813981ba01f591b15bbdd735615",
-        "version" : "8.8.0"
+        "revision" : "259d8bc75aa4028416535d35840ff19fc7661292",
+        "version" : "8.9.3"
       }
     },
     {


### PR DESCRIPTION
Changes since last update:
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.9.0
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.9.1
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.9.2
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.9.3

When reviewing this, if you could also do the same for the accompanying Focus PR (https://github.com/mozilla-mobile/focus-ios/pull/3821), I would appreciate it. Thanks!