### PR TITLE
Add FXIOS-7496 [v120] Record extra keys for surfaceDisplayed telemetry event

### DIFF
--- a/Client/Frontend/Fakespot/FakespotViewController.swift
+++ b/Client/Frontend/Fakespot/FakespotViewController.swift
@@ -130,8 +130,7 @@ class FakespotViewController: UIViewController, Themeable, Notifiable, UIAdaptiv
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         guard #available(iOS 15.0, *) else { return }
-        let currentDetent = viewModel.getCurrentDetent(for: presentationController)
-        viewModel.recordBottomSheetDisplayed(in: currentDetent == .large ? .fullView : .halfView)
+        viewModel.recordBottomSheetDisplayed(presentationController)
     }
 
     override func viewDidDisappear(_ animated: Bool) {

--- a/Client/Frontend/Fakespot/FakespotViewController.swift
+++ b/Client/Frontend/Fakespot/FakespotViewController.swift
@@ -113,7 +113,6 @@ class FakespotViewController: UIViewController, Themeable, Notifiable, UIAdaptiv
 
         setupView()
         listenForThemeChange(view)
-        viewModel.sendTelemetryOnAppear()
         viewModel.fetchProductIfOptedIn()
     }
 
@@ -126,6 +125,13 @@ class FakespotViewController: UIViewController, Themeable, Notifiable, UIAdaptiv
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         viewModel.isSwiping = false
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        guard #available(iOS 15.0, *) else { return }
+        let currentDetent = viewModel.getCurrentDetent(for: presentationController)
+        viewModel.recordBottomSheetDisplayed(in: currentDetent == .large ? .fullView : .halfView)
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -378,9 +384,8 @@ class FakespotViewController: UIViewController, Themeable, Notifiable, UIAdaptiv
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
         delegate?.fakespotControllerDidDismiss()
         guard #available(iOS 15.0, *) else { return }
-        guard let sheetPresentationController = presentationController as? UISheetPresentationController else { return }
+        let currentDetent = viewModel.getCurrentDetent(for: presentationController)
 
-        let currentDetent = sheetPresentationController.selectedDetentIdentifier
         if viewModel.isSwiping || currentDetent == .large {
             viewModel.recordDismissTelemetry(by: .swipingTheSurfaceHandle)
         } else {

--- a/Client/Frontend/Fakespot/FakespotViewModel.swift
+++ b/Client/Frontend/Fakespot/FakespotViewModel.swift
@@ -309,12 +309,15 @@ class FakespotViewModel {
         )
     }
 
-    func recordBottomSheetDisplayed(in state: TelemetryWrapper.EventExtraKey.Shopping) {
+    @available(iOS 15.0, *)
+    func recordBottomSheetDisplayed(_ presentedController: UIPresentationController?) {
+        let currentDetent = getCurrentDetent(for: presentedController)
+        let state: TelemetryWrapper.EventExtraKey.Shopping = currentDetent == .large ? .fullView : .halfView
         TelemetryWrapper.recordEvent(
             category: .action,
             method: .view,
             object: .shoppingBottomSheet,
-            extras: [TelemetryWrapper.ExtraKey.action.rawValue: state.rawValue]
+            extras: [TelemetryWrapper.ExtraKey.size.rawValue: state.rawValue]
         )
     }
 }

--- a/Client/Frontend/Fakespot/FakespotViewModel.swift
+++ b/Client/Frontend/Fakespot/FakespotViewModel.swift
@@ -293,6 +293,12 @@ class FakespotViewModel {
         observeProductTask?.cancel()
     }
 
