### PR TITLE
Bugfix FXIOS-6591 [v119] Fix a11y / dynamic type support for Saved Password cell

### DIFF
--- a/Client/Frontend/PasswordManagement/Cells/PasswordManagerTableViewCell.swift
+++ b/Client/Frontend/PasswordManagement/Cells/PasswordManagerTableViewCell.swift
@@ -42,12 +42,14 @@ class PasswordManagerTableViewCell: ThemedTableViewCell {
     lazy var hostnameLabel: UILabel = .build { label in
         label.font = UIFont.systemFont(ofSize: 16, weight: .regular)
         label.numberOfLines = 1
+        label.adjustsFontForContentSizeCategory = true
         label.setContentHuggingPriority(.required, for: .vertical)
     }
 
     lazy var usernameLabel: UILabel = .build { label in
         label.font = UIFont.systemFont(ofSize: 14, weight: .regular)
         label.numberOfLines = 1
+        label.adjustsFontForContentSizeCategory = true
     }
 
     private lazy var textStack: UIStackView = .build { [weak self] stack in
@@ -117,7 +119,9 @@ class PasswordManagerTableViewCell: ThemedTableViewCell {
     override func applyTheme(theme: Theme) {
         super.applyTheme(theme: theme)
         hostnameLabel.textColor = theme.colors.textPrimary
+        hostnameLabel.font =  DefaultDynamicFontHelper.preferredFont(withTextStyle: .headline, size: 16.0)
         usernameLabel.textColor = theme.colors.textSecondary
+        usernameLabel.font =  DefaultDynamicFontHelper.preferredFont(withTextStyle: .subheadline, size: 14.0)
         breachAlertImageView.tintColor = theme.colors.iconWarning
     }
 }

--- a/Client/Frontend/PasswordManagement/Cells/PasswordManagerTableViewCell.swift
+++ b/Client/Frontend/PasswordManagement/Cells/PasswordManagerTableViewCell.swift
@@ -40,14 +40,14 @@ class PasswordManagerTableViewCell: ThemedTableViewCell {
     }()
 
     lazy var hostnameLabel: UILabel = .build { label in
-        label.font = UIFont.systemFont(ofSize: 16, weight: .regular)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .title1, size: 16.0)
         label.numberOfLines = 1
         label.adjustsFontForContentSizeCategory = true
         label.setContentHuggingPriority(.required, for: .vertical)
     }
 
     lazy var usernameLabel: UILabel = .build { label in
-        label.font = UIFont.systemFont(ofSize: 14, weight: .regular)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .title2, size: 14.0)
         label.numberOfLines = 1
         label.adjustsFontForContentSizeCategory = true
     }
@@ -119,9 +119,7 @@ class PasswordManagerTableViewCell: ThemedTableViewCell {
     override func applyTheme(theme: Theme) {
         super.applyTheme(theme: theme)
         hostnameLabel.textColor = theme.colors.textPrimary
-        hostnameLabel.font =  DefaultDynamicFontHelper.preferredFont(withTextStyle: .title1, size: 16.0)
         usernameLabel.textColor = theme.colors.textSecondary
-        usernameLabel.font =  DefaultDynamicFontHelper.preferredFont(withTextStyle: .title2, size: 14.0)
         breachAlertImageView.tintColor = theme.colors.iconWarning
     }
 }

--- a/Client/Frontend/PasswordManagement/Cells/PasswordManagerTableViewCell.swift
+++ b/Client/Frontend/PasswordManagement/Cells/PasswordManagerTableViewCell.swift
@@ -119,9 +119,9 @@ class PasswordManagerTableViewCell: ThemedTableViewCell {
     override func applyTheme(theme: Theme) {
         super.applyTheme(theme: theme)
         hostnameLabel.textColor = theme.colors.textPrimary
-        hostnameLabel.font =  DefaultDynamicFontHelper.preferredFont(withTextStyle: .headline, size: 16.0)
+        hostnameLabel.font =  DefaultDynamicFontHelper.preferredFont(withTextStyle: .title1, size: 16.0)
         usernameLabel.textColor = theme.colors.textSecondary
-        usernameLabel.font =  DefaultDynamicFontHelper.preferredFont(withTextStyle: .subheadline, size: 14.0)
+        usernameLabel.font =  DefaultDynamicFontHelper.preferredFont(withTextStyle: .title2, size: 14.0)
         breachAlertImageView.tintColor = theme.colors.iconWarning
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6591)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14750)

## :bulb: Description

Update Saved Password cell to support dynamic type.

## UX Notes

There is still a potential a11y concern with the labels, as we have previous code which limits the labels to a single line. Currently if dynamic type is increased, the text can become truncated and so the host names are not fully readable. May need additional clarification on whether we should allow multi-line support for these, however doing so may have UX implications since the hostnames can be quite long and might make the list difficult to scroll/navigate.

## 🖼️ Screenshots

Comparison 

Before
![Screenshot 2023-09-19 at 1 43 17 PM](https://github.com/mozilla-mobile/firefox-ios/assets/145381717/a1faa3b6-484e-4932-a179-ae436e81f153)

After
![Screenshot 2023-09-19 at 2 50 38 PM](https://github.com/mozilla-mobile/firefox-ios/assets/145381717/a9eff0e5-76de-45c0-9fa6-89f992204058)

(Fixed cell with dynamic type off, for reference)
![Screenshot 2023-09-19 at 2 51 03 PM](https://github.com/mozilla-mobile/firefox-ios/assets/145381717/9f583e2c-faf2-4274-ba7e-8602eca7f357)


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

