### PR TITLE
Bugfix FXIOS-16400[v119] - Slashed lock icon displayed on Reader Mode should be hidden

### DIFF
--- a/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -435,6 +435,8 @@ extension TabLocationView: TabEventHandler {
             trackingProtectionButton.alpha = 1.0
             let themeManager: ThemeManager = AppContainer.shared.resolve()
             self.blockerStatus = blocker.status
+            // We need to hide the trackingProtectionButton when the user activates the reader mode(Bug 16400). When user turns on the reader mode the url is changed to localhost hence we check whether url contains http://localhost or not, according to this we will hide or show the trackingProtectionButton.
+            self.trackingProtectionButton.isHidden = tab.webView?.url?.absoluteString.contains("http://localhost") ?? false
             self.hasSecureContent = (tab.webView?.hasOnlySecureContent ?? false)
             setTrackingProtection(theme: themeManager.currentTheme)
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16400)

## :bulb: Description
When user used to turn on the reader mode we used to show the lock with slashed icon indicating that the website is not safe as the app runs the reader mode on local host. Hence I made change to hide the lock icon button based on whether or not the website url contains http://localhost, it means that we are in the reader mode.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

