### PR TITLE
Bugfix MTE-1579 [v119] testFindInLargeDoc fails intermittently

### DIFF
--- a/Tests/XCUITests/FindInPageTest.swift
+++ b/Tests/XCUITests/FindInPageTest.swift
@@ -20,6 +20,7 @@ class FindInPageTests: BaseTestCase {
 
     func testFindInLargeDoc() {
         navigator.openURL("http://localhost:\(serverPort)/test-fixture/find-in-page-test.html")
+        waitUntilPageLoad()
         // Workaround until FxSGraph is fixed to allow the previous way with goto
         navigator.nowAt(BrowserTab)
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1579)

## :bulb: Description
After the work for MTE-1549, `testFindInLargeDoc()` may not have enough time to fully load the page before the menu is opened. The test fails because the menu display less items when the page is still loading.

Let's ensure the page is fully loaded before opening the menu.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

