### PR TITLE
Refactor FXIOS-7448 [v119] Move support urls to central place

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -1290,6 +1290,7 @@
 		E19B38B128A3E69300D8C541 /* WallpaperCollectionAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19B38B028A3E69300D8C541 /* WallpaperCollectionAvailabilityTests.swift */; };
 		E19B38B328A42D5E00D8C541 /* WallpaperCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19B38B228A42D5D00D8C541 /* WallpaperCollectionViewCell.swift */; };
 		E19B38B528A42EBC00D8C541 /* WallpaperCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19B38B428A42EBC00D8C541 /* WallpaperCellViewModel.swift */; };
+		E1A102D62AC19B30007B617A /* FakespotUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A102D52AC19B30007B617A /* FakespotUtils.swift */; };
 		E1A6AB4628CA6A4C00EBEBDD /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A6AB4528CA6A4C00EBEBDD /* String+Extension.swift */; };
 		E1A6AB4828CA833000EBEBDD /* WallpaperBaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A6AB4728CA833000EBEBDD /* WallpaperBaseViewController.swift */; };
 		E1AEC176286E0CF500062E29 /* JumpBackInViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AEC16F286E0CF500062E29 /* JumpBackInViewModelTests.swift */; };
@@ -6493,6 +6494,7 @@
 		E19B38B028A3E69300D8C541 /* WallpaperCollectionAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperCollectionAvailabilityTests.swift; sourceTree = "<group>"; };
 		E19B38B228A42D5D00D8C541 /* WallpaperCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WallpaperCollectionViewCell.swift; sourceTree = "<group>"; };
 		E19B38B428A42EBC00D8C541 /* WallpaperCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperCellViewModel.swift; sourceTree = "<group>"; };
+		E1A102D52AC19B30007B617A /* FakespotUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakespotUtils.swift; sourceTree = "<group>"; };
 		E1A6AB4528CA6A4C00EBEBDD /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		E1A6AB4728CA833000EBEBDD /* WallpaperBaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperBaseViewController.swift; sourceTree = "<group>"; };
 		E1AEC16F286E0CF500062E29 /* JumpBackInViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JumpBackInViewModelTests.swift; sourceTree = "<group>"; };
@@ -10022,6 +10024,7 @@
 				AB03032A2AB47AF300DCD8EF /* FakespotOptInCardViewModel.swift */,
 				E13E9AB02AAB0FB4001A0E9D /* FakespotViewController.swift */,
 				E13E9AB22AAB0FB4001A0E9D /* FakespotViewModel.swift */,
+				E1A102D52AC19B30007B617A /* FakespotUtils.swift */,
 				8C44A9D12A6A99FE009A1AA7 /* ShoppingProduct.swift */,
 			);
 			path = Fakespot;
@@ -12906,6 +12909,7 @@
 				8ADAE41E2A33A0E2007BF926 /* ShowIntroductionSetting.swift in Sources */,
 				8AF10D8F29D774090086351D /* SceneSetupHelper.swift in Sources */,
 				C4E398601D22C409004E89BA /* TopTabsLayout.swift in Sources */,
