### PR TITLE
Refactor FXIOS-6934 [v120] Sync tab empty view, related refactors

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		1D2F68AB2ACB262900524B92 /* RemoteTabsPanelAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2F68AA2ACB262900524B92 /* RemoteTabsPanelAction.swift */; };
 		1D2F68AD2ACB266300524B92 /* RemoteTabsPanelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2F68AC2ACB266300524B92 /* RemoteTabsPanelState.swift */; };
 		1D2F68AF2ACB272500524B92 /* RemoteTabsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2F68AE2ACB272500524B92 /* RemoteTabsTableViewController.swift */; };
+		1D2F68B12ACCA22000524B92 /* RemoteTabsEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2F68B02ACCA22000524B92 /* RemoteTabsEmptyView.swift */; };
 		1D69FF8D27B17286001F660E /* HomeLogoHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D69FF8C27B17285001F660E /* HomeLogoHeaderCell.swift */; };
 		1D9E1FE524FEF56C006E561D /* TopSites in Resources */ = {isa = PBXBuildFile; fileRef = 3BC659481E5BA4AE006D560F /* TopSites */; };
 		1DA3CE5D24EEE73100422BB2 /* OpenTabsWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA3CE5C24EEE73100422BB2 /* OpenTabsWidget.swift */; };
@@ -2075,6 +2076,7 @@
 		1D2F68AA2ACB262900524B92 /* RemoteTabsPanelAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabsPanelAction.swift; sourceTree = "<group>"; };
 		1D2F68AC2ACB266300524B92 /* RemoteTabsPanelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabsPanelState.swift; sourceTree = "<group>"; };
 		1D2F68AE2ACB272500524B92 /* RemoteTabsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabsTableViewController.swift; sourceTree = "<group>"; };
+		1D2F68B02ACCA22000524B92 /* RemoteTabsEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabsEmptyView.swift; sourceTree = "<group>"; };
 		1D69FF8C27B17285001F660E /* HomeLogoHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeLogoHeaderCell.swift; sourceTree = "<group>"; };
 		1D774B3D9C6E21B77FB7B38F /* kab */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kab; path = kab.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
 		1D90440B860A503D4DBA4213 /* cy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cy; path = cy.lproj/Storage.strings; sourceTree = "<group>"; };
@@ -7243,6 +7245,7 @@
 				1D2F68AA2ACB262900524B92 /* RemoteTabsPanelAction.swift */,
 				1D2F68AC2ACB266300524B92 /* RemoteTabsPanelState.swift */,
 				210887CB293E8800000AB4EE /* RemoteTabsErrorCell.swift */,
+				1D2F68B02ACCA22000524B92 /* RemoteTabsEmptyView.swift */,
 				21357F2C293FDB60004BF9FD /* RemoteTabsErrorDataSource.swift */,
 				21357F2E294237D8004BF9FD /* RemoteTabsClientAndTabsDataSource.swift */,
 			);
@@ -12895,6 +12898,7 @@
 				8A8DDEBF276259A900E7B97A /* RatingPromptManager.swift in Sources */,
 				8AB8571D27D929350075C173 /* TopSitesViewModel.swift in Sources */,
 				8A93F85E29D36DA9004159D9 /* Coordinator.swift in Sources */,
