### PR TITLE
Refactor MTE-1858 [v121] Workaround for testLongPressReload

### DIFF
--- a/Tests/XCUITests/DesktopModeTests.swift
+++ b/Tests/XCUITests/DesktopModeTests.swift
@@ -207,7 +207,7 @@ class DesktopModeTestsIphone: IphoneOnlyTestCase {
         // https://github.com/mozilla-mobile/firefox-ios/issues/16810
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.performAction(Action.CloseURLBarOpen)
-        
+
         navigator.performAction(Action.AcceptRemovingAllTabs)
         waitUntilPageLoad()
         navigator.nowAt(NewTabScreen)

--- a/Tests/XCUITests/DesktopModeTests.swift
+++ b/Tests/XCUITests/DesktopModeTests.swift
@@ -26,6 +26,8 @@ class DesktopModeTestsIpad: IpadOnlyTestCase {
         waitUntilPageLoad()
         XCTAssert(app.webViews.staticTexts.matching(identifier: "MOBILE_UA").count > 0)
 
+        // Workaround: Open a new tab before closing all tabs.
+        // https://github.com/mozilla-mobile/firefox-ios/issues/16810
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.performAction(Action.AcceptRemovingAllTabs)
         waitUntilPageLoad()
@@ -199,6 +201,8 @@ class DesktopModeTestsIphone: IphoneOnlyTestCase {
         waitUntilPageLoad()
         XCTAssert(app.webViews.staticTexts.matching(identifier: "DESKTOP_UA").count > 0)
 
+        // Workaround: Open a new tab before closing all tabs.
+        // https://github.com/mozilla-mobile/firefox-ios/issues/16810
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.performAction(Action.AcceptRemovingAllTabs)
         waitUntilPageLoad()

--- a/Tests/XCUITests/DesktopModeTests.swift
+++ b/Tests/XCUITests/DesktopModeTests.swift
@@ -29,6 +29,7 @@ class DesktopModeTestsIpad: IpadOnlyTestCase {
         // Workaround: Open a new tab before closing all tabs.
         // https://github.com/mozilla-mobile/firefox-ios/issues/16810
         navigator.performAction(Action.OpenNewTabFromTabTray)
+        navigator.performAction(Action.CloseURLBarOpen)
         navigator.performAction(Action.AcceptRemovingAllTabs)
         waitUntilPageLoad()
 
@@ -204,6 +205,7 @@ class DesktopModeTestsIphone: IphoneOnlyTestCase {
         // Workaround: Open a new tab before closing all tabs.
         // https://github.com/mozilla-mobile/firefox-ios/issues/16810
         navigator.performAction(Action.OpenNewTabFromTabTray)
+        navigator.performAction(Action.CloseURLBarOpen)
         navigator.performAction(Action.AcceptRemovingAllTabs)
         waitUntilPageLoad()
         navigator.nowAt(NewTabScreen)

--- a/Tests/XCUITests/DesktopModeTests.swift
+++ b/Tests/XCUITests/DesktopModeTests.swift
@@ -30,7 +30,7 @@ class DesktopModeTestsIpad: IpadOnlyTestCase {
         // https://github.com/mozilla-mobile/firefox-ios/issues/16810
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.performAction(Action.CloseURLBarOpen)
-        
+
         navigator.performAction(Action.AcceptRemovingAllTabs)
         waitUntilPageLoad()
 

--- a/Tests/XCUITests/DesktopModeTests.swift
+++ b/Tests/XCUITests/DesktopModeTests.swift
@@ -30,6 +30,7 @@ class DesktopModeTestsIpad: IpadOnlyTestCase {
         // https://github.com/mozilla-mobile/firefox-ios/issues/16810
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
 
         navigator.performAction(Action.AcceptRemovingAllTabs)
         waitUntilPageLoad()
@@ -207,6 +208,7 @@ class DesktopModeTestsIphone: IphoneOnlyTestCase {
         // https://github.com/mozilla-mobile/firefox-ios/issues/16810
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.performAction(Action.CloseURLBarOpen)
+        navigator.nowAt(NewTabScreen)
 
         navigator.performAction(Action.AcceptRemovingAllTabs)
         waitUntilPageLoad()

--- a/Tests/XCUITests/DesktopModeTests.swift
+++ b/Tests/XCUITests/DesktopModeTests.swift
@@ -30,6 +30,7 @@ class DesktopModeTestsIpad: IpadOnlyTestCase {
         // https://github.com/mozilla-mobile/firefox-ios/issues/16810
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.performAction(Action.CloseURLBarOpen)
+        
         navigator.performAction(Action.AcceptRemovingAllTabs)
         waitUntilPageLoad()
 
@@ -206,6 +207,7 @@ class DesktopModeTestsIphone: IphoneOnlyTestCase {
         // https://github.com/mozilla-mobile/firefox-ios/issues/16810
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.performAction(Action.CloseURLBarOpen)
+        
         navigator.performAction(Action.AcceptRemovingAllTabs)
         waitUntilPageLoad()
         navigator.nowAt(NewTabScreen)

--- a/Tests/XCUITests/DesktopModeTests.swift
+++ b/Tests/XCUITests/DesktopModeTests.swift
@@ -23,10 +23,10 @@ class DesktopModeTestsIpad: IpadOnlyTestCase {
 
         // Covering scenario that when reloading the page should preserve Desktop site
         navigator.performAction(Action.ReloadURL)
+        waitUntilPageLoad()
         XCTAssert(app.webViews.staticTexts.matching(identifier: "MOBILE_UA").count > 0)
 
-        navigator.goto(TabTray)
-        navigator.goto(CloseTabMenu)
+        navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.performAction(Action.AcceptRemovingAllTabs)
         waitUntilPageLoad()
 
@@ -196,10 +196,10 @@ class DesktopModeTestsIphone: IphoneOnlyTestCase {
 
         // Covering scenario that when reloading the page should preserve Desktop site
         navigator.performAction(Action.ReloadURL)
+        waitUntilPageLoad()
         XCTAssert(app.webViews.staticTexts.matching(identifier: "DESKTOP_UA").count > 0)
 
-        navigator.goto(TabTray)
-        navigator.goto(CloseTabMenu)
+        navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.performAction(Action.AcceptRemovingAllTabs)
         waitUntilPageLoad()
         navigator.nowAt(NewTabScreen)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1858)

## :bulb: Description
A reliable workaround for the smoke test `testLongPressReload()` is to open a new tab before closing all. I suggest we use a workaround in the meanwhile to prevent test failing intermittently. 😢 

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

