### PR TITLE
Refactor MTE-726 [v120] Remove Rosetta workarounds

### DIFF
--- a/Tests/XCUITests/BaseTestCase.swift
+++ b/Tests/XCUITests/BaseTestCase.swift
@@ -238,15 +238,9 @@ class BaseTestCase: XCTestCase {
         mozWaitForElementToExist(savedToReadingList)
 
         // Remove the item from reading list
-        if processIsTranslatedStr() == m1Rosetta {
-            savedToReadingList.press(forDuration: 2)
-            mozWaitForElementToExist(app.otherElements["Remove"])
-            app.otherElements["Remove"].tap()
-        } else {
-            savedToReadingList.swipeLeft()
-            mozWaitForElementToExist(app.buttons["Remove"])
-            app.buttons["Remove"].tap()
-        }
+        savedToReadingList.swipeLeft()
+        mozWaitForElementToExist(app.buttons["Remove"])
+        app.buttons["Remove"].tap()
     }
 
      func selectOptionFromContextMenu(option: String) {

--- a/Tests/XCUITests/BookmarksTests.swift
+++ b/Tests/XCUITests/BookmarksTests.swift
@@ -210,18 +210,9 @@ class BookmarksTests: BaseTestCase {
     func testDeleteBookmarkSwiping() {
         addNewBookmark()
         // Remove by swiping
-        if processIsTranslatedStr() != m1Rosetta {
-            app.tables["Bookmarks List"].staticTexts["BBC"].swipeLeft()
-            mozWaitForElementToExist(app.buttons["Delete"])
-            app.buttons["Delete"].tap()
-        } else {
-            // Workaround for deleting bookmark by using edit button
-            app.buttons["Edit"].tap()
-            mozWaitForElementToExist(app.tables["Bookmarks List"].buttons["Delete BBC"])
-            app.tables["Bookmarks List"].buttons["Delete BBC"].tap()
-            mozWaitForElementToExist(app.buttons["Delete"])
-            app.buttons["Delete"].tap()
-        }
+        app.tables["Bookmarks List"].staticTexts["BBC"].swipeLeft()
+        mozWaitForElementToExist(app.buttons["Delete"])
+        app.buttons["Delete"].tap()
         // Verify that there are only 1 cell (desktop bookmark folder)
         checkItemsInBookmarksList(items: 1)
     }

--- a/Tests/XCUITests/BookmarksTests.swift
+++ b/Tests/XCUITests/BookmarksTests.swift
@@ -304,14 +304,8 @@ class BookmarksTests: BaseTestCase {
         mozWaitForElementToExist(app.tables["Bookmarks List"], timeout: 5)
 
         // Delete the Bookmark added, check it is removed
-        if processIsTranslatedStr() == m1Rosetta {
-            app.tables["Bookmarks List"].cells.staticTexts["Example Domain"].press(forDuration: 1)
-            mozWaitForElementToExist(app.tables["Context Menu"])
-            app.tables.otherElements["Remove Bookmark"].tap()
-        } else {
-            app.tables["Bookmarks List"].cells.staticTexts["Example Domain"].swipeLeft()
-            app.buttons["Delete"].tap()
-        }
+        app.tables["Bookmarks List"].cells.staticTexts["Example Domain"].swipeLeft()
+        app.buttons["Delete"].tap()
         mozWaitForElementToNotExist(app.tables["Bookmarks List"].cells.staticTexts["Example Domain"], timeout: 10)
         XCTAssertFalse(app.tables["Bookmarks List"].cells.staticTexts["Example Domain"].exists, "Bookmark not removed successfully")
     }

--- a/Tests/XCUITests/ClipBoardTests.swift
+++ b/Tests/XCUITests/ClipBoardTests.swift
@@ -59,11 +59,7 @@ class ClipBoardTests: BaseTestCase {
         navigator.goto(URLBarOpen)
         app.textFields["address"].press(forDuration: 3)
         app.menuItems["Paste"].tap()
-        if processIsTranslatedStr() == m1Rosetta {
-            mozWaitForElementToNotExist(app.menuItems["Paste"])
-        } else {
-            mozWaitForValueContains(app.textFields["address"], value: "www.example.com")
-        }
+        mozWaitForValueContains(app.textFields["address"], value: "www.example.com")
     }
 
     // Smoketest

--- a/Tests/XCUITests/DownloadsTests.swift
+++ b/Tests/XCUITests/DownloadsTests.swift
@@ -167,6 +167,7 @@ class DownloadsTests: BaseTestCase {
 
     private func downloadBLOBFile() {
         navigator.openURL(testBLOBURL)
+        waitUntilPageLoad()
         mozWaitForElementToExist(app.webViews.links["Download Text"], timeout: TIMEOUT)
         app.webViews.links["Download Text"].press(forDuration: 1)
         app.buttons["Download Link"].tap()

--- a/Tests/XCUITests/DownloadsTests.swift
+++ b/Tests/XCUITests/DownloadsTests.swift
@@ -16,23 +16,13 @@ class DownloadsTests: BaseTestCase {
     override func tearDown() {
         // The downloaded file has to be removed between tests
         mozWaitForElementToExist(app.tables["DownloadsTable"])
-        if processIsTranslatedStr() == m1Rosetta {
-            navigator.nowAt(LibraryPanel_Downloads)
-            navigator.goto(HomePanelsScreen)
-            navigator.nowAt(NewTabScreen)
-            navigator.goto(ClearPrivateDataSettings)
-            app.cells.switches["Downloaded Files"].tap()
-            app.tables.cells["ClearPrivateData"].tap()
-            app.alerts.buttons["OK"].tap()
-        } else {
-            let list = app.tables["DownloadsTable"].cells.count
-            if list != 0 {
-                for _ in 0...list-1 {
-                    mozWaitForElementToExist(app.tables["DownloadsTable"].cells.element(boundBy: 0))
-                    app.tables["DownloadsTable"].cells.element(boundBy: 0).swipeLeft()
-                    mozWaitForElementToExist(app.tables.cells.buttons["Delete"])
-                    app.tables.cells.buttons["Delete"].tap()
-                }
+        let list = app.tables["DownloadsTable"].cells.count
+        if list != 0 {
+            for _ in 0...list-1 {
+                mozWaitForElementToExist(app.tables["DownloadsTable"].cells.element(boundBy: 0))
+                app.tables["DownloadsTable"].cells.element(boundBy: 0).swipeLeft()
+                mozWaitForElementToExist(app.tables.cells.buttons["Delete"])
+                app.tables.cells.buttons["Delete"].tap()
             }
         }
         super.tearDown()
@@ -109,14 +99,10 @@ class DownloadsTests: BaseTestCase {
         navigator.goto(BrowserTabMenu)
         navigator.goto(LibraryPanel_Downloads)
         mozWaitForElementToExist(app.tables["DownloadsTable"])
-        if processIsTranslatedStr() == m1Rosetta {
-            throw XCTSkip("swipeLeft() does not work on M1")
-        } else {
-            deleteItem(itemName: testFileNameDownloadPanel)
-            mozWaitForElementToNotExist(app.tables.cells.staticTexts[testFileNameDownloadPanel])
-            // After removing the number of items should be 0
-            checkTheNumberOfDownloadedItems(items: 0)
-        }
+        deleteItem(itemName: testFileNameDownloadPanel)
+        mozWaitForElementToNotExist(app.tables.cells.staticTexts[testFileNameDownloadPanel])
+        // After removing the number of items should be 0
+        checkTheNumberOfDownloadedItems(items: 0)
     }
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2306901
@@ -124,26 +110,22 @@ class DownloadsTests: BaseTestCase {
         downloadFile(fileName: testFileName, numberOfDownloads: 1)
         navigator.goto(BrowserTabMenu)
         navigator.goto(LibraryPanel_Downloads)
-        if processIsTranslatedStr() == m1Rosetta {
-            throw XCTSkip("swipeLeft() does not work on M1")
+        let shareButton = app.tables.buttons.staticTexts["Share"]
+        app.tables.cells.staticTexts[testFileNameDownloadPanel].swipeLeft()
+        mozWaitForElementToExist(shareButton)
+        XCTAssertTrue(shareButton.exists)
+        XCTAssertTrue(app.tables.buttons.staticTexts["Delete"].exists)
+        shareButton.tap(force: true)
+        mozWaitForElementToExist(app.tables["DownloadsTable"])
+        XCTAssertTrue(app.tables["DownloadsTable"].staticTexts[testFileNameDownloadPanel].exists)
+        XCTAssertTrue(app.collectionViews.cells["Copy"].exists)
+        if !iPad() {
+            app.buttons["Close"].tap()
         } else {
-            let shareButton = app.tables.buttons.staticTexts["Share"]
-            app.tables.cells.staticTexts[testFileNameDownloadPanel].swipeLeft()
-            mozWaitForElementToExist(shareButton)
-            XCTAssertTrue(shareButton.exists)
-            XCTAssertTrue(app.tables.buttons.staticTexts["Delete"].exists)
-            shareButton.tap(force: true)
-            mozWaitForElementToExist(app.tables["DownloadsTable"])
-            XCTAssertTrue(app.tables["DownloadsTable"].staticTexts[testFileNameDownloadPanel].exists)
-            XCTAssertTrue(app.collectionViews.cells["Copy"].exists)
-            if !iPad() {
-                app.buttons["Close"].tap()
-            } else {
-                // Workaround to close the context menu.
-                // XCUITest does not allow me to click the greyed out portion of the app.
-                app.otherElements["ActivityListView"].cells["XCElementSnapshotPrivilegedValuePlaceholder"].firstMatch.tap()
-                app.navigationBars["Add Tag"].buttons["Done"].tap()
-            }
+            // Workaround to close the context menu.
+            // XCUITest does not allow me to click the greyed out portion of the app.
+            app.otherElements["ActivityListView"].cells["XCElementSnapshotPrivilegedValuePlaceholder"].firstMatch.tap()
+            app.navigationBars["Add Tag"].buttons["Done"].tap()
         }
     }
 

--- a/Tests/XCUITests/LoginsTests.swift
+++ b/Tests/XCUITests/LoginsTests.swift
@@ -163,6 +163,8 @@ class LoginTest: BaseTestCase {
     func testDeleteLogin() {
         saveLogin(givenUrl: testLoginPage)
         openLoginsSettings()
+        mozWaitForElementToExist(app.staticTexts[domain])
+        mozWaitForElementToExist(app.staticTexts[domainLogin])
         app.staticTexts[domain].tap()
         app.cells.staticTexts["Delete"].tap()
         mozWaitForElementToExist(app.alerts["Are you sure?"])
@@ -195,6 +197,8 @@ class LoginTest: BaseTestCase {
         saveLogin(givenUrl: testLoginPage)
         openLoginsSettings()
         // Enter on Search mode
+        mozWaitForElementToExist(app.searchFields["Filter"])
+        XCTAssert(app.searchFields["Filter"].isEnabled)
         app.searchFields["Filter"].tap()
         // Type Text that matches user, website
         app.searchFields["Filter"].typeText("test")
@@ -252,6 +256,12 @@ class LoginTest: BaseTestCase {
         navigator.goto(LoginsSettings)
         unlockLoginsView()
         mozWaitForElementToExist(app.tables["Login List"], timeout: 15)
+        mozWaitForElementToExist(app.navigationBars["Passwords"])
+        mozWaitForElementToExist(app.staticTexts["No logins found"])
+        mozWaitForElementToExist(app.buttons["Add"])
+        mozWaitForElementToExist(app.buttons["Edit"])
+        XCTAssertFalse(app.buttons["Edit"].isEnabled)
+        XCTAssertTrue(app.buttons["Add"].isEnabled)
         app.buttons["Add"].tap()
         mozWaitForElementToExist(app.tables["Add Credential"], timeout: 15)
         XCTAssertTrue(app.tables["Add Credential"].cells.staticTexts["Website"].exists)

--- a/Tests/XCUITests/NavigationTest.swift
+++ b/Tests/XCUITests/NavigationTest.swift
@@ -181,10 +181,9 @@ class NavigationTest: BaseTestCase {
     }
 
     func testLongPressOnAddressBar() throws {
-        if processIsTranslatedStr() == m1Rosetta {
-            // Long press on the URL requires copy & paste permission
-            throw XCTSkip("Copy & paste may not work on M1")
-        } else {
+        // Long press on the URL requires copy & paste permission
+        throw XCTSkip("Test needs to be updated")
+        /*
             // This test is for populated clipboard only so we need to make sure there's something in Pasteboard
             app.textFields["address"].typeText("www.google.com")
             // Tapping two times when the text is not selected will reveal the menu
@@ -239,6 +238,7 @@ class NavigationTest: BaseTestCase {
                 XCTAssertTrue(app.menuItems["Open Link"].exists)
             }
         }
+         */
     }
 
     private func longPressLinkOptions(optionSelected: String) {

--- a/Tests/XCUITests/ReadingListTests.swift
+++ b/Tests/XCUITests/ReadingListTests.swift
@@ -128,15 +128,11 @@ class ReadingListTests: BaseTestCase {
         XCTAssertTrue(savedToReadingList.exists)
 
         // Mark it as read/unread
-        if processIsTranslatedStr() == m1Rosetta {
-            throw XCTSkip("swipeLeft() does not work on M1")
-        } else {
-            savedToReadingList.swipeLeft()
-            mozWaitForElementToExist(app.tables.cells.buttons.staticTexts["Mark as  Read"], timeout: TIMEOUT)
-            app.tables["ReadingTable"].cells.buttons.element(boundBy: 1).tap()
-            savedToReadingList.swipeLeft()
-            mozWaitForElementToExist(app.tables.cells.buttons.staticTexts["Mark as  Unread"])
-        }
+        savedToReadingList.swipeLeft()
+        mozWaitForElementToExist(app.tables.cells.buttons.staticTexts["Mark as  Read"], timeout: TIMEOUT)
+        app.tables["ReadingTable"].cells.buttons.element(boundBy: 1).tap()
+        savedToReadingList.swipeLeft()
+        mozWaitForElementToExist(app.tables.cells.buttons.staticTexts["Mark as  Unread"])
     }
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2306998
@@ -149,15 +145,9 @@ class ReadingListTests: BaseTestCase {
         mozWaitForElementToExist(savedToReadingList)
 
         // Remove the item from reading list
-        if processIsTranslatedStr() == m1Rosetta {
-            savedToReadingList.press(forDuration: 2)
-            mozWaitForElementToExist(app.otherElements["Remove"])
-            app.otherElements["Remove"].tap()
-        } else {
-            savedToReadingList.swipeLeft()
-            mozWaitForElementToExist(app.buttons["Remove"])
-            app.buttons["Remove"].tap()
-        }
+        savedToReadingList.swipeLeft()
+        mozWaitForElementToExist(app.buttons["Remove"])
+        app.buttons["Remove"].tap()
         XCTAssertFalse(savedToReadingList.exists)
 
         // Reader list view should be empty

--- a/Tests/XCUITests/SearchTest.swift
+++ b/Tests/XCUITests/SearchTest.swift
@@ -239,6 +239,7 @@ class SearchTests: BaseTestCase {
             app.buttons[AccessibilityIdentifiers.Toolbar.searchButton].tap()
 
             let addressBar = app.textFields["address"]
+            mozWaitForElementToExist(addressBar)
             XCTAssertTrue(addressBar.value(forKey: "hasKeyboardFocus") as? Bool ?? false)
             let keyboardCount = app.keyboards.count
             XCTAssert(keyboardCount > 0, "The keyboard is not shown")
@@ -259,6 +260,7 @@ class SearchTests: BaseTestCase {
             XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.searchButton].label, "Search")
             app.buttons[AccessibilityIdentifiers.Toolbar.searchButton].tap()
 
+            mozWaitForElementToExist(addressBar)
             XCTAssertTrue(addressBar.value(forKey: "hasKeyboardFocus") as? Bool ?? false)
             let keyboardsCount = app.keyboards.count
             XCTAssert(keyboardsCount > 0, "The keyboard is not shown")

--- a/Tests/XCUITests/ThirdPartySearchTest.swift
+++ b/Tests/XCUITests/ThirdPartySearchTest.swift
@@ -21,13 +21,9 @@ class ThirdPartySearchTest: BaseTestCase {
         // Perform a search using a custom search engine
         app.textFields["url"].tap()
         mozWaitForElementToExist(app.buttons["urlBar-cancel"])
-        if processIsTranslatedStr() == m1Rosetta {
-            app.textFields.firstMatch.typeText("window")
-        } else {
-            UIPasteboard.general.string = "window"
-            app.textFields.firstMatch.press(forDuration: 1)
-            app.staticTexts["Paste"].tap()
-        }
+        UIPasteboard.general.string = "window"
+        app.textFields.firstMatch.press(forDuration: 1)
+        app.staticTexts["Paste"].tap()
         app.scrollViews.otherElements.buttons["Mozilla Engine search"].tap()
         waitUntilPageLoad()
 
@@ -50,13 +46,7 @@ class ThirdPartySearchTest: BaseTestCase {
 
         // Perform a search to check
         app.textFields["url"].tap()
-        if processIsTranslatedStr() == m1Rosetta {
-            app.textFields.firstMatch.typeText("window\n")
-        } else {
-            UIPasteboard.general.string = "window"
-            app.textFields.firstMatch.press(forDuration: 1)
-            app.staticTexts["Paste & Go"].tap()
-        }
+        app.textFields.firstMatch.typeText("window\n")
 
         waitUntilPageLoad()
 
@@ -76,13 +66,9 @@ class ThirdPartySearchTest: BaseTestCase {
         app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].tap()
         app.textFields["url"].tap()
         mozWaitForElementToExist(app.buttons["urlBar-cancel"])
-        if processIsTranslatedStr() == m1Rosetta {
-            app.textFields.firstMatch.typeText("window")
-        } else {
-            UIPasteboard.general.string = "window"
-            app.textFields.firstMatch.press(forDuration: 1)
-            app.staticTexts["Paste"].tap()
-        }
+        UIPasteboard.general.string = "window"
+        app.textFields.firstMatch.press(forDuration: 1)
+        app.staticTexts["Paste"].tap()
         mozWaitForElementToExist(app.scrollViews.otherElements.buttons["Mozilla Engine search"])
         XCTAssertTrue(app.scrollViews.otherElements.buttons["Mozilla Engine search"].exists)
 
@@ -101,13 +87,9 @@ class ThirdPartySearchTest: BaseTestCase {
         mozWaitForElementToExist(app.textFields["url"], timeout: 3)
         app.textFields["url"].tap()
         mozWaitForElementToExist(app.buttons["urlBar-cancel"])
-       if processIsTranslatedStr() == m1Rosetta {
-            app.textFields.firstMatch.typeText("window")
-        } else {
-            UIPasteboard.general.string = "window"
-            app.textFields.firstMatch.press(forDuration: 1)
-            app.staticTexts["Paste"].tap()
-        }
+        UIPasteboard.general.string = "window"
+        app.textFields.firstMatch.press(forDuration: 1)
+        app.staticTexts["Paste"].tap()
 
         mozWaitForElementToNotExist(app.scrollViews.otherElements.buttons["Mozilla Engine search"])
         XCTAssertFalse(app.scrollViews.otherElements.buttons["Mozilla Engine search"].exists)
@@ -140,15 +122,10 @@ class ThirdPartySearchTest: BaseTestCase {
 
         XCTAssertTrue(customengineurlTextView.exists)
 
-        if processIsTranslatedStr() == m1Rosetta {
-            customengineurlTextView.tap()
-            tablesQuery.textViews["customEngineUrl"].typeText(searchUrl)
-        } else {
-            UIPasteboard.general.string = searchUrl
-            customengineurlTextView.tap()
-            customengineurlTextView.press(forDuration: 2.0)
-            app.staticTexts["Paste"].tap()
-        }
+        UIPasteboard.general.string = searchUrl
+        customengineurlTextView.tap()
+        customengineurlTextView.press(forDuration: 2.0)
+        app.staticTexts["Paste"].tap()
 
         mozWaitForElementToExist(app.buttons["customEngineSaveButton"], timeout: 3)
         app.buttons["customEngineSaveButton"].tap()

--- a/Tests/XCUITests/ToolbarMenuTests.swift
+++ b/Tests/XCUITests/ToolbarMenuTests.swift
@@ -34,7 +34,6 @@ class ToolbarMenuTests: BaseTestCase {
         validateMenuOptions()
         XCUIDevice.shared.orientation = .landscapeLeft
         mozWaitForElementToExist(hamburgerMenu, timeout: 15)
-        mozWaitForElementToExist(app.textFields["url"])
         mozWaitForElementToNotExist(app.tables["Context Menu"])
         mozWaitForElementToExist(app.textFields["url"])
         mozWaitForElementToExist(app.webViews["contentView"])

--- a/Tests/XCUITests/ToolbarMenuTests.swift
+++ b/Tests/XCUITests/ToolbarMenuTests.swift
@@ -18,10 +18,14 @@ class ToolbarMenuTests: BaseTestCase {
         let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
         let firstPocketCell = app.collectionViews.cells["PocketCell"].firstMatch
         let bookmarksButton = app.buttons[AccessibilityIdentifiers.Toolbar.bookmarksButton]
+        mozWaitForElementToExist(hamburgerMenu)
+        mozWaitForElementToExist(firstPocketCell)
         if iPad() {
+            mozWaitForElementToExist(bookmarksButton)
             XCTAssertTrue(hamburgerMenu.isRightOf(rightElement: bookmarksButton), "Menu button is not on the right side of bookmarks button")
             XCTAssertTrue(hamburgerMenu.isAbove(element: firstPocketCell), "Menu button is not above the pocket cells area")
         } else {
+            mozWaitForElementToExist(tabsButton)
             XCTAssertTrue(hamburgerMenu.isRightOf(rightElement: tabsButton), "Menu button is not on the right side of tabs button")
             XCTAssertTrue(hamburgerMenu.isBelow(element: firstPocketCell), "Menu button is not below the pocket cells area")
         }
@@ -30,6 +34,7 @@ class ToolbarMenuTests: BaseTestCase {
         validateMenuOptions()
         XCUIDevice.shared.orientation = .landscapeLeft
         mozWaitForElementToExist(hamburgerMenu, timeout: 15)
+        mozWaitForElementToExist(app.textFields["url"])
         mozWaitForElementToNotExist(app.tables["Context Menu"])
         mozWaitForElementToExist(app.textFields["url"])
         mozWaitForElementToExist(app.webViews["contentView"])

--- a/Tests/XCUITests/ToolbarMenuTests.swift
+++ b/Tests/XCUITests/ToolbarMenuTests.swift
@@ -31,11 +31,16 @@ class ToolbarMenuTests: BaseTestCase {
         XCUIDevice.shared.orientation = .landscapeLeft
         mozWaitForElementToExist(hamburgerMenu, timeout: 15)
         mozWaitForElementToNotExist(app.tables["Context Menu"])
+        mozWaitForElementToExist(app.textFields["url"])
+        mozWaitForElementToExist(app.webViews["contentView"])
         if iPad() {
+            mozWaitForElementToExist(bookmarksButton)
             XCTAssertTrue(hamburgerMenu.isRightOf(rightElement: bookmarksButton), "Menu button is not on the right side of bookmarks button")
         } else {
+            mozWaitForElementToExist(tabsButton)
             XCTAssertTrue(hamburgerMenu.isRightOf(rightElement: tabsButton), "Menu button is not on the right side of tabs button")
         }
+        mozWaitForElementToExist(firstPocketCell)
         XCTAssertTrue(hamburgerMenu.isAbove(element: firstPocketCell), "Menu button is not below the pocket cells area")
         hamburgerMenu.tap()
         mozWaitForElementToExist(app.tables["Context Menu"])


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-725)

## :bulb: Description

https://github.com/mozilla-mobile/firefox-ios/pull/16602 allows us to use native M1 binaries to run Firefox iOS instead of relying on Rosetta emulation. Now we can remove the M1-Rosetta workarounds. In addition, since the tests are running faster (saving approx 1/6 of time) there are some tests that fail due to the app not ready to be tapped. Some additional mozWait* have been added.

(cherry picked from https://github.com/mozilla-mobile/firefox-ios/pull/16653)

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

