### PR TITLE
Refactor FXIOS-6921 [v120] Minor refactors & renames for new sync tab VC

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -592,7 +592,7 @@
 		8A590C6128C123100032F1AA /* OpenPassBookHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A590C6028C123100032F1AA /* OpenPassBookHelper.swift */; };
 		8A5BD95A28788A3D000FE773 /* TopSitesHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5BD9582878871B000FE773 /* TopSitesHelperTests.swift */; };
 		8A5BD95F2878B7B6000FE773 /* TopSitesWidgetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5BD95E2878B7B6000FE773 /* TopSitesWidgetManager.swift */; };
-		8A5C3BC5282ABF8E003A8CCF /* RemoteTabsPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5C3BC4282ABF8E003A8CCF /* RemoteTabsPanelTests.swift */; };
+		8A5C3BC5282ABF8E003A8CCF /* LegacyRemoteTabsPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5C3BC4282ABF8E003A8CCF /* LegacyRemoteTabsPanelTests.swift */; };
 		8A5CDEED27E510F500CC60FF /* pocketglobalfeed.json in Resources */ = {isa = PBXBuildFile; fileRef = 3B61CD621F2A769D00D38DE1 /* pocketglobalfeed.json */; };
 		8A5D1CA02A30C9D7005AD35C /* MockAppSettingsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5D1C9F2A30C9D7005AD35C /* MockAppSettingsDelegate.swift */; };
 		8A5D1CA42A30D69A005AD35C /* SearchSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5D1CA32A30D69A005AD35C /* SearchSetting.swift */; };
@@ -4909,7 +4909,7 @@
 		8A5BD9582878871B000FE773 /* TopSitesHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSitesHelperTests.swift; sourceTree = "<group>"; };
 		8A5BD95B2878AA74000FE773 /* PinnedSite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedSite.swift; sourceTree = "<group>"; };
 		8A5BD95E2878B7B6000FE773 /* TopSitesWidgetManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSitesWidgetManager.swift; sourceTree = "<group>"; };
-		8A5C3BC4282ABF8E003A8CCF /* RemoteTabsPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabsPanelTests.swift; sourceTree = "<group>"; };
+		8A5C3BC4282ABF8E003A8CCF /* LegacyRemoteTabsPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyRemoteTabsPanelTests.swift; sourceTree = "<group>"; };
 		8A5D1C9F2A30C9D7005AD35C /* MockAppSettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAppSettingsDelegate.swift; sourceTree = "<group>"; };
 		8A5D1CA32A30D69A005AD35C /* SearchSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSetting.swift; sourceTree = "<group>"; };
 		8A5D1CA52A30D6BD005AD35C /* NewTabPageSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageSetting.swift; sourceTree = "<group>"; };
@@ -10459,7 +10459,7 @@
 				0BA896491A250E6500C1010C /* ProfileTest.swift */,
 				8A11C8102731CFD700AC7318 /* ReaderModeStyleTests.swift */,
 				03CCC9171AF05E7300DBF30D /* RelativeDatesTests.swift */,
-				8A5C3BC4282ABF8E003A8CCF /* RemoteTabsPanelTests.swift */,
+				8A5C3BC4282ABF8E003A8CCF /* LegacyRemoteTabsPanelTests.swift */,
 				F80D53CD2A09A30F0047ED14 /* RustSyncManagerTests.swift */,
 				8A5D1CA12A30CF2E005AD35C /* Settings */,
 				8A04136A2825ABEA00D20B10 /* SponsoredTileTelemetryTests.swift */,
@@ -13165,7 +13165,7 @@
 				C869915428917803007ACC5C /* WallpaperTestDataProvider.swift in Sources */,
 				8A5604F629DF09FA00035CA3 /* MockLaunchCoordinatorDelegate.swift in Sources */,
 				C807CCCC28367446008E6A5A /* FeatureFlagManagerTests.swift in Sources */,
