### PR TITLE
Bugfix EXP-3953 [v121] Use bootstrap instead of content_blocker_update in bitrise.yaml

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1023,7 +1023,7 @@ workflows:
             # debug log
             set -x
 
-            ./content_blocker_update.sh
+            ./bootstrap.sh
     - set-xcode-build-number@1:
         inputs:
         - build_short_version_string: "$BITRISE_RELEASE_VERSION"
@@ -1149,7 +1149,7 @@ workflows:
             # debug log
             set -x
 
-            ./content_blocker_update.sh
+            ./bootstrap.sh
     - set-xcode-build-number@1:
         inputs:
         - build_short_version_string: "$BITRISE_BETA_VERSION"
@@ -1246,7 +1246,7 @@ workflows:
             # debug log
             set -x
 
-            ./content_blocker_update.sh
+            ./bootstrap.sh
     - set-xcode-build-number@1:
         inputs:
         - build_short_version_string: "$BITRISE_NIGHTLY_VERSION"


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/ EXP-3953)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
bitrise.yaml uses content_blocker_update.sh bare instead of `bootstrap.sh`. This PR fixes that.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

