### PR TITLE
Refactor MTE-1738 [v120] Update Firebase Performance Zip Step to Work with XCode 15 Artifacts

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1493,7 +1493,7 @@ workflows:
             SDK="iphoneos"
             DESTINATION="generic/platform=iOS"
             PRODUCTS_DIR="$DERIVED_DATA_DIR/Build/Products"
-            TEST_PLAN="Fennec_Enterprise_PerformanceTestPlan"
+            TEST_PLAN="$SCHEME_PerformanceTestPlan"
 
             echo "-- build-for-testing --"
             mkdir DerivedData
@@ -1524,7 +1524,7 @@ workflows:
                 exit 1
             fi
 
-            if [[ ! -d "$PRODUCTS_DIR/Fennec_Enterprise-$SDK" ]]; then
+            if [[ ! -d "$PRODUCTS_DIR/$SCHEME-$SDK" ]]; then
                 echo "Error: Missing sdk for iPhone OS. Check your build sdk argument and try again."
                 echo "The files in $PRODUCTS_DIR are:"
                 ls -l "$PRODUCTS_DIR"
@@ -1539,11 +1539,16 @@ workflows:
             #!/usr/bin/env bash
             set -euxo pipefail
 
-            echo "-- create .zip artifact --"
             PRODUCTS_DIR="/Users/vagrant/git/DerivedData/Build/Products"
+            SCHEME="Fennec_Enterprise"
+            SDK="iphoneos"
+            TEST_PLAN="PerformanceTestPlan"
+            FIREBASE_ZIP="/Users/vagrant/git/Fennec_Enterprise.zip"
 
-            ( cd "$PRODUCTS_DIR" && zip -r Fennec_Enterprise.zip Fennec_Enterprise-iphoneos Fennec_Enterprise_PerformanceTestPlan*.xctestrun )
-            mv "$PRODUCTS_DIR/Fennec_Enterprise.zip /Users/vagrant/git/Fennec_Enterprise.zip
+            echo "-- create .zip artifact --"
+
+            ( cd "$PRODUCTS_DIR" && zip -r $SCHEME.zip $SCHEME-$SDK $SCHEME_$TEST_PLAN*.xctestrun )
+            mv "$PRODUCTS_DIR/$SCHEME.zip $FIREBASE_ZIP
     - cache-pull@2.7.2:
         inputs:
         - cache_paths: "$HOME/google-cloud-sdk"
@@ -1580,6 +1585,7 @@ workflows:
             DEVICE_MODEL="iphone14pro" # if updating device model and version, also update firebase-performance.kind
             DEVICE_VERSION="16.6"
             XCRESULT_PATH="gs://$GOOGLE_CLOUD_BUCKET/$RESULTS_DIR/$DEVICE_MODEL-$DEVICE_VERSION-en-portrait/TestLogs/"
+            FIREBASE_ZIP="/Users/vagrant/git/Fennec_Enterprise.zip" # this should be the same as the artifact created in the previous step
 
             curl -o /tmp/key-file.json $BITRISEIO_GOOGLE_APPLICATION_CREDENTIALS_URL 
             $HOME/google-cloud-sdk/bin/gcloud version
@@ -1587,13 +1593,12 @@ workflows:
             $HOME/google-cloud-sdk/bin/gcloud config set project "$GOOGLE_CLOUD_PROJECT"
 
             FIREBASE_TEST_RESULT=$($HOME/google-cloud-sdk/bin/gcloud firebase test ios run \
-                --test /Users/vagrant/git/Fennec_Enterprise.zip \
+                --test $FIREBASE_ZIP \
                 --device model="$DEVICE_MODEL",version="$DEVICE_VERSION" \
                 --client-details=matrixLabel="Bitrise" \
                 --num-flaky-test-attempts=2 \
                 --results-bucket="$GOOGLE_CLOUD_BUCKET" \
                 --results-dir="$RESULTS_DIR")
