### PR TITLE
Refactor FXIOS-7656 [v119] Fix constraint crash in SyncNow settings cell

### DIFF
--- a/Client/Application/ImageIdentifiers.swift
+++ b/Client/Application/ImageIdentifiers.swift
@@ -10,6 +10,7 @@ import Foundation
 /// Sing the song if you must.
 public struct ImageIdentifiers {
     public static let addToReadingList = "addToReadingList"
+    public static let amberCaution = "AmberCaution"
     public static let badgeMask = "badge-mask"
     public static let circleFill = "circle.fill"
     public static let competitiveness = "competitiveness"
@@ -57,6 +58,7 @@ public struct ImageIdentifiers {
     public static let privateMaskSmall = "smallPrivateMask"
     public static let privateModeBadge = "privateModeBadge"
     public static let readingList = "menu-panel-ReadingList"
+    public static let redCaution = "RedCaution"
     public static let reportSiteIssue = "menu-reportSiteIssue"
     public static let settings = "menu-Settings"
     public static let share = "action_share"

--- a/Client/Frontend/Settings/Main/Account/SyncNowSetting.swift
+++ b/Client/Frontend/Settings/Main/Account/SyncNowSetting.swift
@@ -145,26 +145,29 @@ class SyncNowSetting: WithAccountSetting {
         // swiftlint:enable unused_setter_value
     }
 
-    private lazy var troubleshootButton: UIButton = {
-        let troubleshootButton = UIButton(type: .roundedRect)
+    private lazy var troubleshootButton: UIButton = .build { [weak self] troubleshootButton in
+        guard let self = self else { return }
         troubleshootButton.setTitle(.FirefoxSyncTroubleshootTitle, for: .normal)
         troubleshootButton.addTarget(self, action: #selector(self.troubleshoot), for: .touchUpInside)
-        troubleshootButton.tintColor = theme.colors.actionPrimary
-        troubleshootButton.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 12, weight: .regular)
-        troubleshootButton.sizeToFit()
-        return troubleshootButton
-    }()
+        troubleshootButton.setTitleColor(self.theme.colors.actionPrimary, for: .normal)
+        troubleshootButton.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
+                                                                                     size: 12,
+                                                                                     weight: .regular)
+    }
+
+    private lazy var accessoryViewContainer: UIStackView = .build { stackView in
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.distribution = .fillProportionally
+        stackView.spacing = 4
+    }
 
     private lazy var warningIcon: UIImageView = {
-        let imageView = UIImageView(image: UIImage(named: "AmberCaution"))
-        imageView.sizeToFit()
-        return imageView
+        return UIImageView(image: UIImage(named: "AmberCaution"))
     }()
 
     private lazy var errorIcon: UIImageView = {
-        let imageView = UIImageView(image: UIImage(named: "RedCaution"))
-        imageView.sizeToFit()
-        return imageView
+        return UIImageView(image: UIImage(named: "RedCaution"))
     }()
 
     private let syncSUMOURL = SupportUtils.URLForTopic("sync-status-ios")
@@ -186,8 +189,7 @@ class SyncNowSetting: WithAccountSetting {
                     // add the red warning symbol
                     // add a link to the MANA page
                     cell.detailTextLabel?.attributedText = nil
-                    cell.accessoryView = troubleshootButton
-                    addIcon(errorIcon, toCell: cell)
+                    addAccessoryView(with: errorIcon, to: cell)
                 } else {
                     cell.detailTextLabel?.attributedText = status
                     cell.accessoryView = nil
@@ -196,8 +198,7 @@ class SyncNowSetting: WithAccountSetting {
                 // add the amber warning symbol
                 // add a link to the MANA page
                 cell.detailTextLabel?.attributedText = nil
-                cell.accessoryView = troubleshootButton
-                addIcon(warningIcon, toCell: cell)
+                addAccessoryView(with: warningIcon, to: cell)
             case .good:
                 cell.detailTextLabel?.attributedText = status
                 fallthrough
@@ -237,19 +238,11 @@ class SyncNowSetting: WithAccountSetting {
         }
     }
 
-    private func addIcon(_ image: UIImageView, toCell cell: UITableViewCell) {
-        cell.contentView.addSubview(image)
+    private func addAccessoryView(with image: UIImageView, to cell: UITableViewCell) {
+        accessoryViewContainer.addArrangedSubview(image)
+        accessoryViewContainer.addArrangedSubview(troubleshootButton)
 
-        cell.textLabel?.snp.updateConstraints { make in
-            make.leading.equalTo(image.snp.trailing).offset(5)
-            make.trailing.lessThanOrEqualTo(cell.contentView)
-            make.centerY.equalTo(cell.contentView)
-        }
-
-        image.snp.makeConstraints { make in
-            make.leading.equalTo(cell.contentView).offset(17)
-            make.top.equalTo(cell.textLabel!).offset(2)
-        }
+        cell.accessoryView = accessoryViewContainer
     }
 
     override func onClick(_ navigationController: UINavigationController?) {

--- a/Client/Frontend/Settings/Main/Account/SyncNowSetting.swift
+++ b/Client/Frontend/Settings/Main/Account/SyncNowSetting.swift
@@ -163,11 +163,11 @@ class SyncNowSetting: WithAccountSetting {
     }
 
     private lazy var warningIcon: UIImageView = {
-        return UIImageView(image: UIImage(named: "AmberCaution"))
+        return UIImageView(image: UIImage(named: ImageIdentifiers.amberCaution))
     }()
 
     private lazy var errorIcon: UIImageView = {
-        return UIImageView(image: UIImage(named: "RedCaution"))
+        return UIImageView(image: UIImage(named: ImageIdentifiers.redCaution))
     }()
 
     private let syncSUMOURL = SupportUtils.URLForTopic("sync-status-ios")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7656)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17076)

## :bulb: Description
- Fix constraint crash in SyncNow settings cell
- Removed SnapKit usage at the same time

### Before
Was crashing showing this, we were changing constraints in a way that I think is not permitted anymore? (adding a view in the cell, then changing the textLabel UITableViewCell position)
![image](https://github.com/mozilla-mobile/firefox-ios/assets/11338480/faffb2f4-fd1e-4710-b653-0606a511ab7a)

### After
![Screenshot 2023-10-31 at 3 35 01 PM](https://github.com/mozilla-mobile/firefox-ios/assets/11338480/5dd3428b-2c0a-496c-b403-bee13bb97f2c)

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

