### PR TITLE
Bump FXIOS-7566 DISCO-2637 [v120] Update uses of `SuggestionQuery`.

### DIFF
--- a/Storage/Rust/RustFirefoxSuggest.swift
+++ b/Storage/Rust/RustFirefoxSuggest.swift
@@ -29,10 +29,16 @@ public actor RustFirefoxSuggest {
         includeSponsored: Bool,
         includeNonSponsored: Bool
     ) async throws -> [RustFirefoxSuggestion] {
+        var providers = [SuggestionProvider]()
+        if includeSponsored {
+            providers.append(.amp)
+        }
+        if includeNonSponsored {
+            providers.append(.wikipedia)
+        }
         return try store.query(query: SuggestionQuery(
             keyword: keyword,
-            includeSponsored: includeSponsored,
-            includeNonSponsored: includeNonSponsored
+            providers: providers
         )).compactMap(RustFirefoxSuggestion.init)
     }
 


### PR DESCRIPTION
This commit fixes the breaking change introduced in mozilla/application-services#5867.

Once mozilla/application-services#5867 lands, let's fold this commit into the next PR that bumps the `rust-components-swift` dependency.

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7566)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16837)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

