### PR TITLE
Bugfix FXIOS-7013 [v118] "Continue" button for SaveLoginsTest

### DIFF
--- a/Tests/XCUITests/SaveLoginsTests.swift
+++ b/Tests/XCUITests/SaveLoginsTests.swift
@@ -40,6 +40,11 @@ class SaveLoginTest: BaseTestCase {
     }
 
     private func unlockLoginsView() {
+        // Press continue button on the password onboarding if it's shown
+        if app.buttons[AccessibilityIdentifiers.Settings.Passwords.onboardingContinue].exists {
+            app.buttons[AccessibilityIdentifiers.Settings.Passwords.onboardingContinue].tap()
+        }
+        
         let passcodeInput = springboard.otherElements.secureTextFields.firstMatch
         waitForExistence(passcodeInput, timeout: 20)
         passcodeInput.tap()

--- a/Tests/XCUITests/SaveLoginsTests.swift
+++ b/Tests/XCUITests/SaveLoginsTests.swift
@@ -44,7 +44,7 @@ class SaveLoginTest: BaseTestCase {
         if app.buttons[AccessibilityIdentifiers.Settings.Passwords.onboardingContinue].exists {
             app.buttons[AccessibilityIdentifiers.Settings.Passwords.onboardingContinue].tap()
         }
-        
+
         let passcodeInput = springboard.otherElements.secureTextFields.firstMatch
         waitForExistence(passcodeInput, timeout: 20)
         passcodeInput.tap()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7013)

## :bulb: Description
https://github.com/mozilla-mobile/firefox-ios/pull/15992/ addresses the issues on the biometric screen for the XCUITest. One fix place is missing from SmokeTest4 test plan: `SaveLoginTest` fails when the simulator was launched for the first time. The same test passes on the second run consistently.

https://addons-testing.bitrise.io/builds/c997c088-171c-4c2c-8945-0c8c86971b4f/testreport/3b5e87ca-a2ec-4261-b8de-3dd2fe608b81/testsuite/0/testcases?status=failed

Let's have the test to pass in the first run by detecting the "Continue" button.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