-				8A5C3BC5282ABF8E003A8CCF /* RemoteTabsPanelTests.swift in Sources */,
+				8A5C3BC5282ABF8E003A8CCF /* LegacyRemoteTabsPanelTests.swift in Sources */,
 				8AABBD032A001CBC0089941E /* MockApplicationHelper.swift in Sources */,
 				8A1E3BE328CBACDD003388C4 /* SponsoredContentFilterUtilityTests.swift in Sources */,
 				2173326829CCDA8E007F20C7 /* TabScrollControllerTests.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -212,7 +212,7 @@
 		2FCAE2841ABB533A00877008 /* MockFiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FCAE2791ABB533A00877008 /* MockFiles.swift */; };
 		2FDB10931A9FBEC5006CF312 /* PrefsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FDB10921A9FBEC5006CF312 /* PrefsTests.swift */; };
 		2FDBCF611ABFC9DE00AFF7F0 /* SyncAuthState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FDBCF601ABFC9DE00AFF7F0 /* SyncAuthState.swift */; };
-		2FDE87FE1ABB3817005317B1 /* RemoteTabsPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FDE87FD1ABB3817005317B1 /* RemoteTabsPanel.swift */; };
+		2FDE87FE1ABB3817005317B1 /* LegacyRemoteTabsPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FDE87FD1ABB3817005317B1 /* LegacyRemoteTabsPanel.swift */; };
 		318FB6EB1DB5600D0004E40F /* SQLiteHistoryFactories.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318FB6EA1DB5600D0004E40F /* SQLiteHistoryFactories.swift */; };
 		31ADB5DA1E58CEC300E87909 /* ClipboardBarDisplayHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31ADB5D91E58CEC300E87909 /* ClipboardBarDisplayHandler.swift */; };
 		39012F281F8ED262002E3D31 /* ScreenGraphTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39012F271F8ED262002E3D31 /* ScreenGraphTest.swift */; };
@@ -2335,7 +2335,7 @@
 		2FDB10921A9FBEC5006CF312 /* PrefsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrefsTests.swift; sourceTree = "<group>"; };
 		2FDBCF601ABFC9DE00AFF7F0 /* SyncAuthState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncAuthState.swift; sourceTree = "<group>"; };
 		2FDE46BCA5E27EF7DC02CE20 /* sq */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sq; path = sq.lproj/FindInPage.strings; sourceTree = "<group>"; };
-		2FDE87FD1ABB3817005317B1 /* RemoteTabsPanel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteTabsPanel.swift; sourceTree = "<group>"; };
+		2FDE87FD1ABB3817005317B1 /* LegacyRemoteTabsPanel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyRemoteTabsPanel.swift; sourceTree = "<group>"; };
 		2FEBABAE1AB3659000DB5728 /* ResultTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultTests.swift; sourceTree = "<group>"; };
 		30144AD1A59EDCE27EEAC079 /* ast */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ast; path = ast.lproj/Storage.strings; sourceTree = "<group>"; };
 		307540CEA37CBA7C3163075C /* mr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = mr; path = mr.lproj/HistoryPanel.strings; sourceTree = "<group>"; };
@@ -7199,7 +7199,7 @@
 		21357F2B293FDB07004BF9FD /* RemoteTabs */ = {
 			isa = PBXGroup;
 			children = (
-				2FDE87FD1ABB3817005317B1 /* RemoteTabsPanel.swift */,
+				2FDE87FD1ABB3817005317B1 /* LegacyRemoteTabsPanel.swift */,
 				210887CB293E8800000AB4EE /* RemoteTabsErrorCell.swift */,
 				21357F2C293FDB60004BF9FD /* RemoteTabsErrorDataSource.swift */,
 				21357F2E294237D8004BF9FD /* RemoteTabsClientAndTabsDataSource.swift */,
@@ -12602,7 +12602,7 @@
 				DF529EA12AB1B421003C5373 /* FakespotReliabilityScoreView.swift in Sources */,
 				9636D92A27F767EC00771F5E /* NimbusMessagingEvaluationUtility.swift in Sources */,
 				E127313F28B6C194006F39D2 /* WallpaperSettingsHeaderView.swift in Sources */,
-				2FDE87FE1ABB3817005317B1 /* RemoteTabsPanel.swift in Sources */,
+				2FDE87FE1ABB3817005317B1 /* LegacyRemoteTabsPanel.swift in Sources */,
 				8A3EF80F2A2FD05D00796E3A /* ToggleInactiveTabs.swift in Sources */,
 				435222C125882E3800FCA5B6 /* WidgetKitTopSiteModel.swift in Sources */,
 				96EB6C3E27D9266500A9D159 /* HistoryActionables.swift in Sources */,

--- a/Client/Frontend/Browser/Tabs/Legacy/LegacyTabTrayViewModel.swift
+++ b/Client/Frontend/Browser/Tabs/Legacy/LegacyTabTrayViewModel.swift
@@ -57,7 +57,7 @@ class LegacyTabTrayViewModel {
 
     // Tab Tray Views
     let tabTrayView: TabTrayViewDelegate
-    let syncedTabsController: RemoteTabsPanel
+    let syncedTabsController: LegacyRemoteTabsPanel
 
     var segmentToFocus: LegacyTabTrayViewModel.Segment?
     var layout: Layout = .compact
@@ -80,7 +80,7 @@ class LegacyTabTrayViewModel {
                                                        profile: profile,
                                                        tabTrayDelegate: tabTrayDelegate,
                                                        tabToFocus: tabToFocus)
-        self.syncedTabsController = RemoteTabsPanel(profile: self.profile)
+        self.syncedTabsController = LegacyRemoteTabsPanel(profile: self.profile)
         self.segmentToFocus = segmentToFocus
     }
 

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/LegacyRemoteTabsPanel.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/LegacyRemoteTabsPanel.swift
@@ -14,13 +14,13 @@ protocol RemotePanelDelegate: AnyObject {
 }
 
 // MARK: - RemoteTabsPanel
-class RemoteTabsPanel: UIViewController, Themeable {
+class LegacyRemoteTabsPanel: UIViewController, Themeable {
     var themeManager: ThemeManager
     var themeObserver: NSObjectProtocol?
     var notificationCenter: NotificationProtocol
     var remotePanelDelegate: RemotePanelDelegate?
     var profile: Profile
-    var tableViewController: RemoteTabsTableViewController
+    var tableViewController: LegacyRemoteTabsTableViewController
 
     init(profile: Profile,
          themeManager: ThemeManager = AppContainer.shared.resolve(),
@@ -28,7 +28,7 @@ class RemoteTabsPanel: UIViewController, Themeable {
         self.profile = profile
         self.themeManager = themeManager
         self.notificationCenter = notificationCenter
-        self.tableViewController = RemoteTabsTableViewController(profile: profile)
+        self.tableViewController = LegacyRemoteTabsTableViewController(profile: profile)
 
         super.init(nibName: nil, bundle: nil)
         notificationCenter.addObserver(self,
@@ -103,12 +103,12 @@ protocol CollapsibleTableViewSection: AnyObject {
 }
 
 // MARK: - RemoteTabsTableViewController
-class RemoteTabsTableViewController: UITableViewController, Themeable {
+class LegacyRemoteTabsTableViewController: UITableViewController, Themeable {
     struct UX {
         static let rowHeight = SiteTableViewControllerUX.RowHeight
     }
 
-    weak var remoteTabsPanel: RemoteTabsPanel?
+    weak var remoteTabsPanel: LegacyRemoteTabsPanel?
     private var profile: Profile!
     var themeManager: ThemeManager
     var themeObserver: NSObjectProtocol?
@@ -315,7 +315,7 @@ class RemoteTabsTableViewController: UITableViewController, Themeable {
     }
 }
 
-extension RemoteTabsTableViewController: CollapsibleTableViewSection {
+extension LegacyRemoteTabsTableViewController: CollapsibleTableViewSection {
     func hideTableViewSection(_ section: Int) {
         guard let dataSource = tableViewDelegate as? RemoteTabsClientAndTabsDataSource else { return }
 
@@ -330,7 +330,7 @@ extension RemoteTabsTableViewController: CollapsibleTableViewSection {
 }
 
 // MARK: LibraryPanelContextMenu
-extension RemoteTabsTableViewController: LibraryPanelContextMenu {
+extension LegacyRemoteTabsTableViewController: LibraryPanelContextMenu {
     func presentContextMenu(for site: Site, with indexPath: IndexPath,
                             completionHandler: @escaping () -> PhotonActionSheet?) {
         guard let contextMenu = completionHandler() else { return }

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/LegacyRemoteTabsPanel.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/LegacyRemoteTabsPanel.swift
@@ -14,7 +14,7 @@ protocol RemotePanelDelegate: AnyObject {
 }
 
 // MARK: - RemoteTabsPanel
-class LegacyRemoteTabsPanel: UIViewController, Themeable {
+class LegacyRemoteTabsPanel: UIViewController, Themeable, RemoteTabsClientAndTabsDataSourceDelegate {
     var themeManager: ThemeManager
     var themeObserver: NSObjectProtocol?
     var notificationCenter: NotificationProtocol
@@ -92,6 +92,11 @@ class LegacyRemoteTabsPanel: UIViewController, Themeable {
             // no need to do anything at all
             break
         }
+    }
+
+    func remoteTabsClientAndTabsDataSourceDidSelectURL(_ url: URL, visitType: VisitType) {
+        // Pass event along to our delegate
+        remotePanelDelegate?.remotePanel(didSelectURL: url, visitType: VisitType.typed)
     }
 }
 
@@ -243,7 +248,7 @@ class LegacyRemoteTabsTableViewController: UITableViewController, Themeable {
             return
         }
 
-        let tabsPanelDataSource = RemoteTabsClientAndTabsDataSource(remoteTabPanel: remoteTabsPanel,
+        let tabsPanelDataSource = RemoteTabsClientAndTabsDataSource(actionDelegate: remoteTabsPanel,
                                                                     clientAndTabs: nonEmptyClientAndTabs,
                                                                     profile: profile,
                                                                     theme: themeManager.currentTheme)

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsClientAndTabsDataSource.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsClientAndTabsDataSource.swift
@@ -14,12 +14,12 @@ class RemoteTabsClientAndTabsDataSource: NSObject, RemoteTabsPanelDataSource {
     }
 
     weak var collapsibleSectionDelegate: CollapsibleTableViewSection?
-    weak var remoteTabPanel: RemoteTabsPanel?
+    weak var remoteTabPanel: LegacyRemoteTabsPanel?
     var clientAndTabs: [ClientAndTabs]
     var hiddenSections = Set<Int>()
     private var theme: Theme
 
-    init(remoteTabPanel: RemoteTabsPanel,
+    init(remoteTabPanel: LegacyRemoteTabsPanel,
          clientAndTabs: [ClientAndTabs],
          profile: Profile,
          theme: Theme) {

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsClientAndTabsDataSource.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsClientAndTabsDataSource.swift
@@ -8,22 +8,26 @@ import Storage
 import Shared
 import SiteImageView
 
+protocol RemoteTabsClientAndTabsDataSourceDelegate: AnyObject {
+    func remoteTabsClientAndTabsDataSourceDidSelectURL(_ url: URL, visitType: VisitType)
+}
+
 class RemoteTabsClientAndTabsDataSource: NSObject, RemoteTabsPanelDataSource {
     struct UX {
         static let headerHeight = SiteTableViewControllerUX.RowHeight
     }
 
     weak var collapsibleSectionDelegate: CollapsibleTableViewSection?
-    weak var remoteTabPanel: LegacyRemoteTabsPanel?
+    weak var actionDelegate: RemoteTabsClientAndTabsDataSourceDelegate?
     var clientAndTabs: [ClientAndTabs]
     var hiddenSections = Set<Int>()
     private var theme: Theme
 
-    init(remoteTabPanel: LegacyRemoteTabsPanel,
+    init(actionDelegate: RemoteTabsClientAndTabsDataSourceDelegate?,
          clientAndTabs: [ClientAndTabs],
          profile: Profile,
          theme: Theme) {
-        self.remoteTabPanel = remoteTabPanel
+        self.actionDelegate = actionDelegate
         self.clientAndTabs = clientAndTabs
         self.theme = theme
     }
@@ -114,6 +118,6 @@ class RemoteTabsClientAndTabsDataSource: NSObject, RemoteTabsPanelDataSource {
         tableView.deselectRow(at: indexPath, animated: false)
         let tab = tabAtIndexPath(indexPath)
         // Remote panel delegate for cell selection
-        remoteTabPanel?.remotePanelDelegate?.remotePanel(didSelectURL: tab.URL, visitType: VisitType.typed)
+        actionDelegate?.remoteTabsClientAndTabsDataSourceDidSelectURL(tab.URL, visitType: VisitType.typed)
     }
 }

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsErrorDataSource.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsErrorDataSource.swift
@@ -25,11 +25,11 @@ class RemoteTabsErrorDataSource: NSObject, RemoteTabsPanelDataSource, ThemeAppli
         }
     }
 
-    weak var remoteTabsPanel: RemoteTabsPanel?
+    weak var remoteTabsPanel: LegacyRemoteTabsPanel?
     var error: ErrorType
     private var theme: Theme
 
-    init(remoteTabsPanel: RemoteTabsPanel,
+    init(remoteTabsPanel: LegacyRemoteTabsPanel,
          error: ErrorType,
          theme: Theme) {
         self.remoteTabsPanel = remoteTabsPanel

--- a/Tests/ClientTests/LegacyRemoteTabsPanelTests.swift
+++ b/Tests/ClientTests/LegacyRemoteTabsPanelTests.swift
@@ -8,7 +8,7 @@ import Shared
 import Common
 @testable import Client
 
-class RemoteTabsPanelTests: XCTestCase {
+class LegacyRemoteTabsPanelTests: XCTestCase {
     override func setUp() {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
@@ -102,7 +102,7 @@ class RemoteTabsPanelTests: XCTestCase {
     }
 }
 
-private extension RemoteTabsPanelTests {
+private extension LegacyRemoteTabsPanelTests {
     var remoteClient: RemoteClient {
         return RemoteClient(guid: nil,
                             name: "Fake client",

--- a/Tests/ClientTests/RemoteTabsPanelTests.swift
+++ b/Tests/ClientTests/RemoteTabsPanelTests.swift
@@ -123,7 +123,7 @@ private extension RemoteTabsPanelTests {
                           icon: nil)]
     }
 
-    func panelRefreshWithExpectation(panel: RemoteTabsPanel, completion: @escaping () -> Void) {
+    func panelRefreshWithExpectation(panel: LegacyRemoteTabsPanel, completion: @escaping () -> Void) {
         let expectation = expectation(description: "Tabs should be refreshed")
         panel.tableViewController.refreshTabs {
             completion()
@@ -136,12 +136,12 @@ private extension RemoteTabsPanelTests {
                      hasSyncEnabled: Bool = true,
                      clientAndTabs: [ClientAndTabs] = [],
                      file: StaticString = #file,
-                     line: UInt = #line) -> RemoteTabsPanel {
+                     line: UInt = #line) -> LegacyRemoteTabsPanel {
         let profile = MockProfile()
         profile.prefs.setBool(hasSyncEnabled, forKey: PrefsKeys.TabSyncEnabled)
         profile.hasSyncableAccountMock = hasAccount
         profile.mockClientAndTabs = clientAndTabs
-        let panel = RemoteTabsPanel(profile: profile)
+        let panel = LegacyRemoteTabsPanel(profile: profile)
         panel.viewDidLoad()
 
         trackForMemoryLeaks(panel, file: file, line: line)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6921)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15399)

## :bulb: Description

Early prep work for FXIOS-6921 (WIP, still forthcoming):
- Renames existing VC as legacy in preparation for forthcoming new sync VC
- Decouples the remote tabs datasource from the remote tabs panel

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

