### PR TITLE
Bugfix FXIOS-7240 [v121] Run BrowserVC activation code during app launch

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -434,11 +434,11 @@ class BrowserViewController: UIViewController,
             urlBar.locationView.tabDidChangeContentBlocking(tab)
         }
 
-        if tabManager.startAtHomeCheck() {
+        didStartAtHome = tabManager.startAtHomeCheck()
+        if didStartAtHome {
             guard presentedViewController != nil else { return }
                 dismissVC()
         }
-        updateWallpaperMetadata()
 
         // When, for example, you "Load in Background" via the share sheet, the tab is added to `Profile`'s `TabQueue`.
         // Make sure that our startup flow is completed and the Profile has been sync'd (at least once) before we load.
@@ -2216,7 +2216,6 @@ extension BrowserViewController: TabManagerDelegate {
     }
 
     func tabManagerDidRestoreTabs(_ tabManager: TabManager) {
-        didStartAtHome = tabManager.startAtHomeCheck()
         updateTabCountUsingTabManager(tabManager)
         openUrlAfterRestore()
     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -437,7 +437,7 @@ class BrowserViewController: UIViewController,
         didStartAtHome = tabManager.startAtHomeCheck()
         if didStartAtHome {
             guard presentedViewController != nil else { return }
-                dismissVC()
+            dismissVC()
         }
 
         // When, for example, you "Load in Background" via the share sheet, the tab is added to `Profile`'s `TabQueue`.

--- a/Client/Frontend/Browser/Event Queue/AppEvent.swift
+++ b/Client/Frontend/Browser/Event Queue/AppEvent.swift
@@ -19,6 +19,9 @@ public enum AppEvent: Int, AppEventType {
     // Activities: Profile Syncing
     case profileSyncing
 
+    // Activities: Browser
+    case browserDidBecomeActive
+
     // Activites: Tabs
     case tabRestoration
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7240)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16057)

## :bulb: Description

Adds additional hooks to ensure that a few critical codepaths within BrowserVC's `appDidBecomeActive` code are run during app launch; currently that code is not run during startup, only once the app has already been launched, backgrounded, and then foregrounded.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods