### PR TITLE
Refactor FXIOS-7509 [v120] Initial Redux wiring for Sync tab

### DIFF
--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanel.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanel.swift
@@ -119,8 +119,8 @@ class RemoteTabsPanel: UIViewController,
 
     private func subscribeRedux() {
         guard isReduxIntegrationEnabled else { return }
-        store.dispatch(RemoteTabsPanelAction.panelDidAppear)
         store.dispatch(ActiveScreensStateAction.showScreen(.remoteTabsPanel))
+        store.dispatch(RemoteTabsPanelAction.panelDidAppear)
         store.subscribe(self, transform: {
             return $0.select(RemoteTabsPanelState.init)
         })

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanel.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanel.swift
@@ -47,6 +47,7 @@ class RemoteTabsPanel: UIViewController,
 
     deinit {
         if isReduxIntegrationEnabled {
+            store.dispatch(ActiveScreensStateAction.closeScreen(.remoteTabsPanel))
             store.unsubscribe(self)
         }
     }

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanel.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanel.swift
@@ -11,7 +11,12 @@ import Redux
 class RemoteTabsPanel: UIViewController,
                        Themeable,
                        RemoteTabsClientAndTabsDataSourceDelegate,
-                       RemotePanelDelegateProvider {
+                       RemotePanelDelegateProvider,
+                       StoreSubscriber {
+    typealias SubscriberStateType = RemoteTabsPanelState
+
+    // MARK: - Properties
+
     private(set) var state: RemoteTabsPanelState
     var tableViewController: RemoteTabsTableViewController
     weak var remotePanelDelegate: RemotePanelDelegate?
@@ -20,10 +25,13 @@ class RemoteTabsPanel: UIViewController,
     var themeObserver: NSObjectProtocol?
     var notificationCenter: NotificationProtocol
 
-    init(state: RemoteTabsPanelState,
-         themeManager: ThemeManager = AppContainer.shared.resolve(),
+    lazy var isReduxIntegrationEnabled: Bool = ReduxFlagManager.isReduxEnabled
+
+    // MARK: - Initializer
+
+    init(themeManager: ThemeManager = AppContainer.shared.resolve(),
          notificationCenter: NotificationProtocol = NotificationCenter.default) {
-        self.state = state
+        self.state = RemoteTabsPanelState()
         self.themeManager = themeManager
         self.notificationCenter = notificationCenter
         self.tableViewController = RemoteTabsTableViewController(state: state)
@@ -37,7 +45,15 @@ class RemoteTabsPanel: UIViewController,
 
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
-    func observeNotifications() {
+    deinit {
+        if isReduxIntegrationEnabled {
+            store.unsubscribe(self)
+        }
+    }
+
+    // MARK: - Internal Utilities
+
+    private func observeNotifications() {
         // TODO: State to be provided by forthcoming Redux updates. TBD.
         // For now, continue to observe notifications.
         let notificationCenter = NotificationCenter.default
@@ -51,12 +67,25 @@ class RemoteTabsPanel: UIViewController,
                                        object: nil)
     }
 
+    @objc
+    func notificationReceived(_ notification: Notification) {
+        let name = notification.name
+        if name == .FirefoxAccountChanged || name == .ProfileDidFinishSyncing {
+            ensureMainThread {
+                self.tableViewController.refreshTabs(state: self.state)
+            }
+        }
+    }
+
+    // MARK: - View & Layout
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
         listenForThemeChange(view)
         setupLayout()
         applyTheme()
+        subscribeRedux()
     }
 
     private func setupLayout() {
@@ -81,19 +110,27 @@ class RemoteTabsPanel: UIViewController,
         tableViewController.refreshTabs(state: state)
     }
 
-    func forceRefreshTabs() {
+    // MARK: - Redux
+
+    private func forceRefreshTabs() {
         tableViewController.refreshTabs(state: state, updateCache: true)
     }
 
-    @objc
-    func notificationReceived(_ notification: Notification) {
-        let name = notification.name
-        if name == .FirefoxAccountChanged || name == .ProfileDidFinishSyncing {
-            ensureMainThread {
-                self.tableViewController.refreshTabs(state: self.state)
-            }
-        }
+    private func subscribeRedux() {
+        guard isReduxIntegrationEnabled else { return }
+        store.dispatch(RemoteTabsPanelAction.panelDidAppear)
+        store.dispatch(ActiveScreensStateAction.showScreen(.remoteTabsPanel))
+        store.subscribe(self, transform: {
+            return $0.select(RemoteTabsPanelState.init)
+        })
     }
+
+    func newState(state: RemoteTabsPanelState) {
+        self.state = state
+        tableViewController.newState(state: state)
+    }
+
+    // MARK: - RemoteTabsClientAndTabsDataSourceDelegate
 
     func remoteTabsClientAndTabsDataSourceDidSelectURL(_ url: URL, visitType: VisitType) {
         // Pass event along to our delegate

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelAction.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelAction.swift
@@ -5,7 +5,9 @@
 import Common
 import Redux
 
+/// Defines actions sent to Redux for Sync tab in tab tray
 enum RemoteTabsPanelAction: Action {
+    case panelDidAppear
     case refreshCachedTabs
     case refreshTabs
 }

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelState.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelState.swift
@@ -74,6 +74,7 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
     }
 
     static let reducer: Reducer<Self> = { state, action in
+        // TODO: Additional Reducer support forthcoming. [FXIOS-7512]
         switch action {
         default: return state
         }

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelState.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelState.swift
@@ -33,18 +33,35 @@ enum RemoteTabsPanelEmptyState {
 }
 
 /// State for RemoteTabsPanel. WIP.
-struct RemoteTabsPanelState {
+struct RemoteTabsPanelState: ScreenState, Equatable {
     let refreshState: RemoteTabsPanelRefreshState
     let clientAndTabs: [ClientAndTabs]
     let allowsRefresh: Bool                                // True if `hasSyncableAccount()`
     let showingEmptyState: RemoteTabsPanelEmptyState?      // If showing empty (or error) state
     let syncIsSupported: Bool                              // Reference: `prefs.boolForKey(PrefsKeys.TabSyncEnabled)`
 
-    static func emptyState() -> RemoteTabsPanelState {
-        return RemoteTabsPanelState(refreshState: .loaded,
-                                    clientAndTabs: [],
-                                    allowsRefresh: false,
-                                    showingEmptyState: .noTabs,
-                                    syncIsSupported: true)
+    init(_ appState: AppState) {
+//        guard let panelState = store.state.screenState(RemoteTabsPanelState.self, for: .remoteTabsPanel) else {
+//            self.init()
+//            logger.log("Error retrieving screen state",
+//                       level: .debug,
+//                       category: .redux)
+//        }
+//        self.init(
+        self.init()
+    }
+
+    init() {
+        refreshState = .loaded
+        clientAndTabs = []
+        allowsRefresh = false
+        showingEmptyState = .noTabs
+        syncIsSupported = false
+    }
+
+    static let reducer: Reducer<Self> = { state, action in
+        switch action {
+        default: return state
+        }
     }
 }

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelState.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelState.swift
@@ -41,22 +41,36 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
     let syncIsSupported: Bool                              // Reference: `prefs.boolForKey(PrefsKeys.TabSyncEnabled)`
 
     init(_ appState: AppState) {
-//        guard let panelState = store.state.screenState(RemoteTabsPanelState.self, for: .remoteTabsPanel) else {
-//            self.init()
-//            logger.log("Error retrieving screen state",
-//                       level: .debug,
-//                       category: .redux)
-//        }
-//        self.init(
-        self.init()
+        guard let panelState = store.state.screenState(RemoteTabsPanelState.self, for: .remoteTabsPanel) else {
+            self.init()
+            return
+        }
+
+        self.init(refreshState: panelState.refreshState,
+                  clientAndTabs: panelState.clientAndTabs,
+                  allowsRefresh: panelState.allowsRefresh,
+                  showingEmptyState: panelState.showingEmptyState,
+                  syncIsSupported: panelState.syncIsSupported)
     }
 
     init() {
-        refreshState = .loaded
-        clientAndTabs = []
-        allowsRefresh = false
-        showingEmptyState = .noTabs
-        syncIsSupported = false
+        self.init(refreshState: .loaded,
+                  clientAndTabs: [],
+                  allowsRefresh: true,
+                  showingEmptyState: .noTabs,
+                  syncIsSupported: true)
+    }
+
+    init(refreshState: RemoteTabsPanelRefreshState,
+         clientAndTabs: [ClientAndTabs],
+         allowsRefresh: Bool,
+         showingEmptyState: RemoteTabsPanelEmptyState?,
+         syncIsSupported: Bool) {
+        self.refreshState = refreshState
+        self.clientAndTabs = clientAndTabs
+        self.allowsRefresh = allowsRefresh
+        self.showingEmptyState = showingEmptyState
+        self.syncIsSupported = syncIsSupported
     }
 
     static let reducer: Reducer<Self> = { state, action in

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
@@ -81,7 +81,7 @@ class RemoteTabsTableViewController: UITableViewController,
         listenForThemeChange(view)
         applyTheme()
 
-        refreshUI()
+        reloadUI()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -107,13 +107,12 @@ class RemoteTabsTableViewController: UITableViewController,
 
     // MARK: - UI
 
-    func applyTheme() {
-        tableView.separatorColor = themeManager.currentTheme.colors.layerLightGrey30
-        emptyView.applyTheme(theme: themeManager.currentTheme)
-        // TODO: Ensure theme applied to any custom cells.
+    func newState(state: RemoteTabsPanelState) {
+        self.state = state
+        reloadUI()
     }
 
-    private func refreshUI() {
+    func reloadUI() {
         emptyView.isHidden = !isShowingEmptyView
 
         if isShowingEmptyView {
@@ -121,6 +120,12 @@ class RemoteTabsTableViewController: UITableViewController,
         }
 
         tableView.reloadData()
+    }
+
+    func applyTheme() {
+        tableView.separatorColor = themeManager.currentTheme.colors.layerLightGrey30
+        emptyView.applyTheme(theme: themeManager.currentTheme)
+        // TODO: Ensure theme applied to any custom cells.
     }
 
     private func configureEmptyView() {
@@ -162,7 +167,7 @@ class RemoteTabsTableViewController: UITableViewController,
     func updateDelegateClientAndTabData(_ clientAndTabs: [ClientAndTabs]) {
         // TODO: Forthcoming as part of ongoing tab tray Redux refactors. [FXIOS-6942] & [FXIOS-7509]
 
-        refreshUI()
+        reloadUI()
     }
 
     func refreshTabs(state: RemoteTabsPanelState, updateCache: Bool = false, completion: (() -> Void)? = nil) {
@@ -198,7 +203,7 @@ class RemoteTabsTableViewController: UITableViewController,
             hiddenSections.insert(section)
         }
 
-        refreshUI()
+        reloadUI()
     }
 
     func presentContextMenu(for site: Site, with indexPath: IndexPath,

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
@@ -124,8 +124,9 @@ class RemoteTabsTableViewController: UITableViewController,
 
     func applyTheme() {
         tableView.separatorColor = themeManager.currentTheme.colors.layerLightGrey30
-        emptyView.applyTheme(theme: themeManager.currentTheme)
-        // TODO: Ensure theme applied to any custom cells.
+        let theme = themeManager.currentTheme
+        emptyView.applyTheme(theme: theme)
+        tableView.visibleCells.forEach { ($0 as? ThemeApplicable)?.applyTheme(theme: theme) }
     }
 
     private func configureEmptyView() {

--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -263,8 +263,7 @@ class TabTrayViewController: UIViewController,
         case .privateTabs:
             return TabDisplayViewController(isPrivateMode: true)
         case .syncedTabs:
-            let state = RemoteTabsPanelState.emptyState() // Temporary. [FXIOS-6942]
-            let panel = RemoteTabsPanel(state: state)
+            let panel = RemoteTabsPanel()
             panel.remotePanelDelegate = self
             return panel
         }

--- a/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
+++ b/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
@@ -76,6 +76,7 @@ class ThemeSettingsController: ThemedTableViewController, StoreSubscriber {
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         if isReduxIntegrationEnabled {
+            store.dispatch(ActiveScreensStateAction.closeScreen(.themeSettings))
             store.unsubscribe(self)
         }
     }

--- a/Client/Redux/GlobalState/ActiveScreenAction.swift
+++ b/Client/Redux/GlobalState/ActiveScreenAction.swift
@@ -7,6 +7,7 @@ import Redux
 
 enum AppScreen {
     case themeSettings
+    case remoteTabsPanel
 }
 
 enum ActiveScreensStateAction: Action {

--- a/Client/Redux/GlobalState/ActiveScreenState.swift
+++ b/Client/Redux/GlobalState/ActiveScreenState.swift
@@ -7,10 +7,12 @@ import Redux
 
 enum AppScreenState: Equatable {
     case themeSettings(ThemeSettingsState)
+    case remoteTabsPanel(RemoteTabsPanelState)
 
     static let reducer: Reducer<Self> = { state, action in
         switch state {
         case .themeSettings(let state): return .themeSettings(ThemeSettingsState.reducer(state, action))
+        case .remoteTabsPanel(let state): return .remoteTabsPanel(RemoteTabsPanelState.reducer(state, action))
         }
     }
 }
@@ -34,7 +36,17 @@ struct ActiveScreensState: Equatable {
             case .showScreen(.themeSettings):
                 screens += [.themeSettings(ThemeSettingsState())]
             case .closeScreen(.themeSettings):
-                screens = []
+                screens = screens.filter({
+                    if case .themeSettings = $0 { return false }
+                    return true
+                })
+            case .showScreen(.remoteTabsPanel):
+                screens += [.remoteTabsPanel(RemoteTabsPanelState())]
+            case .closeScreen(.remoteTabsPanel):
+                screens = screens.filter({
+                    if case .remoteTabsPanel = $0 { return false }
+                    return true
+                })
             }
         }
 

--- a/Client/Redux/GlobalState/ActiveScreenState.swift
+++ b/Client/Redux/GlobalState/ActiveScreenState.swift
@@ -16,6 +16,7 @@ enum AppScreenState: Equatable {
         }
     }
 
+    /// Returns the matching AppScreen enum for a given AppScreenState
     var associatedAppScreen: AppScreen {
         switch self {
         case .themeSettings: return .themeSettings

--- a/Client/Redux/GlobalState/ActiveScreenState.swift
+++ b/Client/Redux/GlobalState/ActiveScreenState.swift
@@ -15,6 +15,13 @@ enum AppScreenState: Equatable {
         case .remoteTabsPanel(let state): return .remoteTabsPanel(RemoteTabsPanelState.reducer(state, action))
         }
     }
+
+    var associatedAppScreen: AppScreen {
+        switch self {
+        case .themeSettings: return .themeSettings
+        case .remoteTabsPanel: return .remoteTabsPanel
+        }
+    }
 }
 
 struct ActiveScreensState: Equatable {
@@ -33,20 +40,12 @@ struct ActiveScreensState: Equatable {
 
         if let action = action as? ActiveScreensStateAction {
             switch action {
+            case .closeScreen(let screenType):
+                screens = screens.filter({ return $0.associatedAppScreen != screenType })
             case .showScreen(.themeSettings):
                 screens += [.themeSettings(ThemeSettingsState())]
-            case .closeScreen(.themeSettings):
-                screens = screens.filter({
-                    if case .themeSettings = $0 { return false }
-                    return true
-                })
             case .showScreen(.remoteTabsPanel):
                 screens += [.remoteTabsPanel(RemoteTabsPanelState())]
-            case .closeScreen(.remoteTabsPanel):
-                screens = screens.filter({
-                    if case .remoteTabsPanel = $0 { return false }
-                    return true
-                })
             }
         }
 

--- a/Client/Redux/GlobalState/AppState.swift
+++ b/Client/Redux/GlobalState/AppState.swift
@@ -17,6 +17,8 @@ struct AppState: StateType {
             .compactMap {
                 switch ($0, screen) {
                 case (.themeSettings(let state), .themeSettings): return state as? S
+                case (.remoteTabsPanel(let state), .remoteTabsPanel): return state as? S
+                default: return nil
                 }
             }
             .first

--- a/Tests/ClientTests/RemoteTabPanelTests.swift
+++ b/Tests/ClientTests/RemoteTabPanelTests.swift
@@ -40,7 +40,7 @@ final class RemoteTabPanelTests: XCTestCase {
     // MARK: - Private
 
     private func generateEmptyState() -> RemoteTabsPanelState {
-        return RemoteTabsPanelState.emptyState()
+        return RemoteTabsPanelState()
     }
 
     private func generateStateOneClientTwoTabs() -> RemoteTabsPanelState {

--- a/Tests/ClientTests/RemoteTabPanelTests.swift
+++ b/Tests/ClientTests/RemoteTabPanelTests.swift
@@ -76,7 +76,7 @@ final class RemoteTabPanelTests: XCTestCase {
     private func createSubject(state: RemoteTabsPanelState,
                                file: StaticString = #file,
                                line: UInt = #line) -> RemoteTabsPanel {
-        let subject = RemoteTabsPanel(state: state)
+        let subject = RemoteTabsPanel()
 
         trackForMemoryLeaks(subject, file: file, line: line)
         return subject

--- a/Tests/ClientTests/RemoteTabPanelTests.swift
+++ b/Tests/ClientTests/RemoteTabPanelTests.swift
@@ -77,6 +77,7 @@ final class RemoteTabPanelTests: XCTestCase {
                                file: StaticString = #file,
                                line: UInt = #line) -> RemoteTabsPanel {
         let subject = RemoteTabsPanel()
+        subject.newState(state: state)
 
         trackForMemoryLeaks(subject, file: file, line: line)
         return subject


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7509)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16673)

## :bulb: Description

Adds some early Redux hooks to the new Sync tab controller. Still a WIP but this PR:
- Updates State and VC to conform to protocols for Redux
- Adds actions to retrieve initial state; subscribes to updates
- Adds some related plumbing in preparation for Reducers and middleware (forthcoming)
- Fixes a few miscellaneous things in related code

This primarily is following the same patterns as `ThemeSettingsController` for now, some areas may change as it continues to be updated.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

