### PR TITLE
Refactor FXIOS-7606 [v121] [WIP] Early Event Queue integration

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -47,6 +47,12 @@
 		1D06AE6624FEE4D5000B092B /* TopSitesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D06AE6524FEE4D5000B092B /* TopSitesProvider.swift */; };
 		1D06AE6A24FEE8D6000B092B /* TabProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D06AE6924FEE8D6000B092B /* TabProvider.swift */; };
 		1D0BA05C24F46A0400D731B5 /* TopSitesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D0BA05B24F46A0400D731B5 /* TopSitesProvider.swift */; };
+		1D1933742AF2C8C8005089C9 /* EventQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D7B78962ADF32590011E9F2 /* EventQueue.swift */; };
+		1D1933752AF2C8C9005089C9 /* EventQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D7B78962ADF32590011E9F2 /* EventQueue.swift */; };
+		1D1933762AF2C8C9005089C9 /* EventQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D7B78962ADF32590011E9F2 /* EventQueue.swift */; };
+		1D1933772AF2C8CE005089C9 /* AppEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D7B78982ADF328E0011E9F2 /* AppEvent.swift */; };
+		1D1933782AF2C8CE005089C9 /* AppEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D7B78982ADF328E0011E9F2 /* AppEvent.swift */; };
+		1D1933792AF2C8CF005089C9 /* AppEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D7B78982ADF328E0011E9F2 /* AppEvent.swift */; };
 		1D2F68AB2ACB262900524B92 /* RemoteTabsPanelAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2F68AA2ACB262900524B92 /* RemoteTabsPanelAction.swift */; };
 		1D2F68AD2ACB266300524B92 /* RemoteTabsPanelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2F68AC2ACB266300524B92 /* RemoteTabsPanelState.swift */; };
 		1D2F68AF2ACB272500524B92 /* RemoteTabsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2F68AE2ACB272500524B92 /* RemoteTabsTableViewController.swift */; };
@@ -12342,7 +12348,9 @@
 				45355B232A269E7100B1EA8E /* Autopush.swift in Sources */,
 				45355B262A269EAC00B1EA8E /* PushConfiguration.swift in Sources */,
 				396E38CC1EE0816C00CC180F /* Profile.swift in Sources */,
+				1D1933792AF2C8CF005089C9 /* AppEvent.swift in Sources */,
 				396E38DD1EE081DA00CC180F /* SyncDisplayState.swift in Sources */,
+				1D1933762AF2C8C9005089C9 /* EventQueue.swift in Sources */,
 				6025B10E267B6C7F00F59F6B /* LoginRecordExtension.swift in Sources */,
 				396E38F21EE0C8ED00CC180F /* FxAPushMessageHandler.swift in Sources */,
 				F8A0B08329AD64790091C75B /* RustSyncManager.swift in Sources */,
@@ -12505,9 +12513,11 @@
 				60CE80C12667780D004026C7 /* CredentialListPresenter.swift in Sources */,
 				F80DF73F27034F6400E4C37D /* LegacyDynamicFontHelper.swift in Sources */,
 				6025B111267B6EE100F59F6B /* CredentialWelcomeViewController.swift in Sources */,
+				1D1933742AF2C8C8005089C9 /* EventQueue.swift in Sources */,
 				C87DF962267246730097E707 /* photon-colors.swift in Sources */,
 				6025B10A267B6BB300F59F6B /* SelectPasswordCell.swift in Sources */,
 				8AB8574127D9630E0075C173 /* LegacyTheme.swift in Sources */,
+				1D1933772AF2C8CE005089C9 /* AppEvent.swift in Sources */,
 				F8324B122649B707007E4BFA /* Profile.swift in Sources */,
 				F8324B262649B76E007E4BFA /* SyncDisplayState.swift in Sources */,
 				C87DF976267246830097E707 /* LegacyThemeManager.swift in Sources */,
@@ -13566,6 +13576,8 @@
 				E1CD81C0290C5C9800124B27 /* DevicePickerTableViewCell.swift in Sources */,
 				E1CD81BA290C4ED900124B27 /* AccessibilityIdentifiers.swift in Sources */,
 				E1CD81BF290C5C9500124B27 /* DevicePickerTableViewHeaderCell.swift in Sources */,
