### PR TITLE
Refactor FXIOS-7509 [v120] More early Redux wiring for Sync tab

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		1D2F68B12ACCA22000524B92 /* RemoteTabsEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2F68B02ACCA22000524B92 /* RemoteTabsEmptyView.swift */; };
 		1D3C90882ACE1AF400304C87 /* RemoteTabPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3C90872ACE1AF400304C87 /* RemoteTabPanelTests.swift */; };
 		1D69FF8D27B17286001F660E /* HomeLogoHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D69FF8C27B17285001F660E /* HomeLogoHeaderCell.swift */; };
+		1D8487B42AD0C6C100F7527C /* RemoteTabsPanelMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8487B32AD0C6C100F7527C /* RemoteTabsPanelMiddleware.swift */; };
 		1D9E1FE524FEF56C006E561D /* TopSites in Resources */ = {isa = PBXBuildFile; fileRef = 3BC659481E5BA4AE006D560F /* TopSites */; };
 		1DA3CE5D24EEE73100422BB2 /* OpenTabsWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA3CE5C24EEE73100422BB2 /* OpenTabsWidget.swift */; };
 		1DA3CE5F24EEE7C600422BB2 /* LegacyTabDataRetriever.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA3CE5E24EEE7C600422BB2 /* LegacyTabDataRetriever.swift */; };
@@ -2081,6 +2082,7 @@
 		1D3C90872ACE1AF400304C87 /* RemoteTabPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabPanelTests.swift; sourceTree = "<group>"; };
 		1D69FF8C27B17285001F660E /* HomeLogoHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeLogoHeaderCell.swift; sourceTree = "<group>"; };
 		1D774B3D9C6E21B77FB7B38F /* kab */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kab; path = kab.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
+		1D8487B32AD0C6C100F7527C /* RemoteTabsPanelMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabsPanelMiddleware.swift; sourceTree = "<group>"; };
 		1D90440B860A503D4DBA4213 /* cy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cy; path = cy.lproj/Storage.strings; sourceTree = "<group>"; };
 		1DA24C60879E7D4B2073FD63 /* kab */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kab; path = kab.lproj/Search.strings; sourceTree = "<group>"; };
 		1DA3CE5C24EEE73100422BB2 /* OpenTabsWidget.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenTabsWidget.swift; sourceTree = "<group>"; };
@@ -7247,6 +7249,7 @@
 				1DEBC55D2AC4ED70006E4801 /* RemoteTabsPanel.swift */,
 				1D2F68AE2ACB272500524B92 /* RemoteTabsTableViewController.swift */,
 				1D2F68AA2ACB262900524B92 /* RemoteTabsPanelAction.swift */,
+				1D8487B32AD0C6C100F7527C /* RemoteTabsPanelMiddleware.swift */,
 				1D2F68AC2ACB266300524B92 /* RemoteTabsPanelState.swift */,
 				210887CB293E8800000AB4EE /* RemoteTabsErrorCell.swift */,
 				1D2F68B02ACCA22000524B92 /* RemoteTabsEmptyView.swift */,
@@ -12837,6 +12840,7 @@
 				1D2F68AB2ACB262900524B92 /* RemoteTabsPanelAction.swift in Sources */,
 				8A5D1CB92A30DBDB005AD35C /* ChinaSyncServiceSetting.swift in Sources */,
 				216A0D712A40D0FB008077BA /* ReduxFlagManager.swift in Sources */,
