### PR TITLE
Refactor FXIOS-6923 [v120] New TabCell and updates for tab tray refactors

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		1DA3CE6324EEE83200422BB2 /* LegacySavedTab+ConfigureExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA3CE6224EEE83200422BB2 /* LegacySavedTab+ConfigureExtension.swift */; };
 		1DA3CE6724EEE86C00422BB2 /* AppInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65075641E37F7AB006961AC /* AppInfo.swift */; };
 		1DDAD13E24F0651C007623C8 /* TopSitesWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DDAD13C24F064F7007623C8 /* TopSitesWidget.swift */; };
+		1DDE3DB32AC34E1E0039363B /* TabCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DDE3DB22AC34E1E0039363B /* TabCell.swift */; };
 		1DF426CF251BDF6A0086386A /* photon-colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C49854D206173C800893DAE /* photon-colors.swift */; };
 		1DFE57FB27B2CB870025DE58 /* HighlightItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DFE57FA27B2CB870025DE58 /* HighlightItem.swift */; };
 		1DFE57FD27BADD7D0025DE58 /* HomepageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DFE57FC27BADD7C0025DE58 /* HomepageViewModel.swift */; };
@@ -2064,6 +2065,7 @@
 		1DA3CE6224EEE83200422BB2 /* LegacySavedTab+ConfigureExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LegacySavedTab+ConfigureExtension.swift"; sourceTree = "<group>"; };
 		1DA64656B1F6A74800D22055 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/LoginManager.strings; sourceTree = "<group>"; };
 		1DDAD13C24F064F7007623C8 /* TopSitesWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSitesWidget.swift; sourceTree = "<group>"; };
+		1DDE3DB22AC34E1E0039363B /* TabCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TabCell.swift; path = Tabs/TabCell.swift; sourceTree = "<group>"; };
 		1DE6449A95FE587845F9A459 /* si */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = si; path = si.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		1DFE57FA27B2CB870025DE58 /* HighlightItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightItem.swift; sourceTree = "<group>"; };
 		1DFE57FC27BADD7C0025DE58 /* HomepageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageViewModel.swift; sourceTree = "<group>"; };
@@ -9604,6 +9606,7 @@
 				3BF56D261CDBBE1F00AC4D75 /* SimpleToast.swift */,
 				E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */,
 				213B67A527CE682B000542F5 /* StartAtHomeHelper.swift */,
+				1DDE3DB22AC34E1E0039363B /* TabCell.swift */,
 				7BA0601A1C0F4DE200DFADB6 /* TabPeekViewController.swift */,
 				DD31E0FA1B382B520077078A /* TabPrintPageRenderer.swift */,
 				E698FFD91B4AADF40001F623 /* TabScrollController.swift */,
@@ -12746,6 +12749,7 @@
 				0BA02DB22942605600C92603 /* CreditCardHelper.swift in Sources */,
 				8A19ACB82A329128001C2147 /* PrivacyPolicySetting.swift in Sources */,
 				E68AEDB01B18F81A00133D99 /* SwipeAnimator.swift in Sources */,
+				1DDE3DB32AC34E1E0039363B /* TabCell.swift in Sources */,
 				3BF56D271CDBBE1F00AC4D75 /* SimpleToast.swift in Sources */,
 				C8B0F5F6283B7CCE007AE65D /* PocketStory.swift in Sources */,
 				C81AC6B626160091007800C5 /* LegacyTabTrayViewModel.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		1DA3CE6724EEE86C00422BB2 /* AppInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65075641E37F7AB006961AC /* AppInfo.swift */; };
 		1DDAD13E24F0651C007623C8 /* TopSitesWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DDAD13C24F064F7007623C8 /* TopSitesWidget.swift */; };
 		1DDE3DB32AC34E1E0039363B /* TabCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DDE3DB22AC34E1E0039363B /* TabCell.swift */; };
+		1DDE3DB52AC360EC0039363B /* TabCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DDE3DB42AC360EC0039363B /* TabCellTests.swift */; };
 		1DF426CF251BDF6A0086386A /* photon-colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C49854D206173C800893DAE /* photon-colors.swift */; };
 		1DFE57FB27B2CB870025DE58 /* HighlightItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DFE57FA27B2CB870025DE58 /* HighlightItem.swift */; };
 		1DFE57FD27BADD7D0025DE58 /* HomepageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DFE57FC27BADD7C0025DE58 /* HomepageViewModel.swift */; };
@@ -2066,6 +2067,7 @@
 		1DA64656B1F6A74800D22055 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/LoginManager.strings; sourceTree = "<group>"; };
 		1DDAD13C24F064F7007623C8 /* TopSitesWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSitesWidget.swift; sourceTree = "<group>"; };
 		1DDE3DB22AC34E1E0039363B /* TabCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TabCell.swift; path = Tabs/TabCell.swift; sourceTree = "<group>"; };
+		1DDE3DB42AC360EC0039363B /* TabCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabCellTests.swift; sourceTree = "<group>"; };
 		1DE6449A95FE587845F9A459 /* si */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = si; path = si.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		1DFE57FA27B2CB870025DE58 /* HighlightItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightItem.swift; sourceTree = "<group>"; };
 		1DFE57FC27BADD7C0025DE58 /* HomepageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageViewModel.swift; sourceTree = "<group>"; };
@@ -10470,6 +10472,7 @@
 				8C6DA7D02A6FE78F00DE264F /* ShoppingProductTests.swift */,
 				8A6E13972A71BA4E00A88FA8 /* TabWebViewTests.swift */,
 				8A6E13992A71BA8B00A88FA8 /* TabLayoutDelegateTests.swift */,
