### PR TITLE
Add FXIOS-7807 DISCO-2548 [v123] Add FxSuggest Search Settings

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -191,6 +191,7 @@
 		23BEA76A251A99ED00A014BF /* NewYorkMedium-RegularItalic.otf in Resources */ = {isa = PBXBuildFile; fileRef = 23BEA764251A99E200A014BF /* NewYorkMedium-RegularItalic.otf */; };
 		23D57E6E25ED6F2700883FAD /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D57E6D25ED6F2700883FAD /* SearchViewController.swift */; };
 		23ED80FF25C89C9800D0E9D5 /* DefaultBrowserOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23ED80FE25C89C9800D0E9D5 /* DefaultBrowserOnboardingViewController.swift */; };
+		253648E12B2111C100D5C2C5 /* SearchViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 253648E02B2111C100D5C2C5 /* SearchViewControllerTests.swift */; };
 		274A36CC239EB99400A21587 /* LibraryPanelContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274A36CB239EB99400A21587 /* LibraryPanelContextMenu.swift */; };
 		274A36CE239EB9EC00A21587 /* LibraryViewController+LibraryPanelDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274A36CD239EB9EC00A21587 /* LibraryViewController+LibraryPanelDelegate.swift */; };
 		2816F0001B33E05400522243 /* UIConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2816EFFF1B33E05400522243 /* UIConstants.swift */; };
@@ -2337,6 +2338,7 @@
 		24A24DCBB0474D4E4B643441 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Search.strings; sourceTree = "<group>"; };
 		24B04235AF0225758090E9E9 /* rm */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = rm; path = "rm.lproj/Default Browser.strings"; sourceTree = "<group>"; };
 		24DA4827BEDC3FC4334F5505 /* af */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = af; path = af.lproj/Search.strings; sourceTree = "<group>"; };
+		253648E02B2111C100D5C2C5 /* SearchViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewControllerTests.swift; sourceTree = "<group>"; };
 		25404EFD8E59C9EBCF4AFBBE /* gd */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = gd; path = gd.lproj/Menu.strings; sourceTree = "<group>"; };
 		255B49C5B2976844285FB746 /* af */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = af; path = af.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		258D4CEDBF09798787FB9370 /* kab */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kab; path = kab.lproj/Storage.strings; sourceTree = "<group>"; };
@@ -11275,6 +11277,7 @@
 				8A6E139B2A71BB5700A88FA8 /* LegacyTabCellTests.swift */,
 				8A6E139D2A71C78A00A88FA8 /* GridTabViewControllerTests.swift */,
 				1D74FF4D2B27962200FF01D0 /* WindowManagerTests.swift */,
+				253648E02B2111C100D5C2C5 /* SearchViewControllerTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -14060,6 +14063,7 @@
 				6ADB651B285C03B100947EA4 /* DownloadHelperTests.swift in Sources */,
 				8A6B77CC2811C468001110D2 /* URLProtocolStub.swift in Sources */,
 				CA7BD568248189E800A0A61B /* BreachAlertsTests.swift in Sources */,
+				253648E12B2111C100D5C2C5 /* SearchViewControllerTests.swift in Sources */,
 				4A59B58AD11B5EE1F80BBDEB /* TestHistory.swift in Sources */,
 				A83E5B1D1C1DA8D80026D912 /* UIPasteboardExtensionsTests.swift in Sources */,
 				8A635ECD289437A8006378BA /* SyncedTabCellTests.swift in Sources */,

