### PR TITLE
Refractor FXIOS-7591 [v121] Replace ThemedSwitch(s) in SearchSettingsTableViewController

### DIFF
--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 import Shared
-
+import ComponentLibrary
 protocol SearchEnginePickerDelegate: AnyObject {
     func searchEnginePicker(_ searchEnginePicker: SearchEnginePicker?, didSelectSearchEngine engine: OpenSearchEngine?)
 }
@@ -104,8 +104,9 @@ class SearchSettingsTableViewController: ThemedTableViewController {
             case ItemDefaultSuggestions:
                 cell.textLabel?.text = .SearchSettingsShowSearchSuggestions
                 cell.textLabel?.numberOfLines = 0
-                let toggle = UISwitch()
-                toggle.onTintColor = themeManager.currentTheme.colors.actionPrimary
+                let toggle = ThemedSwitch()
+                toggle.applyTheme(theme: themeManager.currentTheme)
+                toggle.isEnabled = true
                 toggle.addTarget(self, action: #selector(didToggleSearchSuggestions), for: .valueChanged)
                 toggle.isOn = model.shouldShowSearchSuggestions
                 cell.editingAccessoryView = toggle
@@ -121,8 +122,9 @@ class SearchSettingsTableViewController: ThemedTableViewController {
                 engine = model.orderedEngines[index]
                 cell.showsReorderControl = true
 
-                let toggle = UISwitch()
-                toggle.onTintColor = themeManager.currentTheme.colors.actionPrimary
+                let toggle = ThemedSwitch()
+                toggle.applyTheme(theme: themeManager.currentTheme)
+                toggle.isEnabled = true
                 // This is an easy way to get from the toggle control to the corresponding index.
                 toggle.tag = index
                 toggle.addTarget(self, action: #selector(didToggleEngine), for: .valueChanged)
@@ -329,7 +331,7 @@ class SearchSettingsTableViewController: ThemedTableViewController {
 // MARK: - Selectors
 extension SearchSettingsTableViewController {
     @objc
-    func didToggleEngine(_ toggle: UISwitch) {
+    func didToggleEngine(_ toggle: ThemedSwitch) {
         let engine = model.orderedEngines[toggle.tag] // The tag is 1-based.
         if toggle.isOn {
             model.enableEngine(engine)
@@ -339,7 +341,7 @@ extension SearchSettingsTableViewController {
     }
 
     @objc
-    func didToggleSearchSuggestions(_ toggle: UISwitch) {
+    func didToggleSearchSuggestions(_ toggle: ThemedSwitch) {
         // Setting the value in settings dismisses any opt-in.
         model.shouldShowSearchSuggestions = toggle.isOn
     }

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -5,6 +5,7 @@
 import UIKit
 import Shared
 import ComponentLibrary
+
 protocol SearchEnginePickerDelegate: AnyObject {
     func searchEnginePicker(_ searchEnginePicker: SearchEnginePicker?, didSelectSearchEngine engine: OpenSearchEngine?)
 }
@@ -106,7 +107,6 @@ class SearchSettingsTableViewController: ThemedTableViewController {
                 cell.textLabel?.numberOfLines = 0
                 let toggle = ThemedSwitch()
                 toggle.applyTheme(theme: themeManager.currentTheme)
-                toggle.isEnabled = true
                 toggle.addTarget(self, action: #selector(didToggleSearchSuggestions), for: .valueChanged)
                 toggle.isOn = model.shouldShowSearchSuggestions
                 cell.editingAccessoryView = toggle
@@ -124,7 +124,6 @@ class SearchSettingsTableViewController: ThemedTableViewController {
 
                 let toggle = ThemedSwitch()
                 toggle.applyTheme(theme: themeManager.currentTheme)
-                toggle.isEnabled = true
                 // This is an easy way to get from the toggle control to the corresponding index.
                 toggle.tag = index
                 toggle.addTarget(self, action: #selector(didToggleEngine), for: .valueChanged)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7591)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16892)

## :bulb: Description
Replaced UISwitch() in SearchSettingsTableViewController with ThemedSwitch() from Component Library to ThemedSwitch(), ThemedSwitch is from the component library.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

