### PR TITLE
Bugfix MTE-1575 [v119] Upgrade XCode for import string Github Actions

### DIFF
--- a/.github/workflows/import-strings.yml
+++ b/.github/workflows/import-strings.yml
@@ -1,7 +1,7 @@
 name: Create a PR with changes after importing strings
-on: push
-#  schedule:
-#    - cron: '0 11 * * 1'
+on:
+  schedule:
+    - cron: '0 11 * * 1'
   workflow_dispatch:
     inputs:
       branchName:

--- a/.github/workflows/import-strings.yml
+++ b/.github/workflows/import-strings.yml
@@ -1,7 +1,7 @@
 name: Create a PR with changes after importing strings
-on:
-  schedule:
-    - cron: '0 11 * * 1'
+on: push
+#  schedule:
+#    - cron: '0 11 * * 1'
   workflow_dispatch:
     inputs:
       branchName:
@@ -15,7 +15,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: [3.9]
-        xcode: ["14.3.0"]
+        xcode: ["14.3.1"]
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/import-strings.yml
+++ b/.github/workflows/import-strings.yml
@@ -1,13 +1,13 @@
 name: Create a PR with changes after importing strings
-on:
-  schedule:
-    - cron: '0 11 * * 1'
-  workflow_dispatch:
-    inputs:
-      branchName:
-        description: 'Branch used as target for automation'
-        required: true
-        default: 'main'
+on: push
+  #schedule:
+  #  - cron: '0 11 * * 1'
+  #workflow_dispatch:
+  #  inputs:
+  #    branchName:
+  #      description: 'Branch used as target for automation'
+  #      required: true
+  #      default: 'main'
 jobs:
   build:
     runs-on: macos-13

--- a/.github/workflows/import-strings.yml
+++ b/.github/workflows/import-strings.yml
@@ -1,13 +1,13 @@
 name: Create a PR with changes after importing strings
-on: push
-  #schedule:
-  #  - cron: '0 11 * * 1'
-  #workflow_dispatch:
-  #  inputs:
-  #    branchName:
-  #      description: 'Branch used as target for automation'
-  #      required: true
-  #      default: 'main'
+on:
+  schedule:
+    - cron: '0 11 * * 1'
+  workflow_dispatch:
+    inputs:
+      branchName:
+        description: 'Branch used as target for automation'
+        required: true
+        default: 'main'
 jobs:
   build:
     runs-on: macos-13


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1575)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Github Actions `import-strings.yml` fails due to the XCode version not supported anymore. 

https://github.com/mozilla-mobile/firefox-ios/actions/runs/6238406899/job/16934179583

Let me bump the XCode version to 14.3.1. Here's a sample run on the job on my fork.

https://github.com/clarmso/firefox-ios/actions/runs/6239116648/job/16936355632

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

