### PR TITLE
Bugfix FXIOS-7135 [v117] Settings button replaced with back button in tracking protection screen

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		210E0EBA298D9D6400BB4F33 /* OpenSearchEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1E3BE528CBBF44003388C4 /* OpenSearchEngine.swift */; };
 		210E0EBB298D9D6600BB4F33 /* OpenSearchEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1E3BE528CBBF44003388C4 /* OpenSearchEngine.swift */; };
 		211046C92A7ADE9000A7309F /* BlockPopupSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211046C82A7ADE9000A7309F /* BlockPopupSetting.swift */; };
+		211046CD2A7D842A00A7309F /* TPAccessoryInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211046CC2A7D842A00A7309F /* TPAccessoryInfo.swift */; };
 		21112968289480630082C08B /* HomepageMessageCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21112967289480630082C08B /* HomepageMessageCardViewModel.swift */; };
 		211F00AC27F4D918001D9189 /* HistoryPanel+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211F00AB27F4D918001D9189 /* HistoryPanel+Search.swift */; };
 		2128E27B292E624400FB91BE /* SendToDeviceActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2128E27A292E624400FB91BE /* SendToDeviceActivity.swift */; };
@@ -2084,6 +2085,7 @@
 		210887CB293E8800000AB4EE /* RemoteTabsErrorCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabsErrorCell.swift; sourceTree = "<group>"; };
 		2109478828AFD24C00B73D44 /* OnboardingViewControllerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewControllerProtocol.swift; sourceTree = "<group>"; };
 		211046C82A7ADE9000A7309F /* BlockPopupSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockPopupSetting.swift; sourceTree = "<group>"; };
+		211046CC2A7D842A00A7309F /* TPAccessoryInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPAccessoryInfo.swift; sourceTree = "<group>"; };
 		21112967289480630082C08B /* HomepageMessageCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageMessageCardViewModel.swift; sourceTree = "<group>"; };
 		211F00AB27F4D918001D9189 /* HistoryPanel+Search.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HistoryPanel+Search.swift"; sourceTree = "<group>"; };
 		2128E27A292E624400FB91BE /* SendToDeviceActivity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendToDeviceActivity.swift; sourceTree = "<group>"; };
@@ -7409,6 +7411,7 @@
 				CEFA977D1FAA6B490016F365 /* SyncContentSettingsViewController.swift */,
 				8AE1E1CE27B191160024C45E /* SearchBar */,
 				C22753422A3CA25100B9C0D1 /* WebsiteDataManagement */,
+				211046CC2A7D842A00A7309F /* TPAccessoryInfo.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -12905,6 +12908,7 @@
 				C23889E12A4F3E7200429673 /* ParentCoordinatorDelegate.swift in Sources */,
 				8AD40FCD27BADC5C00672675 /* TabLocationContainerView.swift in Sources */,
 				8A720C602A4C8B700003018A /* SharedSettingsDelegate.swift in Sources */,
+				211046CD2A7D842A00A7309F /* TPAccessoryInfo.swift in Sources */,
 				5AE371872A4E11750092A760 /* AboutSettingsDelegate.swift in Sources */,
 				E18EA57128AD46D3003F97FC /* WallpaperCollectionType.swift in Sources */,
 				C84655E42887394B00861B4A /* WallpaperMetadata.swift in Sources */,

--- a/Client/Application/AccessibilityIdentifiers.swift
+++ b/Client/Application/AccessibilityIdentifiers.swift
@@ -324,6 +324,11 @@ public struct AccessibilityIdentifiers {
         struct Version {
             static let title = "FxVersion"
         }
+
+        struct TrackingProtection {
+            static let basic = "Settings.TrackingProtectionOption.BlockListBasic"
+            static let strict = "Settings.TrackingProtectionOption.BlockListStrict"
+        }
     }
 
     struct ShareTo {

--- a/Client/Coordinators/SettingsCoordinator.swift
+++ b/Client/Coordinators/SettingsCoordinator.swift
@@ -116,7 +116,8 @@ class SettingsCoordinator: BaseCoordinator,
             }
 
         case .contentBlocker:
-            let contentBlockerVC = ContentBlockerSettingViewController(prefs: profile.prefs)
+            let contentBlockerVC = ContentBlockerSettingViewController(prefs: profile.prefs,
+                                                                       isPresentedFromSettings: false)
             contentBlockerVC.settingsDelegate = self
             contentBlockerVC.profile = profile
             contentBlockerVC.tabManager = tabManager

