### PR TITLE
Remove FXIOS-6557 [v119] Remove presenting modal view controller delegate

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1918,12 +1918,6 @@ extension BrowserViewController: QRCodeViewControllerDelegate {
     }
 }
 
-extension BrowserViewController: PresentingModalViewControllerDelegate {
-    func dismissPresentedModalViewController(_ modalViewController: UIViewController, animated: Bool) {
-        self.dismiss(animated: animated, completion: nil)
-    }
-}
-
 /**
  * History visit management.
  * TODO: this should be expanded to track various visit types; see Bug 1166084.

--- a/Client/Frontend/Settings/SettingsNavigationController.swift
+++ b/Client/Frontend/Settings/SettingsNavigationController.swift
@@ -11,8 +11,6 @@ class ThemedNavigationController: DismissableNavigationViewController, Themeable
     var themeObserver: NSObjectProtocol?
     var notificationCenter: NotificationProtocol
 
-    var presentingModalViewControllerDelegate: PresentingModalViewControllerDelegate?
-
     init(themeManager: ThemeManager = AppContainer.shared.resolve(),
          notificationCenter: NotificationProtocol = NotificationCenter.default) {
         self.themeManager = themeManager
@@ -32,15 +30,6 @@ class ThemedNavigationController: DismissableNavigationViewController, Themeable
         super.init(rootViewController: rootViewController)
     }
 
-    @objc
-    func done() {
-        if let delegate = presentingModalViewControllerDelegate {
-            delegate.dismissPresentedModalViewController(self, animated: true)
-        } else {
-            self.dismiss(animated: true, completion: nil)
-        }
-    }
-
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return topViewController?.preferredStatusBarStyle ?? LegacyThemeManager.instance.statusBarStyle
     }
@@ -52,9 +41,7 @@ class ThemedNavigationController: DismissableNavigationViewController, Themeable
         applyTheme()
         listenForThemeChange(view)
     }
-}
 
-extension ThemedNavigationController {
     private func setupNavigationBarAppearance(theme: Theme) {
         let standardAppearance = UINavigationBarAppearance()
         standardAppearance.configureWithDefaultBackground()
@@ -74,10 +61,6 @@ extension ThemedNavigationController {
         setupNavigationBarAppearance(theme: themeManager.currentTheme)
         setNeedsStatusBarAppearanceUpdate()
     }
-}
-
-protocol PresentingModalViewControllerDelegate: AnyObject {
-    func dismissPresentedModalViewController(_ modalViewController: UIViewController, animated: Bool)
 }
 
 class ModalSettingsNavigationController: UINavigationController {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6557)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14684)

## :bulb: Description
Remove presenting modal view controller delegate since it's not used anymore.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

