### PR TITLE
FXIOS-7258 iPhone only test from PrivateBrowsingTest

### DIFF
--- a/Tests/XCUITests/PrivateBrowsingTest.swift
+++ b/Tests/XCUITests/PrivateBrowsingTest.swift
@@ -201,33 +201,6 @@ class PrivateBrowsingTest: BaseTestCase {
         XCTAssertTrue(app.buttons["Copy Link"].exists, "The option is not shown")
         XCTAssertTrue(app.buttons["Download Link"].exists, "The option is not shown")
     }
-
-    // This test is disabled for iPad because the toast menu is not shown there
-    // https://testrail.stage.mozaws.net/index.php?/cases/view/2254045
-    // Smoketest
-    func testSwitchBetweenPrivateTabsToastButton() {
-        if skipPlatform { return }
-
-        // Go to Private mode
-        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
-        navigator.openURL(urlExample)
-        waitUntilPageLoad()
-        waitForExistence(app.webViews.links.firstMatch)
-        app.webViews.links.firstMatch.press(forDuration: 1)
-        waitForExistence(app.buttons["Open in New Private Tab"])
-        app.buttons["Open in New Private Tab"].press(forDuration: 1)
-        waitForExistence(app.buttons["Switch"])
-        app.buttons["Switch"].tap()
-
-        // Check that the tab has changed
-        waitUntilPageLoad()
-        waitForExistence(app.textFields["url"], timeout: 5)
-        waitForValueContains(app.textFields["url"], value: "iana")
-        XCTAssertTrue(app.links["RFC 2606"].exists)
-        waitForExistence(app.buttons["Show Tabs"])
-        let numPrivTab = app.buttons["Show Tabs"].value as? String
-        XCTAssertEqual("2", numPrivTab)
-    }
 }
 
 fileprivate extension BaseTestCase {
@@ -255,6 +228,35 @@ fileprivate extension BaseTestCase {
         }
         let closePrivateTabsSwitch = settingsTableView.switches["settings.closePrivateTabs"]
         closePrivateTabsSwitch.tap()
+    }
+}
+
+class PrivateBrowsingTestIphone: IphoneOnlyTestCase {
+    // This test is disabled for iPad because the toast menu is not shown there
+    // https://testrail.stage.mozaws.net/index.php?/cases/view/2254045
+    // Smoketest
+    func testSwitchBetweenPrivateTabsToastButton() {
+        if skipPlatform { return }
+
+        // Go to Private mode
+        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
+        navigator.openURL(urlExample)
+        waitUntilPageLoad()
+        waitForExistence(app.webViews.links.firstMatch)
+        app.webViews.links.firstMatch.press(forDuration: 1)
+        waitForExistence(app.buttons["Open in New Private Tab"])
+        app.buttons["Open in New Private Tab"].press(forDuration: 1)
+        waitForExistence(app.buttons["Switch"])
+        app.buttons["Switch"].tap()
+
+        // Check that the tab has changed
+        waitUntilPageLoad()
+        waitForExistence(app.textFields["url"], timeout: 5)
+        waitForValueContains(app.textFields["url"], value: "iana")
+        XCTAssertTrue(app.links["RFC 2606"].exists)
+        waitForExistence(app.buttons["Show Tabs"])
+        let numPrivTab = app.buttons["Show Tabs"].value as? String
+        XCTAssertEqual("2", numPrivTab)
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7258)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16101)

## :bulb: Description
`testSwitchBetweenPrivateTabsToastButton` has been failing during the last few days on iPad only. This test is intended to run on iPhone only.

Let me make use of the `skipPlatform` pattern in this case.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

