### PR TITLE
Add EXP-3965 [v121] Add unenrollment tests to experiment integration test suite.

### DIFF
--- a/firefox-ios/Tests/ExperimentIntegrationTests/test_generic.py
+++ b/firefox-ios/Tests/ExperimentIntegrationTests/test_generic.py
@@ -9,3 +9,14 @@ def test_experiment_unenrolls_after_studies_toggle(xcodebuild, setup_experiment,
     xcodebuild.test(
         "XCUITests/ExperimentIntegrationTests/testStudiesToggleDisablesExperiment", erase=False
     )
+
+
+@pytest.mark.parametrize("load_branches", [("branch")], indirect=True)
+def test_experiment_unenrolls_after_studies_toggle(xcodebuild, setup_experiment, start_app, load_branches):
+    xcodebuild.install()
+    setup_experiment(load_branches)
+    xcodebuild.test("XCUITests/ExperimentIntegrationTests/testVerifyExperimentEnrolled", erase=False)
+    start_app()
+    xcodebuild.test(
+        "XCUITests/ExperimentIntegrationTests/testStudiesToggleDisablesExperiment", erase=False
+    )

--- a/firefox-ios/Tests/ExperimentIntegrationTests/test_generic.py
+++ b/firefox-ios/Tests/ExperimentIntegrationTests/test_generic.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 @pytest.mark.parametrize("load_branches", [("branch")], indirect=True)
 def test_experiment_unenrolls_after_studies_toggle(xcodebuild, setup_experiment, start_app, load_branches):
     xcodebuild.install()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/EXP-3965)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

