### PR TITLE
Bugfix FXIOS-7804 [v121] Can't present Fakespot sheet if switching tabs

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -80,6 +80,7 @@ class BrowserViewController: UIViewController,
     let tabManager: TabManager
     let ratingPromptManager: RatingPromptManager
     lazy var isTabTrayRefactorEnabled: Bool = TabTrayFlagManager.isRefactorEnabled
+    private var fakespotState: FakespotState?
 
     // Header stack view can contain the top url bar, top reader mode, top ZoomPageBar
     var header: BaseAlphaStackView = .build { _ in }
@@ -464,6 +465,8 @@ class BrowserViewController: UIViewController,
         ensureMainThread { [weak self] in
             guard let self else { return }
 
+            fakespotState = state
+
             // opens or close sidebar/bottom sheet to match the saved state
             if state.isOpenOnProductPage {
                 guard let productURL = urlBar.currentURL else { return }
@@ -734,8 +737,7 @@ class BrowserViewController: UIViewController,
         var fakespotNeedsUpdate = false
         if urlBar.currentURL != nil {
             fakespotNeedsUpdate = contentStackView.isSidebarVisible != FakespotUtils().shouldDisplayInSidebar(viewSize: size)
-            if isReduxIntegrationEnabled,
-                let fakespotState = store.state.screenState(FakespotState.self, for: .fakespot) {
+            if isReduxIntegrationEnabled, let fakespotState = fakespotState {
                 fakespotNeedsUpdate = fakespotNeedsUpdate && fakespotState.isOpenOnProductPage
             }
 
@@ -1681,7 +1683,7 @@ class BrowserViewController: UIViewController,
                   !tab.isPrivate,
                   FakespotUtils().shouldDisplayInSidebar(),
                   isReduxIntegrationEnabled,
-                  let fakespotState = store.state.screenState(FakespotState.self, for: .fakespot),
+                  let fakespotState = fakespotState,
                   fakespotState.isOpenOnProductPage {
             handleFakespotFlow(productURL: url)
         } else if contentStackView.isSidebarVisible {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -464,6 +464,7 @@ class BrowserViewController: UIViewController,
         ensureMainThread { [weak self] in
             guard let self else { return }
 
+            // opens or close sidebar/bottom sheet to match the saved state
             if state.isOpenOnProductPage {
                 guard let productURL = urlBar.currentURL else { return }
                 handleFakespotFlow(productURL: productURL)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -734,6 +734,10 @@ class BrowserViewController: UIViewController,
         var fakespotNeedsUpdate = false
         if urlBar.currentURL != nil {
             fakespotNeedsUpdate = contentStackView.isSidebarVisible != FakespotUtils().shouldDisplayInSidebar(viewSize: size)
+            if isReduxIntegrationEnabled,
+                let fakespotState = store.state.screenState(FakespotState.self, for: .fakespot) {
+                fakespotNeedsUpdate = fakespotNeedsUpdate && fakespotState.isOpenOnProductPage
+            }
 
             if fakespotNeedsUpdate {
                 _ = dismissFakespotIfNeeded(animated: false)

--- a/Client/Frontend/Fakespot/FakespotViewController.swift
+++ b/Client/Frontend/Fakespot/FakespotViewController.swift
@@ -43,6 +43,8 @@ class FakespotViewController:
     private var viewModel: FakespotViewModel
     weak var delegate: FakespotViewControllerDelegate?
 
+    lazy var isReduxIntegrationEnabled: Bool = ReduxFlagManager.isReduxEnabled
+
     private lazy var scrollView: UIScrollView = .build()
 
     private lazy var contentStackView: UIStackView = .build { stackView in
@@ -475,8 +477,16 @@ class FakespotViewController:
 
     @objc
     private func closeTapped() {
-        delegate?.fakespotControllerDidDismiss(animated: true)
+        triggerDismiss()
         viewModel.recordDismissTelemetry(by: .closeButton)
+    }
+
+    private func triggerDismiss() {
+        delegate?.fakespotControllerDidDismiss(animated: true)
+
+        if isReduxIntegrationEnabled {
+            store.dispatch(FakespotAction.toggleAppearance(false))
+        }
     }
 
     deinit {
@@ -504,7 +514,8 @@ class FakespotViewController:
     // MARK: - UIAdaptivePresentationControllerDelegate
 
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
-        delegate?.fakespotControllerDidDismiss(animated: true)
+        triggerDismiss()
+
         let currentDetent = viewModel.getCurrentDetent(for: presentationController)
 
         if viewModel.isSwiping || currentDetent == .large {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7804)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17404)

## :bulb: Description
Fixes Fakespot not being able to be opened due to the state not being saved in all the correct places. Also fixes bottom sheet opening on non-product pages.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

