### PR TITLE
Refactor FXIOS-7512 [v120] Redux action and middleware updates for Sync tab

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		1D3C90882ACE1AF400304C87 /* RemoteTabPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3C90872ACE1AF400304C87 /* RemoteTabPanelTests.swift */; };
 		1D69FF8D27B17286001F660E /* HomeLogoHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D69FF8C27B17285001F660E /* HomeLogoHeaderCell.swift */; };
 		1D8487B42AD0C6C100F7527C /* RemoteTabsPanelMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8487B32AD0C6C100F7527C /* RemoteTabsPanelMiddleware.swift */; };
+		1D8487B62AD6038100F7527C /* RemoteTabPanelStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8487B52AD6038100F7527C /* RemoteTabPanelStateTests.swift */; };
 		1D9E1FE524FEF56C006E561D /* TopSites in Resources */ = {isa = PBXBuildFile; fileRef = 3BC659481E5BA4AE006D560F /* TopSites */; };
 		1DA3CE5D24EEE73100422BB2 /* OpenTabsWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA3CE5C24EEE73100422BB2 /* OpenTabsWidget.swift */; };
 		1DA3CE5F24EEE7C600422BB2 /* LegacyTabDataRetriever.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA3CE5E24EEE7C600422BB2 /* LegacyTabDataRetriever.swift */; };
@@ -2093,6 +2094,7 @@
 		1D69FF8C27B17285001F660E /* HomeLogoHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeLogoHeaderCell.swift; sourceTree = "<group>"; };
 		1D774B3D9C6E21B77FB7B38F /* kab */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kab; path = kab.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
 		1D8487B32AD0C6C100F7527C /* RemoteTabsPanelMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabsPanelMiddleware.swift; sourceTree = "<group>"; };
+		1D8487B52AD6038100F7527C /* RemoteTabPanelStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabPanelStateTests.swift; sourceTree = "<group>"; };
 		1D90440B860A503D4DBA4213 /* cy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cy; path = cy.lproj/Storage.strings; sourceTree = "<group>"; };
 		1DA24C60879E7D4B2073FD63 /* kab */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kab; path = kab.lproj/Search.strings; sourceTree = "<group>"; };
 		1DA3CE5C24EEE73100422BB2 /* OpenTabsWidget.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenTabsWidget.swift; sourceTree = "<group>"; };
@@ -10553,6 +10555,7 @@
 				8A11C8102731CFD700AC7318 /* ReaderModeStyleTests.swift */,
 				03CCC9171AF05E7300DBF30D /* RelativeDatesTests.swift */,
 				1D3C90872ACE1AF400304C87 /* RemoteTabPanelTests.swift */,
+				1D8487B52AD6038100F7527C /* RemoteTabPanelStateTests.swift */,
 				8A5C3BC4282ABF8E003A8CCF /* LegacyRemoteTabsPanelTests.swift */,
 				F80D53CD2A09A30F0047ED14 /* RustSyncManagerTests.swift */,
 				8A5D1CA12A30CF2E005AD35C /* Settings */,
@@ -13237,6 +13240,7 @@
 				8ACA8F7629198D6400D3075D /* ThrottlerTests.swift in Sources */,
 				217AEF76284666D4004EED37 /* IntroViewModelTests.swift in Sources */,
 				E16C76812ABDC0DB00172DB5 /* FakespotHighlightsCardViewModelTests.swift in Sources */,
