### PR TITLE
Bugfix FXIOS-7497 [v121] scroll position is reset to the top of previous page when navigating back

### DIFF
--- a/Client/Frontend/Browser/TabScrollController.swift
+++ b/Client/Frontend/Browser/TabScrollController.swift
@@ -310,16 +310,20 @@ private extension TabScrollingController {
         let isShownFromHidden = headerTopOffset == -topScrollHeight && headerOffset == 0
 
         let animation: () -> Void = {
-            if isShownFromHidden {
-                scrollView.contentOffset = CGPoint(x: initialContentOffset.x, y: initialContentOffset.y + self.topScrollHeight)
-            }
             self.headerTopOffset = headerOffset
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {  [weak self] in
+                self?.header?.updateAlphaForSubviews(alpha)
+                self?.header?.superview?.layoutIfNeeded()
+                self?.zoomPageBar?.updateAlphaForSubviews(alpha)
+                self?.zoomPageBar?.superview?.layoutIfNeeded()
+                if isShownFromHidden {
+                    guard let topScrollHeight = self?.topScrollHeight else { return }
+                    let contentOffset = CGPoint(x: initialContentOffset.x, y: initialContentOffset.y + topScrollHeight)
+                    scrollView.contentOffset = contentOffset
+                }
+            }
             self.bottomContainerOffset = bottomContainerOffset
             self.overKeyboardContainerOffset = overKeyboardOffset
-            self.header?.updateAlphaForSubviews(alpha)
-            self.header?.superview?.layoutIfNeeded()
-            self.zoomPageBar?.updateAlphaForSubviews(alpha)
-            self.zoomPageBar?.superview?.layoutIfNeeded()
         }
 
         if animated {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7497)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16643)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Besides a complete refactor, adding a small delay for the automatic scroll is the only thing that somewhat alleviates the issue at hand, all other solutions I tested would either break something else or cause different UI issues.
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

