### PR TITLE
Fix MTE-1872 [v121] for PrivateBrowsingTest tests

### DIFF
--- a/Tests/XCUITests/PrivateBrowsingTest.swift
+++ b/Tests/XCUITests/PrivateBrowsingTest.swift
@@ -89,7 +89,7 @@ class PrivateBrowsingTest: BaseTestCase {
         navigator.goto(SettingsScreen)
         let settingsTableView = app.tables[AccessibilityIdentifiers.Settings.tableViewController]
 
-        while settingsTableView.staticTexts["Close Private Tabs"].exists == false {
+        while settingsTableView.staticTexts["Close Private Tabs"].isHittable == false {
             settingsTableView.swipeUp()
         }
 
@@ -122,6 +122,9 @@ class PrivateBrowsingTest: BaseTestCase {
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: TIMEOUT)
         navigator.nowAt(BrowserTab)
         navigator.goto(SettingsScreen)
+        while settingsTableView.staticTexts["Close Private Tabs"].isHittable == false {
+            settingsTableView.swipeUp()
+        }
         closePrivateTabsSwitch.tap()
         navigator.goto(BrowserTab)
         waitForTabsButton()
@@ -223,7 +226,7 @@ fileprivate extension BaseTestCase {
         navigator.goto(SettingsScreen)
         let settingsTableView = app.tables[AccessibilityIdentifiers.Settings.tableViewController]
 
-        while settingsTableView.staticTexts["Close Private Tabs"].exists == false {
+        while settingsTableView.staticTexts["Close Private Tabs"].isHittable == false {
             settingsTableView.swipeUp()
         }
         let closePrivateTabsSwitch = settingsTableView.switches["settings.closePrivateTabs"]


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1872)

## :bulb: Description
The fix consists of making sure "Close Private Tabs" is hittable.
This PR fixes  testClearIndexedDB and testClosePrivateTabsOptionClosesPrivateTabs tests.
