### PR TITLE
Add FXIOS-7205 [v116] Adding other logs related to tabs loss investigation

### DIFF
--- a/Client/Application/AppLaunchUtil.swift
+++ b/Client/Application/AppLaunchUtil.swift
@@ -80,6 +80,10 @@ class AppLaunchUtil {
 
         // Add swizzle on top of UIControl to automatically log when there's an action sent
         UIControl.loggerSwizzle()
+
+        logger.log("App version \(AppInfo.appVersion), Build number \(AppInfo.buildNumber)",
+                   level: .debug,
+                   category: .setup)
     }
 
     func setUpPostLaunchDependencies() {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1717,6 +1717,10 @@ class BrowserViewController: UIViewController,
 
         // Credit card sync telemetry
         self.profile.hasSyncAccount { [unowned self] hasSync in
+            logger.log("User has sync account setup \(hasSync)",
+                       level: .debug,
+                       category: .setup)
+
             guard hasSync else { return }
             let syncStatus = self.profile.syncManager.checkCreditCardEngineEnablement()
             TelemetryWrapper.recordEvent(

--- a/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -58,7 +58,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     var tabs = [Tab]()
     private var _selectedIndex = -1
     var selectedIndex: Int { return _selectedIndex }
-    private let logger: Logger
+    let logger: Logger
     var backupCloseTab: BackupCloseTab?
 
     var tabDisplayType: TabDisplayType = .TabGrid
@@ -943,6 +943,10 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
             let tabToSelect = createStartAtHomeTab(withExistingTab: existingHomeTab,
                                                    inPrivateMode: wasLastSessionPrivate,
                                                    and: profile.prefs)
+
+            logger.log("Start at home triggered with last session private \(wasLastSessionPrivate)",
+                       level: .debug,
+                       category: .tabs)
             selectTab(tabToSelect)
         }
     }

--- a/Client/TabManagement/TabManagerImplementation.swift
+++ b/Client/TabManagement/TabManagerImplementation.swift
@@ -138,7 +138,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
             newTab.metadataManager?.tabGroupData = groupData
 
             if newTab.url == nil {
-                logger.log("Tab restored has empty URL for tab id \(tabData.id.uuidString). It was last used \(Date.fromTimestamp(tabData.lastUsedTime))",
+                logger.log("Tab restored has empty URL for tab id \(tabData.id.uuidString). It was last used \(tabData.lastUsedTime)",
                            level: .debug,
                            category: .tabs)
             }

--- a/Client/TabManagement/TabManagerImplementation.swift
+++ b/Client/TabManagement/TabManagerImplementation.swift
@@ -48,7 +48,9 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
               forced || tabs.isEmpty
         else { return }
 
-        logger.log("Tabs restore started with \(forced), \(tabs.isEmpty)", level: .debug, category: .tabs)
+        logger.log("Tabs restore started being force; \(forced), with empty tabs; \(tabs.isEmpty)",
+                   level: .debug,
+                   category: .tabs)
 
         guard !AppConstants.isRunningUITests,
               !DebugSettingsBundleOptions.skipSessionRestore


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7205)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15989)

## :bulb: Description
Added some logs for:
- New homepage tab created after four hours  (start at home feature triggered)
- Make sure we have the version of the application in the logs and build number
- The amount of tabs saved VS the amount of tabs we get back when we restore them
- Log when we start restoring the tabs, when it ends 
- Log when we start saving the tabs, when it ends
- Log how many inactive tabs, private tabs and normal tabs the user has
- Log if the user has a sync account

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

