### PR TITLE
Refactor FXIOS-7659 [v121] Remove SnapKit from ContentBlockerSettingViewController

### DIFF
--- a/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -134,10 +134,13 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
 
             defaultFooter.addSubview(button)
 
-            button.snp.makeConstraints { (make) in
-                make.top.equalTo(defaultFooter.titleLabel.snp.bottom)
-                make.leading.equalTo(defaultFooter.titleLabel)
-            }
+            button.translatesAutoresizingMaskIntoConstraints = false
+
+            NSLayoutConstraint.activate([
+                button.topAnchor.constraint(equalTo: defaultFooter.titleLabel.bottomAnchor),
+                button.leadingAnchor.constraint(equalTo: defaultFooter.titleLabel.leadingAnchor)
+            ])
+
             return defaultFooter
         }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7659)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17079)

## :bulb: Description
Remove SnapKit from ContentBlockerSettingViewController

<img width=330 src="https://github.com/mozilla-mobile/firefox-ios/assets/43574230/ad519f61-2ea8-44ae-9e12-91dc592d4a14"/>

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

