### PR TITLE
Bump [v120] Update Sentry to version 8.13.1

### DIFF
--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
             exact: "2.0.0"),
         .package(
             url: "https://github.com/getsentry/sentry-cocoa.git",
-            exact: "8.13.0"),
+            exact: "8.13.1"),
     ],
     targets: [
         .target(

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -19425,7 +19425,7 @@
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa.git";
 			requirement = {
 				kind = exactVersion;
-				version = 8.13.0;
+				version = 8.13.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "0a915b93ff3abee1a9752448e47808334d306980",
-        "version" : "8.13.0"
+        "revision" : "7b0d185631a6d4b7756468efa464a68725c061d2",
+        "version" : "8.13.1"
       }
     },
     {


### PR DESCRIPTION
Changes since last update: https://github.com/getsentry/sentry-cocoa/releases/tag/8.13.1