### PR TITLE
Bugfix FXIOS-7741 [v121] Fix duplicate tabs when tapping Recently Closed item

### DIFF
--- a/Client/Frontend/Browser/Event Queue/AppEvent.swift
+++ b/Client/Frontend/Browser/Event Queue/AppEvent.swift
@@ -6,7 +6,7 @@ import Foundation
 
 public protocol AppEventType: Hashable { }
 
-public enum AppEvent: Int, AppEventType {
+public enum AppEvent: AppEventType {
     // Events: Startup flow
     case startupFlowComplete
 
@@ -24,4 +24,5 @@ public enum AppEvent: Int, AppEventType {
 
     // Activites: Tabs
     case tabRestoration
+    case selectTab(URL)
 }

--- a/Client/Frontend/Browser/Event Queue/EventQueue.swift
+++ b/Client/Frontend/Browser/Event Queue/EventQueue.swift
@@ -136,9 +136,9 @@ public final class EventQueue<QueueEventType: Hashable> {
         mainQueue.ensureMainThread { [weak self] in
             guard let self else { return }
             let currentState = self.signalledEvents[event]
-            guard currentState == .inProgress else {
-                logger.log("Completing \(event) which is not in progress.", level: .warning, category: .library)
-                return
+            if currentState != .inProgress {
+                logger.log("Completing activity \(event) that is not in progress.", level: .warning, category: .library)
+                // Warn for this, but no early return; allow event to be updated to .completed as requested.
             }
 
             self.signalledEvents[event] = .completed

--- a/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
+++ b/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
@@ -118,9 +118,21 @@ class RecentlyClosedTabsPanelSiteTableViewController: SiteTableViewController {
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        recentlyClosedTabsDelegate?.openRecentlyClosedSiteInNewTab(recentlyClosedTabs[indexPath.row].url, isPrivate: false)
-        let visitType = VisitType.typed    // Means History, too.
-        libraryPanelDelegate?.libraryPanel(didSelectURL: recentlyClosedTabs[indexPath.row].url, visitType: visitType)
+        let url = recentlyClosedTabs[indexPath.row].url
+        recentlyClosedTabsDelegate?.openRecentlyClosedSiteInNewTab(url, isPrivate: false)
+
+        // The code above creates new tab and selects it, but TabManagerImplementation.selectTab()
+        // currently performs the actual selection update asynchronously via Swift Async + Task/Await.
+        // This means that selectTab() returns before the tab is actually selected. As a result, the
+        // delegate callback below will incorrectly cause a duplicate tab (since it will treat the
+        // url as having been applied to the current tab, not our newly-added tab from above). This
+        // is avoided by making sure we wait for our expected tab above to be selected before
+        // notifying our library panel delegate. [FXIOS-7741]
+
+        AppEventQueue.wait(for: .selectTab(url)) {
+            let visitType = VisitType.typed    // Means History, too.
+            self.libraryPanelDelegate?.libraryPanel(didSelectURL: url, visitType: visitType)
+        }
     }
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {

--- a/Client/TabManagement/TabManagerImplementation.swift
+++ b/Client/TabManagement/TabManagerImplementation.swift
@@ -301,10 +301,13 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
     // MARK: - Select Tab
 
     override func selectTab(_ tab: Tab?, previous: Tab? = nil) {
+        let url = tab?.url
         guard shouldUseNewTabStore(),
               let tab = tab,
               let tabUUID = UUID(uuidString: tab.tabUUID)
         else {
+            willSelectTab(url)
+            defer { didSelectTab(url) }
             super.selectTab(tab, previous: previous)
             return
         }
@@ -315,10 +318,13 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
         guard !AppConstants.isRunningUITests,
               !DebugSettingsBundleOptions.skipSessionRestore
         else {
+            willSelectTab(url)
+            defer { didSelectTab(url) }
             super.selectTab(tab, previous: previous)
             return
         }
 
+        willSelectTab(url)
         Task(priority: .high) {
             if tab.isFxHomeTab {
                 await selectTabWithSession(tab: tab,
@@ -330,7 +336,18 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
                                            previous: previous,
                                            sessionData: sessionData)
             }
+            didSelectTab(url)
         }
+    }
+
+    private func willSelectTab(_ url: URL?) {
+        guard let url else { return }
+        AppEventQueue.started(.selectTab(url))
+    }
+
+    private func didSelectTab(_ url: URL?) {
+        guard let url else { return }
+        AppEventQueue.completed(.selectTab(url))
     }
 
     @MainActor

--- a/Client/TabManagement/TabManagerImplementation.swift
+++ b/Client/TabManagement/TabManagerImplementation.swift
@@ -307,8 +307,8 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
               let tabUUID = UUID(uuidString: tab.tabUUID)
         else {
             willSelectTab(url)
-            defer { didSelectTab(url) }
             super.selectTab(tab, previous: previous)
+            didSelectTab(url)
             return
         }
 
@@ -319,8 +319,8 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
               !DebugSettingsBundleOptions.skipSessionRestore
         else {
             willSelectTab(url)
-            defer { didSelectTab(url) }
             super.selectTab(tab, previous: previous)
+            didSelectTab(url)
             return
         }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7741)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17268)

## :bulb: Description

This PR fixes a bug causing duplicate tabs when users select a URL from the Recently Closed history panel. The underlying culprit is part of a broader architectural issue that may warrant further discussion. I've tried to summarize the issue below, but I'm also happy to hop on a call to discuss if needed.

Basically, the main problem is that the async/await code within `TabManagerImplementation.selectTab()` causes that function to return before the tab is actually selected. In practice I think this may potentially lead to other bugs wherever we have synchronous code that expects the tab state to be up-to-date by the time `selectTab()` returns.

More specifically, in this particular scenario (FXIOS-7741) what is happening is:

1. User selects a recently-closed tab
2. In `RecentlyClosedTabsPanel` code for didSelectRow, we make 2 calls:
3. 1️⃣ First, the code calls into `recentlyClosedTabsDelegate?.openRecentlyClosedSiteInNewTab`, which creates a new tab and selects it
4. 2️⃣ Second, the code calls into `libraryPanelDelegate?.libraryPanel(didSelectURL:)` which calls into `finishEditingAndSubmit()` which has the effect of applying the same URL to the current tab

Because the newly-created tab has (incorrectly) not yet been actually selected, the follow-up call to finishEditingAndSubmit winds up opening the URL in the current tab (often the home tab) before the newly-created tab actually appears. The end result is duplicate tabs for the same URL.

## Possible Solutions

I explored a couple solutions for this:

#### Changing `TabManagerImplementation.selectTab()` so that it immediately selects the tab (synchronously).
This would involve changing or removing the async/await code there and I had concerns about potential impacts in other areas of the codebase. I think this is the "most correct" fix but it would also potentially have broader repercussions, so I wanted to get add'tl feedback from the team on that first.

#### Removing the call to `libraryPanelDelegate?.libraryPanel(didSelectURL:)`
I can't actually see why this delegate callback is necessary for `RecentlyClosedTabsPanel`, however I didn't feel I had enough context to safely remove it. _(*Edit: updated comment related to this inline, see below.)_

#### Ensuring the newly-created tab is selected before notifying the libraryPanelDelegate
This is the fix in the current PR, and was the lowest-impact and most targeted fix I could find, since it only affects `RecentlyClosedTabsPanel`. I also looked into using the tab UUID instead of URL as the associated value for the `selectTab` event added in this PR, but that ended up being a much messier change unfortunately (due to requiring updating several protocols across the codebase). And so I opted for the slightly cleaner solution here referencing the tab URL.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

