### PR TITLE
Add MTE-1584 [v119] Push Firebase Performance Test Results to GCS Bucket

### DIFF
--- a/Tests/PerformanceTestPlan.xctestplan
+++ b/Tests/PerformanceTestPlan.xctestplan
@@ -53,6 +53,8 @@
         "NoImageTests",
         "OnboardingTests",
         "OpeningScreenTests",
+        "PerformanceTests\/testPerfTabs_3_20tabTray()",
+        "PerformanceTests\/testPerfTabs_4_1280tabTray()",
         "PhotonActionSheetTest",
         "PocketTest",
         "PrivateBrowsingTest",

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1538,15 +1538,24 @@ workflows:
         - content: |-
             #!/usr/bin/env bash
             set -e 
+            TIMESTAMP=$(date "+%Y%m%d%H%M%S")
+            RESULTS_DIR="firefox_ios_performance_tests_$TIMESTAMP"
+
             curl -o /tmp/key-file.json $BITRISEIO_GOOGLE_APPLICATION_CREDENTIALS_URL 
             $HOME/google-cloud-sdk/bin/gcloud version
             $HOME/google-cloud-sdk/bin/gcloud auth activate-service-account -q --key-file /tmp/key-file.json
             $HOME/google-cloud-sdk/bin/gcloud config set project "$GOOGLE_CLOUD_PROJECT"
-            $HOME/google-cloud-sdk/bin/gcloud firebase test ios run \
+
+            FIREBASE_TEST_RESULT=$($HOME/google-cloud-sdk/bin/gcloud firebase test ios run \
                 --test /Users/vagrant/git/Fennec_Enterprise.zip \
                 --device model=iphone14pro,version=16.6 \
                 --client-details=matrixLabel="Bitrise" \
-                --num-flaky-test-attempts=2
+                --num-flaky-test-attempts=2 \
+                --results-bucket=firefox_ios_test_artifacts \
+                --results-dir="$RESULTS_DIR" \
+                --format=json)
+                
+            echo $FIREBASE_TEST_RESULT
 app:
   envs:
   - opts:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1584)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
I'm temporarily disabling the two failing performance tests in Firebase until I finish testing perfherder ingest of the Firebase test results:

`testPerfTabs_3_20tabTray`
`testPerfTabs_4_1280tabTray`

I'm adding a destination bucket and directory name for the results and outputting them as json to parse in the next steps that will take the `.xcresult` artifact produced in Firebase and parse it with `xcresult_extract.py` to format it for perfherder ingest.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

