### PR TITLE
Refactor FXIOS-7416 [v120] Pass recently closed tabs panel delegate from history coordinator

### DIFF
--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -320,6 +320,7 @@ class BrowserCoordinator: BaseCoordinator,
     }
 
     // MARK: - SettingsCoordinatorDelegate
+
     func openURLinNewTab(_ url: URL) {
         browserViewController.openURLInNewTab(url)
     }
@@ -330,6 +331,24 @@ class BrowserCoordinator: BaseCoordinator,
     }
 
     // MARK: - LibraryCoordinatorDelegate
+
+    func openRecentlyClosedSiteInSameTab(_ url: URL) {
+        browserViewController.openRecentlyClosedSiteInSameTab(url)
+    }
+
+    func openRecentlyClosedSiteInNewTab(_ url: URL, isPrivate: Bool) {
+        browserViewController.openRecentlyClosedSiteInNewTab(url, isPrivate: isPrivate)
+    }
+
+    func libraryPanelDidRequestToOpenInNewTab(_ url: URL, isPrivate: Bool) {
+        browserViewController.libraryPanelDidRequestToOpenInNewTab(url, isPrivate: isPrivate)
+        router.dismiss()
+    }
+
+    func libraryPanel(didSelectURL url: URL, visitType: Storage.VisitType) {
+        browserViewController.libraryPanel(didSelectURL: url, visitType: visitType)
+        router.dismiss()
+    }
 
     func didFinishLibrary(from coordinator: LibraryCoordinator) {
         router.dismiss(animated: true, completion: nil)
@@ -417,18 +436,6 @@ class BrowserCoordinator: BaseCoordinator,
         let bottomSheetCoordinator = CredentialAutofillCoordinator(profile: profile, router: router, parentCoordinator: self)
         add(child: bottomSheetCoordinator)
         return bottomSheetCoordinator
-    }
-
-    // MARK: - LibraryPanelDelegate
-
-    func libraryPanelDidRequestToOpenInNewTab(_ url: URL, isPrivate: Bool) {
-        browserViewController.libraryPanelDidRequestToOpenInNewTab(url, isPrivate: isPrivate)
-        router.dismiss()
-    }
-
-    func libraryPanel(didSelectURL url: URL, visitType: Storage.VisitType) {
-        browserViewController.libraryPanel(didSelectURL: url, visitType: visitType)
-        router.dismiss()
     }
 
     // MARK: - ParentCoordinatorDelegate

--- a/Client/Coordinators/Library/HistoryCoordinator.swift
+++ b/Client/Coordinators/Library/HistoryCoordinator.swift
@@ -48,6 +48,7 @@ class HistoryCoordinator: BaseCoordinator, HistoryCoordinatorDelegate {
         let controller = RecentlyClosedTabsPanel(profile: profile)
         controller.title = .RecentlyClosedTabsPanelTitle
         controller.libraryPanelDelegate = parentCoordinator
+        controller.recentlyClosedTabsDelegate = parentCoordinator
         router.push(controller)
     }
 

--- a/Client/Coordinators/Library/LibraryCoordinator.swift
+++ b/Client/Coordinators/Library/LibraryCoordinator.swift
@@ -7,7 +7,7 @@ import Foundation
 import Shared
 import Storage
 
