### PR TITLE
Refactor FXIOS-7105 [v117] Use dynamic font helper

### DIFF
--- a/Client/AccessoryViewProvider.swift
+++ b/Client/AccessoryViewProvider.swift
@@ -79,8 +79,8 @@ class AccessoryViewProvider: UIView, Themeable {
         ])
     }
 
-    lazy private var useCardTextLabel: UILabel = .build { label in
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .title3, size: 16, weight: .medium)
+    private lazy var useCardTextLabel: UILabel = .build { label in
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .title3, size: 16, weight: .medium)
         label.text = .CreditCard.Settings.UseSavedCardFromKeyboard
         label.numberOfLines = 0
     }

--- a/Client/Extensions/String+Extension.swift
+++ b/Client/Extensions/String+Extension.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
 
 extension String {
@@ -30,8 +31,8 @@ extension String {
 
         // if we have a text style, we are using dynamic text so the attributed text should do too
         if let textStyle = font.fontDescriptor.fontAttributes[.textStyle] as? UIFont.TextStyle {
-            boldFont = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: textStyle,
-                                                                               size: font.pointSize)
+            boldFont = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: textStyle,
+                                                                  size: font.pointSize)
         }
 
         let boldFontAttribute = [NSAttributedString.Key.font: boldFont]

--- a/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetFooterView.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetFooterView.swift
@@ -17,7 +17,7 @@ class CreditCardBottomSheetFooterView: UITableViewHeaderFooterView, ReusableCell
     }
 
     public lazy var manageCardsButton: ResizableButton = .build { button in
-        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(
+        button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(
             withTextStyle: .callout,
             size: UX.manageCardsButtonFontSize)
         button.setTitle(.CreditCard.UpdateCreditCard.ManageCardsButtonTitle, for: .normal)

--- a/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetHeaderView.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetHeaderView.swift
@@ -42,7 +42,7 @@ class CreditCardBottomSheetHeaderView: UITableViewHeaderFooterView, ReusableCell
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
         label.text = .CreditCard.RememberCreditCard.MainTitle
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(
+        label.font = DefaultDynamicFontHelper.preferredBoldFont(
             withTextStyle: .headline,
             size: UX.titleLabelFontSize)
         label.adjustsFontForContentSizeCategory = true
@@ -56,7 +56,7 @@ class CreditCardBottomSheetHeaderView: UITableViewHeaderFooterView, ReusableCell
         label.setContentHuggingPriority(.defaultHigh, for: .vertical)
         label.text = String(format: String.CreditCard.RememberCreditCard.Header, AppName.shortName.rawValue)
 
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(
+        label.font = DefaultDynamicFontHelper.preferredFont(
             withTextStyle: .body,
             size: UX.headerLabelFontSize)
         label.adjustsFontForContentSizeCategory = true

--- a/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
@@ -82,7 +82,7 @@ class CreditCardBottomSheetViewController: UIViewController, UITableViewDelegate
     }
 
     private lazy var yesButton: ResizableButton = .build { button in
-        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(
+        button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(
             withTextStyle: .headline,
             size: UX.yesButtonFontSize)
         button.addTarget(self, action: #selector(self.didTapYes), for: .touchUpInside)

--- a/Client/Frontend/Browser/BackForwardTableViewCell.swift
+++ b/Client/Frontend/Browser/BackForwardTableViewCell.swift
@@ -118,11 +118,11 @@ class BackForwardTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
 
         label.text = viewModel.cellTittle
         if viewModel.isCurrentTab {
-            label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
-                                                                                 size: UX.fontSize)
+            label.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .body,
+                                                                    size: UX.fontSize)
         } else {
-            label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
-                                                                             size: UX.fontSize)
+            label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
+                                                                size: UX.fontSize)
         }
         setNeedsLayout()
         applyTheme(theme: theme)

--- a/Client/Frontend/Browser/ButtonToast.swift
+++ b/Client/Frontend/Browser/ButtonToast.swift
@@ -41,22 +41,22 @@ class ButtonToast: Toast {
     }
 
     private var titleLabel: UILabel = .build { label in
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
-                                                                             size: UX.titleFontSize)
+        label.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .body,
+                                                                size: UX.titleFontSize)
         label.numberOfLines = 0
     }
 
     private var descriptionLabel: UILabel = .build { label in
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
-                                                                             size: UX.descriptionFontSize)
+        label.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .body,
+                                                                size: UX.descriptionFontSize)
         label.numberOfLines = 0
     }
 
     private var roundedButton: UIButton = .build { button in
         button.layer.cornerRadius = UX.buttonBorderRadius
         button.layer.borderWidth = UX.buttonBorderWidth
-        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
-                                                                                      size: Toast.UX.fontSize)
+        button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
+                                                                         size: Toast.UX.fontSize)
         button.titleLabel?.numberOfLines = 1
         button.titleLabel?.lineBreakMode = .byClipping
         button.titleLabel?.adjustsFontSizeToFitWidth = true

--- a/Client/Frontend/Browser/DownloadToast.swift
+++ b/Client/Frontend/Browser/DownloadToast.swift
@@ -31,14 +31,14 @@ class DownloadToast: Toast {
     }
 
     private var titleLabel: UILabel = .build { label in
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
-                                                                             size: ButtonToast.UX.titleFontSize)
+        label.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .body,
+                                                                size: ButtonToast.UX.titleFontSize)
         label.numberOfLines = 0
     }
 
     private var descriptionLabel: UILabel = .build { label in
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
-                                                                             size: ButtonToast.UX.descriptionFontSize)
+        label.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .body,
+                                                                size: ButtonToast.UX.descriptionFontSize)
         label.numberOfLines = 0
     }
 

--- a/Client/Frontend/Browser/SimpleToast.swift
+++ b/Client/Frontend/Browser/SimpleToast.swift
@@ -8,8 +8,8 @@ import Shared
 
 struct SimpleToast: ThemeApplicable {
     private let toastLabel: UILabel = .build { label in
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
-                                                                             size: Toast.UX.fontSize)
+        label.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .body,
+                                                                size: Toast.UX.fontSize)
         label.numberOfLines = 0
         label.textAlignment = .center
     }

