### PR TITLE
Bugfix FXIOS-7631 [v121] Default browser tutorial dismissed incorrectly

### DIFF
--- a/Client/Coordinators/BaseCoordinator.swift
+++ b/Client/Coordinators/BaseCoordinator.swift
@@ -54,6 +54,8 @@ open class BaseCoordinator: NSObject, Coordinator {
                 // Dismiss any child of the matching coordinator that handles a route
                 for child in matchingCoordinator.childCoordinators {
                     guard child.isDismissable else { continue }
+                    guard shouldDismiss(coordinator: matchingCoordinator, for: route) else { continue }
+
                     matchingCoordinator.router.dismiss()
                     matchingCoordinator.remove(child: child)
                 }
@@ -66,5 +68,16 @@ open class BaseCoordinator: NSObject, Coordinator {
         savedRoute = route
         logger.log("Saved a route", level: .info, category: .coordinator)
         return nil
+    }
+
+    // Tentative fix for FXIOS-7631; this fixes the bug but may warrant add'tl team discussion/investigation to better
+    // understand the ideal way of addressing this. Related PR: https://github.com/mozilla-mobile/firefox-ios/pull/16789
+    private func shouldDismiss(coordinator: Coordinator, for route: Route) -> Bool {
+        switch route {
+        case .defaultBrowser(section: .tutorial):
+            return !(coordinator is BrowserCoordinator)
+        default:
+            return true
+        }
     }
 }

--- a/Client/Coordinators/BaseCoordinator.swift
+++ b/Client/Coordinators/BaseCoordinator.swift
@@ -12,7 +12,7 @@ open class BaseCoordinator: NSObject, Coordinator {
     var router: Router
     var logger: Logger
     var isDismissable: Bool { true }
-    var newlyAdded: Bool = false
+    var newlyAdded = false
 
     init(router: Router,
          logger: Logger = DefaultLogger.shared) {

--- a/Client/Coordinators/BaseCoordinator.swift
+++ b/Client/Coordinators/BaseCoordinator.swift
@@ -68,7 +68,6 @@ open class BaseCoordinator: NSObject, Coordinator {
                 // Dismiss any child of the matching coordinator that handles a route
                 for child in matchingCoordinator.childCoordinators {
                     guard child.isDismissable else { continue }
-
                     matchingCoordinator.router.dismiss()
                     matchingCoordinator.remove(child: child)
                 }

--- a/Client/Coordinators/BaseCoordinator.swift
+++ b/Client/Coordinators/BaseCoordinator.swift
@@ -29,7 +29,7 @@ open class BaseCoordinator: NSObject, Coordinator {
         // coordinators were added as part of the handling for the route. This fixes FXIOS-7631
         // though we will probably want to revisit to investigate a more elegant solution.
         coordinator.newlyAdded = true
-        DispatchQueue.main.async { coordinator.newlyAdded = false }
+        DispatchQueue.main.async { [weak coordinator] in coordinator?.newlyAdded = false }
     }
 
     func remove(child coordinator: Coordinator?) {

--- a/Client/Coordinators/BaseCoordinator.swift
+++ b/Client/Coordinators/BaseCoordinator.swift
@@ -52,12 +52,13 @@ open class BaseCoordinator: NSObject, Coordinator {
                 savedRoute = nil
 
                 // Dismiss any child of the matching coordinator that handles a route
-                for child in matchingCoordinator.childCoordinators {
-                    guard child.isDismissable else { continue }
-                    guard shouldDismiss(coordinator: matchingCoordinator, for: route) else { continue }
+                if shouldDismiss(coordinator: matchingCoordinator, for: route) {
+                    for child in matchingCoordinator.childCoordinators {
+                        guard child.isDismissable else { continue }
 
-                    matchingCoordinator.router.dismiss()
-                    matchingCoordinator.remove(child: child)
+                        matchingCoordinator.router.dismiss()
+                        matchingCoordinator.remove(child: child)
+                    }
                 }
 
                 return matchingCoordinator

--- a/Client/Coordinators/Coordinator.swift
+++ b/Client/Coordinators/Coordinator.swift
@@ -10,6 +10,7 @@ protocol Coordinator: AnyObject {
     var childCoordinators: [Coordinator] { get }
     var router: Router { get }
     var logger: Logger { get }
+    var newlyAdded: Bool { get set }
 
     /// Determines whether this coordinator can be dismissed or not, in some cases the coordinator cannot be dismissed for example due to state saving.
     /// This isn't ideal for this pattern, but was deemed necessary to keep existing behavior while moving away from previous pattern. By default, all coordinators

--- a/Tests/ClientTests/Mocks/MockCoordinator.swift
+++ b/Tests/ClientTests/Mocks/MockCoordinator.swift
@@ -13,6 +13,7 @@ class MockCoordinator: Coordinator {
     var savedRoute: Route?
     var logger: Logger = MockLogger()
     var isDismissable = true
+    var newlyAdded = false
 
     var addChildCalled = 0
     var removedChildCalled = 0


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7631)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17009)

## :bulb: Description

When handling the default browser tutorial router we end up also calling into `dimiss` on the `LaunchCoordinator` child of the `BrowserCoordinator` (related: https://github.com/mozilla-mobile/firefox-ios/pull/16789). The trouble is that the coordinator was added as part of the same recursive handling in `findAndHandle(route:)` which also runs the dismissal code. There are a couple potential approaches to this, and I think it may warrant revisiting at some point later down the road.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

