### PR TITLE
Bugfix FXIOS-1997 [v120] Invalidate collection view layout after `TopTabsViewController` laid out its subviews

### DIFF
--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -116,6 +116,11 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        collectionView.collectionViewLayout.invalidateLayout()
+    }
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         view.setNeedsLayout()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-1997)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/8713)

## :bulb: Description
`TopTabsViewController` wasn't laying out it's subviews after the orientation change.  From the [Discussion section of `viewDidLayoutSubviews`](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621398-viewdidlayoutsubviews#discussion), emphasis mine:

> ___When the bounds change for a view controller's view, the view adjusts the positions of its subviews and then the system calls this method___. However, this method being called does not indicate that the individual layouts of the view's subviews have been adjusted. Each subview is responsible for adjusting its own layout.
>
> ___Your view controller can override this method to make changes after the view lays out its subviews___. The default implementation of this method does nothing.

Given the above documentation, I invalidated `TopTabsViewController.collectionView.collectionViewLayout` inside `viewDidLayoutSubviews`.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

