### PR TITLE
Refactor FXIOS-7651 [v121] RustAutofill class cleanup

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -876,6 +876,8 @@
 		B10997432A97251D00CC8860 /* UrlBarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10997422A97251D00CC8860 /* UrlBarTests.swift */; };
 		B12DDFED2A8DE825008CE9CF /* ToolbarMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12DDFEC2A8DE825008CE9CF /* ToolbarMenuTests.swift */; };
 		B15058812AA0A878008B7382 /* OpeningScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15058802AA0A878008B7382 /* OpeningScreenTests.swift */; };
+		B2999FED2B044A5900F0FEC1 /* UnencryptedCreditCardFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2999FEC2B044A5900F0FEC1 /* UnencryptedCreditCardFields.swift */; };
+		B2999FEF2B044B4E00F0FEC1 /* RustAutofillEncryptionKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2999FEE2B044B4E00F0FEC1 /* RustAutofillEncryptionKeys.swift */; };
 		B640467E29B9B58200C5C7B6 /* TabLocationViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B640467D29B9B58200C5C7B6 /* TabLocationViewTests.swift */; };
 		BCFF93EE2AAA9F6E005B5B71 /* RustFirefoxSuggest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF93ED2AAA9C47005B5B71 /* RustFirefoxSuggest.swift */; };
 		BCFF93F02AABA55A005B5B71 /* BackgroundFirefoxSuggestIngestUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF93EF2AAB97A8005B5B71 /* BackgroundFirefoxSuggestIngestUtility.swift */; };
@@ -5644,6 +5646,8 @@
 		B25D4E72A0116CFE5BEC29CC /* es-CL */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-CL"; path = "es-CL.lproj/ClearPrivateData.strings"; sourceTree = "<group>"; };
 		B29049688244A8F79950DF35 /* af */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = af; path = af.lproj/Shared.strings; sourceTree = "<group>"; };
 		B2944B3EAFB1DA22E7F28520 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Shared.strings; sourceTree = "<group>"; };