+				E1A102D62AC19B30007B617A /* FakespotUtils.swift in Sources */,
 				8A5D1CC12A30DCA4005AD35C /* SettingDisclosureUtility.swift in Sources */,
 				E1442FD5294782D9003680B0 /* UIView+SnapKit.swift in Sources */,
 				2816F0001B33E05400522243 /* UIConstants.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -10016,13 +10016,13 @@
 		E1D3FFAF2A66A9BD002D31EF /* Fakespot */ = {
 			isa = PBXGroup;
 			children = (
+				8C92DE942A7128FB0090BD28 /* Client */,
 				E16258F02A83D5DE00522742 /* Views */,
 				E13E9AB12AAB0FB4001A0E9D /* FakespotCoordinator.swift */,
-				E13E9AB02AAB0FB4001A0E9D /* FakespotViewController.swift */,
 				AB03032A2AB47AF300DCD8EF /* FakespotOptInCardViewModel.swift */,
+				E13E9AB02AAB0FB4001A0E9D /* FakespotViewController.swift */,
 				E13E9AB22AAB0FB4001A0E9D /* FakespotViewModel.swift */,
 				8C44A9D12A6A99FE009A1AA7 /* ShoppingProduct.swift */,
-				8C92DE942A7128FB0090BD28 /* Client */,
 			);
 			path = Fakespot;
 			sourceTree = "<group>";

--- a/Client/Frontend/Fakespot/FakespotOptInCardViewModel.swift
+++ b/Client/Frontend/Fakespot/FakespotOptInCardViewModel.swift
@@ -75,9 +75,9 @@ struct FakespotOptInCardViewModel {
     var onOptIn: (() -> Void)?
 
     // MARK: Links
-    let fakespotPrivacyPolicyLink = URL(string: "https://www.fakespot.com/privacy-policy")
-    let fakespotTermsOfUseLink = URL(string: "https://www.fakespot.com/terms")
-    let fakespotLearnMoreLink = URL(string: "https://support.mozilla.org/kb/review-checker-review-quality")
+    let fakespotPrivacyPolicyLink = FakespotUtils.privacyPolicyUrl
+    let fakespotTermsOfUseLink = FakespotUtils.termsOfUseUrl
+    let fakespotLearnMoreLink = FakespotUtils.learnMoreUrl
 
     // MARK: Init
     init(profile: Profile = AppContainer.shared.resolve(),

--- a/Client/Frontend/Fakespot/FakespotUtils.swift
+++ b/Client/Frontend/Fakespot/FakespotUtils.swift
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// Utility functions related to Fakespot
+public struct FakespotUtils {
+    public static var learnMoreUrl: URL? {
+        // Returns the predefined URL associated to learn more button action.
+        return URL(string: "https://support.mozilla.org/kb/review-checker-review-quality")
+    }
+
+    public static var privacyPolicyUrl: URL? {
+        // Returns the predefined URL associated to privacy policy button action.
+        return URL(string: "https://www.fakespot.com/privacy-policy")
+    }
+
+    public static var termsOfUseUrl: URL? {
+        // Returns the predefined URL associated to terms of use button action.
+        return URL(string: "https://www.fakespot.com/terms")
+    }
+
+    public static var fakespotUrl: URL? {
+        // Returns the predefined URL associated to Fakespot button action.
+        return URL(string: "http://fakespot.com/")
+    }
+}

--- a/Client/Frontend/Fakespot/Views/FakespotReviewQualityCardView.swift
+++ b/Client/Frontend/Fakespot/Views/FakespotReviewQualityCardView.swift
@@ -10,7 +10,7 @@ import ComponentLibrary
 // MARK: View Model
 final class FakespotReviewQualityCardViewModel {
     private let tabManager: TabManager
-    let fakespotLearnMoreLink = URL(string: "https://support.mozilla.org/kb/review-checker-review-quality")
+    let fakespotLearnMoreLink = FakespotUtils.learnMoreUrl
     var dismissViewController: (() -> Void)?
 
     // MARK: Init

--- a/Client/Frontend/Fakespot/Views/FakespotSettingsCardView.swift
+++ b/Client/Frontend/Fakespot/Views/FakespotSettingsCardView.swift
@@ -22,7 +22,7 @@ class FakespotSettingsCardViewModel {
     let footerActionTitle: String = .Shopping.SettingsCardFooterAction
     let footerA11yTitleIdentifier: String = a11yIds.footerTitle
     let footerA11yActionIdentifier: String = a11yIds.footerAction
-    let footerActionUrl = URL(string: "http://fakespot.com/")
+    let footerActionUrl = FakespotUtils.fakespotUrl
     var dismissViewController: (() -> Void)?
 
     var isReviewQualityCheckOn: Bool {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7448)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16507)

## :bulb: Description
Moves all Fakespot related button action urls in one file.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

