### PR TITLE
Bugfix FXIOS-7567 [v121] Close button for onboarding lacks accessible label

### DIFF
--- a/Client/Frontend/Fakespot/FakespotViewController.swift
+++ b/Client/Frontend/Fakespot/FakespotViewController.swift
@@ -83,7 +83,7 @@ class FakespotViewController:
     private lazy var closeButton: UIButton = .build { button in
         button.setImage(UIImage(named: StandardImageIdentifiers.ExtraLarge.crossCircleFill), for: .normal)
         button.addTarget(self, action: #selector(self.closeTapped), for: .touchUpInside)
-        button.accessibilityLabel = .CloseButtonTitle
+        button.accessibilityLabel = .Shopping.CloseButtonAccessibilityLabel
         button.accessibilityIdentifier = AccessibilityIdentifiers.Shopping.sheetCloseButton
     }
 

--- a/Client/Frontend/Onboarding/ViewControllers/FirstInstall/IntroViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/FirstInstall/IntroViewController.swift
@@ -31,6 +31,7 @@ class IntroViewController: UIViewController,
     private lazy var closeButton: UIButton = .build { button in
         button.setImage(UIImage(named: StandardImageIdentifiers.ExtraLarge.crossCircleFill), for: .normal)
         button.addTarget(self, action: #selector(self.closeOnboarding), for: .touchUpInside)
+        button.accessibilityLabel = String.localizedStringWithFormat(.Onboarding.Welcome.CloseButtonAccessibilityLabel, AppName.shortName.rawValue)
         button.accessibilityIdentifier = AccessibilityIdentifiers.Onboarding.closeButton
     }
 

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -1019,6 +1019,11 @@ extension String {
         }
 
         public struct Welcome {
+            public static let CloseButtonAccessibilityLabel = MZLocalizedString(
+                key: "Onboarding.Welcome.Close.AccessibilityLabel.v121",
+                tableName: "Onboarding",
+                value: "Close and exit %@ onboarding",
+                comment: "Accessibility label for close button that dismisses the welcome onboarding screen. Placeholder is for the app name.")
             public static let Title = MZLocalizedString(
                 key: "Onboarding.Welcome.Title.v114",
                 tableName: "Onboarding",
@@ -3696,6 +3701,11 @@ extension String {
             tableName: "Shopping",
             value: "BETA",
             comment: "Beta label for the header of the Shopping Experience (Fakespot) sheet")
+        public static let CloseButtonAccessibilityLabel = MZLocalizedString(
+            key: "Shopping.Sheet.Close.AccessibilityLabel.v121",
+            tableName: "Shopping",
+            value: "Close Review Checker",
+            comment: "Accessibility label for close button that dismisses the Shopping Experience (Fakespot) sheet.")
         public static let ReliabilityCardTitle = MZLocalizedString(
             key: "Shopping.ReviewQuality.ReliabilityCardTitle.v120",
             tableName: "Shopping",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7567)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16841)

## :bulb: Description
This adds the accessibility label to the close button for the onboarding screen.
Also, fixes accessibility label for close button for the Fakespot (Review Checker) sheet as it was using `PhotoMenu.close` string

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

## Screenshots
**Onboarding**
| Before | After |
| --- | --- |
| ![image](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/1b5c09f1-a2a1-4e71-a982-fe923b704e63) | ![image](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/7d1a6b4f-343b-4a2b-9c6f-bbb5639a1aaa) |   

**Fakespot / Review Checker**
| Before | After |
| --- | --- |
| ![image](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/e1c64d44-2e67-4705-986c-8f770cef2cad) | ![image](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/08f576b5-1d44-4b26-ae35-edb529de1da6) |
