### PR TITLE
Add FXIOS-7714 [v121] new theming system to Tab.swift

### DIFF
--- a/BrowserKit/Sources/Common/Theming/ThemeType.swift
+++ b/BrowserKit/Sources/Common/Theming/ThemeType.swift
@@ -35,4 +35,16 @@ public enum ThemeType: String {
             return "\(name)_dark"
         }
     }
+
+    public func keyboardAppearence(isPrivate: Bool) -> UIKeyboardAppearance {
+        if isPrivate {
+            return .dark
+        }
+        return switch self {
+        case .dark:
+            .dark
+        case .light:
+            .light
+        }
+    }
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1768,11 +1768,11 @@ class BrowserViewController: UIViewController,
 
         // Update the `background-color` of any blank webviews.
         let webViews = tabManager.tabs.compactMap({ $0.webView })
-        webViews.forEach({ $0.applyTheme() })
+        webViews.forEach({ $0.applyTheme(theme: currentTheme) })
 
         let tabs = tabManager.tabs
         tabs.forEach {
-            $0.applyTheme()
+            $0.applyTheme(theme: currentTheme)
         }
 
         guard let contentScript = tabManager.selectedTab?.getContentScript(name: ReaderMode.name()) else { return }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2120,6 +2120,11 @@ extension BrowserViewController: TabManagerDelegate {
 
                 let ui: [PrivateModeUI?] = [toolbar, topTabsViewController, urlBar]
                 ui.forEach { $0?.applyUIMode(isPrivate: tab.isPrivate, theme: themeManager.currentTheme) }
+            } else {
+                // Theme is applied to the tab and webView in the else case
+                // because in the if block is applied already to all the tabs and web views
+                tab.applyTheme(theme: themeManager.currentTheme)
+                webView.applyTheme(theme: themeManager.currentTheme)
             }
 
             readerModeCache = tab.isPrivate ? MemoryReaderModeCache.sharedInstance : DiskReaderModeCache.sharedInstance

--- a/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -297,7 +297,6 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         }
         if let tab = selectedTab {
             TabEvent.post(.didGainFocus, for: tab)
-            tab.applyTheme()
         }
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .tab)
 
@@ -552,11 +551,6 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
                 let url = NewTabHomePageAccessors.getHomePage(profile.prefs)!
                 tab.loadRequest(URLRequest(url: url))
             case .blankPage:
-                // If we're showing "about:blank" in a webview, set
-                // the <html> `background-color` to match the theme.
-                if let webView = tab.webView {
-                    webView.applyTheme()
-                }
                 break
             default:
                 // The common case, where the NewTabPage enum defines

--- a/Client/TabManagement/Tab.swift
+++ b/Client/TabManagement/Tab.swift
@@ -845,14 +845,7 @@ class Tab: NSObject, ThemeApplicable {
     // MARK: - ThemeApplicable
 
     func applyTheme(theme: Theme) {
-        UITextField.appearance().keyboardAppearance = isPrivate ? .dark : (theme.type == .dark) ? .dark : .light
-    }
-
-    // MARK: - LegacyTheme
-
-    // This function needs to be in place since the LegacyTabManager still exists
-    func applyTheme() {
-        UITextField.appearance().keyboardAppearance = isPrivate ? .dark : (LegacyThemeManager.instance.currentName == .dark ? .dark : .light)
+        UITextField.appearance().keyboardAppearance = theme.type.keyboardAppearence(isPrivate: isPrivate)
     }
 }
 
