### PR TITLE
Fix MTE-1750 [v120] for downloads and tracking protection tests

### DIFF
--- a/Tests/XCUITests/TrackingProtectionTests.swift
+++ b/Tests/XCUITests/TrackingProtectionTests.swift
@@ -145,7 +145,7 @@ class TrackingProtectionTests: BaseTestCase {
         // Dismiss the view and visit "badssl.com". Tap on "expired"
         app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].tap(force: true)
         navigator.nowAt(BrowserTab)
-        navigator.openURL("https://www.badssl.com")
+        navigator.openNewURL(urlString: "https://www.badssl.com")
         waitUntilPageLoad()
         app.links["expired"].tap()
         waitUntilPageLoad()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1750)

## :bulb: Description
Fixed 2 downloads tests by finding a different way to tap outside the context menu to close it.
For tracking protection test i have preferred to open a new tab and open the link, because now on iPad there is a different behaviour when selecting the url bar having a link on it, the link needs an extra step to be selected and then override it with the new link.

