### PR TITLE
Refactor FXIOS-7396 [v119] Replace rounded buttons in onboarding

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButtonViewModel.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButtonViewModel.swift
@@ -5,10 +5,10 @@
 import Foundation
 
 public struct SecondaryRoundedButtonViewModel {
-    public let title: String?
+    public let title: String
     public let a11yIdentifier: String
 
-    public init(title: String?, a11yIdentifier: String) {
+    public init(title: String, a11yIdentifier: String) {
         self.title = title
         self.a11yIdentifier = a11yIdentifier
     }

--- a/Client/Frontend/Onboarding/ViewControllers/OnboardingCardViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/OnboardingCardViewController.swift
@@ -12,7 +12,6 @@ class OnboardingCardViewController: UIViewController, Themeable {
         static let stackViewSpacingWithLink: CGFloat = 15
         static let stackViewSpacingWithoutLink: CGFloat = 24
         static let stackViewSpacingButtons: CGFloat = 16
-        static let buttonCornerRadius: CGFloat = 13
         static let topStackViewSpacing: CGFloat = 24
         static let topStackViewPaddingPad: CGFloat = 70
         static let topStackViewPaddingPhone: CGFloat = 90
@@ -117,34 +116,12 @@ class OnboardingCardViewController: UIViewController, Themeable {
         stack.axis = .vertical
     }
 
-    private lazy var primaryButton: ResizableButton = .build { button in
-        button.titleLabel?.font = DefaultDynamicFontHelper.preferredBoldFont(
-            withTextStyle: .callout,
-            size: UX.buttonFontSize)
-        button.layer.cornerRadius = UX.buttonCornerRadius
-        button.titleLabel?.textAlignment = .center
+    private lazy var primaryButton: PrimaryRoundedButton = .build { button in
         button.addTarget(self, action: #selector(self.primaryAction), for: .touchUpInside)
-        button.titleLabel?.adjustsFontForContentSizeCategory = true
-        button.accessibilityIdentifier = "\(self.viewModel.a11yIdRoot)PrimaryButton"
-        button.contentEdgeInsets = UIEdgeInsets(top: UX.buttonVerticalInset,
-                                                left: UX.buttonHorizontalInset,
-                                                bottom: UX.buttonVerticalInset,
-                                                right: UX.buttonHorizontalInset)
     }
 
-    private lazy var secondaryButton: ResizableButton = .build { button in
-        button.titleLabel?.font = DefaultDynamicFontHelper.preferredBoldFont(
-            withTextStyle: .callout,
-            size: UX.buttonFontSize)
-        button.layer.cornerRadius = UX.buttonCornerRadius
-        button.titleLabel?.textAlignment = .center
+    private lazy var secondaryButton: SecondaryRoundedButton = .build { button in
         button.addTarget(self, action: #selector(self.secondaryAction), for: .touchUpInside)
-        button.accessibilityIdentifier = "\(self.viewModel.a11yIdRoot)SecondaryButton"
-        button.titleLabel?.adjustsFontForContentSizeCategory = true
-        button.contentEdgeInsets = UIEdgeInsets(top: UX.buttonVerticalInset,
-                                                left: UX.buttonHorizontalInset,
-                                                bottom: UX.buttonVerticalInset,
-                                                right: UX.buttonHorizontalInset)
     }
 
     private lazy var linkButton: ResizableButton = .build { button in
@@ -334,10 +311,15 @@ class OnboardingCardViewController: UIViewController, Themeable {
     private func updateLayout() {
         titleLabel.text = viewModel.title
         descriptionLabel.text = viewModel.body
-
         imageView.image = viewModel.image
-        primaryButton.setTitle(viewModel.buttons.primary.title,
-                               for: .normal)
+
+        let buttonViewModel = PrimaryRoundedButtonViewModel(
+            title: viewModel.buttons.primary.title,
+            a11yIdentifier: "\(self.viewModel.a11yIdRoot)PrimaryButton"
+        )
+        primaryButton.configure(viewModel: buttonViewModel)
+        primaryButton.applyTheme(theme: themeManager.currentTheme)
+
         setupSecondaryButton()
     }
 
@@ -350,7 +332,12 @@ class OnboardingCardViewController: UIViewController, Themeable {
             return
         }
 
-        secondaryButton.setTitle(buttonTitle, for: .normal)
+        let buttonViewModel = SecondaryRoundedButtonViewModel(
+            title: buttonTitle,
+            a11yIdentifier: "\(self.viewModel.a11yIdRoot)SecondaryButton"
+        )
+        secondaryButton.configure(viewModel: buttonViewModel)
+        secondaryButton.applyTheme(theme: themeManager.currentTheme)
     }
 
     private func setupLinkButton() {
@@ -395,11 +382,6 @@ class OnboardingCardViewController: UIViewController, Themeable {
         titleLabel.textColor = theme.colors.textPrimary
         descriptionLabel.textColor  = theme.colors.textPrimary
 
-        primaryButton.setTitleColor(theme.colors.textInverted, for: .normal)
-        primaryButton.backgroundColor = theme.colors.actionPrimary
-
-        secondaryButton.setTitleColor(theme.colors.textSecondaryAction, for: .normal)
-        secondaryButton.backgroundColor = theme.colors.actionSecondary
         setupSecondaryButton()
         setupLinkButton()
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7396)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16393)

## :bulb: Description
Replace existing primary and secondary buttons in `OnboardingCardViewController` to use the new UI component library.
Tested by forcing one and two buttons in the onboarding to ensure layout was the same as before.

![Simulator Screenshot - iPhone 14 Pro - 2023-09-15 at 14 43 47](https://github.com/mozilla-mobile/firefox-ios/assets/11338480/d12df144-20de-4d38-b611-b2cb06985675)
![Simulator Screenshot - iPhone 14 Pro - 2023-09-15 at 14 43 50](https://github.com/mozilla-mobile/firefox-ios/assets/11338480/65ff9b42-55d9-411e-90c4-7e2e7753ea82)

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

