### PR TITLE
Bugfix FXIOS- [v118] missing a11y in LibraryViewController

### DIFF
--- a/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -205,9 +205,10 @@ class LibraryViewController: UIViewController, Themeable {
               index < viewModel.panelDescriptors.count else { return }
 
         if CoordinatorFlagManager.isLibraryCoordinatorEnabled {
+            let panelDescriptor = viewModel.panelDescriptors[index]
             if let panelVC = childPanelControllers[index].topViewController {
                 let panelNavigationController = childPanelControllers[index]
-                setupLibraryPanel(panelVC, accessibilityLabel: "", accessibilityIdentifier: "")
+                setupLibraryPanel(panelVC, accessibilityLabel: panelDescriptor.accessibilityLabel, accessibilityIdentifier: panelDescriptor.accessibilityIdentifier)
                 showPanel(panelNavigationController)
                 navigationHandler?.start(panelType: viewModel.selectedPanel ?? .bookmarks, navigationController: panelNavigationController)
             }

--- a/nimbus-features/libraryCoordinatorRefactor.yaml
+++ b/nimbus-features/libraryCoordinatorRefactor.yaml
@@ -15,5 +15,5 @@ features:
           enabled: false
       - channel: developer
         value:
-          enabled: true
+          enabled: false
 

--- a/nimbus-features/libraryCoordinatorRefactor.yaml
+++ b/nimbus-features/libraryCoordinatorRefactor.yaml
@@ -15,5 +15,5 @@ features:
           enabled: false
       - channel: developer
         value:
-          enabled: false
+          enabled: true
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7099)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15773)

## :bulb: Description

Bugfix missing a11y to setup function in `LibraryViewController`

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

