### PR TITLE
Refactor FXIOS-6928 [v120] Hook up all of the UI elements on the TabTrayViewController

### DIFF
--- a/Client/Frontend/Browser/Tabs/EmptyPrivateTabsView.swift
+++ b/Client/Frontend/Browser/Tabs/EmptyPrivateTabsView.swift
@@ -38,7 +38,6 @@ class EmptyPrivateTabsView: UIView {
         label.adjustsFontForContentSizeCategory = true
         label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .title2,
                                                             size: UX.titleSizeFont)
-        label.numberOfLines = 0
         label.text =  .PrivateBrowsingTitle
         label.textAlignment = .center
     }
@@ -54,6 +53,7 @@ class EmptyPrivateTabsView: UIView {
 
     let learnMoreButton: UIButton = .build { button in
         button.setTitle( .PrivateBrowsingLearnMore, for: [])
+        button.titleLabel?.adjustsFontForContentSizeCategory = true
         button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .subheadline,
                                                                          size: UX.buttonSizeFont)
     }

--- a/Client/Frontend/Browser/Tabs/TabDisplayView.swift
+++ b/Client/Frontend/Browser/Tabs/TabDisplayView.swift
@@ -5,18 +5,6 @@
 import Common
 import UIKit
 
-struct TabDisplayViewState {
-    var isPrivateTabs: Bool
-    var isInactiveTabEmpty: Bool
-    var isInactiveTabsExpanded = false
-    var inactiveTabs = ["One",
-                        "Two",
-                        "Three",
-                        "Four",
-                        "Five",
-                        "Six"]
-}
-
 class TabDisplayView: UIView,
                       ThemeApplicable,
                       UICollectionViewDataSource,
@@ -30,7 +18,7 @@ class TabDisplayView: UIView,
         case inactiveTabs
     }
 
-    var state: TabDisplayViewState
+    var state: TabTrayState
     var inactiveTabsSectionManager: InactiveTabsSectionManager
     var theme: Theme?
 
@@ -59,9 +47,10 @@ class TabDisplayView: UIView,
     }()
 
     override init(frame: CGRect) {
-        state = TabDisplayViewState(isPrivateTabs: false,
-                                    isInactiveTabEmpty: false,
-                                    isInactiveTabsExpanded: true)
+        state = TabTrayState(isPrivateMode: false,
+                             isPrivateTabsEmpty: false,
+                             isInactiveTabEmpty: false,
+                             isInactiveTabsExpanded: true)
         self.inactiveTabsSectionManager = InactiveTabsSectionManager()
         super.init(frame: frame)
         setupLayout()
@@ -118,7 +107,7 @@ class TabDisplayView: UIView,
         case .inactiveTabs:
             // Hide inactive tray if there are no inactive tabs or if is PrivateTabs
             guard !state.isInactiveTabEmpty,
-                  !state.isPrivateTabs else { return 0 }
+                  !state.isPrivateMode else { return 0 }
 
             return state.isInactiveTabsExpanded ? state.inactiveTabs.count : 0
         default:

--- a/Client/Frontend/Browser/Tabs/TabDisplayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabDisplayViewController.swift
@@ -8,32 +8,25 @@ import UIKit
 class TabDisplayViewController: UIViewController,
                                 Themeable,
                                 EmptyPrivateTabsViewDelegate {
-    struct UX {}
-
     var notificationCenter: NotificationProtocol
     var themeManager: ThemeManager
     var themeObserver: NSObjectProtocol?
 
     // MARK: UI elements
-    private var backgroundPrivacyOverlay: UIView = .build { _ in }
     private var tabDisplayView: TabDisplayView = .build { _ in }
-
-    private lazy var emptyPrivateTabsView: EmptyPrivateTabsView = {
-        let emptyView = EmptyPrivateTabsView()
-        return emptyView
-    }()
+    private var backgroundPrivacyOverlay: UIView = .build { _ in }
+    private lazy var emptyPrivateTabsView: EmptyPrivateTabsView = .build { _ in }
 
     // MARK: Redux state
-    var isPrivateMode: Bool
-    var isPrivateTabsEmpty: Bool {
-        // TODO: FXIOS-6937 Use var from state if private tabs are empty
-        return isPrivateMode && true
-    }
+    var state: TabTrayState
 
     init(isPrivateMode: Bool,
          notificationCenter: NotificationProtocol = NotificationCenter.default,
          themeManager: ThemeManager = AppContainer.shared.resolve()) {
-        self.isPrivateMode = isPrivateMode
+        // TODO: FXIOS-6936 Integrate Redux state
+        self.state = TabTrayState(isPrivateMode: isPrivateMode,
+                                  isPrivateTabsEmpty: true,
+                                  isInactiveTabEmpty: false)
         self.notificationCenter = notificationCenter
         self.themeManager = themeManager
         super.init(nibName: nil, bundle: nil)
@@ -67,12 +60,12 @@ class TabDisplayViewController: UIViewController,
             backgroundPrivacyOverlay.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
 
-        backgroundPrivacyOverlay.isHidden = !isPrivateMode
+        backgroundPrivacyOverlay.isHidden = !state.isPrivateMode
         setupEmptyView()
     }
 
     func setupEmptyView() {
-        guard isPrivateTabsEmpty else { return }
+        guard state.isPrivateMode, state.isPrivateTabsEmpty else { return }
 
         view.insertSubview(emptyPrivateTabsView, aboveSubview: tabDisplayView)
         NSLayoutConstraint.activate([
@@ -82,6 +75,8 @@ class TabDisplayViewController: UIViewController,
             emptyPrivateTabsView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
         emptyPrivateTabsView.isHidden = false
+        tabDisplayView.isHidden = true
+        backgroundPrivacyOverlay.isHidden = true
     }
 
     func applyTheme() {

--- a/Client/Frontend/Browser/Tabs/TabTrayState.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayState.swift
@@ -4,4 +4,15 @@
 
 import Foundation
 
-struct TabTrayState {}
+struct TabTrayState {
+    var isPrivateMode: Bool
+    var isPrivateTabsEmpty: Bool
+    var isInactiveTabEmpty: Bool
+    var isInactiveTabsExpanded = false
+    var inactiveTabs = ["One",
+                        "Two",
+                        "Three",
+                        "Four",
+                        "Five",
+                        "Six"]
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6928)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15406)

## :bulb: Description
- Fix showing empty private tab view 
- Update TabTrayStay with stub data

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

