### PR TITLE
Add MTE-1549 [v119] Optimize XCUITest wait methods

### DIFF
--- a/L10nSnapshotTests/L10nBaseSnapshotTests.swift
+++ b/L10nSnapshotTests/L10nBaseSnapshotTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 let testPageBase = "http://www.example.com"
 let loremIpsumURL = "\(testPageBase)"
-
+let TIMEOUT: TimeInterval = 15
 class L10nBaseSnapshotTests: XCTestCase {
     var app: XCUIApplication!
     var navigator: MMNavigator<FxUserState>!
@@ -46,6 +46,19 @@ class L10nBaseSnapshotTests: XCTestCase {
             waitFor(element, with: "exists == true", timeout: timeout, file: file, line: line)
     }
 
+    // is up to 25x more performant than the above waitForExistence method
+    func mozWaitForElementToExist(element: XCUIElement, timeout: TimeInterval? = TIMEOUT) {
+        let startTime = Date()
+
+        while !element.exists {
+            if Date().timeIntervalSince(startTime) > timeoutInSeconds {
+                XCTFail("Timed out waiting for element \(element) to exist")
+                break
+            }
+            usleep(10000)
+        }
+    }
+
     private func waitFor(_ element: XCUIElement, with predicateString: String, description: String? = nil, timeout: TimeInterval = 5.0, file: String, line: UInt) {
             let predicate = NSPredicate(format: predicateString)
             let expectation = XCTNSPredicateExpectation(predicate: predicate, object: element)
@@ -62,6 +75,18 @@ class L10nBaseSnapshotTests: XCTestCase {
     func waitForNoExistence(_ element: XCUIElement, timeoutValue: TimeInterval = 5.0, file: String = #file, line: UInt = #line) {
         waitFor(element, with: "exists != true", timeout: timeoutValue, file: file, line: line)
     }
+    // is up to 25x more performant than the above waitForNoExistence method
+    func mozWaitForElementToNotExist(element: XCUIElement, timeout: TimeInterval? = TIMEOUT) {
+        let startTime = Date()
+
+        while element.exists {
+            if Date().timeIntervalSince(startTime) > timeoutInSeconds {
+                XCTFail("Timed out waiting for element \(element) to not exist")
+                break
+            }
+            usleep(10000)
+        }
+    }
 
     func loadWebPage(url: String, waitForOtherElementWithAriaLabel ariaLabel: String) {
         userState.url = url
@@ -76,6 +101,6 @@ class L10nBaseSnapshotTests: XCTestCase {
     func waitUntilPageLoad() {
         let app = XCUIApplication()
         let progressIndicator = app.progressIndicators.element(boundBy: 0)
-        waitForNoExistence(progressIndicator, timeoutValue: 20.0)
+        mozWaitForElementToNotExist(progressIndicator, timeoutValue: 20.0)
     }
 }

--- a/L10nSnapshotTests/L10nBaseSnapshotTests.swift
+++ b/L10nSnapshotTests/L10nBaseSnapshotTests.swift
@@ -47,7 +47,7 @@ class L10nBaseSnapshotTests: XCTestCase {
     }
 
     // is up to 25x more performant than the above waitForExistence method
-    func mozWaitForElementToExist(element: XCUIElement, timeout: TimeInterval? = TIMEOUT) {
+    func mozWaitForElementToExist(_ element: XCUIElement, timeout: TimeInterval? = TIMEOUT) {
         let startTime = Date()
 
         while !element.exists {
@@ -76,7 +76,7 @@ class L10nBaseSnapshotTests: XCTestCase {
         waitFor(element, with: "exists != true", timeout: timeoutValue, file: file, line: line)
     }
     // is up to 25x more performant than the above waitForNoExistence method
-    func mozWaitForElementToNotExist(element: XCUIElement, timeout: TimeInterval? = TIMEOUT) {
+    func mozWaitForElementToNotExist(_ element: XCUIElement, timeout: TimeInterval? = TIMEOUT) {
         let startTime = Date()
 
         while element.exists {

--- a/L10nSnapshotTests/L10nMktSuiteSnapshotTests.swift
+++ b/L10nSnapshotTests/L10nMktSuiteSnapshotTests.swift
@@ -13,7 +13,7 @@ class L10nMktSuiteSnapshotTests: L10nBaseSnapshotTests {
         super.setUp()
     }
     func test1SettingsETP() {
-        waitForExistence(app.buttons["urlBar-cancel"])
+        mozWaitForElementToExist(app.buttons["urlBar-cancel"])
         app.buttons["urlBar-cancel"].tap()
         navigator.goto(TrackingProtectionSettings)
         
@@ -22,7 +22,7 @@ class L10nMktSuiteSnapshotTests: L10nBaseSnapshotTests {
         app.alerts.buttons.firstMatch.tap()
         sleep(3)
         snapshot("TrackingProtectionStrictWarning-01")
-        waitForExistence(app.cells["Settings.TrackingProtectionOption.BlockListBasic"])
+        mozWaitForElementToExist(app.cells["Settings.TrackingProtectionOption.BlockListBasic"])
     }
     
     func testAwesemoBarWithResults() {
@@ -40,7 +40,7 @@ class L10nMktSuiteSnapshotTests: L10nBaseSnapshotTests {
 
     // DarkMode for these tests
     func test3DefaultTopSites() {
-        waitForExistence(app.buttons["urlBar-cancel"])
+        mozWaitForElementToExist(app.buttons["urlBar-cancel"])
         app.buttons["urlBar-cancel"].tap()
         // Enable Dark Mode
         navigator.goto(SettingsScreen)
@@ -58,14 +58,14 @@ class L10nMktSuiteSnapshotTests: L10nBaseSnapshotTests {
         profile.prefs.setInt(0, forKey: PrefsKeys.ChronTabsPrefKey)
     }*/
     func test4PrivateBrowsingTabsEmptyState() {
-        waitForExistence(app.buttons["urlBar-cancel"])
+        mozWaitForElementToExist(app.buttons["urlBar-cancel"])
         app.buttons["urlBar-cancel"].tap()
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         snapshot("PrivateBrowsingMode")
     }
     
     func test5DefaultSearchEngine() {
-        waitForExistence(app.buttons["urlBar-cancel"])
+        mozWaitForElementToExist(app.buttons["urlBar-cancel"])
         app.buttons["urlBar-cancel"].tap()
         navigator.goto(SearchSettings)
         XCTAssert(app.tables.staticTexts["Google"].exists)

--- a/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
@@ -27,33 +27,33 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
     }
 
     func testIntro() {
-        waitForExistence(app.scrollViews.staticTexts["\(rootA11yId)TitleLabel"], timeout: 15)
-        waitForExistence(app.scrollViews.staticTexts["\(rootA11yId)DescriptionLabel"], timeout: 15)
+        mozWaitForElementToExist(app.scrollViews.staticTexts["\(rootA11yId)TitleLabel"], timeout: 15)
+        mozWaitForElementToExist(app.scrollViews.staticTexts["\(rootA11yId)DescriptionLabel"], timeout: 15)
         snapshot("Onboarding-1")
 
         // Swipe to the second screen
         app.buttons["\(rootA11yId)SecondaryButton"].tap()
         currentScreen += 1
-        waitForExistence(app.scrollViews.staticTexts["\(rootA11yId)TitleLabel"], timeout: 15)
-        waitForExistence(app.scrollViews.staticTexts["\(rootA11yId)DescriptionLabel"], timeout: 15)
-        waitForExistence(app.buttons["\(rootA11yId)PrimaryButton"])
-        waitForExistence(app.buttons["\(rootA11yId)SecondaryButton"])
+        mozWaitForElementToExist(app.scrollViews.staticTexts["\(rootA11yId)TitleLabel"], timeout: 15)
+        mozWaitForElementToExist(app.scrollViews.staticTexts["\(rootA11yId)DescriptionLabel"], timeout: 15)
+        mozWaitForElementToExist(app.buttons["\(rootA11yId)PrimaryButton"])
+        mozWaitForElementToExist(app.buttons["\(rootA11yId)SecondaryButton"])
         snapshot("Onboarding-2")
 
         // Swipe to the third screen
         app.buttons["\(rootA11yId)SecondaryButton"].tap()
         currentScreen += 1
-        waitForExistence(app.scrollViews.staticTexts["\(rootA11yId)TitleLabel"], timeout: 15)
-        waitForExistence(app.scrollViews.staticTexts["\(rootA11yId)DescriptionLabel"], timeout: 15)
-        waitForExistence(app.buttons["\(rootA11yId)PrimaryButton"])
-        waitForExistence(app.buttons["\(rootA11yId)SecondaryButton"])
+        mozWaitForElementToExist(app.scrollViews.staticTexts["\(rootA11yId)TitleLabel"], timeout: 15)
+        mozWaitForElementToExist(app.scrollViews.staticTexts["\(rootA11yId)DescriptionLabel"], timeout: 15)
+        mozWaitForElementToExist(app.buttons["\(rootA11yId)PrimaryButton"])
+        mozWaitForElementToExist(app.buttons["\(rootA11yId)SecondaryButton"])
         snapshot("Onboarding-3")
 
         // Swipe to the Homescreen
         app.buttons["\(rootA11yId)SecondaryButton"].tap()
         currentScreen += 1
-        waitForExistence(app.textFields["url"])
-        waitForExistence(app.webViews["contentView"])
+        mozWaitForElementToExist(app.textFields["url"])
+        mozWaitForElementToExist(app.webViews["contentView"])
         snapshot("Homescreen-first-visit")
     }
 
@@ -69,8 +69,8 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
 //
 //        // Link
 //        navigator.openURL("http://wikipedia.org")
-//        waitForNoExistence(app.staticTexts["XCUITests-Runner pasted from Fennec"])
-//        waitForExistence(app.webViews.element(boundBy: 0).links.element(boundBy: 0), timeout: 5)
+//        mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
+//        mozWaitForElementToExist(app.webViews.element(boundBy: 0).links.element(boundBy: 0), timeout: 5)
 //        navigator.goto(WebLinkContextMenu)
 //        drag()
 //        snapshot("WebViewContextMenu-01-link")
@@ -78,8 +78,8 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
 //
 //        // Image
 //        navigator.openURL("http://wikipedia.org")
-//        waitForNoExistence(app.staticTexts["XCUITests-Runner pasted from Fennec"])
-//        waitForExistence(app.webViews.element(boundBy: 0).images.element(boundBy: 0), timeout: 5)
+//        mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
+//        mozWaitForElementToExist(app.webViews.element(boundBy: 0).images.element(boundBy: 0), timeout: 5)
 //        navigator.goto(WebImageContextMenu)
 //        drag()
 //        snapshot("WebViewContextMenu-02-image")
@@ -88,7 +88,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
 
     func testWebViewAuthenticationDialog() {
         navigator.openURL("https://jigsaw.w3.org/HTTP/Basic/", waitForLoading: false)
-        waitForNoExistence(app.staticTexts["XCUITests-Runner pasted from Fennec"])
+        mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
         navigator.nowAt(BasicAuthDialog)
         snapshot("WebViewAuthenticationDialog-01", waitForLoadingIndicator: false)
     }
@@ -96,7 +96,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
     func test3ReloadButtonContextMenu() {
         navigator.openURL(loremIpsumURL)
         waitUntilPageLoad()
-        waitForNoExistence(app.staticTexts["XCUITests-Runner pasted from Fennec"])
+        mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
 
         navigator.toggleOff(userState.requestDesktopSite, withAction: Action.ToggleRequestDesktopSite)
         navigator.goto(ReloadLongPressMenu)
@@ -108,7 +108,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
 
     func testTopSitesMenu() {
         sleep(3)
-        // waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 15)
+        // mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 15)
         navigator.nowAt(NewTabScreen)
         app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell].firstMatch.swipeUp()
         snapshot("TopSitesMenu-00")
@@ -116,7 +116,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
         // Workaround since in some locales Top Sites are not shown right away
 //        navigator.goto(SettingsScreen)
 //        navigator.goto(HomePanel_TopSites)
-//        waitForExistence(app.buttons["urlBar-cancel"], timeout: 15)
+//        mozWaitForElementToExist(app.buttons["urlBar-cancel"], timeout: 15)
 //        app.buttons["urlBar-cancel"].tap()
 //        navigator.goto(TopSitesPanelContextMenu)
 //        snapshot("TopSitesMenu-01")
@@ -124,14 +124,14 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
 
     func testHistoryTableContextMenu() {
         navigator.openURL(loremIpsumURL)
-        waitForNoExistence(app.staticTexts["XCUITests-Runner pasted from Fennec"], timeoutValue: 5)
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
+        mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"], timeoutValue: 5)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
         navigator.goto(LibraryPanel_History)
-        waitForExistence(app.tables["History List"])
+        mozWaitForElementToExist(app.tables["History List"])
         app.tables["History List"].cells.element(boundBy: 1).staticTexts.element(boundBy: 1).press(forDuration: 2)
         snapshot("HistoryTableContextMenu-01")
     }
@@ -140,8 +140,8 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
         sleep(3)
         navigator.openURL(loremIpsumURL)
         // There is no other way the test work with the new Copied.. snackbar ahow on iOS14
-        waitForNoExistence(app.staticTexts["XCUITests-Runner pasted from Fennec"])
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 15)
+        mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 15)
         navigator.performAction(Action.Bookmark)
         navigator.createNewTab()
         // Disable due to issue #7521
@@ -157,13 +157,13 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
     func test21ReaderModeSettingsMenu() {
         loadWebPage(url: "en.m.wikipedia.org/wiki/Main_Page")
         app.buttons[ AccessibilityIdentifiers.Toolbar.readerModeButton].tap()
-        waitForExistence(app.buttons["ReaderModeBarView.settingsButton"])
+        mozWaitForElementToExist(app.buttons["ReaderModeBarView.settingsButton"])
         app.buttons["ReaderModeBarView.settingsButton"].tap()
         snapshot("21ReaderModeSettingsMenu-01")
     }*/
 
     func testETPperSite() {
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
         navigator.nowAt(NewTabScreen)
         // Enable Strict ETP
         navigator.goto(TrackingProtectionSettings)
@@ -174,8 +174,8 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
 
         // Website without blocked elements
         navigator.openURL(loremIpsumURL)
-        waitForNoExistence(app.staticTexts["XCUITests-Runner pasted from Fennec"])
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection], timeout: 5)
+        mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection], timeout: 5)
         navigator.goto(TrackingProtectionContextMenuDetails)
         snapshot("TrackingProtectionEnabledPerSite-01")
 
@@ -186,20 +186,20 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
     }
 
     func testSettingsETP() {
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
         navigator.nowAt(NewTabScreen)
         navigator.goto(TrackingProtectionSettings)
 
-        waitForExistence(app.cells["Settings.TrackingProtectionOption.BlockListBasic"])
+        mozWaitForElementToExist(app.cells["Settings.TrackingProtectionOption.BlockListBasic"])
         app.cells["Settings.TrackingProtectionOption.BlockListBasic"].buttons.firstMatch.tap()
         snapshot("TrackingProtectionBasicMoreInfo-01")
 
-        waitForExistence(app.navigationBars["Client.TPAccessoryInfo"])
+        mozWaitForElementToExist(app.navigationBars["Client.TPAccessoryInfo"])
         // Go back to TP settings
         app.navigationBars["Client.TPAccessoryInfo"].buttons.firstMatch.tap()
 
         // See Strict mode info
-        waitForExistence(app.cells["Settings.TrackingProtectionOption.BlockListStrict"])
+        mozWaitForElementToExist(app.cells["Settings.TrackingProtectionOption.BlockListStrict"])
         app.cells["Settings.TrackingProtectionOption.BlockListStrict"].buttons.firstMatch.tap()
         app.tables.cells.staticTexts.firstMatch.swipeUp()
         snapshot("TrackingProtectionStrictMoreInfo-02")
@@ -208,22 +208,22 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
     func testMenuOnTopSites() {
         typealias homeTabBannerA11y = AccessibilityIdentifiers.FirefoxHomepage.HomeTabBanner
 
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
         navigator.nowAt(NewTabScreen)
         navigator.goto(BrowserTabMenu)
         snapshot("MenuOnTopSites-01")
 
         // Set as Default browser screenshot
         navigator.goto(NewTabScreen)
-        waitForExistence(app.buttons[homeTabBannerA11y.ctaButton], timeout: 15)
+        mozWaitForElementToExist(app.buttons[homeTabBannerA11y.ctaButton], timeout: 15)
         app.buttons[homeTabBannerA11y.ctaButton].tap()
-        waitForExistence(app.buttons["HomeTabBanner.goToSettingsButton"], timeout: 15)
+        mozWaitForElementToExist(app.buttons["HomeTabBanner.goToSettingsButton"], timeout: 15)
         snapshot("HomeDefaultBrowserLearnMore")
     }
 
     func testSettings() {
         let table = app.tables.element(boundBy: 0)
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
         navigator.nowAt(NewTabScreen)
         navigator.goto(SettingsScreen)
         table.forEachScreen { i in
@@ -239,14 +239,14 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
     }
 
     func testPrivateBrowsingTabsEmptyState() {
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
         navigator.nowAt(NewTabScreen)
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         snapshot("PrivateBrowsingTabsEmptyState-01")
     }
 
     func testTakeMarketingScreenshots() {
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
         snapshot("00TopSites")
 
         // go to synced tabs home screen
@@ -265,7 +265,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
 
         // perform a search but don't complete (we're testing autocomplete here)
         navigator.createNewTab()
-        waitForExistence(app.textFields["url"], timeout: 10)
+        mozWaitForElementToExist(app.textFields["url"], timeout: 10)
         app.typeText("firef")
         sleep(2)
         snapshot("01SearchResults")

--- a/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
@@ -8,7 +8,7 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
     let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
 
     func testPanelsEmptyState() {
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
         navigator.nowAt(NewTabScreen)
         navigator.goto(LibraryPanel_Bookmarks)
         snapshot("PanelsEmptyState-LibraryPanels.Bookmarks")
@@ -23,10 +23,10 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
     func testLongPressOnTextOptions() {
         navigator.openURL(loremIpsumURL)
         waitUntilPageLoad()
-        waitForNoExistence(app.staticTexts["XCUITests-Runner pasted from Fennec"])
+        mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
 
         // Select some text and long press to find the option
-        waitForExistence(app.webViews.element(boundBy: 0).staticTexts.element(boundBy: 0), timeout: 10)
+        mozWaitForElementToExist(app.webViews.element(boundBy: 0).staticTexts.element(boundBy: 0), timeout: 10)
         app.webViews.element(boundBy: 0).staticTexts.element(boundBy: 0).press(forDuration: 1)
         snapshot("LongPressTextOptions-01")
         if app.menuItems["show.next.items.menu.button"].exists {
@@ -61,7 +61,7 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
 
     func testMenuOnWebPage() {
         navigator.openURL(loremIpsumURL)
-        waitForNoExistence(app.staticTexts["XCUITests-Runner pasted from Fennec"])
+        mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
         navigator.goto(BrowserTabMenu)
         snapshot("MenuOnWebPage-01")
 
@@ -75,20 +75,20 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
 
     func testPageMenuOnWebPage() {
         navigator.openURL(loremIpsumURL)
-        waitForNoExistence(app.staticTexts["XCUITests-Runner pasted from Fennec"])
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 15)
+        mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 15)
         navigator.goto(BrowserTabMenu)
         snapshot("MenuOnWebPage-03")
     }
 
     func testFxASignInPage() {
         navigator.openURL(loremIpsumURL)
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
         navigator.nowAt(NewTabScreen)
         navigator.goto(BrowserTabMenu)
-        waitForExistence(app.tables.otherElements[ImageIdentifiers.sync], timeout: 5)
+        mozWaitForElementToExist(app.tables.otherElements[ImageIdentifiers.sync], timeout: 5)
         navigator.goto(Intro_FxASignin)
-        waitForExistence(app.navigationBars.staticTexts["FxASingin.navBar"], timeout: 10)
+        mozWaitForElementToExist(app.navigationBars.staticTexts["FxASingin.navBar"], timeout: 10)
         snapshot("FxASignInScreen-01")
     }
 
@@ -107,7 +107,7 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
             app.buttons.staticTexts["Continue"].tap()
             app.tables["Add Credential"].cells.element(boundBy: 1).tap()
         }
-        waitForExistence(key, timeout: 5)
+        mozWaitForElementToExist(key, timeout: 5)
         key.tap()
     }
 
@@ -115,9 +115,9 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         let key = 15
         navigator.nowAt(NewTabScreen)
         navigator.goto(SettingsScreen)
-        waitForExistence(app.cells["Search"], timeout: 5)
+        mozWaitForElementToExist(app.cells["Search"], timeout: 5)
         app.cells["Search"].swipeUp()
-        waitForExistence(app.cells["Logins"], timeout: 15)
+        mozWaitForElementToExist(app.cells["Logins"], timeout: 15)
         app.cells["Logins"].tap()
 
         // Press continue button on the password onboarding if it's shown
@@ -126,26 +126,26 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         }
 
         let passcodeInput = springboard.secureTextFields.firstMatch
-        waitForExistence(passcodeInput, timeout: 30)
+        mozWaitForElementToExist(passcodeInput, timeout: 30)
         passcodeInput.tap()
         passcodeInput.typeText("foo\n")
 
-        waitForExistence(app.tables["Login List"], timeout: 10)
+        mozWaitForElementToExist(app.tables["Login List"], timeout: 10)
         app.buttons[AccessibilityIdentifiers.Settings.Passwords.addCredentialButton].tap()
-        waitForExistence(app.tables["Add Credential"], timeout: 10)
+        mozWaitForElementToExist(app.tables["Add Credential"], timeout: 10)
         snapshot("CreateLogin")
         app.tables["Add Credential"].cells.element(boundBy: 0).tap()
         tapKeyboardKey(key)
-        waitForExistence(app.tables["Add Credential"].cells.element(boundBy: 1), timeout: 15)
+        mozWaitForElementToExist(app.tables["Add Credential"].cells.element(boundBy: 1), timeout: 15)
 
         app.tables["Add Credential"].cells.element(boundBy: 1).tap()
         tapKeyboardKey(key)
-        waitForExistence(app.tables["Add Credential"].cells.element(boundBy: 2), timeout: 5)
+        mozWaitForElementToExist(app.tables["Add Credential"].cells.element(boundBy: 2), timeout: 5)
         app.tables["Add Credential"].cells.element(boundBy: 2).tap()
         tapKeyboardKey(key)
-        waitForExistence(app.navigationBars["Client.AddCredentialView"].buttons.element(boundBy: 1), timeout: 5)
+        mozWaitForElementToExist(app.navigationBars["Client.AddCredentialView"].buttons.element(boundBy: 1), timeout: 5)
         app.navigationBars["Client.AddCredentialView"].buttons.element(boundBy: 1).tap()
-        waitForExistence(app.tables["Login List"], timeout: 15)
+        mozWaitForElementToExist(app.tables["Login List"], timeout: 15)
         snapshot("CreatedLoginView")
 
         app.tables["Login List"].cells.element(boundBy: 2).tap()

--- a/Tests/XCUITests/ActivityStreamTest.swift
+++ b/Tests/XCUITests/ActivityStreamTest.swift
@@ -41,7 +41,7 @@ class ActivityStreamTest: BaseTestCase {
     // Smoketest
     func testDefaultSites() throws {
         XCTExpectFailure("The app was not launched", strict: false) {
-            waitForExistence(TopSiteCellgroup, timeout: 60)
+            mozWaitForElementToExist(TopSiteCellgroup, timeout: 60)
         }
         XCTAssertTrue(app.collectionViews[AccessibilityIdentifiers.FirefoxHomepage.collectionView].exists)
         // There should be 5 top sites by default
@@ -71,7 +71,7 @@ class ActivityStreamTest: BaseTestCase {
     }
 
     func testTopSitesRemoveAllExceptDefaultClearPrivateData() {
-        waitForExistence(app.cells.staticTexts[newTopSite["bookmarkLabel"]!], timeout: 15)
+        mozWaitForElementToExist(app.cells.staticTexts[newTopSite["bookmarkLabel"]!], timeout: 15)
         XCTAssertTrue(app.cells.staticTexts[newTopSite["bookmarkLabel"]!].exists)
         // A new site has been added to the top sites
         if iPad() {
@@ -93,7 +93,7 @@ class ActivityStreamTest: BaseTestCase {
     }
 
     func testTopSitesRemoveAllExceptPinnedClearPrivateData() {
-        waitForExistence(TopSiteCellgroup, timeout: TIMEOUT)
+        mozWaitForElementToExist(TopSiteCellgroup, timeout: TIMEOUT)
         if iPad() {
             app.textFields.element(boundBy: 0).tap()
             app.typeText("mozilla.org\n")
@@ -107,23 +107,23 @@ class ActivityStreamTest: BaseTestCase {
         navigator.performAction(Action.OpenNewTabFromTabTray)
 
         let topSitesCells = app.collectionViews.cells["TopSitesCell"]
-        waitForExistence(topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!], timeout: TIMEOUT)
+        mozWaitForElementToExist(topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!], timeout: TIMEOUT)
         XCTAssertTrue(topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!].exists)
         checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 6)
 
         topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!].press(forDuration: 1)
         selectOptionFromContextMenu(option: "Pin")
-        waitForExistence(topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!], timeout: TIMEOUT)
+        mozWaitForElementToExist(topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!], timeout: TIMEOUT)
         XCTAssertTrue(topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!].exists)
 
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         navigator.goto(SettingsScreen)
         navigator.goto(ClearPrivateDataSettings)
         navigator.performAction(Action.AcceptClearPrivateData)
         navigator.goto(HomePanelsScreen)
-        waitForExistence(topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!])
+        mozWaitForElementToExist(topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!])
         XCTAssertTrue(topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!].exists)
         checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 6)
     }
@@ -138,13 +138,13 @@ class ActivityStreamTest: BaseTestCase {
         XCTAssertTrue(topSiteSecondCell == allDefaultTopSites[1])
 
         // Remove facebook top sites, first cell
-        waitForExistence(allTopSites.element(boundBy: 0), timeout: TIMEOUT)
+        mozWaitForElementToExist(allTopSites.element(boundBy: 0), timeout: TIMEOUT)
         allTopSites.element(boundBy: 0).press(forDuration: 1)
         selectOptionFromContextMenu(option: "Remove")
 
         // Check top site in first cell now
         let updatedAllTopSites = app.collectionViews.cells.matching(identifier: "TopSitesCell")
-        waitForExistence(updatedAllTopSites.element(boundBy: 0))
+        mozWaitForElementToExist(updatedAllTopSites.element(boundBy: 0))
         let topSiteCells = updatedAllTopSites.staticTexts
         let topSiteFirstCellAfter = updatedAllTopSites.element(boundBy: 0).label
         XCTAssertTrue(topSiteFirstCellAfter == topSiteCells[allDefaultTopSites[1]].label, "First top site does not match")
@@ -153,11 +153,11 @@ class ActivityStreamTest: BaseTestCase {
     // Smoketest
     func testTopSitesOpenInNewPrivateTab() throws {
         XCTExpectFailure("The app was not launched", strict: false) {
-            waitForExistence(TopSiteCellgroup, timeout: 60)
+            mozWaitForElementToExist(TopSiteCellgroup, timeout: 60)
         }
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 5)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 5)
         // Long tap on Wikipedia top site
-        waitForExistence(app.collectionViews.cells.staticTexts["Wikipedia"], timeout: 3)
+        mozWaitForElementToExist(app.collectionViews.cells.staticTexts["Wikipedia"], timeout: 3)
         app.collectionViews.cells.staticTexts["Wikipedia"].press(forDuration: 1)
         app.tables["Context Menu"].cells.otherElements["Open in a Private Tab"].tap()
 
@@ -165,10 +165,10 @@ class ActivityStreamTest: BaseTestCase {
 
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         navigator.goto(TabTray)
-        waitForExistence(app.cells.staticTexts.element(boundBy: 0), timeout: 10)
+        mozWaitForElementToExist(app.cells.staticTexts.element(boundBy: 0), timeout: 10)
 
         navigator.nowAt(TabTray)
-        waitForExistence(app.otherElements["Tabs Tray"].collectionViews.cells["Wikipedia"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.otherElements["Tabs Tray"].collectionViews.cells["Wikipedia"], timeout: TIMEOUT)
         app.otherElements["Tabs Tray"].collectionViews.cells["Wikipedia"].tap()
 
         // The website is open
@@ -180,13 +180,13 @@ class ActivityStreamTest: BaseTestCase {
     // Smoketest
     func testTopSitesOpenInNewPrivateTabDefaultTopSite() {
         XCTExpectFailure("The app was not launched", strict: false) {
-            waitForExistence(TopSiteCellgroup, timeout: 60)
+            mozWaitForElementToExist(TopSiteCellgroup, timeout: 60)
         }
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 5)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 5)
         navigator.nowAt(NewTabScreen)
         // Open one of the sites from Topsites and wait until page is loaded
         // Long tap on apple top site, second cell
-        waitForExistence(app.collectionViews.cells.element(boundBy: 4), timeout: 3)
+        mozWaitForElementToExist(app.collectionViews.cells.element(boundBy: 4), timeout: 3)
         app.collectionViews.cells.element(boundBy: 4).press(forDuration: 1)
         selectOptionFromContextMenu(option: "Open in a Private Tab")
 
@@ -198,7 +198,7 @@ class ActivityStreamTest: BaseTestCase {
 
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
 
-        waitForExistence(app.cells.staticTexts[defaultTopSite["bookmarkLabel"]!])
+        mozWaitForElementToExist(app.cells.staticTexts[defaultTopSite["bookmarkLabel"]!])
         var numTabsOpen = app.collectionViews.element(boundBy: 1).cells.count
         if iPad() {
             navigator.goto(TabTray)
@@ -208,7 +208,7 @@ class ActivityStreamTest: BaseTestCase {
     }
 
     private func checkNumberOfExpectedTopSites(numberOfExpectedTopSites: Int) {
-        waitForExistence(app.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
+        mozWaitForElementToExist(app.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
         XCTAssertTrue(app.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell].exists)
         let numberOfTopSites = app.collectionViews.cells.matching(identifier: AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell).count
 
@@ -220,7 +220,7 @@ class ActivityStreamTest: BaseTestCase {
         // can't scroll only to that area. Needs investigation
         if iPad() {
             XCUIDevice.shared.orientation = .landscapeLeft
-            waitForExistence(TopSiteCellgroup, timeout: TIMEOUT)
+            mozWaitForElementToExist(TopSiteCellgroup, timeout: TIMEOUT)
             app.collectionViews.cells.staticTexts["Wikipedia"].press(forDuration: 1)
 
             let contextMenuHeight = app.tables["Context Menu"].frame.size.height

--- a/Tests/XCUITests/ActivityStreamTest.swift
+++ b/Tests/XCUITests/ActivityStreamTest.swift
@@ -174,7 +174,7 @@ class ActivityStreamTest: BaseTestCase {
         // The website is open
         XCTAssertFalse(TopSiteCellgroup.exists)
         XCTAssertTrue(app.textFields["url"].exists)
-        waitForValueContains(app.textFields["url"], value: "wikipedia.org")
+        mozWaitForValueContains(app.textFields["url"], value: "wikipedia.org")
     }
 
     // Smoketest

--- a/Tests/XCUITests/AuthenticationTest.swift
+++ b/Tests/XCUITests/AuthenticationTest.swift
@@ -8,11 +8,11 @@ let testBasicHTTPAuthURL = "https://jigsaw.w3.org/HTTP/Basic/"
 
 class AuthenticationTest: BaseTestCase {
     func testBasicHTTPAuthenticationPromptVisible() {
-        waitForExistence(app.textFields["url"], timeout: 5)
+        mozWaitForElementToExist(app.textFields["url"], timeout: 5)
         navigator.nowAt(NewTabScreen)
         navigator.openURL(testBasicHTTPAuthURL)
-        waitForExistence(app.staticTexts["Authentication required"], timeout: 100)
-        waitForExistence(app.staticTexts["A username and password are being requested by jigsaw.w3.org. The site says: test"])
+        mozWaitForElementToExist(app.staticTexts["Authentication required"], timeout: 100)
+        mozWaitForElementToExist(app.staticTexts["A username and password are being requested by jigsaw.w3.org. The site says: test"])
 
         let placeholderValueUsername = app.alerts.textFields.element(boundBy: 0).value as! String
         let placeholderValuePassword = app.alerts.secureTextFields.element(boundBy: 0).value as! String
@@ -20,12 +20,12 @@ class AuthenticationTest: BaseTestCase {
         XCTAssertEqual(placeholderValueUsername, "Username")
         XCTAssertEqual(placeholderValuePassword, "Password")
 
-        waitForExistence(app.alerts.buttons["Cancel"])
-        waitForExistence(app.alerts.buttons["Log in"])
+        mozWaitForElementToExist(app.alerts.buttons["Cancel"])
+        mozWaitForElementToExist(app.alerts.buttons["Log in"])
 
         // Skip login due to HTTP Basic Authentication crash in #5757
         // Dismiss authentication prompt
         app.alerts.buttons["Cancel"].tap()
-        waitForNoExistence(app.alerts.buttons["Cancel"], timeoutValue: 5)
+        mozWaitForElementToNotExist(app.alerts.buttons["Cancel"], timeoutValue: 5)
     }
 }

--- a/Tests/XCUITests/BaseTestCase.swift
+++ b/Tests/XCUITests/BaseTestCase.swift
@@ -114,7 +114,7 @@ class BaseTestCase: XCTestCase {
     }
 
     // is up to 25x more performant than the above waitForExistence method
-    func mozWaitForElementToExist(element: XCUIElement, timeout: TimeInterval? = TIMEOUT) {
+    func mozWaitForElementToExist(_ element: XCUIElement, timeout: TimeInterval? = TIMEOUT) {
         let startTime = Date()
 
         while !element.exists {
@@ -131,7 +131,7 @@ class BaseTestCase: XCTestCase {
     }
 
     // is up to 25x more performant than the above waitForNoExistence method
-    func mozWaitForElementToNotExist(element: XCUIElement, timeout: TimeInterval? = TIMEOUT) {
+    func mozWaitForElementToNotExist(_ element: XCUIElement, timeout: TimeInterval? = TIMEOUT) {
         let startTime = Date()
 
         while element.exists {

--- a/Tests/XCUITests/BaseTestCase.swift
+++ b/Tests/XCUITests/BaseTestCase.swift
@@ -147,6 +147,20 @@ class BaseTestCase: XCTestCase {
         waitFor(element, with: "value CONTAINS '\(value)'", file: file, line: line)
     }
 
+    func mozWaitForValueContains(_ element: XCUIElement, value: String, timeout: TimeInterval? = TIMEOUT) {
+        let startTime = Date()
+
+        while true {
+            if let elementValue = element.value as? String, elementValue.contains(value) {
+                break
+            } else if Date().timeIntervalSince(startTime) > timeout {
+                XCTFail("Timed out waiting for element \(element) to contain value \(value)")
+                break
+            }
+            usleep(10000) // waits for 0.01 seconds
+        }
+    }
+
     private func waitFor(_ element: XCUIElement, with predicateString: String, description: String? = nil, timeout: TimeInterval = 5.0, file: String, line: UInt) {
         let predicate = NSPredicate(format: predicateString)
         let expectation = XCTNSPredicateExpectation(predicate: predicate, object: element)

--- a/Tests/XCUITests/BaseTestCase.swift
+++ b/Tests/XCUITests/BaseTestCase.swift
@@ -143,7 +143,7 @@ class BaseTestCase: XCTestCase {
         }
     }
 
-    func waitForValueContains(_ element: XCUIElement, value: String, file: String = #file, line: UInt = #line) {
+    func WaitForValueContains(_ element: XCUIElement, value: String, file: String = #file, line: UInt = #line) {
         waitFor(element, with: "value CONTAINS '\(value)'", file: file, line: line)
     }
 

--- a/Tests/XCUITests/BookmarkingTests.swift
+++ b/Tests/XCUITests/BookmarkingTests.swift
@@ -15,7 +15,7 @@ let url_4 = "test-password-2.html"
 class BookmarkingTests: BaseTestCase {
     private func checkBookmarked() {
         navigator.goto(BrowserTabMenu)
-        waitForExistence(app.tables.otherElements[StandardImageIdentifiers.Large.bookmarkSlash])
+        mozWaitForElementToExist(app.tables.otherElements[StandardImageIdentifiers.Large.bookmarkSlash])
         if iPad() {
             app.otherElements["PopoverDismissRegion"].tap()
             navigator.nowAt(BrowserTab)
@@ -26,16 +26,16 @@ class BookmarkingTests: BaseTestCase {
 
     private func undoBookmarkRemoval() {
         navigator.goto(BrowserTabMenu)
-        waitForExistence(app.tables.otherElements[StandardImageIdentifiers.Large.bookmarkSlash])
+        mozWaitForElementToExist(app.tables.otherElements[StandardImageIdentifiers.Large.bookmarkSlash])
         app.otherElements[StandardImageIdentifiers.Large.bookmarkSlash].tap()
         navigator.nowAt(BrowserTab)
-        waitForExistence(app.buttons["Undo"], timeout: 3)
+        mozWaitForElementToExist(app.buttons["Undo"], timeout: 3)
         app.buttons["Undo"].tap()
     }
 
     private func checkUnbookmarked() {
         navigator.goto(BrowserTabMenu)
-        waitForExistence(app.tables.otherElements[StandardImageIdentifiers.Large.bookmark])
+        mozWaitForElementToExist(app.tables.otherElements[StandardImageIdentifiers.Large.bookmark])
         if iPad() {
             app.otherElements["PopoverDismissRegion"].tap()
             navigator.nowAt(BrowserTab)
@@ -83,13 +83,13 @@ class BookmarkingTests: BaseTestCase {
     }
 
     private func checkEmptyBookmarkList() {
-        waitForExistence(app.tables["Bookmarks List"], timeout: 5)
+        mozWaitForElementToExist(app.tables["Bookmarks List"], timeout: 5)
         let list = app.tables["Bookmarks List"].cells.count
         XCTAssertEqual(list, 0, "There should not be any entry in the bookmarks list")
     }
 
     private func checkItemInBookmarkList() {
-        waitForExistence(app.tables["Bookmarks List"], timeout: 5)
+        mozWaitForElementToExist(app.tables["Bookmarks List"], timeout: 5)
         let bookmarksList = app.tables["Bookmarks List"]
         let list = bookmarksList.cells.count
         XCTAssertEqual(list, 2, "There should be an entry in the bookmarks list")
@@ -103,7 +103,7 @@ class BookmarkingTests: BaseTestCase {
         navigator.openURL(path(forTestPage: url_2["url"]!))
         waitUntilPageLoad()
         navigator.nowAt(BrowserTab)
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
         bookmark()
 
         // There should be a bookmark
@@ -114,11 +114,11 @@ class BookmarkingTests: BaseTestCase {
     // Smoketest
     func testBookmarksAwesomeBar() {
         XCTExpectFailure("The app was not launched", strict: false) {
-            waitForExistence(app.textFields["url"], timeout: 60)
+            mozWaitForElementToExist(app.textFields["url"], timeout: 60)
         }
         typeOnSearchBar(text: "www.google")
-        waitForExistence(app.tables["SiteTable"])
-        waitForExistence(app.tables["SiteTable"].cells.staticTexts["www.google"], timeout: 5)
+        mozWaitForElementToExist(app.tables["SiteTable"])
+        mozWaitForElementToExist(app.tables["SiteTable"].cells.staticTexts["www.google"], timeout: 5)
         XCTAssertTrue(app.tables["SiteTable"].cells.staticTexts["www.google"].exists)
         app.textFields["address"].typeText(".com")
         app.textFields["address"].typeText("\r")
@@ -131,7 +131,7 @@ class BookmarkingTests: BaseTestCase {
         typeOnSearchBar(text: "https://mozilla.org")
 
         // Site table exists but is empty
-        waitForExistence(app.tables["SiteTable"])
+        mozWaitForElementToExist(app.tables["SiteTable"])
         XCTAssertEqual(app.tables["SiteTable"].cells.count, 0)
         app.textFields["address"].typeText("\r")
         navigator.nowAt(BrowserTab)
@@ -142,12 +142,12 @@ class BookmarkingTests: BaseTestCase {
         bookmark()
 
         // Now the site should be suggested
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
         navigator.performAction(Action.AcceptClearPrivateData)
         navigator.goto(BrowserTab)
         typeOnSearchBar(text: "mozilla.org")
-        waitForExistence(app.tables["SiteTable"])
-        waitForExistence(app.cells.staticTexts["mozilla.org"])
+        mozWaitForElementToExist(app.tables["SiteTable"])
+        mozWaitForElementToExist(app.cells.staticTexts["mozilla.org"])
         XCTAssertNotEqual(app.tables["SiteTable"].cells.count, 0)
     }
     /* Disable due to https://github.com/mozilla-mobile/firefox-ios/issues/7521
@@ -155,14 +155,14 @@ class BookmarkingTests: BaseTestCase {
         addNewBookmark()
         // Verify that clicking on bookmark opens the website
         app.tables["Bookmarks List"].cells.element(boundBy: 0).tap()
-        waitForExistence(app.textFields["url"], timeout: 5)
+        mozWaitForElementToExist(app.textFields["url"], timeout: 5)
     }
 
     func testAddNewFolder() {
         navigator.goto(MobileBookmarks)
         navigator.goto(MobileBookmarksAdd)
         navigator.performAction(Action.AddNewFolder)
-        waitForExistence(app.navigationBars["New Folder"])
+        mozWaitForElementToExist(app.navigationBars["New Folder"])
         // XCTAssertFalse(app.buttons["Save"].isEnabled), is this a bug allowing empty folder name?
         app.tables["SiteTable"].cells.textFields.element(boundBy: 0).tap()
         app.tables["SiteTable"].cells.textFields.element(boundBy: 0).typeText("Test Folder")
@@ -172,7 +172,7 @@ class BookmarkingTests: BaseTestCase {
         navigator.nowAt(MobileBookmarks)
         // Now remove the folder
         navigator.performAction(Action.RemoveItemMobileBookmarks)
-        waitForExistence(app.buttons[StandardImageIdentifiers.Large.delete])
+        mozWaitForElementToExist(app.buttons[StandardImageIdentifiers.Large.delete])
         navigator.performAction(Action.ConfirmRemoveItemMobileBookmarks)
         checkItemsInBookmarksList(items: 0)
     }
@@ -187,7 +187,7 @@ class BookmarkingTests: BaseTestCase {
         // Remove it
         navigator.nowAt(MobileBookmarks)
         navigator.performAction(Action.RemoveItemMobileBookmarks)
-        waitForExistence(app.buttons[StandardImageIdentifiers.Large.delete])
+        mozWaitForElementToExist(app.buttons[StandardImageIdentifiers.Large.delete])
         navigator.performAction(Action.ConfirmRemoveItemMobileBookmarks)
         checkItemsInBookmarksList(items: 0)
     }
@@ -204,7 +204,7 @@ class BookmarkingTests: BaseTestCase {
         addNewBookmark()
         // Remove by long press and select option from context menu
         app.tables.staticTexts.element(boundBy: 0).press(forDuration: 1)
-        waitForExistence(app.tables["Context Menu"])
+        mozWaitForElementToExist(app.tables["Context Menu"])
         app.tables["Context Menu"].cells[StandardImageIdentifiers.Large.bookmarkSlash].tap()
         checkItemsInBookmarksList(items: 0)
     }*/
@@ -222,7 +222,7 @@ class BookmarkingTests: BaseTestCase {
     private func addNewBookmark() {
         navigator.goto(MobileBookmarksAdd)
         navigator.performAction(Action.AddNewBookmark)
-        waitForExistence(app.navigationBars["New Bookmark"], timeout: 3)
+        mozWaitForElementToExist(app.navigationBars["New Bookmark"], timeout: 3)
         // Enter the bookmarks details
         app.tables["SiteTable"].cells.textFields.element(boundBy: 0).tap()
         app.tables["SiteTable"].cells.textFields.element(boundBy: 0).typeText("BBC")
@@ -235,12 +235,12 @@ class BookmarkingTests: BaseTestCase {
     }
 
     private func checkItemsInBookmarksList(items: Int) {
-        waitForExistence(app.tables["Bookmarks List"], timeout: 3)
+        mozWaitForElementToExist(app.tables["Bookmarks List"], timeout: 3)
         XCTAssertEqual(app.tables["Bookmarks List"].cells.count, items)
     }
 
     private func typeOnSearchBar(text: String) {
-        waitForExistence(app.textFields["url"], timeout: 5)
+        mozWaitForElementToExist(app.textFields["url"], timeout: 5)
         app.textFields["url"].tap()
         app.textFields["address"].typeText(text)
     }
@@ -249,13 +249,13 @@ class BookmarkingTests: BaseTestCase {
     func testBookmarkLibraryAddDeleteBookmark() {
         // Verify that there are only 1 cell (desktop bookmark folder)
         XCTExpectFailure("The app was not launched", strict: false) {
-            waitForExistence(app.textFields["url"], timeout: 60)
+            mozWaitForElementToExist(app.textFields["url"], timeout: 60)
         }
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
         navigator.goto(LibraryPanel_Bookmarks)
         // There is only one row in the bookmarks panel, which is the desktop folder
-        waitForExistence(app.tables["Bookmarks List"], timeout: 5)
+        mozWaitForElementToExist(app.tables["Bookmarks List"], timeout: 5)
         XCTAssertEqual(app.tables["Bookmarks List"].cells.count, 1)
 
         // Add a bookmark
@@ -268,18 +268,18 @@ class BookmarkingTests: BaseTestCase {
 
         // Check that it appears in Bookmarks panel
         navigator.goto(LibraryPanel_Bookmarks)
-        waitForExistence(app.tables["Bookmarks List"], timeout: 5)
+        mozWaitForElementToExist(app.tables["Bookmarks List"], timeout: 5)
 
         // Delete the Bookmark added, check it is removed
         if processIsTranslatedStr() == m1Rosetta {
             app.tables["Bookmarks List"].cells.staticTexts["Example Domain"].press(forDuration: 1)
-            waitForExistence(app.tables["Context Menu"])
+            mozWaitForElementToExist(app.tables["Context Menu"])
             app.tables.otherElements["Remove Bookmark"].tap()
         } else {
             app.tables["Bookmarks List"].cells.staticTexts["Example Domain"].swipeLeft()
             app.buttons[StandardImageIdentifiers.Large.delete].tap()
         }
-        waitForNoExistence(app.tables["Bookmarks List"].cells.staticTexts["Example Domain"], timeoutValue: 10)
+        mozWaitForElementToNotExist(app.tables["Bookmarks List"].cells.staticTexts["Example Domain"], timeoutValue: 10)
         XCTAssertFalse(app.tables["Bookmarks List"].cells.staticTexts["Example Domain"].exists, "Bookmark not removed successfully")
     }
 
@@ -289,12 +289,12 @@ class BookmarkingTests: BaseTestCase {
         waitForTabsButton()
         navigator.goto(LibraryPanel_Bookmarks)
         // There is only one folder at the root of the bookmarks
-        waitForExistence(app.tables["Bookmarks List"], timeout: 5)
+        mozWaitForElementToExist(app.tables["Bookmarks List"], timeout: 5)
         XCTAssertEqual(app.tables["Bookmarks List"].cells.count, 1)
 
         // There is only three folders inside the desktop bookmarks
         app.tables["Bookmarks List"].cells.firstMatch.tap()
-        waitForExistence(app.tables["Bookmarks List"], timeout: 5)
+        mozWaitForElementToExist(app.tables["Bookmarks List"], timeout: 5)
         XCTAssertEqual(app.tables["Bookmarks List"].cells.count, 3)
     }
 }

--- a/Tests/XCUITests/BrowsingPDFTests.swift
+++ b/Tests/XCUITests/BrowsingPDFTests.swift
@@ -10,7 +10,7 @@ class BrowsingPDFTests: BaseTestCase {
     func testOpenPDFViewer() {
         navigator.openURL(PDF_website["url"]!)
         waitUntilPageLoad()
-        waitForValueContains(app.textFields["url"], value: PDF_website["pdfValue"]!)
+        mozWaitForValueContains(app.textFields["url"], value: PDF_website["pdfValue"]!)
         // Swipe Up and Down
         app.swipeUp()
         mozWaitForElementToExist(app.staticTexts["1 of 1"])
@@ -28,12 +28,12 @@ class BrowsingPDFTests: BaseTestCase {
         // Click on a link on the pdf and check that the website is shown
         app.links.element(boundBy: 0).tapOnApp()
         waitUntilPageLoad()
-        waitForValueContains(app.textFields["url"], value: PDF_website["urlValue"]!)
+        mozWaitForValueContains(app.textFields["url"], value: PDF_website["urlValue"]!)
         XCTAssertTrue(app.staticTexts["Education and schools"].exists)
 
         // Go back to pdf view
         app.buttons[AccessibilityIdentifiers.Toolbar.backButton].tap()
-        waitForValueContains(app.textFields["url"], value: PDF_website["pdfValue"]!)
+        mozWaitForValueContains(app.textFields["url"], value: PDF_website["pdfValue"]!)
          */
     }
 
@@ -80,7 +80,7 @@ class BrowsingPDFTests: BaseTestCase {
         let pdfTopSite = app.collectionViews[AccessibilityIdentifiers.FirefoxHomepage.collectionView].cells[PDF_website["bookmarkLabel"]!].children(matching: .other).element.children(matching: .other).element(boundBy: 0)
         pdfTopSite.tap()
         waitUntilPageLoad()
-        waitForValueContains(app.textFields["url"], value: PDF_website["pdfValue"]!)
+        mozWaitForValueContains(app.textFields["url"], value: PDF_website["pdfValue"]!)
 
         // Remove pdf pinned site
         navigator.performAction(Action.OpenNewTabFromTabTray)

--- a/Tests/XCUITests/BrowsingPDFTests.swift
+++ b/Tests/XCUITests/BrowsingPDFTests.swift
@@ -13,7 +13,7 @@ class BrowsingPDFTests: BaseTestCase {
         waitForValueContains(app.textFields["url"], value: PDF_website["pdfValue"]!)
         // Swipe Up and Down
         app.swipeUp()
-        waitForExistence(app.staticTexts["1 of 1"])
+        mozWaitForElementToExist(app.staticTexts["1 of 1"])
         app.swipeDown()
         XCTAssertTrue(app.staticTexts["1 of 1"].exists)
     }
@@ -43,11 +43,11 @@ class BrowsingPDFTests: BaseTestCase {
         // Long press on a link on the pdf and check the options shown
         app.webViews.links.element(boundBy: 0).pressAtPoint(CGPoint(x: 10, y: 0), forDuration: 3)
 
-        waitForExistence(app.staticTexts[PDF_website["longUrlValue"]!])
-        waitForExistence(app.buttons["Open"])
-        waitForExistence(app.buttons["Add to Reading List"])
-        waitForExistence(app.buttons["Copy Link"])
-        waitForExistence(app.buttons["Share…"])
+        mozWaitForElementToExist(app.staticTexts[PDF_website["longUrlValue"]!])
+        mozWaitForElementToExist(app.buttons["Open"])
+        mozWaitForElementToExist(app.buttons["Add to Reading List"])
+        mozWaitForElementToExist(app.buttons["Copy Link"])
+        mozWaitForElementToExist(app.buttons["Share…"])
     }
 
     func testLongPressOnPDFLinkToAddToReadingList() {
@@ -56,14 +56,14 @@ class BrowsingPDFTests: BaseTestCase {
         // Long press on a link on the pdf and check the options shown
         app.webViews.links.element(boundBy: 0).pressAtPoint(CGPoint(x: 10, y: 0), forDuration: 3)
 
-        waitForExistence(app.staticTexts[PDF_website["longUrlValue"]!])
+        mozWaitForElementToExist(app.staticTexts[PDF_website["longUrlValue"]!])
         app.buttons["Add to Reading List"].tap()
         navigator.nowAt(BrowserTab)
 
         // Go to reading list and check that the item is there
         navigator.goto(LibraryPanel_ReadingList)
         let savedToReadingList = app.tables["ReadingTable"].cells.staticTexts[PDF_website["longUrlValue"]!]
-        waitForExistence(savedToReadingList)
+        mozWaitForElementToExist(savedToReadingList)
         XCTAssertTrue(savedToReadingList.exists)
     }
 
@@ -72,8 +72,8 @@ class BrowsingPDFTests: BaseTestCase {
         waitUntilPageLoad()
         navigator.performAction(Action.PinToTopSitesPAM)
         navigator.performAction(Action.OpenNewTabFromTabTray)
-        waitForExistence(app.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell], timeout: 10)
-        waitForExistence(app.collectionViews.cells.staticTexts[PDF_website["bookmarkLabel"]!])
+        mozWaitForElementToExist(app.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell], timeout: 10)
+        mozWaitForElementToExist(app.collectionViews.cells.staticTexts[PDF_website["bookmarkLabel"]!])
         XCTAssertTrue(app.collectionViews.cells.staticTexts[PDF_website["bookmarkLabel"]!].exists)
 
         // Open pdf from pinned site
@@ -84,11 +84,11 @@ class BrowsingPDFTests: BaseTestCase {
 
         // Remove pdf pinned site
         navigator.performAction(Action.OpenNewTabFromTabTray)
-        waitForExistence(app.collectionViews.cells.staticTexts[PDF_website["bookmarkLabel"]!])
+        mozWaitForElementToExist(app.collectionViews.cells.staticTexts[PDF_website["bookmarkLabel"]!])
         pdfTopSite.press(forDuration: 1)
-        waitForExistence(app.tables.cells.otherElements[StandardImageIdentifiers.Large.pinSlash])
+        mozWaitForElementToExist(app.tables.cells.otherElements[StandardImageIdentifiers.Large.pinSlash])
         app.tables.cells.otherElements[StandardImageIdentifiers.Large.pinSlash].tap()
-        waitForExistence(app.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
+        mozWaitForElementToExist(app.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
         XCTAssertTrue(app.collectionViews.cells.staticTexts[PDF_website["bookmarkLabel"]!].exists)
     }
 
@@ -99,7 +99,7 @@ class BrowsingPDFTests: BaseTestCase {
         waitUntilPageLoad()
         navigator.goto(BrowserTabMenu)
         navigator.goto(LibraryPanel_Bookmarks)
-        waitForExistence(app.tables["Bookmarks List"])
+        mozWaitForElementToExist(app.tables["Bookmarks List"])
         XCTAssertTrue(app.tables["Bookmarks List"].staticTexts[PDF_website["bookmarkLabel"]!].exists)
     }
 }

--- a/Tests/XCUITests/ClipBoardTests.swift
+++ b/Tests/XCUITests/ClipBoardTests.swift
@@ -10,7 +10,7 @@ class ClipBoardTests: BaseTestCase {
     // Check for test url in the browser
     func checkUrl() {
         let urlTextField = app.textFields["url"]
-        waitForValueContains(urlTextField, value: "www.example")
+        mozWaitForValueContains(urlTextField, value: "www.example")
     }
 
     // Copy url from the browser
@@ -62,7 +62,7 @@ class ClipBoardTests: BaseTestCase {
         if processIsTranslatedStr() == m1Rosetta {
             mozWaitForElementToNotExist(app.menuItems["Paste"])
         } else {
-            waitForValueContains(app.textFields["address"], value: "www.example.com")
+            mozWaitForValueContains(app.textFields["address"], value: "www.example.com")
         }
     }
 
@@ -85,6 +85,6 @@ class ClipBoardTests: BaseTestCase {
         mozWaitForElementToExist(app.tables["Context Menu"].otherElements[AccessibilityIdentifiers.Photon.pasteAndGoAction])
         app.tables["Context Menu"].otherElements[AccessibilityIdentifiers.Photon.pasteAndGoAction].tap()
         mozWaitForElementToExist(app.textFields["url"])
-        waitForValueContains(app.textFields["url"], value: "www.example.com")
+        mozWaitForValueContains(app.textFields["url"], value: "www.example.com")
     }
 }

--- a/Tests/XCUITests/ClipBoardTests.swift
+++ b/Tests/XCUITests/ClipBoardTests.swift
@@ -16,9 +16,9 @@ class ClipBoardTests: BaseTestCase {
     // Copy url from the browser
     func copyUrl() {
         navigator.goto(URLBarOpen)
-        waitForExistence(app.textFields["address"])
+        mozWaitForElementToExist(app.textFields["address"])
         app.textFields["address"].tap()
-        waitForExistence(app.menuItems["Copy"])
+        mozWaitForElementToExist(app.menuItems["Copy"])
         app.menuItems["Copy"].tap()
         app.typeText("\r")
         navigator.nowAt(BrowserTab)
@@ -30,7 +30,7 @@ class ClipBoardTests: BaseTestCase {
             if let myString = UIPasteboard.general.string {
                 let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
                 let allowBtn = springboard.buttons["Allow Paste"]
-                if allowBtn.waitForExistence(timeout: 10) {
+                if allowBtn.mozWaitForElementToExist(timeout: 10) {
                     allowBtn.tap()
                 }
 
@@ -54,13 +54,13 @@ class ClipBoardTests: BaseTestCase {
         checkCopiedUrl()
 
         navigator.createNewTab()
-        waitForNoExistence(app.staticTexts["XCUITests-Runner pasted from Fennec"])
+        mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
         navigator.nowAt(NewTabScreen)
         navigator.goto(URLBarOpen)
         app.textFields["address"].press(forDuration: 3)
         app.menuItems["Paste"].tap()
         if processIsTranslatedStr() == m1Rosetta {
-            waitForNoExistence(app.menuItems["Paste"])
+            mozWaitForElementToNotExist(app.menuItems["Paste"])
         } else {
             waitForValueContains(app.textFields["address"], value: "www.example.com")
         }
@@ -70,21 +70,21 @@ class ClipBoardTests: BaseTestCase {
     func testClipboardPasteAndGo() {
         navigator.openURL(url)
         waitUntilPageLoad()
-        waitForNoExistence(app.staticTexts["Fennec pasted from XCUITests-Runner"])
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.shareButton], timeout: 10)
+        mozWaitForElementToNotExist(app.staticTexts["Fennec pasted from XCUITests-Runner"])
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.shareButton], timeout: 10)
         app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].tap()
-        waitForExistence(app.cells["Copy"], timeout: 15)
+        mozWaitForElementToExist(app.cells["Copy"], timeout: 15)
         app.cells["Copy"].tap()
 
         checkCopiedUrl()
-        waitForNoExistence(app.staticTexts["XCUITests-Runner pasted from Fennec"])
+        mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
         navigator.createNewTab()
-        waitForNoExistence(app.staticTexts["XCUITests-Runner pasted from Fennec"])
+        mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
         app.textFields["url"].press(forDuration: 3)
-        waitForExistence(app.tables["Context Menu"])
-        waitForExistence(app.tables["Context Menu"].otherElements[AccessibilityIdentifiers.Photon.pasteAndGoAction])
+        mozWaitForElementToExist(app.tables["Context Menu"])
+        mozWaitForElementToExist(app.tables["Context Menu"].otherElements[AccessibilityIdentifiers.Photon.pasteAndGoAction])
         app.tables["Context Menu"].otherElements[AccessibilityIdentifiers.Photon.pasteAndGoAction].tap()
-        waitForExistence(app.textFields["url"])
+        mozWaitForElementToExist(app.textFields["url"])
         waitForValueContains(app.textFields["url"], value: "www.example.com")
     }
 }

--- a/Tests/XCUITests/DataManagementTests.swift
+++ b/Tests/XCUITests/DataManagementTests.swift
@@ -10,22 +10,22 @@ class DataManagementTests: BaseTestCase {
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
         navigator.goto(WebsiteDataSettings)
-        waitForExistence(app.tables.otherElements["Website Data"], timeout: 3)
+        mozWaitForElementToExist(app.tables.otherElements["Website Data"], timeout: 3)
         app.tables.otherElements["Website Data"].swipeDown()
-        waitForExistence(app.searchFields["Filter Sites"], timeout: 3)
+        mozWaitForElementToExist(app.searchFields["Filter Sites"], timeout: 3)
         navigator.performAction(Action.TapOnFilterWebsites)
         app.typeText("bing")
-        waitForExistence(app.tables["Search results"])
+        mozWaitForElementToExist(app.tables["Search results"])
         let expectedSearchResults = app.tables["Search results"].cells.count
         sleep(3)
         XCTAssertEqual(expectedSearchResults, 1)
         navigator.performAction(Action.TapOnFilterWebsites)
 
         app.buttons["Cancel"].tap()
-        waitForExistence(app.tables.otherElements["Website Data"], timeout: 3)
+        mozWaitForElementToExist(app.tables.otherElements["Website Data"], timeout: 3)
 
         navigator.performAction(Action.AcceptClearAllWebsiteData)
-        waitForExistence(app.tables.cells["ClearAllWebsiteData"].staticTexts["Clear All Website Data"])
+        mozWaitForElementToExist(app.tables.cells["ClearAllWebsiteData"].staticTexts["Clear All Website Data"])
         let expectedWebsitesCleared = app.tables.cells.count
         XCTAssertEqual(expectedWebsitesCleared, 1)
     }

--- a/Tests/XCUITests/DatabaseFixtureTest.swift
+++ b/Tests/XCUITests/DatabaseFixtureTest.swift
@@ -23,18 +23,18 @@ class DatabaseFixtureTest: BaseTestCase {
 
     /* Disabled due to issue with db: 8281*/
     /*func testOneBookmark() {
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: 5)
+        mozWaitForElementToExist(app.buttons["urlBar-cancel"], timeout: 5)
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         navigator.goto(LibraryPanel_Bookmarks)
-        waitForExistence(app.cells.staticTexts["Mobile Bookmarks"], timeout: 5)
+        mozWaitForElementToExist(app.cells.staticTexts["Mobile Bookmarks"], timeout: 5)
         navigator.goto(MobileBookmarks)
         let list = app.tables["Bookmarks List"].cells.count
         XCTAssertEqual(list, 1, "There should be an entry in the bookmarks list")
     }*/
 
     func testBookmarksDatabaseFixture() {
-        // Warning: Avoid using waitForExistence as it is up to 25x less performant
+        // Warning: Avoid using mozWaitForElementToExist as it is up to 25x less performant
         let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
         mozWaitForElementToExist(element: tabsButton, timeoutInSeconds: TIMEOUT)
 

--- a/Tests/XCUITests/DesktopModeTests.swift
+++ b/Tests/XCUITests/DesktopModeTests.swift
@@ -100,16 +100,16 @@ class DesktopModeTestsIphone: IphoneOnlyTestCase {
         navigator.openURL(path(forTestPage: "test-user-agent.html"))
         waitUntilPageLoad()
         XCTAssert(app.webViews.staticTexts.matching(identifier: "MOBILE_UA").count > 0)
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton])
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton])
         navigator.goto(BrowserTabMenu)
-        waitForExistence(app.tables["Context Menu"].otherElements[StandardImageIdentifiers.Large.deviceDesktop])
+        mozWaitForElementToExist(app.tables["Context Menu"].otherElements[StandardImageIdentifiers.Large.deviceDesktop])
         navigator.goto(RequestDesktopSite)
         waitUntilPageLoad()
         XCTAssert(app.webViews.staticTexts.matching(identifier: "DESKTOP_UA").count > 0)
 
         navigator.nowAt(BrowserTab)
         navigator.goto(BrowserTabMenu)
-        waitForExistence(app.tables["Context Menu"].otherElements[StandardImageIdentifiers.Large.deviceMobile])
+        mozWaitForElementToExist(app.tables["Context Menu"].otherElements[StandardImageIdentifiers.Large.deviceMobile])
         // Select Mobile site here, the identifier is the same but the Text is not
         navigator.goto(RequestMobileSite)
         waitUntilPageLoad()
@@ -135,7 +135,7 @@ class DesktopModeTestsIphone: IphoneOnlyTestCase {
         navigator.openURL(path(forTestPage: "test-user-agent.html"))
         // Workaround to be sure the snackbar disappears
         waitUntilPageLoad()
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.reloadButton], timeout: 5)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.reloadButton], timeout: 5)
         app.buttons[AccessibilityIdentifiers.Toolbar.reloadButton].tap()
         navigator.goto(BrowserTabMenu)
         navigator.goto(RequestMobileSite) // toggle off
@@ -181,7 +181,7 @@ class DesktopModeTestsIphone: IphoneOnlyTestCase {
         if skipPlatform { return }
         navigator.openURL(path(forTestPage: "test-user-agent.html"))
         waitUntilPageLoad()
-        waitForExistence(app.webViews.staticTexts.firstMatch, timeout: 5)
+        mozWaitForElementToExist(app.webViews.staticTexts.firstMatch, timeout: 5)
         XCTAssert(app.webViews.staticTexts.matching(identifier: "MOBILE_UA").count > 0)
 
         navigator.goto(ReloadLongPressMenu)

--- a/Tests/XCUITests/DisplaySettingsTests.swift
+++ b/Tests/XCUITests/DisplaySettingsTests.swift
@@ -8,7 +8,7 @@ class DisplaySettingTests: BaseTestCase {
     func testCheckDisplaySettingsDefault() {
         navigator.nowAt(NewTabScreen)
         navigator.goto(DisplaySettings)
-        waitForExistence(app.navigationBars["Theme"])
+        mozWaitForElementToExist(app.navigationBars["Theme"])
         XCTAssertTrue(app.tables["DisplayTheme.Setting.Options"].exists)
         let switchValue = app.switches["SystemThemeSwitchValue"].value!
         XCTAssertEqual(switchValue as! String, "1")
@@ -17,14 +17,14 @@ class DisplaySettingTests: BaseTestCase {
     func testCheckSystemThemeChanges() {
         navigator.nowAt(NewTabScreen)
         navigator.goto(DisplaySettings)
-        waitForExistence(app.switches["SystemThemeSwitchValue"])
+        mozWaitForElementToExist(app.switches["SystemThemeSwitchValue"])
         navigator.performAction(Action.SystemThemeSwitch)
-        waitForExistence(app.tables["DisplayTheme.Setting.Options"].otherElements.staticTexts["SWITCH MODE"])
+        mozWaitForElementToExist(app.tables["DisplayTheme.Setting.Options"].otherElements.staticTexts["SWITCH MODE"])
 
         // Going back to Settings and Display settings keeps the value
         navigator.goto(SettingsScreen)
         navigator.goto(DisplaySettings)
-        waitForExistence(app.switches["SystemThemeSwitchValue"])
+        mozWaitForElementToExist(app.switches["SystemThemeSwitchValue"])
         let switchValue = app.switches["SystemThemeSwitchValue"].value!
         XCTAssertEqual(switchValue as! String, "0")
         XCTAssertTrue(app.cells.staticTexts["Light"].exists)

--- a/Tests/XCUITests/DomainAutocompleteTest.swift
+++ b/Tests/XCUITests/DomainAutocompleteTest.swift
@@ -43,14 +43,14 @@ class DomainAutocompleteTest: BaseTestCase {
         navigator.goto(URLBarOpen)
         app.textFields["address"].typeText("moz")
 
-        waitForValueContains(app.textFields["address"], value: website["value"]!)
+        mozWaitForValueContains(app.textFields["address"], value: website["value"]!)
         let value = app.textFields["address"].value
         XCTAssertEqual(value as? String, website["value"]!, "Wrong autocompletion")
 
         // Enter the complete website and check that there is not more text added, just what user typed
         app.buttons["Clear text"].tap()
         app.textFields["address"].typeText(website["value"]!)
-        waitForValueContains(app.textFields["address"], value: website["value"]!)
+        mozWaitForValueContains(app.textFields["address"], value: website["value"]!)
         let value2 = app.textFields["address"].value
         XCTAssertEqual(value2 as? String, website["value"]!, "Wrong autocompletion")
     }
@@ -72,10 +72,10 @@ class DomainAutocompleteTest: BaseTestCase {
         app.textFields["address"].typeText("\u{0008}")
         // Then remove an extra char and check that the autocompletion stops working
         app.textFields["address"].typeText("\u{0008}")
-        waitForValueContains(app.textFields["address"], value: "mo")
+        mozWaitForValueContains(app.textFields["address"], value: "mo")
         // Then write another letter and the autocompletion works again
         app.textFields["address"].typeText("z")
-        waitForValueContains(app.textFields["address"], value: "moz")
+        mozWaitForValueContains(app.textFields["address"], value: "moz")
 
         let value = app.textFields["address"].value
         XCTAssertEqual(value as? String, website["value"]!, "Wrong autocompletion")
@@ -100,7 +100,7 @@ class DomainAutocompleteTest: BaseTestCase {
         waitUntilPageLoad()
         navigator.goto(URLBarOpen)
         app.textFields["address"].typeText("ex")
-        waitForValueContains(app.otherElements.textFields["Address Bar"], value: "www.example.com/")
+        mozWaitForValueContains(app.otherElements.textFields["Address Bar"], value: "www.example.com/")
         let value = app.textFields["address"].value
         XCTAssertEqual(value as? String, "example.com", "Wrong autocompletion")
     }
@@ -155,19 +155,19 @@ class DomainAutocompleteTest: BaseTestCase {
     func test2DefaultDomains() {
         navigator.goto(URLBarOpen)
         app.textFields["address"].typeText("a")
-        waitForValueContains(app.textFields["address"], value: ".com")
+        mozWaitForValueContains(app.textFields["address"], value: ".com")
         let value = app.textFields["address"].value
         XCTAssertEqual(value as? String, "amazon.com", "Wrong autocompletion")
 
         app.buttons["Clear text"].tap()
         app.textFields["address"].typeText("an")
-        waitForValueContains(app.textFields["address"], value: ".com")
+        mozWaitForValueContains(app.textFields["address"], value: ".com")
         let value2 = app.textFields["address"].value
         XCTAssertEqual(value2 as? String, "answers.com", "Wrong autocompletion")
 
         app.buttons["Clear text"].tap()
         app.textFields["address"].typeText("anc")
-        waitForValueContains(app.textFields["address"], value: ".com")
+        mozWaitForValueContains(app.textFields["address"], value: ".com")
         let value3 = app.textFields["address"].value
         XCTAssertEqual(value3 as? String, "ancestry.com", "Wrong autocompletion")
     }
@@ -176,21 +176,21 @@ class DomainAutocompleteTest: BaseTestCase {
     func testMixedCaseAutocompletion() {
         navigator.goto(URLBarOpen)
         app.textFields["address"].typeText("MoZ")
-        waitForValueContains(app.textFields["address"], value: ".org")
+        mozWaitForValueContains(app.textFields["address"], value: ".org")
         let value = app.textFields["address"].value
         XCTAssertEqual(value as? String, "MoZilla.org", "Wrong autocompletion")
 
         // Test that leading spaces still show suggestions.
         app.buttons["Clear text"].tap()
         app.textFields["address"].typeText("    moz")
-        waitForValueContains(app.textFields["address"], value: ".org")
+        mozWaitForValueContains(app.textFields["address"], value: ".org")
         let value2 = app.textFields["address"].value
         XCTAssertEqual(value2 as? String, "    mozilla.org", "Wrong autocompletion")
 
         // Test that trailing spaces do *not* show suggestions.
         app.buttons["Clear text"].tap()
         app.textFields["address"].typeText("    moz ")
-        waitForValueContains(app.textFields["address"], value: "moz")
+        mozWaitForValueContains(app.textFields["address"], value: "moz")
         let value3 = app.textFields["address"].value
         // No autocompletion, just what user typed
         XCTAssertEqual(value3 as? String, "    moz ", "Wrong autocompletion")

--- a/Tests/XCUITests/DomainAutocompleteTest.swift
+++ b/Tests/XCUITests/DomainAutocompleteTest.swift
@@ -65,7 +65,7 @@ class DomainAutocompleteTest: BaseTestCase {
         navigator.goto(CloseTabMenu)
         navigator.performAction(Action.AcceptRemovingAllTabs)
         navigator.goto(URLBarOpen)
-        waitForExistence(app.textFields["address"])
+        mozWaitForElementToExist(app.textFields["address"])
         app.textFields["address"].typeText("moz")
 
         // First delete the autocompleted part
@@ -84,14 +84,14 @@ class DomainAutocompleteTest: BaseTestCase {
     func test6DeleteEntireString() {
         navigator.goto(URLBarOpen)
         app.textFields["address"].typeText("www.moz")
-        waitForExistence(app.buttons["Clear text"])
+        mozWaitForElementToExist(app.buttons["Clear text"])
         app.buttons["Clear text"].tap()
 
         // Check that the address field is empty and that the home panels are shown
         let value = app.textFields["address"].value
         XCTAssertEqual(value as? String, "", "The url has not been removed correctly")
 
-        waitForExistence(app.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
+        mozWaitForElementToExist(app.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
     }
 
     // Ensure that the scheme is included in the autocompletion.
@@ -204,7 +204,7 @@ class DomainAutocompleteTest: BaseTestCase {
         navigator.goto(URLBarOpen)
         app.typeText("gith")
 
-        waitForExistence(app.tables["SiteTable"].cells.staticTexts[url2["label"]!])
+        mozWaitForElementToExist(app.tables["SiteTable"].cells.staticTexts[url2["label"]!])
         // There should be only one matching entry
         XCTAssertTrue(app.tables["SiteTable"].staticTexts[url2["label"]!].exists)
         XCTAssertFalse(app.tables["SiteTable"].staticTexts[url1["label"]!].exists)
@@ -223,7 +223,7 @@ class DomainAutocompleteTest: BaseTestCase {
             app.typeText("\u{0008}")
         }
 
-        waitForNoExistence(app.tables["SiteTable"].staticTexts[url2["label"]!])
+        mozWaitForElementToNotExist(app.tables["SiteTable"].staticTexts[url2["label"]!])
         XCTAssertFalse(app.tables["SiteTable"].staticTexts[url2["label"]!].exists)
         XCTAssertFalse(app.tables["SiteTable"].staticTexts[url1["label"]!].exists)
     }

--- a/Tests/XCUITests/DownloadFilesTests.swift
+++ b/Tests/XCUITests/DownloadFilesTests.swift
@@ -15,7 +15,7 @@ let testBLOBFileSize = "35 bytes"
 class DownloadFilesTests: BaseTestCase {
     override func tearDown() {
         // The downloaded file has to be removed between tests
-        waitForExistence(app.tables["DownloadsTable"])
+        mozWaitForElementToExist(app.tables["DownloadsTable"])
         if processIsTranslatedStr() == m1Rosetta {
             navigator.nowAt(LibraryPanel_Downloads)
             navigator.goto(HomePanelsScreen)
@@ -28,9 +28,9 @@ class DownloadFilesTests: BaseTestCase {
             let list = app.tables["DownloadsTable"].cells.count
             if list != 0 {
                 for _ in 0...list-1 {
-                    waitForExistence(app.tables["DownloadsTable"].cells.element(boundBy: 0))
+                    mozWaitForElementToExist(app.tables["DownloadsTable"].cells.element(boundBy: 0))
                     app.tables["DownloadsTable"].cells.element(boundBy: 0).swipeLeft()
-                    waitForExistence(app.tables.cells.buttons[StandardImageIdentifiers.Large.delete])
+                    mozWaitForElementToExist(app.tables.cells.buttons[StandardImageIdentifiers.Large.delete])
                     app.tables.cells.buttons[StandardImageIdentifiers.Large.delete].tap()
                 }
             }
@@ -40,14 +40,14 @@ class DownloadFilesTests: BaseTestCase {
 
     private func deleteItem(itemName: String) {
         app.tables.cells.staticTexts[itemName].swipeLeft()
-        waitForExistence(app.tables.cells.buttons[StandardImageIdentifiers.Large.delete], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.tables.cells.buttons[StandardImageIdentifiers.Large.delete], timeout: TIMEOUT)
         app.tables.cells.buttons[StandardImageIdentifiers.Large.delete].tap()
     }
 
     func testDownloadFilesAppMenuFirstTime() {
         navigator.nowAt(NewTabScreen)
         navigator.goto(LibraryPanel_Downloads)
-        waitForExistence(app.tables["DownloadsTable"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.tables["DownloadsTable"], timeout: TIMEOUT)
         XCTAssertTrue(app.tables["DownloadsTable"].exists)
         // Check that there is not any items and the default text shown is correct
         checkTheNumberOfDownloadedItems(items: 0)
@@ -64,7 +64,7 @@ class DownloadFilesTests: BaseTestCase {
         }
         app.webViews.links[testFileName].firstMatch.tap()
 
-        waitForExistence(app.tables["Context Menu"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.tables["Context Menu"], timeout: TIMEOUT)
         XCTAssertTrue(app.tables["Context Menu"].staticTexts[testFileNameDownloadPanel].exists)
         XCTAssertTrue(app.tables["Context Menu"].otherElements[StandardImageIdentifiers.Large.download].exists)
         app.buttons["Cancel"].tap()
@@ -79,7 +79,7 @@ class DownloadFilesTests: BaseTestCase {
         navigator.goto(BrowserTabMenu)
         navigator.goto(LibraryPanel_Downloads)
 
-        waitForExistence(app.tables["DownloadsTable"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.tables["DownloadsTable"], timeout: TIMEOUT)
         // There should be one item downloaded. It's name and size should be shown
         checkTheNumberOfDownloadedItems(items: 1)
         XCTAssertTrue(app.tables.cells.staticTexts[testFileNameDownloadPanel].exists)
@@ -88,11 +88,11 @@ class DownloadFilesTests: BaseTestCase {
 
     func testDownloadBLOBFile() {
         downloadBLOBFile()
-        waitForExistence(app.buttons["Downloads"])
+        mozWaitForElementToExist(app.buttons["Downloads"])
         navigator.goto(BrowserTabMenu)
         navigator.goto(LibraryPanel_Downloads)
 
-        waitForExistence(app.tables["DownloadsTable"])
+        mozWaitForElementToExist(app.tables["DownloadsTable"])
         // There should be one item downloaded. It's name and size should be shown
         checkTheNumberOfDownloadedItems(items: 1)
         // We can only check for the BLOB file size since the name is generated
@@ -103,12 +103,12 @@ class DownloadFilesTests: BaseTestCase {
         downloadFile(fileName: testFileName, numberOfDownloads: 1)
         navigator.goto(BrowserTabMenu)
         navigator.goto(LibraryPanel_Downloads)
-        waitForExistence(app.tables["DownloadsTable"])
+        mozWaitForElementToExist(app.tables["DownloadsTable"])
         if processIsTranslatedStr() == m1Rosetta {
             throw XCTSkip("swipeLeft() does not work on M1")
         } else {
             deleteItem(itemName: testFileNameDownloadPanel)
-            waitForNoExistence(app.tables.cells.staticTexts[testFileNameDownloadPanel])
+            mozWaitForElementToNotExist(app.tables.cells.staticTexts[testFileNameDownloadPanel])
             // After removing the number of items should be 0
             checkTheNumberOfDownloadedItems(items: 0)
         }
@@ -132,10 +132,10 @@ class DownloadFilesTests: BaseTestCase {
         navigator.goto(BrowserTabMenu)
         navigator.goto(LibraryPanel_Downloads)
 
-        waitForExistence(app.tables["DownloadsTable"])
+        mozWaitForElementToExist(app.tables["DownloadsTable"])
         // Commenting out until share sheet can be managed with automated tests issue #5477
         app.tables.cells.staticTexts[testFileNameDownloadPanel].press(forDuration: 2)
-        waitForExistence(app.otherElements["ActivityListView"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.otherElements["ActivityListView"], timeout: TIMEOUT)
         if !iPad() {
             app.buttons["Close"].tap()
         } else {
@@ -151,18 +151,18 @@ class DownloadFilesTests: BaseTestCase {
         waitUntilPageLoad()
         app.webViews.firstMatch.swipeLeft()
         for _ in 0..<numberOfDownloads {
-            waitForExistence(app.webViews.links[testFileName], timeout: TIMEOUT)
+            mozWaitForElementToExist(app.webViews.links[testFileName], timeout: TIMEOUT)
 
             app.webViews.links[testFileName].firstMatch.tap()
 
-            waitForExistence(app.tables["Context Menu"].otherElements[StandardImageIdentifiers.Large.download], timeout: TIMEOUT)
+            mozWaitForElementToExist(app.tables["Context Menu"].otherElements[StandardImageIdentifiers.Large.download], timeout: TIMEOUT)
             app.tables["Context Menu"].otherElements[StandardImageIdentifiers.Large.download].tap()
         }
     }
 
     private func downloadBLOBFile() {
         navigator.openURL(testBLOBURL)
-        waitForExistence(app.webViews.links["Download Text"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.webViews.links["Download Text"], timeout: TIMEOUT)
         app.webViews.links["Download Text"].press(forDuration: 1)
         app.buttons["Download Link"].tap()
     }
@@ -172,7 +172,7 @@ class DownloadFilesTests: BaseTestCase {
         navigator.goto(BrowserTabMenu)
         navigator.goto(LibraryPanel_Downloads)
 
-        waitForExistence(app.tables["DownloadsTable"])
+        mozWaitForElementToExist(app.tables["DownloadsTable"])
         checkTheNumberOfDownloadedItems(items: 2)
     }
 
@@ -189,12 +189,12 @@ class DownloadFilesTests: BaseTestCase {
         navigator.goto(BrowserTabMenu)
         navigator.goto(LibraryPanel_Downloads)
 
-        waitForExistence(app.tables["DownloadsTable"])
+        mozWaitForElementToExist(app.tables["DownloadsTable"])
         checkTheNumberOfDownloadedItems(items: 1)
 
         // Remove private data once the switch to remove downloaded files is enabled
         navigator.goto(NewTabScreen)
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         navigator.goto(ClearPrivateDataSettings)
@@ -209,16 +209,16 @@ class DownloadFilesTests: BaseTestCase {
     }
 
     private func checkTheNumberOfDownloadedItems(items: Int) {
-        waitForExistence(app.tables["DownloadsTable"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.tables["DownloadsTable"], timeout: TIMEOUT)
         let list = app.tables["DownloadsTable"].cells.count
         XCTAssertEqual(list, items, "The number of items in the downloads table is not correct")
     }
     // Smoketest
     func testToastButtonToGoToDownloads() {
         downloadFile(fileName: testFileName, numberOfDownloads: 1)
-        waitForExistence(app.buttons["Downloads"])
+        mozWaitForElementToExist(app.buttons["Downloads"])
         app.buttons["Downloads"].tap()
-        waitForExistence(app.tables["DownloadsTable"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.tables["DownloadsTable"], timeout: TIMEOUT)
         checkTheNumberOfDownloadedItems(items: 1)
     }
 }

--- a/Tests/XCUITests/DragAndDropTests.swift
+++ b/Tests/XCUITests/DragAndDropTests.swift
@@ -238,7 +238,7 @@ class DragAndDropTestIpad: IpadOnlyTestCase {
         navigator.openURL("developer.mozilla.org/en-US")
         waitUntilPageLoad()
         // Check the text in the search field before dragging and dropping the url text field
-        waitForValueContains(app.webViews.searchFields.element(boundBy: 0), value: "Search")
+        mozWaitForValueContains(app.webViews.searchFields.element(boundBy: 0), value: "Search")
         // DragAndDrop the url for only one second so that the TP menu is not shown and the search box is not covered
         app.textFields["url"].press(forDuration: 1, thenDragTo: app.webViews.searchFields.element(boundBy: 0))
 

--- a/Tests/XCUITests/DragAndDropTests.swift
+++ b/Tests/XCUITests/DragAndDropTests.swift
@@ -26,7 +26,7 @@ class DragAndDropTests: BaseTestCase {
         navigator.goto(TabTray)
         checkTabsOrder(dragAndDropTab: false, firstTab: firstWebsite.tabName, secondTab: secondWebsite.tabName)
         dragAndDrop(dragElement: app.collectionViews.cells[firstWebsite.tabName], dropOnElement: app.collectionViews.cells[secondWebsite.tabName])
-        waitForExistence(app.collectionViews.cells["Internet for people, not profit — Mozilla"], timeout: 10)
+        mozWaitForElementToExist(app.collectionViews.cells["Internet for people, not profit — Mozilla"], timeout: 10)
         checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite.tabName, secondTab: firstWebsite.tabName)
     }
 
@@ -38,7 +38,7 @@ class DragAndDropTests: BaseTestCase {
         openTwoWebsites()
         navigator.goto(TabTray)
         navigator.performAction(Action.OpenNewTabFromTabTray)
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 10)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 10)
 
         navigator.openNewURL(urlString: thirdWebsite.url)
         waitUntilPageLoad()
@@ -190,7 +190,7 @@ class DragAndDropTestIpad: IpadOnlyTestCase {
         navigator.openURL(secondWebsite.url)
         waitUntilPageLoad()
         checkTabsOrder(dragAndDropTab: false, firstTab: homeTabName, secondTab: secondWebsite.tabName)
-        waitForExistence(app.collectionViews.cells.element(boundBy: 1))
+        mozWaitForElementToExist(app.collectionViews.cells.element(boundBy: 1))
 
         // Drag and drop home tab from the second position to the first one
         dragAndDrop(dragElement: app.collectionViews.cells["Homepage"], dropOnElement: app.collectionViews.cells[secondWebsite.tabName])
@@ -254,7 +254,7 @@ class DragAndDropTestIpad: IpadOnlyTestCase {
         typealias historyPanelA11y = AccessibilityIdentifiers.LibraryPanels.HistoryPanel
 
         // Drop a bookmark/history entry is only allowed on other apps. This test is to check that nothing happens within the app
-        waitForExistence(app.textFields["url"], timeout: 5)
+        mozWaitForElementToExist(app.textFields["url"], timeout: 5)
         navigator.nowAt(NewTabScreen)
         navigator.goto(BrowserTabMenu)
         navigator.goto(LibraryPanel_History)
@@ -279,10 +279,10 @@ class DragAndDropTestIpad: IpadOnlyTestCase {
         /*
         if skipPlatform { return }
 
-        waitForExistence(app.textFields["url"], timeout: 5)
+        mozWaitForElementToExist(app.textFields["url"], timeout: 5)
         navigator.nowAt(NewTabScreen)
         navigator.goto(MobileBookmarks)
-        waitForExistence(app.tables["Bookmarks List"])
+        mozWaitForElementToExist(app.tables["Bookmarks List"])
 
         let firstEntryOnList = app.tables["Bookmarks List"].cells.element(boundBy: 0).staticTexts[exampleDomainTitle]
         let secondEntryOnList = app.tables["Bookmarks List"].cells.element(boundBy: 3).staticTexts[twitterTitle]
@@ -306,7 +306,7 @@ class DragAndDropTestIpad: IpadOnlyTestCase {
         typealias historyPanelA11y = AccessibilityIdentifiers.LibraryPanels.HistoryPanel
 
         navigator.goto(LibraryPanel_History)
-        waitForExistence(app.tables[historyPanelA11y.tableView].cells.staticTexts[twitterTitle])
+        mozWaitForElementToExist(app.tables[historyPanelA11y.tableView].cells.staticTexts[twitterTitle])
 
         app.tables[historyPanelA11y.tableView].cells.staticTexts[twitterTitle].press(forDuration: 1, thenDragTo: app.textFields["url"])
 
@@ -321,7 +321,7 @@ class DragAndDropTestIpad: IpadOnlyTestCase {
         if skipPlatform { return }
 
         navigator.goto(MobileBookmarks)
-        waitForExistence(app.tables["Bookmarks List"])
+        mozWaitForElementToExist(app.tables["Bookmarks List"])
         app.tables["Bookmarks List"].cells.staticTexts[twitterTitle].press(forDuration: 1, thenDragTo: app.textFields["url"])
 
         // It is not allowed to drop the entry on the url field

--- a/Tests/XCUITests/EngagementNotificationTests.swift
+++ b/Tests/XCUITests/EngagementNotificationTests.swift
@@ -25,10 +25,10 @@ class EngagementNotificationTests: BaseTestCase {
         // XCUIDevice.shared.press(XCUIDevice.Button.home)
 
         // let notification = springboard.otherElements["Notification"]
-        // XCTAssertTrue(notification.waitForExistence(timeout: TIMEOUT_LONG)) // implicit wait
+        // XCTAssertTrue(notification.mozWaitForElementToExist(timeout: TIMEOUT_LONG)) // implicit wait
         // notification.tap()
 
-        // waitForExistence(app.textFields["url"])
+        // mozWaitForElementToExist(app.textFields["url"])
         // let url = app.textFields["url"].value as! String
         // XCTAssertEqual(url, "mozilla.com", "Wrong url loaded")
     }
@@ -38,7 +38,7 @@ class EngagementNotificationTests: BaseTestCase {
     private func goThroughOnboarding() {
         // Complete the First run from first screen to the latest one
         // Check that the first's tour screen is shown as well as all the elements in there
-        waitForExistence(app.images["\(rootA11yId)ImageView"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.images["\(rootA11yId)ImageView"], timeout: TIMEOUT)
         XCTAssertTrue(app.images["\(rootA11yId)ImageView"].exists)
         XCTAssertTrue(app.buttons["\(rootA11yId)PrimaryButton"].exists)
         XCTAssertTrue(app.buttons["\(AccessibilityIdentifiers.Onboarding.closeButton)"].exists)
@@ -46,7 +46,7 @@ class EngagementNotificationTests: BaseTestCase {
         // Go to the second screen
         app.buttons["\(rootA11yId)PrimaryButton"].tap()
         currentScreen += 1
-        waitForExistence(app.images["\(rootA11yId)ImageView"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.images["\(rootA11yId)ImageView"], timeout: TIMEOUT)
         XCTAssertTrue(app.images["\(rootA11yId)ImageView"].exists)
         XCTAssertTrue(app.buttons["\(rootA11yId)PrimaryButton"].exists)
         XCTAssertTrue(app.buttons["\(rootA11yId)SecondaryButton"].exists)
@@ -54,7 +54,7 @@ class EngagementNotificationTests: BaseTestCase {
         // Go to the third screen
         app.buttons["\(rootA11yId)SecondaryButton"].tap()
         currentScreen += 1
-        waitForExistence(app.images["\(rootA11yId)ImageView"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.images["\(rootA11yId)ImageView"], timeout: TIMEOUT)
         XCTAssertTrue(app.images["\(rootA11yId)ImageView"].exists)
         XCTAssertTrue(app.buttons["\(rootA11yId)PrimaryButton"].exists)
         XCTAssertTrue(app.buttons["\(rootA11yId)SecondaryButton"].exists)
@@ -70,6 +70,6 @@ class EngagementNotificationTests: BaseTestCase {
         }
 
         let topSites = app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]
-        waitForExistence(topSites)
+        mozWaitForElementToExist(topSites)
     }
 }

--- a/Tests/XCUITests/ExperimentIntegrationTests.swift
+++ b/Tests/XCUITests/ExperimentIntegrationTests.swift
@@ -45,6 +45,6 @@ final class ExperimentIntegrationTests: BaseTestCase {
 
         wait(forElement: surveyLink.element, timeout: 15)
         surveyLink.element.tap()
-        waitForValueContains(app.textFields["url"], value: "survey")
+        mozWaitForValueContains(app.textFields["url"], value: "survey")
     }
 }

--- a/Tests/XCUITests/FindInPageTest.swift
+++ b/Tests/XCUITests/FindInPageTest.swift
@@ -13,8 +13,8 @@ class FindInPageTests: BaseTestCase {
 
         navigator.goto(FindInPage)
 
-        waitForExistence(app.buttons[AccessibilityIdentifiers.FindInPage.findNextButton], timeout: 5)
-        waitForExistence(app.buttons[AccessibilityIdentifiers.FindInPage.findPreviousButton], timeout: 5)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.FindInPage.findNextButton], timeout: 5)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.FindInPage.findPreviousButton], timeout: 5)
         XCTAssertTrue(app.textFields["FindInPage.searchField"].exists)
     }
 
@@ -23,15 +23,15 @@ class FindInPageTests: BaseTestCase {
         // Workaround until FxSGraph is fixed to allow the previous way with goto
         navigator.nowAt(BrowserTab)
 
-        waitForNoExistence(app.staticTexts["Fennec pasted from XCUITests-Runner"])
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 15)
+        mozWaitForElementToNotExist(app.staticTexts["Fennec pasted from XCUITests-Runner"])
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 15)
         app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton].tap()
-        waitForExistence(app.tables["Context Menu"].otherElements[ImageIdentifiers.findInPage], timeout: 10)
+        mozWaitForElementToExist(app.tables["Context Menu"].otherElements[ImageIdentifiers.findInPage], timeout: 10)
         app.tables["Context Menu"].otherElements[ImageIdentifiers.findInPage].tap()
 
         // Enter some text to start finding
         app.textFields["FindInPage.searchField"].typeText("Book")
-        waitForExistence(app.textFields["Book"], timeout: 15)
+        mozWaitForElementToExist(app.textFields["Book"], timeout: 15)
         XCTAssertEqual(app.staticTexts["FindInPage.matchCount"].label, "1/500+", "The book word count does match")
     }
 
@@ -44,31 +44,31 @@ class FindInPageTests: BaseTestCase {
         app.textFields["FindInPage.searchField"].typeText("Book")
 
         // Once there are matches, test previous/next buttons
-        waitForExistence(app.staticTexts["1/6"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.staticTexts["1/6"], timeout: TIMEOUT)
         XCTAssertTrue(app.staticTexts["1/6"].exists)
 
         let nextInPageResultButton = app.buttons[AccessibilityIdentifiers.FindInPage.findNextButton]
         nextInPageResultButton.tap()
-        waitForExistence(app.staticTexts["2/6"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.staticTexts["2/6"], timeout: TIMEOUT)
         XCTAssertTrue(app.staticTexts["2/6"].exists)
 
         nextInPageResultButton.tap()
-        waitForExistence(app.staticTexts["3/6"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.staticTexts["3/6"], timeout: TIMEOUT)
         XCTAssertTrue(app.staticTexts["3/6"].exists)
 
         let previousInPageResultButton = app.buttons[AccessibilityIdentifiers.FindInPage.findPreviousButton]
         previousInPageResultButton.tap()
 
-        waitForExistence(app.staticTexts["2/6"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.staticTexts["2/6"], timeout: TIMEOUT)
         XCTAssertTrue(app.staticTexts["2/6"].exists)
 
         previousInPageResultButton.tap()
-        waitForExistence(app.staticTexts["1/6"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.staticTexts["1/6"], timeout: TIMEOUT)
         XCTAssertTrue(app.staticTexts["1/6"].exists)
 
         // Tapping on close dismisses the search bar
         navigator.goto(BrowserTab)
-        waitForNoExistence(app.textFields["Book"])
+        mozWaitForElementToNotExist(app.textFields["Book"])
     }
 
     func testFindInPageTwoWordsSearch() {
@@ -78,7 +78,7 @@ class FindInPageTests: BaseTestCase {
         app.textFields["FindInPage.searchField"].typeText("The Book of")
 
         // Once there are matches, test previous/next buttons
-        waitForExistence(app.staticTexts["1/6"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.staticTexts["1/6"], timeout: TIMEOUT)
         XCTAssertTrue(app.staticTexts["1/6"].exists)
     }
 
@@ -87,12 +87,12 @@ class FindInPageTests: BaseTestCase {
         // Workaround until FxSGraph is fixed to allow the previous way with goto
         waitUntilPageLoad()
         navigator.nowAt(BrowserTab)
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 15)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 15)
         app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton].tap()
         // Enter some text to start finding
         app.tables["Context Menu"].otherElements[ImageIdentifiers.findInPage].tap()
         app.textFields["FindInPage.searchField"].typeText("The Book of")
-        waitForExistence(app.textFields["The Book of"], timeout: 15)
+        mozWaitForElementToExist(app.textFields["The Book of"], timeout: 15)
         XCTAssertEqual(app.staticTexts["FindInPage.matchCount"].label, "1/500+", "The book word count does match")
     }
 
@@ -103,7 +103,7 @@ class FindInPageTests: BaseTestCase {
         app.textFields["FindInPage.searchField"].typeText("lorem")
 
         // There should be matches
-        waitForExistence(app.staticTexts["1/5"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.staticTexts["1/5"], timeout: TIMEOUT)
         XCTAssertTrue(app.staticTexts["1/5"].exists)
     }
 
@@ -113,7 +113,7 @@ class FindInPageTests: BaseTestCase {
 
         // Try to find text which does not match and check that there are not results
         app.textFields["FindInPage.searchField"].typeText("foo")
-        waitForExistence(app.staticTexts["0/0"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.staticTexts["0/0"], timeout: TIMEOUT)
         XCTAssertTrue(app.staticTexts["0/0"].exists, "There should not be any matches")
     }
 
@@ -126,7 +126,7 @@ class FindInPageTests: BaseTestCase {
         app.textFields["address"].typeText("\n")
 
         // Once the page is reloaded the search bar should not appear
-        waitForNoExistence(app.textFields[""])
+        mozWaitForElementToNotExist(app.textFields[""])
         XCTAssertFalse(app.textFields[""].exists)
     }
 
@@ -141,7 +141,7 @@ class FindInPageTests: BaseTestCase {
         // Going to tab tray and back to the website hides the search field.
         navigator.goto(TabTray)
 
-        waitForExistence(app.cells.staticTexts["The Book of Mozilla"])
+        mozWaitForElementToExist(app.cells.staticTexts["The Book of Mozilla"])
         app.cells.staticTexts["The Book of Mozilla"].firstMatch.tap()
         XCTAssertFalse(app.textFields[""].exists)
         XCTAssertFalse(app.buttons[AccessibilityIdentifiers.FindInPage.findNextButton].exists)
@@ -155,20 +155,20 @@ class FindInPageTests: BaseTestCase {
 
         // Long press on the word to be found
         waitUntilPageLoad()
-        waitForExistence(app.webViews.staticTexts[textToFind])
+        mozWaitForElementToExist(app.webViews.staticTexts[textToFind])
         let stringToFind = app.webViews.staticTexts.matching(identifier: textToFind)
         let firstStringToFind = stringToFind.element(boundBy: 0)
         firstStringToFind.press(forDuration: 3)
-        waitForExistence(app.menuItems["Copy"], timeout: 5)
+        mozWaitForElementToExist(app.menuItems["Copy"], timeout: 5)
         // Find in page is correctly launched, bar with text pre-filled and
         // the buttons to find next and previous
         while !app.collectionViews.menuItems["Find in Page"].exists {
             app.buttons["Forward"].firstMatch.tap()
-            waitForExistence(app.collectionViews.menuItems.firstMatch)
-            waitForExistence(app.buttons["Forward"])
+            mozWaitForElementToExist(app.collectionViews.menuItems.firstMatch)
+            mozWaitForElementToExist(app.buttons["Forward"])
         }
         app.menuItems["Find in Page"].tap()
-        waitForExistence(app.textFields[textToFind])
+        mozWaitForElementToExist(app.textFields[textToFind])
         XCTAssertTrue(app.textFields[textToFind].exists, "The bar does not appear with the text selected to be found")
         XCTAssertTrue(app.buttons[AccessibilityIdentifiers.FindInPage.findPreviousButton].exists, "Find previous button exists")
         XCTAssertTrue(app.buttons[AccessibilityIdentifiers.FindInPage.findNextButton].exists, "Find next button exists")

--- a/Tests/XCUITests/FxScreenGraph.swift
+++ b/Tests/XCUITests/FxScreenGraph.swift
@@ -1014,7 +1014,7 @@ extension MMNavigator where T == FxUserState {
     // Opens a URL in a new tab.
     func openNewURL(urlString: String) {
         let app = XCUIApplication()
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 10)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 10)
 
         self.goto(TabTray)
         createNewTab()
@@ -1033,7 +1033,7 @@ extension MMNavigator where T == FxUserState {
     func createSeveralTabsFromTabTray(numberTabs: Int) {
         let app = XCUIApplication()
         for _ in 1...numberTabs {
-            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 5)
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 5)
             self.goto(TabTray)
             self.goto(HomePanelsScreen)
         }

--- a/Tests/XCUITests/HistoryTests.swift
+++ b/Tests/XCUITests/HistoryTests.swift
@@ -43,7 +43,7 @@ class HistoryTests: BaseTestCase {
 
         // Go to History List from Top Sites and check it is empty
         navigator.goto(LibraryPanel_History)
-        waitForExistence(app.tables.cells[HistoryPanelA11y.recentlyClosedCell])
+        mozWaitForElementToExist(app.tables.cells[HistoryPanelA11y.recentlyClosedCell])
         XCTAssertTrue(app.tables.cells[HistoryPanelA11y.recentlyClosedCell].staticTexts["Recently Closed"].exists)
         XCTAssertTrue(app.tables[HistoryPanelA11y.tableView].staticTexts[emptyRecentlyClosedMesg].exists)
     }
@@ -53,7 +53,7 @@ class HistoryTests: BaseTestCase {
         navigator.nowAt(NewTabScreen)
         navigator.goto(TabTray)
         navigator.performAction(Action.ToggleSyncMode)
-        waitForExistence(app.tables.cells.staticTexts["Firefox Sync"])
+        mozWaitForElementToExist(app.tables.cells.staticTexts["Firefox Sync"])
         XCTAssertTrue(app.tables.buttons["Sync and Save Data"].exists, "Sign in button does not appear")
     }
 
@@ -64,7 +64,7 @@ class HistoryTests: BaseTestCase {
 
         // Browse to have an item in history list
         navigator.goto(LibraryPanel_History)
-        waitForExistence(app.tables.cells[HistoryPanelA11y.recentlyClosedCell], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.tables.cells[HistoryPanelA11y.recentlyClosedCell], timeout: TIMEOUT)
         XCTAssertTrue(app.tables.cells.staticTexts[webpage["label"]!].exists)
         XCTAssertFalse(app.tables[HistoryPanelA11y.tableView].staticTexts[emptyRecentlyClosedMesg].exists)
 
@@ -75,8 +75,8 @@ class HistoryTests: BaseTestCase {
         // Back on History panel view check that there is not any item
         navigator.goto(HomePanelsScreen)
         navigator.goto(LibraryPanel_History)
-        waitForExistence(app.tables[HistoryPanelA11y.tableView])
-        waitForExistence(app.tables.cells[HistoryPanelA11y.recentlyClosedCell])
+        mozWaitForElementToExist(app.tables[HistoryPanelA11y.tableView])
+        mozWaitForElementToExist(app.tables.cells[HistoryPanelA11y.recentlyClosedCell])
         XCTAssertFalse(app.tables.cells.staticTexts[webpage["label"]!].exists)
         XCTAssertTrue(app.tables[HistoryPanelA11y.tableView].staticTexts[emptyRecentlyClosedMesg].exists)
         */
@@ -86,15 +86,15 @@ class HistoryTests: BaseTestCase {
     func testClearPrivateDataButtonDisabled() throws {
         XCTExpectFailure("The app was not launched", strict: false) {
         navigator.nowAt(NewTabScreen)
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: TIMEOUT)
         // Clear private data from settings and confirm
         navigator.goto(ClearPrivateDataSettings)
         app.tables.cells["ClearPrivateData"].tap()
-        waitForExistence(app.tables.cells["ClearPrivateData"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.tables.cells["ClearPrivateData"], timeout: TIMEOUT)
         app.alerts.buttons["OK"].tap()
 
         // Wait for OK pop-up to disappear after confirming
-        waitForNoExistence(app.alerts.buttons["OK"], timeoutValue: TIMEOUT)
+        mozWaitForElementToNotExist(app.alerts.buttons["OK"], timeoutValue: TIMEOUT)
 
         // Try to tap on the disabled Clear Private Data button
         app.tables.cells["ClearPrivateData"].tap()
@@ -108,7 +108,7 @@ class HistoryTests: BaseTestCase {
         // "Recently Closed Tabs List" is empty by default
         navigator.nowAt(NewTabScreen)
         navigator.goto(LibraryPanel_History)
-        waitForExistence(app.tables[HistoryPanelA11y.tableView])
+        mozWaitForElementToExist(app.tables[HistoryPanelA11y.tableView])
         XCTAssertFalse(app.tables.cells.staticTexts[bookOfMozilla["label"]!].exists)
         XCTAssertTrue(app.tables[HistoryPanelA11y.tableView].staticTexts[emptyRecentlyClosedMesg].exists)
     }
@@ -120,7 +120,7 @@ class HistoryTests: BaseTestCase {
         // The tab, which is still opened, is not included in the "Recently Closed Tabs List"
         navigator.goto(BrowserTabMenu)
         navigator.goto(LibraryPanel_History)
-        waitForExistence(app.tables[HistoryPanelA11y.tableView])
+        mozWaitForElementToExist(app.tables[HistoryPanelA11y.tableView])
         XCTAssertFalse(app.tables.cells.staticTexts[bookOfMozilla["label"]!].exists)
         XCTAssertTrue(app.tables[HistoryPanelA11y.tableView].staticTexts[emptyRecentlyClosedMesg].exists)
     }
@@ -133,7 +133,7 @@ class HistoryTests: BaseTestCase {
         // On regular mode, the closed tab is listed in "Recently Closed Tabs List"
         navigator.nowAt(NewTabScreen)
         navigator.goto(HistoryRecentlyClosed)
-        waitForExistence(app.tables["Recently Closed Tabs List"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.tables["Recently Closed Tabs List"], timeout: TIMEOUT)
         XCTAssertTrue(app.tables.cells.staticTexts[bookOfMozilla["label"]!].exists)
 
         // On private mode, the closed tab on regular mode is listed in "Recently Closed Tabs List" as well
@@ -141,7 +141,7 @@ class HistoryTests: BaseTestCase {
         navigator.performAction(Action.OpenNewTabFromTabTray)
         closeKeyboard()
         navigator.goto(HistoryRecentlyClosed)
-        waitForExistence(app.tables["Recently Closed Tabs List"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.tables["Recently Closed Tabs List"], timeout: TIMEOUT)
         XCTAssertTrue(app.tables.cells.staticTexts[bookOfMozilla["label"]!].exists)
     }
 
@@ -159,7 +159,7 @@ class HistoryTests: BaseTestCase {
         navigator.nowAt(NewTabScreen)
         closeKeyboard()
         navigator.goto(LibraryPanel_History)
-        waitForExistence(app.tables[HistoryPanelA11y.tableView])
+        mozWaitForElementToExist(app.tables[HistoryPanelA11y.tableView])
         XCTAssertTrue(app.tables[HistoryPanelA11y.tableView].staticTexts[emptyRecentlyClosedMesg].exists)
         XCTAssertFalse(app.tables.cells.staticTexts[bookOfMozilla["label"]!].exists)
     }
@@ -177,7 +177,7 @@ class HistoryTests: BaseTestCase {
         navigator.goto(HomePanelsScreen)
         navigator.nowAt(NewTabScreen)
         navigator.goto(LibraryPanel_History)
-        waitForExistence(app.tables[HistoryPanelA11y.tableView])
+        mozWaitForElementToExist(app.tables[HistoryPanelA11y.tableView])
         XCTAssertTrue(app.tables[HistoryPanelA11y.tableView].staticTexts[emptyRecentlyClosedMesg].exists)
         XCTAssertFalse(app.tables.cells.staticTexts[bookOfMozilla["label"]!].exists)
     }
@@ -190,7 +190,7 @@ class HistoryTests: BaseTestCase {
         // Once the website is visited and closed it will appear in Recently Closed Tabs list
         navigator.nowAt(NewTabScreen)
         navigator.goto(HistoryRecentlyClosed)
-        waitForExistence(app.tables["Recently Closed Tabs List"])
+        mozWaitForElementToExist(app.tables["Recently Closed Tabs List"])
         XCTAssertTrue(app.tables.cells.staticTexts[bookOfMozilla["label"]!].exists)
 
         // Clear all private data via the settings
@@ -202,7 +202,7 @@ class HistoryTests: BaseTestCase {
 
         // The closed tab is *not* listed in "Recently Closed Tabs List"
         navigator.goto(LibraryPanel_History)
-        waitForExistence(app.tables[HistoryPanelA11y.tableView])
+        mozWaitForElementToExist(app.tables[HistoryPanelA11y.tableView])
         XCTAssertTrue(app.tables[HistoryPanelA11y.tableView].staticTexts[emptyRecentlyClosedMesg].exists)
         XCTAssertFalse(app.tables.cells.staticTexts[bookOfMozilla["label"]!].exists)
     }
@@ -215,10 +215,10 @@ class HistoryTests: BaseTestCase {
         // Long tap a recently closed item launches a context menu
         navigator.nowAt(NewTabScreen)
         navigator.goto(HistoryRecentlyClosed)
-        waitForExistence(app.tables["Recently Closed Tabs List"])
+        mozWaitForElementToExist(app.tables["Recently Closed Tabs List"])
         XCTAssertTrue(app.tables.cells.staticTexts[bookOfMozilla["label"]!].exists)
         app.tables.cells.staticTexts[bookOfMozilla["label"]!].press(forDuration: 1)
-        waitForExistence(app.tables["Context Menu"])
+        mozWaitForElementToExist(app.tables["Context Menu"])
         XCTAssertTrue(app.tables.otherElements[StandardImageIdentifiers.Large.plus].exists)
         XCTAssertTrue(app.tables.otherElements[ImageIdentifiers.newPrivateTab].exists)
     }
@@ -231,20 +231,20 @@ class HistoryTests: BaseTestCase {
         // Open the page on a new tab from History Recently Closed screen
         navigator.nowAt(NewTabScreen)
         navigator.goto(HistoryRecentlyClosed)
-        waitForExistence(app.tables["Recently Closed Tabs List"])
+        mozWaitForElementToExist(app.tables["Recently Closed Tabs List"])
         XCTAssertTrue(app.tables.cells.staticTexts[bookOfMozilla["label"]!].exists)
         XCTAssertEqual(userState.numTabs, 1)
         app.tables.cells.staticTexts[bookOfMozilla["label"]!].press(forDuration: 1)
-        waitForExistence(app.tables["Context Menu"])
+        mozWaitForElementToExist(app.tables["Context Menu"])
         app.tables.otherElements[StandardImageIdentifiers.Large.plus].tap()
 
         // The page is opened on the new tab
         navigator.nowAt(NewTabScreen)
         navigator.goto(TabTray)
         if isTablet {
-            waitForExistence(app.navigationBars.segmentedControls["navBarTabTray"])
+            mozWaitForElementToExist(app.navigationBars.segmentedControls["navBarTabTray"])
         } else {
-            waitForExistence(app.navigationBars.staticTexts["Open Tabs"])
+            mozWaitForElementToExist(app.navigationBars.staticTexts["Open Tabs"])
         }
         XCTAssertTrue(app.staticTexts[bookOfMozilla["title"]!].exists)
         XCTAssertEqual(userState.numTabs, 2)
@@ -258,26 +258,26 @@ class HistoryTests: BaseTestCase {
         // Open the page on a new private tab from History Recently Closed screen
         navigator.nowAt(NewTabScreen)
         navigator.goto(HistoryRecentlyClosed)
-        waitForExistence(app.tables["Recently Closed Tabs List"])
+        mozWaitForElementToExist(app.tables["Recently Closed Tabs List"])
         XCTAssertTrue(app.tables.cells.staticTexts[bookOfMozilla["label"]!].exists)
         app.tables.cells.staticTexts[bookOfMozilla["label"]!].press(forDuration: 1)
-        waitForExistence(app.tables["Context Menu"])
+        mozWaitForElementToExist(app.tables["Context Menu"])
         app.tables.otherElements[ImageIdentifiers.newPrivateTab].tap()
 
         // The page is opened only on the new private tab
         navigator.nowAt(NewTabScreen)
         navigator.goto(TabTray)
         if isTablet {
-            waitForExistence(app.navigationBars.segmentedControls["navBarTabTray"])
+            mozWaitForElementToExist(app.navigationBars.segmentedControls["navBarTabTray"])
         } else {
-            waitForExistence(app.navigationBars.staticTexts["Open Tabs"])
+            mozWaitForElementToExist(app.navigationBars.staticTexts["Open Tabs"])
         }
         XCTAssertFalse(app.staticTexts[bookOfMozilla["title"]!].isHittable)
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         if isTablet {
             XCTAssertTrue(app.segmentedControls.buttons["Private"].isSelected)
         } else {
-            waitForExistence(app.staticTexts["Private Browsing"])
+            mozWaitForElementToExist(app.staticTexts["Private Browsing"])
         }
         XCTAssertTrue(app.staticTexts[bookOfMozilla["title"]!].exists)
         XCTAssertEqual(userState.numTabs, 1)
@@ -297,7 +297,7 @@ class HistoryTests: BaseTestCase {
         // Close the private tab "Book of Mozilla" by tapping 'x' button
         waitForTabsButton()
         navigator.goto(TabTray)
-        waitForExistence(app.cells.staticTexts[webpage["label"]!])
+        mozWaitForElementToExist(app.cells.staticTexts[webpage["label"]!])
         closeFirstTabByX()
 
         // On private mode, the "Recently Closed Tabs List" is empty
@@ -305,8 +305,8 @@ class HistoryTests: BaseTestCase {
         navigator.goto(HomePanelsScreen)
         closeKeyboard()
         navigator.goto(LibraryPanel_History)
-        waitForExistence(app.tables[HistoryPanelA11y.tableView])
-        waitForNoExistence(app.tables["Recently Closed Tabs List"])
+        mozWaitForElementToExist(app.tables[HistoryPanelA11y.tableView])
+        mozWaitForElementToNotExist(app.tables["Recently Closed Tabs List"])
         XCTAssertFalse(app.cells.staticTexts["Recently Closed"].isSelected)
         XCTAssertTrue(app.tables[HistoryPanelA11y.tableView].staticTexts[emptyRecentlyClosedMesg].exists)
         XCTAssertFalse(app.tables.cells.staticTexts[bookOfMozilla["label"]!].exists)
@@ -316,8 +316,8 @@ class HistoryTests: BaseTestCase {
         navigator.goto(NewTabScreen)
         closeKeyboard()
         navigator.goto(LibraryPanel_History)
-        waitForExistence(app.tables[HistoryPanelA11y.tableView])
-        waitForNoExistence(app.tables["Recently Closed Tabs List"])
+        mozWaitForElementToExist(app.tables[HistoryPanelA11y.tableView])
+        mozWaitForElementToNotExist(app.tables["Recently Closed Tabs List"])
         XCTAssertFalse(app.cells.staticTexts["Recently Closed"].isSelected)
         XCTAssertTrue(app.tables[HistoryPanelA11y.tableView].staticTexts[emptyRecentlyClosedMesg].exists)
         XCTAssertFalse(app.tables.cells.staticTexts[bookOfMozilla["label"]!].exists)
@@ -361,12 +361,12 @@ class HistoryTests: BaseTestCase {
         // Workaround as the item does not appear if there is only that tab open
         navigator.goto(TabTray)
         navigator.performAction(Action.OpenNewTabFromTabTray)
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT_LONG)
+        mozWaitForElementToExist(app.buttons["urlBar-cancel"], timeout: TIMEOUT_LONG)
         navigator.performAction(Action.CloseURLBarOpen)
         waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.goto(LibraryPanel_History)
-        waitForExistence(app.tables[HistoryPanelA11y.tableView], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.tables[HistoryPanelA11y.tableView], timeout: TIMEOUT)
         XCTAssertTrue(app.tables.cells.staticTexts["Example Domain"].exists)
     }
 
@@ -390,7 +390,7 @@ class HistoryTests: BaseTestCase {
     }
 
     private func closeKeyboard() {
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
     }
@@ -433,7 +433,7 @@ class HistoryTests: BaseTestCase {
         // Tapping everything removes both current data and older data.
         tapOnClearRecentHistoryOption(optionSelected: "Everything")
         for entry in oldHistoryEntries {
-            waitForNoExistence(app.tables.cells.staticTexts[entry], timeoutValue: 10)
+            mozWaitForElementToNotExist(app.tables.cells.staticTexts[entry], timeoutValue: 10)
 
         XCTAssertFalse(app.tables.cells.staticTexts[entry].exists, "History not removed")
         }
@@ -447,11 +447,11 @@ class HistoryTests: BaseTestCase {
         } else {
             navigateToGoogle()
             navigator.goto(LibraryPanel_History)
-            waitForExistence(app.cells.staticTexts["http://example.com/"], timeout: TIMEOUT)
+            mozWaitForElementToExist(app.cells.staticTexts["http://example.com/"], timeout: TIMEOUT)
             app.cells.staticTexts["http://example.com/"].firstMatch.swipeLeft()
-            waitForExistence(app.buttons[StandardImageIdentifiers.Large.delete], timeout: TIMEOUT)
+            mozWaitForElementToExist(app.buttons[StandardImageIdentifiers.Large.delete], timeout: TIMEOUT)
             app.buttons[StandardImageIdentifiers.Large.delete].tap()
-            waitForNoExistence(app.staticTexts["http://example.com"])
+            mozWaitForElementToNotExist(app.staticTexts["http://example.com"])
         }
     }
 }

--- a/Tests/XCUITests/HistoryTests.swift
+++ b/Tests/XCUITests/HistoryTests.swift
@@ -344,7 +344,7 @@ class HistoryTests: BaseTestCase {
         urlBarForwardButton.press(forDuration: 1)
         XCTAssertTrue(app.tables.staticTexts["The Book of Mozilla"].exists)
         app.tables.staticTexts["The Book of Mozilla"].tap()
-        waitForValueContains(app.textFields["url"], value: "test-fixture/test-mozilla-book.html")
+        mozWaitForValueContains(app.textFields["url"], value: "test-fixture/test-mozilla-book.html")
     }
 
     // Private function created to select desired option from the "Clear Recent History" list

--- a/Tests/XCUITests/HomeButtonTests.swift
+++ b/Tests/XCUITests/HomeButtonTests.swift
@@ -16,7 +16,7 @@ class HomeButtonTests: BaseTestCase {
             navigator.nowAt(NewTabScreen)
         }
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"), waitForLoading: true)
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton], timeout: 10)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton], timeout: 10)
         XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton].exists)
         app.buttons[AccessibilityIdentifiers.Toolbar.homeButton].tap()
         navigator.nowAt(NewTabScreen)
@@ -31,7 +31,7 @@ class HomeButtonTests: BaseTestCase {
             navigator.nowAt(NewTabScreen)
         }
         navigator.openURL(path(forTestPage: "test-mozilla-book.html"), waitForLoading: true)
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton], timeout: 5)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton], timeout: 5)
         XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton].exists)
 
         XCUIDevice.shared.orientation = .landscapeRight

--- a/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -89,7 +89,7 @@ class HomePageSettingsUITests: BaseTestCase {
         mozWaitForElementToExist(homePageMenuItem, timeout: TIMEOUT)
         homePageMenuItem.tap()
         waitUntilPageLoad()
-        waitForValueContains(app.textFields["url"], value: "example")
+        mozWaitForValueContains(app.textFields["url"], value: "example")
     }
 
     func testClipboard() {
@@ -101,7 +101,7 @@ class HomePageSettingsUITests: BaseTestCase {
         app.textFields["HomeAsCustomURLTextField"].press(forDuration: 3)
         mozWaitForElementToExist(app.menuItems["Paste"])
         app.menuItems["Paste"].tap()
-        waitForValueContains(app.textFields["HomeAsCustomURLTextField"], value: "mozilla")
+        mozWaitForValueContains(app.textFields["HomeAsCustomURLTextField"], value: "mozilla")
         // Check that the webpage has been correctly copied into the correct field
         let value = app.textFields["HomeAsCustomURLTextField"].value as! String
         XCTAssertEqual(value, websiteUrl1)
@@ -144,7 +144,7 @@ class HomePageSettingsUITests: BaseTestCase {
         // Workaround needed after Xcode 11.3 update Issue 5937
         // Lets check only that website is open
         mozWaitForElementToExist(app.textFields["url"], timeout: TIMEOUT)
-        waitForValueContains(app.textFields["url"], value: "mozilla")
+        mozWaitForValueContains(app.textFields["url"], value: "mozilla")
     }
 
     func testDisableTopSitesSettingsRemovesSection() {
@@ -168,7 +168,7 @@ class HomePageSettingsUITests: BaseTestCase {
         navigator.nowAt(HomeSettings)
         // Enter a custom URL
         enterWebPageAsHomepage(text: websiteUrl1)
-        waitForValueContains(app.textFields["HomeAsCustomURLTextField"], value: "mozilla")
+        mozWaitForValueContains(app.textFields["HomeAsCustomURLTextField"], value: "mozilla")
         navigator.goto(SettingsScreen)
         XCTAssertEqual(app.tables.cells["Home"].label, "Homepage, Custom")
         // Switch to FXHome and check label

--- a/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -41,10 +41,10 @@ class HomePageSettingsUITests: BaseTestCase {
         navigator.nowAt(NewTabScreen)
         navigator.goto(HomeSettings)
 
-        waitForExistence(app.navigationBars["Homepage"])
-        waitForExistence(app.tables.otherElements["OPENING SCREEN"])
-        waitForExistence(app.tables.otherElements["INCLUDE ON HOMEPAGE"])
-        waitForExistence(app.tables.otherElements["CURRENT HOMEPAGE"])
+        mozWaitForElementToExist(app.navigationBars["Homepage"])
+        mozWaitForElementToExist(app.tables.otherElements["OPENING SCREEN"])
+        mozWaitForElementToExist(app.tables.otherElements["INCLUDE ON HOMEPAGE"])
+        mozWaitForElementToExist(app.tables.otherElements["CURRENT HOMEPAGE"])
 
         // Opening Screen
         XCTAssertFalse(app.tables.cells["StartAtHomeAlways"].isSelected)
@@ -86,7 +86,7 @@ class HomePageSettingsUITests: BaseTestCase {
 
         // Now check open home page should load the previously saved home page
         let homePageMenuItem = app.buttons[AccessibilityIdentifiers.Toolbar.homeButton]
-        waitForExistence(homePageMenuItem, timeout: TIMEOUT)
+        mozWaitForElementToExist(homePageMenuItem, timeout: TIMEOUT)
         homePageMenuItem.tap()
         waitUntilPageLoad()
         waitForValueContains(app.textFields["url"], value: "example")
@@ -99,7 +99,7 @@ class HomePageSettingsUITests: BaseTestCase {
         navigator.goto(HomeSettings)
         app.textFields["HomeAsCustomURLTextField"].tap()
         app.textFields["HomeAsCustomURLTextField"].press(forDuration: 3)
-        waitForExistence(app.menuItems["Paste"])
+        mozWaitForElementToExist(app.menuItems["Paste"])
         app.menuItems["Paste"].tap()
         waitForValueContains(app.textFields["HomeAsCustomURLTextField"], value: "mozilla")
         // Check that the webpage has been correctly copied into the correct field
@@ -118,14 +118,14 @@ class HomePageSettingsUITests: BaseTestCase {
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
         waitUntilPageLoad()
         navigator.performAction(Action.GoToHomePage)
-        waitForExistence(app.textFields["url"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.textFields["url"], timeout: TIMEOUT)
 
         // Now after setting History, make sure FF home is set
         navigator.goto(SettingsScreen)
         navigator.goto(NewTabSettings)
         navigator.performAction(Action.SelectHomeAsFirefoxHomePage)
         navigator.performAction(Action.GoToHomePage)
-        waitForExistence(app.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
+        mozWaitForElementToExist(app.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
     }
 
     func testSetCustomURLAsHome() {
@@ -143,12 +143,12 @@ class HomePageSettingsUITests: BaseTestCase {
 
         // Workaround needed after Xcode 11.3 update Issue 5937
         // Lets check only that website is open
-        waitForExistence(app.textFields["url"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.textFields["url"], timeout: TIMEOUT)
         waitForValueContains(app.textFields["url"], value: "mozilla")
     }
 
     func testDisableTopSitesSettingsRemovesSection() {
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: TIMEOUT)
         navigator.nowAt(NewTabScreen)
         navigator.goto(HomeSettings)
         app.staticTexts["Shortcuts"].tap()
@@ -158,8 +158,8 @@ class HomePageSettingsUITests: BaseTestCase {
         navigator.goto(NewTabScreen)
         app.buttons["Done"].tap()
 
-        waitForNoExistence(app.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
-        waitForNoExistence(app.collectionViews.cells.staticTexts["YouTube"])
+        mozWaitForElementToNotExist(app.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
+        mozWaitForElementToNotExist(app.collectionViews.cells.staticTexts["YouTube"])
     }
 
     func testChangeHomeSettingsLabel() {
@@ -180,7 +180,7 @@ class HomePageSettingsUITests: BaseTestCase {
 
     // Function to check the number of top sites shown given a selected number of rows
     private func checkNumberOfExpectedTopSites(numberOfExpectedTopSites: Int) {
-        waitForExistence(app.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
+        mozWaitForElementToExist(app.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
         XCTAssertTrue(app.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell].exists)
         let numberOfTopSites = app.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell].collectionViews.cells.count
         XCTAssertEqual(numberOfTopSites, numberOfExpectedTopSites)
@@ -194,15 +194,15 @@ class HomePageSettingsUITests: BaseTestCase {
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.nowAt(NewTabScreen)
         if !iPad() {
-            waitForExistence(app.buttons["urlBar-cancel"], timeout: 5)
+            mozWaitForElementToExist(app.buttons["urlBar-cancel"], timeout: 5)
             navigator.performAction(Action.CloseURLBarOpen)
         }
-        waitForExistence(app.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.jumpBackIn], timeout: 5)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.jumpBackIn], timeout: 5)
         XCTAssertTrue(app.otherElements.cells[AccessibilityIdentifiers.FirefoxHomepage.JumpBackIn.itemCell].staticTexts[urlExampleLabel].exists)
-        waitForExistence(app.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.jumpBackIn], timeout: 5)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.jumpBackIn], timeout: 5)
         app.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.jumpBackIn].tap()
         // Tab tray is open with recently open tab
-        waitForExistence(app.otherElements.cells[AccessibilityIdentifiers.FirefoxHomepage.JumpBackIn.itemCell].staticTexts[urlExampleLabel], timeout: 3)
+        mozWaitForElementToExist(app.otherElements.cells[AccessibilityIdentifiers.FirefoxHomepage.JumpBackIn.itemCell].staticTexts[urlExampleLabel], timeout: 3)
         app.buttons["Done"].tap()
         // Validation for when Jump In section is not displayed
         navigator.nowAt(NewTabScreen)
@@ -210,7 +210,7 @@ class HomePageSettingsUITests: BaseTestCase {
         app.tables.cells.switches["Jump Back In"].tap()
         app.buttons["Done"].tap()
         navigator.nowAt(NewTabScreen)
-        waitForNoExistence(app.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.jumpBackIn])
+        mozWaitForElementToNotExist(app.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.jumpBackIn])
     }
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/1548962
@@ -231,7 +231,7 @@ class HomePageSettingsUITests: BaseTestCase {
         }
         XCTAssertFalse(app.scrollViews.cells[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.recentlySaved].exists)
         if !iPad() {
-            waitForExistence(app.buttons["urlBar-cancel"], timeout: 3)
+            mozWaitForElementToExist(app.buttons["urlBar-cancel"], timeout: 3)
             navigator.performAction(Action.CloseURLBarOpen)
         }
         navigator.nowAt(NewTabScreen)
@@ -239,7 +239,7 @@ class HomePageSettingsUITests: BaseTestCase {
         navigator.nowAt(HomeSettings)
         navigator.performAction(Action.OpenNewTabFromTabTray)
         if !iPad() {
-            waitForExistence(app.buttons["urlBar-cancel"], timeout: 3)
+            mozWaitForElementToExist(app.buttons["urlBar-cancel"], timeout: 3)
             navigator.performAction(Action.CloseURLBarOpen)
         }
         checkRecentlySaved()
@@ -261,7 +261,7 @@ class HomePageSettingsUITests: BaseTestCase {
         navigator.openURL(websiteUrl1)
         waitUntilPageLoad()
         navigator.performAction(Action.GoToHomePage)
-        waitForExistence(app.scrollViews.cells[AccessibilityIdentifiers.FirefoxHomepage.HistoryHighlights.itemCell].staticTexts[urlMozillaLabel])
+        mozWaitForElementToExist(app.scrollViews.cells[AccessibilityIdentifiers.FirefoxHomepage.HistoryHighlights.itemCell].staticTexts[urlMozillaLabel])
         navigator.goto(HomeSettings)
         navigator.performAction(Action.ToggleRecentlyVisited)
 
@@ -275,7 +275,7 @@ class HomePageSettingsUITests: BaseTestCase {
 
         XCTAssertFalse(app.scrollViews.cells[AccessibilityIdentifiers.FirefoxHomepage.HistoryHighlights.itemCell].staticTexts[urlMozillaLabel].exists)
         if !iPad() {
-            waitForExistence(app.buttons["urlBar-cancel"], timeout: 3)
+            mozWaitForElementToExist(app.buttons["urlBar-cancel"], timeout: 3)
             navigator.performAction(Action.CloseURLBarOpen)
         }
         navigator.nowAt(NewTabScreen)
@@ -297,15 +297,15 @@ class HomePageSettingsUITests: BaseTestCase {
 
     func testCustomizeHomepage() {
         if !iPad() {
-            waitForExistence(app.collectionViews["FxCollectionView"], timeout: TIMEOUT)
+            mozWaitForElementToExist(app.collectionViews["FxCollectionView"], timeout: TIMEOUT)
             app.collectionViews["FxCollectionView"].swipeUp()
             app.collectionViews["FxCollectionView"].swipeUp()
             app.collectionViews["FxCollectionView"].swipeUp()
-            waitForExistence(app.cells.otherElements.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.customizeHomePage], timeout: TIMEOUT)
+            mozWaitForElementToExist(app.cells.otherElements.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.customizeHomePage], timeout: TIMEOUT)
         }
         app.cells.otherElements.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.customizeHomePage].tap()
         // Verify default settings
-        waitForExistence(app.navigationBars[AccessibilityIdentifiers.Settings.Homepage.homePageNavigationBar], timeout: TIMEOUT_LONG)
+        mozWaitForElementToExist(app.navigationBars[AccessibilityIdentifiers.Settings.Homepage.homePageNavigationBar], timeout: TIMEOUT_LONG)
         XCTAssertTrue(app.tables.cells[AccessibilityIdentifiers.Settings.Homepage.StartAtHome.always].exists)
         XCTAssertTrue(app.tables.cells[AccessibilityIdentifiers.Settings.Homepage.StartAtHome.disabled].exists)
         XCTAssertTrue(app.tables.cells[AccessibilityIdentifiers.Settings.Homepage.StartAtHome.afterFourHours].exists)

--- a/Tests/XCUITests/IntegrationTests.swift
+++ b/Tests/XCUITests/IntegrationTests.swift
@@ -54,8 +54,8 @@ class IntegrationTests: BaseTestCase {
         navigator.goto(Intro_FxASignin)
         navigator.performAction(Action.OpenEmailToSignIn)
         sleep(5)
-        waitForExistence(app.navigationBars[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaNavigationBar], timeout: TIMEOUT_LONG)
-        waitForExistence(app.staticTexts["Continue to Firefox accounts"], timeout: TIMEOUT_LONG)
+        mozWaitForElementToExist(app.navigationBars[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaNavigationBar], timeout: TIMEOUT_LONG)
+        mozWaitForElementToExist(app.staticTexts["Continue to Firefox accounts"], timeout: TIMEOUT_LONG)
         userState.fxaUsername = ProcessInfo.processInfo.environment["FXA_EMAIL"]!
         userState.fxaPassword = ProcessInfo.processInfo.environment["FXA_PASSWORD"]!
         navigator.performAction(Action.FxATypeEmail)
@@ -70,14 +70,14 @@ class IntegrationTests: BaseTestCase {
     private func waitForInitialSyncComplete() {
         navigator.nowAt(BrowserTab)
         navigator.goto(SettingsScreen)
-        waitForExistence(app.staticTexts["FIREFOX ACCOUNT"], timeout: TIMEOUT_LONG)
-        waitForNoExistence(app.staticTexts["Sync and Save Data"])
+        mozWaitForElementToExist(app.staticTexts["FIREFOX ACCOUNT"], timeout: TIMEOUT_LONG)
+        mozWaitForElementToNotExist(app.staticTexts["Sync and Save Data"])
         sleep(5)
         if app.tables.staticTexts["Sync Now"].exists {
             app.tables.staticTexts["Sync Now"].tap()
         }
-        waitForNoExistence(app.tables.staticTexts["Syncing…"])
-        waitForExistence(app.tables.staticTexts["Sync Now"], timeout: TIMEOUT_LONG)
+        mozWaitForElementToNotExist(app.tables.staticTexts["Syncing…"])
+        mozWaitForElementToExist(app.tables.staticTexts["Sync Now"], timeout: TIMEOUT_LONG)
     }
 
     func testFxASyncHistory () {
@@ -97,19 +97,19 @@ class IntegrationTests: BaseTestCase {
         navigator.goto(Intro_FxASignin)
         navigator.performAction(Action.OpenEmailToSignIn)
 
-        waitForExistence(app.navigationBars[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaNavigationBar], timeout: TIMEOUT_LONG)
-        waitForExistence(app.webViews.staticTexts["Continue to Firefox accounts"], timeout: TIMEOUT_LONG)
-        waitForExistence(app.webViews.textFields[AccessibilityIdentifiers.Settings.FirefoxAccount.emailTextField])
-        waitForExistence(app.webViews.buttons[AccessibilityIdentifiers.Settings.FirefoxAccount.continueButton])
+        mozWaitForElementToExist(app.navigationBars[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaNavigationBar], timeout: TIMEOUT_LONG)
+        mozWaitForElementToExist(app.webViews.staticTexts["Continue to Firefox accounts"], timeout: TIMEOUT_LONG)
+        mozWaitForElementToExist(app.webViews.textFields[AccessibilityIdentifiers.Settings.FirefoxAccount.emailTextField])
+        mozWaitForElementToExist(app.webViews.buttons[AccessibilityIdentifiers.Settings.FirefoxAccount.continueButton])
     }
 
     func testFxASyncBookmark () {
         // Bookmark is added by the DB
         // Sign into Firefox Accounts
         navigator.openURL("example.com")
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection], timeout: 5)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection], timeout: 5)
         navigator.goto(BrowserTabMenu)
-        waitForExistence(app.tables.otherElements[StandardImageIdentifiers.Large.bookmark], timeout: 15)
+        mozWaitForElementToExist(app.tables.otherElements[StandardImageIdentifiers.Large.bookmark], timeout: 15)
         app.tables.otherElements[StandardImageIdentifiers.Large.bookmark].tap()
         navigator.nowAt(BrowserTab)
         signInFxAccounts()
@@ -125,7 +125,7 @@ class IntegrationTests: BaseTestCase {
         // Wait for initial sync to complete
         waitForInitialSyncComplete()
         navigator.goto(LibraryPanel_Bookmarks)
-        waitForExistence(app.tables["Bookmarks List"].cells.staticTexts["Example Domain"], timeout: 5)
+        mozWaitForElementToExist(app.tables["Bookmarks List"].cells.staticTexts["Example Domain"], timeout: 5)
     }
 
     func testFxASyncTabs () {
@@ -138,16 +138,16 @@ class IntegrationTests: BaseTestCase {
         navigator.nowAt(BrowserTab)
         // This is only to check that the device's name changed
         navigator.goto(SettingsScreen)
-        waitForExistence(app.tables.cells.element(boundBy: 1), timeout: 10)
+        mozWaitForElementToExist(app.tables.cells.element(boundBy: 1), timeout: 10)
         app.tables.cells.element(boundBy: 1).tap()
-        waitForExistence(app.cells["DeviceNameSetting"].textFields["DeviceNameSettingTextField"], timeout: 10)
+        mozWaitForElementToExist(app.cells["DeviceNameSetting"].textFields["DeviceNameSettingTextField"], timeout: 10)
         XCTAssertEqual(app.cells["DeviceNameSetting"].textFields["DeviceNameSettingTextField"].value! as! String, "Fennec (administrator) on iOS")
 
         // Sync again just to make sure to sync after new name is shown
         app.buttons["Settings"].tap()
-        waitForExistence(app.staticTexts["FIREFOX ACCOUNT"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.staticTexts["FIREFOX ACCOUNT"], timeout: TIMEOUT)
         app.tables.cells.element(boundBy: 2).tap()
-        waitForExistence(app.tables.staticTexts["Sync Now"], timeout: TIMEOUT_LONG)
+        mozWaitForElementToExist(app.tables.staticTexts["Sync Now"], timeout: TIMEOUT_LONG)
     }
 
     func testFxASyncLogins () {
@@ -155,18 +155,18 @@ class IntegrationTests: BaseTestCase {
         waitUntilPageLoad()
 
         // Log in in order to save it
-        waitForExistence(app.webViews.textFields["Email or phone"])
+        mozWaitForElementToExist(app.webViews.textFields["Email or phone"])
         app.webViews.textFields["Email or phone"].tap()
         app.webViews.textFields["Email or phone"].typeText(userName)
         app.webViews.buttons["Next"].tap()
-        waitForExistence(app.webViews.secureTextFields["Password"])
+        mozWaitForElementToExist(app.webViews.secureTextFields["Password"])
         app.webViews.secureTextFields["Password"].tap()
         app.webViews.secureTextFields["Password"].typeText(userPassword)
 
         app.webViews.buttons["Sign in"].tap()
 
         // Save the login
-        waitForExistence(app.buttons["SaveLoginPrompt.saveLoginButton"])
+        mozWaitForElementToExist(app.buttons["SaveLoginPrompt.saveLoginButton"])
         app.buttons["SaveLoginPrompt.saveLoginButton"].tap()
 
         // Sign in with FxAccount
@@ -184,7 +184,7 @@ class IntegrationTests: BaseTestCase {
 
         // Check synced History
         navigator.goto(LibraryPanel_History)
-        waitForExistence(app.tables.cells.staticTexts[historyItemSavedOnDesktop], timeout: 5)
+        mozWaitForElementToExist(app.tables.cells.staticTexts[historyItemSavedOnDesktop], timeout: 5)
     }
 
     func testFxASyncPasswordDesktop () {
@@ -197,7 +197,7 @@ class IntegrationTests: BaseTestCase {
         // Check synced Logins
         navigator.nowAt(SettingsScreen)
         navigator.goto(LoginsSettings)
-        waitForExistence(app.buttons.firstMatch)
+        mozWaitForElementToExist(app.buttons.firstMatch)
         app.buttons["Continue"].tap()
 
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
@@ -206,7 +206,7 @@ class IntegrationTests: BaseTestCase {
         passcodeInput.typeText("foo\n")
 
         navigator.goto(LoginsSettings)
-        waitForExistence(app.tables["Login List"], timeout: 5)
+        mozWaitForElementToExist(app.tables["Login List"], timeout: 5)
         XCTAssertTrue(app.tables.cells.staticTexts[loginEntry].exists, "The login saved on desktop is not synced")
     }
 
@@ -225,7 +225,7 @@ class IntegrationTests: BaseTestCase {
 
         // Need to swipe to get the data on the screen on focus
         app.swipeDown()
-        waitForExistence(app.tables.otherElements["profile1"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.tables.otherElements["profile1"], timeout: TIMEOUT)
         XCTAssertTrue(app.tables.staticTexts[tabOpenInDesktop].exists, "The tab is not synced")
     }
 
@@ -238,8 +238,8 @@ class IntegrationTests: BaseTestCase {
         navigator.nowAt(SettingsScreen)
         // Check Bookmarks
         navigator.goto(LibraryPanel_Bookmarks)
-        waitForExistence(app.tables["Bookmarks List"], timeout: 3)
-        waitForExistence(app.tables["Bookmarks List"].cells.staticTexts["Example Domain"], timeout: 5)
+        mozWaitForElementToExist(app.tables["Bookmarks List"], timeout: 3)
+        mozWaitForElementToExist(app.tables["Bookmarks List"].cells.staticTexts["Example Domain"], timeout: 5)
 
         // Check Login
         navigator.performAction(Action.CloseBookmarkPanel)
@@ -249,7 +249,7 @@ class IntegrationTests: BaseTestCase {
         navigator.goto(SettingsScreen)
         navigator.nowAt(SettingsScreen)
         navigator.goto(LoginsSettings)
-        waitForExistence(app.buttons.firstMatch)
+        mozWaitForElementToExist(app.buttons.firstMatch)
         app.buttons["Continue"].tap()
 
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
@@ -257,18 +257,18 @@ class IntegrationTests: BaseTestCase {
         passcodeInput.tap()
         passcodeInput.typeText("foo\n")
 
-        waitForExistence(app.tables["Login List"], timeout: 3)
+        mozWaitForElementToExist(app.tables["Login List"], timeout: 3)
         // Verify the login
-        waitForExistence(app.staticTexts["https://accounts.google.com"])
+        mozWaitForElementToExist(app.staticTexts["https://accounts.google.com"])
 
         // Disconnect account
         navigator.goto(SettingsScreen)
         app.tables.cells.element(boundBy: 1).tap()
-        waitForExistence(app.cells["DeviceNameSetting"].textFields["DeviceNameSettingTextField"], timeout: 10)
+        mozWaitForElementToExist(app.cells["DeviceNameSetting"].textFields["DeviceNameSettingTextField"], timeout: 10)
 
         app.cells["SignOut"].tap()
 
-        waitForExistence(app.buttons["Disconnect"], timeout: 5)
+        mozWaitForElementToExist(app.buttons["Disconnect"], timeout: 5)
         app.buttons["Disconnect"].tap()
         sleep(3)
 
@@ -277,21 +277,21 @@ class IntegrationTests: BaseTestCase {
         app.tables.cells["SignInToSync"].tap()
         app.buttons["EmailSignIn.button"].tap()
 
-        waitForExistence(app.secureTextFields.element(boundBy: 0), timeout: 10)
+        mozWaitForElementToExist(app.secureTextFields.element(boundBy: 0), timeout: 10)
         app.secureTextFields.element(boundBy: 0).tap()
         app.secureTextFields.element(boundBy: 0).typeText(userState.fxaPassword!)
-        waitForExistence(app.webViews.buttons.element(boundBy: 0), timeout: 5)
+        mozWaitForElementToExist(app.webViews.buttons.element(boundBy: 0), timeout: 5)
         app.webViews.buttons.element(boundBy: 0).tap()
 
         navigator.nowAt(SettingsScreen)
-        waitForExistence(app.staticTexts["GENERAL"])
+        mozWaitForElementToExist(app.staticTexts["GENERAL"])
         app.swipeDown()
-        waitForExistence(app.staticTexts["FIREFOX ACCOUNT"], timeout: TIMEOUT)
-        waitForExistence(app.tables.staticTexts["Sync Now"], timeout: 35)
+        mozWaitForElementToExist(app.staticTexts["FIREFOX ACCOUNT"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.tables.staticTexts["Sync Now"], timeout: 35)
 
         // Check Bookmarks
         navigator.goto(LibraryPanel_Bookmarks)
-        waitForExistence(app.tables["Bookmarks List"].cells.staticTexts["Example Domain"], timeout: 5)
+        mozWaitForElementToExist(app.tables["Bookmarks List"].cells.staticTexts["Example Domain"], timeout: 5)
 
         // Check Logins
         navigator.performAction(Action.CloseBookmarkPanel)
@@ -303,7 +303,7 @@ class IntegrationTests: BaseTestCase {
         passcodeInput.tap()
         passcodeInput.typeText("foo\n")
 
-        waitForExistence(app.tables["Login List"], timeout: 10)
-        waitForExistence(app.staticTexts["https://accounts.google.com"], timeout: 10)
+        mozWaitForElementToExist(app.tables["Login List"], timeout: 10)
+        mozWaitForElementToExist(app.staticTexts["https://accounts.google.com"], timeout: 10)
     }
 }

--- a/Tests/XCUITests/JumpBackInTests.swift
+++ b/Tests/XCUITests/JumpBackInTests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 class JumpBackInTests: BaseTestCase {
     func closeKeyboard() {
-        waitForExistence(app.buttons["urlBar-cancel"])
+        mozWaitForElementToExist(app.buttons["urlBar-cancel"])
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
@@ -41,7 +41,7 @@ class JumpBackInTests: BaseTestCase {
         closeKeyboard()
 
         // "Jump Back In" section is displayed
-        waitForExistence(app.cells["JumpBackInCell"].firstMatch, timeout: TIMEOUT)
+        mozWaitForElementToExist(app.cells["JumpBackInCell"].firstMatch, timeout: TIMEOUT)
         // The contextual hint box is not displayed consistently, so
         // I don't test for its existence.
     }
@@ -54,14 +54,14 @@ class JumpBackInTests: BaseTestCase {
 //
 //        // Open a new tab and check the "Jump Back In" section
 //        navigator.goto(TabTray)
-//        waitForExistence(app.buttons[AccessibilityIdentifiers.TabTray.newTabButton], timeout: TIMEOUT)
+//        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.TabTray.newTabButton], timeout: TIMEOUT)
 //        navigator.performAction(Action.OpenNewTabFromTabTray)
 //        closeKeyboard()
 //
 //        // Twitter tab is visible in the "Jump Back In" section
 //        scrollDown()
-//        waitForExistence(app.cells["JumpBackInCell"].firstMatch)
-//        waitForExistence(app.cells["JumpBackInCell"].staticTexts["Twitter"])
+//        mozWaitForElementToExist(app.cells["JumpBackInCell"].firstMatch)
+//        mozWaitForElementToExist(app.cells["JumpBackInCell"].staticTexts["Twitter"])
 //
 //        // Open private browsing
 //        navigator.goto(TabTray)
@@ -79,25 +79,25 @@ class JumpBackInTests: BaseTestCase {
 //
 //        // Twitter should be in "Jump Back In"
 //        scrollDown()
-//        waitForExistence(app.cells["JumpBackInCell"].firstMatch)
-//        waitForExistence(app.cells["JumpBackInCell"].staticTexts["Twitter"])
-//        waitForNoExistence(app.cells["JumpBackInCell"].staticTexts["YouTube"])
+//        mozWaitForElementToExist(app.cells["JumpBackInCell"].firstMatch)
+//        mozWaitForElementToExist(app.cells["JumpBackInCell"].staticTexts["Twitter"])
+//        mozWaitForElementToNotExist(app.cells["JumpBackInCell"].staticTexts["YouTube"])
 //
 //        // Visit "amazon.com" and check the "Jump Back In" section
 //        navigator.openURL("https://www.amazon.com")
 //        waitUntilPageLoad()
 //
 //        navigator.goto(TabTray)
-//        waitForExistence(app.buttons[AccessibilityIdentifiers.TabTray.newTabButton], timeout: TIMEOUT)
+//        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.TabTray.newTabButton], timeout: TIMEOUT)
 //        navigator.performAction(Action.OpenNewTabFromTabTray)
 //        closeKeyboard()
 //
 //        // Amazon and Twitter are visible in the "Jump Back In" section
 //        scrollDown()
-//        waitForExistence(app.cells["JumpBackInCell"].firstMatch)
-//        waitForExistence(app.cells["JumpBackInCell"].staticTexts["Amazon"])
-//        waitForExistence(app.cells["JumpBackInCell"].staticTexts["Twitter"])
-//        waitForNoExistence(app.cells["JumpBackInCell"].staticTexts["YouTube"])
+//        mozWaitForElementToExist(app.cells["JumpBackInCell"].firstMatch)
+//        mozWaitForElementToExist(app.cells["JumpBackInCell"].staticTexts["Amazon"])
+//        mozWaitForElementToExist(app.cells["JumpBackInCell"].staticTexts["Twitter"])
+//        mozWaitForElementToNotExist(app.cells["JumpBackInCell"].staticTexts["YouTube"])
 //
 //        // Tap on Twitter from "Jump Back In"
 //        app.cells["JumpBackInCell"].staticTexts["Twitter"].tap()
@@ -108,37 +108,37 @@ class JumpBackInTests: BaseTestCase {
 //
 //        // Open a new tab in normal browsing
 //        navigator.goto(TabTray)
-//        waitForExistence(app.buttons[AccessibilityIdentifiers.TabTray.newTabButton], timeout: TIMEOUT)
+//        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.TabTray.newTabButton], timeout: TIMEOUT)
 //        navigator.performAction(Action.OpenNewTabFromTabTray)
 //        closeKeyboard()
 //
 //        // Check the "Jump Back In Section"
 //        scrollDown()
-//        waitForExistence(app.cells["JumpBackInCell"].firstMatch)
+//        mozWaitForElementToExist(app.cells["JumpBackInCell"].firstMatch)
 //
 //        // Amazon is visible in "Jump Back In"
-//        waitForExistence(app.cells["JumpBackInCell"].staticTexts["Amazon"])
+//        mozWaitForElementToExist(app.cells["JumpBackInCell"].staticTexts["Amazon"])
 //
 //        // Close the amazon tab
 //        navigator.goto(TabTray)
 //        if isTablet {
-//            waitForExistence(app.navigationBars.segmentedControls["navBarTabTray"])
+//            mozWaitForElementToExist(app.navigationBars.segmentedControls["navBarTabTray"])
 //        } else {
-//            waitForExistence(app.navigationBars.staticTexts["Open Tabs"])
+//            mozWaitForElementToExist(app.navigationBars.staticTexts["Open Tabs"])
 //        }
 //        app.cells["Amazon.com. Spend less. Smile more."].buttons[StandardImageIdentifiers.Large.cross].tap()
 //
 //        // Revisit the "Jump Back In" section
-//        waitForExistence(app.buttons[AccessibilityIdentifiers.TabTray.newTabButton], timeout: TIMEOUT)
+//        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.TabTray.newTabButton], timeout: TIMEOUT)
 //        navigator.performAction(Action.OpenNewTabFromTabTray)
 //        closeKeyboard()
 //
 //        // The "Jump Back In" section is still here with twitter listed
 //        scrollDown()
-//        waitForExistence(app.cells["JumpBackInCell"].firstMatch)
+//        mozWaitForElementToExist(app.cells["JumpBackInCell"].firstMatch)
 //        // FXIOS-5448 - Amazon should not be listed because we've closed the Amazon tab
-//        // waitForNoExistence(app.cells["JumpBackInCell"].staticTexts["Amazon"])
-//        waitForExistence(app.cells["JumpBackInCell"].staticTexts["Twitter"])
-//        waitForNoExistence(app.cells["JumpBackInCell"].staticTexts["YouTube"])
+//        // mozWaitForElementToNotExist(app.cells["JumpBackInCell"].staticTexts["Amazon"])
+//        mozWaitForElementToExist(app.cells["JumpBackInCell"].staticTexts["Twitter"])
+//        mozWaitForElementToNotExist(app.cells["JumpBackInCell"].staticTexts["YouTube"])
     }
 }

--- a/Tests/XCUITests/LibraryTests.swift
+++ b/Tests/XCUITests/LibraryTests.swift
@@ -8,13 +8,13 @@ class LibraryTestsIpad: IpadOnlyTestCase {
     func testLibraryShortcut() {
         if skipPlatform {return}
         // Open Library from shortcut
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.bookmarksButton])
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.bookmarksButton])
         let libraryShorcutButton = app.buttons[AccessibilityIdentifiers.Toolbar.bookmarksButton]
         libraryShorcutButton.tap()
         navigator.nowAt(HomePanel_Library)
-        waitForExistence(app.tables["Bookmarks List"])
+        mozWaitForElementToExist(app.tables["Bookmarks List"])
         // Go to a different panel, like History
         navigator.goto(LibraryPanel_History)
-        waitForExistence(app.tables[AccessibilityIdentifiers.LibraryPanels.HistoryPanel.tableView])
+        mozWaitForElementToExist(app.tables[AccessibilityIdentifiers.LibraryPanels.HistoryPanel.tableView])
     }
 }

--- a/Tests/XCUITests/MailAppSettingsTests.swift
+++ b/Tests/XCUITests/MailAppSettingsTests.swift
@@ -11,7 +11,7 @@ class MailAppSettingsTests: BaseTestCase {
         navigator.goto(OpenWithSettings)
 
         // Check that the list is shown
-        waitForExistence(app.tables["OpenWithPage.Setting.Options"])
+        mozWaitForElementToExist(app.tables["OpenWithPage.Setting.Options"])
         XCTAssertTrue(app.tables["OpenWithPage.Setting.Options"].exists)
 
         // Check that the list is shown with all elements disabled
@@ -27,7 +27,7 @@ class MailAppSettingsTests: BaseTestCase {
         XCTAssertFalse(app.tables.cells.staticTexts["Fastmail"].isSelected)
 
         // Check that tapping on an element does nothing
-        waitForExistence(app.tables["OpenWithPage.Setting.Options"])
+        mozWaitForElementToExist(app.tables["OpenWithPage.Setting.Options"])
         app.tables.cells.staticTexts["Airmail"].tap()
         XCTAssertFalse(app.tables.cells.staticTexts["Airmail"].isSelected)
 

--- a/Tests/XCUITests/NavigationTest.swift
+++ b/Tests/XCUITests/NavigationTest.swift
@@ -53,7 +53,7 @@ class NavigationTest: BaseTestCase {
             app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].tap()
         } else {
             // Go forward to next visited web site
-            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton])
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton])
             app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].tap()
         }
         waitUntilPageLoad()
@@ -75,7 +75,7 @@ class NavigationTest: BaseTestCase {
         navigator.goto(SettingsScreen)
         // Open FxAccount from settings menu and check the Sign in to Firefox screen
         let signInToFirefoxStaticText = app.tables[AccessibilityIdentifiers.Settings.tableViewController].staticTexts[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaSettingsButton]
-        waitForExistence(signInToFirefoxStaticText)
+        mozWaitForElementToExist(signInToFirefoxStaticText)
         signInToFirefoxStaticText.tap()
         checkFirefoxSyncScreenShownViaSettings()
 
@@ -89,9 +89,9 @@ class NavigationTest: BaseTestCase {
 
     // Because the Settings menu does not stretch tot the top we need a different function to check if the Firefox Sync screen is shown
     private func checkFirefoxSyncScreenShownViaSettings() {
-        waitForExistence(app.navigationBars[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaNavigationBar], timeout: TIMEOUT_LONG)
+        mozWaitForElementToExist(app.navigationBars[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaNavigationBar], timeout: TIMEOUT_LONG)
         app.buttons["EmailSignIn.button"].tap()
-        waitForExistence(app.webViews.textFields.element(boundBy: 0), timeout: TIMEOUT_LONG)
+        mozWaitForElementToExist(app.webViews.textFields.element(boundBy: 0), timeout: TIMEOUT_LONG)
 
         let email = app.webViews.textFields.element(boundBy: 0)
         // Verify the placeholdervalues here for the textFields
@@ -113,7 +113,7 @@ class NavigationTest: BaseTestCase {
 
     private func checkFirefoxSyncScreenShown() {
         // Disable check, page load issues on iOS13.3 sims, issue #5937
-        waitForExistence(app.webViews.firstMatch, timeout: TIMEOUT_LONG)
+        mozWaitForElementToExist(app.webViews.firstMatch, timeout: TIMEOUT_LONG)
     }
 
     func testScrollsToTopWithMultipleTabs() {
@@ -134,15 +134,15 @@ class NavigationTest: BaseTestCase {
 
         // Scroll to top
         topElement.tap()
-        waitForExistence(topElement)
+        mozWaitForElementToExist(topElement)
     }
 
     // Smoketest
     func testLongPressLinkOptions() {
         navigator.openURL(path(forTestPage: "test-example.html"))
-        waitForExistence(app.webViews.links[website_2["link"]!], timeout: TIMEOUT_LONG)
+        mozWaitForElementToExist(app.webViews.links[website_2["link"]!], timeout: TIMEOUT_LONG)
         app.webViews.links[website_2["link"]!].press(forDuration: 2)
-        waitForExistence(app.otherElements.collectionViews.element(boundBy: 0), timeout: TIMEOUT)
+        mozWaitForElementToExist(app.otherElements.collectionViews.element(boundBy: 0), timeout: TIMEOUT)
 
         XCTAssertTrue(app.buttons["Open in New Tab"].exists, "The option is not shown")
         XCTAssertTrue(app.buttons["Open in New Private Tab"].exists, "The option is not shown")
@@ -158,7 +158,7 @@ class NavigationTest: BaseTestCase {
         navigator.goto(NewTabScreen)
         app.textFields["url"].press(forDuration: 2)
 
-        waitForExistence(app.tables["Context Menu"])
+        mozWaitForElementToExist(app.tables["Context Menu"])
         app.tables.otherElements[AccessibilityIdentifiers.Photon.pasteAction].tap()
         app.buttons["Go"].tap()
         waitUntilPageLoad()
@@ -170,11 +170,11 @@ class NavigationTest: BaseTestCase {
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         longPressLinkOptions(optionSelected: "Copy Link")
         navigator.goto(NewTabScreen)
-        waitForExistence(app.textFields["url"])
+        mozWaitForElementToExist(app.textFields["url"])
         app.textFields["url"].press(forDuration: 2)
 
         app.tables.otherElements[AccessibilityIdentifiers.Photon.pasteAction].tap()
-        waitForExistence(app.buttons["Go"])
+        mozWaitForElementToExist(app.buttons["Go"])
         app.buttons["Go"].tap()
         waitUntilPageLoad()
         waitForValueContains(app.textFields["url"], value: website_2["moreLinkLongPressInfo"]!)
@@ -189,15 +189,15 @@ class NavigationTest: BaseTestCase {
             app.textFields["address"].typeText("www.google.com")
             // Tapping two times when the text is not selected will reveal the menu
             app.textFields["address"].tap()
-            waitForExistence(app.textFields["address"])
+            mozWaitForElementToExist(app.textFields["address"])
             app.textFields["address"].tap()
-            waitForExistence(app.menuItems["Select All"])
+            mozWaitForElementToExist(app.menuItems["Select All"])
             XCTAssertTrue(app.menuItems["Select All"].exists)
             XCTAssertTrue(app.menuItems["Select"].exists)
 
             // Tap on Select All option and make sure Copy, Cut, Paste, and Look Up are shown
             app.menuItems["Select All"].tap()
-            waitForExistence(app.menuItems["Copy"])
+            mozWaitForElementToExist(app.menuItems["Copy"])
             if iPad() {
                 XCTAssertTrue(app.menuItems["Copy"].exists)
                 XCTAssertTrue(app.menuItems["Cut"].exists)
@@ -215,7 +215,7 @@ class NavigationTest: BaseTestCase {
 
             app.textFields["address"].typeText("\n")
             waitUntilPageLoad()
-            waitForNoExistence(app.staticTexts["XCUITests-Runner pasted from Fennec"])
+            mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
 
             app.textFields["url"].press(forDuration: 3)
             app.tables.otherElements[StandardImageIdentifiers.Large.link].tap()
@@ -224,9 +224,9 @@ class NavigationTest: BaseTestCase {
             app.textFields["url"].tap()
             // Since the textField value appears all selected first time is clicked
             // this workaround is necessary
-            waitForNoExistence(app.staticTexts["XCUITests-Runner pasted from Fennec"])
+            mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
             app.textFields["address"].tap()
-            waitForExistence(app.menuItems["Copy"])
+            mozWaitForElementToExist(app.menuItems["Copy"])
             if iPad() {
                 XCTAssertTrue(app.menuItems["Cut"].exists)
                 XCTAssertTrue(app.menuItems["Copy"].exists)
@@ -259,12 +259,12 @@ class NavigationTest: BaseTestCase {
 
     func testDownloadLink() {
         longPressLinkOptions(optionSelected: "Download Link")
-        waitForExistence(app.tables["Context Menu"])
+        mozWaitForElementToExist(app.tables["Context Menu"])
         XCTAssertTrue(app.tables["Context Menu"].otherElements[StandardImageIdentifiers.Large.download].exists)
         app.tables["Context Menu"].otherElements[StandardImageIdentifiers.Large.download].tap()
         navigator.goto(BrowserTabMenu)
         navigator.goto(LibraryPanel_Downloads)
-        waitForExistence(app.tables["DownloadsTable"])
+        mozWaitForElementToExist(app.tables["DownloadsTable"])
         // There should be one item downloaded. It's name and size should be shown
         let downloadedList = app.tables["DownloadsTable"].cells.count
         XCTAssertEqual(downloadedList, 1, "The number of items in the downloads table is not correct")
@@ -278,7 +278,7 @@ class NavigationTest: BaseTestCase {
 
     func testShareLink() {
         longPressLinkOptions(optionSelected: "Share Link")
-        waitForExistence(app.cells["Copy"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.cells["Copy"], timeout: TIMEOUT)
         XCTAssertTrue(app.cells["Copy"].exists, "The share menu is not shown")
     }
 
@@ -286,7 +286,7 @@ class NavigationTest: BaseTestCase {
         navigator.nowAt(NewTabScreen)
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         longPressLinkOptions(optionSelected: "Share Link")
-        waitForExistence(app.cells["Copy"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.cells["Copy"], timeout: TIMEOUT)
         XCTAssertTrue(app.cells["Copy"].exists, "The share menu is not shown")
     }
 
@@ -295,9 +295,9 @@ class NavigationTest: BaseTestCase {
         throw XCTSkip("This test is flakey")
 //        // Check that it is enabled by default
 //        navigator.nowAt(BrowserTab)
-//        waitForExistence(app.buttons["TabToolbar.menuButton"], timeout: TIMEOUT)
+//        mozWaitForElementToExist(app.buttons["TabToolbar.menuButton"], timeout: TIMEOUT)
 //        navigator.goto(SettingsScreen)
-//        waitForExistence(app.tables[AccessibilityIdentifiers.Settings.tableViewController])
+//        mozWaitForElementToExist(app.tables[AccessibilityIdentifiers.Settings.tableViewController])
 //        let switchBlockPopUps = app.tables.cells.switches["blockPopups"]
 //        let switchValue = switchBlockPopUps.value!
 //        XCTAssertEqual(switchValue as? String, "1")
@@ -305,7 +305,7 @@ class NavigationTest: BaseTestCase {
 //        // Check that there are no pop ups
 //        navigator.openURL(popUpTestUrl)
 //        waitForValueContains(app.textFields["url"], value: "blocker.html")
-//        waitForExistence(app.webViews.staticTexts["Blocked Element"])
+//        mozWaitForElementToExist(app.webViews.staticTexts["Blocked Element"])
 //
 //        let numTabs = app.buttons["Show Tabs"].value
 //        XCTAssertEqual("1", numTabs as? String, "There should be only on tab")
@@ -313,7 +313,7 @@ class NavigationTest: BaseTestCase {
 //        // Now disable the Block PopUps option
 //        navigator.goto(BrowserTabMenu)
 //        navigator.goto(SettingsScreen)
-//        waitForExistence(switchBlockPopUps, timeout: TIMEOUT)
+//        mozWaitForElementToExist(switchBlockPopUps, timeout: TIMEOUT)
 //        switchBlockPopUps.tap()
 //        let switchValueAfter = switchBlockPopUps.value!
 //        XCTAssertEqual(switchValueAfter as? String, "0")
@@ -331,12 +331,12 @@ class NavigationTest: BaseTestCase {
         navigator.nowAt(NewTabScreen)
 
         navigator.openURL("https://expired.badssl.com/")
-        waitForExistence(app.buttons["Advanced"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.buttons["Advanced"], timeout: TIMEOUT)
         app.buttons["Advanced"].tap()
 
-        waitForExistence(app.links["Visit site anyway"])
+        mozWaitForElementToExist(app.links["Visit site anyway"])
         app.links["Visit site anyway"].tap()
-        waitForExistence(app.webViews.otherElements["expired.badssl.com"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.webViews.otherElements["expired.badssl.com"], timeout: TIMEOUT)
         XCTAssertTrue(app.webViews.otherElements["expired.badssl.com"].exists)
     }
 
@@ -345,7 +345,7 @@ class NavigationTest: BaseTestCase {
         waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.goto(SettingsScreen)
-        waitForExistence(app.tables[AccessibilityIdentifiers.Settings.tableViewController])
+        mozWaitForElementToExist(app.tables[AccessibilityIdentifiers.Settings.tableViewController])
         let switchBlockPopUps = app.tables.cells.switches["blockPopups"]
         switchBlockPopUps.tap()
         let switchValueAfter = switchBlockPopUps.value!
@@ -354,16 +354,16 @@ class NavigationTest: BaseTestCase {
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
         waitUntilPageLoad()
         navigator.openURL(path(forTestPage: "test-window-opener.html"))
-        waitForExistence(app.links["link-created-by-parent"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.links["link-created-by-parent"], timeout: TIMEOUT)
     }
 
     // Smoketest
     // https://testrail.stage.mozaws.net/index.php?/cases/view/1613987
     func testVerifyBrowserTabMenu() {
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: TIMEOUT)
         navigator.nowAt(NewTabScreen)
         navigator.goto(BrowserTabMenu)
-        waitForExistence(app.tables["Context Menu"])
+        mozWaitForElementToExist(app.tables["Context Menu"])
 
         XCTAssertTrue(app.tables.otherElements[StandardImageIdentifiers.Large.bookmarkTrayFill].exists)
         XCTAssertTrue(app.tables.otherElements[StandardImageIdentifiers.Large.history].exists)
@@ -381,7 +381,7 @@ class NavigationTest: BaseTestCase {
     // Smoketest
     func testURLBar() {
         let urlBar = app.textFields["url"]
-        waitForExistence(urlBar, timeout: TIMEOUT)
+        mozWaitForElementToExist(urlBar, timeout: TIMEOUT)
         urlBar.tap()
 
         let addressBar = app.textFields["address"]

--- a/Tests/XCUITests/NavigationTest.swift
+++ b/Tests/XCUITests/NavigationTest.swift
@@ -33,21 +33,21 @@ class NavigationTest: BaseTestCase {
         }
         navigator.openURL(path(forTestPage: "test-example.html"))
         waitUntilPageLoad()
-        waitForValueContains(app.textFields["url"], value: "test-example.html")
+        mozWaitForValueContains(app.textFields["url"], value: "test-example.html")
         XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
         XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
 
         // Once a second url is open, back button is enabled but not the forward one till we go back to url_1
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
         waitUntilPageLoad()
-        waitForValueContains(app.textFields["url"], value: "test-mozilla-org.html")
+        mozWaitForValueContains(app.textFields["url"], value: "test-mozilla-org.html")
         XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
         XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
         // Go back to previous visited web site
         app.buttons[AccessibilityIdentifiers.Toolbar.backButton].tap()
 
         waitUntilPageLoad()
-        waitForValueContains(app.textFields["url"], value: "test-example.html")
+        mozWaitForValueContains(app.textFields["url"], value: "test-example.html")
 
         if iPad() {
             app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].tap()
@@ -57,7 +57,7 @@ class NavigationTest: BaseTestCase {
             app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].tap()
         }
         waitUntilPageLoad()
-        waitForValueContains(app.textFields["url"], value: "test-mozilla-org")
+        mozWaitForValueContains(app.textFields["url"], value: "test-mozilla-org")
     }
 
     func testTapSignInShowsFxAFromTour() {
@@ -119,7 +119,7 @@ class NavigationTest: BaseTestCase {
     func testScrollsToTopWithMultipleTabs() {
         navigator.goto(TabTray)
         navigator.openURL(website_1["url"]!)
-        waitForValueContains(app.textFields["url"], value: website_1["value"]!)
+        mozWaitForValueContains(app.textFields["url"], value: website_1["value"]!)
         // Element at the TOP. TBChanged once the web page is correctly shown
         let topElement = app.links.staticTexts["Mozilla"].firstMatch
 
@@ -162,7 +162,7 @@ class NavigationTest: BaseTestCase {
         app.tables.otherElements[AccessibilityIdentifiers.Photon.pasteAction].tap()
         app.buttons["Go"].tap()
         waitUntilPageLoad()
-        waitForValueContains(app.textFields["url"], value: website_2["moreLinkLongPressInfo"]!)
+        mozWaitForValueContains(app.textFields["url"], value: website_2["moreLinkLongPressInfo"]!)
     }
 
     func testCopyLinkPrivateMode() {
@@ -177,7 +177,7 @@ class NavigationTest: BaseTestCase {
         mozWaitForElementToExist(app.buttons["Go"])
         app.buttons["Go"].tap()
         waitUntilPageLoad()
-        waitForValueContains(app.textFields["url"], value: website_2["moreLinkLongPressInfo"]!)
+        mozWaitForValueContains(app.textFields["url"], value: website_2["moreLinkLongPressInfo"]!)
     }
 
     func testLongPressOnAddressBar() throws {
@@ -273,7 +273,7 @@ class NavigationTest: BaseTestCase {
         // Tap on the just downloaded link to check that the web page is loaded
         app.tables.cells.staticTexts["example-domains.html"].tap()
         waitUntilPageLoad()
-        waitForValueContains(app.textFields["url"], value: "example-domains.html")
+        mozWaitForValueContains(app.textFields["url"], value: "example-domains.html")
     }
 
     func testShareLink() {
@@ -304,7 +304,7 @@ class NavigationTest: BaseTestCase {
 //
 //        // Check that there are no pop ups
 //        navigator.openURL(popUpTestUrl)
-//        waitForValueContains(app.textFields["url"], value: "blocker.html")
+//        mozWaitForValueContains(app.textFields["url"], value: "blocker.html")
 //        mozWaitForElementToExist(app.webViews.staticTexts["Blocked Element"])
 //
 //        let numTabs = app.buttons["Show Tabs"].value
@@ -321,7 +321,7 @@ class NavigationTest: BaseTestCase {
 //        // Check that now pop ups are shown, two sites loaded
 //        navigator.openURL(popUpTestUrl)
 //        waitUntilPageLoad()
-//        waitForValueContains(app.textFields["url"], value: "example.com")
+//        mozWaitForValueContains(app.textFields["url"], value: "example.com")
 //        let numTabsAfter = app.buttons["Show Tabs"].value
 //        XCTAssertNotEqual("1", numTabsAfter as? String, "Several tabs are open")
     }
@@ -393,7 +393,7 @@ class NavigationTest: BaseTestCase {
         app.typeText("example.com\n")
 
 //        waitUntilPageLoad()
-        waitForValueContains(urlBar, value: "example.com/")
+        mozWaitForValueContains(urlBar, value: "example.com/")
         XCTAssertFalse(app.keyboards.count > 0, "The keyboard is shown")
         // swiftlint:enable empty_count
     }

--- a/Tests/XCUITests/NewTabSettings.swift
+++ b/Tests/XCUITests/NewTabSettings.swift
@@ -62,7 +62,7 @@ class NewTabSettingsTest: BaseTestCase {
         // Check the value typed
         app.textFields["NewTabAsCustomURLTextField"].typeText("mozilla.org")
         let valueTyped = app.textFields["NewTabAsCustomURLTextField"].value as! String
-        waitForValueContains(app.textFields["NewTabAsCustomURLTextField"], value: "mozilla")
+        mozWaitForValueContains(app.textFields["NewTabAsCustomURLTextField"], value: "mozilla")
         XCTAssertEqual(valueTyped, "mozilla.org")
         // Open new page and check that the custom url is used
         navigator.performAction(Action.OpenNewTabFromTabTray)
@@ -71,7 +71,7 @@ class NewTabSettingsTest: BaseTestCase {
         // Disabling and modifying this check xcode 11.3 update Issue 5937
         // Let's just check that website is open
         mozWaitForElementToExist(app.webViews.firstMatch, timeout: 20)
-        // waitForValueContains(app.textFields["url"], value: "mozilla")
+        // mozWaitForValueContains(app.textFields["url"], value: "mozilla")
     }
 
     func testChangeNewTabSettingsLabel() {
@@ -81,7 +81,7 @@ class NewTabSettingsTest: BaseTestCase {
         navigator.nowAt(NewTabSettings)
         // Enter a custom URL
         app.textFields["NewTabAsCustomURLTextField"].typeText(websiteUrl)
-        waitForValueContains(app.textFields["NewTabAsCustomURLTextField"], value: "mozilla")
+        mozWaitForValueContains(app.textFields["NewTabAsCustomURLTextField"], value: "mozilla")
         navigator.goto(SettingsScreen)
         // Assert that the label showing up in Settings is equal to the URL entered (NOT CURRENTLY WORKING, SHOWING HOMEPAGE INSTEAD)
         XCTAssertEqual(app.tables.cells["NewTab"].label, "New Tab, Custom")

--- a/Tests/XCUITests/NewTabSettings.swift
+++ b/Tests/XCUITests/NewTabSettings.swift
@@ -8,10 +8,10 @@ let websiteUrl = "www.mozilla.org"
 class NewTabSettingsTest: BaseTestCase {
     // Smoketest
     func testCheckNewTabSettingsByDefault() {
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 5)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 5)
         navigator.nowAt(NewTabScreen)
         navigator.goto(NewTabSettings)
-        waitForExistence(app.navigationBars["New Tab"])
+        mozWaitForElementToExist(app.navigationBars["New Tab"])
         XCTAssertTrue(app.tables.cells["Firefox Home"].exists)
         XCTAssertTrue(app.tables.cells["Blank Page"].exists)
         XCTAssertTrue(app.tables.cells["NewTabAsCustomURL"].exists)
@@ -19,17 +19,17 @@ class NewTabSettingsTest: BaseTestCase {
 
     // Smoketest
     func testChangeNewTabSettingsShowBlankPage() {
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 5)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 5)
         navigator.nowAt(NewTabScreen)
         navigator.goto(NewTabSettings)
-        waitForExistence(app.navigationBars["New Tab"])
+        mozWaitForElementToExist(app.navigationBars["New Tab"])
 
         navigator.performAction(Action.SelectNewTabAsBlankPage)
         navigator.performAction(Action.OpenNewTabFromTabTray)
 
-        waitForNoExistence(app.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
-        waitForNoExistence(app.collectionViews.cells.staticTexts["YouTube"])
-        waitForNoExistence(app.staticTexts["Highlights"])
+        mozWaitForElementToNotExist(app.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
+        mozWaitForElementToNotExist(app.collectionViews.cells.staticTexts["YouTube"])
+        mozWaitForElementToNotExist(app.staticTexts["Highlights"])
     }
 
     func testChangeNewTabSettingsShowFirefoxHome() {
@@ -38,23 +38,23 @@ class NewTabSettingsTest: BaseTestCase {
         navigator.nowAt(NewTabScreen)
         navigator.performAction(Action.SelectNewTabAsBlankPage)
         navigator.performAction(Action.OpenNewTabFromTabTray)
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
-        waitForNoExistence(app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
+        mozWaitForElementToNotExist(app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
 
         // Now check if it switches to FF Home
         navigator.goto(SettingsScreen)
         navigator.goto(NewTabSettings)
         navigator.performAction(Action.SelectNewTabAsFirefoxHomePage)
         navigator.performAction(Action.OpenNewTabFromTabTray)
-        waitForExistence(app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
+        mozWaitForElementToExist(app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
     }
 
     func testChangeNewTabSettingsShowCustomURL() {
         navigator.nowAt(NewTabScreen)
         navigator.goto(NewTabSettings)
-        waitForExistence(app.navigationBars["New Tab"])
+        mozWaitForElementToExist(app.navigationBars["New Tab"])
         // Check the placeholder value
         let placeholderValue = app.textFields["NewTabAsCustomURLTextField"].value as! String
         XCTAssertEqual(placeholderValue, "Custom URL")
@@ -70,7 +70,7 @@ class NewTabSettingsTest: BaseTestCase {
         navigator.nowAt(NewTabScreen)
         // Disabling and modifying this check xcode 11.3 update Issue 5937
         // Let's just check that website is open
-        waitForExistence(app.webViews.firstMatch, timeout: 20)
+        mozWaitForElementToExist(app.webViews.firstMatch, timeout: 20)
         // waitForValueContains(app.textFields["url"], value: "mozilla")
     }
 

--- a/Tests/XCUITests/NightModeTests.swift
+++ b/Tests/XCUITests/NightModeTests.swift
@@ -5,11 +5,11 @@
 import XCTest
 class NightModeTests: BaseTestCase {
     private func checkNightModeOn() {
-        waitForExistence(app.tables.otherElements[ImageIdentifiers.nightMode])
+        mozWaitForElementToExist(app.tables.otherElements[ImageIdentifiers.nightMode])
     }
 
     private func checkNightModeOff() {
-        waitForExistence(app.tables.otherElements[ImageIdentifiers.nightMode])
+        mozWaitForElementToExist(app.tables.otherElements[ImageIdentifiers.nightMode])
     }
 
     func testNightModeUI() {

--- a/Tests/XCUITests/NoImageTests.swift
+++ b/Tests/XCUITests/NoImageTests.swift
@@ -7,7 +7,7 @@ import XCTest
 class NoImageTests: BaseTestCase {
     private func checkShowImages(showImages: Bool = true) {
         let noImageStatusMode = app.otherElements.tables.cells.switches["NoImageModeStatus"]
-        waitForExistence(noImageStatusMode)
+        mozWaitForElementToExist(noImageStatusMode)
         if showImages {
             XCTAssertEqual(noImageStatusMode.value as! String, "0")
         } else {
@@ -25,14 +25,14 @@ class NoImageTests: BaseTestCase {
         let blockImagesSwitch = app.otherElements.tables.cells.switches[AccessibilityIdentifiers.Settings.BlockImages.title]
         navigator.goto(SettingsScreen)
         navigator.nowAt(SettingsScreen)
-        waitForExistence(blockImagesSwitch)
+        mozWaitForElementToExist(blockImagesSwitch)
         navigator.performAction(Action.ToggleNoImageMode)
         checkShowImages(showImages: false)
 
         // Select show images
         navigator.goto(SettingsScreen)
         navigator.nowAt(SettingsScreen)
-        waitForExistence(blockImagesSwitch)
+        mozWaitForElementToExist(blockImagesSwitch)
         navigator.performAction(Action.ToggleNoImageMode)
         checkShowImages(showImages: true)
     }

--- a/Tests/XCUITests/OnboardingTests.swift
+++ b/Tests/XCUITests/OnboardingTests.swift
@@ -22,7 +22,7 @@ class OnboardingTests: BaseTestCase {
     func testFirstRunTour() {
         // Complete the First run from first screen to the latest one
         // Check that the first's tour screen is shown as well as all the elements in there
-        waitForExistence(app.images["\(rootA11yId)ImageView"], timeout: 15)
+        mozWaitForElementToExist(app.images["\(rootA11yId)ImageView"], timeout: 15)
         XCTAssertTrue(app.images["\(rootA11yId)ImageView"].exists)
         XCTAssertTrue(app.staticTexts["\(rootA11yId)TitleLabel"].exists)
         XCTAssertTrue(app.staticTexts["\(rootA11yId)DescriptionLabel"].exists)
@@ -34,7 +34,7 @@ class OnboardingTests: BaseTestCase {
         // Swipe to the second screen
         app.buttons["\(rootA11yId)SecondaryButton"].tap()
         currentScreen += 1
-        waitForExistence(app.images["\(rootA11yId)ImageView"], timeout: 15)
+        mozWaitForElementToExist(app.images["\(rootA11yId)ImageView"], timeout: 15)
         XCTAssertTrue(app.images["\(rootA11yId)ImageView"].exists)
         XCTAssertTrue(app.staticTexts["\(rootA11yId)TitleLabel"].exists)
         XCTAssertTrue(app.staticTexts["\(rootA11yId)DescriptionLabel"].exists)
@@ -44,7 +44,7 @@ class OnboardingTests: BaseTestCase {
         // Swipe to the third screen
         app.buttons["\(rootA11yId)SecondaryButton"].tap()
         currentScreen += 1
-        waitForExistence(app.images["\(rootA11yId)ImageView"], timeout: 15)
+        mozWaitForElementToExist(app.images["\(rootA11yId)ImageView"], timeout: 15)
         XCTAssertTrue(app.images["\(rootA11yId)ImageView"].exists)
         XCTAssertTrue(app.staticTexts["\(rootA11yId)TitleLabel"].exists)
         XCTAssertTrue(app.staticTexts["\(rootA11yId)DescriptionLabel"].exists)
@@ -54,7 +54,7 @@ class OnboardingTests: BaseTestCase {
         // Finish onboarding
         app.buttons["\(rootA11yId)SecondaryButton"].tap()
         let topSites = app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]
-        waitForExistence(topSites)
+        mozWaitForElementToExist(topSites)
     }
 
     // Smoketest
@@ -62,7 +62,7 @@ class OnboardingTests: BaseTestCase {
     func testCloseTour() {
         app.buttons["\(AccessibilityIdentifiers.Onboarding.closeButton)"].tap()
         let topSites = app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]
-        waitForExistence(topSites)
+        mozWaitForElementToExist(topSites)
     }
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/67227

--- a/Tests/XCUITests/OnboardingTests.swift
+++ b/Tests/XCUITests/OnboardingTests.swift
@@ -82,7 +82,7 @@ class OnboardingTests: BaseTestCase {
         let releaseVersion = String(mySubstring)
 
         XCTAssertTrue(app.staticTexts[releaseVersion].exists)
-        waitForValueContains(app.textFields["url"], value: "www.mozilla.org/en-US/firefox/ios/" + releaseVersion + "/releasenotes/")
+        mozWaitForValueContains(app.textFields["url"], value: "www.mozilla.org/en-US/firefox/ios/" + releaseVersion + "/releasenotes/")
         XCTAssertTrue(app.staticTexts["Release Notes"].exists)
         if iPad() {
             XCTAssertTrue(app.staticTexts["Firefox for iOS \(releaseVersion), See All New Features, Updates and Fixes"].exists)

--- a/Tests/XCUITests/OpeningScreenTests.swift
+++ b/Tests/XCUITests/OpeningScreenTests.swift
@@ -12,10 +12,10 @@ class OpeningScreenTests: BaseTestCase {
         // Close the app from app switcher. Relaunch the app
         closeFromAppSwitcherAndRelaunch()
         // After re-launching the app, the last visited page is displayed
-        waitForValueContains(app.textFields["url"], value: "test-mozilla-org")
+        mozWaitForValueContains(app.textFields["url"], value: "test-mozilla-org")
         // Background and restore Firefox
         restartInBackground()
         // After re-launching the app, the last visited page is displayed
-        waitForValueContains(app.textFields["url"], value: "test-mozilla-org")
+        mozWaitForValueContains(app.textFields["url"], value: "test-mozilla-org")
     }
 }

--- a/Tests/XCUITests/PerformanceTests.swift
+++ b/Tests/XCUITests/PerformanceTests.swift
@@ -79,7 +79,7 @@ class PerformanceTests: BaseTestCase {
     }
 
     func testPerfTabs_3_20tabTray() {
-        // Warning: Avoid using waitForExistence as it is up to 25x less performant
+        // Warning: Avoid using mozWaitForElementToExist as it is up to 25x less performant
         let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
         let tabsButtonNumber = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].staticTexts["20"]
         let doneButton = app.buttons[AccessibilityIdentifiers.TabTray.doneButton]
@@ -103,7 +103,7 @@ class PerformanceTests: BaseTestCase {
     }
 
     func testPerfTabs_4_1280tabTray() {
-        // Warning: Avoid using waitForExistence as it is up to 25x less performant
+        // Warning: Avoid using mozWaitForElementToExist as it is up to 25x less performant
         let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
         let tabsButtonNumber = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].staticTexts["∞"]
         let doneButton = app.buttons[AccessibilityIdentifiers.TabTray.doneButton]
@@ -127,7 +127,7 @@ class PerformanceTests: BaseTestCase {
     }
 
     func testPerfHistory1startUp() {
-        // Warning: Avoid using waitForExistence as it is up to 25x less performant
+        // Warning: Avoid using mozWaitForElementToExist as it is up to 25x less performant
         let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
         mozWaitForElementToExist(element: tabsButton, timeoutInSeconds: TIMEOUT)
         app.terminate()
@@ -148,7 +148,7 @@ class PerformanceTests: BaseTestCase {
     }
 
     func testPerfHistory1openMenu() {
-        // Warning: Avoid using waitForExistence as it is up to 25x less performant
+        // Warning: Avoid using mozWaitForElementToExist as it is up to 25x less performant
         let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
         mozWaitForElementToExist(element: tabsButton, timeoutInSeconds: TIMEOUT)
 
@@ -187,7 +187,7 @@ class PerformanceTests: BaseTestCase {
     }
 
     func testPerfHistory100startUp() {
-        // Warning: Avoid using waitForExistence as it is up to 25x less performant
+        // Warning: Avoid using mozWaitForElementToExist as it is up to 25x less performant
         let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
         mozWaitForElementToExist(element: tabsButton, timeoutInSeconds: TIMEOUT)
         app.terminate()
@@ -208,7 +208,7 @@ class PerformanceTests: BaseTestCase {
     }
 
     func testPerfHistory100openMenu() {
-        // Warning: Avoid using waitForExistence as it is up to 25x less performant
+        // Warning: Avoid using mozWaitForElementToExist as it is up to 25x less performant
         let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
         mozWaitForElementToExist(element: tabsButton, timeoutInSeconds: TIMEOUT)
 
@@ -247,7 +247,7 @@ class PerformanceTests: BaseTestCase {
     }
 
     func testPerfBookmarks1startUp() {
-        // Warning: Avoid using waitForExistence as it is up to 25x less performant
+        // Warning: Avoid using mozWaitForElementToExist as it is up to 25x less performant
         let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
         mozWaitForElementToExist(element: tabsButton, timeoutInSeconds: TIMEOUT)
         app.terminate()
@@ -268,7 +268,7 @@ class PerformanceTests: BaseTestCase {
     }
 
     func testPerfBookmarks1openMenu() {
-        // Warning: Avoid using waitForExistence as it is up to 25x less performant
+        // Warning: Avoid using mozWaitForElementToExist as it is up to 25x less performant
         let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
         mozWaitForElementToExist(element: tabsButton, timeoutInSeconds: TIMEOUT)
 
@@ -304,7 +304,7 @@ class PerformanceTests: BaseTestCase {
     }
 
     func testPerfBookmarks100startUp() {
-        // Warning: Avoid using waitForExistence as it is up to 25x less performant
+        // Warning: Avoid using mozWaitForElementToExist as it is up to 25x less performant
         let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
         mozWaitForElementToExist(element: tabsButton, timeoutInSeconds: TIMEOUT)
         app.terminate()
@@ -325,7 +325,7 @@ class PerformanceTests: BaseTestCase {
     }
 
     func testPerfBookmarks100openMenu() {
-        // Warning: Avoid using waitForExistence as it is up to 25x less performant
+        // Warning: Avoid using mozWaitForElementToExist as it is up to 25x less performant
         let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
         mozWaitForElementToExist(element: tabsButton, timeoutInSeconds: TIMEOUT)
 
@@ -361,7 +361,7 @@ class PerformanceTests: BaseTestCase {
     }
 
     func testPerfBookmarks1000startUp() {
-        // Warning: Avoid using waitForExistence as it is up to 25x less performant
+        // Warning: Avoid using mozWaitForElementToExist as it is up to 25x less performant
         let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
         mozWaitForElementToExist(element: tabsButton, timeoutInSeconds: TIMEOUT)
         app.terminate()
@@ -382,7 +382,7 @@ class PerformanceTests: BaseTestCase {
     }
 
     func testPerfBookmarks1000openMenu() {
-        // Warning: Avoid using waitForExistence as it is up to 25x less performant
+        // Warning: Avoid using mozWaitForElementToExist as it is up to 25x less performant
         let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
         mozWaitForElementToExist(element: tabsButton, timeoutInSeconds: TIMEOUT)
 

--- a/Tests/XCUITests/PhotonActionSheetTest.swift
+++ b/Tests/XCUITests/PhotonActionSheetTest.swift
@@ -19,7 +19,7 @@ class PhotonActionSheetTest: BaseTestCase {
 
         // Verify that the site is pinned to top
         let cell = app.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell].staticTexts["Example Domain"]
-        waitForExistence(cell)
+        mozWaitForElementToExist(cell)
 
         // Remove pin
         cell.press(forDuration: 2)
@@ -27,31 +27,31 @@ class PhotonActionSheetTest: BaseTestCase {
 
         // Check that it has been unpinned
         cell.press(forDuration: 2)
-        waitForExistence(app.tables.cells.otherElements[StandardImageIdentifiers.Large.pin])
+        mozWaitForElementToExist(app.tables.cells.otherElements[StandardImageIdentifiers.Large.pin])
     }
 
     func testShareOptionIsShown() {
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
         waitUntilPageLoad()
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.shareButton], timeout: 10)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.shareButton], timeout: 10)
         app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].tap()
 
         // Wait to see the Share options sheet
-        waitForExistence(app.cells["Copy"], timeout: 10)
+        mozWaitForElementToExist(app.cells["Copy"], timeout: 10)
     }
 
     // Smoketest
     func testShareOptionIsShownFromShortCut() {
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
         waitUntilPageLoad()
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.shareButton], timeout: 10)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.shareButton], timeout: 10)
         app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].tap()
 
         // Wait to see the Share options sheet
         if iPad() {
-            waitForExistence(app.cells["Copy"], timeout: 15)
+            mozWaitForElementToExist(app.cells["Copy"], timeout: 15)
         } else {
-            waitForExistence(app.buttons["Close"], timeout: 15)
+            mozWaitForElementToExist(app.buttons["Close"], timeout: 15)
         }
     }
 
@@ -59,11 +59,11 @@ class PhotonActionSheetTest: BaseTestCase {
         // User not logged in
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
         waitUntilPageLoad()
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.shareButton], timeout: 10)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.shareButton], timeout: 10)
         app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].tap()
-        waitForExistence(app.cells["Send Link to Device"], timeout: 10)
+        mozWaitForElementToExist(app.cells["Send Link to Device"], timeout: 10)
         app.cells["Send Link to Device"].tap()
-        waitForExistence(app.buttons[AccessibilityIdentifiers.ShareTo.HelpView.doneButton])
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.ShareTo.HelpView.doneButton])
         XCTAssertTrue(app.staticTexts["You are not signed in to your Firefox Account."].exists)
     }
     // Disable issue #5554, More button is not accessible
@@ -72,8 +72,8 @@ class PhotonActionSheetTest: BaseTestCase {
     func testSendToDeviceFromShareOption() {
         // Open and Wait to see the Share options sheet
         navigator.browserPerformAction(.shareOption)
-        waitForExistence(app.buttons["More"])
-        waitForNoExistence(app.buttons["Send Tab"])
+        mozWaitForElementToExist(app.buttons["More"])
+        mozWaitForElementToNotExist(app.buttons["Send Tab"])
         app.collectionViews.cells/*@START_MENU_TOKEN@*/.collectionViews.containing(.button, identifier:"Copy")/*[[".collectionViews.containing(.button, identifier:\"Create PDF\")",".collectionViews.containing(.button, identifier:\"Print\")",".collectionViews.containing(.button, identifier:\"Copy\")"],[[[-1,2],[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.buttons["More"].tap()
 
         // Enable Send Tab
@@ -82,39 +82,39 @@ class PhotonActionSheetTest: BaseTestCase {
         app.navigationBars["Activities"].buttons["Done"].tap()
 
         // Send Tab option appears on the Share options sheet
-        waitForExistence(app.buttons["Send Tab"])
+        mozWaitForElementToExist(app.buttons["Send Tab"])
         app.buttons["Send Tab"].tap()
 
         // User not logged in
-        waitForExistence(app.images[ImageIdentifiers.emptySyncImageName])
+        mozWaitForElementToExist(app.images[ImageIdentifiers.emptySyncImageName])
         XCTAssertTrue(app.staticTexts["You are not signed in to your Firefox Account."].exists)
     }*/
 
     private func openNewShareSheet() {
         navigator.openURL("example.com")
         waitUntilPageLoad()
-        waitForNoExistence(app.staticTexts["Fennec pasted from CoreSimulatorBridge"])
+        mozWaitForElementToNotExist(app.staticTexts["Fennec pasted from CoreSimulatorBridge"])
 
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.shareButton], timeout: 10)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.shareButton], timeout: 10)
         app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].tap()
 
         // This is not ideal but only way to get the element on iPhone 8
         // for iPhone 11, that would be boundBy: 2
-        waitForExistence(app.collectionViews.cells["Copy"], timeout: TIMEOUT)
-        waitForExistence(app.collectionViews.scrollViews.cells["XCElementSnapshotPrivilegedValuePlaceholder"].firstMatch, timeout: TIMEOUT)
+        mozWaitForElementToExist(app.collectionViews.cells["Copy"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.collectionViews.scrollViews.cells["XCElementSnapshotPrivilegedValuePlaceholder"].firstMatch, timeout: TIMEOUT)
         var  fennecElement = app.collectionViews.scrollViews.cells.element(boundBy: 2)
         if iPad() {
             fennecElement = app.collectionViews.scrollViews.cells.element(boundBy: 1)
         }
-        waitForExistence(fennecElement, timeout: 5)
+        mozWaitForElementToExist(fennecElement, timeout: 5)
         fennecElement.tap()
-        waitForExistence(app.navigationBars["ShareTo.ShareView"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.navigationBars["ShareTo.ShareView"], timeout: TIMEOUT)
     }
 
     // Smoketest
     func testSharePageWithShareSheetOptions() {
         openNewShareSheet()
-        waitForExistence(app.staticTexts["Open in Firefox"], timeout: 10)
+        mozWaitForElementToExist(app.staticTexts["Open in Firefox"], timeout: 10)
         XCTAssertTrue(app.staticTexts["Open in Firefox"].exists)
         XCTAssertTrue(app.staticTexts["Load in Background"].exists)
         XCTAssertTrue(app.staticTexts["Bookmark This Page"].exists)
@@ -125,7 +125,7 @@ class PhotonActionSheetTest: BaseTestCase {
     func testShareSheetSendToDevice() {
         openNewShareSheet()
         app.staticTexts["Send to Device"].tap()
-        waitForExistence(app.navigationBars.buttons[AccessibilityIdentifiers.ShareTo.HelpView.doneButton], timeout: 10)
+        mozWaitForElementToExist(app.navigationBars.buttons[AccessibilityIdentifiers.ShareTo.HelpView.doneButton], timeout: 10)
 
         XCTAssertTrue(app.staticTexts["You are not signed in to your Firefox Account."].exists)
         app.navigationBars.buttons[AccessibilityIdentifiers.ShareTo.HelpView.doneButton].tap()
@@ -135,7 +135,7 @@ class PhotonActionSheetTest: BaseTestCase {
         openNewShareSheet()
         app.buttons["Cancel"].tap()
         // User is back to the BrowserTab where the sharesheet was launched
-        waitForExistence(app.textFields["url"])
+        mozWaitForElementToExist(app.textFields["url"])
         waitForValueContains(app.textFields["url"], value: "example.com/")
     }
 }

--- a/Tests/XCUITests/PhotonActionSheetTest.swift
+++ b/Tests/XCUITests/PhotonActionSheetTest.swift
@@ -136,6 +136,6 @@ class PhotonActionSheetTest: BaseTestCase {
         app.buttons["Cancel"].tap()
         // User is back to the BrowserTab where the sharesheet was launched
         mozWaitForElementToExist(app.textFields["url"])
-        waitForValueContains(app.textFields["url"], value: "example.com/")
+        mozWaitForValueContains(app.textFields["url"], value: "example.com/")
     }
 }

--- a/Tests/XCUITests/PocketTests.swift
+++ b/Tests/XCUITests/PocketTests.swift
@@ -7,7 +7,7 @@ import XCTest
 class PocketTest: BaseTestCase {
     func testPocketEnabledByDefault() {
         navigator.goto(NewTabScreen)
-        waitForExistence(app.staticTexts[AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.pocket])
+        mozWaitForElementToExist(app.staticTexts[AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.pocket])
         XCTAssertEqual(app.staticTexts[AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.pocket].label, "Thought-Provoking Stories")
 
         // There should be at least 8 stories on iPhone and three on iPad
@@ -18,11 +18,11 @@ class PocketTest: BaseTestCase {
         navigator.performAction(Action.TogglePocketInNewTab)
 
         navigator.goto(NewTabScreen)
-        waitForNoExistence(app.staticTexts[AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.pocket])
+        mozWaitForElementToNotExist(app.staticTexts[AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.pocket])
         // Enable it again
         navigator.performAction(Action.TogglePocketInNewTab)
         navigator.goto(NewTabScreen)
-        waitForExistence(app.staticTexts[AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.pocket])
+        mozWaitForElementToExist(app.staticTexts[AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.pocket])
 
         // Tap on the first Pocket element
         app.collectionViews.scrollViews.cells[AccessibilityIdentifiers.FirefoxHomepage.Pocket.itemCell].firstMatch.tap()

--- a/Tests/XCUITests/PrivateBrowsingTest.swift
+++ b/Tests/XCUITests/PrivateBrowsingTest.swift
@@ -34,7 +34,7 @@ class PrivateBrowsingTest: BaseTestCase {
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
 
         navigator.openURL(url2)
-        waitForValueContains(app.textFields["url"], value: "mozilla")
+        mozWaitForValueContains(app.textFields["url"], value: "mozilla")
         navigator.goto(LibraryPanel_History)
         mozWaitForElementToExist(app.tables[HistoryPanelA11y.tableView])
         XCTAssertTrue(app.tables[HistoryPanelA11y.tableView].staticTexts[url1And3Label].exists)
@@ -64,7 +64,7 @@ class PrivateBrowsingTest: BaseTestCase {
         navigator.goto(URLBarOpen)
         waitUntilPageLoad()
         navigator.openURL(url3)
-        waitForValueContains(app.textFields["url"], value: "test-example")
+        mozWaitForValueContains(app.textFields["url"], value: "test-example")
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
         navigator.goto(TabTray)
@@ -252,7 +252,7 @@ class PrivateBrowsingTestIphone: IphoneOnlyTestCase {
         // Check that the tab has changed
         waitUntilPageLoad()
         mozWaitForElementToExist(app.textFields["url"], timeout: 5)
-        waitForValueContains(app.textFields["url"], value: "iana")
+        mozWaitForValueContains(app.textFields["url"], value: "iana")
         XCTAssertTrue(app.links["RFC 2606"].exists)
         mozWaitForElementToExist(app.buttons["Show Tabs"])
         let numPrivTab = app.buttons["Show Tabs"].value as? String

--- a/Tests/XCUITests/PrivateBrowsingTest.swift
+++ b/Tests/XCUITests/PrivateBrowsingTest.swift
@@ -22,7 +22,7 @@ class PrivateBrowsingTest: BaseTestCase {
         navigator.goto(BrowserTabMenu)
         // Go to History screen
         navigator.goto(LibraryPanel_History)
-        waitForExistence(app.tables[HistoryPanelA11y.tableView])
+        mozWaitForElementToExist(app.tables[HistoryPanelA11y.tableView])
 
         XCTAssertTrue(app.tables[HistoryPanelA11y.tableView].staticTexts[url1And3Label].exists)
         // History without counting Clear Recent History and Recently Closed
@@ -36,7 +36,7 @@ class PrivateBrowsingTest: BaseTestCase {
         navigator.openURL(url2)
         waitForValueContains(app.textFields["url"], value: "mozilla")
         navigator.goto(LibraryPanel_History)
-        waitForExistence(app.tables[HistoryPanelA11y.tableView])
+        mozWaitForElementToExist(app.tables[HistoryPanelA11y.tableView])
         XCTAssertTrue(app.tables[HistoryPanelA11y.tableView].staticTexts[url1And3Label].exists)
         XCTAssertFalse(app.tables[HistoryPanelA11y.tableView].staticTexts[url2Label].exists)
 
@@ -53,7 +53,7 @@ class PrivateBrowsingTest: BaseTestCase {
         waitUntilPageLoad()
         waitForTabsButton()
         navigator.goto(TabTray)
-        waitForExistence(app.otherElements["Tabs Tray"])
+        mozWaitForElementToExist(app.otherElements["Tabs Tray"])
         XCTAssertNotNil(app.otherElements["Tabs Tray"].collectionViews.cells.staticTexts.element(boundBy: 1).label.range(of: url2Label))
         let numTabs = app.otherElements["Tabs Tray"].cells.count
         XCTAssertEqual(numTabs, 2, "The number of regular tabs is not correct")
@@ -68,15 +68,15 @@ class PrivateBrowsingTest: BaseTestCase {
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
         navigator.goto(TabTray)
-        waitForExistence(app.otherElements["Tabs Tray"].cells.staticTexts[url1And3Label])
+        mozWaitForElementToExist(app.otherElements["Tabs Tray"].cells.staticTexts[url1And3Label])
         let numPrivTabs = app.otherElements["Tabs Tray"].cells.count
         XCTAssertEqual(numPrivTabs, 1, "The number of private tabs is not correct")
         // Go back to regular mode and check the total number of tabs
         navigator.toggleOff(userState.isPrivate, withAction: Action.ToggleRegularMode)
 
-        waitForExistence(app.otherElements["Tabs Tray"])
+        mozWaitForElementToExist(app.otherElements["Tabs Tray"])
         XCTAssertNotNil(app.otherElements["Tabs Tray"].collectionViews.cells.staticTexts.element(boundBy: 1).label.range(of: url2Label))
-        waitForNoExistence(app.otherElements["Tabs Tray"].collectionViews.cells.staticTexts[url1And3Label])
+        mozWaitForElementToNotExist(app.otherElements["Tabs Tray"].collectionViews.cells.staticTexts[url1And3Label])
         let numRegularTabs = app.otherElements["Tabs Tray"].cells.count
         XCTAssertEqual(numRegularTabs, 2, "The number of regular tabs is not correct")
     }
@@ -85,7 +85,7 @@ class PrivateBrowsingTest: BaseTestCase {
     func testClosePrivateTabsOptionClosesPrivateTabs() {
         // Check that Close Private Tabs when closing the Private Browsing Button is off by default
         navigator.nowAt(NewTabScreen)
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: TIMEOUT)
         navigator.goto(SettingsScreen)
         let settingsTableView = app.tables[AccessibilityIdentifiers.Settings.tableViewController]
 
@@ -108,7 +108,7 @@ class PrivateBrowsingTest: BaseTestCase {
 
         // Go back to private browsing and check that the tab has not been closed
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
-        waitForExistence(app.otherElements["Tabs Tray"])
+        mozWaitForElementToExist(app.otherElements["Tabs Tray"])
         XCTAssertNotNil(app.otherElements["Tabs Tray"].collectionViews.cells.staticTexts.element(boundBy: 0).label.range(of: url2Label))
         checkOpenTabsBeforeClosingPrivateMode()
 
@@ -119,7 +119,7 @@ class PrivateBrowsingTest: BaseTestCase {
             app.otherElements["Tabs Tray"].collectionViews.cells.staticTexts[url2Label].tap()
         }
         waitForTabsButton()
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: TIMEOUT)
         navigator.nowAt(BrowserTab)
         navigator.goto(SettingsScreen)
         closePrivateTabsSwitch.tap()
@@ -132,7 +132,7 @@ class PrivateBrowsingTest: BaseTestCase {
         navigator.nowAt(NewTabScreen)
 
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
-        waitForNoExistence(app.cells.staticTexts["Internet for people, not profit — Mozilla. Currently selected tab."])
+        mozWaitForElementToNotExist(app.cells.staticTexts["Internet for people, not profit — Mozilla. Currently selected tab."])
         checkOpenTabsAfterClosingPrivateMode()
     }
 
@@ -193,9 +193,9 @@ class PrivateBrowsingTest: BaseTestCase {
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
 
         navigator.openURL(path(forTestPage: "test-example.html"))
-        waitForExistence(app.webViews.links[website_2["link"]!], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.webViews.links[website_2["link"]!], timeout: TIMEOUT)
         app.webViews.links[website_2["link"]!].press(forDuration: 2)
-        waitForExistence(app.collectionViews.staticTexts[website_2["moreLinkLongPressUrl"]!], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.collectionViews.staticTexts[website_2["moreLinkLongPressUrl"]!], timeout: TIMEOUT)
         XCTAssertFalse(app.buttons["Open in New Tab"].exists, "The option is not shown")
         XCTAssertTrue(app.buttons["Open in New Private Tab"].exists, "The option is not shown")
         XCTAssertTrue(app.buttons["Copy Link"].exists, "The option is not shown")
@@ -242,19 +242,19 @@ class PrivateBrowsingTestIphone: IphoneOnlyTestCase {
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         navigator.openURL(urlExample)
         waitUntilPageLoad()
-        waitForExistence(app.webViews.links.firstMatch)
+        mozWaitForElementToExist(app.webViews.links.firstMatch)
         app.webViews.links.firstMatch.press(forDuration: 1)
-        waitForExistence(app.buttons["Open in New Private Tab"])
+        mozWaitForElementToExist(app.buttons["Open in New Private Tab"])
         app.buttons["Open in New Private Tab"].press(forDuration: 1)
-        waitForExistence(app.buttons["Switch"])
+        mozWaitForElementToExist(app.buttons["Switch"])
         app.buttons["Switch"].tap()
 
         // Check that the tab has changed
         waitUntilPageLoad()
-        waitForExistence(app.textFields["url"], timeout: 5)
+        mozWaitForElementToExist(app.textFields["url"], timeout: 5)
         waitForValueContains(app.textFields["url"], value: "iana")
         XCTAssertTrue(app.links["RFC 2606"].exists)
-        waitForExistence(app.buttons["Show Tabs"])
+        mozWaitForElementToExist(app.buttons["Show Tabs"])
         let numPrivTab = app.buttons["Show Tabs"].value as? String
         XCTAssertEqual("2", numPrivTab)
     }
@@ -270,7 +270,7 @@ class PrivateBrowsingTestIpad: IpadOnlyTestCase {
         waitForTabsButton()
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         navigator.openURL(url2)
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: TIMEOUT)
         enableClosePrivateBrowsingOptionWhenLeaving()
         // Leave PM by tapping on PM shourt cut
         navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateModeFromTabBarHomePanel)
@@ -297,7 +297,7 @@ class PrivateBrowsingTestIpad: IpadOnlyTestCase {
         navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateModeFromTabBarHomePanel)
         navigator.nowAt(NewTabScreen)
         navigator.goto(LibraryPanel_History)
-        waitForExistence(app.tables[HistoryPanelA11y.tableView])
+        mozWaitForElementToExist(app.tables[HistoryPanelA11y.tableView])
         // History without counting Clear Recent History, Recently Closed
         let history = app.tables[HistoryPanelA11y.tableView].cells.count - 2
         XCTAssertEqual(history, 0, "History list should be empty")
@@ -317,12 +317,12 @@ class PrivateBrowsingTestIpad: IpadOnlyTestCase {
         navigator.openURL("http://example.com")
         navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateModeFromTabBarBrowserTab)
         navigator.goto(LibraryPanel_History)
-        waitForExistence(app.tables[HistoryPanelA11y.tableView])
+        mozWaitForElementToExist(app.tables[HistoryPanelA11y.tableView])
         // History without counting Clear Recent History, Recently Closed
         let history = app.tables[HistoryPanelA11y.tableView].cells.count - 1
         XCTAssertEqual(history, 1, "There should be one entry in History")
         let savedToHistory = app.tables[HistoryPanelA11y.tableView].cells.element(boundBy: 1).staticTexts.element(boundBy: 1)
-        waitForExistence(savedToHistory)
+        mozWaitForElementToExist(savedToHistory)
         XCTAssertNotNil(savedToHistory.label.range(of: url2Label))
     }
 }

--- a/Tests/XCUITests/ReaderViewUITest.swift
+++ b/Tests/XCUITests/ReaderViewUITest.swift
@@ -10,16 +10,16 @@ class ReaderViewTest: BaseTestCase {
     func testLoadReaderContent() {
         navigator.openURL(path(forTestPage: "test-mozilla-book.html"))
         navigator.goto(BrowserTab)
-        waitForNoExistence(app.staticTexts["Fennec pasted from XCUITests-Runner"])
-        waitForExistence(app.buttons["Reader View"], timeout: TIMEOUT)
+        mozWaitForElementToNotExist(app.staticTexts["Fennec pasted from XCUITests-Runner"])
+        mozWaitForElementToExist(app.buttons["Reader View"], timeout: TIMEOUT)
         app.buttons["Reader View"].tap()
         // The settings of reader view are shown as well as the content of the web site
-        waitForExistence(app.buttons["Display Settings"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.buttons["Display Settings"], timeout: TIMEOUT)
         XCTAssertTrue(app.webViews.staticTexts["The Book of Mozilla"].exists)
     }
 
     private func checkReadingListNumberOfItems(items: Int) {
-        waitForExistence(app.tables["ReadingTable"])
+        mozWaitForElementToExist(app.tables["ReadingTable"])
         let list = app.tables["ReadingTable"].cells.count
         XCTAssertEqual(list, items, "The number of items in the reading table is not correct")
     }
@@ -41,7 +41,7 @@ class ReaderViewTest: BaseTestCase {
 
         // Check that there is one item
         let savedToReadingList = app.tables["ReadingTable"].cells.staticTexts["The Book of Mozilla"]
-        waitForExistence(savedToReadingList)
+        mozWaitForElementToExist(savedToReadingList)
         XCTAssertTrue(savedToReadingList.exists)
         checkReadingListNumberOfItems(items: 1)
     }
@@ -50,7 +50,7 @@ class ReaderViewTest: BaseTestCase {
         navigator.nowAt(NewTabScreen)
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         navigator.performAction(Action.OpenNewTabFromTabTray)
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
@@ -67,7 +67,7 @@ class ReaderViewTest: BaseTestCase {
 
         // Check that there is one item
         let savedToReadingList = app.tables["ReadingTable"].cells.staticTexts["The Book of Mozilla"]
-        waitForExistence(savedToReadingList)
+        mozWaitForElementToExist(savedToReadingList)
         XCTAssertTrue(savedToReadingList.exists)
         checkReadingListNumberOfItems(items: 1)
         app.buttons["Done"].tap()
@@ -75,7 +75,7 @@ class ReaderViewTest: BaseTestCase {
         // Check that it appears on regular mode
         navigator.toggleOff(userState.isPrivate, withAction: Action.ToggleRegularMode)
         navigator.performAction(Action.OpenNewTabFromTabTray)
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
@@ -88,21 +88,21 @@ class ReaderViewTest: BaseTestCase {
 
         // Mark the content as read, so the mark as unread buttons appear
         app.buttons["Mark as Read"].tap()
-        waitForExistence(app.buttons["Mark as Unread"])
+        mozWaitForElementToExist(app.buttons["Mark as Unread"])
 
         // Mark the content as unread, so the mark as read button appear
         app.buttons["Mark as Unread"].tap()
-        waitForExistence(app.buttons["Mark as Read"])
+        mozWaitForElementToExist(app.buttons["Mark as Read"])
     }
 
     func testRemoveFromReadingView() {
         addContentToReaderView()
         // Once the content has been added, remove it
-        waitForExistence(app.buttons["Remove from Reading List"])
+        mozWaitForElementToExist(app.buttons["Remove from Reading List"])
         app.buttons["Remove from Reading List"].tap()
 
         // Check that instead of the remove icon now it is shown the add to read list
-        waitForExistence(app.buttons["Add to Reading List"])
+        mozWaitForElementToExist(app.buttons["Add to Reading List"])
 
         // Go to reader list view to check that there is not any item there
         navigator.goto(BrowserTabMenu)
@@ -116,7 +116,7 @@ class ReaderViewTest: BaseTestCase {
         navigator.goto(BrowserTabMenu)
         navigator.goto(LibraryPanel_ReadingList)
 
-        waitForExistence(app.tables["ReadingTable"])
+        mozWaitForElementToExist(app.tables["ReadingTable"])
         // Check that there is one item
         let savedToReadingList = app.tables["ReadingTable"].cells.staticTexts["The Book of Mozilla"]
         XCTAssertTrue(savedToReadingList.exists)
@@ -126,10 +126,10 @@ class ReaderViewTest: BaseTestCase {
             throw XCTSkip("swipeLeft() does not work on M1")
         } else {
             savedToReadingList.swipeLeft()
-            waitForExistence(app.tables.cells.buttons.staticTexts["Mark as  Read"], timeout: TIMEOUT)
+            mozWaitForElementToExist(app.tables.cells.buttons.staticTexts["Mark as  Read"], timeout: TIMEOUT)
             app.tables["ReadingTable"].cells.buttons.element(boundBy: 1).tap()
             savedToReadingList.swipeLeft()
-            waitForExistence(app.tables.cells.buttons.staticTexts["Mark as  Unread"])
+            mozWaitForElementToExist(app.tables.cells.buttons.staticTexts["Mark as  Unread"])
         }
     }
 
@@ -139,16 +139,16 @@ class ReaderViewTest: BaseTestCase {
         navigator.goto(LibraryPanel_ReadingList)
 
         let savedToReadingList = app.tables["ReadingTable"].cells.staticTexts["The Book of Mozilla"]
-        waitForExistence(savedToReadingList)
+        mozWaitForElementToExist(savedToReadingList)
 
         // Remove the item from reading list
         if processIsTranslatedStr() == m1Rosetta {
             savedToReadingList.press(forDuration: 2)
-            waitForExistence(app.otherElements["Remove"])
+            mozWaitForElementToExist(app.otherElements["Remove"])
             app.otherElements["Remove"].tap()
         } else {
             savedToReadingList.swipeLeft()
-            waitForExistence(app.buttons["Remove"])
+            mozWaitForElementToExist(app.buttons["Remove"])
             app.buttons["Remove"].tap()
         }
         XCTAssertFalse(savedToReadingList.exists)
@@ -184,11 +184,11 @@ class ReaderViewTest: BaseTestCase {
 
         // Long tap on the item just saved
         let savedToReadingList = app.tables["ReadingTable"].cells.staticTexts["The Book of Mozilla"]
-        waitForExistence(savedToReadingList)
+        mozWaitForElementToExist(savedToReadingList)
         savedToReadingList.press(forDuration: 1)
 
         // Select to open in New Tab
-        waitForExistence(app.tables["Context Menu"])
+        mozWaitForElementToExist(app.tables["Context Menu"])
         app.tables.otherElements[StandardImageIdentifiers.Large.plus].tap()
         updateScreenGraph()
         // Now there should be two tabs open
@@ -204,24 +204,24 @@ class ReaderViewTest: BaseTestCase {
 
         // Long tap on the item just saved and choose remove
         let savedToReadingList = app.tables["ReadingTable"].cells.staticTexts["The Book of Mozilla"]
-        waitForExistence(savedToReadingList)
+        mozWaitForElementToExist(savedToReadingList)
         savedToReadingList.press(forDuration: 1)
-        waitForExistence(app.tables["Context Menu"])
+        mozWaitForElementToExist(app.tables["Context Menu"])
         app.tables.otherElements[StandardImageIdentifiers.Large.cross].tap()
 
         // Verify the item has been removed
-        waitForNoExistence(app.tables["ReadingTable"].cells.staticTexts["The Book of Mozilla"])
+        mozWaitForElementToNotExist(app.tables["ReadingTable"].cells.staticTexts["The Book of Mozilla"])
         XCTAssertFalse(app.tables["ReadingTable"].cells.staticTexts["The Book of Mozilla"].exists)
     }
 
     // Smoketest
     func testAddToReaderListOptions() throws {
         XCTExpectFailure("The app was not launched", strict: false) {
-            waitForExistence(app.collectionViews["FxCollectionView"], timeout: TIMEOUT)
+            mozWaitForElementToExist(app.collectionViews["FxCollectionView"], timeout: TIMEOUT)
         }
         addContentToReaderView()
         // Check that Settings layouts options are shown
-        waitForExistence(app.buttons["ReaderModeBarView.settingsButton"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.buttons["ReaderModeBarView.settingsButton"], timeout: TIMEOUT)
         app.buttons["ReaderModeBarView.settingsButton"].tap()
         XCTAssertTrue(app.buttons["Light"].exists)
     }

--- a/Tests/XCUITests/SaveLoginsTests.swift
+++ b/Tests/XCUITests/SaveLoginsTests.swift
@@ -23,20 +23,20 @@ class SaveLoginTest: BaseTestCase {
     private func saveLogin(givenUrl: String) {
         navigator.openURL(givenUrl)
         waitUntilPageLoad()
-        waitForExistence(app.buttons["submit"], timeout: 10)
+        mozWaitForElementToExist(app.buttons["submit"], timeout: 10)
         app.buttons["submit"].tap()
-        waitForExistence(app.buttons["SaveLoginPrompt.saveLoginButton"], timeout: 10)
+        mozWaitForElementToExist(app.buttons["SaveLoginPrompt.saveLoginButton"], timeout: 10)
         app.buttons["SaveLoginPrompt.saveLoginButton"].tap()
     }
 
     private func openLoginsSettings() {
         navigator.goto(SettingsScreen)
-        waitForExistence(app.cells["SignInToSync"], timeout: 5)
+        mozWaitForElementToExist(app.cells["SignInToSync"], timeout: 5)
         app.cells["SignInToSync"].swipeUp()
         navigator.goto(LoginsSettings)
 
         unlockLoginsView()
-        waitForExistence(app.tables["Login List"])
+        mozWaitForElementToExist(app.tables["Login List"])
     }
 
     private func unlockLoginsView() {
@@ -46,7 +46,7 @@ class SaveLoginTest: BaseTestCase {
         }
 
         let passcodeInput = springboard.otherElements.secureTextFields.firstMatch
-        waitForExistence(passcodeInput, timeout: 20)
+        mozWaitForElementToExist(passcodeInput, timeout: 20)
         passcodeInput.tap()
         passcodeInput.typeText("foo\n")
     }
@@ -56,7 +56,7 @@ class SaveLoginTest: BaseTestCase {
         // Make sure you can access empty Login List from Browser Tab Menu
         navigator.goto(LoginsSettings)
         unlockLoginsView()
-        waitForExistence(app.tables["Login List"])
+        mozWaitForElementToExist(app.tables["Login List"])
         XCTAssertTrue(app.searchFields["Filter"].exists)
         XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList)
         app.buttons["Settings"].tap()
@@ -65,7 +65,7 @@ class SaveLoginTest: BaseTestCase {
         // Make sure you can access populated Login List from Browser Tab Menu
         navigator.goto(LoginsSettings)
         unlockLoginsView()
-        waitForExistence(app.tables["Login List"])
+        mozWaitForElementToExist(app.tables["Login List"])
         XCTAssertTrue(app.searchFields["Filter"].exists)
         XCTAssertTrue(app.staticTexts[domain].exists)
         XCTAssertTrue(app.staticTexts[domainLogin].exists)
@@ -81,14 +81,14 @@ class SaveLoginTest: BaseTestCase {
         // Save a login and check that it appears on the list
         saveLogin(givenUrl: testLoginPage)
         openLoginsSettings()
-        waitForExistence(app.tables["Login List"])
+        mozWaitForElementToExist(app.tables["Login List"])
         XCTAssertTrue(app.staticTexts[domain].exists)
         // XCTAssertTrue(app.staticTexts[domainLogin].exists)
         XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList + 1)
         // Check to see how it works with multiple entries in the list- in this case, two for now
         saveLogin(givenUrl: testSecondLoginPage)
         openLoginsSettings()
-        waitForExistence(app.tables["Login List"])
+        mozWaitForElementToExist(app.tables["Login List"])
         XCTAssertTrue(app.staticTexts[domain].exists)
         // XCTAssertTrue(app.staticTexts[domainSecondLogin].exists)
         // Workaround for Bitrise specific issue. "vagrant" user is used in Bitrise.
@@ -125,7 +125,7 @@ class SaveLoginTest: BaseTestCase {
         XCTAssertTrue(app.staticTexts[domainLogin].exists)
 
         app.staticTexts[domain].tap()
-        waitForExistence(app.buttons["Deselect All"])
+        mozWaitForElementToExist(app.buttons["Deselect All"])
 
         XCTAssertTrue(app.buttons["Deselect All"].exists)
         XCTAssertTrue(app.buttons["Delete"].exists)
@@ -136,9 +136,9 @@ class SaveLoginTest: BaseTestCase {
         openLoginsSettings()
         app.staticTexts[domain].tap()
         app.cells.staticTexts["Delete"].tap()
-        waitForExistence(app.alerts["Are you sure?"])
+        mozWaitForElementToExist(app.alerts["Are you sure?"])
         app.alerts.buttons["Delete"].tap()
-        waitForExistence(app.tables["Login List"])
+        mozWaitForElementToExist(app.tables["Login List"])
         XCTAssertFalse(app.staticTexts[domain].exists)
         XCTAssertFalse(app.staticTexts[domainLogin].exists)
         XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList)
@@ -150,7 +150,7 @@ class SaveLoginTest: BaseTestCase {
 //        XCTAssertTrue(app.staticTexts[domain].exists)
 //        XCTAssertTrue(app.staticTexts[domainLogin].exists)
 //        app.staticTexts[domain].tap()
-//        waitForExistence(app.tables["Login Detail List"])
+//        mozWaitForElementToExist(app.tables["Login Detail List"])
 //        XCTAssertTrue(app.tables.cells[loginsListURLLabel].exists)
 //        XCTAssertTrue(app.tables.cells[loginsListUsernameLabel].exists)
 //        XCTAssertTrue(app.tables.cells[loginsListPasswordLabel].exists)
@@ -169,7 +169,7 @@ class SaveLoginTest: BaseTestCase {
         // Type Text that does not match
         app.typeText("b")
         XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsEmptyFilterList)
-        // waitForExistence(app.tables["No logins found"])
+        // mozWaitForElementToExist(app.tables["No logins found"])
 
         // Clear Text
         app.buttons["Clear text"].tap()
@@ -181,7 +181,7 @@ class SaveLoginTest: BaseTestCase {
         navigator.openURL(urlLogin)
         waitUntilPageLoad()
         // Provided text fields are completely empty
-        waitForExistence(app.webViews.staticTexts["Username:"], timeout: 15)
+        mozWaitForElementToExist(app.webViews.staticTexts["Username:"], timeout: 15)
 
         // Fill in the username text box
         app.webViews.textFields.element(boundBy: 0).tap()
@@ -192,7 +192,7 @@ class SaveLoginTest: BaseTestCase {
 
         // Submit form and choose to save the logins
         app.buttons["submit"].tap()
-        waitForExistence(app.buttons["SaveLoginPrompt.saveLoginButton"], timeout: 5)
+        mozWaitForElementToExist(app.buttons["SaveLoginPrompt.saveLoginButton"], timeout: 5)
         app.buttons["SaveLoginPrompt.saveLoginButton"].tap()
 
         // Clear Data and go to test page, fields should be filled in
@@ -203,7 +203,7 @@ class SaveLoginTest: BaseTestCase {
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.openURL(urlLogin)
         waitUntilPageLoad()
-        waitForExistence(app.webViews.textFields.element(boundBy: 0), timeout: 3)
+        mozWaitForElementToExist(app.webViews.textFields.element(boundBy: 0), timeout: 3)
         // let emailValue = app.webViews.textFields.element(boundBy: 0).value!
         // XCTAssertEqual(emailValue as! String, mailLogin)
         // let passwordValue = app.webViews.secureTextFields.element(boundBy: 0).value!
@@ -215,9 +215,9 @@ class SaveLoginTest: BaseTestCase {
         closeURLBar()
         navigator.goto(LoginsSettings)
         unlockLoginsView()
-        waitForExistence(app.tables["Login List"], timeout: 15)
+        mozWaitForElementToExist(app.tables["Login List"], timeout: 15)
         app.buttons["Add"].tap()
-        waitForExistence(app.tables["Add Credential"], timeout: 15)
+        mozWaitForElementToExist(app.tables["Add Credential"], timeout: 15)
         XCTAssertTrue(app.tables["Add Credential"].cells.staticTexts["Website"].exists)
         XCTAssertTrue(app.tables["Add Credential"].cells.staticTexts["Username"].exists)
         XCTAssertTrue(app.tables["Add Credential"].cells.staticTexts["Password"].exists)
@@ -232,7 +232,7 @@ class SaveLoginTest: BaseTestCase {
         enterTextInField(typedText: "bar")
 
         app.buttons["Save"].tap()
-        waitForExistence(app.tables["Login List"].otherElements["SAVED LOGINS"])
+        mozWaitForElementToExist(app.tables["Login List"].otherElements["SAVED LOGINS"])
         // XCTAssertTrue(app.cells.staticTexts["foo"].exists)
     }
 

--- a/Tests/XCUITests/SearchSettingsUITest.swift
+++ b/Tests/XCUITests/SearchSettingsUITest.swift
@@ -14,13 +14,13 @@ class SearchSettingsUITests: BaseTestCase {
         navigator.goto(SearchSettings)
         // Check the default browser
         let defaultSearchEngine = app.tables.cells.element(boundBy: 0)
-        waitForExistence(app.tables.cells.staticTexts[defaultSearchEngine1])
+        mozWaitForElementToExist(app.tables.cells.staticTexts[defaultSearchEngine1])
 
         // Change to another browser and check it is set as default
         defaultSearchEngine.tap()
         let listOfEngines = app.tables
         listOfEngines.staticTexts[defaultSearchEngine2].tap()
-        waitForExistence(app.tables.cells.staticTexts[defaultSearchEngine2])
+        mozWaitForElementToExist(app.tables.cells.staticTexts[defaultSearchEngine2])
     }
 
     func testCustomSearchEngineIsEditable() {
@@ -29,28 +29,28 @@ class SearchSettingsUITests: BaseTestCase {
         // Add a custom search engine
         addCustomSearchEngine()
         // Check that the custom search appears on the list
-        waitForExistence(app.tables.cells.staticTexts[customSearchEngine["name"]!])
+        mozWaitForElementToExist(app.tables.cells.staticTexts[customSearchEngine["name"]!])
 
         // Check that it can be edited
         XCTAssertTrue(app.buttons["Edit"].isEnabled)
         app.buttons["Edit"].tap()
 
-        waitForExistence(app.tables.buttons["Delete \(customSearchEngine["name"]!)"])
+        mozWaitForElementToExist(app.tables.buttons["Delete \(customSearchEngine["name"]!)"])
     }
 
     private func addCustomSearchEngine() {
-        waitForExistence(app.tables.cells[AccessibilityIdentifiers.Settings.Search.customEngineViewButton])
+        mozWaitForElementToExist(app.tables.cells[AccessibilityIdentifiers.Settings.Search.customEngineViewButton])
         app.tables.cells[AccessibilityIdentifiers.Settings.Search.customEngineViewButton].tap()
-        waitForExistence(app.tables.cells.staticTexts["Search Engine"])
+        mozWaitForElementToExist(app.tables.cells.staticTexts["Search Engine"])
         app.tables.cells.textViews["customEngineTitle"].tap()
         app.tables.cells.textViews["customEngineTitle"].typeText(customSearchEngine["name"]!)
 
         app.tables.cells.textViews["customEngineUrl"].tap()
         app.tables.cells.textViews["customEngineUrl"].typeText(customSearchEngine["url"]!)
-        waitForExistence(app.buttons["Save"], timeout: 5)
+        mozWaitForElementToExist(app.buttons["Save"], timeout: 5)
         app.buttons["Save"].tap()
         // Check that custom engine has been added successfully
-        waitForExistence(app.tables.cells.staticTexts[customSearchEngine["name"]!])
+        mozWaitForElementToExist(app.tables.cells.staticTexts[customSearchEngine["name"]!])
     }
 
     func testCustomSearchEngineAsDefaultIsNotEditable() {
@@ -91,7 +91,7 @@ class SearchSettingsUITests: BaseTestCase {
 
         // Check to see we're not in editing state, edit is enable and done does not appear
         XCTAssertTrue(app.buttons["Edit"].isEnabled)
-        waitForNoExistence(app.buttons["Done"])
+        mozWaitForElementToNotExist(app.buttons["Done"])
 
         // Make sure switches are there
         XCTAssertEqual(app.tables.cells.switches.count, app.tables.cells.count - 2)

--- a/Tests/XCUITests/SearchTest.swift
+++ b/Tests/XCUITests/SearchTest.swift
@@ -15,7 +15,7 @@ private let SuggestedSite6: String = "foobar bit perfect"
 
 class SearchTests: BaseTestCase {
     private func typeOnSearchBar(text: String) {
-        waitForExistence(app.textFields.firstMatch, timeout: 10)
+        mozWaitForElementToExist(app.textFields.firstMatch, timeout: 10)
         app.textFields.firstMatch.tap()
         app.textFields.firstMatch.tap()
         app.textFields.firstMatch.typeText(text)
@@ -44,10 +44,10 @@ class SearchTests: BaseTestCase {
         // Suggestion is on by default (starting on Oct 24th 2017), so the prompt should not appear
         navigator.goto(URLBarOpen)
         typeOnSearchBar(text: "foobar")
-        waitForNoExistence(app.staticTexts[LabelPrompt])
+        mozWaitForElementToNotExist(app.staticTexts[LabelPrompt])
 
         // Suggestions should be shown
-        waitForExistence(app.tables["SiteTable"].cells.firstMatch)
+        mozWaitForElementToExist(app.tables["SiteTable"].cells.firstMatch)
         XCTAssertTrue(app.tables["SiteTable"].cells.firstMatch.exists)
 
         // Disable Search suggestion
@@ -59,11 +59,11 @@ class SearchTests: BaseTestCase {
         suggestionsOnOff()
 
         // Suggestions should not be shown
-        waitForNoExistence(app.tables["SiteTable"].cells.firstMatch)
+        mozWaitForElementToNotExist(app.tables["SiteTable"].cells.firstMatch)
         navigator.nowAt(BrowserTab)
         navigator.goto(URLBarOpen)
         typeOnSearchBar(text: "foobar")
-        waitForNoExistence(app.tables["SiteTable"].cells.firstMatch)
+        mozWaitForElementToNotExist(app.tables["SiteTable"].cells.firstMatch)
         XCTAssertFalse(app.tables["SiteTable"].cells.firstMatch.exists)
 
         // Verify that previous choice is remembered
@@ -72,7 +72,7 @@ class SearchTests: BaseTestCase {
         waitForTabsButton()
 
         typeOnSearchBar(text: "foobar")
-        waitForNoExistence(app.tables["SiteTable"].cells[SuggestedSite])
+        mozWaitForElementToNotExist(app.tables["SiteTable"].cells[SuggestedSite])
         XCTAssertFalse(app.tables["SiteTable"].cells.firstMatch.exists)
 
         app.buttons["urlBar-cancel"].tap()
@@ -87,7 +87,7 @@ class SearchTests: BaseTestCase {
 
         // Suggestions prompt should appear
         typeOnSearchBar(text: "foobar")
-        waitForExistence(app.tables["SiteTable"].cells.firstMatch)
+        mozWaitForElementToExist(app.tables["SiteTable"].cells.firstMatch)
         XCTAssertTrue(app.tables["SiteTable"].cells.firstMatch.exists)
     }
 
@@ -96,26 +96,26 @@ class SearchTests: BaseTestCase {
         // the suggestions are shown again
         navigator.goto(URLBarOpen)
         typeOnSearchBar(text: "foobar")
-        waitForNoExistence(app.staticTexts[LabelPrompt])
+        mozWaitForElementToNotExist(app.staticTexts[LabelPrompt])
 
         // Suggestions should be shown
-        waitForExistence(app.tables["SiteTable"])
+        mozWaitForElementToExist(app.tables["SiteTable"])
         if !(app.tables["SiteTable"].cells.staticTexts[SuggestedSite].exists) {
             if !(app.tables["SiteTable"].cells.staticTexts[SuggestedSite2].exists) {
-                waitForExistence(app.tables["SiteTable"].cells.staticTexts[SuggestedSite3], timeout: 5)
+                mozWaitForElementToExist(app.tables["SiteTable"].cells.staticTexts[SuggestedSite3], timeout: 5)
             }
         }
 
         // Typing / should stop showing suggestions
         app.textFields["address"].typeText("/")
-        waitForNoExistence(app.tables["SiteTable"].cells[SuggestedSite])
+        mozWaitForElementToNotExist(app.tables["SiteTable"].cells[SuggestedSite])
 
         // Typing space and char after / should show suggestions again
         app.textFields["address"].typeText(" b")
-        waitForExistence(app.tables["SiteTable"])
+        mozWaitForElementToExist(app.tables["SiteTable"])
         if !(app.tables["SiteTable"].cells.staticTexts[SuggestedSite4].exists) {
             if !(app.tables["SiteTable"].cells.staticTexts[SuggestedSite5].exists) {
-                waitForExistence(app.tables["SiteTable"].cells.staticTexts[SuggestedSite6])
+                mozWaitForElementToExist(app.tables["SiteTable"].cells.staticTexts[SuggestedSite6])
             }
         }
     }
@@ -126,23 +126,23 @@ class SearchTests: BaseTestCase {
         typeOnSearchBar(text: "www.mozilla.org")
         app.textFields["address"].press(forDuration: 5)
         app.menuItems["Select All"].tap()
-        waitForExistence(app.menuItems["Copy"], timeout: 3)
+        mozWaitForElementToExist(app.menuItems["Copy"], timeout: 3)
         app.menuItems["Copy"].tap()
-        waitForExistence(app.buttons["urlBar-cancel"])
+        mozWaitForElementToExist(app.buttons["urlBar-cancel"])
         app.buttons["urlBar-cancel"].tap()
 
         navigator.nowAt(HomePanelsScreen)
-        waitForExistence(app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell], timeout: 10)
-        waitForExistence(app.textFields["url"], timeout: 3)
+        mozWaitForElementToExist(app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell], timeout: 10)
+        mozWaitForElementToExist(app.textFields["url"], timeout: 3)
         app.textFields["url"].tap()
-        waitForExistence(app.textFields["address"], timeout: 3)
+        mozWaitForElementToExist(app.textFields["address"], timeout: 3)
         app.textFields["address"].tap()
 
-        waitForExistence(app.menuItems["Paste"])
+        mozWaitForElementToExist(app.menuItems["Paste"])
         app.menuItems["Paste"].tap()
 
         // Verify that the Paste shows the search controller with prompt
-        waitForNoExistence(app.staticTexts[LabelPrompt])
+        mozWaitForElementToNotExist(app.staticTexts[LabelPrompt])
         app.typeText("\r")
         waitUntilPageLoad()
 
@@ -162,7 +162,7 @@ class SearchTests: BaseTestCase {
 
     private func changeSearchEngine(searchEngine: String) {
         sleep(2)
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton])
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton])
         navigator.goto(SearchSettings)
         // Open the list of default search engines and select the desired
         app.tables.cells.element(boundBy: 0).tap()
@@ -171,7 +171,7 @@ class SearchTests: BaseTestCase {
 
         navigator.openURL("foo bar")
         // Workaroud needed after xcode 11.3 update Issue 5937
-        // waitForExistence(app.webViews.firstMatch, timeout: 3)
+        // mozWaitForElementToExist(app.webViews.firstMatch, timeout: 3)
         waitForValueContains(app.textFields["url"], value: searchEngine.lowercased())
     }
 
@@ -198,17 +198,17 @@ class SearchTests: BaseTestCase {
         navigator.nowAt(NewTabScreen)
         navigator.openURL(path(forTestPage: "test-mozilla-book.html"))
         waitUntilPageLoad()
-        waitForExistence(app.webViews.staticTexts["cloud"], timeout: 10)
+        mozWaitForElementToExist(app.webViews.staticTexts["cloud"], timeout: 10)
         // Select some text and long press to find the option
         app.webViews.staticTexts["cloud"].press(forDuration: 1)
         // Click on the > button to get to that option only on iPhone
         while !app.collectionViews.menuItems["Search with Firefox"].exists {
             app.buttons["Forward"].firstMatch.tap()
-            waitForExistence(app.collectionViews.menuItems.firstMatch)
-            waitForExistence(app.buttons["Forward"])
+            mozWaitForElementToExist(app.collectionViews.menuItems.firstMatch)
+            mozWaitForElementToExist(app.buttons["Forward"])
         }
 
-        waitForExistence(app.menuItems["Search with Firefox"])
+        mozWaitForElementToExist(app.menuItems["Search with Firefox"])
         app.menuItems["Search with Firefox"].tap()
         waitUntilPageLoad()
         waitForValueContains(app.textFields["url"], value: "google")
@@ -219,10 +219,10 @@ class SearchTests: BaseTestCase {
     // Bug https://bugzilla.mozilla.org/show_bug.cgi?id=1541832 scenario 4
     func testSearchStartAfterTypingTwoWords() {
         navigator.goto(URLBarOpen)
-        waitForExistence(app.textFields["url"], timeout: 10)
+        mozWaitForElementToExist(app.textFields["url"], timeout: 10)
         app.typeText("foo bar")
         app.typeText(XCUIKeyboardKey.return.rawValue)
-        waitForExistence(app.textFields["url"], timeout: 20)
+        mozWaitForElementToExist(app.textFields["url"], timeout: 20)
         waitForValueContains(app.textFields["url"], value: "google")
     }
 
@@ -233,7 +233,7 @@ class SearchTests: BaseTestCase {
             waitForTabsButton()
 
             // Search icon is displayed.
-            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.searchButton])
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.searchButton])
             XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.searchButton].label, "Search")
             XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.searchButton].exists)
             app.buttons[AccessibilityIdentifiers.Toolbar.searchButton].tap()
@@ -247,12 +247,12 @@ class SearchTests: BaseTestCase {
             waitUntilPageLoad()
 
             // Reload icon is displayed.
-            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton])
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton])
             XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton].label, "Home")
             app.buttons[AccessibilityIdentifiers.Toolbar.homeButton].tap()
             app.buttons[AccessibilityIdentifiers.Toolbar.backButton].tap()
 
-            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton])
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton])
             XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton].label, "Home")
             app.buttons[AccessibilityIdentifiers.Toolbar.homeButton].tap()
             XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.searchButton].label, "Search")

--- a/Tests/XCUITests/SearchTest.swift
+++ b/Tests/XCUITests/SearchTest.swift
@@ -147,7 +147,7 @@ class SearchTests: BaseTestCase {
         waitUntilPageLoad()
 
         // Check that the website is loaded
-        waitForValueContains(app.textFields["url"], value: "www.mozilla.org")
+        mozWaitForValueContains(app.textFields["url"], value: "www.mozilla.org")
         waitUntilPageLoad()
 
         // Go back, write part of moz, check the autocompletion
@@ -155,7 +155,7 @@ class SearchTests: BaseTestCase {
         navigator.nowAt(HomePanelsScreen)
         waitForTabsButton()
         typeOnSearchBar(text: "moz")
-        waitForValueContains(app.textFields["address"], value: "mozilla.org")
+        mozWaitForValueContains(app.textFields["address"], value: "mozilla.org")
         let value = app.textFields["address"].value
         XCTAssertEqual(value as? String, "mozilla.org")
     }
@@ -172,7 +172,7 @@ class SearchTests: BaseTestCase {
         navigator.openURL("foo bar")
         // Workaroud needed after xcode 11.3 update Issue 5937
         // mozWaitForElementToExist(app.webViews.firstMatch, timeout: 3)
-        waitForValueContains(app.textFields["url"], value: searchEngine.lowercased())
+        mozWaitForValueContains(app.textFields["url"], value: searchEngine.lowercased())
     }
 
     // Smoketest
@@ -211,7 +211,7 @@ class SearchTests: BaseTestCase {
         mozWaitForElementToExist(app.menuItems["Search with Firefox"])
         app.menuItems["Search with Firefox"].tap()
         waitUntilPageLoad()
-        waitForValueContains(app.textFields["url"], value: "google")
+        mozWaitForValueContains(app.textFields["url"], value: "google")
         // Now there should be two tabs open
         let numTab = app.buttons["Show Tabs"].value as? String
         XCTAssertEqual("2", numTab)
@@ -223,7 +223,7 @@ class SearchTests: BaseTestCase {
         app.typeText("foo bar")
         app.typeText(XCUIKeyboardKey.return.rawValue)
         mozWaitForElementToExist(app.textFields["url"], timeout: 20)
-        waitForValueContains(app.textFields["url"], value: "google")
+        mozWaitForValueContains(app.textFields["url"], value: "google")
     }
 
     func testSearchIconOnAboutHome() throws {

--- a/Tests/XCUITests/SettingsTest.swift
+++ b/Tests/XCUITests/SettingsTest.swift
@@ -19,7 +19,7 @@ class SettingsTest: BaseTestCase {
 
         waitUntilPageLoad()
         waitForValueContains(app.textFields["url"], value: "support.mozilla.org")
-        waitForExistence(app.webViews.staticTexts["Firefox for iOS Support"])
+        mozWaitForElementToExist(app.webViews.staticTexts["Firefox for iOS Support"])
 
         let numTabs = app.buttons["Show Tabs"].value
         XCTAssertEqual("2", numTabs as? String, "Sume should be open in a different tab")
@@ -29,19 +29,19 @@ class SettingsTest: BaseTestCase {
         waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.performAction(Action.OpenSiriFromSettings)
-        waitForExistence(app.cells["SiriSettings"], timeout: 5)
+        mozWaitForElementToExist(app.cells["SiriSettings"], timeout: 5)
     }
     /* Disable test since the option to set Firefox is not available in this build after issue #8513 landed, issue #8627
     func testDefaultBrowser() {
         // A default browser card should be available on the home screen
-        waitForExistence(app.staticTexts["Set links from websites, emails, and Messages to open automatically in Firefox."], timeout: 5)
-        waitForExistence(app.buttons["Learn More"], timeout: 5)
+        mozWaitForElementToExist(app.staticTexts["Set links from websites, emails, and Messages to open automatically in Firefox."], timeout: 5)
+        mozWaitForElementToExist(app.buttons["Learn More"], timeout: 5)
         app.buttons["Learn More"].tap()
 
-        waitForExistence(app.buttons["Go to Settings"], timeout: 5)
+        mozWaitForElementToExist(app.buttons["Go to Settings"], timeout: 5)
         app.buttons["Go to Settings"].tap()
         // Tap on "Default Browser App" and set the browser as a default (Safari is listed first)
-        waitForExistence(iOS_Settings.tables.cells.element(boundBy: 1), timeout: 5)
+        mozWaitForElementToExist(iOS_Settings.tables.cells.element(boundBy: 1), timeout: 5)
         iOS_Settings.tables.cells.element(boundBy: 2).tap()
         iOS_Settings.tables.staticTexts.element(boundBy: 0).tap()
         
@@ -49,7 +49,7 @@ class SettingsTest: BaseTestCase {
         app.activate()
 
         // Tap on "Set as Default Browser" from the in-browser settings
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: 5)
+        mozWaitForElementToExist(app.buttons["urlBar-cancel"], timeout: 5)
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         navigator.goto(SettingsScreen)
@@ -58,9 +58,9 @@ class SettingsTest: BaseTestCase {
         defaultBrowserButton.tap()
 
         // Verify the browser is selected as a default in iOS settings
-        waitForExistence(iOS_Settings.tables.buttons.element(boundBy: 1), timeout: 5)
+        mozWaitForElementToExist(iOS_Settings.tables.buttons.element(boundBy: 1), timeout: 5)
         iOS_Settings.tables.buttons.element(boundBy: 1).tap()
-        waitForExistence(iOS_Settings.tables.cells.buttons["checkmark"])
+        mozWaitForElementToExist(iOS_Settings.tables.cells.buttons["checkmark"])
         XCTAssertFalse(iOS_Settings.tables.cells.buttons["checkmark"].isEnabled)
     }*/
 }

--- a/Tests/XCUITests/SettingsTest.swift
+++ b/Tests/XCUITests/SettingsTest.swift
@@ -18,7 +18,7 @@ class SettingsTest: BaseTestCase {
         helpMenu.tap()
 
         waitUntilPageLoad()
-        waitForValueContains(app.textFields["url"], value: "support.mozilla.org")
+        mozWaitForValueContains(app.textFields["url"], value: "support.mozilla.org")
         mozWaitForElementToExist(app.webViews.staticTexts["Firefox for iOS Support"])
 
         let numTabs = app.buttons["Show Tabs"].value

--- a/Tests/XCUITests/SiteLoadTest.swift
+++ b/Tests/XCUITests/SiteLoadTest.swift
@@ -22,15 +22,15 @@ class SiteLoadTest: BaseTestCase {
 
             navigator.performAction(Action.AcceptRemovingAllTabs)
             navigator.goto(BrowserTab)
-            waitForNoExistence(app.staticTexts["1 tab(s) closed"])
+            mozWaitForElementToNotExist(app.staticTexts["1 tab(s) closed"])
 
             // clear the cache
             navigator.goto(ClearPrivateDataSettings)
             app.tables.staticTexts["Clear Private Data"].tap()
-            waitForExistence(app.alerts.buttons["OK"])
+            mozWaitForElementToExist(app.alerts.buttons["OK"])
             app.alerts.buttons["OK"].tap()
             navigator.goto(BrowserTab)
-            waitForExistence(app.textFields["url"])
+            mozWaitForElementToExist(app.textFields["url"])
             counter += 1
         }
     }

--- a/Tests/XCUITests/SyncFAUITests.swift
+++ b/Tests/XCUITests/SyncFAUITests.swift
@@ -27,15 +27,15 @@ class SyncUITests: BaseTestCase {
         waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.goto(BrowserTabMenu)
-        waitForExistence(app.tables["Context Menu"].otherElements[ImageIdentifiers.sync])
+        mozWaitForElementToExist(app.tables["Context Menu"].otherElements[ImageIdentifiers.sync])
         navigator.goto(Intro_FxASignin)
         navigator.performAction(Action.OpenEmailToSignIn)
         verifyFxASigninScreen()
     }
 
     private func verifyFxASigninScreen() {
-        waitForExistence(app.navigationBars[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaNavigationBar], timeout: 30)
-        waitForExistence(app.webViews.textFields[AccessibilityIdentifiers.Settings.FirefoxAccount.emailTextField], timeout: 10)
+        mozWaitForElementToExist(app.navigationBars[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaNavigationBar], timeout: 30)
+        mozWaitForElementToExist(app.webViews.textFields[AccessibilityIdentifiers.Settings.FirefoxAccount.emailTextField], timeout: 10)
         XCTAssertTrue(app.webViews.textFields[AccessibilityIdentifiers.Settings.FirefoxAccount.emailTextField].exists)
 
         // Verify the placeholdervalues here for the textFields
@@ -49,12 +49,12 @@ class SyncUITests: BaseTestCase {
         waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.goto(FxASigninScreen)
-        waitForExistence(app.navigationBars[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaNavigationBar], timeout: 60)
+        mozWaitForElementToExist(app.navigationBars[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaNavigationBar], timeout: 60)
 
         // Tap Sign in without any value in email Password focus on Email
-        waitForExistence(app.webViews.buttons[AccessibilityIdentifiers.Settings.FirefoxAccount.continueButton], timeout: 20)
+        mozWaitForElementToExist(app.webViews.buttons[AccessibilityIdentifiers.Settings.FirefoxAccount.continueButton], timeout: 20)
         navigator.performAction(Action.FxATapOnContinueButton)
-        waitForExistence(app.webViews.staticTexts["Valid email required"])
+        mozWaitForElementToExist(app.webViews.staticTexts["Valid email required"])
 
         // Enter only email, wrong and correct and tap sign in
         userState.fxaUsername = "foo1bar2baz3@gmail.com"
@@ -65,23 +65,23 @@ class SyncUITests: BaseTestCase {
         userState.fxaPassword = "foo"
         navigator.performAction(Action.FxATypePassword)
         navigator.performAction(Action.FxATapOnSignInButton)
-        waitForExistence(app.webViews.staticTexts["At least 8 characters"])
+        mozWaitForElementToExist(app.webViews.staticTexts["At least 8 characters"])
 
         // Enter valid but incorrect, it does not exists, password
         userState.fxaPassword = "atleasteight"
         navigator.performAction(Action.FxATypePassword)
-        waitForExistence(app.secureTextFields["Repeat password"], timeout: 10)
+        mozWaitForElementToExist(app.secureTextFields["Repeat password"], timeout: 10)
     }
 
     func testCreateAnAccountLink() {
         navigator.nowAt(NewTabScreen)
         navigator.goto(FxASigninScreen)
-        waitForExistence(app.webViews.firstMatch, timeout: 20)
-        waitForExistence(app.webViews.textFields[AccessibilityIdentifiers.Settings.FirefoxAccount.emailTextField], timeout: 40)
+        mozWaitForElementToExist(app.webViews.firstMatch, timeout: 20)
+        mozWaitForElementToExist(app.webViews.textFields[AccessibilityIdentifiers.Settings.FirefoxAccount.emailTextField], timeout: 40)
         userState.fxaUsername = "foo1bar2@gmail.com"
         navigator.performAction(Action.FxATypeEmail)
         navigator.performAction(Action.FxATapOnContinueButton)
-        waitForExistence(app.webViews.buttons["Create account"])
+        mozWaitForElementToExist(app.webViews.buttons["Create account"])
     }
 
     func testShowPassword() {
@@ -89,7 +89,7 @@ class SyncUITests: BaseTestCase {
         waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.goto(FxASigninScreen)
-        waitForExistence(app.webViews.textFields[AccessibilityIdentifiers.Settings.FirefoxAccount.emailTextField], timeout: 20)
+        mozWaitForElementToExist(app.webViews.textFields[AccessibilityIdentifiers.Settings.FirefoxAccount.emailTextField], timeout: 20)
         // Typing on Email should not show Show (password) option
         userState.fxaUsername = "iosmztest@gmail.com"
         navigator.performAction(Action.FxATypeEmail)
@@ -97,10 +97,10 @@ class SyncUITests: BaseTestCase {
         // Typing on Password should show Show (password) option
         userState.fxaPassword = "f"
         navigator.performAction(Action.FxATypePassword)
-        waitForExistence(app.webViews.otherElements["Show password"], timeout: 3)
+        mozWaitForElementToExist(app.webViews.otherElements["Show password"], timeout: 3)
         // Remove the password typed, Show (password) option should not be shown
         app.secureTextFields.element(boundBy: 0).typeText(XCUIKeyboardKey.delete.rawValue)
-        waitForNoExistence(app.webViews.staticTexts["Show password"])
+        mozWaitForElementToNotExist(app.webViews.staticTexts["Show password"])
     }
 
     func testQRPairing() {
@@ -109,8 +109,8 @@ class SyncUITests: BaseTestCase {
         navigator.goto(Intro_FxASignin)
         // QR does not work on sim but checking that the button works, no crash
         navigator.performAction(Action.OpenEmailToQR)
-        waitForExistence(app.navigationBars[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaNavigationBar], timeout: 5)
+        mozWaitForElementToExist(app.navigationBars[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaNavigationBar], timeout: 5)
         app.navigationBars[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaNavigationBar].buttons["Close"].tap()
-        waitForExistence(app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
+        mozWaitForElementToExist(app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
     }
 }

--- a/Tests/XCUITests/TabCounterTests.swift
+++ b/Tests/XCUITests/TabCounterTests.swift
@@ -27,7 +27,7 @@ class TabCounterTests: BaseTestCase {
         if !iPad() {
             navigator.goto(TabTray)
             let navBarTabTrayButton = app.segmentedControls["navBarTabTray"].buttons.firstMatch
-            waitForExistence(navBarTabTrayButton)
+            mozWaitForElementToExist(navBarTabTrayButton)
             XCTAssertTrue(navBarTabTrayButton.isSelected)
             let tabsOpenTabTray: String = navBarTabTrayButton.label
             XCTAssertTrue(tabsOpenTabTray.hasSuffix("2"))
@@ -58,7 +58,7 @@ class TabCounterTests: BaseTestCase {
             app.otherElements["Tabs Tray"].collectionViews.cells.element(boundBy: 0).buttons[StandardImageIdentifiers.Large.cross].tap()
         } else {
             let navBarTabTrayButton = app.segmentedControls["navBarTabTray"].buttons.firstMatch
-            waitForExistence(navBarTabTrayButton)
+            mozWaitForElementToExist(navBarTabTrayButton)
             XCTAssertTrue(navBarTabTrayButton.isSelected)
             let tabsOpenTabTray: String = navBarTabTrayButton.label
             XCTAssertTrue(tabsOpenTabTray.hasSuffix("2"))
@@ -75,14 +75,14 @@ class TabCounterTests: BaseTestCase {
 
         navigator.goto(TabTray)
         if isTablet {
-            waitForExistence(app.navigationBars["Client.TabTrayView"])
+            mozWaitForElementToExist(app.navigationBars["Client.TabTrayView"])
         } else {
-            waitForExistence(app.navigationBars["Open Tabs"])
+            mozWaitForElementToExist(app.navigationBars["Open Tabs"])
         }
         tabsOpen = app.segmentedControls.buttons.element(boundBy: 0).label
         XCTAssertTrue(app.segmentedControls.buttons.element(boundBy: 0).isSelected)
         if !isTablet {
-            waitForExistence(app.segmentedControls.firstMatch, timeout: 5)
+            mozWaitForElementToExist(app.segmentedControls.firstMatch, timeout: 5)
             let tabsOpenTabTray: String = app.segmentedControls.buttons.firstMatch.label
             XCTAssertTrue(tabsOpenTabTray.hasSuffix("1"))
         }

--- a/Tests/XCUITests/ThirdPartySearchTest.swift
+++ b/Tests/XCUITests/ThirdPartySearchTest.swift
@@ -14,13 +14,13 @@ class ThirdPartySearchTest: BaseTestCase {
     func testCustomSearchEngines() {
         addCustomSearchEngine()
 
-        waitForExistence(app.navigationBars["Search"].buttons["Settings"], timeout: 3)
+        mozWaitForElementToExist(app.navigationBars["Search"].buttons["Settings"], timeout: 3)
         app.navigationBars["Search"].buttons["Settings"].tap()
         app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].tap()
 
         // Perform a search using a custom search engine
         app.textFields["url"].tap()
-        waitForExistence(app.buttons["urlBar-cancel"])
+        mozWaitForElementToExist(app.buttons["urlBar-cancel"])
         if processIsTranslatedStr() == m1Rosetta {
             app.textFields.firstMatch.typeText("window")
         } else {
@@ -42,9 +42,9 @@ class ThirdPartySearchTest: BaseTestCase {
         addCustomSearchEngine()
 
         // Go to settings and set MDN as the default
-        waitForExistence(app.tables.staticTexts["Google"])
+        mozWaitForElementToExist(app.tables.staticTexts["Google"])
         app.tables.staticTexts["Google"].tap()
-        waitForExistence(app.tables.staticTexts["Mozilla Engine"])
+        mozWaitForElementToExist(app.tables.staticTexts["Mozilla Engine"])
         app.tables.staticTexts["Mozilla Engine"].tap()
         dismissSearchScreen()
 
@@ -70,12 +70,12 @@ class ThirdPartySearchTest: BaseTestCase {
 
     func testCustomSearchEngineDeletion() {
         addCustomSearchEngine()
-        waitForExistence(app.navigationBars["Search"].buttons["Settings"], timeout: 3)
+        mozWaitForElementToExist(app.navigationBars["Search"].buttons["Settings"], timeout: 3)
 
         app.navigationBars["Search"].buttons["Settings"].tap()
         app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].tap()
         app.textFields["url"].tap()
-        waitForExistence(app.buttons["urlBar-cancel"])
+        mozWaitForElementToExist(app.buttons["urlBar-cancel"])
         if processIsTranslatedStr() == m1Rosetta {
             app.textFields.firstMatch.typeText("window")
         } else {
@@ -83,24 +83,24 @@ class ThirdPartySearchTest: BaseTestCase {
             app.textFields.firstMatch.press(forDuration: 1)
             app.staticTexts["Paste"].tap()
         }
-        waitForExistence(app.scrollViews.otherElements.buttons["Mozilla Engine search"])
+        mozWaitForElementToExist(app.scrollViews.otherElements.buttons["Mozilla Engine search"])
         XCTAssertTrue(app.scrollViews.otherElements.buttons["Mozilla Engine search"].exists)
 
         // Need to go step by step to Search Settings. The ScreenGraph will fail to go to the Search Settings Screen
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: 3)
+        mozWaitForElementToExist(app.buttons["urlBar-cancel"], timeout: 3)
         app.buttons["urlBar-cancel"].tap()
         app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton].tap()
         app.tables["Context Menu"].otherElements["Settings"].tap()
-        waitForExistence(app.tables.staticTexts["Google"])
+        mozWaitForElementToExist(app.tables.staticTexts["Google"])
         app.tables.staticTexts["Google"].tap()
 
         navigator.performAction(Action.RemoveCustomSearchEngine)
         dismissSearchScreen()
 
         // Perform a search to check
-        waitForExistence(app.textFields["url"], timeout: 3)
+        mozWaitForElementToExist(app.textFields["url"], timeout: 3)
         app.textFields["url"].tap()
-        waitForExistence(app.buttons["urlBar-cancel"])
+        mozWaitForElementToExist(app.buttons["urlBar-cancel"])
        if processIsTranslatedStr() == m1Rosetta {
             app.textFields.firstMatch.typeText("window")
         } else {
@@ -109,7 +109,7 @@ class ThirdPartySearchTest: BaseTestCase {
             app.staticTexts["Paste"].tap()
         }
 
-        waitForNoExistence(app.scrollViews.otherElements.buttons["Mozilla Engine search"])
+        mozWaitForElementToNotExist(app.scrollViews.otherElements.buttons["Mozilla Engine search"])
         XCTAssertFalse(app.scrollViews.otherElements.buttons["Mozilla Engine search"].exists)
     }
 
@@ -117,12 +117,12 @@ class ThirdPartySearchTest: BaseTestCase {
         waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.performAction(Action.AddCustomSearchEngine)
-        waitForExistence(app.buttons["customEngineSaveButton"], timeout: 3)
+        mozWaitForElementToExist(app.buttons["customEngineSaveButton"], timeout: 3)
         app.buttons["customEngineSaveButton"].tap()
     }
 
     private func dismissSearchScreen() {
-        waitForExistence(app.navigationBars["Search"].buttons["Settings"])
+        mozWaitForElementToExist(app.navigationBars["Search"].buttons["Settings"])
         app.navigationBars["Search"].buttons["Settings"].tap()
         app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].tap()
     }
@@ -150,12 +150,12 @@ class ThirdPartySearchTest: BaseTestCase {
             app.staticTexts["Paste"].tap()
         }
 
-        waitForExistence(app.buttons["customEngineSaveButton"], timeout: 3)
+        mozWaitForElementToExist(app.buttons["customEngineSaveButton"], timeout: 3)
         app.buttons["customEngineSaveButton"].tap()
-        waitForExistence(app.navigationBars["Add Search Engine"], timeout: 3)
+        mozWaitForElementToExist(app.navigationBars["Add Search Engine"], timeout: 3)
         app.navigationBars["Add Search Engine"].buttons["Save"].tap()
 
-        waitForExistence(app.alerts.element(boundBy: 0))
+        mozWaitForElementToExist(app.alerts.element(boundBy: 0))
         XCTAssert(app.alerts.element(boundBy: 0).label == "Failed")
     }
 }

--- a/Tests/XCUITests/ToolbarMenuTests.swift
+++ b/Tests/XCUITests/ToolbarMenuTests.swift
@@ -26,11 +26,11 @@ class ToolbarMenuTests: BaseTestCase {
             XCTAssertTrue(hamburgerMenu.isBelow(element: firstPocketCell), "Menu button is not below the pocket cells area")
         }
         navigator.goto(BrowserTabMenu)
-        waitForExistence(app.tables["Context Menu"])
+        mozWaitForElementToExist(app.tables["Context Menu"])
         validateMenuOptions()
         XCUIDevice.shared.orientation = .landscapeLeft
-        waitForExistence(hamburgerMenu, timeout: 15)
-        waitForNoExistence(app.tables["Context Menu"])
+        mozWaitForElementToExist(hamburgerMenu, timeout: 15)
+        mozWaitForElementToNotExist(app.tables["Context Menu"])
         if iPad() {
             XCTAssertTrue(hamburgerMenu.isRightOf(rightElement: bookmarksButton), "Menu button is not on the right side of bookmarks button")
         } else {
@@ -38,10 +38,10 @@ class ToolbarMenuTests: BaseTestCase {
         }
         XCTAssertTrue(hamburgerMenu.isAbove(element: firstPocketCell), "Menu button is not below the pocket cells area")
         hamburgerMenu.tap()
-        waitForExistence(app.tables["Context Menu"])
+        mozWaitForElementToExist(app.tables["Context Menu"])
         validateMenuOptions()
         app.otherElements["PopoverDismissRegion"].tap()
-        waitForNoExistence(app.tables["Context Menu"])
+        mozWaitForElementToNotExist(app.tables["Context Menu"])
     }
 
     private func validateMenuOptions() {

--- a/Tests/XCUITests/ToolbarTest.swift
+++ b/Tests/XCUITests/ToolbarTest.swift
@@ -36,7 +36,7 @@ class ToolbarTests: BaseTestCase {
         // Navigate to two pages and press back once so that all buttons are enabled in landscape mode.
         navigator.openURL(website1["url"]!)
         waitUntilPageLoad()
-        waitForExistence(app.webViews.links["Mozilla"], timeout: 10)
+        mozWaitForElementToExist(app.webViews.links["Mozilla"], timeout: 10)
         let valueMozilla = app.textFields["url"].value as! String
         XCTAssertEqual(valueMozilla, urlValueLong)
         XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
@@ -63,7 +63,7 @@ class ToolbarTests: BaseTestCase {
         // Open new tab and then go back to previous tab to test navigation buttons.
         waitForTabsButton()
         navigator.goto(TabTray)
-        waitForExistence(app.cells.staticTexts[website1["label"]!])
+        mozWaitForElementToExist(app.cells.staticTexts[website1["label"]!])
         if iPad() {
             app.cells.element(boundBy: 1).tap()
         } else {
@@ -81,7 +81,7 @@ class ToolbarTests: BaseTestCase {
         navigator.openURL(website1["url"]!)
         waitUntilPageLoad()
         waitForTabsButton()
-        waitForExistence(app.webViews.links["Mozilla"], timeout: 10)
+        mozWaitForElementToExist(app.webViews.links["Mozilla"], timeout: 10)
         let valueMozilla = app.textFields["url"].value as! String
         XCTAssertEqual(valueMozilla, urlValueLong)
 
@@ -100,12 +100,12 @@ class ToolbarTests: BaseTestCase {
             // Workaround when testing on iPhone. If the orientation is in landscape on iPhone the tests will fail.
 
             XCUIDevice.shared.orientation = UIDeviceOrientation.portrait
-            waitForExistence(app.otherElements["Navigation Toolbar"])
+            mozWaitForElementToExist(app.otherElements["Navigation Toolbar"])
 
             navigator.openURL(website1["url"]!, waitForLoading: true)
             // Adding the waiter right after navigating to the webpage in order to make the test more stable
             waitUntilPageLoad()
-            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
             let PageOptionsMenu = app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton]
             let statusbarElement: XCUIElement = XCUIApplication(bundleIdentifier: "com.apple.springboard").statusBars.firstMatch
             app.swipeUp()
@@ -114,7 +114,7 @@ class ToolbarTests: BaseTestCase {
             XCTAssertTrue(PageOptionsMenu.isHittable)
             statusbarElement.tap(force: true)
             let topElement = app.webViews.otherElements["Internet for people, not profit — Mozilla"].children(matching: .other).matching(identifier: "navigation").element(boundBy: 0).staticTexts["Mozilla"]
-            waitForExistence(topElement, timeout: 10)
+            mozWaitForElementToExist(topElement, timeout: 10)
             XCTAssertTrue(topElement.isHittable)
         }
    }

--- a/Tests/XCUITests/ToolbarTest.swift
+++ b/Tests/XCUITests/ToolbarTest.swift
@@ -49,7 +49,7 @@ class ToolbarTests: BaseTestCase {
 
         navigator.openURL(website2)
         waitUntilPageLoad()
-        waitForValueContains(app.textFields["url"], value: "localhost:\(serverPort)")
+        mozWaitForValueContains(app.textFields["url"], value: "localhost:\(serverPort)")
         XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
         XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
 

--- a/Tests/XCUITests/TopTabsTest.swift
+++ b/Tests/XCUITests/TopTabsTest.swift
@@ -398,7 +398,7 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
 
         // Check that the tab has changed
         waitUntilPageLoad()
-        waitForValueContains(app.textFields["url"], value: "iana")
+        mozWaitForValueContains(app.textFields["url"], value: "iana")
         XCTAssertTrue(app.links["RFC 2606"].exists)
         mozWaitForElementToExist(app.buttons["Show Tabs"])
         let numTab = app.buttons["Show Tabs"].value as? String
@@ -422,7 +422,7 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
         // Check that the tab has changed to the new open one and that the user is in private mode
         waitUntilPageLoad()
         mozWaitForElementToExist(app.textFields["url"], timeout: 5)
-        waitForValueContains(app.textFields["url"], value: "iana")
+        mozWaitForValueContains(app.textFields["url"], value: "iana")
         navigator.goto(TabTray)
         XCTAssertTrue(app.buttons["smallPrivateMask"].isEnabled)
     }

--- a/Tests/XCUITests/TopTabsTest.swift
+++ b/Tests/XCUITests/TopTabsTest.swift
@@ -20,7 +20,7 @@ let toastUrl = ["url": "twitter.com", "link": "About", "urlLabel": "about"]
 class TopTabsTest: BaseTestCase {
     func testAddTabFromTabTray() throws {
         XCTExpectFailure("The app was not launched", strict: false) {
-            waitForExistence(app.collectionViews["FxCollectionView"], timeout: TIMEOUT)
+            mozWaitForElementToExist(app.collectionViews["FxCollectionView"], timeout: TIMEOUT)
         }
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
@@ -34,12 +34,12 @@ class TopTabsTest: BaseTestCase {
 
         // The tab tray shows the correct tabs
         if iPad() {
-            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 15)
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 15)
             app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].tap()
         } else {
             navigator.goto(TabTray)
         }
-        waitForExistence(app.cells.staticTexts[urlLabel], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.cells.staticTexts[urlLabel], timeout: TIMEOUT)
     }
 
     func testAddTabFromContext() {
@@ -50,21 +50,21 @@ class TopTabsTest: BaseTestCase {
         XCTAssertEqual("1", tabsOpenInitially as? String)
 
         // Open link in a different tab and switch to it
-        waitForExistence(app.webViews.links.staticTexts["More information..."], timeout: 5)
+        mozWaitForElementToExist(app.webViews.links.staticTexts["More information..."], timeout: 5)
         app.webViews.links.staticTexts["More information..."].press(forDuration: 5)
         app.buttons["Open in New Tab"].tap()
         waitUntilPageLoad()
 
         // Open tab tray to check that both tabs are there
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
-        waitForExistence(app.cells.staticTexts["Example Domain"])
+        mozWaitForElementToExist(app.cells.staticTexts["Example Domain"])
         if !app.cells.staticTexts["Example Domains"].exists {
             navigator.goto(TabTray)
             app.cells.staticTexts["Examples Domain"].firstMatch.tap()
             waitUntilPageLoad()
             navigator.nowAt(BrowserTab)
             navigator.goto(TabTray)
-            waitForExistence(app.otherElements.cells.staticTexts["Examples Domains"])
+            mozWaitForElementToExist(app.otherElements.cells.staticTexts["Examples Domains"])
         }
     }
 
@@ -77,7 +77,7 @@ class TopTabsTest: BaseTestCase {
         waitForTabsButton()
         navigator.goto(TabTray)
 
-        waitForExistence(app.cells.staticTexts[urlLabel])
+        mozWaitForElementToExist(app.cells.staticTexts[urlLabel])
         app.cells.staticTexts[urlLabel].firstMatch.tap()
         let valueMozilla = app.textFields["url"].value as! String
         XCTAssertEqual(valueMozilla, urlValueLong)
@@ -86,7 +86,7 @@ class TopTabsTest: BaseTestCase {
         waitForTabsButton()
         navigator.goto(TabTray)
 
-        waitForExistence(app.cells.staticTexts[urlLabelExample])
+        mozWaitForElementToExist(app.cells.staticTexts[urlLabelExample])
         app.cells.staticTexts[urlLabelExample].firstMatch.tap()
         let value = app.textFields["url"].value as! String
         XCTAssertEqual(value, urlValueLongExample)
@@ -98,7 +98,7 @@ class TopTabsTest: BaseTestCase {
         waitForTabsButton()
         navigator.goto(TabTray)
 
-        waitForExistence(app.cells.staticTexts[urlLabel])
+        mozWaitForElementToExist(app.cells.staticTexts[urlLabel])
         // Close the tab using 'x' button
         if iPad() {
             app.cells.buttons[StandardImageIdentifiers.Large.cross].tap()
@@ -107,7 +107,7 @@ class TopTabsTest: BaseTestCase {
         }
 
         // After removing only one tab it automatically goes to HomepanelView
-        waitForExistence(app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
+        mozWaitForElementToExist(app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
         XCTAssert(app.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell].exists)
     }
 
@@ -126,13 +126,13 @@ class TopTabsTest: BaseTestCase {
         waitForTabsButton()
         navigator.nowAt(BrowserTab)
         if iPad() {
-            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 10)
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 10)
             app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].tap()
-            waitForExistence(app.buttons[AccessibilityIdentifiers.TabTray.newTabButton], timeout: 10)
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.TabTray.newTabButton], timeout: 10)
             app.buttons[AccessibilityIdentifiers.TabTray.newTabButton].tap()
         } else {
             navigator.performAction(Action.OpenNewTabFromTabTray)
-            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 5)
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 5)
         }
 
         if iPad() {
@@ -145,13 +145,13 @@ class TopTabsTest: BaseTestCase {
         // Close all tabs, undo it and check that the number of tabs is correct
         navigator.performAction(Action.AcceptRemovingAllTabs)
 
-        waitForExistence(app.otherElements.buttons.staticTexts["Undo"])
+        mozWaitForElementToExist(app.otherElements.buttons.staticTexts["Undo"])
         app.otherElements.buttons.staticTexts["Undo"].tap()
 
-        waitForExistence(app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell], timeout: 5)
+        mozWaitForElementToExist(app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell], timeout: 5)
         navigator.nowAt(BrowserTab)
         if !iPad() {
-            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 5)
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 5)
         }
 
         if iPad() {
@@ -161,12 +161,12 @@ class TopTabsTest: BaseTestCase {
         }
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
 
-        waitForExistence(app.cells.staticTexts[urlLabel])
+        mozWaitForElementToExist(app.cells.staticTexts[urlLabel])
     }
 
     func testCloseAllTabsPrivateModeUndo() {
         navigator.goto(URLBarOpen)
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT_LONG)
+        mozWaitForElementToExist(app.buttons["urlBar-cancel"], timeout: TIMEOUT_LONG)
         navigator.back()
         // A different tab than home is open to do the proper checks
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
@@ -175,13 +175,13 @@ class TopTabsTest: BaseTestCase {
         waitForTabsButton()
 
         if iPad() {
-            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 10)
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 10)
             app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].tap()
-            waitForExistence(app.buttons[AccessibilityIdentifiers.TabTray.newTabButton], timeout: 10)
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.TabTray.newTabButton], timeout: 10)
             app.buttons[AccessibilityIdentifiers.TabTray.newTabButton].tap()
         } else {
             navigator.performAction(Action.OpenNewTabFromTabTray)
-            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 5)
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 5)
         }
 
         navigator.goto(URLBarOpen)
@@ -193,10 +193,10 @@ class TopTabsTest: BaseTestCase {
         }
         // Close all tabs, undo it and check that the number of tabs is correct
         navigator.performAction(Action.AcceptRemovingAllTabs)
-        waitForExistence(app.staticTexts["Private Browsing"], timeout: 10)
+        mozWaitForElementToExist(app.staticTexts["Private Browsing"], timeout: 10)
         XCTAssertTrue(app.staticTexts["Private Browsing"].exists, "Private welcome screen is not shown")
         // New behaviour on v14, there is no Undo in Private mode
-        waitForExistence(app.staticTexts["Private Browsing"], timeout: 10)
+        mozWaitForElementToExist(app.staticTexts["Private Browsing"], timeout: 10)
     }
 
     func testCloseAllTabs() {
@@ -208,7 +208,7 @@ class TopTabsTest: BaseTestCase {
         navigator.performAction(Action.OpenNewTabFromTabTray)
         if !iPad() {
             navigator.performAction(Action.CloseURLBarOpen)
-            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton])
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton])
         }
         navigator.nowAt(NewTabScreen)
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
@@ -216,11 +216,11 @@ class TopTabsTest: BaseTestCase {
         // Close all tabs and check that the number of tabs is correct
         navigator.performAction(Action.AcceptRemovingAllTabs)
         if !iPad() {
-            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton])
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton])
         }
         navigator.nowAt(NewTabScreen)
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
-        waitForExistence(app.cells.staticTexts["Homepage"])
+        mozWaitForElementToExist(app.cells.staticTexts["Homepage"])
     }
 
     func testCloseAllTabsPrivateMode() {
@@ -239,7 +239,7 @@ class TopTabsTest: BaseTestCase {
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
         // Close all tabs and check that the number of tabs is correct
         navigator.performAction(Action.AcceptRemovingAllTabs)
-        waitForExistence(app.staticTexts["Private Browsing"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.staticTexts["Private Browsing"], timeout: TIMEOUT)
     }
 
     // Smoketest
@@ -247,10 +247,10 @@ class TopTabsTest: BaseTestCase {
         XCUIDevice.shared.orientation = .landscapeLeft
         // Verify the '+' icon is shown and open a tab with it
         if iPad() {
-            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton])
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton])
             app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton].tap()
         } else {
-            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton], timeout: 15)
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton], timeout: 15)
             app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton].tap()
         }
         app.typeText("google.com\n")
@@ -260,7 +260,7 @@ class TopTabsTest: BaseTestCase {
         XCUIDevice.shared.orientation = .portrait
         // Verify that the '+' is not displayed
         if !iPad() {
-            waitForNoExistence(app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton])
+            mozWaitForElementToNotExist(app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton])
         }
     }
 
@@ -269,9 +269,9 @@ class TopTabsTest: BaseTestCase {
         if !iPad() {
             // Long tap on Tab Counter should show the correct options
             navigator.nowAt(NewTabScreen)
-            waitForExistence(app.buttons["Show Tabs"], timeout: 10)
+            mozWaitForElementToExist(app.buttons["Show Tabs"], timeout: 10)
             app.buttons["Show Tabs"].press(forDuration: 1)
-            waitForExistence(app.cells.otherElements[StandardImageIdentifiers.Large.plus])
+            mozWaitForElementToExist(app.cells.otherElements[StandardImageIdentifiers.Large.plus])
             XCTAssertTrue(app.cells.otherElements[StandardImageIdentifiers.Large.plus].exists)
             XCTAssertTrue(app.cells.otherElements[StandardImageIdentifiers.Large.cross].exists)
 
@@ -281,30 +281,30 @@ class TopTabsTest: BaseTestCase {
 
             waitForTabsButton()
             checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
-            waitForExistence(app.cells.staticTexts["Homepage"])
+            mozWaitForElementToExist(app.cells.staticTexts["Homepage"])
             app.cells.staticTexts["Homepage"].firstMatch.tap()
-            waitForExistence(app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
+            mozWaitForElementToExist(app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
 
             // Close tab
             navigator.nowAt(HomePanelsScreen)
             navigator.nowAt(NewTabScreen)
 
-            waitForExistence(app.buttons["Show Tabs"])
+            mozWaitForElementToExist(app.buttons["Show Tabs"])
             app.buttons["Show Tabs"].press(forDuration: 1)
-            waitForExistence(app.tables.cells.otherElements[StandardImageIdentifiers.Large.plus])
+            mozWaitForElementToExist(app.tables.cells.otherElements[StandardImageIdentifiers.Large.plus])
             app.tables.cells.otherElements[StandardImageIdentifiers.Large.cross].tap()
             navigator.nowAt(NewTabScreen)
             checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
 
             // Go to Private Mode
-            waitForExistence(app.cells.staticTexts["Homepage"])
+            mozWaitForElementToExist(app.cells.staticTexts["Homepage"])
             app.cells.staticTexts["Homepage"].firstMatch.tap()
-            waitForExistence(app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
+            mozWaitForElementToExist(app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
             navigator.nowAt(HomePanelsScreen)
             navigator.nowAt(NewTabScreen)
-            waitForExistence(app.buttons["Show Tabs"])
+            mozWaitForElementToExist(app.buttons["Show Tabs"])
             app.buttons["Show Tabs"].press(forDuration: 1)
-            waitForExistence(app.tables.cells.otherElements["Private Browsing Mode"])
+            mozWaitForElementToExist(app.tables.cells.otherElements["Private Browsing Mode"])
             app.tables.cells.otherElements["Private Browsing Mode"].tap()
             navigator.nowAt(NewTabScreen)
             checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
@@ -377,7 +377,7 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
         navigator.goto(URLBarOpen)
         navigator.back()
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
-        waitForExistence(app.buttons["smallPrivateMask"])
+        mozWaitForElementToExist(app.buttons["smallPrivateMask"])
         XCTAssertTrue(app.buttons["smallPrivateMask"].isEnabled)
         XCTAssertTrue(userState.isPrivate)
     }
@@ -391,16 +391,16 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
         waitUntilPageLoad()
 
         app.webViews.links.firstMatch.press(forDuration: 1)
-        waitForExistence(app.buttons["Open in New Tab"])
+        mozWaitForElementToExist(app.buttons["Open in New Tab"])
         app.buttons["Open in New Tab"].press(forDuration: 1)
-        waitForExistence(app.buttons["Switch"])
+        mozWaitForElementToExist(app.buttons["Switch"])
         app.buttons["Switch"].tap()
 
         // Check that the tab has changed
         waitUntilPageLoad()
         waitForValueContains(app.textFields["url"], value: "iana")
         XCTAssertTrue(app.links["RFC 2606"].exists)
-        waitForExistence(app.buttons["Show Tabs"])
+        mozWaitForElementToExist(app.buttons["Show Tabs"])
         let numTab = app.buttons["Show Tabs"].value as? String
         XCTAssertEqual("2", numTab)
     }
@@ -414,14 +414,14 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
         waitUntilPageLoad()
 
         app.webViews.links.firstMatch.press(forDuration: 1)
-        waitForExistence(app.buttons["Open in New Tab"], timeout: 3)
+        mozWaitForElementToExist(app.buttons["Open in New Tab"], timeout: 3)
         app.buttons["Open in New Private Tab"].press(forDuration: 1)
-        waitForExistence(app.buttons["Switch"], timeout: 5)
+        mozWaitForElementToExist(app.buttons["Switch"], timeout: 5)
         app.buttons["Switch"].tap()
 
         // Check that the tab has changed to the new open one and that the user is in private mode
         waitUntilPageLoad()
-        waitForExistence(app.textFields["url"], timeout: 5)
+        mozWaitForElementToExist(app.textFields["url"], timeout: 5)
         waitForValueContains(app.textFields["url"], value: "iana")
         navigator.goto(TabTray)
         XCTAssertTrue(app.buttons["smallPrivateMask"].isEnabled)
@@ -435,20 +435,20 @@ class TopTabsTestIpad: IpadOnlyTestCase {
         // Open three tabs by tapping on '+' button
         app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton].tap()
         app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton].tap()
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton])
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton])
         let numTab = app.buttons["Show Tabs"].value as? String
         XCTAssertEqual("3", numTab)
         // Remove one tab by tapping on 'x' button
         app.collectionViews["Top Tabs View"].children(matching: .cell).matching(identifier: "Homepage").element(boundBy: 1).buttons["Remove page — Homepage"].tap()
         waitForTabsButton()
-        waitForNoExistence(app.buttons["Show Tabs"].staticTexts["3"])
-        waitForExistence(app.buttons["Show Tabs"].staticTexts["2"])
+        mozWaitForElementToNotExist(app.buttons["Show Tabs"].staticTexts["3"])
+        mozWaitForElementToExist(app.buttons["Show Tabs"].staticTexts["2"])
         let numTabAfterRemovingThirdTab = app.buttons["Show Tabs"].value as? String
         XCTAssertEqual("2", numTabAfterRemovingThirdTab)
         app.collectionViews["Top Tabs View"].children(matching: .cell).element(boundBy: 1).buttons["Remove page — Homepage"].tap()
         waitForTabsButton()
-        waitForNoExistence(app.buttons["Show Tabs"].staticTexts["2"])
-        waitForExistence(app.buttons["Show Tabs"].staticTexts["1"])
+        mozWaitForElementToNotExist(app.buttons["Show Tabs"].staticTexts["2"])
+        mozWaitForElementToExist(app.buttons["Show Tabs"].staticTexts["1"])
         let numTabAfterRemovingSecondTab = app.buttons["Show Tabs"].value as? String
         XCTAssertEqual("1", numTabAfterRemovingSecondTab)
     }

--- a/Tests/XCUITests/TrackingProtectionTests.swift
+++ b/Tests/XCUITests/TrackingProtectionTests.swift
@@ -14,7 +14,7 @@ class TrackingProtectionTests: BaseTestCase {
     // Smoketest
     func testTrackingProtection() {
         navigator.goto(URLBarOpen)
-        waitForExistence(app.buttons["urlBar-cancel"], timeout: TIMEOUT_LONG)
+        mozWaitForElementToExist(app.buttons["urlBar-cancel"], timeout: TIMEOUT_LONG)
         navigator.back()
         navigator.goto(TrackingProtectionSettings)
 
@@ -29,8 +29,8 @@ class TrackingProtectionTests: BaseTestCase {
         waitUntilPageLoad()
 
         // The lock icon should still be there
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection])
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 5)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection])
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 5)
 
         // Switch to Private Browsing
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
@@ -38,13 +38,13 @@ class TrackingProtectionTests: BaseTestCase {
         waitUntilPageLoad()
 
         // Make sure TP is also there in PBM
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection])
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection])
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: TIMEOUT)
         navigator.goto(BrowserTabMenu)
-        waitForExistence(app.tables.otherElements[ImageIdentifiers.settings], timeout: 5)
+        mozWaitForElementToExist(app.tables.otherElements[ImageIdentifiers.settings], timeout: 5)
         app.tables.otherElements[ImageIdentifiers.settings].tap()
         navigator.nowAt(SettingsScreen)
-        waitForExistence(app.tables.cells["NewTab"], timeout: 5)
+        mozWaitForElementToExist(app.tables.cells["NewTab"], timeout: 5)
         app.tables.cells["NewTab"].swipeUp()
         // Enable TP again
         navigator.goto(TrackingProtectionSettings)
@@ -57,12 +57,12 @@ class TrackingProtectionTests: BaseTestCase {
     }
 
     private func checkTrackingProtectionDisabledForSite() {
-        waitForNoExistence(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection])
+        mozWaitForElementToNotExist(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection])
     }
 
     private func checkTrackingProtectionEnabledForSite() {
         navigator.goto(TrackingProtectionContextMenuDetails)
-        waitForExistence(app.cells.staticTexts["Enhanced Tracking Protection is ON for this site."])
+        mozWaitForElementToExist(app.cells.staticTexts["Enhanced Tracking Protection is ON for this site."])
     }
 
     private func enableStrictMode() {
@@ -76,9 +76,9 @@ class TrackingProtectionTests: BaseTestCase {
     func testETPLockMenu() {
         navigator.openURL(differentWebsite)
         waitUntilPageLoad()
-        waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection])
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection])
         navigator.goto(TrackingProtectionContextMenuDetails)
-        waitForExistence(app.staticTexts["Connection is not secure"], timeout: 5)
+        mozWaitForElementToExist(app.staticTexts["Connection is not secure"], timeout: 5)
         var switchValue = app.switches.firstMatch.value!
         // Need to make sure first the setting was not turned off previously
         if switchValue as! String == "0" {
@@ -93,7 +93,7 @@ class TrackingProtectionTests: BaseTestCase {
 
         // Open TP Settings menu
         app.buttons["Protection Settings"].tap()
-        waitForExistence(app.navigationBars["Tracking Protection"], timeout: 5)
+        mozWaitForElementToExist(app.navigationBars["Tracking Protection"], timeout: 5)
         let switchSettingsValue = app.switches["prefkey.trackingprotection.normalbrowsing"].value!
         XCTAssertEqual(switchSettingsValue as! String, "1")
         app.switches["prefkey.trackingprotection.normalbrowsing"].tap()
@@ -102,7 +102,7 @@ class TrackingProtectionTests: BaseTestCase {
         app.buttons["Done"].tap()
         navigator.nowAt(BrowserTab)
         navigator.goto(TrackingProtectionContextMenuDetails)
-        waitForExistence(app.staticTexts["Connection is not secure"], timeout: 5)
+        mozWaitForElementToExist(app.staticTexts["Connection is not secure"], timeout: 5)
         XCTAssertFalse(app.switches.element.exists)
     }
 

--- a/Tests/XCUITests/UrlBarTests.swift
+++ b/Tests/XCUITests/UrlBarTests.swift
@@ -33,7 +33,7 @@ class UrlBarTests: BaseTestCase {
         // Type a search term and hit "go"
         typeSearchTermAndHitGo(searchTerm: "Firefox")
         // The search is conducted correctly trough the default search engine
-        waitForValueContains(app.textFields["url"], value: "google")
+        mozWaitForValueContains(app.textFields["url"], value: "google")
         // Add a custom search engine and add it as default search engine
         navigator.goto(SearchSettings)
         let defaultSearchEngine = app.tables.cells.element(boundBy: 0)
@@ -47,7 +47,7 @@ class UrlBarTests: BaseTestCase {
         tapUrlBarValidateKeyboardAndIcon()
         typeSearchTermAndHitGo(searchTerm: "Firefox")
         // The search is conducted correctly trough the default search engine
-        waitForValueContains(app.textFields["url"], value: "amazon")
+        mozWaitForValueContains(app.textFields["url"], value: "amazon")
     }
 
     private func tapUrlBarValidateKeyboardAndIcon() {

--- a/Tests/XCUITests/UrlBarTests.swift
+++ b/Tests/XCUITests/UrlBarTests.swift
@@ -37,10 +37,10 @@ class UrlBarTests: BaseTestCase {
         // Add a custom search engine and add it as default search engine
         navigator.goto(SearchSettings)
         let defaultSearchEngine = app.tables.cells.element(boundBy: 0)
-        waitForExistence(app.tables.cells.staticTexts[defaultSearchEngine1])
+        mozWaitForElementToExist(app.tables.cells.staticTexts[defaultSearchEngine1])
         defaultSearchEngine.tap()
         app.tables.staticTexts[defaultSearchEngine2].tap()
-        waitForExistence(app.tables.cells.staticTexts[defaultSearchEngine2])
+        mozWaitForElementToExist(app.tables.cells.staticTexts[defaultSearchEngine2])
         navigator.goto(SettingsScreen)
         app.navigationBars.buttons["Done"].tap()
         app.buttons[AccessibilityIdentifiers.Toolbar.homeButton].tap()
@@ -71,7 +71,7 @@ class UrlBarTests: BaseTestCase {
     private func typeSearchTermAndHitGo(searchTerm: String) {
         app.textFields["address"].typeText(searchTerm)
         waitUntilPageLoad()
-        waitForExistence(app.buttons["Go"])
+        mozWaitForElementToExist(app.buttons["Go"])
         app.buttons["Go"].tap()
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
The current XCUITest methods waitForExistence, waitForNoExistence, waitForValueContains, and waitFor are very slow-running and need to be optimized.

Performance testing them using measure gave measurment of ~1.5 seconds up to 3 seconds per execution.

Updating those methods to use a simple while-loop takes execution time down to 0.05 up to 0.101, a performance improvement of about 25x for the average element assertion.

The current count of the use of those methods are as follows:

waitForExistence: 642
waitForNoExistence: 72
waitForValueContains: 59
Total: 773

The current total runtime for those assertions is on average 1159.50 seconds.

Replacing those with the updated code will reduce the runtime on average by 695.70 seconds, a runtime savings of over 10 minutes.

The current Full Functional Test Suite runs on average at 3778.881 seconds and will be reduced to an average runtime of 3083.181 seconds, a performance improvement of 28.5%.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

