### PR TITLE
Bugfix FXIOS-7603 [v122] Downloaded Video not available for other applications

### DIFF
--- a/Client/Frontend/Browser/OpenInHelper/DownloadHelper.swift
+++ b/Client/Frontend/Browser/OpenInHelper/DownloadHelper.swift
@@ -39,7 +39,8 @@ struct MIMEType {
     private static let downloadableMIMETypes: [String] = [
         MIMEType.JPEG,
         MIMEType.MP4,
-        MIMEType.OctetStream
+        MIMEType.OctetStream,
+        MIMEType.PNG
     ]
 
     static func canShowInWebView(_ mimeType: String) -> Bool {

--- a/Client/Frontend/Browser/OpenInHelper/DownloadHelper.swift
+++ b/Client/Frontend/Browser/OpenInHelper/DownloadHelper.swift
@@ -15,6 +15,7 @@ struct MIMEType {
     static let JavaScript = "text/javascript"
     static let JPEG = "image/jpeg"
     static let HTML = "text/html"
+    static let MP4 = "video/mp4"
     static let OctetStream = "application/octet-stream"
     static let Passbook = "application/vnd.apple.pkpass"
     static let PDF = "application/pdf"
@@ -35,8 +36,18 @@ struct MIMEType {
         MIMEType.PNG,
         MIMEType.WebP]
 
+    private static let downloadableMIMETypes: [String] = [
+        MIMEType.JPEG,
+        MIMEType.MP4,
+        MIMEType.OctetStream
+    ]
+
     static func canShowInWebView(_ mimeType: String) -> Bool {
         return webViewViewableTypes.contains(mimeType.lowercased())
+    }
+
+    static func canBeDownloaded(_ mimeType: String) -> Bool {
+        return downloadableMIMETypes.contains(mimeType.lowercased())
     }
 
     static func mimeTypeFromFileExtension(_ fileExtension: String) -> String {
@@ -78,7 +89,7 @@ class DownloadHelper: NSObject {
         guard let request = request else { return nil }
 
         let mimeType = response.mimeType ?? MIMEType.OctetStream
-        let isAttachment = mimeType == MIMEType.OctetStream
+        let isAttachment = MIMEType.canBeDownloaded(mimeType)
 
         // Bug 1474339 - Don't auto-download files served with 'Content-Disposition: attachment'
         // Leaving this here for now, but commented out. Checking this HTTP header is


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7603)
No Github issue associated

## :bulb: Description
- Add support to download MIMEType for jpEG and MP4
- Video and image are downloadable and showing in Downloads but we don't the option to open them from Downloads I will attach a video with the new behavior

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

