### PR TITLE
Refactor FXIOS-7541 [v121] Show re-analysis progress when analysis is started from no analysis card

### DIFF
--- a/Client/Frontend/Fakespot/FakespotViewController.swift
+++ b/Client/Frontend/Fakespot/FakespotViewController.swift
@@ -353,17 +353,10 @@ class FakespotViewController:
 
         case .noAnalysisCard:
              let view: FakespotNoAnalysisCardView = .build()
-             viewModel.noAnalysisCardViewModel.onTapStartAnalysis = { [weak view, weak self] in
-                 view?.updateLayoutForInProgress()
+             viewModel.noAnalysisCardViewModel.onTapStartAnalysis = { [weak self] in
                  self?.onNeedsAnalysisTap()
              }
              view.configure(viewModel.noAnalysisCardViewModel)
-             return view
-
-        case .progressAnalysisCard:
-             let view: FakespotNoAnalysisCardView = .build()
-             view.configure(viewModel.noAnalysisCardViewModel)
-             view.updateLayoutForInProgress()
              return view
 
         case .productAdCard:

--- a/Client/Frontend/Fakespot/FakespotViewModel.swift
+++ b/Client/Frontend/Fakespot/FakespotViewModel.swift
@@ -138,7 +138,6 @@ class FakespotViewModel {
         case qualityDeterminationCard
         case settingsCard
         case noAnalysisCard
-        case progressAnalysisCard
         case productAdCard
         case messageCard(MessageType)
         enum MessageType {

--- a/Client/Frontend/Fakespot/FakespotViewModel.swift
+++ b/Client/Frontend/Fakespot/FakespotViewModel.swift
@@ -61,7 +61,7 @@ class FakespotViewModel {
                 var cards: [ViewElement] = []
 
                 if analysisStatus?.isAnalyzing == true {
-                    cards.append(.progressAnalysisCard)
+                    cards.append(.messageCard(.analysisInProgress))
                 } else {
                     cards.append(.noAnalysisCard)
                 }
@@ -78,7 +78,7 @@ class FakespotViewModel {
                     cards.append(.messageCard(.notEnoughReviews))
                 } else {
                     if analysisStatus?.isAnalyzing == true {
-                        cards.append(.progressAnalysisCard)
+                        cards.append(.messageCard(.analysisInProgress))
                     } else {
                         cards.append(.noAnalysisCard)
                     }

--- a/Client/Frontend/Fakespot/FakespotViewModel.swift
+++ b/Client/Frontend/Fakespot/FakespotViewModel.swift
@@ -338,6 +338,12 @@ class FakespotViewModel {
             await fetchProductAnalysis()
             return
         }
+
+        if case .loaded(let productAnalysisData, _, _) = state {
+            // update the state to in progress so UI is updated
+            state = .loaded(productAnalysisData, status, analysisCount: analyzeCount)
+        }
+
         do {
             // Listen for analysis status until it's completed, then fetch new information
             for try await status in observeProductAnalysisStatus() where status.isAnalyzing == false {

--- a/Client/Frontend/Fakespot/Views/FakespotNoAnalysisCardView.swift
+++ b/Client/Frontend/Fakespot/Views/FakespotNoAnalysisCardView.swift
@@ -15,8 +15,6 @@ struct FakespotNoAnalysisCardViewModel {
     let bodyLabelA11yId: String = AccessibilityIdentifiers.Shopping.NoAnalysisCard.bodyTitle
     let analyzerButtonText: String = .Shopping.NoAnalysisCardAnalyzerButtonTitle
     let analyzerButtonA11yId: String = AccessibilityIdentifiers.Shopping.NoAnalysisCard.analyzerButtonTitle
-    let inProgressHeadlineText: String = .Shopping.NoAnalysisCardInProgressTitle
-    let inProgressBodyText: String = .Shopping.NoAnalysisCardInProgressBodyLabel
     var onTapStartAnalysis: (() -> Void)?
 
     func recordStartAnalysisTelemetry() {
@@ -39,7 +37,6 @@ final class FakespotNoAnalysisCardView: UIView, ThemeApplicable {
     }
 
     private var viewModel: FakespotNoAnalysisCardViewModel?
-    private var isAnalysisInProgress = false
 
     private lazy var cardContainer: ShadowCardView = .build()
     private lazy var mainView: UIView = .build()
@@ -78,7 +75,6 @@ final class FakespotNoAnalysisCardView: UIView, ThemeApplicable {
         view.axis = .horizontal
         view.spacing = UX.titleStackViewSpacing
     }
-    private lazy var activityIndicatorView: UIActivityIndicatorView = .build()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -114,7 +110,6 @@ final class FakespotNoAnalysisCardView: UIView, ThemeApplicable {
         let colors = theme.colors
         headlineLabel.textColor = colors.textPrimary
         bodyLabel.textColor = colors.textPrimary
-        activityIndicatorView.color = colors.textPrimary
     }
 
     private func setupLayout() {
@@ -150,19 +145,5 @@ final class FakespotNoAnalysisCardView: UIView, ThemeApplicable {
     private func didTapStartAnalysis() {
         viewModel?.onTapStartAnalysis?()
         viewModel?.recordStartAnalysisTelemetry()
-        updateLayoutForInProgress()
-    }
-
-    public func updateLayoutForInProgress() {
-        isAnalysisInProgress = true
-
-        contentStackView.removeArrangedSubview(analyzerButton)
-        analyzerButton.removeFromSuperview()
-
-        headlineLabel.text = viewModel?.inProgressHeadlineText
-        bodyLabel.text = viewModel?.inProgressBodyText
-
-        titleStackView.insertArrangedSubview(activityIndicatorView, at: 0)
-        activityIndicatorView.startAnimating()
     }
 }

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -3837,16 +3837,18 @@ extension String {
             tableName: "Shopping",
             value: "Check Review Quality",
             comment: "Text for the analyzer button displayed when an analysis can be updated for a product.")
-        public static let NoAnalysisCardInProgressTitle = MZLocalizedString(
+        public static let NoAnalysisCardInProgressTitleNotUsed = MZLocalizedString(
             key: "Shopping.NoAnalysisCard.InProgress.Headline.Title.v120",
             tableName: "Shopping",
             value: "Checking review quality",
-            comment: "Title for the card displayed when a shopping product has not been analysed yet but the analysis is in progress.")
-        public static let NoAnalysisCardInProgressBodyLabel = MZLocalizedString(
+            comment: "Title for the card displayed when a shopping product has not been analysed yet but the analysis is in progress.",
+            lastUsedInVersion: 120)
+        public static let NoAnalysisCardInProgressBodyLabelNotUsed = MZLocalizedString(
             key: "Shopping.NoAnalysisCard.InProgress.Body.Label.v120",
             tableName: "Shopping",
             value: "This could take about 60 seconds.",
-            comment: "Description for the card displayed when a shopping product has not been analysed yet but the analysis is in progress.")
+            comment: "Description for the card displayed when a shopping product has not been analysed yet but the analysis is in progress.",
+            lastUsedInVersion: 120)
         public static let ReviewQualityCardLabelTitle = MZLocalizedString(
             key: "Shopping.ReviewQualityCard.Label.Title.v120",
             tableName: "Shopping",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7541)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16768)

## :bulb: Description
Updates Fakespot to display the in progress message card when the initial analysis of a product is started.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

