### PR TITLE
Add FXIOS-7393 DISCO-2547 [v120] Show suggestions from Firefox Suggest in the awesomebar

### DIFF
--- a/.experimenter.yaml
+++ b/.experimenter.yaml
@@ -23,6 +23,14 @@ credit-card-autofill:
     credit-card-autofill-status:
       type: boolean
       description: "If true, we will allow user to use the credit autofill feature"
+firefox-suggest-feature:
+  description: Configuration for the Firefox Suggest feature.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    status:
+      type: boolean
+      description: "Whether the feature is enabled. When Firefox Suggest is enabled, Firefox will download and store new search suggestions in the background, and show additional Search settings to control which suggestions appear in the awesomebar. When Firefox Suggest is disabled, Firefox will not download new suggestions, and hide the additional Search settings.\n"
 general-app-features:
   description: The feature that contains feature flags for the entire application
   hasExposure: true

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -842,6 +842,8 @@
 		BCFF93EE2AAA9F6E005B5B71 /* RustFirefoxSuggest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF93ED2AAA9C47005B5B71 /* RustFirefoxSuggest.swift */; };
 		BCFF93F02AABA55A005B5B71 /* BackgroundFirefoxSuggestIngestUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF93EF2AAB97A8005B5B71 /* BackgroundFirefoxSuggestIngestUtility.swift */; };
 		BCFF93F62AB11A47005B5B71 /* RustFirefoxSuggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF93F52AB11A47005B5B71 /* RustFirefoxSuggestion.swift */; };
+		BCFF93F22AAF9688005B5B71 /* FirefoxSuggestSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF93F12AAF9688005B5B71 /* FirefoxSuggestSettings.swift */; };
+		BCFF93F42AAF9879005B5B71 /* FirefoxSuggestSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF93F32AAF9879005B5B71 /* FirefoxSuggestSettingsViewController.swift */; };
 		BD1C89CA2A1E3CE7000A4201 /* PocketFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1C89C92A1E3CE7000A4201 /* PocketFooterView.swift */; };
 		BD4B2DE229BB4CD9005FAA50 /* SnackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4B2DE129BB4CD9005FAA50 /* SnackButton.swift */; };
 		BD4B2DE429BB4D9A005FAA50 /* TimerSnackBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4B2DE329BB4D9A005FAA50 /* TimerSnackBar.swift */; };
@@ -5554,6 +5556,8 @@
 		BCFF93ED2AAA9C47005B5B71 /* RustFirefoxSuggest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustFirefoxSuggest.swift; sourceTree = "<group>"; };
 		BCFF93EF2AAB97A8005B5B71 /* BackgroundFirefoxSuggestIngestUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundFirefoxSuggestIngestUtility.swift; sourceTree = "<group>"; };
 		BCFF93F52AB11A47005B5B71 /* RustFirefoxSuggestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustFirefoxSuggestion.swift; sourceTree = "<group>"; };
+		BCFF93F12AAF9688005B5B71 /* FirefoxSuggestSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirefoxSuggestSettings.swift; sourceTree = "<group>"; };
+		BCFF93F32AAF9879005B5B71 /* FirefoxSuggestSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirefoxSuggestSettingsViewController.swift; sourceTree = "<group>"; };
 		BD1C89C92A1E3CE7000A4201 /* PocketFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketFooterView.swift; sourceTree = "<group>"; };
 		BD2A4E1791139257129D9DE2 /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		BD4B2DE129BB4CD9005FAA50 /* SnackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnackButton.swift; sourceTree = "<group>"; };
@@ -7450,6 +7454,7 @@
 				0B62EFD11AD63CD100ACB9CD /* Clearables.swift */,
 				D3E8EEE71B97A87A001900FB /* ClearPrivateDataTableViewController.swift */,
 				3B39EDCA1E16E1AA00EF029F /* CustomSearchViewController.swift */,
+				BCFF93F32AAF9879005B5B71 /* FirefoxSuggestSettingsViewController.swift */,
 				DFACBF83277B9B36003D5F41 /* HomepageSettings */,
 				C8656D76270F858900E199EA /* TabsSettingsViewControler.swift */,
 				C82F4C2A29AE2DF0005BD116 /* NotificationsSettingsViewController.swift */,
@@ -8226,6 +8231,7 @@
 				8A3EF7F32A2FCF5700796E3A /* ExportBrowserDataSetting.swift */,
 				8A3EF7F62A2FCF6D00796E3A /* ExportLogDataSetting.swift */,
 				8A3EF8002A2FCFC900796E3A /* FasterInactiveTabs.swift */,
+				BCFF93F12AAF9688005B5B71 /* FirefoxSuggestSettings.swift */,
 				8A3EF7FA2A2FCF9D00796E3A /* ForceCrashSetting.swift */,
 				8A3EF8042A2FCFE500796E3A /* ForgetSyncAuthStateDebugSetting.swift */,
 				8A3EF7EF2A2FCF3100796E3A /* HiddenSettings.swift */,
@@ -12967,6 +12973,8 @@
 				8A3EF7FB2A2FCF9D00796E3A /* ForceCrashSetting.swift in Sources */,
 				2178A6A4291455F7002EC290 /* ReaderModeFontSizeButton.swift in Sources */,
 				BCFF93F02AABA55A005B5B71 /* BackgroundFirefoxSuggestIngestUtility.swift in Sources */,
