### PR TITLE
Bugfix MTE-1557 [v119] Harden testSearchIconOnAboutHome

### DIFF
--- a/Tests/XCUITests/SearchTest.swift
+++ b/Tests/XCUITests/SearchTest.swift
@@ -250,6 +250,7 @@ class SearchTests: BaseTestCase {
             waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton])
             XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton].label, "Home")
             app.buttons[AccessibilityIdentifiers.Toolbar.homeButton].tap()
+            waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.backButton])
             app.buttons[AccessibilityIdentifiers.Toolbar.backButton].tap()
 
             waitForExistence(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton])


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1557)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
`testSearchIconOnAboutHome()` has been failing intermittently. I confirmed that the following line, which tap the back button, may not be ready for tapping.

https://github.com/mozilla-mobile/firefox-ios/blob/main/Tests/XCUITests/SearchTest.swift#L253

Let me ensure that the back button is ready before tapping. I have tested this solution by running the test for 20 times and the test passed all the time.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

