### PR TITLE
Refactor FXIOS-6925 [v120]  Create the private tabs empty screen view

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -277,7 +277,7 @@
 		43118CDD251A9CA700F24376 /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288A2D861AB8B3260023ABC3 /* Shared.framework */; };
 		43118CF3251A9CCA00F24376 /* LegacyTabDataRetriever.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA3CE5E24EEE7C600422BB2 /* LegacyTabDataRetriever.swift */; };
 		43118D07251A9CD100F24376 /* LegacySavedTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63306D3821103EAE00F25400 /* LegacySavedTab.swift */; };
-		43162A2F2492DB7800F91658 /* LegacyEmptyPrivateTabsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43162A2E2492DB7800F91658 /* LegacyEmptyPrivateTabsView.swift */; };
+		43162A2F2492DB7800F91658 /* EmptyPrivateTabsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43162A2E2492DB7800F91658 /* EmptyPrivateTabsView.swift */; };
 		43175DB626B8774D00C41C31 /* Ads.js in Resources */ = {isa = PBXBuildFile; fileRef = 43175DB526B8774D00C41C31 /* Ads.js */; };
 		43175DB826B87D2C00C41C31 /* AdsTelemetryHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43175DB726B87D2C00C41C31 /* AdsTelemetryHelper.swift */; };
 		431C0CA925C890E500395CE4 /* DefaultBrowserOnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 431C0CA825C890E500395CE4 /* DefaultBrowserOnboardingViewModel.swift */; };
