### PR TITLE
Refactor FXIOS-7105 [v117] Move dynamic font helper common

### DIFF
--- a/BrowserKit/Sources/Common/Utilities/DynamicFontHelper.swift
+++ b/BrowserKit/Sources/Common/Utilities/DynamicFontHelper.swift
@@ -1,0 +1,64 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+
+public protocol DynamicFontHelper {
+    /// Returns a font that will dynamically scale with dynamic text
+    /// - Parameters:
+    ///   - textStyle: The desired textStyle for the font
+    ///   - size: The size of the font
+    /// - Returns: The UIFont with the specified font size and style
+    static func preferredFont(withTextStyle textStyle: UIFont.TextStyle,
+                              size: CGFloat,
+                              weight: UIFont.Weight?,
+                              symbolicTraits: UIFontDescriptor.SymbolicTraits?
+    ) -> UIFont
+
+    /// Return a bold font that will dynamically scale up to a certain size
+    /// - Parameters:
+    ///   - textStyle: The desired textStyle for the font
+    ///   - size: The size of the font
+    /// - Returns: The UIFont with the specified font size, style and bold weight
+    static func preferredBoldFont(withTextStyle textStyle: UIFont.TextStyle,
+                                  size: CGFloat
+    ) -> UIFont
+}
+
+public extension DynamicFontHelper {
+    static func preferredFont(withTextStyle textStyle: UIFont.TextStyle,
+                              size: CGFloat,
+                              weight: UIFont.Weight? = nil,
+                              symbolicTraits: UIFontDescriptor.SymbolicTraits? = nil
+    ) -> UIFont {
+        preferredFont(withTextStyle: textStyle, size: size, weight: weight, symbolicTraits: symbolicTraits)
+    }
+}
+
+public struct DefaultDynamicFontHelper: DynamicFontHelper {
+    public static func preferredFont(withTextStyle textStyle: UIFont.TextStyle,
+                                     size: CGFloat,
+                                     weight: UIFont.Weight? = nil,
+                                     symbolicTraits: UIFontDescriptor.SymbolicTraits? = nil) -> UIFont {
+        let fontMetrics = UIFontMetrics(forTextStyle: textStyle)
+        var fontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: textStyle)
+
+        if let symbolicTraits = symbolicTraits, let descriptor = fontDescriptor.withSymbolicTraits(symbolicTraits) {
+            fontDescriptor = descriptor
+        }
+
+        var font: UIFont
+        if let weight = weight {
+            font = UIFont.systemFont(ofSize: size, weight: weight)
+        } else {
+            font = UIFont(descriptor: fontDescriptor, size: size)
+        }
+
+        return fontMetrics.scaledFont(for: font)
+    }
+
+    public static func preferredBoldFont(withTextStyle textStyle: UIFont.TextStyle, size: CGFloat) -> UIFont {
+        return preferredFont(withTextStyle: textStyle, size: size, weight: .bold)
+    }
+}

--- a/BrowserKit/Tests/CommonTests/Utilities/DynamicFontHelperTests.swift
+++ b/BrowserKit/Tests/CommonTests/Utilities/DynamicFontHelperTests.swift
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Common
+
+final class DynamicFontHelperTests: XCTestCase {
+    func testPreferredFont_returnsExpectedFont() {
+        let result = DefaultDynamicFontHelper.preferredFont(withTextStyle: .caption1, size: 11)
+
+        XCTAssertEqual(result.pointSize, 11)
+        XCTAssertEqual(result.fontName, ".SFUI-Regular")
+    }
+
+    func testPreferredBoldFont_returnsExpectedFont() {
+        let result = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .body, size: 10)
+
+        XCTAssertEqual(result.pointSize, 10)
+        XCTAssertEqual(result.fontName, ".SFUI-Bold")
+    }
+}

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -1339,7 +1339,7 @@
 		E63ED7D81BFCD9990097D08E /* LoginDetailTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63ED7D71BFCD9990097D08E /* LoginDetailTableViewCell.swift */; };
 		E63ED8E11BFD25580097D08E /* PasswordManagerListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63ED8E01BFD25580097D08E /* PasswordManagerListViewController.swift */; };
 		E63F71881DB7FBE200A995C9 /* TestSQLiteMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63F71871DB7FBE200A995C9 /* TestSQLiteMetadata.swift */; };
-		E65075541E37F6FC006961AC /* DynamicFontHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65075531E37F6FC006961AC /* DynamicFontHelper.swift */; };
+		E65075541E37F6FC006961AC /* LegacyDynamicFontHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65075531E37F6FC006961AC /* LegacyDynamicFontHelper.swift */; };
 		E650755C1E37F747006961AC /* Swizzling.m in Sources */ = {isa = PBXBuildFile; fileRef = E650755B1E37F747006961AC /* Swizzling.m */; };
 		E65075611E37F77D006961AC /* MenuHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65075601E37F77D006961AC /* MenuHelper.swift */; };
 		E65075921E37F7AB006961AC /* Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65075621E37F7AB006961AC /* Accessibility.swift */; };
@@ -1443,7 +1443,7 @@
 		F35B8D2B1D6380EA008E3D61 /* SessionRestore.html in Resources */ = {isa = PBXBuildFile; fileRef = F35B8D2A1D6380EA008E3D61 /* SessionRestore.html */; };
 		F35B8D2D1D6383E9008E3D61 /* SessionRestoreHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F35B8D2C1D6383E9008E3D61 /* SessionRestoreHelper.swift */; };
 		F80D53CF2A09A3350047ED14 /* RustSyncManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F80D53CD2A09A30F0047ED14 /* RustSyncManagerTests.swift */; };
-		F80DF73F27034F6400E4C37D /* DynamicFontHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65075531E37F6FC006961AC /* DynamicFontHelper.swift */; };
+		F80DF73F27034F6400E4C37D /* LegacyDynamicFontHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65075531E37F6FC006961AC /* LegacyDynamicFontHelper.swift */; };
 		F80DF7412703BC8E00E4C37D /* CredentialPasscodeRequirementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F80DF7402703BC8E00E4C37D /* CredentialPasscodeRequirementViewController.swift */; };
 		F80DF74B270CB9CA00E4C37D /* AppAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65D89171C8647420006EA35 /* AppAuthenticator.swift */; };
 		F8324A072649A188007E4BFA /* AuthenticationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8324A062649A188007E4BFA /* AuthenticationServices.framework */; };
@@ -6522,7 +6522,7 @@
 		E63ED7D71BFCD9990097D08E /* LoginDetailTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginDetailTableViewCell.swift; sourceTree = "<group>"; };
 		E63ED8E01BFD25580097D08E /* PasswordManagerListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasswordManagerListViewController.swift; sourceTree = "<group>"; };
 		E63F71871DB7FBE200A995C9 /* TestSQLiteMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSQLiteMetadata.swift; sourceTree = "<group>"; };
-		E65075531E37F6FC006961AC /* DynamicFontHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DynamicFontHelper.swift; path = Helpers/DynamicFontHelper.swift; sourceTree = "<group>"; };
+		E65075531E37F6FC006961AC /* LegacyDynamicFontHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LegacyDynamicFontHelper.swift; path = Helpers/LegacyDynamicFontHelper.swift; sourceTree = "<group>"; };
 		E650755A1E37F747006961AC /* Swizzling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Swizzling.h; sourceTree = "<group>"; };
 		E650755B1E37F747006961AC /* Swizzling.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Swizzling.m; sourceTree = "<group>"; };
 		E65075601E37F77D006961AC /* MenuHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MenuHelper.swift; path = Helpers/MenuHelper.swift; sourceTree = "<group>"; };
@@ -7522,7 +7522,7 @@
 				8A07910E278F62F2005529CB /* AdjustHelper.swift */,
 				2165B2C12860C2F4004C0786 /* AdjustTelemetryHelper.swift */,
 				D83821FF1FC7961D00303C12 /* DispatchQueueHelper.swift */,
-				E65075531E37F6FC006961AC /* DynamicFontHelper.swift */,
+				E65075531E37F6FC006961AC /* LegacyDynamicFontHelper.swift */,
 				E65075601E37F77D006961AC /* MenuHelper.swift */,
 				E18259DA29AEB34900E6BE76 /* OnboardingNotificationCardHelper.swift */,
 				39A359E31BFCCE94006B9E87 /* UserActivityHandler.swift */,
@@ -12248,7 +12248,7 @@
 				C8CE38BB265E71FE0009B09E /* ItemListCell.swift in Sources */,
 				F8324A0A2649A188007E4BFA /* CredentialProviderViewController.swift in Sources */,
 				60CE80C12667780D004026C7 /* CredentialListPresenter.swift in Sources */,
-				F80DF73F27034F6400E4C37D /* DynamicFontHelper.swift in Sources */,
+				F80DF73F27034F6400E4C37D /* LegacyDynamicFontHelper.swift in Sources */,
 				6025B111267B6EE100F59F6B /* CredentialWelcomeViewController.swift in Sources */,
 				C87DF962267246730097E707 /* photon-colors.swift in Sources */,
 				6025B10A267B6BB300F59F6B /* SelectPasswordCell.swift in Sources */,
@@ -12746,7 +12746,7 @@
 				C869912D28917688007ACC5C /* WallpaperImageLoader.swift in Sources */,
 				96A5F73829928B3700234E5F /* GeneralizedImageFetcher.swift in Sources */,
 				43F7952525795F69005AEE40 /* SearchTelemetry.swift in Sources */,
-				E65075541E37F6FC006961AC /* DynamicFontHelper.swift in Sources */,
+				E65075541E37F6FC006961AC /* LegacyDynamicFontHelper.swift in Sources */,
 				8ADAE4242A33A126007BF926 /* StudiesToggleSetting.swift in Sources */,
 				C82CDD47233E8996002E2743 /* Tab+ChangeUserAgent.swift in Sources */,
 				C4E3984C1D21F2FD004E89BA /* TabTrayButtonExtensions.swift in Sources */,

--- a/Client/AccessoryViewProvider.swift
+++ b/Client/AccessoryViewProvider.swift
@@ -80,7 +80,7 @@ class AccessoryViewProvider: UIView, Themeable {
     }
 
     lazy private var useCardTextLabel: UILabel = .build { label in
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .title3, size: 16, weight: .medium)
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .title3, size: 16, weight: .medium)
         label.text = .CreditCard.Settings.UseSavedCardFromKeyboard
         label.numberOfLines = 0
     }

--- a/Client/Application/AppLaunchUtil.swift
+++ b/Client/Application/AppLaunchUtil.swift
@@ -39,7 +39,7 @@ class AppLaunchUtil {
         setUserAgent()
 
         KeyboardHelper.defaultHelper.startObserving()
-        DynamicFontHelper.defaultHelper.startObserving()
+        LegacyDynamicFontHelper.defaultHelper.startObserving()
         MenuHelper.defaultHelper.setItems()
 
         // Initialize conversion value by specifying fineValue and coarseValue.

--- a/Client/Extensions/String+Extension.swift
+++ b/Client/Extensions/String+Extension.swift
@@ -30,7 +30,7 @@ extension String {
 
         // if we have a text style, we are using dynamic text so the attributed text should do too
         if let textStyle = font.fontDescriptor.fontAttributes[.textStyle] as? UIFont.TextStyle {
-            boldFont = DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: textStyle,
+            boldFont = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: textStyle,
                                                                          size: font.pointSize)
         }
 

--- a/Client/Extensions/String+Extension.swift
+++ b/Client/Extensions/String+Extension.swift
@@ -31,7 +31,7 @@ extension String {
         // if we have a text style, we are using dynamic text so the attributed text should do too
         if let textStyle = font.fontDescriptor.fontAttributes[.textStyle] as? UIFont.TextStyle {
             boldFont = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: textStyle,
-                                                                         size: font.pointSize)
+                                                                               size: font.pointSize)
         }
 
         let boldFontAttribute = [NSAttributedString.Key.font: boldFont]

--- a/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetFooterView.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetFooterView.swift
@@ -17,7 +17,7 @@ class CreditCardBottomSheetFooterView: UITableViewHeaderFooterView, ReusableCell
     }
 
     public lazy var manageCardsButton: ResizableButton = .build { button in
-        button.titleLabel?.font = DynamicFontHelper.defaultHelper.preferredFont(
+        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(
             withTextStyle: .callout,
             size: UX.manageCardsButtonFontSize)
         button.setTitle(.CreditCard.UpdateCreditCard.ManageCardsButtonTitle, for: .normal)

--- a/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetHeaderView.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetHeaderView.swift
@@ -42,7 +42,7 @@ class CreditCardBottomSheetHeaderView: UITableViewHeaderFooterView, ReusableCell
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
         label.text = .CreditCard.RememberCreditCard.MainTitle
-        label.font = DynamicFontHelper.defaultHelper.preferredBoldFont(
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(
             withTextStyle: .headline,
             size: UX.titleLabelFontSize)
         label.adjustsFontForContentSizeCategory = true
@@ -56,7 +56,7 @@ class CreditCardBottomSheetHeaderView: UITableViewHeaderFooterView, ReusableCell
         label.setContentHuggingPriority(.defaultHigh, for: .vertical)
         label.text = String(format: String.CreditCard.RememberCreditCard.Header, AppName.shortName.rawValue)
 
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(
             withTextStyle: .body,
             size: UX.headerLabelFontSize)
         label.adjustsFontForContentSizeCategory = true

--- a/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
@@ -82,7 +82,7 @@ class CreditCardBottomSheetViewController: UIViewController, UITableViewDelegate
     }
 
     private lazy var yesButton: ResizableButton = .build { button in
-        button.titleLabel?.font = DynamicFontHelper.defaultHelper.preferredFont(
+        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(
             withTextStyle: .headline,
             size: UX.yesButtonFontSize)
         button.addTarget(self, action: #selector(self.didTapYes), for: .touchUpInside)

--- a/Client/Frontend/Browser/BackForwardTableViewCell.swift
+++ b/Client/Frontend/Browser/BackForwardTableViewCell.swift
@@ -118,10 +118,10 @@ class BackForwardTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
 
         label.text = viewModel.cellTittle
         if viewModel.isCurrentTab {
-            label.font = DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
+            label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
                                                                            size: UX.fontSize)
         } else {
-            label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
+            label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
                                                                        size: UX.fontSize)
         }
         setNeedsLayout()

--- a/Client/Frontend/Browser/BackForwardTableViewCell.swift
+++ b/Client/Frontend/Browser/BackForwardTableViewCell.swift
@@ -119,10 +119,10 @@ class BackForwardTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
         label.text = viewModel.cellTittle
         if viewModel.isCurrentTab {
             label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
-                                                                           size: UX.fontSize)
+                                                                                 size: UX.fontSize)
         } else {
             label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
-                                                                       size: UX.fontSize)
+                                                                             size: UX.fontSize)
         }
         setNeedsLayout()
         applyTheme(theme: theme)

