### PR TITLE
Add FXIOS-6610 [v119] openClearRecentSearch key command to history coordinator

### DIFF
--- a/Client/Coordinators/Library/HistoryCoordinator.swift
+++ b/Client/Coordinators/Library/HistoryCoordinator.swift
@@ -3,6 +3,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import Common
+import Shared
 
 protocol HistoryCoordinatorDelegate: AnyObject {
     func showRecentlyClosedTab()
@@ -12,6 +14,7 @@ class HistoryCoordinator: BaseCoordinator, HistoryCoordinatorDelegate {
     // MARK: - Properties
 
     private let profile: Profile
+    private let notificationCenter: NotificationProtocol
     private weak var parentCoordinator: LibraryCoordinatorDelegate?
 
     // MARK: - Initializers
@@ -19,11 +22,20 @@ class HistoryCoordinator: BaseCoordinator, HistoryCoordinatorDelegate {
     init(
         profile: Profile,
         router: Router,
+        notificationCenter: NotificationProtocol = NotificationCenter.default,
         parentCoordinator: LibraryCoordinatorDelegate?
     ) {
         self.profile = profile
         self.parentCoordinator = parentCoordinator
+        self.notificationCenter = notificationCenter
         super.init(router: router)
+        self.notificationCenter.addObserver(self, selector: #selector(openClearHistory), name: .OpenClearRecentHistory, object: nil)
+    }
+
+    @objc
+    private func openClearHistory() {
+        guard let historyPanel = router.rootViewController as? HistoryPanel else { return }
+        historyPanel.showClearRecentHistory()
     }
 
     // MARK: - HistoryCoordinatorDelegate
@@ -32,5 +44,9 @@ class HistoryCoordinator: BaseCoordinator, HistoryCoordinatorDelegate {
         let controller = RecentlyClosedTabsPanel(profile: profile)
         controller.libraryPanelDelegate = parentCoordinator
         router.push(controller)
+    }
+
+    deinit {
+        notificationCenter.removeObserver(self)
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -41,13 +41,17 @@ extension BrowserViewController {
 
     @objc
     func openClearHistoryPanelKeyCommand() {
-        guard let libraryViewController = self.libraryViewController else {
-            let clearHistoryHelper = ClearHistorySheetProvider(profile: profile, tabManager: tabManager)
-            clearHistoryHelper.showClearRecentHistory(onViewController: self)
-            return
-        }
+        if CoordinatorFlagManager.isLibraryCoordinatorEnabled {
+            navigationHandler?.show(homepanelSection: .history)
+        } else {
+            guard let libraryViewController = self.libraryViewController else {
+                let clearHistoryHelper = ClearHistorySheetProvider(profile: profile, tabManager: tabManager)
+                clearHistoryHelper.showClearRecentHistory(onViewController: self)
+                return
+            }
 
-        libraryViewController.viewModel.selectedPanel = .history
+            libraryViewController.viewModel.selectedPanel = .history
+        }
         NotificationCenter.default.post(name: .OpenClearRecentHistory, object: nil)
     }
 

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -283,7 +283,7 @@ class HistoryPanel: UIViewController,
         return siteItem
     }
 
-    private func showClearRecentHistory() {
+    func showClearRecentHistory() {
         clearHistoryHelper.showClearRecentHistory(onViewController: self) { [weak self] dateOption in
             // Delete groupings that belong to THAT section.
             switch dateOption {
@@ -761,8 +761,7 @@ extension HistoryPanel {
         updatePanelState(newState: .history(state: .mainView))
 
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .deleteHistory)
-        // TODO: Yoana remove notification and handle directly
-        NotificationCenter.default.post(name: .OpenClearRecentHistory, object: nil)
+        showClearRecentHistory()
     }
 
     // MARK: - User Interactions

--- a/Tests/ClientTests/Coordinators/Library/HistoryCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/Library/HistoryCoordinatorTests.swift
@@ -9,12 +9,14 @@ final class HistoryCoordinatorTests: XCTestCase {
     private var router: MockRouter!
     private var profile: MockProfile!
     private var parentCoordinator: MockLibraryCoordinatorDelegate!
+    private var notificationCenter: MockNotificationCenter!
 
     override func setUp() {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         router = MockRouter(navigationController: UINavigationController())
         profile = MockProfile()
+        notificationCenter = MockNotificationCenter()
         parentCoordinator = MockLibraryCoordinatorDelegate()
     }
 
@@ -24,6 +26,7 @@ final class HistoryCoordinatorTests: XCTestCase {
         router = nil
         profile = nil
         parentCoordinator = nil
+        notificationCenter = nil
     }
 
     func testShowRecentlyClosedTabs() {
@@ -35,10 +38,20 @@ final class HistoryCoordinatorTests: XCTestCase {
         XCTAssertEqual(router.pushCalled, 1)
     }
 
+    func testOpenClearRecentSearch_receiveNotificationCorrectly() {
+        let subject = createSubject()
+
+        notificationCenter.post(name: .OpenClearRecentHistory)
+
+        XCTAssertEqual(notificationCenter.addObserverCallCount, 1)
+        XCTAssertEqual(notificationCenter.postCallCount, 1)
+    }
+
     private func createSubject() -> HistoryCoordinator {
         let subject = HistoryCoordinator(
             profile: profile,
             router: router,
+            notificationCenter: notificationCenter,
             parentCoordinator: parentCoordinator
         )
         trackForMemoryLeaks(subject)

--- a/nimbus-features/libraryCoordinatorRefactor.yaml
+++ b/nimbus-features/libraryCoordinatorRefactor.yaml
@@ -15,5 +15,5 @@ features:
           enabled: false
       - channel: developer
         value:
-          enabled: true
+          enabled: false
 

--- a/nimbus-features/libraryCoordinatorRefactor.yaml
+++ b/nimbus-features/libraryCoordinatorRefactor.yaml
@@ -15,5 +15,5 @@ features:
           enabled: false
       - channel: developer
         value:
-          enabled: false
+          enabled: true
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6610)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14786)

## :bulb: Description
Add `openClearRecentSearch` key command to `HistoryCoordinator`.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

