### PR TITLE
Refactor FXIOS-7380 [v119] Renew expired telemetry probes

### DIFF
--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -582,7 +582,7 @@ app:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2023-12-01"
+    expires: never
   notification_permission:
     type: event
     description: |
@@ -2477,7 +2477,7 @@ settings_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2023-12-01"
+    expires: never
   show_tour_pressed:
     type: event
     description: |

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -580,6 +580,7 @@ app:
       - https://github.com/mozilla-mobile/firefox-ios/pull/9673
       - https://github.com/mozilla-mobile/firefox-ios/pull/12334
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
+      - https://github.com/mozilla-mobile/firefox-ios/pull/16375
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
@@ -2475,6 +2476,7 @@ settings_menu:
       - https://github.com/mozilla-mobile/firefox-ios/pull/9673
       - https://github.com/mozilla-mobile/firefox-ios/pull/12334
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
+      - https://github.com/mozilla-mobile/firefox-ios/pull/16375
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7380)
[Github issue ref1](https://github.com/mozilla-mobile/firefox-ios/issues/16358)
[Github issue ref2](https://github.com/mozilla-mobile/firefox-ios/issues/16374)

# Request for Data Collection Renewal

1) Provide a link to the initial Data Collection Review Request for this collection.
set_as_default_browser_pressed:
opened_as_default_browser:
- https://github.com/mozilla-mobile/firefox-ios/pull/14102

2) When will this collection now expire?
Never
3) Why was the initial period of collection insufficient?
We still want to monitor this data.

