### PR TITLE
Fix MTE-1590 [v119] for photonActionSheet and search settings tests

### DIFF
--- a/Tests/XCUITests/PhotonActionSheetTest.swift
+++ b/Tests/XCUITests/PhotonActionSheetTest.swift
@@ -64,7 +64,7 @@ class PhotonActionSheetTest: BaseTestCase {
         mozWaitForElementToExist(app.cells["Send Link to Device"], timeout: 10)
         app.cells["Send Link to Device"].tap()
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.ShareTo.HelpView.doneButton])
-        XCTAssertTrue(app.staticTexts["You are not signed in to your Firefox Account."].exists)
+        XCTAssertTrue(app.staticTexts["You are not signed in to your account."].exists)
     }
     // Disable issue #5554, More button is not accessible
     /*
@@ -127,7 +127,7 @@ class PhotonActionSheetTest: BaseTestCase {
         app.staticTexts["Send to Device"].tap()
         mozWaitForElementToExist(app.navigationBars.buttons[AccessibilityIdentifiers.ShareTo.HelpView.doneButton], timeout: 10)
 
-        XCTAssertTrue(app.staticTexts["You are not signed in to your Firefox Account."].exists)
+        XCTAssertTrue(app.staticTexts["You are not signed in to your account."].exists)
         app.navigationBars.buttons[AccessibilityIdentifiers.ShareTo.HelpView.doneButton].tap()
     }
 

--- a/Tests/XCUITests/SearchSettingsUITest.swift
+++ b/Tests/XCUITests/SearchSettingsUITest.swift
@@ -112,8 +112,6 @@ class SearchSettingsUITests: BaseTestCase {
         let tablesQuery = app.tables
         tablesQuery.buttons["Delete \(customSearchEngine["name"]!)"].tap()
         tablesQuery.buttons[AccessibilityIdentifiers.Settings.Search.deleteButton].tap()
-
-        // FXIOS-5772: The button should be "Edit" and is disabled
-        XCTAssertTrue(app.buttons["Done"].isEnabled)
+        XCTAssertFalse(app.buttons["Edit"].isEnabled)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1590)

## :bulb: Description
Fixes for photonActionSheet tests - updating You are not signed in message 
Included in this PR a fix for testDeletingLastCustomEngineExitsEditing due to the fact that FXIOS-5772 has been fixed and now the normal behaviour is present, having the edit button on disabled mode.