+				1D2F68B12ACCA22000524B92 /* RemoteTabsEmptyView.swift in Sources */,
 				43D16B8729831EEF009F8279 /* RemoveCardButton.swift in Sources */,
 				D59431ED25E9912900F0BA82 /* WidgetIntents.intentdefinition in Sources */,
 				213778632980448C00D01309 /* DownloadFileFetcher.swift in Sources */,

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsEmptyView.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsEmptyView.swift
@@ -74,14 +74,8 @@ class RemoteTabsEmptyView: UIView, ThemeApplicable {
     }
 
     func configure(state: RemoteTabsPanelEmptyState,
-                   theme: Theme?,
                    delegate: RemotePanelDelegate?) {
         self.delegate = delegate
-
-        if let theme = theme {
-            // TODO: Theming forthcoming as part of Redux updates.
-            applyTheme(theme: theme)
-        }
 
         emptyStateImageView.image = UIImage.templateImageNamed(ImageIdentifiers.emptySyncImageName)
         titleLabel.text =  .EmptySyncedTabsPanelStateTitle

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsEmptyView.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsEmptyView.swift
@@ -116,9 +116,6 @@ class RemoteTabsEmptyView: UIView, ThemeApplicable {
             emptyStateImageView.widthAnchor.constraint(equalToConstant: UX.imageSize.width),
             emptyStateImageView.heightAnchor.constraint(equalToConstant: UX.imageSize.height),
         ])
-
-        titleLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
-        instructionsLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
     }
 
     func applyTheme(theme: Theme) {

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsEmptyView.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsEmptyView.swift
@@ -1,0 +1,137 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import ComponentLibrary
+import UIKit
+import Shared
+
+class RemoteTabsEmptyView: UIView, ThemeApplicable {
+    struct UX {
+        static let verticalPadding: CGFloat = 40
+        static let horizontalPadding: CGFloat = 24
+        static let paddingInBetweenItems: CGFloat = 15
+        static let buttonCornerRadius: CGFloat = 13
+        static let titleSizeFont: CGFloat = 22
+        static let descriptionSizeFont: CGFloat = 17
+        static let buttonSizeFont: CGFloat = 16
+        static let imageSize = CGSize(width: 90, height: 60)
+        static let buttonVerticalInset: CGFloat = 12
+    }
+
+    weak var delegate: RemotePanelDelegate?
+
+    // MARK: - UI
+
+    private lazy var stackView: UIStackView = .build { stackView in
+        stackView.axis = .vertical
+        stackView.alignment = .fill
+        stackView.distribution = .fillProportionally
+        stackView.spacing = UX.paddingInBetweenItems
+        stackView.alignment = .center
+    }
+
+    private let emptyStateImageView: UIImageView = .build { imageView in
+        imageView.contentMode = .scaleAspectFit
+    }
+
+    private let titleLabel: UILabel = .build { label in
+        label.adjustsFontForContentSizeCategory = true
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .title2,
+                                                            size: UX.titleSizeFont)
+        label.numberOfLines = 0
+        label.textAlignment = .center
+    }
+
+    private let instructionsLabel: UILabel = .build { label in
+        label.adjustsFontForContentSizeCategory = true
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
+                                                            size: UX.descriptionSizeFont)
+        label.numberOfLines = 0
+        label.textAlignment = .center
+    }
+
+    private let signInButton: ResizableButton = .build { button in
+        button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .callout,
+                                                                         size: UX.buttonSizeFont)
+        button.setTitle(.Settings.Sync.ButtonTitle, for: [])
+        button.layer.cornerRadius = UX.buttonCornerRadius
+        button.contentEdgeInsets = UIEdgeInsets(top: UX.buttonVerticalInset,
+                                                left: UX.buttonVerticalInset,
+                                                bottom: UX.buttonVerticalInset,
+                                                right: UX.buttonVerticalInset)
+        button.accessibilityIdentifier = AccessibilityIdentifiers.TabTray.syncDataButton
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(state: RemoteTabsPanelEmptyState,
+                   theme: Theme?,
+                   delegate: RemotePanelDelegate?) {
+        self.delegate = delegate
+        
+        if let theme = theme {
+            // TODO: Theming forthcoming as part of Redux updates.
+            applyTheme(theme: theme)
+        }
+
+        emptyStateImageView.image = UIImage.templateImageNamed(ImageIdentifiers.emptySyncImageName)
+        titleLabel.text =  .EmptySyncedTabsPanelStateTitle
+        instructionsLabel.text = state.localizedString()
+
+        // Show signIn button only for notLoggedIn case
+        if state == .notLoggedIn || state == .syncDisabledByUser {
+            signInButton.isHidden = false
+            signInButton.addTarget(self, action: #selector(presentSignIn), for: .touchUpInside)
+        }
+    }
+
+    private func setupLayout() {
+        stackView.addArrangedSubview(emptyStateImageView)
+        stackView.addArrangedSubview(titleLabel)
+        stackView.addArrangedSubview(instructionsLabel)
+        stackView.addArrangedSubview(signInButton)
+        addSubview(stackView)
+
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: self.leadingAnchor,
+                                               constant: UX.horizontalPadding),
+            stackView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+            stackView.topAnchor.constraint(equalTo: self.topAnchor,
+                                           constant: UX.verticalPadding),
+            stackView.trailingAnchor.constraint(equalTo: self.trailingAnchor,
+                                                constant: -UX.horizontalPadding),
+            stackView.bottomAnchor.constraint(equalTo: self.bottomAnchor,
+                                              constant: -UX.verticalPadding).priority(.defaultLow),
+            signInButton.leadingAnchor.constraint(equalTo: instructionsLabel.leadingAnchor),
+            signInButton.trailingAnchor.constraint(equalTo: instructionsLabel.trailingAnchor),
+            emptyStateImageView.widthAnchor.constraint(equalToConstant: UX.imageSize.width),
+            emptyStateImageView.heightAnchor.constraint(equalToConstant: UX.imageSize.height),
+        ])
+    }
+
+    func applyTheme(theme: Theme) {
+        emptyStateImageView.tintColor = theme.colors.textPrimary
+        titleLabel.textColor = theme.colors.textPrimary
+        instructionsLabel.textColor = theme.colors.textPrimary
+        signInButton.setTitleColor(theme.colors.textInverted, for: .normal)
+        signInButton.backgroundColor = theme.colors.actionPrimary
+        backgroundColor = theme.colors.layer3
+    }
+
+    @objc
+    private func presentSignIn() {
+        if let delegate = self.delegate {
+            TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .syncSignIn)
+            delegate.remotePanelDidRequestToSignIn()
+        }
+    }
+}

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsEmptyView.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsEmptyView.swift
@@ -116,6 +116,9 @@ class RemoteTabsEmptyView: UIView, ThemeApplicable {
             emptyStateImageView.widthAnchor.constraint(equalToConstant: UX.imageSize.width),
             emptyStateImageView.heightAnchor.constraint(equalToConstant: UX.imageSize.height),
         ])
