### PR TITLE
Add MTE-1599 [v119] Add gsutil fallback for multi-processed copy

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1577,7 +1577,18 @@ workflows:
 
             # Get the process ID of the backgrounded gsutil command
             PID=$!
-            sleep 60
+
+            TIMEOUT=60
+            CHECK_INTERVAL=5
+            ITERATIONS=$((TIMEOUT / CHECK_INTERVAL))
+
+            for ((i = 0; i < ITERATIONS; i++)); do
+                echo "Waiting for gsutil to complete..."
+                sleep $CHECK_INTERVAL
+                if ! ps -p $PID > /dev/null; then
+                    break
+                fi
+            done
 
             # if gsutil is still running after 60s, it is hanging and needs to be killed
             if ps -p $PID > /dev/null; then

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1572,7 +1572,24 @@ workflows:
 
             # pull firebase xcresult and rename it to extract measurement data
             mkdir test_firebase_xcresult
-            $HOME/google-cloud-sdk/bin/gsutil -m cp -r $FIREBASE_XCRESULT_PATH ./test_firebase_xcresult
+
+            $HOME/google-cloud-sdk/bin/gsutil -m cp -r $FIREBASE_XCRESULT_PATH ./test_firebase_xcresult &
+
+            # Get the process ID of the backgrounded gsutil command
+            PID=$!
+            sleep 60
+
+            # if gsutil is still running after 60s, it is hanging and needs to be killed
+            if ps -p $PID > /dev/null; then
+                echo "The gsutil command exceeded the timeout. Stopping and removing contents..."
+                kill -9 $PID
+
+                rm -rf ./test_firebase_xcresult
+                mkdir ./test_firebase_xcresult
+                echo "Retrying xcresult copy without multithreading..."
+                $HOME/google-cloud-sdk/bin/gsutil cp -r $FIREBASE_XCRESULT_PATH ./test_firebase_xcresult
+            fi
+
             mv ./test_firebase_xcresult/*.xcresult ./test_firebase_xcresult/Test-Fennec-test.xcresult
 
             # firebase xcresult needs to be in the Test dir created during earlier build-for-testing step

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1597,7 +1597,7 @@ workflows:
 
                 rm -rf ./test_firebase_xcresult
                 mkdir ./test_firebase_xcresult
-                echo "Retrying xcresult copy without multithreading..."
+                echo "Retrying xcresult copy without multi-processing..."
                 $HOME/google-cloud-sdk/bin/gsutil cp -r $FIREBASE_XCRESULT_PATH ./test_firebase_xcresult
             fi
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1599)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
The `gsutil -m` command can hang when performing a `multi-processed copy`, and we need a check to see if it is hanging.

I'm adding a `60s` timeout, which should be more than enough for it to complete successfully. If it hasn't completed after 60 seconds, then it's hanging and will retry in synchronous mode.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