@@ -2704,8 +2704,8 @@
 		4315C1E528EAF9C300BA61F5 /* be */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = be; path = be.lproj/Shared.strings; sourceTree = "<group>"; };
 		4315C1E628EAF9C300BA61F5 /* be */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = be; path = be.lproj/ToolbarLocation.strings; sourceTree = "<group>"; };
 		4315F5832A1B87DE00D6BA24 /* sl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sl; path = sl.lproj/FirefoxSync.strings; sourceTree = "<group>"; };
-		43162A2E2492DB7800F91658 /* LegacyEmptyPrivateTabsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyEmptyPrivateTabsView.swift; sourceTree = "<group>"; };
 		43169E8F2ACAE188007FEA66 /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/Share.strings; sourceTree = "<group>"; };
+		43162A2E2492DB7800F91658 /* EmptyPrivateTabsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyPrivateTabsView.swift; sourceTree = "<group>"; };
 		4316B10328D8876A004F010C /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = th; path = th.lproj/JumpBackIn.strings; sourceTree = "<group>"; };
 		4316B7072A5C213B00F9EBBA /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/CustomizeFirefoxHome.strings; sourceTree = "<group>"; };
 		4316B7082A5C213B00F9EBBA /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/SelectCreditCard.strings; sourceTree = "<group>"; };
@@ -7224,7 +7224,6 @@
 		212429F22AA27204002D57A8 /* Legacy */ = {
 			isa = PBXGroup;
 			children = (
-				43162A2E2492DB7800F91658 /* LegacyEmptyPrivateTabsView.swift */,
 				D301AAED1A3A55B70078DD1D /* LegacyGridTabViewController.swift */,
 				43BDBBFD2752FA8600254DE4 /* LegacyTabCell.swift */,
 				DA52E1D925F5961F0092204C /* LegacyTabTrayViewController.swift */,
@@ -7357,6 +7356,7 @@
 				212429F22AA27204002D57A8 /* Legacy */,
 				216E9A3829D2119300ABE69B /* InactiveTabs */,
 				21357F2B293FDB07004BF9FD /* RemoteTabs */,
+				43162A2E2492DB7800F91658 /* EmptyPrivateTabsView.swift */,
 				21E77E4D2AA8BA5200FABA10 /* TabTrayViewController.swift */,
 				21E77E4F2AA8BAEC00FABA10 /* TabTrayModel.swift */,
 				21E77E512AA8BE5C00FABA10 /* TabTrayFlagManager.swift */,
@@ -12927,7 +12927,7 @@
 				8A5D1CB62A30DBB0005AD35C /* DefaultBrowserSetting.swift in Sources */,
 				4393932029AC6CE900DC5A85 /* EnvironmentValues+Extension.swift in Sources */,
 				ABEF80D12A24D2BE003F52C4 /* CreditCardBottomSheetViewModel.swift in Sources */,
-				43162A2F2492DB7800F91658 /* LegacyEmptyPrivateTabsView.swift in Sources */,
+				43162A2F2492DB7800F91658 /* EmptyPrivateTabsView.swift in Sources */,
 				D0625C98208E87F10081F3B2 /* DownloadQueue.swift in Sources */,
 				9636D92E27F9E5D900771F5E /* GleanPlumbMessage.swift in Sources */,
 				8D8251811F4DE67F00780643 /* AdvancedAccountSettingViewController.swift in Sources */,

--- a/Client/Frontend/Browser/Tabs/EmptyPrivateTabsView.swift
+++ b/Client/Frontend/Browser/Tabs/EmptyPrivateTabsView.swift
@@ -75,9 +75,9 @@ class EmptyPrivateTabsView: UIView {
     }
 
     private func setupLayout() {
-        button.addTarget(self,
-                         action: #selector(didTapLearnMore),
-                         for: .touchUpInside)
+        learnMoreButton.addTarget(self,
+                                  action: #selector(didTapLearnMore),
+                                  for: .touchUpInside)
         containerView.addSubviews(iconImageView, titleLabel, descriptionLabel, learnMoreButton)
         scrollView.addSubview(containerView)
         addSubview(scrollView)

--- a/Client/Frontend/Browser/Tabs/EmptyPrivateTabsView.swift
+++ b/Client/Frontend/Browser/Tabs/EmptyPrivateTabsView.swift
@@ -7,8 +7,12 @@ import UIKit
 import Foundation
 import Shared
 
+protocol EmptyPrivateTabsViewDelegate: AnyObject {
+    func didTapLearnMore(urlRequest: URLRequest)
+}
+
 // View we display when there are no private tabs created
-class LegacyEmptyPrivateTabsView: UIView {
+class EmptyPrivateTabsView: UIView {
     struct UX {
         static let titleSizeFont: CGFloat = 22
         static let descriptionSizeFont: CGFloat = 17
@@ -20,6 +24,8 @@ class LegacyEmptyPrivateTabsView: UIView {
     }
 
     // MARK: - Properties
+
+    weak var delegate: EmptyPrivateTabsViewDelegate?
 
     // UI
     private let scrollView: UIScrollView = .build { scrollview in
@@ -50,6 +56,9 @@ class LegacyEmptyPrivateTabsView: UIView {
         button.setTitle( .PrivateBrowsingLearnMore, for: [])
         button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .subheadline,
                                                                          size: UX.buttonSizeFont)
+        button.addTarget(self,
+                         action: #selector(didTapLearnMore),
+                         for: .touchUpInside)
     }
 
     private let iconImageView: UIImageView = .build { imageView in
@@ -120,5 +129,14 @@ class LegacyEmptyPrivateTabsView: UIView {
         descriptionLabel.textColor = theme.colors.textPrimary
         learnMoreButton.setTitleColor(theme.colors.borderAccentPrivate, for: [])
         iconImageView.tintColor = theme.colors.indicatorActive
+    }
+
+    @objc
+    private func didTapLearnMore() {
+        let appVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+        if let langID = Locale.preferredLanguages.first {
+            let learnMoreRequest = URLRequest(url: "https://support.mozilla.org/1/mobile/\(appVersion ?? "0.0")/iOS/\(langID)/private-browsing-ios".asURL!)
+            delegate?.didTapLearnMore(urlRequest: learnMoreRequest)
+        }
     }
 }

--- a/Client/Frontend/Browser/Tabs/EmptyPrivateTabsView.swift
+++ b/Client/Frontend/Browser/Tabs/EmptyPrivateTabsView.swift
@@ -56,9 +56,6 @@ class EmptyPrivateTabsView: UIView {
         button.setTitle( .PrivateBrowsingLearnMore, for: [])
         button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .subheadline,
                                                                          size: UX.buttonSizeFont)
-        button.addTarget(self,
-                         action: #selector(didTapLearnMore),
-                         for: .touchUpInside)
     }
 
     private let iconImageView: UIImageView = .build { imageView in
@@ -78,6 +75,9 @@ class EmptyPrivateTabsView: UIView {
     }
 
     private func setupLayout() {
+        button.addTarget(self,
+                         action: #selector(didTapLearnMore),
+                         for: .touchUpInside)
         containerView.addSubviews(iconImageView, titleLabel, descriptionLabel, learnMoreButton)
         scrollView.addSubview(containerView)
         addSubview(scrollView)

--- a/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
+++ b/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
@@ -17,7 +17,10 @@ protocol TabTrayDelegate: AnyObject {
     func tabTrayDidCloseLastTab(toast: ButtonToast)
 }
 
-class LegacyGridTabViewController: UIViewController, TabTrayViewDelegate, Themeable {
+class LegacyGridTabViewController: UIViewController,
+                                   TabTrayViewDelegate,
+                                   Themeable,
+                                   EmptyPrivateTabsViewDelegate {
     struct UX {
         static let cornerRadius: CGFloat = 6
         static let textBoxHeight: CGFloat = 32
@@ -91,11 +94,9 @@ class LegacyGridTabViewController: UIViewController, TabTrayViewDelegate, Themea
         return true
     }
 
-    private lazy var emptyPrivateTabsView: LegacyEmptyPrivateTabsView = {
-        let emptyView = LegacyEmptyPrivateTabsView()
-        emptyView.learnMoreButton.addTarget(self,
-                                            action: #selector(didTapLearnMore),
-                                            for: .touchUpInside)
+    private lazy var emptyPrivateTabsView: EmptyPrivateTabsView = {
+        let emptyView = EmptyPrivateTabsView()
+        emptyView.delegate = self
         return emptyView
     }()
 
@@ -314,13 +315,10 @@ class LegacyGridTabViewController: UIViewController, TabTrayViewDelegate, Themea
         collectionView.reloadData()
     }
 
-    @objc
-    func didTapLearnMore() {
-        let appVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
-        if let langID = Locale.preferredLanguages.first {
-            let learnMoreRequest = URLRequest(url: "https://support.mozilla.org/1/mobile/\(appVersion ?? "0.0")/iOS/\(langID)/private-browsing-ios".asURL!)
-            openNewTab(learnMoreRequest, isPrivate: tabDisplayManager.isPrivate)
-        }
+    // MARK: EmptyPrivateTabsViewDelegate
+    func didTapLearnMore(urlRequest: URLRequest) {
+        openNewTab(urlRequest,
+                   isPrivate: tabDisplayManager.isPrivate)
     }
 
     func closeTabsTrayBackground() {

--- a/Client/Frontend/Browser/Tabs/TabDisplayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabDisplayViewController.swift
@@ -6,7 +6,8 @@ import Common
 import UIKit
 
 class TabDisplayViewController: UIViewController,
-                                   Themeable {
+                                Themeable,
+                                EmptyPrivateTabsViewDelegate {
     struct UX {}
 
     var notificationCenter: NotificationProtocol
@@ -17,8 +18,17 @@ class TabDisplayViewController: UIViewController,
     private var backgroundPrivacyOverlay: UIView = .build { _ in }
     private var tabDisplayView: TabDisplayView = .build { _ in }
 
-    // Redux state
+    private lazy var emptyPrivateTabsView: EmptyPrivateTabsView = {
+        let emptyView = EmptyPrivateTabsView()
+        return emptyView
+    }()
+
+    // MARK: Redux state
     var isPrivateMode: Bool
+    var privateTabsAreEmpty: Bool {
+        // TODO: FXIOS-6937 Use var from state if private tabs are empty
+        return isPrivateMode && true
+    }
 
     init(isPrivateMode: Bool,
          notificationCenter: NotificationProtocol = NotificationCenter.default,
@@ -44,6 +54,7 @@ class TabDisplayViewController: UIViewController,
     private func setupView() {
         view.addSubview(tabDisplayView)
         view.addSubview(backgroundPrivacyOverlay)
+        view.insertSubview(emptyPrivateTabsView, aboveSubview: tabDisplayView)
 
         NSLayoutConstraint.activate([
             tabDisplayView.topAnchor.constraint(equalTo: view.topAnchor),
@@ -54,14 +65,22 @@ class TabDisplayViewController: UIViewController,
             backgroundPrivacyOverlay.topAnchor.constraint(equalTo: view.topAnchor),
             backgroundPrivacyOverlay.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             backgroundPrivacyOverlay.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            backgroundPrivacyOverlay.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+            backgroundPrivacyOverlay.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+
+            emptyPrivateTabsView.topAnchor.constraint(equalTo: view.topAnchor),
+            emptyPrivateTabsView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            emptyPrivateTabsView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            emptyPrivateTabsView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
 
         backgroundPrivacyOverlay.isHidden = !isPrivateMode
-        // TODO: Empty private tabs view FXIOS-6925
+        emptyPrivateTabsView.isHidden = !privateTabsAreEmpty
     }
 
     func applyTheme() {
         backgroundPrivacyOverlay.backgroundColor = themeManager.currentTheme.colors.layerScrim
     }
+
+    // MARK: EmptyPrivateTabsViewDelegate
+    func didTapLearnMore(urlRequest: URLRequest) {}
 }

--- a/Tests/ClientTests/GridTabViewControllerTests.swift
+++ b/Tests/ClientTests/GridTabViewControllerTests.swift
@@ -5,7 +5,7 @@
 import XCTest
 @testable import Client
 
-final class GridTabViewControllerTests: XCTestCase {
+final class LegacyGridTabViewControllerTests: XCTestCase {
     private var manager: TabManager!
     private var profile: MockProfile!
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6925)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
- Contains https://github.com/mozilla-mobile/firefox-ios/pull/16646
- Rename `LegacyEmptyPrivateTabsView` to `EmptyPrivateTabsView` and reuse for both versions
- Minor refactor to add delegate protocol and decouple logic to show learn more button from `LegacyGridTabViewController`

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

