### PR TITLE
Add FXIOS-7765 [v121] Telemetry - password manager - logins.autofill event is not triggered for the Open & fill action

### DIFF
--- a/Client/Frontend/Settings/PasswordDetailViewController.swift
+++ b/Client/Frontend/Settings/PasswordDetailViewController.swift
@@ -421,6 +421,7 @@ extension PasswordDetailViewController: LoginDetailTableViewCellDelegate {
         guard let url = (viewModel.login.formSubmitUrl?.asURL ?? viewModel.login.hostname.asURL) else { return }
 
         coordinator?.openURL(url: url)
+        sendLoginsAutofilledTelemetry()
     }
 
     func shouldReturnAfterEditingDescription(_ cell: LoginDetailTableViewCell) -> Bool {
@@ -453,5 +454,11 @@ extension PasswordDetailViewController: LoginDetailTableViewCellDelegate {
         TelemetryWrapper.recordEvent(category: .action,
                                      method: .change,
                                      object: .loginsModified)
+    }
+
+    private func sendLoginsAutofilledTelemetry() {
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .tap,
+                                     object: .loginsAutofilled)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7765)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17322)
Added the logins.autofilled event for the Open & Fill action
## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

