### PR TITLE
Bugfix FXIOS-7411 [v120] Sync process shows white screen when scanning QR code to get signed in

### DIFF
--- a/RustFxA/FxAWebViewModel.swift
+++ b/RustFxA/FxAWebViewModel.swift
@@ -162,6 +162,8 @@ extension FxAWebViewModel {
             case .login:
                 if let data = data {
                     onLogin(data: data, webView: webView)
+                } else {
+                    onDismissController?()
                 }
             case .changePassword:
                 if let data = data {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7411)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16438)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
I reviewed this issue and was unable to reproduce it on both iPhone and iPad, whether using QR or email login. Our current approach involves loading a webview that sends a callback to the view controller to trigger dismissal. It appears that either the callback is not being received, or the data it contains is invalid. To address this, I've implemented a solution where I explicitly call the onDismiss function in cases like this, which should enhance the user experience.

Additionally, we can further improve the user experience by implementing an alert or a similar notification mechanism to inform the user when such failures occur.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

