### PR TITLE
Bugfix FXIOS-7495 [v120] Fakespot: Incorrect order of sections displayed in the "Highlights from recent reviews" card

### DIFF
--- a/Client/Frontend/Fakespot/Client/ProductAnalysisData.swift
+++ b/Client/Frontend/Fakespot/Client/ProductAnalysisData.swift
@@ -76,8 +76,8 @@ struct Highlights: Codable {
         var items = [FakespotHighlightGroup]()
         items.append(FakespotHighlightGroup(type: .price, reviews: price))
         items.append(FakespotHighlightGroup(type: .quality, reviews: quality))
-        items.append(FakespotHighlightGroup(type: .competitiveness, reviews: competitiveness))
         items.append(FakespotHighlightGroup(type: .shipping, reviews: shipping))
+        items.append(FakespotHighlightGroup(type: .competitiveness, reviews: competitiveness))
         items.append(FakespotHighlightGroup(type: .packaging, reviews: packaging))
         return items.compactMap { group in group.reviews.isEmpty ? nil : group }
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16637)

## :bulb: Description
Fix order of highlight groups in Fakespot.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