--- a/Client/Frontend/Browser/Tabs/EmptyPrivateTabsView.swift
+++ b/Client/Frontend/Browser/Tabs/EmptyPrivateTabsView.swift
@@ -30,8 +30,8 @@ class EmptyPrivateTabsView: UIView {
 
     private let titleLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .title2,
-                                                                         size: UX.titleSizeFont)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .title2,
+                                                            size: UX.titleSizeFont)
         label.numberOfLines = 0
         label.text =  .PrivateBrowsingTitle
         label.textAlignment = .center
@@ -39,8 +39,8 @@ class EmptyPrivateTabsView: UIView {
 
     private let descriptionLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
-                                                                         size: UX.descriptionSizeFont)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
+                                                            size: UX.descriptionSizeFont)
         label.textAlignment = .center
         label.numberOfLines = 0
         label.text = .TabTrayPrivateBrowsingDescription
@@ -48,8 +48,8 @@ class EmptyPrivateTabsView: UIView {
 
     let learnMoreButton: UIButton = .build { button in
         button.setTitle( .PrivateBrowsingLearnMore, for: [])
-        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline,
-                                                                                      size: UX.buttonSizeFont)
+        button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .subheadline,
+                                                                         size: UX.buttonSizeFont)
     }
 
     private let iconImageView: UIImageView = .build { imageView in

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsErrorCell.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsErrorCell.swift
@@ -37,23 +37,23 @@ class RemoteTabsErrorCell: UITableViewCell, ReusableCell, ThemeApplicable {
 
     private let titleLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .title2,
-                                                                         size: UX.titleSizeFont)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .title2,
+                                                            size: UX.titleSizeFont)
         label.numberOfLines = 0
         label.textAlignment = .center
     }
 
     private let instructionsLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
-                                                                         size: UX.descriptionSizeFont)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
+                                                            size: UX.descriptionSizeFont)
         label.numberOfLines = 0
         label.textAlignment = .center
     }
 
     private let signInButton: ResizableButton = .build { button in
-        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .callout,
-                                                                                      size: UX.buttonSizeFont)
+        button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .callout,
+                                                                         size: UX.buttonSizeFont)
         button.setTitle(.Settings.Sync.ButtonTitle, for: [])
         button.layer.cornerRadius = UX.buttonCornerRadius
         button.contentEdgeInsets = UIEdgeInsets(top: UX.buttonVerticalInset,

--- a/Client/Frontend/Browser/ZoomPageBar.swift
+++ b/Client/Frontend/Browser/ZoomPageBar.swift
@@ -68,9 +68,9 @@ class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
     }
 
     private let zoomLevel: UILabel = .build { label in
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .callout,
-                                                                         size: UX.fontSize,
-                                                                         weight: .semibold)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .callout,
+                                                            size: UX.fontSize,
+                                                            weight: .semibold)
         label.accessibilityIdentifier = AccessibilityIdentifiers.ZoomPageBar.zoomPageZoomLevelLabel
         label.isUserInteractionEnabled = true
         label.adjustsFontForContentSizeCategory = true

--- a/Client/Frontend/Components/LabelButtonHeaderView.swift
+++ b/Client/Frontend/Components/LabelButtonHeaderView.swift
@@ -43,16 +43,16 @@ class LabelButtonHeaderView: UICollectionReusableView, ReusableCell {
 
     lazy var titleLabel: UILabel = .build { label in
         label.text = self.title
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .title3,
-                                                                             size: UX.titleLabelTextSize)
+        label.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .title3,
+                                                                size: UX.titleLabelTextSize)
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
     }
 
     private lazy var moreButton: ActionButton = .build { button in
         button.isHidden = true
-        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline,
-                                                                                      size: UX.moreButtonTextSize)
+        button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .subheadline,
+                                                                         size: UX.moreButtonTextSize)
     }
 
     // MARK: - Variables

--- a/Client/Frontend/ContextualHint/ContextualHintViewController.swift
+++ b/Client/Frontend/ContextualHint/ContextualHintViewController.swift
@@ -39,7 +39,7 @@ class ContextualHintViewController: UIViewController, OnViewDismissable, Themeab
     }
 
     private lazy var descriptionLabel: UILabel = .build { [weak self] label in
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 17)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 17)
         label.textAlignment = .left
         label.numberOfLines = 0
     }
@@ -318,7 +318,7 @@ class ContextualHintViewController: UIViewController, OnViewDismissable, Themeab
 
         if viewModel.isActionType() {
             let textAttributes: [NSAttributedString.Key: Any] = [
-                .font: LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 17),
+                .font: DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 17),
                 .foregroundColor: theme.colors.textOnColor,
                 .underlineStyle: NSUnderlineStyle.single.rawValue
             ]

--- a/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
+++ b/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
@@ -70,33 +70,33 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
     }
 
     private lazy var titleLabel: UILabel = .build { [weak self] label in
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .title1,
-                                                                             size: self?.titleFontSize ?? UX.titleSize)
+        label.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .title1,
+                                                                size: self?.titleFontSize ?? UX.titleSize)
         label.textAlignment = .center
         label.numberOfLines = 0
         label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.HomeTabBanner.titleLabel
     }
 
     private lazy var descriptionText: UILabel = .build { label in
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 17)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 17)
         label.numberOfLines = 0
         label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.HomeTabBanner.descriptionLabel
     }
 
     private lazy var descriptionLabel1: UILabel = .build { label in
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 17)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 17)
         label.numberOfLines = 0
         label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.HomeTabBanner.descriptionLabel1
     }
 
     private lazy var descriptionLabel2: UILabel = .build { label in
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 17)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 17)
         label.numberOfLines = 0
         label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.HomeTabBanner.descriptionLabel2
     }
 
     private lazy var descriptionLabel3: UILabel = .build { label in
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 17)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 17)
         label.numberOfLines = 0
         label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.HomeTabBanner.descriptionLabel3
     }
@@ -104,7 +104,7 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
     private lazy var goToSettingsButton: ResizableButton = .build { button in
         button.layer.cornerRadius = UX.ctaButtonCornerRadius
         button.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.HomeTabBanner.ctaButton
-        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .title3, size: 20)
+        button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .title3, size: 20)
         button.contentEdgeInsets = UIEdgeInsets(top: 15, left: 15, bottom: 15, right: 15)
         button.titleLabel?.textAlignment = .center
     }

