### PR TITLE
Refactor FXIOS-6932 [v120] Additional wiring for new Sync tab and table cells

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		1D2F68AD2ACB266300524B92 /* RemoteTabsPanelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2F68AC2ACB266300524B92 /* RemoteTabsPanelState.swift */; };
 		1D2F68AF2ACB272500524B92 /* RemoteTabsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2F68AE2ACB272500524B92 /* RemoteTabsTableViewController.swift */; };
 		1D2F68B12ACCA22000524B92 /* RemoteTabsEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2F68B02ACCA22000524B92 /* RemoteTabsEmptyView.swift */; };
+		1D3C90882ACE1AF400304C87 /* RemoteTabPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3C90872ACE1AF400304C87 /* RemoteTabPanelTests.swift */; };
 		1D69FF8D27B17286001F660E /* HomeLogoHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D69FF8C27B17285001F660E /* HomeLogoHeaderCell.swift */; };
 		1D9E1FE524FEF56C006E561D /* TopSites in Resources */ = {isa = PBXBuildFile; fileRef = 3BC659481E5BA4AE006D560F /* TopSites */; };
 		1DA3CE5D24EEE73100422BB2 /* OpenTabsWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA3CE5C24EEE73100422BB2 /* OpenTabsWidget.swift */; };
@@ -2077,6 +2078,7 @@
 		1D2F68AC2ACB266300524B92 /* RemoteTabsPanelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabsPanelState.swift; sourceTree = "<group>"; };
 		1D2F68AE2ACB272500524B92 /* RemoteTabsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabsTableViewController.swift; sourceTree = "<group>"; };
 		1D2F68B02ACCA22000524B92 /* RemoteTabsEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabsEmptyView.swift; sourceTree = "<group>"; };
+		1D3C90872ACE1AF400304C87 /* RemoteTabPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabPanelTests.swift; sourceTree = "<group>"; };
 		1D69FF8C27B17285001F660E /* HomeLogoHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeLogoHeaderCell.swift; sourceTree = "<group>"; };
 		1D774B3D9C6E21B77FB7B38F /* kab */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kab; path = kab.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
 		1D90440B860A503D4DBA4213 /* cy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cy; path = cy.lproj/Storage.strings; sourceTree = "<group>"; };
@@ -2706,8 +2708,8 @@
 		4315C1E528EAF9C300BA61F5 /* be */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = be; path = be.lproj/Shared.strings; sourceTree = "<group>"; };
 		4315C1E628EAF9C300BA61F5 /* be */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = be; path = be.lproj/ToolbarLocation.strings; sourceTree = "<group>"; };
 		4315F5832A1B87DE00D6BA24 /* sl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sl; path = sl.lproj/FirefoxSync.strings; sourceTree = "<group>"; };
-		43169E8F2ACAE188007FEA66 /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/Share.strings; sourceTree = "<group>"; };
 		43162A2E2492DB7800F91658 /* EmptyPrivateTabsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyPrivateTabsView.swift; sourceTree = "<group>"; };
+		43169E8F2ACAE188007FEA66 /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/Share.strings; sourceTree = "<group>"; };
 		4316B10328D8876A004F010C /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = th; path = th.lproj/JumpBackIn.strings; sourceTree = "<group>"; };
 		4316B7072A5C213B00F9EBBA /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/CustomizeFirefoxHome.strings; sourceTree = "<group>"; };
 		4316B7082A5C213B00F9EBBA /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/SelectCreditCard.strings; sourceTree = "<group>"; };
@@ -10512,6 +10514,7 @@
 				0BA896491A250E6500C1010C /* ProfileTest.swift */,
 				8A11C8102731CFD700AC7318 /* ReaderModeStyleTests.swift */,
 				03CCC9171AF05E7300DBF30D /* RelativeDatesTests.swift */,
+				1D3C90872ACE1AF400304C87 /* RemoteTabPanelTests.swift */,
 				8A5C3BC4282ABF8E003A8CCF /* LegacyRemoteTabsPanelTests.swift */,
 				F80D53CD2A09A30F0047ED14 /* RustSyncManagerTests.swift */,
 				8A5D1CA12A30CF2E005AD35C /* Settings */,
@@ -13279,6 +13282,7 @@
 				3B61CD591F2A750800D38DE1 /* PocketFeedTests.swift in Sources */,
 				C8E1BC0A28085AA700C62964 /* NimbusFeatureFlagLayerTests.swift in Sources */,
 				F80D53CF2A09A3350047ED14 /* RustSyncManagerTests.swift in Sources */,
