### PR TITLE
Bugfix FXIOS-5684 [v119] Reading list: support Dynamic Type for empty state

### DIFF
--- a/Client/Frontend/Library/ReaderPanel.swift
+++ b/Client/Frontend/Library/ReaderPanel.swift
@@ -194,6 +194,15 @@ class ReadingListPanel: UITableViewController,
         (navigationController as? ThemedNavigationController)?.applyTheme()
         tableView.accessibilityIdentifier = "ReadingTable"
     }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        // Set reading list accessibility content size as needed
+        let size = CGSize(width: self.emptyStateViewA11YScroll.frame.size.width,
+                          height: self.emptyStateView.frame.size.height)
+        self.emptyStateViewA11YScroll.contentSize = size
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -237,20 +246,57 @@ class ReadingListPanel: UITableViewController,
             records = newRecords
 
             if let records = records, records.isEmpty {
-                tableView.isScrollEnabled = false
-                DispatchQueue.main.async { self.tableView.backgroundView = self.emptyStateView }
+                updateEmptyReadingListMessage(visible: true)
             } else {
                 if prevNumberOfRecords == 0 {
-                    tableView.isScrollEnabled = true
-                    DispatchQueue.main.async { self.tableView.backgroundView = nil }
+                    updateEmptyReadingListMessage(visible: false)
                 }
             }
             self.tableView.reloadData()
         }
     }
 
+    func updateEmptyReadingListMessage(visible: Bool) {
+        ensureMainThread {
+            self.tableView.isScrollEnabled = !visible
+
+            let scrollView = self.emptyStateViewA11YScroll
+            let emptyView = self.emptyStateView
+
+            if visible {
+                guard scrollView.superview == nil else { return }
+                scrollView.addSubview(emptyView)
+                NSLayoutConstraint.activate([
+                    emptyView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+                    emptyView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+                    emptyView.widthAnchor.constraint(lessThanOrEqualTo: scrollView.widthAnchor),
+                    emptyView.heightAnchor.constraint(greaterThanOrEqualTo: scrollView.heightAnchor)
+                ])
+                self.tableView.superview?.insertSubview(scrollView, aboveSubview: self.tableView)
+                scrollView.frame = self.tableView.bounds
+                scrollView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+                scrollView.translatesAutoresizingMaskIntoConstraints = true
+                scrollView.isScrollEnabled = true
+            } else {
+                scrollView.subviews.forEach { $0.removeFromSuperview() }
+                scrollView.removeFromSuperview()
+            }
+        }
+    }
+
+    private lazy var emptyStateViewA11YScroll: UIScrollView = {
+        let scrollView: UIScrollView = .build { scrollView in
+            scrollView.showsHorizontalScrollIndicator = false
+            scrollView.bouncesZoom = false
+            scrollView.minimumZoomScale = 1.0
+            scrollView.maximumZoomScale = 1.0
+        }
+
+        return scrollView
+    }()
+
     private lazy var emptyStateView: UIView = {
-        let view = UIView()
+        let view: UIView = .build()
 
         let welcomeLabel: UILabel = .build { label in
             label.text = .ReaderPanelWelcome
@@ -311,7 +357,7 @@ class ReadingListPanel: UITableViewController,
             readingListImageView.trailingAnchor.constraint(equalTo: welcomeLabel.trailingAnchor),
             readingListImageView.widthAnchor.constraint(equalToConstant: ReadingListPanelUX.WelcomeScreenItemImageWidth),
 
-            readingListLabel.bottomAnchor.constraint(equalTo: emptyStateViewWrapper.bottomAnchor),
+            readingListLabel.bottomAnchor.constraint(equalTo: emptyStateViewWrapper.bottomAnchor).priority(.defaultLow),
 
             // overall positioning of emptyStateViewWrapper
             emptyStateViewWrapper.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: ReadingListPanelUX.WelcomeScreenHorizontalMinPadding),
@@ -319,8 +365,11 @@ class ReadingListPanel: UITableViewController,
             emptyStateViewWrapper.widthAnchor.constraint(lessThanOrEqualToConstant: ReadingListPanelUX.WelcomeScreenMaxWidth),
 
             emptyStateViewWrapper.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            emptyStateViewWrapper.topAnchor.constraint(equalTo: view.topAnchor, constant: ReadingListPanelUX.WelcomeScreenTopPadding)
+            emptyStateViewWrapper.topAnchor.constraint(equalTo: view.topAnchor, constant: ReadingListPanelUX.WelcomeScreenTopPadding),
+            emptyStateViewWrapper.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
+
+        readingListLabel.setContentHuggingPriority(.defaultHigh, for: .vertical)
 
         return view
     }()

--- a/Client/Frontend/Library/ReaderPanel.swift
+++ b/Client/Frontend/Library/ReaderPanel.swift
@@ -269,7 +269,7 @@ class ReadingListPanel: UITableViewController,
                 NSLayoutConstraint.activate([
                     emptyView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
                     emptyView.topAnchor.constraint(equalTo: scrollView.topAnchor),
-                    emptyView.widthAnchor.constraint(lessThanOrEqualTo: scrollView.widthAnchor),
+                    emptyView.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
                     emptyView.heightAnchor.constraint(greaterThanOrEqualTo: scrollView.heightAnchor)
                 ])
                 self.tableView.superview?.insertSubview(scrollView, aboveSubview: self.tableView)

--- a/Client/Frontend/Library/ReaderPanel.swift
+++ b/Client/Frontend/Library/ReaderPanel.swift
@@ -256,7 +256,7 @@ class ReadingListPanel: UITableViewController,
         }
     }
 
-    func updateEmptyReadingListMessage(visible: Bool) {
+    private func updateEmptyReadingListMessage(visible: Bool) {
         ensureMainThread {
             self.tableView.isScrollEnabled = !visible
 

--- a/Client/Frontend/Library/ReaderPanel.swift
+++ b/Client/Frontend/Library/ReaderPanel.swift
@@ -194,7 +194,7 @@ class ReadingListPanel: UITableViewController,
         (navigationController as? ThemedNavigationController)?.applyTheme()
         tableView.accessibilityIdentifier = "ReadingTable"
     }
-    
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5684)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13103)

## :bulb: Description

Support Dynamic Type for the reading list "empty state". Due to the text length this requires scrolling for most devices. 

There are a few other UX/UI considerations that may need to be addressed here in follow-up tickets (the icons, for example, are not currently scaled).

## 🖼️ Screenshots / Videos

Video of scrolling

https://github.com/mozilla-mobile/firefox-ios/assets/145381717/8a184577-d1b7-4ad8-a252-49399f7d3885

Normal text size
![Simulator Screenshot - iPhone 14 Pro - 2023-09-20 at 12 07 43](https://github.com/mozilla-mobile/firefox-ios/assets/145381717/7df8bd53-1ecc-4f56-80af-6296210021ae)

XXL text size
![Simulator Screenshot - iPhone 14 Pro - 2023-09-20 at 12 09 28](https://github.com/mozilla-mobile/firefox-ios/assets/145381717/19d5bf2a-a699-40c4-b081-79c070aed15b)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

