### PR TITLE
Refactor [v121] Clean up unused strings + reduce warnings threshold

### DIFF
--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -1029,18 +1029,6 @@ extension String {
                 tableName: "Onboarding",
                 value: "Our non-profit backed browser helps stop companies from secretly following you around the web.",
                 comment: "String used to describes the description of what Firefox is on the welcome onboarding page for current version in our Onboarding screens. Placeholder is for the app name.")
-            public static let TitleTreatmentANotUsed = MZLocalizedString(
-                key: "Onboarding.Welcome.Title.TreatementA.v114",
-                tableName: "Onboarding",
-                value: "Make %@ your go-to browser",
-                comment: "String used to describes the title of what Firefox is on the welcome onboarding page for current version in our Onboarding screens. Placeholder is for the app name.",
-                lastUsedInVersion: 114)
-            public static let DescriptionTreatementANotUsed = MZLocalizedString(
-                key: "Onboarding.Welcome.Description.TreatementA.v114",
-                tableName: "Onboarding",
-                value: "%@ puts people over profits and defends your privacy as you browse.",
-                comment: "String used to describes the description of what Firefox is on the welcome onboarding page for current version in our Onboarding screens. Placeholder is for the app name.",
-                lastUsedInVersion: 114)
             public static let TitleTreatmentA = MZLocalizedString(
                 key: "Onboarding.Welcome.Title.TreatementA.v120",
                 tableName: "Onboarding",
@@ -1069,18 +1057,6 @@ extension String {
         }
 
         public struct Sync {
-            public static let TitleNotUsed = MZLocalizedString(
-                key: "Onboarding.Sync.Title.v114",
-                tableName: "Onboarding",
-                value: "Hop from phone to laptop and back",
-                comment: "String used to describes the title of what Firefox is on the Sync onboarding page for current version in our Onboarding screens.",
-                lastUsedInVersion: 114)
-            public static let DescriptionNotUsed = MZLocalizedString(
-                key: "Onboarding.Sync.Description.v114",
-                tableName: "Onboarding",
-                value: "Grab tabs and passwords from your other devices to pick up where you left off.",
-                comment: "String used to describes the description of what Firefox is on the Sync onboarding page for current version in our Onboarding screens.",
-                lastUsedInVersion: 114)
             public static let Title = MZLocalizedString(
                 key: "Onboarding.Sync.Title.v120",
                 tableName: "Onboarding",
@@ -1104,18 +1080,6 @@ extension String {
         }
 
         public struct Notification {
-            public static let TitleNotUsed = MZLocalizedString(
-                key: "Onboarding.Notification.Title.v114",
-                tableName: "Onboarding",
-                value: "Notifications help you do more with %@",
-                comment: "String used to describe the title of the notification onboarding page in our Onboarding screens. Placeholder is for the app name.",
-                lastUsedInVersion: 114)
-            public static let DescriptionNotUsed = MZLocalizedString(
-                key: "Onboarding.Notification.Description.v114",
-                tableName: "Onboarding",
-                value: "Send tabs between your devices and get tips about how to get the most out of %@.",
-                comment: "String used to describe the description of the notification onboarding page in our Onboarding screens. Placeholder is for the app name.",
-                lastUsedInVersion: 114)
             public static let Title = MZLocalizedString(
                 key: "Onboarding.Notification.Title.v120",
                 tableName: "Onboarding",

--- a/test-fixtures/generate-metrics.sh
+++ b/test-fixtures/generate-metrics.sh
@@ -4,8 +4,8 @@ set -e
 
 BUILD_LOG_FILE="$1"
 TYPE_LOG_FILE="$2"
-THRESHOLD_UNIT_TEST=104
-THRESHOLD_XCUITEST=104
+THRESHOLD_UNIT_TEST=91
+THRESHOLD_XCUITEST=91
 
 WARNING_COUNT=$(grep -E -v "SourcePackages/checkouts" "$BUILD_LOG_FILE" | grep -E "(^|:)[0-9]+:[0-9]+:|warning:|ld: warning:|<unknown>:0: warning:|fatal|===" | uniq | wc -l)
 


### PR DESCRIPTION
## :scroll: Tickets
No ticket

## :bulb: Description
- Remove unused strings from l10n that were last used in v114.
- Decrease warnings threshold as some warnings related tasks were completed recently.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

