### PR TITLE
Refactor FXIOS-6993 [v118] Refactor ContileProvider

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -758,6 +758,8 @@
 		8AF10D8F29D774090086351D /* SceneSetupHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF10D8E29D774090086351D /* SceneSetupHelper.swift */; };
 		8AF10D9129D7761A0086351D /* MockLaunchScreenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF10D9029D776190086351D /* MockLaunchScreenManager.swift */; };
 		8AF2D0FC2A5F272A00C7DD69 /* ComponentLibrary in Frameworks */ = {isa = PBXBuildFile; productRef = 8AF2D0FB2A5F272A00C7DD69 /* ComponentLibrary */; };
+		8AF6D4DF2A856A9000B0474B /* MockContileNetworking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF6D4DE2A856A9000B0474B /* MockContileNetworking.swift */; };
+		8AF6D4E12A856B4500B0474B /* ContileNetworking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF6D4E02A856B4500B0474B /* ContileNetworking.swift */; };
 		8AF99B4D29EF076800108DEC /* WebviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF99B4C29EF076800108DEC /* WebviewViewController.swift */; };
 		8AF99B4F29EF1BA700108DEC /* BrowserDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF99B4E29EF1BA700108DEC /* BrowserDelegate.swift */; };
 		8AF99B5429EF2AF100108DEC /* MockLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF99B5329EF2AF100108DEC /* MockLogger.swift */; };
@@ -4994,6 +4996,8 @@
 		8AF10D8929D713F50086351D /* LaunchScreenViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchScreenViewModelTests.swift; sourceTree = "<group>"; };
 		8AF10D8E29D774090086351D /* SceneSetupHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneSetupHelper.swift; sourceTree = "<group>"; };
 		8AF10D9029D776190086351D /* MockLaunchScreenManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLaunchScreenManager.swift; sourceTree = "<group>"; };
+		8AF6D4DE2A856A9000B0474B /* MockContileNetworking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockContileNetworking.swift; sourceTree = "<group>"; };
+		8AF6D4E02A856B4500B0474B /* ContileNetworking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContileNetworking.swift; sourceTree = "<group>"; };
 		8AF99B4C29EF076800108DEC /* WebviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebviewViewController.swift; sourceTree = "<group>"; };
 		8AF99B4E29EF1BA700108DEC /* BrowserDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDelegate.swift; sourceTree = "<group>"; };
 		8AF99B5329EF2AF100108DEC /* MockLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLogger.swift; sourceTree = "<group>"; };
@@ -8401,6 +8405,7 @@
 			isa = PBXGroup;
 			children = (
 				96A5629F27D6D0E80045144A /* ContileProvider.swift */,
+				8AF6D4E02A856B4500B0474B /* ContileNetworking.swift */,
 				96A562A227D7B32A0045144A /* Contile.swift */,
 				8AB8572B27D945FA0075C173 /* TopSitesDataAdaptor.swift */,
 				43AB6F9C25DC53D20016B015 /* GoogleTopSiteManager.swift */,
@@ -9265,6 +9270,7 @@
 				8A5038132A5DFCE000A1B02A /* MockBrowserProfile.swift */,
 				8A9E46BC2A6599E5003327D4 /* MockStatusBarScrollDelegate.swift */,
 				21D884402A79628E00AF144C /* MockSettingsDelegate.swift */,
+				8AF6D4DE2A856A9000B0474B /* MockContileNetworking.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -12932,6 +12938,7 @@
 				213778632980448C00D01309 /* DownloadFileFetcher.swift in Sources */,
 				F85C7EDF2710B4DD004BDBA4 /* LoginOnboarding.swift in Sources */,
 				C8B0F5F5283B7CCE007AE65D /* PocketSponsoredStory.swift in Sources */,
+				8AF6D4E12A856B4500B0474B /* ContileNetworking.swift in Sources */,
 				8AB8571F27D931B40075C173 /* EmptyTopSiteCell.swift in Sources */,
 				CAC458F1249429C20042561A /* PasswordManagerSelectionHelper.swift in Sources */,
 				C8656D75270F834600E199EA /* FlaggableFeatureOptions.swift in Sources */,
@@ -13229,6 +13236,7 @@
 				4331D3EF2A059C1C00542BDD /* SyncContentSettingsViewControllerTests.swift in Sources */,
 				39D0DA7629D767DE000760B8 /* NimbusMessagingTriggerTests.swift in Sources */,
 				21B41A1D298B187A008BC0A2 /* MockOverlayModeManager.swift in Sources */,
+				8AF6D4DF2A856A9000B0474B /* MockContileNetworking.swift in Sources */,
 				2FDB10931A9FBEC5006CF312 /* PrefsTests.swift in Sources */,
 				C89C91AD2A1FE9E900BE57B1 /* OnboardingTelemetryDelegationTests.swift in Sources */,
 				8A36BE2C29EDE16C00AC1C5C /* ContentContainerTests.swift in Sources */,

