### PR TITLE
Refactor FXIOS-7522 Update VisitType to match Destkop and Rust

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -19479,7 +19479,7 @@
 			repositoryURL = "https://github.com/mozilla/rust-components-swift.git";
 			requirement = {
 				kind = exactVersion;
-				version = 120.0.20231014050328;
+				version = 120.0.20231016222808;
 			};
 		};
 		435C85EE2788F4D00072B526 /* XCRemoteSwiftPackageReference "glean-swift" */ = {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla/rust-components-swift.git",
       "state" : {
-        "revision" : "314c701c77865a009c1ac9cd13b769f95af67baa",
-        "version" : "120.0.20231014050328"
+        "revision" : "40a6bacc8f138b1a8b0001f02605dc33d546d022",
+        "version" : "120.0.20231016222808"
       }
     },
     {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2627,7 +2627,7 @@ extension BrowserViewController: TabTrayDelegate {
 
     func tabTrayOpenRecentlyClosedTab(_ url: URL) {
         guard let tab = self.tabManager.selectedTab else { return }
-        self.finishEditingAndSubmit(url, visitType: .recentlyClosed, forTab: tab)
+        self.finishEditingAndSubmit(url, visitType: .link, forTab: tab)
     }
 
     // This function animates and resets the tab chrome transforms when

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -353,17 +353,17 @@ open class BrowserProfile: Profile {
 
     @objc
     func onLocationChange(notification: NSNotification) {
-        if let v = notification.userInfo!["visitType"] as? Int,
-           let visitType = VisitType(rawValue: v),
-           let url = notification.userInfo!["url"] as? URL, !isIgnoredURL(url),
-           let title = notification.userInfo!["title"] as? NSString {
+        let v = notification.userInfo!["visitType"] as? Int
+        let visitType = VisitType.fromRawValue(rawValue: v)
+        if let url = notification.userInfo!["url"] as? URL, !isIgnoredURL(url),
+        let title = notification.userInfo!["title"] as? NSString {
             // Only record local vists if the change notification originated from a non-private tab
             if !(notification.userInfo!["isPrivate"] as? Bool ?? false) {
                 let result = self.places.applyObservation(
                     visitObservation: VisitObservation(
                         url: url.description,
                         title: title as String,
-                        visitType: VisitTransition.fromVisitType(visitType: visitType)
+                        visitType: visitType
                     )
                 )
                 result.upon { result in

--- a/Storage/SQL/SQLiteHistoryFactories.swift
+++ b/Storage/SQL/SQLiteHistoryFactories.swift
@@ -30,7 +30,7 @@ extension BrowserDBSQLite {
 
         let latest = max(local, remote, either)
         if latest > 0 {
-            site.latestVisit = Visit(date: latest, type: VisitType.unknown)
+            site.latestVisit = Visit(date: latest, type: .link)
         }
         return site
     }

--- a/Storage/Visit.swift
+++ b/Storage/Visit.swift
@@ -5,45 +5,6 @@
 import Foundation
 import Shared
 
-// These are taken from the Places docs
-// http://mxr.mozilla.org/mozilla-central/source/toolkit/components/places/nsINavHistoryService.idl#1187
-@objc
-public enum VisitType: Int, CaseIterable {
-    case unknown
-
-    /**
-     * This transition type means the user followed a link and got a new toplevel
-     * window.
-     */
-    case link
-
-    /**
-     * This transition type means that the user typed the page's URL in the
-     * URL bar or selected it from URL bar autocomplete results, clicked on
-     * it from a history query (from the History sidebar, History menu,
-     * or history query in the personal toolbar or Places organizer).
-     */
-    case typed
-
-    case bookmark
-    case embed
-    case permanentRedirect
-    case temporaryRedirect
-    case download
-    case framedLink
-    case recentlyClosed
-}
-
-// WKWebView has these:
-/*
-WKNavigationTypeLinkActivated,
-WKNavigationTypeFormSubmitted,
-WKNavigationTypeBackForward,
-WKNavigationTypeReload,
-WKNavigationTypeFormResubmitted,
-WKNavigationTypeOther = -1,
-*/
-
 /**
  * SiteVisit is a sop to the existing API, which expects to be able to go
  * backwards from a visit to a site, and preserve the ID of the database row.
@@ -66,24 +27,9 @@ open class Visit: Hashable {
         hasher.combine(type)
     }
 
-    public init(date: MicrosecondTimestamp, type: VisitType = .unknown) {
+    public init(date: MicrosecondTimestamp, type: VisitType = .link) {
         self.date = date
         self.type = type
-    }
-
-    open class func fromJSON(_ json: [String: Any]) -> Visit? {
-        if let type = json["type"] as? Int,
-            let typeEnum = VisitType(rawValue: type),
-            let date = json["date"] as? Int64, date >= 0 {
-                return Visit(date: MicrosecondTimestamp(date), type: typeEnum)
-        }
-        return nil
-    }
-
-    open func toJSON() -> [String: Any] {
-        let d = NSNumber(value: self.date)
-        let o: [String: Any] = ["type": self.type.rawValue, "date": d]
-        return o
     }
 }
 
@@ -103,7 +49,7 @@ open class SiteVisit: Visit {
         hasher.combine(site.id)
     }
 
-    public init(site: Site, date: MicrosecondTimestamp, type: VisitType = .unknown) {
+    public init(site: Site, date: MicrosecondTimestamp, type: VisitType = .link) {
         self.site = site
         super.init(date: date, type: type)
     }

--- a/Tests/ClientTests/Frontend/Browser/TopSitesHelperTests.swift
+++ b/Tests/ClientTests/Frontend/Browser/TopSitesHelperTests.swift
@@ -189,7 +189,7 @@ extension TopSitesHelperTests {
 
     func addFrecencySitesToPlaces(_ sites: [Site], places: RustPlaces) {
         for site in sites {
-            let visit = VisitObservation(url: site.url, title: site.title, visitType: VisitTransition.link)
+            let visit = VisitObservation(url: site.url, title: site.title, visitType: .link)
             // force synchronous call
             _ = places.applyObservation(visitObservation: visit).value
         }

--- a/Tests/ClientTests/Library/HistoryPanelViewModelTests.swift
+++ b/Tests/ClientTests/Library/HistoryPanelViewModelTests.swift
@@ -250,7 +250,7 @@ class HistoryPanelViewModelTests: XCTestCase {
     }
 
     private func addSiteVisit(_ profile: MockProfile, url: String, title: String) {
-        let visitObservation = VisitObservation(url: url, title: title, visitType: VisitTransition.link)
+        let visitObservation = VisitObservation(url: url, title: title, visitType: .link)
         let result = profile.places.applyObservation(visitObservation: visitObservation)
 
         XCTAssertEqual(true, result.value.isSuccess, "Site added: \(url).")
@@ -291,7 +291,7 @@ class HistoryPanelViewModelTests: XCTestCase {
         for index in 0...3 {
             let site = Site(url: "http://site\(index).com", title: "Site \(index)")
             site.latestVisit = Visit(date: timestamp)
-            let visit = VisitObservation(url: site.url, title: site.title, visitType: VisitTransition.link, at: Int64(timestamp) / 1000)
+            let visit = VisitObservation(url: site.url, title: site.title, visitType: .link, at: Int64(timestamp) / 1000)
             XCTAssertTrue(profile.places.applyObservation(visitObservation: visit).value.isSuccess, "Site added: \(site.url).")
             groupSites.append(site)
         }

--- a/Tests/StorageTests/StorageTestUtils.swift
+++ b/Tests/StorageTests/StorageTestUtils.swift
@@ -45,7 +45,7 @@ func populateHistoryForFrecencyCalculations(_ places: RustPlaces, siteCount coun
 }
 
 func addVisitForSite(_ site: Site, intoPlaces places: RustPlaces, atTime: MicrosecondTimestamp) {
-    let visit = VisitObservation(url: site.url, visitType: VisitTransition.link, at: Int64(atTime) / 1000)
+    let visit = VisitObservation(url: site.url, visitType: .link, at: Int64(atTime) / 1000)
     _ = places.applyObservation(visitObservation: visit).value
 }
 


### PR DESCRIPTION
This should not land until https://github.com/mozilla/application-services/pull/5846 lands. However open to review.

1. One unfortunate thing is the VisitType has diverged slightly from a-s/android since they start link at `1` and iOS does at `2` however I've tested this and a +1 index on everything seems to be working fine via testing clicking on links. 
2. the previous enums `.unknown` and `.recentlyClosed` were just wrappers to `.link` so I also removed that layer of abstractness. This should allow us to be almost in-line with desktop/rust/android (even though one off from the enum index)

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7522)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16706)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

