### PR TITLE
Refactor FXIOS-7551 [v120] Background tab dismiss bottom sheet

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -546,6 +546,8 @@
 		8A11C8132731E54800AC7318 /* DictionaryExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A11C8122731E54800AC7318 /* DictionaryExtensionsTests.swift */; };
 		8A13FA892AD82BC8007527AB /* AppSendTabDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A13FA882AD82BC8007527AB /* AppSendTabDelegateTests.swift */; };
 		8A13FA8B2AD82E6D007527AB /* ApplicationStateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A13FA8A2AD82E6D007527AB /* ApplicationStateProvider.swift */; };
+		8A13FA8D2AD834FA007527AB /* BackgroundTabLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A13FA8C2AD834FA007527AB /* BackgroundTabLoader.swift */; };
+		8A13FA8F2AD83F00007527AB /* DefaultBackgroundTabLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A13FA8E2AD83F00007527AB /* DefaultBackgroundTabLoaderTests.swift */; };
 		8A161411282C035D00DDBB02 /* CustomizeHomepageSectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A161410282C035D00DDBB02 /* CustomizeHomepageSectionViewModel.swift */; };
 		8A171A6329F82B0E0085770E /* SceneDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A171A6129F82AE20085770E /* SceneDelegateTests.swift */; };
 		8A19ACAB2A32895E001C2147 /* BrowserNavigationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A19ACAA2A32895E001C2147 /* BrowserNavigationHandler.swift */; };
@@ -4901,6 +4903,8 @@
 		8A11C8122731E54800AC7318 /* DictionaryExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryExtensionsTests.swift; sourceTree = "<group>"; };
 		8A13FA882AD82BC8007527AB /* AppSendTabDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSendTabDelegateTests.swift; sourceTree = "<group>"; };
 		8A13FA8A2AD82E6D007527AB /* ApplicationStateProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationStateProvider.swift; sourceTree = "<group>"; };
+		8A13FA8C2AD834FA007527AB /* BackgroundTabLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTabLoader.swift; sourceTree = "<group>"; };
+		8A13FA8E2AD83F00007527AB /* DefaultBackgroundTabLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBackgroundTabLoaderTests.swift; sourceTree = "<group>"; };
 		8A161410282C035D00DDBB02 /* CustomizeHomepageSectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomizeHomepageSectionViewModel.swift; sourceTree = "<group>"; };
 		8A171A6129F82AE20085770E /* SceneDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegateTests.swift; sourceTree = "<group>"; };
 		8A19ACAA2A32895E001C2147 /* BrowserNavigationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserNavigationHandler.swift; sourceTree = "<group>"; };
@@ -8213,6 +8217,7 @@
 				8A1E3BE128CBACD7003388C4 /* SponsoredContentFilterUtilityTests.swift */,
 				8ACA8F7529198D6400D3075D /* ThrottlerTests.swift */,
 				961D6B822995AF84001B9CF1 /* GeneralizedImageFetcherTests.swift */,
+				8A13FA8E2AD83F00007527AB /* DefaultBackgroundTabLoaderTests.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -10189,6 +10194,7 @@
 				5A430D782853DFDD00782BFF /* OrientationLockUtility.swift */,
 				8A1E3BDE28CBA81E003388C4 /* SponsoredContentFilterUtility.swift */,
 				C2296FCB2A601C190046ECA6 /* IntensityVisualEffectView.swift */,
+				8A13FA8C2AD834FA007527AB /* BackgroundTabLoader.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -12661,6 +12667,7 @@
 				DFACBF85277B9B5B003D5F41 /* TopSitesRowCountSettingsController.swift in Sources */,
 				9614BF4428AD1C6700D3F7EA /* AccountSyncHandler.swift in Sources */,
 				282DA4731A68C1E700A406E2 /* OpenSearchParser.swift in Sources */,
+				8A13FA8D2AD834FA007527AB /* BackgroundTabLoader.swift in Sources */,
 				D04CD74B216CF86B004FF5B0 /* DevicePickerViewController.swift in Sources */,
 				C8DC90BD2A06699E0008832B /* MarkupNode.swift in Sources */,
 				E63ED8E11BFD25580097D08E /* PasswordManagerListViewController.swift in Sources */,
