### PR TITLE
Bugfix MTE-1873 [v121] Sync Integration Tests after directory reorg

### DIFF
--- a/firefox-ios/Tests/SyncIntegrationTests/xcodebuild.py
+++ b/firefox-ios/Tests/SyncIntegrationTests/xcodebuild.py
@@ -57,6 +57,7 @@ class XCodeBuild(object):
                 cwd=os.chdir("../../.."),
                 stderr=subprocess.STDOUT,
                 universal_newlines=True)
+            os.chdir("firefox-ios/Tests/SyncIntegrationTests")
         except subprocess.CalledProcessError as e:
             out = e.output
             raise


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1873)

## :bulb: Description
After the tests were consolidated in the same directory, some of the Sync Integration Tests are not running properly. In addition to the command on Jenkins, `xcodebuild` should return the current directory to Sync Integration Tests' location instead of the top level directory. If we use the code as-is, the `tps.run` command from `test_integration.py` could not find the `.js` file required.

I have tested the change on MacStadium.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

