### PR TITLE
Refactor FXIOS-6350 [v118] Replace use of DefaultStandardFontBold with preferredFont

### DIFF
--- a/Client/Frontend/Settings/Main/Account/AccountStatusSetting.swift
+++ b/Client/Frontend/Settings/Main/Account/AccountStatusSetting.swift
@@ -41,23 +41,15 @@ class AccountStatusSetting: WithAccountSetting {
     }
 
     override var title: NSAttributedString? {
-        if let displayName = RustFirefoxAccounts.shared.userProfile?.displayName {
-            return NSAttributedString(
-                string: displayName,
-                attributes: [
-                    NSAttributedString.Key.font: LegacyDynamicFontHelper.defaultHelper.DefaultStandardFontBold,
-                    NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
-        }
+        guard let profile = RustFirefoxAccounts.shared.userProfile else { return nil }
 
-        if let email = RustFirefoxAccounts.shared.userProfile?.email {
-            return NSAttributedString(
-                string: email,
-                attributes: [
-                    NSAttributedString.Key.font: LegacyDynamicFontHelper.defaultHelper.DefaultStandardFontBold,
-                    NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
-        }
+        let string = profile.displayName ?? profile.email
 
-        return nil
+        return NSAttributedString(
+            string: string,
+            attributes: [
+                NSAttributedString.Key.font: DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 17, weight: .semibold),
+                NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }
 
     override var status: NSAttributedString? {

--- a/Client/Helpers/LegacyDynamicFontHelper.swift
+++ b/Client/Helpers/LegacyDynamicFontHelper.swift
@@ -117,9 +117,6 @@ class LegacyDynamicFontHelper: NSObject {
     var DefaultStandardFont: UIFont {
         return UIFont.systemFont(ofSize: defaultStandardFontSize, weight: UIFont.Weight.regular)
     }
-    var DefaultStandardFontBold: UIFont {
-        return UIFont.boldSystemFont(ofSize: defaultStandardFontSize)
-    }
 
     /**
      * Reader mode


### PR DESCRIPTION
## :scroll: Tickets

[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6350)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14270)

## :bulb: Description

I replaced the usages of `DefaultStandardFontBold` with `DefaultDynamicFontHelper.preferredFont` using a weight of `.semibold`

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

