### PR TITLE
Bugfix FXIOS-5772 [v120] The upper right corner show "Edit" after deletion in search engines

### DIFF
--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -294,8 +294,10 @@ class SearchSettingsTableViewController: ThemedTableViewController {
             let index = indexPath.item + 1
             let engine = model.orderedEngines[index]
 
-            model.deleteCustomEngine(engine) {
+            model.deleteCustomEngine(engine) { [weak self] in
                 tableView.deleteRows(at: [indexPath], with: .right)
+                // Change navigationItem's right button item title to Edit and disable the edit button once the deletion is done
+                self?.setEditing(false, animated: true)
             }
 
             // End editing if we are no longer edit since we've deleted all editable cells.


### PR DESCRIPTION
If user will add custom search engine and deletes it the button will renamed to edit. Button will be disabled as we don't want user to delete the default search engines.