### PR TITLE
Refactor MTE-1523 [v119] Remove test from the perf test plan

### DIFF
--- a/Tests/PerformanceTestPlan.xctestplan
+++ b/Tests/PerformanceTestPlan.xctestplan
@@ -56,6 +56,7 @@
         "PocketTest",
         "PrivateBrowsingTest",
         "PrivateBrowsingTestIpad",
+        "PrivateBrowsingTestIphone",
         "ReaderViewTest",
         "SaveLoginTest",
         "ScreenGraphTest",

--- a/Tests/SyncIntegrationTestPlan.xctestplan
+++ b/Tests/SyncIntegrationTestPlan.xctestplan
@@ -78,6 +78,7 @@
         "PocketTest",
         "PrivateBrowsingTest",
         "PrivateBrowsingTestIpad",
+        "PrivateBrowsingTestIphone",
         "ReaderViewTest",
         "SaveLoginTest",
         "ScreenGraphTest",


### PR DESCRIPTION
The perfhereder workflow is not reporting data because one test that does not belong to the perf test plan is running there. We need to disable it.