### PR TITLE
Add [v118] Implement a temporary ping for analysis of the baseline ping behavior

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -7,6 +7,7 @@ import Storage
 import CoreSpotlight
 import UIKit
 import Common
+import Glean
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
     let logger = DefaultLogger.shared
@@ -44,6 +45,40 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private var widgetManager: TopSitesWidgetManager?
     private var menuBuilderHelper: MenuBuilderHelper?
 
+    /// Tracking active status of the application.
+    private var isActive = false
+
+    /// Handle the `willEnterForegroundNotification` the same way Glean handles it.
+    func handleForegroundEvent() {
+        if !isActive {
+            GleanMetrics.Pings.shared.tempBaseline.submit(reason: .active)
+            GleanMetrics.BaselineValidation.startupDuration.start()
+            GleanMetrics.BaselineValidation.baselineDuration.start()
+            NSUserDefaultsPrefs(prefix: "profile").setBool(true, forKey: AppConstants.prefGleanTempDirtyFlag)
+
+            isActive = true
+        }
+    }
+
+    /// Handle the `didBecomeActiveNotification` the way Glean would handle it
+    func handleVisibleEvent() {
+        GleanMetrics.BaselineValidation.startupDuration.stop()
+        GleanMetrics.Pings.shared.tempBaseline.submit(reason: .foreground)
+        GleanMetrics.BaselineValidation.visibleDuration.start()
+    }
+
+    /// Handle the `didEnterBackgroundNotification` the same way Glean handles it.
+    func handleBackgroundEvent() {
+        if isActive {
+            GleanMetrics.BaselineValidation.baselineDuration.stop()
+            GleanMetrics.BaselineValidation.visibleDuration.stop()
+            GleanMetrics.Pings.shared.tempBaseline.submit(reason: .inactive)
+            NSUserDefaultsPrefs(prefix: "profile").setBool(false, forKey: AppConstants.prefGleanTempDirtyFlag)
+
+            isActive = false
+        }
+    }
+
     func application(
         _ application: UIApplication,
         willFinishLaunchingWithOptions
@@ -65,6 +100,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         appLaunchUtil = AppLaunchUtil(profile: profile)
         appLaunchUtil?.setUpPreLaunchDependencies()
+
+        // Handle the dirty bit the same way Glean handles it
+        // and submit the right ping.
+        let prefs = NSUserDefaultsPrefs(prefix: "profile")
+        let dirtyFlag = prefs.boolForKey(AppConstants.prefGleanTempDirtyFlag) ?? false
+        prefs.setBool(true, forKey: AppConstants.prefGleanTempDirtyFlag)
+        if dirtyFlag {
+            GleanMetrics.Pings.shared.tempBaseline.submit(reason: .dirtyStartup)
+        }
+
+        // Glean does this as part of the LifecycleObserver too.
+        // `isActive` tracks active status to avoid double-triggers.
+        handleForegroundEvent()
 
         // Set up a web server that serves us static content. Do this early so that it is ready when the UI is presented.
         webServerUtil = WebServerUtil(profile: profile)
@@ -130,6 +178,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         profile.syncManager.applicationDidBecomeActive()
         webServerUtil?.setUpWebServer()
 
+        handleVisibleEvent()
         TelemetryWrapper.recordEvent(category: .action, method: .foreground, object: .app)
 
         // update top sites widget
@@ -161,6 +210,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                    level: .info,
                    category: .lifecycle)
 
+        handleBackgroundEvent()
         TelemetryWrapper.recordEvent(category: .action, method: .background, object: .app)
         TabsQuantityTelemetry.trackTabsQuantity(tabManager: tabManager)
 
@@ -183,6 +233,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                    category: .lifecycle)
     }
 
+    func applicationWillEnterForeground(_ application: UIApplication) {
+        handleForegroundEvent()
+    }
+
     func applicationWillTerminate(_ application: UIApplication) {
         // We have only five seconds here, so let's hope this doesn't take too long.
         profile.shutdown()
@@ -202,7 +256,8 @@ extension AppDelegate: Notifiable {
     private func addObservers() {
         setupNotifications(forObserver: self, observing: [UIApplication.didBecomeActiveNotification,
                                                           UIApplication.willResignActiveNotification,
-                                                          UIApplication.didEnterBackgroundNotification])
+                                                          UIApplication.didEnterBackgroundNotification,
+                                                          UIApplication.willEnterForegroundNotification])
     }
 
     /// When migrated to Scenes, these methods aren't called. Consider this a temporary solution to calling into those methods.
