### PR TITLE
Bugfix MTE-1812 [v121] Ensure ActivityListView is up

### DIFF
--- a/Tests/XCUITests/PhotonActionSheetTests.swift
+++ b/Tests/XCUITests/PhotonActionSheetTests.swift
@@ -67,6 +67,8 @@ class PhotonActionSheetTests: BaseTestCase {
 
         // This is not ideal but only way to get the element on iPhone 8
         // for iPhone 11, that would be boundBy: 2
+        mozWaitForElementToExist(app.otherElements["ActivityListView"].otherElements["Example Domain"])
+        mozWaitForElementToExist(app.otherElements["ActivityListView"].otherElements["example.com"])
         mozWaitForElementToExist(app.collectionViews.cells["Copy"], timeout: TIMEOUT)
 
         var  fennecElement = app.collectionViews.scrollViews.cells.element(boundBy: 3)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1812)

## :bulb: Description
Occasionally, the `ActivityListView` is not ready before the XCUITest taps on its icons. In particular, the "Fennec" icon (rightmost icon) may not be ready but exists.
![Simulator Screenshot - iPhone 15 Plus - 2023-10-25 at 14 17 30](https://github.com/mozilla-mobile/firefox-ios/assets/1740517/738865de-2855-4fe1-8a13-099f425936dd)

This change ensures that the view is up first.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

