### PR TITLE
Add FXIOS-7501 [v120] Updated A-S logging and Sentry support

### DIFF
--- a/BrowserKit/Sources/Common/Logger/DefaultLogger.swift
+++ b/BrowserKit/Sources/Common/Logger/DefaultLogger.swift
@@ -29,6 +29,10 @@ public class DefaultLogger: Logger {
         crashManager?.setup(sendUsageData: sendUsageData)
     }
 
+    public func logCustomError(error: Error) {
+        crashManager?.captureError(error: error)
+    }
+
     public func log(_ message: String,
                     level: LoggerLevel,
                     category: LoggerCategory,

--- a/BrowserKit/Sources/Common/Logger/Logger.swift
+++ b/BrowserKit/Sources/Common/Logger/Logger.swift
@@ -9,6 +9,7 @@ public protocol Logger {
 
     func setup(sendUsageData: Bool)
     func configure(crashManager: CrashManager)
+    func logCustomError(error: Error)
 
     /// Log a new message to the logging system
     /// - Parameters:

--- a/BrowserKit/Sources/Common/Logger/Wrapper/SentryWrapper.swift
+++ b/BrowserKit/Sources/Common/Logger/Wrapper/SentryWrapper.swift
@@ -11,6 +11,7 @@ public protocol SentryWrapper {
 
     func startWithConfigureOptions(configure options: @escaping (Options) -> Void)
     func captureMessage(message: String, with scopeBlock: @escaping (Scope) -> Void)
+    func captureError(error: Error)
     func addBreadcrumb(crumb: Breadcrumb)
     func configureScope(scope: @escaping (Scope) -> Void)
 }
@@ -38,6 +39,10 @@ public class DefaultSentry: SentryWrapper {
 
     public func captureMessage(message: String, with scopeBlock: @escaping (Scope) -> Void) {
         SentrySDK.capture(message: message, block: scopeBlock)
+    }
+
+    public func captureError(error: Error) {
+        SentrySDK.capture(error: error)
     }
 
     public func addBreadcrumb(crumb: Breadcrumb) {

--- a/BrowserKit/Tests/CommonTests/LoggerTests/CrashManagerTests.swift
+++ b/BrowserKit/Tests/CommonTests/LoggerTests/CrashManagerTests.swift
@@ -201,6 +201,11 @@ private class MockSentryWrapper: SentryWrapper {
         savedMessage = message
     }
 
+    var savedError: Error?
+    func captureError(error: Error) {
+        savedError = error
+    }
+
     var savedBreadcrumb: Breadcrumb?
     func addBreadcrumb(crumb: Breadcrumb) {
         savedBreadcrumb = crumb

--- a/BrowserKit/Tests/CommonTests/LoggerTests/LoggerTests.swift
+++ b/BrowserKit/Tests/CommonTests/LoggerTests/LoggerTests.swift
@@ -219,4 +219,9 @@ class MockCrashManager: CrashManager {
         self.level = level
         self.extraEvents = extraEvents
     }
+
+    var error: Error?
+    func captureError(error: Error) {
+        self.error = error
+    }
 }

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -1528,6 +1528,10 @@
 		F8AAC1B429663619000BCDEC /* RustAutofill.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AAC1B329663618000BCDEC /* RustAutofill.swift */; };
 		F8AAC1B7296637CE000BCDEC /* RustAutofillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AAC1B5296637B7000BCDEC /* RustAutofillTests.swift */; };
 		F8B18F5529EE01A2008724A8 /* RustSyncManagerAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B18F5429EE01A1008724A8 /* RustSyncManagerAPITests.swift */; };
+		F8B7109E2ABE380B0029726E /* RustErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B7109D2ABE380B0029726E /* RustErrors.swift */; };
+		F8B7109F2ABE38970029726E /* RustErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B7109D2ABE380B0029726E /* RustErrors.swift */; };
+		F8B710A02ABE38980029726E /* RustErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B7109D2ABE380B0029726E /* RustErrors.swift */; };
+		F8B710A12ABE38980029726E /* RustErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B7109D2ABE380B0029726E /* RustErrors.swift */; };
 		F8DEACC52A3D43DA00C3B19D /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = F8DEACC42A3D43DA00C3B19D /* Sentry */; };
 		F98CB66E2A4123F1005F38E9 /* EnhancedTrackingProtectionMenuVMTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F98CB66C2A4123E7005F38E9 /* EnhancedTrackingProtectionMenuVMTests.swift */; };
 		FA6B2AC21D41F02D00429414 /* String+Punycode.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6B2AC11D41F02D00429414 /* String+Punycode.swift */; };