--- a/Client/Frontend/Home/TopSites/DataManagement/ContileNetworking.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/ContileNetworking.swift
@@ -1,0 +1,59 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+import Shared
+
+struct ContileResultData {
+    var data: Data
+    var response: HTTPURLResponse
+}
+
+typealias NetworkingContileResult = Swift.Result<(ContileResultData), Error>
+
+enum ContileNetworkingError: Error {
+    case dataUnavailable
+}
+
+protocol ContileNetworking {
+    func data(from request: URLRequest, completion: @escaping (NetworkingContileResult) -> Void)
+}
+
+class DefaultContileNetwork: ContileNetworking {
+    private var urlSession: URLSessionProtocol
+    private var logger: Logger
+
+    init(with urlSession: URLSessionProtocol,
+         logger: Logger = DefaultLogger.shared) {
+        self.urlSession = urlSession
+        self.logger = logger
+    }
+
+    func data(from request: URLRequest, completion: @escaping (NetworkingContileResult) -> Void) {
+        urlSession.dataTaskWith(request: request) { [weak self] data, response, error in
+            guard let self = self else { return }
+
+            if let error = error {
+                self.logger.log("An error occurred while fetching data: \(error)",
+                                level: .debug,
+                                category: .homepage)
+                completion(.failure(ContileNetworkingError.dataUnavailable))
+                return
+            }
+
+            guard let response = validatedHTTPResponse(response, statusCode: 200..<300),
+                  let data = data
+            else {
+                self.logger.log("Response isn't valid, data is nil?: \(data == nil)",
+                                level: .debug,
+                                category: .homepage)
+                completion(.failure(ContileNetworkingError.dataUnavailable))
+                return
+            }
+
+            completion(.success(ContileResultData(data: data, response: response)))
+        }.resume()
+    }
+}

--- a/Client/Protocols/URLSession/URLSessionProtocol.swift
+++ b/Client/Protocols/URLSession/URLSessionProtocol.swift
@@ -10,9 +10,19 @@ protocol URLSessionProtocol {
     func dataTaskWith(_ url: URL,
                       completionHandler: @escaping DataTaskResult
     ) -> URLSessionDataTaskProtocol
+
+    func dataTaskWith(
+        request: URLRequest,
+        completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void
+    ) -> URLSessionDataTaskProtocol
 }
 
 extension URLSession: URLSessionProtocol {
+    func dataTaskWith(request: URLRequest,
+                      completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol {
+        return dataTask(with: request, completionHandler: completionHandler)
+    }
+
     func dataTaskWith(_ url: URL,
                       completionHandler: @escaping DataTaskResult
     ) -> URLSessionDataTaskProtocol {

--- a/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataAdaptorTests.swift
+++ b/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataAdaptorTests.swift
@@ -137,7 +137,7 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
     }
 
     func testCalculateTopSitesData_doesNotAddSponsoredTileIfError() {
-        let expectedContileResult = ContileResult.failure(ContileProvider.Error.failure)
+        let expectedContileResult = ContileResult.failure(ContileProvider.Error.noDataAvailable)
         let subject = createSubject(expectedContileResult: expectedContileResult)
 
         subject.recalculateTopSiteData(for: 6)

--- a/Tests/ClientTests/Mocks/MockContileNetworking.swift
+++ b/Tests/ClientTests/Mocks/MockContileNetworking.swift
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+@testable import Client
+
+class MockContileNetworking: ContileNetworking {
+    var error: Error?
+    var data: Data?
+    var response: HTTPURLResponse?
+    var dataFromCalled = 0
+
+    func data(from request: URLRequest, completion: (NetworkingContileResult) -> Void) {
+        dataFromCalled += 1
+        if let error {
+            completion(.failure(error))
+        } else if let data, let response {
+            completion(.success(ContileResultData(data: data, response: response)))
+        }
+    }
+}

--- a/Tests/ClientTests/Wallpaper/Mocks/WallpaperURLSessionMock.swift
+++ b/Tests/ClientTests/Wallpaper/Mocks/WallpaperURLSessionMock.swift
@@ -36,4 +36,13 @@ class WallpaperURLSessionMock: URLSessionProtocol {
         completion(data, response, error)
         return dataTask
     }
+
+    func dataTaskWith(request: URLRequest,
+                      completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol {
+        return MockURLSessionDataTaskProtocol()
+    }
+}
+
+class MockURLSessionDataTaskProtocol: URLSessionDataTaskProtocol {
+    func resume() {}
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6993)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15512)

## :bulb: Description
`ContileProvider` was coupled with it's `URLSession`, which was making unit tests dependent on using `URLProtocol` stubbing. This was seemingly causing flaky tests, so took the opportunity to introduce a `ContileNetworking` so we can properly mock this networking part of the provider. Ideally we would also mock the `URLCache`, but I don't want to put more time on this for now since the goal is just to improve the unit tests suite at the moment to remove flakyness.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

