### PR TITLE
Refactor FXIOS-6914 [v119] Create empty tab tray view controller

### DIFF
--- a/.experimenter.yaml
+++ b/.experimenter.yaml
@@ -195,6 +195,14 @@ start-at-home-feature:
         - after-four-hours
         - always
         - disabled
+tab-tray-refactor-feature:
+  description: "This feature is for managing the roll out of the Tab Tray refactor feature\n"
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "Enables the feature\n"
 tabTrayFeature:
   description: The tab tray screen that the user goes to when they open the tab tray.
   hasExposure: true

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -125,6 +125,9 @@
 		21D7B60628077CA5003F7E94 /* LibraryViewController+ToolbarActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7B60528077CA5003F7E94 /* LibraryViewController+ToolbarActions.swift */; };
 		21D8843F2A7959D000AF144C /* HomePageSettingViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D8843E2A7959D000AF144C /* HomePageSettingViewControllerTests.swift */; };
 		21D884412A79628E00AF144C /* MockSettingsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D884402A79628E00AF144C /* MockSettingsDelegate.swift */; };
+		21E77E4E2AA8BA5200FABA10 /* TabTrayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E77E4D2AA8BA5200FABA10 /* TabTrayViewController.swift */; };
+		21E77E502AA8BAEC00FABA10 /* TabTrayModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E77E4F2AA8BAEC00FABA10 /* TabTrayModel.swift */; };
+		21E77E522AA8BE5C00FABA10 /* TabTrayFlagManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E77E512AA8BE5C00FABA10 /* TabTrayFlagManager.swift */; };
 		21E78A7028F9A8C500F8D687 /* MockUIDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E78A6F28F9A8C500F8D687 /* MockUIDevice.swift */; };
 		21E78A7228F9A93100F8D687 /* UIDeviceInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E78A7128F9A93100F8D687 /* UIDeviceInterface.swift */; };
 		2386E4E624F8358E0072EF17 /* HomepageMessageCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2386E4E524F8358E0072EF17 /* HomepageMessageCard.swift */; };
@@ -2151,6 +2154,9 @@
 		21D8843E2A7959D000AF144C /* HomePageSettingViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePageSettingViewControllerTests.swift; sourceTree = "<group>"; };
 		21D884402A79628E00AF144C /* MockSettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSettingsDelegate.swift; sourceTree = "<group>"; };
 		21DD4778B3C11A24D552AB34 /* lo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lo; path = lo.lproj/Localizable.strings; sourceTree = "<group>"; };
+		21E77E4D2AA8BA5200FABA10 /* TabTrayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTrayViewController.swift; sourceTree = "<group>"; };
+		21E77E4F2AA8BAEC00FABA10 /* TabTrayModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTrayModel.swift; sourceTree = "<group>"; };
+		21E77E512AA8BE5C00FABA10 /* TabTrayFlagManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTrayFlagManager.swift; sourceTree = "<group>"; };
 		21E78A6F28F9A8C500F8D687 /* MockUIDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockUIDevice.swift; sourceTree = "<group>"; };
 		21E78A7128F9A93100F8D687 /* UIDeviceInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIDeviceInterface.swift; sourceTree = "<group>"; };
 		220A4CC8B2685EEA3146A967 /* fa */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fa; path = fa.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
@@ -7301,6 +7307,9 @@
 				212429F22AA27204002D57A8 /* Legacy */,
 				216E9A3829D2119300ABE69B /* InactiveTabs */,
 				21357F2B293FDB07004BF9FD /* RemoteTabs */,
+				21E77E4D2AA8BA5200FABA10 /* TabTrayViewController.swift */,
+				21E77E4F2AA8BAEC00FABA10 /* TabTrayModel.swift */,
+				21E77E512AA8BE5C00FABA10 /* TabTrayFlagManager.swift */,
 			);
 			path = Tabs;
 			sourceTree = "<group>";
@@ -12427,6 +12436,7 @@
 				D0FCF7F51FE45842004A7995 /* UserScriptManager.swift in Sources */,
 				8AB8573027D94CAD0075C173 /* HomepageViewModelProtocol.swift in Sources */,
 				E1877A832875DEDE00F5BDF2 /* SyncedTabCell.swift in Sources */,
+				21E77E522AA8BE5C00FABA10 /* TabTrayFlagManager.swift in Sources */,
 				CA8226F324C11DB7008A6F38 /* PasswordManagerTableViewCell.swift in Sources */,
 				E4A960061ABB9C450069AD6F /* ReaderModeUtils.swift in Sources */,
 				8AD40FCB27BADC4B00672675 /* StatefulButton.swift in Sources */,