-
 
             FIREBASE_XCRESULT_PATH=$($HOME/google-cloud-sdk/bin/gsutil ls $XCRESULT_PATH | grep ".xcresult")
             envman add --key FIREBASE_XCRESULT_PATH --value "$FIREBASE_XCRESULT_PATH"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1484,27 +1484,66 @@ workflows:
         title: Firebase Build for Testing Physical Devices
         inputs:
         - content: |
+            #!/usr/bin/env bash
             set -euxo pipefail
+
+            DERIVED_DATA_DIR="/Users/vagrant/git/DerivedData"
+            PROJECT="/Users/vagrant/git/Client.xcodeproj"
+            SCHEME="Fennec_Enterprise"
+            SDK="iphoneos"
+            DESTINATION="generic/platform=iOS"
+            PRODUCTS_DIR="$DERIVED_DATA_DIR/Build/Products"
+            TEST_PLAN="Fennec_Enterprise_PerformanceTestPlan"
+
             echo "-- build-for-testing --"
             mkdir DerivedData
             xcodebuild -resolvePackageDependencies -onlyUsePackageVersionsFromResolvedFile
-            xcodebuild build-for-testing -project /Users/vagrant/git/Client.xcodeproj \
-                -scheme Fennec_Enterprise \
-                -sdk iphoneos \
-                -destination "generic/platform=iOS" \
-                -derivedDataPath "/Users/vagrant/git/DerivedData"
+            xcodebuild build-for-testing -project $PROJECT \
+                -scheme $SCHEME \
+                -sdk $SDK \
+                -destination "$DESTINATION" \
+                -derivedDataPath "$DERIVED_DATA_DIR"
+
+            echo "-- verify build artifacts --"
+
+            if [[ ! -d "$PRODUCTS_DIR" ]]; then
+                echo "Error: $PRODUCTS_DIR was not created. Check your build steps and try again."
+                exit 1
+            fi
+
+            if [[ -z $(find "$PRODUCTS_DIR" -type f -name "$TEST_PLAN*.xctestrun") ]]; then
+                echo "Error: Missing $TEST_PLAN. Check your scheme and ensure the Test Plan is added."
+                echo "The files in $PRODUCTS_DIR are:"
+                ls -l "$PRODUCTS_DIR"
+                echo "The available test plans in this environment are:"
+                awk '/<TestPlanReference/,/<\/TestPlanReference>/' \
+                    $PROJECT/xcshareddata/xcschemes/$SCHEME.xcscheme | \
+                    grep "reference" | \
+                    cut -d '"' -f 2 | \
+                    sed -n 's|container:Tests/\(.*\).xctestplan|\1|p'
+                exit 1
+            fi
+
+            if [[ ! -d "$PRODUCTS_DIR/Fennec_Enterprise-$SDK" ]]; then
+                echo "Error: Missing sdk for iPhone OS. Check your build sdk argument and try again."
+                echo "The files in $PRODUCTS_DIR are:"
+                ls -l "$PRODUCTS_DIR"
+                echo "The available sdks in this environment are:"
+                xcodebuild -showsdks | grep -E 'iphoneos|iphonesimulator'
+                exit 1
+            fi
     - script@1.1:
         title: Create .zip artifact for Firebase Testing
         inputs:
         - content: |
+            #!/usr/bin/env bash
             set -euxo pipefail
-            echo "-- create .zip artifact --"
-            ls /Users/vagrant/git/DerivedData
-            ls /Users/vagrant/git/DerivedData/Build/Products
 
-            cd DerivedData/Build/Products
-            zip -r Fennec_Enterprise.zip Fennec_Enterprise-iphoneos Fennec_Enterprise_PerformanceTestPlan_iphoneos16.4-arm64.xctestrun
-            mv Fennec_Enterprise.zip /Users/vagrant/git/Fennec_Enterprise.zip
+            echo "-- create .zip artifact --"
+            PRODUCTS_DIR="/Users/vagrant/git/DerivedData/Build/Products"
+
+            ( cd "$PRODUCTS_DIR" && zip -r Fennec_Enterprise.zip Fennec_Enterprise-iphoneos Fennec_Enterprise_PerformanceTestPlan*.xctestrun )
+            mv "$PRODUCTS_DIR/Fennec_Enterprise.zip /Users/vagrant/git/Fennec_Enterprise.zip
     - cache-pull@2.7.2:
         inputs:
         - cache_paths: "$HOME/google-cloud-sdk"
