### PR TITLE
Bugfix FXIOS-7631 [v120] Default browser tutorial dismissed incorrectly

### DIFF
--- a/Client/Coordinators/BaseCoordinator.swift
+++ b/Client/Coordinators/BaseCoordinator.swift
@@ -54,6 +54,8 @@ open class BaseCoordinator: NSObject, Coordinator {
                 // Dismiss any child of the matching coordinator that handles a route
                 for child in matchingCoordinator.childCoordinators {
                     guard child.isDismissable else { continue }
+                    guard shouldDismiss(coordinator: matchingCoordinator, for: route) else { continue }
+
                     matchingCoordinator.router.dismiss()
                     matchingCoordinator.remove(child: child)
                 }
@@ -66,5 +68,16 @@ open class BaseCoordinator: NSObject, Coordinator {
         savedRoute = route
         logger.log("Saved a route", level: .info, category: .coordinator)
         return nil
+    }
+
+    // Tentative fix for FXIOS-7631; this fixes the bug but may warrant add'tl team discussion/investigation to better
+    // understand the ideal way of addressing this. Related PR: https://github.com/mozilla-mobile/firefox-ios/pull/16789
+    private func shouldDismiss(coordinator: Coordinator, for route: Route) -> Bool {
+        switch route {
+        case .defaultBrowser(section: .tutorial):
+            return !(coordinator is BrowserCoordinator)
+        default:
+            return true
+        }
     }
 }