@@ -214,6 +269,8 @@ extension AppDelegate: Notifiable {
             applicationWillResignActive(UIApplication.shared)
         case UIApplication.didEnterBackgroundNotification:
             applicationDidEnterBackground(UIApplication.shared)
+        case UIApplication.willEnterForegroundNotification:
+            applicationWillEnterForeground(UIApplication.shared)
 
         default: break
         }

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -4172,3 +4172,58 @@ credit_card:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2023-12-31"
+
+baseline.validation:
+  startup_duration:
+    type: timespan
+    time_unit: millisecond
+    description: |
+      The duration from startup until the app is visible to the user.
+    send_in_pings:
+      - temp-baseline
+    lifetime: ping
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1850361
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1850361#c1
+    notification_emails:
+      - jrediger@mozilla.com
+    expires: 2023-12-31
+    data_sensitivity:
+      - interaction
+  baseline_duration:
+    type: timespan
+    time_unit: millisecond
+    description: |
+      The duration from startup to the backgrounding event.
+      This should be equivalent to `baseline.duration`
+    send_in_pings:
+      - temp-baseline
+    lifetime: ping
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1850361
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1850361#c1
+    notification_emails:
+      - jrediger@mozilla.com
+    expires: 2023-12-31
+    data_sensitivity:
+      - interaction
+  visible_duration:
+    type: timespan
+    time_unit: millisecond
+    description: |
+      The duration from when the app is visible to the user
+      until it is backgrounded.
+    send_in_pings:
+      - temp-baseline
+    lifetime: ping
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1850361
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1850361#c1
+    notification_emails:
+      - jrediger@mozilla.com
+    expires: 2023-12-31
+    data_sensitivity:
+      - interaction

--- a/Client/pings.yaml
+++ b/Client/pings.yaml
@@ -28,3 +28,28 @@ first-session:
     - https://github.com/mozilla-mobile/firefox-ios/pull/11089
   notification_emails:
     - fx-ios-data-stewards@mozilla.com
+
+temp-baseline:
+  description: |
+    Temporary ping to measure when the app UI is visible to the user.
+  include_client_id: true
+  # We set some validation metrics,
+  # when they expire we don't want to send anything anymore.
+  # (That's also when we remove the ping)
+  send_if_empty: false
+  bugs:
+    - https://bugzilla.mozilla.org/show_bug.cgi?id=1850361
+  data_reviews:
+    - https://bugzilla.mozilla.org/show_bug.cgi?id=1850361#c1
+  notification_emails:
+    - jrediger@mozilla.com
+  reasons:
+    dirty_startup: |
+      The ping was submitted at startup, because the application process was
+      killed before becoming inactive, in the last session.
+    inactive: |
+      The ping was submitted when becoming inactive.
+    active: |
+      The ping was submitted when the application starts.
+    foreground: |
+      The ping was submitted when the application became foregrounded.

--- a/Shared/AppConstants.swift
+++ b/Shared/AppConstants.swift
@@ -70,6 +70,7 @@ public class AppConstants {
 
     public static let prefSendUsageData = "settings.sendUsageData"
     public static let prefStudiesToggle = "settings.studiesToggle"
+    public static let prefGleanTempDirtyFlag = "glean.temp.dirtyFlag"
 
     /// Build Channel.
     public static let buildChannel: AppBuildChannel = {


### PR DESCRIPTION
This ping mirrors the builtin `baseline` ping with one extension: A ping with reason `foreground` is submitted when the app receives a `didBecomeActiveNotification`, which indicates that the app is actually visible to the user.

## :scroll: Tickets
[bugzilla ticket](https://bugzilla.mozilla.org/show_bug.cgi?id=1850361)
I do not have a JIRA ticket for this. Does it need one?

## :bulb: Description

Implement a temporary ping for analysis of the baseline ping behavior.

This ping mirrors the builtin `baseline` ping with one extension:
A ping with reason `foreground` is submitted
when the app receives a `didBecomeActiveNotification`,
which indicates that the app is actually visible to the user.

This is a followup to the recent behavior change in baseline pings we've seen.

cc @OrlaM @travis79 

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

