### PR TITLE
Bugfix FXIOS-7317 [v119] Firefox retains data from Private Browsing Mode

### DIFF
--- a/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/URLFetcher/HTMLDataRequest.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/URLFetcher/HTMLDataRequest.swift
@@ -15,7 +15,7 @@ struct DefaultHTMLDataRequest: HTMLDataRequest {
     }
 
     func fetchDataForURL(_ url: URL) async throws -> Data {
-        let configuration = URLSessionConfiguration.default
+        let configuration = URLSessionConfiguration.ephemeral
         configuration.httpAdditionalHeaders = ["User-Agent": RequestConstants.userAgent]
         configuration.timeoutIntervalForRequest = RequestConstants.timeout
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7317)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16244)

## :bulb: Description
Use ephemeral session configuration to retrieve favIcons similar to using nonPersistent store for data storage configuration

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

