### PR TITLE
Add FXIOS-7188 [v121] Add & update search settings strings

### DIFF
--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -50,7 +50,7 @@ class SearchSettingsTableViewController: ThemedTableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        navigationItem.title = .SearchSettingsTitle
+        navigationItem.title = .Settings.Search.Title
 
         // To allow re-ordering the list of search engines at all times.
         tableView.isEditing = true
@@ -96,14 +96,14 @@ class SearchSettingsTableViewController: ThemedTableViewController {
             case ItemDefaultEngine:
                 engine = model.defaultEngine
                 cell.editingAccessoryType = .disclosureIndicator
-                cell.accessibilityLabel = .SearchSettingsDefaultSearchEngineAccessibilityLabel
+                cell.accessibilityLabel = .Settings.Search.AccessibilityLabels.DefaultSearchEngine
                 cell.accessibilityValue = engine.shortName
                 cell.textLabel?.text = engine.shortName
                 cell.imageView?.image = engine.image.createScaled(IconSize)
                 cell.imageView?.layer.cornerRadius = 4
                 cell.imageView?.layer.masksToBounds = true
             case ItemDefaultSuggestions:
-                cell.textLabel?.text = .SearchSettingsShowSearchSuggestions
+                cell.textLabel?.text = .Settings.Search.ShowSearchSuggestions
                 cell.textLabel?.numberOfLines = 0
                 let toggle = ThemedSwitch()
                 toggle.applyTheme(theme: themeManager.currentTheme)
@@ -235,9 +235,9 @@ class SearchSettingsTableViewController: ThemedTableViewController {
 
         var sectionTitle: String
         if section == SectionDefault {
-            sectionTitle = .SearchSettingsDefaultSearchEngineTitle
+            sectionTitle = .Settings.Search.DefaultSearchEngineTitle
         } else {
-            sectionTitle = .SearchSettingsQuickSearchEnginesTitle
+            sectionTitle = .Settings.Search.QuickSearchEnginesTitle
         }
         headerView.titleLabel.text = sectionTitle
 

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -1624,6 +1624,47 @@ extension String {
                     comment: "Title for the page where the user sign in to their Firefox Sync account.")
             }
         }
+
+        public struct Search {
+            public static let Title = MZLocalizedString(
+                key: "Settings.Search.PageTitle.v121",
+                tableName: "Settings",
+                value: "Search",
+                comment: "Navigation title for search page in the Settings menu.")
+            public static let ShowSearchSuggestions = MZLocalizedString(
+                key: "Settings.Search.ShowSuggestions.v121",
+                tableName: "Settings",
+                value: "Show Search Suggestions",
+                comment: "Label for show search suggestions setting, in the Search Settings page.")
+            public static let DefaultSearchEngineTitle = MZLocalizedString(
+                key: "Settings.Search.DefaultSearchEngine.Title.v121",
+                tableName: "Settings",
+                value: "Default Search Engine",
+                comment: "Title for default search engine settings section in the Search page in the Settings menu.")
+            public static let QuickSearchEnginesTitle = MZLocalizedString(
+                key: "Settings.Search.QuickEnginesTitle.v121",
+                tableName: "Settings",
+                value: "Quick-Search Engines",
+                comment: "Title for quick-search engines settings section in the Search page in the Settings menu.")
+            public static let PrivateSessionTitle = MZLocalizedString(
+                key: "Settings.Search.PrivateSession.Title.v121",
+                tableName: "Settings",
+                value: "Private Session",
+                comment: "Title for the Private Session settings section in the Search page in the Settings menu.")
+            public static let PrivateSessionSetting = MZLocalizedString(
+                key: "Settings.Search.PrivateSession.Setting.v121",
+                tableName: "Settings",
+                value: "Turn off suggestions in private browsing",
+                comment: "Label for toggle. Explains that, in private browsing mode, search suggestions, the suggestions appearing at the top of the search bar, can be toggled on or off. Located in the Private Session section in the Search page in the Settings menu.")
+
+            public struct AccessibilityLabels {
+                public static let DefaultSearchEngine = MZLocalizedString(
+                    key: "Settings.Search.Accessibility.DefaultSearchEngine.v106",
+                    tableName: "Settings",
+                    value: "Default Search Engine",
+                    comment: "Accessibility label for default search engine setting.")
+            }
+        }
     }
 }
 
