### PR TITLE
Bugfix MTE-1760 [v120] DownloadsTests for iPad

### DIFF
--- a/Tests/XCUITests/DownloadsTests.swift
+++ b/Tests/XCUITests/DownloadsTests.swift
@@ -123,9 +123,8 @@ class DownloadsTests: BaseTestCase {
             app.buttons["Close"].tap()
         } else {
             // Workaround to close the context menu.
-            // XCUITest does not allow me to click the greyed out portion of the app.
-            app.otherElements["ActivityListView"].cells["XCElementSnapshotPrivilegedValuePlaceholder"].firstMatch.tap()
-            app.navigationBars["Add Tag"].buttons["Done"].tap()
+            // XCUITest does not allow me to click the greyed out portion of the app without the force option.
+            app.buttons["Done"].tap(force: true)
         }
     }
 
@@ -145,9 +144,8 @@ class DownloadsTests: BaseTestCase {
             app.buttons["Close"].tap()
         } else {
             // Workaround to close the context menu.
-            // XCUITest does not allow me to click the greyed out portion of the app.
-            app.otherElements["ActivityListView"].cells["XCElementSnapshotPrivilegedValuePlaceholder"].firstMatch.tap()
-            app.navigationBars["Add Tag"].buttons["Done"].tap()
+            // XCUITest does not allow me to click the greyed out portion of the app without the force option.
+            app.buttons["Done"].tap(force: true)
         }
      }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1760)

## :bulb: Description
The workaround for closing the context menu no longer works on iOS 17. Instead, force tapping an area outside of the context menu does.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

