### PR TITLE
Bugfix FXIOS-7304 [v117.3] Move DefaultThemeManager into Common

### DIFF
--- a/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import UIKit
-import Common
 
 /// The `ThemeManager` will be responsible for providing the theme throughout the app
 public final class DefaultThemeManager: ThemeManager, Notifiable {
@@ -28,6 +27,7 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
     public var notificationCenter: NotificationProtocol
     private var userDefaults: UserDefaultsInterface
     private var mainQueue: DispatchQueueInterface
+    private var sharedContainerIdentifier: String
 
     public var window: UIWindow?
 
@@ -35,10 +35,12 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
 
     public init(userDefaults: UserDefaultsInterface = UserDefaults.standard,
                 notificationCenter: NotificationProtocol = NotificationCenter.default,
-                mainQueue: DispatchQueueInterface = DispatchQueue.main) {
+                mainQueue: DispatchQueueInterface = DispatchQueue.main,
+                sharedContainerIdentifier: String) {
         self.userDefaults = userDefaults
         self.notificationCenter = notificationCenter
         self.mainQueue = mainQueue
+        self.sharedContainerIdentifier = sharedContainerIdentifier
 
         migrateDefaultsToUseStandard()
 
@@ -153,7 +155,7 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
     }
 
     private func migrateDefaultsToUseStandard() {
-        guard let oldDefaultsStore = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier) else { return }
+        guard let oldDefaultsStore = UserDefaults(suiteName: sharedContainerIdentifier) else { return }
 
         if let systemThemeIsOn = oldDefaultsStore.value(forKey: ThemeKeys.systemThemeIsOn) {
             userDefaults.set(systemThemeIsOn, forKey: ThemeKeys.systemThemeIsOn)

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -388,7 +388,6 @@
 		59A68FD5260B8D520F890F4A /* ReaderPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A685F4EAD19EDEC854BCA4 /* ReaderPanel.swift */; };
 		5A06135A29D6052E008F3D38 /* TabDataStore in Frameworks */ = {isa = PBXBuildFile; productRef = 5A06135929D6052E008F3D38 /* TabDataStore */; };
 		5A271ABD2860B0D700471CE4 /* WebServerUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A271ABC2860B0D700471CE4 /* WebServerUtil.swift */; };
-		5A292124295C8C5600242235 /* DefaultThemeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8954A4F2729AD9C001C7283 /* DefaultThemeManager.swift */; };
 		5A292129295CA8A900242235 /* ThemableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A96C4B828F9DD8700B75884 /* ThemableTests.swift */; };
 		5A29212A295CAA1700242235 /* XCTestCaseRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A96C4BA28F9E7B300B75884 /* XCTestCaseRootViewController.swift */; };
 		5A31275828906422001F30FA /* RecentlySavedDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A31275728906422001F30FA /* RecentlySavedDelegateMock.swift */; };
