### PR TITLE
Fix MTE-1858 [v121] testLongPressReload smoke test

### DIFF
--- a/Tests/XCUITests/DesktopModeTests.swift
+++ b/Tests/XCUITests/DesktopModeTests.swift
@@ -25,11 +25,14 @@ class DesktopModeTestsIpad: IpadOnlyTestCase {
         navigator.performAction(Action.ReloadURL)
         XCTAssert(app.webViews.staticTexts.matching(identifier: "MOBILE_UA").count > 0)
 
+        navigator.goto(TabTray)
+        navigator.goto(CloseTabMenu)
         navigator.performAction(Action.AcceptRemovingAllTabs)
+        waitUntilPageLoad()
 
         // Covering scenario that when closing a tab and re-opening should preserve Mobile mode
-        navigator.createNewTab()
         navigator.nowAt(NewTabScreen)
+        navigator.createNewTab()
         navigator.openURL(path(forTestPage: "test-user-agent.html"))
         waitUntilPageLoad()
         XCTAssert(app.webViews.staticTexts.matching(identifier: "MOBILE_UA").count > 0)
@@ -195,7 +198,10 @@ class DesktopModeTestsIphone: IphoneOnlyTestCase {
         navigator.performAction(Action.ReloadURL)
         XCTAssert(app.webViews.staticTexts.matching(identifier: "DESKTOP_UA").count > 0)
 
+        navigator.goto(TabTray)
+        navigator.goto(CloseTabMenu)
         navigator.performAction(Action.AcceptRemovingAllTabs)
+        waitUntilPageLoad()
         navigator.nowAt(NewTabScreen)
         // Covering scenario that when closing a tab and re-opening should preserve Desktop mode
         navigator.createNewTab()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1858)

## :bulb: Description
testLongPressReload keeps failing on our smoke checks runs. Fixed by adding the navigation until we actually reach the point where we accept the removal of the tabs. Locally the issue is not reproducing anymore. 
