### PR TITLE
Bugfix FXIOS-7358 [v119] Lock icon label contains wrong text

### DIFF
--- a/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -301,7 +301,7 @@ class TabLocationView: UIView, FeatureFlaggable {
 
     private func setTrackingProtection(theme: Theme) {
         var lockImage: UIImage?
-        if hasSecureContent {
+        if !hasSecureContent {
             lockImage = UIImage(imageLiteralResourceName: StandardImageIdentifiers.Large.lockSlash)
         } else if let tintColor = trackingProtectionButton.tintColor {
             lockImage = UIImage(imageLiteralResourceName: StandardImageIdentifiers.Large.lock)
@@ -416,7 +416,7 @@ extension TabLocationView: TabEventHandler {
             trackingProtectionButton.alpha = 1.0
             let themeManager: ThemeManager = AppContainer.shared.resolve()
             self.blockerStatus = blocker.status
-            self.hasSecureContent = !(tab.webView?.hasOnlySecureContent ?? false)
+            self.hasSecureContent = (tab.webView?.hasOnlySecureContent ?? false)
             setTrackingProtection(theme: themeManager.currentTheme)
         }
     }

--- a/Tests/XCUITests/TrackingProtectionTests.swift
+++ b/Tests/XCUITests/TrackingProtectionTests.swift
@@ -138,6 +138,7 @@ class TrackingProtectionTests: BaseTestCase {
         // A page displaying the connection is secure
         XCTAssertTrue(app.staticTexts["mozilla.org"].exists)
         XCTAssertTrue(app.staticTexts["Connection is secure"].exists, "Missing Connection is secure info")
+        XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label, "Secure connection")
         // Dismiss the view and visit "badssl.com". Tap on "expired"
         app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].tap(force: true)
         navigator.nowAt(BrowserTab)
@@ -148,6 +149,6 @@ class TrackingProtectionTests: BaseTestCase {
         // The page is correctly displayed with the lock icon disabled
         XCTAssertTrue(app.staticTexts["This Connection is Untrusted"].exists, "Missing This Connection is Untrusted info")
         XCTAssertTrue(app.staticTexts.elementContainingText("Firefox has not connected to this website.").exists)
-        XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label, "lockSlashLarge")
+        XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label, "Connection not secure")
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7358)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16297)

## :bulb: Description
`testLockIconSecureConnection()` fails after https://github.com/mozilla-mobile/firefox-ios/pull/16237 has been merged. This PR exposes that the lock icon's label was not toggled correctly.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

