### PR TITLE
Bugfix MTE-1487 [v119] Optimize performance tests to fix timeouts

### DIFF
--- a/Client/Application/UITestAppDelegate.swift
+++ b/Client/Application/UITestAppDelegate.swift
@@ -148,11 +148,11 @@ class UITestAppDelegate: AppDelegate, FeatureFlaggable {
         if ProcessInfo.processInfo.arguments.contains(LaunchArguments.ClearProfile) {
             resetApplication()
         }
-        
+
         if CommandLine.arguments.contains("-disableAnimations") {
                     UIView.setAnimationsEnabled(false)
                 }
-        
+
         Tab.ChangeUserAgent.clear()
 
         return super.application(application, willFinishLaunchingWithOptions: launchOptions)

--- a/Client/Application/UITestAppDelegate.swift
+++ b/Client/Application/UITestAppDelegate.swift
@@ -148,7 +148,11 @@ class UITestAppDelegate: AppDelegate, FeatureFlaggable {
         if ProcessInfo.processInfo.arguments.contains(LaunchArguments.ClearProfile) {
             resetApplication()
         }
-
+        
+        if CommandLine.arguments.contains("-disableAnimations") {
+                    UIView.setAnimationsEnabled(false)
+                }
+        
         Tab.ChangeUserAgent.clear()
 
         return super.application(application, willFinishLaunchingWithOptions: launchOptions)

--- a/Client/Application/UITestAppDelegate.swift
+++ b/Client/Application/UITestAppDelegate.swift
@@ -149,10 +149,6 @@ class UITestAppDelegate: AppDelegate, FeatureFlaggable {
             resetApplication()
         }
 
-        if CommandLine.arguments.contains("-disableAnimations") {
-                    UIView.setAnimationsEnabled(false)
-                }
-
         Tab.ChangeUserAgent.clear()
 
         return super.application(application, willFinishLaunchingWithOptions: launchOptions)

--- a/Tests/XCUITests/BaseTestCase.swift
+++ b/Tests/XCUITests/BaseTestCase.swift
@@ -113,6 +113,19 @@ class BaseTestCase: XCTestCase {
         waitFor(element, with: "exists == true", timeout: timeout, file: file, line: line)
     }
 
+    // is up to 25x more performant than the above waitForExistence method
+    func mozWaitForElementToExist(element: XCUIElement, timeoutInSeconds: TimeInterval) {
+        let startTime = Date()
+
+        while !element.exists {
+            if Date().timeIntervalSince(startTime) > timeoutInSeconds {
+                XCTFail("Timed out waiting for element \(element) to exist")
+                break
+            }
+            usleep(10000)
+        }
+    }
+
     func waitForNoExistence(_ element: XCUIElement, timeoutValue: TimeInterval = 5.0, file: String = #file, line: UInt = #line) {
         waitFor(element, with: "exists != true", timeout: timeoutValue, file: file, line: line)
     }

--- a/Tests/XCUITests/BaseTestCase.swift
+++ b/Tests/XCUITests/BaseTestCase.swift
@@ -69,6 +69,7 @@ class BaseTestCase: XCTestCase {
         } else {
             app.launchArguments = [LaunchArguments.PerformanceTest] + launchArguments
         }
+        app.launchArguments.append("-disableAnimations")
         app.launch()
     }
 

--- a/Tests/XCUITests/BaseTestCase.swift
+++ b/Tests/XCUITests/BaseTestCase.swift
@@ -69,7 +69,6 @@ class BaseTestCase: XCTestCase {
         } else {
             app.launchArguments = [LaunchArguments.PerformanceTest] + launchArguments
         }
-        app.launchArguments.append("-disableAnimations")
         app.launch()
     }
 