+				BCFF93F22AAF9688005B5B71 /* FirefoxSuggestSettings.swift in Sources */,
+				BCFF93F42AAF9879005B5B71 /* FirefoxSuggestSettingsViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -839,6 +839,9 @@
 		B12DDFED2A8DE825008CE9CF /* ToolbarMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12DDFEC2A8DE825008CE9CF /* ToolbarMenuTests.swift */; };
 		B15058812AA0A878008B7382 /* OpeningScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15058802AA0A878008B7382 /* OpeningScreenTests.swift */; };
 		B640467E29B9B58200C5C7B6 /* TabLocationViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B640467D29B9B58200C5C7B6 /* TabLocationViewTests.swift */; };
+		BCFF93EE2AAA9F6E005B5B71 /* RustFirefoxSuggest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF93ED2AAA9C47005B5B71 /* RustFirefoxSuggest.swift */; };
+		BCFF93F02AABA55A005B5B71 /* BackgroundFirefoxSuggestIngestUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF93EF2AAB97A8005B5B71 /* BackgroundFirefoxSuggestIngestUtility.swift */; };
+		BCFF93F62AB11A47005B5B71 /* RustFirefoxSuggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF93F52AB11A47005B5B71 /* RustFirefoxSuggestion.swift */; };
 		BD1C89CA2A1E3CE7000A4201 /* PocketFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1C89C92A1E3CE7000A4201 /* PocketFooterView.swift */; };
 		BD4B2DE229BB4CD9005FAA50 /* SnackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4B2DE129BB4CD9005FAA50 /* SnackButton.swift */; };
 		BD4B2DE429BB4D9A005FAA50 /* TimerSnackBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4B2DE329BB4D9A005FAA50 /* TimerSnackBar.swift */; };
@@ -5548,6 +5551,9 @@
 		BC4B49618B8FC822D4D0FCC2 /* hr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hr; path = hr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		BC81442AA84F635F3067A2C5 /* es-CL */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-CL"; path = "es-CL.lproj/PrivateBrowsing.strings"; sourceTree = "<group>"; };
 		BCD04CE4A62EAA4DF96DE812 /* es-MX */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-MX"; path = "es-MX.lproj/Storage.strings"; sourceTree = "<group>"; };
+		BCFF93ED2AAA9C47005B5B71 /* RustFirefoxSuggest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustFirefoxSuggest.swift; sourceTree = "<group>"; };
+		BCFF93EF2AAB97A8005B5B71 /* BackgroundFirefoxSuggestIngestUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundFirefoxSuggestIngestUtility.swift; sourceTree = "<group>"; };
+		BCFF93F52AB11A47005B5B71 /* RustFirefoxSuggestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustFirefoxSuggestion.swift; sourceTree = "<group>"; };
 		BD1C89C92A1E3CE7000A4201 /* PocketFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketFooterView.swift; sourceTree = "<group>"; };
 		BD2A4E1791139257129D9DE2 /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		BD4B2DE129BB4CD9005FAA50 /* SnackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnackButton.swift; sourceTree = "<group>"; };
@@ -9411,6 +9417,8 @@
 				D057B2AA220103BC000614E0 /* RustLogins.swift */,
 				D05434E2225BBC4100FDE4EF /* RustShared.swift */,
 				15DE98FC27FCED4F00F1ECDB /* RustRemoteTabs.swift */,
+				BCFF93ED2AAA9C47005B5B71 /* RustFirefoxSuggest.swift */,
+				BCFF93F52AB11A47005B5B71 /* RustFirefoxSuggestion.swift */,
 			);
 			path = Rust;
 			sourceTree = "<group>";
@@ -10523,6 +10531,7 @@
 				5A47CFF42860FB8900B2B7BF /* AppLaunchUtil.swift */,
 				AB52ED3A2A0E8873001067F5 /* UserConversionMetrics.swift */,
 				E1FE133029C22726002A65FF /* BackgroundFetchAndProcessingUtility.swift */,
+				BCFF93EF2AAB97A8005B5B71 /* BackgroundFirefoxSuggestIngestUtility.swift */,
 				E1FE133229C22782002A65FF /* BackgroundNotificationSurfaceUtility.swift */,
 				5A3A2A0C287F742C00B79EAC /* BackgroundSyncUtility.swift */,
 				602B3D6629B0E1DB0066DEF8 /* ConversionValueUtil.swift */,
@@ -12028,6 +12037,8 @@
 				D0A627662270C982006AFA2E /* photon-colors.swift in Sources */,
 				2FCAE25F1ABB531100877008 /* Cursor.swift in Sources */,
 				28302E401AF0747800521E2E /* DatabaseError.swift in Sources */,
+				BCFF93EE2AAA9F6E005B5B71 /* RustFirefoxSuggest.swift in Sources */,
+				BCFF93F62AB11A47005B5B71 /* RustFirefoxSuggestion.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -12955,6 +12966,7 @@
 				E1C437A32A96343A00D188CB /* FakespotFadeLabel.swift in Sources */,
 				8A3EF7FB2A2FCF9D00796E3A /* ForceCrashSetting.swift in Sources */,
 				2178A6A4291455F7002EC290 /* ReaderModeFontSizeButton.swift in Sources */,
