### PR TITLE
Bugfix FXIOS-7295 [v120] reload page if stuck at loading

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2290,8 +2290,8 @@ extension BrowserViewController: TabManagerDelegate {
             topTabsDidChangeTab()
         }
 
-       /// If the selectedTab is showing an error page trigger a reload
-        if let url = selected?.url, let internalUrl = InternalURL(url), internalUrl.isErrorPage {
+       /// If the selectedTab is showing an error page or stuck on loading trigger a reload
+        if let url = selected?.url, (InternalURL(url)?.isErrorPage ?? false || selected?.webView?.isLoading ?? false) {
             selected?.reloadPage()
             return
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7295)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16194)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Sometimes on opening a few pages in a new tab (whether private or regular), it was getting stuck on the loading screen. The reason is that in those cases `webView(_:didCommit:)` is called but not called `webView(_:didFinish:)` nor giving an error callback. It seems since the page gets loaded in the background (not in the view hierarchy) this issue happens on pages with heavy loading. Was able to reproduce this on a few guardian pages. A possible fix added is to reload the page on the opening tab if it was stuck at the loading state.


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