--- a/Client/Frontend/Browser/ButtonToast.swift
+++ b/Client/Frontend/Browser/ButtonToast.swift
@@ -41,13 +41,13 @@ class ButtonToast: Toast {
     }
 
     private var titleLabel: UILabel = .build { label in
-        label.font = DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
                                                                        size: UX.titleFontSize)
         label.numberOfLines = 0
     }
 
     private var descriptionLabel: UILabel = .build { label in
-        label.font = DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
                                                                        size: UX.descriptionFontSize)
         label.numberOfLines = 0
     }
@@ -55,7 +55,7 @@ class ButtonToast: Toast {
     private var roundedButton: UIButton = .build { button in
         button.layer.cornerRadius = UX.buttonBorderRadius
         button.layer.borderWidth = UX.buttonBorderWidth
-        button.titleLabel?.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
+        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
                                                                                 size: Toast.UX.fontSize)
         button.titleLabel?.numberOfLines = 1
         button.titleLabel?.lineBreakMode = .byClipping

--- a/Client/Frontend/Browser/ButtonToast.swift
+++ b/Client/Frontend/Browser/ButtonToast.swift
@@ -42,21 +42,21 @@ class ButtonToast: Toast {
 
     private var titleLabel: UILabel = .build { label in
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
-                                                                       size: UX.titleFontSize)
+                                                                             size: UX.titleFontSize)
         label.numberOfLines = 0
     }
-
+    
     private var descriptionLabel: UILabel = .build { label in
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
-                                                                       size: UX.descriptionFontSize)
+                                                                             size: UX.descriptionFontSize)
         label.numberOfLines = 0
     }
-
+    
     private var roundedButton: UIButton = .build { button in
         button.layer.cornerRadius = UX.buttonBorderRadius
         button.layer.borderWidth = UX.buttonBorderWidth
         button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
-                                                                                size: Toast.UX.fontSize)
+                                                                                      size: Toast.UX.fontSize)
         button.titleLabel?.numberOfLines = 1
         button.titleLabel?.lineBreakMode = .byClipping
         button.titleLabel?.adjustsFontSizeToFitWidth = true

--- a/Client/Frontend/Browser/ButtonToast.swift
+++ b/Client/Frontend/Browser/ButtonToast.swift
@@ -45,13 +45,13 @@ class ButtonToast: Toast {
                                                                              size: UX.titleFontSize)
         label.numberOfLines = 0
     }
-    
+
     private var descriptionLabel: UILabel = .build { label in
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
                                                                              size: UX.descriptionFontSize)
         label.numberOfLines = 0
     }
-    
+
     private var roundedButton: UIButton = .build { button in
         button.layer.cornerRadius = UX.buttonBorderRadius
         button.layer.borderWidth = UX.buttonBorderWidth

--- a/Client/Frontend/Browser/DownloadToast.swift
+++ b/Client/Frontend/Browser/DownloadToast.swift
@@ -32,13 +32,13 @@ class DownloadToast: Toast {
 
     private var titleLabel: UILabel = .build { label in
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
-                                                                       size: ButtonToast.UX.titleFontSize)
+                                                                             size: ButtonToast.UX.titleFontSize)
         label.numberOfLines = 0
     }
-
+    
     private var descriptionLabel: UILabel = .build { label in
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
-                                                                       size: ButtonToast.UX.descriptionFontSize)
+                                                                             size: ButtonToast.UX.descriptionFontSize)
         label.numberOfLines = 0
     }
 

--- a/Client/Frontend/Browser/DownloadToast.swift
+++ b/Client/Frontend/Browser/DownloadToast.swift
@@ -31,13 +31,13 @@ class DownloadToast: Toast {
     }
 
     private var titleLabel: UILabel = .build { label in
-        label.font = DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
                                                                        size: ButtonToast.UX.titleFontSize)
         label.numberOfLines = 0
     }
 
     private var descriptionLabel: UILabel = .build { label in
-        label.font = DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
                                                                        size: ButtonToast.UX.descriptionFontSize)
         label.numberOfLines = 0
     }

--- a/Client/Frontend/Browser/DownloadToast.swift
+++ b/Client/Frontend/Browser/DownloadToast.swift
@@ -35,7 +35,7 @@ class DownloadToast: Toast {
                                                                              size: ButtonToast.UX.titleFontSize)
         label.numberOfLines = 0
     }
-    
+
     private var descriptionLabel: UILabel = .build { label in
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
                                                                              size: ButtonToast.UX.descriptionFontSize)

--- a/Client/Frontend/Browser/OpenInHelper/OpenInHelper.swift
+++ b/Client/Frontend/Browser/OpenInHelper/OpenInHelper.swift
@@ -121,7 +121,7 @@ class DownloadHelper: NSObject {
 
         filenameItem.customRender = { label, contentView in
             label.numberOfLines = 2
-            label.font = DynamicFontHelper.defaultHelper.DeviceFontSmallBold
+            label.font = LegacyDynamicFontHelper.defaultHelper.DeviceFontSmallBold
             label.lineBreakMode = .byCharWrapping
         }
 

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -634,7 +634,7 @@ class SearchViewController: SiteTableViewController,
         guard searchPhrase != query, let upperBound = range?.upperBound else { return nil }
 
         let attributedString = searchPhrase.attributedText(boldIn: upperBound..<searchPhrase.endIndex,
-                                                           font: DynamicFontHelper().DefaultStandardFont)
+                                                           font: LegacyDynamicFontHelper().DefaultStandardFont)
         return attributedString
     }
 

--- a/Client/Frontend/Browser/SimpleToast.swift
+++ b/Client/Frontend/Browser/SimpleToast.swift
@@ -8,7 +8,7 @@ import Shared
 
 struct SimpleToast: ThemeApplicable {
     private let toastLabel: UILabel = .build { label in
-        label.font = DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
                                                                        size: Toast.UX.fontSize)
         label.numberOfLines = 0
         label.textAlignment = .center

--- a/Client/Frontend/Browser/SimpleToast.swift
+++ b/Client/Frontend/Browser/SimpleToast.swift
@@ -9,7 +9,7 @@ import Shared
 struct SimpleToast: ThemeApplicable {
     private let toastLabel: UILabel = .build { label in
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
-                                                                       size: Toast.UX.fontSize)
+                                                                             size: Toast.UX.fontSize)
         label.numberOfLines = 0
         label.textAlignment = .center
     }

--- a/Client/Frontend/Browser/TabPrintPageRenderer.swift
+++ b/Client/Frontend/Browser/TabPrintPageRenderer.swift
@@ -6,7 +6,7 @@ import Foundation
 
 private struct PrintedPageUX {
     static let PageInsets = CGFloat(36.0)
-    static let PageTextFont = DynamicFontHelper.defaultHelper.DefaultSmallFont
+    static let PageTextFont = LegacyDynamicFontHelper.defaultHelper.DefaultSmallFont
     static let PageMarginScale = CGFloat(0.5)
 }
 

--- a/Client/Frontend/Browser/Tabs/EmptyPrivateTabsView.swift
+++ b/Client/Frontend/Browser/Tabs/EmptyPrivateTabsView.swift
@@ -30,7 +30,7 @@ class EmptyPrivateTabsView: UIView {
 
     private let titleLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .title2,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .title2,
                                                                    size: UX.titleSizeFont)
         label.numberOfLines = 0
         label.text =  .PrivateBrowsingTitle
@@ -39,7 +39,7 @@ class EmptyPrivateTabsView: UIView {
 
     private let descriptionLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
                                                                    size: UX.descriptionSizeFont)
         label.textAlignment = .center
         label.numberOfLines = 0
@@ -48,7 +48,7 @@ class EmptyPrivateTabsView: UIView {
 
     let learnMoreButton: UIButton = .build { button in
         button.setTitle( .PrivateBrowsingLearnMore, for: [])
-        button.titleLabel?.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline,
+        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline,
                                                                                 size: UX.buttonSizeFont)
     }
 

--- a/Client/Frontend/Browser/Tabs/EmptyPrivateTabsView.swift
+++ b/Client/Frontend/Browser/Tabs/EmptyPrivateTabsView.swift
@@ -27,7 +27,7 @@ class EmptyPrivateTabsView: UIView {
     }
 
     private lazy var containerView: UIView = .build { _ in }
-    
+
     private let titleLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .title2,
@@ -36,7 +36,7 @@ class EmptyPrivateTabsView: UIView {
         label.text =  .PrivateBrowsingTitle
         label.textAlignment = .center
     }
-    
+
     private let descriptionLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
@@ -45,7 +45,7 @@ class EmptyPrivateTabsView: UIView {
         label.numberOfLines = 0
         label.text = .TabTrayPrivateBrowsingDescription
     }
-    
+
     let learnMoreButton: UIButton = .build { button in
         button.setTitle( .PrivateBrowsingLearnMore, for: [])
         button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline,

--- a/Client/Frontend/Browser/Tabs/EmptyPrivateTabsView.swift
+++ b/Client/Frontend/Browser/Tabs/EmptyPrivateTabsView.swift
@@ -27,29 +27,29 @@ class EmptyPrivateTabsView: UIView {
     }
 
     private lazy var containerView: UIView = .build { _ in }
-
+    
     private let titleLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .title2,
-                                                                   size: UX.titleSizeFont)
+                                                                         size: UX.titleSizeFont)
         label.numberOfLines = 0
         label.text =  .PrivateBrowsingTitle
         label.textAlignment = .center
     }
-
+    
     private let descriptionLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
-                                                                   size: UX.descriptionSizeFont)
+                                                                         size: UX.descriptionSizeFont)
         label.textAlignment = .center
         label.numberOfLines = 0
         label.text = .TabTrayPrivateBrowsingDescription
     }
-
+    
     let learnMoreButton: UIButton = .build { button in
         button.setTitle( .PrivateBrowsingLearnMore, for: [])
         button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline,
-                                                                                size: UX.buttonSizeFont)
+                                                                                      size: UX.buttonSizeFont)
     }
 
     private let iconImageView: UIImageView = .build { imageView in

--- a/Client/Frontend/Browser/Tabs/InactiveTabs/InactiveTabButton.swift
+++ b/Client/Frontend/Browser/Tabs/InactiveTabs/InactiveTabButton.swift
@@ -25,7 +25,7 @@ class InactiveTabButton: UITableViewCell, ThemeApplicable, ReusableCell {
 
     private lazy var roundedButton: UIButton = {
         let button = UIButton()
-        button.titleLabel?.font = DynamicFontHelper.defaultHelper.preferredFont(
+        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(
             withTextStyle: .body,
             weight: .semibold,
             maxSize: 16)

--- a/Client/Frontend/Browser/Tabs/InactiveTabs/InactiveTabHeader.swift
+++ b/Client/Frontend/Browser/Tabs/InactiveTabs/InactiveTabHeader.swift
@@ -15,7 +15,7 @@ class InactiveTabHeader: UITableViewHeaderFooterView, ReusableCell {
 
     lazy var titleLabel: UILabel = .build { titleLabel in
         titleLabel.text = self.title
-        titleLabel.font = DynamicFontHelper.defaultHelper.preferredFont(
+        titleLabel.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(
             withTextStyle: .headline,
             maxSize: 17)
         titleLabel.adjustsFontForContentSizeCategory = true

--- a/Client/Frontend/Browser/Tabs/InactiveTabs/InactiveTabItemCellModel.swift
+++ b/Client/Frontend/Browser/Tabs/InactiveTabs/InactiveTabItemCellModel.swift
@@ -19,7 +19,7 @@ struct InactiveTabItemCellModel {
     }
 
     var fontForLabel: UIFont {
-        return DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, maxSize: 17)
+        return LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, maxSize: 17)
     }
 
     var title: String?

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsErrorCell.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsErrorCell.swift
@@ -37,7 +37,7 @@ class RemoteTabsErrorCell: UITableViewCell, ReusableCell, ThemeApplicable {
 
     private let titleLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .title2,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .title2,
                                                                    size: UX.titleSizeFont)
         label.numberOfLines = 0
         label.textAlignment = .center
@@ -45,14 +45,14 @@ class RemoteTabsErrorCell: UITableViewCell, ReusableCell, ThemeApplicable {
 
     private let instructionsLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
                                                                    size: UX.descriptionSizeFont)
         label.numberOfLines = 0
         label.textAlignment = .center
     }
 
     private let signInButton: ResizableButton = .build { button in
-        button.titleLabel?.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .callout,
+        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .callout,
                                                                                 size: UX.buttonSizeFont)
         button.setTitle(.Settings.Sync.ButtonTitle, for: [])
         button.layer.cornerRadius = UX.buttonCornerRadius

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsErrorCell.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsErrorCell.swift
@@ -38,22 +38,22 @@ class RemoteTabsErrorCell: UITableViewCell, ReusableCell, ThemeApplicable {
     private let titleLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .title2,
-                                                                   size: UX.titleSizeFont)
+                                                                         size: UX.titleSizeFont)
         label.numberOfLines = 0
         label.textAlignment = .center
     }
-
+    
     private let instructionsLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
-                                                                   size: UX.descriptionSizeFont)
+                                                                         size: UX.descriptionSizeFont)
         label.numberOfLines = 0
         label.textAlignment = .center
     }
