### PR TITLE
Bugfix FXIOS-6727 [v117] Fix isZeroSearch and contextual hint showing

### DIFF
--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -380,7 +380,7 @@ class HomepageViewController: UIViewController, FeatureFlaggable, Themeable, Con
     // Check if we already present something on top of the homepage,
     // if the homepage is actually being shown to the user and if the page is shown from a loaded webpage (zero search).
     private var canModalBePresented: Bool {
-        return presentedViewController == nil && !viewModel.isZeroSearch
+        return presentedViewController == nil && viewModel.isZeroSearch
     }
 
     // MARK: - Contextual hint


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6727)

## :bulb: Description
We need to show the contextual hint when the homepage is a Zero search page (so not shown from clicking the URL bar). Somehow we had a `!` which was working before we did the homepage coordinator changes. With the latest changes, we get this proper and we need to fix this issue otherwise the contextual hint doesn't appear on homepage.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

