### PR TITLE
Refactor FXIOS-7717 [v122] Remove legacy color from ReaderModeBarView

### DIFF
--- a/Client/Frontend/Reader/View/ReaderModeBarView.swift
+++ b/Client/Frontend/Reader/View/ReaderModeBarView.swift
@@ -53,7 +53,7 @@ class ReaderModeBarView: UIView, AlphaDimmable, TopBottomInterchangeable, Search
 
     var parent: UIStackView?
 
-    var contextStrokeColor: UIColor!
+    var contextStrokeColor: UIColor?
 
     var readStatusButton: UIButton!
     var settingsButton: UIButton!
@@ -105,7 +105,8 @@ class ReaderModeBarView: UIView, AlphaDimmable, TopBottomInterchangeable, Search
     override func draw(_ rect: CGRect) {
         super.draw(rect)
 
-        guard let context = UIGraphicsGetCurrentContext() else { return }
+        guard let context = UIGraphicsGetCurrentContext(),
+              let contextStrokeColor = contextStrokeColor else { return }
 
         context.setLineWidth(0.5)
         context.setStrokeColor(contextStrokeColor.cgColor)

--- a/Client/Frontend/Reader/View/ReaderModeBarView.swift
+++ b/Client/Frontend/Reader/View/ReaderModeBarView.swift
@@ -45,9 +45,15 @@ protocol ReaderModeBarViewDelegate: AnyObject {
 }
 
 class ReaderModeBarView: UIView, AlphaDimmable, TopBottomInterchangeable, SearchBarLocationProvider {
+    private struct UX {
+        static let buttonWidth: CGFloat = 80
+    }
+
     weak var delegate: ReaderModeBarViewDelegate?
 
     var parent: UIStackView?
+
+    var contextStrokeColor: UIColor!
 
     var readStatusButton: UIButton!
     var settingsButton: UIButton!
@@ -70,7 +76,7 @@ class ReaderModeBarView: UIView, AlphaDimmable, TopBottomInterchangeable, Search
             readStatusButton.leadingAnchor.constraint(equalTo: leadingAnchor),
             readStatusButton.heightAnchor.constraint(equalTo: heightAnchor),
             readStatusButton.centerYAnchor.constraint(equalTo: centerYAnchor),
-            readStatusButton.widthAnchor.constraint(equalToConstant: 80)
+            readStatusButton.widthAnchor.constraint(equalToConstant: UX.buttonWidth)
         ])
 
         settingsButton = createButton(.settings, action: #selector(tappedSettingsButton))
@@ -79,7 +85,7 @@ class ReaderModeBarView: UIView, AlphaDimmable, TopBottomInterchangeable, Search
             settingsButton.heightAnchor.constraint(equalTo: heightAnchor),
             settingsButton.centerXAnchor.constraint(equalTo: centerXAnchor),
             settingsButton.centerYAnchor.constraint(equalTo: centerYAnchor),
-            settingsButton.widthAnchor.constraint(equalToConstant: 80)
+            settingsButton.widthAnchor.constraint(equalToConstant: UX.buttonWidth)
         ])
 
         listStatusButton = createButton(.addToReadingList, action: #selector(tappedListStatusButton))
@@ -88,7 +94,7 @@ class ReaderModeBarView: UIView, AlphaDimmable, TopBottomInterchangeable, Search
             listStatusButton.rightAnchor.constraint(equalTo: safeAreaLayoutGuide.rightAnchor),
             listStatusButton.heightAnchor.constraint(equalTo: heightAnchor),
             listStatusButton.centerYAnchor.constraint(equalTo: centerYAnchor),
-            listStatusButton.widthAnchor.constraint(equalToConstant: 80)
+            listStatusButton.widthAnchor.constraint(equalToConstant: UX.buttonWidth)
         ])
     }
 
@@ -102,7 +108,7 @@ class ReaderModeBarView: UIView, AlphaDimmable, TopBottomInterchangeable, Search
         guard let context = UIGraphicsGetCurrentContext() else { return }
 
         context.setLineWidth(0.5)
-        context.setStrokeColor(UIColor.Photon.Grey50.cgColor)
+        context.setStrokeColor(contextStrokeColor.cgColor)
         context.beginPath()
         let yPosition = isBottomSearchBar ? 0 : frame.height
         context.move(to: CGPoint(x: 0, y: yPosition))
@@ -158,7 +164,9 @@ class ReaderModeBarView: UIView, AlphaDimmable, TopBottomInterchangeable, Search
 
 extension ReaderModeBarView: ThemeApplicable {
     func applyTheme(theme: Theme) {
-        backgroundColor = theme.colors.layer1
-        buttonTintColor = theme.colors.textPrimary
+        let colors = theme.colors
+        backgroundColor = colors.layer1
+        buttonTintColor = colors.textPrimary
+        contextStrokeColor = colors.textSecondary
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7717)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17208)

## :bulb: Description
- Remove legacy color from ReaderModeBarView and use the new theming system.

| Light Theme  | Dark Theme | 
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2023-11-20 at 15 54 27](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/09a193a2-8bbc-4a57-a39f-4c6b6372f8ca) | ![Simulator Screenshot - iPhone 15 Pro - 2023-11-20 at 15 54 43](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/488426d1-5a5e-4634-82cc-6e26c14c7978) |


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods