### PR TITLE
Add FXIOS-7344 [v119] Add publish docc yml

### DIFF
--- a/.github/workflows/publish-docc.yml
+++ b/.github/workflows/publish-docc.yml
@@ -1,0 +1,48 @@
+name: Deploy Docc:
+on:
+  # Runs on pushes where BrowserKit files are modified
+  push:
+    paths:
+      - BrowserKit/**
+  workflow_dispatch: {} # adding the workflow_dispatch so it can be triggered manually
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      # Must be set to this for deploying to GitHub Pages
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: macos-12
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+      - name: Build DocC
+        run: |
+          xcodebuild docbuild -scheme ComponentLibrary \
+            -derivedDataPath /tmp/docbuild \
+            -destination 'generic/platform=iOS';
+          $(xcrun --find docc) process-archive \
+            transform-for-static-hosting /tmp/docbuild/Build/Products/Debug-iphoneos/ComponentLibrary.doccarchive \
+            --hosting-base-path ComponentLibrary \
+            --output-path docs;
+          echo "<script>window.location.href += \"/documentation/componentlibrary\"</script>" > docs/index.html;
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # Upload only docs directory
+          path: 'docs'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7344)

## :bulb: Description
Adding a GitHub action to publish a [Docc](https://developer.apple.com/documentation/docc) website on our Github for the Component Library. I'm not entirely sure if this will work as is, but I need to merge to main to be able to try it out.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

