### PR TITLE
Bugfix FXIOS-7747 [v120] Fix the link and the image ids

### DIFF
--- a/nimbus-features/onboardingFrameworkFeature.yaml
+++ b/nimbus-features/onboardingFrameworkFeature.yaml
@@ -34,6 +34,10 @@ features:
               order: 10
               title: Onboarding/Onboarding.Welcome.Title.TreatementA.v120
               body: Onboarding/Onboarding.Welcome.Description.TreatementA.v120
+              image: welcome-globe
+              link:
+                title: Onboarding/Onboarding.Welcome.Link.Action.v114
+                url: "https://www.mozilla.org/privacy/firefox/"
               buttons:
                 primary:
                   title: Onboarding/Onboarding.Welcome.ActionTreatementA.v114


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7747)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17288)

## :bulb: Description
They were removed accidentally. Now they are back. Back again. Guess who's back. The link and the correct image ID.

![Simulator Screenshot - iPhone 15 Pro - 2023-11-14 at 10 55 56](https://github.com/mozilla-mobile/firefox-ios/assets/11182210/dedf5dca-89ca-4108-b517-2e63dd6c2ff8)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