+        
+        titleLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+        instructionsLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
     }
 
     func applyTheme(theme: Theme) {

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsEmptyView.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsEmptyView.swift
@@ -77,7 +77,7 @@ class RemoteTabsEmptyView: UIView, ThemeApplicable {
                    theme: Theme?,
                    delegate: RemotePanelDelegate?) {
         self.delegate = delegate
-        
+
         if let theme = theme {
             // TODO: Theming forthcoming as part of Redux updates.
             applyTheme(theme: theme)
@@ -116,7 +116,7 @@ class RemoteTabsEmptyView: UIView, ThemeApplicable {
             emptyStateImageView.widthAnchor.constraint(equalToConstant: UX.imageSize.width),
             emptyStateImageView.heightAnchor.constraint(equalToConstant: UX.imageSize.height),
         ])
-        
+
         titleLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
         instructionsLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
     }

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanel.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanel.swift
@@ -14,7 +14,7 @@ class RemoteTabsPanel: UIViewController,
                        RemotePanelDelegateProvider {
     private(set) var state: RemoteTabsPanelState
     var tableViewController: RemoteTabsTableViewController
-    var remotePanelDelegate: RemotePanelDelegate?
+    weak var remotePanelDelegate: RemotePanelDelegate?
 
     var themeManager: ThemeManager
     var themeObserver: NSObjectProtocol?

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelState.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelState.swift
@@ -7,23 +7,6 @@ import Redux
 import Shared
 import Storage
 
-/// State for RemoteTabsPanel. WIP.
-struct RemoteTabsPanelState {
-    let refreshState: RemoteTabsPanelRefreshState
-    let clientAndTabs: [ClientAndTabs]
-    let allowsRefresh: Bool                                // True if `hasSyncableAccount()`
-    let showingEmptyState: RemoteTabsPanelEmptyState?      // If showing empty (or error) state
-    let syncIsSupported: Bool                              // Reference: `prefs.boolForKey(PrefsKeys.TabSyncEnabled)`
-
-    static func emptyState() -> RemoteTabsPanelState {
-        return RemoteTabsPanelState(refreshState: .loaded,
-                                    clientAndTabs: [],
-                                    allowsRefresh: false,
-                                    showingEmptyState: .noTabs,
-                                    syncIsSupported: true)
-    }
-}
-
 /// Status of tab refresh.
 enum RemoteTabsPanelRefreshState {
     case loaded
@@ -46,5 +29,22 @@ enum RemoteTabsPanelEmptyState {
         case .failedToSync: return .RemoteTabErrorFailedToSync
         case .syncDisabledByUser: return .TabsTray.Sync.SyncTabsDisabled
         }
+    }
+}
+
+/// State for RemoteTabsPanel. WIP.
+struct RemoteTabsPanelState {
+    let refreshState: RemoteTabsPanelRefreshState
+    let clientAndTabs: [ClientAndTabs]
+    let allowsRefresh: Bool                                // True if `hasSyncableAccount()`
+    let showingEmptyState: RemoteTabsPanelEmptyState?      // If showing empty (or error) state
+    let syncIsSupported: Bool                              // Reference: `prefs.boolForKey(PrefsKeys.TabSyncEnabled)`
+
+    static func emptyState() -> RemoteTabsPanelState {
+        return RemoteTabsPanelState(refreshState: .loaded,
+                                    clientAndTabs: [],
+                                    allowsRefresh: false,
+                                    showingEmptyState: .noTabs,
+                                    syncIsSupported: true)
     }
 }

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelState.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelState.swift
@@ -7,32 +7,44 @@ import Redux
 import Shared
 import Storage
 
+/// State for RemoteTabsPanel. WIP.
 struct RemoteTabsPanelState {
     let refreshState: RemoteTabsPanelRefreshState
     let clientAndTabs: [ClientAndTabs]
-    let allowsRefresh: Bool // True if hasSyncableAccount
-    let showingError: RemoteTabsPanelErrorState?
-    let syncIsSupported: Bool // Reference: `prefs.boolForKey(PrefsKeys.TabSyncEnabled)`
+    let allowsRefresh: Bool                                // True if `hasSyncableAccount()`
+    let showingEmptyState: RemoteTabsPanelEmptyState?      // If showing empty (or error) state
+    let syncIsSupported: Bool                              // Reference: `prefs.boolForKey(PrefsKeys.TabSyncEnabled)`
 
     static func emptyState() -> RemoteTabsPanelState {
         return RemoteTabsPanelState(refreshState: .loaded,
                                     clientAndTabs: [],
                                     allowsRefresh: false,
-                                    showingError: nil,
+                                    showingEmptyState: nil,
                                     syncIsSupported: true)
     }
 }
 
+/// Status of tab refresh.
 enum RemoteTabsPanelRefreshState {
     case loaded
     case refreshing
 }
 
-// This now replaces RemoteTabsErrorDataSource.ErrorType
-enum RemoteTabsPanelErrorState {
+/// Replaces RemoteTabsErrorDataSource.ErrorType
+enum RemoteTabsPanelEmptyState {
     case notLoggedIn
     case noClients
     case noTabs
     case failedToSync
     case syncDisabledByUser
+
+    func localizedString() -> String {
+        switch self {
+        case .notLoggedIn: return .EmptySyncedTabsPanelNotSignedInStateDescription
+        case .noClients: return .EmptySyncedTabsPanelNullStateDescription
+        case .noTabs: return .RemoteTabErrorNoTabs
+        case .failedToSync: return .RemoteTabErrorFailedToSync
+        case .syncDisabledByUser: return .TabsTray.Sync.SyncTabsDisabled
+        }
+    }
 }

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelState.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelState.swift
@@ -19,7 +19,7 @@ struct RemoteTabsPanelState {
         return RemoteTabsPanelState(refreshState: .loaded,
                                     clientAndTabs: [],
                                     allowsRefresh: false,
-                                    showingEmptyState: nil,
+                                    showingEmptyState: .noTabs,
                                     syncIsSupported: true)
     }
 }

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
@@ -14,7 +14,7 @@ class RemoteTabsTableViewController: UITableViewController,
     struct UX {
         static let rowHeight = SiteTableViewControllerUX.RowHeight
     }
-    
+
     // MARK: - Properties
 
     private(set) var state: RemoteTabsPanelState
@@ -23,14 +23,14 @@ class RemoteTabsTableViewController: UITableViewController,
     var themeObserver: NSObjectProtocol?
     var notificationCenter: NotificationProtocol
     weak var remoteTabsPanel: RemoteTabsPanel?
-    
+
     private var isShowingEmptyView: Bool { state.showingEmptyState != nil }
     private let emptyView: RemoteTabsEmptyView = .build()
 
     private lazy var longPressRecognizer: UILongPressGestureRecognizer = {
         return UILongPressGestureRecognizer(target: self, action: #selector(longPress))
     }()
-    
+
     // MARK: - Initializer
 
     init(state: RemoteTabsPanelState,
@@ -43,7 +43,7 @@ class RemoteTabsTableViewController: UITableViewController,
     }
 
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
-    
+
     // MARK: - View Controller
 
     override func viewDidLoad() {

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
@@ -72,8 +72,6 @@ class RemoteTabsTableViewController: UITableViewController,
         NSLayoutConstraint.activate([
             emptyView.centerXAnchor.constraint(equalTo: tableView.centerXAnchor),
             emptyView.topAnchor.constraint(equalTo: tableView.topAnchor),
-            emptyView.widthAnchor.constraint(greaterThanOrEqualToConstant: 500),
-            emptyView.heightAnchor.constraint(greaterThanOrEqualToConstant: 250),
         ])
 
         listenForThemeChange(view)

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
@@ -158,7 +158,7 @@ class RemoteTabsTableViewController: UITableViewController,
     }
 
     func updateDelegateClientAndTabData(_ clientAndTabs: [ClientAndTabs]) {
-        // TODO: Forthcoming as part of ongoing tab tray Redux refactors.
+        // TODO: Forthcoming as part of ongoing tab tray Redux refactors. [FXIOS-6942] & [FXIOS-7509]
 
         refreshUI()
     }
@@ -177,7 +177,7 @@ class RemoteTabsTableViewController: UITableViewController,
             return
         }
 
-        // TODO: Send Redux action to get cached clients & tabs, update once new state is received. Forthcoming.
+        // TODO: Send Redux action to get clients & tabs, update once state received. Forthcoming.  [FXIOS-6942] & [FXIOS-7509]
         // store.dispatch(RemoteTabsPanelAction.refreshCachedTabs)
     }
 
