### PR TITLE
Refactor FXIOS-5848 [v122] Remove SnapKit from DevicePickerTableViewCell

### DIFF
--- a/Client/Frontend/DevicePickerTableViewCell.swift
+++ b/Client/Frontend/DevicePickerTableViewCell.swift
@@ -13,7 +13,12 @@ class DevicePickerTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable 
         static let deviceRowTextPaddingRight: CGFloat = 50
     }
 
-    var nameLabel: UILabel
+    var nameLabel: UILabel = .build { label in
+        label.font = UX.deviceRowTextFont
+        label.numberOfLines = 2
+        label.lineBreakMode = .byWordWrapping
+    }
+
     var checked = false {
         didSet {
             self.accessoryType = checked ? .checkmark : .none
@@ -27,12 +32,8 @@ class DevicePickerTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable 
     }
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        nameLabel = UILabel()
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         contentView.addSubview(nameLabel)
-        nameLabel.font = UX.deviceRowTextFont
-        nameLabel.numberOfLines = 2
-        nameLabel.lineBreakMode = .byWordWrapping
         self.tintColor = UIColor.label
         self.preservesSuperviewLayoutMargins = false
         self.selectionStyle = .none
@@ -41,11 +42,11 @@ class DevicePickerTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable 
     override func layoutSubviews() {
         super.layoutSubviews()
 
-        nameLabel.snp.makeConstraints { (make) -> Void in
-            make.left.equalTo(UX.deviceRowTextPaddingLeft)
-            make.centerY.equalTo(self.snp.centerY)
-            make.right.equalTo(self.snp.right).offset(-UX.deviceRowTextPaddingRight)
-        }
+        NSLayoutConstraint.activate([
+            nameLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: UX.deviceRowTextPaddingLeft),
+            nameLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+            nameLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -UX.deviceRowTextPaddingRight)
+        ])
     }
 
     required init(coder aDecoder: NSCoder) {
@@ -53,8 +54,9 @@ class DevicePickerTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable 
     }
 
     func applyTheme(theme: Theme) {
-        nameLabel.textColor = theme.colors.textPrimary
+        let colors = theme.colors
+        nameLabel.textColor = colors.textPrimary
         imageView?.image = imageView?.image?.withRenderingMode(.alwaysTemplate)
-        imageView?.tintColor = theme.colors.textPrimary
+        imageView?.tintColor = colors.textPrimary
     }
 }

--- a/Client/Frontend/DevicePickerTableViewCell.swift
+++ b/Client/Frontend/DevicePickerTableViewCell.swift
@@ -13,10 +13,15 @@ class DevicePickerTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable 
         static let deviceRowTextPaddingRight: CGFloat = 50
     }
 
-    var nameLabel: UILabel = .build { label in
+    private lazy var nameLabel: UILabel = .build { label in
         label.font = UX.deviceRowTextFont
         label.numberOfLines = 2
         label.lineBreakMode = .byWordWrapping
+    }
+
+    func configureCell(_ text: String, _ clientType: ClientType) {
+        nameLabel.text = text
+        self.clientType = clientType
     }
 
     var checked = false {
@@ -34,18 +39,17 @@ class DevicePickerTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         contentView.addSubview(nameLabel)
+        setupLayout()
         self.tintColor = UIColor.label
         self.preservesSuperviewLayoutMargins = false
         self.selectionStyle = .none
     }
 
-    override func layoutSubviews() {
-        super.layoutSubviews()
-
+    private func setupLayout() {
         NSLayoutConstraint.activate([
-            nameLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: UX.deviceRowTextPaddingLeft),
+            nameLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: UX.deviceRowTextPaddingLeft),
             nameLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
-            nameLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -UX.deviceRowTextPaddingRight)
+            nameLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -UX.deviceRowTextPaddingRight)
         ])
     }
 

--- a/Client/Frontend/DevicePickerTableViewCell.swift
+++ b/Client/Frontend/DevicePickerTableViewCell.swift
@@ -19,11 +19,6 @@ class DevicePickerTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable 
         label.lineBreakMode = .byWordWrapping
     }
 
-    func configureCell(_ text: String, _ clientType: ClientType) {
-        nameLabel.text = text
-        self.clientType = clientType
-    }
-
     var checked = false {
         didSet {
             self.accessoryType = checked ? .checkmark : .none
@@ -51,6 +46,11 @@ class DevicePickerTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable 
             nameLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
             nameLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -UX.deviceRowTextPaddingRight)
         ])
+    }
+
+    func configureCell(_ text: String, _ clientType: ClientType) {
+        nameLabel.text = text
+        self.clientType = clientType
     }
 
     required init(coder aDecoder: NSCoder) {

--- a/Client/Frontend/Extensions/DevicePickerViewController.swift
+++ b/Client/Frontend/Extensions/DevicePickerViewController.swift
@@ -196,8 +196,7 @@ class DevicePickerViewController: UITableViewController {
                 withIdentifier: DevicePickerTableViewCell.cellIdentifier,
                 for: indexPath) as? DevicePickerTableViewCell {
                 let item = devices[indexPath.row]
-                clientCell.nameLabel.text = item.name
-                clientCell.clientType = ClientType.fromFxAType(item.type)
+                clientCell.configureCell(item.name, ClientType.fromFxAType(item.type))
 
                 if let id = item.id {
                     clientCell.checked = selectedIdentifiers.contains(id)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5848)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13360)

## :bulb: Description
- Remove SnapKit from DevicePickerTableViewCell and replace with normal constraints

| Portrait | Landscape | 
| ------------- | ------------- |
| ![portrait](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/ddf13b8d-658c-4ac3-b606-8b7851da9a8a) | ![landscape](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/055922ae-0793-4486-bee2-fbaa60406e52) |


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods