### PR TITLE
Refactor FXIOS-7577 [v121] Fakespot - Replace primary button in FakespotOptInCardView to PrimaryRoundedButton

### DIFF
--- a/Client/Frontend/Fakespot/Views/FakespotOptInCardView.swift
+++ b/Client/Frontend/Fakespot/Views/FakespotOptInCardView.swift
@@ -19,9 +19,6 @@ final class FakespotOptInCardView: UIView, ThemeApplicable {
         static let learnMoreInsets = UIEdgeInsets(top: -10, left: 0, bottom: 10, right: 0)
         static let termsOfUseButtonTitleFontSize: CGFloat = 13
         static let privacyPolicyButtonTitleFontSize: CGFloat = 13
-        static let mainButtonFontSize: CGFloat = 16
-        static let mainButtonCornerRadius: CGFloat = 14
-        static let mainButtonInsets = UIEdgeInsets(top: 12, left: 0, bottom: 12, right: 0)
         static let secondaryButtonFontSize: CGFloat = 13
         static let contentStackViewSpacing: CGFloat = 12
         static let contentStackViewPadding: CGFloat = 16
@@ -102,15 +99,8 @@ final class FakespotOptInCardView: UIView, ThemeApplicable {
                                                                          size: UX.privacyPolicyButtonTitleFontSize)
     }
 
-    private lazy var mainButton: ResizableButton = .build { button in
-        button.contentHorizontalAlignment = .center
-        button.buttonEdgeSpacing = 0
-        button.layer.cornerRadius = UX.mainButtonCornerRadius
-        button.contentEdgeInsets = UX.mainButtonInsets
+    private lazy var mainButton: PrimaryRoundedButton = .build { button in
         button.addTarget(self, action: #selector(self.didTapMainButton), for: .touchUpInside)
-        button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .headline,
-                                                                         size: UX.mainButtonFontSize,
-                                                                         weight: .semibold)
     }
 
     private lazy var secondaryButton: ResizableButton = .build { button in
@@ -223,8 +213,11 @@ final class FakespotOptInCardView: UIView, ThemeApplicable {
         privacyPolicyButton.setTitle(viewModel.privacyPolicyButtonText, for: .normal)
         privacyPolicyButton.accessibilityIdentifier = viewModel.privacyPolicyButtonA11yId
 
-        mainButton.setTitle(viewModel.mainButtonText, for: .normal)
-        mainButton.accessibilityIdentifier = viewModel.mainButtonA11yId
+        let buttonViewModel = PrimaryRoundedButtonViewModel(
+            title: viewModel.mainButtonText,
+            a11yIdentifier: viewModel.mainButtonA11yId
+        )
+        mainButton.configure(viewModel: buttonViewModel)
 
         secondaryButton.setTitle(viewModel.secondaryButtonText, for: .normal)
         secondaryButton.accessibilityIdentifier = viewModel.secondaryButtonA11yId
@@ -250,8 +243,7 @@ final class FakespotOptInCardView: UIView, ThemeApplicable {
         learnMoreButton.setTitleColor(colors.textAccent, for: .normal)
         termsOfUseButton.setTitleColor(colors.textAccent, for: .normal)
         privacyPolicyButton.setTitleColor(colors.textAccent, for: .normal)
-        mainButton.setTitleColor(colors.textInverted, for: .normal)
-        mainButton.backgroundColor = colors.actionPrimary
+        mainButton.applyTheme(theme: theme)
         secondaryButton.setTitleColor(colors.textAccent, for: .normal)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7577)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16864)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This commit is a refactor work that changes the mainButton in FakespotOptInCardView to use PrimaryRoundedButton by the requirements.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

