### PR TITLE
Bugfix FXIOS-7770 [v121] - [regression] Some of current web page is visible at the top of the Firefox homepage

### DIFF
--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -230,7 +230,7 @@ class HomepageViewController: UIViewController, FeatureFlaggable, Themeable, Con
         view.addSubview(wallpaperView)
 
         // Constraint so wallpaper appears under the status bar
-        let wallpaperTopConstant: CGFloat = view.window?.safeAreaInsets.top ?? statusBarFrame?.height ?? 0
+        let wallpaperTopConstant: CGFloat = UIWindow.keyWindow?.safeAreaInsets.top ?? statusBarFrame?.height ?? 0
 
         NSLayoutConstraint.activate([
             wallpaperView.topAnchor.constraint(equalTo: view.topAnchor, constant: -wallpaperTopConstant),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7770)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17335)

## :bulb: Description
This was a regression caused by fc770e2cd7c52f5283a3f622b43dabba6487308f when the Firefox homepage has a wallpaper set. `configureWallpaperView()` was getting called before the view was added to the window causing the top constraint to be incorrect.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

