### PR TITLE
Add FXIOS-7423 [v121] Show info error if product is not in stock/recently back in stock with an action to report

### DIFF
--- a/Client/Application/AccessibilityIdentifiers.swift
+++ b/Client/Application/AccessibilityIdentifiers.swift
@@ -120,6 +120,13 @@ public struct AccessibilityIdentifiers {
         static let sheetHeaderBetaLabel = "Shopping.Sheet.HeaderBetaLabel"
         static let sheetCloseButton = "Shopping.Sheet.CloseButton"
 
+        struct ReportProductInStockCard {
+            static let card = "Shopping.ReportProductInStockCard.Card"
+            static let title = "Shopping.ReportProductInStockCard.Title"
+            static let description = "Shopping.ReportProductInStockCard.Description"
+            static let primaryAction = "Shopping.ReportProductInStockCard.PrimaryAction"
+        }
+
         struct AnalysisProgressInfoCard {
             static let card = "Shopping.AnalysisProgressInfoCard.Card"
             static let title = "Shopping.AnalysisProgressInfoCard.Title"

--- a/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -15,6 +15,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case contextualHintForToolbar
     case credentialAutofillCoordinatorRefactor
     case creditCardAutofillStatus
+    case fakespotBackInStock
     case fakespotFeature
     case feltPrivacyUI
     case firefoxSuggestFeature
@@ -24,7 +25,6 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case isToolbarCFREnabled
     case jumpBackIn
     case libraryCoordinatorRefactor
-    case productBackInStockFakespotFeature
     case qrCodeCoordinatorRefactor
     case reduxIntegration
     case reportSiteIssue
@@ -75,10 +75,10 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .addressAutofill,
                 .creditCardAutofillStatus,
                 .credentialAutofillCoordinatorRefactor,
+                .fakespotBackInStock,
                 .fakespotFeature,
                 .isToolbarCFREnabled,
                 .libraryCoordinatorRefactor,
-                .productBackInStockFakespotFeature,
                 .qrCodeCoordinatorRefactor,
                 .reduxIntegration,
                 .reportSiteIssue,

--- a/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -24,6 +24,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case isToolbarCFREnabled
     case jumpBackIn
     case libraryCoordinatorRefactor
+    case productBackInStockFakespotFeature
     case qrCodeCoordinatorRefactor
     case reduxIntegration
     case reportSiteIssue
@@ -77,6 +78,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .fakespotFeature,
                 .isToolbarCFREnabled,
                 .libraryCoordinatorRefactor,
+                .productBackInStockFakespotFeature,
                 .qrCodeCoordinatorRefactor,
                 .reduxIntegration,
                 .reportSiteIssue,

--- a/Client/Frontend/Fakespot/Client/ProductAnalysisData.swift
+++ b/Client/Frontend/Fakespot/Client/ProductAnalysisData.swift
@@ -45,6 +45,28 @@ struct ProductAnalysisData: Codable {
 
     var reportProductInStockCardVisible: Bool { isProductDeleted }
 
+    init(
+        productId: String? = nil,
+        grade: ReliabilityGrade? = nil,
+        adjustedRating: Double? = nil,
+        needsAnalysis: Bool,
+        analysisUrl: URL? = nil,
+        highlights: Highlights? = nil,
+        pageNotSupported: Bool,
+        isProductDeletedReported: Bool,
+        isProductDeleted: Bool
+    ) {
+        self.productId = productId
+        self.grade = grade
+        self.adjustedRating = adjustedRating
+        self.needsAnalysis = needsAnalysis
+        self.analysisUrl = analysisUrl
+        self.highlights = highlights
+        self.pageNotSupported = pageNotSupported
+        self.isProductDeletedReported = isProductDeletedReported
+        self.isProductDeleted = isProductDeleted
+    }
+
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         productId = try container.decodeIfPresent(String.self, forKey: .productId)

--- a/Client/Frontend/Fakespot/Client/ProductAnalysisData.swift
+++ b/Client/Frontend/Fakespot/Client/ProductAnalysisData.swift
@@ -8,10 +8,12 @@ struct ProductAnalysisData: Codable {
     let productId: String?
     let grade: ReliabilityGrade?
     let adjustedRating: Double?
-    let needsAnalysis: Bool?
+    let needsAnalysis: Bool
     let analysisUrl: URL?
     let highlights: Highlights?
-    let pageNotSupported: Bool?
+    let pageNotSupported: Bool
+    let isProductDeletedReported: Bool
+    let isProductDeleted: Bool
 
     private enum CodingKeys: String, CodingKey {
         case productId = "product_id"
@@ -21,6 +23,8 @@ struct ProductAnalysisData: Codable {
         case analysisUrl = "analysis_url"
         case highlights
         case pageNotSupported = "page_not_supported"
+        case isProductDeletedReported = "deleted_product_reported"
+        case isProductDeleted = "deleted_product"
     }
 
     var needsAnalysisCardVisible: Bool {
@@ -37,6 +41,21 @@ struct ProductAnalysisData: Codable {
 
     var notEnoughReviewsCardVisible: Bool {
         (grade == nil || adjustedRating == nil) || productId == nil
+    }
+
+    var reportProductInStockCardVisible: Bool { isProductDeleted }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        productId = try container.decodeIfPresent(String.self, forKey: .productId)
+        grade = try container.decodeIfPresent(ReliabilityGrade.self, forKey: .grade)
+        adjustedRating = try container.decodeIfPresent(Double.self, forKey: .adjustedRating)
+        needsAnalysis = try container.decodeIfPresent(Bool.self, forKey: .needsAnalysis) ?? false
+        analysisUrl = try container.decodeIfPresent(URL.self, forKey: .analysisUrl)
+        highlights = try container.decodeIfPresent(Highlights.self, forKey: .highlights)
+        pageNotSupported = try container.decodeIfPresent(Bool.self, forKey: .pageNotSupported) ?? false
+        isProductDeletedReported = try container.decodeIfPresent(Bool.self, forKey: .isProductDeletedReported) ?? false
+        isProductDeleted = try container.decodeIfPresent(Bool.self, forKey: .isProductDeleted) ?? false
     }
 }
 

--- a/Client/Frontend/Fakespot/FakespotViewController.swift
+++ b/Client/Frontend/Fakespot/FakespotViewController.swift
@@ -386,6 +386,14 @@ class FakespotViewController:
                 let view: FakespotMessageCardView = .build()
                 view.configure(viewModel.analysisProgressViewModel)
                 return view
+
+            case .reportProductInStock:
+                let view: FakespotMessageCardView = .build()
+                viewModel.reportProductInStockViewModel.primaryAction = { [weak self] in
+                    self?.viewModel.reportProductBackInStock()
+                }
+                view.configure(viewModel.reportProductInStockViewModel)
+                return view
             }
         }
     }

--- a/Client/Frontend/Fakespot/ShoppingProduct.swift
+++ b/Client/Frontend/Fakespot/ShoppingProduct.swift
@@ -57,6 +57,10 @@ class ShoppingProduct: FeatureFlaggable {
         return true
     }
 
+    var isProductBackInStockFeatureEnabled: Bool {
+        featureFlags.isFeatureEnabled(.productBackInStockFakespotFeature, checking: .buildOnly)
+    }
+
     var isShoppingButtonVisible: Bool {
         return product != nil && isFakespotFeatureEnabled
     }

--- a/Client/Frontend/Fakespot/ShoppingProduct.swift
+++ b/Client/Frontend/Fakespot/ShoppingProduct.swift
@@ -58,7 +58,7 @@ class ShoppingProduct: FeatureFlaggable {
     }
 
     var isProductBackInStockFeatureEnabled: Bool {
-        featureFlags.isFeatureEnabled(.productBackInStockFakespotFeature, checking: .buildOnly)
+        featureFlags.isFeatureEnabled(.fakespotBackInStock, checking: .buildOnly)
     }
 
     var isShoppingButtonVisible: Bool {

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -3981,6 +3981,21 @@ extension String {
             tableName: "Shopping",
             value: "This could take about 60 seconds.",
             comment: "Description for info card when the product is in analysis mode")
+        public static let InfoCardProductNotInStockTitle = MZLocalizedString(
+            key: "", // Shopping.InfoCard.ProductNotInStock.Title.v121
+            tableName: "Shopping",
+            value: "Product Is Not Available",
+            comment: "Title for info card when the product is not in stock or recently back in stock")
+        public static let InfoCardProductNotInStockDescription = MZLocalizedString(
+            key: "", // Shopping.InfoCard.ProductNotInStock.Description.v121
+            tableName: "Shopping",
+            value: "If you see this product is back in stock, report it and we’ll work on checking the reviews.",
+            comment: "Description for info card when the product is not in stock or recently back in stock")
+        public static let InfoCardProductNotInStockPrimaryAction = MZLocalizedString(
+            key: "", // Shopping.InfoCard.ProductNotInStock.PrimaryAction.v121
+            tableName: "Shopping",
+            value: "Report Product Back in Stock",
+            comment: "Primary action label when encouraging users to report a product back in stock")
     }
 }
 

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -3985,17 +3985,17 @@ extension String {
             key: "", // Shopping.InfoCard.ProductNotInStock.Title.v121
             tableName: "Shopping",
             value: "Product Is Not Available",
-            comment: "Title for info card when the product is not in stock or recently back in stock")
+            comment: "Title for the information card displayed by the review checker feature when the product the user is looking at is out of stock. This title is used for info card where the user can report if it's back in stock.")
         public static let InfoCardProductNotInStockDescription = MZLocalizedString(
             key: "", // Shopping.InfoCard.ProductNotInStock.Description.v121
             tableName: "Shopping",
             value: "If you see this product is back in stock, report it and we’ll work on checking the reviews.",
-            comment: "Description for info card when the product is not in stock or recently back in stock")
+            comment: "Description for the information card displayed by the review checker feature when the product the user is looking at is out of stock. This description is used for info card where the user can report if it's back in stock.")
         public static let InfoCardProductNotInStockPrimaryAction = MZLocalizedString(
             key: "", // Shopping.InfoCard.ProductNotInStock.PrimaryAction.v121
             tableName: "Shopping",
             value: "Report Product Back in Stock",
-            comment: "Primary action label when encouraging users to report a product back in stock")
+            comment: "Primary action label for the information card displayed by the review checker feature when the product the user is looking at is out of stock. This primary action label is used for info card button where the user can report if it's back in stock.")
     }
 }
 