--- a/Client/Frontend/Fakespot/Components/CollapsibleCardContainer.swift
+++ b/Client/Frontend/Fakespot/Components/CollapsibleCardContainer.swift
@@ -49,7 +49,7 @@ class CollapsibleCardContainer: CardContainer, UIGestureRecognizerDelegate {
 
     lazy var titleLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .headline, size: 17.0)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .headline, size: 17.0)
         label.numberOfLines = 0
     }
 

--- a/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionCell.swift
+++ b/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionCell.swift
@@ -19,8 +19,8 @@ class CustomizeHomepageSectionCell: UICollectionViewCell, ReusableCell {
     // MARK: - UI Elements
     private let goToSettingsButton: ActionButton = .build { button in
         button.setTitle(.FirefoxHomepage.CustomizeHomepage.ButtonTitle, for: .normal)
-        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .subheadline,
-                                                                                          size: UX.buttonFontSize)
+        button.titleLabel?.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .subheadline,
+                                                                             size: UX.buttonFontSize)
         button.layer.cornerRadius = UX.buttonCornerRadius
         button.accessibilityIdentifier = a11y.customizeHome
         button.contentEdgeInsets = UIEdgeInsets(top: UX.buttonVerticalInset,

--- a/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsCell.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsCell.swift
@@ -19,14 +19,14 @@ class HistoryHighlightsCell: UICollectionViewCell, ReusableCell {
     let imageView: FaviconImageView = .build { imageView in }
 
     let itemTitle: UILabel = .build { label in
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
-                                                                         size: 15)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
+                                                            size: 15)
         label.adjustsFontForContentSizeCategory = true
     }
 
     let itemDescription: UILabel = .build { label in
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption1,
-                                                                         size: 12)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .caption1,
+                                                            size: 12)
         label.adjustsFontForContentSizeCategory = true
     }
 

--- a/Client/Frontend/Home/JumpBackIn/Cell/JumpBackInCell.swift
+++ b/Client/Frontend/Home/JumpBackIn/Cell/JumpBackInCell.swift
@@ -62,8 +62,8 @@ class JumpBackInCell: UICollectionViewCell, ReusableCell {
 
     private let itemTitle: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline,
-                                                                         size: UX.titleFontSize)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .subheadline,
+                                                            size: UX.titleFontSize)
         label.numberOfLines = 2
     }
 
@@ -75,8 +75,8 @@ class JumpBackInCell: UICollectionViewCell, ReusableCell {
     private var websiteLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 2
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .caption1,
-                                                                             size: UX.siteFontSize)
+        label.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .caption1,
+                                                                size: UX.siteFontSize)
         label.textColor = .label
     }
 

--- a/Client/Frontend/Home/JumpBackIn/Cell/SyncedTabCell.swift
+++ b/Client/Frontend/Home/JumpBackIn/Cell/SyncedTabCell.swift
@@ -50,14 +50,14 @@ class SyncedTabCell: UICollectionViewCell, ReusableCell {
 
     private let cardTitle: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .headline,
-                                                                         size: UX.cardTitleFontSize)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .headline,
+                                                            size: UX.cardTitleFontSize)
         label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.SyncedTab.cardTitle
     }
 
     private let syncedTabsButton: UIButton = .build { button in
-        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline,
-                                                                                      size: UX.deviceSourceFontSize)
+        button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .subheadline,
+                                                                         size: UX.deviceSourceFontSize)
         button.titleLabel?.adjustsFontForContentSizeCategory = true
         button.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.SyncedTab.showAllButton
     }
@@ -82,8 +82,8 @@ class SyncedTabCell: UICollectionViewCell, ReusableCell {
 
     private let tabItemTitle: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline,
-                                                                         size: UX.itemTitleFontSize)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .subheadline,
+                                                            size: UX.itemTitleFontSize)
         label.numberOfLines = 2
         label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.SyncedTab.itemTitle
     }
@@ -102,8 +102,8 @@ class SyncedTabCell: UICollectionViewCell, ReusableCell {
     private let syncedDeviceLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 2
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .caption1,
-                                                                             size: UX.deviceSourceFontSize)
+        label.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .caption1,
+                                                                size: UX.deviceSourceFontSize)
         label.textColor = .label
         label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.SyncedTab.descriptionLabel
     }

--- a/Client/Frontend/Home/MessageCard/HomepageMessageCard.swift
+++ b/Client/Frontend/Home/MessageCard/HomepageMessageCard.swift
@@ -46,8 +46,8 @@ class HomepageMessageCardCell: UICollectionViewCell, ReusableCell {
     private lazy var bannerTitle: UILabel = .build { label in
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .headline,
-                                                                         size: UX.bannerTitleFontSize)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .headline,
+                                                            size: UX.bannerTitleFontSize)
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = a11y.titleLabel
     }
@@ -55,15 +55,15 @@ class HomepageMessageCardCell: UICollectionViewCell, ReusableCell {
     private lazy var descriptionText: UILabel = .build { label in
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
-                                                                         size: UX.descriptionTextFontSize)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
+                                                            size: UX.descriptionTextFontSize)
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = a11y.descriptionLabel
     }
 
     private lazy var ctaButton: ActionButton = .build { [weak self] button in
-        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body,
-                                                                                          size: UX.buttonFontSize)
+        button.titleLabel?.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .body,
+                                                                             size: UX.buttonFontSize)
 
         button.layer.cornerRadius = UIFontMetrics.default.scaledValue(for: UX.cornerRadius)
         button.titleLabel?.adjustsFontForContentSizeCategory = true

--- a/Client/Frontend/Home/Pocket/PocketDiscoverCell.swift
+++ b/Client/Frontend/Home/Pocket/PocketDiscoverCell.swift
@@ -17,8 +17,8 @@ class PocketDiscoverCell: UICollectionViewCell, ReusableCell {
     // MARK: - UI Elements
     let itemTitle: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .title3,
-                                                                             size: UX.discoverMoreFontSize)
+        label.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .title3,
+                                                                size: UX.discoverMoreFontSize)
         label.numberOfLines = 0
         label.textAlignment = .left
     }

