### PR TITLE
Bugfix FXIOS-7616 [v121] Fix errant log files remaining in Cache

### DIFF
--- a/BrowserKit/Sources/Common/Logger/DefaultLogger.swift
+++ b/BrowserKit/Sources/Common/Logger/DefaultLogger.swift
@@ -78,6 +78,10 @@ public class DefaultLogger: Logger {
         fileManager.copyLogsToDocuments()
     }
 
+    public func deleteCachedLogFiles() {
+        fileManager.deleteCachedLogFiles()
+    }
+
     // MARK: - Private
 
     private func bundleExtraEvents(extra: [String: String]?,

--- a/BrowserKit/Sources/Common/Logger/Logger.swift
+++ b/BrowserKit/Sources/Common/Logger/Logger.swift
@@ -32,6 +32,9 @@ public protocol Logger {
 
     /// Provide method to save log files to document folder so we can retrieve it more easily on devices
     func copyLogsToDocuments()
+
+    /// Deletes cached log files.
+    func deleteCachedLogFiles()
 }
 
 public extension Logger {

--- a/BrowserKit/Sources/Common/Logger/LoggerFileManager.swift
+++ b/BrowserKit/Sources/Common/Logger/LoggerFileManager.swift
@@ -10,6 +10,9 @@ protocol LoggerFileManager {
 
     /// Copy logs files from the cache to the documents folder so the user can access them
     func copyLogsToDocuments()
+
+    /// Deletes cached log files.
+    func deleteCachedLogFiles()
 }
 
 class DefaultLoggerFileManager: LoggerFileManager {
@@ -37,15 +40,25 @@ class DefaultLoggerFileManager: LoggerFileManager {
     }
 
     func copyLogsToDocuments() {
-        deleteOldLogs()
+        deleteOldDocumentDirectoryLogs()
         copyLogs()
     }
 
     // MARK: - Private
 
+    /// Deletes all log files in Caches (and Documents) directory.
+    func deleteCachedLogFiles() {
+        deleteOldLogs(inDocuments: false)
+        deleteOldLogs(inDocuments: true)
+    }
+
     /// Delete logs in Documents folder to make sure we can copy in the latest version of the logs file
-    private func deleteOldLogs() {
-        guard let logDirectoryPath = logFileDirectoryPath(inDocuments: true),
+    private func deleteOldDocumentDirectoryLogs() {
+        deleteOldLogs(inDocuments: true)
+    }
+
+    private func deleteOldLogs(inDocuments: Bool) {
+        guard let logDirectoryPath = logFileDirectoryPath(inDocuments: inDocuments),
               let logFiles = try? fileManager.contentsOfDirectoryAtPath(logDirectoryPath,
                                                                         withFilenamePrefix: fileNameRoot)
         else { return }

--- a/BrowserKit/Tests/CommonTests/LoggerTests/LoggerFileManagerTests.swift
+++ b/BrowserKit/Tests/CommonTests/LoggerTests/LoggerFileManagerTests.swift
@@ -52,6 +52,16 @@ final class LoggerFileManagerTests: XCTestCase {
         XCTAssertEqual(fileManager.removeItemCalled, 1)
     }
 
+    func testDeleteCachedLogFiles_fileExistsWillDelete() {
+        fileManager.contentsOfDirectory = ["path/file1"]
+        fileManager.contentsOfDirectoryAtPath = ["path/file1"]
+
+        subject.deleteCachedLogFiles()
+        // Note: we expect this to be called twice since `deleteCachedLogFiles`
+        // will remove files from both /Caches/Logs and /Documents/Logs.
+        XCTAssertEqual(fileManager.removeItemCalled, 2)
+    }
+
     func testDeleteOldLogFiles_fileDoesntExistsDoesntDelete_andCopy() {
         fileManager.contentsOfDirectory = ["path/file1"]
 

--- a/Client/Frontend/Reader/ReaderModeCache.swift
+++ b/Client/Frontend/Reader/ReaderModeCache.swift
@@ -34,7 +34,7 @@ protocol ReaderModeCache {
     func clear()
 }
 
-/// A non-persistent cache for reader mode  content for times when you don't want to write reader data to disk.
+/// A non-persistent cache for reader mode content for times when you don't want to write reader data to disk.
 /// For example, when the user is in a private tab, we want to make sure that we leave no trace on the file system
 class MemoryReaderModeCache: ReaderModeCache {
     var cache: NSCache<AnyObject, AnyObject>

--- a/Tests/ClientTests/Helpers/RatingPromptManagerTests.swift
+++ b/Tests/ClientTests/Helpers/RatingPromptManagerTests.swift
@@ -295,6 +295,7 @@ class CrashingMockLogger: Logger {
     func configure(crashManager: CrashManager) {}
     func copyLogsToDocuments() {}
     func logCustomError(error: Error) {}
+    func deleteCachedLogFiles() {}
 
     var enableCrashOnLastLaunch = false
     var crashedLastLaunch: Bool {

--- a/Tests/ClientTests/Mocks/MockLogger.swift
+++ b/Tests/ClientTests/Mocks/MockLogger.swift
@@ -14,6 +14,7 @@ class MockLogger: Logger {
     func configure(crashManager: Common.CrashManager) {}
     func copyLogsToDocuments() {}
     func logCustomError(error: Error) {}
+    func deleteCachedLogFiles() {}
 
     func log(_ message: String,
              level: LoggerLevel,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7616)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16956)

## :bulb: Description

This is part of a broader investigation into [FXIOS-7616](https://mozilla-hub.atlassian.net/browse/FXIOS-7616). A few aspects are still being looked into, notably:
- The cause of the app size increase for some users (current evidence points to log files though [browsing history might also be a problem](https://github.com/mozilla-mobile/firefox-ios/issues/16235))
- Why clearing app data does not resolve the problem

The runaway log files were addressed in https://github.com/mozilla-mobile/firefox-ios/pull/16530 though I'm investigating if there are other potential culprits involved. However there is also the problem that users attempting to clear data via `Settings > Data Management` cannot free up this excess space. Only after deleting + reinstalling is this resolved. iOS is notoriously stubborn for not clearing `Cache` folders within the app bundles even in cases where disk space has become limited.

This PR attempts to fix part of the above issue by ensuring that when users clear their Cache data we also clear all log data (which, depending on what bugs may have previously impacted those users, could be very large and possibly not removed correctly by our logging system).

Although [SwiftyBeaver](https://github.com/SwiftyBeaver/SwiftyBeaver) should now be properly rotating log files and limiting their size, it's conceivable that other issues could have caused older log files to remain in `Library/Caches/Logs`. I tested the same steps as Johan from https://github.com/mozilla-mobile/firefox-ios/issues/16956 and verified that data in `/Library/Caches/Logs` is not cleared; this PR ensures that we remove old log data as part of the Cache deletion also.

![afterClearing](https://github.com/mozilla-mobile/firefox-ios/assets/145381717/42aff31e-9822-45d1-ba89-6b57485406e9)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