@@ -12576,6 +12586,7 @@
 				21618A8C2A438A0900A5189E /* ActiveScreenAction.swift in Sources */,
 				E15DE7C2293A7AED00B32667 /* PhotonActionSheetLineSeparator.swift in Sources */,
 				8A832A9429DC99BA0025D5DD /* LaunchScreenViewController.swift in Sources */,
+				21E77E4E2AA8BA5200FABA10 /* TabTrayViewController.swift in Sources */,
 				43BDBBFE2752FA8600254DE4 /* LegacyTabCell.swift in Sources */,
 				E60D03181D511398002FE3F6 /* SyncDisplayState.swift in Sources */,
 				C4E3983D1D21F1E7004E89BA /* TopTabCell.swift in Sources */,
@@ -12935,6 +12946,7 @@
 				8A720C602A4C8B700003018A /* SharedSettingsDelegate.swift in Sources */,
 				8C3879852A965210003966B0 /* FakespotViewModel.swift in Sources */,
 				211046CD2A7D842A00A7309F /* TPAccessoryInfo.swift in Sources */,
+				21E77E502AA8BAEC00FABA10 /* TabTrayModel.swift in Sources */,
 				5AE371872A4E11750092A760 /* AboutSettingsDelegate.swift in Sources */,
 				E18EA57128AD46D3003F97FC /* WallpaperCollectionType.swift in Sources */,
 				C84655E42887394B00861B4A /* WallpaperMetadata.swift in Sources */,

--- a/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -33,6 +33,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case shareSheetChanges
     case shareToolbarChanges
     case startAtHome
+    case tabTrayRefactor
     case topSites
     case wallpapers
     case wallpaperOnboardingSheet
@@ -96,6 +97,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .shareExtensionCoordinatorRefactor,
                 .shareSheetChanges,
                 .shareToolbarChanges,
+                .tabTrayRefactor,
                 .wallpaperOnboardingSheet,
                 .wallpaperVersion,
                 .zoomFeature:

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -72,11 +72,12 @@ class BrowserViewController: UIViewController,
     var copyAddressAction: AccessibleAction!
 
     weak var gridTabTrayController: LegacyGridTabViewController?
-    var tabTrayViewController: LegacyTabTrayViewController?
+    var tabTrayViewController: TabTrayController?
 
     let profile: Profile
     let tabManager: TabManager
     let ratingPromptManager: RatingPromptManager
