### PR TITLE
Refactor [v117] Improve stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -50,7 +50,7 @@ jobs:
           ### PULL REQUESTS ###
           # Idle number of days before marking PRs stale
           # We need to review PRs faster than 2 weeks. If there's no action on a PR for this period of time we should close it.
-          days-before-pr-stale: 15
+          days-before-pr-stale: 14
 
           # Idle number of days before closing stale PRs
           days-before-pr-close: 7
@@ -62,4 +62,4 @@ jobs:
           stale-pr-label: "stale"
 
           # Labels on PRs exempted from stale
-          exempt-pr-labels: "do not stale"
+          exempt-pr-labels: "do not stale,weekly-release"


### PR DESCRIPTION
## :scroll: Tickets
No ticket

## :bulb: Description
This is a quick PR to improve the stale bot, ensuring PRs with the `weekly-release` label never gets staled automatically. Reasoning behind this is that `weekly-release` PRs could sit for a while depending on when they are created/when the weekly release is made. A good example is [this PR](https://github.com/mozilla-mobile/firefox-ios/pull/15658).

Also, put 14 days instead of 15 for the number of days before a PR gets staled. Noticed I was saying 2 weeks in the comment, not sure why I put 15. 

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

