### PR TITLE
Bugfix MTE-1598 [v120] Fix error in L10n screenshot tests

### DIFF
--- a/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
@@ -124,7 +124,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
 
     func testHistoryTableContextMenu() {
         navigator.openURL(loremIpsumURL)
-        mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"], timeoutValue: 5)
+        mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"], timeout: 5)
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.performAction(Action.CloseURLBarOpen)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1598)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
The L10n screenshot tests are not running since the introduction of `mozWait*`. Let me ensure that the L10n screenshot tests could be run without errors again.

I have tested with the locales en, fr and zh-TW.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

