### PR TITLE
Bugfix FXIOS-7622 [v120] No CFR for "Jump back in" section displayed on Home screen

### DIFF
--- a/Client/Frontend/ContextualHint/ContextualHintViewProvider.swift
+++ b/Client/Frontend/ContextualHint/ContextualHintViewProvider.swift
@@ -43,8 +43,10 @@ class ContextualHintViewProvider: ContextualHintPrefsKeysProvider, SearchBarLoca
     // MARK: - Interface
 
     func shouldPresentContextualHint() -> Bool {
-        let hintEligibilityUtility = ContextualHintEligibilityUtility(with: profile,
-                                                                      overlayState: overlayState)
+        let hintEligibilityUtility = ContextualHintEligibilityUtility(
+            with: profile,
+            overlayState: overlayState,
+            isCFRToolbarFeatureEnabled: featureFlags.isFeatureEnabled(.isToolbarCFREnabled, checking: .buildOnly))
 
         return hintEligibilityUtility.canPresent(hintType)
     }

--- a/Tests/ClientTests/Frontend/ContextualHints/ContextualHintEligibilityUtilityTests.swift
+++ b/Tests/ClientTests/Frontend/ContextualHints/ContextualHintEligibilityUtilityTests.swift
@@ -22,6 +22,7 @@ class ContextualHintEligibilityUtilityTests: XCTestCase {
         urlBar = MockURLBarView()
         overlayState = MockOverlayModeManager()
         overlayState.setURLBar(urlBarView: urlBar)
+        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
         subject = ContextualHintEligibilityUtility(with: profile,
                                                    overlayState: nil,
                                                    device: MockUIDevice(isIpad: false))
@@ -52,36 +53,72 @@ class ContextualHintEligibilityUtilityTests: XCTestCase {
         XCTAssertTrue(result)
     }
 
+    // MARK: Jump Back in and Synced tabs
     func test_shouldPresentJumpBackHint() {
+        subject = ContextualHintEligibilityUtility(with: profile,
+                                                   overlayState: overlayState,
+                                                   device: MockUIDevice(isIpad: false),
+                                                   isCFRToolbarFeatureEnabled: true)
         profile.prefs.setBool(true, forKey: CFRPrefsKeys.toolbarOnboardingKey.rawValue)
 
         let result = subject.canPresent(.jumpBackIn)
         XCTAssertTrue(result)
     }
 
-    func test_shouldPresentJumpBackHint_iPhoneWithoutToolbar() {
+    func test_shouldNotPresentJumpBackHint_iPhoneWithoutAndToolbarCFREnabled() {
+        subject = ContextualHintEligibilityUtility(with: profile,
+                                                   overlayState: overlayState,
+                                                   device: MockUIDevice(isIpad: false),
+                                                   isCFRToolbarFeatureEnabled: true)
         let result = subject.canPresent(.jumpBackIn)
         XCTAssertFalse(result)
+    }
+
+    func test_shouldPresentJumpBackHint_iPhoneWithoutAndToolbarCFRDisabled() {
+        subject = ContextualHintEligibilityUtility(with: profile,
+                                                   overlayState: overlayState,
+                                                   device: MockUIDevice(isIpad: false),
+                                                   isCFRToolbarFeatureEnabled: false)
+        let result = subject.canPresent(.jumpBackIn)
+        XCTAssertTrue(result)
     }
 
     func test_shouldPresentJumpBackHint_iPadWithoutToolbar() {
         subject = ContextualHintEligibilityUtility(with: profile,
                                                    overlayState: overlayState,
-                                                   device: MockUIDevice(isIpad: true))
+                                                   device: MockUIDevice(isIpad: true),
+                                                   isCFRToolbarFeatureEnabled: true)
         let result = subject.canPresent(.jumpBackIn)
         XCTAssertTrue(result)
     }
 
     func test_shouldPresentSyncedTabHint() {
+        subject = ContextualHintEligibilityUtility(with: profile,
+                                                   overlayState: overlayState,
+                                                   device: MockUIDevice(isIpad: false),
+                                                   isCFRToolbarFeatureEnabled: true)
         profile.prefs.setBool(true, forKey: CFRPrefsKeys.toolbarOnboardingKey.rawValue)
 
         let result = subject.canPresent(.jumpBackInSyncedTab)
         XCTAssertTrue(result)
     }
 
-    func test_shouldPresentSyncedHint_iPhoneWithoutToolbar() {
+    func test_shouldNotPresentSyncedHint_iPhoneWithoutToolbarAndFeatureEnabled() {
+        subject = ContextualHintEligibilityUtility(with: profile,
+                                                   overlayState: overlayState,
+                                                   device: MockUIDevice(isIpad: false),
+                                                   isCFRToolbarFeatureEnabled: true)
         let result = subject.canPresent(.jumpBackInSyncedTab)
         XCTAssertFalse(result)
+    }
+
+    func test_shouldPresentSyncedHint_iPhoneWithoutToolbarAndFeatureDisabled() {
+        subject = ContextualHintEligibilityUtility(with: profile,
+                                                   overlayState: overlayState,
+                                                   device: MockUIDevice(isIpad: false),
+                                                   isCFRToolbarFeatureEnabled: false)
+        let result = subject.canPresent(.jumpBackInSyncedTab)
+        XCTAssertTrue(result)
     }
 
     func test_shouldPresentSyncedHint_iPadWithoutToolbar() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7622)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16985)

## :bulb: Description
Note: Due to the change done in [PR](https://github.com/mozilla-mobile/firefox-ios/pull/16738/files) for issue #16102 the toolbar CFR is now disabled by default.
- JumpBack in CFR depends on the Toolbar CFR to be shown first so in this PR we updated the rules to bypass this condition if Toolbar CFR flag is disabled. If the flag is enabled Toolbar CFR takes precedence before JumpBack in CFR.
- Added and updated unit test

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