-
+    
     private let signInButton: ResizableButton = .build { button in
         button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .callout,
-                                                                                size: UX.buttonSizeFont)
+                                                                                      size: UX.buttonSizeFont)
         button.setTitle(.Settings.Sync.ButtonTitle, for: [])
         button.layer.cornerRadius = UX.buttonCornerRadius
         button.contentEdgeInsets = UIEdgeInsets(top: UX.buttonVerticalInset,

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsErrorCell.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsErrorCell.swift
@@ -42,7 +42,7 @@ class RemoteTabsErrorCell: UITableViewCell, ReusableCell, ThemeApplicable {
         label.numberOfLines = 0
         label.textAlignment = .center
     }
-    
+
     private let instructionsLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
@@ -50,7 +50,7 @@ class RemoteTabsErrorCell: UITableViewCell, ReusableCell, ThemeApplicable {
         label.numberOfLines = 0
         label.textAlignment = .center
     }
-    
+
     private let signInButton: ResizableButton = .build { button in
         button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .callout,
                                                                                       size: UX.buttonSizeFont)

--- a/Client/Frontend/Browser/Tabs/TabCell.swift
+++ b/Client/Frontend/Browser/Tabs/TabCell.swift
@@ -56,7 +56,7 @@ class TabCell: UICollectionViewCell,
     lazy var titleText: UILabel = .build { label in
         label.isUserInteractionEnabled = false
         label.numberOfLines = 1
-        label.font = DynamicFontHelper.defaultHelper.DefaultSmallFontBold
+        label.font = LegacyDynamicFontHelper.defaultHelper.DefaultSmallFontBold
     }
 
     lazy var smallFaviconView: FaviconImageView = .build { _ in }
@@ -223,7 +223,7 @@ class TabCell: UICollectionViewCell,
         screenshotView.image = nil
         backgroundHolder.transform = .identity
         backgroundHolder.alpha = 1
-        self.titleText.font = DynamicFontHelper.defaultHelper.DefaultSmallFontBold
+        self.titleText.font = LegacyDynamicFontHelper.defaultHelper.DefaultSmallFontBold
         layer.shadowOffset = .zero
         layer.shadowPath = nil
         layer.shadowOpacity = 0

--- a/Client/Frontend/Browser/TopTabCell.swift
+++ b/Client/Frontend/Browser/TopTabCell.swift
@@ -35,7 +35,7 @@ class TopTabCell: UICollectionViewCell, ThemeApplicable, TabTrayCell, ReusableCe
         label.textAlignment = .natural
         label.isUserInteractionEnabled = false
         label.lineBreakMode = .byCharWrapping
-        label.font = DynamicFontHelper.defaultHelper.DefaultSmallFont
+        label.font = LegacyDynamicFontHelper.defaultHelper.DefaultSmallFont
         label.semanticContentAttribute = .forceLeftToRight
         label.isAccessibilityElement = false
     }

--- a/Client/Frontend/Browser/ZoomPageBar.swift
+++ b/Client/Frontend/Browser/ZoomPageBar.swift
@@ -68,7 +68,7 @@ class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
     }
 
     private let zoomLevel: UILabel = .build { label in
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .callout,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .callout,
                                                                    size: UX.fontSize,
                                                                    weight: .semibold)
         label.accessibilityIdentifier = AccessibilityIdentifiers.ZoomPageBar.zoomPageZoomLevelLabel

--- a/Client/Frontend/Browser/ZoomPageBar.swift
+++ b/Client/Frontend/Browser/ZoomPageBar.swift
@@ -69,8 +69,8 @@ class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
 
     private let zoomLevel: UILabel = .build { label in
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .callout,
-                                                                   size: UX.fontSize,
-                                                                   weight: .semibold)
+                                                                         size: UX.fontSize,
+                                                                         weight: .semibold)
         label.accessibilityIdentifier = AccessibilityIdentifiers.ZoomPageBar.zoomPageZoomLevelLabel
         label.isUserInteractionEnabled = true
         label.adjustsFontForContentSizeCategory = true

--- a/Client/Frontend/Components/LabelButtonHeaderView.swift
+++ b/Client/Frontend/Components/LabelButtonHeaderView.swift
@@ -44,15 +44,15 @@ class LabelButtonHeaderView: UICollectionReusableView, ReusableCell {
     lazy var titleLabel: UILabel = .build { label in
         label.text = self.title
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .title3,
-                                                                       size: UX.titleLabelTextSize)
+                                                                             size: UX.titleLabelTextSize)
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
     }
-
+    
     private lazy var moreButton: ActionButton = .build { button in
         button.isHidden = true
         button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline,
-                                                                                size: UX.moreButtonTextSize)
+                                                                                      size: UX.moreButtonTextSize)
     }
 
     // MARK: - Variables

--- a/Client/Frontend/Components/LabelButtonHeaderView.swift
+++ b/Client/Frontend/Components/LabelButtonHeaderView.swift
@@ -43,7 +43,7 @@ class LabelButtonHeaderView: UICollectionReusableView, ReusableCell {
 
     lazy var titleLabel: UILabel = .build { label in
         label.text = self.title
-        label.font = DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .title3,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .title3,
                                                                        size: UX.titleLabelTextSize)
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
@@ -51,7 +51,7 @@ class LabelButtonHeaderView: UICollectionReusableView, ReusableCell {
 
     private lazy var moreButton: ActionButton = .build { button in
         button.isHidden = true
-        button.titleLabel?.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline,
+        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline,
                                                                                 size: UX.moreButtonTextSize)
     }
 

--- a/Client/Frontend/Components/LabelButtonHeaderView.swift
+++ b/Client/Frontend/Components/LabelButtonHeaderView.swift
@@ -48,7 +48,7 @@ class LabelButtonHeaderView: UICollectionReusableView, ReusableCell {
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
     }
-    
+
     private lazy var moreButton: ActionButton = .build { button in
         button.isHidden = true
         button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline,

--- a/Client/Frontend/ContextualHint/ContextualHintViewController.swift
+++ b/Client/Frontend/ContextualHint/ContextualHintViewController.swift
@@ -39,7 +39,7 @@ class ContextualHintViewController: UIViewController, OnViewDismissable, Themeab
     }
 
     private lazy var descriptionLabel: UILabel = .build { [weak self] label in
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 17)
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 17)
         label.textAlignment = .left
         label.numberOfLines = 0
     }
@@ -318,7 +318,7 @@ class ContextualHintViewController: UIViewController, OnViewDismissable, Themeab
 
         if viewModel.isActionType() {
             let textAttributes: [NSAttributedString.Key: Any] = [
-                .font: DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 17),
+                .font: LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 17),
                 .foregroundColor: theme.colors.textOnColor,
                 .underlineStyle: NSUnderlineStyle.single.rawValue
             ]

--- a/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
+++ b/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
@@ -70,7 +70,7 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
     }
 
     private lazy var titleLabel: UILabel = .build { [weak self] label in
-        label.font = DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .title1,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .title1,
                                                                        size: self?.titleFontSize ?? UX.titleSize)
         label.textAlignment = .center
         label.numberOfLines = 0
@@ -78,25 +78,25 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
     }
 
     private lazy var descriptionText: UILabel = .build { label in
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 17)
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 17)
         label.numberOfLines = 0
         label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.HomeTabBanner.descriptionLabel
     }
 
     private lazy var descriptionLabel1: UILabel = .build { label in
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 17)
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 17)
         label.numberOfLines = 0
         label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.HomeTabBanner.descriptionLabel1
     }
 
     private lazy var descriptionLabel2: UILabel = .build { label in
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 17)
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 17)
         label.numberOfLines = 0
         label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.HomeTabBanner.descriptionLabel2
     }
 
     private lazy var descriptionLabel3: UILabel = .build { label in
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 17)
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 17)
         label.numberOfLines = 0
         label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.HomeTabBanner.descriptionLabel3
     }
@@ -104,7 +104,7 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
     private lazy var goToSettingsButton: ResizableButton = .build { button in
         button.layer.cornerRadius = UX.ctaButtonCornerRadius
         button.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.HomeTabBanner.ctaButton
-        button.titleLabel?.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .title3, size: 20)
+        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .title3, size: 20)
         button.contentEdgeInsets = UIEdgeInsets(top: 15, left: 15, bottom: 15, right: 15)
         button.titleLabel?.textAlignment = .center
     }

--- a/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
+++ b/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
@@ -71,7 +71,7 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
 
     private lazy var titleLabel: UILabel = .build { [weak self] label in
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .title1,
-                                                                       size: self?.titleFontSize ?? UX.titleSize)
+                                                                             size: self?.titleFontSize ?? UX.titleSize)
         label.textAlignment = .center
         label.numberOfLines = 0
         label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.HomeTabBanner.titleLabel

--- a/Client/Frontend/Fakespot/Components/CollapsibleCardContainer.swift
+++ b/Client/Frontend/Fakespot/Components/CollapsibleCardContainer.swift
@@ -49,7 +49,7 @@ class CollapsibleCardContainer: CardContainer, UIGestureRecognizerDelegate {
 
     lazy var titleLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .headline, size: 17.0)
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .headline, size: 17.0)
         label.numberOfLines = 0
     }
 

--- a/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionCell.swift
+++ b/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionCell.swift
@@ -19,7 +19,7 @@ class CustomizeHomepageSectionCell: UICollectionViewCell, ReusableCell {
     // MARK: - UI Elements
     private let goToSettingsButton: ActionButton = .build { button in
         button.setTitle(.FirefoxHomepage.CustomizeHomepage.ButtonTitle, for: .normal)
-        button.titleLabel?.font = DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .subheadline,
+        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .subheadline,
                                                                                     size: UX.buttonFontSize)
         button.layer.cornerRadius = UX.buttonCornerRadius
         button.accessibilityIdentifier = a11y.customizeHome

--- a/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionCell.swift
+++ b/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionCell.swift
@@ -20,7 +20,7 @@ class CustomizeHomepageSectionCell: UICollectionViewCell, ReusableCell {
     private let goToSettingsButton: ActionButton = .build { button in
         button.setTitle(.FirefoxHomepage.CustomizeHomepage.ButtonTitle, for: .normal)
         button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .subheadline,
-                                                                                    size: UX.buttonFontSize)
+                                                                                          size: UX.buttonFontSize)
         button.layer.cornerRadius = UX.buttonCornerRadius
         button.accessibilityIdentifier = a11y.customizeHome
         button.contentEdgeInsets = UIEdgeInsets(top: UX.buttonVerticalInset,

--- a/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsCell.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsCell.swift
@@ -23,7 +23,7 @@ class HistoryHighlightsCell: UICollectionViewCell, ReusableCell {
                                                                          size: 15)
         label.adjustsFontForContentSizeCategory = true
     }
-    
+
     let itemDescription: UILabel = .build { label in
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption1,
                                                                          size: 12)

--- a/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsCell.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsCell.swift
@@ -20,13 +20,13 @@ class HistoryHighlightsCell: UICollectionViewCell, ReusableCell {
 
     let itemTitle: UILabel = .build { label in
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
-                                                                   size: 15)
+                                                                         size: 15)
         label.adjustsFontForContentSizeCategory = true
     }
-
+    
     let itemDescription: UILabel = .build { label in
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption1,
-                                                                   size: 12)
+                                                                         size: 12)
         label.adjustsFontForContentSizeCategory = true
     }
 

--- a/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsCell.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsCell.swift
@@ -19,13 +19,13 @@ class HistoryHighlightsCell: UICollectionViewCell, ReusableCell {
     let imageView: FaviconImageView = .build { imageView in }
 
     let itemTitle: UILabel = .build { label in
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
                                                                    size: 15)
         label.adjustsFontForContentSizeCategory = true
     }
 
     let itemDescription: UILabel = .build { label in
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption1,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption1,
                                                                    size: 12)
         label.adjustsFontForContentSizeCategory = true
     }

--- a/Client/Frontend/Home/JumpBackIn/Cell/JumpBackInCell.swift
+++ b/Client/Frontend/Home/JumpBackIn/Cell/JumpBackInCell.swift
@@ -63,20 +63,20 @@ class JumpBackInCell: UICollectionViewCell, ReusableCell {
     private let itemTitle: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline,
-                                                                   size: UX.titleFontSize)
+                                                                         size: UX.titleFontSize)
         label.numberOfLines = 2
     }
-
+    
     // Contains the websiteImage and websiteLabel
     private var websiteContainer: UIView = .build { view in
         view.backgroundColor = .clear
     }
-
+    
     private var websiteLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 2
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .caption1,
-                                                                       size: UX.siteFontSize)
+                                                                             size: UX.siteFontSize)
         label.textColor = .label
     }
 

