### PR TITLE
Bugfix MTE-1491 [v120] Fix testSaveLogin

### DIFF
--- a/Tests/XCUITests/LoginsTests.swift
+++ b/Tests/XCUITests/LoginsTests.swift
@@ -62,6 +62,7 @@ class LoginTest: BaseTestCase {
         mozWaitForElementToExist(passcodeInput, timeout: 20)
         passcodeInput.tap()
         passcodeInput.typeText("foo\n")
+        mozWaitForElementToNotExist(passcodeInput)
     }
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2306961
@@ -104,7 +105,7 @@ class LoginTest: BaseTestCase {
         openLoginsSettings()
         mozWaitForElementToExist(app.tables["Login List"])
         XCTAssertTrue(app.staticTexts[domain].exists)
-        // XCTAssertTrue(app.staticTexts[domainLogin].exists)
+        XCTAssertTrue(app.staticTexts[domainLogin].exists)
         XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList + 1)
         // Check to see how it works with multiple entries in the list- in this case, two for now
         app.buttons["Settings"].tap()
@@ -146,6 +147,7 @@ class LoginTest: BaseTestCase {
         openLoginsSettings()
         XCTAssertTrue(app.staticTexts[domain].exists)
         XCTAssertTrue(app.staticTexts[domainLogin].exists)
+        XCTAssertTrue(app.buttons["Edit"].isHittable)
         app.buttons["Edit"].tap()
 
         XCTAssertTrue(app.buttons["Select All"].exists)

--- a/Tests/XCUITests/LoginsTests.swift
+++ b/Tests/XCUITests/LoginsTests.swift
@@ -105,7 +105,7 @@ class LoginTest: BaseTestCase {
         openLoginsSettings()
         mozWaitForElementToExist(app.tables["Login List"])
         XCTAssertTrue(app.staticTexts[domain].exists)
-        XCTAssertTrue(app.staticTexts[domainLogin].exists)
+        // XCTAssertTrue(app.staticTexts[domainLogin].exists)
         XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList + 1)
         // Check to see how it works with multiple entries in the list- in this case, two for now
         app.buttons["Settings"].tap()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTe-1491)


## :bulb: Description
`testSaveLogin()` and some other tests from `LoginsTest` fail intermittently. The cause could be the springboard isn't closed before tapping on the Settings page.

The recent upgrade to XCode 15 seems to magnify the issue. I have seen `LoginsTest` from smoke tests to fail.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

