### PR TITLE
Refactor FXIOS-7578 [v121] Replace secondary button in FakespotHighlightsCardView

### DIFF
--- a/Client/Frontend/Fakespot/Views/FakespotHighlightsCardView.swift
+++ b/Client/Frontend/Fakespot/Views/FakespotHighlightsCardView.swift
@@ -74,18 +74,8 @@ class FakespotHighlightsCardView: UIView, ThemeApplicable {
         view.spacing = UX.highlightSpacing
     }
 
-    private lazy var moreButton: ActionButton = .build { button in
-        button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(
-            withTextStyle: .body,
-            size: UX.buttonFontSize,
-            weight: .semibold)
-        button.layer.cornerRadius = UX.buttonCornerRadius
-        button.titleLabel?.textAlignment = .center
+    private lazy var moreButton: SecondaryRoundedButton = .build { button in
         button.addTarget(self, action: #selector(self.showMoreAction), for: .touchUpInside)
-        button.contentEdgeInsets = UIEdgeInsets(top: UX.buttonVerticalInset,
-                                                left: UX.buttonHorizontalInset,
-                                                bottom: UX.buttonVerticalInset,
-                                                right: UX.buttonHorizontalInset)
     }
 
     private lazy var dividerView: UIView = .build()
@@ -125,8 +115,11 @@ class FakespotHighlightsCardView: UIView, ThemeApplicable {
         titleLabel.text = viewModel.title
         titleLabel.accessibilityIdentifier = viewModel.titleA11yId
 
-        moreButton.setTitle(viewModel.moreButtonTitle, for: .normal)
-        moreButton.accessibilityIdentifier = viewModel.moreButtonA11yId
+        let moreButtonViewModel = SecondaryRoundedButtonViewModel(
+            title: viewModel.moreButtonTitle,
+            a11yIdentifier: viewModel.moreButtonA11yId
+        )
+        moreButton.configure(viewModel: moreButtonViewModel)
 
         if !viewModel.shouldShowMoreButton {
             // remove divider & button and adjust bottom spacing
@@ -144,8 +137,7 @@ class FakespotHighlightsCardView: UIView, ThemeApplicable {
         highlightGroups.forEach { $0.applyTheme(theme: theme) }
 
         titleLabel.textColor = theme.colors.textPrimary
-        moreButton.setTitleColor(theme.colors.textOnLight, for: .normal)
-        moreButton.backgroundColor = theme.colors.actionSecondary
+        moreButton.applyTheme(theme: theme)
         dividerView.backgroundColor = theme.colors.borderPrimary
     }
 
@@ -189,10 +181,11 @@ class FakespotHighlightsCardView: UIView, ThemeApplicable {
         isShowingPreview = !isShowingPreview
         updateHighlights()
 
-        moreButton.setTitle(
-            isShowingPreview ? viewModel.moreButtonTitle : viewModel.lessButtonTitle,
-            for: .normal)
-        moreButton.accessibilityIdentifier = isShowingPreview ? viewModel.moreButtonA11yId : viewModel.lessButtonA11yId
+        let moreButtonViewModel = SecondaryRoundedButtonViewModel(
+            title: isShowingPreview ? viewModel.moreButtonTitle : viewModel.lessButtonTitle,
+            a11yIdentifier: isShowingPreview ? viewModel.moreButtonA11yId : viewModel.lessButtonA11yId
+        )
+        moreButton.configure(viewModel: moreButtonViewModel)
 
         if !isShowingPreview {
             recordTelemetry()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7578)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16865)

## :bulb: Description
- changed button type from `ActionButton` to `SecondaryRoundedButton` for `moreButton` in `FakespotHighlightsCardView`
- updated configuration of `moreButton`

<details>
  <summary>Before / After, Light mode</summary>

![before-after](https://github.com/mozilla-mobile/firefox-ios/assets/26223450/9b70e9e5-2e7d-4df9-b91e-6a7c7d58908c)

</details>

<details>
  <summary>Before / After, Dark mode</summary>

![before-after-dark](https://github.com/mozilla-mobile/firefox-ios/assets/26223450/8ec741b2-38ae-4203-a791-d80b9d72f254)

</details>

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

