### PR TITLE
Add FXIOS-7444 [v120] QR code coordinator implementation

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -878,6 +878,10 @@
 		C2446B312A856D13000C527D /* MockLibraryCoordinatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2446B302A856D13000C527D /* MockLibraryCoordinatorDelegate.swift */; };
 		C2506C932A6A863600F2B76E /* HistoryCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2506C922A6A863600F2B76E /* HistoryCoordinator.swift */; };
 		C2506C952A6A8D2600F2B76E /* HistoryCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2506C942A6A8D2600F2B76E /* HistoryCoordinatorTests.swift */; };
+		C29B64812AD6959E00F3244B /* QRCodeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C29B64802AD6959E00F3244B /* QRCodeCoordinator.swift */; };
+		C29B64832AD69C3E00F3244B /* MockQRCodeParentCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C29B64822AD69C3E00F3244B /* MockQRCodeParentCoordinator.swift */; };
+		C29B64872AD69D0200F3244B /* QRCodeCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C29B64862AD69D0200F3244B /* QRCodeCoordinatorTests.swift */; };
+		C29B64EE2AD937D500F3244B /* QRCodeNavigationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C29B64ED2AD937D400F3244B /* QRCodeNavigationHandler.swift */; };
 		C2A72A672A76938C002ACCE2 /* DownloadsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A72A662A76938C002ACCE2 /* DownloadsCoordinator.swift */; };
 		C2A72A692A769460002ACCE2 /* ReadingListCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A72A682A769460002ACCE2 /* ReadingListCoordinator.swift */; };
 		C2A72A6B2A77AC10002ACCE2 /* ReadingListCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A72A6A2A77AC10002ACCE2 /* ReadingListCoordinatorTests.swift */; };
@@ -5665,6 +5669,10 @@
 		C2506C942A6A8D2600F2B76E /* HistoryCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryCoordinatorTests.swift; sourceTree = "<group>"; };
 		C26C4D1F8CFB13730BA74DF5 /* an */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = an; path = an.lproj/FindInPage.strings; sourceTree = "<group>"; };
 		C29B428A81B120AFF0666037 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/Menu.strings; sourceTree = "<group>"; };
+		C29B64802AD6959E00F3244B /* QRCodeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeCoordinator.swift; sourceTree = "<group>"; };
+		C29B64822AD69C3E00F3244B /* MockQRCodeParentCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockQRCodeParentCoordinator.swift; sourceTree = "<group>"; };
+		C29B64862AD69D0200F3244B /* QRCodeCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeCoordinatorTests.swift; sourceTree = "<group>"; };
+		C29B64ED2AD937D400F3244B /* QRCodeNavigationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeNavigationHandler.swift; sourceTree = "<group>"; };
 		C2A72A662A76938C002ACCE2 /* DownloadsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadsCoordinator.swift; sourceTree = "<group>"; };
 		C2A72A682A769460002ACCE2 /* ReadingListCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingListCoordinator.swift; sourceTree = "<group>"; };
 		C2A72A6A2A77AC10002ACCE2 /* ReadingListCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingListCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -8076,6 +8084,7 @@
 				C23889E42A50329200429673 /* MockParentCoordinatorDelegate.swift */,
 				C2446B302A856D13000C527D /* MockLibraryCoordinatorDelegate.swift */,
 				C2D80BEC2AAF3C6B00CDF7A9 /* MockBrowserCoordinator.swift */,
+				C29B64822AD69C3E00F3244B /* MockQRCodeParentCoordinator.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -8435,6 +8444,7 @@
 				C2D1A10B2A66C61600205DCC /* Library */,
 				8AF10D8D29D773FC0086351D /* Scene */,
 				8A93F86E29D3A147004159D9 /* Router */,
+				C29B64EC2AD937C200F3244B /* QRCode */,
 				8A1E93E92A3CDC6100DD540A /* BaseCoordinator.swift */,
 				8A93F85D29D36DA9004159D9 /* Coordinator.swift */,
 				8A76B01329F6E45600A82607 /* CoordinatorFlagManager.swift */,
@@ -8471,6 +8481,7 @@
 				8C8D8C792AA067AD00490D32 /* FakespotCoordinatorTests.swift */,
 				C2D80BEA2AAF395200CDF7A9 /* CredentialAutofillCoordinatorTests.swift */,
 				21420EF82ABC75A400B28550 /* TabTrayCoordinatorTests.swift */,
+				C29B64862AD69D0200F3244B /* QRCodeCoordinatorTests.swift */,
 			);
 			path = Coordinators;
 			sourceTree = "<group>";
@@ -8915,6 +8926,15 @@
 				C2B808EB2A7A5F6E00A65487 /* MockLibraryCoordinatorDelegate.swift */,
 			);
 			name = "Recovered References";
+			sourceTree = "<group>";
+		};
+		C29B64EC2AD937C200F3244B /* QRCode */ = {
+			isa = PBXGroup;
+			children = (
+				C29B64802AD6959E00F3244B /* QRCodeCoordinator.swift */,
+				C29B64ED2AD937D400F3244B /* QRCodeNavigationHandler.swift */,
+			);
+			path = QRCode;
 			sourceTree = "<group>";
 		};
 		C2D1A10B2A66C61600205DCC /* Library */ = {
@@ -12649,6 +12669,7 @@
 				8A3EF7F72A2FCF6D00796E3A /* ExportLogDataSetting.swift in Sources */,
 				43E69EC3254D081D00B591C2 /* SimpleTab.swift in Sources */,
 				8ADAE4202A33A0FD007BF926 /* SendFeedbackSetting.swift in Sources */,
+				C29B64812AD6959E00F3244B /* QRCodeCoordinator.swift in Sources */,
 				21A7C45028353D0E0071D996 /* OnboardingCardViewController.swift in Sources */,
 				742A56391D80B54A00BDB803 /* PhotonActionSheet.swift in Sources */,
 				C4EFEECF1CEBB6F2009762A4 /* BackForwardTableViewCell.swift in Sources */,
@@ -13039,6 +13060,7 @@
 				59A68E0B4ABBF55E14819668 /* BookmarksPanel.swift in Sources */,
 				BD4B2DE429BB4D9A005FAA50 /* TimerSnackBar.swift in Sources */,
 				D04D1B862097859B0074B35F /* DownloadToast.swift in Sources */,
+				C29B64EE2AD937D500F3244B /* QRCodeNavigationHandler.swift in Sources */,
 				8A19ACB42A3290D9001C2147 /* ContentBlockerSetting.swift in Sources */,
 				E1463D022981DA190074E16E /* NotificationManager.swift in Sources */,
 				8A3EF8112A2FD06B00796E3A /* ToggleHistoryGroups.swift in Sources */,
@@ -13129,6 +13151,7 @@
 				961D6B832995AF84001B9CF1 /* GeneralizedImageFetcherTests.swift in Sources */,
 				E1AEC177286E0CF500062E29 /* HistoryHighlightsViewModelTests.swift in Sources */,
 				2165B2C42860CB34004C0786 /* MockAdjustTelemetryData.swift in Sources */,
+				C29B64872AD69D0200F3244B /* QRCodeCoordinatorTests.swift in Sources */,
 				0BA8964B1A250E6500C1010C /* ProfileTest.swift in Sources */,
 				8AE80BAF2891960300BC12EA /* MockTraitCollection.swift in Sources */,
 				8A832A9729DCBD3C0025D5DD /* LaunchTypeTests.swift in Sources */,
@@ -13251,6 +13274,7 @@
 				1D8487B62AD6038100F7527C /* RemoteTabPanelStateTests.swift in Sources */,
 				2137786129802B7000D01309 /* DownloadsPanelViewModelTests.swift in Sources */,
 				8A5BD95A28788A3D000FE773 /* TopSitesHelperTests.swift in Sources */,
+				C29B64832AD69C3E00F3244B /* MockQRCodeParentCoordinator.swift in Sources */,
 				C8B41E0F29F0357300FE218A /* NimbusOnboardingFeatureLayerTests.swift in Sources */,
 				5AF6254728A58AC100A90253 /* MockHistoryHighlightsDataAdaptor.swift in Sources */,
 				8A7A26E329D4ACF300EA76F1 /* SceneCoordinatorTests.swift in Sources */,

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -439,17 +439,14 @@ class BrowserCoordinator: BaseCoordinator,
     }
 
     func showQRCode() {
-        let coordinator = makeQRCodeCoordinator()
-        coordinator.showQRCode(delegate: browserViewController)
-    }
-
-    private func makeQRCodeCoordinator() -> QRCodeCoordinator {
+        var coordinator: QRCodeCoordinator
         if let qrCodeCoordinator = childCoordinators.first(where: { $0 is QRCodeCoordinator }) as? QRCodeCoordinator {
-            return qrCodeCoordinator
+            coordinator = qrCodeCoordinator
+        } else {
+            coordinator = QRCodeCoordinator(parentCoordinator: self, router: router)
+            add(child: coordinator)
         }
-        let qrCodeCoordinator = QRCodeCoordinator(parentCoordinator: self, router: router)
-        add(child: qrCodeCoordinator)
-        return qrCodeCoordinator
+        coordinator.showQRCode(delegate: browserViewController)
     }
 
     // MARK: - ParentCoordinatorDelegate

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -438,6 +438,20 @@ class BrowserCoordinator: BaseCoordinator,
         return bottomSheetCoordinator
     }
 
