### PR TITLE
Bugfix MTE-1597 [v119] testRecentlySaved fails intermittently

### DIFF
--- a/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -219,8 +219,8 @@ class HomePageSettingsUITests: BaseTestCase {
         bookmarkPages()
         addContentToReaderView()
         navigator.performAction(Action.GoToHomePage)
-        waitForTabsButton()
-        checkRecentlySaved()
+        // print(app.debugDescription)
+        mozWaitForElementToExist(app.staticTexts["Recently Saved"])
         navigator.performAction(Action.ToggleRecentlySaved)
         // On iPad we have the homepage button always present,
         // on iPhone we have the search button instead when we're on a new tab page

--- a/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -219,7 +219,6 @@ class HomePageSettingsUITests: BaseTestCase {
         bookmarkPages()
         addContentToReaderView()
         navigator.performAction(Action.GoToHomePage)
-        // print(app.debugDescription)
         mozWaitForElementToExist(app.staticTexts["Recently Saved"])
         navigator.performAction(Action.ToggleRecentlySaved)
         // On iPad we have the homepage button always present,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1597)

## :bulb: Description
`testRecentlySaved()` is failing on iPhone (intermittently?). We may need to ensure that the homepage is fully loaded before the next action. `waitForTabsButton()` is not good enough because the tabs button is ready to be tapped even if the homepage is not loaded fully. 😞 

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

