### PR TITLE
Bugfix FXIOS-6828 & 7605 [v121] Fix deeplink after app crash (Event Queue)

### DIFF
--- a/Client/Application/SceneDelegate.swift
+++ b/Client/Application/SceneDelegate.swift
@@ -59,9 +59,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         sceneCoordinator = SceneCoordinator(scene: scene)
         sceneCoordinator?.start()
 
-        // Adding a half second delay to ensure start up actions have resolved prior to attempting deeplink actions
-        // This is a hacky fix and a long term solution will be add in FXIOS-6828
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+        AppEventQueue.wait(for: [.startupFlowComplete, .tabRestoration]) {
             self.handle(connectionOptions: connectionOptions)
         }
     }

--- a/Client/Application/SceneDelegate.swift
+++ b/Client/Application/SceneDelegate.swift
@@ -59,8 +59,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         sceneCoordinator = SceneCoordinator(scene: scene)
         sceneCoordinator?.start()
 
-        AppEventQueue.wait(for: [.startupFlowComplete, .tabRestoration]) {
-            self.handle(connectionOptions: connectionOptions)
+        AppEventQueue.wait(for: [.startupFlowComplete, .tabRestoration]) { [weak self] in
+            self?.handle(connectionOptions: connectionOptions)
         }
     }
 

--- a/Client/Coordinators/BaseCoordinator.swift
+++ b/Client/Coordinators/BaseCoordinator.swift
@@ -43,9 +43,6 @@ open class BaseCoordinator: NSObject, Coordinator {
 
     @discardableResult
     func findAndHandle(route: Route) -> Coordinator? {
-        // If the app crashed last session then we abandon the deeplink
-        guard !logger.crashedLastLaunch else { return nil }
-
         guard let matchingCoordinator = find(route: route) else { return nil }
 
         // Dismiss any child of the matching coordinator that handles a route

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -866,6 +866,7 @@ class BrowserViewController: UIViewController,
                 self.isCrashAlertShowing = false
                 self.tabManager.selectTab(self.tabManager.addTab())
                 self.openUrlAfterRestore()
+                AppEventQueue.signal(event: .tabRestoration)
             }
         )
         self.present(alert, animated: true, completion: nil)

--- a/Tests/ClientTests/EventQueueTests.swift
+++ b/Tests/ClientTests/EventQueueTests.swift
@@ -228,11 +228,9 @@ final class EventQueueTests: XCTestCase {
     }
 
     func testNestedDependencies() {
-        var actionRun = false
-
         // Enqueue action
-        queue.wait(for: [.parentEvent, .activityEvent], then: { actionRun = true })
-        XCTAssertFalse(actionRun)
+        queue.wait(for: [.parentEvent, .activityEvent], then: {  })
+        XCTAssertFalse(queue.hasSignalled(.parentEvent))
 
         // Create a parent event that depends on 3 sub-events
         queue.establishDependencies(for: .parentEvent, against: [
@@ -245,17 +243,17 @@ final class EventQueueTests: XCTestCase {
         queue.started(.activityEvent)
         queue.completed(.activityEvent)
         // Action should not yet run
-        XCTAssertFalse(actionRun)
+        XCTAssertFalse(queue.hasSignalled(.parentEvent))
 
         // Complete 2 of 3 sub-events of parent
         queue.signal(event: .startingEvent)
         queue.signal(event: .middleEvent)
         // Action not run
-        XCTAssertFalse(actionRun)
+        XCTAssertFalse(queue.hasSignalled(.parentEvent))
 
         // Complete 3rd sub-event of parent
         queue.signal(event: .laterEvent)
         // At this point all dependencies should be complete.
-        XCTAssertTrue(actionRun)
+        XCTAssertTrue(queue.hasSignalled(.parentEvent))
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6828)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15215)

[Related Jira spike ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7605)
[Related Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16918)

## :bulb: Description

Changes in this PR:

- Fix issue when deeplinking into the app after a crash (previously the deeplink was ignored, it should now open correctly once the necessary launch flow steps are complete)
- Fixes a bug in the `EventQueue` which could potentially cause enqueued actions to execute multiple times

👉  Part of ongoing early work to integrate the new [Event Queue](https://docs.google.com/document/d/185jXC9vcoJa6KXitFYLStSMTc2yXHoEmbCUgM-y9SLc/edit). Aspects of this are a WIP.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

