### PR TITLE
Refactor FXIOS-6530 [v122] Library panel clean up

### DIFF
--- a/Client/Coordinators/Library/LibraryCoordinator.swift
+++ b/Client/Coordinators/Library/LibraryCoordinator.swift
@@ -43,7 +43,6 @@ class LibraryCoordinator: BaseCoordinator, LibraryPanelDelegate, LibraryNavigati
 
     func start(with homepanelSection: Route.HomepanelSection) {
         libraryViewController.setupOpenPanel(panelType: homepanelSection.libraryPanel)
-        libraryViewController.resetHistoryPanelPagination()
     }
 
     private func makeChildPanels() -> [UINavigationController] {

--- a/Client/Frontend/Library/LibraryPanelDescriptor.swift
+++ b/Client/Frontend/Library/LibraryPanelDescriptor.swift
@@ -6,32 +6,13 @@ import UIKit
 
 /// Data for identifying and constructing a LibraryPanel.
 class LibraryPanelDescriptor {
-    var viewController: UIViewController?
-    var navigationController: UINavigationController?
-
-    private let profile: Profile
-    private let tabManager: TabManager
-
     let accessibilityLabel: String
     let accessibilityIdentifier: String
     let panelType: LibraryPanelType
 
-    // Returns latest libraryPanel viewController filtering out "details view controllers" from navigationController
-    // Handles Bookmarks case where BookmarksPanel is used for main folder and subfolder state
-    var shownPanel: UIViewController? {
-        let libraryPanel = navigationController?.viewControllers.filter { $0 is LibraryPanel }
-        return libraryPanel?.last
-    }
-
-    init(viewController: LibraryPanel?,
-         profile: Profile,
-         tabManager: TabManager,
-         accessibilityLabel: String,
+    init(accessibilityLabel: String,
          accessibilityIdentifier: String,
          panelType: LibraryPanelType) {
-        self.viewController = viewController
-        self.profile = profile
-        self.tabManager = tabManager
         self.accessibilityLabel = accessibilityLabel
         self.accessibilityIdentifier = accessibilityIdentifier
         self.panelType = panelType

--- a/Client/Frontend/Library/LibraryPanelHelper.swift
+++ b/Client/Frontend/Library/LibraryPanelHelper.swift
@@ -74,11 +74,9 @@ enum LibraryPanelType: Int, CaseIterable {
 
 class LibraryPanelHelper {
     private let profile: Profile
-    private let tabManager: TabManager
 
-    init(profile: Profile, tabManager: TabManager) {
+    init(profile: Profile) {
         self.profile = profile
-        self.tabManager = tabManager
     }
 
     lazy var enabledPanels: [LibraryPanelDescriptor] = {
@@ -86,33 +84,21 @@ class LibraryPanelHelper {
 
         return [
             LibraryPanelDescriptor(
-                viewController: BookmarksPanel(viewModel: bookmarksViewModel),
-                profile: profile,
-                tabManager: tabManager,
                 accessibilityLabel: .LibraryPanelBookmarksAccessibilityLabel,
                 accessibilityIdentifier: AccessibilityIdentifiers.LibraryPanels.bookmarksView,
                 panelType: .bookmarks),
 
             LibraryPanelDescriptor(
-                viewController: HistoryPanel(profile: profile, tabManager: tabManager),
-                profile: profile,
-                tabManager: tabManager,
                 accessibilityLabel: .LibraryPanelHistoryAccessibilityLabel,
                 accessibilityIdentifier: AccessibilityIdentifiers.LibraryPanels.historyView,
                 panelType: .history),
 
             LibraryPanelDescriptor(
-                viewController: DownloadsPanel(),
-                profile: profile,
-                tabManager: tabManager,
                 accessibilityLabel: .LibraryPanelDownloadsAccessibilityLabel,
                 accessibilityIdentifier: AccessibilityIdentifiers.LibraryPanels.downloadsView,
                 panelType: .downloads),
 
             LibraryPanelDescriptor(
-                viewController: ReadingListPanel(profile: profile),
-                profile: profile,
-                tabManager: tabManager,
                 accessibilityLabel: .LibraryPanelReadingListAccessibilityLabel,
                 accessibilityIdentifier: AccessibilityIdentifiers.LibraryPanels.readingListView,
                 panelType: .readingList)

--- a/Client/Frontend/Library/LibraryViewController/LibraryViewController+ToolbarActions.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryViewController+ToolbarActions.swift
@@ -11,7 +11,7 @@ extension LibraryViewController {
         guard let navController = children.first as? UINavigationController else { return }
 
         navController.popViewController(animated: true)
-        var panel = getCurrentPanel()
+        let panel = getCurrentPanel()
         panel?.handleLeftTopButton()
     }
 

--- a/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -72,7 +72,7 @@ class LibraryViewController: UIViewController, Themeable {
          notificationCenter: NotificationProtocol = NotificationCenter.default,
          themeManager: ThemeManager = AppContainer.shared.resolve(),
          logger: Logger = DefaultLogger.shared) {
-        self.viewModel = LibraryViewModel(withProfile: profile, tabManager: tabManager)
+        self.viewModel = LibraryViewModel(withProfile: profile)
         self.notificationCenter = notificationCenter
         self.themeManager = themeManager
         self.logger = logger
@@ -124,10 +124,6 @@ class LibraryViewController: UIViewController, Themeable {
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
         LegacyThemeManager.instance.statusBarStyle
-    }
-
-    func resetHistoryPanelPagination() {
-        viewModel.resetHistoryPanelPagination()
     }
 
     func updateViewWithState() {

--- a/Client/Frontend/Library/LibraryViewController/LibraryViewModel.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryViewModel.swift
@@ -7,7 +7,6 @@ import Foundation
 
 class LibraryViewModel {
     let profile: Profile
-    let tabManager: TabManager
     let panelDescriptors: [LibraryPanelDescriptor]
     var selectedPanel: LibraryPanelType?
 
@@ -18,17 +17,8 @@ class LibraryViewModel {
          UIImage(named: ImageIdentifiers.libraryReadingList) ?? UIImage()]
     }
 
-    init(withProfile profile: Profile, tabManager: TabManager) {
+    init(withProfile profile: Profile) {
         self.profile = profile
-        self.tabManager = tabManager
-        self.panelDescriptors = LibraryPanelHelper(profile: profile, tabManager: tabManager).enabledPanels
-    }
-
-    func resetHistoryPanelPagination() {
-        // Reset history panel pagination to get latest history visit
-        if let historyPanel = panelDescriptors.first(where: { $0.panelType == .history }),
-           let vcPanel = historyPanel.viewController as? HistoryPanel {
-            vcPanel.viewModel.shouldResetHistory = true
-        }
+        self.panelDescriptors = LibraryPanelHelper(profile: profile).enabledPanels
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/LibraryViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/LibraryViewModelTests.swift
@@ -9,7 +9,6 @@ import Common
 class LibraryViewModelTests: XCTestCase {
     private var subject: LibraryViewModel!
     private var profile: MockProfile!
-    private var tabManager: TabManager!
 
     override func setUp() {
         super.setUp()
@@ -17,7 +16,6 @@ class LibraryViewModelTests: XCTestCase {
         DependencyHelperMock().bootstrapDependencies()
         profile = MockProfile(databasePrefix: "historyHighlights_tests")
         profile.reopen()
-        tabManager = TabManagerImplementation(profile: profile, imageStore: nil)
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
     }
 
@@ -26,18 +24,17 @@ class LibraryViewModelTests: XCTestCase {
         AppContainer.shared.reset()
         profile.shutdown()
         profile = nil
-        tabManager = nil
     }
 
     func testInitialState_Init() {
-        subject = LibraryViewModel(withProfile: profile, tabManager: tabManager)
+        subject = LibraryViewModel(withProfile: profile)
         subject.selectedPanel = .bookmarks
 
         XCTAssertEqual(subject.panelDescriptors.count, 4)
     }
 
     func testLibraryPanelTitle() {
-        subject = LibraryViewModel(withProfile: profile, tabManager: tabManager)
+        subject = LibraryViewModel(withProfile: profile)
         subject.selectedPanel = .bookmarks
 
         for panel in subject.panelDescriptors {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6530)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14641)

## :bulb: Description
Library panel clean up to ensure we don't use any references to the panel descriptor VCs. Panels VCs are now kept as reference under the `LibraryCoordinator`. Note that there was the method `resetHistoryPanelPagination` that was still using the descriptor to get access to the history panel, but we can safely remove it as this is handled instead now [here](https://github.com/mozilla-mobile/firefox-ios/blob/907b4f9d6a7cffa95f6e6842c7c34f8827ffa103/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift#L190).

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

