### PR TITLE
Bugfix FXIOS-7139 [v116] Use the correct value for last used time conversion

### DIFF
--- a/Client/TabManagement/TabManagerImplementation.swift
+++ b/Client/TabManagement/TabManagerImplementation.swift
@@ -117,6 +117,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
             newTab.tabUUID = tabData.id.uuidString
             newTab.screenshotUUID = tabData.id
             newTab.firstCreatedTime = tabData.createdAtTime.toTimestamp()
+            newTab.lastExecutedTime = tabData.lastUsedTime.toTimestamp()
             newTab.sessionData = LegacySessionData(currentPage: 0,
                                                    urls: [],
                                                    lastUsedTime: tabData.lastUsedTime.toTimestamp())
@@ -203,7 +204,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
                            siteUrl: tab.url?.absoluteString ?? "",
                            faviconURL: tab.faviconURL,
                            isPrivate: tab.isPrivate,
-                           lastUsedTime: Date.fromTimestamp(tab.sessionData?.lastUsedTime ?? 0),
+                           lastUsedTime: Date.fromTimestamp(tab.lastExecutedTime ?? 0),
                            createdAtTime: Date.fromTimestamp(tab.firstCreatedTime ?? 0),
                            tabGroupData: groupData)
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7139)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15869)

## :bulb: Description
Updates the conversion of the tab model to the storage model to use the correct value for the last used time

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

