### PR TITLE
Bugfix FXIOS-7121 [v116] [Experiment] Part 2 of the fix for saved credit cards cannot be synced on first launch

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -464,6 +464,13 @@ class BrowserViewController: UIViewController,
 
         // Credit card initial setup telemetry
         creditCardInitialSetupTelemetry()
+        // Feature flag for credit card until we fully enable this feature
+        let autofillCreditCardStatus = featureFlags.isFeatureEnabled(
+            .creditCardAutofillStatus, checking: .buildOnly)
+        // We need to update autofill status on sync manager as there could be delay from nimbus
+        // in getting the value. When the delay happens the credit cards might not sync
+        // as the default value is false
+        profile.syncManager.updateCreditCardAutofillStatus(value: autofillCreditCardStatus)
     }
 
     private func setupAccessibleActions() {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -462,8 +462,6 @@ class BrowserViewController: UIViewController,
         statusBarOverlay.hasTopTabs = shouldShowTopTabsForTraitCollection(traitCollection)
         statusBarOverlay.applyTheme(theme: theme)
 
-        // Credit card initial setup telemetry
-        creditCardInitialSetupTelemetry()
         // Feature flag for credit card until we fully enable this feature
         let autofillCreditCardStatus = featureFlags.isFeatureEnabled(
             .creditCardAutofillStatus, checking: .buildOnly)
@@ -471,6 +469,8 @@ class BrowserViewController: UIViewController,
         // in getting the value. When the delay happens the credit cards might not sync
         // as the default value is false
         profile.syncManager.updateCreditCardAutofillStatus(value: autofillCreditCardStatus)
+        // Credit card initial setup telemetry
+        creditCardInitialSetupTelemetry()
     }
 
     private func setupAccessibleActions() {

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -36,6 +36,7 @@ public protocol SyncManager {
     func onRemovedAccount() -> Success
     @discardableResult
     func onAddedAccount() -> Success
+    func updateCreditCardAutofillStatus(value: Bool)
 }
 
 /// This exists to pass in external context: e.g., the UIApplication can

--- a/Providers/RustSyncManager.swift
+++ b/Providers/RustSyncManager.swift
@@ -84,6 +84,10 @@ public class RustSyncManager: NSObject, SyncManager {
                                     repeats: true)
     }
 
+    public func updateCreditCardAutofillStatus(value: Bool) {
+        creditCardAutofillEnabled = value
+    }
+
     func syncEverythingSoon() {
         doInBackgroundAfter(SyncConstants.SyncOnForegroundAfterMillis) {
             self.logger.log("Running delayed startup sync.",

--- a/Tests/ClientTests/Mocks/MockProfile.swift
+++ b/Tests/ClientTests/Mocks/MockProfile.swift
@@ -30,7 +30,7 @@ open class ClientSyncManagerSpy: ClientSyncManager {
     open func syncTabs() -> Deferred<Maybe<SyncResult>> { return emptySyncResult }
     open func syncHistory() -> Deferred<Maybe<SyncResult>> { return emptySyncResult }
     open func syncEverything(why: SyncReason) -> Success { return succeed() }
-    open func updateCreditCardAutofillStatus(value: Bool)
+    open func updateCreditCardAutofillStatus(value: Bool) {}
 
     var syncNamedCollectionsCalled = 0
     open func syncNamedCollections(why: SyncReason, names: [String]) -> Success {

--- a/Tests/ClientTests/Mocks/MockProfile.swift
+++ b/Tests/ClientTests/Mocks/MockProfile.swift
@@ -30,6 +30,7 @@ open class ClientSyncManagerSpy: ClientSyncManager {
     open func syncTabs() -> Deferred<Maybe<SyncResult>> { return emptySyncResult }
     open func syncHistory() -> Deferred<Maybe<SyncResult>> { return emptySyncResult }
     open func syncEverything(why: SyncReason) -> Success { return succeed() }
+    open func updateCreditCardAutofillStatus(value: Bool)
 
     var syncNamedCollectionsCalled = 0
     open func syncNamedCollections(why: SyncReason, names: [String]) -> Success {

--- a/nimbus-features/creditCardAutofillFeature.yaml
+++ b/nimbus-features/creditCardAutofillFeature.yaml
@@ -9,7 +9,7 @@ features:
     defaults:
       - channel: developer
         value: {
-            "credit-card-autofill-status": true
+            "credit-card-autofill-status": false
         }
       - channel: beta
         value: {

--- a/nimbus-features/creditCardAutofillFeature.yaml
+++ b/nimbus-features/creditCardAutofillFeature.yaml
@@ -9,7 +9,7 @@ features:
     defaults:
       - channel: developer
         value: {
-            "credit-card-autofill-status": false
+            "credit-card-autofill-status": true
         }
       - channel: beta
         value: {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7121)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15811)

## :bulb: Description
Part 2 of the fix for saved credit cards cannot be synced on the first launch. This time instead of relying on AppDelegate to fetch the first launch value have added an update method to get new values from Nimbus and update RustSyncManager of the change. This is added to BrowserViewcontroller to not cause too much delay for the flag to be fetched.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

