### PR TITLE
Bugfix FXIOS-7768 [v120] CFRs are not displayed correctly in landscape mode 

### DIFF
--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -738,12 +738,18 @@ extension HomepageViewController: UIPopoverPresentationControllerDelegate {
         popoverPresentationController.presentedViewController.dismiss(animated: false, completion: nil)
     }
 
-    func adaptivePresentationStyle(for controller: UIPresentationController) -> UIModalPresentationStyle {
-        return .none
-    }
-
     func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
         return true
+    }
+}
+
+// MARK: - UIAdaptivePresentationControllerDelegate
+extension HomepageViewController: UIAdaptivePresentationControllerDelegate {
+    func adaptivePresentationStyle(
+        for controller: UIPresentationController,
+        traitCollection: UITraitCollection
+    ) -> UIModalPresentationStyle {
+        .none
     }
 }
 

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -425,7 +425,7 @@ class HomepageViewController: UIViewController, FeatureFlaggable, Themeable, Con
             contextualHintViewController.stopTimer()
             return
         }
-
+        contextualHintViewController.isPresenting = true
         present(contextualHintViewController, animated: true, completion: nil)
 
         UIAccessibility.post(notification: .layoutChanged, argument: contextualHintViewController)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7768)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17333)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- This PR replaces the adaptivePresentationStyle from UIPopoverPresentationControllerDelegate with the one from UIAdaptivePresentationControllerDelegate.

iPhone 14 Pro Max, iOS 16.2
<img width="948" alt="Screenshot 2023-11-17 at 00 03 39" src="https://github.com/mozilla-mobile/firefox-ios/assets/51127880/75a4843b-efb8-43b1-8683-d0a409256dde">

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

