### PR TITLE
Remove FXIOS-6737 [v120] Remove recentlySaved feature flag

### DIFF
--- a/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -24,7 +24,6 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case jumpBackIn
     case libraryCoordinatorRefactor
     case qrCodeCoordinatorRefactor
-    case recentlySaved
     case reduxIntegration
     case reportSiteIssue
     case searchHighlights
@@ -67,8 +66,6 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
             return FlagKeys.InactiveTabs
         case .jumpBackIn:
             return FlagKeys.JumpBackInSection
-        case .recentlySaved:
-            return FlagKeys.RecentlySavedSection
         case .topSites:
             return FlagKeys.TopSiteSection
         case .wallpapers:

--- a/Client/Frontend/Home/RecentlySaved/RecentlySavedViewModel.swift
+++ b/Client/Frontend/Home/RecentlySaved/RecentlySavedViewModel.swift
@@ -112,7 +112,7 @@ extension RecentlySavedViewModel: HomepageViewModelProtocol, FeatureFlaggable {
     }
 
     var isEnabled: Bool {
-        return featureFlags.isFeatureEnabled(.recentlySaved, checking: .buildAndUser)
+        return profile.prefs.boolForKey(PrefsKeys.UserFeatureFlagPrefs.RecentlySavedSection) ?? true
     }
 
     var hasData: Bool {

--- a/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -19,10 +19,6 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
         return featureFlags.isFeatureEnabled(.jumpBackIn, checking: .buildOnly)
     }
 
-    var isRecentlySavedSectionEnabled: Bool {
-        return featureFlags.isFeatureEnabled(.recentlySaved, checking: .buildOnly)
-    }
-
     var isWallpaperSectionEnabled: Bool {
         return wallpaperManager.canSettingsBeShown &&
             featureFlags.isFeatureEnabled(.wallpapers, checking: .buildOnly)
@@ -144,8 +140,13 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
         let jumpBackInSetting = BoolSetting(with: .jumpBackIn,
                                             titleText: NSAttributedString(string: .Settings.Homepage.CustomizeFirefoxHome.JumpBackIn))
 
-        let recentlySavedSetting = BoolSetting(with: .recentlySaved,
-                                               titleText: NSAttributedString(string: .Settings.Homepage.CustomizeFirefoxHome.RecentlySaved))
+        let recentlySavedSetting = BoolSetting(
+            prefs: profile.prefs,
+            theme: themeManager.currentTheme,
+            prefKey: PrefsKeys.UserFeatureFlagPrefs.RecentlySavedSection,
+            defaultValue: true,
+            titleText: .Settings.Homepage.CustomizeFirefoxHome.RecentlySaved
+        )
 
         let historyHighlightsSetting = BoolSetting(with: .historyHighlights,
                                                    titleText: NSAttributedString(string: .Settings.Homepage.CustomizeFirefoxHome.RecentlyVisited))
@@ -160,9 +161,7 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
             sectionItems.append(jumpBackInSetting)
         }
 
