### PR TITLE
Bugfix FXIOS-7223 [v118]: Fix places DB hang on homepage

### DIFF
--- a/Providers/TopSitesProvider.swift
+++ b/Providers/TopSitesProvider.swift
@@ -52,12 +52,6 @@ class TopSitesProviderImplementation: TopSitesProvider {
         prefs: Prefs
     ) {
         self.placesFetcher = placesFetcher
-        // It's possible that the top sites fetch is the
-        // very first use of places, lets make sure that
-        // our connection is open
-        if !self.placesFetcher.isOpen {
-            _ = self.placesFetcher.reopenIfClosed()
-        }
         self.pinnedSiteFetcher = pinnedSiteFetcher
         self.prefs = prefs
     }
@@ -85,14 +79,26 @@ class TopSitesProviderImplementation: TopSitesProvider {
 private extension TopSitesProviderImplementation {
     func getFrecencySites(group: DispatchGroup, numberOfMaxItems: Int) {
         group.enter()
-        placesFetcher.getTopFrecentSiteInfos(limit: numberOfMaxItems, thresholdOption: FrecencyThresholdOption.none)
-            .uponQueue(.global()) { [weak self] result in
-                if let sites = result.successValue {
-                    self?.frecencySites = sites
-                }
-
+        DispatchQueue.global().async { [weak self] in
+            // It's possible that the top sites fetch is the
+            // very first use of places, lets make sure that
+            // our connection is open
+            guard let placesFetcher = self?.placesFetcher else {
                 group.leave()
+                return
             }
+            if !placesFetcher.isOpen {
+                _ = placesFetcher.reopenIfClosed()
+            }
+            placesFetcher.getTopFrecentSiteInfos(limit: numberOfMaxItems, thresholdOption: FrecencyThresholdOption.none)
+                .uponQueue(.global()) { [weak self] result in
+                    if let sites = result.successValue {
+                        self?.frecencySites = sites
+                    }
+
+                    group.leave()
+                }
+        }
     }
 
     func getPinnedSites(group: DispatchGroup) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7223)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16018)

## :bulb: Description
Moves the opening of the places DB to a background thread in the top sites fetcher and outside the constructor. This way if the opening takes too long the main thread isn't impacted and the outcome is that the top places sites aren't fetched until the opening is done.

I simulated a delay by sleeping right before `reopenIfClosed` and the app didn't hang while the thread is sleeping.

It's important to note that it's not guaranteed that this fixes what users in https://github.com/mozilla-mobile/firefox-ios/issues/16018 are experiencing, but we should definitely move the opening of the connection out of the main thread regardless

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