--- a/Client/Frontend/Home/JumpBackIn/Cell/JumpBackInCell.swift
+++ b/Client/Frontend/Home/JumpBackIn/Cell/JumpBackInCell.swift
@@ -62,7 +62,7 @@ class JumpBackInCell: UICollectionViewCell, ReusableCell {
 
     private let itemTitle: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline,
                                                                    size: UX.titleFontSize)
         label.numberOfLines = 2
     }
@@ -75,7 +75,7 @@ class JumpBackInCell: UICollectionViewCell, ReusableCell {
     private var websiteLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 2
-        label.font = DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .caption1,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .caption1,
                                                                        size: UX.siteFontSize)
         label.textColor = .label
     }

--- a/Client/Frontend/Home/JumpBackIn/Cell/JumpBackInCell.swift
+++ b/Client/Frontend/Home/JumpBackIn/Cell/JumpBackInCell.swift
@@ -66,12 +66,12 @@ class JumpBackInCell: UICollectionViewCell, ReusableCell {
                                                                          size: UX.titleFontSize)
         label.numberOfLines = 2
     }
-    
+
     // Contains the websiteImage and websiteLabel
     private var websiteContainer: UIView = .build { view in
         view.backgroundColor = .clear
     }
-    
+
     private var websiteLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 2

--- a/Client/Frontend/Home/JumpBackIn/Cell/SyncedTabCell.swift
+++ b/Client/Frontend/Home/JumpBackIn/Cell/SyncedTabCell.swift
@@ -87,18 +87,18 @@ class SyncedTabCell: UICollectionViewCell, ReusableCell {
         label.numberOfLines = 2
         label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.SyncedTab.itemTitle
     }
-    
+
     // Contains the syncedDeviceImage and syncedDeviceLabel
     private var syncedDeviceContainer: UIView = .build { view in
         view.backgroundColor = .clear
     }
-    
+
     private let syncedDeviceImage: UIImageView = .build { imageView in
         imageView.contentMode = .scaleAspectFit
         imageView.clipsToBounds = true
         imageView.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.SyncedTab.favIconImage
     }
-    
+
     private let syncedDeviceLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 2

--- a/Client/Frontend/Home/JumpBackIn/Cell/SyncedTabCell.swift
+++ b/Client/Frontend/Home/JumpBackIn/Cell/SyncedTabCell.swift
@@ -51,13 +51,13 @@ class SyncedTabCell: UICollectionViewCell, ReusableCell {
     private let cardTitle: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .headline,
-                                                                   size: UX.cardTitleFontSize)
+                                                                         size: UX.cardTitleFontSize)
         label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.SyncedTab.cardTitle
     }
 
     private let syncedTabsButton: UIButton = .build { button in
         button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline,
-                                                                                size: UX.deviceSourceFontSize)
+                                                                                      size: UX.deviceSourceFontSize)
         button.titleLabel?.adjustsFontForContentSizeCategory = true
         button.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.SyncedTab.showAllButton
     }
@@ -83,27 +83,27 @@ class SyncedTabCell: UICollectionViewCell, ReusableCell {
     private let tabItemTitle: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline,
-                                                                   size: UX.itemTitleFontSize)
+                                                                         size: UX.itemTitleFontSize)
         label.numberOfLines = 2
         label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.SyncedTab.itemTitle
     }
-
+    
     // Contains the syncedDeviceImage and syncedDeviceLabel
     private var syncedDeviceContainer: UIView = .build { view in
         view.backgroundColor = .clear
     }
-
+    
     private let syncedDeviceImage: UIImageView = .build { imageView in
         imageView.contentMode = .scaleAspectFit
         imageView.clipsToBounds = true
         imageView.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.SyncedTab.favIconImage
     }
-
+    
     private let syncedDeviceLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 2
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .caption1,
-                                                                       size: UX.deviceSourceFontSize)
+                                                                             size: UX.deviceSourceFontSize)
         label.textColor = .label
         label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.SyncedTab.descriptionLabel
     }

--- a/Client/Frontend/Home/JumpBackIn/Cell/SyncedTabCell.swift
+++ b/Client/Frontend/Home/JumpBackIn/Cell/SyncedTabCell.swift
@@ -50,13 +50,13 @@ class SyncedTabCell: UICollectionViewCell, ReusableCell {
 
     private let cardTitle: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .headline,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .headline,
                                                                    size: UX.cardTitleFontSize)
         label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.SyncedTab.cardTitle
     }
 
     private let syncedTabsButton: UIButton = .build { button in
-        button.titleLabel?.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline,
+        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline,
                                                                                 size: UX.deviceSourceFontSize)
         button.titleLabel?.adjustsFontForContentSizeCategory = true
         button.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.SyncedTab.showAllButton
@@ -82,7 +82,7 @@ class SyncedTabCell: UICollectionViewCell, ReusableCell {
 
     private let tabItemTitle: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline,
                                                                    size: UX.itemTitleFontSize)
         label.numberOfLines = 2
         label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.SyncedTab.itemTitle
@@ -102,7 +102,7 @@ class SyncedTabCell: UICollectionViewCell, ReusableCell {
     private let syncedDeviceLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 2
-        label.font = DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .caption1,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .caption1,
                                                                        size: UX.deviceSourceFontSize)
         label.textColor = .label
         label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.SyncedTab.descriptionLabel

--- a/Client/Frontend/Home/MessageCard/HomepageMessageCard.swift
+++ b/Client/Frontend/Home/MessageCard/HomepageMessageCard.swift
@@ -47,23 +47,23 @@ class HomepageMessageCardCell: UICollectionViewCell, ReusableCell {
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .headline,
-                                                                   size: UX.bannerTitleFontSize)
+                                                                         size: UX.bannerTitleFontSize)
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = a11y.titleLabel
     }
-
+    
     private lazy var descriptionText: UILabel = .build { label in
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
-                                                                   size: UX.descriptionTextFontSize)
+                                                                         size: UX.descriptionTextFontSize)
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = a11y.descriptionLabel
     }
-
+    
     private lazy var ctaButton: ActionButton = .build { [weak self] button in
         button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
-                                                                                    size: UX.buttonFontSize)
+                                                                                          size: UX.buttonFontSize)
 
         button.layer.cornerRadius = UIFontMetrics.default.scaledValue(for: UX.cornerRadius)
         button.titleLabel?.adjustsFontForContentSizeCategory = true

--- a/Client/Frontend/Home/MessageCard/HomepageMessageCard.swift
+++ b/Client/Frontend/Home/MessageCard/HomepageMessageCard.swift
@@ -46,7 +46,7 @@ class HomepageMessageCardCell: UICollectionViewCell, ReusableCell {
     private lazy var bannerTitle: UILabel = .build { label in
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .headline,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .headline,
                                                                    size: UX.bannerTitleFontSize)
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = a11y.titleLabel
@@ -55,14 +55,14 @@ class HomepageMessageCardCell: UICollectionViewCell, ReusableCell {
     private lazy var descriptionText: UILabel = .build { label in
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
                                                                    size: UX.descriptionTextFontSize)
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = a11y.descriptionLabel
     }
 
     private lazy var ctaButton: ActionButton = .build { [weak self] button in
-        button.titleLabel?.font = DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
+        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
                                                                                     size: UX.buttonFontSize)
 
         button.layer.cornerRadius = UIFontMetrics.default.scaledValue(for: UX.cornerRadius)

--- a/Client/Frontend/Home/MessageCard/HomepageMessageCard.swift
+++ b/Client/Frontend/Home/MessageCard/HomepageMessageCard.swift
@@ -51,7 +51,7 @@ class HomepageMessageCardCell: UICollectionViewCell, ReusableCell {
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = a11y.titleLabel
     }
-    
+
     private lazy var descriptionText: UILabel = .build { label in
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
@@ -60,7 +60,7 @@ class HomepageMessageCardCell: UICollectionViewCell, ReusableCell {
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = a11y.descriptionLabel
     }
-    
+
     private lazy var ctaButton: ActionButton = .build { [weak self] button in
         button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
                                                                                           size: UX.buttonFontSize)

--- a/Client/Frontend/Home/Pocket/PocketDiscoverCell.swift
+++ b/Client/Frontend/Home/Pocket/PocketDiscoverCell.swift
@@ -17,7 +17,7 @@ class PocketDiscoverCell: UICollectionViewCell, ReusableCell {
     // MARK: - UI Elements
     let itemTitle: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .title3,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .title3,
                                                                        size: UX.discoverMoreFontSize)
         label.numberOfLines = 0
         label.textAlignment = .left

--- a/Client/Frontend/Home/Pocket/PocketDiscoverCell.swift
+++ b/Client/Frontend/Home/Pocket/PocketDiscoverCell.swift
@@ -18,7 +18,7 @@ class PocketDiscoverCell: UICollectionViewCell, ReusableCell {
     let itemTitle: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .title3,
-                                                                       size: UX.discoverMoreFontSize)
+                                                                             size: UX.discoverMoreFontSize)
         label.numberOfLines = 0
         label.textAlignment = .left
     }

--- a/Client/Frontend/Home/Pocket/PocketStandardCell.swift
+++ b/Client/Frontend/Home/Pocket/PocketStandardCell.swift
@@ -30,7 +30,7 @@ class PocketStandardCell: UICollectionViewCell, ReusableCell {
 
     private lazy var titleLabel: UILabel = .build { title in
         title.adjustsFontForContentSizeCategory = true
-        title.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline,
+        title.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline,
                                                                    size: UX.titleFontSize)
         title.numberOfLines = 2
     }
@@ -51,7 +51,7 @@ class PocketStandardCell: UICollectionViewCell, ReusableCell {
 
     private lazy var sponsoredLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption2,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption2,
                                                                    size: UX.sponsoredFontSize)
         label.text = .FirefoxHomepage.Pocket.Sponsored
     }
@@ -62,7 +62,7 @@ class PocketStandardCell: UICollectionViewCell, ReusableCell {
 
     private lazy var descriptionLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = DynamicFontHelper.defaultHelper.preferredBoldFont(
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(
             withTextStyle: .caption1,
             size: UX.siteFontSize)
     }
@@ -104,9 +104,9 @@ class PocketStandardCell: UICollectionViewCell, ReusableCell {
         heroImageView.setHeroImage(heroImageViewModel)
         sponsoredStack.isHidden = viewModel.shouldHideSponsor
         descriptionLabel.font = viewModel.shouldHideSponsor
-        ? DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption1,
+        ? LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption1,
                                                         size: UX.siteFontSize)
-        : DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .caption1,
+        : LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .caption1,
                                                             size: UX.siteFontSize)
 
         sponsoredStack.isHidden  = viewModel.shouldHideSponsor

--- a/Client/Frontend/Home/Pocket/PocketStandardCell.swift
+++ b/Client/Frontend/Home/Pocket/PocketStandardCell.swift
@@ -31,7 +31,7 @@ class PocketStandardCell: UICollectionViewCell, ReusableCell {
     private lazy var titleLabel: UILabel = .build { title in
         title.adjustsFontForContentSizeCategory = true
         title.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline,
-                                                                   size: UX.titleFontSize)
+                                                                         size: UX.titleFontSize)
         title.numberOfLines = 2
     }
 
@@ -52,7 +52,7 @@ class PocketStandardCell: UICollectionViewCell, ReusableCell {
     private lazy var sponsoredLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption2,
-                                                                   size: UX.sponsoredFontSize)
+                                                                         size: UX.sponsoredFontSize)
         label.text = .FirefoxHomepage.Pocket.Sponsored
     }
 
@@ -105,9 +105,9 @@ class PocketStandardCell: UICollectionViewCell, ReusableCell {
         sponsoredStack.isHidden = viewModel.shouldHideSponsor
         descriptionLabel.font = viewModel.shouldHideSponsor
         ? LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption1,
-                                                        size: UX.siteFontSize)
+                                                              size: UX.siteFontSize)
         : LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .caption1,
-                                                            size: UX.siteFontSize)
+                                                                  size: UX.siteFontSize)
 
         sponsoredStack.isHidden  = viewModel.shouldHideSponsor
 

--- a/Client/Frontend/Home/PocketFooterView.swift
+++ b/Client/Frontend/Home/PocketFooterView.swift
@@ -28,16 +28,16 @@ class PocketFooterView: UICollectionReusableView, ReusableCell, ThemeApplicable 
         label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption1,
-                                                                   size: UX.fontSize)
+                                                                         size: UX.fontSize)
     }
-
+    
     private let learnMoreLabel: UILabel = .build { label in
         label.text = .FirefoxHomepage.Pocket.Footer.LearnMore
         label.isUserInteractionEnabled = true
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.Pocket.footerLearnMoreLabel
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption1,
-                                                                   size: UX.fontSize)
+                                                                         size: UX.fontSize)
     }
 
     private let labelsContainer: UIStackView = .build { stackView in

--- a/Client/Frontend/Home/PocketFooterView.swift
+++ b/Client/Frontend/Home/PocketFooterView.swift
@@ -30,7 +30,7 @@ class PocketFooterView: UICollectionReusableView, ReusableCell, ThemeApplicable 
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption1,
                                                                          size: UX.fontSize)
     }
-    
+
     private let learnMoreLabel: UILabel = .build { label in
         label.text = .FirefoxHomepage.Pocket.Footer.LearnMore
         label.isUserInteractionEnabled = true

--- a/Client/Frontend/Home/PocketFooterView.swift
+++ b/Client/Frontend/Home/PocketFooterView.swift
@@ -27,7 +27,7 @@ class PocketFooterView: UICollectionReusableView, ReusableCell, ThemeApplicable 
                             AppName.shortName.rawValue)
         label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption1,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption1,
                                                                    size: UX.fontSize)
     }
 