-        if isRecentlySavedSectionEnabled {
-            sectionItems.append(recentlySavedSetting)
-        }
+        sectionItems.append(recentlySavedSetting)
 
         if isHistoryHighlightsSectionEnabled {
             sectionItems.append(historyHighlightsSetting)

--- a/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -23,7 +23,6 @@ final class NimbusFeatureFlagLayer {
             return checkCredentialAutofillCoordinatorRefactorFeature(from: nimbus)
 
         case .jumpBackIn,
-                .recentlySaved,
                 .historyHighlights,
                 .topSites:
             return checkHomescreenSectionsFeature(for: featureID, from: nimbus)
@@ -114,7 +113,6 @@ final class NimbusFeatureFlagLayer {
         switch featureID {
         case .topSites: nimbusID = HomeScreenSection.topSites
         case .jumpBackIn: nimbusID = HomeScreenSection.jumpBackIn
-        case .recentlySaved: nimbusID = HomeScreenSection.recentlySaved
         case .historyHighlights: nimbusID = HomeScreenSection.recentExplorations
         default: return false
         }

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -321,7 +321,7 @@ class TelemetryWrapper: TelemetryWrapperProtocol, FeatureFlaggable {
         let isRecentlyVisitedEnabled = featureFlags.isFeatureEnabled(.historyHighlights, checking: .buildAndUser)
         GleanMetrics.Preferences.recentlyVisited.set(isRecentlyVisitedEnabled)
 
-        let isRecentlySavedEnabled = featureFlags.isFeatureEnabled(.recentlySaved, checking: .buildAndUser)
+        let isRecentlySavedEnabled = prefs.boolForKey(PrefsKeys.UserFeatureFlagPrefs.RecentlySavedSection) ?? true
         GleanMetrics.Preferences.recentlySaved.set(isRecentlySavedEnabled)
 
         let isFeatureEnabled = prefs.boolForKey(PrefsKeys.UserFeatureFlagPrefs.ASPocketStories) ?? true

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -74,13 +74,13 @@ public struct PrefsKeys {
         public static let HistoryGroups = "HistoryGroupsUserPrefsKey"
         public static let InactiveTabs = "InactiveTabsUserPrefsKey"
         public static let JumpBackInSection = "JumpBackInSectionUserPrefsKey"
-        public static let RecentlySavedSection = "RecentlySavedSectionUserPrefsKey"
         public static let SearchBarPosition = "SearchBarPositionUsersPrefsKey"
         public static let TopSiteSection = "TopSitesUserPrefsKey"
     }
 
     public struct UserFeatureFlagPrefs {
         public static let ASPocketStories = "ASPocketStoriesUserPrefsKey"
+        public static let RecentlySavedSection = "RecentlySavedSectionUserPrefsKey"
         public static let SponsoredShortcuts = "SponsoredShortcutsUserPrefsKey"
         public static let StartAtHome = "StartAtHomeUserPrefsKey"
     }

--- a/Tests/ClientTests/FeatureFlagManagerTests.swift
+++ b/Tests/ClientTests/FeatureFlagManagerTests.swift
@@ -42,8 +42,6 @@ class FeatureFlagManagerTests: XCTestCase, FeatureFlaggable {
         XCTAssertTrue(featureFlags.isFeatureEnabled(.inactiveTabs, checking: .userOnly))
         XCTAssertTrue(featureFlags.isFeatureEnabled(.jumpBackIn, checking: .buildOnly))
         XCTAssertTrue(featureFlags.isFeatureEnabled(.jumpBackIn, checking: .userOnly))
-        XCTAssertTrue(featureFlags.isFeatureEnabled(.recentlySaved, checking: .buildOnly))
-        XCTAssertTrue(featureFlags.isFeatureEnabled(.recentlySaved, checking: .userOnly))
         XCTAssertTrue(featureFlags.isFeatureEnabled(.reportSiteIssue, checking: .buildOnly))
         XCTAssertTrue(featureFlags.isFeatureEnabled(.reportSiteIssue, checking: .userOnly))
         XCTAssertTrue(featureFlags.isFeatureEnabled(.topSites, checking: .buildOnly))

--- a/nimbus-features/homescreenFeature.yaml
+++ b/nimbus-features/homescreenFeature.yaml
@@ -11,7 +11,6 @@ features:
           {
             "top-sites": true,
             "jump-back-in": true,
-            "recently-saved": true,
             "recent-explorations": true,
           }
       pocket-sponsored-stories:
@@ -26,7 +25,6 @@ features:
           "sections-enabled": {
             "top-sites": true,
             "jump-back-in": true,
-            "recently-saved": true,
             "recent-explorations": true,
           },
           "pocket-sponsored-stories": true
@@ -36,7 +34,6 @@ features:
           "sections-enabled": {
             "top-sites": true,
             "jump-back-in": true,
-            "recently-saved": true,
             "recent-explorations": true,
           },
           "pocket-sponsored-stories": false
@@ -48,8 +45,6 @@ enums:
     variants:
       top-sites:
         description: The frecency and pinned sites.
-      recently-saved:
-        description: The sites the user has bookmarked recently.
       jump-back-in:
         description: The tabs the user was looking immediately before being interrupted.
       recent-explorations:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6737)

## :bulb: Description
- Removing the .recentlySaved feature flag, meaning the Recently saved section won't be experimentable anymore with Nimbus
- Similarly done to [removing the pocket feature flag](https://github.com/mozilla-mobile/firefox-ios/pull/16825)

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

