### PR TITLE
Refactor FXIOS-7529 [v119] Make sure startAtHome is called

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2282,6 +2282,7 @@ extension BrowserViewController: TabManagerDelegate {
     }
 
     func tabManagerDidRestoreTabs(_ tabManager: TabManager) {
+        tabManager.startAtHomeCheck()
         updateTabCountUsingTabManager(tabManager)
         openUrlAfterRestore()
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7529)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16726)

## :bulb: Description
Make sure `startAtHome` is called when we cold launch the app. Basically, the `startAtHome` is called in `appDidBecomeActiveNotification`, but since we now change start path there's the high chance that BVC won't receive the first notification of `didBecomeActiveNotification` when we cold launch the app (since the observer on BVC is added later during app start). This makes sure after restoring tabs we call start at home (and we restore tabs only once, so this should be fine for now as a patch).

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

