### PR TITLE
Refactor FXIOS-6347 [v119] Replace use of DefaultMediumFont with preferredFont

### DIFF
--- a/Client/Frontend/Settings/Main/Account/SyncNowSetting.swift
+++ b/Client/Frontend/Settings/Main/Account/SyncNowSetting.swift
@@ -46,7 +46,7 @@ class SyncNowSetting: WithAccountSetting {
                 string: .FxANoInternetConnection,
                 attributes: [
                     NSAttributedString.Key.foregroundColor: theme.colors.textWarning,
-                    NSAttributedString.Key.font: LegacyDynamicFontHelper.defaultHelper.DefaultMediumFont
+                    NSAttributedString.Key.font: DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 13, weight: .regular)
                 ]
             )
         }

--- a/Client/Frontend/Settings/TPAccessoryInfo.swift
+++ b/Client/Frontend/Settings/TPAccessoryInfo.swift
@@ -105,7 +105,7 @@ class TPAccessoryInfo: ThemedTableViewController {
         }
         cell.imageView?.tintColor = themeManager.currentTheme.colors.iconPrimary
         if indexPath.row == 1 {
-            cell.textLabel?.font = LegacyDynamicFontHelper.defaultHelper.DefaultMediumFont
+            cell.textLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 13, weight: .regular)
         }
         cell.textLabel?.numberOfLines = 0
         cell.detailTextLabel?.numberOfLines = 0

--- a/Client/Helpers/LegacyDynamicFontHelper.swift
+++ b/Client/Helpers/LegacyDynamicFontHelper.swift
@@ -21,7 +21,6 @@ class LegacyDynamicFontHelper: NSObject {
     override init() {
         defaultStandardFontSize = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .body).pointSize // 14pt -> 17pt -> 23pt
         deviceFontSize = defaultStandardFontSize * (UIDevice.current.userInterfaceIdiom == .pad ? iPadFactor : iPhoneFactor)
-        defaultMediumFontSize = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .footnote).pointSize // 12pt -> 13pt -> 19pt
         defaultSmallFontSize = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .caption1).pointSize // 11pt -> 12pt -> 17pt
 
         super.init()
@@ -97,14 +96,6 @@ class LegacyDynamicFontHelper: NSObject {
     }
 
     /**
-     * Medium
-     */
-    fileprivate var defaultMediumFontSize: CGFloat
-    var DefaultMediumFont: UIFont {
-        return UIFont.systemFont(ofSize: defaultMediumFontSize, weight: UIFont.Weight.regular)
-    }
-
-    /**
      * Standard
      */
     fileprivate var defaultStandardFontSize: CGFloat
@@ -125,7 +116,6 @@ class LegacyDynamicFontHelper: NSObject {
     func refreshFonts() {
         defaultStandardFontSize = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .body).pointSize
         deviceFontSize = defaultStandardFontSize * (UIDevice.current.userInterfaceIdiom == .pad ? iPadFactor : iPhoneFactor)
-        defaultMediumFontSize = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .footnote).pointSize
         defaultSmallFontSize = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .caption2).pointSize
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6347)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14267)

## :bulb: Description
Replace use of DefaultMediumFont with preferredFont and remove defaultMediumFontSize from LegacyDynamicFontHelper as it was no longer read by any symbols

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

