### PR TITLE
Bugfix MTE-1783 [v120] Update account branding

### DIFF
--- a/Tests/XCUITests/IntegrationTests.swift
+++ b/Tests/XCUITests/IntegrationTests.swift
@@ -113,7 +113,6 @@ class IntegrationTests: BaseTestCase {
         app.tables.otherElements[StandardImageIdentifiers.Large.bookmark].tap()
         navigator.nowAt(BrowserTab)
         signInFxAccounts()
-        mozWaitForElementToExist(app.staticTexts["Jump Back In"])
 
         // Wait for initial sync to complete
         waitForInitialSyncComplete()
@@ -134,7 +133,6 @@ class IntegrationTests: BaseTestCase {
         waitUntilPageLoad()
         navigator.goto(BrowserTabMenu)
         signInFxAccounts()
-        mozWaitForElementToExist(app.staticTexts["Jump Back In"])
 
         // Wait for initial sync to complete
         navigator.nowAt(BrowserTab)

--- a/Tests/XCUITests/IntegrationTests.swift
+++ b/Tests/XCUITests/IntegrationTests.swift
@@ -55,7 +55,7 @@ class IntegrationTests: BaseTestCase {
         navigator.performAction(Action.OpenEmailToSignIn)
         sleep(5)
         mozWaitForElementToExist(app.navigationBars[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaNavigationBar], timeout: TIMEOUT_LONG)
-        mozWaitForElementToExist(app.staticTexts["Continue to Firefox accounts"], timeout: TIMEOUT_LONG)
+        mozWaitForElementToExist(app.staticTexts["Continue to your Mozilla account"], timeout: TIMEOUT_LONG)
         userState.fxaUsername = ProcessInfo.processInfo.environment["FXA_EMAIL"]!
         userState.fxaPassword = ProcessInfo.processInfo.environment["FXA_PASSWORD"]!
         navigator.performAction(Action.FxATypeEmail)
@@ -82,7 +82,7 @@ class IntegrationTests: BaseTestCase {
 
     func testFxASyncHistory () {
         // History is generated using the DB so go directly to Sign in
-        // Sign into Firefox Accounts
+        // Sign into Mozilla account
         navigator.goto(BrowserTabMenu)
         signInFxAccounts()
 
@@ -92,20 +92,20 @@ class IntegrationTests: BaseTestCase {
 
     func testFxASyncPageUsingChinaFxA () {
         // History is generated using the DB so go directly to Sign in
-        // Sign into Firefox Accounts
+        // Sign into Mozilla account
         navigator.goto(BrowserTabMenu)
         navigator.goto(Intro_FxASignin)
         navigator.performAction(Action.OpenEmailToSignIn)
 
         mozWaitForElementToExist(app.navigationBars[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaNavigationBar], timeout: TIMEOUT_LONG)
-        mozWaitForElementToExist(app.webViews.staticTexts["Continue to Firefox accounts"], timeout: TIMEOUT_LONG)
+        mozWaitForElementToExist(app.webViews.staticTexts["Continue to your Mozilla account"], timeout: TIMEOUT_LONG)
         mozWaitForElementToExist(app.webViews.textFields[AccessibilityIdentifiers.Settings.FirefoxAccount.emailTextField])
         mozWaitForElementToExist(app.webViews.buttons[AccessibilityIdentifiers.Settings.FirefoxAccount.continueButton])
     }
 
     func testFxASyncBookmark () {
         // Bookmark is added by the DB
-        // Sign into Firefox Accounts
+        // Sign into Mozilla account
         navigator.openURL("example.com")
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection], timeout: 5)
         navigator.goto(BrowserTabMenu)
@@ -113,13 +113,14 @@ class IntegrationTests: BaseTestCase {
         app.tables.otherElements[StandardImageIdentifiers.Large.bookmark].tap()
         navigator.nowAt(BrowserTab)
         signInFxAccounts()
+        mozWaitForElementToExist(app.staticTexts["Jump Back In"])
 
         // Wait for initial sync to complete
         waitForInitialSyncComplete()
     }
 
     func testFxASyncBookmarkDesktop () {
-        // Sign into Firefox Accounts
+        // Sign into Mozilla account
         signInFxAccounts()
 
         // Wait for initial sync to complete
@@ -133,6 +134,7 @@ class IntegrationTests: BaseTestCase {
         waitUntilPageLoad()
         navigator.goto(BrowserTabMenu)
         signInFxAccounts()
+        mozWaitForElementToExist(app.staticTexts["Jump Back In"])
 
         // Wait for initial sync to complete
         navigator.nowAt(BrowserTab)
@@ -141,7 +143,7 @@ class IntegrationTests: BaseTestCase {
         mozWaitForElementToExist(app.tables.cells.element(boundBy: 1), timeout: 10)
         app.tables.cells.element(boundBy: 1).tap()
         mozWaitForElementToExist(app.cells["DeviceNameSetting"].textFields["DeviceNameSettingTextField"], timeout: 10)
-        XCTAssertEqual(app.cells["DeviceNameSetting"].textFields["DeviceNameSettingTextField"].value! as! String, "Fennec (administrator) on iOS")
+        XCTAssertEqual(app.cells["DeviceNameSetting"].textFields["DeviceNameSettingTextField"].value! as! String, "Fennec (cso) on iOS")
 
         // Sync again just to make sure to sync after new name is shown
         app.buttons["Settings"].tap()
@@ -176,7 +178,7 @@ class IntegrationTests: BaseTestCase {
     }
 
     func testFxASyncHistoryDesktop () {
-        // Sign into Firefox Accounts
+        // Sign into Mozilla account
         signInFxAccounts()
 
         // Wait for initial sync to complete
@@ -188,7 +190,7 @@ class IntegrationTests: BaseTestCase {
     }
 
     func testFxASyncPasswordDesktop () {
-        // Sign into Firefox Accounts
+        // Sign into Mozilla account
         signInFxAccounts()
 
         // Wait for initial sync to complete
@@ -211,7 +213,7 @@ class IntegrationTests: BaseTestCase {
     }
 
     func testFxASyncTabsDesktop () {
-        // Sign into Firefox Accounts
+        // Sign into Mozilla account
         signInFxAccounts()
 
         // Wait for initial sync to complete
@@ -230,7 +232,7 @@ class IntegrationTests: BaseTestCase {
     }
 
     func testFxADisconnectConnect() {
-        // Sign into Firefox Accounts
+        // Sign into Mozilla account
         signInFxAccounts()
 
         // Wait for initial sync to complete

--- a/Tests/XCUITests/IntegrationTests.swift
+++ b/Tests/XCUITests/IntegrationTests.swift
@@ -143,7 +143,7 @@ class IntegrationTests: BaseTestCase {
         mozWaitForElementToExist(app.tables.cells.element(boundBy: 1), timeout: 10)
         app.tables.cells.element(boundBy: 1).tap()
         mozWaitForElementToExist(app.cells["DeviceNameSetting"].textFields["DeviceNameSettingTextField"], timeout: 10)
-        XCTAssertEqual(app.cells["DeviceNameSetting"].textFields["DeviceNameSettingTextField"].value! as! String, "Fennec (cso) on iOS")
+        XCTAssertEqual(app.cells["DeviceNameSetting"].textFields["DeviceNameSettingTextField"].value! as! String, "Fennec (administrator) on iOS")
 
         // Sync again just to make sure to sync after new name is shown
         app.buttons["Settings"].tap()

--- a/Tests/XCUITests/IntegrationTests.swift
+++ b/Tests/XCUITests/IntegrationTests.swift
@@ -48,6 +48,7 @@ class IntegrationTests: BaseTestCase {
             return true
         }
         app.swipeDown()
+        sleep(5)
     }
 
     private func signInFxAccounts() {
@@ -82,7 +83,7 @@ class IntegrationTests: BaseTestCase {
 
     func testFxASyncHistory () {
         // History is generated using the DB so go directly to Sign in
-        // Sign into Mozilla account
+        // Sign into Mozilla Account
         navigator.goto(BrowserTabMenu)
         signInFxAccounts()
 
@@ -92,7 +93,7 @@ class IntegrationTests: BaseTestCase {
 
     func testFxASyncPageUsingChinaFxA () {
         // History is generated using the DB so go directly to Sign in
-        // Sign into Mozilla account
+        // Sign into Mozilla Account
         navigator.goto(BrowserTabMenu)
         navigator.goto(Intro_FxASignin)
         navigator.performAction(Action.OpenEmailToSignIn)
@@ -105,7 +106,7 @@ class IntegrationTests: BaseTestCase {
 
     func testFxASyncBookmark () {
         // Bookmark is added by the DB
-        // Sign into Mozilla account
+        // Sign into Mozilla Account
         navigator.openURL("example.com")
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection], timeout: 5)
         navigator.goto(BrowserTabMenu)
@@ -119,7 +120,7 @@ class IntegrationTests: BaseTestCase {
     }
 
     func testFxASyncBookmarkDesktop () {
-        // Sign into Mozilla account
+        // Sign into Mozilla Account
         signInFxAccounts()
 
         // Wait for initial sync to complete
@@ -176,7 +177,7 @@ class IntegrationTests: BaseTestCase {
     }
 
     func testFxASyncHistoryDesktop () {
-        // Sign into Mozilla account
+        // Sign into Mozilla Account
         signInFxAccounts()
 
         // Wait for initial sync to complete
@@ -188,7 +189,7 @@ class IntegrationTests: BaseTestCase {
     }
 
     func testFxASyncPasswordDesktop () {
-        // Sign into Mozilla account
+        // Sign into Mozilla Account
         signInFxAccounts()
 
         // Wait for initial sync to complete
@@ -211,7 +212,7 @@ class IntegrationTests: BaseTestCase {
     }
 
     func testFxASyncTabsDesktop () {
-        // Sign into Mozilla account
+        // Sign into Mozilla Account
         signInFxAccounts()
 
         // Wait for initial sync to complete
@@ -230,7 +231,7 @@ class IntegrationTests: BaseTestCase {
     }
 
     func testFxADisconnectConnect() {
-        // Sign into Mozilla account
+        // Sign into Mozilla Account
         signInFxAccounts()
 
         // Wait for initial sync to complete

--- a/Tests/XCUITests/IntegrationTests.swift
+++ b/Tests/XCUITests/IntegrationTests.swift
@@ -48,7 +48,6 @@ class IntegrationTests: BaseTestCase {
             return true
         }
         app.swipeDown()
-        sleep(5)
     }
 
     private func signInFxAccounts() {
@@ -99,7 +98,7 @@ class IntegrationTests: BaseTestCase {
         navigator.performAction(Action.OpenEmailToSignIn)
 
         mozWaitForElementToExist(app.navigationBars[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaNavigationBar], timeout: TIMEOUT_LONG)
-        mozWaitForElementToExist(app.webViews.staticTexts["Continue to your Mozilla account"], timeout: TIMEOUT_LONG)
+        mozWaitForElementToExist(app.webViews.staticTexts["Continue to Firefox accounts"], timeout: TIMEOUT_LONG)
         mozWaitForElementToExist(app.webViews.textFields[AccessibilityIdentifiers.Settings.FirefoxAccount.emailTextField])
         mozWaitForElementToExist(app.webViews.buttons[AccessibilityIdentifiers.Settings.FirefoxAccount.continueButton])
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1783)

## :bulb: Description
Firefox Account is now known as Mozilla Account. The branding on the sign in page has been updated. This PR updates the static text to be expected when the login page is loaded.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

