### PR TITLE
Add FXIOS-7180 [v121] Private mode theme

### DIFF
--- a/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
@@ -130,6 +130,8 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
             return LightTheme()
         case .dark:
             return DarkTheme()
+        case .privateMode:
+            return PrivateModeTheme()
         }
     }
 

--- a/BrowserKit/Sources/Common/Theming/LightTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/LightTheme.swift
@@ -29,10 +29,22 @@ private struct LightColourPalette: ThemeColourPalette {
     var layerAccentPrivateNonOpaque: UIColor = FXColors.Purple60.withAlphaComponent(0.1)
     var layerLightGrey30: UIColor = FXColors.LightGrey30
     var layerSepia: UIColor = FXColors.Orange05
+    var layerHomepage = Gradient(colors: [
+        FXColors.LightGrey10.withAlphaComponent(1),
+        FXColors.LightGrey10.withAlphaComponent(1),
+        FXColors.LightGrey10.withAlphaComponent(1)
+    ])
     var layerInfo: UIColor = FXColors.Blue50.withAlphaComponent(0.44)
     var layerConfirmation: UIColor = FXColors.Green20
     var layerWarning: UIColor = FXColors.Yellow20
     var layerError: UIColor = FXColors.Red10
+    var layerSearch: UIColor = FXColors.LightGrey30
+    var layerGradientURL = Gradient(colors: [
+        FXColors.LightGrey30.withAlphaComponent(0),
+        FXColors.LightGrey30.withAlphaComponent(1)
+    ])
+
+    // MARK: - Ratings
     var layerRatingA: UIColor = FXColors.Green20
     var layerRatingASubdued: UIColor = FXColors.Green05.withAlphaComponent(0.7)
     var layerRatingB: UIColor = FXColors.Blue10
@@ -56,6 +68,8 @@ private struct LightColourPalette: ThemeColourPalette {
     var actionConfirmation: UIColor = FXColors.Green60
     var actionWarning: UIColor = FXColors.Yellow60.withAlphaComponent(0.4)
     var actionError: UIColor = FXColors.Red30
+    var actionTabActive: UIColor = FXColors.Purple60
+    var actionTabInactive: UIColor = FXColors.Ink50
 
     // MARK: - Text
     var textPrimary: UIColor = FXColors.DarkGrey90
@@ -88,6 +102,7 @@ private struct LightColourPalette: ThemeColourPalette {
     var borderAccentNonOpaque: UIColor = FXColors.Blue50.withAlphaComponent(0.1)
     var borderAccentPrivate: UIColor = FXColors.Purple60
     var borderInverted: UIColor = FXColors.LightGrey05
+    var borderToolbarDivider: UIColor = FXColors.LightGrey10
 
     // MARK: - Shadow
     var shadowDefault: UIColor = FXColors.DarkGrey40.withAlphaComponent(0.16)

--- a/BrowserKit/Sources/Common/Theming/PrivateModeTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/PrivateModeTheme.swift
@@ -4,44 +4,46 @@
 
 import UIKit
 
-public struct DarkTheme: Theme {
-    public var type: ThemeType = .dark
-    public var colors: ThemeColourPalette = DarkColourPalette()
+public struct PrivateModeTheme: Theme {
+    public var type: ThemeType = .privateMode
+    public var colors: ThemeColourPalette = PrivateModeColorPalette()
 
     public init() {}
 }
 
-private struct DarkColourPalette: ThemeColourPalette {
+private struct PrivateModeColorPalette: ThemeColourPalette {
     // MARK: - Layers
-    var layer1: UIColor = FXColors.DarkGrey60
-    var layer2: UIColor = FXColors.DarkGrey30
-    var layer3: UIColor = FXColors.DarkGrey80
+    var layer1: UIColor = FXColors.Ink50
+    var layer2: UIColor = FXColors.Ink50
+    var layer3: UIColor = FXColors.Ink90
     var layer4: UIColor = FXColors.DarkGrey20.withAlphaComponent(0.7)
     var layer5: UIColor = FXColors.DarkGrey40
     var layer6: UIColor = FXColors.DarkGrey60
     var layer5Hover: UIColor = FXColors.DarkGrey20
     var layerScrim: UIColor = FXColors.DarkGrey90.withAlphaComponent(0.95)
     var layerGradient = Gradient(colors: [FXColors.Violet40, FXColors.Violet70])
-    var layerGradientOverlay = Gradient(colors: [FXColors.DarkGrey40.withAlphaComponent(0),
-                                                 FXColors.DarkGrey40.withAlphaComponent(0.4)])
+    var layerGradientOverlay = Gradient(colors: [
+        FXColors.DarkGrey40.withAlphaComponent(0),
+        FXColors.DarkGrey40.withAlphaComponent(0.4)
+    ])
     var layerAccentNonOpaque: UIColor = FXColors.Blue20.withAlphaComponent(0.2)
     var layerAccentPrivate: UIColor = FXColors.Purple60
     var layerAccentPrivateNonOpaque: UIColor = FXColors.Purple60.withAlphaComponent(0.3)
     var layerLightGrey30: UIColor = FXColors.LightGrey30
     var layerSepia: UIColor = FXColors.Orange05
     var layerHomepage = Gradient(colors: [
-        FXColors.DarkGrey60.withAlphaComponent(1),
-        FXColors.DarkGrey60.withAlphaComponent(1),
-        FXColors.DarkGrey60.withAlphaComponent(1)
+        FXColors.Ink05,
+        FXColors.Violet80,
+        FXColors.Purple70
     ])
     var layerInfo: UIColor = FXColors.Blue60.withAlphaComponent(0.8)
     var layerConfirmation: UIColor = FXColors.Green80
     var layerWarning: UIColor = FXColors.Yellow70.withAlphaComponent(0.77)
     var layerError: UIColor = FXColors.Pink80
-    var layerSearch: UIColor = FXColors.DarkGrey80
+    var layerSearch: UIColor = FXColors.Ink90
     var layerGradientURL = Gradient(colors: [
-        FXColors.DarkGrey80.withAlphaComponent(0),
-        FXColors.DarkGrey80.withAlphaComponent(1)
+        FXColors.Ink90.withAlphaComponent(0),
+        FXColors.Ink90.withAlphaComponent(1)
     ])
 
     // MARK: - Ratings
@@ -102,7 +104,7 @@ private struct DarkColourPalette: ThemeColourPalette {
     var borderAccentNonOpaque: UIColor = FXColors.Blue20.withAlphaComponent(0.2)
     var borderAccentPrivate: UIColor = FXColors.Purple60
     var borderInverted: UIColor = FXColors.DarkGrey90
-    var borderToolbarDivider: UIColor = FXColors.DarkGrey60
+    var borderToolbarDivider: UIColor = FXColors.Violet80
 
     // MARK: - Shadow
     var shadowDefault: UIColor = FXColors.DarkGrey90.withAlphaComponent(0.16)

--- a/BrowserKit/Sources/Common/Theming/ThemeColourPalette.swift
+++ b/BrowserKit/Sources/Common/Theming/ThemeColourPalette.swift
@@ -24,10 +24,15 @@ public protocol ThemeColourPalette {
     var layerAccentPrivateNonOpaque: UIColor { get }
     var layerLightGrey30: UIColor { get }
     var layerSepia: UIColor { get }
+    var layerHomepage: Gradient { get }
     var layerInfo: UIColor { get }
     var layerConfirmation: UIColor { get }
     var layerWarning: UIColor { get }
     var layerError: UIColor { get }
+    var layerSearch: UIColor { get }
+    var layerGradientURL: Gradient { get }
+
+    // MARK: - Ratings
     var layerRatingA: UIColor { get }
     var layerRatingASubdued: UIColor { get }
     var layerRatingB: UIColor { get }
@@ -51,6 +56,8 @@ public protocol ThemeColourPalette {
     var actionConfirmation: UIColor { get }
     var actionWarning: UIColor { get }
     var actionError: UIColor { get }
+    var actionTabActive: UIColor { get }
+    var actionTabInactive: UIColor { get }
 
     // MARK: - Text
     var textPrimary: UIColor { get }
@@ -83,6 +90,7 @@ public protocol ThemeColourPalette {
     var borderAccentNonOpaque: UIColor { get }
     var borderAccentPrivate: UIColor { get }
     var borderInverted: UIColor { get }
+    var borderToolbarDivider: UIColor { get }
 
     // MARK: - Shadow
     var shadowDefault: UIColor { get }

--- a/BrowserKit/Sources/Common/Theming/ThemeType.swift
+++ b/BrowserKit/Sources/Common/Theming/ThemeType.swift
@@ -8,12 +8,15 @@ import UIKit
 public enum ThemeType: String {
     case light = "normal" // This needs to match the string used in the legacy system
     case dark
+    case privateMode
 
     public func getInterfaceStyle() -> UIUserInterfaceStyle {
         switch self {
         case .light:
             return .light
         case .dark:
+            return .dark
+        case .privateMode:
             return .dark
         }
     }
@@ -24,15 +27,8 @@ public enum ThemeType: String {
             return .default
         case .dark:
             return .black
-        }
-    }
-
-    public func getThemedImageName(name: String) -> String {
-        switch self {
-        case .light:
-            return name
-        case .dark:
-            return "\(name)_dark"
+        case .privateMode:
+            return .black
         }
     }
 
@@ -45,6 +41,8 @@ public enum ThemeType: String {
             .dark
         case .light:
             .light
+        case .privateMode:
+            .dark
         }
     }
 }

--- a/firefox-ios/Tests/ClientTests/Mocks/MockThemeManager.swift
+++ b/firefox-ios/Tests/ClientTests/Mocks/MockThemeManager.swift
@@ -19,6 +19,8 @@ class MockThemeManager: ThemeManager {
             currentTheme = LightTheme()
         case .dark:
             currentTheme = DarkTheme()
+        case .privateMode:
+            currentTheme = PrivateModeTheme()
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7180)

## :bulb: Description
* Add private mode theme colors and removed unused `getThemedImageName` method
* Private colors will default to dark theme colors unless specified in the design system

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods