### PR TITLE
Bugfix FXIOS-7031 [v116] Fix race condition when loading initial selected tab

### DIFF
--- a/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -123,7 +123,6 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         if !(0..<count ~= _selectedIndex) {
             return nil
         }
-
         return tabs[_selectedIndex]
     }
 

--- a/Client/TabManagement/TabManagerImplementation.swift
+++ b/Client/TabManagement/TabManagerImplementation.swift
@@ -109,6 +109,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
     private func generateTabs(from windowData: WindowData) async {
         let filteredTabs = filterPrivateTabs(from: windowData,
                                              clearPrivateTabs: shouldClearPrivateTabs())
+        var tabToSelect: Tab?
 
         for tabData in filteredTabs {
             let newTab = addTab(flushToDisk: false, zombie: true, isPrivate: tabData.isPrivate)
@@ -130,12 +131,14 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
             restoreScreenshot(tab: newTab)
 
             if windowData.activeTabId == tabData.id {
-                selectTab(newTab)
+                tabToSelect = newTab
             }
         }
 
+        selectTab(tabToSelect)
+
         // If tabToSelect is nil after restoration, force selection of first tab normal tab
-        if selectedTab == nil {
+        if tabToSelect == nil {
             guard let tabToSelect = tabs.first(where: { !$0.isPrivate }) else {
                 selectTab(addTab())
                 return
@@ -150,7 +153,6 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
         if clearPrivateTabs {
             savedTabs = windowData.tabData.filter { !$0.isPrivate }
         }
-
         return savedTabs
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7031)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15625)

## :bulb: Description
This PR fixes a race condition between selecting the stored active tab and the fall back if no tab is selected.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

