### PR TITLE
Bug MTE-1691 [v120] Disable Firebase Error Override

### DIFF
--- a/Tests/PerformanceTestPlan.xctestplan
+++ b/Tests/PerformanceTestPlan.xctestplan
@@ -54,6 +54,8 @@
         "NoImageTests",
         "OnboardingTests",
         "OpeningScreenTests",
+        "PerformanceTests\/testPerfTabs_3_20tabTray()",
+        "PerformanceTests\/testPerfTabs_4_1280tabTray()",
         "PhotonActionSheetTest",
         "PocketTest",
         "PrivateBrowsingTest",

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1504,7 +1504,7 @@ workflows:
             ls /Users/vagrant/git/DerivedData/Build/Products
 
             cd DerivedData/Build/Products
-            zip -r Fennec_Enterprise.zip Fennec_Enterprise-iphoneos Fennec_Enterprise_PerformanceTestPlan_iphoneos16.4-arm64.xctestrun
+            zip -r Fennec_Enterprise.zip Fennec_Enterprise-iphoneos Fennec_Enterprise_PerformanceTestPlan_iphoneos16.6-arm64.xctestrun
             mv Fennec_Enterprise.zip /Users/vagrant/git/Fennec_Enterprise.zip
     - cache-pull@2.7.2:
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1547,16 +1547,13 @@ workflows:
             $HOME/google-cloud-sdk/bin/gcloud auth activate-service-account -q --key-file /tmp/key-file.json
             $HOME/google-cloud-sdk/bin/gcloud config set project "$GOOGLE_CLOUD_PROJECT"
 
-            # Firebase returns a non-zero exit code on test failure, which causes the script to exit
-            #     leaving FIREBASE_XCRESULT_PATH empty for the next step.
-            # We need to ignore any non-zero exit code for now until Firebase issues are fixed
             FIREBASE_TEST_RESULT=$($HOME/google-cloud-sdk/bin/gcloud firebase test ios run \
                 --test /Users/vagrant/git/Fennec_Enterprise.zip \
                 --device model="$DEVICE_MODEL",version="$DEVICE_VERSION" \
                 --client-details=matrixLabel="Bitrise" \
                 --num-flaky-test-attempts=2 \
                 --results-bucket="$GOOGLE_CLOUD_BUCKET" \
-                --results-dir="$RESULTS_DIR" || true)
+                --results-dir="$RESULTS_DIR")
 
 
             FIREBASE_XCRESULT_PATH=$($HOME/google-cloud-sdk/bin/gsutil ls $XCRESULT_PATH | grep ".xcresult")

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1538,8 +1538,8 @@ workflows:
             TIMESTAMP=$(date "+%Y%m%d%H%M%S")
             RESULTS_DIR="firefox_ios_performance_tests_$TIMESTAMP"
             GOOGLE_CLOUD_BUCKET="firefox_ios_test_artifacts"
-            DEVICE_MODEL="iphone13pro"
-            DEVICE_VERSION="15.7"
+            DEVICE_MODEL="iphone14pro" # if updating device model and version, also update firebase-performance.kind
+            DEVICE_VERSION="16.6"
             XCRESULT_PATH="gs://$GOOGLE_CLOUD_BUCKET/$RESULTS_DIR/$DEVICE_MODEL-$DEVICE_VERSION-en-portrait/TestLogs/"
 
             curl -o /tmp/key-file.json $BITRISEIO_GOOGLE_APPLICATION_CREDENTIALS_URL 

--- a/taskcluster/ci/firebase-performance/kind.yml
+++ b/taskcluster/ci/firebase-performance/kind.yml
@@ -19,5 +19,5 @@ tasks:
         treeherder:
             symbol: firebase-perf
             kind: test
-            platform: ios-physical-iphone13pro-15-7/opt
+            platform: ios-physical-iphone14pro-16-6/opt
             tier: 1


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
There was an error in firebase that caused device instability, which necessitated error overriding. I'm disabling the override as it swallows all errors, even legitimate  errors, which caused an unnoticed device failure.

I'm also updating the test to use a newer device, as the older device was a recommendation from firebase as a temporary work-around for the issue, which didn't work.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

