### PR TITLE
Bugfix FXIOS-7498 [v119] Crash when adding icon to sync now setting 

### DIFF
--- a/Client/Frontend/Settings/Main/Account/SyncNowSetting.swift
+++ b/Client/Frontend/Settings/Main/Account/SyncNowSetting.swift
@@ -239,10 +239,11 @@ class SyncNowSetting: WithAccountSetting {
     }
 
     private func addAccessoryView(with image: UIImageView, to cell: UITableViewCell) {
-        accessoryViewContainer.addArrangedSubview(image)
-        accessoryViewContainer.addArrangedSubview(troubleshootButton)
-
-        cell.accessoryView = accessoryViewContainer
+        DispatchQueue.main.async {
+            self.accessoryViewContainer.addArrangedSubview(image)
+            self.accessoryViewContainer.addArrangedSubview(self.troubleshootButton)
+            cell.accessoryView = self.accessoryViewContainer
+        }
     }
 
     override func onClick(_ navigationController: UINavigationController?) {

--- a/Client/Frontend/Settings/Main/Account/SyncNowSetting.swift
+++ b/Client/Frontend/Settings/Main/Account/SyncNowSetting.swift
@@ -239,10 +239,11 @@ class SyncNowSetting: WithAccountSetting {
     }
 
     private func addAccessoryView(with image: UIImageView, to cell: UITableViewCell) {
-        DispatchQueue.main.async {
-            self.accessoryViewContainer.addArrangedSubview(image)
-            self.accessoryViewContainer.addArrangedSubview(self.troubleshootButton)
-            cell.accessoryView = self.accessoryViewContainer
+        DispatchQueue.main.async { [weak self] in
+            guard let troubleshootButton = self?.troubleshootButton else { return }
+            self?.accessoryViewContainer.addArrangedSubview(image)
+            self?.accessoryViewContainer.addArrangedSubview(troubleshootButton )
+            cell.accessoryView = self?.accessoryViewContainer
         }
     }
 

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -830,10 +830,17 @@ class SettingsTableViewController: ThemedTableViewController {
         if let setting = section[indexPath.row] {
             let cell = dequeueCellFor(indexPath: indexPath, setting: setting)
             setting.onConfigureCell(cell, theme: themeManager.currentTheme)
-            cell.applyTheme(theme: themeManager.currentTheme)
             return cell
         }
         return super.tableView(tableView, cellForRowAt: indexPath)
+    }
+
+    override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        let section = settings[indexPath.section]
+        if let setting = section[indexPath.row], let themedCell = cell as? ThemedTableViewCell {
+            setting.onConfigureCell(themedCell, theme: themeManager.currentTheme)
+            themedCell.applyTheme(theme: themeManager.currentTheme)
+        }
     }
 
     private func dequeueCellFor(indexPath: IndexPath, setting: Setting) -> ThemedTableViewCell {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7498)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16644)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
I was getting the PR ready for this crash but @lmarceau fixed the crash already in [FXIOS-7656](https://mozilla-hub.atlassian.net/browse/FXIOS-7656). This issue happens because of some race conditions and this PR only alleviates the effects until the refactor of the settings menu is started. Basically I added a delay when assigning the image so the cell has time to be drawn on screen and moved the theming part into the `willDisplay cell` method so that scrolling the settings menu won't ruin the layout anymore. There is still a bug that happens when you start a tap event but don't finish it, but unlike the other 2, it's not part of the usual flow a user makes when doing a sync and rather more of an edge case.
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