@@ -190,7 +190,7 @@ class RemoteTabsTableViewController: UITableViewController,
     }
 
     func hideTableViewSection(_ section: Int) {
-        // TODO: Forthcoming as part of ongoing Redux refactors.
+        // TODO: Forthcoming as part of ongoing Redux refactors. [FXIOS-6942] & [FXIOS-7509]
 
         refreshUI()
     }
@@ -203,7 +203,7 @@ class RemoteTabsTableViewController: UITableViewController,
     }
 
     func getSiteDetails(for indexPath: IndexPath) -> Site? {
-        // TODO: Forthcoming as part of ongoing Redux refactors.
+        // TODO: Forthcoming as part of ongoing Redux refactors. [FXIOS-6942] & [FXIOS-7509]
 
         return nil
     }
@@ -218,7 +218,7 @@ class RemoteTabsTableViewController: UITableViewController,
         if isShowingEmptyView {
             return 0
         } else {
-            // TODO: Show clients and tabs. Forthcoming.
+            // TODO: Show clients and tabs. Forthcoming. [FXIOS-6942]
             return 0
         }
     }
@@ -227,7 +227,7 @@ class RemoteTabsTableViewController: UITableViewController,
         if isShowingEmptyView {
             return 0
         } else {
-            // TODO: Show clients and tabs. Forthcoming.
+            // TODO: Show clients and tabs. Forthcoming. [FXIOS-6942]
             return 0
         }
     }
