### PR TITLE
Bugfix MTE-1798 [v121] ClipBoardTests for iPad

### DIFF
--- a/Tests/XCUITests/ClipBoardTests.swift
+++ b/Tests/XCUITests/ClipBoardTests.swift
@@ -19,7 +19,7 @@ class ClipBoardTests: BaseTestCase {
         mozWaitForElementToExist(app.textFields["address"])
         app.textFields["address"].tap()
         if iPad() {
-            app.textFields["address"].tap()
+            app.textFields["address"].press(forDuration: 1)
             app.menuItems["Select All"].tap()
         }
         mozWaitForElementToExist(app.menuItems["Copy"])


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1798)

## :bulb: Description
`testClipboard` fails on iPad because tapping on the URL bar no longer select the URL. A workaround is to press the URL bar a bit longer to have the "Select All" option available.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