@@ -36,7 +36,7 @@ class PocketFooterView: UICollectionReusableView, ReusableCell, ThemeApplicable 
         label.isUserInteractionEnabled = true
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.Pocket.footerLearnMoreLabel
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption1,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption1,
                                                                    size: UX.fontSize)
     }
 

--- a/Client/Frontend/Home/RecentlySaved/RecentlySavedCell.swift
+++ b/Client/Frontend/Home/RecentlySaved/RecentlySavedCell.swift
@@ -26,7 +26,7 @@ class RecentlySavedCell: UICollectionViewCell, ReusableCell {
     private var heroImageView: HeroImageView = .build { _ in }
 
     let itemTitle: UILabel = .build { label in
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
                                                                    size: UX.bookmarkTitleFontSize)
         label.adjustsFontForContentSizeCategory = true
     }

--- a/Client/Frontend/Home/RecentlySaved/RecentlySavedCell.swift
+++ b/Client/Frontend/Home/RecentlySaved/RecentlySavedCell.swift
@@ -27,7 +27,7 @@ class RecentlySavedCell: UICollectionViewCell, ReusableCell {
 
     let itemTitle: UILabel = .build { label in
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
-                                                                   size: UX.bookmarkTitleFontSize)
+                                                                         size: UX.bookmarkTitleFontSize)
         label.adjustsFontForContentSizeCategory = true
     }
 

--- a/Client/Frontend/Home/TopSites/Cell/TopSiteItemCell.swift
+++ b/Client/Frontend/Home/TopSites/Cell/TopSiteItemCell.swift
@@ -64,7 +64,7 @@ class TopSiteItemCell: UICollectionViewCell, ReusableCell {
 
     private lazy var titleLabel: UILabel = .build { titleLabel in
         titleLabel.textAlignment = .center
-        titleLabel.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption1,
+        titleLabel.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption1,
                                                                         size: UX.titleFontSize)
         titleLabel.adjustsFontForContentSizeCategory = true
         titleLabel.preferredMaxLayoutWidth = UX.imageBackgroundSize.width + HomepageViewModel.UX.shadowRadius
@@ -74,7 +74,7 @@ class TopSiteItemCell: UICollectionViewCell, ReusableCell {
 
     private lazy var sponsoredLabel: UILabel = .build { sponsoredLabel in
         sponsoredLabel.textAlignment = .center
-        sponsoredLabel.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption2,
+        sponsoredLabel.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption2,
                                                                             size: UX.sponsorFontSize)
         sponsoredLabel.adjustsFontForContentSizeCategory = true
         sponsoredLabel.preferredMaxLayoutWidth = UX.imageBackgroundSize.width + HomepageViewModel.UX.shadowRadius

--- a/Client/Frontend/Home/TopSites/Cell/TopSiteItemCell.swift
+++ b/Client/Frontend/Home/TopSites/Cell/TopSiteItemCell.swift
@@ -65,21 +65,21 @@ class TopSiteItemCell: UICollectionViewCell, ReusableCell {
     private lazy var titleLabel: UILabel = .build { titleLabel in
         titleLabel.textAlignment = .center
         titleLabel.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption1,
-                                                                        size: UX.titleFontSize)
+                                                                              size: UX.titleFontSize)
         titleLabel.adjustsFontForContentSizeCategory = true
         titleLabel.preferredMaxLayoutWidth = UX.imageBackgroundSize.width + HomepageViewModel.UX.shadowRadius
         titleLabel.backgroundColor = .clear
         titleLabel.setContentHuggingPriority(UILayoutPriority(1000), for: .vertical)
     }
-
+    
     private lazy var sponsoredLabel: UILabel = .build { sponsoredLabel in
         sponsoredLabel.textAlignment = .center
         sponsoredLabel.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption2,
-                                                                            size: UX.sponsorFontSize)
+                                                                                  size: UX.sponsorFontSize)
         sponsoredLabel.adjustsFontForContentSizeCategory = true
         sponsoredLabel.preferredMaxLayoutWidth = UX.imageBackgroundSize.width + HomepageViewModel.UX.shadowRadius
     }
-
+    
     private lazy var selectedOverlay: UIView = .build { selectedOverlay in
         selectedOverlay.isHidden = true
         selectedOverlay.layer.cornerRadius = HomepageViewModel.UX.generalCornerRadius

--- a/Client/Frontend/Home/TopSites/Cell/TopSiteItemCell.swift
+++ b/Client/Frontend/Home/TopSites/Cell/TopSiteItemCell.swift
@@ -71,7 +71,7 @@ class TopSiteItemCell: UICollectionViewCell, ReusableCell {
         titleLabel.backgroundColor = .clear
         titleLabel.setContentHuggingPriority(UILayoutPriority(1000), for: .vertical)
     }
-    
+
     private lazy var sponsoredLabel: UILabel = .build { sponsoredLabel in
         sponsoredLabel.textAlignment = .center
         sponsoredLabel.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption2,
@@ -79,7 +79,7 @@ class TopSiteItemCell: UICollectionViewCell, ReusableCell {
         sponsoredLabel.adjustsFontForContentSizeCategory = true
         sponsoredLabel.preferredMaxLayoutWidth = UX.imageBackgroundSize.width + HomepageViewModel.UX.shadowRadius
     }
-    
+
     private lazy var selectedOverlay: UIView = .build { selectedOverlay in
         selectedOverlay.isHidden = true
         selectedOverlay.layer.cornerRadius = HomepageViewModel.UX.generalCornerRadius

--- a/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperSelectorViewController.swift
+++ b/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperSelectorViewController.swift
@@ -26,17 +26,17 @@ class WallpaperSelectorViewController: WallpaperBaseViewController, Themeable {
 
     private lazy var headerLabel: UILabel = .build { label in
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .headline,
-                                                                   size: 17)
+                                                                         size: 17)
         label.adjustsFontForContentSizeCategory = true
         label.text = .Onboarding.Wallpaper.SelectorTitle
         label.textAlignment = .center
         label.numberOfLines = 0
         label.accessibilityIdentifier = AccessibilityIdentifiers.Onboarding.Wallpaper.title
     }
-
+    
     private lazy var instructionLabel: UILabel = .build { label in
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
-                                                                   size: 12)
+                                                                         size: 12)
         label.adjustsFontForContentSizeCategory = true
         label.text = .Onboarding.Wallpaper.SelectorDescription
         label.textAlignment = .center

--- a/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperSelectorViewController.swift
+++ b/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperSelectorViewController.swift
@@ -25,7 +25,7 @@ class WallpaperSelectorViewController: WallpaperBaseViewController, Themeable {
     private var collectionViewHeightConstraint: NSLayoutConstraint!
 
     private lazy var headerLabel: UILabel = .build { label in
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .headline,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .headline,
                                                                    size: 17)
         label.adjustsFontForContentSizeCategory = true
         label.text = .Onboarding.Wallpaper.SelectorTitle
@@ -35,7 +35,7 @@ class WallpaperSelectorViewController: WallpaperBaseViewController, Themeable {
     }
 
     private lazy var instructionLabel: UILabel = .build { label in
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
                                                                    size: 12)
         label.adjustsFontForContentSizeCategory = true
         label.text = .Onboarding.Wallpaper.SelectorDescription

--- a/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperSelectorViewController.swift
+++ b/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperSelectorViewController.swift
@@ -33,7 +33,7 @@ class WallpaperSelectorViewController: WallpaperBaseViewController, Themeable {
         label.numberOfLines = 0
         label.accessibilityIdentifier = AccessibilityIdentifiers.Onboarding.Wallpaper.title
     }
-    
+
     private lazy var instructionLabel: UILabel = .build { label in
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
                                                                          size: 12)

--- a/Client/Frontend/Library/Downloads/DownloadsPanel.swift
+++ b/Client/Frontend/Library/Downloads/DownloadsPanel.swift
@@ -230,7 +230,7 @@ class DownloadsPanel: UIViewController,
         let welcomeLabel: UILabel = .build { label in
             label.text = .DownloadsPanelEmptyStateTitle
             label.textAlignment = .center
-            label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
+            label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
                                                                        size: 17,
                                                                        weight: .light)
             label.textColor = self.themeManager.currentTheme.colors.textSecondary

--- a/Client/Frontend/Library/Downloads/DownloadsPanel.swift
+++ b/Client/Frontend/Library/Downloads/DownloadsPanel.swift
@@ -231,8 +231,8 @@ class DownloadsPanel: UIViewController,
             label.text = .DownloadsPanelEmptyStateTitle
             label.textAlignment = .center
             label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
-                                                                       size: 17,
-                                                                       weight: .light)
+                                                                             size: 17,
+                                                                             weight: .light)
             label.textColor = self.themeManager.currentTheme.colors.textSecondary
             label.numberOfLines = 0
             label.adjustsFontSizeToFitWidth = true

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -134,7 +134,7 @@ class HistoryPanel: UIViewController,
     lazy var welcomeLabel: UILabel = .build { label in
         label.text = self.viewModel.emptyStateText
         label.textAlignment = .center
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
                                                                    size: 17,
                                                                    weight: .light)
         label.numberOfLines = 0

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -135,8 +135,8 @@ class HistoryPanel: UIViewController,
         label.text = self.viewModel.emptyStateText
         label.textAlignment = .center
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
-                                                                   size: 17,
-                                                                   weight: .light)
+                                                                         size: 17,
+                                                                         weight: .light)
         label.numberOfLines = 0
         label.adjustsFontSizeToFitWidth = true
     }

--- a/Client/Frontend/Library/ReaderPanel.swift
+++ b/Client/Frontend/Library/ReaderPanel.swift
@@ -62,11 +62,11 @@ class ReadingListTableViewCell: UITableViewCell, ThemeApplicable {
     }
     let titleLabel: UILabel = .build { label in
         label.numberOfLines = 2
-        label.font = DynamicFontHelper.defaultHelper.DeviceFont
+        label.font = LegacyDynamicFontHelper.defaultHelper.DeviceFont
     }
     let hostnameLabel: UILabel = .build { label in
         label.numberOfLines = 1
-        label.font = DynamicFontHelper.defaultHelper.DeviceFontSmallLight
+        label.font = LegacyDynamicFontHelper.defaultHelper.DeviceFontSmallLight
     }
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -252,13 +252,13 @@ class ReadingListPanel: UITableViewController,
         let welcomeLabel: UILabel = .build { label in
             label.text = .ReaderPanelWelcome
             label.textAlignment = .center
-            label.font = DynamicFontHelper.defaultHelper.DeviceFontSmallBold
+            label.font = LegacyDynamicFontHelper.defaultHelper.DeviceFontSmallBold
             label.adjustsFontSizeToFitWidth = true
             label.textColor = self.themeManager.currentTheme.colors.textSecondary
         }
         let readerModeLabel: UILabel = .build { label in
             label.text = .ReaderPanelReadingModeDescription
-            label.font = DynamicFontHelper.defaultHelper.DeviceFontSmallLight
+            label.font = LegacyDynamicFontHelper.defaultHelper.DeviceFontSmallLight
             label.numberOfLines = 0
             label.textColor = self.themeManager.currentTheme.colors.textSecondary
         }
@@ -269,7 +269,7 @@ class ReadingListPanel: UITableViewController,
         }
         let readingListLabel: UILabel = .build { label in
             label.text = .ReaderPanelReadingListDescription
-            label.font = DynamicFontHelper.defaultHelper.DeviceFontSmallLight
+            label.font = LegacyDynamicFontHelper.defaultHelper.DeviceFontSmallLight
             label.numberOfLines = 0
             label.textColor = self.themeManager.currentTheme.colors.textSecondary
         }

--- a/Client/Frontend/Onboarding/ViewControllers/OnboardingCardViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/OnboardingCardViewController.swift
@@ -95,7 +95,7 @@ class OnboardingCardViewController: UIViewController, Themeable {
         label.numberOfLines = 0
         label.textAlignment = .center
         let fontSize = self.shouldUseSmallDeviceLayout ? UX.smallTitleFontSize : UX.titleFontSize
-        label.font = DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .largeTitle,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .largeTitle,
                                                                        size: fontSize)
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = "\(self.viewModel.a11yIdRoot)TitleLabel"
@@ -104,7 +104,7 @@ class OnboardingCardViewController: UIViewController, Themeable {
     private lazy var descriptionLabel: UILabel = .build { label in
         label.numberOfLines = 0
         label.textAlignment = .center
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
                                                                    size: UX.descriptionFontSize)
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = "\(self.viewModel.a11yIdRoot)DescriptionLabel"
@@ -117,7 +117,7 @@ class OnboardingCardViewController: UIViewController, Themeable {
     }
 
     private lazy var primaryButton: ResizableButton = .build { button in
-        button.titleLabel?.font = DynamicFontHelper.defaultHelper.preferredBoldFont(
+        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(
             withTextStyle: .callout,
             size: UX.buttonFontSize)
         button.layer.cornerRadius = UX.buttonCornerRadius
@@ -132,7 +132,7 @@ class OnboardingCardViewController: UIViewController, Themeable {
     }
 
     private lazy var secondaryButton: ResizableButton = .build { button in
-        button.titleLabel?.font = DynamicFontHelper.defaultHelper.preferredBoldFont(
+        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(
             withTextStyle: .callout,
             size: UX.buttonFontSize)
         button.layer.cornerRadius = UX.buttonCornerRadius
@@ -147,7 +147,7 @@ class OnboardingCardViewController: UIViewController, Themeable {
     }
 
     private lazy var linkButton: ResizableButton = .build { button in
-        button.titleLabel?.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline, size: UX.buttonFontSize)
+        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline, size: UX.buttonFontSize)
         button.titleLabel?.textAlignment = .center
         button.addTarget(self, action: #selector(self.linkButtonAction), for: .touchUpInside)
         button.setTitleColor(.systemBlue, for: .normal)

--- a/Client/Frontend/Onboarding/ViewControllers/OnboardingCardViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/OnboardingCardViewController.swift
@@ -100,7 +100,7 @@ class OnboardingCardViewController: UIViewController, Themeable {
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = "\(self.viewModel.a11yIdRoot)TitleLabel"
     }
-    
+
     private lazy var descriptionLabel: UILabel = .build { label in
         label.numberOfLines = 0
         label.textAlignment = .center

--- a/Client/Frontend/Onboarding/ViewControllers/OnboardingCardViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/OnboardingCardViewController.swift
@@ -96,16 +96,16 @@ class OnboardingCardViewController: UIViewController, Themeable {
         label.textAlignment = .center
         let fontSize = self.shouldUseSmallDeviceLayout ? UX.smallTitleFontSize : UX.titleFontSize
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .largeTitle,
-                                                                       size: fontSize)
+                                                                             size: fontSize)
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = "\(self.viewModel.a11yIdRoot)TitleLabel"
     }
-
+    
     private lazy var descriptionLabel: UILabel = .build { label in
         label.numberOfLines = 0
         label.textAlignment = .center
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
-                                                                   size: UX.descriptionFontSize)
+                                                                         size: UX.descriptionFontSize)
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = "\(self.viewModel.a11yIdRoot)DescriptionLabel"
     }

--- a/Client/Frontend/Onboarding/ViewControllers/OnboardingInstructionPopupViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/OnboardingInstructionPopupViewController.swift
@@ -49,7 +49,7 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
     private lazy var titleLabel: UILabel = .build { label in
         label.textAlignment = .center
         label.numberOfLines = 0
-        label.font = DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .title3, size: UX.titleFontSize)
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .title3, size: UX.titleFontSize)
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = "\(self.viewModel.a11yIdRoot).DefaultBrowserSettings.TitleLabel"
     }
