### PR TITLE
Add FXIOS-7454 [v120] Start analysis when button in no analysis card is tapped

### DIFF
--- a/Client/Frontend/Fakespot/FakespotViewController.swift
+++ b/Client/Frontend/Fakespot/FakespotViewController.swift
@@ -306,9 +306,25 @@ class FakespotViewController: UIViewController, Themeable, Notifiable, UIAdaptiv
             return view
 
         case .noAnalysisCard:
-            let view: FakespotNoAnalysisCardView = .build()
-            view.configure(viewModel.noAnalysisCardViewModel)
-            return view
+             let view: FakespotNoAnalysisCardView = .build()
+             viewModel.noAnalysisCardViewModel.onTapStartAnalysis = { [weak view, weak self] in
+                 view?.updateLayoutForInProgress()
+                 self?.onNeedsAnalysisTap()
+             }
+             viewModel.onAnalysisStatusChange = { [weak view, weak self] in
+                 self?.onAnalysisStatusChange(sender: view)
+             }
+             view.configure(viewModel.noAnalysisCardViewModel)
+             return view
+
+         case .progressAnalysisCard:
+             let view: FakespotNoAnalysisCardView = .build()
+             viewModel.onAnalysisStatusChange = { [weak view, weak self] in
+                 self?.onAnalysisStatusChange(sender: view)
+             }
+             view.configure(viewModel.noAnalysisCardViewModel)
+             view.updateLayoutForInProgress()
+             return view
 
         case .messageCard(let messageType):
             switch messageType {
@@ -335,7 +351,9 @@ class FakespotViewController: UIViewController, Themeable, Notifiable, UIAdaptiv
             case .needsAnalysis:
                 let view: FakespotMessageCardView = .build()
                 viewModel.needsAnalysisViewModel.primaryAction = { [weak view, weak self] in
-                    self?.onNeedsAnalysisTap(sender: view)
+                    guard let self else { return }
+                    view?.configure(self.viewModel.analysisProgressViewModel)
+                    self.onNeedsAnalysisTap()
                 }
                 view.configure(viewModel.needsAnalysisViewModel)
                 viewModel.onAnalysisStatusChange = { [weak view, weak self] in
@@ -363,8 +381,7 @@ class FakespotViewController: UIViewController, Themeable, Notifiable, UIAdaptiv
         }
     }
 