--- a/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -50,6 +50,9 @@ final class NimbusFeatureFlagLayer {
         case .feltPrivacyUI:
             return checkFeltPrivacyUIFeature(from: nimbus)
 
+        case .productBackInStockFakespotFeature:
+            return checkProductBackInStockFakespotFeature(from: nimbus)
+
         case .qrCodeCoordinatorRefactor:
             return checkQRCodeCoordinatorRefactorFeature(from: nimbus)
 
@@ -249,6 +252,12 @@ final class NimbusFeatureFlagLayer {
         let config = nimbus.features.shopping2023.value()
 
         return config.status
+    }
+
+    private func checkProductBackInStockFakespotFeature(from nimbus: FxNimbus) -> Bool {
+        let config = nimbus.features.shopping2023.value()
+
+        return config.backInStockReporting
     }
 
     private func checkAddressAutofill(from nimbus: FxNimbus) -> Bool {

--- a/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -50,7 +50,7 @@ final class NimbusFeatureFlagLayer {
         case .feltPrivacyUI:
             return checkFeltPrivacyUIFeature(from: nimbus)
 
-        case .productBackInStockFakespotFeature:
+        case .fakespotBackInStock:
             return checkProductBackInStockFakespotFeature(from: nimbus)
 
         case .qrCodeCoordinatorRefactor:

--- a/Tests/ClientTests/ShoppingProductTests.swift
+++ b/Tests/ClientTests/ShoppingProductTests.swift
@@ -296,6 +296,8 @@ extension ProductAnalysisData {
         needsAnalysis: false,
         analysisUrl: URL(string: "https://www.example.com")!,
         highlights: Highlights(price: [], quality: [], competitiveness: [], shipping: [], packaging: []),
-        pageNotSupported: true
+        pageNotSupported: true,
+        isProductDeletedReported: false,
+        isProductDeleted: false
     )
 }

--- a/nimbus-features/fakespotFeature.yaml
+++ b/nimbus-features/fakespotFeature.yaml
@@ -15,6 +15,12 @@ features:
            to be shown to the user based on their preference.
         type: Boolean
         default: false
+      back_in_stock_reporting:
+        description: >
+          If true, enables for users the reporting feature for
+          products back in stock.
+        type: Boolean
+        default: false
       config:
         type: Map<String, WebsiteConfig>
         description: >
@@ -39,10 +45,12 @@ features:
         value:
           status: true
           product-recommendations: false
+          back_in_stock_reporting: false
       - channel: developer
         value:
           status: true
           product-recommendations: true
+          back_in_stock_reporting: true
 
 objects:
   WebsiteConfig:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7423)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16461)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This issue adds a nimbus flag to control back in stock feature. Shows a info card with a button with the option to report back in stock. Next PR will show the confirmation card.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

