### PR TITLE
Add MTE-1283 [v118] Add Firebase Test Lab Performance Workflow

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1463,7 +1463,103 @@ workflows:
             App|${BITRISE_APP_URL}
             #mobile-testeng|https://mozilla.slack.com/archives/C02KDDS9QM9
             Mana|https://mana.mozilla.org/wiki/display/MTE/Mobile+Test+Engineering
-
+  Firebase_Performance_Test:
+    before_run:
+    - 1_git_clone_and_post_clone
+    - 2_certificate_and_profile
+    - 3_provisioning_and_npm_installation
+    steps:
+    - xcode-archive@4.7.2:
+        inputs:
+        - compile_bitcode: 'no'
+        - upload_bitcode: 'no'
+        - team_id: 9G8J6YA743
+        - export_method: development
+        - distribution_method: development
+        - export_development_team: 9G8J6YA743
+        - output_tool: xcodebuild
+        - scheme: Fennec_Enterprise
+        - configuration: Fennec_Enterprise
+        - project_path: "$BITRISE_PROJECT_PATH"
+    - deploy-to-bitrise-io@2: {}
+    - script@1.1:
+        title: Firebase Build for Testing Physical Devices
+        inputs:
+        - content: |
+            set -euxo pipefail
+            echo "-- build-for-testing --"
+            mkdir DerivedData
+            xcodebuild -resolvePackageDependencies -onlyUsePackageVersionsFromResolvedFile
+            xcodebuild build-for-testing -project /Users/vagrant/git/Client.xcodeproj \
+                -scheme Fennec_Enterprise \
+                -configuration Fennec_Enterprise \
+                -sdk iphoneos \
+                -destination "generic/platform=iOS" \
+                -derivedDataPath "/Users/vagrant/git/DerivedData" \
+                DEVELOPMENT_TEAM="Mozilla Corporation" \
+                CODE_SIGN_STYLE=Manual \
+                CODE_SIGN_IDENTITY="iPhone Distribution: org.mozilla.ios.Fennec" \
+                PROVISIONING_PROFILE_SPECIFIER="org.mozilla.ios.Fennec_Enterprise"| xcpretty | tee xcodebuild_fennec.log
+    - deploy-to-bitrise-io@2: {}
+    - script@1.1:
+        title: Verify App signature, Test, and Runner
+        inputs:
+        - content: |
+            set -euxo pipefail
+            echo "-- verify test and runner signature --"
+            codesign --verify --deep --strict --verbose DerivedData/Build/Products/Debug-iphoneos/Client.app
+            echo "-- test app --"
+            xcodebuild -project /Users/vagrant/git/Client.xcodeproj \
+                -scheme Fennec_Enterprise \
+                -configuration Fennec_Enterprise \
+                -sdk iphoneos \
+                -derivedDataPath "/Users/vagrant/git/DerivedData" test-without-building | xcpretty | tee xcodebuild_fennec.log
+        title: Create .zip artifact for Firebase Testing
+        inputs:
+        - content: |
+            set -euxo pipefail
+            echo "-- create .zip artifact --"
+            cd DerivedData/Build/Products
+            zip -r Fennec_Enterprise.zip Debug-iphones Fennec_Enterprise_PerformanceTestPlan_iphoneos16.4-arm64.xctestrun
+            mv Fennec_Enterprise.zip /Users/vagrant/git/Fennec_Enterprise.zip
+    - deploy-to-bitrise-io@2: {}
+    - cache-pull@2.7.2:
+        inputs:
+        - cache_paths: "$HOME/google-cloud-sdk"
+    - script@1:
+        title: Install Google Cloud SDK
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -e
+             
+            if [ -e $HOME/google-cloud-sdk ]; then
+              echo "Google Cloud SDK found, skipping installation..."
+            else
+              echo "Google Cloud SDK not found, installing..."
+              curl https://sdk.cloud.google.com > install.sh
+              bash install.sh --disable-prompts
+              source $HOME/google-cloud-sdk/path.bash.inc
+            fi
+    - cache-push@2.7.1:
+        inputs:
+        - cache_paths: "$HOME/google-cloud-sdk"
+        - ignore_check_on_paths: "!/Users/vagrant/Library/Developer/Xcode/DerivedData/**"
+        - compress_archive: "true"
+    - script@1:
+        title: Run Performance Tests in Firebase Test Lab
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -e 
+            curl -o /tmp/key-file.json $BITRISEIO_GOOGLE_APPLICATION_CREDENTIALS_URL 
+            $HOME/google-cloud-sdk/bin/gcloud version
+            $HOME/google-cloud-sdk/bin/gcloud auth activate-service-account -q --key-file /tmp/key-file.json
+            $HOME/google-cloud-sdk/bin/gcloud config set project "$GOOGLE_CLOUD_PROJECT"
+            ls /Users/vagrant/git/Fennec_Enterprise.zip
+            gcloud firebase test ios run --test /Users/vagrant/git/Fennec_Enterprise.zip \
+                --model=iphone14pro,version=16.4 \
+                --xcode-version=14.3.1
 app:
   envs:
   - opts:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1491,15 +1491,9 @@ workflows:
             mkdir DerivedData
             xcodebuild -resolvePackageDependencies -onlyUsePackageVersionsFromResolvedFile
             xcodebuild build-for-testing -project /Users/vagrant/git/Client.xcodeproj \
-                -scheme Fennec_Enterprise \
-                -configuration Fennec_Enterprise \
                 -sdk iphoneos \
                 -destination "generic/platform=iOS" \
-                -derivedDataPath "/Users/vagrant/git/DerivedData" \
-                DEVELOPMENT_TEAM="Mozilla Corporation" \
-                CODE_SIGN_STYLE=Manual \
-                CODE_SIGN_IDENTITY="iPhone Distribution: org.mozilla.ios.Fennec" \
-                PROVISIONING_PROFILE_SPECIFIER="org.mozilla.ios.Fennec_Enterprise"| xcpretty | tee xcodebuild_fennec.log
+                -derivedDataPath "/Users/vagrant/git/DerivedData" | xcpretty | tee xcodebuild_fennec.log
     - deploy-to-bitrise-io@2: {}
     - script@1.1:
         title: Verify App signature, Test, and Runner
@@ -1510,10 +1504,9 @@ workflows:
             codesign --verify --deep --strict --verbose DerivedData/Build/Products/Debug-iphoneos/Client.app
             echo "-- test app --"
             xcodebuild -project /Users/vagrant/git/Client.xcodeproj \
-                -scheme Fennec_Enterprise \
-                -configuration Fennec_Enterprise \
                 -sdk iphoneos \
                 -derivedDataPath "/Users/vagrant/git/DerivedData" test-without-building | xcpretty | tee xcodebuild_fennec.log
+    - script@1.1:
         title: Create .zip artifact for Firebase Testing
         inputs:
         - content: |


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1283)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
In order to support performance testing on remote physical devices, we need to add a bitrise workflow to build on Firebase Test Lab.

I've added a new workflow to do that which builds, signs, verifies the signing, and tests the runner before pushing the test `.zip` artifact to Firebase for testing.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