--- a/Client/Coordinators/SettingsCoordinator.swift
+++ b/Client/Coordinators/SettingsCoordinator.swift
@@ -117,7 +117,7 @@ class SettingsCoordinator: BaseCoordinator,
 
         case .contentBlocker:
             let contentBlockerVC = ContentBlockerSettingViewController(prefs: profile.prefs,
-                                                                       isPresentedFromSettings: false)
+                                                                       isShownFromSettings: false)
             contentBlockerVC.settingsDelegate = self
             contentBlockerVC.profile = profile
             contentBlockerVC.tabManager = tabManager

--- a/Client/Coordinators/SettingsCoordinator.swift
+++ b/Client/Coordinators/SettingsCoordinator.swift
@@ -117,6 +117,7 @@ class SettingsCoordinator: BaseCoordinator,
 
         case .contentBlocker:
             let contentBlockerVC = ContentBlockerSettingViewController(prefs: profile.prefs)
+            contentBlockerVC.settingsDelegate = self
             contentBlockerVC.profile = profile
             contentBlockerVC.tabManager = tabManager
             return contentBlockerVC
@@ -195,6 +196,7 @@ class SettingsCoordinator: BaseCoordinator,
 
     func pressedContentBlocker() {
         let viewController = ContentBlockerSettingViewController(prefs: profile.prefs)
+        viewController.settingsDelegate = self
         viewController.profile = profile
         viewController.tabManager = tabManager
         router.push(viewController)

--- a/Client/Frontend/Browser/FirefoxTabContentBlocker.swift
+++ b/Client/Frontend/Browser/FirefoxTabContentBlocker.swift
@@ -24,6 +24,44 @@ enum BlockingStrength: String {
     static let allOptions: [BlockingStrength] = [.basic, .strict]
 }
 
+extension BlockingStrength {
+    var settingStatus: String {
+        switch self {
+        case .basic:
+            return .TrackingProtectionOptionBlockListLevelStandardStatus
+        case .strict:
+            return .TrackingProtectionOptionBlockListLevelStrict
+        }
+    }
+
+    var settingTitle: String {
+        switch self {
+        case .basic:
+            return .TrackingProtectionOptionBlockListLevelStandard
+        case .strict:
+            return .TrackingProtectionOptionBlockListLevelStrict
+        }
+    }
+
+    var settingSubtitle: String {
+        switch self {
+        case .basic:
+            return .TrackingProtectionStandardLevelDescription
+        case .strict:
+            return .TrackingProtectionStrictLevelDescription
+        }
+    }
+
+    static func accessibilityId(for strength: BlockingStrength) -> String {
+        switch strength {
+        case .basic:
+            return "Settings.TrackingProtectionOption.BlockListBasic"
+        case .strict:
+            return "Settings.TrackingProtectionOption.BlockListStrict"
+        }
+    }
+}
+
 /// Firefox-specific implementation of tab content blocking.
 class FirefoxTabContentBlocker: TabContentBlocker, TabContentScript {
     let userPrefs: Prefs

--- a/Client/Frontend/Browser/FirefoxTabContentBlocker.swift
+++ b/Client/Frontend/Browser/FirefoxTabContentBlocker.swift
@@ -55,9 +55,9 @@ extension BlockingStrength {
     static func accessibilityId(for strength: BlockingStrength) -> String {
         switch strength {
         case .basic:
-            return "Settings.TrackingProtectionOption.BlockListBasic"
+            return AccessibilityIdentifiers.Settings.TrackingProtection.basic
         case .strict:
-            return "Settings.TrackingProtectionOption.BlockListStrict"
+            return AccessibilityIdentifiers.Settings.TrackingProtection.strict
         }
     }
 }

--- a/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -6,163 +6,6 @@ import Common
 import Foundation
 import Shared
 
-extension BlockingStrength {
-    var settingStatus: String {
-        switch self {
-        case .basic:
-            return .TrackingProtectionOptionBlockListLevelStandardStatus
-        case .strict:
-            return .TrackingProtectionOptionBlockListLevelStrict
-        }
-    }
-
-    var settingTitle: String {
-        switch self {
-        case .basic:
-            return .TrackingProtectionOptionBlockListLevelStandard
-        case .strict:
-            return .TrackingProtectionOptionBlockListLevelStrict
-        }
-    }
-
-    var settingSubtitle: String {
-        switch self {
-        case .basic:
-            return .TrackingProtectionStandardLevelDescription
-        case .strict:
-            return .TrackingProtectionStrictLevelDescription
-        }
-    }
-
-    static func accessibilityId(for strength: BlockingStrength) -> String {
-        switch strength {
-        case .basic:
-            return "Settings.TrackingProtectionOption.BlockListBasic"
-        case .strict:
-            return "Settings.TrackingProtectionOption.BlockListStrict"
-        }
-    }
-}
-
-// MARK: Additional information shown when the info accessory button is tapped.
-class TPAccessoryInfo: ThemedTableViewController {
-    var isStrictMode = false
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        tableView.register(cellType: ThemedSubtitleTableViewCell.self)
-        tableView.estimatedRowHeight = 130
-        tableView.rowHeight = UITableView.automaticDimension
-        tableView.separatorStyle = .none
-
-        tableView.sectionHeaderHeight = 0
-        tableView.sectionFooterHeight = 0
-        applyTheme()
-        listenForThemeChange(view)
-    }
-
-    func headerView() -> UIView {
-        let stack = UIStackView(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: 10))
-        stack.axis = .vertical
-
-        let header = UILabel()
-        header.text = .TPAccessoryInfoBlocksTitle
-        header.font = LegacyDynamicFontHelper.defaultHelper.DefaultMediumBoldFont
-        header.textColor = themeManager.currentTheme.colors.textSecondary
-
-        stack.addArrangedSubview(UIView())
-        stack.addArrangedSubview(header)
-
-        stack.layoutMargins = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
-        stack.isLayoutMarginsRelativeArrangement = true
-
-        let topStack = UIStackView(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: 40))
-        topStack.axis = .vertical
-        let sep = UIView()
-        topStack.addArrangedSubview(stack)
-        topStack.addArrangedSubview(sep)
-        topStack.spacing = 10
-
-        topStack.layoutMargins = UIEdgeInsets(top: 8, left: 0, bottom: 0, right: 0)
-        topStack.isLayoutMarginsRelativeArrangement = true
-
-        sep.backgroundColor = themeManager.currentTheme.colors.borderPrimary
-        sep.snp.makeConstraints { make in
-            make.height.equalTo(0.5)
-            make.width.equalToSuperview()
-        }
-        return topStack
-    }
-
-    override func applyTheme() {
-        super.applyTheme()
-        tableView.tableHeaderView = headerView()
-    }
-
-    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 2
-    }
-
-    override func numberOfSections(in tableView: UITableView) -> Int {
-        return isStrictMode ? 5 : 4
-    }
-
-    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = dequeueCellFor(indexPath: indexPath)
-        cell.applyTheme(theme: themeManager.currentTheme)
-        if indexPath.section == 0 {
-            if indexPath.row == 0 {
-                cell.textLabel?.text = .TPSocialBlocked
-            } else {
-                cell.textLabel?.text = .TPCategoryDescriptionSocial
-            }
-        } else if indexPath.section == 1 {
-            if indexPath.row == 0 {
-                cell.textLabel?.text = .TPCrossSiteBlocked
-            } else {
-                cell.textLabel?.text = .TPCategoryDescriptionCrossSite
-            }
-        } else if indexPath.section == 2 {
-            if indexPath.row == 0 {
-                cell.textLabel?.text = .TPCryptominersBlocked
-            } else {
-                cell.textLabel?.text = .TPCategoryDescriptionCryptominers
-            }
-        } else if indexPath.section == 3 {
-            if indexPath.row == 0 {
-                cell.textLabel?.text = .TPFingerprintersBlocked
-            } else {
-                cell.textLabel?.text = .TPCategoryDescriptionFingerprinters
-            }
-        } else if indexPath.section == 4 {
-            if indexPath.row == 0 {
-                cell.textLabel?.text = .TPContentBlocked
-            } else {
-                cell.textLabel?.text = .TPCategoryDescriptionContentTrackers
-            }
-        }
-        cell.imageView?.tintColor = themeManager.currentTheme.colors.iconPrimary
-        if indexPath.row == 1 {
-            cell.textLabel?.font = LegacyDynamicFontHelper.defaultHelper.DefaultMediumFont
-        }
-        cell.textLabel?.numberOfLines = 0
-        cell.detailTextLabel?.numberOfLines = 0
-        cell.backgroundColor = .clear
-        cell.textLabel?.textColor = themeManager.currentTheme.colors.textPrimary
-        cell.selectionStyle = .none
-        return cell
-    }
-
-    override func dequeueCellFor(indexPath: IndexPath) -> ThemedTableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: ThemedSubtitleTableViewCell.cellIdentifier, for: indexPath) as? ThemedSubtitleTableViewCell
-        else {
-            return ThemedSubtitleTableViewCell()
-        }
-        return cell
-    }
-}
-
 class ContentBlockerSettingViewController: SettingsTableViewController {
     private let button = UIButton()
     let prefs: Prefs
@@ -176,6 +19,12 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
         super.init(style: .grouped)
 
         self.title = .SettingsTrackingProtectionSectionName
+
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            title: .AppSettingsDone,
+            style: .plain,
+            target: self,
+            action: #selector(done))
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -305,5 +154,10 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
         let viewController = SettingsContentViewController()
         viewController.url = SupportUtils.URLForTopic("tracking-protection-ios")
         navigationController?.pushViewController(viewController, animated: true)
+    }
+
+    @objc
+    func done() {
+        settingsDelegate?.didFinish()
     }
 }