+				1D8487B42AD0C6C100F7527C /* RemoteTabsPanelMiddleware.swift in Sources */,
 				C849E46526B9C3DD00260F0B /* SlideoverPresentationController.swift in Sources */,
 				E18F44072A951C330056160F /* FakespotHighlightGroup.swift in Sources */,
 				D5D0532E2645B3A700759F85 /* ExperimentsTableView.swift in Sources */,

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsEmptyView.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsEmptyView.swift
@@ -73,7 +73,7 @@ class RemoteTabsEmptyView: UIView, ThemeApplicable {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func configure(state: RemoteTabsPanelEmptyState,
+    func configure(state: RemoteTabsPanelEmptyStateReason,
                    delegate: RemotePanelDelegate?) {
         self.delegate = delegate
 

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanel.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanel.swift
@@ -52,7 +52,17 @@ class RemoteTabsPanel: UIViewController,
         }
     }
 
+    // MARK: - Actions
+
+    func tableViewControllerDidPullToRefresh() {
+        refreshTabs()
+    }
+
     // MARK: - Internal Utilities
+
+    private func refreshTabs() {
+        store.dispatch(RemoteTabsPanelAction.refreshTabs)
+    }
 
     private func observeNotifications() {
         // TODO: State to be provided by forthcoming Redux updates. TBD.
@@ -72,9 +82,7 @@ class RemoteTabsPanel: UIViewController,
     func notificationReceived(_ notification: Notification) {
         let name = notification.name
         if name == .FirefoxAccountChanged || name == .ProfileDidFinishSyncing {
-            ensureMainThread {
-                self.tableViewController.refreshTabs(state: self.state)
-            }
+            refreshTabs()
         }
     }
 
@@ -107,15 +115,12 @@ class RemoteTabsPanel: UIViewController,
         view.backgroundColor = themeManager.currentTheme.colors.layer4
         tableViewController.tableView.backgroundColor =  themeManager.currentTheme.colors.layer3
         tableViewController.tableView.separatorColor = themeManager.currentTheme.colors.borderPrimary
-        tableViewController.tableView.reloadData()
-        tableViewController.refreshTabs(state: state)
+
+        // Matches previous legacy behavior; refresh tabs after theme apply.
+        refreshTabs()
     }
 
     // MARK: - Redux
-
-    private func forceRefreshTabs() {
-        tableViewController.refreshTabs(state: state, updateCache: true)
-    }
 
     private func subscribeRedux() {
         guard isReduxIntegrationEnabled else { return }

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanel.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanel.swift
@@ -139,9 +139,6 @@ class RemoteTabsPanel: UIViewController,
 
             self.state = state
             tableViewController.newState(state: state)
-            if state.refreshState != .refreshing {
-                tableViewController.endRefreshing()
-            }
         }
     }
 

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanel.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanel.swift
@@ -99,6 +99,11 @@ class RemoteTabsPanel: UIViewController,
         applyTheme()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        refreshTabs() // Matches legacy behavior.
+    }
+
     private func setupLayout() {
         tableViewController.view.translatesAutoresizingMaskIntoConstraints = false
         addChild(tableViewController)

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanel.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanel.swift
@@ -134,6 +134,9 @@ class RemoteTabsPanel: UIViewController,
     func newState(state: RemoteTabsPanelState) {
         self.state = state
         tableViewController.newState(state: state)
+        if state.refreshState != .refreshing {
+            tableViewController.endRefreshing()
+        }
     }
 
     // MARK: - RemoteTabsClientAndTabsDataSourceDelegate

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanel.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanel.swift
@@ -101,7 +101,7 @@ class RemoteTabsPanel: UIViewController,
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        refreshTabs() // Matches legacy behavior.
+        refreshTabs()
     }
 
     private func setupLayout() {
@@ -122,9 +122,6 @@ class RemoteTabsPanel: UIViewController,
         view.backgroundColor = themeManager.currentTheme.colors.layer4
         tableViewController.tableView.backgroundColor =  themeManager.currentTheme.colors.layer3
         tableViewController.tableView.separatorColor = themeManager.currentTheme.colors.borderPrimary
-
-        // Matches previous legacy behavior; refresh tabs after theme apply.
-        refreshTabs()
     }
 
     // MARK: - Redux

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelAction.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelAction.swift
@@ -12,5 +12,6 @@ enum RemoteTabsPanelAction: Action {
     case refreshCachedTabs
     case refreshTabs
     case refreshDidFail(RemoteTabsPanelEmptyStateReason)
+    case cachedResultsAvailable([ClientAndTabs], Bool)
     case refreshDidSucceed([ClientAndTabs])
 }

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelAction.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelAction.swift
@@ -10,4 +10,6 @@ enum RemoteTabsPanelAction: Action {
     case panelDidAppear
     case refreshCachedTabs
     case refreshTabs
+    case refreshDidFail
+    case refreshDidSucceed
 }

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelAction.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelAction.swift
@@ -4,6 +4,7 @@
 
 import Common
 import Redux
