### PR TITLE
Refactor FXCM-701 [v121] Update credit card scripts to be more generic for address autofill

### DIFF
--- a/Client/Assets/CC_Script/FormAutofillExtras.ios.mjs
+++ b/Client/Assets/CC_Script/FormAutofillExtras.ios.mjs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-class CreditCardExtras {
+export class FormAutofillExtras {
 
   isFocusable(element) {
     let style = window.getComputedStyle(element);
@@ -35,4 +35,4 @@ class CreditCardExtras {
   }
 }
 
-export { CreditCardExtras };
+export default FormAutofillExtras;

--- a/Client/Frontend/TabContentsScripts/CreditCardHelper.swift
+++ b/Client/Frontend/TabContentsScripts/CreditCardHelper.swift
@@ -153,7 +153,7 @@ class CreditCardHelper: TabContentScript {
                 return
             }
 
-            let fillCreditCardInfoCallback = "__firefox__.CreditCardHelper.fillFormFields(\(jsonDataVal))"
+            let fillCreditCardInfoCallback = "__firefox__.FormAutofillHelper.fillFormFields(\(jsonDataVal))"
             webView.evaluateJavascriptInDefaultContentWorld(fillCreditCardInfoCallback, frame) { _, error in
                 guard let error = error else {
                     TelemetryWrapper.recordEvent(category: .action,
@@ -194,7 +194,7 @@ class CreditCardHelper: TabContentScript {
 
     static func focusNextInputField(tabWebView: WKWebView,
                                     logger: Logger) {
-        let fxWindowValExtras = "window.__firefox__.CreditCardExtras"
+        let fxWindowValExtras = "window.__firefox__.FormAutofillExtras"
         let fillCreditCardInfoCallback = "\(fxWindowValExtras).focusNextInputField()"
 
         tabWebView.evaluateJavascriptInDefaultContentWorld(fillCreditCardInfoCallback) { _, error in
@@ -207,7 +207,7 @@ class CreditCardHelper: TabContentScript {
 
     static func focusPreviousInputField(tabWebView: WKWebView,
                                         logger: Logger) {
-        let fxWindowValExtras = "window.__firefox__.CreditCardExtras"
+        let fxWindowValExtras = "window.__firefox__.FormAutofillExtras"
         let fillCreditCardInfoCallback = "\(fxWindowValExtras).focusPreviousInputField()"
 
         tabWebView.evaluateJavascriptInDefaultContentWorld(fillCreditCardInfoCallback) { _, error in

--- a/Client/Frontend/UserContent/UserScripts/AllFrames/AutofillAtDocumentStart/FormAutofillHelper.js
+++ b/Client/Frontend/UserContent/UserScripts/AllFrames/AutofillAtDocumentStart/FormAutofillHelper.js
@@ -3,8 +3,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 // /* eslint-disable mozilla/balanced-listeners, no-undef */
-import CreditCardHelper from "resource://gre/modules/shared/EntryFile.sys.mjs";
-import { CreditCardExtras } from "Assets/CC_Script/CreditCardExtras.ios.mjs";
+import FormAutofillHelper from "resource://gre/modules/shared/EntryFile.sys.mjs";
+import FormAutofillExtras from "Assets/CC_Script/FormAutofillExtras.ios.mjs";
 
 // Define supported message types.
 const messageTypes = {
@@ -41,31 +41,29 @@ const sendFillCreditCardFormMessage = sendMessage(
   messageTypes.FILL_CREDIT_CARD_FORM
 );
 
-// Create a CreditCardHelper object and expose it to the window object.
-// The CreditCardHelper should:
+// Create a FormAutofillHelper object and expose it to the window object.
+// The FormAutofillHelper should:
 // - expose a method .fillFormFields(payload) that can be called from swift to fill in data.
 // - call sendCaptureCreditCardFormMessage(payload) when a credit card form submission is detected.
 // - call sendFillCreditCardFormMessage(payload) when a credit card form is detected.
 // The implementation file can be changed in Client/Assets/CC_Script/Overrides.ios.js
-Object.defineProperty(window.__firefox__, "CreditCardHelper", {
+Object.defineProperty(window.__firefox__, "FormAutofillHelper", {
   enumerable: false,
   configurable: false,
   writable: false,
   value: Object.freeze(
-    new CreditCardHelper(
+    new FormAutofillHelper(
       sendCaptureCreditCardFormMessage,
       sendFillCreditCardFormMessage
     )
   ),
 });
 
-// Create a CreditCardExtras object and expose it to the window object.
-// CreditCardExtras class contains methods to focus next and previous input fields.
-Object.defineProperty(window.__firefox__, "CreditCardExtras", {
+// Create a FormAutofillExtras object and expose it to the window object.
+// FormAutofillExtras class contains methods to focus next and previous input fields.
+Object.defineProperty(window.__firefox__, "FormAutofillExtras", {
   enumerable: false,
   configurable: false,
   writable: false,
-  value: Object.freeze(
-    new CreditCardExtras()
-  ),
+  value: Object.freeze(new FormAutofillExtras()),
 });


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXCM-701)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17001)

## :bulb: Description
This PR: 
- Adds placeholder callbacks for address autofill.
- Makes CC code more generic and rrenames `CreditCard` to `FormAutofill`.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] ~Wrote unit tests and/or ensured the tests suite is passing~
- [ ] ~When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)~
- [ ] ~If needed I updated documentation / comments for complex code and public methods~