+    @available(iOS 15.0, *)
+    func getCurrentDetent(for presentedController: UIPresentationController?) -> UISheetPresentationController.Detent.Identifier? {
+        guard let sheetController = presentedController as? UISheetPresentationController else { return nil }
+        return sheetController.selectedDetentIdentifier
+    }
+
     // MARK: - Telemetry
     func recordDismissTelemetry(by action: TelemetryWrapper.EventExtraKey.Shopping) {
         TelemetryWrapper.recordEvent(
@@ -303,9 +309,12 @@ class FakespotViewModel {
         )
     }
 
-    func sendTelemetryOnAppear() {
-        TelemetryWrapper.recordEvent(category: .action,
-                                     method: .view,
-                                     object: .shoppingBottomSheet)
+    func recordBottomSheetDisplayed(in state: TelemetryWrapper.EventExtraKey.Shopping) {
+        TelemetryWrapper.recordEvent(
+            category: .action,
+            method: .view,
+            object: .shoppingBottomSheet,
+            extras: [TelemetryWrapper.ExtraKey.action.rawValue: state.rawValue]
+        )
     }
 }

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -729,11 +729,15 @@ extension TelemetryWrapper {
 
         // Shopping Experience
         public enum Shopping: String {
+            // Extra Keys for `surface_closed` event
             case clickOutside = "click-outside"
             case interactionWithALink = "interaction-with-a-link"
             case swipingTheSurfaceHandle = "swiping-the-surface-handle"
             case optingOutOfTheFeature = "opting-out-of-the-feature"
             case closeButton = "close-button"
+            // Extra Keys for `surface_displayed` event
+            case halfView = "half-view"
+            case fullView = "full-view"
         }
     }
 
@@ -1069,8 +1073,18 @@ extension TelemetryWrapper {
             }
         case (.action, .tap, .shoppingRecentReviews, _, _):
             GleanMetrics.Shopping.surfaceShowMoreRecentReviewsClicked.record()
-        case (.action, .view, .shoppingBottomSheet, _, _):
-            GleanMetrics.Shopping.surfaceDisplayed.record()
+        case (.action, .view, .shoppingBottomSheet, _, let extras):
+            if let action = extras?[EventExtraKey.action.rawValue] as? String {
+                let actionExtra = GleanMetrics.Shopping.SurfaceDisplayedExtra(action: action)
+                GleanMetrics.Shopping.surfaceDisplayed.record(actionExtra)
+            } else {
+                recordUninstrumentedMetrics(
+                    category: category,
+                    method: method,
+                    object: object,
+                    value: value,
+                    extras: extras)
+            }
         case (.action, .tap, .shoppingSettingsCardTurnOffButton, _, _):
             GleanMetrics.Shopping.settingsComponentOptedOut.record()
         case (.action, .view, .shoppingSettingsChevronButton, _, _):

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -666,6 +666,7 @@ extension TelemetryWrapper {
         case preferenceChanged = "to"
         case isPrivate = "is-private"
         case action = "action"
+        case size = "size"
 
         case wallpaperName = "wallpaperName"
         case wallpaperType = "wallpaperType"
@@ -1074,9 +1075,9 @@ extension TelemetryWrapper {
         case (.action, .tap, .shoppingRecentReviews, _, _):
             GleanMetrics.Shopping.surfaceShowMoreRecentReviewsClicked.record()
         case (.action, .view, .shoppingBottomSheet, _, let extras):
-            if let action = extras?[EventExtraKey.action.rawValue] as? String {
-                let actionExtra = GleanMetrics.Shopping.SurfaceDisplayedExtra(action: action)
-                GleanMetrics.Shopping.surfaceDisplayed.record(actionExtra)
+            if let size = extras?[EventExtraKey.size.rawValue] as? String {
+                let sizeExtra = GleanMetrics.Shopping.SurfaceDisplayedExtra(size: size)
+                GleanMetrics.Shopping.surfaceDisplayed.record(sizeExtra)
             } else {
                 recordUninstrumentedMetrics(
                     category: category,

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -706,7 +706,7 @@ shopping:
     description: |
       Records when the surface (bottom sheet) is displayed
     extra_keys:
-      action:
+      size:
         type: string
         description: |
           Records the state of the bottom sheet:

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -705,6 +705,12 @@ shopping:
     type: event
     description: |
       Records when the surface (bottom sheet) is displayed
+    extra_keys:
+      action:
+        type: string
+        description: |
+          Records the state of the bottom sheet:
+          "half-view / full-view"
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/16248
     data_reviews:

--- a/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -297,8 +297,21 @@ class TelemetryWrapperTests: XCTestCase {
         testEventMetricRecordingSuccess(metric: GleanMetrics.Shopping.surfaceShowMoreRecentReviewsClicked)
 	}
 
-    func test_shoppingSurfaceDisplayed_GleanIsCalled() {
-        TelemetryWrapper.recordEvent(category: .action, method: .view, object: .shoppingBottomSheet)
+    func test_shoppingSurfaceDisplayeddWithExtras_GleanIsCalledFullViewState() {
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .view,
+                                     object: .shoppingBottomSheet,
+                                     extras: [TelemetryWrapper.ExtraKey.action.rawValue:
+                                                TelemetryWrapper.EventExtraKey.Shopping.fullView.rawValue])
+        testEventMetricRecordingSuccess(metric: GleanMetrics.Shopping.surfaceDisplayed)
+    }
+
+    func test_shoppingSurfaceDisplayeddWithExtras_GleanIsCalledHalfViewState() {
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .view,
+                                     object: .shoppingBottomSheet,
+                                     extras: [TelemetryWrapper.ExtraKey.action.rawValue:
+                                                TelemetryWrapper.EventExtraKey.Shopping.halfView.rawValue])
         testEventMetricRecordingSuccess(metric: GleanMetrics.Shopping.surfaceDisplayed)
     }
 

--- a/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -301,7 +301,7 @@ class TelemetryWrapperTests: XCTestCase {
         TelemetryWrapper.recordEvent(category: .action,
                                      method: .view,
                                      object: .shoppingBottomSheet,
-                                     extras: [TelemetryWrapper.ExtraKey.action.rawValue:
+                                     extras: [TelemetryWrapper.ExtraKey.size.rawValue:
                                                 TelemetryWrapper.EventExtraKey.Shopping.fullView.rawValue])
         testEventMetricRecordingSuccess(metric: GleanMetrics.Shopping.surfaceDisplayed)
     }
@@ -310,7 +310,7 @@ class TelemetryWrapperTests: XCTestCase {
         TelemetryWrapper.recordEvent(category: .action,
                                      method: .view,
                                      object: .shoppingBottomSheet,
-                                     extras: [TelemetryWrapper.ExtraKey.action.rawValue:
+                                     extras: [TelemetryWrapper.ExtraKey.size.rawValue:
                                                 TelemetryWrapper.EventExtraKey.Shopping.halfView.rawValue])
         testEventMetricRecordingSuccess(metric: GleanMetrics.Shopping.surfaceDisplayed)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7496)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16638)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Record extra keys for the state of the surface when is displayed:
- half-view 
- full-view

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

