### PR TITLE
Bug MTE-0000 [v120] Example Unit Test Refactor

### DIFF
--- a/Tests/UnitTest.xctestplan
+++ b/Tests/UnitTest.xctestplan
@@ -119,8 +119,7 @@
     },
     {
       "skippedTests" : [
-        "RustLoginsTests\/testUpdateLogin()",
-        "TestBrowserDB\/testMovesDB()"
+        "RustLoginsTests\/testUpdateLogin()"
       ],
       "target" : {
         "containerPath" : "container:Client.xcodeproj",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This is only a stand-in example for how a test could be written to avoid the use of in-line `XCTAssert`, which is often problematic as it exposes the tests to race conditions.

This can be avoided by polling for the assertion, allowing for a more graceful test execution should an unintentional race condition be introduced.

If there are any performance concerns, as there seems to be more overhead than in the original test, it took `0.030` seconds to run in Bitrise compared to the previous tests runtime, when passing, of `0.07` seconds.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

