### PR TITLE
Refactor FXIOS-7596 [v121] Remove hasTabsToRestoreAtStartup

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -847,10 +847,6 @@ class BrowserViewController: UIViewController,
     }
 
     fileprivate func showRestoreTabsAlert() {
-        guard tabManager.hasTabsToRestoreAtStartup() else {
-            tabManager.selectTab(tabManager.addTab())
-            return
-        }
         let alert = UIAlertController.restoreTabsAlert(
             okayCallback: { _ in
                 let extra = [TelemetryWrapper.EventExtraKey.isRestoreTabsStarted.rawValue: true]

--- a/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -358,16 +358,11 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     // TODO: FXIOS-7596 Remove when moving the TabManager protocol to TabManagerImplementation
     func storeChanges() { fatalError("should never be called") }
 
-    func hasTabsToRestoreAtStartup() -> Bool {
-        return store.hasTabsToRestoreAtStartup
-    }
-
     func restoreTabs(_ forced: Bool = false) {
         defer { checkForSingleTab() }
         guard forced || tabs.isEmpty,
               !AppConstants.isRunningUITests,
-              !DebugSettingsBundleOptions.skipSessionRestore,
-              store.hasTabsToRestoreAtStartup
+              !DebugSettingsBundleOptions.skipSessionRestore
         else { return }
 
         isRestoringTabs = true

--- a/Client/TabManagement/Legacy/LegacyTabManagerStore.swift
+++ b/Client/TabManagement/Legacy/LegacyTabManagerStore.swift
@@ -9,7 +9,6 @@ import Shared
 
 protocol LegacyTabManagerStore {
     var isRestoringTabs: Bool { get }
-    var hasTabsToRestoreAtStartup: Bool { get }
     var tabs: [LegacySavedTab] { get }
 
     func restoreStartupTabs(clearPrivateTabs: Bool,
@@ -30,10 +29,6 @@ class LegacyTabManagerStoreImplementation: LegacyTabManagerStore, FeatureFlaggab
 
     var isRestoringTabs: Bool {
         return lockedForReading
-    }
-
-    var hasTabsToRestoreAtStartup: Bool {
-        return !tabs.isEmpty
     }
 
     // MARK: - Initializer

--- a/Client/TabManagement/TabManager.swift
+++ b/Client/TabManagement/TabManager.swift
@@ -43,7 +43,6 @@ protocol TabManager: AnyObject {
     func preserveTabs()
     func restoreTabs(_ forced: Bool)
     func startAtHomeCheck() -> Bool
-    func hasTabsToRestoreAtStartup() -> Bool
     func getTabForUUID(uuid: String) -> Tab?
     func getTabForURL(_ url: URL) -> Tab?
     func expireSnackbars()

--- a/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -97,10 +97,6 @@ class MockTabManager: TabManager {
         false
     }
 
-    func hasTabsToRestoreAtStartup() -> Bool {
-        return false
-    }
-
     func getTabForUUID(uuid: String) -> Tab? {
         return nil
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7596)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16900)

## :bulb: Description
I discovered that this check doesn't actually do anything since it's impossible for the app to have crashed last session and have zero tabs, there is always at least 1 tab.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