+				1DDE3DB42AC360EC0039363B /* TabCellTests.swift */,
 				8A6E139B2A71BB5700A88FA8 /* LegacyTabCellTests.swift */,
 				8A6E139D2A71C78A00A88FA8 /* GridTabViewControllerTests.swift */,
 			);
@@ -12959,6 +12962,7 @@
 				5AF6254528A57B6700A90253 /* MockHistoryHighlightsManager.swift in Sources */,
 				E571EE7E28756A130051D9AA /* PocketStoryProviderTests.swift in Sources */,
 				21420EF92ABC75A400B28550 /* TabTrayCoordinatorTests.swift in Sources */,
+				1DDE3DB52AC360EC0039363B /* TabCellTests.swift in Sources */,
 				8AFCE50729DE0CD500B1B253 /* LaunchCoordinatorTests.swift in Sources */,
 				961D6B832995AF84001B9CF1 /* GeneralizedImageFetcherTests.swift in Sources */,
 				E1AEC177286E0CF500062E29 /* HistoryHighlightsViewModelTests.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -612,7 +612,7 @@
 		8A6B77CC2811C468001110D2 /* URLProtocolStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6B77CB2811C468001110D2 /* URLProtocolStub.swift */; };
 		8A6E13982A71BA4E00A88FA8 /* TabWebViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6E13972A71BA4E00A88FA8 /* TabWebViewTests.swift */; };
 		8A6E139A2A71BA8B00A88FA8 /* TabLayoutDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6E13992A71BA8B00A88FA8 /* TabLayoutDelegateTests.swift */; };
-		8A6E139C2A71BB5700A88FA8 /* TabCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6E139B2A71BB5700A88FA8 /* TabCellTests.swift */; };
+		8A6E139C2A71BB5700A88FA8 /* LegacyTabCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6E139B2A71BB5700A88FA8 /* LegacyTabCellTests.swift */; };
 		8A6E139E2A71C78A00A88FA8 /* GridTabViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6E139D2A71C78A00A88FA8 /* GridTabViewControllerTests.swift */; };
 		8A720C5E2A4C85DA0003018A /* AccountSettingsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A720C5D2A4C85DA0003018A /* AccountSettingsDelegate.swift */; };
 		8A720C602A4C8B700003018A /* SharedSettingsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A720C5F2A4C8B700003018A /* SharedSettingsDelegate.swift */; };
@@ -4925,7 +4925,7 @@
 		8A6B77CB2811C468001110D2 /* URLProtocolStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLProtocolStub.swift; sourceTree = "<group>"; };
 		8A6E13972A71BA4E00A88FA8 /* TabWebViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabWebViewTests.swift; sourceTree = "<group>"; };
 		8A6E13992A71BA8B00A88FA8 /* TabLayoutDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabLayoutDelegateTests.swift; sourceTree = "<group>"; };
-		8A6E139B2A71BB5700A88FA8 /* TabCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabCellTests.swift; sourceTree = "<group>"; };
+		8A6E139B2A71BB5700A88FA8 /* LegacyTabCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyTabCellTests.swift; sourceTree = "<group>"; };
 		8A6E139D2A71C78A00A88FA8 /* GridTabViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridTabViewControllerTests.swift; sourceTree = "<group>"; };
 		8A720C5D2A4C85DA0003018A /* AccountSettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSettingsDelegate.swift; sourceTree = "<group>"; };
 		8A720C5F2A4C8B700003018A /* SharedSettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedSettingsDelegate.swift; sourceTree = "<group>"; };
@@ -10470,7 +10470,7 @@
 				8C6DA7D02A6FE78F00DE264F /* ShoppingProductTests.swift */,
 				8A6E13972A71BA4E00A88FA8 /* TabWebViewTests.swift */,
 				8A6E13992A71BA8B00A88FA8 /* TabLayoutDelegateTests.swift */,
-				8A6E139B2A71BB5700A88FA8 /* TabCellTests.swift */,
+				8A6E139B2A71BB5700A88FA8 /* LegacyTabCellTests.swift */,
 				8A6E139D2A71C78A00A88FA8 /* GridTabViewControllerTests.swift */,
 			);
 			path = ClientTests;
@@ -13075,7 +13075,7 @@
 				D815A3A824A53F3200AAB221 /* TabToolbarHelperTests.swift in Sources */,
 				967EDABF29D769A10089208D /* CreditCardInputFieldTests.swift in Sources */,
 				C8445AD126443C7F00B83F53 /* LibraryPanelViewStateTests.swift in Sources */,
