### PR TITLE
Bugfix FXIOS-6790 [v118] fix the `Use saved card` button background in both Dark and Light mode (#15127)

### DIFF
--- a/Client/AccessoryViewProvider.swift
+++ b/Client/AccessoryViewProvider.swift
@@ -180,7 +180,7 @@ class AccessoryViewProvider: UIView, Themeable {
         nextButton.tintColor = theme.colors.iconAccentBlue
         doneButton.tintColor = theme.colors.iconAccentBlue
         cardImageView.tintColor = theme.colors.iconPrimary
-        cardButtonStackView.backgroundColor = .systemBackground
+        cardButtonStackView.backgroundColor = theme.colors.layer5Hover
     }
 
     // MARK: - Actions


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6790)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15127)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Updated the color for the background of the Use Saved Card button
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X If needed I updated documentation / comments for complex code and public methods