@@ -65,7 +65,7 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
     }
 
     private lazy var primaryButton: ResizableButton = .build { button in
-        button.titleLabel?.font = DynamicFontHelper.defaultHelper.preferredBoldFont(
+        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(
             withTextStyle: .callout,
             size: UX.buttonFontSize)
         button.layer.cornerRadius = UX.buttonCornerRadius
@@ -203,14 +203,14 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
     private func createLabels(from descriptionTexts: [String]) {
         numeratedLabels.removeAll()
         let attributedStrings = viewModel.getAttributedStrings(
-            with: DynamicFontHelper.defaultHelper.preferredFont(
+            with: LegacyDynamicFontHelper.defaultHelper.preferredFont(
                 withTextStyle: .subheadline,
                 size: UX.numeratedTextFontSize))
         attributedStrings.forEach { attributedText in
             let index = attributedStrings.firstIndex(of: attributedText)! as Int
             let label: UILabel = .build { label in
                 label.textAlignment = .left
-                label.font = DynamicFontHelper.defaultHelper.preferredFont(
+                label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(
                     withTextStyle: .subheadline,
                     size: UX.numeratedTextFontSize)
                 label.adjustsFontForContentSizeCategory = true

--- a/Client/Frontend/PasswordManagement/BreachAlertsDetailView.swift
+++ b/Client/Frontend/PasswordManagement/BreachAlertsDetailView.swift
@@ -43,7 +43,7 @@ class BreachAlertsDetailView: UIView, ThemeApplicable {
 
     lazy var titleLabel: UILabel = {
         let label = UILabel()
-        label.font = DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .headline,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .headline,
                                                                        size: 19)
         label.text = .BreachAlertsTitle
         label.sizeToFit()
@@ -55,7 +55,7 @@ class BreachAlertsDetailView: UIView, ThemeApplicable {
 
     lazy var learnMoreButton: UIButton = {
         let button = UIButton()
-        button.titleLabel?.font = DynamicFontHelper.defaultHelper.DeviceFontSmallBold
+        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.DeviceFontSmallBold
         button.isAccessibilityElement = true
         button.accessibilityTraits = .button
         button.accessibilityLabel = .BreachAlertsLearnMore
@@ -72,7 +72,7 @@ class BreachAlertsDetailView: UIView, ThemeApplicable {
         let label = UILabel()
         label.text = .BreachAlertsBreachDate
         label.numberOfLines = 0
-        label.font = DynamicFontHelper.defaultHelper.DeviceFontSmallBold
+        label.font = LegacyDynamicFontHelper.defaultHelper.DeviceFontSmallBold
         label.isAccessibilityElement = true
         label.accessibilityTraits = .staticText
         label.accessibilityLabel = .BreachAlertsBreachDate
@@ -83,7 +83,7 @@ class BreachAlertsDetailView: UIView, ThemeApplicable {
         let label = UILabel()
         label.text = .BreachAlertsDescription
         label.numberOfLines = 0
-        label.font = DynamicFontHelper.defaultHelper.DeviceFontSmall
+        label.font = LegacyDynamicFontHelper.defaultHelper.DeviceFontSmall
         label.isAccessibilityElement = true
         label.accessibilityTraits = .staticText
         return label
@@ -91,7 +91,7 @@ class BreachAlertsDetailView: UIView, ThemeApplicable {
 
     lazy var goToButton: UILabel = {
         let button = UILabel()
-        button.font = DynamicFontHelper.defaultHelper.DeviceFontSmallBold
+        button.font = LegacyDynamicFontHelper.defaultHelper.DeviceFontSmallBold
         button.numberOfLines = 0
         button.isUserInteractionEnabled = true
         button.isAccessibilityElement = true

--- a/Client/Frontend/PasswordManagement/BreachAlertsDetailView.swift
+++ b/Client/Frontend/PasswordManagement/BreachAlertsDetailView.swift
@@ -44,7 +44,7 @@ class BreachAlertsDetailView: UIView, ThemeApplicable {
     lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .headline,
-                                                                       size: 19)
+                                                                             size: 19)
         label.text = .BreachAlertsTitle
         label.sizeToFit()
         label.isAccessibilityElement = true

--- a/Client/Frontend/PasswordManagement/Cells/LoginDetailCenteredTableViewCell.swift
+++ b/Client/Frontend/PasswordManagement/Cells/LoginDetailCenteredTableViewCell.swift
@@ -20,7 +20,7 @@ class LoginDetailCenteredTableViewCell: UITableViewCell, ThemeApplicable, Reusab
     private var viewModel: LoginDetailCenteredTableViewCellModel?
 
     private lazy var centeredLabel: UILabel = .build { label in
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .callout, size: UX.fontSize)
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .callout, size: UX.fontSize)
         label.textAlignment = .center
         label.numberOfLines = 0
     }

--- a/Client/Frontend/PasswordManagement/Cells/LoginDetailTableViewCell.swift
+++ b/Client/Frontend/PasswordManagement/Cells/LoginDetailTableViewCell.swift
@@ -59,7 +59,7 @@ class LoginDetailTableViewCell: UITableViewCell, ThemeApplicable, ReusableCell, 
     lazy var descriptionLabel: UITextField = .build { [weak self] label in
         guard let self = self else { return }
 
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: UX.descriptionFontSize)
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: UX.descriptionFontSize)
         label.isUserInteractionEnabled = false
         label.autocapitalizationType = .none
         label.autocorrectionType = .no
@@ -70,7 +70,7 @@ class LoginDetailTableViewCell: UITableViewCell, ThemeApplicable, ReusableCell, 
     }
 
     private lazy var highlightedLabel: UILabel = .build { label in
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .callout,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .callout,
                                                                    size: UX.highlightedFontSize)
         label.numberOfLines = 0
     }
@@ -126,7 +126,7 @@ class LoginDetailTableViewCell: UITableViewCell, ThemeApplicable, ReusableCell, 
         descriptionLabel.isUserInteractionEnabled = viewModel.isEditingFieldData
 
         if viewModel.displayDescriptionAsPassword {
-            descriptionLabel.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
+            descriptionLabel.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
                                                                                   size: 16,
                                                                                   symbolicTraits: [.traitMonoSpace])
         }

--- a/Client/Frontend/PasswordManagement/Cells/LoginDetailTableViewCell.swift
+++ b/Client/Frontend/PasswordManagement/Cells/LoginDetailTableViewCell.swift
@@ -71,7 +71,7 @@ class LoginDetailTableViewCell: UITableViewCell, ThemeApplicable, ReusableCell, 
 
     private lazy var highlightedLabel: UILabel = .build { label in
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .callout,
-                                                                   size: UX.highlightedFontSize)
+                                                                         size: UX.highlightedFontSize)
         label.numberOfLines = 0
     }
 
@@ -127,8 +127,8 @@ class LoginDetailTableViewCell: UITableViewCell, ThemeApplicable, ReusableCell, 
 
         if viewModel.displayDescriptionAsPassword {
             descriptionLabel.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
-                                                                                  size: 16,
-                                                                                  symbolicTraits: [.traitMonoSpace])
+                                                                                        size: 16,
+                                                                                        symbolicTraits: [.traitMonoSpace])
         }
     }
 

--- a/Client/Frontend/PasswordManagement/DevicePasscodeRequiredViewController.swift
+++ b/Client/Frontend/PasswordManagement/DevicePasscodeRequiredViewController.swift
@@ -11,7 +11,7 @@ class DevicePasscodeRequiredViewController: SettingsViewController {
     private var warningLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = DynamicFontHelper().DeviceFontExtraLarge
+        label.font = LegacyDynamicFontHelper().DeviceFontExtraLarge
         label.text = .LoginsDevicePasscodeRequiredMessage
         label.textAlignment = .center
         label.numberOfLines = 0
@@ -23,7 +23,7 @@ class DevicePasscodeRequiredViewController: SettingsViewController {
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setTitle(.LoginsDevicePasscodeRequiredLearnMoreButtonTitle, for: .normal)
         button.addTarget(self, action: #selector(learnMoreButtonTapped), for: .touchUpInside)
-        button.titleLabel?.font = DynamicFontHelper().DeviceFontExtraLarge
+        button.titleLabel?.font = LegacyDynamicFontHelper().DeviceFontExtraLarge
         return button
     }()
 

--- a/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
+++ b/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
@@ -12,7 +12,7 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.text = .Settings.Passwords.OnboardingMessage
-        label.font = DynamicFontHelper().DeviceFontExtraLarge
+        label.font = LegacyDynamicFontHelper().DeviceFontExtraLarge
         label.textAlignment = .center
         label.numberOfLines = 0
         return label
@@ -23,7 +23,7 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setTitle(.LoginsOnboardingLearnMoreButtonTitle, for: .normal)
         button.addTarget(self, action: #selector(learnMoreButtonTapped), for: .touchUpInside)
-        button.titleLabel?.font = DynamicFontHelper().DeviceFontExtraLarge
+        button.titleLabel?.font = LegacyDynamicFontHelper().DeviceFontExtraLarge
         return button
     }()
 
@@ -32,7 +32,7 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
         button.translatesAutoresizingMaskIntoConstraints = false
         button.layer.cornerRadius = 8
         button.setTitle(.LoginsOnboardingContinueButtonTitle, for: .normal)
-        button.titleLabel?.font = DynamicFontHelper().MediumSizeBoldFontAS
+        button.titleLabel?.font = LegacyDynamicFontHelper().MediumSizeBoldFontAS
         button.titleEdgeInsets = UIEdgeInsets(top: 0, left: 15, bottom: 0, right: 0)
         button.addTarget(self, action: #selector(proceedButtonTapped), for: .touchUpInside)
         return button

--- a/Client/Frontend/Reader/View/ReaderModeFontSizeButton.swift
+++ b/Client/Frontend/Reader/View/ReaderModeFontSizeButton.swift
@@ -28,6 +28,6 @@ class ReaderModeFontSizeButton: UIButton {
             accessibilityLabel = .ReaderModeResetFontSizeAccessibilityLabel
         }
 
-        titleLabel?.font = UIFont(name: "SF-Pro-Text-Regular", size: DynamicFontHelper.defaultHelper.ReaderBigFontSize)
+        titleLabel?.font = UIFont(name: "SF-Pro-Text-Regular", size: LegacyDynamicFontHelper.defaultHelper.ReaderBigFontSize)
     }
 }

--- a/Client/Frontend/Reader/View/ReaderModeFontSizeLabel.swift
+++ b/Client/Frontend/Reader/View/ReaderModeFontSizeLabel.swift
@@ -19,10 +19,10 @@ class ReaderModeFontSizeLabel: UILabel {
             switch fontType {
             case .sansSerif,
                  .sansSerifBold:
-                font = UIFont(name: "SF-Pro-Text-Regular", size: DynamicFontHelper.defaultHelper.ReaderBigFontSize)
+                font = UIFont(name: "SF-Pro-Text-Regular", size: LegacyDynamicFontHelper.defaultHelper.ReaderBigFontSize)
             case .serif,
                  .serifBold:
-                font = UIFont(name: "NewYorkMedium-Regular", size: DynamicFontHelper.defaultHelper.ReaderBigFontSize)
+                font = UIFont(name: "NewYorkMedium-Regular", size: LegacyDynamicFontHelper.defaultHelper.ReaderBigFontSize)
             }
         }
     }

--- a/Client/Frontend/Reader/View/ReaderModeFontTypeButton.swift
+++ b/Client/Frontend/Reader/View/ReaderModeFontTypeButton.swift
@@ -17,12 +17,12 @@ class ReaderModeFontTypeButton: UIButton {
         case .sansSerif,
              .sansSerifBold:
             setTitle(.ReaderModeStyleSansSerifFontType, for: [])
-            let font = UIFont(name: "SF-Pro-Text-Regular", size: DynamicFontHelper.defaultHelper.ReaderStandardFontSize)
+            let font = UIFont(name: "SF-Pro-Text-Regular", size: LegacyDynamicFontHelper.defaultHelper.ReaderStandardFontSize)
             titleLabel?.font = font
         case .serif,
              .serifBold:
             setTitle(.ReaderModeStyleSerifFontType, for: [])
-            let font = UIFont(name: "NewYorkMedium-Regular", size: DynamicFontHelper.defaultHelper.ReaderStandardFontSize)
+            let font = UIFont(name: "NewYorkMedium-Regular", size: LegacyDynamicFontHelper.defaultHelper.ReaderStandardFontSize)
             titleLabel?.font = font
         }
     }

--- a/Client/Frontend/Reader/View/ReaderModeThemeButton.swift
+++ b/Client/Frontend/Reader/View/ReaderModeThemeButton.swift
@@ -14,10 +14,10 @@ class ReaderModeThemeButton: UIButton {
             switch fontType {
             case .sansSerif,
                  .sansSerifBold:
-                titleLabel?.font = UIFont(name: "SF-Pro", size: DynamicFontHelper.defaultHelper.ReaderStandardFontSize)
+                titleLabel?.font = UIFont(name: "SF-Pro", size: LegacyDynamicFontHelper.defaultHelper.ReaderStandardFontSize)
             case .serif,
                  .serifBold:
-                titleLabel?.font = UIFont(name: "NewYorkMedium-Regular", size: DynamicFontHelper.defaultHelper.ReaderStandardFontSize)
+                titleLabel?.font = UIFont(name: "NewYorkMedium-Regular", size: LegacyDynamicFontHelper.defaultHelper.ReaderStandardFontSize)
             }
         }
     }