+				1D3C90882ACE1AF400304C87 /* RemoteTabPanelTests.swift in Sources */,
 				43446CF02412DDBE00F5C643 /* UpdateViewModelTests.swift in Sources */,
 				8A93F86829D373B0004159D9 /* MockNavigationController.swift in Sources */,
 				8AE1E1D927B1BD380024C45E /* UIStackViewExtensionsTests.swift in Sources */,

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
@@ -227,9 +227,7 @@ class RemoteTabsTableViewController: UITableViewController,
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        guard !isShowingEmptyView else { return 0 }
-
-        guard !hiddenSections.contains(section) else { return 0 }
+        guard !isShowingEmptyView, !hiddenSections.contains(section) else { return 0 }
         return state.clientAndTabs[section].tabs.count
     }
 

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
@@ -271,7 +271,8 @@ class RemoteTabsTableViewController: UITableViewController,
          hideTableViewSection(section)
     }
 
-    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    override func tableView(_ tableView: UITableView,
+                            didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: false)
         let tab = state.clientAndTabs[indexPath.section].tabs[indexPath.item]
         // Remote panel delegate for cell selection

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
@@ -192,7 +192,11 @@ class RemoteTabsTableViewController: UITableViewController,
     }
 
     func hideTableViewSection(_ section: Int) {
-        // TODO: Forthcoming as part of ongoing Redux refactors. [FXIOS-6942] & [FXIOS-7509]
+        if hiddenSections.contains(section) {
+            hiddenSections.remove(section)
+        } else {
+            hiddenSections.insert(section)
+        }
 
         refreshUI()
     }
@@ -217,22 +221,16 @@ class RemoteTabsTableViewController: UITableViewController,
     // MARK: - UITableView
 
     override func numberOfSections(in tableView: UITableView) -> Int {
-        if isShowingEmptyView {
-            return 0
-        } else {
-            // TODO: Show clients and tabs. Forthcoming. [FXIOS-6942]
-            return state.clientAndTabs.count
-        }
+        guard !isShowingEmptyView else { return 0 }
+        
+        return state.clientAndTabs.count
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        if isShowingEmptyView {
-            return 0
-        } else {
-            // TODO: Show clients and tabs. Forthcoming. [FXIOS-6942]
+        guard !isShowingEmptyView else { return 0 }
 
-            return state.clientAndTabs[section].tabs.count
-        }
+        guard !hiddenSections.contains(section) else { return 0 }
+        return state.clientAndTabs[section].tabs.count
     }
 
     override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
@@ -269,8 +267,8 @@ class RemoteTabsTableViewController: UITableViewController,
 
     @objc
     private func sectionHeaderTapped(sender: UIGestureRecognizer) {
-        // guard let section = sender.view?.tag else { return }
-        // collapsibleSectionDelegate?.hideTableViewSection(section)
+         guard let section = sender.view?.tag else { return }
+         hideTableViewSection(section)
     }
 
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
@@ -271,6 +271,13 @@ class RemoteTabsTableViewController: UITableViewController,
          hideTableViewSection(section)
     }
 
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: false)
+        let tab = state.clientAndTabs[indexPath.section].tabs[indexPath.item]
+        // Remote panel delegate for cell selection
+        remoteTabsPanel?.remoteTabsClientAndTabsDataSourceDidSelectURL(tab.URL, visitType: VisitType.typed)
+    }
+
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard let headerView = tableView.dequeueReusableHeaderFooterView(
             withIdentifier: SiteTableViewHeader.cellIdentifier) as? SiteTableViewHeader else { return nil }

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
@@ -222,7 +222,7 @@ class RemoteTabsTableViewController: UITableViewController,
 
     override func numberOfSections(in tableView: UITableView) -> Int {
         guard !isShowingEmptyView else { return 0 }
-        
+
         return state.clientAndTabs.count
     }
 

--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -263,7 +263,8 @@ class TabTrayViewController: UIViewController,
         case .privateTabs:
             return TabDisplayViewController(isPrivateMode: true)
         case .syncedTabs:
