### PR TITLE
Refactor FXIOS-7458 [v119] Onboarding bottom sheet should open to full height

### DIFF
--- a/Client/Frontend/Fakespot/FakespotCoordinator.swift
+++ b/Client/Frontend/Fakespot/FakespotCoordinator.swift
@@ -38,6 +38,7 @@ class FakespotCoordinator: BaseCoordinator, FakespotViewControllerDelegate, Feat
             if let sheet = fakespotViewController.sheetPresentationController {
                 sheet.detents = [.medium(), .large()]
 
+                // Show onboarding in full height
                 if !isOptedIn {
                     sheet.selectedDetentIdentifier = .large
                 }

--- a/Client/Frontend/Fakespot/FakespotCoordinator.swift
+++ b/Client/Frontend/Fakespot/FakespotCoordinator.swift
@@ -2,7 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
+import Shared
 
 protocol FakespotCoordinatorDelegate: AnyObject {
     // Define any coordinator delegate methods
@@ -14,15 +16,31 @@ protocol FakespotViewControllerDelegate: AnyObject {
 
 class FakespotCoordinator: BaseCoordinator, FakespotViewControllerDelegate, FeatureFlaggable {
     weak var parentCoordinator: ParentCoordinatorDelegate?
+    private var profile: Profile
+
+    private var isOptedIn: Bool {
+        return profile.prefs.boolForKey(PrefsKeys.Shopping2023OptIn) ?? false
+    }
+
+    init(router: Router, profile: Profile = AppContainer.shared.resolve()) {
+        self.profile = profile
+        super.init(router: router)
+    }
 
     func start(productURL: URL) {
         let environment = featureFlags.isCoreFeatureEnabled(.useStagingFakespotAPI) ? FakespotEnvironment.staging : .prod
-        let viewModel = FakespotViewModel(shoppingProduct: ShoppingProduct(url: productURL, client: FakespotClient(environment: environment)))
+        let viewModel = FakespotViewModel(shoppingProduct: ShoppingProduct(
+            url: productURL,
+            client: FakespotClient(environment: environment)))
         let fakespotViewController = FakespotViewController(viewModel: viewModel)
         fakespotViewController.delegate = self
         if #available(iOS 15.0, *) {
             if let sheet = fakespotViewController.sheetPresentationController {
                 sheet.detents = [.medium(), .large()]
+
+                if !isOptedIn {
+                    sheet.selectedDetentIdentifier = .large
+                }
             }
         }
         router.present(fakespotViewController, animated: true)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7458)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16540)

## :bulb: Description
Shows onboarding in large instead medium sheet size.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

