### PR TITLE
Bugfix FXIOS-7251 [v118] Fix deeplinks not working when backgrounding the app for a long time

### DIFF
--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -16,7 +16,8 @@ class BrowserCoordinator: BaseCoordinator,
                           LibraryCoordinatorDelegate,
                           EnhancedTrackingProtectionCoordinatorDelegate,
                           FakespotCoordinatorDelegate,
-                          ParentCoordinatorDelegate {
+                          ParentCoordinatorDelegate,
+                          TabManagerDelegate {
     var browserViewController: BrowserViewController
     var webviewController: WebviewViewController?
     var homepageViewController: HomepageViewController?
@@ -53,6 +54,7 @@ class BrowserCoordinator: BaseCoordinator,
 
         browserViewController.browserDelegate = self
         browserViewController.navigationHandler = self
+        tabManager.addDelegate(self)
     }
 
     func start(with launchType: LaunchType?) {
@@ -161,8 +163,12 @@ class BrowserCoordinator: BaseCoordinator,
     // MARK: - Route handling
 
     override func handle(route: Route) -> Bool {
-        guard browserIsReady else {
-            logger.log("Could not handle route, wasn't ready", level: .info, category: .coordinator)
+        guard browserIsReady, !tabManager.isRestoringTabs else {
+            let readyMessage = "browser is ready? \(browserIsReady)"
+            let restoringMessage = "is restoring tabs? \(tabManager.isRestoringTabs)"
+            logger.log("Could not handle route, \(readyMessage), \(restoringMessage)",
+                       level: .info,
+                       category: .coordinator)
             return false
         }
 
@@ -528,5 +534,14 @@ class BrowserCoordinator: BaseCoordinator,
 
     func didFinish(from childCoordinator: Coordinator) {
         remove(child: childCoordinator)
+    }
+
+    // MARK: - TabManagerDelegate
+
+    func tabManagerDidRestoreTabs(_ tabManager: TabManager) {
+        // Once tab restore is made, if there's any saved route we make sure to call it
+        if let savedRoute {
+            findAndHandle(route: savedRoute)
+        }
     }
 }

--- a/Client/Coordinators/Router/RouteBuilder.swift
+++ b/Client/Coordinators/Router/RouteBuilder.swift
@@ -57,7 +57,7 @@ final class RouteBuilder {
                 return .searchQuery(query: urlScanner.value(query: "text") ?? "")
 
             case .glean:
-                    return .glean(url: url)
+                return .glean(url: url)
 
             case .widgetMediumTopSitesOpenUrl:
                 // Widget Top sites - open url

--- a/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -21,6 +21,13 @@ protocol TabManagerDelegate: AnyObject {
 }
 
 extension TabManagerDelegate {
+    func tabManager(_ tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?, isRestoring: Bool) {}
+    func tabManager(_ tabManager: TabManager, didAddTab tab: Tab, placeNextToParentTab: Bool, isRestoring: Bool) {}
+    func tabManager(_ tabManager: TabManager, didRemoveTab tab: Tab, isRestoring: Bool) {}
+
+    func tabManagerDidRestoreTabs(_ tabManager: TabManager) {}
+    func tabManagerDidAddTabs(_ tabManager: TabManager) {}
+    func tabManagerDidRemoveAllTabs(_ tabManager: TabManager, toast: ButtonToast?) {}
     func tabManagerUpdateCount() {}
 }
 

--- a/Client/TabManagement/TabManager.swift
+++ b/Client/TabManagement/TabManager.swift
@@ -10,6 +10,7 @@ import Shared
 
 // MARK: - TabManager protocol
 protocol TabManager: AnyObject {
+    var isRestoringTabs: Bool { get }
     var delaySelectingNewPopupTab: TimeInterval { get }
     var recentlyAccessedNormalTabs: [Tab] { get }
     var tabs: [Tab] { get }

--- a/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -766,6 +766,32 @@ final class BrowserCoordinatorTests: XCTestCase {
         XCTAssertNil(coordinator)
     }
 
+    func testSavesRoute_whenTabManagerIsRestoring() {
+        tabManager.isRestoringTabs = true
+        let subject = createSubject()
+        subject.browserHasLoaded()
+
+        let coordinator = subject.findAndHandle(route: .defaultBrowser(section: .tutorial))
+
+        XCTAssertNotNil(subject.savedRoute)
+        XCTAssertNil(coordinator)
+    }
+
+    func testSavedRouteCalled_whenRestoredTabsIsCalled() {
+        tabManager.isRestoringTabs = true
+        let subject = createSubject()
+        subject.browserHasLoaded()
+        subject.findAndHandle(route: .defaultBrowser(section: .tutorial))
+
+        tabManager.isRestoringTabs = false
+        subject.tabManagerDidRestoreTabs(tabManager)
+
+        XCTAssertNotNil(mockRouter.presentedViewController as? DefaultBrowserOnboardingViewController)
+        XCTAssertEqual(mockRouter.presentCalled, 1)
+    }
+
+    // MARK: - Library
+
     func testOneLibraryCoordinatorInstanceExists_whenPresetingMultipleLibraryTabs() {
         let subject = createSubject()
 
@@ -850,6 +876,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         let subject = BrowserCoordinator(router: mockRouter,
                                          screenshotService: screenshotService,
                                          profile: profile,
+                                         tabManager: tabManager,
                                          glean: glean,
                                          applicationHelper: applicationHelper,
                                          wallpaperManager: wallpaperManager,

--- a/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -8,7 +8,7 @@ import WebKit
 @testable import Client
 
 class MockTabManager: TabManager {
-    var isRestoringTabs: Bool = false
+    var isRestoringTabs = false
     var selectedTab: Tab?
     var backupCloseTab: Client.BackupCloseTab?
 

--- a/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -8,6 +8,7 @@ import WebKit
 @testable import Client
 
 class MockTabManager: TabManager {
+    var isRestoringTabs: Bool = false
     var selectedTab: Tab?
     var backupCloseTab: Client.BackupCloseTab?
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7251)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16079)

## :bulb: Description
This will normally fix the issue where deeplinks aren't opened when we come back from backgrounding the app. The assumption is that the tabs are restoring, which overrides the deeplink opening a tab which is occuring at the same time. 

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