--- a/Tests/XCUITests/PerformanceTests.swift
+++ b/Tests/XCUITests/PerformanceTests.swift
@@ -25,7 +25,7 @@ class PerformanceTests: BaseTestCase {
         let parts = name.replacingOccurrences(of: "]", with: "").split(separator: " ")
         let functionName = String(parts[1])
         // defaults
-        launchArguments = [LaunchArguments.PerformanceTest, LaunchArguments.SkipIntro, LaunchArguments.SkipWhatsNew, LaunchArguments.SkipETPCoverSheet, LaunchArguments.SkipContextualHints,  LaunchArguments.DisableAnimations]
+        launchArguments = [LaunchArguments.PerformanceTest, LaunchArguments.SkipIntro, LaunchArguments.SkipWhatsNew, LaunchArguments.SkipETPCoverSheet, LaunchArguments.SkipContextualHints, LaunchArguments.DisableAnimations]
         // append specific load profiles to LaunchArguments
         if fixtures.keys.contains(functionName) {
             launchArguments.append(LaunchArguments.LoadTabsStateArchive + fixtures[functionName]!)

--- a/Tests/XCUITests/PerformanceTests.swift
+++ b/Tests/XCUITests/PerformanceTests.swift
@@ -26,7 +26,6 @@ class PerformanceTests: BaseTestCase {
         let functionName = String(parts[1])
         // defaults
         launchArguments = [LaunchArguments.PerformanceTest, LaunchArguments.SkipIntro, LaunchArguments.SkipWhatsNew, LaunchArguments.SkipETPCoverSheet, LaunchArguments.SkipContextualHints]
-
         // append specific load profiles to LaunchArguments
         if fixtures.keys.contains(functionName) {
             launchArguments.append(LaunchArguments.LoadTabsStateArchive + fixtures[functionName]!)
@@ -82,7 +81,7 @@ class PerformanceTests: BaseTestCase {
     func testPerfTabs_3_20tabTray() {
         // Warning: Avoid using waitForExistence as it is up to 25x less performant
         let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
-        let tabsButtonNumber = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].staticTexts["∞"]
+        let tabsButtonNumber = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].staticTexts["20"]
         let doneButton = app.buttons[AccessibilityIdentifiers.TabTray.doneButton]
 
         mozWaitForElementToExist(element: tabsButton, timeoutInSeconds: TIMEOUT)
@@ -238,7 +237,7 @@ class PerformanceTests: BaseTestCase {
                     // multiple age buckets.
                     // This will cause this test to fail as we are expecting exactly one age bucket for these to fail into.
                     // If this test fails because the actual count is 1 greater than expected, that is why.
-                    XCTAssertEqual(historyItems.count, 100, "Number of cells in 'History List' is not equal to 101")
+                    XCTAssertEqual(historyItems.count, 100, "Number of cells in 'History List' is not equal to 100")
                 } catch {
                     XCTFail("Failed to take snapshot: \(error)")
                 }

--- a/Tests/XCUITests/PerformanceTests.swift
+++ b/Tests/XCUITests/PerformanceTests.swift
@@ -164,7 +164,7 @@ class PerformanceTests: BaseTestCase {
     func testPerfHistory1openMenu() {
         waitForTabsButton()
         do {
-            let snapshot = app.tables["History List"].snapshot()
+            let snapshot = try app.tables["History List"].snapshot()
             measure(metrics: [
                 XCTMemoryMetric(),
                 XCTClockMetric(), // to measure timeClock Mon
@@ -237,7 +237,7 @@ class PerformanceTests: BaseTestCase {
         waitForTabsButton()
         navigator.goto(LibraryPanel_Bookmarks)
         do {
-            let snapshot = app.tables["Bookmarks List"].snapshot()
+            let snapshot = try app.tables["Bookmarks List"].snapshot()
             measure(metrics: [
                 XCTMemoryMetric(),
                 XCTClockMetric(), // to measure timeClock Mon

--- a/Tests/XCUITests/PerformanceTests.swift
+++ b/Tests/XCUITests/PerformanceTests.swift
@@ -231,11 +231,11 @@ class PerformanceTests: BaseTestCase {
                     let historyListCells = historyListSnapshot.children.filter { $0.elementType == .cell }
                     let historyItems = historyListCells.dropFirst()
 
-                    // Warning: If the history database used for this test is updated, so will the date of those history items
+                    // Warning: If the history database used for this test is updated, so will the date of those history items.
                     // This means as those history items age, they will fall into older buckets, causing new cells to be created
                     // representing this new age bucket (i.e. 'yesterday', 'a week', etc) where the 100 entries will be split across
                     // multiple age buckets.
-                    // This will cause this test to fail as we are expecting exactly one age bucket for these to fail into.
+                    // This will cause this test to fail as we are expecting exactly one age bucket for these to fall into.
                     // If this test fails because the actual count is 1 greater than expected, that is why.
                     XCTAssertEqual(historyItems.count, 100, "Number of cells in 'History List' is not equal to 100")
                 } catch {

--- a/Tests/XCUITests/PerformanceTests.swift
+++ b/Tests/XCUITests/PerformanceTests.swift
@@ -48,6 +48,7 @@ class PerformanceTests: BaseTestCase {
     // Taking the edges, low and high load. For more values in the middle
     // check the available archives
     func testPerfTabs_1_20startup() {
+        app.terminate()
         measure(metrics: [
             XCTMemoryMetric(),
             XCTClockMetric(), // to measure timeClock Mon
@@ -56,10 +57,14 @@ class PerformanceTests: BaseTestCase {
             XCTMemoryMetric()]) {
             // activity measurement here
             app.launch()
+            app.terminate()
         }
+        // Handle termination ourselves as it sometimes hangs when given to xctrunner
+        app.terminate()
     }
 
     func testPerfTabs_2_1280startup() {
+        app.terminate()
         measure(metrics: [
             XCTMemoryMetric(),
             XCTClockMetric(), // to measure timeClock Mon
@@ -68,13 +73,20 @@ class PerformanceTests: BaseTestCase {
             XCTMemoryMetric()]) {
             // activity measurement here
             app.launch()
+            app.terminate()
         }
+        // Handle termination ourselves as it sometimes hangs when given to xctrunner
+        app.terminate()
     }
 
     func testPerfTabs_3_20tabTray() {
-        app.launch()
-        waitForTabsButton()
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].staticTexts["20"], timeout: TIMEOUT_LONG)
+        // Warning: Avoid using waitForExistence as it is up to 25x less performant
+        let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
+        let tabsButtonNumber = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].staticTexts["∞"]
+        let doneButton = app.buttons[AccessibilityIdentifiers.TabTray.doneButton]
+
+        mozWaitForElementToExist(element: tabsButton, timeoutInSeconds: TIMEOUT)
+        mozWaitForElementToExist(element: tabsButtonNumber, timeoutInSeconds: TIMEOUT)
 
         measure(metrics: [
             XCTClockMetric(), // to measure timeClock Mon
@@ -82,28 +94,37 @@ class PerformanceTests: BaseTestCase {
             XCTStorageMetric(), // to measure storage consuming
             XCTMemoryMetric()]) {
             // go to tab tray
-            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: TIMEOUT_LONG)
-            app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].tap()
-            waitForExistence(app.buttons[AccessibilityIdentifiers.TabTray.doneButton])
-            app.buttons[AccessibilityIdentifiers.TabTray.doneButton].tap()
+            mozWaitForElementToExist(element: tabsButton, timeoutInSeconds: TIMEOUT)
+            tabsButton.tap()
+            mozWaitForElementToExist(element: doneButton, timeoutInSeconds: TIMEOUT)
+            doneButton.tap()
         }
+        // Handle termination ourselves as it sometimes hangs when given to xctrunner
+        app.terminate()
     }
 
     func testPerfTabs_4_1280tabTray() {
-        app.launch()
-        waitForTabsButton()
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].staticTexts["∞"], timeout: TIMEOUT_LONG)
+        // Warning: Avoid using waitForExistence as it is up to 25x less performant
+        let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
+        let tabsButtonNumber = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].staticTexts["∞"]
+        let doneButton = app.buttons[AccessibilityIdentifiers.TabTray.doneButton]
+
+        mozWaitForElementToExist(element: tabsButton, timeoutInSeconds: TIMEOUT)
+        mozWaitForElementToExist(element: tabsButtonNumber, timeoutInSeconds: TIMEOUT)
+
         measure(metrics: [
             XCTClockMetric(), // to measure timeClock Mon
             XCTCPUMetric(), // to measure cpu cycles
             XCTStorageMetric(), // to measure storage consuming
             XCTMemoryMetric()]) {
             // go to tab tray
-            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton])
-            app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].tap()
-            waitForExistence(app.buttons[AccessibilityIdentifiers.TabTray.doneButton])
-            app.buttons[AccessibilityIdentifiers.TabTray.doneButton].tap()
+            mozWaitForElementToExist(element: tabsButton, timeoutInSeconds: TIMEOUT)
+            tabsButton.tap()
+            mozWaitForElementToExist(element: doneButton, timeoutInSeconds: TIMEOUT)
+            doneButton.tap()
         }
+        // Handle termination ourselves as it sometimes hangs when given to xctrunner
+        app.terminate()
     }
 
     func testPerfHistory1startUp() {

--- a/Tests/XCUITests/PerformanceTests.swift
+++ b/Tests/XCUITests/PerformanceTests.swift
@@ -25,7 +25,7 @@ class PerformanceTests: BaseTestCase {
         let parts = name.replacingOccurrences(of: "]", with: "").split(separator: " ")
         let functionName = String(parts[1])
         // defaults
-        launchArguments = [LaunchArguments.PerformanceTest, LaunchArguments.SkipIntro, LaunchArguments.SkipWhatsNew, LaunchArguments.SkipETPCoverSheet, LaunchArguments.SkipContextualHints]
+        launchArguments = [LaunchArguments.PerformanceTest, LaunchArguments.SkipIntro, LaunchArguments.SkipWhatsNew, LaunchArguments.SkipETPCoverSheet, LaunchArguments.SkipContextualHints,  LaunchArguments.DisableAnimations]
         // append specific load profiles to LaunchArguments
         if fixtures.keys.contains(functionName) {
             launchArguments.append(LaunchArguments.LoadTabsStateArchive + fixtures[functionName]!)

--- a/Tests/XCUITests/PerformanceTests.swift
+++ b/Tests/XCUITests/PerformanceTests.swift
@@ -107,8 +107,11 @@ class PerformanceTests: BaseTestCase {
     }
 
     func testPerfHistory1startUp() {
-        waitForTabsButton()
+        // Warning: Avoid using waitForExistence as it is up to 25x less performant
+        let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
+        mozWaitForElementToExist(element: tabsButton, timeoutInSeconds: TIMEOUT)
         app.terminate()
+
         measure(metrics: [
             XCTMemoryMetric(),
             XCTClockMetric(), // to measure timeClock Mon
@@ -117,38 +120,58 @@ class PerformanceTests: BaseTestCase {
             XCTMemoryMetric()]) {
                 // activity measurement here
                 app.launch()
-                waitForTabsButton()
+                mozWaitForElementToExist(element: tabsButton, timeoutInSeconds: TIMEOUT)
+                app.terminate()
         }
         // Handle termination ourselves as it sometimes hangs when given to xctrunner
         app.terminate()
     }
 
     func testPerfHistory1openMenu() {
-        waitForTabsButton()
-        do {
-            let snapshot = try app.tables["History List"].snapshot()
-            measure(metrics: [
-                XCTMemoryMetric(),
-                XCTClockMetric(), // to measure timeClock Mon
-                XCTCPUMetric(), // to measure cpu cycles
-                XCTStorageMetric(), // to measure storage consuming
-                XCTMemoryMetric()]) {
-                    navigator.goto(LibraryPanel_History)
-                    let historyList = app.tables["History List"]
-                    waitForExistence(historyList, timeout: TIMEOUT_LONG)
-                    let expectedCount = 2
-                    XCTAssertEqual(snapshot.children.count, expectedCount, "Number of cells in 'History List' is not equal to \(expectedCount)")
-            }
-        } catch {
-            XCTFail("Failed to take snapshot: \(error)")
+        // Warning: Avoid using waitForExistence as it is up to 25x less performant
+        let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
+        mozWaitForElementToExist(element: tabsButton, timeoutInSeconds: TIMEOUT)
+
+        navigator.goto(LibraryPanel_History)
+
+        // Ensure 'History List' exists before taking a snapshot to avoid expensive retries.
+        // Return firstMatch to avoid traversing the entire { Window, Window } element tree.
+        let historyList = app.tables["History List"].firstMatch
+        mozWaitForElementToExist(element: historyList, timeoutInSeconds: TIMEOUT)
+
+        measure(metrics: [
+            XCTMemoryMetric(),
+            XCTClockMetric(), // to measure timeClock Mon
+            XCTCPUMetric(), // to measure cpu cycles
+            XCTStorageMetric(), // to measure storage consuming
+            XCTMemoryMetric()]) {
+                // Include snapshot here as it is the closest aproximation to an element load measurement
+                do {
+                    let historyListSnapshot = try historyList.snapshot()
+                    let historyListCells = historyListSnapshot.children.filter { $0.elementType == .cell }
+                    let historyItems = historyListCells.dropFirst()
+
+                    // Warning: If the history database used for this test is updated, so will the date of those history items
+                    // This means as those history items age, they will fall into older buckets, causing new cells to be created
+                    // representing this new age bucket (i.e. 'yesterday', 'a week', etc) where the 100 entries will be split across
+                    // multiple age buckets.
+                    // This will cause this test to fail as we are expecting exactly one age bucket for these to fail into.
+                    // If this test fails because the actual count is 1 greater than expected, that is why.
+                    XCTAssertEqual(historyItems.count, 1, "Number of cells in 'History List' is not equal to 1")
+                } catch {
+                    XCTFail("Failed to take snapshot: \(error)")
+                }
         }
         // Handle termination ourselves as it sometimes hangs when given to xctrunner
         app.terminate()
     }
 
     func testPerfHistory100startUp() {
-        waitForTabsButton()
+        // Warning: Avoid using waitForExistence as it is up to 25x less performant
+        let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
+        mozWaitForElementToExist(element: tabsButton, timeoutInSeconds: TIMEOUT)
         app.terminate()
+
         measure(metrics: [
             XCTMemoryMetric(),
             XCTClockMetric(), // to measure timeClock Mon
@@ -157,30 +180,47 @@ class PerformanceTests: BaseTestCase {
             XCTMemoryMetric()]) {
                 // activity measurement here
                 app.launch()
-                waitForTabsButton()
+                mozWaitForElementToExist(element: tabsButton, timeoutInSeconds: TIMEOUT)
+                app.terminate()
         }
         // Handle termination ourselves as it sometimes hangs when given to xctrunner
         app.terminate()
     }
 
     func testPerfHistory100openMenu() {
-        waitForTabsButton()
-        do {
-            let snapshot = try app.tables["History List"].snapshot()
-            measure(metrics: [
-                XCTMemoryMetric(),
-                XCTClockMetric(), // to measure timeClock Mon
-                XCTCPUMetric(), // to measure cpu cycles
-                XCTStorageMetric(), // to measure storage consuming
-                XCTMemoryMetric()]) {
-                    navigator.goto(LibraryPanel_History)
-                    let historyList = app.tables["History List"]
-                    waitForExistence(historyList, timeout: TIMEOUT_LONG)
-                    let expectedCount = 101
-                    XCTAssertEqual(snapshot.children.count, expectedCount, "Number of cells in 'History List' is not equal to \(expectedCount)")
-            }
-        } catch {
-            XCTFail("Failed to take snapshot: \(error)")
+        // Warning: Avoid using waitForExistence as it is up to 25x less performant
+        let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
+        mozWaitForElementToExist(element: tabsButton, timeoutInSeconds: TIMEOUT)
+
+        navigator.goto(LibraryPanel_History)
+
+        // Ensure 'History List' exists before taking a snapshot to avoid expensive retries.
+        // Return firstMatch to avoid traversing the entire { Window, Window } element tree.
+        let historyList = app.tables["History List"].firstMatch
+        mozWaitForElementToExist(element: historyList, timeoutInSeconds: TIMEOUT)
+
+        measure(metrics: [
+            XCTMemoryMetric(),
+            XCTClockMetric(), // to measure timeClock Mon
+            XCTCPUMetric(), // to measure cpu cycles
+            XCTStorageMetric(), // to measure storage consuming
+            XCTMemoryMetric()]) {
+                // Include snapshot here as it is the closest aproximation to an element load measurement
+                do {
+                    let historyListSnapshot = try historyList.snapshot()
+                    let historyListCells = historyListSnapshot.children.filter { $0.elementType == .cell }
+                    let historyItems = historyListCells.dropFirst()
+
+                    // Warning: If the history database used for this test is updated, so will the date of those history items
+                    // This means as those history items age, they will fall into older buckets, causing new cells to be created
+                    // representing this new age bucket (i.e. 'yesterday', 'a week', etc) where the 100 entries will be split across
+                    // multiple age buckets.
+                    // This will cause this test to fail as we are expecting exactly one age bucket for these to fail into.
+                    // If this test fails because the actual count is 1 greater than expected, that is why.
+                    XCTAssertEqual(historyItems.count, 100, "Number of cells in 'History List' is not equal to 101")
+                } catch {
+                    XCTFail("Failed to take snapshot: \(error)")
+                }
         }
         // Handle termination ourselves as it sometimes hangs when given to xctrunner
         app.terminate()
@@ -191,7 +231,7 @@ class PerformanceTests: BaseTestCase {
         let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
         mozWaitForElementToExist(element: tabsButton, timeoutInSeconds: TIMEOUT)
         app.terminate()
-        
+
         measure(metrics: [
             XCTMemoryMetric(),
             XCTClockMetric(), // to measure timeClock Mon
@@ -232,9 +272,9 @@ class PerformanceTests: BaseTestCase {
                     // Activity measurement here
                     let bookmarksListSnapshot = try bookmarksList.snapshot()
                     let bookmarksListCells = bookmarksListSnapshot.children.filter { $0.elementType == .cell }
-                    let filteredBookmarksList = bookmarksListCells.dropFirst()
+                    let bookmarks = bookmarksListCells.dropFirst()
 
-                    XCTAssertEqual(filteredBookmarksList.count, 1, "Number of cells in 'Bookmarks List' is not equal to 1")
+                    XCTAssertEqual(bookmarks.count, 1, "Number of cells in 'Bookmarks List' is not equal to 1")
                 } catch {
                     XCTFail("Failed to take snapshot: \(error)")
                 }
@@ -288,10 +328,10 @@ class PerformanceTests: BaseTestCase {
                 do {
                     let bookmarksListSnapshot = try bookmarksList.snapshot()
                     let bookmarksListCells = bookmarksListSnapshot.children.filter { $0.elementType == .cell }
-                    let filteredBookmarksList = bookmarksListCells.dropFirst()
+                    let bookmarks = bookmarksListCells.dropFirst()
 
                     // Activity measurement here
-                    XCTAssertEqual(filteredBookmarksList.count, 100, "Number of cells in 'Bookmarks List' is not equal to 100")
+                    XCTAssertEqual(bookmarks.count, 100, "Number of cells in 'Bookmarks List' is not equal to 100")
                 } catch {
                     XCTFail("Failed to take a snapshot: \(error)")
                 }
@@ -332,7 +372,7 @@ class PerformanceTests: BaseTestCase {
         // Return firstMatch to avoid traversing the entire { Window, Window } element tree.
         let bookmarksList = app.tables["Bookmarks List"].firstMatch
         mozWaitForElementToExist(element: bookmarksList, timeoutInSeconds: TIMEOUT)
-        
+
         measure(metrics: [
             XCTMemoryMetric(),
             XCTClockMetric(), // to measure timeClock Mon
@@ -346,9 +386,9 @@ class PerformanceTests: BaseTestCase {
                     // Activity measurement here
                     let bookmarksListSnapshot = try bookmarksList.snapshot()
                     let bookmarksListCells = bookmarksListSnapshot.children.filter { $0.elementType == .cell }
-                    let filteredBookmarksList = bookmarksListCells.dropFirst()
+                    let bookmarks = bookmarksListCells.dropFirst()
 
-                    XCTAssertEqual(filteredBookmarksList.count, 1000, "Number of cells in 'Bookmarks List' is not equal to 1000")
+                    XCTAssertEqual(bookmarks.count, 1000, "Number of cells in 'Bookmarks List' is not equal to 1000")
                 } catch {
                     XCTFail("Failed to take a snapshot: \(error)")
                 }

--- a/Tests/XCUITests/PerformanceTests.swift
+++ b/Tests/XCUITests/PerformanceTests.swift
@@ -163,17 +163,22 @@ class PerformanceTests: BaseTestCase {
 
     func testPerfHistory1openMenu() {
         waitForTabsButton()
-        measure(metrics: [
-            XCTMemoryMetric(),
-            XCTClockMetric(), // to measure timeClock Mon
-            XCTCPUMetric(), // to measure cpu cycles
-            XCTStorageMetric(), // to measure storage consuming
-            XCTMemoryMetric()]) {
-                navigator.goto(LibraryPanel_History)
-                let historyList = app.tables["History List"]
-                waitForExistence(historyList, timeout: TIMEOUT_LONG)
-                let expectedCount = 2
-                XCTAssertEqual(historyList.cells.count, expectedCount, "Number of cells in 'History List' is not equal to \(expectedCount)")
+        do {
+            let snapshot = app.tables["History List"].snapshot()
+            measure(metrics: [
+                XCTMemoryMetric(),
+                XCTClockMetric(), // to measure timeClock Mon
+                XCTCPUMetric(), // to measure cpu cycles
+                XCTStorageMetric(), // to measure storage consuming
+                XCTMemoryMetric()]) {
+                    navigator.goto(LibraryPanel_History)
+                    let historyList = app.tables["History List"]
+                    waitForExistence(historyList, timeout: TIMEOUT_LONG)
+                    let expectedCount = 2
+                    XCTAssertEqual(snapshot.children.count, expectedCount, "Number of cells in 'History List' is not equal to \(expectedCount)")
+            }
+        } catch {
+            XCTFail("Failed to take snapshot: \(error)")
         }
     }
 
@@ -194,17 +199,22 @@ class PerformanceTests: BaseTestCase {
 
     func testPerfHistory100openMenu() {
         waitForTabsButton()
-        measure(metrics: [
-            XCTMemoryMetric(),
-            XCTClockMetric(), // to measure timeClock Mon
-            XCTCPUMetric(), // to measure cpu cycles
-            XCTStorageMetric(), // to measure storage consuming
-            XCTMemoryMetric()]) {
-                navigator.goto(LibraryPanel_History)
-                let historyList = app.tables["History List"]
-                waitForExistence(historyList, timeout: TIMEOUT_LONG)
-                let expectedCount = 101
-                XCTAssertEqual(historyList.cells.count, expectedCount, "Number of cells in 'History List' is not equal to \(expectedCount)")
+        do {
+            let snapshot = try app.tables["History List"].snapshot()
+            measure(metrics: [
+                XCTMemoryMetric(),
+                XCTClockMetric(), // to measure timeClock Mon
+                XCTCPUMetric(), // to measure cpu cycles
+                XCTStorageMetric(), // to measure storage consuming
+                XCTMemoryMetric()]) {
+                    navigator.goto(LibraryPanel_History)
+                    let historyList = app.tables["History List"]
+                    waitForExistence(historyList, timeout: TIMEOUT_LONG)
+                    let expectedCount = 101
+                    XCTAssertEqual(snapshot.children.count, expectedCount, "Number of cells in 'History List' is not equal to \(expectedCount)")
+            }
+        } catch {
+            XCTFail("Failed to take snapshot: \(error)")
         }
     }
 
@@ -226,17 +236,22 @@ class PerformanceTests: BaseTestCase {
     func testPerfBookmarks1openMenu() {
         waitForTabsButton()
         navigator.goto(LibraryPanel_Bookmarks)
-        measure(metrics: [
-            XCTMemoryMetric(),
-            XCTClockMetric(), // to measure timeClock Mon
-            XCTCPUMetric(), // to measure cpu cycles
-            XCTStorageMetric(), // to measure storage consuming
-            XCTMemoryMetric()]) {
-                // activity measurement here
-                let bookmarkTable = app.tables["Bookmarks List"]
-                waitForExistence(bookmarkTable, timeout: TIMEOUT_LONG)
-                let expectedCount = 2
-                XCTAssertEqual(bookmarkTable.cells.count, expectedCount, "Number of cells in 'Bookmarks List' is not equal to \(expectedCount)")
+        do {
+            let snapshot = app.tables["Bookmarks List"].snapshot()
+            measure(metrics: [
+                XCTMemoryMetric(),
+                XCTClockMetric(), // to measure timeClock Mon
+                XCTCPUMetric(), // to measure cpu cycles
+                XCTStorageMetric(), // to measure storage consuming
+                XCTMemoryMetric()]) {
+                    // activity measurement here
+                    let bookmarkTable = app.tables["Bookmarks List"]
+                    waitForExistence(bookmarkTable, timeout: TIMEOUT_LONG)
+                    let expectedCount = 2
+                    XCTAssertEqual(snapshot.children.count, expectedCount, "Number of cells in 'Bookmarks List' is not equal to \(expectedCount)")
+                }
+        } catch {
+            XCTFail("Failed to take snapshot: \(error)")
         }
     }
 
@@ -258,17 +273,22 @@ class PerformanceTests: BaseTestCase {
     func testPerfBookmarks100openMenu() {
         waitForTabsButton()
         navigator.goto(LibraryPanel_Bookmarks)
-        measure(metrics: [
-            XCTMemoryMetric(),
-            XCTClockMetric(), // to measure timeClock Mon
-            XCTCPUMetric(), // to measure cpu cycles
-            XCTStorageMetric(), // to measure storage consuming
-            XCTMemoryMetric()]) {
-                // activity measurement here
-                let bookmarkTable = app.tables["Bookmarks List"]
-                waitForExistence(bookmarkTable, timeout: TIMEOUT_LONG)
-                let expectedCount = 101
-                XCTAssertEqual(bookmarkTable.cells.count, expectedCount, "Number of cells in 'Bookmarks List' is not equal to \(expectedCount)")
+        do {
+            let snapshot = try app.tables["Bookmarks List"].snapshot()
+            measure(metrics: [
+                XCTMemoryMetric(),
+                XCTClockMetric(), // to measure timeClock Mon
+                XCTCPUMetric(), // to measure cpu cycles
+                XCTStorageMetric(), // to measure storage consuming
+                XCTMemoryMetric()]) {
+                    // activity measurement here
+                    let bookmarkTable = app.tables["Bookmarks List"]
+                    waitForExistence(bookmarkTable, timeout: TIMEOUT_LONG)
+                    let expectedCount = 101
+                    XCTAssertEqual(snapshot.children.count, expectedCount, "Number of cells in 'Bookmarks List' is not equal to \(expectedCount)")
+            }
+        } catch {
+            XCTFail("Failed to take a snapshot: \(error)")
         }
     }
 
@@ -290,17 +310,23 @@ class PerformanceTests: BaseTestCase {
     func testPerfBookmarks1000openMenu() {
         waitForTabsButton()
         navigator.goto(LibraryPanel_Bookmarks)
-        measure(metrics: [
-            XCTMemoryMetric(),
-            XCTClockMetric(), // to measure timeClock Mon
-            XCTCPUMetric(), // to measure cpu cycles
-            XCTStorageMetric(), // to measure storage consuming
-            XCTMemoryMetric()]) {
-                // activity measurement here
-                let bookmarkTable = app.tables["Bookmarks List"]
-                waitForExistence(bookmarkTable, timeout: TIMEOUT_LONG)
-                let expectedCount = 1001
-                XCTAssertEqual(bookmarkTable.cells.count, expectedCount, "Number of cells in 'Bookmarks List' is not equal to \(expectedCount)")
+
+        do {
+            let snapshot = try app.tables["Bookmarks List"].snapshot()
+            measure(metrics: [
+                XCTMemoryMetric(),
+                XCTClockMetric(), // to measure timeClock Mon
+                XCTCPUMetric(), // to measure CPU cycles
+                XCTStorageMetric(), // to measure storage consumption
+                XCTMemoryMetric()]) {
+                    // Activity measurement here
+                    let bookmarkTable = app.tables["Bookmarks List"]
+                    waitForExistence(bookmarkTable, timeout: TIMEOUT_LONG)
+                    let expectedCount = 1001
+                    XCTAssertEqual(snapshot.children.count, expectedCount, "Number of cells in 'Bookmarks List' is not equal to \(expectedCount)")
+            }
+        } catch {
+            XCTFail("Failed to take a snapshot: \(error)")
         }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1487)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Our performance tests are taking too long to run in bitrise causing the bitrise runs to fail. I've included a number of optimizations to address the performance of those tests so this won't be an issue anymore.

These changes reduced my test runtimes for the databaseFixture tests from over 200 seconds to about 18 seconds.
The performance tests as a whole went from about 800 seconds to 275 seconds from my local tests, as most of the time savings are essentially from two tests being dramatically improved.

Animations are now disabled for the performance tests. This is necessary for the tab test specifically because some sites that are visited have very long running animations and cause the idle-check to poll for extremely long times. The current measurements in the performance tests aren't focused enough to become effected by disabling the animations; though, a better solution should be found once the element/page load measurement strategy is solved.

I've included a new method `mozWaitForElementToExist` which takes ~0.059 seconds to verify an element exists compared to the previously used methods like `waitFor`, `waitForExistence`, and NSPredicate/Expectations that take ~1.5-3 seconds to verify an element exists.

I've included manual snapshots that target the first occurrence of an element, greatly reducing the amount of time a snapshot takes, from ~9 seconds to ~5 seconds.

I've also opted for taking our own snapshots instead of passing them to the XCUITest Runner itself as it is very slow at doing so and takes snapshots before each action and `waitFor` call. Using the new `mozWaitForElementToExist` method bypasses the additional `snapshot` calls made under-the-hood.

The biggest performance gain is by getting a `count` of the `snapshot.children` to verify instead of using the previous approach that made a new snapshot on each call and traversed the entire snapshot including both `{ Window, Window }` elements which would unintentionally query the simulator window as well as the app.

Finally, I've added `app.terminate()` at the end of each test to add stability to the tests because the XCUITest Runner often loses the ability to terminate the app itself, causing test failures unrelated to any test assertions.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

