### PR TITLE
Bugfix FXIOS-7230 [v116.3] google.com search field closes the keyboard before you can finish typing

### DIFF
--- a/Client/Frontend/Browser/WebView/WebviewViewController.swift
+++ b/Client/Frontend/Browser/WebView/WebviewViewController.swift
@@ -40,15 +40,10 @@ class WebviewViewController: UIViewController, ContentContainable, Screenshotabl
     }
 
     func update(webView: WKWebView, isPrivate: Bool = false) {
-        removeWebview()
         self.webView = webView
         setupWebView()
         setupScreenTimeController()
         setScreenTimeUsage(isPrivate: isPrivate)
-    }
-
-    private func removeWebview() {
-        webView.removeFromSuperview()
     }
 
     // MARK: - Rotation


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7230)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16035)

## :bulb: Description
Revert removeWebview call

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

