### PR TITLE
Refactor FXIOS-7596 [v121] tab cleanup

### DIFF
--- a/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -151,7 +151,6 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     // MARK: - Initializer
 
     init(profile: Profile,
-         imageStore: DiskImageStore?,
          logger: Logger = DefaultLogger.shared
     ) {
         self.profile = profile
@@ -159,7 +158,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         self.tabEventHandlers = TabEventHandlers.create(with: profile)
         self.logger = logger
 
-        self.store = LegacyTabManagerStoreImplementation(prefs: profile.prefs, imageStore: imageStore)
+        self.store = LegacyTabManagerStoreImplementation(prefs: profile.prefs)
         super.init()
 
         register(self, forTabEvents: .didSetScreenshot)

--- a/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -1018,28 +1018,3 @@ extension LegacyTabManager: WKNavigationDelegate {
         }
     }
 }
-
-// MARK: - Test cases helpers
-extension LegacyTabManager {
-    func testRemoveAll() {
-        assert(AppConstants.isRunningTest)
-        if !AppConstants.isRunningTest {
-            logger.log("This method was used outside of tests!",
-                       level: .warning,
-                       category: .tabs)
-        }
-
-        removeTabs(self.tabs)
-    }
-
-    func testClearArchive() {
-        assert(AppConstants.isRunningTest)
-        if !AppConstants.isRunningTest {
-            logger.log("This method was used outside of tests!",
-                       level: .warning,
-                       category: .tabs)
-        }
-
-        store.clearArchive()
-    }
-}

--- a/Client/TabManagement/Legacy/LegacyTabManagerStore.swift
+++ b/Client/TabManagement/Legacy/LegacyTabManagerStore.swift
@@ -15,7 +15,6 @@ protocol LegacyTabManagerStore {
     func restoreStartupTabs(clearPrivateTabs: Bool,
                             addTabClosure: @escaping (Bool) -> Tab) -> Tab?
 
-    func clearArchive()
 }
 
 class LegacyTabManagerStoreImplementation: LegacyTabManagerStore, FeatureFlaggable {
@@ -93,19 +92,6 @@ class LegacyTabManagerStoreImplementation: LegacyTabManagerStore, FeatureFlaggab
         }
 
         return tabToSelect
-    }
-
-    func clearArchive() {
-        guard let path = tabsStateArchivePath() else { return }
-
-        do {
-            try fileManager.removeItem(at: path)
-        } catch let error {
-            logger.log("Clear archive couldn't be completed",
-                       level: .warning,
-                       category: .tabs,
-                       description: error.localizedDescription)
-        }
     }
 
     // MARK: - Private

--- a/Client/TabManagement/TabManager.swift
+++ b/Client/TabManagement/TabManager.swift
@@ -62,8 +62,6 @@ protocol TabManager: AnyObject {
                                  didClearTabs: @escaping (_ tabsToRemove: [Tab],
                                                           _ isPrivate: Bool,
                                                           _ previousTabUUID: String) -> Void)