--- a/Client/Frontend/Home/Pocket/PocketStandardCell.swift
+++ b/Client/Frontend/Home/Pocket/PocketStandardCell.swift
@@ -30,8 +30,8 @@ class PocketStandardCell: UICollectionViewCell, ReusableCell {
 
     private lazy var titleLabel: UILabel = .build { title in
         title.adjustsFontForContentSizeCategory = true
-        title.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline,
-                                                                         size: UX.titleFontSize)
+        title.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .subheadline,
+                                                            size: UX.titleFontSize)
         title.numberOfLines = 2
     }
 
@@ -51,8 +51,8 @@ class PocketStandardCell: UICollectionViewCell, ReusableCell {
 
     private lazy var sponsoredLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption2,
-                                                                         size: UX.sponsoredFontSize)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .caption2,
+                                                            size: UX.sponsoredFontSize)
         label.text = .FirefoxHomepage.Pocket.Sponsored
     }
 
@@ -62,7 +62,7 @@ class PocketStandardCell: UICollectionViewCell, ReusableCell {
 
     private lazy var descriptionLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(
+        label.font = DefaultDynamicFontHelper.preferredBoldFont(
             withTextStyle: .caption1,
             size: UX.siteFontSize)
     }
@@ -104,10 +104,10 @@ class PocketStandardCell: UICollectionViewCell, ReusableCell {
         heroImageView.setHeroImage(heroImageViewModel)
         sponsoredStack.isHidden = viewModel.shouldHideSponsor
         descriptionLabel.font = viewModel.shouldHideSponsor
-        ? LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption1,
-                                                              size: UX.siteFontSize)
-        : LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .caption1,
-                                                                  size: UX.siteFontSize)
+        ? DefaultDynamicFontHelper.preferredFont(withTextStyle: .caption1,
+                                                 size: UX.siteFontSize)
+        : DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .caption1,
+                                                     size: UX.siteFontSize)
 
         sponsoredStack.isHidden  = viewModel.shouldHideSponsor
 

--- a/Client/Frontend/Home/PocketFooterView.swift
+++ b/Client/Frontend/Home/PocketFooterView.swift
@@ -27,8 +27,8 @@ class PocketFooterView: UICollectionReusableView, ReusableCell, ThemeApplicable 
                             AppName.shortName.rawValue)
         label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption1,
-                                                                         size: UX.fontSize)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .caption1,
+                                                            size: UX.fontSize)
     }
 
     private let learnMoreLabel: UILabel = .build { label in
@@ -36,8 +36,8 @@ class PocketFooterView: UICollectionReusableView, ReusableCell, ThemeApplicable 
         label.isUserInteractionEnabled = true
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.Pocket.footerLearnMoreLabel
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption1,
-                                                                         size: UX.fontSize)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .caption1,
+                                                            size: UX.fontSize)
     }
 
     private let labelsContainer: UIStackView = .build { stackView in

--- a/Client/Frontend/Home/RecentlySaved/RecentlySavedCell.swift
+++ b/Client/Frontend/Home/RecentlySaved/RecentlySavedCell.swift
@@ -26,8 +26,8 @@ class RecentlySavedCell: UICollectionViewCell, ReusableCell {
     private var heroImageView: HeroImageView = .build { _ in }
 
     let itemTitle: UILabel = .build { label in
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
-                                                                         size: UX.bookmarkTitleFontSize)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
+                                                            size: UX.bookmarkTitleFontSize)
         label.adjustsFontForContentSizeCategory = true
     }
 

--- a/Client/Frontend/Home/TopSites/Cell/TopSiteItemCell.swift
+++ b/Client/Frontend/Home/TopSites/Cell/TopSiteItemCell.swift
@@ -64,8 +64,8 @@ class TopSiteItemCell: UICollectionViewCell, ReusableCell {
 
     private lazy var titleLabel: UILabel = .build { titleLabel in
         titleLabel.textAlignment = .center
-        titleLabel.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption1,
-                                                                              size: UX.titleFontSize)
+        titleLabel.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .caption1,
+                                                                 size: UX.titleFontSize)
         titleLabel.adjustsFontForContentSizeCategory = true
         titleLabel.preferredMaxLayoutWidth = UX.imageBackgroundSize.width + HomepageViewModel.UX.shadowRadius
         titleLabel.backgroundColor = .clear
@@ -74,8 +74,8 @@ class TopSiteItemCell: UICollectionViewCell, ReusableCell {
 
     private lazy var sponsoredLabel: UILabel = .build { sponsoredLabel in
         sponsoredLabel.textAlignment = .center
-        sponsoredLabel.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption2,
-                                                                                  size: UX.sponsorFontSize)
+        sponsoredLabel.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .caption2,
+                                                                     size: UX.sponsorFontSize)
         sponsoredLabel.adjustsFontForContentSizeCategory = true
         sponsoredLabel.preferredMaxLayoutWidth = UX.imageBackgroundSize.width + HomepageViewModel.UX.shadowRadius
     }

--- a/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperSelectorViewController.swift
+++ b/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperSelectorViewController.swift
@@ -25,8 +25,8 @@ class WallpaperSelectorViewController: WallpaperBaseViewController, Themeable {
     private var collectionViewHeightConstraint: NSLayoutConstraint!
 
     private lazy var headerLabel: UILabel = .build { label in
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .headline,
-                                                                         size: 17)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .headline,
+                                                            size: 17)
         label.adjustsFontForContentSizeCategory = true
         label.text = .Onboarding.Wallpaper.SelectorTitle
         label.textAlignment = .center
@@ -35,8 +35,8 @@ class WallpaperSelectorViewController: WallpaperBaseViewController, Themeable {
     }
 
     private lazy var instructionLabel: UILabel = .build { label in
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
-                                                                         size: 12)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
+                                                            size: 12)
         label.adjustsFontForContentSizeCategory = true
         label.text = .Onboarding.Wallpaper.SelectorDescription
         label.textAlignment = .center

