### PR TITLE
Bugfix FXIOS-7799 [v122] Fix APN deeplinks when app is not running

### DIFF
--- a/Client/Application/SceneDelegate.swift
+++ b/Client/Application/SceneDelegate.swift
@@ -134,5 +134,21 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                                               tabSetting: NewTabAccessors.getNewTabPage(profile.prefs)) {
             sceneCoordinator?.findAndHandle(route: route)
         }
+
+        // Check if our connection options include a user response to a push notification
+        // that is for Sent Tabs. If so, route the related tab URLs.
+        if let notification = connectionOptions.notificationResponse?.notification,
+           let userInfo = notification.request.content.userInfo["sentTabs"] as? [[String: Any]] {
+            handleAPNSentTabs(userInfo)
+        }
+    }
+
+    private func handleAPNSentTabs(_ userInfo: [[String: Any]]) {
+        for tab in userInfo {
+            guard let urlString = tab["url"] as? String,
+                  let url = URL(string: urlString),
+                  let route = routeBuilder.makeRoute(url: url) else { continue }
+            sceneCoordinator?.findAndHandle(route: route)
+        }
     }
 }

--- a/Client/Application/SceneDelegate.swift
+++ b/Client/Application/SceneDelegate.swift
@@ -135,15 +135,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             sceneCoordinator?.findAndHandle(route: route)
         }
 
-        // Check if our connection options include a user response to a push notification
-        // that is for Sent Tabs. If so, route the related tab URLs.
+        // Check if our connection options include a user response to a push
+        // notification that is for Sent Tabs. If so, route the related tab URLs.
         if let notification = connectionOptions.notificationResponse?.notification,
            let userInfo = notification.request.content.userInfo["sentTabs"] as? [[String: Any]] {
-            handleAPNSentTabs(userInfo)
+            handleConnectionOptionsSentTabs(userInfo)
         }
     }
 
-    private func handleAPNSentTabs(_ userInfo: [[String: Any]]) {
+    private func handleConnectionOptionsSentTabs(_ userInfo: [[String: Any]]) {
+        // For Sent Tab data structure, see also:
+        // NotificationService.displayNewSentTabNotification()
         for tab in userInfo {
             guard let urlString = tab["url"] as? String,
                   let url = URL(string: urlString),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7799)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17395)

## :bulb: Description

This PR fixes the handling when using 'Send to Device' to Firefox iOS and the app is not running. When the app is already running these notification URLs are handled by `scene(openURLContexts:)`, but when the app must be launched to handle a push notification that scene delegate function is not called. 

The notification data is available within a few callbacks, including the `connectionOptions` for `scene(willConnectTo:)`. Since the handler for that callback is where we are also routing URLs for `urlContexts` and `shortcutItems` etc., it seemed like an appropriate place to handle this.

There didn't appear to be any existing code for this flow, and the ticket reporter mentioned that the feature hasn't worked for at least a year. There may be other related scenarios for push notifications that might also need to be fixed; if anyone has suggestions on other ways we should address this that would be more robust please LMK. Would greatly appreciate any extra :eyes: from folks who are familiar with our push notification code.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

