### PR TITLE
Refactor FXIOS-7480 [v120] Add a11y id to bottom sheet close button

### DIFF
--- a/Client/Application/AccessibilityIdentifiers.swift
+++ b/Client/Application/AccessibilityIdentifiers.swift
@@ -118,6 +118,7 @@ public struct AccessibilityIdentifiers {
     struct Shopping {
         static let sheetHeaderTitle = "Shopping.Sheet.HeaderTitle"
         static let sheetHeaderBetaLabel = "Shopping.Sheet.HeaderBetaLabel"
+        static let sheetCloseButton = "Shopping.Sheet.CloseButton"
 
         struct NotEnoughReviewsInfoCard {
             static let card = "Shopping.NotEnoughReviewsInfoCard.Card"

--- a/Client/Frontend/Fakespot/FakespotViewController.swift
+++ b/Client/Frontend/Fakespot/FakespotViewController.swift
@@ -78,6 +78,7 @@ class FakespotViewController: UIViewController, Themeable, Notifiable, UIAdaptiv
         button.setImage(UIImage(named: StandardImageIdentifiers.ExtraLarge.crossCircleFill), for: .normal)
         button.addTarget(self, action: #selector(self.closeTapped), for: .touchUpInside)
         button.accessibilityLabel = .CloseButtonTitle
+        button.accessibilityIdentifier = AccessibilityIdentifiers.Shopping.sheetCloseButton
     }
 
     // MARK: - Initializers


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7480)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16608)

## :bulb: Description
Adds a11y id to bottom sheet close button for UITesting.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

