### PR TITLE
Fix MTE-1578 [v119] failing tests

### DIFF
--- a/Tests/XCUITests/SyncFAUITests.swift
+++ b/Tests/XCUITests/SyncFAUITests.swift
@@ -64,7 +64,6 @@ class SyncUITests: BaseTestCase {
         // Enter invalid (too short, it should be at least 8 chars) and incorrect password
         userState.fxaPassword = "foo"
         navigator.performAction(Action.FxATypePassword)
-        navigator.performAction(Action.FxATapOnSignInButton)
         mozWaitForElementToExist(app.webViews.staticTexts["At least 8 characters"])
 
         // Enter valid but incorrect, it does not exists, password

--- a/Tests/XCUITests/TabCounterTests.swift
+++ b/Tests/XCUITests/TabCounterTests.swift
@@ -75,7 +75,7 @@ class TabCounterTests: BaseTestCase {
 
         navigator.goto(TabTray)
         if isTablet {
-            mozWaitForElementToExist(app.navigationBars["Client.TabTrayView"])
+            mozWaitForElementToExist(app.navigationBars["Client.LegacyTabTrayView"])
         } else {
             mozWaitForElementToExist(app.navigationBars["Open Tabs"])
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1578)

## :bulb: Description
For testTypeOnGivenFields now when entering an invalid email address the user is redirected to create account screen, so sign in button is no longer available. 
I have included in this PR a fix for testTabDecrement test also, changing the navigation bar from "TabTrayView" to "LegacyTabTrayView" for tablet only.
