### PR TITLE
Refactor FXIOS-7523 [v120] Remote tab dismiss bottom sheet

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -545,6 +545,7 @@
 		8A11C8112731CFD700AC7318 /* ReaderModeStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A11C8102731CFD700AC7318 /* ReaderModeStyleTests.swift */; };
 		8A11C8132731E54800AC7318 /* DictionaryExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A11C8122731E54800AC7318 /* DictionaryExtensionsTests.swift */; };
 		8A13FA892AD82BC8007527AB /* AppSendTabDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A13FA882AD82BC8007527AB /* AppSendTabDelegateTests.swift */; };
+		8A13FA8B2AD82E6D007527AB /* ApplicationStateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A13FA8A2AD82E6D007527AB /* ApplicationStateProvider.swift */; };
 		8A161411282C035D00DDBB02 /* CustomizeHomepageSectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A161410282C035D00DDBB02 /* CustomizeHomepageSectionViewModel.swift */; };
 		8A171A6329F82B0E0085770E /* SceneDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A171A6129F82AE20085770E /* SceneDelegateTests.swift */; };
 		8A19ACAB2A32895E001C2147 /* BrowserNavigationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A19ACAA2A32895E001C2147 /* BrowserNavigationHandler.swift */; };
@@ -4895,6 +4896,7 @@
 		8A11C8102731CFD700AC7318 /* ReaderModeStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeStyleTests.swift; sourceTree = "<group>"; };
 		8A11C8122731E54800AC7318 /* DictionaryExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryExtensionsTests.swift; sourceTree = "<group>"; };
 		8A13FA882AD82BC8007527AB /* AppSendTabDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSendTabDelegateTests.swift; sourceTree = "<group>"; };
+		8A13FA8A2AD82E6D007527AB /* ApplicationStateProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationStateProvider.swift; sourceTree = "<group>"; };
 		8A161410282C035D00DDBB02 /* CustomizeHomepageSectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomizeHomepageSectionViewModel.swift; sourceTree = "<group>"; };
 		8A171A6129F82AE20085770E /* SceneDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegateTests.swift; sourceTree = "<group>"; };
 		8A19ACAA2A32895E001C2147 /* BrowserNavigationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserNavigationHandler.swift; sourceTree = "<group>"; };
@@ -9813,6 +9815,7 @@
 				21E78A7128F9A93100F8D687 /* UIDeviceInterface.swift */,
 				C8B509E2293FA39900AC013C /* AppVersionUpdateCheckerProtocol.swift */,
 				8A93F86129D36F0F004159D9 /* NavigationController.swift */,
+				8A13FA8A2AD82E6D007527AB /* ApplicationStateProvider.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -12798,6 +12801,7 @@
 				C8656D79270F866700E199EA /* CustomizeHomepageSectionCell.swift in Sources */,
 				ABE4393E2AC432040074FFE1 /* PartnerWebsites.swift in Sources */,
 				C84655FB28879FC600861B4A /* WallpaperStorageUtility.swift in Sources */,
+				8A13FA8B2AD82E6D007527AB /* ApplicationStateProvider.swift in Sources */,
 				4347B39A298DA5BB0045F677 /* CreditCardInputViewModel.swift in Sources */,
 				6025B10D267B6C5400F59F6B /* LoginRecordExtension.swift in Sources */,
 				2F44FCC51A9E85E900FD20CC /* SettingsTableViewController.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -544,6 +544,7 @@
 		8A11C80F2731916E00AC7318 /* defaultOnlyTestList.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A11C80D2731916E00AC7318 /* defaultOnlyTestList.json */; };
 		8A11C8112731CFD700AC7318 /* ReaderModeStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A11C8102731CFD700AC7318 /* ReaderModeStyleTests.swift */; };
 		8A11C8132731E54800AC7318 /* DictionaryExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A11C8122731E54800AC7318 /* DictionaryExtensionsTests.swift */; };
+		8A13FA892AD82BC8007527AB /* AppSendTabDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A13FA882AD82BC8007527AB /* AppSendTabDelegateTests.swift */; };
 		8A161411282C035D00DDBB02 /* CustomizeHomepageSectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A161410282C035D00DDBB02 /* CustomizeHomepageSectionViewModel.swift */; };
 		8A171A6329F82B0E0085770E /* SceneDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A171A6129F82AE20085770E /* SceneDelegateTests.swift */; };
 		8A19ACAB2A32895E001C2147 /* BrowserNavigationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A19ACAA2A32895E001C2147 /* BrowserNavigationHandler.swift */; };
