### PR TITLE
Bugfix FXIOS-7205 [v116.2] stop tab overwrite and ensure migration is run

### DIFF
--- a/Client/TabManagement/TabManagerImplementation.swift
+++ b/Client/TabManagement/TabManagerImplementation.swift
@@ -100,6 +100,9 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
 
             // Safety check incase something went wrong during launch where a migration should have occured
             if tabs.count <= 1 && store.tabs.count > 1 {
+                logger.log("Rerunning migration due to inconsistent tab counts, old tab store count: \(store.tabs.count)",
+                           level: .fatal,
+                           category: .tabs)
                 isRestoringTabs = true
                 migrateAndRestore()
             }
@@ -216,6 +219,9 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
         // (there should always be at least a homepage)
         // Also if the a restore is in progress then presevering tabs could cause issues
         if tabs.isEmpty || isRestoringTabs {
+            logger.log("Attempted to preserve tabs while tabs were restoring or empty, tab count \(tabs.count), isRestoring \(isRestoringTabs)",
+                       level: .warning,
+                       category: .tabs)
             return
         }
 

--- a/Client/TabManagement/TabManagerImplementation.swift
+++ b/Client/TabManagement/TabManagerImplementation.swift
@@ -206,6 +206,13 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
     // MARK: - Save tabs
 
     override func preserveTabs() {
+        // If there are no tabs then we do not need to preserve as we are initalizing the app
+        // (there should always be at least a homepage)
+        // Also if the a restore is in progress then presevering tabs could cause issues
+        if tabs.count == 0 || isRestoringTabs {
+            return
+        }
+        
         // For now we want to continue writing to both data stores so that we can revert to the old system if needed
         super.preserveTabs()
         guard shouldUseNewTabStore() else { return }

--- a/Client/TabManagement/TabManagerImplementation.swift
+++ b/Client/TabManagement/TabManagerImplementation.swift
@@ -97,6 +97,12 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
             await buildTabRestore(window: await self.tabDataStore.fetchWindowData())
             logger.log("Tabs restore ended after fetching window data", level: .debug, category: .tabs)
             logger.log("Normal tabs count; \(normalTabs.count), Inactive tabs count; \(inactiveTabs.count), Private tabs count; \(privateTabs).count", level: .debug, category: .tabs)
+
+            // Safety check incase something went wrong during launch where a migration should have occured
+            if tabs.count <= 1 && store.tabs.count > 1 {
+                isRestoringTabs = true
+                migrateAndRestore()
+            }
         }
     }
 
@@ -209,10 +215,10 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
         // If there are no tabs then we do not need to preserve as we are initalizing the app
         // (there should always be at least a homepage)
         // Also if the a restore is in progress then presevering tabs could cause issues
-        if tabs.count == 0 || isRestoringTabs {
+        if tabs.isEmpty || isRestoringTabs {
             return
         }
-        
+
         // For now we want to continue writing to both data stores so that we can revert to the old system if needed
         super.preserveTabs()
         guard shouldUseNewTabStore() else { return }

--- a/Client/TabManagement/TabManagerImplementation.swift
+++ b/Client/TabManagement/TabManagerImplementation.swift
@@ -220,7 +220,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
         // Also if the a restore is in progress then presevering tabs could cause issues
         if tabs.isEmpty || isRestoringTabs {
             logger.log("Attempted to preserve tabs while tabs were restoring or empty, tab count \(tabs.count), isRestoring \(isRestoringTabs)",
-                       level: .warning,
+                       level: .fatal,
                        category: .tabs)
             return
         }

--- a/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -86,7 +86,7 @@ class TabManagerTests: XCTestCase {
     func testPreserveTabsWithNoTabs() async throws {
         subject.preserveTabs()
         try await Task.sleep(nanoseconds: sleepTime)
-        XCTAssertEqual(mockTabStore.saveWindowDataCalledCount, 1)
+        XCTAssertEqual(mockTabStore.saveWindowDataCalledCount, 0)
         XCTAssertEqual(subject.tabs.count, 0)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7205)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15989)

## :bulb: Description
There are two hypothesis in addressed in this PR

1. Due to the now async nature of tab loading and preservation some users are running into a race condition where the tabs get persevered before they are restored, resulting in overwriting any previous tabs with empty data.

2. Somehow the flag we use to determine if a migration should be run is not correct. So this PR checks if the old store has data and after the new store restores if the data is empty it means a migration should be run. Since we still write to both stores this should only ever happen in the case of a user upgrading to a version with the new store.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