@@ -6917,6 +6921,7 @@
 		F8AAC1B329663618000BCDEC /* RustAutofill.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RustAutofill.swift; sourceTree = "<group>"; };
 		F8AAC1B5296637B7000BCDEC /* RustAutofillTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RustAutofillTests.swift; sourceTree = "<group>"; };
 		F8B18F5429EE01A1008724A8 /* RustSyncManagerAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustSyncManagerAPITests.swift; sourceTree = "<group>"; };
+		F8B7109D2ABE380B0029726E /* RustErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustErrors.swift; sourceTree = "<group>"; };
 		F8CA43008FC72296965ED032 /* ne-NP */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ne-NP"; path = "ne-NP.lproj/ClearPrivateDataConfirm.strings"; sourceTree = "<group>"; };
 		F8DB4306B31FC3DC90685A8C /* af */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = af; path = af.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
 		F8EF4290ACE53B2692EA362F /* hr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hr; path = hr.lproj/LoginManager.strings; sourceTree = "<group>"; };
@@ -9578,6 +9583,7 @@
 				1D0BA05B24F46A0400D731B5 /* TopSitesProvider.swift */,
 				8A5BD95E2878B7B6000FE773 /* TopSitesWidgetManager.swift */,
 				F8A0B08129AD61FA0091C75B /* RustSyncManager.swift */,
+				F8B7109D2ABE380B0029726E /* RustErrors.swift */,
 			);
 			path = Providers;
 			sourceTree = "<group>";
@@ -12161,6 +12167,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				397848DE1ED86605004C0C0B /* NotificationService.swift in Sources */,
+				F8B710A12ABE38980029726E /* RustErrors.swift in Sources */,
 				45355B232A269E7100B1EA8E /* Autopush.swift in Sources */,
 				45355B262A269EAC00B1EA8E /* PushConfiguration.swift in Sources */,
 				396E38CC1EE0816C00CC180F /* Profile.swift in Sources */,
@@ -12337,6 +12344,7 @@
 				C87DF976267246830097E707 /* LegacyThemeManager.swift in Sources */,
 				C8CE38BD265E71FE0009B09E /* UIFontExtension.swift in Sources */,
 				F80DF74B270CB9CA00E4C37D /* AppAuthenticator.swift in Sources */,
+				F8B7109F2ABE38970029726E /* RustErrors.swift in Sources */,
 				F80DF7412703BC8E00E4C37D /* CredentialPasscodeRequirementViewController.swift in Sources */,
 				60D71AEC26AAF45E00355588 /* UIColorExtension.swift in Sources */,
 				C87DF98A2672468F0097E707 /* LegacyDarkTheme.swift in Sources */,
@@ -12823,6 +12831,7 @@
 				39EF434E260A73950011E22E /* Experiments.swift in Sources */,
 				E15DE7C0293A670700B32667 /* PhotonActionSheetSeparator.swift in Sources */,
 				DFEA639E279F468A00D489C3 /* DynamicHeightCollectionView.swift in Sources */,
+				F8B7109E2ABE380B0029726E /* RustErrors.swift in Sources */,
 				C8124BB129D6F55400540B79 /* Route.swift in Sources */,
 				63306D3921103EAE00F25400 /* LegacySavedTab.swift in Sources */,
 				2F44FCCB1A9E972E00FD20CC /* SearchEnginePicker.swift in Sources */,
@@ -13364,6 +13373,7 @@
 				DDA24A451FD84D630098F159 /* DefaultSearchPrefs.swift in Sources */,
 				F8708D321A0970B70051AB07 /* ShareViewController.swift in Sources */,
 				EB9407492081353100702E05 /* UXConstants.swift in Sources */,
