### PR TITLE
Fix MTE-1528 [119] lock icon secure label

### DIFF
--- a/Tests/XCUITests/OpeningScreenTests.swift
+++ b/Tests/XCUITests/OpeningScreenTests.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 class OpeningScreenTests: BaseTestCase {
+    // https://testrail.stage.mozaws.net/index.php?/cases/view/1608924
     func testLastOpenedTab() {
         // Open a web page
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"), waitForLoading: true)

--- a/Tests/XCUITests/TrackingProtectionTests.swift
+++ b/Tests/XCUITests/TrackingProtectionTests.swift
@@ -148,6 +148,6 @@ class TrackingProtectionTests: BaseTestCase {
         // The page is correctly displayed with the lock icon disabled
         XCTAssertTrue(app.staticTexts["This Connection is Untrusted"].exists, "Missing This Connection is Untrusted info")
         XCTAssertTrue(app.staticTexts.elementContainingText("Firefox has not connected to this website.").exists)
-        XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label, "lockSlashLarge")
+        XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label, "Secure connection")
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1528)

## :bulb: Description 
Small fix for lock icon secure label.
Added test rail link for testLastOpenedTab test.


