### PR TITLE
FXIOS-7669 [v121] Fakespot spinner remains in an infinite loop for some products after the user taps Check now

### DIFF
--- a/Client/Frontend/Fakespot/FakespotViewModel.swift
+++ b/Client/Frontend/Fakespot/FakespotViewModel.swift
@@ -317,7 +317,19 @@ class FakespotViewModel {
                     for try await status in self.observeProductAnalysisStatus() where status.isAnalyzing == false {
                         await self.fetchProductAnalysis(showLoading: false)
                     }
-                } catch {}
+                } catch {
+                    if case .loaded(let productState) = state {
+                        // Restore the previous state in case of a failure
+                        state = .loaded(
+                            ProductState(
+                                product: productState.product,
+                                productAds: productState.productAds,
+                                analysisStatus: nil,
+                                analyzeCount: analyzeCount
+                            )
+                        )
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7669)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17102)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
We have seen situations where pe API fails during status polling. This PR restores previous loaded state.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

