### PR TITLE
Bump [v120] Update Adjust SDK to version 4.35.2

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -19369,7 +19369,7 @@
 			repositoryURL = "https://github.com/adjust/ios_sdk.git";
 			requirement = {
 				kind = exactVersion;
-				version = 4.33.4;
+				version = 4.35.2;
 			};
 		};
 		433F87CC2788EAB600693368 /* XCRemoteSwiftPackageReference "GCDWebServer" */ = {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/adjust/ios_sdk.git",
       "state" : {
-        "revision" : "6ae03883c3b7d22e72e2a5937ad5dd8765d9c31d",
-        "version" : "4.33.4"
+        "revision" : "20c2666082c372f9f2c0adf871d8cef195d011f7",
+        "version" : "4.35.2"
       }
     },
     {


### PR DESCRIPTION
Been awhile since the last update. Changelogs available below:
* https://github.com/adjust/ios_sdk/releases/tag/v4.33.5
* https://github.com/adjust/ios_sdk/releases/tag/v4.33.6
* https://github.com/adjust/ios_sdk/releases/tag/v4.34.0
* https://github.com/adjust/ios_sdk/releases/tag/v4.34.1
* https://github.com/adjust/ios_sdk/releases/tag/v4.34.2
* https://github.com/adjust/ios_sdk/releases/tag/v4.35.0
* https://github.com/adjust/ios_sdk/releases/tag/v4.35.1
* https://github.com/adjust/ios_sdk/releases/tag/v4.35.2