### PR TITLE
Refactor FXIOS-7057 [v121] Orientation API bug with OrientationLockUtility

### DIFF
--- a/Client/Frontend/SurveySurface/SurveySurfaceViewController.swift
+++ b/Client/Frontend/SurveySurface/SurveySurfaceViewController.swift
@@ -116,20 +116,10 @@ class SurveySurfaceViewController: UIViewController, Themeable {
         applyTheme()
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        viewModel.setOrientationLockTo(on: true)
-    }
-
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         viewModel.didDisplayMessage()
         animateElements()
-    }
-
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        viewModel.setOrientationLockTo(on: false)
     }
 
     // MARK: - View setup
@@ -244,5 +234,22 @@ class SurveySurfaceViewController: UIViewController, Themeable {
 
         dismissSurveyButton.setTitleColor(theme.colors.textSecondaryAction, for: .normal)
         dismissSurveyButton.backgroundColor = theme.colors.actionSecondary
+    }
+}
+
+// MARK: - UIViewController setup
+extension SurveySurfaceViewController {
+    override var prefersStatusBarHidden: Bool {
+        return true
+    }
+
+    override var shouldAutorotate: Bool {
+        return false
+    }
+
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        // This actually does the right thing on iPad where the modally
+        // presented version happily rotates with the iPad orientation.
+        return .portrait
     }
 }

--- a/Client/Frontend/SurveySurface/SurveySurfaceViewController.swift
+++ b/Client/Frontend/SurveySurface/SurveySurfaceViewController.swift
@@ -41,6 +41,21 @@ class SurveySurfaceViewController: UIViewController, Themeable {
     var themeObserver: NSObjectProtocol?
     var imageViewYConstraint: NSLayoutConstraint!
 
+    // MARK: - Orientation
+    override var prefersStatusBarHidden: Bool {
+        return true
+    }
+
+    override var shouldAutorotate: Bool {
+        return false
+    }
+
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        // This actually does the right thing on iPad where the modally
+        // presented version happily rotates with the iPad orientation.
+        return .portrait
+    }
+
     // MARK: - UI Elements
     // Other than the imageView, all elements begin with an alpha of 0.0 as,
     // they are meant to be invisible, and appear during the animation.
@@ -234,22 +249,5 @@ class SurveySurfaceViewController: UIViewController, Themeable {
 
         dismissSurveyButton.setTitleColor(theme.colors.textSecondaryAction, for: .normal)
         dismissSurveyButton.backgroundColor = theme.colors.actionSecondary
-    }
-}
-
-// MARK: - UIViewController setup
-extension SurveySurfaceViewController {
-    override var prefersStatusBarHidden: Bool {
-        return true
-    }
-
-    override var shouldAutorotate: Bool {
-        return false
-    }
-
-    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        // This actually does the right thing on iPad where the modally
-        // presented version happily rotates with the iPad orientation.
-        return .portrait
     }
 }

--- a/Client/Frontend/SurveySurface/SurveySurfaceViewModel.swift
+++ b/Client/Frontend/SurveySurface/SurveySurfaceViewModel.swift
@@ -30,20 +30,4 @@ class SurveySurfaceViewModel {
     func didTapDismissSurvey() {
         delegate?.didTapDismissSurvey()
     }
-
-    // MARK: - Orientation
-    /// As per design, we will be locking the orientation for the survey
-    /// surface to portait on iPhones.
-    func setOrientationLockTo(on: Bool) {
-        guard UIDevice.current.userInterfaceIdiom == .phone else { return }
-
-        if on {
-            // Portrait orientation: lock enable
-            OrientationLockUtility.lockOrientation(UIInterfaceOrientationMask.portrait,
-                                                   andRotateTo: UIInterfaceOrientation.portrait)
-        } else {
-            // Portrait orientation: lock disable
-            OrientationLockUtility.lockOrientation(UIInterfaceOrientationMask.all)
-        }
-    }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7057)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15687)

## :bulb: Description
Change `SurveySurface` to use `supportedInterfaceOrientations` instead of OrientationLockUtility

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

