### PR TITLE
Remove FXIOS-7664 [v121] Remove SwiftyJSON from NetworkUtils

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -495,6 +495,7 @@
 		6A5F591D28627C0100FABA92 /* TabManagerNavDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A5F591C28627C0100FABA92 /* TabManagerNavDelegateTests.swift */; };
 		6ACB550C28633860007A6ABD /* TabManagerNavDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ACB550B28633860007A6ABD /* TabManagerNavDelegate.swift */; };
 		6ADB651B285C03B100947EA4 /* DownloadHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ADB651A285C03B100947EA4 /* DownloadHelperTests.swift */; };
+		6F994AFD2AF56234008B8112 /* NetworkUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F994AFC2AF56234008B8112 /* NetworkUtilsTests.swift */; };
 		742A56391D80B54A00BDB803 /* PhotonActionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742A56381D80B54A00BDB803 /* PhotonActionSheet.swift */; };
 		742BD99E2A13AC9000BA6B15 /* OnboardingInstructionPopupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742BD99D2A13AC9000BA6B15 /* OnboardingInstructionPopupViewController.swift */; };
 		744B0FFE1B4F172E00100422 /* ToolbarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 744B0FFD1B4F172E00100422 /* ToolbarTests.swift */; };
@@ -4739,6 +4740,7 @@
 		6EF844BCAE6B25C7DD422FD8 /* my */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = my; path = my.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		6F26428FA7243D3005F5BD22 /* nn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nn; path = nn.lproj/HistoryPanel.strings; sourceTree = "<group>"; };
 		6F8E45CDB77B45E526B94406 /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bg; path = bg.lproj/ClearPrivateData.strings; sourceTree = "<group>"; };
+		6F994AFC2AF56234008B8112 /* NetworkUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkUtilsTests.swift; sourceTree = "<group>"; };
 		6FA74E93925DF4222B411650 /* gu-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "gu-IN"; path = "gu-IN.lproj/ClearHistoryConfirm.strings"; sourceTree = "<group>"; };
 		6FAC4AC9B5397399E498ECE5 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = "es.lproj/Default Browser.strings"; sourceTree = "<group>"; };
 		6FCE40009921CB4DB5086DFA /* es-MX */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-MX"; path = "es-MX.lproj/ClearPrivateData.strings"; sourceTree = "<group>"; };
@@ -10433,6 +10435,7 @@
 				E4E7EB6C1C4AED5E0094275D /* SupportUtilsTests.swift */,
 				28A6CE891AC082E200C1A2D4 /* UtilsTests.swift */,
 				C8C1880E287608BF00BF3735 /* DateExtensionsTests.swift */,
+				6F994AFC2AF56234008B8112 /* NetworkUtilsTests.swift */,
 			);
 			path = SharedTests;
 			sourceTree = "<group>";
@@ -12449,6 +12452,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6F994AFD2AF56234008B8112 /* NetworkUtilsTests.swift in Sources */,
 				28532BEB1C472015000072D9 /* UtilsTests.swift in Sources */,
 				28532BEA1C472008000072D9 /* DeferredTests.swift in Sources */,
 				5A292129295CA8A900242235 /* ThemableTests.swift in Sources */,

--- a/Shared/NetworkUtils.swift
+++ b/Shared/NetworkUtils.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import Network
-import SwiftyJSON
 
 public func makeURLSession(userAgent: String, configuration: URLSessionConfiguration, timeout: TimeInterval? = nil) -> URLSession {
     configuration.httpAdditionalHeaders = ["User-Agent": userAgent]
@@ -48,18 +47,13 @@ public enum JSONSerializeError: Error {
     case parseError
 }
 
-public func jsonResponse(fromData data: Data?) throws -> JSON {
+public func jsonResponse(fromData data: Data?) throws -> [String: Any]? {
     guard let data = data, !data.isEmpty else {
         throw JSONSerializeError.noData
     }
 
-    do {
-        let json = try JSON(data: data)
-        if json.isError() {
-            throw JSONSerializeError.parseError
-        }
-        return json
-    } catch {
-        throw(JSONSerializeError.parseError)
+    guard let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else {
+        throw JSONSerializeError.parseError
     }
+    return json
 }

--- a/Tests/SharedTests/NetworkUtilsTests.swift
+++ b/Tests/SharedTests/NetworkUtilsTests.swift
@@ -1,0 +1,73 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import XCTest
+@testable import Shared // Replace with your actual module name
+
+class NetworkUtilsTests: XCTestCase {
+    func testJsonResponseWithNilData() {
+        // 1. Given nil data
+        let data: Data? = nil
+
+        // 2. When
+        do {
+            _ = try jsonResponse(fromData: data)
+            XCTFail("Expected JSONSerializeError.noData to be thrown")
+        } catch let error as JSONSerializeError {
+            // 3. Then
+            XCTAssertEqual(error, JSONSerializeError.noData)
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testJsonResponseWithEmptyData() {
+        // Given empty data
+        let data = Data()
+
+        // When
+        do {
+            _ = try jsonResponse(fromData: data)
+            XCTFail("Expected JSONSerializeError.noData to be thrown")
+        } catch let error as JSONSerializeError {
+            // Then
+            XCTAssertEqual(error, JSONSerializeError.noData)
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testJsonResponseWithInvalidJson() {
+        // Given invalid JSON data
+        let invalidJsonData = "invalid json".data(using: .utf8)!
+
+        // When
+        do {
+            _ = try jsonResponse(fromData: invalidJsonData)
+            XCTFail("Expected JSONSerializeError.parseError to be thrown")
+        } catch let error as JSONSerializeError {
+            // Then
+            XCTAssertEqual(error, JSONSerializeError.parseError)
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testJsonResponseWithValidJson() {
+        // Given valid JSON data
+        let validJson = "{\"key\":\"value\"}"
+        let validJsonData = validJson.data(using: .utf8)!
+
+        // When
+        do {
+            let json = try jsonResponse(fromData: validJsonData)
+            // Then
+            XCTAssertNotNil(json)
+            XCTAssertEqual(json?["key"] as? String, "value")
+        } catch {
+            XCTFail("No error should have been thrown, but got \(error)")
+        }
+    }
+}

--- a/Tests/SharedTests/NetworkUtilsTests.swift
+++ b/Tests/SharedTests/NetworkUtilsTests.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 import XCTest
-@testable import Shared // Replace with your actual module name
+@testable import Shared
 
 class NetworkUtilsTests: XCTestCase {
     func testJsonResponseWithNilData() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7664)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17097)

## :bulb: Description
Removes SwiftyJSON from NetworkUtils.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

