### PR TITLE
Refactor FXIOS-7778 [v122] Theming to match design system

### DIFF
--- a/BrowserKit/Sources/Common/Theming/DarkTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/DarkTheme.swift
@@ -74,7 +74,6 @@ private struct DarkColourPalette: ThemeColourPalette {
     // MARK: - Text
     var textPrimary: UIColor = FXColors.LightGrey05
     var textSecondary: UIColor = FXColors.LightGrey40
-    var textSecondaryAction: UIColor = FXColors.DarkGrey90
     var textDisabled: UIColor = FXColors.LightGrey05.withAlphaComponent(0.4)
     var textWarning: UIColor = FXColors.Red20
     var textAccent: UIColor = FXColors.Blue30

--- a/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
@@ -56,10 +56,6 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
 
     // MARK: - ThemeManager
 
-    public func getInterfaceStyle() -> UIUserInterfaceStyle {
-        return currentTheme.type.getInterfaceStyle()
-    }
-
     public func changeCurrentTheme(_ newTheme: ThemeType) {
         guard currentTheme.type != newTheme else { return }
         currentTheme = newThemeForType(newTheme)

--- a/BrowserKit/Sources/Common/Theming/LightTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/LightTheme.swift
@@ -74,7 +74,6 @@ private struct LightColourPalette: ThemeColourPalette {
     // MARK: - Text
     var textPrimary: UIColor = FXColors.DarkGrey90
     var textSecondary: UIColor = FXColors.DarkGrey05
-    var textSecondaryAction: UIColor = FXColors.DarkGrey90
     var textDisabled: UIColor = FXColors.DarkGrey90.withAlphaComponent(0.4)
     var textWarning: UIColor = FXColors.Red70
     var textAccent: UIColor = FXColors.Blue50

--- a/BrowserKit/Sources/Common/Theming/PrivateModeTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/PrivateModeTheme.swift
@@ -76,7 +76,6 @@ private struct PrivateModeColorPalette: ThemeColourPalette {
     // MARK: - Text
     var textPrimary: UIColor = FXColors.LightGrey05
     var textSecondary: UIColor = FXColors.LightGrey40
-    var textSecondaryAction: UIColor = FXColors.DarkGrey90
     var textDisabled: UIColor = FXColors.LightGrey05.withAlphaComponent(0.4)
     var textWarning: UIColor = FXColors.Red20
     var textAccent: UIColor = FXColors.Blue30

--- a/BrowserKit/Sources/Common/Theming/ThemeColourPalette.swift
+++ b/BrowserKit/Sources/Common/Theming/ThemeColourPalette.swift
@@ -62,7 +62,6 @@ public protocol ThemeColourPalette {
     // MARK: - Text
     var textPrimary: UIColor { get }
     var textSecondary: UIColor { get }
-    var textSecondaryAction: UIColor { get }
     var textDisabled: UIColor { get }
     var textWarning: UIColor { get }
     var textAccent: UIColor { get }

--- a/BrowserKit/Sources/Common/Theming/ThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/ThemeManager.swift
@@ -8,7 +8,6 @@ public protocol ThemeManager {
     var currentTheme: Theme { get }
     var window: UIWindow? { get set }
 
-    func getInterfaceStyle() -> UIUserInterfaceStyle
     func changeCurrentTheme(_ newTheme: ThemeType)
     func systemThemeChanged()
     func setSystemTheme(isOn: Bool)

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
@@ -52,7 +52,7 @@ public class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
         highlightedTintColor = theme.colors.actionSecondaryHover
         normalTintColor = theme.colors.actionSecondary
 
-        setTitleColor(theme.colors.textSecondaryAction, for: .normal)
+        setTitleColor(theme.colors.textOnLight, for: .normal)
         backgroundColor = theme.colors.actionSecondary
     }
 }

--- a/Client/Frontend/SurveySurface/SurveySurfaceViewController.swift
+++ b/Client/Frontend/SurveySurface/SurveySurfaceViewController.swift
@@ -247,7 +247,7 @@ class SurveySurfaceViewController: UIViewController, Themeable {
         takeSurveyButton.setTitleColor(theme.colors.textInverted, for: .normal)
         takeSurveyButton.backgroundColor = theme.colors.actionPrimary
 
-        dismissSurveyButton.setTitleColor(theme.colors.textSecondaryAction, for: .normal)
+        dismissSurveyButton.setTitleColor(theme.colors.textOnLight, for: .normal)
         dismissSurveyButton.backgroundColor = theme.colors.actionSecondary
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7778)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17351)

## :bulb: Description
Replace `textSecondaryAction` token with `textOnLight`. The `textSecondaryAction` did not exist in the colors design system and `textOnLight` uses `FXColors.DarkGrey90` for both themes as well.

Remove unused `getInterfaceStyle()` method from default theme manager

Note: As part of this work, the figma file was also updated to be more consistent with the codebase.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods
