### PR TITLE
Bugfix FXIOS-7569 [v121] Onboarding screen includes implicit heading

### DIFF
--- a/Client/Frontend/Onboarding/ViewControllers/OnboardingCardViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/OnboardingCardViewController.swift
@@ -97,6 +97,7 @@ class OnboardingCardViewController: UIViewController, Themeable {
                                                                 size: fontSize)
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = "\(self.viewModel.a11yIdRoot)TitleLabel"
+        label.accessibilityTraits.insert(.header)
     }
 
     private lazy var descriptionLabel: UILabel = .build { label in


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7569)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16843)

## :bulb: Description
This adds the header trait to accessibility traits so the user can navigate using the rotor.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

## Screenshots
| Before | After |
| --- | --- |
| ![Screenshot 2023-11-13 at 2 45 56 PM](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/ff830508-7ccd-4f4b-b9be-1f11a6888529)| ![Screenshot 2023-11-13 at 3 06 05 PM](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/3cf072af-1c76-4971-a417-53b186331179) |
