### PR TITLE
Add FXIOS-7790 [v122] New metric for logins keychain data loss

### DIFF
--- a/Storage/Rust/RustLogins.swift
+++ b/Storage/Rust/RustLogins.swift
@@ -978,6 +978,7 @@ public class RustLogins {
                 if hasLogins {
                     // Since the key data isn't present and we have login records in
                     // the database, we both clear the databbase and the reset the key.
+                    GleanMetrics.LoginsStoreKeyRegeneration.keychainDataLost.record()
                     self.resetLoginsAndKey(rustKeys: rustKeys, completion: completion)
                 } else {
                     // There are no records in the database so we don't need to wipe any

--- a/Storage/metrics.yaml
+++ b/Storage/metrics.yaml
@@ -69,3 +69,18 @@ logins_store_key_regeneration:
       - synced-client-integrations@mozilla.com
       - lougenia@mozilla.com
     expires: never
+
+  keychain_data_lost:
+    type: event
+    description: >
+      The encryption key was regenerated because it and the canary phrase are missing from the keychain
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/17380
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/17381
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - synced-client-integrations@mozilla.com
+      - lougenia@mozilla.com
+    expires: never


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7790)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17380)

## :bulb: Description
Adding metrics to track how often users who previously saved logins lose their keychain data which leads to data loss as any saved logins can't be decrypted.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

