### PR TITLE
Bugfix FXIOS-7582 [v120] VoiceOver focus is inconsistently jumping when a card is opened on Review Checker

### DIFF
--- a/Client/Frontend/Fakespot/Views/FakespotReviewQualityCardView.swift
+++ b/Client/Frontend/Fakespot/Views/FakespotReviewQualityCardView.swift
@@ -203,6 +203,18 @@ final class FakespotReviewQualityCardView: UIView, Notifiable, ThemeApplicable {
         setupNotifications(forObserver: self,
                            observing: [.DynamicFontChanged])
         setupLayout()
+
+        headlineStackView.accessibilityElements = [headlineLabel, subHeadlineLabel]
+        ratingsStackView.accessibilityElements = [
+            aReliabilityScoreView,
+            bReliabilityScoreView,
+            reliableReviewsLabel,
+            cReliabilityScoreView,
+            mixReliableReviewsLabel,
+            dReliabilityScoreView,
+            fReliabilityScoreView,
+            unreliableReviewsLabel]
+        contentStackView.accessibilityElements = [headlineStackView, ratingsStackView, footerStackView, learnMoreButton]
     }
 
     required init?(coder: NSCoder) {

--- a/Client/Frontend/Fakespot/Views/FakespotReviewQualityCardView.swift
+++ b/Client/Frontend/Fakespot/Views/FakespotReviewQualityCardView.swift
@@ -204,17 +204,7 @@ final class FakespotReviewQualityCardView: UIView, Notifiable, ThemeApplicable {
                            observing: [.DynamicFontChanged])
         setupLayout()
 
-        headlineStackView.accessibilityElements = [headlineLabel, subHeadlineLabel]
-        ratingsStackView.accessibilityElements = [
-            aReliabilityScoreView,
-            bReliabilityScoreView,
-            reliableReviewsLabel,
-            cReliabilityScoreView,
-            mixReliableReviewsLabel,
-            dReliabilityScoreView,
-            fReliabilityScoreView,
-            unreliableReviewsLabel]
-        contentStackView.accessibilityElements = [headlineStackView, ratingsStackView, footerStackView, learnMoreButton]
+        updateA11yElementOrder()
     }
 
     required init?(coder: NSCoder) {
@@ -271,6 +261,20 @@ final class FakespotReviewQualityCardView: UIView, Notifiable, ThemeApplicable {
 
         setNeedsLayout()
         layoutIfNeeded()
+    }
+
+    private func updateA11yElementOrder() {
+        headlineStackView.accessibilityElements = [headlineLabel, subHeadlineLabel]
+        ratingsStackView.accessibilityElements = [
+            aReliabilityScoreView,
+            bReliabilityScoreView,
+            reliableReviewsLabel,
+            cReliabilityScoreView,
+            mixReliableReviewsLabel,
+            dReliabilityScoreView,
+            fReliabilityScoreView,
+            unreliableReviewsLabel]
+        contentStackView.accessibilityElements = [headlineStackView, ratingsStackView, footerStackView, learnMoreButton]
     }
 
     @objc


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7582)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16872)

## :bulb: Description
Updates the order of a11y elements for the "How we determine review quality" card.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