@@ -4893,6 +4894,7 @@
 		8A11C80D2731916E00AC7318 /* defaultOnlyTestList.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = defaultOnlyTestList.json; sourceTree = "<group>"; };
 		8A11C8102731CFD700AC7318 /* ReaderModeStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeStyleTests.swift; sourceTree = "<group>"; };
 		8A11C8122731E54800AC7318 /* DictionaryExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryExtensionsTests.swift; sourceTree = "<group>"; };
+		8A13FA882AD82BC8007527AB /* AppSendTabDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSendTabDelegateTests.swift; sourceTree = "<group>"; };
 		8A161410282C035D00DDBB02 /* CustomizeHomepageSectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomizeHomepageSectionViewModel.swift; sourceTree = "<group>"; };
 		8A171A6129F82AE20085770E /* SceneDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegateTests.swift; sourceTree = "<group>"; };
 		8A19ACAA2A32895E001C2147 /* BrowserNavigationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserNavigationHandler.swift; sourceTree = "<group>"; };
@@ -8177,6 +8179,7 @@
 			isa = PBXGroup;
 			children = (
 				8A171A6129F82AE20085770E /* SceneDelegateTests.swift */,
+				8A13FA882AD82BC8007527AB /* AppSendTabDelegateTests.swift */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -13088,6 +13091,7 @@
 				8A093D812A4B58330099ABA5 /* MockSettingsFlowDelegate.swift in Sources */,
 				431C0D1E25C9DC4D00395CE4 /* DefaultBrowserOnboardingTests.swift in Sources */,
 				213B67A827CE721E000542F5 /* StartAtHomeHelperTests.swift in Sources */,
+				8A13FA892AD82BC8007527AB /* AppSendTabDelegateTests.swift in Sources */,
 				8A7653C228A2E57D00924ABF /* PocketDataAdaptorTests.swift in Sources */,
 				C8CD80D42A1E268C0097C3AE /* MockGleanPlumbEvaluationUtility.swift in Sources */,
 				E1AEC176286E0CF500062E29 /* JumpBackInViewModelTests.swift in Sources */,

