### PR TITLE
Refactor FXIOS-7580 [v121] Replace secondary button in FakespotSettingsCardView

### DIFF
--- a/Client/Frontend/Fakespot/Views/FakespotSettingsCardView.swift
+++ b/Client/Frontend/Fakespot/Views/FakespotSettingsCardView.swift
@@ -69,14 +69,11 @@ class FakespotSettingsCardViewModel {
 final class FakespotSettingsCardView: UIView, ThemeApplicable {
     private struct UX {
         static let headerLabelFontSize: CGFloat = 15
-        static let buttonLabelFontSize: CGFloat = 16
-        static let buttonCornerRadius: CGFloat = 14
         static let buttonLeadingTrailingPadding: CGFloat = 8
         static let buttonTopPadding: CGFloat = 16
         static let contentStackViewSpacing: CGFloat = 16
         static let labelSwitchStackViewSpacing: CGFloat = 12
         static let contentInsets = UIEdgeInsets(top: 8, left: 0, bottom: 8, right: 0)
-        static let buttonInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
         static let cardBottomSpace: CGFloat = 8
         static let footerHorizontalSpace: CGFloat = 8
     }
@@ -113,15 +110,8 @@ final class FakespotSettingsCardView: UIView, ThemeApplicable {
         uiSwitch.addTarget(self, action: #selector(self.didToggleSwitch), for: .valueChanged)
     }
 
-    private lazy var turnOffButton: ResizableButton = .build { button in
-        button.layer.cornerRadius = UX.buttonCornerRadius
-        button.contentEdgeInsets = UX.buttonInsets
-        button.titleLabel?.textAlignment = .center
-        button.clipsToBounds = true
+    private lazy var turnOffButton: SecondaryRoundedButton = .build { button in
         button.addTarget(self, action: #selector(self.didTapTurnOffButton), for: .touchUpInside)
-        button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .headline,
-                                                                         size: UX.buttonLabelFontSize,
-                                                                         weight: .semibold)
     }
 
     private lazy var footerView: ActionFooterView = .build()
@@ -176,8 +166,11 @@ final class FakespotSettingsCardView: UIView, ThemeApplicable {
         showProductsLabel.text = viewModel.showProductsLabelTitle
         showProductsLabel.accessibilityIdentifier = viewModel.showProductsLabelTitleA11yId
 
-        turnOffButton.setTitle(viewModel.turnOffButtonTitle, for: .normal)
-        turnOffButton.accessibilityIdentifier = viewModel.turnOffButtonTitleA11yId
+        let turnOffButtonViewModel = SecondaryRoundedButtonViewModel(
+            title: viewModel.turnOffButtonTitle,
+            a11yIdentifier: viewModel.turnOffButtonTitleA11yId
+        )
+        turnOffButton.configure(viewModel: turnOffButtonViewModel)
 
         recommendedProductsSwitch.accessibilityIdentifier = viewModel.recommendedProductsSwitchA11yId
 
@@ -223,8 +216,7 @@ final class FakespotSettingsCardView: UIView, ThemeApplicable {
         recommendedProductsSwitch.onTintColor = colors.actionPrimary
         recommendedProductsSwitch.tintColor = colors.formKnob
 
-        turnOffButton.backgroundColor = colors.actionSecondary
-        turnOffButton.setTitleColor(colors.textOnLight, for: .normal)
+        turnOffButton.applyTheme(theme: theme)
 
         footerView.applyTheme(theme: theme)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7580)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16868)

## :bulb: Description
**Screenshots before the PR**
<img width="529" alt="Screenshot 2023-10-31 at 4 49 21 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/15265718/578d08c2-0e86-4e3e-af14-2aea924bcb81">
<img width="529" alt="Screenshot 2023-10-31 at 4 50 17 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/15265718/60a4e8ce-1486-4969-947e-1515e6a57a42">

**Screenshots after the PR**
<img width="529" alt="Screenshot 2023-10-31 at 4 58 15 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/15265718/fab9ca2e-f4e5-4b87-b105-90fcccf37f4a">
<img width="529" alt="Screenshot 2023-10-31 at 4 58 38 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/15265718/52d5648f-0c1c-4802-9402-fc95232691f1">

<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

