### PR TITLE
Add FXIOS-7333 [v117.3] temp-baseline ping: Send even if empty

### DIFF
--- a/Client/pings.yaml
+++ b/Client/pings.yaml
@@ -33,10 +33,7 @@ temp-baseline:
   description: |
     Temporary ping to measure when the app UI is visible to the user.
   include_client_id: true
-  # We set some validation metrics,
-  # when they expire we don't want to send anything anymore.
-  # (That's also when we remove the ping)
-  send_if_empty: false
+  send_if_empty: true
   bugs:
     - https://bugzilla.mozilla.org/show_bug.cgi?id=1850361
   data_reviews:


### PR DESCRIPTION
## :scroll: Tickets
I'm reusing the old tickets.
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7333)
[bugzilla issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1850361)

## :bulb: Description

The `active` ping (and probably the `dirty_startup`) ping will not have any metrics outside the usual ping/client info, but we still want to send it to get that signal.

This was missed in the initial implementation as I tested locally while also setting another metric, which was ultimately removed before landing. That makes the currently received data hard/impossible to analyse.

cc @OrlaM @travis79 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

