### PR TITLE
Refactor FXIOS-7596 [v120] Clean up screenshot stuff

### DIFF
--- a/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -798,27 +798,6 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         delegates.forEach { $0.get()?.tabManagerDidRemoveAllTabs(self, toast: toast) }
     }
 
-    // MARK: - TabEventHandler
-    func tabDidSetScreenshot(_ tab: Tab, hasHomeScreenshot: Bool) {
-        guard tab.screenshot != nil else {
-            // Remove screenshot from image store so we can use favicon
-            // when a screenshot isn't available for the associated tab url
-            removeScreenshot(tab: tab)
-            return
-        }
-        storeScreenshot(tab: tab)
-    }
-
-    func storeScreenshot(tab: Tab) {
-        store.preserveScreenshot(forTab: tab)
-        storeChanges()
-    }
-
-    func removeScreenshot(tab: Tab) {
-        store.removeScreenshot(forTab: tab)
-        storeChanges()
-    }
-
     // MARK: - Private
     @objc
     private func blockPopUpDidChange() {

--- a/Client/TabManagement/Legacy/LegacyTabManagerStore.swift
+++ b/Client/TabManagement/Legacy/LegacyTabManagerStore.swift
@@ -12,9 +12,6 @@ protocol LegacyTabManagerStore {
     var hasTabsToRestoreAtStartup: Bool { get }
     var tabs: [LegacySavedTab] { get }
 
-    func preserveScreenshot(forTab tab: Tab?)
-    func removeScreenshot(forTab tab: Tab?)
-
     func preserveTabs(_ tabs: [Tab],
                       selectedTab: Tab?)
 
@@ -65,24 +62,6 @@ class LegacyTabManagerStoreImplementation: LegacyTabManagerStore, FeatureFlaggab
         self.logger = logger
         self.tabDataRetriever = LegacyTabDataRetrieverImplementation(fileManager: fileManager)
         tabDataRetriever.tabsStateArchivePath = tabsStateArchivePath()
-    }
-
-    // MARK: - Screenshots
-
-    func preserveScreenshot(forTab tab: Tab?) {
-        if let tab = tab, let screenshot = tab.screenshot, let uuidString = tab.screenshotUUID?.uuidString {
-            Task {
-                try? await imageStore?.saveImageForKey(uuidString, image: screenshot)
-            }
-        }
-    }
-
-    func removeScreenshot(forTab tab: Tab?) {
-        if let tab = tab, let screenshotUUID = tab.screenshotUUID {
-            Task {
-                await imageStore?.deleteImageForKey(screenshotUUID.uuidString)
-            }
-        }
     }
 
     // MARK: - Saving


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7596)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16900)

## :bulb: Description
With iOS 14 support dropped we can now clean up the old tab storage code. This isn't trivial because some of it is still needed for the migration path and it's very interconnected with the tab manager so to minimize risk I'm going to do it in small chunks.
This PR cleans up any code paths related to screenshots.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

