### PR TITLE
Bugfix FXIOS-7606 [v121] Fix background tab loading dependencies

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -445,8 +445,8 @@ class BrowserViewController: UIViewController,
         }
 
         // When, for example, you "Load in Background" via the share sheet, the tab is added to `Profile`'s `TabQueue`.
-        // Make sure that our startup flow is completed and the Profile has been sync'd (at least once) before we load.
-        AppEventQueue.wait(for: [.startupFlowComplete, .profileSyncing, .tabRestoration]) { [weak self] in
+        // Make sure that our startup flow is completed and other tabs have been restored before we load.
+        AppEventQueue.wait(for: [.startupFlowComplete, .tabRestoration]) { [weak self] in
             self?.backgroundTabLoader.loadBackgroundTabs()
         }
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7606)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16919)

## :bulb: Description

Fixes background tab loading in flows where the `Profile` may not have been sync'd yet. We open the DB in `AppDelegate.applicationDidBecomeActive` but the Profile is often not sync'd immediately during a typical app launch + browsing, which means that the previous refactors would wait (incorrectly) until the next sync operation is completed before loading tabs (which might not happen until the user e.g. explicitly opens their Sync tab in the tab tray).

This PR removes the `.profileSyncing` dependency so that background tabs will load correctly in these flows; I tested several different use cases (and also without a sync account) and this fixed issues where background tabs were not loading.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

