### PR TITLE
Add FXIOS-7687 [v121] Implement Fakespot telemetry event "shopping.surface_reactivated_button_clicked"

### DIFF
--- a/Client/Frontend/Fakespot/FakespotViewModel.swift
+++ b/Client/Frontend/Fakespot/FakespotViewModel.swift
@@ -349,6 +349,7 @@ class FakespotViewModel {
     }
 
     func reportProductBackInStock() {
+        recordTelemetry(for: .messageCard(.reportProductInStock))
         Task {
             _ = try? await shoppingProduct.reportProductBackInStock()
         }
@@ -422,6 +423,12 @@ class FakespotViewModel {
                 category: .action,
                 method: .tap,
                 object: .shoppingNeedsAnalysisCardViewPrimaryButton
+            )
+        case .messageCard(.reportProductInStock):
+            TelemetryWrapper.recordEvent(
+                category: .action,
+                method: .tap,
+                object: .shoppingProductBackInStockButton
             )
         default: break
         }

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -415,6 +415,7 @@ extension TelemetryWrapper {
         case shoppingPoweredByFakespotLabel = "shopping-powered-by-fakespot-label"
         case shoppingNoAnalysisCardViewPrimaryButton = "shopping-no-analysis-card-view-primary-button"
         case shoppingNeedsAnalysisCardViewPrimaryButton = "shopping-needs-analysis-card-view-primary-button"
+        case shoppingProductBackInStockButton = "shopping-product-back-in-stock-button"
         case shoppingSurfaceStaleAnalysisShown = "shopping-surface-stale-analysis-shown"
         case shoppingNimbusDisabled = "shopping-nimbus-disabled"
         case shoppingComponentOptedOut = "shopping-component-opted-out"
@@ -1196,6 +1197,8 @@ extension TelemetryWrapper {
             GleanMetrics.Shopping.surfaceAnalyzeReviewsNoneAvailableClicked.record()
         case (.action, .tap, .shoppingNeedsAnalysisCardViewPrimaryButton, _, _):
             GleanMetrics.Shopping.surfaceReanalyzeClicked.record()
+        case (.action, .tap, .shoppingProductBackInStockButton, _, _):
+            GleanMetrics.Shopping.surfaceReactivatedButtonClicked.record()
         case (.action, .navigate, .shoppingBottomSheet, _, _):
             GleanMetrics.Shopping.surfaceNoReviewReliabilityAvailable.record()
         case (.action, .view, .shoppingSurfaceStaleAnalysisShown, _, _):

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -913,6 +913,18 @@ shopping:
       - fx-ios-data-stewards@mozilla.com
     expires: "2024-06-01"
 
+  surface_reactivated_button_clicked:
+    type: event
+    description: |
+      Records an event when a user reports a product as back in stock.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/?
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/?
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2024-06-01"
+
 shopping.settings:
   nimbus_disabled_shopping:
     type: boolean

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -918,9 +918,9 @@ shopping:
     description: |
       Records an event when a user reports a product as back in stock.
     bugs:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/?
+      - https://github.com/mozilla-mobile/firefox-ios/issues/17145
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/?
+      - https://github.com/mozilla-mobile/firefox-ios/pull/17230
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2024-06-01"

--- a/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -383,6 +383,11 @@ class TelemetryWrapperTests: XCTestCase {
         testEventMetricRecordingSuccess(metric: GleanMetrics.Shopping.surfaceReanalyzeClicked)
     }
 
+    func test_surfaceReactivatedButtonClicked_GleanIsCalled() {
+        TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .shoppingProductBackInStockButton)
+        testEventMetricRecordingSuccess(metric: GleanMetrics.Shopping.surfaceReactivatedButtonClicked)
+    }
+
     func test_surfaceNoReviewReliabilityAvailable_GleanIsCalled() {
         TelemetryWrapper.recordEvent(category: .action, method: .navigate, object: .shoppingBottomSheet)
         testEventMetricRecordingSuccess(metric: GleanMetrics.Shopping.surfaceNoReviewReliabilityAvailable)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7687)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17145)

## :bulb: Description
Adds telemetry for product back in stock reporting.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