--- a/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -67,7 +67,7 @@ class TPAccessoryInfo: ThemedTableViewController {
 
         let header = UILabel()
         header.text = .TPAccessoryInfoBlocksTitle
-        header.font = DynamicFontHelper.defaultHelper.DefaultMediumBoldFont
+        header.font = LegacyDynamicFontHelper.defaultHelper.DefaultMediumBoldFont
         header.textColor = themeManager.currentTheme.colors.textSecondary
 
         stack.addArrangedSubview(UIView())
@@ -143,7 +143,7 @@ class TPAccessoryInfo: ThemedTableViewController {
         }
         cell.imageView?.tintColor = themeManager.currentTheme.colors.iconPrimary
         if indexPath.row == 1 {
-            cell.textLabel?.font = DynamicFontHelper.defaultHelper.DefaultMediumFont
+            cell.textLabel?.font = LegacyDynamicFontHelper.defaultHelper.DefaultMediumFont
         }
         cell.textLabel?.numberOfLines = 0
         cell.detailTextLabel?.numberOfLines = 0
@@ -270,7 +270,7 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
             // TODO: Get a dedicated string for this.
             let title: String = .TrackerProtectionLearnMore
 
-            let font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline, size: 12.0)
+            let font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline, size: 12.0)
             var attributes = [NSAttributedString.Key: AnyObject]()
             attributes[NSAttributedString.Key.foregroundColor] = themeManager.currentTheme.colors.actionPrimary
             attributes[NSAttributedString.Key.font] = font

--- a/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsHeaderView.swift
+++ b/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsHeaderView.swift
@@ -34,19 +34,19 @@ class WallpaperSettingsHeaderView: UICollectionReusableView, ReusableCell {
     }
 
     private lazy var titleLabel: UILabel = .build { label in
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .headline, size: 12.0, weight: .medium)
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .headline, size: 12.0, weight: .medium)
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
     }
 
     private lazy var descriptionLabel: UILabel = .build { label in
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 12.0)
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 12.0)
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
     }
 
     private lazy var learnMoreButton: ResizableButton = .build { button in
-        button.titleLabel?.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 12.0)
+        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 12.0)
         button.contentHorizontalAlignment = .leading
         button.buttonEdgeSpacing = 0
     }
@@ -143,7 +143,7 @@ extension WallpaperSettingsHeaderView: ThemeApplicable {
         // in iOS 13 the title color set is not used for the attributed text color so we have to set it via attributes
         guard let buttonTitle = viewModel?.buttonTitle else { return }
         let labelAttributes: [NSAttributedString.Key: Any] = [
-            .font: DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 12.0),
+            .font: LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 12.0),
             .foregroundColor: color,
             .underlineStyle: NSUnderlineStyle.single.rawValue
         ]

--- a/Client/Frontend/Settings/Main/Account/AccountStatusSetting.swift
+++ b/Client/Frontend/Settings/Main/Account/AccountStatusSetting.swift
@@ -45,7 +45,7 @@ class AccountStatusSetting: WithAccountSetting {
             return NSAttributedString(
                 string: displayName,
                 attributes: [
-                    NSAttributedString.Key.font: DynamicFontHelper.defaultHelper.DefaultStandardFontBold,
+                    NSAttributedString.Key.font: LegacyDynamicFontHelper.defaultHelper.DefaultStandardFontBold,
                     NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
         }
 
@@ -53,7 +53,7 @@ class AccountStatusSetting: WithAccountSetting {
             return NSAttributedString(
                 string: email,
                 attributes: [
-                    NSAttributedString.Key.font: DynamicFontHelper.defaultHelper.DefaultStandardFontBold,
+                    NSAttributedString.Key.font: LegacyDynamicFontHelper.defaultHelper.DefaultStandardFontBold,
                     NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
         }
 

--- a/Client/Frontend/Settings/Main/Account/SyncNowSetting.swift
+++ b/Client/Frontend/Settings/Main/Account/SyncNowSetting.swift
@@ -46,7 +46,7 @@ class SyncNowSetting: WithAccountSetting {
                 string: .FxANoInternetConnection,
                 attributes: [
                     NSAttributedString.Key.foregroundColor: theme.colors.textWarning,
-                    NSAttributedString.Key.font: DynamicFontHelper.defaultHelper.DefaultMediumFont
+                    NSAttributedString.Key.font: LegacyDynamicFontHelper.defaultHelper.DefaultMediumFont
                 ]
             )
         }
@@ -57,7 +57,7 @@ class SyncNowSetting: WithAccountSetting {
             string: .FxASyncNow,
             attributes: [
                 NSAttributedString.Key.foregroundColor: self.enabled ? syncText : headerLightText,
-                NSAttributedString.Key.font: DynamicFontHelper.defaultHelper.DefaultStandardFont
+                NSAttributedString.Key.font: LegacyDynamicFontHelper.defaultHelper.DefaultStandardFont
             ]
         )
     }
@@ -104,19 +104,19 @@ class SyncNowSetting: WithAccountSetting {
                 string: message,
                 attributes: [
                     NSAttributedString.Key.foregroundColor: theme.colors.textWarning,
-                    NSAttributedString.Key.font: DynamicFontHelper.defaultHelper.DefaultStandardFont])
+                    NSAttributedString.Key.font: LegacyDynamicFontHelper.defaultHelper.DefaultStandardFont])
         case .warning(let message):
             return  NSAttributedString(
                 string: message,
                 attributes: [
                     NSAttributedString.Key.foregroundColor: theme.colors.textWarning,
-                    NSAttributedString.Key.font: DynamicFontHelper.defaultHelper.DefaultStandardFont])
+                    NSAttributedString.Key.font: LegacyDynamicFontHelper.defaultHelper.DefaultStandardFont])
         case .inProgress:
             return NSAttributedString(
                 string: .SyncingMessageWithEllipsis,
                 attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary,
                              NSAttributedString.Key.font: UIFont.systemFont(
-                                ofSize: DynamicFontHelper.defaultHelper.DefaultStandardFontSize,
+                                ofSize: LegacyDynamicFontHelper.defaultHelper.DefaultStandardFontSize,
                                 weight: UIFont.Weight.regular)])
         default:
             return syncNowTitle
@@ -154,7 +154,7 @@ class SyncNowSetting: WithAccountSetting {
         troubleshootButton.setTitle(.FirefoxSyncTroubleshootTitle, for: .normal)
         troubleshootButton.addTarget(self, action: #selector(self.troubleshoot), for: .touchUpInside)
         troubleshootButton.tintColor = theme.colors.actionPrimary
-        troubleshootButton.titleLabel?.font = DynamicFontHelper.defaultHelper.DefaultSmallFont
+        troubleshootButton.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.DefaultSmallFont
         troubleshootButton.sizeToFit()
         return troubleshootButton
     }()

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -533,7 +533,7 @@ class StringSetting: Setting, UITextFieldDelegate {
         cell.accessibilityTraits = UIAccessibilityTraits.none
         cell.contentView.addSubview(textField)
 
-        textField.font = DynamicFontHelper.defaultHelper.DefaultStandardFont
+        textField.font = LegacyDynamicFontHelper.defaultHelper.DefaultStandardFont
 
         textField.snp.makeConstraints { make in
             make.height.equalTo(44)

--- a/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
+++ b/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
@@ -169,7 +169,7 @@ class ThemeSettingsController: ThemedTableViewController, StoreSubscriber {
             label.text = .DisplayThemeSectionFooter
             label.numberOfLines = 0
             label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .footnote,
-                                                                       size: UX.footerFontSize)
+                                                                             size: UX.footerFontSize)
             label.textColor = self.themeManager.currentTheme.colors.textSecondary
         }
         footer.addSubview(label)

--- a/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
+++ b/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
@@ -168,7 +168,7 @@ class ThemeSettingsController: ThemedTableViewController, StoreSubscriber {
         let label: UILabel = .build { label in
             label.text = .DisplayThemeSectionFooter
             label.numberOfLines = 0
-            label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .footnote,
+            label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .footnote,
                                                                        size: UX.footerFontSize)
             label.textColor = self.themeManager.currentTheme.colors.textSecondary
         }

--- a/Client/Frontend/SurveySurface/SurveySurfaceViewController.swift
+++ b/Client/Frontend/SurveySurface/SurveySurfaceViewController.swift
@@ -50,7 +50,7 @@ class SurveySurfaceViewController: UIViewController, Themeable {
 
     private lazy var titleLabel: UILabel = .build { label in
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .title3,
-                                                                       size: UX.titleFontSize)
+                                                                             size: UX.titleFontSize)
         label.numberOfLines = 0
         label.textAlignment = .center
         label.adjustsFontForContentSizeCategory = true

--- a/Client/Frontend/SurveySurface/SurveySurfaceViewController.swift
+++ b/Client/Frontend/SurveySurface/SurveySurfaceViewController.swift
@@ -49,7 +49,7 @@ class SurveySurfaceViewController: UIViewController, Themeable {
     }
 
     private lazy var titleLabel: UILabel = .build { label in
-        label.font = DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .title3,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .title3,
                                                                        size: UX.titleFontSize)
         label.numberOfLines = 0
         label.textAlignment = .center
@@ -59,7 +59,7 @@ class SurveySurfaceViewController: UIViewController, Themeable {
     }
 
     private lazy var takeSurveyButton: ResizableButton = .build { button in
-        button.titleLabel?.font = DynamicFontHelper.defaultHelper.preferredBoldFont(
+        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(
             withTextStyle: .callout,
             size: UX.buttonFontSize)
         button.layer.cornerRadius = UX.buttonCornerRadius
@@ -75,7 +75,7 @@ class SurveySurfaceViewController: UIViewController, Themeable {
     }
 
     private lazy var dismissSurveyButton: ResizableButton = .build { button in
-        button.titleLabel?.font = DynamicFontHelper.defaultHelper.preferredBoldFont(
+        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(
             withTextStyle: .callout,
             size: UX.buttonFontSize)
         button.layer.cornerRadius = UX.buttonCornerRadius

--- a/Client/Frontend/Theme/ThemedTableSectionHeaderFooterView.swift
+++ b/Client/Frontend/Theme/ThemedTableSectionHeaderFooterView.swift
@@ -43,7 +43,7 @@ class ThemedTableSectionHeaderFooterView: UITableViewHeaderFooterView, ReusableC
     }
 
     lazy var titleLabel: UILabel = .build { label in
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline, size: 12.0)
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline, size: 12.0)
         label.numberOfLines = 0
     }
 

--- a/Client/Frontend/Theme/ThemedTableViewCells/ThemedTableViewCell.swift
+++ b/Client/Frontend/Theme/ThemedTableViewCells/ThemedTableViewCell.swift
@@ -52,7 +52,7 @@ class ThemedTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
         super.prepareForReuse()
         textLabel?.text = nil
         textLabel?.textAlignment = .natural
-        textLabel?.font = DynamicFontHelper.defaultHelper.DefaultStandardFont
+        textLabel?.font = LegacyDynamicFontHelper.defaultHelper.DefaultStandardFont
         detailTextLabel?.text = nil
         accessoryView = nil
         accessoryType = .none

--- a/Client/Frontend/Widgets/OneLineTableViewCell.swift
+++ b/Client/Frontend/Widgets/OneLineTableViewCell.swift
@@ -46,7 +46,7 @@ class OneLineTableViewCell: UITableViewCell,
 
     lazy var titleLabel: UILabel = .build { label in
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
-                                                                   size: UX.labelFontSize)
+                                                                         size: UX.labelFontSize)
         label.textAlignment = .natural
     }
 

