### PR TITLE
Bugfix FXIOS-7455 [v119] Fix reader list message vertical alignment

### DIFF
--- a/Client/Frontend/Library/ReaderPanel.swift
+++ b/Client/Frontend/Library/ReaderPanel.swift
@@ -369,6 +369,8 @@ class ReadingListPanel: UITableViewController,
             emptyStateViewWrapper.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
 
+        welcomeLabel.setContentHuggingPriority(.defaultHigh, for: .vertical)
+        readerModeLabel.setContentHuggingPriority(.defaultHigh, for: .vertical)
         readingListLabel.setContentHuggingPriority(.defaultHigh, for: .vertical)
 
         return view


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7455)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16534)

## :bulb: Description

Fixes a vertical alignment issue with the reader list empty message after removing the last item in the reading list.

## 🖼️ Screenshots

Comparison screenshots

![bugfix](https://github.com/mozilla-mobile/firefox-ios/assets/145381717/1ac13d3c-b855-4456-9cc1-e5af0579cda6)

![bug](https://github.com/mozilla-mobile/firefox-ios/assets/145381717/15396eb0-6073-4a4b-afb1-1a79286da224)


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

