### PR TITLE
Bugfix FXIOS-7463 [v119] Update URL initalizer to prepare for XCode 15

### DIFF
--- a/BrowserKit/Sources/Common/Extensions/URLExtension.swift
+++ b/BrowserKit/Sources/Common/Extensions/URLExtension.swift
@@ -5,6 +5,11 @@
 import Foundation
 
 extension URL {
+    /// Temporary init that will be removed with the update to XCode 15 where this URL API is available
+    public init?(string: String, encodingInvalidCharacters: Bool) {
+        self.init(string: string)
+    }
+
     /// Returns a shorter displayable string for a domain
     /// E.g., https://m.foo.com/bar/baz?noo=abc#123  => foo
     /// https://accounts.foo.com/bar/baz?noo=abc#123  => accounts.foo

--- a/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/Cache/FaviconURLCache.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/Cache/FaviconURLCache.swift
@@ -32,7 +32,7 @@ actor DefaultFaviconURLCache: FaviconURLCache {
 
     func getURLFromCache(cacheKey: String) async throws -> URL {
         guard let favicon = urlCache[cacheKey],
-              let url = URL(string: favicon.faviconURL)
+              let url = URL(string: favicon.faviconURL, encodingInvalidCharacters: false)
         else { throw SiteImageError.noURLInCache }
 
         // Update the element in the cache so it's time to expire is reset

--- a/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/URLFetcher/FaviconURLFetcher.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/URLFetcher/FaviconURLFetcher.swift
@@ -43,7 +43,7 @@ struct DefaultFaviconURLFetcher: FaviconURLFetcher {
             if let refresh = meta["http-equiv"], refresh == "Refresh",
                let content = meta["content"],
                let index = content.range(of: "URL="),
-               let url = URL(string: String(content[index.upperBound...])) {
+               let url = URL(string: String(content[index.upperBound...]), encodingInvalidCharacters: false) {
                 reloadURL = url
             }
         }
@@ -63,7 +63,7 @@ struct DefaultFaviconURLFetcher: FaviconURLFetcher {
 
         // Fallback to the favicon at the root of the domain
         // This is a fall back because it's generally low res
-        if let faviconURL = URL(string: siteURL.absoluteString + "/favicon.ico") {
+        if let faviconURL = URL(string: siteURL.absoluteString + "/favicon.ico", encodingInvalidCharacters: false) {
             return faviconURL
         }
 

--- a/BrowserKit/Sources/SiteImageView/SiteImageHandler.swift
+++ b/BrowserKit/Sources/SiteImageView/SiteImageHandler.swift
@@ -29,13 +29,13 @@ public class DefaultSiteImageHandler: SiteImageHandler {
         var imageModel = site
 
         // urlStringRequest possibly cannot be a URL
-        if let siteURL = URL(string: site.siteURLString ?? "") {
+        if let siteURL = URL(string: site.siteURLString ?? "", encodingInvalidCharacters: false) {
             let domain = generateDomainURL(siteURL: siteURL)
             imageModel.siteURL = siteURL
             imageModel.domain = domain
         }
 
-        imageModel.cacheKey = generateCacheKey(siteURL: URL(string: site.siteURLString ?? ""),
+        imageModel.cacheKey = generateCacheKey(siteURL: URL(string: site.siteURLString ?? "", encodingInvalidCharacters: false),
                                                faviconURL: imageModel.faviconURL,
                                                type: imageModel.expectedImageType)
 

--- a/Client/Coordinators/Router/RouteBuilder.swift
+++ b/Client/Coordinators/Router/RouteBuilder.swift
@@ -134,7 +134,7 @@ final class RouteBuilder {
         if userActivity.activityType == CSSearchableItemActionType {
             guard let userInfo = userActivity.userInfo,
                   let urlString = userInfo[CSSearchableItemActivityIdentifier] as? String,
-                  let url = URL(string: urlString)
+                  let url = URL(string: urlString, encodingInvalidCharacters: false)
             else {
                 return nil
             }

--- a/Client/Coordinators/Router/URLScanner.swift
+++ b/Client/Coordinators/Router/URLScanner.swift
@@ -38,7 +38,7 @@ struct URLScanner {
         guard let scheme = urlComponents.scheme, urlSchemes.contains(scheme) else { return nil }
         self.scheme = scheme
         self.host = urlComponents.host ?? ""
-        self.components = URL(string: urlComponents.path)?.pathComponents ?? []
+        self.components = URL(string: urlComponents.path, encodingInvalidCharacters: false)?.pathComponents ?? []
         self.queries = urlComponents.queryItems ?? []
     }
 

--- a/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
+++ b/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
@@ -188,7 +188,7 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
 
         // Create the message action URL.
         let urlString = action.hasPrefix("://") ? URL.mozInternalScheme + action : action
-        guard let url = URL(string: urlString) else {
+        guard let url = URL(string: urlString, encodingInvalidCharacters: false) else {
             self.onMalformedMessage(id: message.id, surface: message.surface)
             return
         }

--- a/Client/Experiments/Settings/ExperimentsSettingsViewController.swift
+++ b/Client/Experiments/Settings/ExperimentsSettingsViewController.swift
@@ -69,7 +69,7 @@ class ExperimentsSettingsViewController: UIViewController {
     private func loadRemoteExperiments(sender: AnyObject) {
         guard
             let text = experimentsView.customRemoteSettingsTextField.text,
-            let url = URL(string: text),
+            let url = URL(string: text, encodingInvalidCharacters: false),
             let data = try? String(contentsOf: url)
             else { return }
 

--- a/Client/Extensions/UIPasteboard+Extension.swift
+++ b/Client/Extensions/UIPasteboard+Extension.swift
@@ -23,8 +23,9 @@ extension UIPasteboard {
 
     private var syncURL: URL? {
         return UIPasteboard.general.string.flatMap {
-            guard let url = URL(string: $0), url.isWebPage() else { return nil }
-
+            guard let url = URL(string: $0, encodingInvalidCharacters: false),
+                    url.isWebPage()
+            else { return nil }
             return url
         }
     }

--- a/Client/Frontend/Accessors/HomePageAccessors.swift
+++ b/Client/Frontend/Accessors/HomePageAccessors.swift
@@ -14,7 +14,7 @@ class NewTabHomePageAccessors {
     static func getHomePage(_ prefs: Prefs) -> URL? {
         let string = prefs.stringForKey(PrefsKeys.NewTabCustomUrlPrefKey) ?? getDefaultHomePageString(prefs)
         guard let urlString = string else { return nil }
-        return URL(string: urlString)
+        return URL(string: urlString, encodingInvalidCharacters: false)
     }
 
     static func getDefaultHomePageString(_ prefs: Prefs) -> String? {
@@ -26,6 +26,6 @@ class HomeButtonHomePageAccessors {
     static func getHomePage(_ prefs: Prefs) -> URL? {
         let string = prefs.stringForKey(PrefsKeys.HomeButtonHomePageURL)
         guard let urlString = string else { return nil }
-        return URL(string: urlString)
+        return URL(string: urlString, encodingInvalidCharacters: false)
     }
 }

--- a/Client/Frontend/Browser/BackForwardTableViewCell.swift
+++ b/Client/Frontend/Browser/BackForwardTableViewCell.swift
@@ -108,7 +108,7 @@ class BackForwardTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
     func configure(viewModel: BackForwardCellViewModel, theme: Theme) {
         self.viewModel = viewModel
 
-        if let url = URL(string: viewModel.site.url),
+        if let url = URL(string: viewModel.site.url, encodingInvalidCharacters: false),
            InternalURL(url)?.isAboutHomeURL == true {
             faviconView.manuallySetImage(UIImage(named: ImageIdentifiers.firefoxFavicon) ?? UIImage())
         } else {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1961,7 +1961,7 @@ extension BrowserViewController: QRCodeViewControllerDelegate {
         case .some(.link(let url)):
             UIApplication.shared.open(url, options: [:], completionHandler: nil)
         case .some(.phoneNumber(let phoneNumber)):
-            if let url = URL(string: "tel:\(phoneNumber)") {
+            if let url = URL(string: "tel:\(phoneNumber)", encodingInvalidCharacters: false) {
                 UIApplication.shared.open(url, options: [:], completionHandler: nil)
             } else {
                 defaultAction()

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -290,7 +290,7 @@ extension BrowserViewController: URLBarDelegate {
                 let range = urlString.range(of: "%s") {
                 urlString.replaceSubrange(range, with: escapedQuery)
 
-                if let url = URL(string: urlString) {
+                if let url = URL(string: urlString, encodingInvalidCharacters: false) {
                     self.finishEditingAndSubmit(url, visitType: VisitType.typed, forTab: currentTab)
                     return
                 }

--- a/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
+++ b/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
@@ -115,7 +115,7 @@ class ClipboardBarDisplayHandler: NSObject, URLChangeDelegate {
             return true
         }
 
-        if let url = URL(string: clipboardURL),
+        if let url = URL(string: clipboardURL, encodingInvalidCharacters: false),
            tabManager?.getTabFor(url) != nil {
             return true
         }

--- a/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -514,7 +514,8 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
         let iconString = needsReAuth ? ImageIdentifiers.warning : StandardImageIdentifiers.Large.avatarCircle
 
         var iconURL: URL?
-        if let str = rustAccount.userProfile?.avatarUrl, let url = URL(string: str) {
+        if let str = rustAccount.userProfile?.avatarUrl,
+            let url = URL(string: str, encodingInvalidCharacters: false) {
             iconURL = url
         }
         let iconType: PhotonActionSheetIconType = needsReAuth ? .Image : .URL

--- a/Client/Frontend/Browser/OpenWithSettingsViewController.swift
+++ b/Client/Frontend/Browser/OpenWithSettingsViewController.swift
@@ -93,7 +93,7 @@ class OpenWithSettingsViewController: ThemedTableViewController {
     }
 
     func canOpenMailScheme(_ scheme: String) -> Bool {
-        if let url = URL(string: scheme) {
+        if let url = URL(string: scheme, encodingInvalidCharacters: false) {
             return UIApplication.shared.canOpenURL(url)
         }
         return false

--- a/Client/Frontend/Browser/SearchEngines/OpenSearchEngine.swift
+++ b/Client/Frontend/Browser/SearchEngines/OpenSearchEngine.swift
@@ -144,7 +144,8 @@ class OpenSearchEngine: NSObject, NSSecureCoding {
     private func isSearchURLForEngine(_ url: URL?) -> Bool {
         guard let urlHost = url?.shortDisplayString,
               let queryEndIndex = searchTemplate.range(of: "?")?.lowerBound,
-              let templateURL = URL(string: String(searchTemplate[..<queryEndIndex])) else { return false }
+              let templateURL = URL(string: String(searchTemplate[..<queryEndIndex]), encodingInvalidCharacters: false)
+        else { return false }
         return urlHost == templateURL.shortDisplayString
     }
 
@@ -162,7 +163,7 @@ class OpenSearchEngine: NSObject, NSSecureCoding {
                 let urlString = encodedSearchTemplate
                     .replacingOccurrences(of: searchTermComponent, with: escapedQuery, options: .literal, range: nil)
                     .replacingOccurrences(of: localeTermComponent, with: localeString, options: .literal, range: nil)
-                return URL(string: urlString)
+                return URL(string: urlString, encodingInvalidCharacters: false)
             }
         }
 

--- a/Client/Frontend/Browser/SearchEngines/OpenSearchParser.swift
+++ b/Client/Frontend/Browser/SearchEngines/OpenSearchParser.swift
@@ -129,7 +129,7 @@ class OpenSearchParser {
 
         let uiImage: UIImage
         if let imageElement = largestImageElement,
-            let imageURL = URL(string: imageElement.stringValue),
+            let imageURL = URL(string: imageElement.stringValue, encodingInvalidCharacters: false),
             let imageData = try? Data(contentsOf: imageURL),
             let image = UIImage(data: imageData) {
             uiImage = image

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -532,13 +532,13 @@ class SearchViewController: SiteTableViewController,
             if let site = data[indexPath.row] {
                 recordSearchListSelectionTelemetry(type: .bookmarksAndHistory,
                                                    isBookmark: site.bookmarked ?? false)
-                if let url = URL(string: site.url) {
+                if let url = URL(string: site.url, encodingInvalidCharacters: false) {
                     searchDelegate?.searchViewController(self, didSelectURL: url, searchTerm: nil)
                 }
             }
         case .searchHighlights:
             if let urlString = searchHighlights[indexPath.row].urlString,
-                let url = URL(string: urlString) {
+                let url = URL(string: urlString, encodingInvalidCharacters: false) {
                 recordSearchListSelectionTelemetry(type: .searchHighlights)
                 searchDelegate?.searchViewController(self, didSelectURL: url, searchTerm: nil)
             }

--- a/Client/Frontend/Browser/URIFixup.swift
+++ b/Client/Frontend/Browser/URIFixup.swift
@@ -8,8 +8,9 @@ import Shared
 
 class URIFixup {
     static func getURL(_ entry: String) -> URL? {
-        if let url = URL(string: entry), InternalURL.isValid(url: url) {
-            return URL(string: entry)
+        if let url = URL(string: entry, encodingInvalidCharacters: false),
+            InternalURL.isValid(url: url) {
+            return URL(string: entry, encodingInvalidCharacters: false)
         }
 
         let trimmed = entry.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -48,7 +49,7 @@ class URIFixup {
             string = replaceHashMarks(url: string)
         }
 
-        guard let url = URL(string: string) else { return nil }
+        guard let url = URL(string: string, encodingInvalidCharacters: false) else { return nil }
 
         var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
         if AppConstants.punyCode {

--- a/Client/Frontend/Home/HistoryHighlights/HighlightItem.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HighlightItem.swift
@@ -36,7 +36,7 @@ extension HistoryHighlight: HighlightItem {
     }
 
     var siteUrl: URL? {
-        return URL(string: url)
+        return URL(string: url, encodingInvalidCharacters: false)
     }
 
     var urlString: String? {

--- a/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsManager.swift
+++ b/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsManager.swift
@@ -12,7 +12,7 @@ private let searchLimit = 1000
 
 extension HistoryHighlight {
     var urlFromString: URL? {
-        return URL(string: url)
+        return URL(string: url, encodingInvalidCharacters: false)
     }
 }
 

--- a/Client/Frontend/Home/HomePanelType.swift
+++ b/Client/Frontend/Home/HomePanelType.swift
@@ -9,7 +9,7 @@ enum HomePanelType: Int {
     case topSites = 0
 
     var internalUrl: URL {
-        let aboutUrl: URL! = URL(string: "\(InternalURL.baseUrl)/\(AboutHomeHandler.path)")
+        let aboutUrl: URL! = URL(string: "\(InternalURL.baseUrl)/\(AboutHomeHandler.path)", encodingInvalidCharacters: false)
         return URL(string: "#panel=\(self.rawValue)", relativeTo: aboutUrl)!
     }
 }

--- a/Client/Frontend/Home/HomepageContextMenuHelper.swift
+++ b/Client/Frontend/Home/HomepageContextMenuHelper.swift
@@ -180,7 +180,7 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
     /// - Returns: Share action
     private func getShareAction(site: Site, sourceView: UIView?) -> PhotonRowActions {
         return SingleActionViewModel(title: .ShareContextMenuTitle, iconString: ImageIdentifiers.share, tapHandler: { _ in
-            guard let url = URL(string: site.url) else { return }
+            guard let url = URL(string: site.url, encodingInvalidCharacters: false) else { return }
 
             if CoordinatorFlagManager.isShareExtensionCoordinatorEnabled {
                 self.browserNavigationHandler?.showShareExtension(

--- a/Client/Frontend/Home/RecentlySaved/RecentlySavedViewModel.swift
+++ b/Client/Frontend/Home/RecentlySaved/RecentlySavedViewModel.swift
@@ -152,7 +152,7 @@ extension RecentlySavedViewModel: HomepageSectionHandler {
                                          value: .recentlySavedBookmarkItemAction,
                                          extras: TelemetryWrapper.getOriginExtras(isZeroSearch: isZeroSearch))
         } else if let item = recentItems[safe: indexPath.row] as? ReadingListItem,
-                  let url = URL(string: item.url),
+                  let url = URL(string: item.url, encodingInvalidCharacters: false),
                   let encodedUrl = url.encodeReaderModeURL(WebServer.sharedInstance.baseReaderModeURL()) {
             let visitType = VisitType.bookmark
             libraryPanelDelegate?.libraryPanel(didSelectURL: encodedUrl, visitType: visitType)

--- a/Client/Frontend/Home/TopSites/Cell/TopSiteItemCell.swift
+++ b/Client/Frontend/Home/TopSites/Cell/TopSiteItemCell.swift
@@ -151,7 +151,7 @@ class TopSiteItemCell: UICollectionViewCell, ReusableCell {
         var imageURL: URL?
 
         if let site = topSite.site as? SponsoredTile {
-            imageURL = URL(string: site.imageURL)
+            imageURL = URL(string: site.imageURL, encodingInvalidCharacters: false)
         }
         let viewModel = FaviconImageViewModel(siteURLString: urlRequest,
                                               faviconURL: imageURL)

--- a/Client/Frontend/Home/TopSites/DataManagement/ContileProvider.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/ContileProvider.swift
@@ -101,8 +101,9 @@ class ContileProvider: ContileProviderInterface, URLCaching, FeatureFlaggable {
     }
 
     private var resourceEndpoint: URL? {
-        if featureFlags.isCoreFeatureEnabled(.useStagingContileAPI) { return URL(string: ContileProvider.contileStagingResourceEndpoint) }
-
-        return URL(string: ContileProvider.contileProdResourceEndpoint)
+        if featureFlags.isCoreFeatureEnabled(.useStagingContileAPI) {
+            return URL(string: ContileProvider.contileStagingResourceEndpoint, encodingInvalidCharacters: false)
+        }
+        return URL(string: ContileProvider.contileProdResourceEndpoint, encodingInvalidCharacters: false)
     }
 }

--- a/Client/Frontend/Home/Wallpapers/v1/Models/WallpaperCollection.swift
+++ b/Client/Frontend/Home/Wallpapers/v1/Models/WallpaperCollection.swift
@@ -40,7 +40,7 @@ struct WallpaperCollection: Codable, Equatable {
 
     var learnMoreUrl: URL? {
         guard let urlString = learnMoreURLString else { return nil }
-        return URL(string: urlString)
+        return URL(string: urlString, encodingInvalidCharacters: false)
     }
 
     /// Wallpaper collections availability:

--- a/Client/Frontend/Library/Bookmarks/BookmarkDetailPanel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarkDetailPanel.swift
@@ -235,7 +235,7 @@ class BookmarkDetailPanel: SiteTableViewController {
     }
 
     private func isBookmarkItemURLValid() -> Bool {
-        let url = URL(string: bookmarkItemURL ?? "")
+        let url = URL(string: bookmarkItemURL ?? "", encodingInvalidCharacters: false)
         return url?.schemeIsValid == true && url?.host != nil
     }
 

--- a/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
@@ -382,7 +382,8 @@ class BookmarksPanel: SiteTableViewController,
 
         updatePanelState(newState: .bookmarks(state: .inFolder))
         if CoordinatorFlagManager.isLibraryCoordinatorEnabled {
-            if let itemData = bookmarkCell as? BookmarkItemData, let url = URL(string: itemData.url) {
+            if let itemData = bookmarkCell as? BookmarkItemData,
+                let url = URL(string: itemData.url, encodingInvalidCharacters: false) {
                 libraryPanelDelegate?.libraryPanel(didSelectURL: url, visitType: .bookmark)
             } else {
                 guard let folder = bookmarkCell as? FxBookmarkNode else { return }

--- a/Client/Frontend/Library/HistoryPanel/GeneralizedTableView/SearchGroupedItemsViewController.swift
+++ b/Client/Frontend/Library/HistoryPanel/GeneralizedTableView/SearchGroupedItemsViewController.swift
@@ -171,7 +171,7 @@ class SearchGroupedItemsViewController: UIViewController, UITableViewDelegate, T
     }
 
     private func handleSiteItemTapped(site: Site) {
-        guard let url = URL(string: site.url) else {
+        guard let url = URL(string: site.url, encodingInvalidCharacters: false) else {
             logger.log("Couldn't navigate to site",
                        level: .warning,
                        category: .library)

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -611,7 +611,7 @@ extension HistoryPanel: UITableViewDelegate {
     }
 
     private func handleSiteItemTapped(site: Site) {
-        guard let url = URL(string: site.url) else {
+        guard let url = URL(string: site.url, encodingInvalidCharacters: false) else {
             self.logger.log("Couldn't navigate to site",
                             level: .warning,
                             category: .library)

--- a/Client/Frontend/Library/LibraryPanelContextMenu.swift
+++ b/Client/Frontend/Library/LibraryPanelContextMenu.swift
@@ -36,7 +36,7 @@ extension LibraryPanelContextMenu {
     }
 
     func getRecentlyClosedTabContexMenuActions(for site: Site, recentlyClosedPanelDelegate: RecentlyClosedPanelDelegate?) -> [PhotonRowActions]? {
-        guard let siteURL = URL(string: site.url) else { return nil }
+        guard let siteURL = URL(string: site.url, encodingInvalidCharacters: false) else { return nil }
 
         let openInNewTabAction = SingleActionViewModel(title: .OpenInNewTabContextMenuTitle, iconString: StandardImageIdentifiers.Large.plus) { _ in
             recentlyClosedPanelDelegate?.openRecentlyClosedSiteInNewTab(siteURL, isPrivate: false)
@@ -50,7 +50,7 @@ extension LibraryPanelContextMenu {
     }
 
     func getRemoteTabContextMenuActions(for site: Site, remotePanelDelegate: RemotePanelDelegate?) -> [PhotonRowActions]? {
-        guard let siteURL = URL(string: site.url) else { return nil }
+        guard let siteURL = URL(string: site.url, encodingInvalidCharacters: false) else { return nil }
 
         let openInNewTabAction = SingleActionViewModel(title: .OpenInNewTabContextMenuTitle, iconString: StandardImageIdentifiers.Large.plus) { _ in
             remotePanelDelegate?.remotePanelDidRequestToOpenInNewTab(siteURL, isPrivate: false)
@@ -64,7 +64,7 @@ extension LibraryPanelContextMenu {
     }
 
     func getDefaultContextMenuActions(for site: Site, libraryPanelDelegate: LibraryPanelDelegate?) -> [PhotonRowActions]? {
-        guard let siteURL = URL(string: site.url) else { return nil }
+        guard let siteURL = URL(string: site.url, encodingInvalidCharacters: false) else { return nil }
 
         let openInNewTabAction = SingleActionViewModel(title: .OpenInNewTabContextMenuTitle,
                                                        iconString: StandardImageIdentifiers.Large.plus) { _ in

--- a/Client/Frontend/Library/ReaderPanel.swift
+++ b/Client/Frontend/Library/ReaderPanel.swift
@@ -396,7 +396,7 @@ class ReadingListPanel: UITableViewController,
         let cell = tableView.dequeueReusableCell(withIdentifier: "ReadingListTableViewCell", for: indexPath) as! ReadingListTableViewCell
         if let record = records?[indexPath.row] {
             cell.title = record.title
-            cell.url = URL(string: record.url)!
+            cell.url = URL(string: record.url, encodingInvalidCharacters: false)!
             cell.unread = record.unread
             cell.applyTheme(theme: themeManager.currentTheme)
         }
@@ -432,7 +432,9 @@ class ReadingListPanel: UITableViewController,
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: false)
-        if let record = records?[indexPath.row], let url = URL(string: record.url), let encodedURL = url.encodeReaderModeURL(WebServer.sharedInstance.baseReaderModeURL()) {
+        if let record = records?[indexPath.row],
+            let url = URL(string: record.url, encodingInvalidCharacters: false),
+            let encodedURL = url.encodeReaderModeURL(WebServer.sharedInstance.baseReaderModeURL()) {
             // Mark the item as read
             profile.readingList.updateRecord(record, unread: false)
             // Reading list items are closest in concept to bookmarks.
@@ -510,7 +512,7 @@ extension ReadingListPanel: LibraryPanelContextMenu {
 extension ReadingListPanel: UITableViewDragDelegate {
     func tableView(_ tableView: UITableView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {
         guard let site = getSiteDetails(for: indexPath),
-              let url = URL(string: site.url),
+              let url = URL(string: site.url, encodingInvalidCharacters: false),
               let itemProvider = NSItemProvider(contentsOf: url)
         else { return [] }
 

--- a/Client/Frontend/PasswordManagement/BreachAlertsClient.swift
+++ b/Client/Frontend/PasswordManagement/BreachAlertsClient.swift
@@ -26,7 +26,7 @@ public class BreachAlertsClient: BreachAlertsClientProtocol {
 
     /// Makes a header-only request to an endpoint and hands off the endpoint's etag to a completion handler.
     func fetchEtag(endpoint: Endpoint, profile: Profile, completion: @escaping (_ etag: String?) -> Void) {
-        guard let url = URL(string: endpoint.rawValue) else { return }
+        guard let url = URL(string: endpoint.rawValue, encodingInvalidCharacters: false) else { return }
         var request = URLRequest(url: url)
         request.httpMethod = "HEAD"
 
@@ -51,7 +51,7 @@ public class BreachAlertsClient: BreachAlertsClientProtocol {
 
     /// Makes a network request to an endpoint and hands off the result to a completion handler.
     func fetchData(endpoint: Endpoint, profile: Profile, completion: @escaping (_ result: Maybe<Data>) -> Void) {
-        guard let url = URL(string: endpoint.rawValue) else { return }
+        guard let url = URL(string: endpoint.rawValue, encodingInvalidCharacters: false) else { return }
 
         dataTask?.cancel()
         dataTask = URLSession.shared.dataTask(with: url) { data, response, error in

--- a/Client/Frontend/Reader/ReaderModeHandlers.swift
+++ b/Client/Frontend/Reader/ReaderModeHandlers.swift
@@ -30,7 +30,7 @@ struct ReaderModeHandlers: ReaderModeHandlersProtocol {
         // the readerized content.
         webServer.registerHandlerForMethod("GET", module: "reader-mode", resource: "page-exists") { (request: GCDWebServerRequest?) -> GCDWebServerResponse? in
             guard let stringURL = request?.query?["url"],
-                  let url = URL(string: stringURL) else {
+                  let url = URL(string: stringURL, encodingInvalidCharacters: false) else {
                 return GCDWebServerResponse(statusCode: 500)
             }
 
@@ -41,7 +41,7 @@ struct ReaderModeHandlers: ReaderModeHandlersProtocol {
         // Register the handler that accepts /reader-mode/page?url=http://www.example.com requests.
         webServer.registerHandlerForMethod("GET", module: "reader-mode", resource: "page") { (request: GCDWebServerRequest?) -> GCDWebServerResponse? in
             if let url = request?.query?["url"] {
-                if let url = URL(string: url), url.isWebPage() {
+                if let url = URL(string: url, encodingInvalidCharacters: false), url.isWebPage() {
                     do {
                         let readabilityResult = try readerModeCache.get(url)
                         // We have this page in our cache, so we can display it. Just grab the correct style from the

--- a/Client/Frontend/Settings/CustomSearchViewController.swift
+++ b/Client/Frontend/Settings/CustomSearchViewController.swift
@@ -88,7 +88,7 @@ class CustomSearchViewController: SettingsTableViewController {
     func createEngine(query: String, name: String) async throws -> OpenSearchEngine {
         guard let template = getSearchTemplate(withString: query),
               let encodedTemplate = template.addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed),
-              let url = URL(string: encodedTemplate),
+              let url = URL(string: encodedTemplate, encodingInvalidCharacters: false),
               url.isWebPage()
         else {
             throw CustomSearchError(.FormInput)
@@ -143,7 +143,7 @@ class CustomSearchViewController: SettingsTableViewController {
     override func generateSettings() -> [SettingSection] {
         func URLFromString(_ string: String?) -> URL? {
             guard let string = string else { return nil }
-            return URL(string: string)
+            return URL(string: string, encodingInvalidCharacters: false)
         }
 
         let titleField = CustomSearchEngineTextView(

--- a/Client/Frontend/Settings/Main/Account/AccountStatusSetting.swift
+++ b/Client/Frontend/Settings/Main/Account/AccountStatusSetting.swift
@@ -88,7 +88,7 @@ class AccountStatusSetting: WithAccountSetting {
                 .tinted(withColor: theme.colors.iconPrimary)
 
             guard let str = RustFirefoxAccounts.shared.userProfile?.avatarUrl,
-                  let actionIconUrl = URL(string: str)
+                  let actionIconUrl = URL(string: str, encodingInvalidCharacters: false)
             else { return }
 
             GeneralizedImageFetcher().getImageFor(url: actionIconUrl) { image in

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -452,7 +452,7 @@ class WebPageSetting: StringPrefSetting {
         guard let string = string, !string.isEmpty else {
             return true
         }
-        return URL(string: string)?.isWebPage() ?? false
+        return URL(string: string, encodingInvalidCharacters: false)?.isWebPage() ?? false
     }
 }
 

--- a/Client/Frontend/TabContentsScripts/ContextMenuHelper.swift
+++ b/Client/Frontend/TabContentsScripts/ContextMenuHelper.swift
@@ -50,13 +50,13 @@ extension ContextMenuHelper: TabContentScript {
         var linkURL: URL?
         if let urlString = data["link"] as? String,
                 let escapedURLString = urlString.addingPercentEncoding(withAllowedCharacters: .URLAllowed) {
-            linkURL = URL(string: escapedURLString)
+            linkURL = URL(string: escapedURLString, encodingInvalidCharacters: false)
         }
 
         var imageURL: URL?
         if let urlString = data["image"] as? String,
                 let escapedURLString = urlString.addingPercentEncoding(withAllowedCharacters: .URLAllowed) {
-            imageURL = URL(string: escapedURLString)
+            imageURL = URL(string: escapedURLString, encodingInvalidCharacters: false)
         }
 
         if linkURL != nil || imageURL != nil {

--- a/Client/Frontend/TabContentsScripts/DownloadContentScript.swift
+++ b/Client/Frontend/TabContentsScripts/DownloadContentScript.swift
@@ -43,7 +43,7 @@ class DownloadContentScript: TabContentScript {
         guard url.scheme == "blob" else {
             return false
         }
-        blobUrlForDownload = URL(string: safeUrl)
+        blobUrlForDownload = URL(string: safeUrl, encodingInvalidCharacters: false)
         tab.webView?.evaluateJavascriptInDefaultContentWorld("window.__firefox__.download('\(safeUrl)', '\(UserScriptManager.appIdToken)')")
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .downloadLinkButton)
         return true
@@ -52,7 +52,7 @@ class DownloadContentScript: TabContentScript {
     func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
         guard let dictionary = message.body as? [String: Any?],
               let _url = dictionary["url"] as? String,
-              let url = URL(string: _url),
+              let url = URL(string: _url, encodingInvalidCharacters: false),
               let mimeType = dictionary["mimeType"] as? String,
               let size = dictionary["size"] as? Int64,
               let base64String = dictionary["base64String"] as? String,

--- a/Client/Frontend/TabContentsScripts/FormPostHelper.swift
+++ b/Client/Frontend/TabContentsScripts/FormPostHelper.swift
@@ -18,7 +18,7 @@ struct FormPostData {
               let target = messageBodyDict["target"],
               let enctype = messageBodyDict["enctype"],
               let requestBodyString = messageBodyDict["requestBody"],
-              let action = URL(string: actionString),
+              let action = URL(string: actionString, encodingInvalidCharacters: false),
               let requestBody = requestBodyString.data(using: .utf8)
         else {
                 return nil

--- a/Client/Frontend/TabContentsScripts/LoginsHelper.swift
+++ b/Client/Frontend/TabContentsScripts/LoginsHelper.swift
@@ -32,7 +32,7 @@ class LoginsHelper: TabContentScript {
     }
 
     fileprivate func getOrigin(_ uriString: String, allowJS: Bool = false) -> String? {
-        guard let uri = URL(string: uriString),
+        guard let uri = URL(string: uriString, encodingInvalidCharacters: false),
               let scheme = uri.scheme, !scheme.isEmpty,
               let host = uri.host
         else {

--- a/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -722,7 +722,10 @@ extension URLBarView: TabLocationViewDelegate {
 
         var overlayText = locationText
         // Make sure to use the result from urlBarDisplayTextForURL as it is responsible for extracting out search terms when on a search page
-        if let text = locationText, let url = URL(string: text), let host = url.host, AppConstants.punyCode {
+        if let text = locationText,
+            let url = URL(string: text, encodingInvalidCharacters: false),
+            let host = url.host,
+            AppConstants.punyCode {
             overlayText = url.absoluteString.replacingOccurrences(of: host, with: host.asciiHostToUTF8())
         }
         enterOverlayMode(overlayText, pasted: false, search: isSearchQuery)

--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -167,7 +167,7 @@ extension SiteTableViewController: UITableViewDragDelegate {
     func tableView(_ tableView: UITableView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {
         guard let panelVC = self as? LibraryPanelContextMenu,
               let site = panelVC.getSiteDetails(for: indexPath),
-              let url = URL(string: site.url), let itemProvider = NSItemProvider(contentsOf: url)
+              let url = URL(string: site.url, encodingInvalidCharacters: false), let itemProvider = NSItemProvider(contentsOf: url)
         else { return [] }
 
         // Telemetry is being sent to legacy, need to add it to metrics.yml

--- a/Client/Helpers/UserActivityHandler.swift
+++ b/Client/Helpers/UserActivityHandler.swift
@@ -60,7 +60,7 @@ extension UserActivityHandler: TabEventHandler {
     }
 
     func tab(_ tab: Tab, didLoadPageMetadata metadata: PageMetadata) {
-        guard let url = URL(string: metadata.siteURL) else { return }
+        guard let url = URL(string: metadata.siteURL, encodingInvalidCharacters: false) else { return }
 
         setUserActivityForTab(tab, url: url)
     }

--- a/Client/Nimbus/OnboardingFeatureLayer/NimbusOnboardingFeatureLayer.swift
+++ b/Client/Nimbus/OnboardingFeatureLayer/NimbusOnboardingFeatureLayer.swift
@@ -176,7 +176,7 @@ class NimbusOnboardingFeatureLayer: NimbusOnboardingFeatureLayerProtocol {
 
     private func getOnboardingLink(from cardLink: NimbusOnboardingLink?) -> OnboardingLinkInfoModel? {
         guard let cardLink = cardLink,
-              let url = URL(string: cardLink.url)
+              let url = URL(string: cardLink.url, encodingInvalidCharacters: false)
         else { return nil }
 
         return OnboardingLinkInfoModel(title: cardLink.title, url: url)

--- a/Client/TabManagement/Legacy/LegacySessionData.swift
+++ b/Client/TabManagement/Legacy/LegacySessionData.swift
@@ -28,11 +28,12 @@ private func migrate(urls: [URL]) -> [URL] {
                     urlStr = newItem + (comp.last ?? "")
                     assertionFailure("SessionData urls have nested internal links, investigate: [\(url.absoluteString)]")
                 }
-                url = URL(string: urlStr) ?? url
+                url = URL(string: urlStr, encodingInvalidCharacters: false) ?? url
             }
         }
 
-        if let internalUrl = InternalURL(url), internalUrl.isAuthorized, let stripped = URL(string: internalUrl.stripAuthorization) {
+        if let internalUrl = InternalURL(url), internalUrl.isAuthorized,
+            let stripped = URL(string: internalUrl.stripAuthorization, encodingInvalidCharacters: false) {
             return stripped
         }
 

--- a/Client/TabManagement/Tab.swift
+++ b/Client/TabManagement/Tab.swift
@@ -134,13 +134,13 @@ class Tab: NSObject {
 
     var canonicalURL: URL? {
         if let string = pageMetadata?.siteURL,
-           let siteURL = URL(string: string) {
+           let siteURL = URL(string: string, encodingInvalidCharacters: false) {
             // If the canonical URL from the page metadata doesn't contain the
             // "#" fragment, check if the tab's URL has a fragment and if so,
             // append it to the canonical URL.
             if siteURL.fragment == nil,
                let fragment = self.url?.fragment,
-               let siteURLWithFragment = URL(string: "\(string)#\(fragment)") {
+               let siteURLWithFragment = URL(string: "\(string)#\(fragment)", encodingInvalidCharacters: false) {
                 return siteURLWithFragment
             }
 
@@ -252,7 +252,7 @@ class Tab: NSObject {
     var faviconURL: String? {
         didSet {
             faviconHelper.cacheFaviconURL(siteURL: url,
-                                          faviconURL: URL(string: faviconURL ?? ""))
+                                          faviconURL: URL(string: faviconURL ?? "", encodingInvalidCharacters: false))
         }
     }
     fileprivate var lastRequest: URLRequest?
@@ -261,7 +261,7 @@ class Tab: NSObject {
     var url: URL? {
         didSet {
             if let _url = url, let internalUrl = InternalURL(_url), internalUrl.isAuthorized {
-                url = URL(string: internalUrl.stripAuthorization)
+                url = URL(string: internalUrl.stripAuthorization, encodingInvalidCharacters: false)
             }
         }
     }
@@ -523,7 +523,7 @@ class Tab: NSObject {
 
             guard let json = jsonDict.asString?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else { return }
 
-            if let restoreURL = URL(string: "\(InternalURL.baseUrl)/\(SessionRestoreHandler.path)?history=\(json)") {
+            if let restoreURL = URL(string: "\(InternalURL.baseUrl)/\(SessionRestoreHandler.path)?history=\(json)", encodingInvalidCharacters: false) {
                 let request = PrivilegedRequest(url: restoreURL) as URLRequest
                 webView.load(request)
                 lastRequest = request

--- a/Client/TabManagement/TabManagerImplementation.swift
+++ b/Client/TabManagement/TabManagerImplementation.swift
@@ -149,7 +149,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
 
         for tabData in filteredTabs {
             let newTab = addTab(flushToDisk: false, zombie: true, isPrivate: tabData.isPrivate)
-            newTab.url = URL(string: tabData.siteUrl)
+            newTab.url = URL(string: tabData.siteUrl, encodingInvalidCharacters: false)
             newTab.lastTitle = tabData.title
             newTab.tabUUID = tabData.id.uuidString
             newTab.screenshotUUID = tabData.id

--- a/Extensions/NotificationService/NotificationService.swift
+++ b/Extensions/NotificationService/NotificationService.swift
@@ -170,7 +170,10 @@ class SyncDataDisplay {
     }
 
     func displayNewSentTabNotification(tab: [String: String]) {
-        if let urlString = tab["url"], let url = URL(string: urlString), url.isWebPage(), let title = tab["title"] {
+        if let urlString = tab["url"],
+            let url = URL(string: urlString, encodingInvalidCharacters: false),
+            url.isWebPage(),
+            let title = tab["title"] {
             let tab = [
                 "title": title,
                 "url": url.absoluteString,

--- a/Extensions/ShareTo/ShareViewController.swift
+++ b/Extensions/ShareTo/ShareViewController.swift
@@ -409,7 +409,7 @@ extension ShareViewController {
             return "firefox://open-url?url=\(encoded)"
         }
 
-        guard let url = URL(string: firefoxUrl(url)) else { return }
+        guard let url = URL(string: firefoxUrl(url), encodingInvalidCharacters: false) else { return }
         var responder = self as UIResponder?
         let selectorOpenURL = sel_registerName("openURL:")
         while let current = responder {

--- a/Providers/Pocket/Model/PocketFeedStory.swift
+++ b/Providers/Pocket/Model/PocketFeedStory.swift
@@ -29,8 +29,8 @@ struct PocketFeedStory {
                       return nil
                   }
 
-            guard let url = URL(string: urlS),
-                  let imageURL = URL(string: imageURLS)
+            guard let url = URL(string: urlS, encodingInvalidCharacters: false),
+                  let imageURL = URL(string: imageURLS, encodingInvalidCharacters: false)
             else { return nil }
 
             return PocketFeedStory(

--- a/Providers/Pocket/PocketProvider.swift
+++ b/Providers/Pocket/PocketProvider.swift
@@ -124,7 +124,7 @@ class PocketProvider: PocketStoriesProviding, FeatureFlaggable, URLCaching {
             params.append(URLQueryItem(name: "consumer_key", value: pocketKey))
         }
 
-        guard let feedURL = URL(string: pocketGlobalFeed)?.withQueryParams(params) else { return nil }
+        guard let feedURL = URL(string: pocketGlobalFeed, encodingInvalidCharacters: false)?.withQueryParams(params) else { return nil }
 
         return URLRequest(url: feedURL, cachePolicy: .reloadIgnoringCacheData, timeoutInterval: 5)
     }

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -608,7 +608,7 @@ open class BrowserProfile: Profile {
                     switch command {
                     case .tabReceived(_, let tabData):
                         let url = tabData.entries.last?.url ?? ""
-                        return URL(string: url)
+                        return URL(string: url, encodingInvalidCharacters: false)
                     }
                 }
                 self.sendTabDelegate?.openSendTabs(for: urls)

--- a/Providers/TopSitesProvider.swift
+++ b/Providers/TopSitesProvider.swift
@@ -121,7 +121,7 @@ private extension TopSitesProviderImplementation {
         // How sites are merged together. We compare against the url's base domain.
         // Example m.youtube.com is compared against `youtube.com`
         let unionOnURL = { (site: Site) -> String in
-            return URL(string: site.url)?.normalizedHost ?? ""
+            return URL(string: site.url, encodingInvalidCharacters: false)?.normalizedHost ?? ""
         }
 
         // Fetch the default sites
@@ -139,7 +139,7 @@ private extension TopSitesProviderImplementation {
             if let site = site as? PinnedSite {
                 return site
             }
-            let domain = URL(string: site.url)?.shortDisplayString
+            let domain = URL(string: site.url, encodingInvalidCharacters: false)?.shortDisplayString
             return defaultSites.find { $0.title.lowercased() == domain } ?? site
         }
 

--- a/Providers/TopSitesWidgetManager.swift
+++ b/Providers/TopSitesWidgetManager.swift
@@ -26,7 +26,7 @@ class TopSitesWidgetManager: TopSitesWidget {
             var widgetkitTopSites = [WidgetKitTopSiteModel]()
             sites.forEach { site in
                 let imageKey = site.tileURL.baseDomain ?? ""
-                if let webUrl = URL(string: site.url) {
+                if let webUrl = URL(string: site.url, encodingInvalidCharacters: false) {
                     widgetkitTopSites.append(WidgetKitTopSiteModel(title: site.title,
                                                                    url: webUrl,
                                                                    imageKey: imageKey))

--- a/RustFxA/FxAWebViewModel.swift
+++ b/RustFxA/FxAWebViewModel.swift
@@ -287,7 +287,7 @@ extension FxAWebViewModel {
         // The app handles this event fully in native UI.
         let redirectUrl = RustFirefoxAccounts.redirectURL
         if let navigationURL = navigationURL {
-            let expectedRedirectURL = URL(string: redirectUrl)!
+            let expectedRedirectURL = URL(string: redirectUrl, encodingInvalidCharacters: false)!
             if navigationURL.scheme == expectedRedirectURL.scheme && navigationURL.host == expectedRedirectURL.host && navigationURL.path == expectedRedirectURL.path {
                 return .cancel
             }

--- a/RustFxA/RustFirefoxAccounts.swift
+++ b/RustFxA/RustFirefoxAccounts.swift
@@ -179,7 +179,7 @@ open class RustFirefoxAccounts {
     private func update() {
         guard let accountManager = accountManager.peek() else { return }
         let avatarUrl = accountManager.accountProfile()?.avatar
-        if let str = avatarUrl, let url = URL(string: str) {
+        if let str = avatarUrl, let url = URL(string: str, encodingInvalidCharacters: false) {
             avatar = Avatar(url: url)
         }
 

--- a/Shared/Extensions/String+Extension.swift
+++ b/Shared/Extensions/String+Extension.swift
@@ -20,8 +20,8 @@ public extension String {
         // Let's escape | for them.
         // We'd love to use one of the more sophisticated CFURL* or NSString.* functions, but
         // none seem to be quite suitable.
-        return URL(string: self) ??
-               URL(string: self.stringWithAdditionalEscaping)
+        return URL(string: self, encodingInvalidCharacters: false) ??
+               URL(string: self.stringWithAdditionalEscaping, encodingInvalidCharacters: false)
     }
 
     // MARK: - Hashing & Encoding

--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -302,9 +302,11 @@ extension URL {
 
     public var decodeReaderModeURL: URL? {
         if self.isReaderModeURL || self.isSyncedReaderModeURL {
-            if let components = URLComponents(url: self, resolvingAgainstBaseURL: false), let queryItems = components.queryItems {
-                if let queryItem = queryItems.find({ $0.name == "url"}), let value = queryItem.value {
-                    return URL(string: value)?.safeEncodedUrl
+            if let components = URLComponents(url: self, resolvingAgainstBaseURL: false),
+                let queryItems = components.queryItems {
+                if let queryItem = queryItems.find({ $0.name == "url"}),
+                    let value = queryItem.value {
+                    return URL(string: value, encodingInvalidCharacters: false)?.safeEncodedUrl
                 }
             }
         }
@@ -313,7 +315,7 @@ extension URL {
 
     public func encodeReaderModeURL(_ baseReaderModeURL: String) -> URL? {
         if let encodedURL = absoluteString.addingPercentEncoding(withAllowedCharacters: .alphanumerics) {
-            if let aboutReaderURL = URL(string: "\(baseReaderModeURL)?url=\(encodedURL)") {
+            if let aboutReaderURL = URL(string: "\(baseReaderModeURL)?url=\(encodedURL)", encodingInvalidCharacters: false) {
                 return aboutReaderURL
             }
         }
@@ -470,7 +472,7 @@ public struct InternalURL {
 
     public var extractedUrlParam: URL? {
         if let nestedUrl = url.getQuery()[InternalURL.Param.url.rawValue]?.unescape() {
-            return URL(string: nestedUrl)
+            return URL(string: nestedUrl, encodingInvalidCharacters: false)
         }
         return nil
     }
@@ -489,7 +491,7 @@ public struct InternalURL {
     /// Return the path after "about/" in the URI.
     public var aboutComponent: String? {
         let aboutPath = "/about/"
-        guard let url = URL(string: stripAuthorization) else { return nil }
+        guard let url = URL(string: stripAuthorization, encodingInvalidCharacters: false) else { return nil }
 
         if url.path.hasPrefix(aboutPath) {
             return String(url.path.dropFirst(aboutPath.count))

--- a/Storage/ExtensionUtils.swift
+++ b/Storage/ExtensionUtils.swift
@@ -88,7 +88,7 @@ public struct ExtensionUtils {
             if !text.hasPrefix("http") {
                 text = "http://" + text
             }
-            let url = URL(string: text)
+            let url = URL(string: text, encodingInvalidCharacters: false)
             return url?.publicSuffix != nil ? url : nil
         }
 

--- a/Storage/Rust/RustRemoteTabs.swift
+++ b/Storage/Rust/RustRemoteTabs.swift
@@ -165,8 +165,8 @@ public class RustRemoteTabs {
 
 public extension RemoteTabRecord {
     func toRemoteTab(client: RemoteClient) -> RemoteTab? {
-        guard let url = Foundation.URL(string: self.urlHistory[0]) else { return nil }
-        let history = self.urlHistory[1...].map { url in Foundation.URL(string: url) }.compactMap { $0 }
+        guard let url = Foundation.URL(string: self.urlHistory[0], encodingInvalidCharacters: false) else { return nil }
+        let history = self.urlHistory[1...].map { url in Foundation.URL(string: url, encodingInvalidCharacters: false) }.compactMap { $0 }
         let icon = self.icon != nil ? Foundation.URL(fileURLWithPath: self.icon ?? "") : nil
 
         return RemoteTab(clientGUID: client.guid, URL: url, title: self.title, history: history, lastUsed: Timestamp(self.lastUsed), icon: icon)

--- a/Storage/SQL/SQLitePinnedSites.swift
+++ b/Storage/SQL/SQLitePinnedSites.swift
@@ -18,7 +18,7 @@ public func isIgnoredURL(_ url: URL) -> Bool {
 }
 
 public func isIgnoredURL(_ url: String) -> Bool {
-    if let url = URL(string: url) {
+    if let url = URL(string: url, encodingInvalidCharacters: false) {
         return isIgnoredURL(url)
     }
 

--- a/Storage/Sharing.swift
+++ b/Storage/Sharing.swift
@@ -18,7 +18,7 @@ public struct ShareItem {
 
     // We only support sharing HTTP and HTTPS URLs, as well as data URIs.
     public var isShareable: Bool {
-        return URL(string: url)?.isWebPage() ?? false
+        return URL(string: url, encodingInvalidCharacters: false)?.isWebPage() ?? false
     }
 }
 

--- a/Storage/Site.swift
+++ b/Storage/Site.swift
@@ -20,12 +20,12 @@ open class Site: Identifiable {
     open var guid: String?
 
     open var tileURL: URL {
-        return URL(string: url)?.domainURL ?? URL(string: "about:blank")!
+        return URL(string: url, encodingInvalidCharacters: false)?.domainURL ?? URL(string: "about:blank")!
     }
 
     // i.e. `http://www.example.com/` --> `example`
     open var secondLevelDomain: String? {
-        return URL(string: url)?.host?.components(separatedBy: ".").suffix(2).first
+        return URL(string: url, encodingInvalidCharacters: false)?.host?.components(separatedBy: ".").suffix(2).first
     }
 
     public let url: String

--- a/Storage/SuggestedSites.swift
+++ b/Storage/SuggestedSites.swift
@@ -7,7 +7,7 @@ import Shared
 
 open class SuggestedSite: Site {
     override open var tileURL: URL {
-        return URL(string: url as String) ?? URL(string: "about:blank")!
+        return URL(string: url as String, encodingInvalidCharacters: false) ?? URL(string: "about:blank")!
     }
 
     let trackingId: Int

--- a/WidgetKit/Helpers.swift
+++ b/WidgetKit/Helpers.swift
@@ -13,5 +13,5 @@ var scheme: String {
 
 func linkToContainingApp(_ urlSuffix: String = "", query: String) -> URL {
     let urlString = "\(scheme)://\(query)\(urlSuffix)"
-    return URL(string: urlString)!
+    return URL(string: urlString, encodingInvalidCharacters: false)!
 }

--- a/WidgetKit/OpenTabs/OpenTabsWidget.swift
+++ b/WidgetKit/OpenTabs/OpenTabsWidget.swift
@@ -110,6 +110,6 @@ struct OpenTabsView: View {
 
     private func linkToContainingApp(_ urlSuffix: String = "", query: String) -> URL {
         let urlString = "\(scheme)://\(query)\(urlSuffix)"
-        return URL(string: urlString)!
+        return URL(string: urlString, encodingInvalidCharacters: false)!
     }
 }

--- a/WidgetKit/TopSites/TopSitesWidget.swift
+++ b/WidgetKit/TopSites/TopSitesWidget.swift
@@ -96,6 +96,6 @@ struct TopSitesView: View {
 
     private func linkToContainingApp(_ urlSuffix: String = "", query: String) -> URL {
         let urlString = "\(scheme)://\(query)\(urlSuffix)"
-        return URL(string: urlString)!
+        return URL(string: urlString, encodingInvalidCharacters: false)!
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7463)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16554)

## :bulb: Description
This is a first step towards upgrading to XCode 15. I've updated anywhere that I could find that doesn't use a hard coded url or a string that can be traced back to a hard coded url with a temporary shim that uses the same API Apple provide in XCode 15 to return URL to it's previous behaviour of failing to init with invalid characters.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

