### PR TITLE
Refactor FXIOS-7593 [v120] Adjust a11y label for grades

### DIFF
--- a/Client/Frontend/Fakespot/Views/FakespotReliabilityCardView.swift
+++ b/Client/Frontend/Fakespot/Views/FakespotReliabilityCardView.swift
@@ -83,6 +83,8 @@ class FakespotReliabilityCardView: UIView, ThemeApplicable {
         titleLabel.accessibilityIdentifier = viewModel.titleA11yId
 
         reliabilityLetterLabel.text = viewModel.grade.rawValue
+        reliabilityLetterLabel.accessibilityLabel = String(format: .Shopping.ReliabilityScoreGradeA11yLabel,
+                                                           viewModel.grade.rawValue)
         reliabilityLetterLabel.accessibilityIdentifier = viewModel.gradeLetterA11yId
         reliabilityDescriptionLabel.text = viewModel.grade.description
         reliabilityDescriptionLabel.accessibilityIdentifier = viewModel.gradeDescriptionA11yId

--- a/Client/Frontend/Fakespot/Views/FakespotReliabilityScoreView.swift
+++ b/Client/Frontend/Fakespot/Views/FakespotReliabilityScoreView.swift
@@ -39,6 +39,8 @@ final class FakespotReliabilityScoreView: UIView, Notifiable, ThemeApplicable {
         setupLayout()
         setupView()
         reliabilityLetterLabel.text = grade.rawValue
+        reliabilityLetterLabel.accessibilityLabel = String(format: .Shopping.ReliabilityScoreGradeA11yLabel,
+                                                           grade.rawValue)
     }
 
     required init?(coder: NSCoder) {

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -3871,6 +3871,11 @@ extension String {
             tableName: "Shopping",
             value: "Learn more about how %@ determines review quality",
             comment: "The title of the learn more button from How we determine review quality card displayed in the shopping review quality bottom sheet. The placeholder will be replaced with the Fakespot app name.")
+        public static let ReliabilityScoreGradeA11yLabel = MZLocalizedString(
+            key: "Shopping.ReliabilityScore.Grade.A11y.Label.v120",
+            tableName: "Shopping",
+            value: "Grade %@",
+            comment: "Accessibility label for the Grade labels used in 'How we determine review quality' card and 'How reliable are these reviews' card displayed in the shopping review quality bottom sheet. The placeholder will be replaced by a grade letter (e.g. A).")
         public static let OptInCardHeaderTitle = MZLocalizedString(
             key: "Shopping.OptInCard.HeaderLabel.Title.v120",
             tableName: "Shopping",

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -3855,12 +3855,12 @@ extension String {
             key: "Shopping.ReviewQualityCard.UnreliableReviews.Label.v120",
             tableName: "Shopping",
             value: "Unreliable reviews. We believe the reviews are likely fake or from biased reviewers.",
-            comment: "Unnreliable reviews label from How we determine review quality card displayed in the shopping review quality bottom sheet.")
+            comment: "Unreliable reviews label from How we determine review quality card displayed in the shopping review quality bottom sheet.")
         public static let ReviewQualityCardAdjustedRatingLabel = MZLocalizedString(
             key: "Shopping.ReviewQualityCard.AdjustedRating.Label.v120",
             tableName: "Shopping",
             value: "*The adjusted rating* is based only on reviews we believe to be reliable.",
-            comment: "Adujusted rating label from How we determine review quality card displayed in the shopping review quality bottom sheet. The *text inside asterisks* denotes part of the string to bold, please leave the text inside the '*' so that it is bolded correctly.")
+            comment: "Adjusted rating label from How we determine review quality card displayed in the shopping review quality bottom sheet. The *text inside asterisks* denotes part of the string to bold, please leave the text inside the '*' so that it is bolded correctly.")
         public static let ReviewQualityCardHighlightsLabel = MZLocalizedString(
             key: "Shopping.ReviewQualityCard.Highlights.Label.v120",
             tableName: "Shopping",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7593)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16895)

## :bulb: Description
Changes the grade letter to be read in voice over as "Grade A" instead of "A" for example.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