-    func testRemoveAll()
-    func testClearArchive()
 }
 
 extension TabManager {

--- a/Client/TabManagement/TabManagerImplementation.swift
+++ b/Client/TabManagement/TabManagerImplementation.swift
@@ -30,7 +30,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
             self.imageStore = imageStore
             self.tabMigration = tabMigration
             self.notificationCenter = notificationCenter
-            super.init(profile: profile, imageStore: imageStore)
+            super.init(profile: profile)
 
             setupNotifications(forObserver: self,
                                observing: [UIApplication.willResignActiveNotification])
@@ -39,12 +39,6 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
     // MARK: - Restore tabs
 
     override func restoreTabs(_ forced: Bool = false) {
-        guard shouldUseNewTabStore()
-        else {
-            super.restoreTabs(forced)
-            return
-        }
-
         guard !isRestoringTabs,
               forced || tabs.isEmpty
         else {
@@ -86,7 +80,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
 
     private func migrateAndRestore() {
         Task {
-            await buildTabRestore(window: await tabMigration.runMigration(savedTabs: store.tabs))
+            await buildTabRestore(window: await tabMigration.runMigration())
             logger.log("Tabs restore ended after migration", level: .debug, category: .tabs)
             logger.log("Normal tabs count; \(normalTabs.count), Inactive tabs count; \(inactiveTabs.count), Private tabs count; \(privateTabs.count)", level: .debug, category: .tabs)
         }
@@ -98,15 +92,6 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
             await buildTabRestore(window: await self.tabDataStore.fetchWindowData())
             logger.log("Tabs restore ended after fetching window data", level: .debug, category: .tabs)
             logger.log("Normal tabs count; \(normalTabs.count), Inactive tabs count; \(inactiveTabs.count), Private tabs count; \(privateTabs.count)", level: .debug, category: .tabs)
-
-            // Safety check incase something went wrong during launch where a migration should have occured
-            if tabs.count <= 1 && store.tabs.count > 1 {
-                logger.log("Rerunning migration due to inconsistent tab counts, old tab store count: \(store.tabs.count)",
-                           level: .fatal,
-                           category: .tabs)
-                isRestoringTabs = true
-                migrateAndRestore()
-            }
         }
     }
 

--- a/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -137,8 +137,4 @@ class MockTabManager: TabManager {
                                  didClearTabs: @escaping (_ tabsToRemove: [Tab],
                                                           _ isPrivate: Bool,
                                                           _ previousTabUUID: String) -> Void) {}
-
-    func testRemoveAll() {}
-
-    func testClearArchive() {}
 }

--- a/Tests/ClientTests/TabManagement/TabMigrationUtilityTests.swift
+++ b/Tests/ClientTests/TabManagement/TabMigrationUtilityTests.swift
@@ -27,40 +27,40 @@ class TabMigrationUtilityTests: XCTestCase {
     func testShouldRunMigration_OnlyOnce() async {
         let subject = createSubject()
         XCTAssertTrue(subject.shouldRunMigration)
-        _ = await subject.runMigration(savedTabs: [LegacySavedTab]())
+        _ = await subject.runMigration()
         XCTAssertFalse(subject.shouldRunMigration)
     }
 
     func testRunMigration_SaveDataCalled() async {
         let subject = createSubject()
-        _ = await subject.runMigration(savedTabs: [LegacySavedTab]())
+        _ = await subject.runMigration()
         XCTAssertEqual(tabDataStore.saveWindowDataCalledCount, 1)
     }
 
     func testRunMigration_SameAmountOfTabs() async {
-        let subject = createSubject()
-        let savedTabs = buildSavedTab(amountOfTabs: 3)
-        let windowData = await subject.runMigration(savedTabs: savedTabs)
-        XCTAssertEqual(windowData.tabData.count, savedTabs.count)
+        var subject = createSubject()
+        subject.legacyTabs = buildSavedTab(amountOfTabs: 3)
+        let windowData = await subject.runMigration()
+        XCTAssertEqual(windowData.tabData.count, subject.legacyTabs.count)
     }
 
     func testRunMigration_EmptyTabs() async {
         let subject = createSubject()
-        let windowData = await subject.runMigration(savedTabs: [LegacySavedTab]())
+        let windowData = await subject.runMigration()
         XCTAssertEqual(windowData.tabData.count, 0)
     }
 
     func testRunMigration_FirstTabAsSelected() async {
-        let subject = createSubject()
-        let savedTabs = buildSavedTab(amountOfTabs: 3)
-        let windowData = await subject.runMigration(savedTabs: savedTabs)
+        var subject = createSubject()
+        subject.legacyTabs = buildSavedTab(amountOfTabs: 3)
+        let windowData = await subject.runMigration()
         XCTAssertEqual(windowData.activeTabId, selectedTabUUID)
     }
 
     func testRunMigration_AllTabDataIsMigrated() async {
-        let subject = createSubject()
-        let savedTabs = buildSavedTab(amountOfTabs: 1)
-        let windowData = await subject.runMigration(savedTabs: savedTabs)
+        var subject = createSubject()
+        subject.legacyTabs = buildSavedTab(amountOfTabs: 1)
+        let windowData = await subject.runMigration()
 
         let migratedTab = windowData.tabData[0]
         XCTAssertEqual(migratedTab.id, selectedTabUUID)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7596)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16900)

## :bulb: Description
More clean up of the tab store
This PR replaces the need to rely on the legacy tab store from the migration utility

The SimpleTab store for the widgets are the only place that still rely on the old tab store, that will be in the next PR.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