-            let panel = RemoteTabsPanel(state: RemoteTabsPanelState.emptyState())
+            let fakeData: [ClientAndTabs] = [ClientAndTabs(client: RemoteClient(guid: "123", name: "Test Client", modified: 0, type: "Test Type", formfactor: "Test", os: "Test", version: "v1.0", fxaDeviceId: "12345"), tabs: [RemoteTab(clientGUID: "123", URL: URL(string:"https://mozilla.com")!, title: "Mozilla Homepage", history: [], lastUsed: 0, icon: nil), RemoteTab(clientGUID: "123", URL: URL(string:"https://google.com")!, title: "Google Homepage", history: [], lastUsed: 0, icon: nil)])]
+            let panel = RemoteTabsPanel(state: RemoteTabsPanelState(refreshState: .loaded, clientAndTabs: fakeData, allowsRefresh: true, showingEmptyState: nil, syncIsSupported: true))
             panel.remotePanelDelegate = self
             return panel
         }

--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -435,6 +435,7 @@ class TabTrayViewController: UIViewController,
 
     func remotePanel(didSelectURL url: URL, visitType: VisitType) {
         TelemetryWrapper.recordEvent(category: .action, method: .open, object: .syncTab)
+        // TODO: Need to provide handler for didSelectURL. Forthcoming.
         self.didSelectUrl?(url, visitType)
         self.dismissVC()
     }

--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -263,8 +263,8 @@ class TabTrayViewController: UIViewController,
         case .privateTabs:
             return TabDisplayViewController(isPrivateMode: true)
         case .syncedTabs:
-            let fakeData: [ClientAndTabs] = [ClientAndTabs(client: RemoteClient(guid: "123", name: "Test Client", modified: 0, type: "Test Type", formfactor: "Test", os: "Test", version: "v1.0", fxaDeviceId: "12345"), tabs: [RemoteTab(clientGUID: "123", URL: URL(string:"https://mozilla.com")!, title: "Mozilla Homepage", history: [], lastUsed: 0, icon: nil), RemoteTab(clientGUID: "123", URL: URL(string:"https://google.com")!, title: "Google Homepage", history: [], lastUsed: 0, icon: nil)])]
-            let panel = RemoteTabsPanel(state: RemoteTabsPanelState(refreshState: .loaded, clientAndTabs: fakeData, allowsRefresh: true, showingEmptyState: nil, syncIsSupported: true))
+            let state = RemoteTabsPanelState.emptyState() // Temporary
+            let panel = RemoteTabsPanel(state: state)
             panel.remotePanelDelegate = self
             return panel
         }

--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -263,7 +263,7 @@ class TabTrayViewController: UIViewController,
         case .privateTabs:
             return TabDisplayViewController(isPrivateMode: true)
         case .syncedTabs:
-            let state = RemoteTabsPanelState.emptyState() // Temporary
+            let state = RemoteTabsPanelState.emptyState() // Temporary. [FXIOS-6942]
             let panel = RemoteTabsPanel(state: state)
             panel.remotePanelDelegate = self
             return panel
@@ -436,7 +436,7 @@ class TabTrayViewController: UIViewController,
 
     func remotePanel(didSelectURL url: URL, visitType: VisitType) {
         TelemetryWrapper.recordEvent(category: .action, method: .open, object: .syncTab)
-        // TODO: Need to provide handler for didSelectURL. Forthcoming.
+        // TODO: [FXIOS-6928] Provide handler for didSelectURL.
         self.didSelectUrl?(url, visitType)
         self.dismissVC()
     }

