### PR TITLE
Bugfix MTE-1562 [v119] Wait until the app is really in the background

### DIFF
--- a/Tests/XCUITests/BaseTestCase.swift
+++ b/Tests/XCUITests/BaseTestCase.swift
@@ -44,7 +44,7 @@ class BaseTestCase: XCTestCase {
         // Send app to background, and re-enter
         XCUIDevice.shared.press(.home)
         // Let's be sure the app is backgrounded
-        app.wait(for: XCUIApplication.State.runningBackgroundSuspended, timeout: TIMEOUT_LONG)
+        let _ = app.wait(for: XCUIApplication.State.runningBackgroundSuspended, timeout: TIMEOUT_LONG)
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
         waitForExistence(springboard.icons["XCUITests-Runner"], timeout: 10)
         app.activate()

--- a/Tests/XCUITests/BaseTestCase.swift
+++ b/Tests/XCUITests/BaseTestCase.swift
@@ -44,7 +44,7 @@ class BaseTestCase: XCTestCase {
         // Send app to background, and re-enter
         XCUIDevice.shared.press(.home)
         // Let's be sure the app is backgrounded
-        let _ = app.wait(for: XCUIApplication.State.runningBackgroundSuspended, timeout: TIMEOUT_LONG)
+        _ = app.wait(for: XCUIApplication.State.runningBackgroundSuspended, timeout: TIMEOUT_LONG)
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
         waitForExistence(springboard.icons["XCUITests-Runner"], timeout: 10)
         app.activate()

--- a/Tests/XCUITests/BaseTestCase.swift
+++ b/Tests/XCUITests/BaseTestCase.swift
@@ -44,6 +44,7 @@ class BaseTestCase: XCTestCase {
         // Send app to background, and re-enter
         XCUIDevice.shared.press(.home)
         // Let's be sure the app is backgrounded
+        app.wait(for: XCUIApplication.State.runningBackgroundSuspended, timeout: TIMEOUT_LONG)
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
         waitForExistence(springboard.icons["XCUITests-Runner"], timeout: 10)
         app.activate()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1562)

## :bulb: Description
One of the smoke tests, `testOpenTabsInSearchSuggestions()`, fails intermittently. The command `restartInBackground()` may not wait long enough that the Firefox iOS app becomes in the background. I added an assertion to ensure that the app is in the background.

I run the tests 50 times repeatedly and all passed.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