--- a/Client/Frontend/Library/Downloads/DownloadsPanel.swift
+++ b/Client/Frontend/Library/Downloads/DownloadsPanel.swift
@@ -230,9 +230,9 @@ class DownloadsPanel: UIViewController,
         let welcomeLabel: UILabel = .build { label in
             label.text = .DownloadsPanelEmptyStateTitle
             label.textAlignment = .center
-            label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
-                                                                             size: 17,
-                                                                             weight: .light)
+            label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
+                                                                size: 17,
+                                                                weight: .light)
             label.textColor = self.themeManager.currentTheme.colors.textSecondary
             label.numberOfLines = 0
             label.adjustsFontSizeToFitWidth = true

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -134,9 +134,9 @@ class HistoryPanel: UIViewController,
     lazy var welcomeLabel: UILabel = .build { label in
         label.text = self.viewModel.emptyStateText
         label.textAlignment = .center
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
-                                                                         size: 17,
-                                                                         weight: .light)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
+                                                            size: 17,
+                                                            weight: .light)
         label.numberOfLines = 0
         label.adjustsFontSizeToFitWidth = true
     }

--- a/Client/Frontend/Onboarding/ViewControllers/OnboardingCardViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/OnboardingCardViewController.swift
@@ -95,8 +95,8 @@ class OnboardingCardViewController: UIViewController, Themeable {
         label.numberOfLines = 0
         label.textAlignment = .center
         let fontSize = self.shouldUseSmallDeviceLayout ? UX.smallTitleFontSize : UX.titleFontSize
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .largeTitle,
-                                                                             size: fontSize)
+        label.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .largeTitle,
+                                                                size: fontSize)
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = "\(self.viewModel.a11yIdRoot)TitleLabel"
     }
@@ -104,8 +104,8 @@ class OnboardingCardViewController: UIViewController, Themeable {
     private lazy var descriptionLabel: UILabel = .build { label in
         label.numberOfLines = 0
         label.textAlignment = .center
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
-                                                                         size: UX.descriptionFontSize)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
+                                                            size: UX.descriptionFontSize)
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = "\(self.viewModel.a11yIdRoot)DescriptionLabel"
     }
@@ -117,7 +117,7 @@ class OnboardingCardViewController: UIViewController, Themeable {
     }
 
     private lazy var primaryButton: ResizableButton = .build { button in
-        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(
+        button.titleLabel?.font = DefaultDynamicFontHelper.preferredBoldFont(
             withTextStyle: .callout,
             size: UX.buttonFontSize)
         button.layer.cornerRadius = UX.buttonCornerRadius
@@ -132,7 +132,7 @@ class OnboardingCardViewController: UIViewController, Themeable {
     }
 
     private lazy var secondaryButton: ResizableButton = .build { button in
-        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(
+        button.titleLabel?.font = DefaultDynamicFontHelper.preferredBoldFont(
             withTextStyle: .callout,
             size: UX.buttonFontSize)
         button.layer.cornerRadius = UX.buttonCornerRadius
@@ -147,7 +147,8 @@ class OnboardingCardViewController: UIViewController, Themeable {
     }
 
     private lazy var linkButton: ResizableButton = .build { button in
-        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline, size: UX.buttonFontSize)
+        button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .subheadline,
+                                                                         size: UX.buttonFontSize)
         button.titleLabel?.textAlignment = .center
         button.addTarget(self, action: #selector(self.linkButtonAction), for: .touchUpInside)
         button.setTitleColor(.systemBlue, for: .normal)

--- a/Client/Frontend/Onboarding/ViewControllers/OnboardingInstructionPopupViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/OnboardingInstructionPopupViewController.swift
@@ -49,7 +49,7 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
     private lazy var titleLabel: UILabel = .build { label in
         label.textAlignment = .center
         label.numberOfLines = 0
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .title3, size: UX.titleFontSize)
+        label.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .title3, size: UX.titleFontSize)
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = "\(self.viewModel.a11yIdRoot).DefaultBrowserSettings.TitleLabel"
     }
@@ -65,7 +65,7 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
     }
 
     private lazy var primaryButton: ResizableButton = .build { button in
-        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(
+        button.titleLabel?.font = DefaultDynamicFontHelper.preferredBoldFont(
             withTextStyle: .callout,
             size: UX.buttonFontSize)
         button.layer.cornerRadius = UX.buttonCornerRadius
@@ -203,14 +203,14 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
     private func createLabels(from descriptionTexts: [String]) {
         numeratedLabels.removeAll()
         let attributedStrings = viewModel.getAttributedStrings(
-            with: LegacyDynamicFontHelper.defaultHelper.preferredFont(
+            with: DefaultDynamicFontHelper.preferredFont(
                 withTextStyle: .subheadline,
                 size: UX.numeratedTextFontSize))
         attributedStrings.forEach { attributedText in
             let index = attributedStrings.firstIndex(of: attributedText)! as Int
             let label: UILabel = .build { label in
                 label.textAlignment = .left
-                label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(
+                label.font = DefaultDynamicFontHelper.preferredFont(
                     withTextStyle: .subheadline,
                     size: UX.numeratedTextFontSize)
                 label.adjustsFontForContentSizeCategory = true

--- a/Client/Frontend/PasswordManagement/BreachAlertsDetailView.swift
+++ b/Client/Frontend/PasswordManagement/BreachAlertsDetailView.swift
@@ -43,8 +43,8 @@ class BreachAlertsDetailView: UIView, ThemeApplicable {
 
     lazy var titleLabel: UILabel = {
         let label = UILabel()
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .headline,
-                                                                             size: 19)
+        label.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .headline,
+                                                                size: 19)
         label.text = .BreachAlertsTitle
         label.sizeToFit()
         label.isAccessibilityElement = true

--- a/Client/Frontend/PasswordManagement/Cells/LoginDetailCenteredTableViewCell.swift
+++ b/Client/Frontend/PasswordManagement/Cells/LoginDetailCenteredTableViewCell.swift
@@ -20,7 +20,7 @@ class LoginDetailCenteredTableViewCell: UITableViewCell, ThemeApplicable, Reusab
     private var viewModel: LoginDetailCenteredTableViewCellModel?
 
     private lazy var centeredLabel: UILabel = .build { label in
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .callout, size: UX.fontSize)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .callout, size: UX.fontSize)
         label.textAlignment = .center
         label.numberOfLines = 0
     }

--- a/Client/Frontend/PasswordManagement/Cells/LoginDetailTableViewCell.swift
+++ b/Client/Frontend/PasswordManagement/Cells/LoginDetailTableViewCell.swift
@@ -59,7 +59,7 @@ class LoginDetailTableViewCell: UITableViewCell, ThemeApplicable, ReusableCell, 
     lazy var descriptionLabel: UITextField = .build { [weak self] label in
         guard let self = self else { return }
 
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: UX.descriptionFontSize)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: UX.descriptionFontSize)
         label.isUserInteractionEnabled = false
         label.autocapitalizationType = .none
         label.autocorrectionType = .no
@@ -70,8 +70,8 @@ class LoginDetailTableViewCell: UITableViewCell, ThemeApplicable, ReusableCell, 
     }
 
     private lazy var highlightedLabel: UILabel = .build { label in
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .callout,
-                                                                         size: UX.highlightedFontSize)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .callout,
+                                                            size: UX.highlightedFontSize)
         label.numberOfLines = 0
     }
 
@@ -126,9 +126,9 @@ class LoginDetailTableViewCell: UITableViewCell, ThemeApplicable, ReusableCell, 
         descriptionLabel.isUserInteractionEnabled = viewModel.isEditingFieldData
 
         if viewModel.displayDescriptionAsPassword {
-            descriptionLabel.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
-                                                                                        size: 16,
-                                                                                        symbolicTraits: [.traitMonoSpace])
+            descriptionLabel.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
+                                                                           size: 16,
+                                                                           symbolicTraits: [.traitMonoSpace])
         }
     }
 

