### PR TITLE
Bugfix FXIOS-7497 [v120] scroll position is reset to the top of previous page when navigating back

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -77,6 +77,7 @@ class BrowserViewController: UIViewController,
     let tabManager: TabManager
     let ratingPromptManager: RatingPromptManager
     lazy var isTabTrayRefactorEnabled: Bool = TabTrayFlagManager.isRefactorEnabled
+    var backListHistory: [WKBackForwardListItem] = []
 
     // Header stack view can contain the top url bar, top reader mode, top ZoomPageBar
     var header: BaseAlphaStackView = .build { _ in }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -759,7 +759,6 @@ extension BrowserViewController: WKNavigationDelegate {
         self.scrollController.resetZoomState()
 
         if tabManager.selectedTab === tab {
-            self.scrollController.showToolbars(animated: false)
             updateUIForReaderHomeStateForTab(tab, focusUrlBar: true)
         }
     }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -759,8 +759,15 @@ extension BrowserViewController: WKNavigationDelegate {
         self.scrollController.resetZoomState()
 
         if tabManager.selectedTab === tab {
+            if let currentItem = webView.backForwardList.currentItem {
+                if !backListHistory.contains(currentItem) {
+                    self.scrollController.showToolbars(animated: false)
+                }
+            }
             updateUIForReaderHomeStateForTab(tab, focusUrlBar: true)
         }
+
+        backListHistory = webView.backForwardList.backList
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7497)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16643)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Removed the line of code that resets the scroll to top when going back
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

