### PR TITLE
Bugfix FXIOS-7688 [v122] Calling out address bar on a pdf sends page to top, for example swiping down on page

### DIFF
--- a/Client/Frontend/Browser/TabScrollController.swift
+++ b/Client/Frontend/Browser/TabScrollController.swift
@@ -91,6 +91,8 @@ class TabScrollingController: NSObject, FeatureFlaggable, SearchBarLocationProvi
     private var scrollViewHeight: CGFloat { return scrollView?.frame.height ?? 0 }
     private var topScrollHeight: CGFloat { header?.frame.height ?? 0 }
     private var contentSize: CGSize { return scrollView?.contentSize ?? .zero }
+    private var contentOffsetBeforeAnimation = CGPoint.zero
+    private var isAnimatingToolbar = false
 
     // Over keyboard content and bottom content
     private var overKeyboardScrollHeight: CGFloat {
@@ -302,8 +304,8 @@ private extension TabScrollingController {
                                     alpha: CGFloat,
                                     completion: ((_ finished: Bool) -> Void)?) {
         guard let scrollView = scrollView else { return }
-        let initialContentOffset = scrollView.contentOffset
-
+        contentOffsetBeforeAnimation = scrollView.contentOffset
+        isAnimatingToolbar = true
         // If this function is used to fully animate the toolbar from hidden to shown, keep the page from scrolling by adjusting contentOffset,
         // Otherwise when the toolbar is hidden and a link navigated, showing the toolbar will scroll the page and
         // produce a ~50px page jumping effect in response to tap navigations.
@@ -311,7 +313,7 @@ private extension TabScrollingController {
 
         let animation: () -> Void = {
             if isShownFromHidden {
-                scrollView.contentOffset = CGPoint(x: initialContentOffset.x, y: initialContentOffset.y + self.topScrollHeight)
+                scrollView.contentOffset = CGPoint(x: self.contentOffsetBeforeAnimation.x, y: self.contentOffsetBeforeAnimation.y + self.topScrollHeight)
             }
             self.headerTopOffset = headerOffset
             self.bottomContainerOffset = bottomContainerOffset
@@ -326,8 +328,10 @@ private extension TabScrollingController {
             UIView.animate(withDuration: duration,
                            delay: 0,
                            options: .allowUserInteraction,
-                           animations: animation,
-                           completion: completion)
+                           animations: animation) { finished in
+                self.isAnimatingToolbar = false
+                completion?(finished)
+            }
         } else {
             animation()
             completion?(true)
@@ -385,6 +389,16 @@ extension TabScrollingController: UIScrollViewDelegate {
             } else if scrollDirection == .down {
                 hideToolbars(animated: true)
             }
+        }
+    }
+
+    // checking if an abrupt scroll event was triggered and adjusting the offset to the one
+    // before the WKWebView's contentOffset is reset as a result of the contentView's frame becoming smaller
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        guard isAnimatingToolbar else { return }
+        if contentOffsetBeforeAnimation.y - scrollView.contentOffset.y > 200 {
+            scrollView.contentOffset = CGPoint(x: contentOffsetBeforeAnimation.x, y: contentOffsetBeforeAnimation.y + self.topScrollHeight)
+            contentOffsetBeforeAnimation.y = 0
         }
     }
 

--- a/Client/Frontend/Browser/TabScrollController.swift
+++ b/Client/Frontend/Browser/TabScrollController.swift
@@ -7,6 +7,10 @@ import SnapKit
 
 private let ToolbarBaseAnimationDuration: CGFloat = 0.2
 class TabScrollingController: NSObject, FeatureFlaggable, SearchBarLocationProvider {
+    private struct UX {
+        static let abruptScrollEventOffset: CGFloat = 200
+    }
+
     enum ScrollDirection {
         case up
         case down
@@ -396,7 +400,7 @@ extension TabScrollingController: UIScrollViewDelegate {
     // before the WKWebView's contentOffset is reset as a result of the contentView's frame becoming smaller
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         guard isAnimatingToolbar else { return }
-        if contentOffsetBeforeAnimation.y - scrollView.contentOffset.y > 200 {
+        if contentOffsetBeforeAnimation.y - scrollView.contentOffset.y > UX.abruptScrollEventOffset {
             scrollView.contentOffset = CGPoint(x: contentOffsetBeforeAnimation.x, y: contentOffsetBeforeAnimation.y + self.topScrollHeight)
             contentOffsetBeforeAnimation.y = 0
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7688)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17146)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Added the UIScrollView delegate method `scrollViewDidScroll` where I check if the difference between the scrollView's contentOffset and the last contentOffset we saved is larger than 200 right after the toolbar animation (it means an unwanted scroll event happened, as users can't scroll that much in one go) and if that's the case then we update the scrollView's contentOffset to the one that's saved before the animation starts.
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

