### PR TITLE
Bugfix FXIOS-7554 [v120] "Close All Tabs" crashes app intermittently

### DIFF
--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -754,9 +754,9 @@ extension HomepageViewController: HomepageViewModelDelegate {
         ensureMainThread { [weak self] in
             guard let self = self else { return }
 
+            self.collectionView.collectionViewLayout.invalidateLayout()
             self.viewModel.refreshData(for: self.traitCollection, size: self.view.frame.size)
             self.collectionView.reloadData()
-            self.collectionView.collectionViewLayout.invalidateLayout()
             self.logger.log("Amount of sections shown is \(self.viewModel.shownSections.count)",
                             level: .debug,
                             category: .homepage)

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -754,8 +754,8 @@ extension HomepageViewController: HomepageViewModelDelegate {
         ensureMainThread { [weak self] in
             guard let self = self else { return }
 
-            self.collectionView.collectionViewLayout.invalidateLayout()
             self.viewModel.refreshData(for: self.traitCollection, size: self.view.frame.size)
+            self.collectionView.collectionViewLayout.invalidateLayout()
             self.collectionView.reloadData()
             self.logger.log("Amount of sections shown is \(self.viewModel.shownSections.count)",
                             level: .debug,

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -755,8 +755,8 @@ extension HomepageViewController: HomepageViewModelDelegate {
             guard let self = self else { return }
 
             self.viewModel.refreshData(for: self.traitCollection, size: self.view.frame.size)
-            self.collectionView.collectionViewLayout.invalidateLayout()
             self.collectionView.reloadData()
+            self.collectionView.collectionViewLayout.invalidateLayout()
             self.logger.log("Amount of sections shown is \(self.viewModel.shownSections.count)",
                             level: .debug,
                             category: .homepage)

--- a/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -30,7 +30,7 @@ class JumpBackInViewModel: FeatureFlaggable {
     var mostRecentSyncedTab: JumpBackInSyncedTab?
 
     // Raw data to calculate what we can show to the user
-    var recentTabs: [Tab] = [Tab]()
+    private var recentTabs: [Tab] = [Tab]()
     var recentSyncedTab: JumpBackInSyncedTab?
 
     private var jumpBackInDataAdaptor: JumpBackInDataAdaptor
@@ -165,10 +165,9 @@ private extension JumpBackInViewModel {
         from tabs: [Tab],
         withMaxTabsCount maxTabs: Int
     ) -> JumpBackInList {
-        let recentTabs = filter(
-            tabs: tabs,
-            withMaxTabsCount: maxTabs
-        )
+        Task { @MainActor in
+            self.recentTabs = await self.jumpBackInDataAdaptor.getRecentTabData()
+        }
 
         return JumpBackInList(tabs: recentTabs)
     }

--- a/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -30,7 +30,7 @@ class JumpBackInViewModel: FeatureFlaggable {
     var mostRecentSyncedTab: JumpBackInSyncedTab?
 
     // Raw data to calculate what we can show to the user
-    private var recentTabs: [Tab] = [Tab]()
+    var recentTabs: [Tab] = [Tab]()
     var recentSyncedTab: JumpBackInSyncedTab?
 
     private var jumpBackInDataAdaptor: JumpBackInDataAdaptor
@@ -153,6 +153,9 @@ class JumpBackInViewModel: FeatureFlaggable {
 // MARK: - Private: Prepare UI data
 private extension JumpBackInViewModel {
     private func refreshData(maxItemsToDisplay: JumpBackInDisplayGroupCount) {
+        Task { @MainActor in
+            self.recentTabs = await self.jumpBackInDataAdaptor.getRecentTabData()
+        }
         jumpBackInList = createJumpBackInList(
             from: recentTabs,
             withMaxTabsCount: maxItemsToDisplay.tabsCount
@@ -165,9 +168,9 @@ private extension JumpBackInViewModel {
         from tabs: [Tab],
         withMaxTabsCount maxTabs: Int
     ) -> JumpBackInList {
-        Task { @MainActor in
-            self.recentTabs = await self.jumpBackInDataAdaptor.getRecentTabData()
-        }
+        let recentTabs = filter(
+            tabs: tabs,
+            withMaxTabsCount: maxTabs)
 
         return JumpBackInList(tabs: recentTabs)
     }

--- a/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -153,7 +153,8 @@ class JumpBackInViewModel: FeatureFlaggable {
 // MARK: - Private: Prepare UI data
 private extension JumpBackInViewModel {
     private func refreshData(maxItemsToDisplay: JumpBackInDisplayGroupCount) {
-        Task { @MainActor in
+        Task { @MainActor [weak self] in
+            guard let self else { return }
             self.recentTabs = await self.jumpBackInDataAdaptor.getRecentTabData()
         }
         jumpBackInList = createJumpBackInList(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7554)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16810)

## :bulb: Description
- Invalidate layout before reloading data
- Update `JumpBackInViewModel` recentTabs from `JumpBackInAdaptor` recentTabs to avoid race condition where tabs were not closed yet and the collectionView was crashing due to invalid section declaration

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