--- a/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
 import Shared
 
@@ -270,7 +271,7 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
             // TODO: Get a dedicated string for this.
             let title: String = .TrackerProtectionLearnMore
 
-            let font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline, size: 12.0)
+            let font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .subheadline, size: 12.0)
             var attributes = [NSAttributedString.Key: AnyObject]()
             attributes[NSAttributedString.Key.foregroundColor] = themeManager.currentTheme.colors.actionPrimary
             attributes[NSAttributedString.Key.font] = font

--- a/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsHeaderView.swift
+++ b/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsHeaderView.swift
@@ -34,19 +34,19 @@ class WallpaperSettingsHeaderView: UICollectionReusableView, ReusableCell {
     }
 
     private lazy var titleLabel: UILabel = .build { label in
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .headline, size: 12.0, weight: .medium)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .headline, size: 12.0, weight: .medium)
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
     }
 
     private lazy var descriptionLabel: UILabel = .build { label in
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 12.0)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 12.0)
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
     }
 
     private lazy var learnMoreButton: ResizableButton = .build { button in
-        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 12.0)
+        button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 12.0)
         button.contentHorizontalAlignment = .leading
         button.buttonEdgeSpacing = 0
     }
@@ -143,7 +143,7 @@ extension WallpaperSettingsHeaderView: ThemeApplicable {
         // in iOS 13 the title color set is not used for the attributed text color so we have to set it via attributes
         guard let buttonTitle = viewModel?.buttonTitle else { return }
         let labelAttributes: [NSAttributedString.Key: Any] = [
-            .font: LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 12.0),
+            .font: DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 12.0),
             .foregroundColor: color,
             .underlineStyle: NSUnderlineStyle.single.rawValue
         ]

--- a/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
+++ b/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
 import Redux
 import Shared
@@ -173,8 +174,8 @@ class ThemeSettingsController: ThemedTableViewController, StoreSubscriber {
         let label: UILabel = .build { label in
             label.text = .DisplayThemeSectionFooter
             label.numberOfLines = 0
-            label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .footnote,
-                                                                             size: UX.footerFontSize)
+            label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .footnote,
+                                                                size: UX.footerFontSize)
             label.textColor = self.themeManager.currentTheme.colors.textSecondary
         }
         footer.addSubview(label)

--- a/Client/Frontend/SurveySurface/SurveySurfaceViewController.swift
+++ b/Client/Frontend/SurveySurface/SurveySurfaceViewController.swift
@@ -49,8 +49,8 @@ class SurveySurfaceViewController: UIViewController, Themeable {
     }
 
     private lazy var titleLabel: UILabel = .build { label in
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .title3,
-                                                                             size: UX.titleFontSize)
+        label.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .title3,
+                                                                size: UX.titleFontSize)
         label.numberOfLines = 0
         label.textAlignment = .center
         label.adjustsFontForContentSizeCategory = true
