### PR TITLE
Refactor FXIOS-7537 [v120] Dismiss any child coordinators when we handle a route

### DIFF
--- a/Client/Coordinators/BaseCoordinator.swift
+++ b/Client/Coordinators/BaseCoordinator.swift
@@ -11,6 +11,7 @@ open class BaseCoordinator: NSObject, Coordinator {
     var childCoordinators: [Coordinator] = []
     var router: Router
     var logger: Logger
+    var isDismissable: Bool { true }
 
     init(router: Router,
          logger: Logger = DefaultLogger.shared) {
@@ -49,6 +50,14 @@ open class BaseCoordinator: NSObject, Coordinator {
         for childCoordinator in childCoordinators {
             if let matchingCoordinator = childCoordinator.findAndHandle(route: route) {
                 savedRoute = nil
+
+                // Dismiss any child of the matching coordinator that handles a route
+                for child in matchingCoordinator.childCoordinators {
+                    guard child.isDismissable else { continue }
+                    matchingCoordinator.router.dismiss()
+                    matchingCoordinator.remove(child: child)
+                }
+
                 return matchingCoordinator
             }
         }

--- a/Client/Coordinators/Coordinator.swift
+++ b/Client/Coordinators/Coordinator.swift
@@ -11,6 +11,11 @@ protocol Coordinator: AnyObject {
     var router: Router { get }
     var logger: Logger { get }
 
+    /// Determines whether this coordinator can be dismissed or not, in some cases the coordinator cannot be dismissed for example due to state saving.
+    /// This isn't ideal for this pattern, but was deemed necessary to keep existing behavior while moving away from previous pattern. By default, all coordinators
+    /// should be dismissable.
+    var isDismissable: Bool { get }
+
     /// Will hold the Route the coordinator was asked to navigate to in case the path could not be handled yet.
     var savedRoute: Route? { get set }
 

--- a/Client/Coordinators/Library/LibraryCoordinator.swift
+++ b/Client/Coordinators/Library/LibraryCoordinator.swift
@@ -20,6 +20,7 @@ class LibraryCoordinator: BaseCoordinator, LibraryPanelDelegate, LibraryNavigati
     private let tabManager: TabManager
     private var libraryViewController: LibraryViewController!
     weak var parentCoordinator: LibraryCoordinatorDelegate?
+    override var isDismissable: Bool { false }
 
     init(
         router: Router,

--- a/Tests/ClientTests/Coordinators/BaseCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/BaseCoordinatorTests.swift
@@ -74,4 +74,42 @@ final class BaseCoordinatorTests: XCTestCase {
         XCTAssertNil(matchingCoordinator)
         XCTAssertNotNil(subject.savedRoute)
     }
+
+    func testRemoveDismissableFromChild() {
+        // Given
+        let subject = BaseCoordinator(router: router)
+        let childCoordinator = MockSearchHandlerRouteCoordinator(router: router)
+        let grandChildCoordinator = BaseCoordinator(router: router)
+
+        subject.add(child: childCoordinator)
+        childCoordinator.add(child: grandChildCoordinator)
+
+        // When
+        let route = Route.search(url: URL(string: "https://www.google.com"), isPrivate: false)
+        let matchingCoordinator = subject.findAndHandle(route: route)
+
+        // Then
+        XCTAssertEqual(matchingCoordinator?.childCoordinators.count, 0, "Child was removed")
+    }
+
+    func testDoesntRemoveNotDismissableFromChild() {
+        // Given
+        let subject = BaseCoordinator(router: router)
+        let childCoordinator = MockSearchHandlerRouteCoordinator(router: router)
+        let grandChildCoordinator = NonDismissableCoordinator(router: router)
+
+        subject.add(child: childCoordinator)
+        childCoordinator.add(child: grandChildCoordinator)
+
+        // When
+        let route = Route.search(url: URL(string: "https://www.google.com"), isPrivate: false)
+        let matchingCoordinator = subject.findAndHandle(route: route)
+
+        // Then
+        XCTAssertEqual(matchingCoordinator?.childCoordinators.count, 1, "Child was not removed")
+    }
+}
+
+class NonDismissableCoordinator: BaseCoordinator {
+    override var isDismissable: Bool { false }
 }

--- a/Tests/ClientTests/Mocks/MockCoordinator.swift
+++ b/Tests/ClientTests/Mocks/MockCoordinator.swift
@@ -12,7 +12,7 @@ class MockCoordinator: Coordinator {
     var router: Router
     var savedRoute: Route?
     var logger: Logger = MockLogger()
-    var isDismissable: Bool = true
+    var isDismissable = true
 
     var addChildCalled = 0
     var removedChildCalled = 0

--- a/Tests/ClientTests/Mocks/MockCoordinator.swift
+++ b/Tests/ClientTests/Mocks/MockCoordinator.swift
@@ -12,6 +12,7 @@ class MockCoordinator: Coordinator {
     var router: Router
     var savedRoute: Route?
     var logger: Logger = MockLogger()
+    var isDismissable: Bool = true
 
     var addChildCalled = 0
     var removedChildCalled = 0


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7537)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16754)

## :bulb: Description
This should cover the use case where Fakespot modal isn't showing anymore after we have a deep link opened (when the modal was already showing on a tab).

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

