### PR TITLE
Bump [v117] Update Glean to v53.1.0

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -19189,7 +19189,7 @@
 			repositoryURL = "https://github.com/mozilla/glean-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 53.0.0;
+				version = 53.1.0;
 			};
 		};
 		4368F83B279669690013419B /* XCRemoteSwiftPackageReference "SnapKit" */ = {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla/glean-swift",
       "state" : {
-        "revision" : "f3f026c327b9964ebfa57f504debd166c25cfe58",
-        "version" : "53.0.0"
+        "revision" : "b7d587b698aaaa028fabba8cd13d5cb5069030b8",
+        "version" : "53.1.0"
       }
     },
     {


### PR DESCRIPTION
Changelog: https://github.com/mozilla/glean/releases/tag/v53.1.0

When reviewing this, if you could also do the same for the accompanying Focus PR (https://github.com/mozilla-mobile/focus-ios/pull/3822), I would appreciate it. Thanks!