@@ -59,7 +59,7 @@ class SurveySurfaceViewController: UIViewController, Themeable {
     }
 
     private lazy var takeSurveyButton: ResizableButton = .build { button in
-        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(
+        button.titleLabel?.font = DefaultDynamicFontHelper.preferredBoldFont(
             withTextStyle: .callout,
             size: UX.buttonFontSize)
         button.layer.cornerRadius = UX.buttonCornerRadius
@@ -75,7 +75,7 @@ class SurveySurfaceViewController: UIViewController, Themeable {
     }
 
     private lazy var dismissSurveyButton: ResizableButton = .build { button in
-        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(
+        button.titleLabel?.font = DefaultDynamicFontHelper.preferredBoldFont(
             withTextStyle: .callout,
             size: UX.buttonFontSize)
         button.layer.cornerRadius = UX.buttonCornerRadius

--- a/Client/Frontend/Theme/ThemedTableSectionHeaderFooterView.swift
+++ b/Client/Frontend/Theme/ThemedTableSectionHeaderFooterView.swift
@@ -43,7 +43,7 @@ class ThemedTableSectionHeaderFooterView: UITableViewHeaderFooterView, ReusableC
     }
 
     lazy var titleLabel: UILabel = .build { label in
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .subheadline, size: 12.0)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .subheadline, size: 12.0)
         label.numberOfLines = 0
     }
 

--- a/Client/Frontend/Widgets/OneLineTableViewCell.swift
+++ b/Client/Frontend/Widgets/OneLineTableViewCell.swift
@@ -45,8 +45,8 @@ class OneLineTableViewCell: UITableViewCell,
     lazy var leftImageView: FaviconImageView = .build { _ in }
 
     lazy var titleLabel: UILabel = .build { label in
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body,
-                                                                         size: UX.labelFontSize)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
+                                                            size: UX.labelFontSize)
         label.textAlignment = .natural
     }
 

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
@@ -49,7 +49,7 @@ class PhotonActionSheet: UIViewController, Themeable {
     private lazy var closeButton: UIButton = .build { button in
         button.setTitle(.CloseButtonTitle, for: .normal)
         button.layer.cornerRadius = UX.cornerRadius
-        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body, size: 19)
+        button.titleLabel?.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .body, size: 19)
         button.addTarget(self, action: #selector(self.dismiss), for: .touchUpInside)
         button.accessibilityIdentifier = AccessibilityIdentifiers.Photon.closeButton
     }

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetSiteHeaderView.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetSiteHeaderView.swift
@@ -19,13 +19,13 @@ class PhotonActionSheetSiteHeaderView: UITableViewHeaderFooterView, ReusableCell
     private lazy var labelContainerView: UIView = .build { _ in }
 
     private lazy var titleLabel: UILabel = .build { label in
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body, size: 17)
+        label.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .body, size: 17)
         label.textAlignment = .left
         label.numberOfLines = 2
     }
 
     private lazy var descriptionLabel: UILabel = .build { label in
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 17)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 17)
         label.textAlignment = .left
         label.numberOfLines = 1
     }

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetTitleHeaderView.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetTitleHeaderView.swift
@@ -13,7 +13,7 @@ class PhotonActionSheetTitleHeaderView: UITableViewHeaderFooterView, ReusableCel
     }
 
     lazy var titleLabel: UILabel = .build { label in
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .caption1, size: 12)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .caption1, size: 12)
         label.numberOfLines = 1
     }
 

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetView.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetView.swift
@@ -200,8 +200,8 @@ class PhotonActionSheetView: UIView, UIGestureRecognizerDelegate, ThemeApplicabl
         titleLabel.text = item.currentTitle
 
         if item.bold {
-            titleLabel.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .headline,
-                                                                                      size: 19)
+            titleLabel.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .headline,
+                                                                         size: 19)
         } else {
             titleLabel.font = LegacyDynamicFontHelper.defaultHelper.SemiMediumRegularWeightAS
         }

--- a/Client/Frontend/Widgets/SiteTableViewHeader.swift
+++ b/Client/Frontend/Widgets/SiteTableViewHeader.swift
@@ -25,8 +25,8 @@ class SiteTableViewHeader: UITableViewHeaderFooterView, ThemeApplicable, Reusabl
 
     private let titleLabel: UILabel = .build { label in
         label.numberOfLines = 0
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .headline,
-                                                                         size: 16)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .headline,
+                                                            size: 16)
         label.adjustsFontForContentSizeCategory = true
     }
 

--- a/Client/Frontend/Widgets/SnackBar.swift
+++ b/Client/Frontend/Widgets/SnackBar.swift
@@ -32,7 +32,7 @@ class SnackBar: UIView {
     }
 
     private lazy var textLabel: UILabel = .build { label in
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: UX.fontSize)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: UX.fontSize)
         label.lineBreakMode = .byWordWrapping
         label.numberOfLines = 0
         label.textColor = UIColor.Photon.Grey90 // If making themeable, change to UIColor.legacyTheme.tableView.rowText