@@ -5222,35 +5263,6 @@ extension String {
         tableName: nil,
         value: nil,
         comment: "Label for Cancel button")
-}
-
-// MARK: - SearchSettings
-extension String {
-    public static let SearchSettingsTitle = MZLocalizedString(
-        key: "SearchSettings.Title.Search.v106",
-        tableName: nil,
-        value: "Search",
-        comment: "Navigation title for search settings.")
-    public static let SearchSettingsDefaultSearchEngineAccessibilityLabel = MZLocalizedString(
-        key: "SearchSettings.Accessibility.DefaultSearchEngine.v106",
-        tableName: nil,
-        value: "Default Search Engine",
-        comment: "Accessibility label for default search engine setting.")
-    public static let SearchSettingsShowSearchSuggestions = MZLocalizedString(
-        key: "Show Search Suggestions",
-        tableName: nil,
-        value: nil,
-        comment: "Label for show search suggestions setting.")
-    public static let SearchSettingsDefaultSearchEngineTitle = MZLocalizedString(
-        key: "SearchSettings.Title.DefaultSearchEngine.v106",
-        tableName: nil,
-        value: "Default Search Engine",
-        comment: "Title for default search engine settings section.")
-    public static let SearchSettingsQuickSearchEnginesTitle = MZLocalizedString(
-        key: "Quick-Search Engines",
-        tableName: nil,
-        value: nil,
-        comment: "Title for quick-search engines settings section.")
 }
 
 // MARK: - SettingsContent

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -5271,27 +5271,32 @@ extension String {
         key: "SearchSettings.Title.Search.v106",
         tableName: nil,
         value: "Search",
-        comment: "Navigation title for search settings.")
+        comment: "Navigation title for search settings.",
+        lastUsedInVersion: 120)
     public static let SearchSettingsDefaultSearchEngineAccessibilityLabel = MZLocalizedString(
         key: "SearchSettings.Accessibility.DefaultSearchEngine.v106",
         tableName: nil,
         value: "Default Search Engine",
-        comment: "Accessibility label for default search engine setting.")
+        comment: "Accessibility label for default search engine setting.",
+        lastUsedInVersion: 120)
     public static let SearchSettingsShowSearchSuggestions = MZLocalizedString(
         key: "Show Search Suggestions",
         tableName: nil,
         value: nil,
-        comment: "Label for show search suggestions setting.")
+        comment: "Label for show search suggestions setting.",
+        lastUsedInVersion: 120)
     public static let SearchSettingsDefaultSearchEngineTitle = MZLocalizedString(
         key: "SearchSettings.Title.DefaultSearchEngine.v106",
         tableName: nil,
         value: "Default Search Engine",
-        comment: "Title for default search engine settings section.")
-    public static let SearchSettingsQuickSearchEnginesTitle = MZLocalizedString(
+        comment: "Title for default search engine settings section.",
+        lastUsedInVersion: 120)
+ public static let SearchSettingsQuickSearchEnginesTitle = MZLocalizedString(
         key: "Quick-Search Engines",
         tableName: nil,
         value: nil,
-        comment: "Title for quick-search engines settings section.")
+        comment: "Title for quick-search engines settings section.",
+        lastUsedInVersion: 120)
 }
 
 // MARK: - SettingsContent

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -1635,12 +1635,12 @@ extension String {
                 key: "Settings.Search.ShowSuggestions.v121",
                 tableName: "Settings",
                 value: "Show Search Suggestions",
-                comment: "Label for show search suggestions setting, in the Search Settings page.")
+                comment: "Label for the `show search suggestions` setting, in the Search Settings page.")
             public static let DefaultSearchEngineTitle = MZLocalizedString(
                 key: "Settings.Search.DefaultSearchEngine.Title.v121",
                 tableName: "Settings",
                 value: "Default Search Engine",
-                comment: "Title for default search engine settings section in the Search page in the Settings menu.")
+                comment: "Title for the `default search engine` settings section in the Search page in the Settings menu.")
             public static let QuickSearchEnginesTitle = MZLocalizedString(
                 key: "Settings.Search.QuickEnginesTitle.v121",
                 tableName: "Settings",
@@ -1650,12 +1650,12 @@ extension String {
                 key: "Settings.Search.PrivateSession.Title.v121",
                 tableName: "Settings",
                 value: "Private Session",
-                comment: "Title for the Private Session settings section in the Search page in the Settings menu.")
+                comment: "Title for the `Private Session` settings section in the Search page in the Settings menu.")
             public static let PrivateSessionSetting = MZLocalizedString(
                 key: "Settings.Search.PrivateSession.Setting.v121",
                 tableName: "Settings",
                 value: "Turn off suggestions in private browsing",
-                comment: "Label for toggle. Explains that, in private browsing mode, search suggestions, the suggestions appearing at the top of the search bar, can be toggled on or off. Located in the Private Session section in the Search page in the Settings menu.")
+                comment: "Label for toggle. Explains that in private browsing mode, the search suggestions which appears at the top of the search bar, can be toggled on or off. Located in the Private Session section in the Search page in the Settings menu.")
 
             public struct AccessibilityLabels {
                 public static let DefaultSearchEngine = MZLocalizedString(

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -5265,6 +5265,35 @@ extension String {
         comment: "Label for Cancel button")
 }
 
+// MARK: - SearchSettings
+extension String {
+    public static let SearchSettingsTitle = MZLocalizedString(
+        key: "SearchSettings.Title.Search.v106",
+        tableName: nil,
+        value: "Search",
+        comment: "Navigation title for search settings.")
+    public static let SearchSettingsDefaultSearchEngineAccessibilityLabel = MZLocalizedString(
+        key: "SearchSettings.Accessibility.DefaultSearchEngine.v106",
+        tableName: nil,
+        value: "Default Search Engine",
+        comment: "Accessibility label for default search engine setting.")
+    public static let SearchSettingsShowSearchSuggestions = MZLocalizedString(
+        key: "Show Search Suggestions",
+        tableName: nil,
+        value: nil,
+        comment: "Label for show search suggestions setting.")
+    public static let SearchSettingsDefaultSearchEngineTitle = MZLocalizedString(
+        key: "SearchSettings.Title.DefaultSearchEngine.v106",
+        tableName: nil,
+        value: "Default Search Engine",
+        comment: "Title for default search engine settings section.")
+    public static let SearchSettingsQuickSearchEnginesTitle = MZLocalizedString(
+        key: "Quick-Search Engines",
+        tableName: nil,
+        value: nil,
+        comment: "Title for quick-search engines settings section.")
+}
+
 // MARK: - SettingsContent
 extension String {
     public static let SettingsContentPageLoadError = MZLocalizedString(

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -1659,7 +1659,7 @@ extension String {
 
             public struct AccessibilityLabels {
                 public static let DefaultSearchEngine = MZLocalizedString(
-                    key: "Settings.Search.Accessibility.DefaultSearchEngine.v106",
+                    key: "Settings.Search.Accessibility.DefaultSearchEngine.v121",
                     tableName: "Settings",
                     value: "Default Search Engine",
                     comment: "Accessibility label for default search engine setting.")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7188)

## :bulb: Description
This was missed, but it's ok, because we pushed string export to Monday. I will do better next time - please don't take away my ice cream.

PR: Update the organization of the search strings. Added tablenames. Updated use locations. Added new strings for privacy.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