+		B2999FEC2B044A5900F0FEC1 /* UnencryptedCreditCardFields.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnencryptedCreditCardFields.swift; sourceTree = "<group>"; };
+		B2999FEE2B044B4E00F0FEC1 /* RustAutofillEncryptionKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustAutofillEncryptionKeys.swift; sourceTree = "<group>"; };
 		B2BA445A91E19959BA9FDED7 /* mr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = mr; path = mr.lproj/FindInPage.strings; sourceTree = "<group>"; };
 		B2C74A199A0619104A7635EC /* bs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bs; path = bs.lproj/ClearPrivateData.strings; sourceTree = "<group>"; };
 		B2CD44128F18BC81432BBB4C /* gu-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "gu-IN"; path = "gu-IN.lproj/Search.strings"; sourceTree = "<group>"; };
@@ -9695,6 +9699,8 @@
 		D057B2AC22022617000614E0 /* Rust */ = {
 			isa = PBXGroup;
 			children = (
+				B2999FEE2B044B4E00F0FEC1 /* RustAutofillEncryptionKeys.swift */,
+				B2999FEC2B044A5900F0FEC1 /* UnencryptedCreditCardFields.swift */,
 				F8AAC1B329663618000BCDEC /* RustAutofill.swift */,
 				D05434D8225BAA6200FDE4EF /* RustPlaces.swift */,
 				D057B2AA220103BC000614E0 /* RustLogins.swift */,
@@ -12281,9 +12287,11 @@
 				E65075C21E37F956006961AC /* ExtensionUtils.swift in Sources */,
 				D057B2AB220103BC000614E0 /* RustLogins.swift in Sources */,
 				E677F0541D94247300ECF1FB /* Metadata.swift in Sources */,
+				B2999FED2B044A5900F0FEC1 /* UnencryptedCreditCardFields.swift in Sources */,
 				15DE98FD27FCED4F00F1ECDB /* RustRemoteTabs.swift in Sources */,
 				285D3B901B4386520035FD22 /* SQLiteQueue.swift in Sources */,
 				394CF6CF1BAA493C00906917 /* DefaultSuggestedSites.swift in Sources */,
+				B2999FEF2B044B4E00F0FEC1 /* RustAutofillEncryptionKeys.swift in Sources */,
 				2FCAE2781ABB531100877008 /* Visit.swift in Sources */,
 				D3BF8CBB1B7425570007AFE6 /* DiskImageStore.swift in Sources */,
 				E6FF6ACA1D873CFF0070C294 /* PageMetadata.swift in Sources */,

--- a/Storage/Rust/RustAutofill.swift
+++ b/Storage/Rust/RustAutofill.swift
@@ -268,8 +268,7 @@ public class RustAutofill {
     // MARK: - Private Helper Methods
 
     private func handleDatabaseError(_ error: NSError) {
-        // This is an unrecoverable
-        // state unless we can move the existing file to a backup
+        // This is an unrecoverable state unless we can move the existing file to a backup
         // location and start over.
         if let autofillStoreError = error as? AutofillApiError {
             logger.log("Rust Autofill store error when opening database",

--- a/Storage/Rust/RustAutofill.swift
+++ b/Storage/Rust/RustAutofill.swift
@@ -9,258 +9,39 @@ import Common
 
 typealias AutofillStore = Store
 
-public extension AutofillApiError {
-    var descriptionValue: String {
-        switch self {
-        case .SqlError: return "SqlError"
-        case .CryptoError: return "CryptoError"
-        case .NoSuchRecord: return "NoSuchRecord"
-        case .UnexpectedAutofillApiError: return "UnexpectedAutofillApiError"
-        case .InterruptedError: return "InterruptedError"
-        }
-    }
-}
-
 public enum AutofillEncryptionKeyError: Error {
     case illegalState
     case noKeyCreated
 }
 
-// Note: This was created in lieu of a view model
-public struct UnencryptedCreditCardFields {
-    public var ccName: String = ""
-    public var ccNumber: String = ""
-    public var ccNumberLast4: String = ""
-    public var ccExpMonth: Int64 = 0
-    public var ccExpYear: Int64 = 0
-    public var ccType: String = ""
-
-    public init() { }
-
-    public init(ccName: String,
-                ccNumber: String,
-                ccNumberLast4: String,
-                ccExpMonth: Int64,
-                ccExpYear: Int64,
-                ccType: String) {
-        self.ccName = ccName
-        self.ccNumber = ccNumber
-        self.ccNumberLast4 = ccNumberLast4
-        self.ccExpMonth = ccExpMonth
-        self.ccExpYear = ccExpYear
-        self.ccType = ccType
-    }
-
-    func toUpdatableCreditCardFields() -> UpdatableCreditCardFields {
-        let rustKeys = RustAutofillEncryptionKeys()
-        let ccNumberEnc = rustKeys.encryptCreditCardNum(creditCardNum: self.ccNumber)
-        return UpdatableCreditCardFields(ccName: self.ccName,
-                                         ccNumberEnc: ccNumberEnc ?? "",
-                                         ccNumberLast4: self.ccNumberLast4,
-                                         ccExpMonth: self.ccExpMonth,
-                                         ccExpYear: self.ccExpYear,
-                                         ccType: self.ccType)
-    }
-
-    public func convertToTempCreditCard() -> CreditCard {
-        let convertedCreditCard = CreditCard(guid: "",
-                                             ccName: self.ccName,
-                                             ccNumberEnc: "",
-                                             ccNumberLast4: self.ccNumberLast4,
-                                             ccExpMonth: self.ccExpMonth,
-                                             ccExpYear: self.ccExpYear,
-                                             ccType: self.ccType,
-                                             timeCreated: Int64(Date().timeIntervalSince1970),
-                                             timeLastUsed: nil,
-                                             timeLastModified: Int64(Date().timeIntervalSince1970),
-                                             timesUsed: 0)
-        return convertedCreditCard
-    }
-
-    public func isEqualToCreditCard(creditCard: CreditCard) -> Bool {
-        return creditCard.ccExpMonth == ccExpMonth &&
-        creditCard.ccExpYear == ccExpYear &&
-        creditCard.ccName == ccName &&
-        creditCard.ccNumberLast4 == ccNumberLast4
-    }
-}
-
-public class RustAutofillEncryptionKeys {
-    public let ccKeychainKey = "appservices.key.creditcard.perfield"
-
-    let keychain = MZKeychainWrapper.sharedClientAppContainerKeychain
-    let ccCanaryPhraseKey = "creditCardCanaryPhrase"
-    let canaryPhrase = "a string for checking validity of the key"
-
-    private let logger: Logger
-
-    public init(logger: Logger = DefaultLogger.shared) {
-        self.logger = logger
-    }
-
-    fileprivate func createAndStoreKey() throws -> String {
-        do {
-            let secret = try createAutofillKey()
-            let canary = try self.createCanary(text: canaryPhrase, key: secret)
-
-            keychain.set(secret,
-                         forKey: ccKeychainKey,
-                         withAccessibility: MZKeychainItemAccessibility.afterFirstUnlock)
-            keychain.set(canary,
-                         forKey: ccCanaryPhraseKey,
-                         withAccessibility: MZKeychainItemAccessibility.afterFirstUnlock)
-
-            return secret
-        } catch let err as NSError {
-            if let autofillStoreError = err as? AutofillApiError {
-                logAutofillStoreError(err: autofillStoreError,
-                                      errorDomain: err.domain,
-                                      errorMessage: "Error while creating and storing credit card key")
-
-                throw AutofillEncryptionKeyError.noKeyCreated
-            } else {
-                logger.log("Unknown error while creating and storing credit card key",
-                           level: .warning,
-                           category: .storage,
-                           description: err.localizedDescription)
-
-                throw AutofillEncryptionKeyError.noKeyCreated
-            }
-        }
-    }
-
-    func decryptCreditCardNum(encryptedCCNum: String) -> String? {
-        guard let key = self.keychain.string(forKey: self.ccKeychainKey) else {
-            return nil
-        }
-
-        do {
-            return try decryptString(key: key, ciphertext: encryptedCCNum)
-        } catch let err as NSError {
-            if let autofillStoreError = err as? AutofillApiError {
-                logAutofillStoreError(err: autofillStoreError,
-                                      errorDomain: err.domain,
-                                      errorMessage: "Error while decrypting credit card")
-            } else {
-                logger.log("Unknown error while decrypting credit card",
-                           level: .warning,
-                           category: .storage,
-                           description: err.localizedDescription)
-            }
-            return nil
-        }
-    }
-
-    fileprivate func checkCanary(canary: String,
-                                 text: String,
-                                 key: String) throws -> Bool {
-        return try decryptString(key: key, ciphertext: canary) == text
-    }
-
-    func encryptCreditCardNum(creditCardNum: String) -> String? {
-        guard let key = self.keychain.string(forKey: self.ccKeychainKey) else {
-            return nil
-        }
-
-        do {
-            return try encryptString(key: key, cleartext: creditCardNum)
-        } catch let err as NSError {
-            if let autofillStoreError = err as? AutofillApiError {
-                logAutofillStoreError(err: autofillStoreError,
-                                      errorDomain: err.domain,
-                                      errorMessage: "Error while encrypting credit card")
-            } else {
-                logger.log("Unknown error while encrypting credit card",
-                           level: .warning,
-                           category: .storage,
-                           description: err.localizedDescription)
-            }
-        }
-        return nil
-    }
-
-    fileprivate func createCanary(text: String,
-                                  key: String) throws -> String {
-        return try encryptString(key: key, cleartext: text)
-    }
-
-    private func logAutofillStoreError(err: AutofillApiError,
-                                       errorDomain: String,
-                                       errorMessage: String) {
-        var message: String {
-            switch err {
-            case .SqlError(let message),
-                    .CryptoError(let message),
-                    .NoSuchRecord(let message),
-                    .UnexpectedAutofillApiError(let message):
-                return message
-            case .InterruptedError:
-                return "Interrupted Error"
-            }
-        }
-
-        logger.log(errorMessage,
-                   level: .warning,
-                   category: .storage,
-                   description: "\(errorDomain) - \(err.descriptionValue): \(message)")
-    }
-}
-
 public class RustAutofill {
     let databasePath: String
-
     let queue: DispatchQueue
     var storage: AutofillStore?
 
     private(set) var isOpen = false
-
     private var didAttemptToMoveToBackup = false
-
     private let logger: Logger
 
-    public init(databasePath: String,
-                logger: Logger = DefaultLogger.shared) {
+    public init(databasePath: String, logger: Logger = DefaultLogger.shared) {
         self.databasePath = databasePath
-
-        queue = DispatchQueue(label: "RustAutofill queue: \(databasePath)",
-                              attributes: [])
+        queue = DispatchQueue(label: "RustAutofill queue: \(databasePath)")
         self.logger = logger
     }
 
-    private func open() -> NSError? {
+    public func open() -> NSError? {
         do {
             try getStoredKey()
             storage = try AutofillStore(dbpath: databasePath)
             isOpen = true
             return nil
         } catch let err as NSError {
-            if let autofillStoreError = err as? AutofillApiError {
-                // This is an unrecoverable
-                // state unless we can move the existing file to a backup
-                // location and start over.
-                logger.log("Rust Autofill store error when opening database",
-                           level: .warning,
-                           category: .storage,
-                           description: autofillStoreError.localizedDescription)
-            } else {
-                logger.log("Unknown error when opening Rust Autofill database",
-                           level: .warning,
-                           category: .storage,
-                           description: err.localizedDescription)
-            }
-
-            if !didAttemptToMoveToBackup {
-                RustShared.moveDatabaseFileToBackupLocation(
-                    databasePath: self.databasePath)
-                didAttemptToMoveToBackup = true
-                return open()
-            }
-
+            handleDatabaseError(err)
             return err
         }
     }
 
-    private func close() -> NSError? {
+    public func close() -> NSError? {
         storage = nil
         isOpen = false
         return nil
@@ -268,58 +49,31 @@ public class RustAutofill {
 
     public func reopenIfClosed() -> NSError? {
         var error: NSError?
-
         queue.sync {
             guard !isOpen else { return }
-
             error = open()
         }
-
         return error
     }
 
     public func forceClose() -> NSError? {
         var error: NSError?
-
         queue.sync {
             guard isOpen else { return }
-
             error = close()
         }
-
         return error
     }
 
     public func addCreditCard(creditCard: UnencryptedCreditCardFields, completion: @escaping (CreditCard?, Error?) -> Void) {
-        queue.async {
-            guard self.isOpen else {
-                let error = AutofillApiError.UnexpectedAutofillApiError(
-                    reason: "Database is closed")
-                completion(nil, error)
-                return
-            }
-
+        performDatabaseOperation { error in
+        if let error = error {
+            completion(nil, error)
+            return
+        }
             do {
                 let id = try self.storage?.addCreditCard(cc: creditCard.toUpdatableCreditCardFields())
                 completion(id!, nil)
-            } catch let err as NSError {
-                completion(nil, err)
-            }
-        }
-    }
-
-    public func getCreditCard(id: String, completion: @escaping (CreditCard?, Error?) -> Void) {
-        queue.async {
-            guard self.isOpen else {
-                let error = AutofillApiError.UnexpectedAutofillApiError(
-                    reason: "Database is closed")
-                completion(nil, error)
-                return
-            }
-
-            do {
-                let record = try self.storage?.getCreditCard(guid: id)
-                completion(record, nil)
             } catch let err as NSError {
                 completion(nil, err)
             }
@@ -331,19 +85,15 @@ public class RustAutofill {
             return nil
         }
         let keys = RustAutofillEncryptionKeys()
-        let num = keys.decryptCreditCardNum(encryptedCCNum: encryptedCCNum)
-        return num
+        return keys.decryptCreditCardNum(encryptedCCNum: encryptedCCNum)
     }
 
     public func listCreditCards(completion: @escaping ([CreditCard]?, Error?) -> Void) {
-        queue.async {
-            guard self.isOpen else {
-                let error = AutofillApiError.UnexpectedAutofillApiError(
-                    reason: "Database is closed")
-                completion(nil, error)
-                return
-            }
-
+        performDatabaseOperation { error in
+        if let error = error {
+            completion(nil, error)
+            return
+        }
             do {
                 let records = try self.storage?.getAllCreditCards()
                 completion(records, nil)
@@ -354,14 +104,11 @@ public class RustAutofill {
     }
 
     public func checkForCreditCardExistance(cardNumber: String, completion: @escaping (CreditCard?, Error?) -> Void) {
-        queue.async {
-            guard self.isOpen else {
-                let error = AutofillApiError.UnexpectedAutofillApiError(
-                    reason: "Database is closed")
-                completion(nil, error)
-                return
-            }
-
+        performDatabaseOperation { error in
+        if let error = error {
+            completion(nil, error)
+            return
+        }
             do {
                 guard let records = try self.storage?.getAllCreditCards(),
                       let foundCard = records.first(where: { $0.ccNumberLast4 == cardNumber })
@@ -377,18 +124,16 @@ public class RustAutofill {
     }
 
     public func updateCreditCard(id: String, creditCard: UnencryptedCreditCardFields, completion: @escaping (Bool, Error?) -> Void) {
-        queue.async {
-            guard self.isOpen else {
-                let error = AutofillApiError.UnexpectedAutofillApiError(
-                    reason: "Database is closed")
-                completion(false, error)
-                return
-            }
-
+        performDatabaseOperation { error in
+        if let error = error {
+            completion(false, error)
+            return
+        }
             do {
                 try self.storage?.updateCreditCard(
                     guid: id,
-                    cc: creditCard.toUpdatableCreditCardFields())
+                    cc: creditCard.toUpdatableCreditCardFields()
+                )
                 completion(true, nil)
             } catch let err as NSError {
                 completion(false, err)
@@ -397,14 +142,11 @@ public class RustAutofill {
     }
 
     public func deleteCreditCard(id: String, completion: @escaping (Bool, Error?) -> Void) {
-        queue.async {
-            guard self.isOpen else {
-                let error = AutofillApiError.UnexpectedAutofillApiError(
-                    reason: "Database is closed")
-                completion(false, error)
-                return
-            }
-
+        performDatabaseOperation { error in
+        if let error = error {
+            completion(false, error)
+            return
+        }
             do {
                 let existed = try self.storage?.deleteCreditCard(guid: id)
                 completion(existed!, nil)
@@ -415,14 +157,11 @@ public class RustAutofill {
     }
 
     public func use(creditCard: CreditCard, completion: @escaping (Bool, Error?) -> Void) {
-        queue.async {
-            guard self.isOpen else {
-                let error = AutofillApiError.UnexpectedAutofillApiError(
-                    reason: "Database is closed")
-                completion(false, error)
-                return
-            }
-
+        performDatabaseOperation { error in
+        if let error = error {
+            completion(false, error)
+            return
+        }
             do {
                 try self.storage?.touchCreditCard(guid: creditCard.guid)
                 completion(true, nil)
@@ -433,14 +172,11 @@ public class RustAutofill {
     }
 
     public func scrubCreditCardNums(completion: @escaping (Bool, Error?) -> Void) {
-        queue.async {
-            guard self.isOpen else {
-                let error = AutofillApiError.UnexpectedAutofillApiError(
-                    reason: "Database is closed")
-                completion(false, error)
-                return
-            }
-
+        performDatabaseOperation { error in
+        if let error = error {
+            completion(false, error)
+            return
+        }
             do {
                 try self.storage?.scrubEncryptedData()
                 completion(true, nil)
@@ -461,24 +197,22 @@ public class RustAutofill {
         let rustKeys = RustAutofillEncryptionKeys()
         let key = rustKeys.keychain.string(forKey: rustKeys.ccKeychainKey)
         let encryptedCanaryPhrase = rustKeys.keychain.string(
-            forKey: rustKeys.ccCanaryPhraseKey)
+            forKey: rustKeys.ccCanaryPhraseKey
+        )
 
-        switch(key, encryptedCanaryPhrase) {
-        case (.some(key), .some(encryptedCanaryPhrase)):
+        switch (key, encryptedCanaryPhrase) {
+        case (.some(let key), .some(let encryptedCanaryPhrase)):
             // We expected the key to be present, and it is.
             do {
                 let canaryIsValid = try rustKeys.checkCanary(
-                    canary: encryptedCanaryPhrase!,
+                    canary: encryptedCanaryPhrase,
                     text: rustKeys.canaryPhrase,
-                    key: key!)
+                    key: key
+                )
                 if canaryIsValid {
-                    return key!
+                    return key
                 } else {
-                    logger.log("Autofill key was corrupted, new one generated",
-                               level: .warning,
-                               category: .storage)
-
-                    self.scrubCreditCardNums(completion: {_, _ in })
+                    handleKeyCorruption()
                     return try rustKeys.createAndStoreKey()
                 }
             } catch let error as NSError {
@@ -487,26 +221,12 @@ public class RustAutofill {
                            category: .storage,
                            description: error.localizedDescription)
             }
-        case (.some(key), .none):
+        case (.some(key), .none), (.none, .some(encryptedCanaryPhrase)):
             // The key is present, but we didn't expect it to be there.
+            // or
+            // We expected the key to be present, but it's gone missing on us
             do {
-                logger.log("Autofill key lost due to storage malfunction, new one generated",
-                           level: .warning,
-                           category: .storage)
-
-                self.scrubCreditCardNums(completion: {_, _ in })
-                return try rustKeys.createAndStoreKey()
-            } catch let error as NSError {
-                throw error
-            }
-        case (.none, .some(encryptedCanaryPhrase)):
-            // We expected the key to be present, but it's gone missing on us.
-            do {
-                logger.log("Autofill key lost, new one generated",
-                           level: .warning,
-                           category: .storage)
-
-                self.scrubCreditCardNums(completion: {_, _ in })
+                handleKeyLoss()
                 return try rustKeys.createAndStoreKey()
             } catch let error as NSError {
                 throw error
@@ -524,9 +244,60 @@ public class RustAutofill {
             // but is disallowed nonetheless
             throw AutofillEncryptionKeyError.illegalState
         }
-
         // This must be declared again for Swift's sake even though the above switch statement
         // handles all cases
         throw AutofillEncryptionKeyError.illegalState
+    }
+
+    // Private Helper Methods
+
+    private func handleDatabaseError(_ error: NSError) {
+        // This is an unrecoverable
+        // state unless we can move the existing file to a backup
+        // location and start over.
+        if let autofillStoreError = error as? AutofillApiError {
+            logger.log("Rust Autofill store error when opening database",
+                       level: .warning,
+                       category: .storage,
+                       description: autofillStoreError.localizedDescription)
+        } else {
+            logger.log("Unknown error when opening Rust Autofill database",
+                       level: .warning,
+                       category: .storage,
+                       description: error.localizedDescription)
+        }
+
+        if !didAttemptToMoveToBackup {
+            RustShared.moveDatabaseFileToBackupLocation(databasePath: self.databasePath)
+            didAttemptToMoveToBackup = true
+            _ = open()
+        }
+    }
+    
+    ///This function can be improved to capture more repeated code
+    private func performDatabaseOperation(_ operation: @escaping (Error?) -> Void) {
+        queue.async {
+            guard self.isOpen else {
+                let error = AutofillApiError.UnexpectedAutofillApiError(
+                    reason: "Database is closed")
+                operation(error)
+                return
+            }
+            operation(nil)
+        }
+    }
+
+    private func handleKeyCorruption() {
+        logger.log("Autofill key was corrupted, new one generated",
+                   level: .warning,
+                   category: .storage)
+        scrubCreditCardNums(completion: { _, _ in })
+    }
+
+    private func handleKeyLoss() {
+        logger.log("Autofill key lost, new one generated",
+                   level: .warning,
+                   category: .storage)
+        scrubCreditCardNums(completion: { _, _ in })
     }
 }

--- a/Storage/Rust/RustAutofill.swift
+++ b/Storage/Rust/RustAutofill.swift
@@ -265,7 +265,7 @@ public class RustAutofill {
         throw AutofillEncryptionKeyError.illegalState
     }
 
-    // Private Helper Methods
+    // MARK: - Private Helper Methods
 
     private func handleDatabaseError(_ error: NSError) {
         // This is an unrecoverable

--- a/Storage/Rust/RustAutofill.swift
+++ b/Storage/Rust/RustAutofill.swift
@@ -67,10 +67,10 @@ public class RustAutofill {
 
     public func addCreditCard(creditCard: UnencryptedCreditCardFields, completion: @escaping (CreditCard?, Error?) -> Void) {
         performDatabaseOperation { error in
-        if let error = error {
-            completion(nil, error)
-            return
-        }
+            if let error = error {
+                completion(nil, error)
+                return
+            }
             do {
                 let id = try self.storage?.addCreditCard(cc: creditCard.toUpdatableCreditCardFields())
                 completion(id!, nil)
@@ -88,12 +88,28 @@ public class RustAutofill {
         return keys.decryptCreditCardNum(encryptedCCNum: encryptedCCNum)
     }
 
+    public func getCreditCard(id: String, completion: @escaping (CreditCard?, Error?) -> Void) {
+        performDatabaseOperation { error in
+            if let error = error {
+                completion(nil, error)
+                return
+            }
+
+            do {
+                let record = try self.storage?.getCreditCard(guid: id)
+                completion(record, nil)
+            } catch let err as NSError {
+                completion(nil, err)
+            }
+        }
+    }
+
     public func listCreditCards(completion: @escaping ([CreditCard]?, Error?) -> Void) {
         performDatabaseOperation { error in
-        if let error = error {
-            completion(nil, error)
-            return
-        }
+            if let error = error {
+                completion(nil, error)
+                return
+            }
             do {
                 let records = try self.storage?.getAllCreditCards()
                 completion(records, nil)
@@ -105,10 +121,10 @@ public class RustAutofill {
 
     public func checkForCreditCardExistance(cardNumber: String, completion: @escaping (CreditCard?, Error?) -> Void) {
         performDatabaseOperation { error in
-        if let error = error {
-            completion(nil, error)
-            return
-        }
+            if let error = error {
+                completion(nil, error)
+                return
+            }
             do {
                 guard let records = try self.storage?.getAllCreditCards(),
                       let foundCard = records.first(where: { $0.ccNumberLast4 == cardNumber })
@@ -125,10 +141,10 @@ public class RustAutofill {
 
     public func updateCreditCard(id: String, creditCard: UnencryptedCreditCardFields, completion: @escaping (Bool, Error?) -> Void) {
         performDatabaseOperation { error in
-        if let error = error {
-            completion(false, error)
-            return
-        }
+            if let error = error {
+                completion(false, error)
+                return
+            }
             do {
                 try self.storage?.updateCreditCard(
                     guid: id,
@@ -143,10 +159,10 @@ public class RustAutofill {
 
     public func deleteCreditCard(id: String, completion: @escaping (Bool, Error?) -> Void) {
         performDatabaseOperation { error in
-        if let error = error {
-            completion(false, error)
-            return
-        }
+            if let error = error {
+                completion(false, error)
+                return
+            }
             do {
                 let existed = try self.storage?.deleteCreditCard(guid: id)
                 completion(existed!, nil)
@@ -158,10 +174,10 @@ public class RustAutofill {
 
     public func use(creditCard: CreditCard, completion: @escaping (Bool, Error?) -> Void) {
         performDatabaseOperation { error in
-        if let error = error {
-            completion(false, error)
-            return
-        }
+            if let error = error {
+                completion(false, error)
+                return
+            }
             do {
                 try self.storage?.touchCreditCard(guid: creditCard.guid)
                 completion(true, nil)
@@ -173,10 +189,10 @@ public class RustAutofill {
 
     public func scrubCreditCardNums(completion: @escaping (Bool, Error?) -> Void) {
         performDatabaseOperation { error in
-        if let error = error {
-            completion(false, error)
-            return
-        }
+            if let error = error {
+                completion(false, error)
+                return
+            }
             do {
                 try self.storage?.scrubEncryptedData()
                 completion(true, nil)

--- a/Storage/Rust/RustAutofill.swift
+++ b/Storage/Rust/RustAutofill.swift
@@ -29,7 +29,7 @@ public class RustAutofill {
         self.logger = logger
     }
 
-    public func open() -> NSError? {
+    internal func open() -> NSError? {
         do {
             try getStoredKey()
             storage = try AutofillStore(dbpath: databasePath)
@@ -41,7 +41,7 @@ public class RustAutofill {
         }
     }
 
-    public func close() -> NSError? {
+    internal func close() -> NSError? {
         storage = nil
         isOpen = false
         return nil

--- a/Storage/Rust/RustAutofill.swift
+++ b/Storage/Rust/RustAutofill.swift
@@ -273,8 +273,7 @@ public class RustAutofill {
             _ = open()
         }
     }
-    
-    ///This function can be improved to capture more repeated code
+
     private func performDatabaseOperation(_ operation: @escaping (Error?) -> Void) {
         queue.async {
             guard self.isOpen else {

--- a/Storage/Rust/RustAutofillEncryptionKeys.swift
+++ b/Storage/Rust/RustAutofillEncryptionKeys.swift
@@ -30,7 +30,7 @@ public class RustAutofillEncryptionKeys {
         self.logger = logger
     }
 
-     func createAndStoreKey() throws -> String {
+    func createAndStoreKey() throws -> String {
         do {
             let secret = try createAutofillKey()
             let canary = try self.createCanary(text: canaryPhrase, key: secret)
@@ -108,7 +108,7 @@ public class RustAutofillEncryptionKeys {
     }
 
     private func createCanary(text: String,
-                                  key: String) throws -> String {
+                              key: String) throws -> String {
         return try encryptString(key: key, cleartext: text)
     }
 

--- a/Storage/Rust/RustAutofillEncryptionKeys.swift
+++ b/Storage/Rust/RustAutofillEncryptionKeys.swift
@@ -107,7 +107,7 @@ public class RustAutofillEncryptionKeys {
         return nil
     }
 
-    fileprivate func createCanary(text: String,
+    private func createCanary(text: String,
                                   key: String) throws -> String {
         return try encryptString(key: key, cleartext: text)
     }

--- a/Storage/Rust/RustAutofillEncryptionKeys.swift
+++ b/Storage/Rust/RustAutofillEncryptionKeys.swift
@@ -62,9 +62,7 @@ public class RustAutofillEncryptionKeys {
     }
 
     func decryptCreditCardNum(encryptedCCNum: String) -> String? {
-        guard let key = self.keychain.string(forKey: self.ccKeychainKey) else {
-            return nil
-        }
+        guard let key = self.keychain.string(forKey: self.ccKeychainKey) else { return nil }
 
         do {
             return try decryptString(key: key, ciphertext: encryptedCCNum)

--- a/Storage/Rust/RustAutofillEncryptionKeys.swift
+++ b/Storage/Rust/RustAutofillEncryptionKeys.swift
@@ -88,9 +88,7 @@ public class RustAutofillEncryptionKeys {
     }
 
     func encryptCreditCardNum(creditCardNum: String) -> String? {
-        guard let key = self.keychain.string(forKey: self.ccKeychainKey) else {
-            return nil
-        }
+        guard let key = self.keychain.string(forKey: self.ccKeychainKey) else { return nil }
 
         do {
             return try encryptString(key: key, cleartext: creditCardNum)

--- a/Storage/Rust/RustAutofillEncryptionKeys.swift
+++ b/Storage/Rust/RustAutofillEncryptionKeys.swift
@@ -1,0 +1,139 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Common
+
+public extension AutofillApiError {
+    var descriptionValue: String {
+        switch self {
+        case .SqlError: return "SqlError"
+        case .CryptoError: return "CryptoError"
+        case .NoSuchRecord: return "NoSuchRecord"
+        case .UnexpectedAutofillApiError: return "UnexpectedAutofillApiError"
+        case .InterruptedError: return "InterruptedError"
+        }
+    }
+}
+
+public class RustAutofillEncryptionKeys {
+    public let ccKeychainKey = "appservices.key.creditcard.perfield"
+
+    let keychain = MZKeychainWrapper.sharedClientAppContainerKeychain
+    let ccCanaryPhraseKey = "creditCardCanaryPhrase"
+    let canaryPhrase = "a string for checking validity of the key"
+
+    private let logger: Logger
+
+    public init(logger: Logger = DefaultLogger.shared) {
+        self.logger = logger
+    }
+
+     func createAndStoreKey() throws -> String {
+        do {
+            let secret = try createAutofillKey()
+            let canary = try self.createCanary(text: canaryPhrase, key: secret)
+
+            keychain.set(secret,
+                         forKey: ccKeychainKey,
+                         withAccessibility: MZKeychainItemAccessibility.afterFirstUnlock)
+            keychain.set(canary,
+                         forKey: ccCanaryPhraseKey,
+                         withAccessibility: MZKeychainItemAccessibility.afterFirstUnlock)
+
+            return secret
+        } catch let err as NSError {
+            if let autofillStoreError = err as? AutofillApiError {
+                logAutofillStoreError(err: autofillStoreError,
+                                      errorDomain: err.domain,
+                                      errorMessage: "Error while creating and storing credit card key")
+
+                throw AutofillEncryptionKeyError.noKeyCreated
+            } else {
+                logger.log("Unknown error while creating and storing credit card key",
+                           level: .warning,
+                           category: .storage,
+                           description: err.localizedDescription)
+
+                throw AutofillEncryptionKeyError.noKeyCreated
+            }
+        }
+    }
+
+    func decryptCreditCardNum(encryptedCCNum: String) -> String? {
+        guard let key = self.keychain.string(forKey: self.ccKeychainKey) else {
+            return nil
+        }
+
+        do {
+            return try decryptString(key: key, ciphertext: encryptedCCNum)
+        } catch let err as NSError {
+            if let autofillStoreError = err as? AutofillApiError {
+                logAutofillStoreError(err: autofillStoreError,
+                                      errorDomain: err.domain,
+                                      errorMessage: "Error while decrypting credit card")
+            } else {
+                logger.log("Unknown error while decrypting credit card",
+                           level: .warning,
+                           category: .storage,
+                           description: err.localizedDescription)
+            }
+            return nil
+        }
+    }
+
+    func checkCanary(canary: String,
+                     text: String,
+                     key: String) throws -> Bool {
+        return try decryptString(key: key, ciphertext: canary) == text
+    }
+
+    func encryptCreditCardNum(creditCardNum: String) -> String? {
+        guard let key = self.keychain.string(forKey: self.ccKeychainKey) else {
+            return nil
+        }
+
+        do {
+            return try encryptString(key: key, cleartext: creditCardNum)
+        } catch let err as NSError {
+            if let autofillStoreError = err as? AutofillApiError {
+                logAutofillStoreError(err: autofillStoreError,
+                                      errorDomain: err.domain,
+                                      errorMessage: "Error while encrypting credit card")
+            } else {
+                logger.log("Unknown error while encrypting credit card",
+                           level: .warning,
+                           category: .storage,
+                           description: err.localizedDescription)
+            }
+        }
+        return nil
+    }
+
+    fileprivate func createCanary(text: String,
+                                  key: String) throws -> String {
+        return try encryptString(key: key, cleartext: text)
+    }
+
+    private func logAutofillStoreError(err: AutofillApiError,
+                                       errorDomain: String,
+                                       errorMessage: String) {
+        var message: String {
+            switch err {
+            case .SqlError(let message),
+                    .CryptoError(let message),
+                    .NoSuchRecord(let message),
+                    .UnexpectedAutofillApiError(let message):
+                return message
+            case .InterruptedError:
+                return "Interrupted Error"
+            }
+        }
+
+        logger.log(errorMessage,
+                   level: .warning,
+                   category: .storage,
+                   description: "\(errorDomain) - \(err.descriptionValue): \(message)")
+    }
+}

--- a/Storage/Rust/UnencryptedCreditCardFields.swift
+++ b/Storage/Rust/UnencryptedCreditCardFields.swift
@@ -1,0 +1,64 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+// Note: This was created in lieu of a view model
+public struct UnencryptedCreditCardFields {
+    public var ccName: String = ""
+    public var ccNumber: String = ""
+    public var ccNumberLast4: String = ""
+    public var ccExpMonth: Int64 = 0
+    public var ccExpYear: Int64 = 0
+    public var ccType: String = ""
+
+    public init() { }
+
+    public init(ccName: String,
+                ccNumber: String,
+                ccNumberLast4: String,
+                ccExpMonth: Int64,
+                ccExpYear: Int64,
+                ccType: String) {
+        self.ccName = ccName
+        self.ccNumber = ccNumber
+        self.ccNumberLast4 = ccNumberLast4
+        self.ccExpMonth = ccExpMonth
+        self.ccExpYear = ccExpYear
+        self.ccType = ccType
+    }
+
+    func toUpdatableCreditCardFields() -> UpdatableCreditCardFields {
+        let rustKeys = RustAutofillEncryptionKeys()
+        let ccNumberEnc = rustKeys.encryptCreditCardNum(creditCardNum: self.ccNumber)
+        return UpdatableCreditCardFields(ccName: self.ccName,
+                                         ccNumberEnc: ccNumberEnc ?? "",
+                                         ccNumberLast4: self.ccNumberLast4,
+                                         ccExpMonth: self.ccExpMonth,
+                                         ccExpYear: self.ccExpYear,
+                                         ccType: self.ccType)
+    }
+
+    public func convertToTempCreditCard() -> CreditCard {
+        let convertedCreditCard = CreditCard(guid: "",
+                                             ccName: self.ccName,
+                                             ccNumberEnc: "",
+                                             ccNumberLast4: self.ccNumberLast4,
+                                             ccExpMonth: self.ccExpMonth,
+                                             ccExpYear: self.ccExpYear,
+                                             ccType: self.ccType,
+                                             timeCreated: Int64(Date().timeIntervalSince1970),
+                                             timeLastUsed: nil,
+                                             timeLastModified: Int64(Date().timeIntervalSince1970),
+                                             timesUsed: 0)
+        return convertedCreditCard
+    }
+
+    public func isEqualToCreditCard(creditCard: CreditCard) -> Bool {
+        return creditCard.ccExpMonth == ccExpMonth &&
+        creditCard.ccExpYear == ccExpYear &&
+        creditCard.ccName == ccName &&
+        creditCard.ccNumberLast4 == ccNumberLast4
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7651)

## :bulb: Description
Refactored class removed repeated code, put RusAutofillEncriptionKeys and UnencryptedCreditCardFields in seperate files 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

