### PR TITLE
Add FXIOS-7716 [v121] new theming system to DevicePickerTableViewHeaderCell

### DIFF
--- a/Client/Frontend/DevicePickerTableViewHeaderCell.swift
+++ b/Client/Frontend/DevicePickerTableViewHeaderCell.swift
@@ -3,11 +3,11 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import UIKit
+import Common
 
-class DevicePickerTableViewHeaderCell: UITableViewCell, ReusableCell {
+class DevicePickerTableViewHeaderCell: UITableViewCell, ReusableCell, ThemeApplicable {
     private struct UX {
         static let tableHeaderTextFont = UIFont.systemFont(ofSize: 16)
-        static let tableHeaderTextColor = UIColor.Photon.Grey50
         static let tableHeaderTextPaddingLeft: CGFloat = 20
     }
 
@@ -18,7 +18,6 @@ class DevicePickerTableViewHeaderCell: UITableViewCell, ReusableCell {
         contentView.addSubview(nameLabel)
         nameLabel.font = UX.tableHeaderTextFont
         nameLabel.text = .SendToDevicesListTitle
-        nameLabel.textColor = UX.tableHeaderTextColor
 
         nameLabel.snp.makeConstraints { (make) -> Void in
             make.left.equalTo(contentView).offset(UX.tableHeaderTextPaddingLeft)
@@ -33,5 +32,11 @@ class DevicePickerTableViewHeaderCell: UITableViewCell, ReusableCell {
 
     required init(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - ThemeApplicable
+
+    func applyTheme(theme: Theme) {
+        nameLabel.textColor = theme.colors.textSecondary
     }
 }

--- a/Client/Frontend/Extensions/DevicePickerViewController.swift
+++ b/Client/Frontend/Extensions/DevicePickerViewController.swift
@@ -190,7 +190,8 @@ class DevicePickerViewController: UITableViewController {
         if !devices.isEmpty {
             if indexPath.section == 0 {
                 cell = tableView.dequeueReusableCell(withIdentifier: DevicePickerTableViewHeaderCell.cellIdentifier,
-                                                     for: indexPath) as? DevicePickerTableViewHeaderCell
+                                                     for: indexPath)
+                (cell as? DevicePickerTableViewHeaderCell)?.applyTheme(theme: themeManager.currentTheme)
             } else if let clientCell = tableView.dequeueReusableCell(
                 withIdentifier: DevicePickerTableViewCell.cellIdentifier,
                 for: indexPath) as? DevicePickerTableViewCell {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7716)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17207)

## :bulb: Description
Add new theming system to `DevicePickerTableViewHeaderCell` and remove legacy color.

## Screenshots 
### light 
![Simulator Screenshot - iPhone 15 Pro - 2023-11-16 at 21 34 15](https://github.com/mozilla-mobile/firefox-ios/assets/55580351/69b90067-01d3-4c91-913b-01c31bf3b677)
### dark
![Simulator Screenshot - iPhone 15 Pro - 2023-11-16 at 21 33 54](https://github.com/mozilla-mobile/firefox-ios/assets/55580351/7b9d8ac8-6075-4a79-91aa-dd9728dee842)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

