### PR TITLE
Refactor MTE-1500 [v119] Skipping just the swipe gesture in testDeleteHistoryEntryBySwiping

### DIFF
--- a/Tests/XCUITests/HistoryTests.swift
+++ b/Tests/XCUITests/HistoryTests.swift
@@ -442,12 +442,12 @@ class HistoryTests: BaseTestCase {
 
     // Smoketest
     func testDeleteHistoryEntryBySwiping() throws {
+        navigateToGoogle()
+        navigator.goto(LibraryPanel_History)
+        waitForExistence(app.cells.staticTexts["http://example.com/"], timeout: TIMEOUT)
         if processIsTranslatedStr() == m1Rosetta {
             throw XCTSkip("Swipe gesture does not work on M1")
         } else {
-            navigateToGoogle()
-            navigator.goto(LibraryPanel_History)
-            waitForExistence(app.cells.staticTexts["http://example.com/"], timeout: TIMEOUT)
             app.cells.staticTexts["http://example.com/"].firstMatch.swipeLeft()
             waitForExistence(app.buttons[StandardImageIdentifiers.Large.delete], timeout: TIMEOUT)
             app.buttons[StandardImageIdentifiers.Large.delete].tap()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1500)

## :bulb: Description
Instead of disabling the whole test for M1, let's execute the test until the swipe gesture is invoked.

Note that swipe is known not to work on M1.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