+				1D1933782AF2C8CE005089C9 /* AppEvent.swift in Sources */,
+				1D1933752AF2C8C9005089C9 /* EventQueue.swift in Sources */,
 				E41A7D4B1A1BE04500245963 /* InitialViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -97,6 +97,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                    level: .info,
                    category: .lifecycle)
 
+        // Establish event dependencies for startup flow
+        AppEventQueue.establishDependencies(for: .startupFlowComplete, against: [
+            .profileInitialized,
+            .preLaunchDependenciesComplete,
+            .postLaunchDependenciesComplete,
+            .accountManagerInitialized
+        ])
+
         // Then setup dependency container as it's needed for everything else
         DependencyHelper().bootstrapDependencies()
 

--- a/Client/Application/AppLaunchUtil.swift
+++ b/Client/Application/AppLaunchUtil.swift
@@ -71,6 +71,7 @@ class AppLaunchUtil {
 
         RustFirefoxAccounts.startup(prefs: profile.prefs).uponQueue(.main) { _ in
             self.logger.log("RustFirefoxAccounts started", level: .info, category: .sync)
+            AppEventQueue.signal(event: .accountManagerInitialized)
         }
 
         // Add swizzle on UIViewControllers to automatically log when there's a new view showing
@@ -86,6 +87,7 @@ class AppLaunchUtil {
         logger.log("Prefs for migration is \(String(describing: profile.prefs.boolForKey(PrefsKeys.TabMigrationKey)))",
                    level: .debug,
                    category: .tabs)
+        AppEventQueue.signal(event: .preLaunchDependenciesComplete)
     }
 
     func setUpPostLaunchDependencies() {
@@ -112,6 +114,7 @@ class AppLaunchUtil {
 
         updateSessionCount()
         adjustHelper.setupAdjust()
+        AppEventQueue.signal(event: .postLaunchDependenciesComplete)
     }
 
     private func setUserAgent() {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -424,8 +424,8 @@ class BrowserViewController: UIViewController,
         updateWallpaperMetadata()
 
         // When, for example, you "Load in Background" via the share sheet, the tab is added to `Profile`'s `TabQueue`.
-        // So, we delay five seconds because we need to wait for `Profile` to be initialized and setup for use.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) { [weak self] in
+        // Make sure that our startup flow is completed and the Profile has been sync'd (at least once) before we load.
+        AppEventQueue.wait(for: [.startupFlowComplete, .profileSyncing, .tabRestoration]) { [weak self] in
             self?.backgroundTabLoader.loadBackgroundTabs()
         }
     }

--- a/Client/Frontend/Browser/Event Queue/AppEvent.swift
+++ b/Client/Frontend/Browser/Event Queue/AppEvent.swift
@@ -4,9 +4,22 @@
 
 import Foundation
 
-protocol AppEventType: Hashable { }
+public protocol AppEventType: Hashable { }
 
-enum AppEvent: Int, AppEventType {
-    case tabRestoreHasFinished
+public enum AppEvent: Int, AppEventType {
+
+    // Events: Startup flow
+    case startupFlowComplete
+
+    // Sub-Events for Startup Flow
+    case profileInitialized
+    case preLaunchDependenciesComplete
+    case postLaunchDependenciesComplete
+    case accountManagerInitialized
+
+    // Activities: Profile Syncing
     case profileSyncing
+
+    // Activites: Tabs
+    case tabRestoration
 }

--- a/Client/Frontend/Browser/Event Queue/AppEvent.swift
+++ b/Client/Frontend/Browser/Event Queue/AppEvent.swift
@@ -7,7 +7,6 @@ import Foundation
 public protocol AppEventType: Hashable { }
 
 public enum AppEvent: Int, AppEventType {
-
     // Events: Startup flow
     case startupFlowComplete
 

--- a/Client/Frontend/Browser/Event Queue/EventQueue.swift
+++ b/Client/Frontend/Browser/Event Queue/EventQueue.swift
@@ -14,17 +14,17 @@ typealias ActionToken = UUID
 ///
 /// (Note: there is an additional implicit state, "not started", which is indicated
 /// by the event being absent from the event queue altogether.)
-enum QueueEventState: Int {
+public enum QueueEventState: Int {
     case inProgress
     case completed
     case failed
 }
 
 /// The default app-wide queue for Firefox.
-let AppEventQueue = EventQueue<AppEvent>()
+public let AppEventQueue = EventQueue<AppEvent>()
 
-final class EventQueue<QueueEventType: Hashable> {
-    struct EnqueuedAction {
+public final class EventQueue<QueueEventType: Hashable> {
+    public struct EnqueuedAction {
         let token: ActionToken
         let action: EventQueueAction
         let dependencies: [QueueEventType]
@@ -171,6 +171,20 @@ final class EventQueue<QueueEventType: Hashable> {
     func activityIsCompleted(_ event: QueueEventType) -> Bool {
         assert(Thread.isMainThread, "Expects to be called on the main thread.")
         return hasSignalled(event)
+    }
+
+    /// This function will automatically signal the parent event when all required sub-dependencies are
+    /// completed. This is simply a convenience for working with hierarchical or nested events.
+    ///
+    /// Example: our startup flow consists of multiple separate steps. All of these together are then part of
+    /// a parent event, .startupFlowComplete. Interested listeners can either depend on one or more individual
+    /// steps or they can listen for the parent event .startupFlowComplete. This allows relationships to be
+    /// easily created between different events.
+    func establishDependencies(for parentEvent: QueueEventType, against otherEvents: [QueueEventType]) {
+        wait(for: otherEvents, token: ActionToken()) { [weak self] in
+            self?.logger.log("DBG: All dependent events complete. Signalling parent event: \(parentEvent)", level: .info, category: .library)
+            self?.signal(event: parentEvent)
+        }
     }
 
     /// Used to cancel an enqueued action using the token that was provided when the action was enqueued.

--- a/Client/Frontend/Browser/Event Queue/EventQueue.swift
+++ b/Client/Frontend/Browser/Event Queue/EventQueue.swift
@@ -182,7 +182,6 @@ public final class EventQueue<QueueEventType: Hashable> {
     /// easily created between different events.
     func establishDependencies(for parentEvent: QueueEventType, against otherEvents: [QueueEventType]) {
         wait(for: otherEvents, token: ActionToken()) { [weak self] in
-            self?.logger.log("DBG: All dependent events complete. Signalling parent event: \(parentEvent)", level: .info, category: .library)
             self?.signal(event: parentEvent)
         }
     }

--- a/Client/TabManagement/TabManagerImplementation.swift
+++ b/Client/TabManagement/TabManagerImplementation.swift
@@ -291,9 +291,6 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
         }
     }
 
-    // FIXME: Had to add this temporarily to fix unit tests
-    var tabRestoreHasFinished: Bool = true
-
     private func saveAllTabData() {
         // Only preserve tabs after the restore has finished
         guard AppEventQueue.activityIsCompleted(.tabRestoration) else { return }

--- a/Client/TabManagement/TabManagerImplementation.swift
+++ b/Client/TabManagement/TabManagerImplementation.swift
@@ -100,6 +100,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
         defer {
             ensureMainThread { [weak self] in
                 self?.isRestoringTabs = false
+                self?.tabRestoreHasFinished = true
                 AppEventQueue.completed(.tabRestoration)
             }
         }
@@ -210,7 +211,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
 
     override func preserveTabs() {
         // Only preserve tabs after the restore has finished
-        guard AppEventQueue.activityIsCompleted(.tabRestoration) else { return }
+        guard tabRestoreHasFinished else { return }
 
         logger.log("Preserve tabs started", level: .debug, category: .tabs)
         preserveTabs(forced: false)
@@ -293,7 +294,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
 
     private func saveAllTabData() {
         // Only preserve tabs after the restore has finished
-        guard AppEventQueue.activityIsCompleted(.tabRestoration) else { return }
+        guard tabRestoreHasFinished else { return }
 
         saveCurrentTabSessionData()
         preserveTabs(forced: true)

--- a/Client/TabManagement/TabManagerImplementation.swift
+++ b/Client/TabManagement/TabManagerImplementation.swift
@@ -98,11 +98,9 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
 
     private func buildTabRestore(window: WindowData?) async {
         defer {
-            ensureMainThread { [weak self] in
-                self?.isRestoringTabs = false
-                self?.tabRestoreHasFinished = true
-                AppEventQueue.completed(.tabRestoration)
-            }
+            isRestoringTabs = false
+            tabRestoreHasFinished = true
+            AppEventQueue.completed(.tabRestoration)
         }
 
         let nonPrivateTabs = window?.tabData.filter { !$0.isPrivate }

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -318,6 +318,7 @@ open class BrowserProfile: Profile {
         if let downloadsPath = try? FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false).appendingPathComponent("Downloads").path {
             try? FileManager.default.createDirectory(atPath: downloadsPath, withIntermediateDirectories: true, attributes: nil)
         }
+        AppEventQueue.signal(event: .profileInitialized)
     }
 
     func reopen() {

--- a/Providers/RustSyncManager.swift
+++ b/Providers/RustSyncManager.swift
@@ -160,6 +160,7 @@ public class RustSyncManager: NSObject, SyncManager {
     private func beginSyncing() {
         syncDisplayState = .inProgress
         notifySyncing(notification: .ProfileDidStartSyncing)
+        AppEventQueue.started(.profileSyncing)
     }
 
     private func resolveSyncState(result: SyncResult) -> SyncDisplayState {
@@ -203,6 +204,7 @@ public class RustSyncManager: NSObject, SyncManager {
         // db access from happening
         if !backgrounded {
             notifySyncing(notification: .ProfileDidFinishSyncing)
+            AppEventQueue.completed(.profileSyncing)
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16919O)

## :bulb: Description

Some early work on actual integration of new Event Management Queue. Principal changes here:
- Signal events for key steps in the app launch flow, as well as `Profile` syncing and tab restoration
- A few minor updates to Event Queue, including adding support for nested events
- Get rid of delayed dispatch for background tab loading in favor of using event queue

👉  This is all part of a broader WIP refactoring effort, so aspects of this are still in flux and may be changing over time.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

