### PR TITLE
Refactor FXIOS-7399 [v120] Replace goToSettingsButton in DefaultBrowserOnboardingViewController

### DIFF
--- a/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
+++ b/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
@@ -102,12 +102,8 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
         label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.HomeTabBanner.descriptionLabel3
     }
 
-    private lazy var goToSettingsButton: ResizableButton = .build { button in
-        button.layer.cornerRadius = UX.ctaButtonCornerRadius
-        button.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.HomeTabBanner.ctaButton
-        button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .title3, size: 20)
-        button.contentEdgeInsets = UIEdgeInsets(top: 15, left: 15, bottom: 15, right: 15)
-        button.titleLabel?.textAlignment = .center
+    private lazy var goToSettingsButton: PrimaryRoundedButton = .build { button in
+        button.addTarget(self, action: #selector(self.goToSettings), for: .touchUpInside)
     }
 
     // MARK: - Inits
@@ -157,10 +153,15 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
         descriptionLabel1.text = viewModel.model?.descriptionText[1]
         descriptionLabel2.text = viewModel.model?.descriptionText[2]
         descriptionLabel3.text = viewModel.model?.descriptionText[3]
-        goToSettingsButton.setTitle(.DefaultBrowserOnboardingButton, for: .normal)
 
         closeButton.addTarget(self, action: #selector(dismissAnimated), for: .touchUpInside)
-        goToSettingsButton.addTarget(self, action: #selector(goToSettings), for: .touchUpInside)
+
+        let goToSettingsButtonViewModel = PrimaryRoundedButtonViewModel(
+            title: .DefaultBrowserOnboardingButton,
+            a11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.HomeTabBanner.ctaButton
+        )
+        goToSettingsButton.configure(viewModel: goToSettingsButtonViewModel)
+        goToSettingsButton.applyTheme(theme: themeManager.currentTheme)
 
         setupLayout()
     }
@@ -274,9 +275,6 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
         descriptionLabel1.textColor = theme.colors.textPrimary
         descriptionLabel2.textColor = theme.colors.textPrimary
         descriptionLabel3.textColor = theme.colors.textPrimary
-
-        goToSettingsButton.backgroundColor = theme.colors.actionPrimary
-        goToSettingsButton.setTitleColor(theme.colors.textInverted, for: .normal)
 
         closeButton.tintColor = theme.colors.textSecondary
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Changed existing `goToSettingsButton` on `DefaultBrowserOnboardingViewController` from `ResizableButton` type to `PrimaryRoundedButton` type

Screenshot:

<img width="360" alt="Screenshot 2023-10-10 at 11 34 39 pm" src="https://github.com/mozilla-mobile/firefox-ios/assets/54324355/b4c07e45-f0a5-47ad-8f48-92ce8960755c">


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

