### PR TITLE
Refactor FXIOS-6869 [v118] Move Resizable Button to component library

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/ResizableButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/ResizableButton.swift
@@ -4,12 +4,15 @@
 
 import UIKit
 
-class ResizableButton: UIButton {
-    struct UX {
-        static let buttonEdgeSpacing: CGFloat = 8
+/// This class is a button that enables resizing with dynamic type
+/// This is a building block component for developement purpose, and isn't the designer component in itself.
+/// See `RoundedButton` for the designer button component (to be done with FXIOS-6948 #15441)
+open class ResizableButton: UIButton {
+    public struct UX {
+        public static let buttonEdgeSpacing: CGFloat = 8
     }
 
-    var buttonEdgeSpacing: CGFloat = UX.buttonEdgeSpacing {
+    public var buttonEdgeSpacing: CGFloat = UX.buttonEdgeSpacing {
         didSet {
             contentEdgeInsets = UIEdgeInsets(top: 0,
                                              left: buttonEdgeSpacing,
@@ -18,12 +21,12 @@ class ResizableButton: UIButton {
         }
     }
 
-    override init(frame: CGRect) {
+    public override init(frame: CGRect) {
         super.init(frame: frame)
         commonInit()
     }
 
-    required init?(coder aDecoder: NSCoder) {
+    required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         fatalError("init(coder:) has not been implemented")
     }
@@ -39,7 +42,7 @@ class ResizableButton: UIButton {
                                          right: buttonEdgeSpacing)
     }
 
-    override var intrinsicContentSize: CGSize {
+    public override var intrinsicContentSize: CGSize {
         guard let title = titleLabel else {
             return super.intrinsicContentSize
         }
@@ -58,7 +61,7 @@ class ResizableButton: UIButton {
                       height: size.height + contentEdgeInsets.top + contentEdgeInsets.bottom)
     }
 
-    override func layoutSubviews() {
+    public override func layoutSubviews() {
         super.layoutSubviews()
         guard let title = titleLabel else { return }
 

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -111,7 +111,6 @@
 		2178A6A229145506002EC290 /* ReaderModeFontSizeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2178A6A129145506002EC290 /* ReaderModeFontSizeLabel.swift */; };
 		2178A6A4291455F7002EC290 /* ReaderModeFontSizeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2178A6A3291455F7002EC290 /* ReaderModeFontSizeButton.swift */; };
 		217AEF76284666D4004EED37 /* IntroViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217AEF75284666D4004EED37 /* IntroViewModelTests.swift */; };
-		217AEF7828480844004EED37 /* ResizableButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217AEF7728480844004EED37 /* ResizableButton.swift */; };
 		2197DF8A287624BF00215624 /* LibraryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2197DF89287624BF00215624 /* LibraryViewModelTests.swift */; };
 		21A1C3C72996AFF800181B7C /* OverlayModeManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A1C3C62996AFF800181B7C /* OverlayModeManagerTests.swift */; };
 		21A43CDD291461C700B1206D /* ReaderModeFontTypeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A43CDC291461C700B1206D /* ReaderModeFontTypeButton.swift */; };
@@ -2124,7 +2123,6 @@
 		2178A6A129145506002EC290 /* ReaderModeFontSizeLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeFontSizeLabel.swift; sourceTree = "<group>"; };
 		2178A6A3291455F7002EC290 /* ReaderModeFontSizeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeFontSizeButton.swift; sourceTree = "<group>"; };
 		217AEF75284666D4004EED37 /* IntroViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroViewModelTests.swift; sourceTree = "<group>"; };
-		217AEF7728480844004EED37 /* ResizableButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizableButton.swift; sourceTree = "<group>"; };
 		2194437EA9B44A00EDC037FA /* gu-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "gu-IN"; path = "gu-IN.lproj/FindInPage.strings"; sourceTree = "<group>"; };
 		2197DF89287624BF00215624 /* LibraryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryViewModelTests.swift; sourceTree = "<group>"; };
 		219F41288625C09DD40F008C /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
@@ -8563,7 +8561,6 @@
 				8AB5958B28414DF60090F4AE /* ActionButton.swift */,
 				8AED23C427AC1F9500DE7E97 /* BaseContentStackView.swift */,
 				43AB6F9E25DC53D20016B015 /* LabelButtonHeaderView.swift */,
-				217AEF7728480844004EED37 /* ResizableButton.swift */,
 				8A36BE2829EDBC6900AC1C5C /* ContentContainer.swift */,
 				8ACE9BFA2A54A010001E7A73 /* ExpandButtonState.swift */,
 				8A0D32832A61E1CC007D976D /* StatusBarOverlay.swift */,
@@ -12987,7 +12984,6 @@
 				96EB6C3C27D82AEA00A9D159 /* HistoryPanel+ContextMenuExtensions.swift in Sources */,
 				E1CD81C2290C62A600124B27 /* HostingTableViewCell.swift in Sources */,
 				43175DB826B87D2C00C41C31 /* AdsTelemetryHelper.swift in Sources */,
-				217AEF7828480844004EED37 /* ResizableButton.swift in Sources */,
 				E58368AA287D632F0087A449 /* StoryProvider.swift in Sources */,
 				8A3EF7FF2A2FCFBB00796E3A /* ChangeToChinaSetting.swift in Sources */,
 				E6327A641BF6438E008D12E0 /* DebugSettingsBundleOptions.swift in Sources */,

--- a/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetFooterView.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetFooterView.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
+import ComponentLibrary
 import UIKit
 import Shared
 

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsErrorCell.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsErrorCell.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
+import ComponentLibrary
 import UIKit
 import Shared
 

--- a/Client/Frontend/Components/ActionButton.swift
+++ b/Client/Frontend/Components/ActionButton.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import ComponentLibrary
 
 // A convenience button class to add a closure as an action on a button instead of a selector
 class ActionButton: ResizableButton {

--- a/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
+++ b/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
+import ComponentLibrary
 import Foundation
 import UIKit
 import Shared

--- a/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionCell.swift
+++ b/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionCell.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
+import ComponentLibrary
 import UIKit
 import Shared
 

--- a/Client/Frontend/Onboarding/ViewControllers/OnboardingCardViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/OnboardingCardViewController.swift
@@ -4,6 +4,7 @@
 
 import UIKit
 import Common
+import ComponentLibrary
 import Shared
 
 class OnboardingCardViewController: UIViewController, Themeable {

--- a/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsHeaderView.swift
+++ b/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsHeaderView.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
+import ComponentLibrary
 import Foundation
 import Shared
 

--- a/Client/Frontend/SurveySurface/SurveySurfaceViewController.swift
+++ b/Client/Frontend/SurveySurface/SurveySurfaceViewController.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
+import ComponentLibrary
 import Foundation
 import Shared
 import UIKit

--- a/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/RustFxA/FirefoxAccountSignInViewController.swift
@@ -6,6 +6,7 @@ import Foundation
 import Shared
 import Account
 import Common
+import ComponentLibrary
 
 /// Reflects parent page that launched FirefoxAccountSignInViewController
 enum FxASignInParentType {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6869)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15302)

## :bulb: Description
- Moving ResizableButton to the component library. 
- Not adding a SampleApplication usage since I don't think we want devs to use this component directly in the future. This is more of a building block for other designer components. Since those components are moving pieces and doesn't exist yet, the ResizableButton is made open to support existing code, but we should move away from this in the future and use the defined designer button components in prod code.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

