### PR TITLE
Refactor FXIOS-7662 [v121] Event queue addition & minor updates

### DIFF
--- a/Client/Frontend/Browser/Event Queue/AppEvent.swift
+++ b/Client/Frontend/Browser/Event Queue/AppEvent.swift
@@ -7,5 +7,6 @@ import Foundation
 protocol AppEventType: Hashable { }
 
 enum AppEvent: Int, AppEventType {
-    case profileDidFinishLoading // Integration forthcoming. [FXIOS-7606]
+    case tabRestoreHasFinished
+    case profileSyncing
 }

--- a/Client/Frontend/Browser/Event Queue/EventQueue.swift
+++ b/Client/Frontend/Browser/Event Queue/EventQueue.swift
@@ -8,7 +8,20 @@ import Common
 typealias EventQueueAction = (() -> Void)
 typealias ActionToken = UUID
 
-let DefaultEventQueue = EventQueue<AppEvent>()
+/// The state of an event. Typical one-shot events are placed into the .completed
+/// state once they have occurred. Activities which represent recurring tasks may
+/// be placed in one of the states below depending on their status.
+///
+/// (Note: there is an additional implicit state, "not started", which is indicated
+/// by the event being absent from the event queue altogether.)
+enum QueueEventState: Int {
+    case inProgress
+    case completed
+    case failed
+}
+
+/// The default app-wide queue for Firefox.
+let AppEventQueue = EventQueue<AppEvent>()
 
 final class EventQueue<QueueEventType: Hashable> {
     struct EnqueuedAction {
@@ -20,7 +33,7 @@ final class EventQueue<QueueEventType: Hashable> {
     // MARK: - Properties
 
     private var actions: [EnqueuedAction] = []
-    private var signalledEvents = Set<QueueEventType>()
+    private var signalledEvents: [QueueEventType: QueueEventState] = [:]
     private let logger: Logger
     private let mainQueue: DispatchQueueInterface
 
@@ -32,25 +45,69 @@ final class EventQueue<QueueEventType: Hashable> {
         self.mainQueue = mainQueue
     }
 
-    /// Signals that a specific event has occurred. Currently signalling the same
-    /// event more than once is considered a usage error.
+    /// Signals that a specific one-shot event has occurred. These types of events are states
+    /// that only ever occur once and do not repeat. An example might be the Profile initializing
+    /// its DB connection etc. Signalling the same event more than once is currently a usage error.
     func signal(event: QueueEventType) {
         mainQueue.ensureMainThread { [weak self] in
             guard let self else { return }
-            guard !self.signalledEvents.contains(event) else {
+            guard self.signalledEvents[event] != .completed else {
                 logger.log("Signalling duplicate event: \(event)", level: .warning, category: .library)
                 return
             }
-            self.signalledEvents.insert(event)
+            self.signalledEvents[event] = .completed
             self.processActions(for: event)
         }
     }
 
-    /// Queues a particular action for execution once the provided events have all
-    /// been signaled. If the events have already all occurred, the block is executed
-    /// immediately.
+    /// Signals that an activity has been started. This transitions the event
+    /// into the In Progress state.
+    func started(_ event: QueueEventType) {
+        mainQueue.ensureMainThread { [weak self] in
+            guard let self else { return }
+            let currentState = self.signalledEvents[event]
+            guard currentState != .inProgress else {
+                logger.log("Started \(event) which is already in progress.", level: .warning, category: .library)
+                return
+            }
+
+            self.signalledEvents[event] = .inProgress
+        }
+    }
+
+    func completed(_ event: QueueEventType, error: Error? = nil) {
+        mainQueue.ensureMainThread { [weak self] in
+            guard let self else { return }
+            let currentState = self.signalledEvents[event]
+            guard currentState == .inProgress else {
+                logger.log("Completing \(event) which is not in progress.", level: .warning, category: .library)
+                return
+            }
+
+            self.signalledEvents[event] = .completed
+            self.processActions(for: event)
+        }
+    }
+
+    func failed(_ event: QueueEventType) {
+        mainQueue.ensureMainThread { [weak self] in
+            self?.signalledEvents[event] = .failed
+        }
+    }
+
+    /// Queues a particular action for execution once the provided events or activities
+    /// have completed. If the dependencies have already all occurred, the block is executed
+    /// immediately. An optional ActionToken may be provided explicitly for particular
+    /// action, if so any subsequent calls to this function will _not_ enqueue that
+    /// action again if it is already pending execution. This provides a convenience for
+    /// automatically avoiding duplicate work.
     /// - Parameters:
     ///   - events: the dependent events.
+    ///   - token: an optional UUID that identifies the specific work being enqueued. If
+    ///   this is provided, it will be used as the token to identify the enqueued work.
+    ///   Callers may wish to provide this directly in order to allow for automatic
+    ///   deduplication, for example in scenarios where the same function may be called
+    ///   multiple times but you only want the action to be enqueued a single time.
     ///   - action: the action or work to perform. Called on main thread by default.
     /// - Returns: a token that can be used to cancel the action.
     ///
@@ -60,10 +117,18 @@ final class EventQueue<QueueEventType: Hashable> {
     /// also will have no usefulness if all dependencies are already satisfied, in which
     /// case the action will be immediately run before the function returns.
     @discardableResult
-    func wait(for events: [QueueEventType], then action: @escaping EventQueueAction) -> ActionToken {
-        let token = ActionToken()
+    func wait(for events: [QueueEventType],
+              token: ActionToken = ActionToken(),
+              then action: @escaping EventQueueAction) -> ActionToken {
         mainQueue.ensureMainThread { [weak self] in
             guard let self else { return }
+
+            // If a specific ID has been provided for this action, ensure
+            guard !actions.contains(where: { $0.token == token }) else {
+                logger.log("Ignoring duplicate action (ID: \(token))", level: .info, category: .library)
+                return
+            }
+
             let enqueued = EnqueuedAction(token: token, action: action, dependencies: events)
             self.actions.append(enqueued)
             self.processActions()
@@ -71,17 +136,37 @@ final class EventQueue<QueueEventType: Hashable> {
         return token
     }
 
-    /// Qeues a particular action for a single dependency.
+    /// Shorthand for waiting on a single event. Convenience func.
     @discardableResult
     func wait(for event: QueueEventType, then action: @escaping EventQueueAction) -> ActionToken {
-        return wait(for: [event], then: action)
+        wait(for: [event], token: ActionToken(), then: action)
     }
 
     /// Used to check whether a particular event has occurred.
     /// - Returns: true if the event has occurred.
     func hasSignalled(_ event: QueueEventType) -> Bool {
         assert(Thread.isMainThread, "Expects to be called on the main thread.")
-        return signalledEvents.contains(event)
+        return signalledEvents[event] == .completed
+    }
+
+    func activityIsInProgress(_ event: QueueEventType) -> Bool {
+        assert(Thread.isMainThread, "Expects to be called on the main thread.")
+        return signalledEvents[event] == .inProgress
+    }
+
+    func activityIsFailed(_ event: QueueEventType) -> Bool {
+        assert(Thread.isMainThread, "Expects to be called on the main thread.")
+        return signalledEvents[event] == .failed
+    }
+
+    func activityIsNotStarted(_ event: QueueEventType) -> Bool {
+        assert(Thread.isMainThread, "Expects to be called on the main thread.")
+        return signalledEvents[event] == nil
+    }
+
+    func activityIsCompleted(_ event: QueueEventType) -> Bool {
+        assert(Thread.isMainThread, "Expects to be called on the main thread.")
+        return hasSignalled(event)
     }
 
     /// Used to cancel an enqueued action using the token that was provided when the action was enqueued.
@@ -111,7 +196,7 @@ final class EventQueue<QueueEventType: Hashable> {
     private func allDependenciesSatisified(_ action: EnqueuedAction) -> Bool {
         let events = action.dependencies
         guard !events.isEmpty else { return true }
-        if events.contains(where: { signalledEvents.contains($0) == false }) {
+        if events.contains(where: { signalledEvents[$0] != .completed }) {
             return false
         }
         return true

--- a/Client/Frontend/Browser/Event Queue/EventQueue.swift
+++ b/Client/Frontend/Browser/Event Queue/EventQueue.swift
@@ -90,7 +90,7 @@ final class EventQueue<QueueEventType: Hashable> {
             self.processActions(for: event)
         }
     }
-    
+
     /// Signals an activity event as having failed (completed with an error).
     /// Dependent actions will not be executed.
     func failed(_ event: QueueEventType) {

--- a/Client/Frontend/Browser/Event Queue/EventQueue.swift
+++ b/Client/Frontend/Browser/Event Queue/EventQueue.swift
@@ -143,7 +143,7 @@ final class EventQueue<QueueEventType: Hashable> {
     /// Shorthand for waiting on a single event. Convenience func.
     @discardableResult
     func wait(for event: QueueEventType, then action: @escaping EventQueueAction) -> ActionToken {
-        wait(for: [event], token: ActionToken(), then: action)
+        return wait(for: [event], token: ActionToken(), then: action)
     }
 
     /// Used to check whether a particular event has occurred.

--- a/Client/Frontend/Browser/Event Queue/EventQueue.swift
+++ b/Client/Frontend/Browser/Event Queue/EventQueue.swift
@@ -74,7 +74,9 @@ final class EventQueue<QueueEventType: Hashable> {
             self.signalledEvents[event] = .inProgress
         }
     }
-
+    /// Signals an activity event as having completed successfully.
+    /// Dependent actions will be executed (if all other dependencies
+    /// are satisfied).
     func completed(_ event: QueueEventType, error: Error? = nil) {
         mainQueue.ensureMainThread { [weak self] in
             guard let self else { return }
@@ -88,7 +90,9 @@ final class EventQueue<QueueEventType: Hashable> {
             self.processActions(for: event)
         }
     }
-
+    
+    /// Signals an activity event as having failed (completed with an error).
+    /// Dependent actions will not be executed.
     func failed(_ event: QueueEventType) {
         mainQueue.ensureMainThread { [weak self] in
             self?.signalledEvents[event] = .failed


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7662)

## :bulb: Description

Small addition to the Event Queue, this is something that wasn't identified during the [initial RFC](https://docs.google.com/document/d/185jXC9vcoJa6KXitFYLStSMTc2yXHoEmbCUgM-y9SLc/edit) but which I think will be useful.

### TL;DR

This extends the abstraction around events to allow them (optionally) to exist in a few sequential states. I think this will be useful for tracking the status of something like `Profile` syncing or tab restoration which can occur repeatedly. We have a lot of tasks throughout the codebase that go from Not Started -> In Progress -> Completed and this will allow those to be used more easily with the Event Queue.

The existing events as they were originally conceived still fit well within this model, they're simply marked as being in a `.completed` state.

### More Info (from Jira)

Throughout the app we have various tasks which can potentially be performed multiple times. These are not ideal use cases for the event queue based on how events are currently defined and would require something slightly more nuanced. An example is Profile syncing, which can happen both during launch and also multiple times during normal app usage

These types of activities almost always fall into one of 3 principal states, which makes them a good candidate for abstraction:

- Not started (the activity has never been performed)
- In progress (the activity has been started but isn’t finished)
- Completed (the activity has finished, either successfully or unsuccessfully)

The Not started state is always the initial default state for an activity; it is similar but distinct from Completed since we often want to e.g. wait for something like the Profile syncing to finish but aren’t necessarily sure whether it has already been attempted at least once or not.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

