### PR TITLE
Bugfix FXIOS-7159 [v116] Firefox iOS blocks popup tab

### DIFF
--- a/Client/Frontend/Settings/Main/General/BlockPopupSetting.swift
+++ b/Client/Frontend/Settings/Main/General/BlockPopupSetting.swift
@@ -9,7 +9,8 @@ class BlockPopupSetting: BoolSetting {
     init(settings: SettingsTableViewController) {
         let currentValue = settings.profile.prefs.boolForKey(PrefsKeys.KeyBlockPopups)
         let didChange = { (isEnabled: Bool) in
-            settings.profile.prefs.setBool(isEnabled, forKey: PrefsKeys.KeyBlockPopups)
+            NotificationCenter.default.post(name: .BlockPopup,
+                                            object: nil)
         }
 
         super.init(title: .AppSettingsBlockPopups,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7159)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15914)

## :bulb: Description
- Send the notification to update blockPopup setting
- Fixes bug introduced by  https://github.com/mozilla-mobile/firefox-ios/pull/15889 when updating the blockPopUp settings doesn't take effect immediately 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

