### PR TITLE
Add FXIOS-7078 [v118] child panel controllers to LibraryViewController from LibraryCoordinator

### DIFF
--- a/Client/Coordinators/Library/LibraryCoordinator.swift
+++ b/Client/Coordinators/Library/LibraryCoordinator.swift
@@ -34,10 +34,24 @@ class LibraryCoordinator: BaseCoordinator, LibraryPanelDelegate, LibraryNavigati
     }
 
     func start(with homepanelSection: Route.HomepanelSection) {
+        libraryViewController.childPanelControllers = makeChildPanels()
         libraryViewController.delegate = self
         libraryViewController.navigationHandler = self
         libraryViewController.setupOpenPanel(panelType: homepanelSection.libraryPanel)
         libraryViewController.resetHistoryPanelPagination()
+    }
+
+    private func makeChildPanels() -> [UINavigationController] {
+        let bookmarksPanel = BookmarksPanel(viewModel: BookmarksPanelViewModel(profile: profile))
+        let historyPanel = HistoryPanel(profile: profile, tabManager: tabManager)
+        let downloadsPanel = DownloadsPanel()
+        let readingListPanel = ReadingListPanel(profile: profile)
+        return [
+            ThemedNavigationController(rootViewController: bookmarksPanel),
+            ThemedNavigationController(rootViewController: historyPanel),
+            ThemedNavigationController(rootViewController: downloadsPanel),
+            ThemedNavigationController(rootViewController: readingListPanel)
+        ]
     }
 
     // MARK: - LibraryNavigationHandler

--- a/Client/Frontend/Library/LibraryViewController/LibraryViewController+ToolbarActions.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryViewController+ToolbarActions.swift
@@ -16,7 +16,13 @@ extension LibraryViewController {
 
     @objc
     func topRightButtonAction() {
-        guard let panel = viewModel.currentPanel else { return }
+        var panel: LibraryPanel?
+        if CoordinatorFlagManager.isLibraryCoordinatorEnabled {
+            panel = getCurrentPanel()
+        } else {
+            panel = viewModel.currentPanel
+        }
+        guard let panel = panel else { return }
 
         if panel.shouldDismissOnDone() {
             dismiss(animated: true, completion: nil)

--- a/Tests/ClientTests/Coordinators/Library/LibraryCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/Library/LibraryCoordinatorTests.swift
@@ -36,6 +36,7 @@ final class LibraryCoordinatorTests: XCTestCase {
         subject.start(with: .bookmarks)
         XCTAssertEqual(mockRouter.setRootViewControllerCalled, 1)
         XCTAssertTrue(mockRouter.rootViewController is LibraryViewController)
+        XCTAssertEqual((mockRouter.rootViewController as? LibraryViewController)?.childPanelControllers.count, 4)
     }
 
     func testStart_withHistoryHomepanelSection_setsUpLibraryViewControllerWithHistoryPanel() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7078)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15732)

## :bulb: Description
Pass the child panel controller from the `LibraryCoordinator` to the `LibraryViewController`.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

