### PR TITLE
Bugfix FXIOS-7749 tab restore after crash

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -854,10 +854,6 @@ class BrowserViewController: UIViewController,
     }
 
     fileprivate func showRestoreTabsAlert() {
-        guard tabManager.hasTabsToRestoreAtStartup() else {
-            tabManager.selectTab(tabManager.addTab())
-            return
-        }
         let alert = UIAlertController.restoreTabsAlert(
             okayCallback: { _ in
                 let extra = [TelemetryWrapper.EventExtraKey.isRestoreTabsStarted.rawValue: true]


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7749)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17291)

## :bulb: Description
This PR needs to be merged directly into the v120 release branch as the issue is not present on main, but the change on main that makes it work is too difficult/risky to uplift.

I'm not sure what caused this issue in v120 but this is a band-aid fix, the check that is in place never actually worked correctly in the first place so removing it should not cause any regressions.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

