### PR TITLE
Refactor FXIOS-7641 [v121] Refactor findAndHandle(route:)

### DIFF
--- a/Client/Coordinators/BaseCoordinator.swift
+++ b/Client/Coordinators/BaseCoordinator.swift
@@ -39,9 +39,7 @@ open class BaseCoordinator: NSObject, Coordinator {
         return false
     }
 
-    func handle(route: Route) { 
-        // Concrete subclasses can override.
-    }
+    func handle(route: Route) { }
 
     @discardableResult
     func findAndHandle(route: Route) -> Coordinator? {

--- a/Client/Coordinators/BaseCoordinator.swift
+++ b/Client/Coordinators/BaseCoordinator.swift
@@ -25,13 +25,6 @@ open class BaseCoordinator: NSObject, Coordinator {
 
     func add(child coordinator: Coordinator) {
         childCoordinators.append(coordinator)
-
-        // Check first whether, during the recursive findAndHandle(route:), we have just added
-        // new children to this coordinator. If so, we want to skip dismissal (we shouldn't ever
-        // immediately dismiss coordinators that were just added and about to appear).
-        // Will be removed as part of larger refactors in [FXIOS-7641].
-        coordinator.newlyAdded = true
-        mainQueue.async { [weak coordinator] in coordinator?.newlyAdded = false }
     }
 
     func remove(child coordinator: Coordinator?) {
@@ -42,8 +35,12 @@ open class BaseCoordinator: NSObject, Coordinator {
         childCoordinators.remove(at: index)
     }
 
-    func handle(route: Route) -> Bool {
+    func canHandle(route: Route) -> Bool {
         return false
+    }
+
+    func handle(route: Route) { 
+        // Concrete subclasses can override.
     }
 
     @discardableResult
@@ -51,30 +48,32 @@ open class BaseCoordinator: NSObject, Coordinator {
         // If the app crashed last session then we abandon the deeplink
         guard !logger.crashedLastLaunch else { return nil }
 
+        guard let matchingCoordinator = find(route: route) else { return nil }
+
+        // Dismiss any child of the matching coordinator that handles a route
+        for child in matchingCoordinator.childCoordinators {
+            guard child.isDismissable else { continue }
+
+            matchingCoordinator.router.dismiss()
+            matchingCoordinator.remove(child: child)
+        }
+
+        matchingCoordinator.handle(route: route)
+        return matchingCoordinator
+    }
+
+    @discardableResult
+    func find(route: Route) -> Coordinator? {
         // Check if the current coordinator can handle the route.
-        if handle(route: route) {
+        if canHandle(route: route) {
             savedRoute = nil
             return self
         }
 
         // If not, recursively search through child coordinators.
         for childCoordinator in childCoordinators {
-            if let matchingCoordinator = childCoordinator.findAndHandle(route: route) {
+            if let matchingCoordinator = childCoordinator.find(route: route) {
                 savedRoute = nil
-
-                // Dismiss any child of the matching coordinator that handles a route
-                for child in matchingCoordinator.childCoordinators {
-                    guard child.isDismissable else { continue }
-
-                    // Check first whether, during the recursive findAndHandle(route:), we have just added
-                    // this child to the coordinator. If so, we want to skip dismissal (we shouldn't ever
-                    // immediately dismiss coordinators that were just added and about to appear).
-                    // Will be removed as part of larger refactors in [FXIOS-7641].
-                    guard !child.newlyAdded else { continue }
-
-                    matchingCoordinator.router.dismiss()
-                    matchingCoordinator.remove(child: child)
-                }
 
                 return matchingCoordinator
             }

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -160,7 +160,7 @@ class BrowserCoordinator: BaseCoordinator,
 
     // MARK: - Route handling
 
-    override func handle(route: Route) -> Bool {
+    override func canHandle(route: Route) -> Bool {
         guard browserIsReady, !tabManager.isRestoringTabs else {
             let readyMessage = "browser is ready? \(browserIsReady)"
             let restoringMessage = "is restoring tabs? \(tabManager.isRestoringTabs)"
@@ -170,46 +170,65 @@ class BrowserCoordinator: BaseCoordinator,
             return false
         }
 
+        switch route {
+        case .searchQuery:
+            return true
+        case .search:
+            return true
+        case .searchURL:
+            return true
+        case .glean:
+            return true
+        case .homepanel:
+            return true
+        case let .settings(section):
+            return canHandleSettings(with: section)
+        case .action:
+           return true
+        case .fxaSignIn:
+            return true
+        case .defaultBrowser:
+            return true
+        }
+    }
+
+    override func handle(route: Route) {
+        guard browserIsReady, !tabManager.isRestoringTabs else {
+            return
+        }
+
         logger.log("Handling a route", level: .info, category: .coordinator)
         switch route {
         case let .searchQuery(query):
             handle(query: query)
-            return true
 
         case let .search(url, isPrivate, options):
             handle(url: url, isPrivate: isPrivate, options: options)
-            return true
 
         case let .searchURL(url, tabId):
             handle(searchURL: url, tabId: tabId)
-            return true
 
         case let .glean(url):
             glean.handleDeeplinkUrl(url: url)
-            return true
 
         case let .homepanel(section):
             handle(homepanelSection: section)
-            return true
 
         case let .settings(section):
-            return handleSettings(with: section)
+            handleSettings(with: section)
 
         case let .action(routeAction):
             switch routeAction {
             case .closePrivateTabs:
                 handleClosePrivateTabs()
-                return true
             case .showQRCode:
                 handleQRCode()
-                return true
             case .showIntroOnboarding:
-                return showIntroOnboarding()
+                showIntroOnboarding()
             }
 
         case let .fxaSignIn(params):
             handle(fxaParams: params)
-            return true
 
         case let .defaultBrowser(section):
             switch section {
@@ -218,15 +237,13 @@ class BrowserCoordinator: BaseCoordinator,
             case .tutorial:
                 startLaunch(with: .defaultBrowser)
             }
-            return true
         }
     }
 
-    private func showIntroOnboarding() -> Bool {
+    private func showIntroOnboarding() {
         let introManager = IntroScreenManager(prefs: profile.prefs)
         let launchType = LaunchType.intro(manager: introManager)
         startLaunch(with: launchType)
-        return true
     }
 
     private func handleQRCode() {
@@ -272,11 +289,18 @@ class BrowserCoordinator: BaseCoordinator,
         browserViewController.presentSignInViewController(fxaParams)
     }
 
-    private func handleSettings(with section: Route.SettingsSection) -> Bool {
+
+    private func canHandleSettings(with section: Route.SettingsSection) -> Bool {
         guard !childCoordinators.contains(where: { $0 is SettingsCoordinator}) else {
             return false // route is handled with existing child coordinator
         }
+        return true
+    }
 
+    private func handleSettings(with section: Route.SettingsSection) {
+        guard !childCoordinators.contains(where: { $0 is SettingsCoordinator}) else {
+            return // route is handled with existing child coordinator
+        }
         let navigationController = ThemedNavigationController()
         let isPad = UIDevice.current.userInterfaceIdiom == .pad
         let modalPresentationStyle: UIModalPresentationStyle = isPad ? .fullScreen: .formSheet
@@ -291,7 +315,6 @@ class BrowserCoordinator: BaseCoordinator,
         router.present(navigationController) { [weak self] in
             self?.didFinishSettings(from: settingsCoordinator)
         }
-        return true
     }
 
     private func showLibrary(with homepanelSection: Route.HomepanelSection) {

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -171,24 +171,10 @@ class BrowserCoordinator: BaseCoordinator,
         }
 
         switch route {
-        case .searchQuery:
-            return true
-        case .search:
-            return true
-        case .searchURL:
-            return true
-        case .glean:
-            return true
-        case .homepanel:
+        case .searchQuery, .search, .searchURL, .glean, .homepanel, .action, .fxaSignIn, .defaultBrowser:
             return true
         case let .settings(section):
-            return canHandleSettings(with: section)
-        case .action:
-           return true
-        case .fxaSignIn:
-            return true
-        case .defaultBrowser:
-            return true
+            return canHandleSettings(with: section)        
         }
     }
 

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -275,7 +275,6 @@ class BrowserCoordinator: BaseCoordinator,
         browserViewController.presentSignInViewController(fxaParams)
     }
 
-
     private func canHandleSettings(with section: Route.SettingsSection) -> Bool {
         guard !childCoordinators.contains(where: { $0 is SettingsCoordinator}) else {
             return false // route is handled with existing child coordinator

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -174,7 +174,7 @@ class BrowserCoordinator: BaseCoordinator,
         case .searchQuery, .search, .searchURL, .glean, .homepanel, .action, .fxaSignIn, .defaultBrowser:
             return true
         case let .settings(section):
-            return canHandleSettings(with: section)        
+            return canHandleSettings(with: section)
         }
     }
 
@@ -373,14 +373,14 @@ class BrowserCoordinator: BaseCoordinator,
     }
 
     func settingsOpenPage(settings: Route.SettingsSection) {
-        _ = handleSettings(with: settings)
+        handleSettings(with: settings)
     }
 
     // MARK: - BrowserNavigationHandler
 
     func show(settings: Route.SettingsSection) {
         presentWithModalDismissIfNeeded {
-            _ = self.handleSettings(with: settings)
+            self.handleSettings(with: settings)
         }
     }
 

--- a/Client/Coordinators/Coordinator.swift
+++ b/Client/Coordinators/Coordinator.swift
@@ -10,7 +10,6 @@ protocol Coordinator: AnyObject {
     var childCoordinators: [Coordinator] { get }
     var router: Router { get }
     var logger: Logger { get }
-    var newlyAdded: Bool { get set }
 
     /// Determines whether this coordinator can be dismissed or not, in some cases the coordinator cannot be dismissed for example due to state saving.
     /// This isn't ideal for this pattern, but was deemed necessary to keep existing behavior while moving away from previous pattern. By default, all coordinators
@@ -20,18 +19,25 @@ protocol Coordinator: AnyObject {
     /// Will hold the Route the coordinator was asked to navigate to in case the path could not be handled yet.
     var savedRoute: Route? { get set }
 
-    /// Handle the Route, this is implemented by each coordinator for Route they will handle.
-    /// When the coordinator cannot handle this particular Route, it returns false.
+    /// Handle the Route, if able. This is implemented by each coordinator for Route they will handle.
     /// - Parameter route: The Route to navigate to
-    /// - Returns: True when the Route was handled
-    func handle(route: Route) -> Bool
+    func handle(route: Route)
 
-    /// Finds a coordinator that can handle a given route by recursively searching through the current coordinator's child coordinators.
+    /// When the coordinator cannot handle this particular Route, it returns false.
+    /// - Parameter route: The Route to navigate to.
+    /// - Returns: true if the route can be handled.
+    func canHandle(route: Route) -> Bool
+    
+    /// Searches for a coordinator to handle the given route by recursively checking `canHandle()` of all
+    /// child coordinators.
     /// - Parameter route: The route to find a matching coordinator for.
-    /// - Returns: An optional `Coordinator` instance that can handle the given `route`, or `nil` if no such coordinator was found.
-    ///
-    /// - DiscardableResult: The result of this method is marked as `@discardableResult` because the caller may choose not to use the returned
-    /// `Coordinator` instance, which is safe to do.
+    /// - Returns: A `Coordinator` that can handle the given `route`, or `nil` if none found.
+    @discardableResult
+    func find(route: Route) -> Coordinator?
+
+    /// Convenience. Calls into `find()` to identify the `Coordinator` to handle a route, and then
+    /// subsequently calls into `handle()` to perform the relevant actions on that route. Note that
+    /// prior to handling the route any children coordinators will be dismissed.
     @discardableResult
     func findAndHandle(route: Route) -> Coordinator?
 

--- a/Client/Coordinators/Coordinator.swift
+++ b/Client/Coordinators/Coordinator.swift
@@ -27,7 +27,7 @@ protocol Coordinator: AnyObject {
     /// - Parameter route: The Route to navigate to.
     /// - Returns: true if the route can be handled.
     func canHandle(route: Route) -> Bool
-    
+
     /// Searches for a coordinator to handle the given route by recursively checking `canHandle()` of all
     /// child coordinators.
     /// - Parameter route: The route to find a matching coordinator for.

--- a/Client/Coordinators/Scene/SceneCoordinator.swift
+++ b/Client/Coordinators/Scene/SceneCoordinator.swift
@@ -34,7 +34,7 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
         router.push(launchScreenVC, animated: false)
     }
 
-    override func canHandle(route: Route) -> Bool{
+    override func canHandle(route: Route) -> Bool {
         switch route {
         case .action(action: .showIntroOnboarding):
             return canShowIntroOnboarding()

--- a/Client/Coordinators/Scene/SceneCoordinator.swift
+++ b/Client/Coordinators/Scene/SceneCoordinator.swift
@@ -34,24 +34,37 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
         router.push(launchScreenVC, animated: false)
     }
 
-    override func handle(route: Route) -> Bool {
+    override func canHandle(route: Route) -> Bool{
         switch route {
         case .action(action: .showIntroOnboarding):
-            return showIntroOnboardingIfNeeded()
+            return canShowIntroOnboarding()
         default:
             return false
         }
     }
 
-    private func showIntroOnboardingIfNeeded() -> Bool {
+    override func handle(route: Route) {
+        switch route {
+        case .action(action: .showIntroOnboarding):
+            showIntroOnboardingIfNeeded()
+        default:
+            break
+        }
+    }
+
+    private func canShowIntroOnboarding() -> Bool {
+        let profile: Profile = AppContainer.shared.resolve()
+        let introManager = IntroScreenManager(prefs: profile.prefs)
+        let launchType = LaunchType.intro(manager: introManager)
+        return launchType.canLaunch(fromType: .SceneCoordinator)
+    }
+
+    private func showIntroOnboardingIfNeeded() {
         let profile: Profile = AppContainer.shared.resolve()
         let introManager = IntroScreenManager(prefs: profile.prefs)
         let launchType = LaunchType.intro(manager: introManager)
         if launchType.canLaunch(fromType: .SceneCoordinator) {
             startLaunch(with: launchType)
-            return true
-        } else {
-            return false
         }
     }
 

--- a/Client/Coordinators/SettingsCoordinator.swift
+++ b/Client/Coordinators/SettingsCoordinator.swift
@@ -57,13 +57,21 @@ class SettingsCoordinator: BaseCoordinator,
         }
     }
 
-    override func handle(route: Route) -> Bool {
+    override func canHandle(route: Route) -> Bool {
         switch route {
-        case let .settings(section):
-            start(with: section)
+        case .settings:
             return true
         default:
             return false
+        }
+    }
+
+    override func handle(route: Route) {
+        switch route {
+        case let .settings(section):
+            start(with: section)
+        default:
+            break
         }
     }
 

--- a/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -302,7 +302,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         subject.browserViewController = mbvc
         subject.browserHasLoaded()
 
-        let result = subject.handle(route: .searchQuery(query: query))
+        let result = testCanHandleAndHandle(subject, route: .searchQuery(query: query))
 
         XCTAssertTrue(result)
         XCTAssertTrue(mbvc.handleQueryCalled)
@@ -316,9 +316,9 @@ final class BrowserCoordinatorTests: XCTestCase {
         subject.browserViewController = mbvc
         subject.browserHasLoaded()
 
-        let result = subject.handle(route: .search(url: URL(string: "https://example.com")!,
-                                                   isPrivate: false,
-                                                   options: nil))
+        let result = testCanHandleAndHandle(subject, route: .search(url: URL(string: "https://example.com")!,
+                                                                    isPrivate: false,
+                                                                    options: nil))
 
         XCTAssertTrue(result)
         XCTAssertTrue(mbvc.switchToTabForURLOrOpenCalled)
@@ -332,9 +332,9 @@ final class BrowserCoordinatorTests: XCTestCase {
         subject.browserViewController = mbvc
         subject.browserHasLoaded()
 
-        let result = subject.handle(route: .search(url: URL(string: "https://example.com")!,
-                                                   isPrivate: false,
-                                                   options: [.switchToNormalMode]))
+        let result = testCanHandleAndHandle(subject, route: .search(url: URL(string: "https://example.com")!,
+                                                                    isPrivate: false,
+                                                                    options: [.switchToNormalMode]))
 
         XCTAssertTrue(result)
         XCTAssertTrue(mbvc.switchToPrivacyModeCalled)
@@ -350,7 +350,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         subject.browserViewController = mbvc
         subject.browserHasLoaded()
 
-        let result = subject.handle(route: .search(url: nil, isPrivate: false))
+        let result = testCanHandleAndHandle(subject, route: .search(url: nil, isPrivate: false))
 
         XCTAssertTrue(result)
         XCTAssertTrue(mbvc.openBlankNewTabCalled)
@@ -364,7 +364,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         subject.browserViewController = mbvc
         subject.browserHasLoaded()
 
-        let result = subject.handle(route: .searchURL(url: URL(string: "https://example.com")!, tabId: "1234"))
+        let result = testCanHandleAndHandle(subject, route: .searchURL(url: URL(string: "https://example.com")!, tabId: "1234"))
 
         XCTAssertTrue(result)
         XCTAssertTrue(mbvc.switchToTabForURLOrOpenCalled)
@@ -378,7 +378,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         subject.browserViewController = mbvc
         subject.browserHasLoaded()
 
-        let result = subject.handle(route: .searchURL(url: nil, tabId: "1234"))
+        let result = testCanHandleAndHandle(subject, route: .searchURL(url: nil, tabId: "1234"))
 
         XCTAssertTrue(result)
         XCTAssertTrue(mbvc.openBlankNewTabCalled)
@@ -394,7 +394,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         subject.browserViewController = mbvc
         subject.browserHasLoaded()
 
-        let result = subject.handle(route: .homepanel(section: .bookmarks))
+        let result = testCanHandleAndHandle(subject, route: .homepanel(section: .bookmarks))
 
         XCTAssertTrue(result)
         XCTAssertTrue(mbvc.showLibraryCalled)
@@ -408,7 +408,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         subject.browserViewController = mbvc
         subject.browserHasLoaded()
 
-        let result = subject.handle(route: .homepanel(section: .history))
+        let result = testCanHandleAndHandle(subject, route: .homepanel(section: .history))
 
         XCTAssertTrue(result)
         XCTAssertTrue(mbvc.showLibraryCalled)
@@ -422,7 +422,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         subject.browserViewController = mbvc
         subject.browserHasLoaded()
 
-        let result = subject.handle(route: .homepanel(section: .readingList))
+        let result = testCanHandleAndHandle(subject, route: .homepanel(section: .readingList))
 
         XCTAssertTrue(result)
         XCTAssertTrue(mbvc.showLibraryCalled)
@@ -436,7 +436,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         subject.browserViewController = mbvc
         subject.browserHasLoaded()
 
-        let result = subject.handle(route: .homepanel(section: .downloads))
+        let result = testCanHandleAndHandle(subject, route: .homepanel(section: .downloads))
 
         XCTAssertTrue(result)
         XCTAssertTrue(mbvc.showLibraryCalled)
@@ -452,7 +452,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         subject.browserHasLoaded()
 
         // When
-        let result = subject.handle(route: .homepanel(section: .topSites))
+        let result = testCanHandleAndHandle(subject, route: .homepanel(section: .topSites))
 
         // Then
         XCTAssertTrue(result)
@@ -469,7 +469,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         subject.browserHasLoaded()
 
         // When
-        let result = subject.handle(route: .search(url: nil, isPrivate: true))
+        let result = testCanHandleAndHandle(subject, route: .search(url: nil, isPrivate: true))
 
         // Then
         XCTAssertTrue(result)
@@ -486,7 +486,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         subject.browserHasLoaded()
 
         // When
-        let result = subject.handle(route: .search(url: nil, isPrivate: false))
+        let result = testCanHandleAndHandle(subject, route: .search(url: nil, isPrivate: false))
 
         // Then
         XCTAssertTrue(result)
@@ -502,7 +502,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         let subject = createSubject()
         subject.browserHasLoaded()
 
-        let result = subject.handle(route: route)
+        let result = testCanHandleAndHandle(subject, route: route)
 
         XCTAssertTrue(result)
         XCTAssertEqual(applicationHelper.openSettingsCalled, 1)
@@ -513,7 +513,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         let subject = createSubject()
         subject.browserHasLoaded()
 
-        let result = subject.handle(route: route)
+        let result = testCanHandleAndHandle(subject, route: route)
 
         XCTAssertTrue(result)
         XCTAssertNotNil(mockRouter.presentedViewController as? DefaultBrowserOnboardingViewController)
@@ -530,7 +530,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         let subject = createSubject()
         subject.browserHasLoaded()
 
-        let result = subject.handle(route: route)
+        let result = testCanHandleAndHandle(subject, route: route)
 
         XCTAssertTrue(result)
         XCTAssertEqual(glean.handleDeeplinkUrlCalled, 1)
@@ -544,7 +544,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         let subject = createSubject()
         subject.browserHasLoaded()
 
-        let result = subject.handle(route: route)
+        let result = testCanHandleAndHandle(subject, route: route)
 
         XCTAssertTrue(result)
         let presentedVC = try XCTUnwrap(mockRouter.presentedViewController as? ThemedNavigationController)
@@ -556,7 +556,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         let subject = createSubject()
         subject.browserHasLoaded()
 
-        let result = subject.handle(route: .settings(section: .general))
+        let result = testCanHandleAndHandle(subject, route: .settings(section: .general))
 
         XCTAssertTrue(result)
         XCTAssertEqual(subject.childCoordinators.count, 1)
@@ -567,8 +567,8 @@ final class BrowserCoordinatorTests: XCTestCase {
         let subject = createSubject()
         subject.browserHasLoaded()
 
-        let result1 = subject.handle(route: .settings(section: .general))
-        let result2 = subject.handle(route: .settings(section: .general))
+        let result1 = testCanHandleAndHandle(subject, route: .settings(section: .general))
+        let result2 = testCanHandleAndHandle(subject, route: .settings(section: .general))
 
         XCTAssertTrue(result1)
         XCTAssertEqual(subject.childCoordinators.count, 1)
@@ -580,7 +580,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         let subject = createSubject()
         subject.browserHasLoaded()
 
-        let result = subject.handle(route: .settings(section: .general))
+        let result = testCanHandleAndHandle(subject, route: .settings(section: .general))
         mockRouter.savedCompletion?()
 
         XCTAssertTrue(result)
@@ -604,7 +604,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         let subject = createSubject()
         subject.browserHasLoaded()
 
-        let result = subject.handle(route: .settings(section: .general))
+        let result = testCanHandleAndHandle(subject, route: .settings(section: .general))
         let settingsCoordinator = subject.childCoordinators[0] as! SettingsCoordinator
         subject.didFinishSettings(from: settingsCoordinator)
 
@@ -647,7 +647,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         // When
         let params = FxALaunchParams(entrypoint: .fxaDeepLinkNavigation,
                                      query: ["signin": "coolcodes", "user": "foo", "email": "bar"])
-        let result = subject.handle(route: .fxaSignIn(params: params))
+        let result = testCanHandleAndHandle(subject, route: .fxaSignIn(params: params))
 
         // Then
         XCTAssertTrue(result)
@@ -667,7 +667,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         subject.browserHasLoaded()
 
         // When
-        let result = subject.handle(route: .action(action: .showQRCode))
+        let result = testCanHandleAndHandle(subject, route: .action(action: .showQRCode))
 
         // Then
         XCTAssertTrue(result)
@@ -682,7 +682,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         subject.browserHasLoaded()
 
         // When
-        let result = subject.handle(route: .action(action: .closePrivateTabs))
+        let result = testCanHandleAndHandle(subject, route: .action(action: .closePrivateTabs))
 
         // Then
         XCTAssertTrue(result)
@@ -693,7 +693,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         let subject = createSubject()
         subject.browserHasLoaded()
 
-        let result = subject.handle(route: .action(action: .showIntroOnboarding))
+        let result = testCanHandleAndHandle(subject, route: .action(action: .showIntroOnboarding))
 
         XCTAssertTrue(result)
         XCTAssertEqual(subject.childCoordinators.count, 1)
@@ -865,5 +865,11 @@ final class BrowserCoordinatorTests: XCTestCase {
 
         trackForMemoryLeaks(subject, file: file, line: line)
         return subject
+    }
+
+    private func testCanHandleAndHandle(_ subject: Coordinator, route: Route) -> Bool {
+        let result = subject.canHandle(route: route)
+        subject.handle(route: route)
+        return result
     }
 }

--- a/Tests/ClientTests/Coordinators/SceneCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/SceneCoordinatorTests.swift
@@ -126,7 +126,7 @@ final class SceneCoordinatorTests: XCTestCase {
     func testHandleShowOnboarding_returnsTrueAndShowsOnboarding() {
         let subject = createSubject()
 
-        let result = subject.handle(route: .action(action: .showIntroOnboarding))
+        let result = testCanHandleAndHandle(subject, route: .action(action: .showIntroOnboarding))
 
         XCTAssertTrue(result)
         XCTAssertEqual(subject.childCoordinators.count, 1)
@@ -142,5 +142,11 @@ final class SceneCoordinatorTests: XCTestCase {
         subject.router = mockRouter
         trackForMemoryLeaks(subject, file: file, line: line)
         return subject
+    }
+
+    private func testCanHandleAndHandle(_ subject: Coordinator, route: Route) -> Bool {
+        let result = subject.canHandle(route: route)
+        subject.handle(route: route)
+        return result
     }
 }

--- a/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
+++ b/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
@@ -294,7 +294,7 @@ final class SettingsCoordinatorTests: XCTestCase {
     func testHandleRouteSettings_generalIsHandled() {
         let subject = createSubject()
 
-        let result = subject.handle(route: .settings(section: .general))
+        let result = testCanHandleAndHandle(subject, route: .settings(section: .general))
 
         XCTAssertTrue(result)
     }
@@ -302,7 +302,7 @@ final class SettingsCoordinatorTests: XCTestCase {
     func testHandleRouteOther_notHandled() {
         let subject = createSubject()
 
-        let result = subject.handle(route: .homepanel(section: .downloads))
+        let result = testCanHandleAndHandle(subject, route: .homepanel(section: .downloads))
 
         XCTAssertFalse(result)
     }
@@ -519,6 +519,12 @@ final class SettingsCoordinatorTests: XCTestCase {
                                           wallpaperManager: wallpaperManager)
         trackForMemoryLeaks(subject)
         return subject
+    }
+
+    private func testCanHandleAndHandle(_ subject: Coordinator, route: Route) -> Bool {
+        let result = subject.canHandle(route: route)
+        subject.handle(route: route)
+        return result
     }
 }
 

--- a/Tests/ClientTests/Mocks/MockCoordinator.swift
+++ b/Tests/ClientTests/Mocks/MockCoordinator.swift
@@ -13,11 +13,10 @@ class MockCoordinator: Coordinator {
     var savedRoute: Route?
     var logger: Logger = MockLogger()
     var isDismissable = true
-    var newlyAdded = false
 
     var addChildCalled = 0
     var removedChildCalled = 0
-    var handleRouteCalled = 0
+    var canHandleRouteCalled = 0
     var findRouteCalled = 0
 
     init(router: MockRouter) {
@@ -32,9 +31,15 @@ class MockCoordinator: Coordinator {
         removedChildCalled += 1
     }
 
-    func handle(route: Route) -> Bool {
-        handleRouteCalled += 1
+    func canHandle(route: Route) -> Bool {
+        canHandleRouteCalled += 1
         return false
+    }
+
+    func handle(route: Route) { }
+
+    func find(route: Route) -> Coordinator? {
+        return nil
     }
 
     @discardableResult

--- a/Tests/ClientTests/Mocks/MockSearchHandlerRouteCoordinator.swift
+++ b/Tests/ClientTests/Mocks/MockSearchHandlerRouteCoordinator.swift
@@ -15,7 +15,5 @@ class MockSearchHandlerRouteCoordinator: BaseCoordinator {
         }
     }
 
-    override func handle(route: Route) {
- 
-    }
+    override func handle(route: Route) { }
 }

--- a/Tests/ClientTests/Mocks/MockSearchHandlerRouteCoordinator.swift
+++ b/Tests/ClientTests/Mocks/MockSearchHandlerRouteCoordinator.swift
@@ -6,12 +6,16 @@ import UIKit
 @testable import Client
 
 class MockSearchHandlerRouteCoordinator: BaseCoordinator {
-    override func handle(route: Route) -> Bool {
+    override func canHandle(route: Route) -> Bool {
         switch route {
         case .search:
             return true
         default:
             return false
         }
+    }
+
+    override func handle(route: Route) {
+        
     }
 }

--- a/Tests/ClientTests/Mocks/MockSearchHandlerRouteCoordinator.swift
+++ b/Tests/ClientTests/Mocks/MockSearchHandlerRouteCoordinator.swift
@@ -16,6 +16,6 @@ class MockSearchHandlerRouteCoordinator: BaseCoordinator {
     }
 
     override func handle(route: Route) {
-        
+ 
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7431)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17043)

## :bulb: Description

Refactors `findAndHandle(route:)` to split the logic into separate steps:

1. Identify a valid `Coordinator` for a given `Route` 
2. Dismiss any children on target Coordinator (if needed)
3. Perform the actual `handle()` action

The important change is that the recursion of finding the coordinator is allowed to fully complete before we proceed to step 2. This provides a more robust solution for a few related issues ([FXIOS-7631](https://mozilla-hub.atlassian.net/browse/FXIOS-7631) & [FXIOS-7537](https://mozilla-hub.atlassian.net/browse/FXIOS-7537) etc).

This PR also removes the previous `newlyAdded` workaround for [FXIOS-7631](https://mozilla-hub.atlassian.net/browse/FXIOS-7631) since with these changes it is no longer needed.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

