### PR TITLE
Add FXIOS-7124 [v117.3] SkAdNetwork onboarding events

### DIFF
--- a/Client/Application/AppLaunchUtil.swift
+++ b/Client/Application/AppLaunchUtil.swift
@@ -46,7 +46,7 @@ class AppLaunchUtil {
         // Initialize conversion value by specifying fineValue and coarseValue.
         // Call update postback conversion value for install event.
         let conversionValue = ConversionValueUtil(fineValue: 0, coarseValue: .low, logger: logger)
-        conversionValue.adNetworkAttributionUpdateConversionInstallEvent()
+        conversionValue.adNetworkAttributionUpdateConversionEvent()
 
         // Initialize the feature flag subsystem.
         // Among other things, it toggles on and off Nimbus, Contile, Adjust.

--- a/Client/Application/ConversionValueUtil.swift
+++ b/Client/Application/ConversionValueUtil.swift
@@ -32,7 +32,7 @@ struct ConversionValueUtil {
         }
     }
 
-    func adNetworkAttributionUpdateConversionInstallEvent() {
+    func adNetworkAttributionUpdateConversionEvent() {
         if #available(iOS 16.1, *) {
             SKAdNetwork.updatePostbackConversionValue(fineValue, coarseValue: coarseValue.value) { error in
                 handleUpdateConversionInstallEvent(error: error)

--- a/Client/Application/UserConversionMetrics.swift
+++ b/Client/Application/UserConversionMetrics.swift
@@ -77,7 +77,7 @@ class UserConversionMetrics {
     private func sendActivationEvent() {
         let logger: Logger = DefaultLogger.shared
         let conversionValue = ConversionValueUtil(fineValue: 0, coarseValue: .high, logger: logger)
-        conversionValue.adNetworkAttributionUpdateConversionInstallEvent()
+        conversionValue.adNetworkAttributionUpdateConversionEvent()
         userDefaults.set(true, forKey: PrefsKeys.Session.didUpdateConversionValue)
     }
 }

--- a/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -49,7 +49,6 @@ class LaunchCoordinator: BaseCoordinator, SurveySurfaceViewControllerDelegate {
         let introViewController = IntroViewController(viewModel: introViewModel)
         introViewController.didFinishFlow = { [weak self] in
             guard let self = self else { return }
-            introViewModel.sendOnboardingUserActivationEvent()
             self.parentCoordinator?.didFinishLaunch(from: self)
         }
 

--- a/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -49,6 +49,7 @@ class LaunchCoordinator: BaseCoordinator, SurveySurfaceViewControllerDelegate {
         let introViewController = IntroViewController(viewModel: introViewModel)
         introViewController.didFinishFlow = { [weak self] in
             guard let self = self else { return }
+            introViewModel.sendOnboardingUserActivationEvent()
             self.parentCoordinator?.didFinishLaunch(from: self)
         }
 

--- a/Client/Frontend/Onboarding/Models/IntroViewModel.swift
+++ b/Client/Frontend/Onboarding/Models/IntroViewModel.swift
@@ -60,7 +60,7 @@ class IntroViewModel: OnboardingViewModelProtocol, FeatureFlaggable {
     }
 
     // MARK: SkAdNetwork
-    // this event can only be sent once in this time window
+    // this event should be sent in the first 24h time window, if it's not sent the conversion value is locked by Apple
     func sendOnboardingUserActivationEvent() {
         let fineValue = OnboardingOptions.allCases.map { chosenOptions.contains($0) ? $0.rawValue : 0 }.reduce(0, +)
         let conversionValue = ConversionValueUtil(fineValue: fineValue, coarseValue: .low, logger: DefaultLogger.shared)

--- a/Client/Frontend/Onboarding/Models/IntroViewModel.swift
+++ b/Client/Frontend/Onboarding/Models/IntroViewModel.swift
@@ -61,12 +61,12 @@ class IntroViewModel: OnboardingViewModelProtocol, FeatureFlaggable {
 
     // MARK: SkAdNetwork
     // this event should be sent in the first 24h time window, if it's not sent the conversion value is locked by Apple
-    func sendOnboardingUserActivationEvent() {
+    func updateOnboardingUserActivationEvent() {
         let fineValue = OnboardingOptions.allCases.map { chosenOptions.contains($0) ? $0.rawValue : 0 }.reduce(0, +)
         let conversionValue = ConversionValueUtil(fineValue: fineValue, coarseValue: .low, logger: DefaultLogger.shared)
         // we should send this event only if an action has been selected during the onboarding flow
         if fineValue > 0 {
-            conversionValue.adNetworkAttributionUpdateConversionInstallEvent()
+            conversionValue.adNetworkAttributionUpdateConversionEvent()
         }
     }
 }

--- a/Client/Frontend/Onboarding/ViewControllers/FirstInstall/IntroViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/FirstInstall/IntroViewController.swift
@@ -228,6 +228,7 @@ extension IntroViewController: OnboardingCardDelegate {
         switch action {
         case .requestNotifications:
             askForNotificationPermission(from: cardName)
+            sendOnboardingUserActivationEvent(fineValue: 1)
         case .nextCard:
             showNextPage(from: cardName) {
                 self.showNextPageCompletionForLastCard()
@@ -242,9 +243,11 @@ extension IntroViewController: OnboardingCardDelegate {
                     self.showNextPageCompletionForLastCard()
                 }
             }
+            sendOnboardingUserActivationEvent(fineValue: 3)
         case .setDefaultBrowser:
             registerForNotification()
             DefaultApplicationHelper().openSettings()
+            sendOnboardingUserActivationEvent(fineValue: 2)
         case .openInstructionsPopup:
             presentDefaultBrowserPopup(
                 from: cardName,
@@ -258,6 +261,11 @@ extension IntroViewController: OnboardingCardDelegate {
 
     func sendCardViewTelemetry(from cardName: String) {
         viewModel.telemetryUtility.sendCardViewTelemetry(from: cardName)
+    }
+
+    func sendOnboardingUserActivationEvent(fineValue: Int) {
+        let conversionValue = ConversionValueUtil(fineValue: fineValue, coarseValue: .low, logger: DefaultLogger.shared)
+        conversionValue.adNetworkAttributionUpdateConversionInstallEvent()
     }
 
     private func showNextPageCompletionForLastCard() {

--- a/Client/Frontend/Onboarding/ViewControllers/FirstInstall/IntroViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/FirstInstall/IntroViewController.swift
@@ -229,6 +229,7 @@ extension IntroViewController: OnboardingCardDelegate {
         switch action {
         case .requestNotifications:
             introViewModel.chosenOptions.insert(.askForNotificationPermission)
+            introViewModel.sendOnboardingUserActivationEvent()
             askForNotificationPermission(from: cardName)
         case .nextCard:
             showNextPage(from: cardName) {
@@ -236,6 +237,7 @@ extension IntroViewController: OnboardingCardDelegate {
             }
         case .syncSignIn:
             introViewModel.chosenOptions.insert(.syncSignIn)
+            introViewModel.sendOnboardingUserActivationEvent()
             let fxaPrams = FxALaunchParams(entrypoint: .introOnboarding, query: [:])
             presentSignToSync(
                 with: fxaPrams,
@@ -247,6 +249,7 @@ extension IntroViewController: OnboardingCardDelegate {
             }
         case .setDefaultBrowser:
             introViewModel.chosenOptions.insert(.setAsDefaultBrowser)
+            introViewModel.sendOnboardingUserActivationEvent()
             registerForNotification()
             DefaultApplicationHelper().openSettings()
         case .openInstructionsPopup:

--- a/Client/Frontend/Onboarding/ViewControllers/FirstInstall/IntroViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/FirstInstall/IntroViewController.swift
@@ -227,13 +227,14 @@ extension IntroViewController: OnboardingCardDelegate {
 
         switch action {
         case .requestNotifications:
-            askForNotificationPermission(from: cardName)
             sendOnboardingUserActivationEvent(fineValue: 1)
+            askForNotificationPermission(from: cardName)
         case .nextCard:
             showNextPage(from: cardName) {
                 self.showNextPageCompletionForLastCard()
             }
         case .syncSignIn:
+            sendOnboardingUserActivationEvent(fineValue: 3)
             let fxaPrams = FxALaunchParams(entrypoint: .introOnboarding, query: [:])
             presentSignToSync(
                 with: fxaPrams,
@@ -243,11 +244,10 @@ extension IntroViewController: OnboardingCardDelegate {
                     self.showNextPageCompletionForLastCard()
                 }
             }
-            sendOnboardingUserActivationEvent(fineValue: 3)
         case .setDefaultBrowser:
+            sendOnboardingUserActivationEvent(fineValue: 2)
             registerForNotification()
             DefaultApplicationHelper().openSettings()
-            sendOnboardingUserActivationEvent(fineValue: 2)
         case .openInstructionsPopup:
             presentDefaultBrowserPopup(
                 from: cardName,

--- a/Client/Frontend/Onboarding/ViewControllers/FirstInstall/IntroViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/FirstInstall/IntroViewController.swift
@@ -229,7 +229,7 @@ extension IntroViewController: OnboardingCardDelegate {
         switch action {
         case .requestNotifications:
             introViewModel.chosenOptions.insert(.askForNotificationPermission)
-            introViewModel.sendOnboardingUserActivationEvent()
+            introViewModel.updateOnboardingUserActivationEvent()
             askForNotificationPermission(from: cardName)
         case .nextCard:
             showNextPage(from: cardName) {
@@ -237,7 +237,7 @@ extension IntroViewController: OnboardingCardDelegate {
             }
         case .syncSignIn:
             introViewModel.chosenOptions.insert(.syncSignIn)
-            introViewModel.sendOnboardingUserActivationEvent()
+            introViewModel.updateOnboardingUserActivationEvent()
             let fxaPrams = FxALaunchParams(entrypoint: .introOnboarding, query: [:])
             presentSignToSync(
                 with: fxaPrams,
@@ -249,7 +249,7 @@ extension IntroViewController: OnboardingCardDelegate {
             }
         case .setDefaultBrowser:
             introViewModel.chosenOptions.insert(.setAsDefaultBrowser)
-            introViewModel.sendOnboardingUserActivationEvent()
+            introViewModel.updateOnboardingUserActivationEvent()
             registerForNotification()
             DefaultApplicationHelper().openSettings()
         case .openInstructionsPopup:

--- a/Client/Frontend/Onboarding/ViewControllers/FirstInstall/IntroViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/FirstInstall/IntroViewController.swift
@@ -229,7 +229,6 @@ extension IntroViewController: OnboardingCardDelegate {
         switch action {
         case .requestNotifications:
             introViewModel.chosenOptions.insert(.askForNotificationPermission)
-            print("introViewModel.chosenOptions = \(introViewModel.chosenOptions)")
             askForNotificationPermission(from: cardName)
         case .nextCard:
             showNextPage(from: cardName) {
@@ -237,7 +236,6 @@ extension IntroViewController: OnboardingCardDelegate {
             }
         case .syncSignIn:
             introViewModel.chosenOptions.insert(.syncSignIn)
-            print("introViewModel.chosenOptions = \(introViewModel.chosenOptions)")
             let fxaPrams = FxALaunchParams(entrypoint: .introOnboarding, query: [:])
             presentSignToSync(
                 with: fxaPrams,
@@ -249,7 +247,6 @@ extension IntroViewController: OnboardingCardDelegate {
             }
         case .setDefaultBrowser:
             introViewModel.chosenOptions.insert(.setAsDefaultBrowser)
-            print("introViewModel.chosenOptions = \(introViewModel.chosenOptions)")
             registerForNotification()
             DefaultApplicationHelper().openSettings()
         case .openInstructionsPopup:

--- a/Client/Frontend/Onboarding/ViewControllers/FirstInstall/IntroViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/FirstInstall/IntroViewController.swift
@@ -225,16 +225,19 @@ extension IntroViewController: OnboardingCardDelegate {
             with: action,
             and: isPrimaryButton)
 
+        guard let introViewModel = viewModel as? IntroViewModel else { return }
         switch action {
         case .requestNotifications:
-            sendOnboardingUserActivationEvent(fineValue: 1)
+            introViewModel.chosenOptions.insert(.askForNotificationPermission)
+            print("introViewModel.chosenOptions = \(introViewModel.chosenOptions)")
             askForNotificationPermission(from: cardName)
         case .nextCard:
             showNextPage(from: cardName) {
                 self.showNextPageCompletionForLastCard()
             }
         case .syncSignIn:
-            sendOnboardingUserActivationEvent(fineValue: 3)
+            introViewModel.chosenOptions.insert(.syncSignIn)
+            print("introViewModel.chosenOptions = \(introViewModel.chosenOptions)")
             let fxaPrams = FxALaunchParams(entrypoint: .introOnboarding, query: [:])
             presentSignToSync(
                 with: fxaPrams,
@@ -245,7 +248,8 @@ extension IntroViewController: OnboardingCardDelegate {
                 }
             }
         case .setDefaultBrowser:
-            sendOnboardingUserActivationEvent(fineValue: 2)
+            introViewModel.chosenOptions.insert(.setAsDefaultBrowser)
+            print("introViewModel.chosenOptions = \(introViewModel.chosenOptions)")
             registerForNotification()
             DefaultApplicationHelper().openSettings()
         case .openInstructionsPopup:
@@ -261,11 +265,6 @@ extension IntroViewController: OnboardingCardDelegate {
 
     func sendCardViewTelemetry(from cardName: String) {
         viewModel.telemetryUtility.sendCardViewTelemetry(from: cardName)
-    }
-
-    func sendOnboardingUserActivationEvent(fineValue: Int) {
-        let conversionValue = ConversionValueUtil(fineValue: fineValue, coarseValue: .low, logger: DefaultLogger.shared)
-        conversionValue.adNetworkAttributionUpdateConversionInstallEvent()
     }
 
     private func showNextPageCompletionForLastCard() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7124)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15822)
Added SKAdNetwork attribution events for “Set as Default Browser”, "Turn on Notifications", "Sign In" for the Onboarding screen.
## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

