### PR TITLE
Refactor FXIOS-7598 [v120] Fakespot - Incorrect font in ReliabilityCardView

### DIFF
--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -3859,7 +3859,7 @@ extension String {
         public static let ReviewQualityCardAdjustedRatingLabel = MZLocalizedString(
             key: "Shopping.ReviewQualityCard.AdjustedRating.Label.v120",
             tableName: "Shopping",
-            value: "*The adjusted rating* is based only on reviews we believe to be reliable.",
+            value: "The *adjusted rating* is based only on reviews we believe to be reliable.",
             comment: "Adjusted rating label from How we determine review quality card displayed in the shopping review quality bottom sheet. The *text inside asterisks* denotes part of the string to bold, please leave the text inside the '*' so that it is bolded correctly.")
         public static let ReviewQualityCardHighlightsLabel = MZLocalizedString(
             key: "Shopping.ReviewQualityCard.Highlights.Label.v120",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7598)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16907)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Removed the word "the" from the bold part of the text "The adjusted rating"
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

