### PR TITLE
Bugfix FXIOS-7013 [v117] Fix screen order for password onboarding

### DIFF
--- a/Client/Application/AccessibilityIdentifiers.swift
+++ b/Client/Application/AccessibilityIdentifiers.swift
@@ -320,6 +320,8 @@ public struct AccessibilityIdentifiers {
             static let passwordField = "passwordField"
             static let websiteField = "websiteField"
             static let onboardingContinue = "onboardingContinue"
+            static let addCredentialButton = "addCredentialButton"
+            static let editButton = "editButton"
         }
 
         struct Version {

--- a/Client/Application/AccessibilityIdentifiers.swift
+++ b/Client/Application/AccessibilityIdentifiers.swift
@@ -319,6 +319,7 @@ public struct AccessibilityIdentifiers {
             static let usernameField = "usernameField"
             static let passwordField = "passwordField"
             static let websiteField = "websiteField"
+            static let onboardingContinue = "onboardingContinue"
         }
 
         struct Version {

--- a/Client/Coordinators/PasswordManagerCoordinator.swift
+++ b/Client/Coordinators/PasswordManagerCoordinator.swift
@@ -12,6 +12,7 @@ protocol PasswordManagerCoordinatorDelegate: AnyObject {
 
 protocol PasswordManagerFlowDelegate: AnyObject {
     func continueFromOnboarding()
+    func showDevicePassCode()
     func pressedPasswordDetail(model: PasswordDetailViewControllerModel)
     func pressedAddPassword(completion: @escaping (LoginEntry) -> Void)
     func openURL(url: URL)
@@ -47,6 +48,12 @@ class PasswordManagerCoordinator: BaseCoordinator,
         let viewController = PasswordManagerOnboardingViewController()
         viewController.coordinator = self
         router.push(viewController)
+    }
+
+    func showDevicePassCode() {
+        let passcodeViewController = DevicePasscodeRequiredViewController()
+        passcodeViewController.profile = profile
+        router.push(passcodeViewController)
     }
 
     // MARK: - PasswordManagerFlowDelegate

--- a/Client/Frontend/PasswordManagement/PasswordManagerListViewController.swift
+++ b/Client/Frontend/PasswordManagement/PasswordManagerListViewController.swift
@@ -236,6 +236,8 @@ class PasswordManagerListViewController: SensitiveViewController, Themeable {
                                                      action: #selector(cancelSelection))
 
     fileprivate func setupDefaultNavButtons() {
+        addCredentialButton.accessibilityIdentifier = AccessibilityIdentifiers.Settings.Passwords.addCredentialButton
+        editButton.accessibilityIdentifier = AccessibilityIdentifiers.Settings.Passwords.editButton
         navigationItem.rightBarButtonItems = [editButton, addCredentialButton]
 
         if shownFromAppMenu {

--- a/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
+++ b/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
@@ -103,13 +103,13 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
     @objc
     func proceedButtonTapped(_ sender: UIButton) {
         if CoordinatorFlagManager.isSettingsCoordinatorEnabled && !shownFromAppMenu {
-            continueToOnboarding()
+            continueFromOnboarding()
         } else {
             proceedHandler()
         }
     }
 
-    private func continueToOnboarding() {
+    private func continueFromOnboarding() {
         appAuthenticator.getAuthenticationState { state in
             switch state {
             case .deviceOwnerAuthenticated:

--- a/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
+++ b/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
@@ -32,6 +32,7 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
         button.translatesAutoresizingMaskIntoConstraints = false
         button.layer.cornerRadius = 8
         button.setTitle(.LoginsOnboardingContinueButtonTitle, for: .normal)
+        button.accessibilityIdentifier = AccessibilityIdentifiers.Settings.Passwords.onboardingContinue
         button.titleLabel?.font = LegacyDynamicFontHelper().MediumSizeBoldFontAS
         button.titleEdgeInsets = UIEdgeInsets(top: 0, left: 15, bottom: 0, right: 0)
         button.addTarget(self, action: #selector(proceedButtonTapped), for: .touchUpInside)

--- a/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
+++ b/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
@@ -39,11 +39,16 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
     }()
 
     weak var coordinator: PasswordManagerFlowDelegate?
+    private var appAuthenticator: AppAuthenticationProtocol
 
     var doneHandler: () -> Void = {}
     var proceedHandler: () -> Void = {}
 
-    init(profile: Profile? = nil, tabManager: TabManager? = nil, shownFromAppMenu: Bool = false) {
+    init(profile: Profile? = nil,
+         tabManager: TabManager? = nil,
+         shownFromAppMenu: Bool = false,
+         appAuthenticator: AppAuthenticationProtocol = AppAuthenticator()) {
+        self.appAuthenticator = appAuthenticator
         super.init(profile: profile, tabManager: tabManager)
         self.shownFromAppMenu = shownFromAppMenu
     }
@@ -56,7 +61,9 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
         super.viewDidLoad()
 
         if shownFromAppMenu {
-            navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(doneButtonTapped))
+            navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel,
+                                                               target: self,
+                                                               action: #selector(doneButtonTapped))
         }
 
         self.title = .Settings.Passwords.Title
@@ -96,9 +103,22 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
     @objc
     func proceedButtonTapped(_ sender: UIButton) {
         if CoordinatorFlagManager.isSettingsCoordinatorEnabled && !shownFromAppMenu {
-            coordinator?.continueFromOnboarding()
+            continueToOnboarding()
         } else {
             proceedHandler()
+        }
+    }
+
+    private func continueToOnboarding() {
+        appAuthenticator.getAuthenticationState { state in
+            switch state {
+            case .deviceOwnerAuthenticated:
+                self.coordinator?.continueFromOnboarding()
+            case .deviceOwnerFailed:
+                break // Keep showing the main settings page
+            case .passCodeRequired:
+                self.coordinator?.showDevicePassCode()
+            }
         }
     }
 

--- a/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -128,19 +128,6 @@ class AppSettingsTableViewController: SettingsTableViewController,
         settingsDelegate?.didFinish()
     }
 
-    // MARK: Handle Route decisions
-
-    func handle(route: Route.SettingsSection) {
-        switch route {
-        case .creditCard, .password:
-            authenticateUserFor(route: route)
-        case .rateApp:
-            RatingPromptManager.goToAppStoreReview()
-        default:
-            break
-        }
-    }
-
     private func setupNavigationBar() {
         navigationItem.title = String.AppSettingsTitle
         if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
@@ -155,6 +142,31 @@ class AppSettingsTableViewController: SettingsTableViewController,
                 style: .done,
                 target: navigationController,
                 action: #selector((navigationController as! ThemedNavigationController).done))
+        }
+    }
+
+    // MARK: Handle Route decisions
+
+    func handle(route: Route.SettingsSection) {
+        switch route {
+        case .password:
+            handlePasswordFlow(route: route)
+        case .creditCard:
+            authenticateUserFor(route: route)
+        case .rateApp:
+            RatingPromptManager.goToAppStoreReview()
+        default:
+            break
+        }
+    }
+
+    private func handlePasswordFlow(route: Route.SettingsSection) {
+        // Show password onboarding before we authenticate
+        if LoginOnboarding.shouldShow() {
+            parentCoordinator?.showPasswordManager(shouldShowOnboarding: true)
+            LoginOnboarding.setShown()
+        } else {
+            authenticateUserFor(route: route)
         }
     }
 
@@ -178,8 +190,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
         case .creditCard:
             self.parentCoordinator?.showCreditCardSettings()
         case .password:
-            self.parentCoordinator?.showPasswordManager(shouldShowOnboarding: LoginOnboarding.shouldShow())
-            LoginOnboarding.setShown()
+            self.parentCoordinator?.showPasswordManager(shouldShowOnboarding: false)
         default:
             break
         }

--- a/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
@@ -60,31 +60,31 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
 
     func testWebViewContextMenu () throws {
         throw XCTSkip("Failing a lot and now new strings here")
-        // Drag the context menu up to show all the options
-        func drag() {
-            let window = XCUIApplication().windows.element(boundBy: 0)
-            let start = window.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.95))
-            let finish = window.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
-            start.press(forDuration: 0.01, thenDragTo: finish)
-        }
-
-        // Link
-        navigator.openURL("http://wikipedia.org")
-        waitForNoExistence(app.staticTexts["XCUITests-Runner pasted from Fennec"])
-        waitForExistence(app.webViews.element(boundBy: 0).links.element(boundBy: 0), timeout: 5)
-        navigator.goto(WebLinkContextMenu)
-        drag()
-        snapshot("WebViewContextMenu-01-link")
-        navigator.back()
-
-        // Image
-        navigator.openURL("http://wikipedia.org")
-        waitForNoExistence(app.staticTexts["XCUITests-Runner pasted from Fennec"])
-        waitForExistence(app.webViews.element(boundBy: 0).images.element(boundBy: 0), timeout: 5)
-        navigator.goto(WebImageContextMenu)
-        drag()
-        snapshot("WebViewContextMenu-02-image")
-        navigator.back()
+//        // Drag the context menu up to show all the options
+//        func drag() {
+//            let window = XCUIApplication().windows.element(boundBy: 0)
+//            let start = window.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.95))
+//            let finish = window.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+//            start.press(forDuration: 0.01, thenDragTo: finish)
+//        }
+//
+//        // Link
+//        navigator.openURL("http://wikipedia.org")
+//        waitForNoExistence(app.staticTexts["XCUITests-Runner pasted from Fennec"])
+//        waitForExistence(app.webViews.element(boundBy: 0).links.element(boundBy: 0), timeout: 5)
+//        navigator.goto(WebLinkContextMenu)
+//        drag()
+//        snapshot("WebViewContextMenu-01-link")
+//        navigator.back()
+//
+//        // Image
+//        navigator.openURL("http://wikipedia.org")
+//        waitForNoExistence(app.staticTexts["XCUITests-Runner pasted from Fennec"])
+//        waitForExistence(app.webViews.element(boundBy: 0).images.element(boundBy: 0), timeout: 5)
+//        navigator.goto(WebImageContextMenu)
+//        drag()
+//        snapshot("WebViewContextMenu-02-image")
+//        navigator.back()
     }
 
     func testWebViewAuthenticationDialog() {

--- a/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
@@ -130,7 +130,7 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         passcodeInput.typeText("foo\n")
 
         waitForExistence(app.tables["Login List"], timeout: 10)
-        app.buttons.element(boundBy: 1).tap()
+        app.buttons[AccessibilityIdentifiers.Settings.Passwords.addCredentialButton].tap()
         waitForExistence(app.tables["Add Credential"], timeout: 10)
         snapshot("CreateLogin")
         app.tables["Add Credential"].cells.element(boundBy: 0).tap()

--- a/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
@@ -121,8 +121,10 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         app.cells["Logins"].tap()
 
         waitForExistence(app.navigationBars.element(boundBy: 0), timeout: 3)
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Settings.Passwords.onboardingContinue])
-        app.buttons[AccessibilityIdentifiers.Settings.Passwords.onboardingContinue].tap()
+        // Press continue button on the password onboarding if it's shown
+        if app.buttons[AccessibilityIdentifiers.Settings.Passwords.onboardingContinue].exists {
+            app.buttons[AccessibilityIdentifiers.Settings.Passwords.onboardingContinue].tap()
+        }
 
         let passcodeInput = springboard.secureTextFields.firstMatch
         waitForExistence(passcodeInput, timeout: 30)

--- a/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
@@ -121,8 +121,8 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         app.cells["Logins"].tap()
 
         waitForExistence(app.navigationBars.element(boundBy: 0), timeout: 3)
-        waitForExistence(app.otherElements.buttons.element(boundBy: 2))
-        app.otherElements.buttons.element(boundBy: 2).tap()
+        waitForExistence(app.buttons[AccessibilityIdentifiers.Settings.Passwords.onboardingContinue])
+        app.buttons[AccessibilityIdentifiers.Settings.Passwords.onboardingContinue].tap()
 
         let passcodeInput = springboard.secureTextFields.firstMatch
         waitForExistence(passcodeInput, timeout: 30)

--- a/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
@@ -120,32 +120,17 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         waitForExistence(app.cells["Logins"], timeout: 15)
         app.cells["Logins"].tap()
 
-        // First time only: The message "Your passwords are now protected
-        // by Face ID..." is present when the Firefox app is run after the
-        // simulator has been erased.
-        // The biometric screen is supposed to appear here.
-        // https://github.com/mozilla-mobile/firefox-ios/issues/15642
-        // waitForExistence(app.navigationBars.element(boundBy: 0), timeout: 3)
-        // waitForExistence(app.otherElements.buttons.element(boundBy: 2))
-        // app.otherElements.buttons.element(boundBy: 2).tap()
+        waitForExistence(app.navigationBars.element(boundBy: 0), timeout: 3)
+        waitForExistence(app.otherElements.buttons.element(boundBy: 2))
+        app.otherElements.buttons.element(boundBy: 2).tap()
 
         let passcodeInput = springboard.secureTextFields.firstMatch
         waitForExistence(passcodeInput, timeout: 30)
-        snapshot("PasscodeInput")
         passcodeInput.tap()
         passcodeInput.typeText("foo\n")
 
-        // The biometric screen is not supposed to be here during the first run.
-        // This snippet is here as a workaround.
-        // https://github.com/mozilla-mobile/firefox-ios/issues/15642
-        waitForNoExistence(passcodeInput)
-        snapshot("BiometricScreen")
-        if app.otherElements.buttons.staticTexts.element(boundBy: 5).exists {
-            app.otherElements.buttons.staticTexts.element(boundBy: 5).tap()
-        }
-
         waitForExistence(app.tables["Login List"], timeout: 10)
-        app.buttons.element(boundBy: 2).tap()
+        app.buttons.element(boundBy: 1).tap()
         waitForExistence(app.tables["Add Credential"], timeout: 10)
         snapshot("CreateLogin")
         app.tables["Add Credential"].cells.element(boundBy: 0).tap()

--- a/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
@@ -120,7 +120,6 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         waitForExistence(app.cells["Logins"], timeout: 15)
         app.cells["Logins"].tap()
 
-        waitForExistence(app.navigationBars.element(boundBy: 0), timeout: 3)
         // Press continue button on the password onboarding if it's shown
         if app.buttons[AccessibilityIdentifiers.Settings.Passwords.onboardingContinue].exists {
             app.buttons[AccessibilityIdentifiers.Settings.Passwords.onboardingContinue].tap()

--- a/Tests/ClientTests/Coordinators/PasswordManagerCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/PasswordManagerCoordinatorTests.swift
@@ -110,6 +110,15 @@ final class PasswordManagerCoordinatorTests: XCTestCase {
         XCTAssertTrue(navigationController?.viewControllers.first is AddCredentialViewController)
     }
 
+    func testShowDevicePassCode() {
+        let subject = createSubject()
+
+        subject.showDevicePassCode()
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+        XCTAssertTrue(mockRouter.pushedViewController is DevicePasscodeRequiredViewController)
+    }
+
     // MARK: - Helper
     func createSubject() -> PasswordManagerCoordinator {
         let subject = PasswordManagerCoordinator(router: mockRouter, profile: MockProfile())

--- a/Tests/ClientTests/Mocks/MockSettingsFlowDelegate.swift
+++ b/Tests/ClientTests/Mocks/MockSettingsFlowDelegate.swift
@@ -17,6 +17,7 @@ class MockSettingsFlowDelegate: SettingsFlowDelegate,
     var didFinishShowingSettingsCalled = 0
     var showExperimentsCalled = 0
     var showPasswordManagerCalled = 0
+    var savedShouldShowOnboarding: Bool = false
 
     func showDevicePassCode() {
         showDevicePassCodeCalled += 1
@@ -35,6 +36,7 @@ class MockSettingsFlowDelegate: SettingsFlowDelegate,
     }
 
     func showPasswordManager(shouldShowOnboarding: Bool) {
+        savedShouldShowOnboarding = shouldShowOnboarding
         showPasswordManagerCalled += 1
     }
 

--- a/Tests/ClientTests/Mocks/MockSettingsFlowDelegate.swift
+++ b/Tests/ClientTests/Mocks/MockSettingsFlowDelegate.swift
@@ -17,7 +17,7 @@ class MockSettingsFlowDelegate: SettingsFlowDelegate,
     var didFinishShowingSettingsCalled = 0
     var showExperimentsCalled = 0
     var showPasswordManagerCalled = 0
-    var savedShouldShowOnboarding: Bool = false
+    var savedShouldShowOnboarding = false
 
     func showDevicePassCode() {
         showDevicePassCodeCalled += 1

--- a/Tests/ClientTests/Settings/AppSettingsTableViewControllerTests.swift
+++ b/Tests/ClientTests/Settings/AppSettingsTableViewControllerTests.swift
@@ -72,6 +72,29 @@ class AppSettingsTableViewControllerTests: XCTestCase {
         XCTAssertEqual(delegate.showCreditCardSettingsCalled, 0)
     }
 
+    func testPassword_whenNeedShowingLoginOnboarding_showOnboarding() {
+        UserDefaults.standard.set(false, forKey: LoginOnboarding.HasSeenLoginOnboardingKey)
+        let subject = createSubject()
+        subject.parentCoordinator = delegate
+
+        subject.handle(route: .password)
+
+        XCTAssertEqual(delegate.showPasswordManagerCalled, 1)
+        XCTAssertTrue(delegate.savedShouldShowOnboarding)
+    }
+
+    func testPassword_whenHasAlreadyShownLoginOnboarding_authenticateAndShowPassword() {
+        appAuthenticator.authenticationState = .deviceOwnerAuthenticated
+        UserDefaults.standard.set(true, forKey: LoginOnboarding.HasSeenLoginOnboardingKey)
+        let subject = createSubject()
+        subject.parentCoordinator = delegate
+
+        subject.handle(route: .password)
+
+        XCTAssertEqual(delegate.showPasswordManagerCalled, 1)
+        XCTAssertFalse(delegate.savedShouldShowOnboarding)
+    }
+
     func testPressedShowTour_openOnboardingDeeplinkURL() {
         let subject = createSubject()
         subject.parentCoordinator = delegate

--- a/Tests/XCUITests/IntegrationTests.swift
+++ b/Tests/XCUITests/IntegrationTests.swift
@@ -199,13 +199,13 @@ class IntegrationTests: BaseTestCase {
         navigator.nowAt(SettingsScreen)
         navigator.goto(LoginsSettings)
         waitForExistence(app.buttons.firstMatch)
-
+        app.buttons["Continue"].tap()
+        
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
         let passcodeInput = springboard.secureTextFields["Passcode field"]
         passcodeInput.tap()
         passcodeInput.typeText("foo\n")
 
-        app.buttons["Continue"].tap()
         navigator.goto(LoginsSettings)
         waitForExistence(app.tables["Login List"], timeout: 5)
         XCTAssertTrue(app.tables.cells.staticTexts[loginEntry].exists, "The login saved on desktop is not synced")
@@ -251,13 +251,13 @@ class IntegrationTests: BaseTestCase {
         navigator.nowAt(SettingsScreen)
         navigator.goto(LoginsSettings)
         waitForExistence(app.buttons.firstMatch)
+        app.buttons["Continue"].tap()
 
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
         let passcodeInput = springboard.secureTextFields["Passcode field"]
         passcodeInput.tap()
         passcodeInput.typeText("foo\n")
 
-        app.buttons["Continue"].tap()
         waitForExistence(app.tables["Login List"], timeout: 3)
         // Verify the login
         waitForExistence(app.staticTexts["https://accounts.google.com"])

--- a/Tests/XCUITests/IntegrationTests.swift
+++ b/Tests/XCUITests/IntegrationTests.swift
@@ -200,7 +200,7 @@ class IntegrationTests: BaseTestCase {
         navigator.goto(LoginsSettings)
         waitForExistence(app.buttons.firstMatch)
         app.buttons["Continue"].tap()
-        
+
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
         let passcodeInput = springboard.secureTextFields["Passcode field"]
         passcodeInput.tap()

--- a/Tests/XCUITests/SaveLoginsTests.swift
+++ b/Tests/XCUITests/SaveLoginsTests.swift
@@ -44,15 +44,6 @@ class SaveLoginTest: BaseTestCase {
         waitForExistence(passcodeInput, timeout: 20)
         passcodeInput.tap()
         passcodeInput.typeText("foo\n")
-
-        // This biometric screen only appears the first time.
-        // The location of this if-statement is a temporary workaround for FXIOS-7033.
-        // This if-statement is supposed to be located before the passcode is entered.
-        // https://github.com/mozilla-mobile/firefox-ios/issues/15642
-        sleep(2)
-        if app.otherElements.buttons["Continue"].exists {
-            app.otherElements.buttons["Continue"].tap()
-        }
     }
 
     func testLoginsListFromBrowserTabMenu() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7013)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15642)

## :bulb: Description
The `PasswordManagerOnboardingViewController` should be shown before we ask the user to authenticate, as it was done before coordinator were used. This fixes that by:
- Checking in `AppSettingsTableViewController` if we need to show the password onboarding before asking to authenticate. Coordinator calls were adjusted for this.
- Making sure we then authenticate after the onboarding in `PasswordManagerOnboardingViewController`, making calls to the right coordinator methods.
- Added unit tests

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