--- a/Tests/ClientTests/RemoteTabPanelTests.swift
+++ b/Tests/ClientTests/RemoteTabPanelTests.swift
@@ -1,0 +1,64 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Storage
+import Shared
+import XCTest
+
+@testable import Client
+
+final class RemoteTabPanelTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        DependencyHelperMock().reset()
+    }
+
+    func testTableView_emptyStateNoRows() {
+        let remotePanel = createSubject(state: generateEmptyState())
+        let tableView = remotePanel.tableViewController.tableView
+
+        XCTAssertNotNil(tableView)
+        XCTAssertEqual(tableView!.numberOfSections, 0)
+    }
+
+    func testTableView_oneClientTwoRows() {
+        let remotePanel = createSubject(state: generateStateOneClientTwoTabs())
+        let tableView = remotePanel.tableViewController.tableView
+
+        XCTAssertNotNil(tableView)
+        XCTAssertEqual(tableView!.numberOfSections, 1)
+        XCTAssertEqual(tableView!.numberOfRows(inSection: 0), 2)
+    }
+
+    // MARK: - Private
+
+    private func generateEmptyState() -> RemoteTabsPanelState {
+        return RemoteTabsPanelState.emptyState()
+    }
+
+    private func generateStateOneClientTwoTabs() -> RemoteTabsPanelState {
+        let fakeTabs: [RemoteTab] = [RemoteTab(clientGUID: "123", URL: URL(string: "https://mozilla.com")!, title: "Mozilla Homepage", history: [], lastUsed: 0, icon: nil), RemoteTab(clientGUID: "123", URL: URL(string: "https://google.com")!, title: "Google Homepage", history: [], lastUsed: 0, icon: nil)]
+        let fakeData: [ClientAndTabs] = [ClientAndTabs(client: RemoteClient(guid: "123", name: "Test Client", modified: 0, type: "Test Type", formfactor: "Test", os: "Test", version: "v1.0", fxaDeviceId: "12345"), tabs: fakeTabs)]
+        return RemoteTabsPanelState(refreshState: .loaded,
+                                    clientAndTabs: fakeData,
+                                    allowsRefresh: true,
+                                    showingEmptyState: nil,
+                                    syncIsSupported: true)
+    }
+
+    private func createSubject(state: RemoteTabsPanelState,
+                               file: StaticString = #file,
+                               line: UInt = #line) -> RemoteTabsPanel {
+        let subject = RemoteTabsPanel(state: state)
+
+        trackForMemoryLeaks(subject, file: file, line: line)
+        return subject
+    }
+}

--- a/Tests/ClientTests/RemoteTabPanelTests.swift
+++ b/Tests/ClientTests/RemoteTabPanelTests.swift
@@ -44,8 +44,28 @@ final class RemoteTabPanelTests: XCTestCase {
     }
 
     private func generateStateOneClientTwoTabs() -> RemoteTabsPanelState {
-        let fakeTabs: [RemoteTab] = [RemoteTab(clientGUID: "123", URL: URL(string: "https://mozilla.com")!, title: "Mozilla Homepage", history: [], lastUsed: 0, icon: nil), RemoteTab(clientGUID: "123", URL: URL(string: "https://google.com")!, title: "Google Homepage", history: [], lastUsed: 0, icon: nil)]
-        let fakeData: [ClientAndTabs] = [ClientAndTabs(client: RemoteClient(guid: "123", name: "Test Client", modified: 0, type: "Test Type", formfactor: "Test", os: "Test", version: "v1.0", fxaDeviceId: "12345"), tabs: fakeTabs)]
+        let tab1 = RemoteTab(clientGUID: "123",
+                             URL: URL(string: "https://mozilla.com")!,
+                             title: "Mozilla Homepage",
+                             history: [],
+                             lastUsed: 0,
+                             icon: nil)
+        let tab2 = RemoteTab(clientGUID: "123",
+                             URL: URL(string: "https://google.com")!,
+                             title: "Google Homepage",
+                             history: [],
+                             lastUsed: 0,
+                             icon: nil)
+        let fakeTabs: [RemoteTab] = [tab1, tab2]
+        let client = RemoteClient(guid: "123",
+                                  name: "Client",
+                                  modified: 0,
+                                  type: "Type (Test)",
+                                  formfactor: "Test",
+                                  os: "macOS",
+                                  version: "v1.0",
+                                  fxaDeviceId: "12345")
+        let fakeData = [ClientAndTabs(client: client, tabs: fakeTabs)]
         return RemoteTabsPanelState(refreshState: .loaded,
                                     clientAndTabs: fakeData,
                                     allowsRefresh: true,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6932)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15411)

## :bulb: Description

This adds support in the new redux-based Sync tab for configuring the client headers and tab cells using data from the Redux state (which has a property which continues to use `ClientAndTabs`). For now it's reusing the existing header views and cells, per team feedback, since there doesn't seem to be any need to duplicate those, and they're used in several places in the app. 

Also adds wiring to support collapsing the section headers to match previous functionality and some initial unit tests for the new remote panel.

Note: aspects of the new sync tab are still a work-in-progress, additional updates forthcoming.

## 🖼️ Screenshot

![test](https://github.com/mozilla-mobile/firefox-ios/assets/145381717/a155d27d-c7db-4f1c-96a9-1251001b420d)

<img width="553" alt="Screenshot 2023-10-04 at 5 02 06 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/145381717/a81b3184-63b9-40b2-a520-a18211bf275a">

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

