### PR TITLE
Bugfix FXIOS-7399 [v119] Changed goToSettingsButton to Primary Button

### DIFF
--- a/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
+++ b/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
@@ -102,7 +102,7 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
         label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.HomeTabBanner.descriptionLabel3
     }
 
-    private lazy var goToSettingsButton: ResizableButton = .build { button in
+    private lazy var goToSettingsButton: PrimaryButton = .build { button in
         button.layer.cornerRadius = UX.ctaButtonCornerRadius
         button.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.HomeTabBanner.ctaButton
         button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .title3, size: 20)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7399)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16396)

## :bulb: Description
Changed the goToSettingsButton to the Primary Button from the Component View.
 private lazy var goToSettingsButton: PrimaryButton


## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

