### PR TITLE
Bugfix FXIOS-7176 [v116] Unowned self reference error in RustSyncManagerAPI.sync function

### DIFF
--- a/Sync/RustSyncManagerAPI.swift
+++ b/Sync/RustSyncManagerAPI.swift
@@ -34,19 +34,20 @@ open class RustSyncManagerAPI {
 
     public func sync(params: SyncParams,
                      completion: @escaping (SyncResult) -> Void) {
-        DispatchQueue.global().async { [unowned self] in
+        DispatchQueue.global().async { [weak self] in
             do {
-                let result = try self.api.sync(params: params)
+                guard let result = try self?.api.sync(params: params) else { return }
+
                 completion(result)
             } catch let err as NSError {
                 if let syncError = err as? SyncManagerError {
                     let syncErrDescription = syncError.localizedDescription
-                    self.logger.log("Rust SyncManager sync error: \(syncErrDescription)",
-                                    level: .warning,
-                                    category: .sync)
+                    self?.logger.log("Rust SyncManager sync error: \(syncErrDescription)",
+                                     level: .warning,
+                                     category: .sync)
                 } else {
                     let errDescription = err.localizedDescription
-                    self.logger.log("""
+                    self?.logger.log("""
                         Unknown error when attempting a rust SyncManager sync:
                         \(errDescription)
                         """,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7176)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15946)

## :bulb: Description
This should fix a low-volume crasher in the error handling of the `RustSyncManagerAPI.sync` function where `unowned self` allows referencing after deallocation.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

