### PR TITLE
Bugfix FXIOS-7820 [v122] Fix tab screenshot cleanup

### DIFF
--- a/Storage/DiskImageStore.swift
+++ b/Storage/DiskImageStore.swift
@@ -86,13 +86,13 @@ public actor DefaultDiskImageStore: DiskImageStore {
     }
 
     public func clearAllScreenshotsExcluding(_ keys: Set<String>) async throws {
-        let keysToDelete = keys.subtracting(keys)
+        let keysToDelete = self.keys.subtracting(keys)
 
         for key in keysToDelete {
             let url = URL(fileURLWithPath: filesDir).appendingPathComponent(key)
             try FileManager.default.removeItem(at: url)
         }
-        self.keys = keys.intersection(keys)
+        self.keys = keys
     }
 
     public func deleteImageForKey(_ key: String) async {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7820)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17434)

## :bulb: Description

Fix for issue in `clearAllScreenshotsExcluding()` that was causing screenshots not to be cleared, due to the function argument variable shadowing the class property.

This is part of a broader investigation into a few possible bugs with the tab screenshots; still doing some additional digging into whether there any other culprits involved. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

