### PR TITLE
Bugfix FXIOS-7540 [v120] Fakespot - Incorrect card is displayed in case the prod analyze is in progress but it was started from a different device

### DIFF
--- a/Client/Frontend/Fakespot/Client/ProductAnalyzeResponse.swift
+++ b/Client/Frontend/Fakespot/Client/ProductAnalyzeResponse.swift
@@ -12,6 +12,7 @@ enum AnalysisStatus: String, Decodable {
     case notAnalyzable = "not_analyzable"
     case notFound = "not_found"
     case unprocessable = "unprocessable"
+    case stale = "stale"
 
     var isAnalyzing: Bool {
         switch self {

--- a/Client/Frontend/Fakespot/Client/ProductAnalyzeResponse.swift
+++ b/Client/Frontend/Fakespot/Client/ProductAnalyzeResponse.swift
@@ -13,6 +13,7 @@ enum AnalysisStatus: String, Decodable {
     case notFound = "not_found"
     case unprocessable = "unprocessable"
     case stale = "stale"
+    case notEnoughReviews = "not_enough_reviews"
 
     var isAnalyzing: Bool {
         switch self {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7540)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16766)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Reorganise again the no analysis + reanalysis flow. 
Sometimes you can get after `in progress` the `unprocessable` so we need to dismiss the progress. 
Also added a new `stale` status.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

