### PR TITLE
Add FXIOS-7781 [v121] Verification logic for logins syncing

### DIFF
--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -12,6 +12,7 @@ public struct PrefsKeys {
 
     // Global sync state for rust sync manager
     public static let RustSyncManagerPersistedState = "rustSyncManagerPersistedStateKey"
+    public static let HasVerifiedRustLogins = "hasVerifiedRustLogins"
 
     public static let KeyLastSyncFinishTime = "lastSyncFinishTime"
     public static let KeyDefaultHomePageURL = "KeyDefaultHomePageURL"


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7781)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17354)

## :bulb: Description
This is the follow-on work from #16973. In this PR logins verification logic is being added that will unblock users who are currently unable to sync logins because some of their saved logins can't be decrypted. This verification logic will iterate over the saved logins, attempt to decrypt each, and if the decryption fails it will be marked for removal. This verification step is initiated during logins syncing and will stop being called once it's been executed successfully.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

