### PR TITLE
Add FXIOS-7191 [v122] Dimming view for private tab

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -88,6 +88,11 @@ class BrowserViewController: UIViewController,
     // the bottom reader mode, the bottom url bar and the ZoomPageBar
     var overKeyboardContainer: BaseAlphaStackView = .build { _ in }
 
+    // Overlay dimming view for private mode
+    lazy var privateModeDimmingView: UIView = .build { view in
+        view.backgroundColor = self.themeManager.currentTheme.colors.layerScrim
+    }
+
     // BottomContainer stack view contains toolbar
     var bottomContainer: BaseAlphaStackView = .build { _ in }
 
@@ -640,6 +645,23 @@ class BrowserViewController: UIViewController,
         view.addSubview(bottomContainer)
     }
 
+    // Configure dimming view to show for private mode
+    func configureDimmingView() {
+        guard featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly) else { return }
+
+        if let selectedTab = tabManager.selectedTab, selectedTab.isPrivate {
+            view.addSubview(privateModeDimmingView)
+            view.bringSubviewToFront(privateModeDimmingView)
+
+            NSLayoutConstraint.activate([
+                privateModeDimmingView.topAnchor.constraint(equalTo: contentStackView.topAnchor),
+                privateModeDimmingView.leadingAnchor.constraint(equalTo: contentStackView.leadingAnchor),
+                privateModeDimmingView.bottomAnchor.constraint(equalTo: contentStackView.bottomAnchor),
+                privateModeDimmingView.trailingAnchor.constraint(equalTo: contentStackView.trailingAnchor)
+            ])
+        }
+    }
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
@@ -1089,6 +1111,7 @@ class BrowserViewController: UIViewController,
     }
 
     func hideSearchController() {
+        privateModeDimmingView.removeFromSuperview()
         guard let searchController = self.searchController else { return }
         searchController.willMove(toParent: nil)
         searchController.view.removeFromSuperview()

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -299,6 +299,8 @@ extension BrowserViewController: URLBarDelegate {
         if text.isEmpty {
             hideSearchController()
         } else {
+            configureDimmingView()
+            // TODO: Show / Hide Search Controller based on Setting - https://mozilla-hub.atlassian.net/browse/FXIOS-7182
             showSearchController()
         }
 
@@ -310,6 +312,8 @@ extension BrowserViewController: URLBarDelegate {
         if text.isEmpty {
             hideSearchController()
         } else {
+            configureDimmingView()
+            // TODO: Show / Hide Search Controller based on Setting - https://mozilla-hub.atlassian.net/browse/FXIOS-7182
             showSearchController()
         }
         urlBar.locationTextField?.applyUIMode(isPrivate: tabManager.selectedTab?.isPrivate ?? false, theme: self.themeManager.currentTheme)

--- a/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
+++ b/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
@@ -8,6 +8,7 @@ protocol OverlayStateProtocol {
     var inOverlayMode: Bool { get }
 }
 
+/// Overlay mode (aka attentive mode) refers to when the URL bar is focused and in the editing state
 protocol OverlayModeManager: OverlayStateProtocol {
     /// Set URLBar which is not available when the manager is created
     /// - Parameter urlBarView: URLBar that contains textfield which open and dismiss the keyboard

--- a/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -101,9 +101,7 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
     var locationTextField: ToolbarTextField?
 
     /// Overlay mode is the state where the lock/reader icons are hidden, the home panels are shown,
-    /// and the Cancel button is visible (allowing the user to leave overlay mode). Overlay mode
-    /// is *not* tied to the location text field's editing state; for instance, when selecting
-    /// a panel, the first responder will be resigned, yet the overlay mode UI is still active.
+    /// and the Cancel button is visible (allowing the user to leave overlay mode).
     var inOverlayMode = false
 
     lazy var locationView: TabLocationView = {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7191)

## :bulb: Description
Add a dimming view in front of content when user is interacting with the URL bar in a private mode. From a user perspective, the user sees the dimming view when search suggestions is disabled by default in private mode.

## Tests Steps
To test the dimming view, comment out the `showSearchController()` as disabling search suggests has not been implemented yet. Also, comment out the feature flag for felt privacy.

Added comment to describe what overlay mode is more clearly

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

# Screenshots
After commenting out showing the search controller:
| iPhone | iPad | 
| --- | --- | 
|![Simulator Screenshot - iPhone 15 - 2023-11-22 at 15 24 16](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/9240045a-a820-4dd3-80c5-544db4bb8ac5)| ![Simulator Screenshot - iPad Air (5th generation) - 2023-11-22 at 15 56 25](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/cd2c74e7-afa6-450f-9791-f9db4b3896ea) |