@@ -13200,6 +13207,7 @@
 				8A83B74C2A265061002FF9AC /* LibraryCoordinatorTests.swift in Sources */,
 				21D884412A79628E00AF144C /* MockSettingsDelegate.swift in Sources */,
 				F1BC457E2A40F6D2005541D5 /* EnhancedTrackingProtectionCoordinatorTests.swift in Sources */,
+				8A13FA8F2AD83F00007527AB /* DefaultBackgroundTabLoaderTests.swift in Sources */,
 				5A31275828906422001F30FA /* RecentlySavedDelegateMock.swift in Sources */,
 				C2B808B12A77FA3F00A65487 /* DownloadsCoordinatorTests.swift in Sources */,
 				5A475E9129DB8AA7009C13FD /* MockDiskImageStore.swift in Sources */,

--- a/Client/DispatchQueueHelper.swift
+++ b/Client/DispatchQueueHelper.swift
@@ -25,13 +25,3 @@ public func ensureMainThread<T>(execute work: @escaping () -> T) {
         }
     }
 }
-
-public func ensureBackgroundThread(execute work: @escaping () -> Void) {
-    if !Thread.current.isMainThread {
-        work()
-    } else {
-        DispatchQueue.global().async {
-            work()
-        }
-    }
-}

--- a/Client/Utils/BackgroundTabLoader.swift
+++ b/Client/Utils/BackgroundTabLoader.swift
@@ -1,0 +1,64 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+import Storage
+import Shared
+
+/// `BackgroundTabLoader` loads tabs from users adding tabs to "Load in Background" via the share sheet. In other words, the `ShareViewController`
+/// adds the tab to the `Profile.TabQueue`, and the `BackgroundTabLoader` dequeues them to be added as tabs in the application.
+protocol BackgroundTabLoader {
+    /// Load the background tabs in the application using deeplinks
+    func loadBackgroundTabs()
+}
+
+final class DefaultBackgroundTabLoader: BackgroundTabLoader {
+    private var tabQueue: TabQueue
+    private var backgroundQueue: DispatchQueueInterface
+    private var applicationHelper: ApplicationHelper
+
+    init(tabQueue: TabQueue,
+         applicationHelper: ApplicationHelper = DefaultApplicationHelper(),
+         backgroundQueue: DispatchQueueInterface = DispatchQueue.global()) {
+        self.tabQueue = tabQueue
+        self.applicationHelper = applicationHelper
+        self.backgroundQueue = backgroundQueue
+    }
+
+    func loadBackgroundTabs() {
+        // Make sure we load queued tabs on a background thread
+        backgroundQueue.async { [weak self] in
+            guard let self = self else { return }
+            self.dequeueQueuedTabs()
+        }
+    }
+
+    private func dequeueQueuedTabs() {
+        tabQueue.getQueuedTabs { [weak self] urls in
+            guard let self = self else { return }
+            // This assumes that the DB returns rows in a sane order.
+            guard !urls.isEmpty else { return }
+
+            // Open queued urls
+            let queuedURLs = urls.compactMap { $0.url.asURL }
+            if !queuedURLs.isEmpty {
+                self.open(urls: queuedURLs)
+            }
+
+            // Clear after making an attempt to open. We're making a bet that
+            // it's better to run the risk of perhaps opening twice on a crash,
+            // rather than losing data.
+            self.tabQueue.clearQueuedTabs()
+        }
+    }
+
+    private func open(urls: [URL]) {
+        for urlToOpen in urls {
+            let urlString = URL.mozInternalScheme + "://open-url?url=\(urlToOpen)"
+            guard let url = URL(string: urlString) else { continue }
+            applicationHelper.open(url)
+        }
+    }
+}

--- a/Storage/Queue.swift
+++ b/Storage/Queue.swift
@@ -7,7 +7,7 @@ import Shared
 
 public protocol TabQueue {
     func addToQueue(_ tab: ShareItem) -> Success
-    func getQueuedTabs() -> Deferred<Maybe<Cursor<ShareItem>>>
+    func getQueuedTabs(completion: @escaping ([ShareItem]) -> Void)
     @discardableResult
     func clearQueuedTabs() -> Success
 }