+    func showQRCode() {
+        let coordinator = makeQRCodeCoordinator()
+        coordinator.showQRCode(delegate: browserViewController)
+    }
+
+    private func makeQRCodeCoordinator() -> QRCodeCoordinator {
+        if let qrCodeCoordinator = childCoordinators.first(where: { $0 is QRCodeCoordinator }) as? QRCodeCoordinator {
+            return qrCodeCoordinator
+        }
+        let qrCodeCoordinator = QRCodeCoordinator(parentCoordinator: self, router: router)
+        add(child: qrCodeCoordinator)
+        return qrCodeCoordinator
+    }
+
     // MARK: - ParentCoordinatorDelegate
 
     func didFinish(from childCoordinator: Coordinator) {

--- a/Client/Coordinators/Browser/BrowserNavigationHandler.swift
+++ b/Client/Coordinators/Browser/BrowserNavigationHandler.swift
@@ -44,8 +44,11 @@ protocol BrowserNavigationHandler: AnyObject {
     /// Shows authentication view controller to authorize access to sensitive data.
     func showRequiredPassCode()
 
-    /// Shows the Tab Tray View Controller 
+    /// Shows the Tab Tray View Controller.
     func showTabTray()
+
+    /// Shows the QRCode View Controller.
+    func showQRCode()
 }
 
 extension BrowserNavigationHandler {

--- a/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -10,7 +10,7 @@ protocol LaunchCoordinatorDelegate: AnyObject {
 }
 
 // Manages different types of onboarding that gets shown at the launch of the application
-class LaunchCoordinator: BaseCoordinator, 
+class LaunchCoordinator: BaseCoordinator,
                          SurveySurfaceViewControllerDelegate,
                          QRCodeNavigationHandler,
                          ParentCoordinatorDelegate {
@@ -130,9 +130,9 @@ class LaunchCoordinator: BaseCoordinator,
         surveySurface.delegate = self
         router.present(surveySurface, animated: false)
     }
-    
+
     // MARK: - QRCodeNavigationHandler
-    
+
     func showQRCode(delegate: QRCodeViewControllerDelegate) {
         let coordinator = makeQRCodeCoordinator()
         coordinator.showQRCode(delegate: delegate)
@@ -146,9 +146,9 @@ class LaunchCoordinator: BaseCoordinator,
         add(child: qrCodeCoordinator)
         return qrCodeCoordinator
     }
-    
+
     // MARK: - ParentCoordinatorDelegate
-    
+
     func didFinish(from childCoordinator: Coordinator) {
         remove(child: childCoordinator)
     }

--- a/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -10,7 +10,10 @@ protocol LaunchCoordinatorDelegate: AnyObject {
 }
 
 // Manages different types of onboarding that gets shown at the launch of the application
-class LaunchCoordinator: BaseCoordinator, SurveySurfaceViewControllerDelegate {
+class LaunchCoordinator: BaseCoordinator, 
+                         SurveySurfaceViewControllerDelegate,
+                         QRCodeNavigationHandler,
+                         ParentCoordinatorDelegate {
     private let profile: Profile
     private let isIphone: Bool
     weak var parentCoordinator: LaunchCoordinatorDelegate?
@@ -47,6 +50,7 @@ class LaunchCoordinator: BaseCoordinator, SurveySurfaceViewControllerDelegate {
                                             model: onboardingModel,
                                             telemetryUtility: telemetryUtility)
         let introViewController = IntroViewController(viewModel: introViewModel)
+        introViewController.qrCodeNavigationHandler = self
         introViewController.didFinishFlow = { [weak self] in
             guard let self = self else { return }
             self.parentCoordinator?.didFinishLaunch(from: self)
@@ -73,6 +77,7 @@ class LaunchCoordinator: BaseCoordinator, SurveySurfaceViewControllerDelegate {
     private func presentUpdateOnboarding(with updateViewModel: UpdateViewModel,
                                          isFullScreen: Bool) {
         let updateViewController = UpdateViewController(viewModel: updateViewModel)
+        updateViewController.qrCodeNavigationHandler = self
         updateViewController.didFinishFlow = { [weak self] in
             guard let self = self else { return }
             self.parentCoordinator?.didFinishLaunch(from: self)
@@ -124,6 +129,28 @@ class LaunchCoordinator: BaseCoordinator, SurveySurfaceViewControllerDelegate {
         surveySurface.modalPresentationStyle = .fullScreen
         surveySurface.delegate = self
         router.present(surveySurface, animated: false)
+    }
+    
+    // MARK: - QRCodeNavigationHandler
+    
+    func showQRCode(delegate: QRCodeViewControllerDelegate) {
+        let coordinator = makeQRCodeCoordinator()
+        coordinator.showQRCode(delegate: delegate)
+    }
+
+    private func makeQRCodeCoordinator() -> QRCodeCoordinator {
+        if let qrCodeCoordinator = childCoordinators.first(where: { $0 is QRCodeCoordinator }) as? QRCodeCoordinator {
+            return qrCodeCoordinator
+        }
+        let qrCodeCoordinator = QRCodeCoordinator(parentCoordinator: self, router: router)
+        add(child: qrCodeCoordinator)
+        return qrCodeCoordinator
+    }
+    
+    // MARK: - ParentCoordinatorDelegate
+    
+    func didFinish(from childCoordinator: Coordinator) {
+        remove(child: childCoordinator)
     }
 
     // MARK: - SurveySurfaceViewControllerDelegate

--- a/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -134,17 +134,14 @@ class LaunchCoordinator: BaseCoordinator,
     // MARK: - QRCodeNavigationHandler
 
     func showQRCode(delegate: QRCodeViewControllerDelegate) {
-        let coordinator = makeQRCodeCoordinator()
-        coordinator.showQRCode(delegate: delegate)
-    }
-
-    private func makeQRCodeCoordinator() -> QRCodeCoordinator {
+        var coordinator: QRCodeCoordinator
         if let qrCodeCoordinator = childCoordinators.first(where: { $0 is QRCodeCoordinator }) as? QRCodeCoordinator {
-            return qrCodeCoordinator
+            coordinator = qrCodeCoordinator
+        } else {
+            coordinator = QRCodeCoordinator(parentCoordinator: self, router: router)
+            add(child: coordinator)
         }
-        let qrCodeCoordinator = QRCodeCoordinator(parentCoordinator: self, router: router)
-        add(child: qrCodeCoordinator)
-        return qrCodeCoordinator
+        coordinator.showQRCode(delegate: delegate)
     }
 
     // MARK: - ParentCoordinatorDelegate

--- a/Client/Coordinators/QRCode/QRCodeCoordinator.swift
+++ b/Client/Coordinators/QRCode/QRCodeCoordinator.swift
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+class QRCodeCoordinator: BaseCoordinator {
+    private weak var parentCoordinator: ParentCoordinatorDelegate?
+
+    init(
+        parentCoordinator: ParentCoordinatorDelegate?,
+        router: Router
+    ) {
+        self.parentCoordinator = parentCoordinator
+        super.init(router: router)
+    }
+
+    func showQRCode(delegate: QRCodeViewControllerDelegate) {
+        let qrCodeViewController = QRCodeViewController()
+        qrCodeViewController.qrCodeDelegate = delegate
+        let navigationController = QRCodeNavigationController(rootViewController: qrCodeViewController)
+        router.present(navigationController, animated: true) { [weak self] in
+            guard let self = self else { return }
+            self.parentCoordinator?.didFinish(from: self)
+        }
+    }
+}

--- a/Client/Coordinators/QRCode/QRCodeNavigationHandler.swift
+++ b/Client/Coordinators/QRCode/QRCodeNavigationHandler.swift
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+protocol QRCodeNavigationHandler: AnyObject {
+    /// Shows the QRCodeViewController
+    func showQRCode(delegate: QRCodeViewControllerDelegate)
+}

--- a/Client/Coordinators/SettingsCoordinator.swift
+++ b/Client/Coordinators/SettingsCoordinator.swift
@@ -190,17 +190,14 @@ class SettingsCoordinator: BaseCoordinator,
     }
 
     func showQRCode(delegate: QRCodeViewControllerDelegate) {
-        let coordinator = makeQRCodeCoordinator()
-        coordinator.showQRCode(delegate: delegate)
-    }
-
-    private func makeQRCodeCoordinator() -> QRCodeCoordinator {
+        var coordinator: QRCodeCoordinator
         if let qrCodeCoordinator = childCoordinators.first(where: { $0 is QRCodeCoordinator }) as? QRCodeCoordinator {
-            return qrCodeCoordinator
+            coordinator = qrCodeCoordinator
+        } else {
+            coordinator = QRCodeCoordinator(parentCoordinator: self, router: router)
+            add(child: coordinator)
         }
-        let qrCodeCoordinator = QRCodeCoordinator(parentCoordinator: self, router: router)
-        add(child: qrCodeCoordinator)
-        return qrCodeCoordinator
+        coordinator.showQRCode(delegate: delegate)
     }
 
     func didFinishShowingSettings() {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -19,7 +19,8 @@ class BrowserViewController: UIViewController,
                              SearchBarLocationProvider,
                              Themeable,
                              LibraryPanelDelegate,
-                             RecentlyClosedPanelDelegate {
+                             RecentlyClosedPanelDelegate,
+                             QRCodeViewControllerDelegate {
     private enum UX {
         static let ShowHeaderTapAreaHeight: CGFloat = 32
         static let ActionSheetTitleMaxLength = 120
@@ -1847,27 +1848,9 @@ class BrowserViewController: UIViewController,
     func openRecentlyClosedSiteInNewTab(_ url: URL, isPrivate: Bool) {
         tabManager.selectTab(tabManager.addTab(URLRequest(url: url)))
     }
-}
 
-extension BrowserViewController: ClipboardBarDisplayHandlerDelegate {
-    func shouldDisplay(clipBoardURL url: URL) {
-        let viewModel = ButtonToastViewModel(labelText: .GoToCopiedLink,
-                                             descriptionText: url.absoluteDisplayString,
-                                             buttonText: .GoButtonTittle)
-        let toast = ButtonToast(viewModel: viewModel,
-                                theme: themeManager.currentTheme,
-                                completion: { [weak self] buttonPressed in
-            if buttonPressed {
-                let isPrivate = self?.tabManager.selectedTab?.isPrivate ?? false
-                self?.openURLInNewTab(url, isPrivate: isPrivate)
-            }
-        })
-        clipboardBarDisplayHandler?.clipboardToast = toast
-        show(toast: toast, duration: ClipboardBarDisplayHandler.UX.toastDelay)
-    }
-}
+    // MARK: - QRCodeViewControllerDelegate
 
-extension BrowserViewController: QRCodeViewControllerDelegate {
     func didScanQRCodeWithURL(_ url: URL) {
         guard let tab = tabManager.selectedTab else { return }
         finishEditingAndSubmit(url, visitType: VisitType.typed, forTab: tab)
@@ -1893,6 +1876,24 @@ extension BrowserViewController: QRCodeViewControllerDelegate {
         default:
             defaultAction()
         }
+    }
+}
+
+extension BrowserViewController: ClipboardBarDisplayHandlerDelegate {
+    func shouldDisplay(clipBoardURL url: URL) {
+        let viewModel = ButtonToastViewModel(labelText: .GoToCopiedLink,
+                                             descriptionText: url.absoluteDisplayString,
+                                             buttonText: .GoButtonTittle)
+        let toast = ButtonToast(viewModel: viewModel,
+                                theme: themeManager.currentTheme,
+                                completion: { [weak self] buttonPressed in
+            if buttonPressed {
+                let isPrivate = self?.tabManager.selectedTab?.isPrivate ?? false
+                self?.openURLInNewTab(url, isPrivate: isPrivate)
+            }
+        })
+        clipboardBarDisplayHandler?.clipboardToast = toast
+        show(toast: toast, duration: ClipboardBarDisplayHandler.UX.toastDelay)
     }
 }
 

--- a/Client/Frontend/Browser/QRCodeViewController.swift
+++ b/Client/Frontend/Browser/QRCodeViewController.swift
@@ -22,7 +22,7 @@ class QRCodeViewController: UIViewController {
         static let scanLineHeight: CGFloat = 6
     }
 
-    var qrCodeDelegate: QRCodeViewControllerDelegate?
+    weak var qrCodeDelegate: QRCodeViewControllerDelegate?
 
     private lazy var captureSession: AVCaptureSession = {
         let session = AVCaptureSession()

--- a/Client/Frontend/Onboarding/Protocols/OnboardingCardDelegate.swift
+++ b/Client/Frontend/Onboarding/Protocols/OnboardingCardDelegate.swift
@@ -35,7 +35,9 @@ protocol OnboardingCardDelegate: AnyObject {
         selector: Selector?,
         completion: @escaping () -> Void,
         flowType: FxAPageType,
-        referringPage: ReferringPage)
+        referringPage: ReferringPage,
+        qrCodeNavigationHandler: QRCodeNavigationHandler?
+    )
 
     func showNextPage(from cardNamed: String, completionIfLastCard completion: (() -> Void)?)
     func pageChanged(from cardName: String)
@@ -109,7 +111,8 @@ extension OnboardingCardDelegate where Self: OnboardingViewControllerProtocol,
         selector: Selector?,
         completion: @escaping () -> Void,
         flowType: FxAPageType = .emailLoginFlow,
-        referringPage: ReferringPage = .onboarding
+        referringPage: ReferringPage = .onboarding,
+        qrCodeNavigationHandler: QRCodeNavigationHandler?
     ) {
         let singInSyncVC = FirefoxAccountSignInViewController.getSignInOrFxASettingsVC(
             fxaOptions,
@@ -123,6 +126,7 @@ extension OnboardingCardDelegate where Self: OnboardingViewControllerProtocol,
             action: selector)
         buttonItem.tintColor = themeManager.currentTheme.colors.actionPrimary
         singInSyncVC.navigationItem.rightBarButtonItem = buttonItem
+        (singInSyncVC as? FirefoxAccountSignInViewController)?.qrCodeNavigationHandler = qrCodeNavigationHandler
 
         let controller = DismissableNavigationViewController(rootViewController: singInSyncVC)
         controller.onViewDismissed = completion

--- a/Client/Frontend/Onboarding/ViewControllers/FirstInstall/IntroViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/FirstInstall/IntroViewController.swift
@@ -26,6 +26,7 @@ class IntroViewController: UIViewController,
     var themeObserver: NSObjectProtocol?
     var userDefaults: UserDefaultsInterface
     var hasRegisteredForDefaultBrowserNotification = false
+    weak var qrCodeNavigationHandler: QRCodeNavigationHandler?
 
     private lazy var closeButton: UIButton = .build { button in
         button.setImage(UIImage(named: StandardImageIdentifiers.ExtraLarge.crossCircleFill), for: .normal)
@@ -241,12 +242,14 @@ extension IntroViewController: OnboardingCardDelegate {
             let fxaPrams = FxALaunchParams(entrypoint: .introOnboarding, query: [:])
             presentSignToSync(
                 with: fxaPrams,
-                selector: #selector(dismissSignInViewController)
-            ) {
-                self.showNextPage(from: cardName) {
-                    self.showNextPageCompletionForLastCard()
-                }
-            }
+                selector: #selector(dismissSignInViewController),
+                completion: {
+                    self.showNextPage(from: cardName) {
+                        self.showNextPageCompletionForLastCard()
+                    }
+                },
+                qrCodeNavigationHandler: qrCodeNavigationHandler
+            )
         case .setDefaultBrowser:
             introViewModel.chosenOptions.insert(.setAsDefaultBrowser)
             introViewModel.updateOnboardingUserActivationEvent()

--- a/Client/Frontend/Onboarding/ViewControllers/Update/UpdateViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/Update/UpdateViewController.swift
@@ -23,6 +23,7 @@ class UpdateViewController: UIViewController,
     var notificationCenter: NotificationProtocol
     var themeManager: ThemeManager
     var themeObserver: NSObjectProtocol?
+    weak var qrCodeNavigationHandler: QRCodeNavigationHandler?
 
     private lazy var closeButton: UIButton = .build { button in
         button.setImage(UIImage(named: StandardImageIdentifiers.ExtraLarge.crossCircleFill), for: .normal)
@@ -213,10 +214,12 @@ extension UpdateViewController: OnboardingCardDelegate {
             let fxaParams = FxALaunchParams(entrypoint: .updateOnboarding, query: [:])
             presentSignToSync(
                 with: fxaParams,
-                selector: #selector(dismissSignInViewController)
-            ) {
-                self.closeUpdate()
-            }
+                selector: #selector(dismissSignInViewController),
+                completion: {
+                    self.closeUpdate()
+                },
+                qrCodeNavigationHandler: qrCodeNavigationHandler
+            )
         case .readPrivacyPolicy:
             presentPrivacyPolicy(
                 from: cardName,

--- a/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -18,7 +18,6 @@ protocol SettingsFlowDelegate: AnyObject,
     func showExperiments()
     func showFirefoxSuggest()
     func showPasswordManager(shouldShowOnboarding: Bool)
-
     func didFinishShowingSettings()
 }
 

--- a/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/RustFxA/FirefoxAccountSignInViewController.swift
@@ -37,6 +37,7 @@ class FirefoxAccountSignInViewController: UIViewController, Themeable {
     var notificationCenter: NotificationProtocol
     var themeManager: ThemeManager
     var themeObserver: NSObjectProtocol?
+    weak var qrCodeNavigationHandler: QRCodeNavigationHandler?
 
     /// This variable is used to track parent page that launched this sign in VC.
     /// telemetryObject deduced from parentType initializer is sent with telemetry events on button click
@@ -278,7 +279,7 @@ class FirefoxAccountSignInViewController: UIViewController, Themeable {
     }
 }
 
-// MARK: QRCodeViewControllerDelegate Functions
+// MARK: - QRCodeViewControllerDelegate Functions
 extension FirefoxAccountSignInViewController: QRCodeViewControllerDelegate {
     func didScanQRCodeWithURL(_ url: URL) {
         let shouldAskForPermission = OnboardingNotificationCardHelper().shouldAskForNotificationsPermission(telemetryObj: telemetryObject)

--- a/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -242,6 +242,13 @@ final class BrowserCoordinatorTests: XCTestCase {
 
         XCTAssertEqual(subject.childCoordinators.count, 1)
         XCTAssertTrue(subject.childCoordinators.first is QRCodeCoordinator)
+    }
+
+    func testShowQRCode_presentsQRCodeNavigationController() {
+        let subject = createSubject()
+
+        subject.showQRCode()
+
         XCTAssertEqual(mockRouter.presentCalled, 1)
         XCTAssertTrue(mockRouter.presentedViewController is QRCodeNavigationController)
     }

--- a/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -235,6 +235,17 @@ final class BrowserCoordinatorTests: XCTestCase {
         XCTAssertTrue(mockRouter.presentedViewController is DevicePasscodeRequiredViewController)
     }
 
+    func testShowQRCode_addsQRCodeCoordinator() {
+        let subject = createSubject()
+
+        subject.showQRCode()
+
+        XCTAssertEqual(subject.childCoordinators.count, 1)
+        XCTAssertTrue(subject.childCoordinators.first is QRCodeCoordinator)
+        XCTAssertEqual(mockRouter.presentCalled, 1)
+        XCTAssertTrue(mockRouter.presentedViewController is QRCodeNavigationController)
+    }
+
     // MARK: - ParentCoordinatorDelegate
 
     func testRemoveChildCoordinator_whenDidFinishCalled() {

--- a/Tests/ClientTests/Coordinators/Launch/LaunchCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/Launch/LaunchCoordinatorTests.swift
@@ -128,6 +128,28 @@ final class LaunchCoordinatorTests: XCTestCase {
         XCTAssertNotNil(pushedVC as? SurveySurfaceViewController)
     }
 
+    // MARK: - QRCodeNavigationHandler
+
+    func testShowQRCode_addsChildQRCodeCoordinator() {
+        let subject = createSubject(isIphone: true)
+        let delegate = MockQRCodeViewControllerDelegate()
+
+        subject.showQRCode(delegate: delegate)
+
+        XCTAssertEqual(subject.childCoordinators.count, 1)
+        XCTAssertTrue(subject.childCoordinators.first is QRCodeCoordinator)
+    }
+
+    func testShowQRCode_presentsQRCodeNavigationController() {
+        let subject = createSubject(isIphone: true)
+        let delegate = MockQRCodeViewControllerDelegate()
+
+        subject.showQRCode(delegate: delegate)
+
+        XCTAssertEqual(mockRouter.presentCalled, 1)
+        XCTAssertTrue(mockRouter.presentedViewController is QRCodeNavigationController)
+    }
+
     // MARK: - Delegates
     func testStart_surveySetsDelegate() throws {
         let messageManager = MockGleanPlumbMessageManagerProtocol()

--- a/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
+++ b/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
@@ -17,6 +17,7 @@ class MockBrowserCoordinator: BrowserNavigationHandler, ParentCoordinatorDelegat
     var showEnhancedTrackingProtectionCalled = 0
     var showShareExtensionCalled = 0
     var showTabTrayCalled = 0
+    var showQrCodeCalled = 0
     var didFinishCalled = 0
 
     func show(settings: Route.SettingsSection) {
@@ -49,6 +50,10 @@ class MockBrowserCoordinator: BrowserNavigationHandler, ParentCoordinatorDelegat
 
     func showTabTray() {
         showTabTrayCalled += 1
+    }
+
+    func showQRCode() {
+        showQrCodeCalled += 1
     }
 
     func didFinish(from childCoordinator: Coordinator) {

--- a/Tests/ClientTests/Coordinators/Mocks/MockQRCodeParentCoordinator.swift
+++ b/Tests/ClientTests/Coordinators/Mocks/MockQRCodeParentCoordinator.swift
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+@testable import Client
+
+class MockQRCodeViewControllerDelegate: QRCodeViewControllerDelegate {
+    var didScanQRCodeWithUrlCalled = 0
+    var didScanQRCodeWithTextCalled = 0
+
+    func didScanQRCodeWithURL(_ url: URL) {
+        didScanQRCodeWithUrlCalled += 1
+    }
+
+    func didScanQRCodeWithText(_ text: String) {
+        didScanQRCodeWithTextCalled += 1
+    }
+}

--- a/Tests/ClientTests/Coordinators/QRCodeCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/QRCodeCoordinatorTests.swift
@@ -1,0 +1,51 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Client
+
+final class QRCodeCoordinatorTests: XCTestCase {
+    private var router: MockRouter!
+    private var parentCoordinator: MockParentCoordinatorDelegate!
+
+    override func setUp() {
+        super.setUp()
+        router = MockRouter(navigationController: UINavigationController())
+        parentCoordinator = MockParentCoordinatorDelegate()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        router = nil
+        parentCoordinator = nil
+    }
+
+    func testShowQRCode_presentsQRCodeNavigationController() {
+        let subject = createSubject()
+        let delegate = MockQRCodeViewControllerDelegate()
+
+        subject.showQRCode(delegate: delegate)
+
+        XCTAssertEqual(router.presentCalled, 1)
+        XCTAssertTrue(router.presentedViewController is QRCodeNavigationController)
+    }
+
+    func testShowQRCode_callsDidFinishOnParentCoordinator() {
+        let subject = createSubject()
+        let delegate = MockQRCodeViewControllerDelegate()
+
+        subject.showQRCode(delegate: delegate)
+        router.savedCompletion?()
+
+        XCTAssertNotNil(router.savedCompletion)
+        XCTAssertEqual(parentCoordinator.didFinishCalled, 1)
+    }
+
+    private func createSubject() -> QRCodeCoordinator {
+        let coordinator = QRCodeCoordinator(parentCoordinator: parentCoordinator,
+                                            router: router)
+        trackForMemoryLeaks(coordinator)
+        return coordinator
+    }
+}

--- a/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
@@ -271,6 +271,16 @@ final class SettingsCoordinatorTests: XCTestCase {
         XCTAssertTrue(subject.childCoordinators.first is QRCodeCoordinator)
     }
 
+    func testShowQRCode_presentsQRCodeNavigationController() {
+        let subject = createSubject()
+        let delegate = MockQRCodeViewControllerDelegate()
+
+        subject.showQRCode(delegate: delegate)
+
+        XCTAssertEqual(mockRouter.presentCalled, 1)
+        XCTAssertTrue(mockRouter.presentedViewController is QRCodeNavigationController)
+    }
+
     func testDidFinishShowingSettings_callsDidFinish() {
         let subject = createSubject()
         subject.parentCoordinator = delegate

--- a/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
@@ -261,6 +261,16 @@ final class SettingsCoordinatorTests: XCTestCase {
         XCTAssertTrue(subject.childCoordinators.first is PasswordManagerCoordinator)
     }
 
+    func testShowQRCode_addsQRCodeChildCoordinator() {
+        let subject = createSubject()
+        let delegate = MockQRCodeViewControllerDelegate()
+
+        subject.showQRCode(delegate: delegate)
+
+        XCTAssertEqual(subject.childCoordinators.count, 1)
+        XCTAssertTrue(subject.childCoordinators.first is QRCodeCoordinator)
+    }
+
     func testDidFinishShowingSettings_callsDidFinish() {
         let subject = createSubject()
         subject.parentCoordinator = delegate

--- a/Tests/ClientTests/Mocks/MockSettingsFlowDelegate.swift
+++ b/Tests/ClientTests/Mocks/MockSettingsFlowDelegate.swift
@@ -18,6 +18,7 @@ class MockSettingsFlowDelegate: SettingsFlowDelegate,
     var showExperimentsCalled = 0
     var showPasswordManagerCalled = 0
     var savedShouldShowOnboarding = false
+    var showQRCodeCalled = 0
 
     func showDevicePassCode() {
         showDevicePassCodeCalled += 1
@@ -40,6 +41,10 @@ class MockSettingsFlowDelegate: SettingsFlowDelegate,
     func showPasswordManager(shouldShowOnboarding: Bool) {
         savedShouldShowOnboarding = shouldShowOnboarding
         showPasswordManagerCalled += 1
+    }
+
+    func showQRCode(delegate: QRCodeViewControllerDelegate) {
+        showQRCodeCalled += 1
     }
 
     // MARK: GeneralSettingsDelegate


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7444)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16488)

## :bulb: Description
Added`QRCodeCoordinator` implementation and related unit tests. Added integration of `QRCodeCoordinator` with related parent coordinator: `LaunchCoordinator`, `SettingsCoordinator`, `BrowserCoordinator`.
Added `QRCodeNavigationHandler` protocol that is conformed by `LaunchCoordinator` and `SettingsCoordinator` and it's used to pass a reference to the `FirefoxAccountSignInViewController` in order to prepare the controller to show the `QRCodeViewController`

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

