### PR TITLE
Bugfix FXIOS-7531 [v120] Fakespot CFR's "Try review checker" link doesn't work for toolbar on bottom

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/ContextualHintView/ContextualHintView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/ContextualHintView/ContextualHintView.swift
@@ -19,9 +19,7 @@ public class ContextualHintView: UIView, ThemeApplicable {
         static let descriptionTextSize: CGFloat = 17
         static let stackViewLeading: CGFloat = 16
         static let stackViewTopArrowTopConstraint: CGFloat = 16
-        static let stackViewTopArrowBottomConstraint: CGFloat = 10
         static let stackViewBottomArrowTopConstraint: CGFloat = 5
-        static let stackViewBottomArrowBottomConstraint: CGFloat = 21
         static let stackViewTrailing: CGFloat = 3
         static let heightSpacing: CGFloat = UX.stackViewTopArrowTopConstraint + UX.stackViewBottomArrowTopConstraint
     }
@@ -100,7 +98,6 @@ public class ContextualHintView: UIView, ThemeApplicable {
     private func setupConstraints() {
         let isArrowUp = viewModel.arrowDirection == .up
         let topPadding = isArrowUp ? UX.stackViewTopArrowTopConstraint : UX.stackViewBottomArrowTopConstraint
-        let bottomPadding = isArrowUp ? UX.stackViewTopArrowBottomConstraint : UX.stackViewBottomArrowBottomConstraint
         let closeButtonPadding = isArrowUp ? UX.closeButtonTop : UX.closeButtonBottom
 
         NSLayoutConstraint.activate([
@@ -128,7 +125,7 @@ public class ContextualHintView: UIView, ThemeApplicable {
                                                constant: UX.stackViewLeading),
             stackView.trailingAnchor.constraint(equalTo: contentContainer.trailingAnchor,
                                                 constant: -UX.closeButtonSize.width - UX.stackViewTrailing),
-            stackView.bottomAnchor.constraint(equalTo: contentContainer.bottomAnchor, constant: bottomPadding),
+            stackView.bottomAnchor.constraint(equalTo: contentContainer.bottomAnchor)
         ])
 
         setNeedsLayout()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7531)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16729)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
| Layout before removing bottom padding  | Layout after removing bottom padding| 
| ------------- | ------------- |
| <img width="378" alt="layoutBefore" src="https://github.com/mozilla-mobile/firefox-ios/assets/51127880/000abc8d-83fd-4eb4-8f06-9d5ca957dd84">|<img width="399" alt="layoutAfter" src="https://github.com/mozilla-mobile/firefox-ios/assets/51127880/e6803391-04d4-49e2-804e-16556661fe53">|

- This PR removes the bottom padding because it wasn't serving any useful purpose. In fact, it was causing a problem by pushing up the content container, making the action button unresponsive to taps. The only reason it appeared to work for the top CFRs was because the padding was set to a lower value there.
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

