### PR TITLE
Add FXIOS-7263 [v120] Add a Nimbus config variable that can remotely override the default OHTTP relay URL with a new URL

### DIFF
--- a/.experimenter.yaml
+++ b/.experimenter.yaml
@@ -165,6 +165,9 @@ shopping2023:
     config:
       type: json
       description: "A Map of website configurations\n"
+    relay:
+      type: string
+      description: "Configurable relay URL for production environment\n"
     status:
       type: boolean
       description: "Whether the Fakespot feature is enabled or disabled\n"

--- a/Client/Frontend/Fakespot/Client/FakeSpotClient.swift
+++ b/Client/Frontend/Fakespot/Client/FakeSpotClient.swift
@@ -110,7 +110,7 @@ enum FakespotEnvironment {
         case .staging:
             return URL(string: "https://mozilla-ohttp-dev.fastly-edge.com/")
         case .prod:
-            return URL(string: "https://mozilla-ohttp-fakespot.fastly-edge.com/")
+            return NimbusFakespotFeatureLayer().relayURL
         }
     }
 }

--- a/Client/Nimbus/NimbusFakespotFeatureLayer.swift
+++ b/Client/Nimbus/NimbusFakespotFeatureLayer.swift
@@ -6,6 +6,7 @@ import Foundation
 
 protocol NimbusFakespotFeatureLayerProtocol {
     func getSiteConfig(siteName: String) -> WebsiteConfig?
+    var relayURL: URL? { get }
 }
 
 class NimbusFakespotFeatureLayer: NimbusFakespotFeatureLayerProtocol {
@@ -17,5 +18,9 @@ class NimbusFakespotFeatureLayer: NimbusFakespotFeatureLayerProtocol {
 
     func getSiteConfig(siteName: String) -> WebsiteConfig? {
         nimbus.features.shopping2023.value().config[siteName]
+    }
+
+    var relayURL: URL? {
+        URL(string: nimbus.features.shopping2023.value().relay)
     }
 }

--- a/nimbus-features/fakespotFeature.yaml
+++ b/nimbus-features/fakespotFeature.yaml
@@ -23,6 +23,11 @@ features:
           bestbuy:
             productIdFromURLRegex: "\\\\/(?<productId>\\\\d+\\\\.p)"
             validTLDs: ["com"]
+      relay:
+        description: >
+           Configurable relay URL for production environment
+        type: String
+        default: "https://mozilla-ohttp-fakespot.fastly-edge.com/"
     defaults:
       - channel: beta
         value:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7263)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16112)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
 Add a Nimbus config variable that can remotely override the default OHTTP relay URL with a new URL

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

