### PR TITLE
Bugfix FXIOS-7368 [v122] Cannot move tabs in iPadOS

### DIFF
--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -758,9 +758,7 @@ extension LegacyTabDisplayManager: UICollectionViewDropDelegate {
 
         filteredTabs.insert(tab, at: destinationIndexPath.item)
 
-        if tabDisplayType == .TabGrid {
-            saveRegularOrderedTabs(from: filteredTabs)
-        }
+        saveRegularOrderedTabs(from: filteredTabs)
 
         /// According to Apple's documentation the best place to make the changes to the collectionView and dataStore is
         /// during the completion call of performBatchUpdates


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7368)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16333)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- I don't know why exactly, but there was a condition checking for grid tabs mode to order the tabs, and I removed it and now, the ordering works in both modes

## Video

https://github.com/mozilla-mobile/firefox-ios/assets/51127880/24f65faa-2bf4-472b-b69c-10a33e44bb14

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

