### PR TITLE
Bugfix FXIOS-6886 [v118] Incorrect voice over order in credit card autofill settings list (#15327)

### DIFF
--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardTableViewModel.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardTableViewModel.swift
@@ -24,15 +24,12 @@ class CreditCardTableViewModel {
 
         let creditCard = creditCards[indexPath.row]
 
-        let components = DateComponents(year: Int(creditCard.ccExpYear), month: Int(creditCard.ccExpMonth))
-        let formattedExpiryDate = DateComponentsFormatter.localizedString(from: components,
-                                                                          unitsStyle: .spellOut) ?? ""
-
+        let localizedDate = localizedDate(year: Int(creditCard.ccExpYear), month: Int(creditCard.ccExpMonth)) ?? ""
         let string = String(format: .CreditCard.Settings.ListItemA11y,
                             creditCard.ccType,
-                            creditCard.ccNumberLast4,
                             creditCard.ccName,
-                            formattedExpiryDate)
+                            creditCard.ccNumberLast4,
+                            localizedDate)
         let attributedString = NSMutableAttributedString(string: string)
         if let range = attributedString.string.range(of: creditCard.ccNumberLast4) {
             attributedString.addAttributes([.accessibilitySpeechSpellOut: true],
@@ -40,5 +37,23 @@ class CreditCardTableViewModel {
         }
 
         return attributedString
+    }
+
+    func localizedDate(year: Int, month: Int) -> String? {
+        var dateComponents = DateComponents()
+        dateComponents.year = year
+        dateComponents.month = month
+        dateComponents.day = 1
+
+        let calendar = Calendar(identifier: .gregorian)
+        guard let date = calendar.date(from: dateComponents) else {
+            return nil
+        }
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateStyle = .long
+        dateFormatter.timeStyle = .none
+        dateFormatter.locale = Locale.current
+        return dateFormatter.string(from: date)
     }
 }

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -243,10 +243,10 @@ extension String {
                 value: "Done",
                 comment: "When a user is in the process of making a purchase and has at least one saved credit card, a view above the keyboard shows actions a user can take. When tapping this label, the keyboard will dismiss from view.")
             public static let ListItemA11y = MZLocalizedString(
-                key: "CreditCard.Settings.ListItemA11y.v112",
+                key: "CreditCard.Settings.ListItemA11y.v118",
                 tableName: "Settings",
-                value: "%1$@ ending in %2$@, issued to %3$@, expires %4$@",
-                comment: "Accessibility label for a credit card list item in autofill settings screen. The first parameter is the credit card type (e.g. Visa). The second parameter is the last 4 digits of the credit card. The third parameter is the name of the credit card holder. The fourth and fifth parameters are the month and year of the credit card's expiration date.")
+                value: "%1$@, issued to %3$@, ending in %2$@, expires %4$@",
+                comment: "Accessibility label for a credit card list item in autofill settings screen. The first parameter is the credit card type (e.g. Visa). The second parameter is is the name of the credit card holdert. The third parameter is the last 4 digits of the credit card. The fourth and fifth parameters are the month and year of the credit card's expiration date.")
         }
 
         // Displaying a credit card


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6886)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15327)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
updated the string and fixed the localized date. Note: DateComponentsFormatter is useful for time intervals (ie. in 3 weeks, last 23 years etc.) for actual dates like expiry dates it's best to use the DateFormatter for the Calendar/Date
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