--- a/Client/Coordinators/BaseCoordinator.swift
+++ b/Client/Coordinators/BaseCoordinator.swift
@@ -12,7 +12,7 @@ open class BaseCoordinator: NSObject, Coordinator {
     var router: Router
     var logger: Logger
     var isDismissable: Bool { true }
-    var newlyAdded: Bool = false
+    var newlyAdded = false
 
     init(router: Router,
          logger: Logger = DefaultLogger.shared) {

--- a/Client/Coordinators/BaseCoordinator.swift
+++ b/Client/Coordinators/BaseCoordinator.swift
@@ -12,7 +12,7 @@ open class BaseCoordinator: NSObject, Coordinator {
     var router: Router
     var logger: Logger
     var isDismissable: Bool { true }
-    
+
     var newlyAdded = false
     private var isPerformingFindAndHandle = 0
 

--- a/Client/Coordinators/BaseCoordinator.swift
+++ b/Client/Coordinators/BaseCoordinator.swift
@@ -68,15 +68,16 @@ open class BaseCoordinator: NSObject, Coordinator {
             if let matchingCoordinator = childCoordinator.findAndHandle(route: route) {
                 savedRoute = nil
 
-                // Check first whether, during the recursive findAndHandle(route:), we have just added
-                // new children to this coordinator. If so, we want to skip dismissal (we shouldn't ever
-                // immediately dismiss coordinators that were just added and about to appear).
-                // Will be removed as part of larger refactors in [FXIOS-7641].
-                guard !matchingCoordinator.childCoordinators.contains(where: { $0.newlyAdded }) else { continue }
-
                 // Dismiss any child of the matching coordinator that handles a route
                 for child in matchingCoordinator.childCoordinators {
                     guard child.isDismissable else { continue }
+
+                    // Check first whether, during the recursive findAndHandle(route:), we have just added
+                    // this child to the coordinator. If so, we want to skip dismissal (we shouldn't ever
+                    // immediately dismiss coordinators that were just added and about to appear).
+                    // Will be removed as part of larger refactors in [FXIOS-7641].
+                    guard !child.newlyAdded else { continue }
+
                     matchingCoordinator.router.dismiss()
                     matchingCoordinator.remove(child: child)
                 }

--- a/Client/Coordinators/BaseCoordinator.swift
+++ b/Client/Coordinators/BaseCoordinator.swift
@@ -68,7 +68,6 @@ open class BaseCoordinator: NSObject, Coordinator {
                 // Dismiss any child of the matching coordinator that handles a route
                 for child in matchingCoordinator.childCoordinators {
                     guard child.isDismissable else { continue }
-
                     matchingCoordinator.router.dismiss()
                     matchingCoordinator.remove(child: child)
                 }

--- a/Client/Coordinators/BaseCoordinator.swift
+++ b/Client/Coordinators/BaseCoordinator.swift
@@ -29,7 +29,7 @@ open class BaseCoordinator: NSObject, Coordinator {
         // coordinators were added as part of the handling for the route. This fixes FXIOS-7631
         // though we will probably want to revisit to investigate a more elegant solution.
         coordinator.newlyAdded = true
-        DispatchQueue.main.async { coordinator.newlyAdded = false }
+        DispatchQueue.main.async { [weak coordinator] in coordinator?.newlyAdded = false }
     }
 
     func remove(child coordinator: Coordinator?) {

--- a/Client/Coordinators/BaseCoordinator.swift
+++ b/Client/Coordinators/BaseCoordinator.swift
@@ -52,12 +52,13 @@ open class BaseCoordinator: NSObject, Coordinator {
                 savedRoute = nil
 
                 // Dismiss any child of the matching coordinator that handles a route
-                for child in matchingCoordinator.childCoordinators {
-                    guard child.isDismissable else { continue }
-                    guard shouldDismiss(coordinator: matchingCoordinator, for: route) else { continue }
+                if shouldDismiss(coordinator: matchingCoordinator, for: route) {
+                    for child in matchingCoordinator.childCoordinators {
+                        guard child.isDismissable else { continue }
 
-                    matchingCoordinator.router.dismiss()
-                    matchingCoordinator.remove(child: child)
+                        matchingCoordinator.router.dismiss()
+                        matchingCoordinator.remove(child: child)
+                    }
                 }
 
                 return matchingCoordinator

--- a/Client/Coordinators/Coordinator.swift
+++ b/Client/Coordinators/Coordinator.swift
@@ -10,6 +10,7 @@ protocol Coordinator: AnyObject {
     var childCoordinators: [Coordinator] { get }
     var router: Router { get }
     var logger: Logger { get }
+    var newlyAdded: Bool { get set }
 
     /// Determines whether this coordinator can be dismissed or not, in some cases the coordinator cannot be dismissed for example due to state saving.
     /// This isn't ideal for this pattern, but was deemed necessary to keep existing behavior while moving away from previous pattern. By default, all coordinators

--- a/Tests/ClientTests/Coordinators/BaseCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/BaseCoordinatorTests.swift
@@ -77,9 +77,9 @@ final class BaseCoordinatorTests: XCTestCase {
 
     func testRemoveDismissableFromChild() {
         // Given
-        let subject = BaseCoordinator(router: router)
-        let childCoordinator = MockSearchHandlerRouteCoordinator(router: router)
-        let grandChildCoordinator = BaseCoordinator(router: router)
+        let subject = BaseCoordinator(router: router, mainQueue: MockDispatchQueue())
+        let childCoordinator = MockSearchHandlerRouteCoordinator(router: router, mainQueue: MockDispatchQueue())
+        let grandChildCoordinator = BaseCoordinator(router: router, mainQueue: MockDispatchQueue())
 
         subject.add(child: childCoordinator)
         childCoordinator.add(child: grandChildCoordinator)

--- a/Tests/ClientTests/Mocks/MockCoordinator.swift
+++ b/Tests/ClientTests/Mocks/MockCoordinator.swift
@@ -13,6 +13,7 @@ class MockCoordinator: Coordinator {
     var savedRoute: Route?
     var logger: Logger = MockLogger()
     var isDismissable = true
+    var newlyAdded = false
 
     var addChildCalled = 0
     var removedChildCalled = 0


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7631)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17009)

## :bulb: Description

When handling the default browser tutorial router we end up also calling into dimiss on the LaunchCoordinator child of the BrowserCoordinator (related: https://github.com/mozilla-mobile/firefox-ios/pull/16789). The trouble is that the coordinator was added as part of the same recursive handling in findAndHandle(route:) which also runs the dismissal code.

The fix here is a bit of a hack/workaround until we can refactor `findAndHandle(route:)` as part of [FXIOS-7641](https://mozilla-hub.atlassian.net/browse/FXIOS-7641). 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