-    private func onNeedsAnalysisTap(sender: FakespotMessageCardView?) {
-        sender?.configure(self.viewModel.analysisProgressViewModel)
+    private func onNeedsAnalysisTap() {
         viewModel.triggerProductAnalysis()
     }
 

--- a/Client/Frontend/Fakespot/FakespotViewController.swift
+++ b/Client/Frontend/Fakespot/FakespotViewController.swift
@@ -317,7 +317,7 @@ class FakespotViewController: UIViewController, Themeable, Notifiable, UIAdaptiv
              view.configure(viewModel.noAnalysisCardViewModel)
              return view
 
-         case .progressAnalysisCard:
+        case .progressAnalysisCard:
              let view: FakespotNoAnalysisCardView = .build()
              viewModel.onAnalysisStatusChange = { [weak view, weak self] in
                  self?.onAnalysisStatusChange(sender: view)

--- a/Client/Frontend/Fakespot/FakespotViewController.swift
+++ b/Client/Frontend/Fakespot/FakespotViewController.swift
@@ -354,7 +354,7 @@ class FakespotViewController: UIViewController, Themeable, Notifiable, UIAdaptiv
                     guard let self else { return }
                     view?.configure(self.viewModel.analysisProgressViewModel)
                     self.onNeedsAnalysisTap()
-                    self?.viewModel.recordTelemetry(for: .messageCard(.needsAnalysis))
+                    self.viewModel.recordTelemetry(for: .messageCard(.needsAnalysis))
                 }
                 view.configure(viewModel.needsAnalysisViewModel)
                 viewModel.onAnalysisStatusChange = { [weak view, weak self] in

--- a/Client/Frontend/Fakespot/FakespotViewModel.swift
+++ b/Client/Frontend/Fakespot/FakespotViewModel.swift
@@ -33,11 +33,20 @@ class FakespotViewModel {
                         .settingsCard
                     ]
                 } else if product.notAnalyzedCardVisible {
-                    return [
-                        .noAnalysisCard,
+                    // Don't show not analyzed message card if analysis is in progress
+                    var cards: [ViewElement] = []
+
+                    if analysisStatus?.isAnalyzing == true {
+                        cards.append(.progressAnalysisCard)
+                    } else {
+                        cards.append(.noAnalysisCard)
+                    }
+
+                    cards += [
                         .qualityDeterminationCard,
                         .settingsCard
                     ]
+                    return cards
                 } else if product.notEnoughReviewsCardVisible {
                     return [
                         .messageCard(.notEnoughReviews),
@@ -101,6 +110,7 @@ class FakespotViewModel {
         case qualityDeterminationCard
         case settingsCard
         case noAnalysisCard
+        case progressAnalysisCard
         case messageCard(MessageType)
         enum MessageType {
             case genericError
@@ -223,7 +233,7 @@ class FakespotViewModel {
     )
 
     let settingsCardViewModel = FakespotSettingsCardViewModel()
-    let noAnalysisCardViewModel = FakespotNoAnalysisCardViewModel()
+    var noAnalysisCardViewModel = FakespotNoAnalysisCardViewModel()
     let reviewQualityCardViewModel = FakespotReviewQualityCardViewModel()
     var optInCardViewModel = FakespotOptInCardViewModel()
 

--- a/Client/Frontend/Fakespot/Views/FakespotNoAnalysisCardView.swift
+++ b/Client/Frontend/Fakespot/Views/FakespotNoAnalysisCardView.swift
@@ -143,7 +143,7 @@ final class FakespotNoAnalysisCardView: UIView, ThemeApplicable {
         updateLayoutForInProgress()
     }
 
-    private func updateLayoutForInProgress() {
+    public func updateLayoutForInProgress() {
         isAnalysisInProgress = true
 
         contentStackView.removeArrangedSubview(analyzerButton)

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -3778,7 +3778,7 @@ extension String {
         public static let NoAnalysisCardInProgressBodyLabel = MZLocalizedString(
             key: "", // Shopping.NoAnalysisCard.InProgress.Body.Label.v118
             tableName: "Shopping",
-            value: "Checking review quality",
+            value: "This could take about 60 seconds.",
             comment: "Description of the No Analysis Card when the analysis is in progress displayed in the shopping review quality bottom sheet.")
         public static let ReviewQualityCardLabelTitle = MZLocalizedString(
             key: "", // Shopping.ReviewQualityCard.Label.Title.v119

--- a/Tests/SharedTests/AsyncReducerTests.swift
+++ b/Tests/SharedTests/AsyncReducerTests.swift
@@ -85,7 +85,7 @@ class AsyncReducerTests: XCTestCase {
 
             // Pretend that some new work arrived while we were handling this.
             if let nextUp = addDuring.popLast() {
-                _ = XCTAssertNoThrow(try reducer.append(nextUp))
+                XCTAssertNoThrow(try reducer.append(nextUp))
             }
 
             return deferMaybe(out)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7454)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16527)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Add state to show progress and hide the view if the analysis is completed.
| Progress | No analysis |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 - 2023-10-09 at 10 40 23](https://github.com/mozilla-mobile/firefox-ios/assets/26011662/6da3e113-c98e-406e-81e8-fe80d3f658d7) | ![Simulator Screenshot - iPhone 15 - 2023-10-09 at 10 40 19](https://github.com/mozilla-mobile/firefox-ios/assets/26011662/51927995-5c1b-4de5-b1f1-36bae39abbff) | 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