-				8A6E139C2A71BB5700A88FA8 /* TabCellTests.swift in Sources */,
+				8A6E139C2A71BB5700A88FA8 /* LegacyTabCellTests.swift in Sources */,
 				8CFD56892AAF06D3003157A6 /* ShoppingProductTests.swift in Sources */,
 				8ACA8F7629198D6400D3075D /* ThrottlerTests.swift in Sources */,
 				217AEF76284666D4004EED37 /* IntroViewModelTests.swift in Sources */,

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -321,7 +321,7 @@ class LegacyTabDisplayManager: NSObject, FeatureFlaggable {
         guard let currentlySelected = currentlySelected else { return nil }
 
         for index in 0..<collectionView.numberOfItems(inSection: inSection) {
-            guard let cell = collectionView.cellForItem(at: IndexPath(row: index, section: inSection)) as? TabTrayCell,
+            guard let cell = collectionView.cellForItem(at: IndexPath(row: index, section: inSection)) as? LegacyTabTrayCell,
                   cell.isSelectedTab,
                   let tab = dataStore.at(index),
                   tab != currentlySelected
@@ -853,18 +853,18 @@ extension LegacyTabDisplayManager: TabEventHandler {
     }
 
     private func refreshCell(atIndexPath indexPath: IndexPath, forceUpdate: Bool = true) {
-        guard let cell = collectionView.cellForItem(at: indexPath) as? TabTrayCell,
+        guard let cell = collectionView.cellForItem(at: indexPath) as? LegacyTabTrayCell,
               let tab = dataStore.at(indexPath.row) else { return }
 
         // Only update from nextTabIndex if needed
         guard forceUpdate || cell.isSelectedTab else { return }
 
         let isSelected = tab == tabManager.selectedTab
-        cell.configureWith(tab: tab,
-                           isSelected: isSelected,
-                           theme: theme)
+        cell.configureLegacyCellWith(tab: tab,
+                                     isSelected: isSelected,
+                                     theme: theme)
     }
-
+    
     func removeAllTabsFromView() {
         operations.removeAll()
         dataStore.removeAll()

--- a/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
+++ b/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
@@ -463,7 +463,7 @@ extension LegacyGridTabViewController: TabDisplayerDelegate {
         tabCell.animator?.delegate = self
         tabCell.delegate = self
         let selected = tab == tabManager.selectedTab
-        tabCell.configureWith(tab: tab, isSelected: selected, theme: themeManager.currentTheme)
+        tabCell.configureLegacyCellWith(tab: tab, isSelected: selected, theme: themeManager.currentTheme)
         return tabCell
     }
 }
@@ -565,7 +565,7 @@ extension LegacyGridTabViewController: SwipeAnimatorDelegate {
 }
 
 // MARK: - TabCellDelegate
-extension LegacyGridTabViewController: TabCellDelegate {
+extension LegacyGridTabViewController: LegacyTabCellDelegate {
     func tabCellDidClose(_ cell: LegacyTabCell) {
         if let indexPath = collectionView.indexPath(for: cell),
            let tab = tabDisplayManager.dataStore.at(indexPath.item) {

--- a/Client/Frontend/Browser/Tabs/Legacy/LegacyTabCell.swift
+++ b/Client/Frontend/Browser/Tabs/Legacy/LegacyTabCell.swift
@@ -9,21 +9,21 @@ import Shared
 import SiteImageView
 
 // MARK: - Tab Tray Cell Protocol
-protocol TabTrayCell where Self: UICollectionViewCell {
+protocol LegacyTabTrayCell where Self: UICollectionViewCell {
     /// True when the tab is the selected tab in the tray
     var isSelectedTab: Bool { get }
 
     /// Configure a tab cell using a Tab object, setting it's selected state at the same time
-    func configureWith(tab: Tab, isSelected selected: Bool, theme: Theme)
+    func configureLegacyCellWith(tab: Tab, isSelected selected: Bool, theme: Theme)
 }
 
-protocol TabCellDelegate: AnyObject {
+protocol LegacyTabCellDelegate: AnyObject {
     func tabCellDidClose(_ cell: LegacyTabCell)
 }
 
 // MARK: - Tab Cell
 class LegacyTabCell: UICollectionViewCell,
-               TabTrayCell,
+               LegacyTabTrayCell,
                ReusableCell,
                ThemeApplicable {
     // MARK: - Constants
@@ -74,7 +74,7 @@ class LegacyTabCell: UICollectionViewCell,
     var animator: SwipeAnimator?
     var isSelectedTab = false
 
-    weak var delegate: TabCellDelegate?
+    weak var delegate: LegacyTabCellDelegate?
 
     // Changes depending on whether we're full-screen or not.
     private var margin = CGFloat(0)
@@ -155,7 +155,7 @@ class LegacyTabCell: UICollectionViewCell,
     }
 
     // MARK: - Configure tab cell with a Tab
-    func configureWith(tab: Tab, isSelected selected: Bool, theme: Theme) {
+    func configureLegacyCellWith(tab: Tab, isSelected selected: Bool, theme: Theme) {
         isSelectedTab = selected
 
         titleText.text = tab.getTabTrayTitle()
@@ -264,7 +264,7 @@ class LegacyTabCell: UICollectionViewCell,
 }
 
 // MARK: - Extension Tab Tray Cell protocol
-extension TabTrayCell {
+extension LegacyTabTrayCell {
     func getA11yTitleLabel(tab: Tab) -> String? {
         let baseName = tab.getTabTrayTitle()
 

--- a/Client/Frontend/Browser/Tabs/TabCell.swift
+++ b/Client/Frontend/Browser/Tabs/TabCell.swift
@@ -10,17 +10,30 @@ import SiteImageView
 
 /// WIP. Defines tab-sepcific state that is reflected in the new TabCell.
 struct TabCellState {
-    let isSelected = false
-    let isPrivate = false
-    let isFxHomeTab = false
+    let isSelected: Bool
+    let isPrivate: Bool
+    let isFxHomeTab: Bool
 
-    let tabTitle: String = ""
-    let url: URL? = nil
+    let tabTitle: String
+    let url: URL?
 
-    let screenshot: UIImage? = nil // TBD.
-    let hasHomeScreenshot = false // TBD.
+    let screenshot: UIImage? // TBD.
+    let hasHomeScreenshot: Bool // TBD.
 
-    let margin: CGFloat = 0.0 // (Changes depending on fullscreen)
+    let margin: CGFloat // (Changes depending on fullscreen)
+}
+
+extension TabCellState {
+    static func emptyTabState() -> TabCellState {
+        return TabCellState(isSelected: false,
+                            isPrivate: false,
+                            isFxHomeTab: false,
+                            tabTitle: "",
+                            url: nil,
+                            screenshot: nil,
+                            hasHomeScreenshot: false,
+                            margin: 0.0)
+    }
 }
 
 private struct TabCellUILayout {
@@ -37,7 +50,7 @@ protocol TabCellDelegate: AnyObject {
 class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
     // MARK: - Properties
 
-    private(set) var state = TabCellState()
+    private(set) var state = TabCellState.emptyTabState()
 
     var isSelectedTab: Bool { return state.isSelected }
     var animator: SwipeAnimator?
@@ -79,7 +92,7 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
 
     // MARK: - Configuration
 
-    func configure(with state: TabCellState, theme: Theme) {
+    func configure(with state: TabCellState, theme: Theme?) {
         self.state = state
 
         titleText.text = state.tabTitle
@@ -94,12 +107,16 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
             favicon.setFavicon(FaviconImageViewModel(siteURLString: tabURL))
         }
 
-        updateUIForSelectedState(state.isSelected, isPrivate: state.isPrivate, theme: theme)
+        updateUIForSelectedState(state.isSelected,
+                                 isPrivate: state.isPrivate,
+                                 theme: theme)
 
         faviconBG.isHidden = true
         configureScreenshot(state: state)
 
-        applyTheme(theme: theme)
+        if let theme = theme {
+            applyTheme(theme: theme)
+        }
     }
 
     // MARK: - Actions
@@ -124,7 +141,8 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         if let url = state.url,
            let tabScreenshot = state.screenshot,
            (url.absoluteString.starts(with: "internal") && state.hasHomeScreenshot) {
-            // Regular screenshot for home or internal url when tab has home screenshot
+            // Regular screenshot for home or internal url when
+            // tab has home screenshot
             let defaultImage = UIImage(named: StandardImageIdentifiers.Large.globe)?
                 .withRenderingMode(.alwaysTemplate)
             smallFaviconView.manuallySetImage(defaultImage ?? UIImage())
@@ -152,7 +170,10 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         }
     }
 
-    private func updateUIForSelectedState(_ selected: Bool, isPrivate: Bool, theme: Theme) {
+    private func updateUIForSelectedState(_ selected: Bool,
+                                          isPrivate: Bool,
+                                          theme: Theme?) {
+        guard let theme = theme else { return }
         if selected {
             layoutMargins = UIEdgeInsets(top: LegacyTabCell.borderWidth,
                                          left: LegacyTabCell.borderWidth,

--- a/Client/Frontend/Browser/Tabs/TabCell.swift
+++ b/Client/Frontend/Browser/Tabs/TabCell.swift
@@ -8,7 +8,7 @@ import UIKit
 import Shared
 import SiteImageView
 
-/// WIP. Defines tab-sepcific state that is reflected in the new TabCell.
+/// WIP. Defines tab-specific state that is reflected in the new TabCell.
 struct TabCellState {
     let isSelected: Bool
     let isPrivate: Bool

--- a/Client/Frontend/Browser/Tabs/TabCell.swift
+++ b/Client/Frontend/Browser/Tabs/TabCell.swift
@@ -1,0 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+
+struct TabCellState: State {
+    
+}

--- a/Client/Frontend/Browser/Tabs/TabCell.swift
+++ b/Client/Frontend/Browser/Tabs/TabCell.swift
@@ -2,8 +2,300 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
+import Foundation
 import UIKit
+import Shared
+import SiteImageView
 
-struct TabCellState: State {
-    
+/// WIP. Defines tab-sepcific state that is reflected in the new TabCell.
+struct TabCellState {
+    let isSelected: Bool = false
+    let isPrivate: Bool = false
+
+    let url: URL = URL()
+
+    // TBD:
+    let screenshot: UIImage?
+    let hasHomeScreenshot: Bool = false
+
+    let tabTitle: String = ""
+    let margin: CGFloat = 0.0 // (Changes depending on fullscreen)
+    let isFxHomeTab: Bool
+}
+
+private struct TabCellUILayout {
+    static let borderWidth: CGFloat = 3.0
+}
+
+protocol TabCellDelegate: AnyObject {
+    func tabCellDidClose(_ cell: TabCell)
+}
+
+/// WIP. Brings over much of the existing functionality from LegacyTabCell but has been
+/// updated to avoid capturing state within the cell itself, instead consuming and returning
+/// read-only state from our Redux app state (and more specifically `TabCellState`).
+class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
+
+    // MARK: - Properties
+
+    private(set) var state: TabCellState = TabCellState()
+
+    var isSelectedTab: Bool { return state.isSelected }
+    var animator: SwipeAnimator?
+    weak var delegate: TabCellDelegate?
+
+    private lazy var smallFaviconView: FaviconImageView = .build()
+    private lazy var favicon: FaviconImageView = .build()
+    private var title =
+        UIVisualEffectView(effect: UIBlurEffect(style: UIColor.legacyTheme.tabTray.tabTitleBlur))
+
+    // MARK: - Initializer
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.animator = SwipeAnimator(animatingView: self)
+        self.closeButton.addTarget(self, action: #selector(close), for: .touchUpInside)
+
+        contentView.addSubview(backgroundHolder)
+
+        faviconBG.addSubview(smallFaviconView)
+        backgroundHolder.addSubviews(screenshotView, faviconBG)
+
+        self.accessibilityCustomActions = [
+            UIAccessibilityCustomAction(name: .TabTrayCloseAccessibilityCustomAction,
+                                        target: self.animator,
+                                        selector: #selector(SwipeAnimator.closeWithoutGesture))
+        ]
+
+        backgroundHolder.addSubview(title)
+        title.translatesAutoresizingMaskIntoConstraints = false
+        title.contentView.addSubview(self.closeButton)
+        title.contentView.addSubview(self.titleText)
+        title.contentView.addSubview(self.favicon)
+
+        setupConstraints()
+    }
+
+    required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) not yet supported") }
+
+    // MARK: - Configuration
+
+    func configure(with state: TabCellState, theme: Theme) {
+        self.state = state
+
+        titleText.text = state.tabTitle
+        accessibilityLabel = getA11yTitleLabel(state: state)
+        isAccessibilityElement = true
+        accessibilityHint = .TabTraySwipeToCloseAccessibilityHint
+
+        favicon.image = UIImage(named: StandardImageIdentifiers.Large.globe)?
+            .withRenderingMode(.alwaysTemplate)
+
+        if !state.isFxHomeTab, let tabURL = tab.url?.absoluteString {
+            favicon.setFavicon(FaviconImageViewModel(siteURLString: tabURL))
+        }
+
+        updateUIForSelectedState(state.isSelected, isPrivate: state.isPrivate, theme: theme)
+
+        faviconBG.isHidden = true
+        configureScreenshot(state: state)
+
+        applyTheme(theme: theme)
+    }
+
+    // MARK: - Actions
+
+    @objc
+    func close() {
+        delegate?.tabCellDidClose(self)
+    }
+
+    // MARK: - UI
+
+    func applyTheme(theme: Theme) {
+        backgroundHolder.backgroundColor = theme.colors.layer1
+        closeButton.tintColor = theme.colors.indicatorActive
+        titleText.textColor = theme.colors.textPrimary
+        screenshotView.backgroundColor = theme.colors.layer1
+        favicon.tintColor = theme.colors.textPrimary
+        smallFaviconView.tintColor = theme.colors.textPrimary
+    }
+
+    private func configureScreenshot(state: TabCellState) {
+        if let url = state.url,
+           let tabScreenshot = state.screenshot,
+           (url.absoluteString.starts(with: "internal") && state.hasHomeScreenshot) {
+            // Regular screenshot for home or internal url when tab has home screenshot
+            let defaultImage = UIImage(named: StandardImageIdentifiers.Large.globe)?
+                .withRenderingMode(.alwaysTemplate)
+            smallFaviconView.manuallySetImage(defaultImage ?? UIImage())
+            screenshotView.image = tabScreenshot
+
+        } else if let url = state.url,
+                  (!url.absoluteString.starts(with: "internal") && state.hasHomeScreenshot) {
+            // Favicon or letter image when home screenshot is present for
+            // a regular (non-internal) url
+            
+            let defaultImage = UIImage(named: StandardImageIdentifiers.Large.globe)?.withRenderingMode(.alwaysTemplate)
+            smallFaviconView.manuallySetImage(defaultImage ?? UIImage())
+            faviconBG.isHidden = false
+            screenshotView.image = nil
+
+        } else if let tabScreenshot = state.screenshot {
+            // Tab screenshot when available
+            screenshotView.image = tabScreenshot
+        } else {
+            // Favicon or letter image when tab screenshot isn't available
+            faviconBG.isHidden = false
+            screenshotView.image = nil
+
+            if let tabURL = state.url?.absoluteString {
+                smallFaviconView.setFavicon(FaviconImageViewModel(siteURLString: tabURL))
+            }
+        }
+    }
+
+    private func updateUIForSelectedState(_ selected: Bool, isPrivate: Bool, theme: Theme) {
+        if selected {
+            layoutMargins = UIEdgeInsets(top: LegacyTabCell.borderWidth,
+                                         left: LegacyTabCell.borderWidth,
+                                         bottom: LegacyTabCell.borderWidth,
+                                         right: LegacyTabCell.borderWidth)
+            layer.borderColor = (isPrivate ? theme.colors.borderAccentPrivate : theme.colors.borderAccent).cgColor
+            layer.borderWidth = LegacyTabCell.borderWidth
+            layer.cornerRadius =
+            LegacyGridTabViewController.UX.cornerRadius + LegacyTabCell.borderWidth
+        } else {
+            layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+            layer.borderColor = UIColor.clear.cgColor
+            layer.borderWidth = 0
+            layer.cornerRadius =
+            LegacyGridTabViewController.UX.cornerRadius + LegacyTabCell.borderWidth
+        }
+    }
+
+    private lazy var backgroundHolder: UIView = .build { view in
+        view.layer.cornerRadius =
+        LegacyGridTabViewController.UX.cornerRadius + TabCellUILayout.borderWidth
+        view.clipsToBounds = true
+    }
+
+    private lazy var faviconBG: UIView = .build { view in
+        view.layer.cornerRadius = HomepageViewModel.UX.generalCornerRadius
+        view.layer.borderWidth = HomepageViewModel.UX.generalBorderWidth
+        view.layer.shadowOffset = HomepageViewModel.UX.shadowOffset
+        view.layer.shadowRadius = HomepageViewModel.UX.shadowRadius
+    }
+
+    private lazy var screenshotView: UIImageView = .build { view in
+        view.contentMode = .scaleAspectFill
+        view.clipsToBounds = true
+        view.isUserInteractionEnabled = false
+    }
+
+    private lazy var titleText: UILabel = .build { label in
+        label.isUserInteractionEnabled = false
+        label.numberOfLines = 1
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 12, weight: .semibold)
+    }
+
+    private lazy var closeButton: UIButton = .build { button in
+        button.setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross), for: [])
+        button.imageView?.contentMode = .scaleAspectFit
+        button.contentMode = .center
+        button.imageEdgeInsets = UIEdgeInsets(equalInset: LegacyGridTabViewController.UX.closeButtonEdgeInset)
+    }
+
+    // MARK: UICollectionViewCell
+
+    override func prepareForReuse() {
+        // Reset any close animations.
+        super.prepareForReuse()
+        screenshotView.image = nil
+        backgroundHolder.transform = .identity
+        backgroundHolder.alpha = 1
+        self.titleText.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 12, weight: .semibold)
+        layer.shadowOffset = .zero
+        layer.shadowPath = nil
+        layer.shadowOpacity = 0
+        isHidden = false
+    }
+
+    // MARK: - Auto Layout
+
+    private func setupConstraints() {
+        NSLayoutConstraint.activate([
+            backgroundHolder.topAnchor.constraint(equalTo: contentView.topAnchor),
+            backgroundHolder.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            backgroundHolder.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            backgroundHolder.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+
+            title.topAnchor.constraint(equalTo: backgroundHolder.topAnchor),
+            title.leftAnchor.constraint(equalTo: backgroundHolder.leftAnchor),
+            title.rightAnchor.constraint(equalTo: backgroundHolder.rightAnchor),
+            title.heightAnchor.constraint(equalToConstant: LegacyGridTabViewController.UX.textBoxHeight),
+
+            favicon.leadingAnchor.constraint(equalTo: title.leadingAnchor, constant: 6),
+            favicon.topAnchor.constraint(equalTo: title.topAnchor, constant: (LegacyGridTabViewController.UX.textBoxHeight - LegacyGridTabViewController.UX.faviconSize) / 2),
+            favicon.heightAnchor.constraint(equalToConstant: LegacyGridTabViewController.UX.faviconSize),
+            favicon.widthAnchor.constraint(equalToConstant: LegacyGridTabViewController.UX.faviconSize),
+
+            closeButton.heightAnchor.constraint(equalToConstant: LegacyGridTabViewController.UX.closeButtonSize),
+            closeButton.widthAnchor.constraint(equalToConstant: LegacyGridTabViewController.UX.closeButtonSize),
+            closeButton.centerYAnchor.constraint(equalTo: title.contentView.centerYAnchor),
+            closeButton.trailingAnchor.constraint(equalTo: title.trailingAnchor),
+
+            titleText.leadingAnchor.constraint(equalTo: favicon.trailingAnchor, constant: 6),
+            titleText.trailingAnchor.constraint(equalTo: closeButton.leadingAnchor, constant: 6),
+            titleText.centerYAnchor.constraint(equalTo: title.contentView.centerYAnchor),
+
+            screenshotView.topAnchor.constraint(equalTo: topAnchor),
+            screenshotView.leftAnchor.constraint(equalTo: backgroundHolder.leftAnchor),
+            screenshotView.rightAnchor.constraint(equalTo: backgroundHolder.rightAnchor),
+            screenshotView.bottomAnchor.constraint(equalTo: backgroundHolder.bottomAnchor),
+
+            faviconBG.centerYAnchor.constraint(equalTo: centerYAnchor, constant: 10),
+            faviconBG.centerXAnchor.constraint(equalTo: centerXAnchor),
+            faviconBG.heightAnchor.constraint(equalToConstant: TopSiteItemCell.UX.imageBackgroundSize.height),
+            faviconBG.widthAnchor.constraint(equalToConstant: TopSiteItemCell.UX.imageBackgroundSize.width),
+
+            smallFaviconView.heightAnchor.constraint(equalToConstant: TopSiteItemCell.UX.iconSize.height),
+            smallFaviconView.widthAnchor.constraint(equalToConstant: TopSiteItemCell.UX.iconSize.width),
+            smallFaviconView.centerYAnchor.constraint(equalTo: faviconBG.centerYAnchor),
+            smallFaviconView.centerXAnchor.constraint(equalTo: faviconBG.centerXAnchor),
+        ])
+    }
+
+    // MARK: - Accessibility
+
+    override func accessibilityScroll(_ direction: UIAccessibilityScrollDirection) -> Bool {
+        var right: Bool
+        switch direction {
+        case .left:
+            right = false
+        case .right:
+            right = true
+        default:
+            return false
+        }
+        animator?.close(right: right)
+        return true
+    }
+}
+
+// MARK: - AX Extension
+
+extension TabCell {
+    func getA11yTitleLabel(state: TabCellState) -> String? {
+        let baseName = state.tabTitle
+
+        if isSelectedTab, let baseName = baseName, !baseName.isEmpty {
+            return baseName + ". " + String.TabTrayCurrentlySelectedTabAccessibilityLabel
+        } else if isSelectedTab {
+            return String.TabTrayCurrentlySelectedTabAccessibilityLabel
+        } else {
+            return baseName
+        }
+    }
 }

--- a/Client/Frontend/Browser/Tabs/TabCell.swift
+++ b/Client/Frontend/Browser/Tabs/TabCell.swift
@@ -175,20 +175,20 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
                                           theme: Theme?) {
         guard let theme = theme else { return }
         if selected {
-            layoutMargins = UIEdgeInsets(top: LegacyTabCell.borderWidth,
-                                         left: LegacyTabCell.borderWidth,
-                                         bottom: LegacyTabCell.borderWidth,
-                                         right: LegacyTabCell.borderWidth)
+            layoutMargins = UIEdgeInsets(top: TabCellUILayout.borderWidth,
+                                         left: TabCellUILayout.borderWidth,
+                                         bottom: TabCellUILayout.borderWidth,
+                                         right: TabCellUILayout.borderWidth)
             layer.borderColor = (isPrivate ? theme.colors.borderAccentPrivate : theme.colors.borderAccent).cgColor
-            layer.borderWidth = LegacyTabCell.borderWidth
+            layer.borderWidth = TabCellUILayout.borderWidth
             layer.cornerRadius =
-            LegacyGridTabViewController.UX.cornerRadius + LegacyTabCell.borderWidth
+            LegacyGridTabViewController.UX.cornerRadius + TabCellUILayout.borderWidth
         } else {
             layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
             layer.borderColor = UIColor.clear.cgColor
             layer.borderWidth = 0
             layer.cornerRadius =
-            LegacyGridTabViewController.UX.cornerRadius + LegacyTabCell.borderWidth
+            LegacyGridTabViewController.UX.cornerRadius + TabCellUILayout.borderWidth
         }
     }
 

--- a/Client/Frontend/Browser/Tabs/TabCell.swift
+++ b/Client/Frontend/Browser/Tabs/TabCell.swift
@@ -10,18 +10,17 @@ import SiteImageView
 
 /// WIP. Defines tab-sepcific state that is reflected in the new TabCell.
 struct TabCellState {
-    let isSelected: Bool = false
-    let isPrivate: Bool = false
-
-    let url: URL = URL()
-
-    // TBD:
-    let screenshot: UIImage?
-    let hasHomeScreenshot: Bool = false
+    let isSelected = false
+    let isPrivate = false
+    let isFxHomeTab = false
 
     let tabTitle: String = ""
+    let url: URL? = nil
+
+    let screenshot: UIImage? = nil // TBD.
+    let hasHomeScreenshot = false // TBD.
+
     let margin: CGFloat = 0.0 // (Changes depending on fullscreen)
-    let isFxHomeTab: Bool
 }
 
 private struct TabCellUILayout {
@@ -36,10 +35,9 @@ protocol TabCellDelegate: AnyObject {
 /// updated to avoid capturing state within the cell itself, instead consuming and returning
 /// read-only state from our Redux app state (and more specifically `TabCellState`).
 class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
-
     // MARK: - Properties
 
-    private(set) var state: TabCellState = TabCellState()
+    private(set) var state = TabCellState()
 
     var isSelectedTab: Bool { return state.isSelected }
     var animator: SwipeAnimator?
@@ -92,7 +90,7 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         favicon.image = UIImage(named: StandardImageIdentifiers.Large.globe)?
             .withRenderingMode(.alwaysTemplate)
 
-        if !state.isFxHomeTab, let tabURL = tab.url?.absoluteString {
+        if !state.isFxHomeTab, let tabURL = state.url?.absoluteString {
             favicon.setFavicon(FaviconImageViewModel(siteURLString: tabURL))
         }
 
@@ -131,17 +129,15 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
                 .withRenderingMode(.alwaysTemplate)
             smallFaviconView.manuallySetImage(defaultImage ?? UIImage())
             screenshotView.image = tabScreenshot
-
         } else if let url = state.url,
                   (!url.absoluteString.starts(with: "internal") && state.hasHomeScreenshot) {
             // Favicon or letter image when home screenshot is present for
             // a regular (non-internal) url
-            
+
             let defaultImage = UIImage(named: StandardImageIdentifiers.Large.globe)?.withRenderingMode(.alwaysTemplate)
             smallFaviconView.manuallySetImage(defaultImage ?? UIImage())
             faviconBG.isHidden = false
             screenshotView.image = nil
-
         } else if let tabScreenshot = state.screenshot {
             // Tab screenshot when available
             screenshotView.image = tabScreenshot
@@ -290,7 +286,7 @@ extension TabCell {
     func getA11yTitleLabel(state: TabCellState) -> String? {
         let baseName = state.tabTitle
 
-        if isSelectedTab, let baseName = baseName, !baseName.isEmpty {
+        if isSelectedTab, !baseName.isEmpty {
             return baseName + ". " + String.TabTrayCurrentlySelectedTabAccessibilityLabel
         } else if isSelectedTab {
             return String.TabTrayCurrentlySelectedTabAccessibilityLabel

--- a/Client/Frontend/Browser/TopTabCell.swift
+++ b/Client/Frontend/Browser/TopTabCell.swift
@@ -7,7 +7,7 @@ import Foundation
 import Shared
 import SiteImageView
 
-class TopTabCell: UICollectionViewCell, ThemeApplicable, TabTrayCell, ReusableCell {
+class TopTabCell: UICollectionViewCell, ThemeApplicable, LegacyTabTrayCell, ReusableCell {
     struct UX {
         static let faviconSize: CGFloat = 20
         static let faviconCornerRadius: CGFloat = 2
@@ -60,7 +60,7 @@ class TopTabCell: UICollectionViewCell, ThemeApplicable, TabTrayCell, ReusableCe
         setupLayout()
     }
 
-    func configureWith(tab: Tab, isSelected selected: Bool, theme: Theme) {
+    func configureLegacyCellWith(tab: Tab, isSelected selected: Bool, theme: Theme) {
         isSelectedTab = selected
 
         titleText.text = tab.getTabTrayTitle()

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -295,9 +295,9 @@ extension TopTabsViewController: TabDisplayerDelegate {
         guard let tabCell = cell as? TopTabCell else { return UICollectionViewCell() }
         tabCell.delegate = self
         let isSelected = (tab == tabManager.selectedTab)
-        tabCell.configureWith(tab: tab,
-                              isSelected: isSelected,
-                              theme: themeManager.currentTheme)
+        tabCell.configureLegacyCellWith(tab: tab,
+                                        isSelected: isSelected,
+                                        theme: themeManager.currentTheme)
         // Not all cells are visible when the appearance changes. Let's make sure
         // the cell has the proper theme when recycled.
         tabCell.applyTheme(theme: themeManager.currentTheme)

--- a/Tests/ClientTests/LegacyTabCellTests.swift
+++ b/Tests/ClientTests/LegacyTabCellTests.swift
@@ -6,7 +6,7 @@
 
 import XCTest
 
-class TabCellTests: XCTestCase {
+class LegacyTabCellTests: XCTestCase {
     func testTabCellDeinit() {
         let subject = LegacyTabCell(frame: .zero)
         trackForMemoryLeaks(subject)

--- a/Tests/ClientTests/TabCellTests.swift
+++ b/Tests/ClientTests/TabCellTests.swift
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+
+import XCTest
+
+class TabCellTests: XCTestCase {
+    func testTabCellDeinit() {
+        let subject = TabCell(frame: .zero)
+        trackForMemoryLeaks(subject)
+    }
+}

--- a/Tests/ClientTests/TabCellTests.swift
+++ b/Tests/ClientTests/TabCellTests.swift
@@ -7,8 +7,46 @@
 import XCTest
 
 class TabCellTests: XCTestCase {
+    private func testState1() -> TabCellState {
+        return TabCellState(isSelected: false,
+                            isPrivate: false,
+                            isFxHomeTab: false,
+                            tabTitle: "Firefox Browser",
+                            url: URL(string: "https://www.mozilla.org/en-US/firefox/")!,
+                            screenshot: nil,
+                            hasHomeScreenshot: false,
+                            margin: 0.0)
+    }
+
+    override func setUp() {
+        super.setUp()
+    }
+
     func testTabCellDeinit() {
         let subject = TabCell(frame: .zero)
         trackForMemoryLeaks(subject)
+    }
+
+    func testConfigureTabAXLabel() {
+        let cell = TabCell(frame: .zero)
+        let state = testState1()
+        cell.configure(with: state, theme: nil)
+        XCTAssert(cell.accessibilityLabel!.contains(state.tabTitle))
+    }
+
+    func testConfigureTabAXHint() {
+        let cell = TabCell(frame: .zero)
+        let state = testState1()
+        cell.configure(with: state, theme: nil)
+        XCTAssertEqual(cell.accessibilityHint!,
+                       String.TabTraySwipeToCloseAccessibilityHint)
+    }
+
+    func testConfigureTabSelectedState() {
+        let cell = TabCell(frame: .zero)
+        let state = testState1()
+        cell.configure(with: state, theme: nil)
+        XCTAssertEqual(cell.isSelectedTab,
+                       state.isSelected)
     }
 }

--- a/Tests/ClientTests/TabDisplayManagerTests.swift
+++ b/Tests/ClientTests/TabDisplayManagerTests.swift
@@ -540,7 +540,7 @@ extension TabDisplayManagerTests {
     func testSelectedCells(tabDisplayManager: LegacyTabDisplayManager, numberOfCells: Int, selectedIndex: Int, file: StaticString = #filePath, line: UInt = #line) {
         XCTAssertEqual(tabDisplayManager.dataStore.count, numberOfCells, file: file, line: line)
         for index in 0..<numberOfCells {
-            let cell = tabDisplayManager.collectionView(collectionView, cellForItemAt: IndexPath(row: index, section: 0)) as! TabTrayCell
+            let cell = tabDisplayManager.collectionView(collectionView, cellForItemAt: IndexPath(row: index, section: 0)) as! LegacyTabTrayCell
             if index == selectedIndex {
                 XCTAssertTrue(cell.isSelectedTab, file: file, line: line)
             } else {
@@ -554,9 +554,9 @@ extension TabDisplayManagerTests: TabDisplayerDelegate {
     func focusSelectedTab() {}
 
     func cellFactory(for cell: UICollectionViewCell, using tab: Tab) -> UICollectionViewCell {
-        guard let tabCell = cell as? TabTrayCell else { return UICollectionViewCell() }
+        guard let tabCell = cell as? LegacyTabTrayCell else { return UICollectionViewCell() }
         let isSelected = (tab == manager.selectedTab)
-        tabCell.configureWith(tab: tab, isSelected: isSelected, theme: LightTheme())
+        tabCell.configureLegacyCellWith(tab: tab, isSelected: isSelected, theme: LightTheme())
         return tabCell
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6923)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15401)

## :bulb: Description

Early refactors and new `TabCell` for use with forthcoming Redux store. Brings over existing `LegacyTabCell` code (tried to clean it up somewhat) and updates a few things for the new read-only state architecture.

Some aspects of this will need to be revisited once we are further along with the tab tray refactor.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

