### PR TITLE
Refactor FXIOS-7784 [v122] Weak wrapper debug description

### DIFF
--- a/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -33,7 +33,7 @@ extension TabManagerDelegate {
 
 // MARK: - WeakTabManagerDelegate
 // We can't use a WeakList here because this is a protocol.
-class WeakTabManagerDelegate {
+class WeakTabManagerDelegate: CustomDebugStringConvertible {
     weak var value: TabManagerDelegate?
 
     init(value: TabManagerDelegate) {
@@ -42,6 +42,13 @@ class WeakTabManagerDelegate {
 
     func get() -> TabManagerDelegate? {
         return value
+    }
+
+    var debugDescription: String {
+        let className = String(describing: type(of: self))
+        let memAddr = Unmanaged.passUnretained(self).toOpaque()
+        let valueStr = (value == nil ? "<nil>" : "\(value!)")
+        return "<\(className): \(memAddr)> Value: \(valueStr)"
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
Minor update; no ticket but done as part of early work on:
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7784)

## :bulb: Description
Minor improvement for debugging, adds wrapped value to debug description for `WeakTabManagerDelegate`.

Before:
```
(lldb) po delegates 
▿ 3 elements
  ▿ 0 : <WeakTabManagerDelegate: 0x600000291360>
  ▿ 1 : <WeakTabManagerDelegate: 0x6000002913c0>
  ▿ 2 : <WeakTabManagerDelegate: 0x6000002c19c0>
```

After
```
(lldb) po delegates 
▿ 3 elements
  ▿ 0 : <WeakTabManagerDelegate: 0x000060000028c9e0> Value: <Client.BrowserViewController: 0x14580ba00>
  ▿ 1 : <WeakTabManagerDelegate: 0x000060000028ca40> Value: <Client.BrowserCoordinator: 0x129e06570>
  ▿ 2 : <WeakTabManagerDelegate: 0x00006000002ac0c0> Value: <Client.LegacyTabDisplayManager: 0x600003e30000>
```

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