--- a/Client/Frontend/Widgets/SnackButton.swift
+++ b/Client/Frontend/Widgets/SnackButton.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
 
 /**
@@ -31,9 +32,9 @@ class SnackButton: UIButton {
         super.init(frame: .zero)
 
         if bold {
-            titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body, size: UX.fontSize)
+            titleLabel?.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .body, size: UX.fontSize)
         } else {
-            titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: UX.fontSize)
+            titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: UX.fontSize)
         }
         titleLabel?.adjustsFontForContentSizeCategory = true
         setTitle(title, for: .normal)

--- a/Client/Frontend/Widgets/TwoLineImageOverlayCell.swift
+++ b/Client/Frontend/Widgets/TwoLineImageOverlayCell.swift
@@ -46,12 +46,12 @@ class TwoLineImageOverlayCell: UITableViewCell,
     }
 
     lazy var titleLabel: UILabel = .build { label in
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 16)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 16)
         label.textAlignment = .natural
     }
 
     lazy var descriptionLabel: UILabel = .build { label in
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .body, size: 14)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 14)
         label.textAlignment = .natural
     }
 

--- a/Client/Helpers/LegacyDynamicFontHelper.swift
+++ b/Client/Helpers/LegacyDynamicFontHelper.swift
@@ -152,7 +152,7 @@ class LegacyDynamicFontHelper: NSObject {
     ///   - maxSize: The maximum size the font can scale - Refer to the human interface guidelines for more information on sizes for each style (optional)
     ///              https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/typography/
     /// - Returns: The UIFont with the specified font size, style and weight
-    @available(*, deprecated, message: "Use preferredFont(withTextStyle:size:weight:) instead")
+    @available(*, deprecated, message: "Use DefaultDynamicFontHelper preferredFont(withTextStyle:size:weight:) instead")
     func preferredFont(withTextStyle textStyle: UIFont.TextStyle, weight: UIFont.Weight? = nil, maxSize: CGFloat? = nil) -> UIFont {
         let fontMetrics = UIFontMetrics(forTextStyle: textStyle)
         let fontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: textStyle)
@@ -169,40 +169,5 @@ class LegacyDynamicFontHelper: NSObject {
         }
 
         return fontMetrics.scaledFont(for: font, maximumPointSize: min(fontDescriptor.pointSize, maxSize))
-    }
-
-    /// Returns a font that will dynamically scale with dynamic text
-    /// - Parameters:
-    ///   - textStyle: The desired textStyle for the font
-    ///   - size: The size of the font
-    /// - Returns: The UIFont with the specified font size and style
-    func preferredFont(withTextStyle textStyle: UIFont.TextStyle,
-                       size: CGFloat,
-                       weight: UIFont.Weight? = nil,
-                       symbolicTraits: UIFontDescriptor.SymbolicTraits? = nil) -> UIFont {
-        let fontMetrics = UIFontMetrics(forTextStyle: textStyle)
-        var fontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: textStyle)
-
-        if let symbolicTraits = symbolicTraits, let descriptor = fontDescriptor.withSymbolicTraits(symbolicTraits) {
-            fontDescriptor = descriptor
-        }
-
-        var font: UIFont
-        if let weight = weight {
-            font = UIFont.systemFont(ofSize: size, weight: weight)
-        } else {
-            font = UIFont(descriptor: fontDescriptor, size: size)
-        }
-
-        return fontMetrics.scaledFont(for: font)
-    }
-
-    /// Return a bold font that will dynamically scale up to a certain size
-    /// - Parameters:
-    ///   - textStyle: The desired textStyle for the font
-    ///   - size: The size of the font
-    /// - Returns: The UIFont with the specified font size, style and bold weight
-    func preferredBoldFont(withTextStyle textStyle: UIFont.TextStyle, size: CGFloat) -> UIFont {
-        return preferredFont(withTextStyle: textStyle, size: size, weight: .bold)
     }
 }

--- a/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/RustFxA/FirefoxAccountSignInViewController.swift
@@ -62,8 +62,8 @@ class FirefoxAccountSignInViewController: UIViewController, Themeable {
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
         label.text = .FxASignin_Subtitle
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .headline,
-                                                                             size: UX.signInLabelFontSize)
+        label.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .headline,
+                                                                size: UX.signInLabelFontSize)
         label.adjustsFontForContentSizeCategory = true
     }
 
@@ -76,8 +76,8 @@ class FirefoxAccountSignInViewController: UIViewController, Themeable {
         label.textAlignment = .center
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
-        label.font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .headline,
-                                                                         size: UX.signInLabelFontSize)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .headline,
+                                                            size: UX.signInLabelFontSize)
         label.adjustsFontForContentSizeCategory = true
 
         let placeholder = "firefox.com/pair"
@@ -85,8 +85,8 @@ class FirefoxAccountSignInViewController: UIViewController, Themeable {
             manager.getPairingAuthorityURL { result in
                 guard let url = try? result.get(), let host = url.host else { return }
 
-                let font = LegacyDynamicFontHelper.defaultHelper.preferredFont(withTextStyle: .headline,
-                                                                               size: UX.signInLabelFontSize)
+                let font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .headline,
+                                                                  size: UX.signInLabelFontSize)
                 let shortUrl = host + url.path // "firefox.com" + "/pair"
                 let msg: String = .FxASignin_QRInstructions.replaceFirstOccurrence(of: placeholder, with: shortUrl)
                 label.attributedText = msg.attributedText(boldString: shortUrl, font: font)
@@ -99,7 +99,7 @@ class FirefoxAccountSignInViewController: UIViewController, Themeable {
         button.setImage(self.signinSyncQRImage?.tinted(withColor: .white), for: .highlighted)
         button.setTitle(.FxASignin_QRScanSignin, for: .normal)
         button.accessibilityIdentifier = AccessibilityIdentifiers.Settings.FirefoxAccount.qrButton
-        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(
+        button.titleLabel?.font = DefaultDynamicFontHelper.preferredBoldFont(
             withTextStyle: .callout,
             size: UX.buttonFontSize)
 
@@ -117,7 +117,7 @@ class FirefoxAccountSignInViewController: UIViewController, Themeable {
         button.accessibilityIdentifier = AccessibilityIdentifiers.Settings.FirefoxAccount.fxaSignInButton
         button.addTarget(self, action: #selector(self.emailLoginTapped), for: .touchUpInside)
         button.titleLabel?.adjustsFontForContentSizeCategory = true
-        button.titleLabel?.font = LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(
+        button.titleLabel?.font = DefaultDynamicFontHelper.preferredBoldFont(
             withTextStyle: .callout,
             size: UX.buttonFontSize)
         button.contentEdgeInsets = UIEdgeInsets(top: UX.buttonVerticalInset,

--- a/Tests/ClientTests/HistoryHighlights/HistoryHighlightsManagerTests.swift
+++ b/Tests/ClientTests/HistoryHighlights/HistoryHighlightsManagerTests.swift
@@ -18,6 +18,8 @@ class HistoryHighlightsTests: XCTestCase {
 
         manager = HistoryHighlightsManager()
         profile = MockProfile(databasePrefix: "historyHighlights_tests")
+        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
+        DependencyHelperMock().bootstrapDependencies()
         profile.reopen()
         let tabManager = LegacyTabManager(profile: profile, imageStore: nil)
         entryProvider = HistoryHighlightsTestEntryProvider(with: profile, and: tabManager)
@@ -30,6 +32,7 @@ class HistoryHighlightsTests: XCTestCase {
         profile.shutdown()
         profile = nil
         entryProvider = nil
+        DependencyHelperMock().reset()
     }
 
     func testEmptyRead() {

--- a/Tests/ClientTests/StringExtensionsTests.swift
+++ b/Tests/ClientTests/StringExtensionsTests.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
 import XCTest
 @testable import Client
@@ -73,7 +74,7 @@ class StringExtensionsTests: XCTestCase {
 
         XCTAssertEqual(
             attributedText.attribute(.font, at: 1, effectiveRange: &effectiveRange) as? UIFont,
-            LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body, size: font.pointSize)
+            DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .body, size: font.pointSize)
         )
         XCTAssertEqual(effectiveRange, NSRange(location: 1, length: 4))
 
@@ -92,7 +93,7 @@ class StringExtensionsTests: XCTestCase {
 
         XCTAssertEqual(
             attributedText.attribute(.font, at: 6, effectiveRange: &effectiveRange) as? UIFont,
-            LegacyDynamicFontHelper.defaultHelper.preferredBoldFont(withTextStyle: .body, size: font.pointSize)
+            DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .body, size: font.pointSize)
         )
         XCTAssertEqual(effectiveRange, NSRange(location: 6, length: 4))
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7105)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15784)

## :bulb: Description
- Remove the methods that are in the new `BrowserKit.Common.DynamicFontHelper` from the `LegacyDynamicFontHelper` and adapt the code to use the new helper.
- There's intermittent failure on BR for history tests, which made another of my PR failed. So including the fix here too.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