--- a/Client/Application/AppDelegate+SyncSentTabs.swift
+++ b/Client/Application/AppDelegate+SyncSentTabs.swift
@@ -24,19 +24,24 @@ extension UIApplication {
 class AppSendTabDelegate: SendTabDelegate {
     private let app: UIApplication
     private let logger: Logger
+    private var applicationHelper: ApplicationHelper
 
-    init(app: UIApplication, logger: Logger = DefaultLogger.shared) {
+    init(app: UIApplication, 
+         logger: Logger = DefaultLogger.shared,
+         applicationHelper: ApplicationHelper = DefaultApplicationHelper()) {
         self.app = app
         self.logger = logger
+        self.applicationHelper = applicationHelper
     }
 
     func openSendTabs(for urls: [URL]) {
         DispatchQueue.main.async {
-            if self.app.applicationState == .active {
-                for url in urls {
-                    let object = OpenTabNotificationObject(type: .switchToTabForURLOrOpen(url))
-                    NotificationCenter.default.post(name: .OpenTabNotification, object: object)
-                }
+            guard self.app.applicationState == .active else { return }
+            // TODO: Laurie check what happens with multiple URLs
+            for urlToOpen in urls {
+                let urlString = URL.mozInternalScheme + "://open-url?url=\(urlToOpen)}"
+                guard let url = URL(string: urlString) else { continue }
+                self.applicationHelper.open(url)
             }
         }
     }

--- a/Client/Application/AppDelegate+SyncSentTabs.swift
+++ b/Client/Application/AppDelegate+SyncSentTabs.swift
@@ -15,31 +15,32 @@ extension UIApplication {
     }
 }
 
-/**
- Sent tabs can be displayed not only by receiving push notifications, but by sync.
- Sync will get the list of sent tabs, and try to display any in that list.
- Thus, push notifications are not needed to receive sent tabs, they can be handled
- when the app performs a sync.
- */
+/// Sent tabs can be displayed not only by receiving push notifications, but by sync.
+/// Sync will get the list of sent tabs, and try to display any in that list.
+/// Thus, push notifications are not needed to receive sent tabs, they can be handled
+/// when the app performs a sync.
 class AppSendTabDelegate: SendTabDelegate {
     private let app: UIApplication
     private let logger: Logger
     private var applicationHelper: ApplicationHelper
+    private var mainQueue: DispatchQueueInterface
 
     init(app: UIApplication,
          logger: Logger = DefaultLogger.shared,
-         applicationHelper: ApplicationHelper = DefaultApplicationHelper()) {
+         applicationHelper: ApplicationHelper = DefaultApplicationHelper(),
+         mainQueue: DispatchQueueInterface = DispatchQueue.main) {
         self.app = app
         self.logger = logger
         self.applicationHelper = applicationHelper
+        self.mainQueue = mainQueue
     }
 
     func openSendTabs(for urls: [URL]) {
-        DispatchQueue.main.async {
+        mainQueue.async {
             guard self.app.applicationState == .active else { return }
-            // TODO: Laurie check what happens with multiple URLs
+
             for urlToOpen in urls {
-                let urlString = URL.mozInternalScheme + "://open-url?url=\(urlToOpen)}"
+                let urlString = URL.mozInternalScheme + "://open-url?url=\(urlToOpen)"
                 guard let url = URL(string: urlString) else { continue }
                 self.applicationHelper.open(url)
             }

--- a/Client/Application/AppDelegate+SyncSentTabs.swift
+++ b/Client/Application/AppDelegate+SyncSentTabs.swift
@@ -20,12 +20,12 @@ extension UIApplication {
 /// Thus, push notifications are not needed to receive sent tabs, they can be handled
 /// when the app performs a sync.
 class AppSendTabDelegate: SendTabDelegate {
-    private let app: UIApplication
+    private let app: ApplicationStateProvider
     private let logger: Logger
     private var applicationHelper: ApplicationHelper
     private var mainQueue: DispatchQueueInterface
 
-    init(app: UIApplication,
+    init(app: ApplicationStateProvider,
          logger: Logger = DefaultLogger.shared,
          applicationHelper: ApplicationHelper = DefaultApplicationHelper(),
          mainQueue: DispatchQueueInterface = DispatchQueue.main) {

--- a/Client/Application/AppDelegate+SyncSentTabs.swift
+++ b/Client/Application/AppDelegate+SyncSentTabs.swift
@@ -26,7 +26,7 @@ class AppSendTabDelegate: SendTabDelegate {
     private let logger: Logger
     private var applicationHelper: ApplicationHelper
 
-    init(app: UIApplication, 
+    init(app: UIApplication,
          logger: Logger = DefaultLogger.shared,
          applicationHelper: ApplicationHelper = DefaultApplicationHelper()) {
         self.app = app

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -230,19 +230,12 @@ class BrowserViewController: UIViewController,
 
     @objc
     func openTabNotification(notification: Notification) {
+        // TODO: remove this notification with FXIOS-7550
         guard let openTabObject = notification.object as? OpenTabNotificationObject else {
             return
         }
 
         switch openTabObject.type {
-        case .loadQueuedTabs(let urls):
-            loadQueuedTabs(receivedURLs: urls)
-        case .openNewTab:
-            openBlankNewTab(focusLocationField: true)
-        case .openSearchNewTab(let searchTerm):
-            openSearchNewTab(searchTerm)
-        case .switchToTabForURLOrOpen(let url):
-            switchToTabForURLOrOpen(url)
         case .debugOption(let numberOfTabs, let url):
             debugOpen(numberOfNewTabs: numberOfTabs, at: url)
         }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -230,7 +230,7 @@ class BrowserViewController: UIViewController,
 
     @objc
     func openTabNotification(notification: Notification) {
-        // TODO: remove this notification with FXIOS-7550
+        // Remove this notification only used for debug settings with FXIOS-7550
         guard let openTabObject = notification.object as? OpenTabNotificationObject else {
             return
         }

--- a/Client/Frontend/Browser/OpenTabNotificationObject.swift
+++ b/Client/Frontend/Browser/OpenTabNotificationObject.swift
@@ -9,10 +9,6 @@ import Foundation
 // as part of the multitasking epic.
 struct OpenTabNotificationObject {
     enum ObjectType {
-        case loadQueuedTabs([URL])
-        case openNewTab
-        case openSearchNewTab(String)
-        case switchToTabForURLOrOpen(URL)
         case debugOption(Int, URL)
     }
 

--- a/Client/Protocols/ApplicationStateProvider.swift
+++ b/Client/Protocols/ApplicationStateProvider.swift
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+
+protocol ApplicationStateProvider {
+    var applicationState: UIApplication.State { get }
+}
+
+extension UIApplication: ApplicationStateProvider {}

--- a/Tests/ClientTests/Application/AppSendTabDelegateTests.swift
+++ b/Tests/ClientTests/Application/AppSendTabDelegateTests.swift
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Client
+
+final class AppSendTabDelegateTests: XCTestCase {
+    private var applicationHelper: MockApplicationHelper!
+
+    override func setUp() {
+        super.setUp()
+        self.applicationHelper = MockApplicationHelper()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        self.applicationHelper = nil
+    }
+
+    func testOpenSendTabs() {
+        let url = URL(string: "https://mozilla.com", invalidCharacters: false)!
+        let subject = createSubject()
+        subject.openSendTabs(for: [url])
+
+        XCTAssertEqual(applicationHelper.openURLCalled, 1)
+        let expectedURL = URL(string: URL.mozInternalScheme + "://open-url?url=\(url)")!
+        XCTAssertEqual(applicationHelper.lastOpenURL, expectedURL)
+    }
+
+    func testOpenSendTabs_multipleURLs() {
+        let url = URL(string: "https://mozilla.com", invalidCharacters: false)!
+        let subject = createSubject()
+        subject.openSendTabs(for: [url, url, url])
+
+        XCTAssertEqual(applicationHelper.openURLCalled, 3)
+    }
+
+    // MARK: - Helper
+
+    func createSubject() -> AppSendTabDelegate {
+        let subject = AppSendTabDelegate(app: UIApplication.shared,
+                                         applicationHelper: applicationHelper,
+                                         mainQueue: MockDispatchQueue())
+        trackForMemoryLeaks(subject)
+        return subject
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7523)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16715)

## :bulb: Description
`AppSendTabDelegate` will now use deeplink to open the remote tab URL instead of notification. This ensures we go through the view hierarchy management of coordinators, instead of bypassing and going to the BVC directly. This will make it easier to support multitasking as well. Took the opportunity to clean up `OpenTabNotificationObject` that was mostly composed of unused cases, the only one missing is for the debug settings and I created a task for it.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

