### PR TITLE
Bugfix FXIOS-7121 - [Experiment] The saved credit cards cannot be synced with other devices on Firefox 116 release channel

### DIFF
--- a/Providers/RustSyncManager.swift
+++ b/Providers/RustSyncManager.swift
@@ -274,9 +274,11 @@ public class RustSyncManager: NSObject, SyncManager {
         } else {
             // Bundle in authState the engines the user activated/disabled since the
             // last sync.
-            syncManagerAPI.rustTogglableEngines
-                .filter({ !self.creditCardAutofillEnabled && $0 != RustSyncManagerAPI.TogglableEngine.creditcards })
-                .forEach { engine in
+            let engines = self.creditCardAutofillEnabled ?
+                syncManagerAPI.rustTogglableEngines :
+                syncManagerAPI.rustTogglableEngines.filter({$0 != RustSyncManagerAPI.TogglableEngine.creditcards })
+
+            engines.forEach { engine in
                 let stateChangedPref = "engine.\(engine).enabledStateChanged"
                 if prefsForSync.boolForKey(stateChangedPref) != nil,
                    let enabled = prefsForSync.boolForKey("engine.\(engine).enabled") {

--- a/Sync/RustSyncManagerAPI.swift
+++ b/Sync/RustSyncManagerAPI.swift
@@ -20,15 +20,10 @@ open class RustSyncManagerAPI {
         case creditcards
     }
 
-    public var rustTogglableEngines: [TogglableEngine] = [.tabs, .passwords, .bookmarks, .history]
-    public init(logger: Logger = DefaultLogger.shared,
-                creditCardAutofillEnabled: Bool = false) {
+    public var rustTogglableEngines: [TogglableEngine] = [.tabs, .passwords, .bookmarks, .history, .creditcards]
+    public init(logger: Logger = DefaultLogger.shared) {
         self.api = SyncManagerComponent()
         self.logger = logger
-
-        if creditCardAutofillEnabled {
-            self.rustTogglableEngines.append(.creditcards)
-        }
     }
 
     public func disconnect() {

--- a/Tests/ClientTests/RustSyncManagerTests.swift
+++ b/Tests/ClientTests/RustSyncManagerTests.swift
@@ -31,7 +31,7 @@ class RustSyncManagerTests: XCTestCase {
                                           creditCardAutofillEnabled: true,
                                           logger: MockLogger(),
                                           notificationCenter: MockNotificationCenter())
-        rustSyncManager.syncManagerAPI = RustSyncManagerAPI(creditCardAutofillEnabled: true)
+        rustSyncManager.syncManagerAPI = RustSyncManagerAPI()
         profile.syncManager = rustSyncManager
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7121)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15811)

## :bulb: Description
[Experiment] The saved credit cards cannot be synced with other devices on Firefox 116 release channel
For this, we will need to disable syncing of credit cards when the experiment is disabled and then start syncing again when the experiment is enabled

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