+				BCFF93F02AABA55A005B5B71 /* BackgroundFirefoxSuggestIngestUtility.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -141,6 +141,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         backgroundWorkUtility = BackgroundFetchAndProcessingUtility()
         backgroundWorkUtility?.registerUtility(BackgroundSyncUtility(profile: profile, application: application))
         backgroundWorkUtility?.registerUtility(BackgroundNotificationSurfaceUtility())
+        if let firefoxSuggest = profile.firefoxSuggest {
+            backgroundWorkUtility?.registerUtility(BackgroundFirefoxSuggestIngestUtility(
+                firefoxSuggest: firefoxSuggest
+            ))
+        }
 
         let topSitesProvider = TopSitesProviderImplementation(
             placesFetcher: profile.places,

--- a/Client/Application/BackgroundFirefoxSuggestIngestUtility.swift
+++ b/Client/Application/BackgroundFirefoxSuggestIngestUtility.swift
@@ -1,0 +1,90 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import BackgroundTasks
+import Common
+import Foundation
+import Shared
+import Storage
+
+/// A background utility that downloads and stores new Firefox Suggest
+/// suggestions when the device is online and connected to power.
+class BackgroundFirefoxSuggestIngestUtility: BackgroundUtilityProtocol {
+    static let taskIdentifier = "org.mozilla.ios.firefox.suggest.ingest"
+
+    let firefoxSuggest: RustFirefoxSuggest
+    let logger: Logger
+
+    init(firefoxSuggest: RustFirefoxSuggest, logger: Logger = DefaultLogger.shared) {
+        self.firefoxSuggest = firefoxSuggest
+        self.logger = logger
+
+        setUp()
+    }
+
+    /// Schedules the ingestion task to run when the app is backgrounded.
+    func scheduleTaskOnAppBackground() {
+        logger.log("Scheduling background ingestion",
+                   level: .debug,
+                   category: .storage)
+        do {
+            try self.submitBackgroundTaskRequest()
+        } catch {
+            logger.log("Failed to schedule background ingestion: \(error.localizedDescription)",
+                       level: .warning,
+                       category: .storage)
+        }
+    }
+
+    /// Submits a request to schedule the background ingestion task.
+    private func submitBackgroundTaskRequest() throws {
+        let request = BGProcessingTaskRequest(identifier: Self.taskIdentifier)
+        request.requiresNetworkConnectivity = true
+        request.requiresExternalPower = true
+        try BGTaskScheduler.shared.submit(request)
+    }
+
+    /// Downloads and stores new Firefox Suggest suggestions. Returns `true` on
+    /// success or `false` on failure.
+    private func ingest() async -> Bool {
+        logger.log("Ingesting new suggestions",
+                   level: .debug,
+                   category: .storage)
+        do {
+            try await firefoxSuggest.ingest()
+            logger.log("Successfully ingested new suggestions",
+                       level: .debug,
+                       category: .storage)
+            return true
+        } catch {
+            logger.log("Failed to ingest new suggestions: \(error.localizedDescription)",
+                       level: .warning,
+                       category: .storage)
+            return false
+        }
+    }
+
+    /// Registers a launch handler for the background ingestion task.
+    private func setUp() {
+        BGTaskScheduler.shared.register(forTaskWithIdentifier: Self.taskIdentifier, using: nil) { task in
+            Task {
+                let success = await self.ingest()
+                if !success {
+                    // If ingestion failed, schedule a follow-up task to retry.
+                    self.logger.log("Scheduling retry ingestion",
+                                    level: .debug,
+                                    category: .storage)
+                    do {
+                        try self.submitBackgroundTaskRequest()
+                    } catch {
+                        self.logger.log("Failed to schedule retry ingestion: \(error.localizedDescription)",
+                                        level: .warning,
+                                        category: .storage)
+                    }
+                }
+                task.setTaskCompleted(success: success)
+            }
+        }
+    }
+}

--- a/Client/Application/BackgroundFirefoxSuggestIngestUtility.swift
+++ b/Client/Application/BackgroundFirefoxSuggestIngestUtility.swift
@@ -10,7 +10,7 @@ import Storage
 
 /// A background utility that downloads and stores new Firefox Suggest
 /// suggestions when the device is online and connected to power.
-class BackgroundFirefoxSuggestIngestUtility: BackgroundUtilityProtocol {
+class BackgroundFirefoxSuggestIngestUtility: BackgroundUtilityProtocol, FeatureFlaggable {
     static let taskIdentifier = "org.mozilla.ios.firefox.suggest.ingest"
 
     let firefoxSuggest: RustFirefoxSuggest
@@ -25,6 +25,7 @@ class BackgroundFirefoxSuggestIngestUtility: BackgroundUtilityProtocol {
 
     /// Schedules the ingestion task to run when the app is backgrounded.
     func scheduleTaskOnAppBackground() {
+        guard featureFlags.isFeatureEnabled(.firefoxSuggestFeature, checking: .buildAndUser) else { return }
         logger.log("Scheduling background ingestion",
                    level: .debug,
                    category: .storage)
@@ -67,6 +68,7 @@ class BackgroundFirefoxSuggestIngestUtility: BackgroundUtilityProtocol {
 
     /// Registers a launch handler for the background ingestion task.
     private func setUp() {
+        guard featureFlags.isFeatureEnabled(.firefoxSuggestFeature, checking: .buildAndUser) else { return }
         BGTaskScheduler.shared.register(forTaskWithIdentifier: Self.taskIdentifier, using: nil) { task in
             Task {
                 let success = await self.ingest()

--- a/Client/Coordinators/SettingsCoordinator.swift
+++ b/Client/Coordinators/SettingsCoordinator.swift
@@ -171,6 +171,11 @@ class SettingsCoordinator: BaseCoordinator,
         router.push(experimentsViewController)
     }
 
+    func showFirefoxSuggest() {
+        let firefoxSuggestViewController = FirefoxSuggestSettingsViewController(profile: profile)
+        router.push(firefoxSuggestViewController)
+    }
+
     func showPasswordManager(shouldShowOnboarding: Bool) {
         let passwordCoordinator = PasswordManagerCoordinator(
             router: router,

--- a/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -15,6 +15,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case credentialAutofillCoordinatorRefactor
     case creditCardAutofillStatus
     case fakespotFeature
+    case firefoxSuggestFeature
     case historyHighlights
     case historyGroups
     case inactiveTabs
@@ -55,6 +56,8 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
         switch featureID {
         case .bottomSearchBar:
             return FlagKeys.SearchBarPosition
+        case .firefoxSuggestFeature:
+            return FlagKeys.FirefoxSuggest
         case .historyHighlights:
             return FlagKeys.HistoryHighlightsSection
         case .historyGroups:

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -16,6 +16,7 @@ private enum SearchListSection: Int, CaseIterable {
     case openedTabs
     case bookmarksAndHistory
     case searchHighlights
+    case firefoxSuggestions
 }
 
 private struct SearchViewControllerUX {
@@ -68,6 +69,7 @@ class SearchViewController: SiteTableViewController,
     private var filteredOpenedTabs = [Tab]()
     private var tabManager: TabManager
     private var searchHighlights = [HighlightItem]()
+    private var firefoxSuggestions = [RustFirefoxSuggestion]()
     private var highlightManager: HistoryHighlightsManagerProtocol
 
     // Views for displaying the bottom scrollable search engine list. searchEngineScrollView is the
@@ -95,6 +97,7 @@ class SearchViewController: SiteTableViewController,
             || !filteredOpenedTabs.isEmpty
             || !filteredRemoteClientTabs.isEmpty
             || !searchHighlights.isEmpty
+            || !firefoxSuggestions.isEmpty
     }
 
     init(profile: Profile,
@@ -160,6 +163,24 @@ class SearchViewController: SiteTableViewController,
             guard let results = results else { return }
             self.searchHighlights = results
             self.tableView.reloadData()
+        }
+    }
+
+    private func loadFirefoxSuggestions() {
+        profile.firefoxSuggest?.interruptReader()
+
+        let tempSearchQuery = searchQuery
+        Task { [weak self] in
+            guard let suggestions = try? await self?.profile.firefoxSuggest?.query(
+                tempSearchQuery,
+                includeSponsored: true,
+                includeNonSponsored: true
+            ) else { return }
+            await MainActor.run {
+                guard let self, self.searchQuery == tempSearchQuery else { return }
+                self.firefoxSuggestions = suggestions
+                self.tableView.reloadData()
+            }
         }
     }
 
@@ -474,6 +495,7 @@ class SearchViewController: SiteTableViewController,
         }
 
         loadSearchHighlights()
+        loadFirefoxSuggestions()
 
         let tempSearchQuery = searchQuery
         suggestClient?.query(searchQuery, callback: { suggestions, error in
@@ -542,6 +564,9 @@ class SearchViewController: SiteTableViewController,
                 recordSearchListSelectionTelemetry(type: .searchHighlights)
                 searchDelegate?.searchViewController(self, didSelectURL: url, searchTerm: nil)
             }
+        case .firefoxSuggestions:
+            let firefoxSuggestion = firefoxSuggestions[indexPath.row]
+            searchDelegate?.searchViewController(self, didSelectURL: firefoxSuggestion.url, searchTerm: nil)
         }
     }
 
@@ -602,6 +627,8 @@ class SearchViewController: SiteTableViewController,
             return data.count
         case .searchHighlights:
             return searchHighlights.count
+        case .firefoxSuggestions:
+            return firefoxSuggestions.count
         }
     }
 
@@ -720,6 +747,22 @@ class SearchViewController: SiteTableViewController,
             twoLineCell.leftImageView.setFavicon(FaviconImageViewModel(siteURLString: site.url))
             twoLineCell.accessoryView = nil
             cell = twoLineCell
+        case .firefoxSuggestions:
+            let firefoxSuggestion = firefoxSuggestions[indexPath.row]
+            twoLineCell.titleLabel.text = firefoxSuggestion.title
+            if firefoxSuggestion.isSponsored {
+                twoLineCell.descriptionLabel.isHidden = false
+                twoLineCell.descriptionLabel.text = .Search.SponsoredSuggestionDescription
+            } else {
+                twoLineCell.descriptionLabel.isHidden = true
+            }
+            twoLineCell.leftOverlayImageView.image = nil
+            twoLineCell.leftImageView.contentMode = .scaleAspectFit
+            twoLineCell.leftImageView.layer.borderColor = SearchViewControllerUX.IconBorderColor.cgColor
+            twoLineCell.leftImageView.layer.borderWidth = SearchViewControllerUX.IconBorderWidth
+            twoLineCell.leftImageView.manuallySetImage(firefoxSuggestion.iconImage ?? UIImage())
+            twoLineCell.accessoryView = nil
+            cell = twoLineCell
         }
 
         // We need to set the correct theme on the cells when the initial display happens
@@ -791,6 +834,9 @@ private extension SearchViewController {
                         TelemetryWrapper.EventValue.historyItem.rawValue
         case .searchHighlights:
             extra = TelemetryWrapper.EventValue.searchHighlights.rawValue
+        case .firefoxSuggestions:
+            // TODO (FXIOS-7393): Add telemetry for Firefox Suggest suggestions.
+            return
         }
 
         TelemetryWrapper.recordEvent(category: .action,

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -167,6 +167,8 @@ class SearchViewController: SiteTableViewController,
     }
 
     private func loadFirefoxSuggestions() {
+        guard featureFlags.isFeatureEnabled(.firefoxSuggestFeature, checking: .buildAndUser) else { return }
+
         profile.firefoxSuggest?.interruptReader()
 
         let tempSearchQuery = searchQuery

--- a/Client/Frontend/Settings/FirefoxSuggestSettingsViewController.swift
+++ b/Client/Frontend/Settings/FirefoxSuggestSettingsViewController.swift
@@ -1,0 +1,82 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+import Shared
+import UIKit
+
+/// A view controller that manages the hidden Firefox Suggest debug settings.
+class FirefoxSuggestSettingsViewController: SettingsTableViewController, FeatureFlaggable {
+    init(profile: Profile) {
+        super.init(style: .grouped)
+        self.profile = profile
+        self.title = "Firefox Suggest"
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func generateSettings() -> [SettingSection] {
+        let enabled = BoolSetting(
+            with: .firefoxSuggestFeature,
+            titleText: NSAttributedString(
+                string: "Enable Firefox Suggest",
+                attributes: [NSAttributedString.Key.foregroundColor: themeManager.currentTheme.colors.textPrimary])
+        ) { [weak self] _ in
+            guard let self else { return }
+            self.settings = self.generateSettings()
+            self.tableView.reloadData()
+        }
+
+        var sections: [SettingSection] = [SettingSection(title: nil, children: [enabled])]
+        if featureFlags.isFeatureEnabled(.firefoxSuggestFeature, checking: .buildAndUser) {
+            sections.append(SettingSection(
+                title: nil,
+                children: [
+                    ForceFirefoxSuggestIngestSetting(profile: profile)
+                ]
+            ))
+        }
+        return sections
+    }
+}
+
+/// A Firefox Suggest debug setting that downloads and stores new suggestions
+/// immediately, without waiting for the background ingestion task to run.
+class ForceFirefoxSuggestIngestSetting: Setting {
+    let profile: Profile
+    let logger: Logger
+
+    init(profile: Profile, logger: Logger = DefaultLogger.shared) {
+        self.profile = profile
+        self.logger = logger
+        super.init()
+    }
+
+    override var title: NSAttributedString? {
+        return NSAttributedString(string: "Ingest new suggestions now",
+                                  attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
+    }
+
+    override func onClick(_: UINavigationController?) {
+        Task { [weak self] in
+            guard let self else { return }
+            logger.log("Ingesting new suggestions",
+                       level: .info,
+                       category: .storage)
+            do {
+                try await self.profile.firefoxSuggest?.ingest()
+                logger.log("Successfully ingested new suggestions",
+                           level: .info,
+                           category: .storage)
+            } catch {
+                logger.log("Failed to ingest new suggestions: \(error.localizedDescription)",
+                           level: .warning,
+                           category: .storage)
+            }
+        }
+    }
+}

--- a/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -16,6 +16,7 @@ protocol SettingsFlowDelegate: AnyObject,
     func showDevicePassCode()
     func showCreditCardSettings()
     func showExperiments()
+    func showFirefoxSuggest()
     func showPasswordManager(shouldShowOnboarding: Bool)
 
     func didFinishShowingSettings()
@@ -307,7 +308,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
     }
 
     private func getDebugSettings() -> [SettingSection] {
-        let hiddenDebugOptions = [
+        var hiddenDebugOptions = [
             ExperimentsSettings(settings: self, settingsDelegate: self),
             ExportLogDataSetting(settings: self),
             ExportBrowserDataSetting(settings: self),
@@ -325,6 +326,10 @@ class AppSettingsTableViewController: SettingsTableViewController,
             FasterInactiveTabs(settings: self, settingsDelegate: self),
             OpenFiftyTabsDebugOption(settings: self),
         ]
+
+        if featureFlags.isFeatureEnabled(.firefoxSuggestFeature, checking: .buildOnly) {
+            hiddenDebugOptions.append(FirefoxSuggestSettings(settings: self, settingsDelegate: self))
+        }
 
         return [SettingSection(title: NSAttributedString(string: "Debug"), children: hiddenDebugOptions)]
     }
@@ -351,6 +356,10 @@ class AppSettingsTableViewController: SettingsTableViewController,
         let urlString = URL.mozInternalScheme + "://deep-link?url=/action/show-intro-onboarding"
         guard let url = URL(string: urlString) else { return }
         applicationHelper.open(url)
+    }
+
+    func pressedFirefoxSuggest() {
+        parentCoordinator?.showFirefoxSuggest()
     }
 
     // MARK: SharedSettingsDelegate

--- a/Client/Frontend/Settings/Main/Debug/DebugSettingsDelegate.swift
+++ b/Client/Frontend/Settings/Main/Debug/DebugSettingsDelegate.swift
@@ -10,4 +10,5 @@ protocol DebugSettingsDelegate: AnyObject, SharedSettingsDelegate {
     func pressedVersion()
     func pressedShowTour()
     func pressedExperiments()
+    func pressedFirefoxSuggest()
 }

--- a/Client/Frontend/Settings/Main/Debug/FirefoxSuggestSettings.swift
+++ b/Client/Frontend/Settings/Main/Debug/FirefoxSuggestSettings.swift
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import UIKit
+
+/// A hidden setting for accessing the Firefox Suggest debug settings.
+class FirefoxSuggestSettings: HiddenSetting {
+    private weak var settingsDelegate: DebugSettingsDelegate?
+
+    override var title: NSAttributedString? { return NSAttributedString(string: "Firefox Suggest") }
+
+    init(settings: SettingsTableViewController, settingsDelegate: DebugSettingsDelegate) {
+        self.settingsDelegate = settingsDelegate
+        super.init(settings: settings)
+    }
+
+    override func onClick(_: UINavigationController?) {
+        settingsDelegate?.pressedFirefoxSuggest()
+    }
+}

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -1187,6 +1187,11 @@ extension String {
             tableName: nil,
             value: "Firefox Suggest",
             comment: "When making a new search from the awesome bar, suggestions appear to the user as they write new letters in their search. Different types of suggestions can appear. This string will be used as a header to separate Firefox suggestions from normal suggestions.")
+        public static let SponsoredSuggestionDescription = MZLocalizedString(
+            key: "Search.SponsoredSuggestionDescription.v119",
+            tableName: "Search",
+            value: "Sponsored",
+            comment: "When making a new search from the awesome bar, suggestions appear to the user as they write new letters in their search. Different types of suggestions can appear. This string will be used as a label for sponsored Firefox suggestions.")
         public static let EngineSectionTitle = MZLocalizedString(
             key: "Search.EngineSection.Title.v108",
             tableName: "SearchHeaderTitle",

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -11,6 +11,7 @@
 		<string>org.mozilla.ios.sync.part1</string>
 		<string>org.mozilla.ios.sync.part2</string>
 		<string>org.mozilla.ios.surface.notification.refresh</string>
+		<string>org.mozilla.ios.firefox.suggest.ingest</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>

--- a/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -37,6 +37,9 @@ final class NimbusFeatureFlagLayer {
         case .fakespotFeature:
             return checkFakespotFeature(from: nimbus)
 
+        case .firefoxSuggestFeature:
+            return checkFirefoxSuggestFeature(from: nimbus)
+
         case .inactiveTabs:
             return checkTabTrayFeature(for: featureID, from: nimbus)
 
@@ -248,6 +251,12 @@ final class NimbusFeatureFlagLayer {
 
     private func checkZoomFeature(from nimbus: FxNimbus) -> Bool {
         let config = nimbus.features.zoomFeature.value()
+
+        return config.status
+    }
+
+    private func checkFirefoxSuggestFeature(from nimbus: FxNimbus) -> Bool {
+        let config = nimbus.features.firefoxSuggestFeature.value()
 
         return config.status
     }

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -83,6 +83,7 @@ protocol Profile: AnyObject {
     var files: FileAccessor { get }
     var pinnedSites: PinnedSites { get }
     var logins: RustLogins { get }
+    var firefoxSuggest: RustFirefoxSuggest? { get }
     var certStore: CertStore { get }
     var recentlyClosedTabs: ClosedTabsStore { get }
 
@@ -624,6 +625,23 @@ open class BrowserProfile: Profile {
         let sqlCipherDatabasePath = URL(fileURLWithPath: (try! files.getAndEnsureDirectory()), isDirectory: true).appendingPathComponent("logins.db").path
 
         return RustLogins(sqlCipherDatabasePath: sqlCipherDatabasePath, databasePath: databasePath)
+    }()
+
+    lazy var firefoxSuggest: RustFirefoxSuggest? = {
+        do {
+            let databaseFileURL = try FileManager.default.url(
+                for: .cachesDirectory,
+                in: .userDomainMask,
+                appropriateFor: nil,
+                create: true
+            ).appendingPathComponent("suggest.db", isDirectory: false)
+            return try RustFirefoxSuggest(databasePath: databaseFileURL.path)
+        } catch {
+            logger.log("Failed to open Firefox Suggest database: \(error.localizedDescription)",
+                       level: .warning,
+                       category: .storage)
+            return nil
+        }
     }()
 
     func hasSyncAccount(completion: @escaping (Bool) -> Void) {

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -70,6 +70,7 @@ public struct PrefsKeys {
     public struct FeatureFlags {
         public static let ASPocketStories = "ASPocketStoriesUserPrefsKey"
         public static let CustomWallpaper = "CustomWallpaperUserPrefsKey"
+        public static let FirefoxSuggest = "FirefoxSuggest"
         public static let HistoryHighlightsSection = "HistoryHighlightsSectionUserPrefsKey"
         public static let HistoryGroups = "HistoryGroupsUserPrefsKey"
         public static let InactiveTabs = "InactiveTabsUserPrefsKey"

--- a/Storage/Rust/RustFirefoxSuggest.swift
+++ b/Storage/Rust/RustFirefoxSuggest.swift
@@ -1,0 +1,43 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import MozillaAppServices
+
+/// An actor that wraps the synchronous Rust `SuggestStore` binding to execute
+/// blocking operations on the default global concurrent executor.
+public actor RustFirefoxSuggest {
+    private let store: SuggestStore
+
+    public init(databasePath: String, remoteSettingsConfig: RemoteSettingsConfig? = nil) throws {
+        store = try SuggestStore(path: databasePath, settingsConfig: remoteSettingsConfig)
+    }
+
+    /// Downloads and stores new Firefox Suggest suggestions.
+    public func ingest() async throws {
+        // Ensure that the Rust networking stack has been initialized before
+        // downloading new suggestions. This is safe to call multiple times.
+        Viaduct.shared.useReqwestBackend()
+
+        try store.ingest(constraints: SuggestIngestionConstraints())
+    }
+
+    /// Searches the store for matching suggestions.
+    public func query(
+        _ keyword: String,
+        includeSponsored: Bool,
+        includeNonSponsored: Bool
+    ) async throws -> [RustFirefoxSuggestion] {
+        return try store.query(query: SuggestionQuery(
+            keyword: keyword,
+            includeSponsored: includeSponsored,
+            includeNonSponsored: includeNonSponsored
+        )).compactMap(RustFirefoxSuggestion.init)
+    }
+
+    /// Interrupts any ongoing queries for suggestions.
+    public nonisolated func interruptReader() {
+        store.interrupt()
+    }
+}

--- a/Storage/Rust/RustFirefoxSuggestion.swift
+++ b/Storage/Rust/RustFirefoxSuggestion.swift
@@ -1,0 +1,47 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import MozillaAppServices
+import UIKit
+
+/// A Firefox Suggest search suggestion. This struct is a Swiftier
+/// representation of the Rust `Suggestion` enum.
+public struct RustFirefoxSuggestion {
+    public let title: String
+    public let url: URL
+    public let isSponsored: Bool
+    public let iconImage: UIImage?
+    public let fullKeyword: String
+
+    internal init?(_ suggestion: Suggestion) {
+        // This code is intentionally written as a chain of `if-case-let`s
+        // instead of a `switch`, because we don't want new `Suggestion` cases
+        // added in Rust to be source-breaking changes in Firefox. A `switch`
+        // with a `default` or `@unknown default` case would emit a "default
+        // will never be executed" warning, because Swift treats `Suggestion`
+        // as frozen, since we can't build Application Services with library
+        // evolution support.
+        if case let .amp(title, urlString, _, iconBytes, fullKeyword, _, _, _, _, _, _) = suggestion {
+            // This use of `URL(string:)` is OK; we don't need to use
+            // `URL(string:encodingInvalidCharacters:)` here.
+            guard let url = URL(string: urlString) else { return nil }
+            self.title = title
+            self.url = url
+            self.isSponsored = true
+            self.iconImage = iconBytes.flatMap { UIImage(data: Data($0)) }
+            self.fullKeyword = fullKeyword
+        } else if case let .wikipedia(title, urlString, iconBytes, fullKeyword) = suggestion {
+            // This use of `URL(string:)` is OK.
+            guard let url = URL(string: urlString) else { return nil }
+            self.title = title
+            self.url = url
+            self.isSponsored = false
+            self.iconImage = iconBytes.flatMap { UIImage(data: Data($0)) }
+            self.fullKeyword = fullKeyword
+        } else {
+            return nil
+        }
+    }
+}

--- a/Tests/ClientTests/Mocks/MockAppSettingsDelegate.swift
+++ b/Tests/ClientTests/Mocks/MockAppSettingsDelegate.swift
@@ -26,6 +26,8 @@ class MockDebugSettingsDelegate: DebugSettingsDelegate {
         pressedExperimentsCalled += 1
     }
 
+    func pressedFirefoxSuggest() {}
+
     func askedToShow(alert: AlertController) {
         askedToShowAlertCalled += 1
     }

--- a/Tests/ClientTests/Mocks/MockProfile.swift
+++ b/Tests/ClientTests/Mocks/MockProfile.swift
@@ -102,6 +102,7 @@ open class MockProfile: Client.Profile {
     public var files: FileAccessor
     public var logins: RustLogins
     public var syncManager: ClientSyncManager!
+    public var firefoxSuggest: RustFirefoxSuggest?
 
     fileprivate var legacyPlaces: PinnedSites
 
@@ -139,6 +140,21 @@ open class MockProfile: Client.Profile {
         legacyPlaces = BrowserDBSQLite(database: self.database, prefs: MockProfilePrefs())
 
         pinnedSites = legacyPlaces
+
+        do {
+            let firefoxSuggestDatabaseName = "\(databasePrefix)_suggest.db"
+            let firefoxSuggestDatabaseURL = try FileManager.default.url(
+                for: .cachesDirectory,
+                in: .userDomainMask,
+                appropriateFor: nil,
+                create: true
+            ).appendingPathComponent(firefoxSuggestDatabaseName, isDirectory: false)
+            try? FileManager.default.removeItem(at: firefoxSuggestDatabaseURL)
+
+            firefoxSuggest = try RustFirefoxSuggest(databasePath: firefoxSuggestDatabaseURL.path)
+        } catch {
+            fatalError("Failed to open Firefox Suggest database: \(error.localizedDescription)")
+        }
     }
 
     public func localName() -> String {

--- a/Tests/ClientTests/Mocks/MockSettingsFlowDelegate.swift
+++ b/Tests/ClientTests/Mocks/MockSettingsFlowDelegate.swift
@@ -35,6 +35,8 @@ class MockSettingsFlowDelegate: SettingsFlowDelegate,
         showExperimentsCalled += 1
     }
 
+    func showFirefoxSuggest() {}
+
     func showPasswordManager(shouldShowOnboarding: Bool) {
         savedShouldShowOnboarding = shouldShowOnboarding
         showPasswordManagerCalled += 1

--- a/nimbus-features/firefoxSuggestFeature.yaml
+++ b/nimbus-features/firefoxSuggestFeature.yaml
@@ -1,0 +1,18 @@
+features:
+  firefox-suggest-feature:
+    description: Configuration for the Firefox Suggest feature.
+    variables:
+      status:
+        description: >
+          Whether the feature is enabled. When Firefox Suggest is enabled,
+          Firefox will download and store new search suggestions in the
+          background, and show additional Search settings to control which
+          suggestions appear in the awesomebar. When Firefox Suggest is
+          disabled, Firefox will not download new suggestions, and hide the
+          additional Search settings.
+        type: Boolean
+        default: false
+    defaults:
+      - channel: developer
+        value:
+          status: true

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -18,6 +18,7 @@ include:
   - nimbus-features/creditCardAutofillFeature.yaml
   - nimbus-features/fakespotFeature.yaml
   - nimbus-features/feltPrivacyFeature.yaml
+  - nimbus-features/firefoxSuggestFeature.yaml
   - nimbus-features/generalFeatures.yaml
   - nimbus-features/homescreenFeature.yaml
   - nimbus-features/libraryCoordinatorRefactor.yaml


### PR DESCRIPTION
## :scroll: Tickets

[Jira ticket](https://mozilla-hub.atlassian.net/browse/DISCO-2547)
[FxiOS Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7393)

## :bulb: Description

[Firefox Suggest](https://support.mozilla.org/en-US/kb/firefox-suggest-faq) provides suggestions for sponsored and web content in the address bar. Firefox for iOS already supports "local" suggestions—bookmarks, history, open tabs, and synced tabs—in the Firefox Suggest section, but not sponsored or web suggestions yet. This PR is the first step to supporting those new suggestion types, with the goal of eventually bringing our mobile Suggest feature up to parity with Desktop as part of the [Enhanced Cross-Platform Suggest](https://mozilla-hub.atlassian.net/wiki/spaces/CLOUDSERVICES/pages/142934432/Enhanced+Cross-Platform+Suggest) project.

This is our first time landing code in Firefox for iOS, so higher-level feedback on the approach and architecture would be amazing, please—in addition to comments on the implementation, of course! ☺️ No tests yet; I wanted to get some higher-level feedback from you folks before going too far with those.

We're planning to run a Nimbus experiment in **Firefox 120**, but there's lots of foundational work to do in the meantime—you can see the bug trees in [DISCO-2544](https://mozilla-hub.atlassian.net/browse/DISCO-2544) and [DISCO-2555](https://mozilla-hub.atlassian.net/browse/DISCO-2555)—that we're starting the implementation in 119. Please let me know if that's okay, and jives with your process for landing new features.

Here's a high-level overview of the implementation:

The Firefox Suggest feature is powered by an [Application Services Rust component](https://github.com/mozilla/application-services/tree/c4ee9ab86442be78e5991bb17e2508ca5f9d0a27/components/suggest) that downloads new suggestions from [Remote Settings](https://remote-settings.readthedocs.io/en/latest/), stores them in an SQLite database, and makes them available for querying. All querying happens on-device; Mozilla never sees what the user types into their address bar. We used a Rust component so that we could reuse it on Desktop and Android as well.

This PR adds:

* A background processing utility to schedule ingestions (downloading and storing new suggestions from Remote Settings) for when the device is online and charging.
* Hidden settings for enabling / disabling Firefox Suggest, and triggering an ingestion, so that you don't need to wait for the background task to run during development and testing.
* An integration in the Search view controller that queries and shows matching suggestions.

Thank you so much for your time, and please let me know if you have questions, concerns, or comments!

![Simulator Screen Recording - iPhone SE (3rd generation) - 2023-09-11 at 15 34 16](https://github.com/mozilla-mobile/firefox-ios/assets/41387967/f134cb26-d19b-4a8f-a673-df2f8ae8f283)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