+				F8B710A02ABE38980029726E /* RustErrors.swift in Sources */,
 				E60D03271D511554002FE3F6 /* SyncDisplayState.swift in Sources */,
 				210E0EBB298D9D6600BB4F33 /* OpenSearchEngine.swift in Sources */,
 				2128E27C2930216F00FB91BE /* SendToDeviceHelper.swift in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -91,6 +91,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Configure logger so we can start tracking logs early
         logger.configure(crashManager: DefaultCrashManager())
+        initializeRustErrors(logger: logger)
         logger.log("willFinishLaunchingWithOptions begin",
                    level: .info,
                    category: .lifecycle)

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -282,40 +282,8 @@ open class BrowserProfile: Profile {
             prefs.clearAll()
         }
 
-        // Set up logging from Rust.
-        if !RustLog.shared.tryEnable({ (level, tag, message) -> Bool in
-            let logString = "[RUST][\(tag ?? "no-tag")] \(message)"
-
-            switch level {
-            case .trace:
-                break
-            case .debug:
-                logger.log(logString,
-                           level: .debug,
-                           category: .sync)
-            case .info:
-                logger.log(logString,
-                           level: .info,
-                           category: .sync)
-            case .warn:
-                logger.log(logString,
-                           level: .warning,
-                           category: .sync)
-            case .error:
-                logger.log(logString,
-                           level: .warning,
-                           category: .sync)
-            }
-
-            return true
-        }) {
-            logger.log("Unable to enable logging from Rust",
-                       level: .warning,
-                       category: .setup)
-        }
-
-        // By default, filter logging from Rust below `.info` level.
-        try? RustLog.shared.setLevelFilter(filter: .info)
+        setLogger(logger: ForwardOnLog(logger: self.logger))
+        setMaxLevel(level: Level.info)
 
         // Initiating the sync manager has to happen prior to the databases being opened,
         // because opening them can trigger events to which the SyncManager listens.

--- a/Providers/RustErrors.swift
+++ b/Providers/RustErrors.swift
@@ -1,0 +1,74 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+import MozillaAppServices
+
+public func initializeRustErrors(logger: Logger) {
+    setApplicationErrorReporter(errorReporter: FirefoxIOSErrorReporter(logger: logger))
+}
+
+/// The `AppServicesErrorReport` class (with its inheritance from `CustomCrashReport`) exists
+/// to distinguish native Sentry reports from reports originating in A-S
+private class AppServicesErrorReport: Error, CustomCrashReport {
+    var typeName: String
+    var message: String
+
+    init(typeName: String, message: String) {
+        self.typeName = typeName
+        self.message = message
+    }
+}
+
+/// The `FirefoxIOSErrorReporter` class contains the callbacks A-S uses to report Sentry errors and
+/// breadcrumbs. These functions are not intended to be explicitly called in this repo.
+private class FirefoxIOSErrorReporter: ApplicationErrorReporter {
+    var logger: Logger
+
+    init(logger: Logger) {
+        self.logger = logger
+    }
+
+    func reportError(typeName: String, message: String) {
+        logger.logCustomError(error: AppServicesErrorReport(typeName: typeName, message: message))
+    }
+
+    func reportBreadcrumb(message: String, module: String, line: UInt32, column: UInt32) {
+        logger.log("\(module)[\(line)]: \(message)",
+                   level: .info,
+                   category: .sync)
+    }
+}
+
+/// The `ForwardOnLog` class exists to support the rust-log-forwarder `setLogger` function.
+internal class ForwardOnLog: AppServicesLogger {
+    var logger: Logger
+
+    init(logger: Logger) {
+        self.logger = logger
+    }
+
+    func log(record: Record) {
+        self.logger.log(record.message,
+                        level: rustLevelToLoggerLevel(level: record.level),
+                        category: LoggerCategory.sync,
+                        extra: ["target": record.target])
+    }
+
+    private func rustLevelToLoggerLevel(level: Level) -> LoggerLevel {
+        switch level {
+        case .trace:
+            return LoggerLevel.debug
+        case .debug:
+            return LoggerLevel.debug
+        case .info:
+            return LoggerLevel.info
+        case .warn:
+            return LoggerLevel.warning
+        case .error:
+            return LoggerLevel.fatal
+        }
+    }
+}

--- a/Tests/ClientTests/Helpers/RatingPromptManagerTests.swift
+++ b/Tests/ClientTests/Helpers/RatingPromptManagerTests.swift
@@ -294,6 +294,7 @@ class CrashingMockLogger: Logger {
     func setup(sendUsageData: Bool) {}
     func configure(crashManager: CrashManager) {}
     func copyLogsToDocuments() {}
+    func logCustomError(error: Error) {}
 
     var enableCrashOnLastLaunch = false
     var crashedLastLaunch: Bool {

--- a/Tests/ClientTests/Mocks/MockLogger.swift
+++ b/Tests/ClientTests/Mocks/MockLogger.swift
@@ -13,6 +13,7 @@ class MockLogger: Logger {
     func setup(sendUsageData: Bool) {}
     func configure(crashManager: Common.CrashManager) {}
     func copyLogsToDocuments() {}
+    func logCustomError(error: Error) {}
 
     func log(_ message: String,
              level: LoggerLevel,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7501)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16651)

## :bulb: Description
Adding Sentry reporting with breadcrumbs in order to more easily detect and resolve issues originating from A-S. These changes will group errors that stem from the same line of code in A-S so that it's easier to see the issue and its magnitude from the resulting Sentry reports.

For instance, with these changes a `tabs-read-remote` error report that stems from the [get_remote_tabs call](https://github.com/mozilla/application-services/blob/760cfdb46ff7b572b0a40d3778a5384c112fd8ec/components/tabs/src/storage.rs#L192) in A-S would look like the image below. All subsequent events of this type would be collected under that report instead of showing up on other differently named error reports.

<img width="1249" alt="Screenshot 2023-09-28 at 6 06 27 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/5533446/da805823-fb1c-4a4c-a6c8-c41b94e47d7e">


Additionally, there will be breadcrumbs from the rust code as shown below.

<img width="920" alt="Screenshot 2023-09-28 at 6 06 57 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/5533446/1c28c4e7-0399-4c7b-86df-7003b8460903">



## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

