### PR TITLE
Bugfix FXIOS-6551 [v118] Fix run away log file

### DIFF
--- a/BrowserKit/Sources/Common/Logger/Wrapper/SwiftyBeaverWrapper.swift
+++ b/BrowserKit/Sources/Common/Logger/Wrapper/SwiftyBeaverWrapper.swift
@@ -61,6 +61,7 @@ struct DefaultSwiftyBeaverBuilder: SwiftyBeaverBuilder {
         file.format = defaultFormat
         file.minLevel = .debug
         file.levelString.error = "FATAL"
+        file.logFileAmount = 2
 
         let logger = SwiftyBeaver.self
         logger.removeAllDestinations()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6551)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14668)

## :bulb: Description
In SwiftyBeaver, if the logFileAmount is set to 1 then it will ignore any size restrictions and allow the log file to continue forever.
This PR introduces an issue where the logs a user provides may not be useful if it has recently hit the overflow and moved to a new file. 5mb is the cap so this case should be rare. I will create a follow up ticket to address this I'm just not sure what the best fix is as I don't want to confuse users over which log file to upload, it's already confusing enough.
I verified that only 2 files are ever stored, the oldest is deleted.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

