### PR TITLE
Bugfix FXIOS-6884 [v117] Incorrect voice-over focus for use saved card button for credit card autofill (#15325)

### DIFF
--- a/Client/AccessoryViewProvider.swift
+++ b/Client/AccessoryViewProvider.swift
@@ -83,6 +83,7 @@ class AccessoryViewProvider: UIView, Themeable {
         label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .title3, size: 16, weight: .medium)
         label.text = .CreditCard.Settings.UseSavedCardFromKeyboard
         label.numberOfLines = 0
+        label.accessibilityTraits = .button
     }
 
     private lazy var cardButtonStackView: UIStackView = .build { [weak self] stackView in
@@ -159,7 +160,10 @@ class AccessoryViewProvider: UIView, Themeable {
 
         if showCreditCard {
             let cardStackViewForBarButton = UIBarButtonItem(customView: cardButtonStackView)
+            cardStackViewForBarButton.accessibilityTraits = .button
+            cardStackViewForBarButton.accessibilityLabel = .CreditCard.Settings.UseSavedCardFromKeyboard
             toolbar.items = [previousButton, nextButton, cardStackViewForBarButton, flexibleSpacer, doneButton]
+            toolbar.accessibilityElements = [previousButton, nextButton, cardStackViewForBarButton, doneButton]
         } else {
             toolbar.items = [previousButton, nextButton, flexibleSpacer, doneButton]
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6884)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15325)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Changed the accessibility trait for the custom view that's used to create the barButton and set the order of the elements on the toolbar.
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

