### PR TITLE
Bugfix FXIOS-7153 [v121] Search engine telemetry bug

### DIFF
--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -132,7 +132,6 @@ class TelemetryWrapper: TelemetryWrapperProtocol, FeatureFlaggable {
             let defaultEngine = profile.searchEngines.defaultEngine
             settings["defaultSearchEngine"] = defaultEngine?.engineID ?? "custom"
 
-
             if let windowBounds = UIWindow.keyWindow?.bounds {
                 settings["windowWidth"] = String(describing: windowBounds.width)
                 settings["windowHeight"] = String(describing: windowBounds.height)

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -129,8 +129,9 @@ class TelemetryWrapper: TelemetryWrapperProtocol, FeatureFlaggable {
 
             var settings: [String: String?] = inputDict["settings"] as? [String: String?] ?? [:]
 
-            let searchEngines = SearchEngines(prefs: profile.prefs, files: profile.files)
-            settings["defaultSearchEngine"] = searchEngines.defaultEngine?.engineID ?? "custom"
+            let defaultEngine = profile.searchEngines.defaultEngine
+            settings["defaultSearchEngine"] = defaultEngine?.engineID ?? "custom"
+
 
             if let windowBounds = UIWindow.keyWindow?.bounds {
                 settings["windowWidth"] = String(describing: windowBounds.width)
@@ -231,8 +232,8 @@ class TelemetryWrapper: TelemetryWrapperProtocol, FeatureFlaggable {
         }
 
         // Record default search engine setting
-        let searchEngines = SearchEngines(prefs: profile.prefs, files: profile.files)
-        GleanMetrics.Search.defaultEngine.set(searchEngines.defaultEngine?.engineID ?? "custom")
+        let defaultEngine = profile.searchEngines.defaultEngine
+        GleanMetrics.Search.defaultEngine.set(defaultEngine?.engineID ?? "custom")
 
         // Record the open tab count
         let delegate = UIApplication.shared.delegate as? AppDelegate


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7153)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15902)

## :bulb: Description
Turns out the bug was that the SearchEngine that was created wasn't using the correctly initialized variable.
We are now using the profile's search engine, so this bug should be resolved. If there's a problem that the optional is `nil`, `custom` will still be returned, but there's no way around that, unless we desire to log the nil value itself.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

