### PR TITLE
Fix MTE-1743 [v120] for toolbar menu test

### DIFF
--- a/Tests/XCUITests/ToolbarTest.swift
+++ b/Tests/XCUITests/ToolbarTest.swift
@@ -107,7 +107,7 @@ class ToolbarTests: BaseTestCase {
             waitUntilPageLoad()
             mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
             let PageOptionsMenu = app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton]
-            let statusbarElement: XCUIElement = XCUIApplication(bundleIdentifier: "com.apple.springboard").statusBars.firstMatch
+            let statusbarElement: XCUIElement = XCUIApplication(bundleIdentifier: "com.apple.springboard").statusBars.element(boundBy: 1)
             app.swipeUp()
             XCTAssertFalse(PageOptionsMenu.isHittable)
             statusbarElement.tap(force: true)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1743)

## :bulb: Description
We need to make sure we are tapping on the status bar in order to reveal the toolbar.
Tested both on 16.4 and 17.0 and the test is passing.