@@ -1534,6 +1573,7 @@ workflows:
         - content: |-
             #!/usr/bin/env bash
             set -ex
+
             TIMESTAMP=$(date "+%Y%m%d%H%M%S")
             RESULTS_DIR="firefox_ios_performance_tests_$TIMESTAMP"
             GOOGLE_CLOUD_BUCKET="firefox_ios_test_artifacts"
@@ -1564,9 +1604,8 @@ workflows:
         - content: |-
             #!/usr/bin/env bash
             # fail if any commands fails
-            set -e
-            # debug log
-            set -x
+            set -ex
+
             # get dependency
             cd ./test-fixtures && git clone https://github.com/isabelrios/xcresult_extract.git
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1492,17 +1492,17 @@ workflows:
             SCHEME="Fennec_Enterprise"
             SDK="iphoneos"
             DESTINATION="generic/platform=iOS"
-            PRODUCTS_DIR="$DERIVED_DATA_DIR/Build/Products"
-            TEST_PLAN="$SCHEME_PerformanceTestPlan"
+            PRODUCTS_DIR="${DERIVED_DATA_DIR}/Build/Products"
+            TEST_PLAN="${SCHEME}_PerformanceTestPlan"
 
             echo "-- build-for-testing --"
             mkdir DerivedData
             xcodebuild -resolvePackageDependencies -onlyUsePackageVersionsFromResolvedFile
-            xcodebuild build-for-testing -project $PROJECT \
-                -scheme $SCHEME \
-                -sdk $SDK \
+            xcodebuild build-for-testing -project "$PROJECT" \
+                -scheme "$SCHEME" \
+                -sdk "$SDK" \
                 -destination "$DESTINATION" \
-                -derivedDataPath "$DERIVED_DATA_DIR"
+                -derivedDataPath "${DERIVED_DATA_DIR}"
 
             echo "-- verify build artifacts --"
 
@@ -1511,20 +1511,20 @@ workflows:
                 exit 1
             fi
 
-            if [[ -z $(find "$PRODUCTS_DIR" -type f -name "$TEST_PLAN*.xctestrun") ]]; then
+            if [[ -z $(find "$PRODUCTS_DIR" -type f -name "${TEST_PLAN}*.xctestrun") ]]; then
                 echo "Error: Missing $TEST_PLAN. Check your scheme and ensure the Test Plan is added."
                 echo "The files in $PRODUCTS_DIR are:"
                 ls -l "$PRODUCTS_DIR"
-                echo "The available test plans for this scheme are:"
+                echo "The available test plans for this scheme, $SCHEME, are:"
                 awk '/<TestPlanReference/,/<\/TestPlanReference>/' \
-                    $PROJECT/xcshareddata/xcschemes/$SCHEME.xcscheme | \
+                    "${PROJECT}/xcshareddata/xcschemes/${SCHEME}.xcscheme" | \
                     grep "reference" | \
                     cut -d '"' -f 2 | \
                     sed -n 's|container:Tests/\(.*\).xctestplan|\1|p'
                 exit 1
             fi
 
-            if [[ ! -d "$PRODUCTS_DIR/$SCHEME-$SDK" ]]; then
+            if [[ ! -d "${PRODUCTS_DIR}/${SCHEME}-${SDK}" ]]; then
                 echo "Error: Missing sdk for iPhone OS. Check your build sdk argument and try again."
                 echo "The files in $PRODUCTS_DIR are:"
                 ls -l "$PRODUCTS_DIR"
@@ -1542,13 +1542,13 @@ workflows:
             PRODUCTS_DIR="/Users/vagrant/git/DerivedData/Build/Products"
             SCHEME="Fennec_Enterprise"
             SDK="iphoneos"
