### PR TITLE
Bugfix MTE-1658 [v120] Disable screenshot for banner image

### DIFF
--- a/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
@@ -213,12 +213,12 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
         navigator.goto(BrowserTabMenu)
         snapshot("MenuOnTopSites-01")
 
-        // Set as Default browser screenshot
-        navigator.goto(NewTabScreen)
-        mozWaitForElementToExist(app.buttons[homeTabBannerA11y.ctaButton], timeout: 15)
-        app.buttons[homeTabBannerA11y.ctaButton].tap()
-        mozWaitForElementToExist(app.buttons["HomeTabBanner.goToSettingsButton"], timeout: 15)
-        snapshot("HomeDefaultBrowserLearnMore")
+        // Set as Default browser screenshot (Not working currently due to FXIOS-7325)
+        // navigator.goto(NewTabScreen)
+        // mozWaitForElementToExist(app.buttons[homeTabBannerA11y.ctaButton], timeout: 15)
+        // app.buttons[homeTabBannerA11y.ctaButton].tap()
+        // mozWaitForElementToExist(app.buttons["HomeTabBanner.goToSettingsButton"], timeout: 15)
+        // snapshot("HomeDefaultBrowserLearnMore")
     }
 
     func testSettings() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1658)

## :bulb: Description
https://github.com/mozilla-mobile/firefox-ios/pull/16640 makes Firefox iOS to display the banner occasionally. `testMenuOnTopSites()` fails because the banner is not found. I have not found a workaround.

Let me disable the portion related to the banner.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

