### PR TITLE
Bugfix MTE-1582 [v119] Firefox Accounts branding

### DIFF
--- a/Tests/XCUITests/IntegrationTests.swift
+++ b/Tests/XCUITests/IntegrationTests.swift
@@ -70,7 +70,7 @@ class IntegrationTests: BaseTestCase {
     private func waitForInitialSyncComplete() {
         navigator.nowAt(BrowserTab)
         navigator.goto(SettingsScreen)
-        mozWaitForElementToExist(app.staticTexts["FIREFOX ACCOUNT"], timeout: TIMEOUT_LONG)
+        mozWaitForElementToExist(app.staticTexts["ACCOUNT"], timeout: TIMEOUT_LONG)
         mozWaitForElementToNotExist(app.staticTexts["Sync and Save Data"])
         sleep(5)
         if app.tables.staticTexts["Sync Now"].exists {
@@ -145,7 +145,7 @@ class IntegrationTests: BaseTestCase {
 
         // Sync again just to make sure to sync after new name is shown
         app.buttons["Settings"].tap()
-        mozWaitForElementToExist(app.staticTexts["FIREFOX ACCOUNT"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.staticTexts["ACCOUNT"], timeout: TIMEOUT)
         app.tables.cells.element(boundBy: 2).tap()
         mozWaitForElementToExist(app.tables.staticTexts["Sync Now"], timeout: TIMEOUT_LONG)
     }
@@ -286,7 +286,7 @@ class IntegrationTests: BaseTestCase {
         navigator.nowAt(SettingsScreen)
         mozWaitForElementToExist(app.staticTexts["GENERAL"])
         app.swipeDown()
-        mozWaitForElementToExist(app.staticTexts["FIREFOX ACCOUNT"], timeout: TIMEOUT)
+        mozWaitForElementToExist(app.staticTexts["ACCOUNT"], timeout: TIMEOUT)
         mozWaitForElementToExist(app.tables.staticTexts["Sync Now"], timeout: 35)
 
         // Check Bookmarks


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1582)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
The branding of "Firefox Accounts" has been change to the generic "Accounts" on the settings page.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