@@ -1054,16 +1047,6 @@ class TabWebView: WKWebView, MenuHelperInterface, ThemeApplicable {
     func applyTheme(theme: Theme) {
         if url == nil {
             let backgroundColor = theme.colors.layer1.hexString
-            evaluateJavascriptInDefaultContentWorld("document.documentElement.style.backgroundColor = '\(backgroundColor)';")
-        }
-    }
-
-    // MARK: - LegacyTheme
-
-    // This function needs to be in place since the LegacyTabManager still exists
-    func applyTheme() {
-        if url == nil {
-            let backgroundColor = LegacyThemeManager.instance.current.browser.background.hexString
             evaluateJavascriptInDefaultContentWorld("document.documentElement.style.backgroundColor = '\(backgroundColor)';")
         }
     }

--- a/Client/TabManagement/Tab.swift
+++ b/Client/TabManagement/Tab.swift
@@ -62,7 +62,7 @@ enum TabUrlType: String {
     case googleTopSiteFollowOn
 }
 
-class Tab: NSObject {
+class Tab: NSObject, ThemeApplicable {
     static let privateModeKey = "PrivateModeKey"
     private var _isPrivate = false
     private(set) var isPrivate: Bool {
@@ -830,10 +830,6 @@ class Tab: NSObject {
         }
     }
 
-    func applyTheme() {
-        UITextField.appearance().keyboardAppearance = isPrivate ? .dark : (LegacyThemeManager.instance.currentName == .dark ? .dark : .light)
-    }
-
     func getProviderForUrl() -> SearchEngine {
         guard let url = self.webView?.url else {
             return .none
@@ -844,6 +840,19 @@ class Tab: NSObject {
         }
 
         return .none
+    }
+
+    // MARK: - ThemeApplicable
+
+    func applyTheme(theme: Theme) {
+        UITextField.appearance().keyboardAppearance = isPrivate ? .dark : (theme.type == .dark) ? .dark : .light
+    }
+
+    // MARK: - LegacyTheme
+
+    // This function needs to be in place since the LegacyTabManager still exists
+    func applyTheme() {
+        UITextField.appearance().keyboardAppearance = isPrivate ? .dark : (LegacyThemeManager.instance.currentName == .dark ? .dark : .light)
     }
 }
 
@@ -954,7 +963,7 @@ protocol TabWebViewDelegate: AnyObject {
     func tabWebViewSearchWithFirefox(_ tabWebViewSearchWithFirefox: TabWebView, didSelectSearchWithFirefoxForSelection selection: String)
 }
 
-class TabWebView: WKWebView, MenuHelperInterface {
+class TabWebView: WKWebView, MenuHelperInterface, ThemeApplicable {
     var accessoryView = AccessoryViewProvider()
     private var logger: Logger = DefaultLogger.shared
     private weak var delegate: TabWebViewDelegate?
@@ -1002,15 +1011,6 @@ class TabWebView: WKWebView, MenuHelperInterface {
         fatalError("init(coder:) has not been implemented")
     }
 
-    // Updates the `background-color` of the webview to match
-    // the theme if the webview is showing "about:blank" (nil).
-    func applyTheme() {
-        if url == nil {
-            let backgroundColor = LegacyThemeManager.instance.current.browser.background.hexString
-            evaluateJavascriptInDefaultContentWorld("document.documentElement.style.backgroundColor = '\(backgroundColor)';")
-        }
-    }
-
     override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
         return super.canPerformAction(action, withSender: sender) || action == MenuHelper.SelectorFindInPage
     }
@@ -1045,5 +1045,26 @@ class TabWebView: WKWebView, MenuHelperInterface {
                 message: "Do not call evaluateJavaScript directly on TabWebViews, should only be called on super class")
     override func evaluateJavaScript(_ javaScriptString: String, completionHandler: ((Any?, Error?) -> Void)? = nil) {
         super.evaluateJavaScript(javaScriptString, completionHandler: completionHandler)
+    }
+
+    // MARK: - ThemeApplicable
+
+    /// Updates the `background-color` of the webview to match
+    /// the theme if the webview is showing "about:blank" (nil).
+    func applyTheme(theme: Theme) {
+        if url == nil {
+            let backgroundColor = theme.colors.layer1.hexString
+            evaluateJavascriptInDefaultContentWorld("document.documentElement.style.backgroundColor = '\(backgroundColor)';")
+        }
+    }
+
+    // MARK: - LegacyTheme
+
+    // This function needs to be in place since the LegacyTabManager still exists
+    func applyTheme() {
+        if url == nil {
+            let backgroundColor = LegacyThemeManager.instance.current.browser.background.hexString
+            evaluateJavascriptInDefaultContentWorld("document.documentElement.style.backgroundColor = '\(backgroundColor)';")
+        }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7714)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17204)

## :bulb: Description
Added New theming system to `Tab.swift`. The legacy theme is still present inside the file, because is used by the `LegacyTabManger`. Should we remove the `LegacyThemeManger` from `Tab.swift` once the `LegacyTabManger` is removed ? 

Here is the screenshots of a blank page with the new theming system.

 
![Simulator Screenshot - iPhone 15 Pro - 2023-11-07 at 17 43 46](https://github.com/mozilla-mobile/firefox-ios/assets/55580351/1358f922-8277-41d8-b8e9-53f37be0ac1e)
![Simulator Screenshot - iPhone 15 Pro - 2023-11-07 at 17 44 01](https://github.com/mozilla-mobile/firefox-ios/assets/55580351/c95323a7-8d56-401b-bc6e-bb9bfb0c92c0)


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