+    lazy var isTabTrayRefactorEnabled: Bool = TabTrayFlagManager.isRefactorEnabled
 
     // Header stack view can contain the top url bar, top reader mode, top ZoomPageBar
     var header: BaseAlphaStackView = .build { _ in }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -35,13 +35,23 @@ extension BrowserViewController: URLBarDelegate {
                      focusedSegment: LegacyTabTrayViewModel.Segment? = nil) {
         updateFindInPageVisibility(visible: false)
 
-        self.tabTrayViewController = LegacyTabTrayViewController(
-            tabTrayDelegate: self,
-            profile: profile,
-            tabToFocus: tabToFocus,
-            tabManager: tabManager,
-            overlayManager: overlayManager,
-            focusedSegment: focusedSegment)
+        // TODO: YRD use feature flag here
+        if isTabTrayRefactorEnabled {
+            self.tabTrayViewController = TabTrayViewController(tabTrayDelegate: self,
+                                                               profile: profile,
+                                                               tabToFocus: tabToFocus,
+                                                               tabManager: tabManager,
+                                                               overlayManager: overlayManager,
+                                                               focusedSegment: focusedSegment)
+        } else {
+            self.tabTrayViewController = LegacyTabTrayViewController(
+                tabTrayDelegate: self,
+                profile: profile,
+                tabToFocus: tabToFocus,
+                tabManager: tabManager,
+                overlayManager: overlayManager,
+                focusedSegment: focusedSegment)
+        }
 
         tabTrayViewController?.openInNewTab = { url, isPrivate in
             let tab = self.tabManager.addTab(URLRequest(url: url), afterTab: self.tabManager.selectedTab, isPrivate: isPrivate)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -35,7 +35,7 @@ extension BrowserViewController: URLBarDelegate {
                      focusedSegment: LegacyTabTrayViewModel.Segment? = nil) {
         updateFindInPageVisibility(visible: false)
 
-        // TODO: YRD use feature flag here
+        // TODO: FXIOS-7355 Move logic to BrowserCoordinator in
         if isTabTrayRefactorEnabled {
             self.tabTrayViewController = TabTrayViewController(tabTrayDelegate: self,
                                                                profile: profile,

--- a/Client/Frontend/Browser/Tabs/Legacy/LegacyTabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/Legacy/LegacyTabTrayViewController.swift
@@ -20,7 +20,7 @@ protocol TabTrayViewDelegate: UIViewController {
 }
 // swiftlint:enable class_delegate_protocol
 
-class LegacyTabTrayViewController: UIViewController, Themeable {
+class LegacyTabTrayViewController: UIViewController, Themeable, TabTrayController {
     struct UX {
         struct NavigationMenu {
             static let height: CGFloat = 32

--- a/Client/Frontend/Browser/Tabs/TabTrayFlagManager.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayFlagManager.swift
@@ -7,7 +7,7 @@ import Foundation
 /// This is a temporary struct made to manage the feature flag for convenience
 struct TabTrayFlagManager {
     static var isRefactorEnabled: Bool {
-        return LegacyFeatureFlagsManager.shared.isFeatureEnabled(.reduxIntegration,
+        return LegacyFeatureFlagsManager.shared.isFeatureEnabled(.tabTrayRefactor,
                                                                  checking: .buildOnly)
     }
 }

--- a/Client/Frontend/Browser/Tabs/TabTrayFlagManager.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayFlagManager.swift
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// This is a temporary struct made to manage the feature flag for convenience
+struct TabTrayFlagManager {
+    static var isRefactorEnabled: Bool {
+        return LegacyFeatureFlagsManager.shared.isFeatureEnabled(.reduxIntegration,
+                                                                 checking: .buildOnly)
+    }
+}

--- a/Client/Frontend/Browser/Tabs/TabTrayModel.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayModel.swift
@@ -1,0 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+struct TabTrayModel {}

--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Storage
+
+protocol TabTrayController: UIViewController, UIAdaptivePresentationControllerDelegate, UIPopoverPresentationControllerDelegate {
+    var openInNewTab: ((_ url: URL, _ isPrivate: Bool) -> Void)? { get set }
+    var didSelectUrl: ((_ url: URL, _ visitType: VisitType) -> Void)? { get set }
+}
+
+class TabTrayViewController: LegacyTabTrayViewController {}

--- a/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -63,6 +63,9 @@ final class NimbusFeatureFlagLayer {
         case .startAtHome:
             return checkNimbusConfigForStartAtHome(using: nimbus) != .disabled
 
+        case .tabTrayRefactor:
+            return checkTabTrayRefactorFeature(from: nimbus)
+
         case .wallpapers,
                 .wallpaperVersion:
             return checkNimbusForWallpapersFeature(using: nimbus)
@@ -192,6 +195,11 @@ final class NimbusFeatureFlagLayer {
 
     private func checkReduxIntegrationFeature(from nimbus: FxNimbus) -> Bool {
         let config = nimbus.features.reduxIntegrationFeature.value()
+        return config.enabled
+    }
+
+    private func checkTabTrayRefactorFeature(from nimbus: FxNimbus) -> Bool {
+        let config = nimbus.features.tabTrayRefactorFeature.value()
         return config.enabled
     }
 

--- a/nimbus-features/tabTrayRefactorFeature.yaml
+++ b/nimbus-features/tabTrayRefactorFeature.yaml
@@ -1,0 +1,18 @@
+# The configuration for the tabStorageRefactorFeature feature
+features:
+  tab-tray-refactor-feature:
+    description: >
+      This feature is for managing the roll out of the Tab Tray refactor feature
+    variables:
+      enabled:
+        description: >
+          Enables the feature
+        type: Boolean
+        default: false
+    defaults:
+      - channel: beta
+        value:
+          enabled: false
+      - channel: developer
+        value:
+          enabled: false

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -32,5 +32,6 @@ include:
   - nimbus-features/spotlightSearchFeature.yaml
   - nimbus-features/startAtHomeFeature.yaml
   - nimbus-features/tabTrayFeature.yaml
+  - nimbus-features/tabTrayRefactorFeature.yaml
   - nimbus-features/wallpaperFeature.yaml
   - nimbus-features/zoomFeature.yaml


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6914)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15392)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Create TabTrayRefactorFeature flag and use to show the empty TabTrayViewController
- Add TODO to move the show logic out of BVC into BrowserCoordinator

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