--- a/firefox-ios/Client/Application/BackgroundFirefoxSuggestIngestUtility.swift
+++ b/firefox-ios/Client/Application/BackgroundFirefoxSuggestIngestUtility.swift
@@ -13,10 +13,10 @@ import Storage
 class BackgroundFirefoxSuggestIngestUtility: BackgroundUtilityProtocol, FeatureFlaggable {
     static let taskIdentifier = "org.mozilla.ios.firefox.suggest.ingest"
 
-    let firefoxSuggest: RustFirefoxSuggest
+    let firefoxSuggest: RustFirefoxSuggestActor
     let logger: Logger
 
-    init(firefoxSuggest: RustFirefoxSuggest, logger: Logger = DefaultLogger.shared) {
+    init(firefoxSuggest: RustFirefoxSuggestActor, logger: Logger = DefaultLogger.shared) {
         self.firefoxSuggest = firefoxSuggest
         self.logger = logger
 

--- a/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
@@ -68,7 +68,7 @@ class SearchViewController: SiteTableViewController,
     private var filteredOpenedTabs = [Tab]()
     private var tabManager: TabManager
     private var searchHighlights = [HighlightItem]()
-    private var firefoxSuggestions = [RustFirefoxSuggestion]()
+    var firefoxSuggestions = [RustFirefoxSuggestion]()
     private var highlightManager: HistoryHighlightsManagerProtocol
 
     // Views for displaying the bottom scrollable search engine list. searchEngineScrollView is the
@@ -167,17 +167,19 @@ class SearchViewController: SiteTableViewController,
         }
     }
 
-    private func loadFirefoxSuggestions() {
-        guard featureFlags.isFeatureEnabled(.firefoxSuggestFeature, checking: .buildAndUser) else { return }
+    func loadFirefoxSuggestions() -> Task<(), Never>? {
+        let includeNonSponsored = profile.prefs.boolForKey(PrefsKeys.FirefoxSuggestShowNonSponsoredSuggestions) ?? false
+        let includeSponsored = profile.prefs.boolForKey(PrefsKeys.FirefoxSuggestShowSponsoredSuggestions) ?? false
+        guard featureFlags.isFeatureEnabled(.firefoxSuggestFeature, checking: .buildAndUser) && (includeNonSponsored || includeSponsored) else { return nil }
 
         profile.firefoxSuggest?.interruptReader()
 
         let tempSearchQuery = searchQuery
-        Task { [weak self] in
+        return Task { [weak self] in
             guard let suggestions = try? await self?.profile.firefoxSuggest?.query(
                 tempSearchQuery,
-                includeSponsored: true,
-                includeNonSponsored: true
+                includeSponsored: includeSponsored,
+                includeNonSponsored: includeNonSponsored
             ) else { return }
             await MainActor.run {
                 guard let self, self.searchQuery == tempSearchQuery else { return }
@@ -518,7 +520,7 @@ class SearchViewController: SiteTableViewController,
         }
 
         loadSearchHighlights()
-        loadFirefoxSuggestions()
+        _ = loadFirefoxSuggestions()
 
         let tempSearchQuery = searchQuery
         suggestClient?.query(searchQuery, callback: { suggestions, error in

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -15,6 +15,7 @@ class SearchSettingsTableViewController: ThemedTableViewController, FeatureFlagg
         case defaultEngine
         case quickEngines
         case privateSession
+        case firefoxSuggestSettings
 
         var title: String {
             switch self {
@@ -24,6 +25,8 @@ class SearchSettingsTableViewController: ThemedTableViewController, FeatureFlagg
                 return .Settings.Search.QuickSearchEnginesTitle
             case .privateSession:
                 return .Settings.Search.PrivateSessionTitle
+            case .firefoxSuggestSettings:
+                return String.localizedStringWithFormat(.Settings.Search.Suggest.AddressBarSettingsTitle, AppName.shortName.rawValue)
             }
         }
     }
@@ -31,15 +34,19 @@ class SearchSettingsTableViewController: ThemedTableViewController, FeatureFlagg
     private let profile: Profile
     private let model: SearchEngines
 
-    fileprivate let ItemDefaultEngine = 0
-    fileprivate let ItemDefaultSuggestions = 1
-    fileprivate let IconSize = CGSize(width: OpenSearchEngine.UX.preferredIconSize,
-                                      height: OpenSearchEngine.UX.preferredIconSize)
+    private let ItemDefaultEngine = 0
+    private let ItemDefaultSuggestions = 1
+    private let ItemSuggestionNonSponsored = 0
+    private let ItemSuggestionSponsored = 1
+    private let ItemSuggestionLearn = 2
+    private let IconSize = CGSize(width: OpenSearchEngine.UX.preferredIconSize,
+                                  height: OpenSearchEngine.UX.preferredIconSize)
 
-    fileprivate var showDeletion = false
+    private var showDeletion = false
+    private var sectionsToDisplay: [SearchSettingsTableViewController.Section] = []
 
     var updateSearchIcon: (() -> Void)?
-    fileprivate var isEditable: Bool {
+    private var isEditable: Bool {
         guard let defaultEngine = model.defaultEngine else { return false }
 
         // If the default engine is a custom one, make sure we have more than one since we can't edit the default.
@@ -102,8 +109,7 @@ class SearchSettingsTableViewController: ThemedTableViewController, FeatureFlagg
         let cell = dequeueCellFor(indexPath: indexPath)
         cell.applyTheme(theme: themeManager.currentTheme)
         var engine: OpenSearchEngine!
-
-        let section = Section(rawValue: indexPath.section) ?? .defaultEngine
+        let section = Section(rawValue: sectionsToDisplay[indexPath.section].rawValue) ?? .defaultEngine
         switch section {
         case .defaultEngine:
             switch indexPath.item {
@@ -168,6 +174,49 @@ class SearchSettingsTableViewController: ThemedTableViewController, FeatureFlagg
             cell.editingAccessoryView = toggle
             cell.selectionStyle = .none
             cell.accessibilityIdentifier = AccessibilityIdentifiers.Settings.Search.disableSearchSuggestsInPrivateMode
+        case .firefoxSuggestSettings:
+            switch indexPath.item {
+            case ItemSuggestionNonSponsored:
+                let setting = BoolSetting(
+                    prefs: profile.prefs,
+                    theme: themeManager.currentTheme,
+                    prefKey: PrefsKeys.FirefoxSuggestShowNonSponsoredSuggestions,
+                    defaultValue: profile.prefs.boolForKey(PrefsKeys.FirefoxSuggestShowNonSponsoredSuggestions) ?? true,
+                    titleText: String.localizedStringWithFormat(.Settings.Search.Suggest.ShowNonSponsoredSuggestionsTitle,
+                                                                AppName.shortName.rawValue),
+                    statusText: String.localizedStringWithFormat(.Settings.Search.Suggest.ShowNonSponsoredSuggestionsDescription,
+                                                                 AppName.shortName.rawValue)
+                )
+                setting.onConfigureCell(cell, theme: themeManager.currentTheme)
+                setting.control.addTarget(self, action: #selector(didToggleEnableNonSponsoredSuggestions), for: .valueChanged)
+                cell.editingAccessoryView = setting.control
+                cell.selectionStyle = .none
+            case ItemSuggestionSponsored:
+                let setting = BoolSetting(
+                    prefs: profile.prefs,
+                    theme: themeManager.currentTheme,
+                    prefKey: PrefsKeys.FirefoxSuggestShowSponsoredSuggestions,
+                    defaultValue: profile.prefs.boolForKey(PrefsKeys.FirefoxSuggestShowSponsoredSuggestions) ?? true,
+                    titleText: .Settings.Search.Suggest.ShowSponsoredSuggestionsTitle,
+                    statusText: String.localizedStringWithFormat(.Settings.Search.Suggest.ShowSponsoredSuggestionsDescription,
+                                                                 AppName.shortName.rawValue)
+                )
+                setting.onConfigureCell(cell, theme: themeManager.currentTheme)
+                setting.control.addTarget(self, action: #selector(didToggleEnableSponsoredSuggestions), for: .valueChanged)
+                cell.editingAccessoryView = setting.control
+                cell.selectionStyle = .none
+            case ItemSuggestionLearn:
+                cell.accessibilityLabel = String.localizedStringWithFormat(.Settings.Search.AccessibilityLabels.LearnAboutSuggestions,
+                                                                           AppName.shortName.rawValue)
+                cell.textLabel?.text = String.localizedStringWithFormat(.Settings.Search.Suggest.LearnAboutSuggestions,
+                                                                        AppName.shortName.rawValue)
+                cell.imageView?.layer.cornerRadius = 4
+                cell.imageView?.layer.masksToBounds = true
+                cell.selectionStyle = .none
+
+            default:
+                break
+            }
         }
 
         // So that the separator line goes all the way to the left edge.
@@ -177,14 +226,18 @@ class SearchSettingsTableViewController: ThemedTableViewController, FeatureFlagg
     }
 
     override func numberOfSections(in tableView: UITableView) -> Int {
-        guard featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly) else {
-            return Section.allCases.count - 1
+        sectionsToDisplay = [Section.defaultEngine, Section.quickEngines]
+        if featureFlags.isFeatureEnabled(.firefoxSuggestFeature, checking: .buildAndUser) {
+            sectionsToDisplay.append(.firefoxSuggestSettings)
         }
-        return Section.allCases.count
+        if featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly) {
+            sectionsToDisplay.append(.privateSession)
+        }
+        return sectionsToDisplay.count
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        let section = Section(rawValue: section) ?? .defaultEngine
+        let section = Section(rawValue: sectionsToDisplay[section].rawValue) ?? .defaultEngine
         switch section {
         case .defaultEngine:
             return 2
@@ -194,11 +247,13 @@ class SearchSettingsTableViewController: ThemedTableViewController, FeatureFlagg
             return model.orderedEngines.count
         case .privateSession:
             return 1
+        case .firefoxSuggestSettings:
+            return 3
         }
     }
 
     override func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
-        let section = Section(rawValue: indexPath.section) ?? .defaultEngine
+        let section = Section(rawValue: sectionsToDisplay[indexPath.section].rawValue) ?? .defaultEngine
         switch section {
         case .defaultEngine:
             guard indexPath.item == ItemDefaultEngine else { return nil }
@@ -223,15 +278,20 @@ class SearchSettingsTableViewController: ThemedTableViewController, FeatureFlagg
             navigationController?.pushViewController(customSearchEngineForm, animated: true)
         case .privateSession:
             return nil
+        case .firefoxSuggestSettings:
+            guard indexPath.item == ItemSuggestionLearn else { return nil }
+            let viewController = SettingsContentViewController()
+            viewController.url = SupportUtils.URLForTopic("search-suggestions-firefox")
+            navigationController?.pushViewController(viewController, animated: true)
         }
         return nil
     }
 
     // Don't show delete button on the left.
     override func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
-        let section = Section(rawValue: indexPath.section) ?? .defaultEngine
+        let section = Section(rawValue: sectionsToDisplay[indexPath.section].rawValue) ?? .defaultEngine
         switch section {
-        case .defaultEngine, .privateSession:
+        case .defaultEngine, .privateSession, .firefoxSuggestSettings:
             return UITableViewCell.EditingStyle.none
         case .quickEngines:
             let isLastItem = indexPath.item + 1 == model.orderedEngines.count
@@ -276,8 +336,7 @@ class SearchSettingsTableViewController: ThemedTableViewController, FeatureFlagg
 
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard let headerView = super.tableView(tableView, viewForHeaderInSection: section) as? ThemedTableSectionHeaderFooterView else { return nil }
-
-        let section = Section(rawValue: section) ?? .defaultEngine
+        let section = Section(rawValue: sectionsToDisplay[section].rawValue) ?? .defaultEngine
         headerView.titleLabel.text = section.title
 
         return headerView
@@ -291,9 +350,9 @@ class SearchSettingsTableViewController: ThemedTableViewController, FeatureFlagg
     }
 
     override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
-        let section = Section(rawValue: indexPath.section) ?? .defaultEngine
+        let section = Section(rawValue: sectionsToDisplay[indexPath.section].rawValue) ?? .defaultEngine
         switch section {
-        case .defaultEngine, .privateSession:
+        case .defaultEngine, .privateSession, .firefoxSuggestSettings:
             return false
         case .quickEngines:
             let isLastItem = indexPath.item + 1 == model.orderedEngines.count
@@ -390,6 +449,16 @@ extension SearchSettingsTableViewController {
     @objc
     func didToggleShowSearchSuggestionsInPrivateMode(_ toggle: ThemedSwitch) {
         model.shouldShowPrivateModeSearchSuggestions = toggle.isOn
+    }
+
+    @objc
+    func didToggleEnableNonSponsoredSuggestions(_ toggle: ThemedSwitch) {
+        profile.prefs.setBool(toggle.isOn, forKey: PrefsKeys.FirefoxSuggestShowNonSponsoredSuggestions)
+    }
+
+    @objc
+    func didToggleEnableSponsoredSuggestions(_ toggle: ThemedSwitch) {
+        profile.prefs.setBool(toggle.isOn, forKey: PrefsKeys.FirefoxSuggestShowSponsoredSuggestions)
     }
 
     func cancel() {

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -1707,6 +1707,45 @@ extension String {
                     tableName: "Settings",
                     value: "Default Search Engine",
                     comment: "Accessibility label for default search engine setting.")
+                public static let LearnAboutSuggestions = MZLocalizedString(
+                    key: "Settings.Search.Accessibility.LearnAboutSuggestions.v124",
+                    tableName: "Settings",
+                    value: "Learn more about %@ Suggest",
+                    comment: "Accessibility label for Learn more about Firefox Suggest. Placeholder is for the app name - Firefox.")
+            }
+
+            public struct Suggest {
+                public static let AddressBarSettingsTitle = MZLocalizedString(
+                    key: "Settings.Search.Suggest.AddressBarSetting.Title.v124",
+                    tableName: "Settings",
+                    value: "Address bar - %@ Suggest",
+                    comment: "In the Search page of the Settings menu, the title for the Firefox Suggest settings section. Placeholder is for the app name - Firefox.")
+                public static let ShowNonSponsoredSuggestionsTitle = MZLocalizedString(
+                    key: "Settings.Search.Suggest.ShowNonSponsoredSuggestions.Title.v124",
+                    tableName: "Settings",
+                    value: "Suggestions from %@",
+                    comment: "In the Search page of the Settings menu, the title for setting to enable Suggestions from Firefox. Placeholder is for the app name - Firefox.")
+                public static let ShowNonSponsoredSuggestionsDescription = MZLocalizedString(
+                    key: "Settings.Search.Suggest.ShowNonSponsoredSuggestions.Description.v124",
+                    tableName: "Settings",
+                    value: "Get suggestions from the web related to your search",
+                    comment: "In the Search page of the Settings menu, the description for the setting to enable Suggestions from Firefox.")
+                public static let ShowSponsoredSuggestionsTitle = MZLocalizedString(
+                    key: "Settings.Search.Suggest.ShowSponsoredSuggestions.Title.v124",
+                    tableName: "Settings",
+                    value: "Suggestions from sponsors",
+                    comment: "In the Search page of the Settings menu, the title for the setting to enable Suggestions from sponsors.")
+                public static let ShowSponsoredSuggestionsDescription = MZLocalizedString(
+                    key: "Settings.Search.Suggest.ShowSponsoredSuggestions.Description.v124",
+                    tableName: "Settings",
+                    value: "Support %@ with occasional sponsored suggestions",
+                    comment: "In the Search page of the Settings menu, the description for the setting to enable Suggestions from sponsors. Placeholder is for the app name - Firefox.")
+                public static let LearnAboutSuggestions = MZLocalizedString(
+                    key: "Settings.Search.Suggest.LearnAboutSuggestions.v124",
+                    tableName: "Settings",
+                    value: "Learn more about %@ Suggest",
+                    comment: "In the search page of the Settings menu, the title for the link to the SUMO Page about Firefox Suggest. Placeholder is for the app name - Firefox."
+                )
             }
         }
     }

--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -83,7 +83,7 @@ protocol Profile: AnyObject {
     var files: FileAccessor { get }
     var pinnedSites: PinnedSites { get }
     var logins: RustLogins { get }
-    var firefoxSuggest: RustFirefoxSuggest? { get }
+    var firefoxSuggest: RustFirefoxSuggestActor? { get }
     var certStore: CertStore { get }
     var recentlyClosedTabs: ClosedTabsStore { get }
 
@@ -610,7 +610,7 @@ open class BrowserProfile: Profile {
         return RustLogins(databasePath: databasePath)
     }()
 
-    lazy var firefoxSuggest: RustFirefoxSuggest? = {
+    lazy var firefoxSuggest: RustFirefoxSuggestActor? = {
         do {
             let databaseFileURL = try FileManager.default.url(
                 for: .cachesDirectory,

--- a/firefox-ios/Shared/Prefs.swift
+++ b/firefox-ios/Shared/Prefs.swift
@@ -164,6 +164,10 @@ public struct PrefsKeys {
 
     // Only used to force showing the App Store review dialog for debugging purposes
     public static let ForceShowAppReviewPromptOverride = "ForceShowAppReviewPromptOverride"
+
+    // Firefox Suggest
+    public static let FirefoxSuggestShowNonSponsoredSuggestions = "FirefoxSuggestShowNonSponsoredSuggestions"
+    public static let FirefoxSuggestShowSponsoredSuggestions = "FirefoxSuggestShowSponsoredSuggestions"
 }
 
 public struct PrefsDefaults {

--- a/firefox-ios/Storage/Rust/RustFirefoxSuggestion.swift
+++ b/firefox-ios/Storage/Rust/RustFirefoxSuggestion.swift
@@ -22,6 +22,15 @@ public struct RustFirefoxSuggestion {
     public let fullKeyword: String
     public let clickInfo: RustFirefoxSuggestionInteractionInfo?
 
+    public init(title: String, url: URL, isSponsored: Bool, iconImage: UIImage?, fullKeyword: String) {
+        self.title = title
+        self.url = url
+        self.isSponsored = isSponsored
+        self.iconImage = iconImage
+        self.fullKeyword = fullKeyword
+        self.clickInfo = nil
+    }
+
     internal init?(_ suggestion: Suggestion) {
         // This code is intentionally written as a chain of `if-case-let`s
         // instead of a `switch`, because we don't want new `Suggestion` cases

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockProfile.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockProfile.swift
@@ -108,32 +108,18 @@ open class MockProfile: Client.Profile {
 
     public var files: FileAccessor
     public var syncManager: ClientSyncManager!
-    public var firefoxSuggest: RustFirefoxSuggest?
+    public var firefoxSuggest: RustFirefoxSuggestActor?
 
     fileprivate let name: String = "mockaccount"
 
     private let directory: String
     private let databasePrefix: String
 
-    init(databasePrefix: String = "mock") {
+    init(databasePrefix: String = "mock", firefoxSuggest: RustFirefoxSuggestActor? = nil) {
         files = MockFiles()
         syncManager = ClientSyncManagerSpy()
         self.databasePrefix = databasePrefix
-
-        do {
-            let firefoxSuggestDatabaseName = "\(databasePrefix)_suggest.db"
-            let firefoxSuggestDatabaseURL = try FileManager.default.url(
-                for: .cachesDirectory,
-                in: .userDomainMask,
-                appropriateFor: nil,
-                create: true
-            ).appendingPathComponent(firefoxSuggestDatabaseName, isDirectory: false)
-            try? FileManager.default.removeItem(at: firefoxSuggestDatabaseURL)
-
-            firefoxSuggest = try RustFirefoxSuggest(databasePath: firefoxSuggestDatabaseURL.path)
-        } catch {
-            fatalError("Failed to open Firefox Suggest database: \(error.localizedDescription)")
-        }
+        self.firefoxSuggest = firefoxSuggest
 
         do {
             directory = try files.getAndEnsureDirectory()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/SearchViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/SearchViewControllerTests.swift
@@ -1,0 +1,70 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Storage
+import XCTest
+import Shared
+
+@testable import Client
+
+actor MockRustFirefoxSuggest: RustFirefoxSuggestActor {
+    func ingest() async throws {
+    }
+    func query(_ keyword: String, includeSponsored: Bool, includeNonSponsored: Bool) async throws -> [RustFirefoxSuggestion] {
+        return [RustFirefoxSuggestion(title: "Mozilla",
+                                      url: URL(string: "https://mozilla.org")!,
+                                      isSponsored: true,
+                                      iconImage: nil,
+                                      fullKeyword: "mozilla"
+                                     )]
+    }
+    nonisolated func interruptReader() {
+    }
+}
+
+@MainActor
+class SearchViewControllerTest: XCTestCase {
+    var profile: MockProfile!
+    var searchViewController: SearchViewController!
+
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+        profile = MockProfile(firefoxSuggest: MockRustFirefoxSuggest())
+        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
+        LegacyFeatureFlagsManager.shared.set(feature: .firefoxSuggestFeature, to: true)
+
+        let mockSearchEngineProvider = MockSearchEngineProvider()
+        let engines = SearchEngines(
+            prefs: profile.prefs,
+            files: profile.files,
+            engineProvider: mockSearchEngineProvider
+        )
+        let viewModel = SearchViewModel(isPrivate: false, isBottomSearchBar: false)
+
+        searchViewController = SearchViewController(profile: profile, viewModel: viewModel, model: engines, tabManager: MockTabManager())
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        profile = nil
+    }
+
+    func testFirefoxSuggestionReturnsSponsoredAndNonSponsored() async throws {
+        profile.prefs.setBool(true, forKey: PrefsKeys.FirefoxSuggestShowSponsoredSuggestions)
+        profile.prefs.setBool(true, forKey: PrefsKeys.FirefoxSuggestShowNonSponsoredSuggestions)
+        try await searchViewController.loadFirefoxSuggestions()?.value
+
+        XCTAssertEqual(searchViewController.firefoxSuggestions.count, 1)
+    }
+
+    func testFirefoxSuggestionReturnsNoSuggestions() async throws {
+        profile.prefs.setBool(false, forKey: PrefsKeys.FirefoxSuggestShowSponsoredSuggestions )
+        profile.prefs.setBool(false, forKey: PrefsKeys.FirefoxSuggestShowNonSponsoredSuggestions)
+        try await searchViewController.loadFirefoxSuggestions()?.value
+
+        XCTAssertEqual(searchViewController.firefoxSuggestions.count, 0)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/SearchViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/SearchViewControllerTests.swift
@@ -55,7 +55,7 @@ class SearchViewControllerTest: XCTestCase {
     func testFirefoxSuggestionReturnsSponsoredAndNonSponsored() async throws {
         profile.prefs.setBool(true, forKey: PrefsKeys.FirefoxSuggestShowSponsoredSuggestions)
         profile.prefs.setBool(true, forKey: PrefsKeys.FirefoxSuggestShowNonSponsoredSuggestions)
-        try await searchViewController.loadFirefoxSuggestions()?.value
+        await searchViewController.loadFirefoxSuggestions()?.value
 
         XCTAssertEqual(searchViewController.firefoxSuggestions.count, 1)
     }
@@ -63,7 +63,7 @@ class SearchViewControllerTest: XCTestCase {
     func testFirefoxSuggestionReturnsNoSuggestions() async throws {
         profile.prefs.setBool(false, forKey: PrefsKeys.FirefoxSuggestShowSponsoredSuggestions )
         profile.prefs.setBool(false, forKey: PrefsKeys.FirefoxSuggestShowNonSponsoredSuggestions)
-        try await searchViewController.loadFirefoxSuggestions()?.value
+        await searchViewController.loadFirefoxSuggestions()?.value
 
         XCTAssertEqual(searchViewController.firefoxSuggestions.count, 0)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7807)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17408)

## :bulb: Description
Add Settings to enable firefox suggest, to enable sponsored suggestions for firefox suggest and a "learn more" menu item. New settings items appear dependent on the fx suggest secret setting.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods
![Screenshot 2023-11-21 at 10 29 34 AM](https://github.com/mozilla-mobile/firefox-ios/assets/25379936/e7c4eadd-c186-49cb-9ef3-2263f126dd48)