+				1D8487B62AD6038100F7527C /* RemoteTabPanelStateTests.swift in Sources */,
 				2137786129802B7000D01309 /* DownloadsPanelViewModelTests.swift in Sources */,
 				8A5BD95A28788A3D000FE773 /* TopSitesHelperTests.swift in Sources */,
 				C8B41E0F29F0357300FE218A /* NimbusOnboardingFeatureLayerTests.swift in Sources */,

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelAction.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelAction.swift
@@ -9,12 +9,11 @@ import Storage
 /// Defines actions sent to Redux for Sync tab in tab tray
 enum RemoteTabsPanelAction: Action {
     case panelDidAppear
-    case refreshCachedTabs
     case refreshTabs
+    case refreshDidBegin
     case refreshDidFail(RemoteTabsPanelEmptyStateReason)
     case cachedTabsAvailable(RemoteTabsPanelCachedResults)
     case refreshDidSucceed([ClientAndTabs])
-    case syncableAccountStatusChanged(Bool)
 }
 
 struct RemoteTabsPanelCachedResults {

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelAction.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelAction.swift
@@ -14,6 +14,7 @@ enum RemoteTabsPanelAction: Action {
     case refreshDidFail(RemoteTabsPanelEmptyStateReason)
     case cachedTabsAvailable(RemoteTabsPanelCachedResults)
     case refreshDidSucceed([ClientAndTabs])
+    case syncableAccountStatusChanged(Bool)
 }
 
 struct RemoteTabsPanelCachedResults {

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelMiddleware.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelMiddleware.swift
@@ -50,8 +50,8 @@ class RemoteTabsPanelMiddleware {
             DispatchQueue.main.async {
                 store.dispatch(RemoteTabsPanelAction.refreshDidBegin)
 
-                DispatchQueue.main.async {
-                    self.profile.getCachedClientsAndTabs { [weak self] result in
+                self.profile.getCachedClientsAndTabs { [weak self] result in
+                    DispatchQueue.main.async {
                         guard let clientAndTabs = result else {
                             store.dispatch(RemoteTabsPanelAction.refreshDidFail(.failedToSync))
                             return

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelMiddleware.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelMiddleware.swift
@@ -16,9 +16,9 @@ class RemoteTabsPanelMiddleware {
     }
 
     lazy var remoteTabsPanelProvider: Middleware<AppState> = { state, action in
-        let tabPanelState = state.screenState(RemoteTabsPanelState.self, for: .remoteTabsPanel)
         switch action {
         case RemoteTabsPanelAction.refreshTabs:
+            let tabPanelState = state.screenState(RemoteTabsPanelState.self, for: .remoteTabsPanel)
             self.updateSyncableAccountState(for: tabPanelState, then: { refreshAllowed in
                 if refreshAllowed {
                     self.refreshTabs(updateCache: true)

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelState.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelState.swift
@@ -55,7 +55,7 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
 
     init() {
         self.init(refreshState: .idle,
-                  allowsRefresh: true,
+                  allowsRefresh: false,
                   clientAndTabs: [],
                   showingEmptyState: .noTabs)
     }
@@ -71,9 +71,15 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
     }
 
     static let reducer: Reducer<Self> = { state, action in
-        // TODO: Additional Reducer support forthcoming. [FXIOS-7512]
         switch action {
+        case RemoteTabsPanelAction.syncableAccountStatusChanged(let hasSyncableAccount):
+            let newState = RemoteTabsPanelState(refreshState: state.refreshState,
+                                                allowsRefresh: hasSyncableAccount,
+                                                clientAndTabs: state.clientAndTabs,
+                                                showingEmptyState: state.showingEmptyState)
+            return newState
         case RemoteTabsPanelAction.refreshTabs:
+            guard state.allowsRefresh else { return state }
             let newState = RemoteTabsPanelState(refreshState: .refreshing,
                                                 allowsRefresh: state.allowsRefresh,
                                                 clientAndTabs: state.clientAndTabs,

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelState.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelState.swift
@@ -72,14 +72,11 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
 
     static let reducer: Reducer<Self> = { state, action in
         switch action {
-        case RemoteTabsPanelAction.syncableAccountStatusChanged(let hasSyncableAccount):
-            let newState = RemoteTabsPanelState(refreshState: state.refreshState,
-                                                allowsRefresh: hasSyncableAccount,
-                                                clientAndTabs: state.clientAndTabs,
-                                                showingEmptyState: state.showingEmptyState)
-            return newState
         case RemoteTabsPanelAction.refreshTabs:
-            guard state.allowsRefresh else { return state }
+            // No change to state until middleware performs necessary logic to
+            // determine whether we can sync account
+            return state
+        case RemoteTabsPanelAction.refreshDidBegin:
             let newState = RemoteTabsPanelState(refreshState: .refreshing,
                                                 allowsRefresh: state.allowsRefresh,
                                                 clientAndTabs: state.clientAndTabs,

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelState.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelState.swift
@@ -82,8 +82,14 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
                                                 clientAndTabs: state.clientAndTabs,
                                                 showingEmptyState: state.showingEmptyState)
             return newState
-        case RemoteTabsPanelAction.refreshDidFail:
+        case RemoteTabsPanelAction.refreshDidFail(let reason):
             // Refresh failed. Show error empty state.
+            let allowsRefresh: Bool = {
+                switch reason {
+                case .notLoggedIn, .syncDisabledByUser: return false
+                default: return true
+                }
+            }()
             let newState = RemoteTabsPanelState(refreshState: .idle,
                                                 allowsRefresh: state.allowsRefresh,
                                                 clientAndTabs: state.clientAndTabs,
@@ -92,13 +98,13 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
         case RemoteTabsPanelAction.refreshDidSucceed(let newClientAndTabs):
             // Send client and tabs state, ensure empty state is nil and refresh is idle
             let newState = RemoteTabsPanelState(refreshState: .idle,
-                                                allowsRefresh: state.allowsRefresh,
+                                                allowsRefresh: true,
                                                 clientAndTabs: newClientAndTabs,
                                                 showingEmptyState: nil)
             return newState
         case RemoteTabsPanelAction.cachedTabsAvailable(let cachedResults):
             let newState = RemoteTabsPanelState(refreshState: cachedResults.isUpdating ? .refreshing : .idle,
-                                                allowsRefresh: state.allowsRefresh,
+                                                allowsRefresh: true,
                                                 clientAndTabs: cachedResults.clientAndTabs,
                                                 showingEmptyState: nil)
             return newState

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelState.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsPanelState.swift
@@ -32,6 +32,16 @@ enum RemoteTabsPanelEmptyStateReason {
         case .syncDisabledByUser: return .TabsTray.Sync.SyncTabsDisabled
         }
     }
+
+    /// Whether this state allows the user to refresh tabs.
+    var allowsRefresh: Bool {
+        switch self {
+        case .notLoggedIn, .syncDisabledByUser:
+            return false
+        default:
+            return true
+        }
+    }
 }
 
 /// State for RemoteTabsPanel. WIP.
@@ -84,14 +94,9 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
             return newState
         case RemoteTabsPanelAction.refreshDidFail(let reason):
             // Refresh failed. Show error empty state.
-            let allowsRefresh: Bool = {
-                switch reason {
-                case .notLoggedIn, .syncDisabledByUser: return false
-                default: return true
-                }
-            }()
+            let allowsRefresh = reason.allowsRefresh
             let newState = RemoteTabsPanelState(refreshState: .idle,
-                                                allowsRefresh: state.allowsRefresh,
+                                                allowsRefresh: allowsRefresh,
                                                 clientAndTabs: state.clientAndTabs,
                                                 showingEmptyState: .failedToSync)
             return newState

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
@@ -87,13 +87,6 @@ class RemoteTabsTableViewController: UITableViewController,
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         (navigationController as? ThemedNavigationController)?.applyTheme()
-
-        // Add a refresh control if the user is logged in and the control
-        // was not added before. If the user is not logged in, remove any
-        // existing control.
-        if state.allowsRefresh && refreshControl == nil {
-            addRefreshControl()
-        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -119,6 +112,15 @@ class RemoteTabsTableViewController: UITableViewController,
 
         if state.refreshState != .refreshing {
             endRefreshing()
+        }
+
+        // Add a refresh control if the user is logged in and the control
+        // was not added before. If the user is not logged in, remove any
+        // existing control.
+        if state.allowsRefresh && refreshControl == nil {
+            addRefreshControl()
+        } else if !state.allowsRefresh {
+            removeRefreshControl()
         }
 
         tableView.reloadData()
@@ -157,7 +159,9 @@ class RemoteTabsTableViewController: UITableViewController,
             endRefreshing()
             return
         }
-
+        guard state.refreshState == .idle else {
+            return
+        }
         refreshControl?.beginRefreshing()
         remoteTabsPanel?.tableViewControllerDidPullToRefresh()
     }

--- a/Tests/ClientTests/RemoteTabPanelStateTests.swift
+++ b/Tests/ClientTests/RemoteTabPanelStateTests.swift
@@ -1,0 +1,87 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Redux
+import Storage
+import Shared
+import XCTest
+
+@testable import Client
+
+final class RemoteTabPanelStateTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        DependencyHelperMock().reset()
+    }
+
+    func testTabsRefreshSuccessStateChange() {
+        let initialState = createSubject()
+        let reducer = remoteTabsPanelReducer()
+        let testTabs = generateOneClientTwoTabs()
+
+        XCTAssertEqual(initialState.clientAndTabs.count, 0)
+
+        let newState = reducer(initialState, RemoteTabsPanelAction.refreshDidSucceed(testTabs))
+
+        XCTAssertEqual(newState.clientAndTabs.count, 1)
+        XCTAssertEqual(newState.clientAndTabs.first!.tabs.count, 2)
+    }
+
+    func testTabsRefreshFailedStateChange() {
+        let initialState = createSubject()
+        let reducer = remoteTabsPanelReducer()
+
+        let newState = reducer(initialState, RemoteTabsPanelAction.refreshDidFail(.failedToSync))
+
+        XCTAssertEqual(newState.refreshState, RemoteTabsPanelRefreshState.idle)
+        XCTAssertNotNil(newState.showingEmptyState)
+    }
+
+    // MARK: - Private
+
+    private func remoteTabsPanelReducer() -> Reducer<RemoteTabsPanelState> {
+        return RemoteTabsPanelState.reducer
+    }
+
+    private func generateEmptyState() -> RemoteTabsPanelState {
+        return RemoteTabsPanelState()
+    }
+
+    private func generateOneClientTwoTabs() -> [ClientAndTabs] {
+        let tab1 = RemoteTab(clientGUID: "123",
+                             URL: URL(string: "https://mozilla.com")!,
+                             title: "Mozilla Homepage",
+                             history: [],
+                             lastUsed: 0,
+                             icon: nil)
+        let tab2 = RemoteTab(clientGUID: "123",
+                             URL: URL(string: "https://google.com")!,
+                             title: "Google Homepage",
+                             history: [],
+                             lastUsed: 0,
+                             icon: nil)
+        let fakeTabs: [RemoteTab] = [tab1, tab2]
+        let client = RemoteClient(guid: "123",
+                                  name: "Client",
+                                  modified: 0,
+                                  type: "Type (Test)",
+                                  formfactor: "Test",
+                                  os: "macOS",
+                                  version: "v1.0",
+                                  fxaDeviceId: "12345")
+        let fakeData = [ClientAndTabs(client: client, tabs: fakeTabs)]
+        return fakeData
+    }
+
+    private func createSubject() -> RemoteTabsPanelState {
+        let subject = RemoteTabsPanelState()
+        return subject
+    }
+}

--- a/Tests/ClientTests/RemoteTabPanelStateTests.swift
+++ b/Tests/ClientTests/RemoteTabPanelStateTests.swift
@@ -30,6 +30,8 @@ final class RemoteTabPanelStateTests: XCTestCase {
 
         let newState = reducer(initialState, RemoteTabsPanelAction.refreshTabs)
 
+        // Refresh should fail since Profile.hasSyncableAccount
+        // is false for unit test, expected state is .idle
         XCTAssertEqual(newState.refreshState,
                        RemoteTabsPanelRefreshState.idle)
     }

--- a/Tests/ClientTests/RemoteTabPanelStateTests.swift
+++ b/Tests/ClientTests/RemoteTabPanelStateTests.swift
@@ -21,6 +21,16 @@ final class RemoteTabPanelStateTests: XCTestCase {
         DependencyHelperMock().reset()
     }
 
+    func testTabsRefreshSkippedIfNotAllowed() {
+        let initialState = RemoteTabsPanelState(refreshState: .idle, allowsRefresh: false, clientAndTabs: [], showingEmptyState: nil)
+        let reducer = remoteTabsPanelReducer()
+
+        let newState = reducer(initialState, RemoteTabsPanelAction.refreshTabs)
+
+        XCTAssertEqual(newState.refreshState,
+                       RemoteTabsPanelRefreshState.idle)
+    }
+
     func testTabsRefreshSuccessStateChange() {
         let initialState = createSubject()
         let reducer = remoteTabsPanelReducer()
@@ -29,6 +39,21 @@ final class RemoteTabPanelStateTests: XCTestCase {
         XCTAssertEqual(initialState.clientAndTabs.count, 0)
 
         let newState = reducer(initialState, RemoteTabsPanelAction.refreshDidSucceed(testTabs))
+
+        XCTAssertEqual(newState.clientAndTabs.count, 1)
+        XCTAssertEqual(newState.clientAndTabs.first!.tabs.count, 2)
+    }
+
+    func testTabsCachedResultAvailableStateChange() {
+        let initialState = createSubject()
+        let reducer = remoteTabsPanelReducer()
+        let testTabs = generateOneClientTwoTabs()
+        let cachedResult = RemoteTabsPanelCachedResults(clientAndTabs: testTabs,
+                                                        isUpdating: false)
+
+        XCTAssertEqual(initialState.clientAndTabs.count, 0)
+
+        let newState = reducer(initialState, RemoteTabsPanelAction.cachedTabsAvailable(cachedResult))
 
         XCTAssertEqual(newState.clientAndTabs.count, 1)
         XCTAssertEqual(newState.clientAndTabs.first!.tabs.count, 2)

--- a/Tests/ClientTests/RemoteTabPanelStateTests.swift
+++ b/Tests/ClientTests/RemoteTabPanelStateTests.swift
@@ -22,7 +22,10 @@ final class RemoteTabPanelStateTests: XCTestCase {
     }
 
     func testTabsRefreshSkippedIfNotAllowed() {
-        let initialState = RemoteTabsPanelState(refreshState: .idle, allowsRefresh: false, clientAndTabs: [], showingEmptyState: nil)
+        let initialState = RemoteTabsPanelState()
+        XCTAssertEqual(initialState.refreshState,
+                       RemoteTabsPanelRefreshState.idle)
+
         let reducer = remoteTabsPanelReducer()
 
         let newState = reducer(initialState, RemoteTabsPanelAction.refreshTabs)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7512)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16676)

## :bulb: Description

Logic updates and fixes for Redux-based Sync tab. In this PR:
- Fixes some logic for `allowsRefresh` on the sync tab redux state
- Adds support for adding/removing the refresh control based on the ability to sync
- A few related updates/fixes

Additional updates for FXIOS-7512 still forthcoming.
 
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

