### PR TITLE
Bugfix FXIOS-7100 [v118] GridTabViewController doesn't get deinit

### DIFF
--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -71,7 +71,6 @@ class TabDisplayManager: NSObject, FeatureFlaggable {
     var dataStore = WeakList<Tab>()
     var operations = [(TabAnimationType, (() -> Void))]()
     var refreshStoreOperation: (() -> Void)?
-    weak var tabDisplayCompletionDelegate: TabDisplayCompletionDelegate?
     var tabDisplayType: TabDisplayType = .TabGrid
     private let tabManager: TabManager
     private let collectionView: UICollectionView
@@ -79,10 +78,10 @@ class TabDisplayManager: NSObject, FeatureFlaggable {
     private let tabReuseIdentifier: String
     private var hasSentInactiveTabShownEvent = false
     var profile: Profile
-    private var nimbus: FxNimbus?
     var notificationCenter: NotificationProtocol
     var theme: Theme
 
+    weak var tabDisplayCompletionDelegate: TabDisplayCompletionDelegate?
     private weak var tabDisplayerDelegate: TabDisplayerDelegate?
     private weak var cfrDelegate: InactiveTabsCFRProtocol?
 
@@ -172,7 +171,7 @@ class TabDisplayManager: NSObject, FeatureFlaggable {
     }
 
     @discardableResult
-    fileprivate func cancelDragAndGestures() -> Bool {
+    private func cancelDragAndGestures() -> Bool {
         let isActive = collectionView.hasActiveDrag || isLongPressGestureStarted
         collectionView.cancelInteractiveMovement()
         collectionView.endInteractiveMovement()
@@ -193,7 +192,6 @@ class TabDisplayManager: NSObject, FeatureFlaggable {
          tabDisplayType: TabDisplayType,
          profile: Profile,
          cfrDelegate: InactiveTabsCFRProtocol? = nil,
-         nimbus: FxNimbus = FxNimbus.shared,
          theme: Theme
     ) {
         self.collectionView = collectionView
@@ -204,7 +202,6 @@ class TabDisplayManager: NSObject, FeatureFlaggable {
         self.tabDisplayType = tabDisplayType
         self.profile = profile
         self.cfrDelegate = cfrDelegate
-        self.nimbus = nimbus
         self.notificationCenter = NotificationCenter.default
         self.theme = theme
 
@@ -214,8 +211,8 @@ class TabDisplayManager: NSObject, FeatureFlaggable {
         tabManager.addDelegate(self)
         register(self, forTabEvents: .didChangeURL, .didSetScreenshot)
         self.dataStore.removeAll()
-        getTabsAndUpdateInactiveState { tabGroup, tabsToDisplay in
-            guard !tabsToDisplay.isEmpty else { return }
+        getTabsAndUpdateInactiveState { [weak self] tabGroup, tabsToDisplay in
+            guard let self, !tabsToDisplay.isEmpty else { return }
             let orderedRegularTabs = tabDisplayType == .TopTabTray ? tabsToDisplay : self.getRegularOrderedTabs() ?? tabsToDisplay
             if self.getRegularOrderedTabs() == nil {
                 self.saveRegularOrderedTabs(from: tabsToDisplay)
@@ -295,7 +292,8 @@ class TabDisplayManager: NSObject, FeatureFlaggable {
         // Inactive tabs - disabled
         if !shouldEnableInactiveTabs {
             // check if groups are enabled and setup from normal tabs
-            setupSearchTermGroupsAndFilteredTabs(tabsToBuildFrom: tabManager.normalTabs, completion: completion)
+            setupSearchTermGroupsAndFilteredTabs(tabsToBuildFrom: tabManager.normalTabs,
+                                                 completion: completion)
         } else {
             // Inactive tabs - enabled
             guard let inactiveViewModel = inactiveViewModel else {
@@ -345,10 +343,10 @@ class TabDisplayManager: NSObject, FeatureFlaggable {
         }
 
         if shouldSelectMostRecentTab {
-            getTabsAndUpdateInactiveState { tabGroup, tabsToDisplay in
+            getTabsAndUpdateInactiveState { [weak self] tabGroup, tabsToDisplay in
                 let tab = mostRecentTab(inTabs: tabsToDisplay) ?? tabsToDisplay.last
                 if let tab = tab {
-                    self.tabManager.selectTab(tab)
+                    self?.tabManager.selectTab(tab)
                 }
             }
         }
@@ -386,9 +384,8 @@ class TabDisplayManager: NSObject, FeatureFlaggable {
         operations.removeAll()
         dataStore.removeAll()
 
-        getTabsAndUpdateInactiveState {
-            tabGroup, tabsToDisplay in
-
+        getTabsAndUpdateInactiveState { [weak self] tabGroup, tabsToDisplay in
+            guard let self else { return }
             tabsToDisplay.forEach {
                 self.dataStore.insert($0)
             }
@@ -468,7 +465,8 @@ class TabDisplayManager: NSObject, FeatureFlaggable {
     func performCloseAction(for tab: Tab) {
         guard !isDragging else { return }
 
-        getTabsAndUpdateInactiveState { tabGroup, tabsToDisplay in
+        getTabsAndUpdateInactiveState { [weak self] tabGroup, tabsToDisplay in
+            guard let self else { return }
             // If it is the last tab of regular mode we automatically create an new tab
             if !self.isPrivate,
                tabsToDisplay.count + (self.tabsInAllGroups?.count ?? 0) == 1 {
@@ -485,8 +483,8 @@ class TabDisplayManager: NSObject, FeatureFlaggable {
         tabManager.undoCloseTab(tab: tab, position: index)
         _ = profile.recentlyClosedTabs.popFirstTab()
 
-        refreshStore {
-            self.updateCellFor(tab: tab, selectedTabChanged: true)
+        refreshStore { [weak self] in
+            self?.updateCellFor(tab: tab, selectedTabChanged: true)
         }
     }
 
@@ -535,6 +533,7 @@ class TabDisplayManager: NSObject, FeatureFlaggable {
     }
 
     deinit {
+        print("YRD TabDisplayMgr deinit")
         notificationCenter.removeObserver(self)
     }
 }
@@ -672,8 +671,8 @@ extension TabDisplayManager: InactiveTabsDelegate {
         tabManager.backupCloseTab = BackupCloseTab(tab: tab, restorePosition: index)
         removeSingleInactiveTab(tab)
 
-        cfrDelegate?.presentUndoSingleToast { undoButtonPressed in
-            guard undoButtonPressed, let closedTab = self.tabManager.backupCloseTab else {
+        cfrDelegate?.presentUndoSingleToast { [weak self] undoButtonPressed in
+            guard undoButtonPressed, let closedTab = self?.tabManager.backupCloseTab else {
                 TelemetryWrapper.recordEvent(category: .action,
                                              method: .tap,
                                              object: .inactiveTabTray,
@@ -681,7 +680,7 @@ extension TabDisplayManager: InactiveTabsDelegate {
                                              extras: nil)
                 return
             }
-            self.undoDeleteInactiveTab(closedTab.tab, at: closedTab.restorePosition ?? 0)
+            self?.undoDeleteInactiveTab(closedTab.tab, at: closedTab.restorePosition ?? 0)
         }
     }
 
@@ -695,10 +694,8 @@ extension TabDisplayManager: InactiveTabsDelegate {
         collectionView.reloadSections(IndexSet(integer: TabDisplaySection.inactiveTabs.rawValue))
 
         cfrDelegate?.presentUndoToast(tabsCount: tabsCount,
-                                      completion: { undoButtonPressed in
-            undoButtonPressed ?
-            self.undoInactiveTabsClose() :
-            self.closeAllInactiveTabs()
+                                      completion: { [weak self] undoButtonPressed in
+            undoButtonPressed ? self?.undoInactiveTabsClose() : self?.closeAllInactiveTabs()
         })
     }
 
@@ -716,7 +713,8 @@ extension TabDisplayManager: InactiveTabsDelegate {
 
     private func removeInactiveTabAndReloadView(tabs: [Tab]) {
         // Remove inactive tabs from tab manager
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(50)) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(50)) { [weak self] in
+            guard let self else { return }
             self.tabManager.removeTabs(tabs)
             let mostRecentTab = mostRecentTab(inTabs: self.tabManager.normalTabs) ?? self.tabManager.normalTabs.last
             self.tabManager.selectTab(mostRecentTab)
@@ -759,7 +757,11 @@ extension TabDisplayManager: InactiveTabsDelegate {
     }
 
     func didSelectInactiveTab(tab: Tab?) {
-        TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .inactiveTabTray, value: .openInactiveTab, extras: nil)
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .tap,
+                                     object: .inactiveTabTray,
+                                     value: .openInactiveTab,
+                                     extras: nil)
         if let tabTray = tabDisplayerDelegate as? GridTabViewController {
             tabManager.selectTab(tab)
             tabTray.dismissTabTray()
@@ -789,9 +791,9 @@ extension TabDisplayManager: InactiveTabsDelegate {
 extension TabDisplayManager: TabSelectionDelegate {
     func didSelectTabAtIndex(_ index: Int) {
         guard let tab = dataStore.at(index) else { return }
-        getTabsAndUpdateInactiveState { tabGroup, tabsToDisplay in
+        getTabsAndUpdateInactiveState { [weak self] tabGroup, tabsToDisplay in
             if tabsToDisplay.contains(tab) {
-                self.tabManager.selectTab(tab)
+                self?.tabManager.selectTab(tab)
             }
             TelemetryWrapper.recordEvent(category: .action, method: .press, object: .tab)
         }

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -533,7 +533,6 @@ class TabDisplayManager: NSObject, FeatureFlaggable {
     }
 
     deinit {
-        print("YRD TabDisplayMgr deinit")
         notificationCenter.removeObserver(self)
     }
 }

--- a/Client/Frontend/Browser/Tabs/GridTabViewController.swift
+++ b/Client/Frontend/Browser/Tabs/GridTabViewController.swift
@@ -195,12 +195,6 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate, Themeable {
         }
     }
 
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-
-        print("YRD gridTabVC viewWillDissapear")
-    }
-
     private func setupView() {
         // TODO: Remove SNAPKIT - this will require some work as the layouts
         // are using other snapkit constraints and this will require modification
@@ -243,7 +237,6 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate, Themeable {
     }
 
     deinit {
-        print("YRD GridTabVC deinit")
         tabManagerTeardown()
     }
 

--- a/Client/Frontend/Browser/Tabs/GridTabViewController.swift
+++ b/Client/Frontend/Browser/Tabs/GridTabViewController.swift
@@ -93,14 +93,15 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate, Themeable {
 
     private lazy var emptyPrivateTabsView: EmptyPrivateTabsView = {
         let emptyView = EmptyPrivateTabsView()
-        emptyView.learnMoreButton.addTarget(self, action: #selector(didTapLearnMore), for: .touchUpInside)
+        emptyView.learnMoreButton.addTarget(self,
+                                            action: #selector(didTapLearnMore),
+                                            for: .touchUpInside)
         return emptyView
     }()
 
     private lazy var tabLayoutDelegate: TabLayoutDelegate = {
         let delegate = TabLayoutDelegate(tabDisplayManager: self.tabDisplayManager,
-                                         traitCollection: self.traitCollection,
-                                         scrollView: self.collectionView)
+                                         traitCollection: self.traitCollection)
         delegate.tabSelectionDelegate = self
         delegate.tabPeekDelegate = self
         return delegate
@@ -143,8 +144,8 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate, Themeable {
             LabelButtonHeaderView.self,
             forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
             withReuseIdentifier: GridTabViewController.independentTabsHeaderIdentifier)
-        tabDisplayManager = TabDisplayManager(collectionView: self.collectionView,
-                                              tabManager: self.tabManager,
+        tabDisplayManager = TabDisplayManager(collectionView: collectionView,
+                                              tabManager: tabManager,
                                               tabDisplayer: self,
                                               reuseID: TabCell.cellIdentifier,
                                               tabDisplayType: .TabGrid,
@@ -194,6 +195,12 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate, Themeable {
         }
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        print("YRD gridTabVC viewWillDissapear")
+    }
+
     private func setupView() {
         // TODO: Remove SNAPKIT - this will require some work as the layouts
         // are using other snapkit constraints and this will require modification
@@ -224,18 +231,19 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate, Themeable {
 
     override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
-        guard let flowlayout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout else { return }
-        flowlayout.invalidateLayout()
+        guard let flowLayout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout else { return }
+        flowLayout.invalidateLayout()
     }
 
     private func tabManagerTeardown() {
-        tabManager.removeDelegate(self.tabDisplayManager)
+        tabManager.removeDelegate(tabDisplayManager)
         tabDisplayManager = nil
         contextualHintViewController.stopTimer()
         notificationCenter.removeObserver(self)
     }
 
     deinit {
+        print("YRD GridTabVC deinit")
         tabManagerTeardown()
     }
 
@@ -271,8 +279,8 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate, Themeable {
             let groupIndex: Int = tabGroups.firstIndex(where: { $0.searchTerm == groupName }) ?? 0
             let offSet = Int(GroupedTabCellProperties.CellUX.defaultCellHeight) * groupIndex
             let rect = CGRect(origin: CGPoint(x: 0, y: offSet), size: CGSize(width: self.collectionView.frame.width, height: self.collectionView.frame.height))
-            DispatchQueue.main.async {
-                self.collectionView.scrollRectToVisible(rect, animated: false)
+            DispatchQueue.main.async { [weak self] in
+                self?.collectionView.scrollRectToVisible(rect, animated: false)
             }
         }
     }
@@ -373,19 +381,20 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate, Themeable {
 
     func closeTabsTrayHelper() {
         if tabDisplayManager.isPrivate {
-            emptyPrivateTabsView.isHidden = !self.privateTabsAreEmpty
+            emptyPrivateTabsView.isHidden = !privateTabsAreEmpty
             if !emptyPrivateTabsView.isHidden {
                 // Fade in the empty private tabs message. This slow fade allows time for the closing tab animations to complete.
                 emptyPrivateTabsView.alpha = 0
                 UIView.animate(
                     withDuration: 0.5,
-                    animations: {
-                        self.emptyPrivateTabsView.alpha = 1
+                    animations: { [weak self] in
+                        self?.emptyPrivateTabsView.alpha = 1
                     })
             }
-        } else if self.tabManager.normalTabs.count == 1, let tab = self.tabManager.normalTabs.first {
-            self.tabManager.selectTab(tab)
-            self.dismissTabTray()
+        } else if tabManager.normalTabs.count == 1,
+                  let tab = tabManager.normalTabs.first {
+            tabManager.selectTab(tab)
+            dismissTabTray()
             notificationCenter.post(name: .TabsTrayDidClose)
         }
     }
@@ -414,8 +423,10 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate, Themeable {
             return
         }
 
-        presentUndoToast(toastType: .singleTab) { undoButtonPressed in
-            guard undoButtonPressed, let closedTab = self.tabManager.backupCloseTab else { return }
+        presentUndoToast(toastType: .singleTab) { [weak self] undoButtonPressed in
+            guard let self,
+                    undoButtonPressed,
+                    let closedTab = self.tabManager.backupCloseTab else { return }
 
             self.tabDisplayManager.undoCloseTab(tab: closedTab.tab, index: closedTab.restorePosition)
             NotificationCenter.default.post(name: .UpdateLabelOnTabClosed, object: nil)
@@ -432,10 +443,11 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate, Themeable {
             buttonText: .TabsTray.CloseTabsToast.Action)
         let toast = ButtonToast(viewModel: viewModel,
                                 theme: themeManager.currentTheme,
-                                completion: { undoButtonPressed in
-            guard undoButtonPressed, let closedTab = self.tabManager.backupCloseTab else { return }
+                                completion: { [weak self]  undoButtonPressed in
+            guard undoButtonPressed, let closedTab = self?.tabManager.backupCloseTab else { return }
 
-            self.tabDisplayManager.undoCloseTab(tab: closedTab.tab, index: closedTab.restorePosition)
+            self?.tabDisplayManager.undoCloseTab(tab: closedTab.tab,
+                                                 index: closedTab.restorePosition)
         })
         delegate?.tabTrayDidCloseLastTab(toast: toast)
     }
@@ -503,10 +515,11 @@ extension GridTabViewController {
         // as part of a private mode tab
         UIView.animate(
             withDuration: 0.2,
-            animations: {
-                self.collectionView.alpha = 1
-                self.emptyPrivateTabsView.alpha = 1
-            }) { _ in
+            animations: { [weak self] in
+                self?.collectionView.alpha = 1
+                self?.emptyPrivateTabsView.alpha = 1
+            }) { [weak self] _ in
+                guard let self else { return }
                 self.backgroundPrivacyOverlay.alpha = 0
                 self.view.sendSubviewToBack(self.backgroundPrivacyOverlay)
             }
@@ -531,7 +544,8 @@ extension GridTabViewController: UIScrollViewAccessibilityDelegate {
     func accessibilityScrollStatus(for scrollView: UIScrollView) -> String? {
         guard var visibleCells = collectionView.visibleCells as? [TabCell] else { return nil }
         var bounds = collectionView.bounds
-        bounds = bounds.offsetBy(dx: collectionView.contentInset.left, dy: collectionView.contentInset.top)
+        bounds = bounds.offsetBy(dx: collectionView.contentInset.left,
+                                 dy: collectionView.contentInset.top)
         bounds.size.width -= collectionView.contentInset.left + collectionView.contentInset.right
         bounds.size.height -= collectionView.contentInset.top + collectionView.contentInset.bottom
         // visible cells do sometimes return also not visible cells when attempting to go past the last cell with VoiceOver right-flick gesture; so make sure we have only visible cells (yeah...)

--- a/Client/Frontend/Browser/Tabs/GridTabViewController.swift
+++ b/Client/Frontend/Browser/Tabs/GridTabViewController.swift
@@ -418,8 +418,8 @@ class GridTabViewController: UIViewController, TabTrayViewDelegate, Themeable {
 
         presentUndoToast(toastType: .singleTab) { [weak self] undoButtonPressed in
             guard let self,
-                    undoButtonPressed,
-                    let closedTab = self.tabManager.backupCloseTab else { return }
+                  undoButtonPressed,
+                  let closedTab = self.tabManager.backupCloseTab else { return }
 
             self.tabDisplayManager.undoCloseTab(tab: closedTab.tab, index: closedTab.restorePosition)
             NotificationCenter.default.post(name: .UpdateLabelOnTabClosed, object: nil)

--- a/Client/Frontend/Browser/Tabs/InactiveTabs/InactiveTabCell.swift
+++ b/Client/Frontend/Browser/Tabs/InactiveTabs/InactiveTabCell.swift
@@ -161,9 +161,9 @@ extension InactiveTabCell: UITableViewDataSource, UITableViewDelegate {
                 return UITableViewCell()
             }
 
-            cell.buttonClosure = {
-                let inactiveTabsCount = self.inactiveTabsViewModel?.inactiveTabs.count
-                self.delegate?.didTapCloseInactiveTabs(tabsCount: inactiveTabsCount ?? 0)
+            cell.buttonClosure = { [weak self] in
+                let inactiveTabsCount = self?.inactiveTabsViewModel?.inactiveTabs.count
+                self?.delegate?.didTapCloseInactiveTabs(tabsCount: inactiveTabsCount ?? 0)
             }
             if let theme = inactiveTabsViewModel?.theme {
                 cell.applyTheme(theme: theme)
@@ -258,10 +258,10 @@ extension InactiveTabCell: UITableViewDataSource, UITableViewDelegate {
         case .inactive:
             let closeAction = UIContextualAction(
                 style: .destructive,
-                title: .TabsTray.InactiveTabs.CloseInactiveTabSwipeActionTitle) { _, _, completion in
-                    if let tab = self.inactiveTabsViewModel?.inactiveTabs[indexPath.item] {
-                        self.removeInactiveTab(at: indexPath)
-                        self.delegate?.closeInactiveTab(tab, index: indexPath.item)
+                title: .TabsTray.InactiveTabs.CloseInactiveTabSwipeActionTitle) { [weak self] _, _, completion in
+                    if let tab = self?.inactiveTabsViewModel?.inactiveTabs[indexPath.item] {
+                        self?.removeInactiveTab(at: indexPath)
+                        self?.delegate?.closeInactiveTab(tab, index: indexPath.item)
                         completion(true)
                     }
                 }

--- a/Client/Frontend/Browser/Tabs/TabLayoutDelegate.swift
+++ b/Client/Frontend/Browser/Tabs/TabLayoutDelegate.swift
@@ -35,10 +35,6 @@ class TabLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayout, UIGesture
         super.init()
     }
 
-    deinit {
-        print("YRD deinit TabLayoutDelegate")
-    }
-
     private func cellHeightForCurrentDevice() -> CGFloat {
         if traitCollection.verticalSizeClass == .compact ||
             traitCollection.horizontalSizeClass == .compact {

--- a/Client/Frontend/Browser/Tabs/TabLayoutDelegate.swift
+++ b/Client/Frontend/Browser/Tabs/TabLayoutDelegate.swift
@@ -7,7 +7,6 @@ import UIKit
 class TabLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayout, UIGestureRecognizerDelegate {
     weak var tabSelectionDelegate: TabSelectionDelegate?
     weak var tabPeekDelegate: TabPeekDelegate?
-    let scrollView: UIScrollView
     var lastYOffset: CGFloat = 0
     var tabDisplayManager: TabDisplayManager
 
@@ -20,7 +19,6 @@ class TabLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayout, UIGesture
         case down
     }
 
-    fileprivate var scrollDirection: ScrollDirection = .down
     var traitCollection: UITraitCollection
     var numberOfColumns: Int {
         // iPhone 4-6+ portrait
@@ -31,11 +29,14 @@ class TabLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayout, UIGesture
         }
     }
 
-    init(tabDisplayManager: TabDisplayManager, traitCollection: UITraitCollection, scrollView: UIScrollView) {
+    init(tabDisplayManager: TabDisplayManager, traitCollection: UITraitCollection) {
         self.tabDisplayManager = tabDisplayManager
-        self.scrollView = scrollView
         self.traitCollection = traitCollection
         super.init()
+    }
+
+    deinit {
+        print("YRD deinit TabLayoutDelegate")
     }
 
     private func cellHeightForCurrentDevice() -> CGFloat {

--- a/Tests/ClientTests/TabDisplayManagerTests.swift
+++ b/Tests/ClientTests/TabDisplayManagerTests.swift
@@ -502,7 +502,9 @@ extension TabDisplayManagerTests {
         waitForExpectations(timeout: 5, handler: nil)
     }
 
-    func createTabDisplayManager(useMockDataStore: Bool = true) -> TabDisplayManager {
+    func createTabDisplayManager(file: StaticString = #file,
+                                 line: UInt = #line,
+                                 useMockDataStore: Bool = true) -> TabDisplayManager {
         let tabDisplayManager = TabDisplayManager(collectionView: collectionView,
                                                   tabManager: manager,
                                                   tabDisplayer: self,
@@ -513,6 +515,7 @@ extension TabDisplayManagerTests {
                                                   theme: LightTheme())
         collectionView.dataSource = tabDisplayManager
         tabDisplayManager.dataStore = useMockDataStore ? mockDataStore : dataStore
+        trackForMemoryLeaks(tabDisplayManager, file: file, line: line)
         return tabDisplayManager
     }
 
@@ -530,6 +533,7 @@ extension TabDisplayManagerTests {
                                                   cfrDelegate: cfrDelegate,
                                                   theme: LightTheme())
         collectionView.dataSource = tabDisplayManager
+        trackForMemoryLeaks(tabDisplayManager)
         return tabDisplayManager
     }
 

--- a/Tests/ClientTests/TabLayoutDelegateTests.swift
+++ b/Tests/ClientTests/TabLayoutDelegateTests.swift
@@ -42,8 +42,7 @@ class TabLayoutDelegateTests: XCTestCase {
     func testTabCellDeinit() {
         let manager = createTabDisplayManager()
         let subject = TabLayoutDelegate(tabDisplayManager: manager,
-                                        traitCollection: UITraitCollection(),
-                                        scrollView: UIScrollView())
+                                        traitCollection: UITraitCollection())
         subject.tabSelectionDelegate = tabSelectionDelegate
         subject.tabPeekDelegate = tabPeekDelegate
         trackForMemoryLeaks(subject)

--- a/Tests/ClientTests/TabToolbarHelperTests.swift
+++ b/Tests/ClientTests/TabToolbarHelperTests.swift
@@ -54,6 +54,12 @@ class TabToolbarHelperTests: XCTestCase {
         mockToolbar.tabToolbarDelegate?.tabToolbarDidPressMenu(mockToolbar, button: mockToolbar.appMenuButton)
         testCounterMetricRecordingSuccess(metric: GleanMetrics.AppMenu.siteMenu)
     }
+
+    func test_tabToolBarHelper_basicCreation_doesntLeak() {
+        let tabToolBar = TabToolbar()
+        let subject = TabToolbarHelper(toolbar: tabToolBar)
+        trackForMemoryLeaks(subject)
+    }
 }
 
 class MockTabsButton: TabsButton {

--- a/content-blocker-lib-ios/src/ContentBlocker.swift
+++ b/content-blocker-lib-ios/src/ContentBlocker.swift
@@ -102,9 +102,9 @@ class ContentBlocker {
         TPStatsBlocklistChecker.shared.startup()
 
         removeOldListsByDateFromStore {
-            self.removeOldListsByNameFromStore { [weak self]
-                self.compileListsNotInStore {
-                    self.setupCompleted = true
+            self.removeOldListsByNameFromStore { [weak self] in
+                self?.compileListsNotInStore {
+                    self?.setupCompleted = true
                     NotificationCenter.default.post(name: .contentBlockerTabSetupRequired, object: nil)
                 }
             }
@@ -294,16 +294,17 @@ extension ContentBlocker {
                 }
                 self?.loadJsonFromBundle(forResource: filename) { jsonString in
                     var str = jsonString
-                    guard let range = str.range(of: "]", options: String.CompareOptions.backwards) else { return }
+                    guard let self,
+                          let range = str.range(of: "]", options: String.CompareOptions.backwards) else { return }
                     str = str.replacingCharacters(in: range, with: self.safelistAsJSON() + "]")
-                    self?.ruleStore?.compileContentRuleList(forIdentifier: filename, encodedContentRuleList: str) { rule, error in
+                    self.ruleStore?.compileContentRuleList(forIdentifier: filename, encodedContentRuleList: str) { rule, error in
                         guard error == nil else {
-                            self?.logger.log("Content blocker errored with: \(String(describing: error))", level: .warning, category: .webview)
+                            self.logger.log("Content blocker errored with: \(String(describing: error))", level: .warning, category: .webview)
                             assert(error == nil)
                             return
                         }
                         guard rule != nil else {
-                            self?.logger.log("We came across a nil rule set for BlockList.", level: .warning, category: .webview)
+                            self.logger.log("We came across a nil rule set for BlockList.", level: .warning, category: .webview)
                             assert(rule != nil)
                             return
                         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7100)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15774)

## :bulb: Description
- Weakify self in code related to GridTabViewController and TabDisplayManager deinit is still not call but I couldn't find leaks related to this classes
- Fix leak related to ContentBlocker found with Instruments

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

