### PR TITLE
Bugfix FXIOS-6891 [v119] Sync notification setting must mimic the Firefox notification setting when the user logs in for the first time (#15336)

### DIFF
--- a/Client/OnboardingNotificationCardHelper.swift
+++ b/Client/OnboardingNotificationCardHelper.swift
@@ -16,4 +16,10 @@ struct OnboardingNotificationCardHelper {
                 || $0.buttons.secondary?.action == .requestNotifications
             }
     }
+
+    func shouldAskForNotificationsPermission(telemetryObj: TelemetryWrapper.EventObject) -> Bool {
+        let isOnboarding = telemetryObj == .onboarding
+        let shouldAskForPermission = !OnboardingNotificationCardHelper().notificationCardIsInOnboarding() || !isOnboarding
+        return shouldAskForPermission
+    }
 }

--- a/Client/OnboardingNotificationCardHelper.swift
+++ b/Client/OnboardingNotificationCardHelper.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 struct OnboardingNotificationCardHelper {
-    private func notificationCardIsInOnboarding(
+    public func notificationCardIsInOnboarding(
         from featureLayer: NimbusOnboardingFeatureLayer = NimbusOnboardingFeatureLayer()
     ) -> Bool {
         return featureLayer
@@ -15,11 +15,5 @@ struct OnboardingNotificationCardHelper {
                 return $0.buttons.primary.action == .requestNotifications
                 || $0.buttons.secondary?.action == .requestNotifications
             }
-    }
-
-    func askForPermissionDuringSync(isOnboarding: Bool) -> Bool {
-        if notificationCardIsInOnboarding() { return false }
-
-        return isOnboarding
     }
 }

--- a/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/RustFxA/FirefoxAccountSignInViewController.swift
@@ -263,14 +263,14 @@ class FirefoxAccountSignInViewController: UIViewController, Themeable {
     /// Use email login button tapped
     @objc
     func emailLoginTapped(_ sender: UIButton) {
-        let askForPermission = OnboardingNotificationCardHelper().askForPermissionDuringSync(
-            isOnboarding: telemetryObject == .onboarding)
+        let isOnboarding = telemetryObject == .onboarding
+        let shouldAskForPermission = !OnboardingNotificationCardHelper().notificationCardIsInOnboarding() || !isOnboarding
 
         let fxaWebVC = FxAWebViewController(pageType: .emailLoginFlow,
                                             profile: profile,
                                             dismissalStyle: fxaDismissStyle,
                                             deepLinkParams: deepLinkParams,
-                                            shouldAskForNotificationPermission: askForPermission)
+                                            shouldAskForNotificationPermission: shouldAskForPermission)
         fxaWebVC.shouldDismissFxASignInViewController = { [weak self] in
             self?.shouldReload?()
             self?.dismissVC()
@@ -283,14 +283,14 @@ class FirefoxAccountSignInViewController: UIViewController, Themeable {
 // MARK: QRCodeViewControllerDelegate Functions
 extension FirefoxAccountSignInViewController: QRCodeViewControllerDelegate {
     func didScanQRCodeWithURL(_ url: URL) {
-        let askForPermission = OnboardingNotificationCardHelper().askForPermissionDuringSync(
-            isOnboarding: telemetryObject == .onboarding)
+        let isOnboarding = telemetryObject == .onboarding
+        let shouldAskForPermission = !OnboardingNotificationCardHelper().notificationCardIsInOnboarding() || !isOnboarding
 
         let vc = FxAWebViewController(pageType: .qrCode(url: url.absoluteString),
                                       profile: profile,
                                       dismissalStyle: fxaDismissStyle,
                                       deepLinkParams: deepLinkParams,
-                                      shouldAskForNotificationPermission: askForPermission)
+                                      shouldAskForNotificationPermission: shouldAskForPermission)
         navigationController?.pushViewController(vc, animated: true)
     }
 

--- a/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/RustFxA/FirefoxAccountSignInViewController.swift
@@ -263,9 +263,7 @@ class FirefoxAccountSignInViewController: UIViewController, Themeable {
     /// Use email login button tapped
     @objc
     func emailLoginTapped(_ sender: UIButton) {
-        let isOnboarding = telemetryObject == .onboarding
-        let shouldAskForPermission = !OnboardingNotificationCardHelper().notificationCardIsInOnboarding() || !isOnboarding
-
+        let shouldAskForPermission = OnboardingNotificationCardHelper().shouldAskForNotificationsPermission(telemetryObj: telemetryObject)
         let fxaWebVC = FxAWebViewController(pageType: .emailLoginFlow,
                                             profile: profile,
                                             dismissalStyle: fxaDismissStyle,
@@ -283,8 +281,7 @@ class FirefoxAccountSignInViewController: UIViewController, Themeable {
 // MARK: QRCodeViewControllerDelegate Functions
 extension FirefoxAccountSignInViewController: QRCodeViewControllerDelegate {
     func didScanQRCodeWithURL(_ url: URL) {
-        let isOnboarding = telemetryObject == .onboarding
-        let shouldAskForPermission = !OnboardingNotificationCardHelper().notificationCardIsInOnboarding() || !isOnboarding
+        let shouldAskForPermission = OnboardingNotificationCardHelper().shouldAskForNotificationsPermission(telemetryObj: telemetryObject)
 
         let vc = FxAWebViewController(pageType: .qrCode(url: url.absoluteString),
                                       profile: profile,

--- a/RustFxA/FxAWebViewModel.swift
+++ b/RustFxA/FxAWebViewModel.swift
@@ -250,7 +250,7 @@ extension FxAWebViewModel {
         profile.rustFxA.accountManager.peek()?.finishAuthentication(authData: auth) { _ in
             self.profile.syncManager.onAddedAccount()
 
-            // only ask for notification permission if it's not onboarding related (e.g. settings)
+            // only ask for notification permission if it's not onboarding related (e.g. settings) or if the onboarding flow is missing the notifications card
             guard self.shouldAskForNotificationPermission else { return }
 
             MZKeychainWrapper.sharedClientAppContainerKeychain.removeObject(forKey: KeychainKey.apnsToken, withAccessibility: MZKeychainItemAccessibility.afterFirstUnlock)

--- a/Tests/ClientTests/NotificationSurface/OnboardingNotificationCardHelperTests.swift
+++ b/Tests/ClientTests/NotificationSurface/OnboardingNotificationCardHelperTests.swift
@@ -25,12 +25,12 @@ class OnboardingNotificationCardHelperTests: XCTestCase {
         nimbusUtility = nil
     }
 
-    func testHelper_fromOnboarding_noNotificationCard_returnsTrue() {
-        nimbusUtility.setupNimbus(withOrder: cards.welcomeSync)
+    func testHelper_fromOnboarding_withNotificationCard_returnsTrue() {
+        nimbusUtility.setupNimbus(withOrder: cards.welcomeNotificationSync)
         let expectedResult = true
         let subject = createSubject()
 
-        let result = subject.askForPermissionDuringSync(isOnboarding: true)
+        let result = subject.notificationCardIsInOnboarding()
 
         XCTAssertEqual(result, expectedResult)
     }
@@ -40,17 +40,7 @@ class OnboardingNotificationCardHelperTests: XCTestCase {
         let expectedResult = false
         let subject = createSubject()
 
-        let result = subject.askForPermissionDuringSync(isOnboarding: false)
-
-        XCTAssertEqual(result, expectedResult)
-    }
-
-    func testHelper_fromOnboarding_withNotificationCard_returnsFalse() {
-        nimbusUtility.setupNimbus(withOrder: cards.welcomeNotificationSync)
-        let expectedResult = false
-        let subject = createSubject()
-
-        let result = subject.askForPermissionDuringSync(isOnboarding: true)
+        let result = subject.notificationCardIsInOnboarding()
 
         XCTAssertEqual(result, expectedResult)
     }

--- a/Tests/ClientTests/NotificationSurface/OnboardingNotificationCardHelperTests.swift
+++ b/Tests/ClientTests/NotificationSurface/OnboardingNotificationCardHelperTests.swift
@@ -54,6 +54,7 @@ class OnboardingNotificationCardHelperTests: XCTestCase {
     }
 
     func testShouldNotAskForPermission_WhenOnboarding() {
+        nimbusUtility.setupNimbus(withOrder: cards.welcomeNotificationSync)
         let telemetryObj = TelemetryWrapper.EventObject.onboarding
         let subject = createSubject()
         let result = subject.shouldAskForNotificationsPermission(telemetryObj: telemetryObj)

--- a/Tests/ClientTests/NotificationSurface/OnboardingNotificationCardHelperTests.swift
+++ b/Tests/ClientTests/NotificationSurface/OnboardingNotificationCardHelperTests.swift
@@ -46,6 +46,7 @@ class OnboardingNotificationCardHelperTests: XCTestCase {
     }
 
     func testShouldAskForPermission_WhenNotOnboarding() {
+        nimbusUtility.setupNimbus(withOrder: cards.welcomeNotificationSync)
         let telemetryObj = TelemetryWrapper.EventObject.home
         let subject = createSubject()
         let result = subject.shouldAskForNotificationsPermission(telemetryObj: telemetryObj)

--- a/Tests/ClientTests/NotificationSurface/OnboardingNotificationCardHelperTests.swift
+++ b/Tests/ClientTests/NotificationSurface/OnboardingNotificationCardHelperTests.swift
@@ -45,6 +45,22 @@ class OnboardingNotificationCardHelperTests: XCTestCase {
         XCTAssertEqual(result, expectedResult)
     }
 
+    func testShouldAskForPermission_WhenNotOnboarding() {
+        let telemetryObj = TelemetryWrapper.EventObject.home
+        let subject = createSubject()
+        let result = subject.shouldAskForNotificationsPermission(telemetryObj: telemetryObj)
+
+        XCTAssertTrue(result)
+    }
+
+    func testShouldNotAskForPermission_WhenOnboarding() {
+        let telemetryObj = TelemetryWrapper.EventObject.onboarding
+        let subject = createSubject()
+        let result = subject.shouldAskForNotificationsPermission(telemetryObj: telemetryObj)
+
+        XCTAssertFalse(result)
+    }
+
     // MARK: - Helper
     private func createSubject() -> OnboardingNotificationCardHelper {
         let subject = OnboardingNotificationCardHelper()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6891)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15336)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

