### PR TITLE
Refactor FXIOS-6733 [v119] Fix upgrade onboarding

### DIFF
--- a/Client/Frontend/Onboarding/Models/UpdateViewModel.swift
+++ b/Client/Frontend/Onboarding/Models/UpdateViewModel.swift
@@ -21,9 +21,9 @@ class UpdateViewModel: OnboardingViewModelProtocol,
         return availableCards.count == 1
     }
 
-    // If the feature is enabled and is not clean install
+    // If the feature has cards available and is not clean install
     var shouldShowFeature: Bool {
-        return !isFreshInstall
+        return !cardModels.isEmpty && !isFreshInstall
     }
 
     var isFreshInstall: Bool {

--- a/nimbus-features/onboardingFrameworkFeature.yaml
+++ b/nimbus-features/onboardingFrameworkFeature.yaml
@@ -89,7 +89,7 @@ features:
                   action: next-card
               type: upgrade
               prerequisites:
-                - ALWAYS
+                - NEVER
             update-sign-to-sync:
               order: 20
               title: Upgrade/Upgrade.SyncSign.Title.v114
@@ -104,7 +104,7 @@ features:
                   action: next-card
               type: upgrade
               prerequisites:
-                - ALWAYS
+                - NEVER
           dismissable: true
 
 objects:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6733)

## :bulb: Description
With those changes, we make sure we only show the upgrade onboarding whenever there's upgrade onboarding cards available. This also change the default experiments so by default there's no upgrade onboarding cards.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

