### PR TITLE
Build FXIOS-16599 - Switch Taskcluster pull request policy to `public…

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -2,7 +2,7 @@
 version: 1
 reporting: checks-v1
 policy:
-    pullRequests: public
+    pullRequests: public_restricted
 tasks:
     - $let:
         # Project-specific trustDomain
@@ -17,7 +17,7 @@ tasks:
                 then: '${event.pusher.email}'
                 # Assume Pull Request
                 else:
-                    $if: 'tasks_for == "github-pull-request"'
+                    $if: 'tasks_for[:19] == "github-pull-request"'
                     then: '${event.pull_request.user.login}@users.noreply.github.com'
                     else:
                         $if: 'tasks_for == "github-release"'
@@ -26,7 +26,7 @@ tasks:
             $if: 'tasks_for in ["github-push", "github-release"]'
             then: '${event.repository.html_url}'
             else:
-                $if: 'tasks_for == "github-pull-request"'
+                $if: 'tasks_for[:19] == "github-pull-request"'
                 then: '${event.pull_request.base.repo.html_url}'
                 else:
                     $if: 'tasks_for in ["cron", "action"]'
@@ -35,7 +35,7 @@ tasks:
             $if: 'tasks_for in ["github-push", "github-release"]'
             then: '${event.repository.html_url}'
             else:
-                $if: 'tasks_for == "github-pull-request"'
+                $if: 'tasks_for[:19] == "github-pull-request"'
                 then: '${event.pull_request.head.repo.html_url}'
                 else:
                     $if: 'tasks_for in ["cron", "action"]'
@@ -44,13 +44,13 @@ tasks:
             $if: 'tasks_for in ["github-push", "github-release"]'
             then: '${event.repository.name}'
             else:
-                $if: 'tasks_for == "github-pull-request"'
+                $if: 'tasks_for[:19] == "github-pull-request"'
                 then: '${event.pull_request.head.repo.name}'
                 else:
                     $if: 'tasks_for in ["cron", "action"]'
                     then: '${repository.project}'
         head_branch:
-            $if: 'tasks_for == "github-pull-request"'
+            $if: 'tasks_for[:19] == "github-pull-request"'
             then: ${event.pull_request.head.ref}
             else:
                 $if: 'tasks_for == "github-push"'
@@ -65,7 +65,7 @@ tasks:
             $if: 'tasks_for == "github-push"'
             then: '${event.after}'
             else:
-                $if: 'tasks_for == "github-pull-request"'
+                $if: 'tasks_for[:19] == "github-pull-request"'
                 then: '${event.pull_request.head.sha}'
                 else:
                     $if: 'tasks_for == "github-release"'
@@ -84,17 +84,19 @@ tasks:
                 $if: 'tasks_for in ["cron", "action"]'
                 then: '${ownTaskId}'
         pullRequestAction:
-            $if: 'tasks_for == "github-pull-request"'
+            $if: 'tasks_for[:19] == "github-pull-request"'
             then: ${event.action}
             else: 'UNDEFINED'
         releaseAction:
             $if: 'tasks_for == "github-release"'
             then: ${event.action}
             else: 'UNDEFINED'
+        isPullRequest:
+            $eval: 'tasks_for[:19] == "github-pull-request"'
       in:
         $if: >
           tasks_for in ["action", "cron"]
-          || (tasks_for == "github-pull-request" && pullRequestAction in ["opened", "reopened", "synchronize"])
+          || (isPullRequest && pullRequestAction in ["opened", "reopened", "synchronize"])
           || (tasks_for == "github-push" && head_branch[:10] != "refs/tags/")
           || (tasks_for == "github-release" && releaseAction == "published")
         then:
@@ -123,7 +125,7 @@ tasks:
                     $merge:
                         - owner: "${ownerEmail}"
                           source: '${repoUrl}/raw/${head_sha}/.taskcluster.yml'
-                        - $if: 'tasks_for in ["github-push", "github-pull-request", "github-release"]'
+                        - $if: 'isPullRequest || tasks_for in ["github-push", "github-release"]'
                           then:
                             name: "Decision Task"
                             description: 'The task that creates all of the other tasks in the task graph'
@@ -138,7 +140,7 @@ tasks:
                 provisionerId: "mobile-${level}"
                 workerType: "decision-gcp"
                 tags:
-                    $if: 'tasks_for in ["github-push", "github-pull-request"]'
+                    $if: 'tasks_for == "github-push" || isPullRequest'
                     then:
                         kind: decision-task
                     else:
@@ -172,9 +174,9 @@ tasks:
                         # `https://` is 8 characters so, ${repoUrl[8:]} is the repository without the protocol.
                         - 'assume:repo:${repoUrl[8:]}:branch:${short_head_branch}'
                     else:
-                        $if: 'tasks_for == "github-pull-request"'
+                        $if: 'isPullRequest'
                         then:
-                            - 'assume:repo:github.com/${event.pull_request.base.repo.full_name}:pull-request'
+                            - 'assume:repo:github.com/${event.pull_request.base.repo.full_name}:${tasks_for[7:]}'
                         else:
                             $if: 'tasks_for == "github-release"'
                             then:
@@ -206,7 +208,7 @@ tasks:
                               REPOSITORIES: {$json: {mobile: "Firefox for iOS"}}
                               HG_STORE_PATH: /builds/worker/checkouts/hg-store
                               ANDROID_SDK_ROOT: /builds/worker/android-sdk
-                            - $if: 'tasks_for in ["github-pull-request"]'
+                            - $if: 'isPullRequest'
                               then:
                                 MOBILE_PULL_REQUEST_NUMBER: '${event.pull_request.number}'
                             - $if: 'tasks_for == "action"'
@@ -280,7 +282,7 @@ tasks:
                             $merge:
                                 - machine:
                                     platform: gecko-decision
-                                - $if: 'tasks_for in ["github-push", "github-pull-request"]'
+                                - $if: 'tasks_for  == "github-push" || isPullRequest'
                                   then:
                                     symbol: D
                                   else:


### PR DESCRIPTION
…_restricted`

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7477)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16599)

## :bulb: Description
This repo is currently using the public PR policy, which means that all pull requests have the same set of scopes no matter who opened it. Taskcluster has a policy called public_restricted, which means that pull requests opened by collaborators are more privileged than pull requests opened by external contributors.

This is useful when projects have tasks that require (not super sensitive) secrets that they'd like to run on collaborator PRs. The firefox-android repo is already using this policy, and I believe firefox-ios should follow suit.

I realize firefox-ios doesn't currently have any Taskcluster tasks running on PRs anyway, but it seems that automation is starting to get built out here, and now would be a good time to make the switch.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

