### PR TITLE
Bugfix FXIOS6513 [v119] Correct reader mode directionality in right-to-left languages

### DIFF
--- a/Client/Frontend/Reader/ReaderModeUtils.swift
+++ b/Client/Frontend/Reader/ReaderModeUtils.swift
@@ -5,14 +5,6 @@
 import Foundation
 
 struct ReaderModeUtils {
-    static let DomainPrefixesToSimplify = ["www.", "mobile.", "m.", "blog."]
-
-    static func simplifyDomain(_ domain: String) -> String {
-        return DomainPrefixesToSimplify.first { domain.hasPrefix($0) }.map {
-            String($0[$0.index($0.startIndex, offsetBy: $0.count)...])
-        } ?? domain
-    }
-
     static func generateReaderContent(_ readabilityResult: ReadabilityResult, initialStyle: ReaderModeStyle) -> String? {
         guard let stylePath = Bundle.main.path(forResource: "Reader", ofType: "css"),
               let css = try? String(contentsOfFile: stylePath, encoding: .utf8),
@@ -22,10 +14,10 @@ struct ReaderModeUtils {
 
         return tmpl.replacingOccurrences(of: "%READER-CSS%", with: css)
             .replacingOccurrences(of: "%READER-STYLE%", with: initialStyle.encode())
-            .replacingOccurrences(of: "%READER-DOMAIN%", with: simplifyDomain(readabilityResult.domain))
-            .replacingOccurrences(of: "%READER-URL%", with: readabilityResult.url)
             .replacingOccurrences(of: "%READER-TITLE%", with: readabilityResult.title)
-            .replacingOccurrences(of: "%READER-CREDITS%", with: readabilityResult.credits)
+            .replacingOccurrences(of: "%READER-BYLINE%", with: readabilityResult.byline)
             .replacingOccurrences(of: "%READER-CONTENT%", with: readabilityResult.content)
+            .replacingOccurrences(of: "%READER-LANGUAGE%", with: readabilityResult.language)
+            .replacingOccurrences(of: "%READER-DIRECTION%", with: readabilityResult.direction.rawValue)
     }
 }

--- a/Client/Frontend/Reader/Resources/Reader.html
+++ b/Client/Frontend/Reader/Resources/Reader.html
@@ -12,10 +12,10 @@
   <title>%READER-TITLE%</title>
 </head>
 
-<body data-readerStyle='%READER-STYLE%'>
+<body data-readerStyle='%READER-STYLE%' dir='%READER-DIRECTION%' lang='%READER-LANGUAGE%'>
   <div id="reader-header" class="header">
     <h1 id="reader-title">%READER-TITLE%</h1>
-    <div id="reader-credits" class="credits">%READER-CREDITS%</div>
+    <div id="reader-credits" class="credits">%READER-BYLINE%</div>
   </div>
 
   <div id="reader-content" class="content">

--- a/Client/Helpers/UserActivityHandler.swift
+++ b/Client/Helpers/UserActivityHandler.swift
@@ -128,7 +128,7 @@ extension UserActivityHandler {
             attributeSet.authors = [author]
         }
 
-        let identifier = !page.url.isEmptyOrWhitespace() ? page.url : tab.currentURL()?.absoluteString
+        let identifier = tab.currentURL()?.absoluteString
 
         let item = CSSearchableItem(uniqueIdentifier: identifier, domainIdentifier: "org.mozilla.ios.firefox", attributeSet: attributeSet)
 
@@ -145,20 +145,6 @@ extension UserActivityHandler {
             logger.log("Spotlight: Indexing error: \(error.localizedDescription)",
                        level: .warning,
                        category: .unlabeled)
-        }
-    }
-
-    func spotlightDeindex(_ page: ReadabilityResult) {
-        searchableIndex.deleteSearchableItems(withIdentifiers: [page.url]) { error in
-            if let error = error {
-                self.logger.log("Spotlight: Deindexing error: \(error.localizedDescription)",
-                                level: .warning,
-                                category: .unlabeled)
-            } else {
-                self.logger.log("Spotlight: Search item successfully removed!",
-                                level: .debug,
-                                category: .unlabeled)
-            }
         }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6513)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14611)

## :bulb: Description

There are several changes in this PR related to [mozilla/readability][mr]:

* it added support for `dir` in [this commit](https://github.com/mozilla/readability/commit/c09880f44fd0e2645e179bdf61ba1cbd0e3fb76c)
* it removed support for `uri` and `spec` in [this commit](https://github.com/mozilla/readability/commit/d60184966cc20028ba5c49f640091d1ce050c3f9)
* They also have support for `lang`, `byline`, `siteName` and a few other elements

I've added properties for each of these.

I also added to `Reader.html` propertiess for `dir` and `lang` as these were the most obvious new properties to use.

Finally, I also removed a few symbols that were no longer used:  `ReaderModeUtils.DomainPrefixesToSimplify`, `ReaderModeUtils.simplifyDomain` and `UserActivityHandler.spotlightDeindex`

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

[mr]: https://github.com/mozilla/readability