@@ -5754,7 +5753,6 @@
 		C88E7A5A2A0553510072E638 /* OnboardingLinkInfoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingLinkInfoModel.swift; sourceTree = "<group>"; };
 		C88E7A5F2A05551B0072E638 /* NimbusOnboardingFeatureLayerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusOnboardingFeatureLayerProtocol.swift; sourceTree = "<group>"; };
 		C893075C265501EE00A1DB2F /* CredentialAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = CredentialAssets.xcassets; sourceTree = "<group>"; };
-		C8954A4F2729AD9C001C7283 /* DefaultThemeManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultThemeManager.swift; sourceTree = "<group>"; };
 		C89C91AC2A1FE9E900BE57B1 /* OnboardingTelemetryDelegationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTelemetryDelegationTests.swift; sourceTree = "<group>"; };
 		C8A012F026AB07D70096A7A7 /* JumpBackInViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpBackInViewModel.swift; sourceTree = "<group>"; };
 		C8A4137328BE58C900D8EFEA /* WallpaperMetadataCodableProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperMetadataCodableProtocol.swift; sourceTree = "<group>"; };
@@ -7901,7 +7899,6 @@
 		5A292121295C8C1B00242235 /* Theme */ = {
 			isa = PBXGroup;
 			children = (
-				C8954A4F2729AD9C001C7283 /* DefaultThemeManager.swift */,
 			);
 			path = Theme;
 			sourceTree = "<group>";
@@ -12046,7 +12043,6 @@
 				EB7FFFC820A9D38D003E1E34 /* AlertController.swift in Sources */,
 				E65075BC1E37F7AB006961AC /* SupportUtils.swift in Sources */,
 				E65075B61E37F7AB006961AC /* Loader.swift in Sources */,
-				5A292124295C8C5600242235 /* DefaultThemeManager.swift in Sources */,
 				E65075BF1E37F7AB006961AC /* UserAgent.swift in Sources */,
 				E65075C01E37F7AB006961AC /* WeakList.swift in Sources */,
 				E65075AE1E37F7AB006961AC /* UIImageExtensions.swift in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -33,7 +33,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             quality: UIConstants.ScreenshotQuality)
     )
 
-    lazy var themeManager: ThemeManager = DefaultThemeManager()
+    lazy var themeManager: ThemeManager = DefaultThemeManager(sharedContainerIdentifier: AppInfo.sharedContainerIdentifier)
     lazy var ratingPromptManager = RatingPromptManager(profile: profile)
     lazy var appSessionManager: AppSessionProvider = AppSessionManager()
     lazy var notificationSurfaceManager = NotificationSurfaceManager()

--- a/Client/Frontend/Extensions/DevicePickerViewController.swift
+++ b/Client/Frontend/Extensions/DevicePickerViewController.swift
@@ -8,6 +8,7 @@ import Storage
 import SnapKit
 import Account
 import SwiftUI
+import Common
 
 protocol DevicePickerViewControllerDelegate: AnyObject {
     func devicePickerViewControllerDidCancel(_ devicePickerViewController: DevicePickerViewController)
@@ -56,7 +57,7 @@ class DevicePickerViewController: UITableViewController {
     private var selectedIdentifiers = Set<String>() // Stores Device.id
     private var notification: Any?
     private var loadingState = LoadingState.loading
-    private let themeManager = DefaultThemeManager()
+    private let themeManager = DefaultThemeManager(sharedContainerIdentifier: AppInfo.sharedContainerIdentifier)
 
     // ShareItem has been added as we are now using this class outside of the ShareTo extension to
     // provide Share To functionality

--- a/Extensions/ShareTo/SendToDevice.swift
+++ b/Extensions/ShareTo/SendToDevice.swift
@@ -6,11 +6,12 @@ import Shared
 import Storage
 import SwiftUI
 import UIKit
+import Common
 
 class SendToDevice: DevicePickerViewControllerDelegate, InstructionsViewDelegate {
     var sharedItem: ShareItem?
     weak var delegate: ShareControllerDelegate?
-    private let themeManager = DefaultThemeManager()
+    private let themeManager = DefaultThemeManager(sharedContainerIdentifier: AppInfo.sharedContainerIdentifier)
     private var profile: Profile {
         let profile = BrowserProfile(localName: "profile")
 

--- a/Extensions/ShareTo/ShareViewController.swift
+++ b/Extensions/ShareTo/ShareViewController.swift
@@ -6,6 +6,7 @@ import UIKit
 import Shared
 import Storage
 import Account
+import Common
 
 extension UIStackView {
     func addBackground(color: UIColor) {
@@ -73,7 +74,7 @@ class ShareViewController: UIViewController {
     private var actionRowHeights = [NSLayoutConstraint]()
     private var pageInfoRowTitleLabel: UILabel?
     private var pageInfoRowUrlLabel: UILabel?
-    private let themeManager = DefaultThemeManager()
+    private let themeManager = DefaultThemeManager(sharedContainerIdentifier: AppInfo.sharedContainerIdentifier)
 
     weak var delegate: ShareControllerDelegate?
 

--- a/Tests/ClientTests/Frontend/Theme/ThemableTests.swift
+++ b/Tests/ClientTests/Frontend/Theme/ThemableTests.swift
@@ -84,7 +84,7 @@ class TestsTableView: NSObject, UITableViewDataSource, UITableViewDelegate {
 
 // MARK: - TestsThemeable
 class TestsThemeable: UIViewController, Themeable {
-    var themeManager: ThemeManager = DefaultThemeManager()
+    var themeManager: ThemeManager = DefaultThemeManager(sharedContainerIdentifier: AppInfo.sharedContainerIdentifier)
     var themeObserver: NSObjectProtocol?
     var notificationCenter: NotificationProtocol = NotificationCenter.default
 

--- a/Tests/ClientTests/Settings/VersionSettingTests.swift
+++ b/Tests/ClientTests/Settings/VersionSettingTests.swift
@@ -5,6 +5,7 @@
 import XCTest
 @testable import Client
 import Shared
+import Common
 
 class VersionSettingTests: XCTestCase {
     private var delegate: MockDebugSettingsDelegate!
@@ -27,7 +28,7 @@ class VersionSettingTests: XCTestCase {
         let settingsTable = SettingsTableViewController(style: .grouped)
         let navigationController = UINavigationController(rootViewController: settingsTable)
         let versionSetting = VersionSetting(settingsDelegate: delegate)
-        versionSetting.theme = DefaultThemeManager().currentTheme
+        versionSetting.theme = DefaultThemeManager(sharedContainerIdentifier: AppInfo.sharedContainerIdentifier).currentTheme
 
         // When
         versionSetting.onLongPress(navigationController)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7304)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16209)

## :bulb: Description
This is a work around for a crash that was introduced in 117 for iOS versions 14.0 up to iOS 14.4.
The issue is that the dependency container can't seem to cast the DefaultThemeManager to a type of ThemeManager because it has visibility of the latter but no visibility of the former. 
A quick but inelegant fix for this is to move DefaultThemeManager into Common for the time being and revert this change once support for iOS 14 is dropped.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