-            TEST_PLAN="PerformanceTestPlan"
-            FIREBASE_ZIP="/Users/vagrant/git/Fennec_Enterprise.zip"
+            TEST_PLAN="${SCHEME}_PerformanceTestPlan"
+            TARGET_ARCHIVE="/Users/vagrant/git/Fennec_Enterprise.zip"
 
             echo "-- create .zip artifact --"
-
-            ( cd "$PRODUCTS_DIR" && zip -r $SCHEME.zip $SCHEME-$SDK $SCHEME_$TEST_PLAN*.xctestrun )
-            mv "$PRODUCTS_DIR/$SCHEME.zip $FIREBASE_ZIP
+            # do not double-quote $TEST_PLAN, as it is a wildcard and we need it to expand
+            ( cd "$PRODUCTS_DIR" && zip -r "${SCHEME}.zip" "${SCHEME}-${SDK}" ${TEST_PLAN}*.xctestrun )
+            mv "${PRODUCTS_DIR}/${SCHEME}.zip" "$TARGET_ARCHIVE"
     - cache-pull@2.7.2:
         inputs:
         - cache_paths: "$HOME/google-cloud-sdk"
@@ -1580,27 +1580,27 @@ workflows:
             set -ex
 
             TIMESTAMP=$(date "+%Y%m%d%H%M%S")
-            RESULTS_DIR="firefox_ios_performance_tests_$TIMESTAMP"
+            RESULTS_DIR="firefox_ios_performance_tests_${TIMESTAMP}"
             GOOGLE_CLOUD_BUCKET="firefox_ios_test_artifacts"
             DEVICE_MODEL="iphone14pro" # if updating device model and version, also update firebase-performance.kind
             DEVICE_VERSION="16.6"
-            XCRESULT_PATH="gs://$GOOGLE_CLOUD_BUCKET/$RESULTS_DIR/$DEVICE_MODEL-$DEVICE_VERSION-en-portrait/TestLogs/"
-            FIREBASE_ZIP="/Users/vagrant/git/Fennec_Enterprise.zip" # this should be the same as the artifact created in the previous step
+            XCRESULT_PATH="gs://${GOOGLE_CLOUD_BUCKET}/${RESULTS_DIR}/${DEVICE_MODEL}-${DEVICE_VERSION}-en-portrait/TestLogs/"
+            TARGET_ARCHIVE="/Users/vagrant/git/Fennec_Enterprise.zip" # this should be the same as the artifact created in the previous step
 
-            curl -o /tmp/key-file.json $BITRISEIO_GOOGLE_APPLICATION_CREDENTIALS_URL 
+            curl -o /tmp/key-file.json "$BITRISEIO_GOOGLE_APPLICATION_CREDENTIALS_URL"
             $HOME/google-cloud-sdk/bin/gcloud version
             $HOME/google-cloud-sdk/bin/gcloud auth activate-service-account -q --key-file /tmp/key-file.json
             $HOME/google-cloud-sdk/bin/gcloud config set project "$GOOGLE_CLOUD_PROJECT"
 
             FIREBASE_TEST_RESULT=$($HOME/google-cloud-sdk/bin/gcloud firebase test ios run \
-                --test $FIREBASE_ZIP \
+                --test "$TARGET_ARCHIVE" \
                 --device model="$DEVICE_MODEL",version="$DEVICE_VERSION" \
                 --client-details=matrixLabel="Bitrise" \
                 --num-flaky-test-attempts=2 \
                 --results-bucket="$GOOGLE_CLOUD_BUCKET" \
                 --results-dir="$RESULTS_DIR")
 
-            FIREBASE_XCRESULT_PATH=$($HOME/google-cloud-sdk/bin/gsutil ls $XCRESULT_PATH | grep ".xcresult")
+            FIREBASE_XCRESULT_PATH=$("${HOME}/google-cloud-sdk/bin/gsutil" ls "$XCRESULT_PATH" | grep ".xcresult")
             envman add --key FIREBASE_XCRESULT_PATH --value "$FIREBASE_XCRESULT_PATH"
     - script@1.1:
         is_always_run: true
