### PR TITLE
Bugfix MTE-1857 [v121] waitForInitialSyncComplete should not crash

### DIFF
--- a/SyncIntegrationTests/tps.py
+++ b/SyncIntegrationTests/tps.py
@@ -27,7 +27,7 @@ class TPS(object):
             'testing.tps.testPhase': phase,
             'testing.tps.ignoreUnusedEngines': ignore_unused_engines,
         })
-        args = ['-marionette']
+        args = ['-marionette','-headless']
         process_args = {'processOutputLine': [self._log]}
         self.logger.info('Running: {} {}'.format(self.firefox, ' '.join(args)))
         self.logger.info('Using profile at: {}'.format(self.profile.profile))

--- a/Tests/XCUITests/IntegrationTests.swift
+++ b/Tests/XCUITests/IntegrationTests.swift
@@ -97,7 +97,7 @@ class IntegrationTests: BaseTestCase {
         navigator.goto(BrowserTabMenu)
         navigator.goto(Intro_FxASignin)
         navigator.performAction(Action.OpenEmailToSignIn)
-        
+
         mozWaitForElementToExist(app.navigationBars[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaNavigationBar], timeout: TIMEOUT_LONG)
     }
 

--- a/Tests/XCUITests/IntegrationTests.swift
+++ b/Tests/XCUITests/IntegrationTests.swift
@@ -96,11 +96,7 @@ class IntegrationTests: BaseTestCase {
         navigator.goto(BrowserTabMenu)
         navigator.goto(Intro_FxASignin)
         navigator.performAction(Action.OpenEmailToSignIn)
-
-        mozWaitForElementToExist(app.navigationBars[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaNavigationBar], timeout: TIMEOUT_LONG)
-        mozWaitForElementToExist(app.webViews.staticTexts["Continue to Firefox accounts"], timeout: TIMEOUT_LONG)
-        mozWaitForElementToExist(app.webViews.textFields[AccessibilityIdentifiers.Settings.FirefoxAccount.emailTextField])
-        mozWaitForElementToExist(app.webViews.buttons[AccessibilityIdentifiers.Settings.FirefoxAccount.continueButton])
+        mozWaitForElementToExist(app.buttons["Sync and Save Data"])
     }
 
     func testFxASyncBookmark () {

--- a/Tests/XCUITests/IntegrationTests.swift
+++ b/Tests/XCUITests/IntegrationTests.swift
@@ -97,6 +97,7 @@ class IntegrationTests: BaseTestCase {
         navigator.goto(BrowserTabMenu)
         navigator.goto(Intro_FxASignin)
         navigator.performAction(Action.OpenEmailToSignIn)
+        
         mozWaitForElementToExist(app.navigationBars[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaNavigationBar], timeout: TIMEOUT_LONG)
     }
 
@@ -138,7 +139,7 @@ class IntegrationTests: BaseTestCase {
         mozWaitForElementToExist(app.tables.cells.element(boundBy: 1), timeout: 10)
         app.tables.cells.element(boundBy: 1).tap()
         mozWaitForElementToExist(app.cells["DeviceNameSetting"].textFields["DeviceNameSettingTextField"], timeout: 10)
-        XCTAssertEqual(app.cells["DeviceNameSetting"].textFields["DeviceNameSettingTextField"].value! as! String, "Fennec (cso) on iOS")
+        XCTAssertEqual(app.cells["DeviceNameSetting"].textFields["DeviceNameSettingTextField"].value! as! String, "Fennec (administrator) on iOS")
 
         // Sync again just to make sure to sync after new name is shown
         app.buttons["Settings"].tap()

--- a/Tests/XCUITests/IntegrationTests.swift
+++ b/Tests/XCUITests/IntegrationTests.swift
@@ -97,7 +97,7 @@ class IntegrationTests: BaseTestCase {
         navigator.goto(BrowserTabMenu)
         navigator.goto(Intro_FxASignin)
         navigator.performAction(Action.OpenEmailToSignIn)
-        mozWaitForElementToExist(app.buttons["Sync and Save Data"])
+        mozWaitForElementToExist(app.navigationBars[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaNavigationBar], timeout: TIMEOUT_LONG)
     }
 
     func testFxASyncBookmark () {

--- a/Tests/XCUITests/IntegrationTests.swift
+++ b/Tests/XCUITests/IntegrationTests.swift
@@ -69,6 +69,7 @@ class IntegrationTests: BaseTestCase {
 
     private func waitForInitialSyncComplete() {
         navigator.nowAt(BrowserTab)
+        waitForTabsButton()
         navigator.goto(SettingsScreen)
         mozWaitForElementToExist(app.staticTexts["ACCOUNT"], timeout: TIMEOUT_LONG)
         mozWaitForElementToNotExist(app.staticTexts["Sync and Save Data"])

--- a/Tests/XCUITests/IntegrationTests.swift
+++ b/Tests/XCUITests/IntegrationTests.swift
@@ -138,7 +138,7 @@ class IntegrationTests: BaseTestCase {
         mozWaitForElementToExist(app.tables.cells.element(boundBy: 1), timeout: 10)
         app.tables.cells.element(boundBy: 1).tap()
         mozWaitForElementToExist(app.cells["DeviceNameSetting"].textFields["DeviceNameSettingTextField"], timeout: 10)
-        XCTAssertEqual(app.cells["DeviceNameSetting"].textFields["DeviceNameSettingTextField"].value! as! String, "Fennec (administrator) on iOS")
+        XCTAssertEqual(app.cells["DeviceNameSetting"].textFields["DeviceNameSettingTextField"].value! as! String, "Fennec (cso) on iOS")
 
         // Sync again just to make sure to sync after new name is shown
         app.buttons["Settings"].tap()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1857)

## :bulb: Description
https://github.com/mozilla-mobile/firefox-ios/pull/17083 (and https://github.com/mozilla-mobile/firefox-ios/issues/16960) indicates that the settings page may be in an undesirable state.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