--- a/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -11,7 +11,8 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
     let prefs: Prefs
     var currentBlockingStrength: BlockingStrength
 
-    init(prefs: Prefs) {
+    init(prefs: Prefs,
+         isShownFromSettings: Bool = true) {
         self.prefs = prefs
 
         currentBlockingStrength = prefs.stringForKey(ContentBlockingConfig.Prefs.StrengthKey).flatMap({BlockingStrength(rawValue: $0)}) ?? .basic
@@ -20,11 +21,13 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
 
         self.title = .SettingsTrackingProtectionSectionName
 
-        navigationItem.rightBarButtonItem = UIBarButtonItem(
-            title: .AppSettingsDone,
-            style: .plain,
-            target: self,
-            action: #selector(done))
+        if !isShownFromSettings {
+            navigationItem.rightBarButtonItem = UIBarButtonItem(
+                title: .AppSettingsDone,
+                style: .plain,
+                target: self,
+                action: #selector(done))
+        }
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -192,7 +192,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
 
         switch deeplink {
         case .contentBlocker:
-            viewController = ContentBlockerSettingViewController(prefs: profile.prefs, isPresentedFromSettings: false)
+            viewController = ContentBlockerSettingViewController(prefs: profile.prefs, isShownFromSettings: false)
             viewController.tabManager = tabManager
 
         case .customizeHomepage:

--- a/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -100,6 +100,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
         self.profile = profile
         self.tabManager = tabManager
         self.settingsDelegate = delegate
+        navigationItem.title = String.AppSettingsTitle
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -100,7 +100,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
         self.profile = profile
         self.tabManager = tabManager
         self.settingsDelegate = delegate
-        navigationItem.title = String.AppSettingsTitle
+        setupNavigationBar()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -111,21 +111,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        navigationItem.title = String.AppSettingsTitle
-        if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
-            navigationItem.rightBarButtonItem = UIBarButtonItem(
-                title: .AppSettingsDone,
-                style: .done,
-                target: self,
-                action: #selector(done))
-        } else {
-            navigationItem.rightBarButtonItem = UIBarButtonItem(
-                title: .AppSettingsDone,
-                style: .done,
-                target: navigationController,
-                action: #selector((navigationController as! ThemedNavigationController).done))
-        }
-
+        setupNavigationBar()
         navigationItem.rightBarButtonItem?.accessibilityIdentifier = AccessibilityIdentifiers.Settings.navigationBarItem
         tableView.accessibilityIdentifier = AccessibilityIdentifiers.Settings.tableViewController
 
@@ -152,6 +138,23 @@ class AppSettingsTableViewController: SettingsTableViewController,
             RatingPromptManager.goToAppStoreReview()
         default:
             break
+        }
+    }
+
+    private func setupNavigationBar() {
+        navigationItem.title = String.AppSettingsTitle
+        if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+            navigationItem.rightBarButtonItem = UIBarButtonItem(
+                title: .AppSettingsDone,
+                style: .done,
+                target: self,
+                action: #selector(done))
+        } else {
+            navigationItem.rightBarButtonItem = UIBarButtonItem(
+                title: .AppSettingsDone,
+                style: .done,
+                target: navigationController,
+                action: #selector((navigationController as! ThemedNavigationController).done))
         }
     }
 
@@ -189,7 +192,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
 
         switch deeplink {
         case .contentBlocker:
-            viewController = ContentBlockerSettingViewController(prefs: profile.prefs)
+            viewController = ContentBlockerSettingViewController(prefs: profile.prefs, isPresentedFromSettings: false)
             viewController.tabManager = tabManager
 
         case .customizeHomepage:

--- a/Client/Frontend/Settings/TPAccessoryInfo.swift
+++ b/Client/Frontend/Settings/TPAccessoryInfo.swift
@@ -1,0 +1,124 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+
+// MARK: Additional information shown when the info accessory button is tapped.
+class TPAccessoryInfo: ThemedTableViewController {
+    var isStrictMode = false
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        tableView.register(cellType: ThemedSubtitleTableViewCell.self)
+        tableView.estimatedRowHeight = 130
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.separatorStyle = .none
+
+        tableView.sectionHeaderHeight = 0
+        tableView.sectionFooterHeight = 0
+        applyTheme()
+        listenForThemeChange(view)
+    }
+
+    func headerView() -> UIView {
+        let stack = UIStackView(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: 10))
+        stack.axis = .vertical
+
+        let header = UILabel()
+        header.text = .TPAccessoryInfoBlocksTitle
+        header.font = LegacyDynamicFontHelper.defaultHelper.DefaultMediumBoldFont
+        header.textColor = themeManager.currentTheme.colors.textSecondary
+
+        stack.addArrangedSubview(UIView())
+        stack.addArrangedSubview(header)
+
+        stack.layoutMargins = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
+        stack.isLayoutMarginsRelativeArrangement = true
+
+        let topStack = UIStackView(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: 40))
+        topStack.axis = .vertical
+        let sep = UIView()
+        topStack.addArrangedSubview(stack)
+        topStack.addArrangedSubview(sep)
+        topStack.spacing = 10
+
+        topStack.layoutMargins = UIEdgeInsets(top: 8, left: 0, bottom: 0, right: 0)
+        topStack.isLayoutMarginsRelativeArrangement = true
+
+        sep.backgroundColor = themeManager.currentTheme.colors.borderPrimary
+        sep.snp.makeConstraints { make in
+            make.height.equalTo(0.5)
+            make.width.equalToSuperview()
+        }
+        return topStack
+    }
+
+    override func applyTheme() {
+        super.applyTheme()
+        tableView.tableHeaderView = headerView()
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 2
+    }
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return isStrictMode ? 5 : 4
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = dequeueCellFor(indexPath: indexPath)
+        cell.applyTheme(theme: themeManager.currentTheme)
+        if indexPath.section == 0 {
+            if indexPath.row == 0 {
+                cell.textLabel?.text = .TPSocialBlocked
+            } else {
+                cell.textLabel?.text = .TPCategoryDescriptionSocial
+            }
+        } else if indexPath.section == 1 {
+            if indexPath.row == 0 {
+                cell.textLabel?.text = .TPCrossSiteBlocked
+            } else {
+                cell.textLabel?.text = .TPCategoryDescriptionCrossSite
+            }
+        } else if indexPath.section == 2 {
+            if indexPath.row == 0 {
+                cell.textLabel?.text = .TPCryptominersBlocked
+            } else {
+                cell.textLabel?.text = .TPCategoryDescriptionCryptominers
+            }
+        } else if indexPath.section == 3 {
+            if indexPath.row == 0 {
+                cell.textLabel?.text = .TPFingerprintersBlocked
+            } else {
+                cell.textLabel?.text = .TPCategoryDescriptionFingerprinters
+            }
+        } else if indexPath.section == 4 {
+            if indexPath.row == 0 {
+                cell.textLabel?.text = .TPContentBlocked
+            } else {
+                cell.textLabel?.text = .TPCategoryDescriptionContentTrackers
+            }
+        }
+        cell.imageView?.tintColor = themeManager.currentTheme.colors.iconPrimary
+        if indexPath.row == 1 {
+            cell.textLabel?.font = LegacyDynamicFontHelper.defaultHelper.DefaultMediumFont
+        }
+        cell.textLabel?.numberOfLines = 0
+        cell.detailTextLabel?.numberOfLines = 0
+        cell.backgroundColor = .clear
+        cell.textLabel?.textColor = themeManager.currentTheme.colors.textPrimary
+        cell.selectionStyle = .none
+        return cell
+    }
+
+    override func dequeueCellFor(indexPath: IndexPath) -> ThemedTableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: ThemedSubtitleTableViewCell.cellIdentifier, for: indexPath) as? ThemedSubtitleTableViewCell
+        else {
+            return ThemedSubtitleTableViewCell()
+        }
+        return cell
+    }
+}

--- a/Tests/ClientTests/Settings/AppSettingsTableViewControllerTests.swift
+++ b/Tests/ClientTests/Settings/AppSettingsTableViewControllerTests.swift
@@ -16,6 +16,7 @@ class AppSettingsTableViewControllerTests: XCTestCase {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         self.profile = MockProfile()
+        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
         self.tabManager = TabManagerImplementation(profile: profile, imageStore: nil)
         self.appAuthenticator = MockAppAuthenticator()
         self.delegate = MockSettingsFlowDelegate()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7135)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15864)

## :bulb: Description
- Show the done button when Tracking protection settings are shown from ETP Bottom sheet and handle action on ViewController.
- Set navigation title for AppSettingsViewController on init for all paths leading to Settings subviews
- Move TPAccessoryInfo to its own file

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

