### PR TITLE
Add FXIOS-7750 [v122] Telemetry - history opened item

### DIFF
--- a/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -579,6 +579,22 @@ class HistoryPanel: UIViewController,
 
         tableView.reloadData()
     }
+
+    // MARK: Telemetry
+
+    func sendOpenedHistoryItemTelemetry() {
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .tap,
+                                     object: .openedHistoryItem)
+    }
+
+    func sendSelectedHistoryItemCount() {
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .tap,
+                                     object: .selectedHistoryItem,
+                                     value: .historyPanelNonGroupItem,
+                                     extras: nil)
+    }
 }
 
 // MARK: - UITableViewDelegate related helpers
@@ -618,11 +634,8 @@ extension HistoryPanel: UITableViewDelegate {
 
         libraryPanelDelegate?.libraryPanel(didSelectURL: url, visitType: .typed)
 
-        TelemetryWrapper.recordEvent(category: .action,
-                                     method: .tap,
-                                     object: .selectedHistoryItem,
-                                     value: .historyPanelNonGroupItem,
-                                     extras: nil)
+        sendSelectedHistoryItemCount()
+        sendOpenedHistoryItemTelemetry()
     }
 
     private func handleHistoryActionableTapped(historyActionable: HistoryActionablesModel) {

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -592,8 +592,7 @@ class HistoryPanel: UIViewController,
         TelemetryWrapper.recordEvent(category: .action,
                                      method: .tap,
                                      object: .selectedHistoryItem,
-                                     value: .historyPanelNonGroupItem,
-                                     extras: nil)
+                                     value: .historyPanelNonGroupItem)
     }
 }
 

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -538,6 +538,7 @@ extension TelemetryWrapper {
         case libraryPanel = "library-panel"
         case navigateToGroupHistory = "navigate-to-group-history"
         case selectedHistoryItem = "selected-history-item"
+        case openedHistoryItem = "opened-item"
         case searchHistory = "search-history"
         case deleteHistory = "delete-history"
         case historySingleItemRemoved = "history-single-item-removed"
@@ -1399,6 +1400,8 @@ extension TelemetryWrapper {
             GleanMetrics.History.groupList.add()
         case (.action, .tap, .selectedHistoryItem, let type?, _):
             GleanMetrics.History.selectedItem[type.rawValue].add()
+        case (.action, .tap, .openedHistoryItem, _, _):
+            GleanMetrics.History.openedItem.record()
         case (.action, .tap, .searchHistory, _, _):
             GleanMetrics.History.searchTap.record()
         case (.action, .tap, .deleteHistory, _, _):

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -2062,7 +2062,7 @@ history:
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/17296
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/14102
+      - https://github.com/mozilla-mobile/firefox-ios/pull/17462
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2024-06-01"

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -2055,6 +2055,17 @@ history:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2024-06-01"
+  opened_item:
+    type: event
+    description: |
+      Recorded when a user opened a history item
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/17296
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/14102
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2024-06-01"
   search_tap:
     type: event
     description: |

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -575,6 +575,14 @@ class TelemetryWrapperTests: XCTestCase {
         testEventMetricRecordingSuccess(metric: GleanMetrics.History.opened)
     }
 
+    func test_openedHistoryItem_GleanIsCalled() {
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .tap,
+                                     object: .openedHistoryItem)
+
+        testEventMetricRecordingSuccess(metric: GleanMetrics.History.openedItem)
+    }
+
     func test_singleHistoryItemRemoved_GleanIsCalled() {
         TelemetryWrapper.recordEvent(category: .action,
                                      method: .swipe,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7750)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17296)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Added the opened history item event that triggers when a user taps a history item table view cell
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

