### PR TITLE
Bugfix FXIOS-5772 [v119] The upper right corner show "Edit" after deletion in search engines

### DIFF
--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -294,8 +294,10 @@ class SearchSettingsTableViewController: ThemedTableViewController {
             let index = indexPath.item + 1
             let engine = model.orderedEngines[index]
 
-            model.deleteCustomEngine(engine) {
+            model.deleteCustomEngine(engine) {[weak self] in
                 tableView.deleteRows(at: [indexPath], with: .right)
+                // Change navigationItem's right button item title to Edit and disable the edit button once the deletion is done
+                self?.setEditing(false, animated: true)
             }
 
             // End editing if we are no longer edit since we've deleted all editable cells.


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5772)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13253)

## :bulb: Description
The upper right corner show "Edit" after deletion of search engine. The edit button is not enabled as default search engines can't be deleted

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

