### PR TITLE
Refactor FXIOS-7536 [v120] Replace Firefox, Fakespot and Mozilla in strings with placeholders

### DIFF
--- a/Client/Frontend/Fakespot/FakespotOptInCardViewModel.swift
+++ b/Client/Frontend/Fakespot/FakespotOptInCardViewModel.swift
@@ -24,7 +24,9 @@ struct FakespotOptInCardViewModel {
     let headerLabelA11yId: String = AccessibilityIdentifiers.Shopping.OptInCard.headerTitle
     let bodyFirstParagraphLabel: String = .Shopping.OptInCardCopy
     let bodyFirstParagraphA11yId: String = AccessibilityIdentifiers.Shopping.OptInCard.optInCopy
-    let disclaimerTextLabel: String = .Shopping.OptInCardDisclaimerText
+    let disclaimerTextLabel = String(format: .Shopping.OptInCardDisclaimerText,
+                                     FakespotName.shortName.rawValue,
+                                     MozillaName.shortName.rawValue)
     let disclaimerTextLabelA11yId: String = AccessibilityIdentifiers.Shopping.OptInCard.disclaimerText
 
     // MARK: Buttons

--- a/Client/Frontend/Fakespot/FakespotOptInCardViewModel.swift
+++ b/Client/Frontend/Fakespot/FakespotOptInCardViewModel.swift
@@ -111,7 +111,13 @@ struct FakespotOptInCardViewModel {
                                                           size: UX.bodyFirstParagraphLabelFontSize)
         let boldFont = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .body,
                                                                   size: UX.bodyFirstParagraphLabelFontSize)
-        let plainText = String.localizedStringWithFormat(bodyFirstParagraphLabel, websites[0], websites[1], websites[2])
+        let plainText = String.localizedStringWithFormat(bodyFirstParagraphLabel,
+                                                         websites[0],
+                                                         websites[1],
+                                                         websites[2],
+                                                         AppName.shortName.rawValue,
+                                                         FakespotName.shortName.rawValue,
+                                                         MozillaName.shortName.rawValue)
         return plainText.attributedText(boldPartsOfString: websites, initialFont: font, boldFont: boldFont)
     }
 

