### PR TITLE
Bugfix FXIOS-7086 [v118] Add unsubscribe call on viewWillDisapear on ThemeSettingsViewController

### DIFF
--- a/BrowserKit/Sources/Redux/DispatchStore.swift
+++ b/BrowserKit/Sources/Redux/DispatchStore.swift
@@ -21,6 +21,7 @@ public protocol DefaultDispatchStore: DispatchStore {
     func subscribe<SubState, S: StoreSubscriber>(_ subscriber: S,
                                                  transform: ((Subscription<State>) -> Subscription<SubState>)?) where S.SubscriberStateType == SubState
     func unsubscribe<S: StoreSubscriber>(_ subscriber: S) where S.SubscriberStateType == State
+    func unsubscribe(_ subscriber: any StoreSubscriber)
 
     func dispatch(_ actionCreator: ActionCreator)
 }

--- a/BrowserKit/Sources/Redux/Store.swift
+++ b/BrowserKit/Sources/Redux/Store.swift
@@ -48,6 +48,12 @@ public class Store<State: StateType>: DefaultDispatchStore {
         subscribe(subscriber, mainSubscription: originalSubscription, transformedSubscription: transformedSubscription)
     }
 
+    public func unsubscribe(_ subscriber: any StoreSubscriber) {
+        if let index = subscriptions.firstIndex(where: { return $0.subscriber === subscriber }) {
+            subscriptions.remove(at: index)
+        }
+    }
+
     public func unsubscribe<S: StoreSubscriber>(_ subscriber: S) where S.SubscriberStateType == State {
         if let index = subscriptions.firstIndex(where: { return $0.subscriber === subscriber }) {
             subscriptions.remove(at: index)

--- a/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
+++ b/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
@@ -69,6 +69,13 @@ class ThemeSettingsController: ThemedTableViewController, StoreSubscriber {
                                                object: nil)
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        if isReduxIntegrationEnabled {
+            store.unsubscribe(self)
+        }
+    }
+
     func newState(state: ThemeSettingsState) {
         themeState = state
         tableView.reloadData()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7086)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15752)

## :bulb: Description
Add unsubscribe function to Store and use at ThemeSettingController

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

