### PR TITLE
Add MTE-1349 [v117] Add History Age Buckets to Testing Tool

### DIFF
--- a/test-fixtures/generate-test-db.py
+++ b/test-fixtures/generate-test-db.py
@@ -163,9 +163,6 @@ def create_and_clean_database(db_new_name, db_path):
 
     # Create the full path for the new database
     db_new_path = os.path.join(script_dir, db_new_name)
-    print("db_new_name: ", db_new_name)
-    print("db_path: ", db_path)
-    print("db_new_path: ", db_new_path)
     try:
         # Copy the database file
         shutil.copyfile(db_path, db_new_path)
@@ -332,22 +329,6 @@ def main():
         'older': args.older,
     }
 
-    age_options_menu = [
-        inquirer.Checkbox('age_options',
-                        message="Select age options for history entries (Press Enter when done selecting):",
-                        choices=[
-                            ('Today', 'today'),
-                            ('Yesterday', 'yesterday'),
-                            ('This week', 'week'),
-                            ('This month', 'month'),
-                            ('Older', 'older'),
-                        ],
-                        default=['today'],
-                        ),
-    ]
-
-    print(args)
-
     db_connection = None  # Initialize db_connection here
     try:
         
@@ -370,14 +351,10 @@ def main():
         # Append .db to the database name
         db_new_name += '.db'
 
-        print("current db_path: ", db_path)
-        print("db_new_name: ", db_new_name)
-        print("age_options: ", age_options) 
         # Create a new database and clean it
         db_connection, db_cursor = create_and_clean_database(db_new_name, db_path)
 
         for age_option, flag in age_options.items():
-            print(age_option, flag)
             if flag:
                 read_websites_and_insert_records(db_connection, db_cursor, history_count, bookmark_count, age_option)
 

--- a/test-fixtures/requirements.txt
+++ b/test-fixtures/requirements.txt
@@ -3,3 +3,4 @@ requests
 ruamel.yaml
 pygithub
 pbxproj
+inquirer


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1349)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/FXIOS-15786)

## :bulb: Description
There appears to be some bugs with the display of history items across different date buckets (i.e. today, yesterday, a week, a month, older), but it's currently very difficult to test because there isn't a tool to quickly add dated history entries into the places.db.

We need to extend the `generate-test-db.py` script to allow for this.

I've added support for updating the `places.db` with specific history entries for all date buckets, where the user can either use arguments to run the script or follow user prompts for the required data.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