+import Storage
 
 /// Defines actions sent to Redux for Sync tab in tab tray
 enum RemoteTabsPanelAction: Action {
@@ -11,5 +12,5 @@ enum RemoteTabsPanelAction: Action {
     case refreshCachedTabs
     case refreshTabs
     case refreshDidFail
-    case refreshDidSucceed
+    case refreshDidSucceed([ClientAndTabs])
 }

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelAction.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelAction.swift
@@ -12,6 +12,11 @@ enum RemoteTabsPanelAction: Action {
     case refreshCachedTabs
     case refreshTabs
     case refreshDidFail(RemoteTabsPanelEmptyStateReason)
-    case cachedResultsAvailable([ClientAndTabs], Bool)
+    case cachedTabsAvailable(RemoteTabsPanelCachedResults)
     case refreshDidSucceed([ClientAndTabs])
+}
+
+struct RemoteTabsPanelCachedResults {
+    let clientAndTabs: [ClientAndTabs]
+    let isUpdating: Bool // Whether we are also fetching updates to cached tabs
 }

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelAction.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelAction.swift
@@ -11,6 +11,6 @@ enum RemoteTabsPanelAction: Action {
     case panelDidAppear
     case refreshCachedTabs
     case refreshTabs
-    case refreshDidFail
+    case refreshDidFail(RemoteTabsPanelEmptyStateReason)
     case refreshDidSucceed([ClientAndTabs])
 }

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelMiddleware.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelMiddleware.swift
@@ -45,8 +45,8 @@ class RemoteTabsPanelMiddleware {
                 return
             }
 
-            profile.getCachedClientsAndTabs().uponQueue(.main) { [weak self] result in
-                guard let clientAndTabs = result.successValue else {
+            profile.getCachedClientsAndTabs { [weak self] result in
+                guard let clientAndTabs = result else {
                     store.dispatch(RemoteTabsPanelAction.refreshDidFail(.failedToSync))
                     return
                 }
@@ -56,8 +56,8 @@ class RemoteTabsPanelMiddleware {
                 store.dispatch(RemoteTabsPanelAction.cachedTabsAvailable(results))
 
                 if updateCache {
-                    self?.profile.getClientsAndTabs().uponQueue(.main) { result in
-                        guard let clientAndTabs = result.successValue else {
+                    self?.profile.getClientsAndTabs { result in
+                        guard let clientAndTabs = result else {
                             store.dispatch(RemoteTabsPanelAction.refreshDidFail(.failedToSync))
                             return
                         }

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelMiddleware.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelMiddleware.swift
@@ -56,11 +56,9 @@ class RemoteTabsPanelMiddleware {
                             store.dispatch(RemoteTabsPanelAction.refreshDidFail(.failedToSync))
                             return
                         }
-
+                        
                         store.dispatch(RemoteTabsPanelAction.refreshDidSucceed(clientAndTabs))
                     }
-                } else {
-                    store.dispatch(RemoteTabsPanelAction.refreshDidSucceed(clientAndTabs))
                 }
             }
         }

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelMiddleware.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelMiddleware.swift
@@ -19,7 +19,8 @@ class RemoteTabsPanelMiddleware {
         switch action {
         case RemoteTabsPanelAction.refreshTabs:
             self.refreshTabs(updateCache: true)
-            break
+        case RemoteTabsPanelAction.refreshCachedTabs:
+            self.refreshTabs(updateCache: false)
         default:
             break
         }
@@ -30,13 +31,17 @@ class RemoteTabsPanelMiddleware {
     private func refreshTabs(updateCache: Bool = false) {
         ensureMainThread { [self] in
             guard profile.hasSyncableAccount() else {
-                store.dispatch(RemoteTabsPanelAction.refreshDidFail(.notLoggedIn))
+                DispatchQueue.main.async {
+                    store.dispatch(RemoteTabsPanelAction.refreshDidFail(.notLoggedIn))
+                }
                 return
             }
 
             let syncEnabled = (profile.prefs.boolForKey(PrefsKeys.TabSyncEnabled) == true)
             guard syncEnabled else {
-                store.dispatch(RemoteTabsPanelAction.refreshDidFail(.syncDisabledByUser))
+                DispatchQueue.main.async {
+                    store.dispatch(RemoteTabsPanelAction.refreshDidFail(.syncDisabledByUser))
+                }
                 return
             }
 

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelMiddleware.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelMiddleware.swift
@@ -1,0 +1,58 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import Storage
+import Common
+import Shared
+import Redux
+
+class RemoteTabsPanelMiddleware {
+    private let profile: Profile
+
+    init(profile: Profile = AppContainer.shared.resolve()) {
+        self.profile = profile
+    }
+
+    lazy var remoteTabsPanelProvider: Middleware<AppState> = { state, action in
+        switch action {
+        case RemoteTabsPanelAction.refreshTabs:
+            // TODO: WIP; additional changes forthcoming. [FXIOS-7509]
+            self.refreshTabs(updateCache: true)
+            break
+        default:
+            break
+        }
+    }
+
+    // MARK: - Internal Utilities
+
+    private func refreshTabs(updateCache: Bool = false) {
+        guard profile.hasSyncableAccount() else {
+            store.dispatch(RemoteTabsPanelAction.refreshDidFail)
+            return
+        }
+        
+        // TODO: Work-in-progress. [FXIOS-7509]
+        profile.getCachedClientsAndTabs().uponQueue(.main) { [weak self] result in
+            guard let clientAndTabs = result.successValue else {
+                store.dispatch(RemoteTabsPanelAction.refreshDidFail)
+                return
+            }
+
+            if updateCache {
+                self?.profile.getClientsAndTabs().uponQueue(.main) { result in
+                    guard let clientAndTabs = result.successValue else {
+                        store.dispatch(RemoteTabsPanelAction.refreshDidFail)
+                        return
+                    }
+
+                    store.dispatch(RemoteTabsPanelAction.refreshDidSucceed)
+                }
+            } else {
+                    store.dispatch(RemoteTabsPanelAction.refreshDidSucceed)
+            }
+        }
+    }
+}

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelMiddleware.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelMiddleware.swift
@@ -46,23 +46,27 @@ class RemoteTabsPanelMiddleware {
             }
 
             profile.getCachedClientsAndTabs { [weak self] result in
-                guard let clientAndTabs = result else {
-                    store.dispatch(RemoteTabsPanelAction.refreshDidFail(.failedToSync))
-                    return
-                }
+                ensureMainThread {
+                    guard let clientAndTabs = result else {
+                        store.dispatch(RemoteTabsPanelAction.refreshDidFail(.failedToSync))
+                        return
+                    }
 
-                let results = RemoteTabsPanelCachedResults(clientAndTabs: clientAndTabs,
-                                                           isUpdating: updateCache)
-                store.dispatch(RemoteTabsPanelAction.cachedTabsAvailable(results))
+                    let results = RemoteTabsPanelCachedResults(clientAndTabs: clientAndTabs,
+                                                               isUpdating: updateCache)
+                    store.dispatch(RemoteTabsPanelAction.cachedTabsAvailable(results))
 
-                if updateCache {
-                    self?.profile.getClientsAndTabs { result in
-                        guard let clientAndTabs = result else {
-                            store.dispatch(RemoteTabsPanelAction.refreshDidFail(.failedToSync))
-                            return
+                    if updateCache {
+                        self?.profile.getClientsAndTabs { result in
+                            ensureMainThread {
+                                guard let clientAndTabs = result else {
+                                    store.dispatch(RemoteTabsPanelAction.refreshDidFail(.failedToSync))
+                                    return
+                                }
+
+                                store.dispatch(RemoteTabsPanelAction.refreshDidSucceed(clientAndTabs))
+                            }
                         }
-
-                        store.dispatch(RemoteTabsPanelAction.refreshDidSucceed(clientAndTabs))
                     }
                 }
             }

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelMiddleware.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelMiddleware.swift
@@ -46,7 +46,9 @@ class RemoteTabsPanelMiddleware {
                     return
                 }
 
-                store.dispatch(RemoteTabsPanelAction.cachedResultsAvailable(clientAndTabs, updateCache))
+                let results = RemoteTabsPanelCachedResults(clientAndTabs: clientAndTabs,
+                                                           isUpdating: updateCache)
+                store.dispatch(RemoteTabsPanelAction.cachedTabsAvailable(results))
 
                 if updateCache {
                     self?.profile.getClientsAndTabs().uponQueue(.main) { result in

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelMiddleware.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelMiddleware.swift
@@ -56,7 +56,7 @@ class RemoteTabsPanelMiddleware {
                             store.dispatch(RemoteTabsPanelAction.refreshDidFail(.failedToSync))
                             return
                         }
-                        
+
                         store.dispatch(RemoteTabsPanelAction.refreshDidSucceed(clientAndTabs))
                     }
                 }

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelMiddleware.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelMiddleware.swift
@@ -35,7 +35,6 @@ class RemoteTabsPanelMiddleware {
             }
 
             let syncEnabled = (profile.prefs.boolForKey(PrefsKeys.TabSyncEnabled) == true)
-
             guard syncEnabled else {
                 store.dispatch(RemoteTabsPanelAction.refreshDidFail(.syncDisabledByUser))
                 return
@@ -47,7 +46,7 @@ class RemoteTabsPanelMiddleware {
                     return
                 }
 
-                // TODO: Update UI with cached results initially? [FXIOS-7509]
+                store.dispatch(RemoteTabsPanelAction.cachedResultsAvailable(clientAndTabs, updateCache))
 
                 if updateCache {
                     self?.profile.getClientsAndTabs().uponQueue(.main) { result in

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelMiddleware.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelMiddleware.swift
@@ -18,7 +18,6 @@ class RemoteTabsPanelMiddleware {
     lazy var remoteTabsPanelProvider: Middleware<AppState> = { state, action in
         switch action {
         case RemoteTabsPanelAction.refreshTabs:
-            // TODO: WIP; additional changes forthcoming. [FXIOS-7509]
             self.refreshTabs(updateCache: true)
             break
         default:

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelMiddleware.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelMiddleware.swift
@@ -34,25 +34,25 @@ class RemoteTabsPanelMiddleware {
                 store.dispatch(RemoteTabsPanelAction.refreshDidFail)
                 return
             }
-            
+
             // TODO: Work-in-progress. [FXIOS-7509]
             profile.getCachedClientsAndTabs().uponQueue(.main) { [weak self] result in
                 guard let clientAndTabs = result.successValue else {
                     store.dispatch(RemoteTabsPanelAction.refreshDidFail)
                     return
                 }
-                
+
                 if updateCache {
                     self?.profile.getClientsAndTabs().uponQueue(.main) { result in
                         guard let clientAndTabs = result.successValue else {
                             store.dispatch(RemoteTabsPanelAction.refreshDidFail)
                             return
                         }
-                        
-                        store.dispatch(RemoteTabsPanelAction.refreshDidSucceed)
+
+                        store.dispatch(RemoteTabsPanelAction.refreshDidSucceed(clientAndTabs))
                     }
                 } else {
-                    store.dispatch(RemoteTabsPanelAction.refreshDidSucceed)
+                    store.dispatch(RemoteTabsPanelAction.refreshDidSucceed(clientAndTabs))
                 }
             }
         }

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelState.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelState.swift
@@ -93,6 +93,12 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
                                                 clientAndTabs: newClientAndTabs,
                                                 showingEmptyState: nil)
             return newState
+        case RemoteTabsPanelAction.cachedResultsAvailable(let cachedClientAndTabs, let isUpdating):
+            let newState = RemoteTabsPanelState(refreshState: isUpdating ? .refreshing : .idle,
+                                                allowsRefresh: state.allowsRefresh,
+                                                clientAndTabs: cachedClientAndTabs,
+                                                showingEmptyState: nil)
+            return newState
         default:
             return state
         }

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelState.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelState.swift
@@ -79,7 +79,6 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
         // TODO: Additional Reducer support forthcoming. [FXIOS-7512]
         switch action {
         case RemoteTabsPanelAction.refreshTabs:
-            // TODO. WIP, add'tl changes forthcoming. [FXIOS-7509]
             let newState = RemoteTabsPanelState(refreshState: .refreshing,
                                                 clientAndTabs: state.clientAndTabs,
                                                 allowsRefresh: state.allowsRefresh,
@@ -87,14 +86,19 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
                                                 syncIsSupported: state.syncIsSupported)
             return newState
         case RemoteTabsPanelAction.refreshDidFail:
-            // TODO. WIP, add'tl changes forthcoming. [FXIOS-7509]
-            fallthrough
-        case RemoteTabsPanelAction.refreshDidSucceed:
-            // TODO. WIP, add'tl changes forthcoming. [FXIOS-7509]
+            // Refresh failed. Show error empty state.
             let newState = RemoteTabsPanelState(refreshState: .idle,
                                                 clientAndTabs: state.clientAndTabs,
                                                 allowsRefresh: state.allowsRefresh,
-                                                showingEmptyState: state.showingEmptyState,
+                                                showingEmptyState: .failedToSync,
+                                                syncIsSupported: state.syncIsSupported)
+            return newState
+        case RemoteTabsPanelAction.refreshDidSucceed(let newClientAndTabs):
+            // Send client and tabs state, ensure empty state is nil and refresh is idle
+            let newState = RemoteTabsPanelState(refreshState: .idle,
+                                                clientAndTabs: newClientAndTabs,
+                                                allowsRefresh: state.allowsRefresh,
+                                                showingEmptyState: nil,
                                                 syncIsSupported: state.syncIsSupported)
             return newState
         default:

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelState.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelState.swift
@@ -77,8 +77,13 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
         // TODO: Additional Reducer support forthcoming. [FXIOS-7512]
         switch action {
         case RemoteTabsPanelAction.refreshTabs:
-            // TODO. Forthcoming. [FXIOS-7509]
-            return state
+            // TODO. WIP, add'tl changes forthcoming. [FXIOS-7509]
+            let newState = RemoteTabsPanelState(refreshState: .refreshing,
+                                                clientAndTabs: state.clientAndTabs,
+                                                allowsRefresh: state.allowsRefresh,
+                                                showingEmptyState: state.showingEmptyState,
+                                                syncIsSupported: state.syncIsSupported)
+            return newState
         default:
             return state
         }

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelState.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelState.swift
@@ -76,7 +76,11 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
     static let reducer: Reducer<Self> = { state, action in
         // TODO: Additional Reducer support forthcoming. [FXIOS-7512]
         switch action {
-        default: return state
+        case RemoteTabsPanelAction.refreshTabs:
+            // TODO. Forthcoming. [FXIOS-7509]
+            return state
+        default:
+            return state
         }
     }
 }

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelState.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelState.swift
@@ -7,9 +7,11 @@ import Redux
 import Shared
 import Storage
 
-/// Status of tab refresh.
+/// Status of Sync tab refresh.
 enum RemoteTabsPanelRefreshState {
-    case loaded
+    /// Not performing any type of refresh.
+    case idle
+    /// Currently performing a refresh of the user's tabs.
     case refreshing
 }
 
@@ -54,7 +56,7 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
     }
 
     init() {
-        self.init(refreshState: .loaded,
+        self.init(refreshState: .idle,
                   clientAndTabs: [],
                   allowsRefresh: true,
                   showingEmptyState: .noTabs,
@@ -79,6 +81,17 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
         case RemoteTabsPanelAction.refreshTabs:
             // TODO. WIP, add'tl changes forthcoming. [FXIOS-7509]
             let newState = RemoteTabsPanelState(refreshState: .refreshing,
+                                                clientAndTabs: state.clientAndTabs,
+                                                allowsRefresh: state.allowsRefresh,
+                                                showingEmptyState: state.showingEmptyState,
+                                                syncIsSupported: state.syncIsSupported)
+            return newState
+        case RemoteTabsPanelAction.refreshDidFail:
+            // TODO. WIP, add'tl changes forthcoming. [FXIOS-7509]
+            fallthrough
+        case RemoteTabsPanelAction.refreshDidSucceed:
+            // TODO. WIP, add'tl changes forthcoming. [FXIOS-7509]
+            let newState = RemoteTabsPanelState(refreshState: .idle,
                                                 clientAndTabs: state.clientAndTabs,
                                                 allowsRefresh: state.allowsRefresh,
                                                 showingEmptyState: state.showingEmptyState,

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelState.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelState.swift
@@ -93,10 +93,10 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
                                                 clientAndTabs: newClientAndTabs,
                                                 showingEmptyState: nil)
             return newState
-        case RemoteTabsPanelAction.cachedResultsAvailable(let cachedClientAndTabs, let isUpdating):
-            let newState = RemoteTabsPanelState(refreshState: isUpdating ? .refreshing : .idle,
+        case RemoteTabsPanelAction.cachedTabsAvailable(let cachedResults):
+            let newState = RemoteTabsPanelState(refreshState: cachedResults.isUpdating ? .refreshing : .idle,
                                                 allowsRefresh: state.allowsRefresh,
-                                                clientAndTabs: cachedClientAndTabs,
+                                                clientAndTabs: cachedResults.clientAndTabs,
                                                 showingEmptyState: nil)
             return newState
         default:

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
@@ -94,8 +94,6 @@ class RemoteTabsTableViewController: UITableViewController,
         if state.allowsRefresh && refreshControl == nil {
             addRefreshControl()
         }
-
-        refreshTabs(state: state, updateCache: true)
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -152,7 +150,7 @@ class RemoteTabsTableViewController: UITableViewController,
     @objc
     func onRefreshPulled() {
         refreshControl?.beginRefreshing()
-        refreshTabs(state: state, updateCache: true)
+        remoteTabsPanel?.tableViewControllerDidPullToRefresh()
     }
 
     func endRefreshing() {
@@ -163,30 +161,6 @@ class RemoteTabsTableViewController: UITableViewController,
         if !state.allowsRefresh {
             removeRefreshControl()
         }
-    }
-
-    func updateDelegateClientAndTabData(_ clientAndTabs: [ClientAndTabs]) {
-        // TODO: Forthcoming as part of ongoing tab tray Redux refactors. [FXIOS-6942] & [FXIOS-7509]
-
-        reloadUI()
-    }
-
-    func refreshTabs(state: RemoteTabsPanelState, updateCache: Bool = false, completion: (() -> Void)? = nil) {
-        ensureMainThread { [self] in
-            self.state = state
-            performRefresh(updateCache: updateCache, completion: completion)
-        }
-    }
-
-    private func performRefresh(updateCache: Bool, completion: (() -> Void)?) {
-        // Short circuit if the user is not logged in
-        guard state.allowsRefresh else {
-            endRefreshing()
-            return
-        }
-
-        // TODO: Send Redux action to get clients & tabs, update once state received. Forthcoming.  [FXIOS-6942] & [FXIOS-7509]
-        // store.dispatch(RemoteTabsPanelAction.refreshCachedTabs)
     }
 
     @objc

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
@@ -117,6 +117,10 @@ class RemoteTabsTableViewController: UITableViewController,
             configureEmptyView()
         }
 
+        if state.refreshState != .refreshing {
+            endRefreshing()
+        }
+
         tableView.reloadData()
     }
 
@@ -153,12 +157,12 @@ class RemoteTabsTableViewController: UITableViewController,
             endRefreshing()
             return
         }
-        
+
         refreshControl?.beginRefreshing()
         remoteTabsPanel?.tableViewControllerDidPullToRefresh()
     }
 
-    func endRefreshing() {
+    private func endRefreshing() {
         // Always end refreshing, even if we failed!
         refreshControl?.endRefreshing()
 

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
@@ -149,6 +149,11 @@ class RemoteTabsTableViewController: UITableViewController,
 
     @objc
     func onRefreshPulled() {
+        guard state.allowsRefresh else {
+            endRefreshing()
+            return
+        }
+        
         refreshControl?.beginRefreshing()
         remoteTabsPanel?.tableViewControllerDidPullToRefresh()
     }

--- a/Client/Frontend/Home/JumpBackIn/Data/JumpBackInDataAdaptor.swift
+++ b/Client/Frontend/Home/JumpBackIn/Data/JumpBackInDataAdaptor.swift
@@ -154,7 +154,7 @@ actor JumpBackInDataAdaptorImplementation: JumpBackInDataAdaptor, FeatureFlaggab
         return await withCheckedContinuation { continuation in
             // Get cached tabs
             profile.getCachedClientsAndTabs { result in
-                continuation.resume(returning: result)
+                continuation.resume(returning: result ?? [])
             }
         }
     }

--- a/Client/Redux/GlobalState/AppState.swift
+++ b/Client/Redux/GlobalState/AppState.swift
@@ -33,4 +33,5 @@ extension AppState {
 
 let store = Store(state: AppState(),
                   reducer: AppState.reducer,
-                  middlewares: [ThemeManagerMiddleware().themeManagerProvider])
+                  middlewares: [ThemeManagerMiddleware().themeManagerProvider,
+                                RemoteTabsPanelMiddleware().remoteTabsPanelProvider])

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -119,8 +119,10 @@ protocol Profile: AnyObject {
     func removeAccount()
 
     func getClientsAndTabs() -> Deferred<Maybe<[ClientAndTabs]>>
-    func getCachedClientsAndTabs(completion: @escaping ([ClientAndTabs]) -> Void)
     func getCachedClientsAndTabs() -> Deferred<Maybe<[ClientAndTabs]>>
+
+    func getClientsAndTabs(completion: @escaping ([ClientAndTabs]?) -> Void)
+    func getCachedClientsAndTabs(completion: @escaping ([ClientAndTabs]?) -> Void)
 
     func cleanupHistoryIfNeeded()
 
@@ -538,10 +540,17 @@ open class BrowserProfile: Profile {
         return self.syncManager.syncTabs() >>> { self.retrieveTabData() }
     }
 
-    public func getCachedClientsAndTabs(completion: @escaping ([ClientAndTabs]) -> Void) {
+    public func getClientsAndTabs(completion: @escaping ([ClientAndTabs]?) -> Void) {
+        let deferredResponse = self.syncManager.syncTabs() >>> { self.retrieveTabData() }
+        deferredResponse.upon { result in
+            completion(result.successValue)
+        }
+    }
+
+    public func getCachedClientsAndTabs(completion: @escaping ([ClientAndTabs]?) -> Void) {
         let defferedResponse = self.retrieveTabData()
         defferedResponse.upon { result in
-            completion(result.successValue ?? [])
+            completion(result.successValue)
         }
     }
 

--- a/Tests/ClientTests/Mocks/MockProfile.swift
+++ b/Tests/ClientTests/Mocks/MockProfile.swift
@@ -271,7 +271,11 @@ open class MockProfile: Client.Profile {
 
     var mockClientAndTabs = [ClientAndTabs]()
 
-    public func getCachedClientsAndTabs(completion: @escaping ([ClientAndTabs]) -> Void) {
+    public func getCachedClientsAndTabs(completion: @escaping ([ClientAndTabs]?) -> Void) {
+        completion(mockClientAndTabs)
+    }
+
+    public func getClientsAndTabs(completion: @escaping ([ClientAndTabs]?) -> Void) {
         completion(mockClientAndTabs)
     }
 

--- a/Tests/ClientTests/RemoteTabPanelTests.swift
+++ b/Tests/ClientTests/RemoteTabPanelTests.swift
@@ -66,11 +66,10 @@ final class RemoteTabPanelTests: XCTestCase {
                                   version: "v1.0",
                                   fxaDeviceId: "12345")
         let fakeData = [ClientAndTabs(client: client, tabs: fakeTabs)]
-        return RemoteTabsPanelState(refreshState: .loaded,
-                                    clientAndTabs: fakeData,
+        return RemoteTabsPanelState(refreshState: .idle,
                                     allowsRefresh: true,
-                                    showingEmptyState: nil,
-                                    syncIsSupported: true)
+                                    clientAndTabs: fakeData,
+                                    showingEmptyState: nil)
     }
 
     private func createSubject(state: RemoteTabsPanelState,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7509)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16673)

## :bulb: Description

Still an ongoing WIP but wanted to open a PR since I'm guessing at least a few questions will come up during this portion of FXIOS-7509.

This PR stubs out some early hooks and wiring for the Redux actions and related middleware for new Sync tab.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

