### PR TITLE
Bugfix FXIOS-6883 [v117] voice over focus is moved to the address bar and the success message "Card saved" is not announced for remember card flow (#15324)

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -245,6 +245,18 @@ class BrowserViewController: UIViewController,
     }
 
     @objc
+    func didFinishAnnouncement(notification: Notification) {
+        if let userInfo = notification.userInfo,
+            let announcementText =  userInfo[UIAccessibility.announcementStringValueUserInfoKey] as? String {
+            let saveSuccessMessage: String = .CreditCard.RememberCreditCard.CreditCardSaveSuccessToastMessage
+            let updateSuccessMessage: String = .CreditCard.UpdateCreditCard.CreditCardUpdateSuccessToastMessage
+            if announcementText == saveSuccessMessage || announcementText == updateSuccessMessage {
+                UIAccessibility.post(notification: .layoutChanged, argument: self.tabManager.selectedTab?.currentWebView())
+            }
+        }
+    }
+
+    @objc
     func searchBarPositionDidChange(notification: Notification) {
         guard let dict = notification.object as? NSDictionary,
               let newSearchBarPosition = dict[PrefsKeys.FeatureFlags.SearchBarPosition] as? SearchBarPosition,
@@ -529,6 +541,11 @@ class BrowserViewController: UIViewController,
             self,
             selector: #selector(openTabNotification),
             name: .OpenTabNotification,
+            object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(didFinishAnnouncement),
+            name: UIAccessibility.announcementDidFinishNotification,
             object: nil)
 
         // PresentIntroView notification and code will be removed with FXIOS-6529

--- a/Client/Frontend/Browser/SimpleToast.swift
+++ b/Client/Frontend/Browser/SimpleToast.swift
@@ -36,6 +36,9 @@ struct SimpleToast: ThemeApplicable {
         ])
         applyTheme(theme: theme)
         animate(toastLabel)
+        if UIAccessibility.isVoiceOverRunning {
+            UIAccessibility.post(notification: .announcement, argument: text)
+        }
     }
 
     func applyTheme(theme: Theme) {
@@ -66,7 +69,8 @@ struct SimpleToast: ThemeApplicable {
                 toast.frame = frame
             },
             completion: { finished in
-                let dispatchTime = DispatchTime.now() + Toast.UX.toastDismissAfter
+                let voiceOverDelay = UIAccessibility.isVoiceOverRunning ? DispatchTimeInterval.milliseconds(1000) : DispatchTimeInterval.milliseconds(0)
+                let dispatchTime = DispatchTime.now() + Toast.UX.toastDismissAfter + voiceOverDelay
 
                 DispatchQueue.main.asyncAfter(deadline: dispatchTime, execute: {
                     self.dismiss(toast)

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -405,7 +405,7 @@ extension String {
                 comment: "This value is used as the title for the Not Now button in the update credit card page")
             public static let CreditCardUpdateSuccessToastMessage = MZLocalizedString(
                 key: "CreditCard.RememberCard.SecondaryButtonTitle.v116",
-                tableName: "RememberCard",
+                tableName: "UpdateCard",
                 value: "Card Information Updated",
                 comment: "This value is used as the toast message for the saving success alert in the remember credit card page")
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6883)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15324)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Added the ability for the SimpleToast to send an announcement if voice over is on and made the controller focus on the last element that was focused before the announcement.
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