@@ -239,7 +239,7 @@ class RemoteTabsTableViewController: UITableViewController,
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard !isShowingEmptyView else { assertionFailure("Empty view state should always have 0 sections/rows."); return .build() }
 
-        // TODO: Show clients and tabs. Forthcoming.
+        // TODO: Show clients and tabs. Forthcoming. [FXIOS-6942]
         return UITableViewCell(frame: .zero)
     }
 }

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
@@ -67,7 +67,7 @@ class RemoteTabsTableViewController: UITableViewController,
         }
 
         tableView.accessibilityIdentifier = AccessibilityIdentifiers.TabTray.syncedTabs
-        
+
         tableView.addSubview(emptyView)
         NSLayoutConstraint.activate([
             emptyView.centerXAnchor.constraint(equalTo: tableView.centerXAnchor),
@@ -75,10 +75,10 @@ class RemoteTabsTableViewController: UITableViewController,
             emptyView.widthAnchor.constraint(greaterThanOrEqualToConstant: 500),
             emptyView.heightAnchor.constraint(greaterThanOrEqualToConstant: 250),
         ])
-        
+
         listenForThemeChange(view)
         applyTheme()
-        
+
         refreshUI()
     }
 
@@ -102,7 +102,7 @@ class RemoteTabsTableViewController: UITableViewController,
             removeRefreshControl()
         }
     }
