### PR TITLE
Bug MTE-1687 [v120] Rename Performance Test Treeherder Symbol

### DIFF
--- a/taskcluster/ci/bitrise-performance/kind.yml
+++ b/taskcluster/ci/bitrise-performance/kind.yml
@@ -17,7 +17,7 @@ tasks:
         description: Run Performance Tests on iOS Simulator in Bitrise
         run-on-tasks-for: []
         treeherder:
-            symbol: bitrise-performance
+            symbol: bitrise-perf
             kind: test
-            platform: ios-simulator-iphone14-16.4/opt
+            platform: ios-simulator-iphone14-16-4/opt
             tier: 1

--- a/taskcluster/ci/firebase-performance/kind.yml
+++ b/taskcluster/ci/firebase-performance/kind.yml
@@ -17,7 +17,7 @@ tasks:
         description: Run Performance Tests on Physical Devices in Firebase
         run-on-tasks-for: []
         treeherder:
-            symbol: firebase-performance
+            symbol: firebase-perf
             kind: test
-            platform: ios-physical-iphone13pro-15.7/opt
+            platform: ios-physical-iphone13pro-15-7/opt
             tier: 1


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1687)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Updating treeherder symbol and platform name to avoid potential collisions and parsing issues for perfherder.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