--- a/Client/Frontend/Fakespot/Views/FakespotReviewQualityCardView.swift
+++ b/Client/Frontend/Fakespot/Views/FakespotReviewQualityCardView.swift
@@ -82,7 +82,10 @@ final class FakespotReviewQualityCardView: UIView, Notifiable, ThemeApplicable {
     }
 
     private lazy var headlineLabel: UILabel = .build { label in
-        label.text = .Shopping.ReviewQualityCardHeadlineLabel
+        let text = String(format: .Shopping.ReviewQualityCardHeadlineLabel,
+                          FakespotName.shortName.rawValue,
+                          MozillaName.shortName.rawValue)
+        label.text = text
         label.accessibilityIdentifier = AccessibilityIdentifiers.Shopping.ReviewQualityCard.headlineLabel
         label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
@@ -185,7 +188,8 @@ final class FakespotReviewQualityCardView: UIView, Notifiable, ThemeApplicable {
 
     private lazy var learnMoreButton: ResizableButton = .build { button in
         button.contentHorizontalAlignment = .leading
-        button.setTitle(.Shopping.ReviewQualityCardLearnMoreButtonTitle, for: .normal)
+        let title = String(format: .Shopping.ReviewQualityCardLearnMoreButtonTitle, FakespotName.shortName.rawValue)
+        button.setTitle(title, for: .normal)
         button.accessibilityIdentifier = AccessibilityIdentifiers.Shopping.ReviewQualityCard.learnMoreButtonTitle
         button.titleLabel?.adjustsFontForContentSizeCategory = true
         button.buttonEdgeSpacing = 0

--- a/Client/Frontend/Fakespot/Views/FakespotSettingsCardView.swift
+++ b/Client/Frontend/Fakespot/Views/FakespotSettingsCardView.swift
@@ -70,7 +70,7 @@ class FakespotSettingsCardViewModel {
 
 final class FakespotSettingsCardView: UIView, ThemeApplicable {
     private struct UX {
-        static let headerLabelFontSize: CGFloat = 17
+        static let headerLabelFontSize: CGFloat = 15
         static let buttonLabelFontSize: CGFloat = 16
         static let buttonCornerRadius: CGFloat = 14
         static let buttonLeadingTrailingPadding: CGFloat = 8
@@ -105,7 +105,7 @@ final class FakespotSettingsCardView: UIView, ThemeApplicable {
         label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
         label.clipsToBounds = true
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .subheadline,
                                                             size: UX.headerLabelFontSize)
     }
 

--- a/Client/Frontend/Fakespot/Views/FakespotSettingsCardView.swift
+++ b/Client/Frontend/Fakespot/Views/FakespotSettingsCardView.swift
@@ -13,13 +13,16 @@ class FakespotSettingsCardViewModel {
     private let tabManager: TabManager
 
     let cardA11yId: String = a11yIds.card
-    let showProductsLabelTitle: String = .Shopping.SettingsCardRecommendedProductsLabel
+    let showProductsLabelTitle = String(format: .Shopping.SettingsCardRecommendedProductsLabel,
+                                        AppName.shortName.rawValue)
     let showProductsLabelTitleA11yId: String = a11yIds.productsLabel
     let turnOffButtonTitle: String = .Shopping.SettingsCardTurnOffButton
     let turnOffButtonTitleA11yId: String = a11yIds.turnOffButton
     let recommendedProductsSwitchA11yId: String = a11yIds.recommendedProductsSwitch
     let footerTitle: String = ""
-    let footerActionTitle: String = .Shopping.SettingsCardFooterAction
+    let footerActionTitle = String(format: .Shopping.SettingsCardFooterAction,
+                                   FakespotName.shortName.rawValue,
+                                   MozillaName.shortName.rawValue)
     let footerA11yTitleIdentifier: String = a11yIds.footerTitle
     let footerA11yActionIdentifier: String = a11yIds.footerAction
     let footerActionUrl = FakespotUtils.fakespotUrl

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -3853,8 +3853,8 @@ extension String {
         public static let OptInCardDisclaimerText = MZLocalizedString(
             key: "", // Shopping.OptInCard.DisclaimerText.Title.v119
             tableName: "Shopping",
-            value: "By selecting “Yes, Try It” you agree to Fakespot by Mozilla’s:",
-            comment: "Text for the disclaimer that appears beneath the rating image of the Shopping Experience Opt In onboarding Card (Fakespot)")
+            value: "By selecting “Yes, Try It” you agree to the %1$@ by %2$@:",
+            comment: "Text for the disclaimer that appears beneath the rating image of the Shopping Experience Opt In onboarding Card (Fakespot). The first parameter will be replaced by the Fakespot app name and the second parameter by the company name of Mozilla.")
         public static let OptInCardPrivacyPolicy = MZLocalizedString(
             key: "", // Shopping.OptInCard.PrivacyPolicyButtonTitle.Title.v119
             tableName: "Shopping",

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -3733,8 +3733,8 @@ extension String {
         public static let SettingsCardRecommendedProductsLabel = MZLocalizedString(
             key: "", // Shopping.SettingsCard.RecommendedProducts.Label.v118
             tableName: "Shopping",
-            value: "Show products recommended by Firefox",
-            comment: "Label of the switch from settings card displayed in the shopping review quality bottom sheet.")
+            value: "Show products recommended by %@",
+            comment: "Label of the switch from settings card displayed in the shopping review quality bottom sheet. The placeholder will be replaced with the app name.")
         public static let SettingsCardTurnOffButton = MZLocalizedString(
             key: "", // Shopping.SettingsCard.TurnOff.Buttton.v118
             tableName: "Shopping",
@@ -3753,8 +3753,8 @@ extension String {
         public static let SettingsCardFooterAction = MZLocalizedString(
             key: "", // Shopping.SettingsCard.Footer.Action.v119
             tableName: "Shopping",
-            value: "Review checker is powered by Fakespot by Mozilla",
-            comment: "Action title of the footer underneath the Settings Card displayed in the shopping review quality bottom sheet.")
+            value: "Review checker is powered by %1$@ by %2$@",
+            comment: "Action title of the footer underneath the Settings Card displayed in the shopping review quality bottom sheet. The first parameter will be replaced by the Fakespot app name and the second parameter by the company name of Mozilla.")
         public static let NoAnalysisCardHeadlineLabelTitle = MZLocalizedString(
             key: "", // Shopping.NoAnalysisCard.HeadlineLabel.Title.v118
             tableName: "Shopping",
@@ -3798,8 +3798,8 @@ extension String {
         public static let ReviewQualityCardHeadlineLabel = MZLocalizedString(
             key: "", // Shopping.ReviewQualityCard.Headline.Label.v119
             tableName: "Shopping",
-            value: "We use AI technology from Fakespot by Mozilla to check the reliability of product reviews. This will only help you assess review quality, not product quality.",
-            comment: "Label of the headline from How we determine review quality card displayed in the shopping review quality bottom sheet.")
+            value: "We use AI technology from %1$@ by %2$@ to check the reliability of product reviews. This will only help you assess review quality, not product quality.",
+            comment: "Label of the headline from How we determine review quality card displayed in the shopping review quality bottom sheet. The first parameter will be replaced by the Fakespot app name and the second parameter by the company name of Mozilla.")
         public static let ReviewQualityCardSubHeadlineLabel = MZLocalizedString(
             key: "", // Shopping.ReviewQualityCard.SubHeadline.Label.v119
             tableName: "Shopping",
@@ -3833,8 +3833,8 @@ extension String {
         public static let ReviewQualityCardLearnMoreButtonTitle = MZLocalizedString(
             key: "", // Shopping.ReviewQualityCard.LearnMoreButton.Title.v119
             tableName: "Shopping",
-            value: "Learn more about how Fakespot determines review quality",
-            comment: "The title of the learn more button from How we determine review quality card displayed in the shopping review quality bottom sheet.")
+            value: "Learn more about how %@ determines review quality",
+            comment: "The title of the learn more button from How we determine review quality card displayed in the shopping review quality bottom sheet. The placeholder will be replaced with the Fakespot app name.")
         public static let OptInCardHeaderTitle = MZLocalizedString(
             key: "", // Shopping.OptInCard.HeaderLabel.Title.v119
             tableName: "Shopping",
@@ -3843,8 +3843,8 @@ extension String {
         public static let OptInCardCopy = MZLocalizedString(
             key: "", // Shopping.OptInCard.FirstParagraph.Title.v119
             tableName: "Shopping",
-            value: "See how reliable product reviews are on %1$@ before you buy. Review checker, an experimental feature from Firefox, is built right into the browser. It works on %2$@ and  %3$@, too.\n\nUsing the power of Fakespot by Mozilla, we help you avoid biased and inauthentic reviews. Our AI model is always improving to protect you as you shop.",
-            comment: "Label for the first paragraph of the Shopping Experience Opt In onboarding Card (Fakespot). The first parameter will be the website the user is coming from when viewing this screen (default Amazon), and the second and third parameters will be the other two websites that are curently supported (Amazon, Best Buy or Walmart) besides the one used for the first parameter")
+            value: "See how reliable product reviews are on %1$@ before you buy. Review checker, an experimental feature from %4$@, is built right into the browser. It works on %2$@ and  %3$@, too.\n\nUsing the power of %5$@ by %6$@, we help you avoid biased and inauthentic reviews. Our AI model is always improving to protect you as you shop.",
+            comment: "Label for the first paragraph of the Shopping Experience Opt In onboarding Card (Fakespot). The first parameter will be the website the user is coming from when viewing this screen (default Amazon), and the second and third parameters will be the other two websites that are currently supported (Amazon, Best Buy or Walmart) besides the one used for the first parameter. The fourth parameter will be replaced by the app name. And the fifth and sixth parameter are the Fakespot app name and the company name of Mozilla.")
         public static let OptInCardLearnMoreButtonTitle = MZLocalizedString(
             key: "", // Shopping.OptInCard.LearnMoreButtonTitle.Title.v119
             tableName: "Shopping",

--- a/Shared/AppConstants.swift
+++ b/Shared/AppConstants.swift
@@ -21,6 +21,22 @@ public enum PocketAppName: String, CustomStringConvertible {
     }
 }
 
+public enum FakespotName: String, CustomStringConvertible {
+    case shortName = "Fakespot"
+
+    public var description: String {
+        return self.rawValue
+    }
+}
+
+public enum MozillaName: String, CustomStringConvertible {
+    case shortName = "Mozilla"
+
+    public var description: String {
+        return self.rawValue
+    }
+}
+
 public enum KVOConstants: String {
     case loading
     case estimatedProgress


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7536)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16753)

## :bulb: Description
Replaces Firefox, Fakespot and Mozilla in strings with placeholders to avoid translation.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

