### PR TITLE
Bugfix FXIOS-7539 [v120] The webpage elements are read behind the "review quality check bottom sheet"

### DIFF
--- a/Client/Frontend/Fakespot/FakespotViewController.swift
+++ b/Client/Frontend/Fakespot/FakespotViewController.swift
@@ -402,6 +402,8 @@ class FakespotViewController:
             }
         }
 
+        // in iOS 15 modals with a large detent read content underneath the modal in voice over
+        // to prevent this we manually turn this off
         view.accessibilityViewIsModal = currentDetent == .large ? true : false
     }
 

--- a/Client/Frontend/Fakespot/FakespotViewController.swift
+++ b/Client/Frontend/Fakespot/FakespotViewController.swift
@@ -7,7 +7,12 @@ import ComponentLibrary
 import UIKit
 import Shared
 
-class FakespotViewController: UIViewController, Themeable, Notifiable, UIAdaptivePresentationControllerDelegate {
+class FakespotViewController:
+    UIViewController,
+    Themeable,
+    Notifiable,
+    UIAdaptivePresentationControllerDelegate,
+    UISheetPresentationControllerDelegate {
     private struct UX {
         static let headerTopSpacing: CGFloat = 22
         static let headerHorizontalSpacing: CGFloat = 18
@@ -108,6 +113,10 @@ class FakespotViewController: UIViewController, Themeable, Notifiable, UIAdaptiv
         super.viewDidLoad()
         presentationController?.delegate = self
 
+        if #available(iOS 15.0, *) {
+            sheetPresentationController?.delegate = self
+        }
+
         setupNotifications(forObserver: self,
                            observing: [.DynamicFontChanged])
 
@@ -131,6 +140,7 @@ class FakespotViewController: UIViewController, Themeable, Notifiable, UIAdaptiv
         super.viewDidAppear(animated)
         guard #available(iOS 15.0, *) else { return }
         viewModel.recordBottomSheetDisplayed(presentationController)
+        updateModalA11y()
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -378,6 +388,23 @@ class FakespotViewController: UIViewController, Themeable, Notifiable, UIAdaptiv
         viewModel.onViewControllerDeinit()
     }
 
+    @available(iOS 15.0, *)
+    private func updateModalA11y() {
+        var currentDetent: UISheetPresentationController.Detent.Identifier? = viewModel.getCurrentDetent(for: sheetPresentationController)
+
+        if currentDetent == nil,
+           let sheetPresentationController,
+           let firstDetent = sheetPresentationController.detents.first {
+            if firstDetent == .medium() {
+                currentDetent = .medium
+            } else if firstDetent == .large() {
+                currentDetent = .large
+            }
+        }
+
+        view.accessibilityViewIsModal = currentDetent == .large ? true : false
+    }
+
     // MARK: - UIAdaptivePresentationControllerDelegate
 
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
@@ -390,5 +417,12 @@ class FakespotViewController: UIViewController, Themeable, Notifiable, UIAdaptiv
         } else {
             viewModel.recordDismissTelemetry(by: .clickOutside)
         }
+    }
+
+    // MARK: - UISheetPresentationControllerDelegate
+
+    @available(iOS 15.0, *)
+    func sheetPresentationControllerDidChangeSelectedDetentIdentifier(_ sheetPresentationController: UISheetPresentationController) {
+        updateModalA11y()
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7539)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16762)

## :bulb: Description
Marks view as presented modally when using accessibility so that the website underneath is not read with VoiceOver.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

