### PR TITLE
Bugfix FXIOS-7639 [v121] Autofill credit card button is unlabeled

### DIFF
--- a/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewController.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewController.swift
@@ -25,10 +25,12 @@ class CreditCardSettingsViewController: SensitiveViewController, Themeable {
     var creditCardTableViewController: CreditCardTableViewController
 
     private lazy var addCreditCardButton: UIBarButtonItem = {
-        return UIBarButtonItem(image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.plus),
-                               style: .plain,
-                               target: self,
-                               action: #selector(addCreditCard))
+        let button = UIBarButtonItem(image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.plus),
+                                     style: .plain,
+                                     target: self,
+                                     action: #selector(addCreditCard))
+        button.accessibilityLabel = .CreditCard.Settings.AddCardAccessibilityLabel
+        return button
     }()
 
     // MARK: Initializers

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -203,6 +203,11 @@ extension String {
     public struct CreditCard {
         // Settings / Empty State / Keyboard input accessory view
         public struct Settings {
+            public static let AddCardAccessibilityLabel = MZLocalizedString(
+                key: "CreditCard.Settings.AddCard.AccessibilityLabel.v121",
+                tableName: "Settings",
+                value: "Add Card",
+                comment: "Accessibility label for the add button in autofill settings screen. Pressing this button presents a modal that allows users to add a card by entering the credit card information.")
             public static let EmptyListTitle = MZLocalizedString(
                 key: "CreditCard.Settings.EmptyListTitle.v112",
                 tableName: "Settings",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7639)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17028)

## :bulb: Description
This adds the accessibility label to the add button for the Autofill Credit Cards screen.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

## Screenshots
| Before | After |
| --- | --- |
| ![Screenshot 2023-11-13 at 2 47 03 PM](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/45489713-6d8c-4f44-aabb-a881412afe79) | ![image](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/d5a2e659-862b-4f6d-bf14-86923889e588) |
