### PR TITLE
Bugfix FXIOS-7145 [v116] Nil URL possibility

### DIFF
--- a/Client/TabManagement/TabManagerImplementation.swift
+++ b/Client/TabManagement/TabManagerImplementation.swift
@@ -264,7 +264,6 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
                            category: .tabs)
             }
 
-            // laurie
             return TabData(id: tabId,
                            title: tab.lastTitle,
                            siteUrl: tab.url?.absoluteString ?? tab.lastKnownUrl?.absoluteString ?? "",

--- a/Client/TabManagement/TabManagerImplementation.swift
+++ b/Client/TabManagement/TabManagerImplementation.swift
@@ -253,8 +253,13 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
                                          tabHistoryCurrentState: state)
 
             let tabId = UUID(uuidString: tab.tabUUID) ?? UUID()
-            if tab.url == nil && tab.lastKnownUrl == nil {
-                logger.log("Tab has empty URL for saving for tab id \(tabId). It was last used \(Date.fromTimestamp(tab.lastExecutedTime ?? 0))",
+            let logMessage = "for saving for tab id \(tabId). It was last used \(Date.fromTimestamp(tab.lastExecutedTime ?? 0))"
+            if tab.url == nil {
+                logger.log("Tab has empty tab.URL \(logMessage)",
+                           level: .debug,
+                           category: .tabs)
+            } else if tab.lastKnownUrl == nil {
+                logger.log("Tab has empty tab.lastKnownURL \(logMessage)",
                            level: .debug,
                            category: .tabs)
             }

--- a/Client/TabManagement/TabManagerImplementation.swift
+++ b/Client/TabManagement/TabManagerImplementation.swift
@@ -260,7 +260,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
                            category: .tabs)
             } else if tab.lastKnownUrl == nil {
                 logger.log("Tab has empty tab.lastKnownURL \(logMessage)",
-                           level: .debug,
+                           level: .fatal,
                            category: .tabs)
             }
 

--- a/Client/TabManagement/TabManagerImplementation.swift
+++ b/Client/TabManagement/TabManagerImplementation.swift
@@ -88,7 +88,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
         Task {
             await buildTabRestore(window: await tabMigration.runMigration(savedTabs: store.tabs))
             logger.log("Tabs restore ended after migration", level: .debug, category: .tabs)
-            logger.log("Normal tabs count; \(normalTabs.count), Inactive tabs count; \(inactiveTabs.count), Private tabs count; \(privateTabs).count", level: .debug, category: .tabs)
+            logger.log("Normal tabs count; \(normalTabs.count), Inactive tabs count; \(inactiveTabs.count), Private tabs count; \(privateTabs.count)", level: .debug, category: .tabs)
         }
     }
 
@@ -97,7 +97,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
         Task {
             await buildTabRestore(window: await self.tabDataStore.fetchWindowData())
             logger.log("Tabs restore ended after fetching window data", level: .debug, category: .tabs)
-            logger.log("Normal tabs count; \(normalTabs.count), Inactive tabs count; \(inactiveTabs.count), Private tabs count; \(privateTabs).count", level: .debug, category: .tabs)
+            logger.log("Normal tabs count; \(normalTabs.count), Inactive tabs count; \(inactiveTabs.count), Private tabs count; \(privateTabs.count)", level: .debug, category: .tabs)
 
             // Safety check incase something went wrong during launch where a migration should have occured
             if tabs.count <= 1 && store.tabs.count > 1 {
@@ -253,15 +253,16 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
                                          tabHistoryCurrentState: state)
 
             let tabId = UUID(uuidString: tab.tabUUID) ?? UUID()
-            if tab.url?.absoluteString == nil {
+            if tab.url == nil && tab.lastKnownUrl == nil {
                 logger.log("Tab has empty URL for saving for tab id \(tabId). It was last used \(Date.fromTimestamp(tab.lastExecutedTime ?? 0))",
                            level: .debug,
                            category: .tabs)
             }
 
+            // laurie
             return TabData(id: tabId,
                            title: tab.lastTitle,
-                           siteUrl: tab.url?.absoluteString ?? "",
+                           siteUrl: tab.url?.absoluteString ?? tab.lastKnownUrl?.absoluteString ?? "",
                            faviconURL: tab.faviconURL,
                            isPrivate: tab.isPrivate,
                            lastUsedTime: Date.fromTimestamp(tab.lastExecutedTime ?? 0),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7145)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15885)

## :bulb: Description
My theory is that there are some occasions where the `tab.url` is nil when we `generateTabDataForSaving` to preserve tabs. The `url` variable is set either when we configure a tab from the `request?.url` or `webView.url` when `didCommit` is called or `observeValue` changed. Depending on the timing, if we're on a cold launch it seems the `url` preserved could be nil. This will make sure we have a fallback.

FYI The `lastKnownURL` was added in https://github.com/mozilla-mobile/firefox-ios/pull/8799.

@thatswinnie could you test this, since you could get this bug sometimes?

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

