### PR TITLE
Bugfix DIS-854 [v118] Post-migration pocket errors caused by Firefox iOS clients sending invalid locales

### DIFF
--- a/Providers/Pocket/PocketProvider.swift
+++ b/Providers/Pocket/PocketProvider.swift
@@ -31,11 +31,11 @@ class PocketProvider: PocketStoriesProviding, FeatureFlaggable, URLCaching {
     private let pocketEnvAPIKey = "PocketEnvironmentAPIKey"
 
     private static let SupportedLocales = [
-        "fr_FR", "fr",
-        "es_ES", "es",
-        "it_IT", "it",
-        "en_CA", "en_GB", "en_US", "en",
-        "de_DE", "de_AT", "de_CH", "de"
+        "fr_FR",
+        "es_ES",
+        "it_IT",
+        "en_CA", "en_GB", "en_US",
+        "de_DE", "de_AT", "de_CH"
     ]
 
     private let pocketGlobalFeed: String

--- a/Providers/Pocket/PocketProvider.swift
+++ b/Providers/Pocket/PocketProvider.swift
@@ -30,13 +30,7 @@ class PocketProvider: PocketStoriesProviding, FeatureFlaggable, URLCaching {
 
     private let pocketEnvAPIKey = "PocketEnvironmentAPIKey"
 
-    private static let SupportedLocales = [
-        "fr_FR",
-        "es_ES",
-        "it_IT",
-        "en_CA", "en_GB", "en_US",
-        "de_DE", "de_AT", "de_CH"
-    ]
+    private static let SupportedLocales = ["en_CA", "en_US", "en_GB", "en_ZA", "de_DE", "de_AT", "de_CH"]
 
     private let pocketGlobalFeed: String
 

--- a/Providers/Pocket/PocketProvider.swift
+++ b/Providers/Pocket/PocketProvider.swift
@@ -30,7 +30,14 @@ class PocketProvider: PocketStoriesProviding, FeatureFlaggable, URLCaching {
 
     private let pocketEnvAPIKey = "PocketEnvironmentAPIKey"
 
-    private static let SupportedLocales = ["en_CA", "en_US", "en_GB", "en_ZA", "de_DE", "de_AT", "de_CH"]
+    private static let SupportedLocales = [
+        "fr_FR", "fr",
+        "es_ES", "es",
+        "it_IT", "it",
+        "en_CA", "en_GB", "en_US", "en",
+        "de_DE", "de_AT", "de_CH", "de"
+    ]
+
     private let pocketGlobalFeed: String
 
     static let GlobalFeed = "https://getpocket.cdn.mozilla.net/v3/firefox/global-recs"
@@ -64,11 +71,22 @@ class PocketProvider: PocketStoriesProviding, FeatureFlaggable, URLCaching {
 
     // Fetch items from the global pocket feed
     func fetchStories(items: Int, completion: @escaping (StoryResult) -> Void) {
+        let isFeatureEnabled = featureFlags.isFeatureEnabled(.pocket, checking: .buildOnly)
+        let isCurrentLocaleSupported = PocketProvider.islocaleSupported(Locale.current.identifier)
+
+        // Check if we should use mock data
         if shouldUseMockData {
             return getMockDataFeed(count: items, completion: completion)
-        } else {
-            return getGlobalFeed(items: items, completion: completion)
         }
+
+        // Ensure the feature is enabled and current locale is supported
+        guard isFeatureEnabled, isCurrentLocaleSupported else {
+            completion(.failure(Error.failure))
+            return
+        }
+
+        // Note: Global feed is restricted to specific locale and feature availability
+        getGlobalFeed(items: items, completion: completion)
     }
 
     private func getGlobalFeed(items: Int, completion: @escaping (StoryResult) -> Void) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
In this PR we updated locales to match the latest valid list of pocket locales and added a check to ensure only to call the backend if both the feature and locale are enabled.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

