### PR TITLE
Remove FXIOS-6529 [v119] More clean up from settings coordinator code

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1880,9 +1880,10 @@ extension BrowserViewController: ClipboardBarDisplayHandlerDelegate {
                                              buttonText: .GoButtonTittle)
         let toast = ButtonToast(viewModel: viewModel,
                                 theme: themeManager.currentTheme,
-                                completion: { buttonPressed in
+                                completion: { [weak self] buttonPressed in
             if buttonPressed {
-                self.settingsOpenURLInNewTab(url)
+                let isPrivate = self?.tabManager.selectedTab?.isPrivate ?? false
+                self?.openURLInNewTab(url, isPrivate: isPrivate)
             }
         })
         clipboardBarDisplayHandler?.clipboardToast = toast
@@ -1916,18 +1917,6 @@ extension BrowserViewController: QRCodeViewControllerDelegate {
         default:
             defaultAction()
         }
-    }
-}
-
-extension BrowserViewController: SettingsDelegate {
-    func settingsOpenURLInNewTab(_ url: URL) {
-        let isPrivate = tabManager.selectedTab?.isPrivate ?? false
-        self.openURLInNewTab(url, isPrivate: isPrivate)
-    }
-
-    func didFinish() {
-        // Does nothing since this is used by Coordinators
-        // BVC will stop being a SettingsDelegate after FXIOS-6529
     }
 }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -56,7 +56,7 @@ class BrowserViewController: UIViewController,
     var openedUrlFromExternalSource = false
     var passBookHelper: OpenPassBookHelper?
     var overlayManager: OverlayModeManager
-    var appAuthenticator: AppAuthenticationProtocol?
+    var appAuthenticator: AppAuthenticationProtocol
     var contextHintVC: ContextualHintViewController
 
     // To avoid presenting multiple times in same launch when forcing to show