-    
+
     // MARK: - UI
 
     func applyTheme() {
@@ -204,16 +204,16 @@ class RemoteTabsTableViewController: UITableViewController,
 
     func getSiteDetails(for indexPath: IndexPath) -> Site? {
         // TODO: Forthcoming as part of ongoing Redux refactors.
-        
+
         return nil
     }
 
     func getContextMenuActions(for site: Site, with indexPath: IndexPath) -> [PhotonRowActions]? {
         return getRemoteTabContextMenuActions(for: site, remotePanelDelegate: remoteTabsPanel?.remotePanelDelegate)
     }
-    
+
     // MARK: - UITableView
-    
+
     override func numberOfSections(in tableView: UITableView) -> Int {
         if isShowingEmptyView {
             return 0

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
@@ -72,6 +72,8 @@ class RemoteTabsTableViewController: UITableViewController,
         NSLayoutConstraint.activate([
             emptyView.centerXAnchor.constraint(equalTo: tableView.centerXAnchor),
             emptyView.topAnchor.constraint(equalTo: tableView.topAnchor),
+            emptyView.leadingAnchor.constraint(equalTo: tableView.leadingAnchor),
+            emptyView.trailingAnchor.constraint(equalTo: tableView.trailingAnchor),
         ])
 
         listenForThemeChange(view)

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
@@ -69,7 +69,12 @@ class RemoteTabsTableViewController: UITableViewController,
         tableView.accessibilityIdentifier = AccessibilityIdentifiers.TabTray.syncedTabs
         
         tableView.addSubview(emptyView)
-        emptyView.frame = tableView.bounds
+        NSLayoutConstraint.activate([
+            emptyView.centerXAnchor.constraint(equalTo: tableView.centerXAnchor),
+            emptyView.topAnchor.constraint(equalTo: tableView.topAnchor),
+            emptyView.widthAnchor.constraint(greaterThanOrEqualToConstant: 500),
+            emptyView.heightAnchor.constraint(greaterThanOrEqualToConstant: 250),
+        ])
         
         listenForThemeChange(view)
         applyTheme()
@@ -108,14 +113,18 @@ class RemoteTabsTableViewController: UITableViewController,
     private func refreshUI() {
         emptyView.isHidden = !isShowingEmptyView
 
-        if !isShowingEmptyView {
+        if isShowingEmptyView {
+            configureEmptyView()
+        } else {
             tableView.reloadData()
         }
     }
 
     private func configureEmptyView() {
         guard let emptyState = state.showingEmptyState else { return }
-        emptyView.configure(state: emptyState, theme: nil, delegate: remoteTabsPanel?.remotePanelDelegate)
+        emptyView.configure(state: emptyState,
+                            theme: themeManager.currentTheme,
+                            delegate: remoteTabsPanel?.remotePanelDelegate)
     }
 
     // MARK: - Refreshing TableView

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
@@ -107,7 +107,8 @@ class RemoteTabsTableViewController: UITableViewController,
 
     func applyTheme() {
         tableView.separatorColor = themeManager.currentTheme.colors.layerLightGrey30
-        // TODO: Ensure theme applied to any subviews or custom cells.
+        emptyView.applyTheme(theme: themeManager.currentTheme)
+        // TODO: Ensure theme applied to any custom cells.
     }
 
     private func refreshUI() {
@@ -122,9 +123,8 @@ class RemoteTabsTableViewController: UITableViewController,
 
     private func configureEmptyView() {
         guard let emptyState = state.showingEmptyState else { return }
-        emptyView.configure(state: emptyState,
-                            theme: themeManager.currentTheme,
-                            delegate: remoteTabsPanel?.remotePanelDelegate)
+        emptyView.configure(state: emptyState, delegate: remoteTabsPanel?.remotePanelDelegate)
+        emptyView.applyTheme(theme: themeManager.currentTheme)
     }
 
     // MARK: - Refreshing TableView

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
@@ -115,9 +115,9 @@ class RemoteTabsTableViewController: UITableViewController,
 
         if isShowingEmptyView {
             configureEmptyView()
-        } else {
-            tableView.reloadData()
         }
+
+        tableView.reloadData()
     }
 
     private func configureEmptyView() {

--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -421,6 +421,8 @@ class TabTrayViewController: UIViewController,
     @objc
     private func syncTabsTapped() {}
 
+    // MARK: - RemotePanelDelegate
+
     func remotePanelDidRequestToSignIn() {
         fxaSignInOrCreateAccountHelper()
     }

--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -392,7 +392,10 @@ class TabTrayViewController: UIViewController,
         }
     }
 
-    private func segmentPanelChange() {}
+    private func segmentPanelChange() {
+        hideCurrentPanel()
+        showPanel(getChildViewController())
+    }
 
     @objc
     private func segmentChanged() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6934)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15412)

## :bulb: Description

Early work for new Redux-based sync tab. Changes in this PR:
- Refactors to remove dependency on previous two data sources for the sync tab table VC
- Stubs out hooks for tableview datasource/delegate to be handled directly by the new remote tabs VC
- Adds new view-based UI for sync tab empty/error states, to replace legacy tableview cell based UI
- Some related fixes and additional hooks/refactors for the sync tab

👉 Additional updates for some sync tab functionality are forthcoming as part of other refactor subtasks. (Sync tab is still a work-in-progress.)

## 🖼️ Screenshots

New UI (when `isRefactorEnabled` is true)

![new iphone view](https://github.com/mozilla-mobile/firefox-ios/assets/145381717/f80c4f40-68a9-447b-b1e1-728e6c59f19f)

![new view ipad](https://github.com/mozilla-mobile/firefox-ios/assets/145381717/b8c0252c-28cd-4bab-b700-06c001754cd8)


## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

