### PR TITLE
Add MTE-1475 [v119] Firebase Test Lab: iOS deprecation

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1423,7 +1423,7 @@ workflows:
                 --type robo \
                 --app "$BITRISE_IPA_PATH" \
                 --device=model=iphone13pro,version=15.7 \
-                --device=model=iphone8,version=16.5 \
+                --device=model=iphone8,version=16.6 \
                 --results-bucket=firefox_ios_test_artifacts \
                 --no-record-video \
                 --client-details=matrixLabel="Bitrise" \


### PR DESCRIPTION
https://firebase.google.com/docs/test-lab/ios/available-testing-devices#deprecated

`iPhone 8`  `16.5` -> `16.6`

Firebase Test Lab Due date: `2023-09-14`