### PR TITLE
Refactor FXIOS-6989 [v119] Replace "Firefox account" with agnostic "Account" branding

### DIFF
--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -1635,6 +1635,13 @@ extension String {
         }
 
         public struct Sync {
+            public static let SyncTabsNotUsed = MZLocalizedString(
+                key: "TabsTray.SyncTabs.SyncTabsButton.Title.v109",
+                tableName: "TabsTray",
+                value: "Sync Tabs",
+                comment: "Button label to sync tabs in your Firefox Account",
+                lastUsedInVersion: 119)
+
             public static let SyncTabs = MZLocalizedString(
                 key: "TabsTray.SyncTabs.SyncTabsButton.Title.v119",
                 tableName: "TabsTray",
@@ -2201,6 +2208,12 @@ extension String {
 // MARK: - Firefox Account
 extension String {
     // Settings strings
+    public static let FxAFirefoxAccountNotUsed = MZLocalizedString(
+        key: "FxA.FirefoxAccount",
+        tableName: nil,
+        value: "Firefox Account",
+        comment: "Settings section title for Firefox Accoun",
+        lastUsedInVersion: 119)
     public static let FxAFirefoxAccount = MZLocalizedString(
         key: "FxA.FirefoxAccount.v119",
         tableName: nil,
@@ -2221,6 +2234,12 @@ extension String {
         tableName: nil,
         value: "No Internet Connection",
         comment: "Label when no internet is present")
+    public static let FxASettingsTitleNotUsed = MZLocalizedString(
+        key: "Settings.FxA.Title",
+        tableName: nil,
+        value: "Firefox Account",
+        comment: "Title displayed in header of the FxA settings panel.",
+        lastUsedInVersion: 119)
     public static let FxASettingsTitle = MZLocalizedString(
         key: "Settings.FxA.Title.v119",
         tableName: nil,
@@ -3491,6 +3510,12 @@ extension String {
         tableName: nil,
         value: "Close",
         comment: "Close button in top navigation bar")
+    public static let SendToNotSignedInTextNotUsed = MZLocalizedString(
+        key: "SendTo.NotSignedIn.Title",
+        tableName: nil,
+        value: "You are not signed in to your Firefox Account.",
+        comment: "See http://mzl.la/1ISlXnU",
+        lastUsedInVersion: 119)
     public static let SendToNotSignedInText = MZLocalizedString(
         key: "SendTo.NotSignedIn.Title.v119",
         tableName: nil,
@@ -3501,6 +3526,12 @@ extension String {
         tableName: nil,
         value: "Please open Firefox, go to Settings and sign in to continue.",
         comment: "See http://mzl.la/1ISlXnU")
+    public static let SendToNoDevicesFoundNotUsed = MZLocalizedString(
+        key: "SendTo.NoDevicesFound.Message",
+        tableName: nil,
+        value: "You don’t have any other devices connected to this Firefox Account available to sync.",
+        comment: "Error message shown in the remote tabs panel",
+        lastUsedInVersion: 119)
     public static let SendToNoDevicesFound = MZLocalizedString(
         key: "SendTo.NoDevicesFound.Message.v119",
         tableName: nil,
@@ -5217,6 +5248,12 @@ extension String {
         tableName: nil,
         value: "No logins found",
         comment: "Label shown when there are no logins saved")
+    public static let LoginsListNoLoginsFoundDescriptionNotUsed = MZLocalizedString(
+        key: "LoginsList.NoLoginsFound.Description",
+        tableName: nil,
+        value: "Saved logins will show up here. If you saved your logins to Firefox on a different device, sign in to your Firefox Account.",
+        comment: "Label shown when there are no logins to list",
+        lastUsedInVersion: 119)
     public static let LoginsListNoLoginsFoundDescription = MZLocalizedString(
         key: "LoginsList.NoLoginsFound.Description.v119",
         tableName: nil,

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -2216,7 +2216,7 @@ extension String {
         lastUsedInVersion: 119)
     public static let FxAFirefoxAccount = MZLocalizedString(
         key: "FxA.FirefoxAccount.v119",
-        tableName: nil,
+        tableName: "Settings",
         value: "account",
         comment: "Settings section title for account")
     public static let FxAManageAccount = MZLocalizedString(
@@ -2242,7 +2242,7 @@ extension String {
         lastUsedInVersion: 119)
     public static let FxASettingsTitle = MZLocalizedString(
         key: "Settings.FxA.Title.v119",
-        tableName: nil,
+        tableName: "Settings",
         value: "account",
         comment: "Title displayed in header of the FxA settings panel.")
     public static let FxASettingsSyncSettings = MZLocalizedString(
@@ -3518,7 +3518,7 @@ extension String {
         lastUsedInVersion: 119)
     public static let SendToNotSignedInText = MZLocalizedString(
         key: "SendTo.NotSignedIn.Title.v119",
-        tableName: nil,
+        tableName: "Share",
         value: "You are not signed in to your account.",
         comment: "See http://mzl.la/1ISlXnU")
     public static let SendToNotSignedInMessage = MZLocalizedString(
@@ -3534,7 +3534,7 @@ extension String {
         lastUsedInVersion: 119)
     public static let SendToNoDevicesFound = MZLocalizedString(
         key: "SendTo.NoDevicesFound.Message.v119",
-        tableName: nil,
+        tableName: "Share",
         value: "You don’t have any other devices connected to this account available to sync.",
         comment: "Error message shown in the remote tabs panel")
     public static let SendToTitle = MZLocalizedString(

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -1636,10 +1636,10 @@ extension String {
 
         public struct Sync {
             public static let SyncTabs = MZLocalizedString(
-                key: "TabsTray.SyncTabs.SyncTabsButton.Title.v109",
+                key: "TabsTray.SyncTabs.SyncTabsButton.Title.v119",
                 tableName: "TabsTray",
                 value: "Sync Tabs",
-                comment: "Button label to sync tabs in your Firefox Account")
+                comment: "Button label to sync tabs in your account")
 
             public static let SyncTabsDisabled = MZLocalizedString(
                 key: "TabsTray.Sync.SyncTabsDisabled.v116",
@@ -2202,10 +2202,10 @@ extension String {
 extension String {
     // Settings strings
     public static let FxAFirefoxAccount = MZLocalizedString(
-        key: "FxA.FirefoxAccount",
+        key: "FxA.FirefoxAccount.v119",
         tableName: nil,
-        value: "Firefox Account",
-        comment: "Settings section title for Firefox Account")
+        value: "account",
+        comment: "Settings section title for account")
     public static let FxAManageAccount = MZLocalizedString(
         key: "FxA.ManageAccount",
         tableName: nil,
@@ -2222,9 +2222,9 @@ extension String {
         value: "No Internet Connection",
         comment: "Label when no internet is present")
     public static let FxASettingsTitle = MZLocalizedString(
-        key: "Settings.FxA.Title",
+        key: "Settings.FxA.Title.v119",
         tableName: nil,
-        value: "Firefox Account",
+        value: "account",
         comment: "Title displayed in header of the FxA settings panel.")
     public static let FxASettingsSyncSettings = MZLocalizedString(
         key: "Settings.FxA.Sync.SectionName",
@@ -2294,7 +2294,7 @@ extension String {
 // For 'Advanced Sync Settings' view, which is a debug setting. English only, there is little value in maintaining L10N strings for these.
 extension String {
     public static let SettingsAdvancedAccountTitle = "Advanced Sync Settings"
-    public static let SettingsAdvancedAccountCustomFxAContentServerURI = "Custom Firefox Account Content Server URI"
+    public static let SettingsAdvancedAccountCustomFxAContentServerURI = "Custom Account Content Server URI"
     public static let SettingsAdvancedAccountUseCustomFxAContentServerURITitle = "Use Custom FxA Content Server"
     public static let SettingsAdvancedAccountCustomSyncTokenServerURI = "Custom Sync Token Server URI"
     public static let SettingsAdvancedAccountUseCustomSyncTokenServerTitle = "Use Custom Sync Token Server"
@@ -3492,9 +3492,9 @@ extension String {
         value: "Close",
         comment: "Close button in top navigation bar")
     public static let SendToNotSignedInText = MZLocalizedString(
-        key: "SendTo.NotSignedIn.Title",
+        key: "SendTo.NotSignedIn.Title.v119",
         tableName: nil,
-        value: "You are not signed in to your Firefox Account.",
+        value: "You are not signed in to your account.",
         comment: "See http://mzl.la/1ISlXnU")
     public static let SendToNotSignedInMessage = MZLocalizedString(
         key: "SendTo.NotSignedIn.Message",
@@ -3502,9 +3502,9 @@ extension String {
         value: "Please open Firefox, go to Settings and sign in to continue.",
         comment: "See http://mzl.la/1ISlXnU")
     public static let SendToNoDevicesFound = MZLocalizedString(
-        key: "SendTo.NoDevicesFound.Message",
+        key: "SendTo.NoDevicesFound.Message.v119",
         tableName: nil,
-        value: "You don’t have any other devices connected to this Firefox Account available to sync.",
+        value: "You don’t have any other devices connected to this account available to sync.",
         comment: "Error message shown in the remote tabs panel")
     public static let SendToTitle = MZLocalizedString(
         key: "SendTo.NavBar.Title",
@@ -5218,9 +5218,9 @@ extension String {
         value: "No logins found",
         comment: "Label shown when there are no logins saved")
     public static let LoginsListNoLoginsFoundDescription = MZLocalizedString(
-        key: "LoginsList.NoLoginsFound.Description",
+        key: "LoginsList.NoLoginsFound.Description.v119",
         tableName: nil,
-        value: "Saved logins will show up here. If you saved your logins to Firefox on a different device, sign in to your Firefox Account.",
+        value: "Saved logins will show up here. If you saved your logins to Firefox on a different device, sign in to your account.",
         comment: "Label shown when there are no logins to list")
     public static let LoginsPasscodeRequirementWarning = MZLocalizedString(
         key: "Logins.PasscodeRequirement.Warning",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6989)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Replace "Firefox account" with agnostic "Account" branding
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

