### PR TITLE
Refactor FXIOS-7398 [v120] Replace RoundedButton in HomepageMessageCardCell

### DIFF
--- a/Client/Frontend/Home/MessageCard/HomepageMessageCard.swift
+++ b/Client/Frontend/Home/MessageCard/HomepageMessageCard.swift
@@ -104,6 +104,7 @@ class HomepageMessageCardCell: UICollectionViewCell, ReusableCell {
         }
 
         applyTheme(theme: theme)
+        ctaButton.applyTheme(theme: theme)
     }
 
     // MARK: - Layout
@@ -225,7 +226,6 @@ extension HomepageMessageCardCell: ThemeApplicable {
         bannerTitle.textColor = theme.colors.textPrimary
         descriptionText.textColor = theme.colors.textPrimary
         dismissButton.imageView?.tintColor = theme.colors.textPrimary
-        ctaButton.applyTheme(theme: theme)
         backgroundColor = .clear
 
         adjustBlur(theme: theme)

--- a/Client/Frontend/Home/MessageCard/HomepageMessageCard.swift
+++ b/Client/Frontend/Home/MessageCard/HomepageMessageCard.swift
@@ -24,14 +24,11 @@ class HomepageMessageCardCell: UICollectionViewCell, ReusableCell {
         static let dismissButtonSize = CGSize(width: 16, height: 16)
         static let dismissButtonSpacing: CGFloat = 12
         static let standardSpacing: CGFloat = 16
-        static let buttonVerticalInset: CGFloat = 12
-        static let buttonHorizontalInset: CGFloat = 16
         static let topCardSafeSpace: CGFloat = 16
         static let bottomCardSafeSpace: CGFloat = 32
         // Max font size
         static let bannerTitleFontSize: CGFloat = 16
         static let descriptionTextFontSize: CGFloat = 15
-        static let buttonFontSize: CGFloat = 16
     }
 
     // MARK: - Properties
@@ -62,18 +59,8 @@ class HomepageMessageCardCell: UICollectionViewCell, ReusableCell {
         label.accessibilityIdentifier = a11y.descriptionLabel
     }
 
-    private lazy var ctaButton: ActionButton = .build { [weak self] button in
-        button.titleLabel?.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .body,
-                                                                             size: UX.buttonFontSize)
-
-        button.layer.cornerRadius = UIFontMetrics.default.scaledValue(for: UX.cornerRadius)
-        button.titleLabel?.adjustsFontForContentSizeCategory = true
-        button.accessibilityIdentifier = a11y.ctaButton
-        button.addTarget(self, action: #selector(self?.handleCTA), for: .touchUpInside)
-        button.contentEdgeInsets = UIEdgeInsets(top: UX.buttonVerticalInset,
-                                                left: UX.buttonHorizontalInset,
-                                                bottom: UX.buttonVerticalInset,
-                                                right: UX.buttonHorizontalInset)
+    private lazy var ctaButton: PrimaryRoundedButton = .build { button in
+        button.addTarget(self, action: #selector(self.handleCTA), for: .touchUpInside)
     }
 
     private lazy var dismissButton: UIButton = .build { [weak self] button in
@@ -184,7 +171,11 @@ class HomepageMessageCardCell: UICollectionViewCell, ReusableCell {
     /// Apply message data, including handling of cases where certain parts of the message are missing.
     private func applyGleanMessage(_ message: GleanPlumbMessage) {
         if let buttonLabel = message.data.buttonLabel {
-            ctaButton.setTitle(buttonLabel, for: .normal)
+            let buttonViewModel = PrimaryRoundedButtonViewModel(
+                title: buttonLabel,
+                a11yIdentifier: a11y.ctaButton
+            )
+            ctaButton.configure(viewModel: buttonViewModel)
         } else {
             ctaButton.removeFromSuperview()
             let cardTapped = UITapGestureRecognizer(target: self, action: #selector(handleCTA))
@@ -234,8 +225,7 @@ extension HomepageMessageCardCell: ThemeApplicable {
         bannerTitle.textColor = theme.colors.textPrimary
         descriptionText.textColor = theme.colors.textPrimary
         dismissButton.imageView?.tintColor = theme.colors.textPrimary
-        ctaButton.backgroundColor = theme.colors.actionPrimary
-        ctaButton.setTitleColor(theme.colors.textInverted, for: .normal)
+        ctaButton.applyTheme(theme: theme)
         backgroundColor = .clear
 
         adjustBlur(theme: theme)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7398)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16395)

## :bulb: Description
Replacing Existing CTA button to use Primary button from component library 
Tested by forcing HomepageMessageCardCell to be displayed to ensure same layout

Screenshot:
![Simulator Screenshot - iPhone 15 Pro - 2023-10-11 at 01 48 04](https://github.com/mozilla-mobile/firefox-ios/assets/20840020/3753dedf-4d1e-405e-a35c-c377b02c12e6)



## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