-protocol LibraryCoordinatorDelegate: AnyObject, LibraryPanelDelegate {
+protocol LibraryCoordinatorDelegate: AnyObject, LibraryPanelDelegate, RecentlyClosedPanelDelegate {
     func didFinishLibrary(from coordinator: LibraryCoordinator)
 }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -18,7 +18,8 @@ import ComponentLibrary
 class BrowserViewController: UIViewController,
                              SearchBarLocationProvider,
                              Themeable,
-                             LibraryPanelDelegate {
+                             LibraryPanelDelegate,
+                             RecentlyClosedPanelDelegate {
     private enum UX {
         static let ShowHeaderTapAreaHeight: CGFloat = 32
         static let ActionSheetTitleMaxLength = 120
@@ -1923,6 +1924,16 @@ class BrowserViewController: UIViewController,
         })
         self.show(toast: toast)
     }
+
+    // MARK: - RecentlyClosedPanelDelegate
+
+    func openRecentlyClosedSiteInSameTab(_ url: URL) {
+        tabTrayOpenRecentlyClosedTab(url)
+    }
+
+    func openRecentlyClosedSiteInNewTab(_ url: URL, isPrivate: Bool) {
+        tabManager.selectTab(tabManager.addTab(URLRequest(url: url)))
+    }
 }
 
 extension BrowserViewController: ClipboardBarDisplayHandlerDelegate {
@@ -2103,17 +2114,6 @@ extension BrowserViewController: LegacyTabDelegate {
 
     func tab(_ tab: Tab, didRemoveSnackbar bar: SnackBar) {
         bottomContentStackView.removeArrangedView(bar)
-    }
-}
-
-// MARK: - RecentlyClosedPanelDelegate
-extension BrowserViewController: RecentlyClosedPanelDelegate {
-    func openRecentlyClosedSiteInSameTab(_ url: URL) {
-        tabTrayOpenRecentlyClosedTab(url)
-    }
-
-    func openRecentlyClosedSiteInNewTab(_ url: URL, isPrivate: Bool) {
-        tabManager.selectTab(tabManager.addTab(URLRequest(url: url)))
     }
 }
 

--- a/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
+++ b/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
@@ -25,7 +25,7 @@ class RecentlyClosedTabsPanel: UIViewController, LibraryPanel, Themeable {
 
     weak var libraryPanelDelegate: LibraryPanelDelegate?
     var state: LibraryPanelMainState = .history(state: .inFolder)
-    var recentlyClosedTabsDelegate: RecentlyClosedPanelDelegate?
+    weak var recentlyClosedTabsDelegate: RecentlyClosedPanelDelegate?
     let profile: Profile
     var bottomToolbarItems: [UIBarButtonItem] = [UIBarButtonItem]()
 
@@ -72,13 +72,15 @@ class RecentlyClosedTabsPanel: UIViewController, LibraryPanel, Themeable {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        // BVC is assigned as `RecentlyClosedTabsPanel` delegate, to support opening tabs from within it.
-        // Previously, BVC was assigned it on panel creation via a foregroundBVC call. But it can be done this way, to
-        // avoid that call. `sceneForVC` will use the focused, active and foregrounded scene's BVC.
-        guard recentlyClosedTabsDelegate != nil else {
-            recentlyClosedTabsDelegate = sceneForVC?.coordinatorBrowserViewController
+        if !CoordinatorFlagManager.isLibraryCoordinatorEnabled {
+            // BVC is assigned as `RecentlyClosedTabsPanel` delegate, to support opening tabs from within it.
+            // Previously, BVC was assigned it on panel creation via a foregroundBVC call. But it can be done this way, to
+            // avoid that call. `sceneForVC` will use the focused, active and foregrounded scene's BVC.
+            guard recentlyClosedTabsDelegate != nil else {
+                recentlyClosedTabsDelegate = sceneForVC?.coordinatorBrowserViewController
 
-            return
+                return
+            }
         }
     }
 
@@ -89,7 +91,7 @@ class RecentlyClosedTabsPanel: UIViewController, LibraryPanel, Themeable {
 
 class RecentlyClosedTabsPanelSiteTableViewController: SiteTableViewController {
     weak var libraryPanelDelegate: LibraryPanelDelegate?
-    var recentlyClosedTabsDelegate: RecentlyClosedPanelDelegate?
+    weak var recentlyClosedTabsDelegate: RecentlyClosedPanelDelegate?
     var recentlyClosedTabs: [ClosedTab] = []
     weak var recentlyClosedTabsPanel: RecentlyClosedTabsPanel?
 

--- a/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -768,10 +768,14 @@ final class BrowserCoordinatorTests: XCTestCase {
         XCTAssertTrue(mbvc.isPrivate)
     }
 
-    func testOpenRecentlyClosedTabInSameTab() {
+    func testOpenRecentlyClosedTabInSameTab_callsReletedMethodInBrowserViewController() {
         let subject = createSubject()
+        let mbvc = MockBrowserViewController(profile: profile, tabManager: tabManager)
+        subject.browserViewController = mbvc
 
         subject.openRecentlyClosedSiteInSameTab(URL(string: "https://www.google.com")!)
+
+        XCTAssertEqual(mbvc.didOpenRecentlyClosedSiteInSameTab, 1)
     }
 
     func testOpenRecentlyClosedSiteInNewTab_addsOneTabToTabManager() {

--- a/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -768,6 +768,20 @@ final class BrowserCoordinatorTests: XCTestCase {
         XCTAssertTrue(mbvc.isPrivate)
     }
 
+    func testOpenRecentlyClosedTabInSameTab() {
+        let subject = createSubject()
+
+        subject.openRecentlyClosedSiteInSameTab(URL(string: "https://www.google.com")!)
+    }
+
+    func testOpenRecentlyClosedSiteInNewTab_addsOneTabToTabManager() {
+        let subject = createSubject()
+
+        subject.openRecentlyClosedSiteInNewTab(URL(string: "https://www.google.com")!, isPrivate: false)
+
+        XCTAssertEqual(tabManager.lastSelectedTabs.count, 1)
+    }
+
     // MARK: - Fakespot
     func testFakespotCoordinatorDelegate_didDidDismiss_removesChild() {
         let subject = createSubject()

--- a/Tests/ClientTests/Coordinators/Mocks/MockLibraryCoordinatorDelegate.swift
+++ b/Tests/ClientTests/Coordinators/Mocks/MockLibraryCoordinatorDelegate.swift
@@ -10,6 +10,8 @@ class MockLibraryCoordinatorDelegate: LibraryCoordinatorDelegate, LibraryPanelDe
     var didFinishSettingsCalled = 0
     var didRequestToOpenInNewTabCalled = false
     var didSelectURLCalled = false
+    var didOpenRecentlyClosedSiteInSameTab = 0
+    var didOpenRecentlyClosedSiteInNewTab = 0
     var lastOpenedURL: URL?
     var lastVisitType: VisitType?
     var isPrivate = false
@@ -28,5 +30,13 @@ class MockLibraryCoordinatorDelegate: LibraryCoordinatorDelegate, LibraryPanelDe
         didSelectURLCalled = true
         lastOpenedURL = url
         lastVisitType = visitType
+    }
+
+    func openRecentlyClosedSiteInSameTab(_ url: URL) {
+        didOpenRecentlyClosedSiteInSameTab += 1
+    }
+
+    func openRecentlyClosedSiteInNewTab(_ url: URL, isPrivate: Bool) {
+        didOpenRecentlyClosedSiteInNewTab += 1
     }
 }

--- a/Tests/ClientTests/Mocks/MockBrowserViewController.swift
+++ b/Tests/ClientTests/Mocks/MockBrowserViewController.swift
@@ -48,6 +48,7 @@ class MockBrowserViewController: BrowserViewController {
 
     var didRequestToOpenInNewTabCalled = false
     var didSelectURLCalled = false
+    var didOpenRecentlyClosedSiteInSameTab = 0
     var lastOpenedURL: URL?
     var lastVisitType: VisitType?
     var isPrivate = false
@@ -130,5 +131,9 @@ class MockBrowserViewController: BrowserViewController {
         didSelectURLCalled = true
         lastOpenedURL = url
         lastVisitType = visitType
+    }
+
+    override func openRecentlyClosedSiteInSameTab(_ url: URL) {
+        didOpenRecentlyClosedSiteInSameTab += 1
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7416)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16450)

## :bulb: Description
Pass `RecentlyClosedPanelDelegate` from `HistoryCoordinator` to `RecentlyClosedTabsPanel`.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

