### PR TITLE
Revert #15142 [v116.4] Undo UA changes that removed FxIOS

### DIFF
--- a/Shared/UserAgent.swift
+++ b/Shared/UserAgent.swift
@@ -6,9 +6,10 @@ import Common
 import WebKit
 import UIKit
 
-public class UserAgent {
+open class UserAgent {
     public static let uaBitSafari = "Safari/605.1.15"
     public static let uaBitMobile = "Mobile/15E148"
+    public static let uaBitFx = "FxiOS/\(AppInfo.appVersion)"
     public static let product = "Mozilla/5.0"
     public static let platform = "AppleWebKit/605.1.15"
     public static let platformDetails = "(KHTML, like Gecko)"
@@ -17,19 +18,6 @@ public class UserAgent {
     public static let uaBitGoogleIpad = "Version/13.0.3"
 
     private static var defaults = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)!
-
-    static var systemInfo: String {
-        var deviceModel = UIDevice.current.model
-        // Only use first part of device name(so "iPod Touch" becomes "iPod")
-        if let deviceNameFirstPart = deviceModel.split(separator: " ").first {
-            deviceModel = String(deviceNameFirstPart)
-        }
-
-        let platform = UIDevice.current.userInterfaceIdiom == .pad ? "OS" : "iPhone OS"
-        let osVersion = UIDevice.current.systemVersion.replacingOccurrences(of: ".", with: "_")
-
-        return "(\(deviceModel); CPU \(platform) \(osVersion) like Mac OS X)"
-    }
 
     private static func clientUserAgent(prefix: String) -> String {
         let versionStr: String
@@ -119,11 +107,11 @@ public struct CustomUserAgentConstant {
 
 public struct UserAgentBuilder {
     // User agent components
-    private var product = ""
-    private var systemInfo = ""
-    private var platform = ""
-    private var platformDetails = ""
-    private var extensions = ""
+    fileprivate var product = ""
+    fileprivate var systemInfo = ""
+    fileprivate var platform = ""
+    fileprivate var platformDetails = ""
+    fileprivate var extensions = ""
 
     init(product: String, systemInfo: String, platform: String, platformDetails: String, extensions: String) {
         self.product = product
@@ -138,16 +126,8 @@ public struct UserAgentBuilder {
         return removeEmptyComponentsAndJoin(uaItems: userAgentItems)
     }
 
-    public func clone(product: String? = nil,
-                      systemInfo: String? = nil,
-                      platform: String? = nil,
-                      platformDetails: String? = nil,
-                      extensions: String? = nil) -> String {
-        let userAgentItems = [product ?? self.product,
-                              systemInfo ?? self.systemInfo,
-                              platform ?? self.platform,
-                              platformDetails ?? self.platformDetails,
-                              extensions ?? self.extensions]
+    public func clone(product: String? = nil, systemInfo: String? = nil, platform: String? = nil, platformDetails: String? = nil, extensions: String? = nil) -> String {
+        let userAgentItems = [product ?? self.product, systemInfo ?? self.systemInfo, platform ?? self.platform, platformDetails ?? self.platformDetails, extensions ?? self.extensions]
         return removeEmptyComponentsAndJoin(uaItems: userAgentItems)
     }
 
@@ -159,10 +139,10 @@ public struct UserAgentBuilder {
     public static func defaultMobileUserAgent() -> UserAgentBuilder {
         return UserAgentBuilder(
             product: UserAgent.product,
-            systemInfo: UserAgent.systemInfo,
+            systemInfo: "(\(UIDevice.current.model); CPU iPhone OS \(UIDevice.current.systemVersion.replacingOccurrences(of: ".", with: "_")) like Mac OS X)",
             platform: UserAgent.platform,
             platformDetails: UserAgent.platformDetails,
-            extensions: "\(UserAgent.uaBitMobile) \(UserAgent.uaBitSafari)")
+            extensions: "FxiOS/\(AppInfo.appVersion)  \(UserAgent.uaBitMobile) \(UserAgent.uaBitSafari)")
     }
 
     public static func defaultDesktopUserAgent() -> UserAgentBuilder {
@@ -171,6 +151,6 @@ public struct UserAgentBuilder {
             systemInfo: "(Macintosh; Intel Mac OS X 10.15)",
             platform: UserAgent.platform,
             platformDetails: UserAgent.platformDetails,
-            extensions: UserAgent.uaBitSafari)
+            extensions: "FxiOS/\(AppInfo.appVersion) \(UserAgent.uaBitSafari)")
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7169)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15938)

## :bulb: Description
Reverting #15142 due to incident. Will find a better solution with a new ticket.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

