### PR TITLE
Bugfix FXIOS-7201 [v118] ETP menu text not updated

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -133,28 +133,28 @@ extension BrowserViewController: URLBarDelegate {
     }
 
     func urlBarDidTapShield(_ urlBar: URLBarView) {
-         guard let tab = self.tabManager.selectedTab,
-               let url = tab.url,
-               let contentBlocker = tab.contentBlocker,
-               let webView = tab.webView else { return }
+        guard let tab = self.tabManager.selectedTab,
+              let url = tab.url,
+              let contentBlocker = tab.contentBlocker,
+              let webView = tab.webView else { return }
 
-         let etpViewModel = EnhancedTrackingProtectionMenuVM(
-             url: url,
-             displayTitle: tab.displayTitle,
-             connectionSecure: webView.hasOnlySecureContent,
-             globalETPIsEnabled: FirefoxTabContentBlocker.isTrackingProtectionEnabled(prefs: profile.prefs),
-             contentBlockerStatus: contentBlocker.status)
-         etpViewModel.onOpenSettingsTapped = { [weak self] in
-             if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
-                 // Wait to show settings in async dispatch since hamburger menu is still showing at that time
-                 DispatchQueue.main.async {
-                     self?.navigationHandler?.show(settings: .contentBlocker)
-                 }
-             } else {
-                 self?.legacyShowSettings(deeplink: .contentBlocker)
-             }
-         }
-         etpViewModel.onToggleSiteSafelistStatus = { tab.reload() }
+        let etpViewModel = EnhancedTrackingProtectionMenuVM(
+            url: url,
+            displayTitle: tab.displayTitle,
+            connectionSecure: webView.hasOnlySecureContent,
+            globalETPIsEnabled: FirefoxTabContentBlocker.isTrackingProtectionEnabled(prefs: profile.prefs),
+            contentBlockerStatus: contentBlocker.status)
+        etpViewModel.onOpenSettingsTapped = { [weak self] in
+            if CoordinatorFlagManager.isSettingsCoordinatorEnabled {
+                // Wait to show settings in async dispatch since hamburger menu is still showing at that time
+                DispatchQueue.main.async {
+                    self?.navigationHandler?.show(settings: .contentBlocker)
+                }
+            } else {
+                self?.legacyShowSettings(deeplink: .contentBlocker)
+            }
+        }
+        etpViewModel.onToggleSiteSafelistStatus = { tab.reload() }
 
         TelemetryWrapper.recordEvent(category: .action, method: .press, object: .trackingProtectionMenu)
         if CoordinatorFlagManager.isEtpCoordinatorEnabled {

--- a/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVC.swift
+++ b/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVC.swift
@@ -380,10 +380,7 @@ class EnhancedTrackingProtectionMenuVC: UIViewController, Themeable {
     func trackingProtectionToggleTapped() {
         // site is safelisted if site ETP is disabled
         viewModel.toggleSiteSafelistStatus()
-        switch viewModel.isSiteETPEnabled {
-        case true: toggleStatusLabel.text = .ETPOn
-        case false: toggleStatusLabel.text = .ETPOff
-        }
+        toggleStatusLabel.text = toggleSwitch.isOn ? .ETPOn : .ETPOff
     }
 
     @objc


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7201)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15981)

## :bulb: Description
- Text wasn't updated right away when toggle was toggled
- Fixed indentation

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

