### PR TITLE
Bugfix FXIOS-7254 [v117] Revert card name

### DIFF
--- a/nimbus-features/onboardingFrameworkFeature.yaml
+++ b/nimbus-features/onboardingFrameworkFeature.yaml
@@ -30,7 +30,7 @@ features:
             ALWAYS:                   "true"
             NEVER:                    "false"
           cards:
-            default-browser:
+            welcome:
               order: 10
               title: Onboarding/Onboarding.Welcome.Title.TreatementA.v114
               body: Onboarding/Onboarding.Welcome.Description.TreatementA.v114


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7254)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16082)

## :bulb: Description
Changing the card name, due to experiments in progress, resulted in double cards. We do not want this! So we're reverting the name.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