@@ -1617,7 +1617,7 @@ workflows:
             # pull firebase xcresult and rename it to extract measurement data
             mkdir test_firebase_xcresult
 
-            $HOME/google-cloud-sdk/bin/gsutil -m cp -r $FIREBASE_XCRESULT_PATH ./test_firebase_xcresult &
+            $HOME/google-cloud-sdk/bin/gsutil -m cp -r "$FIREBASE_XCRESULT_PATH" ./test_firebase_xcresult &
 
             # Get the process ID of the backgrounded gsutil command
             PID=$!
@@ -1642,7 +1642,7 @@ workflows:
                 rm -rf ./test_firebase_xcresult
                 mkdir ./test_firebase_xcresult
                 echo "Retrying xcresult copy without multi-processing..."
-                $HOME/google-cloud-sdk/bin/gsutil cp -r $FIREBASE_XCRESULT_PATH ./test_firebase_xcresult
+                $HOME/google-cloud-sdk/bin/gsutil cp -r "$FIREBASE_XCRESULT_PATH" ./test_firebase_xcresult
             fi
 
             mv ./test_firebase_xcresult/*.xcresult ./test_firebase_xcresult/Test-Fennec-test.xcresult
@@ -1650,12 +1650,16 @@ workflows:
             # firebase xcresult needs to be in the Test dir created during earlier build-for-testing step
             FIREBASE_XCRESULT="./test_firebase_xcresult/Test-Fennec-test.xcresult"
             CLIENT_PATH=$(ls /Users/vagrant/Library/Developer/Xcode/DerivedData | grep 'Client-')
-            BITRISE_XCRESULT="/Users/vagrant/Library/Developer/Xcode/DerivedData/$CLIENT_PATH/Logs/Test/Test-Fennec-test.xcresult"
-            mv $FIREBASE_XCRESULT $BITRISE_XCRESULT
+            BITRISE_XCRESULT="/Users/vagrant/Library/Developer/Xcode/DerivedData/${CLIENT_PATH}/Logs/Test/Test-Fennec-test.xcresult"
+            mv "$FIREBASE_XCRESULT" "$BITRISE_XCRESULT"
 
             # create and print perf data object for perfherder ingest via taskcluster log output
-            xcrun xcresulttool graph --path $BITRISE_XCRESULT
+            xcrun xcresulttool graph --path "$BITRISE_XCRESULT"
             ls ..
+            # If this ever breaks, check the xcresult_extract.py function find_xcresult_path 
+            # and figure out exactly what it is doing because we are using Fennec as the scheme
+            # and it works for both Fennec and Fennec_Enterprise, but I don't know why.
+            # I would change it here but I am too afraid to break it.
             python3 xcresult_extract/xcresult_extract.py -project ../Client.xcodeproj -scheme Fennec
             cat data.txt
             sed 's/.*=//;s/'\''/"/g' data.txt > test.json

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1515,7 +1515,7 @@ workflows:
                 echo "Error: Missing $TEST_PLAN. Check your scheme and ensure the Test Plan is added."
                 echo "The files in $PRODUCTS_DIR are:"
                 ls -l "$PRODUCTS_DIR"
-                echo "The available test plans in this environment are:"
+                echo "The available test plans for this scheme are:"
                 awk '/<TestPlanReference/,/<\/TestPlanReference>/' \
                     $PROJECT/xcshareddata/xcschemes/$SCHEME.xcscheme | \
                     grep "reference" | \


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1738)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
With the update to XCode 15, the name for the artifact created for `xcodebuild build-for-testing` has changed.

I've updated the build and zip step to use a wildcard to zip and send any `xctestrun` file who name starts with `Fennec_Enterprise_PerformanceTestPlan` to account for future changes to the sdk that might be used by Bitrise's XCode version for the `xcodebuild` step.

I've added some additional error handling should the build and zip steps fail in the bitrise workflow as there will be more test plans added to this scheme in the near future; so the debugging will help isolate potential issues with sdk/scheme/test plan mismatches that might occur.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

