### PR TITLE
Bugfix FXIOS-7761 [v121] Add Viaduct init to NotificationService

### DIFF
--- a/Extensions/NotificationService/NotificationService.swift
+++ b/Extensions/NotificationService/NotificationService.swift
@@ -19,6 +19,10 @@ class NotificationService: UNNotificationServiceExtension {
     // AppDelegate.application(_:didReceiveRemoteNotification:completionHandler:)
     // Once the notification is tapped, then the same userInfo is passed to the same method in the AppDelegate.
     override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
+        // Set-up Rust network stack. This is needed in addition to the call
+        // from the AppDelegate due to the fact that this uses a separate process
+        Viaduct.shared.useReqwestBackend()
+
         let userInfo = request.content.userInfo
 
         let content = request.content.mutableCopy() as! UNMutableNotificationContent


### PR DESCRIPTION
fixes: #17315 

Semi-related to https://github.com/mozilla-mobile/firefox-ios/issues/17313. The original issue is unrelated, but since we changed to move Viaduct initialization outside of `RustFirefoxAccounts` in https://github.com/mozilla-mobile/firefox-ios/pull/17222 background notifications got broken due to `NotificationService` running in it's own process. This adds the initialization to that as well

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7761)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17315)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

