### PR TITLE
Add FXIOS-7242 [v119] #16064 Improve error card with accessibility sizes

### DIFF
--- a/Client/Frontend/Fakespot/FakespotViewController.swift
+++ b/Client/Frontend/Fakespot/FakespotViewController.swift
@@ -107,7 +107,7 @@ class FakespotViewController: UIViewController, Themeable {
         let errorCardViewModel = FakespotErrorCardViewModel(title: .Shopping.ErrorCardTitle,
                                                             description: .Shopping.ErrorCardDescription,
                                                             actionTitle: .Shopping.ErrorCardButtonText)
-        errorCardView.configure(viewModel: errorCardViewModel)
+        errorCardView.configure(errorCardViewModel)
 
         let highlightsCardViewModel = HighlightsCardViewModel(
             footerTitle: .Shopping.HighlightsCardFooterText,

--- a/Client/Frontend/Fakespot/Views/FakespotErrorCardView.swift
+++ b/Client/Frontend/Fakespot/Views/FakespotErrorCardView.swift
@@ -90,6 +90,7 @@ final class FakespotErrorCardView: UIView, ThemeApplicable, Notifiable {
                                                 right: UX.buttonHorizontalInset)
     }
 
+    private var iconImageHeightConstraint: NSLayoutConstraint?
     var notificationCenter: NotificationProtocol = NotificationCenter.default
 
     override init(frame: CGRect) {
@@ -121,14 +122,12 @@ final class FakespotErrorCardView: UIView, ThemeApplicable, Notifiable {
         cardView.configure(cardModel)
     }
 
-    private var starRatingHeightConstraint: NSLayoutConstraint?
-
     private func setupLayout() {
         addSubview(cardView)
 
         let size = min(UIFontMetrics.default.scaledValue(for: UX.iconSize), UX.iconMaxSize)
-        starRatingHeightConstraint = iconImageView.heightAnchor.constraint(equalToConstant: size)
-        starRatingHeightConstraint?.isActive = true
+        iconImageHeightConstraint = iconImageView.heightAnchor.constraint(equalToConstant: size)
+        iconImageHeightConstraint?.isActive = true
 
         iconStackView.addArrangedSubview(UIView())
         iconStackView.addArrangedSubview(iconImageView)
@@ -185,7 +184,7 @@ final class FakespotErrorCardView: UIView, ThemeApplicable, Notifiable {
     }
 
     private func adjustLayout() {
-        starRatingHeightConstraint?.constant = min(UIFontMetrics.default.scaledValue(for: UX.iconSize), UX.iconMaxSize)
+        iconImageHeightConstraint?.constant = min(UIFontMetrics.default.scaledValue(for: UX.iconSize), UX.iconMaxSize)
         setNeedsLayout()
         layoutIfNeeded()
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7242)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16064)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
| Accessibility size | Default |
|--------|--------|
| ![image](https://github.com/mozilla-mobile/firefox-ios/assets/26011662/45430cd8-5637-4071-ad1e-c46c7004bce5) | ![image](https://github.com/mozilla-mobile/firefox-ios/assets/26011662/3f6f6738-8fa6-4d6d-8496-cf9c743feebe) | 

According to [this comment](https://u3302489.ct.sendgrid.net/ls/click?upn=5jn-2BNVr6mWrJbcZ1z4kro3nySutAgQPt34lNFAjvKx1Bg5WxduM9Qs9zOCdvdqnVrHZMlOQKZMheHMNHyAmf47z9rzlQs8GYlK6dWcHjKqwmYlu7PnmAxh8JEYN0LshAwqSohf9HUrcSZF5acwpUv1n5jDJYT2icPLlT9CbDp4o-3DEd25_y6WofM1nkwuv5Gb6vv-2Fz-2FJuUbcyv1ELfchiU4D6gs4g6XdrHxvqPfw1n-2Bhn5r5z6U17sMeLfzxurClR160UE1a-2ByxqMvQwmXA-2FQvyvp67UjdBL6L7xRG4O4Fx5yxQrUR2747Z92t30bntTpBPtKMwGChg7CN5W3SSCokAnu-2B4AeYxuQPC-2BnTe3JORhr55TzySfilQizA-2FjvHWddcUGs2XIbRHpesGbO-2BAcG7OMjbWxbCKCoYDCxzJWTsfeQnngQADVBEzZmD17f-2F97BNzfna3g-3D-3D), the icon can grow up to 58 and is aligned horizontally with the title.
Note: Colors are still not updated in Figma.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