@@ -1775,9 +1775,6 @@ class BrowserViewController: UIViewController,
 
     private func authenticateSelectCreditCardBottomSheet(fieldValues: UnencryptedCreditCardFields,
                                                          frame: WKFrameInfo? = nil) {
-        guard let appAuthenticator else {
-            return
-        }
         appAuthenticator.getAuthenticationState { [unowned self] state in
             switch state {
             case .deviceOwnerAuthenticated:

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
@@ -90,7 +90,6 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
                                               buttonView: button,
                                               toastContainer: contentContainer)
         menuHelper.delegate = self
-        menuHelper.menuActionDelegate = self
         menuHelper.sendToDeviceDelegate = self
         menuHelper.navigationHandler = navigationHandler
 

--- a/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
+++ b/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
@@ -14,7 +14,7 @@ class ClipboardBarDisplayHandler: NSObject, URLChangeDelegate {
         static let toastDelay = DispatchTimeInterval.milliseconds(10000)
     }
 
-    weak var delegate: (ClipboardBarDisplayHandlerDelegate & SettingsDelegate)?
+    weak var delegate: ClipboardBarDisplayHandlerDelegate?
     weak var settingsDelegate: SettingsDelegate?
     weak var tabManager: TabManager?
     private var sessionStarted = true

--- a/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -593,7 +593,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
                     // If we successfully got a temp file URL, share it like a downloaded file,
                     // otherwise present the ordinary share menu for the web URL.
                     if let tempDocURL = tempDocURL,
-                       tempDocURL.isFileURL{
+                       tempDocURL.isFileURL {
                         self.share(fileURL: tempDocURL, buttonView: self.buttonView)
                     } else {
                         if CoordinatorFlagManager.isShareExtensionCoordinatorEnabled {

--- a/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -64,7 +64,6 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     let tabManager: TabManager
 
     weak var delegate: ToolBarActionMenuDelegate?
-    weak var menuActionDelegate: MenuActionsDelegate?
     weak var sendToDeviceDelegate: SendToDeviceDelegate?
     weak var navigationHandler: BrowserNavigationHandler?
 
@@ -562,11 +561,10 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
         return SingleActionViewModel(title: .AppMenu.AppMenuSharePageTitleString,
                                      iconString: ImageIdentifiers.share) { _ in
             guard let tab = self.selectedTab,
-                  let url = tab.url,
-                  let presentableVC = self.menuActionDelegate as? PresentableVC
+                  let url = tab.url
             else { return }
 
-            self.share(fileURL: url, buttonView: self.buttonView, presentableVC: presentableVC)
+            self.share(fileURL: url, buttonView: self.buttonView)
         }.items
     }
 
@@ -595,9 +593,8 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
                     // If we successfully got a temp file URL, share it like a downloaded file,
                     // otherwise present the ordinary share menu for the web URL.
                     if let tempDocURL = tempDocURL,
-                       tempDocURL.isFileURL,
-                       let presentableVC = self.menuActionDelegate as? PresentableVC {
-                        self.share(fileURL: tempDocURL, buttonView: self.buttonView, presentableVC: presentableVC)
+                       tempDocURL.isFileURL{
+                        self.share(fileURL: tempDocURL, buttonView: self.buttonView)
                     } else {
                         if CoordinatorFlagManager.isShareExtensionCoordinatorEnabled {
                             self.navigationHandler?.showShareExtension(
@@ -615,7 +612,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     }
 
     // Main menu option Share page with when opening a file
-    private func share(fileURL: URL, buttonView: UIView, presentableVC: PresentableVC) {
+    private func share(fileURL: URL, buttonView: UIView) {
         if CoordinatorFlagManager.isShareExtensionCoordinatorEnabled {
             navigationHandler?.showShareExtension(
                 url: fileURL,

--- a/Client/Frontend/PasswordManagement/DevicePasscodeRequiredViewController.swift
+++ b/Client/Frontend/PasswordManagement/DevicePasscodeRequiredViewController.swift
@@ -25,10 +25,6 @@ class DevicePasscodeRequiredViewController: SettingsViewController {
         return button
     }()
 
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("not implemented")
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
         self.title = .Settings.Passwords.Title

--- a/Client/Frontend/PasswordManagement/DevicePasscodeRequiredViewController.swift
+++ b/Client/Frontend/PasswordManagement/DevicePasscodeRequiredViewController.swift
@@ -6,8 +6,6 @@ import UIKit
 import Shared
 
 class DevicePasscodeRequiredViewController: SettingsViewController {
-    private var shownFromAppMenu = false
-
     private var warningLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -27,22 +25,12 @@ class DevicePasscodeRequiredViewController: SettingsViewController {
         return button
     }()
 
-    init(shownFromAppMenu: Bool = false) {
-        super.init()
-        self.shownFromAppMenu = shownFromAppMenu
-    }
-
     required init?(coder aDecoder: NSCoder) {
         fatalError("not implemented")
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        if shownFromAppMenu {
-            navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(doneButtonTapped))
-        }
-
         self.title = .Settings.Passwords.Title
 
         self.view.addSubviews(warningLabel, learnMoreButton)
@@ -56,11 +44,6 @@ class DevicePasscodeRequiredViewController: SettingsViewController {
             learnMoreButton.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
             learnMoreButton.topAnchor.constraint(equalTo: warningLabel.safeAreaLayoutGuide.bottomAnchor, constant: 20)
         ])
-    }
-
-    @objc
-    func doneButtonTapped(_ sender: UIButton) {
-        dismiss(animated: true)
     }
 
     @objc

--- a/Client/Frontend/PasswordManagement/PasswordManagerListViewController.swift
+++ b/Client/Frontend/PasswordManagement/PasswordManagerListViewController.swift
@@ -25,8 +25,6 @@ class PasswordManagerListViewController: SensitiveViewController, Themeable {
 
     weak var coordinator: PasswordManagerFlowDelegate?
 
-    var shownFromAppMenu = false
-
     fileprivate lazy var selectionButton: UIButton = .build { button in
         button.titleLabel?.font = PasswordManagerViewModel.UX.selectionButtonFont
         button.addTarget(self, action: #selector(self.tappedSelectionButton), for: .touchUpInside)
@@ -37,8 +35,7 @@ class PasswordManagerListViewController: SensitiveViewController, Themeable {
         return prefs.boolForKey(PrefsKeys.LoginsShowShortcutMenuItem) ?? true
     }
 
-    init(shownFromAppMenu: Bool = false,
-         profile: Profile,
+    init(profile: Profile,
          themeManager: ThemeManager = AppContainer.shared.resolve(),
          notificationCenter: NotificationCenter = NotificationCenter.default) {
         self.viewModel = PasswordManagerViewModel(
@@ -49,7 +46,6 @@ class PasswordManagerListViewController: SensitiveViewController, Themeable {
         self.loginDataSource = LoginDataSource(viewModel: viewModel)
         self.themeManager = themeManager
         self.notificationCenter = notificationCenter
-        self.shownFromAppMenu = shownFromAppMenu
         super.init(nibName: nil, bundle: nil)
         listenForThemeChange(view)
     }
@@ -194,14 +190,7 @@ class PasswordManagerListViewController: SensitiveViewController, Themeable {
         addCredentialButton.accessibilityIdentifier = AccessibilityIdentifiers.Settings.Passwords.addCredentialButton
         editButton.accessibilityIdentifier = AccessibilityIdentifiers.Settings.Passwords.editButton
         navigationItem.rightBarButtonItems = [editButton, addCredentialButton]
-
-        if shownFromAppMenu {
-            navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done,
-                                                               target: self,
-                                                               action: #selector(dismissLogins))
-        } else {
-            navigationItem.leftBarButtonItem = nil
-        }
+        navigationItem.leftBarButtonItem = nil
     }
 
     fileprivate func toggleDeleteBarButton() {

--- a/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
+++ b/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
@@ -6,8 +6,6 @@ import UIKit
 import Shared
 
 class PasswordManagerOnboardingViewController: SettingsViewController {
-    private var shownFromAppMenu = false
-
     private var onboardingMessageLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
@@ -16,7 +16,6 @@ protocol PhotonActionSheetProtocol {
 
 extension PhotonActionSheetProtocol {
     typealias PresentableVC = UIViewController & UIPopoverPresentationControllerDelegate
-    typealias MenuActionsDelegate = QRCodeViewControllerDelegate & SettingsDelegate & PresentingModalViewControllerDelegate & UIViewController
 
     func presentSheetWith(viewModel: PhotonActionSheetViewModel,
                           on viewController: PresentableVC,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6529)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14640)

## :bulb: Description
- BVC isn't a `SettingsDelegate` anymore
- `ShownFromAppMenu` option removed in some VC since it wasn't used anymore. We handle the `done`button differently now.
- Change that `AppAuthenticator` was optional on BVC, it's not optional.
- Remove `menuActionDelegate` from `mainMenu` class, wasn't used.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