--- a/Storage/Sharing.swift
+++ b/Storage/Sharing.swift
@@ -21,7 +21,3 @@ public struct ShareItem {
         return URL(string: url, invalidCharacters: false)?.isWebPage() ?? false
     }
 }
-
-public protocol ShareToDestination {
-    func shareItem(_ item: ShareItem) -> Success
-}

--- a/Tests/ClientTests/Mocks/MockProfile.swift
+++ b/Tests/ClientTests/Mocks/MockProfile.swift
@@ -70,16 +70,24 @@ open class ClientSyncManagerSpy: ClientSyncManager {
     }
 }
 
-open class MockTabQueue: TabQueue {
-    open func addToQueue(_ tab: ShareItem) -> Success {
+final class MockTabQueue: TabQueue {
+    var queuedTabs = [ShareItem]()
+    var getQueuedTabsCalled = 0
+    var addToQueueCalled = 0
+    var clearQueuedTabsCalled = 0
+
+    func addToQueue(_ tab: ShareItem) -> Success {
+        addToQueueCalled += 1
         return succeed()
     }
 
-    open func getQueuedTabs() -> Deferred<Maybe<Cursor<ShareItem>>> {
-        return deferMaybe(ArrayCursor<ShareItem>(data: []))
+    func getQueuedTabs(completion: @escaping ([ShareItem]) -> Void) {
+        getQueuedTabsCalled += 1
+        return completion(queuedTabs)
     }
 
-    open func clearQueuedTabs() -> Success {
+    func clearQueuedTabs() -> Success {
+        clearQueuedTabsCalled += 1
         return succeed()
     }
 }

--- a/Tests/ClientTests/Utils/DefaultBackgroundTabLoaderTests.swift
+++ b/Tests/ClientTests/Utils/DefaultBackgroundTabLoaderTests.swift
@@ -1,0 +1,57 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Storage
+import XCTest
+@testable import Client
+
+class DefaultBackgroundTabLoaderTests: XCTestCase {
+    private var applicationHelper: MockApplicationHelper!
+    private var tabQueue: MockTabQueue!
+
+    override func setUp() {
+        super.setUp()
+        self.applicationHelper = MockApplicationHelper()
+        self.tabQueue = MockTabQueue()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        self.applicationHelper = nil
+        self.tabQueue = nil
+    }
+
+    func testLoadBackgroundTabs_noTabs_doesntLoad() {
+        let subject = createSubject()
+
+        subject.loadBackgroundTabs()
+
+        XCTAssertEqual(tabQueue.getQueuedTabsCalled, 1)
+        XCTAssertEqual(applicationHelper.openURLCalled, 0)
+    }
+
+    func testLoadBackgroundTabs_withTabs_load() {
+        let urlString = "https://www.mozilla.com"
+        tabQueue.queuedTabs = [ShareItem(url: urlString, title: "Title 1"),
+                               ShareItem(url: urlString, title: "Title 2"),
+                               ShareItem(url: urlString, title: "Title 3")]
+        let subject = createSubject()
+
+        subject.loadBackgroundTabs()
+
+        XCTAssertEqual(tabQueue.getQueuedTabsCalled, 1)
+        XCTAssertEqual(applicationHelper.openURLCalled, 3)
+        XCTAssertEqual(tabQueue.clearQueuedTabsCalled, 1)
+    }
+
+    // MARK: Helper functions
+
+    func createSubject() -> DefaultBackgroundTabLoader {
+        let subject = DefaultBackgroundTabLoader(tabQueue: tabQueue,
+                                                 applicationHelper: applicationHelper,
+                                                 backgroundQueue: MockDispatchQueue())
+        trackForMemoryLeaks(subject)
+        return subject
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7551)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16795)

## :bulb: Description
- Add a `backgroundTabLoader` that loads tab in background instead of being done in BVC.
- This `backgroundTabLoader` code was tangled with notification service code which isn't needed anymore (the `receivedURLs` parameter wasn't used anywhere. I took the opportunity to clean this up so this code only relates to background tabs.
- Background tabs are opened with deep links now instead of using directly the `tabManager`
- Modified `SQLQueue` to remove deferred since it was used in one place only and I really hate the `>>==` operator
- Remove `ensureBackgroundThread` since wasn't used anymore
- Added unit tests

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