--- a/Client/Frontend/Widgets/OneLineTableViewCell.swift
+++ b/Client/Frontend/Widgets/OneLineTableViewCell.swift
@@ -45,7 +45,7 @@ class OneLineTableViewCell: UITableViewCell,
     lazy var leftImageView: FaviconImageView = .build { _ in }
 
     lazy var titleLabel: UILabel = .build { label in
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
                                                                    size: UX.labelFontSize)
         label.textAlignment = .natural
     }

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
@@ -49,7 +49,7 @@ class PhotonActionSheet: UIViewController, Themeable {
     private lazy var closeButton: UIButton = .build { button in
         button.setTitle(.CloseButtonTitle, for: .normal)
         button.layer.cornerRadius = UX.cornerRadius
-        button.titleLabel?.font = DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body, size: 19)
+        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body, size: 19)
         button.addTarget(self, action: #selector(self.dismiss), for: .touchUpInside)
         button.accessibilityIdentifier = AccessibilityIdentifiers.Photon.closeButton
     }

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetSiteHeaderView.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetSiteHeaderView.swift
@@ -19,13 +19,13 @@ class PhotonActionSheetSiteHeaderView: UITableViewHeaderFooterView, ReusableCell
     private lazy var labelContainerView: UIView = .build { _ in }
 
     private lazy var titleLabel: UILabel = .build { label in
-        label.font = DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body, size: 17)
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body, size: 17)
         label.textAlignment = .left
         label.numberOfLines = 2
     }
 
     private lazy var descriptionLabel: UILabel = .build { label in
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 17)
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 17)
         label.textAlignment = .left
         label.numberOfLines = 1
     }

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetTitleHeaderView.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetTitleHeaderView.swift
@@ -13,7 +13,7 @@ class PhotonActionSheetTitleHeaderView: UITableViewHeaderFooterView, ReusableCel
     }
 
     lazy var titleLabel: UILabel = .build { label in
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption1, size: 12)
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption1, size: 12)
         label.numberOfLines = 1
     }
 

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetView.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetView.swift
@@ -56,14 +56,14 @@ class PhotonActionSheetView: UIView, UIGestureRecognizerDelegate, ThemeApplicabl
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
         label.setContentCompressionResistancePriority(.required, for: .horizontal)
-        label.font = DynamicFontHelper.defaultHelper.LargeSizeRegularWeightAS
+        label.font = LegacyDynamicFontHelper.defaultHelper.LargeSizeRegularWeightAS
         return label
     }()
 
     private lazy var subtitleLabel: UILabel = {
         let label = createLabel()
         label.numberOfLines = 0
-        label.font = DynamicFontHelper.defaultHelper.SmallSizeRegularWeightAS
+        label.font = LegacyDynamicFontHelper.defaultHelper.SmallSizeRegularWeightAS
         return label
     }()
 
@@ -200,10 +200,10 @@ class PhotonActionSheetView: UIView, UIGestureRecognizerDelegate, ThemeApplicabl
         titleLabel.text = item.currentTitle
 
         if item.bold {
-            titleLabel.font = DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .headline,
+            titleLabel.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .headline,
                                                                                 size: 19)
         } else {
-            titleLabel.font = DynamicFontHelper.defaultHelper.SemiMediumRegularWeightAS
+            titleLabel.font = LegacyDynamicFontHelper.defaultHelper.SemiMediumRegularWeightAS
         }
 
         item.customRender?(titleLabel, self)

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetView.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetView.swift
@@ -201,7 +201,7 @@ class PhotonActionSheetView: UIView, UIGestureRecognizerDelegate, ThemeApplicabl
 
         if item.bold {
             titleLabel.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .headline,
-                                                                                size: 19)
+                                                                                      size: 19)
         } else {
             titleLabel.font = LegacyDynamicFontHelper.defaultHelper.SemiMediumRegularWeightAS
         }

--- a/Client/Frontend/Widgets/SiteTableViewHeader.swift
+++ b/Client/Frontend/Widgets/SiteTableViewHeader.swift
@@ -25,7 +25,7 @@ class SiteTableViewHeader: UITableViewHeaderFooterView, ThemeApplicable, Reusabl
 
     private let titleLabel: UILabel = .build { label in
         label.numberOfLines = 0
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .headline,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .headline,
                                                                    size: 16)
         label.adjustsFontForContentSizeCategory = true
     }

--- a/Client/Frontend/Widgets/SiteTableViewHeader.swift
+++ b/Client/Frontend/Widgets/SiteTableViewHeader.swift
@@ -26,7 +26,7 @@ class SiteTableViewHeader: UITableViewHeaderFooterView, ThemeApplicable, Reusabl
     private let titleLabel: UILabel = .build { label in
         label.numberOfLines = 0
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .headline,
-                                                                   size: 16)
+                                                                         size: 16)
         label.adjustsFontForContentSizeCategory = true
     }
 

--- a/Client/Frontend/Widgets/SnackBar.swift
+++ b/Client/Frontend/Widgets/SnackBar.swift
@@ -32,7 +32,7 @@ class SnackBar: UIView {
     }
 
     private lazy var textLabel: UILabel = .build { label in
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: UX.fontSize)
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: UX.fontSize)
         label.lineBreakMode = .byWordWrapping
         label.numberOfLines = 0
         label.textColor = UIColor.Photon.Grey90 // If making themeable, change to UIColor.legacyTheme.tableView.rowText

--- a/Client/Frontend/Widgets/SnackButton.swift
+++ b/Client/Frontend/Widgets/SnackButton.swift
@@ -31,9 +31,9 @@ class SnackButton: UIButton {
         super.init(frame: .zero)
 
         if bold {
-            titleLabel?.font = DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body, size: UX.fontSize)
+            titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body, size: UX.fontSize)
         } else {
-            titleLabel?.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: UX.fontSize)
+            titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: UX.fontSize)
         }
         titleLabel?.adjustsFontForContentSizeCategory = true
         setTitle(title, for: .normal)

--- a/Client/Frontend/Widgets/TwoLineImageOverlayCell.swift
+++ b/Client/Frontend/Widgets/TwoLineImageOverlayCell.swift
@@ -46,12 +46,12 @@ class TwoLineImageOverlayCell: UITableViewCell,
     }
 
     lazy var titleLabel: UILabel = .build { label in
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 16)
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 16)
         label.textAlignment = .natural
     }
 
     lazy var descriptionLabel: UILabel = .build { label in
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 14)
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 14)
         label.textAlignment = .natural
     }
 

--- a/Client/Helpers/LegacyDynamicFontHelper.swift
+++ b/Client/Helpers/LegacyDynamicFontHelper.swift
@@ -6,10 +6,11 @@ import Foundation
 import UIKit
 import Shared
 
-private let iPadFactor: CGFloat = 1.06
-private let iPhoneFactor: CGFloat = 0.88
-
+/// This is the Legacy DynamicFontHelper, please use the `DynamicFontHelper` from `BrowserKit.Common` instead.
 class LegacyDynamicFontHelper: NSObject {
+    private let iPadFactor: CGFloat = 1.06
+    private let iPhoneFactor: CGFloat = 0.88
+
     static var defaultHelper: LegacyDynamicFontHelper {
         struct Singleton {
             static let instance = LegacyDynamicFontHelper()

--- a/Client/Helpers/LegacyDynamicFontHelper.swift
+++ b/Client/Helpers/LegacyDynamicFontHelper.swift
@@ -9,10 +9,10 @@ import Shared
 private let iPadFactor: CGFloat = 1.06
 private let iPhoneFactor: CGFloat = 0.88
 
-class DynamicFontHelper: NSObject {
-    static var defaultHelper: DynamicFontHelper {
+class LegacyDynamicFontHelper: NSObject {
+    static var defaultHelper: LegacyDynamicFontHelper {
         struct Singleton {
-            static let instance = DynamicFontHelper()
+            static let instance = LegacyDynamicFontHelper()
         }
         return Singleton.instance
     }

--- a/CredentialProvider/CredentialPasscodeRequirementViewController.swift
+++ b/CredentialProvider/CredentialPasscodeRequirementViewController.swift
@@ -54,7 +54,7 @@ class CredentialPasscodeRequirementViewController: UIViewController {
         button.backgroundColor = .systemRed
         button.layer.cornerRadius = 8
         button.setTitle(.CancelString, for: .normal)
-        button.titleLabel?.font = DynamicFontHelper().MediumSizeBoldFontAS
+        button.titleLabel?.font = LegacyDynamicFontHelper().MediumSizeBoldFontAS
         button.addTarget(self, action: #selector(cancelButtonTapped), for: .touchUpInside)
         return button
     }()

--- a/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/RustFxA/FirefoxAccountSignInViewController.swift
@@ -62,7 +62,7 @@ class FirefoxAccountSignInViewController: UIViewController, Themeable {
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
         label.text = .FxASignin_Subtitle
-        label.font = DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .headline,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .headline,
                                                                        size: UX.signInLabelFontSize)
         label.adjustsFontForContentSizeCategory = true
     }
@@ -76,7 +76,7 @@ class FirefoxAccountSignInViewController: UIViewController, Themeable {
         label.textAlignment = .center
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
-        label.font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .headline,
+        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .headline,
                                                                    size: UX.signInLabelFontSize)
         label.adjustsFontForContentSizeCategory = true
 
@@ -85,7 +85,7 @@ class FirefoxAccountSignInViewController: UIViewController, Themeable {
             manager.getPairingAuthorityURL { result in
                 guard let url = try? result.get(), let host = url.host else { return }
 
-                let font = DynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .headline,
+                let font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .headline,
                                                                          size: UX.signInLabelFontSize)
                 let shortUrl = host + url.path // "firefox.com" + "/pair"
                 let msg: String = .FxASignin_QRInstructions.replaceFirstOccurrence(of: placeholder, with: shortUrl)
@@ -99,7 +99,7 @@ class FirefoxAccountSignInViewController: UIViewController, Themeable {
         button.setImage(self.signinSyncQRImage?.tinted(withColor: .white), for: .highlighted)
         button.setTitle(.FxASignin_QRScanSignin, for: .normal)
         button.accessibilityIdentifier = AccessibilityIdentifiers.Settings.FirefoxAccount.qrButton
-        button.titleLabel?.font = DynamicFontHelper.defaultHelper.preferredBoldFont(
+        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(
             withTextStyle: .callout,
             size: UX.buttonFontSize)
 
@@ -117,7 +117,7 @@ class FirefoxAccountSignInViewController: UIViewController, Themeable {
         button.accessibilityIdentifier = AccessibilityIdentifiers.Settings.FirefoxAccount.fxaSignInButton
         button.addTarget(self, action: #selector(self.emailLoginTapped), for: .touchUpInside)
         button.titleLabel?.adjustsFontForContentSizeCategory = true
-        button.titleLabel?.font = DynamicFontHelper.defaultHelper.preferredBoldFont(
+        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(
             withTextStyle: .callout,
             size: UX.buttonFontSize)
         button.contentEdgeInsets = UIEdgeInsets(top: UX.buttonVerticalInset,

--- a/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/RustFxA/FirefoxAccountSignInViewController.swift
@@ -63,7 +63,7 @@ class FirefoxAccountSignInViewController: UIViewController, Themeable {
         label.lineBreakMode = .byWordWrapping
         label.text = .FxASignin_Subtitle
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .headline,
-                                                                       size: UX.signInLabelFontSize)
+                                                                             size: UX.signInLabelFontSize)
         label.adjustsFontForContentSizeCategory = true
     }
 
@@ -77,7 +77,7 @@ class FirefoxAccountSignInViewController: UIViewController, Themeable {
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
         label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .headline,
-                                                                   size: UX.signInLabelFontSize)
+                                                                         size: UX.signInLabelFontSize)
         label.adjustsFontForContentSizeCategory = true
 
         let placeholder = "firefox.com/pair"
@@ -86,7 +86,7 @@ class FirefoxAccountSignInViewController: UIViewController, Themeable {
                 guard let url = try? result.get(), let host = url.host else { return }
 
                 let font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .headline,
-                                                                         size: UX.signInLabelFontSize)
+                                                                               size: UX.signInLabelFontSize)
                 let shortUrl = host + url.path // "firefox.com" + "/pair"
                 let msg: String = .FxASignin_QRInstructions.replaceFirstOccurrence(of: placeholder, with: shortUrl)
                 label.attributedText = msg.attributedText(boldString: shortUrl, font: font)

--- a/Tests/ClientTests/StringExtensionsTests.swift
+++ b/Tests/ClientTests/StringExtensionsTests.swift
@@ -73,7 +73,7 @@ class StringExtensionsTests: XCTestCase {
 
         XCTAssertEqual(
             attributedText.attribute(.font, at: 1, effectiveRange: &effectiveRange) as? UIFont,
-            DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body, size: font.pointSize)
+            LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body, size: font.pointSize)
         )
         XCTAssertEqual(effectiveRange, NSRange(location: 1, length: 4))
 
@@ -92,7 +92,7 @@ class StringExtensionsTests: XCTestCase {
 
         XCTAssertEqual(
             attributedText.attribute(.font, at: 6, effectiveRange: &effectiveRange) as? UIFont,
-            DynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body, size: font.pointSize)
+            LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body, size: font.pointSize)
         )
         XCTAssertEqual(effectiveRange, NSRange(location: 6, length: 4))
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7105)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15784)

## :bulb: Description
- Rename old `DynamicFontHelper` to `LegacyDynamicFontHelper`, add comment on it's usage
- Add a new `DynamicFontHelper` which you can get fonts from with static methods. I think in this case since it's getting a `UIFont` this make sense. You can see how it would be used in the unit tests `DynamicFontHelperTests`.
- If this is approved, I'll make another PR, so we remove the "good" methods from `LegacyDynamicFontHelper` and start using `DynamicFontHelper` in our existing code where dynamic type is proplery implemented.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

