### PR TITLE
Refactor SYNC-3840 [v119] Remove call to SQLCipher migration

### DIFF
--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -617,8 +617,11 @@ open class BrowserProfile: Profile {
     }
 
     lazy var logins: RustLogins = {
-        let sqlCipherDatabasePath = URL(fileURLWithPath: (try! files.getAndEnsureDirectory()), isDirectory: true).appendingPathComponent("logins.db").path
+        // TODO: #16076 - We should avoid force unwraps
         let databasePath = URL(fileURLWithPath: (try! files.getAndEnsureDirectory()), isDirectory: true).appendingPathComponent("loginsPerField.db").path
+        // Though we don't migrate SQLCipher DBs anymore, we keep this call to
+        // delete any existing DBs if they still exist
+        let sqlCipherDatabasePath = URL(fileURLWithPath: (try! files.getAndEnsureDirectory()), isDirectory: true).appendingPathComponent("logins.db").path
 
         return RustLogins(sqlCipherDatabasePath: sqlCipherDatabasePath, databasePath: databasePath)
     }()

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -113,12 +113,12 @@ open class SwiftData {
 
         self.primaryConnectionQueue = DispatchQueue(label: "SwiftData primary queue: \(filename)", attributes: [])
 
-        // Ensure that SQLite/SQLCipher has been compiled with
+        // Ensure that SQLite has been compiled with
         // `SQLITE_THREADSAFE=1` or `SQLITE_THREADSAFE=2`.
         // https://www.sqlite.org/compile.html#threadsafe
         // https://www.sqlite.org/threadsafe.html
         if sqlite3_threadsafe() < 0 {
-            logger.log("SQLite/SQLCipher was not compiled with SQLITE_THREADSAFE=1 or SQLITE_THREADSAFE=2",
+            logger.log("SQLite was not compiled with SQLITE_THREADSAFE=1 or SQLITE_THREADSAFE=2",
                        level: .warning,
                        category: .storage)
         }


### PR DESCRIPTION
Removes the calls to SQLCipher migration. We should do this first before actually removing it from a-s to prevent any breaking changes needed.

a-s tracking issue: https://github.com/mozilla/application-services/issues/5777
a-s tracking epic: https://mozilla-hub.atlassian.net/browse/SYNC-3838

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/SYNC-3840)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16055)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

