### PR TITLE
Bugfix FXIOS-14990 [v120] | Switching the browsing mode from normal to private or vice versa in tabs tray without selecting a tab doesn't take effect

### DIFF
--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -298,12 +298,7 @@ class LegacyTabDisplayManager: NSObject, FeatureFlaggable {
         }
 
         if shouldSelectMostRecentTab {
-            getTabsAndUpdateInactiveState { [weak self] tabsToDisplay in
-                let tab = mostRecentTab(inTabs: tabsToDisplay) ?? tabsToDisplay.last
-                if let tab = tab {
-                    self?.tabManager.selectTab(tab)
-                }
-            }
+            selectMostRecentTab()
         }
 
         refreshStore(evenIfHidden: false, shouldAnimate: true)
@@ -312,6 +307,15 @@ class LegacyTabDisplayManager: NSObject, FeatureFlaggable {
         NotificationCenter.default.post(name: .TabsPrivacyModeChanged, object: notificationObject)
     }
 
+    func selectMostRecentTab() {
+        getTabsAndUpdateInactiveState { [weak self] tabsToDisplay in
+            let tab = mostRecentTab(inTabs: tabsToDisplay) ?? tabsToDisplay.last
+            if let tab = tab {
+                self?.tabManager.selectTab(tab)
+            }
+        }
+    }
+    
     /// Find the previously selected cell, which is still displayed as selected
     /// - Parameters:
     ///   - currentlySelected: The currently selected tab

--- a/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
+++ b/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
@@ -679,6 +679,10 @@ extension LegacyGridTabViewController {
         controller.popoverPresentationController?.barButtonItem = sender
         present(controller, animated: true, completion: nil)
     }
+    
+    func performDoneButtonAction() {
+        self.tabDisplayManager.selectMostRecentTab()
+    }
 }
 
 // MARK: - DevicePickerViewControllerDelegate

--- a/Client/Frontend/Browser/Tabs/Legacy/LegacyTabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/Legacy/LegacyTabTrayViewController.swift
@@ -17,6 +17,7 @@ enum TabTrayViewAction {
 protocol TabTrayViewDelegate: UIViewController {
     func didTogglePrivateMode(_ togglePrivateModeOn: Bool)
     func performToolbarAction(_ action: TabTrayViewAction, sender: UIBarButtonItem)
+    func performDoneButtonAction()
 }
 // swiftlint:enable class_delegate_protocol
 
@@ -572,9 +573,7 @@ extension LegacyTabTrayViewController {
     @objc
     func didTapDone() {
         notificationCenter.post(name: .TabsTrayDidClose)
-        // Update Private mode when closing TabTray, if the mode toggle but no tab is pressed with return to previous state
-        updatePrivateUIState()
-        viewModel.tabTrayView.didTogglePrivateMode(viewModel.tabManager.selectedTab?.isPrivate ?? false)
+        viewModel.tabTrayView.performDoneButtonAction()
         if viewModel.segmentToFocus == .privateTabs {
             TelemetryWrapper.recordEvent(category: .action,
                                          method: .tap,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6713)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14990)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

