### PR TITLE
Bugfix FXIOS-7085 [v118] Add logic to ignore or filter newState for actions handled by the Middleware

### DIFF
--- a/BrowserKit/Sources/Redux/Store.swift
+++ b/BrowserKit/Sources/Redux/Store.swift
@@ -62,6 +62,7 @@ public class Store<State: StateType>: DefaultDispatchStore {
 
     public func dispatch(_ action: Action) {
         let newState = reducer(state, action)
+        print("YRD newState \(action)")
 
         middlewares.forEach { middleware in
             middleware(newState, action)

--- a/BrowserKit/Sources/Redux/Store.swift
+++ b/BrowserKit/Sources/Redux/Store.swift
@@ -62,7 +62,6 @@ public class Store<State: StateType>: DefaultDispatchStore {
 
     public func dispatch(_ action: Action) {
         let newState = reducer(state, action)
-        print("YRD newState \(action)")
 
         middlewares.forEach { middleware in
             middleware(newState, action)

--- a/Client/Frontend/Settings/ThemeSettings/ThemeMiddleware.swift
+++ b/Client/Frontend/Settings/ThemeSettings/ThemeMiddleware.swift
@@ -53,7 +53,8 @@ class ThemeManagerMiddleware: ThemeManagerProvider {
         case ThemeSettingsAction.receivedSystemBrightnessChange:
             DispatchQueue.main.async {
                 self.updateThemeBasedOnSystemBrightness()
-                store.dispatch(ThemeSettingsAction.systemBrightnessChanged)
+                let systemBrightness = self.getScreenBrightness()
+                store.dispatch(ThemeSettingsAction.systemBrightnessChanged(systemBrightness))
             }
         default:
             break
@@ -64,7 +65,8 @@ class ThemeManagerMiddleware: ThemeManagerProvider {
         ThemeSettingsState(useSystemAppearance: legacyThemeManager.systemThemeIsOn,
                            isAutomaticBrightnessEnable: legacyThemeManager.automaticBrightnessIsOn,
                            manualThemeSelected: legacyThemeManager.currentName,
-                           userBrightnessThreshold: legacyThemeManager.automaticBrightnessValue)
+                           userBrightnessThreshold: legacyThemeManager.automaticBrightnessValue,
+                           systemBrightness: getScreenBrightness())
     }
 
     func toggleUseSystemAppearance(_ enabled: Bool) {
@@ -90,5 +92,9 @@ class ThemeManagerMiddleware: ThemeManagerProvider {
 
     func updateThemeBasedOnSystemBrightness() {
         legacyThemeManager.updateCurrentThemeBasedOnScreenBrightness()
+    }
+
+    func getScreenBrightness() -> Float {
+        return Float(UIScreen.main.brightness)
     }
 }

--- a/Client/Frontend/Settings/ThemeSettings/ThemeMiddleware.swift
+++ b/Client/Frontend/Settings/ThemeSettings/ThemeMiddleware.swift
@@ -50,7 +50,6 @@ class ThemeManagerMiddleware: ThemeManagerProvider {
                 self.updateUserBrightness(value)
                 store.dispatch(ThemeSettingsAction.userBrightnessChanged(value))
             }
-
         case ThemeSettingsAction.receivedSystemBrightnessChange:
             DispatchQueue.main.async {
                 self.updateThemeBasedOnSystemBrightness()

--- a/Client/Frontend/Settings/ThemeSettings/ThemeSettingsAction.swift
+++ b/Client/Frontend/Settings/ThemeSettings/ThemeSettingsAction.swift
@@ -19,5 +19,5 @@ enum ThemeSettingsAction: Action {
     case automaticBrightnessChanged(Bool)
     case manualThemeChanged(BuiltinThemeName)
     case userBrightnessChanged(Float)
-    case systemBrightnessChanged
+    case systemBrightnessChanged(Float)
 }

--- a/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
+++ b/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
@@ -69,8 +69,8 @@ class ThemeSettingsController: ThemedTableViewController, StoreSubscriber {
                                                object: nil)
     }
 
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
         if isReduxIntegrationEnabled {
             store.unsubscribe(self)
         }
@@ -78,7 +78,7 @@ class ThemeSettingsController: ThemedTableViewController, StoreSubscriber {
 
     func newState(state: ThemeSettingsState) {
         themeState = state
-        tableView.reloadData()
+        // Reload of tableView is needed to reflect the new state. Currently applyTheme calls tableview.reload
         applyTheme()
     }
 

--- a/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
+++ b/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
@@ -79,6 +79,7 @@ class ThemeSettingsController: ThemedTableViewController, StoreSubscriber {
     func newState(state: ThemeSettingsState) {
         themeState = state
         tableView.reloadData()
+        applyTheme()
     }
 
     // MARK: - UI actions
@@ -138,8 +139,8 @@ class ThemeSettingsController: ThemedTableViewController, StoreSubscriber {
         } else {
             themeManager.setAutomaticBrightnessValue(control.value)
             LegacyThemeManager.instance.automaticBrightnessValue = control.value
+            brightnessChanged()
         }
-        brightnessChanged()
     }
 
     private func makeSlider(parent: UIView) -> UISlider {
@@ -337,20 +338,7 @@ class ThemeSettingsController: ThemedTableViewController, StoreSubscriber {
 
     private func configureLightDarkTheme(indexPath: IndexPath, cell: ThemedTableViewCell) {
         if isAutoBrightnessOn {
-            let deviceBrightnessIndicator = makeSlider(parent: cell.contentView)
-            let slider = makeSlider(parent: cell.contentView)
-            slider.addTarget(self, action: #selector(sliderValueChanged), for: .valueChanged)
-            if isReduxIntegrationEnabled {
-                slider.value = themeState.userBrightnessThreshold
-            } else {
-                slider.value = Float(LegacyThemeManager.instance.automaticBrightnessValue)
-            }
-            deviceBrightnessIndicator.value = Float(UIScreen.main.brightness)
-            deviceBrightnessIndicator.isUserInteractionEnabled = false
-            deviceBrightnessIndicator.minimumTrackTintColor = .clear
-            deviceBrightnessIndicator.maximumTrackTintColor = .clear
-            deviceBrightnessIndicator.thumbTintColor = themeManager.currentTheme.colors.formKnob
-            self.slider = (slider, deviceBrightnessIndicator)
+            configureAutomaticBrightness(cell: cell)
         } else {
             if indexPath.row == 0 {
                 cell.textLabel?.text = .DisplayThemeOptionLight
@@ -367,5 +355,23 @@ class ThemeSettingsController: ThemedTableViewController, StoreSubscriber {
                 cell.accessoryType = .none
             }
         }
+    }
+
+    private func configureAutomaticBrightness(cell: ThemedTableViewCell) {
+        let deviceBrightnessIndicator = makeSlider(parent: cell.contentView)
+        let slider = makeSlider(parent: cell.contentView)
+        slider.addTarget(self, action: #selector(sliderValueChanged), for: .valueChanged)
+        if isReduxIntegrationEnabled {
+            slider.value = themeState.userBrightnessThreshold
+            deviceBrightnessIndicator.value = themeState.systemBrightness
+        } else {
+            slider.value = Float(LegacyThemeManager.instance.automaticBrightnessValue)
+            deviceBrightnessIndicator.value = Float(UIScreen.main.brightness)
+        }
+        deviceBrightnessIndicator.isUserInteractionEnabled = false
+        deviceBrightnessIndicator.minimumTrackTintColor = .clear
+        deviceBrightnessIndicator.maximumTrackTintColor = .clear
+        deviceBrightnessIndicator.thumbTintColor = themeManager.currentTheme.colors.formKnob
+        self.slider = (slider, deviceBrightnessIndicator)
     }
 }

--- a/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
+++ b/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
@@ -64,7 +64,7 @@ class ThemeSettingsController: ThemedTableViewController, StoreSubscriber {
                            forHeaderFooterViewReuseIdentifier: ThemedTableSectionHeaderFooterView.cellIdentifier)
 
         NotificationCenter.default.addObserver(self,
-                                               selector: #selector(brightnessChanged),
+                                               selector: #selector(systemBrightnessChanged),
                                                name: UIScreen.brightnessDidChangeNotification,
                                                object: nil)
     }
@@ -110,11 +110,19 @@ class ThemeSettingsController: ThemedTableViewController, StoreSubscriber {
     }
 
     @objc
-    func brightnessChanged() {
+    func systemBrightnessChanged() {
         guard LegacyThemeManager.instance.automaticBrightnessIsOn else { return }
+
         if isReduxIntegrationEnabled {
             store.dispatch(ThemeSettingsAction.receivedSystemBrightnessChange)
-        } else {
+        }
+        brightnessChanged()
+    }
+
+    func brightnessChanged() {
+        guard LegacyThemeManager.instance.automaticBrightnessIsOn else { return }
+
+        if !isReduxIntegrationEnabled {
             LegacyThemeManager.instance.updateCurrentThemeBasedOnScreenBrightness()
         }
         applyTheme()

--- a/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
+++ b/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
@@ -119,6 +119,7 @@ class ThemeSettingsController: ThemedTableViewController, StoreSubscriber {
         brightnessChanged()
     }
 
+    /// Update Theme if user or system brightness change due to user action
     func brightnessChanged() {
         guard LegacyThemeManager.instance.automaticBrightnessIsOn else { return }
 
@@ -339,7 +340,11 @@ class ThemeSettingsController: ThemedTableViewController, StoreSubscriber {
             let deviceBrightnessIndicator = makeSlider(parent: cell.contentView)
             let slider = makeSlider(parent: cell.contentView)
             slider.addTarget(self, action: #selector(sliderValueChanged), for: .valueChanged)
-            slider.value = Float(LegacyThemeManager.instance.automaticBrightnessValue)
+            if isReduxIntegrationEnabled {
+                slider.value = themeState.userBrightnessThreshold
+            } else {
+                slider.value = Float(LegacyThemeManager.instance.automaticBrightnessValue)
+            }
             deviceBrightnessIndicator.value = Float(UIScreen.main.brightness)
             deviceBrightnessIndicator.isUserInteractionEnabled = false
             deviceBrightnessIndicator.minimumTrackTintColor = .clear

--- a/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
+++ b/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
@@ -10,11 +10,8 @@ struct ThemeSettingsState: ScreenState, Equatable {
     var isAutomaticBrightnessEnable: Bool
     var manualThemeSelected: BuiltinThemeName
     var userBrightnessThreshold: Float
+    var systemBrightness: Float
     private var logger: Logger
-
-    var systemBrightness: Float {
-        return Float(UIScreen.main.brightness)
-    }
 
     init(_ appState: AppState) {
         guard let themeState = store.state.screenState(ThemeSettingsState.self, for: .themeSettings) else {
@@ -28,25 +25,29 @@ struct ThemeSettingsState: ScreenState, Equatable {
         self.init(useSystemAppearance: themeState.useSystemAppearance,
                   isAutomaticBrightnessEnable: themeState.isAutomaticBrightnessEnable,
                   manualThemeSelected: themeState.manualThemeSelected,
-                  userBrightnessThreshold: themeState.userBrightnessThreshold)
+                  userBrightnessThreshold: themeState.userBrightnessThreshold,
+                  systemBrightness: themeState.systemBrightness)
     }
 
     init() {
         self.init(useSystemAppearance: false,
                   isAutomaticBrightnessEnable: false,
                   manualThemeSelected: .normal,
-                  userBrightnessThreshold: 0)
+                  userBrightnessThreshold: 0,
+                  systemBrightness: 1)
     }
 
     init(useSystemAppearance: Bool,
          isAutomaticBrightnessEnable: Bool,
          manualThemeSelected: BuiltinThemeName,
          userBrightnessThreshold: Float,
+         systemBrightness: Float,
          logger: Logger = DefaultLogger.shared) {
         self.useSystemAppearance = useSystemAppearance
         self.isAutomaticBrightnessEnable = isAutomaticBrightnessEnable
         self.manualThemeSelected = manualThemeSelected
         self.userBrightnessThreshold = userBrightnessThreshold
+        self.systemBrightness = systemBrightness
         self.logger = logger
     }
 
@@ -55,29 +56,43 @@ struct ThemeSettingsState: ScreenState, Equatable {
         case ThemeSettingsAction.receivedThemeManagerValues(let themeState):
             return themeState
 
-        case ThemeSettingsAction.systemThemeChanged(let isEnabled):
+        case ThemeSettingsAction.toggleUseSystemAppearance(let isEnabled), ThemeSettingsAction.systemThemeChanged(let isEnabled):
             return ThemeSettingsState(useSystemAppearance: isEnabled,
                                       isAutomaticBrightnessEnable: state.isAutomaticBrightnessEnable,
                                       manualThemeSelected: state.manualThemeSelected,
-                                      userBrightnessThreshold: state.userBrightnessThreshold)
+                                      userBrightnessThreshold: state.userBrightnessThreshold,
+                                      systemBrightness: state.systemBrightness)
 
-        case ThemeSettingsAction.automaticBrightnessChanged(let isEnabled):
+        case ThemeSettingsAction.enableAutomaticBrightness(let isEnabled),
+            ThemeSettingsAction.automaticBrightnessChanged(let isEnabled):
             return ThemeSettingsState(useSystemAppearance: state.useSystemAppearance,
                                       isAutomaticBrightnessEnable: isEnabled,
                                       manualThemeSelected: state.manualThemeSelected,
-                                      userBrightnessThreshold: state.userBrightnessThreshold)
+                                      userBrightnessThreshold: state.userBrightnessThreshold,
+                                      systemBrightness: state.systemBrightness)
 
-        case ThemeSettingsAction.manualThemeChanged(let theme):
+        case ThemeSettingsAction.switchManualTheme(let theme),
+            ThemeSettingsAction.manualThemeChanged(let theme):
             return ThemeSettingsState(useSystemAppearance: state.useSystemAppearance,
                                       isAutomaticBrightnessEnable: state.isAutomaticBrightnessEnable,
                                       manualThemeSelected: theme,
-                                      userBrightnessThreshold: state.userBrightnessThreshold)
+                                      userBrightnessThreshold: state.userBrightnessThreshold,
+                                      systemBrightness: state.systemBrightness)
 
-        case ThemeSettingsAction.userBrightnessChanged(let brightnessValue):
+        case ThemeSettingsAction.updateUserBrightness(let brightnessValue),
+            ThemeSettingsAction.userBrightnessChanged(let brightnessValue):
             return ThemeSettingsState(useSystemAppearance: state.useSystemAppearance,
                                       isAutomaticBrightnessEnable: state.isAutomaticBrightnessEnable,
                                       manualThemeSelected: state.manualThemeSelected,
-                                      userBrightnessThreshold: brightnessValue)
+                                      userBrightnessThreshold: brightnessValue,
+                                      systemBrightness: state.systemBrightness)
+
+        case ThemeSettingsAction.systemBrightnessChanged(let brightnessValue):
+            return ThemeSettingsState(useSystemAppearance: state.useSystemAppearance,
+                                      isAutomaticBrightnessEnable: state.isAutomaticBrightnessEnable,
+                                      manualThemeSelected: state.manualThemeSelected,
+                                      userBrightnessThreshold: state.userBrightnessThreshold,
+                                      systemBrightness: brightnessValue)
         default:
             return state
         }

--- a/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
+++ b/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
@@ -12,6 +12,10 @@ struct ThemeSettingsState: ScreenState, Equatable {
     var userBrightnessThreshold: Float
     private var logger: Logger
 
+    var systemBrightness: Float {
+        return Float(UIScreen.main.brightness)
+    }
+
     init(_ appState: AppState) {
         guard let themeState = store.state.screenState(ThemeSettingsState.self, for: .themeSettings) else {
             self.init()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7085)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15751)

## :bulb: Description
- Break down brightness change on user and system value change
- Update user brightness using the  state value if Redux is enabled
- Add computed var for system brightness and use if Redux is enabled
- Call applyTheme at `newState` needed for userBrightnessChanged and systemBrightness Changed.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

