### PR TITLE
Bump [v120] Update Sentry to version 8.13.0

### DIFF
--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
             exact: "2.0.0"),
         .package(
             url: "https://github.com/getsentry/sentry-cocoa.git",
-            exact: "8.9.3"),
+            exact: "8.13.0"),
     ],
     targets: [
         .target(

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -19355,7 +19355,7 @@
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa.git";
 			requirement = {
 				kind = exactVersion;
-				version = 8.9.3;
+				version = 8.13.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "259d8bc75aa4028416535d35840ff19fc7661292",
-        "version" : "8.9.3"
+        "revision" : "0a915b93ff3abee1a9752448e47808334d306980",
+        "version" : "8.13.0"
       }
     },
     {


### PR DESCRIPTION
Changes since last update:
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.9.4
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.9.5
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.9.6
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.10.0
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.11.0
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.12.0
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.13.0

When reviewing this, if you could also do the same for the accompanying Focus PR (https://github.com/mozilla-mobile/focus-ios/pull/3874), I would appreciate it. Thanks!