### PR TITLE
Refactor FXIOS-7825 [v122] Remove the shadow from the margin of the Shopping header view

### DIFF
--- a/Client/Frontend/Fakespot/FakespotViewController.swift
+++ b/Client/Frontend/Fakespot/FakespotViewController.swift
@@ -146,7 +146,14 @@ class FakespotViewController:
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         viewModel.isSwiping = false
-        shadowView.layer.shadowPath = UIBezierPath(rect: shadowView.bounds).cgPath
+        // Calculate the rect for the shadowPath, ensuring it is at the bottom of the view
+        let shadowPathRect = CGRect(
+            x: 0,
+            y: shadowView.bounds.maxY - shadowView.layer.shadowRadius,
+            width: shadowView.bounds.width,
+            height: shadowView.layer.shadowRadius
+        )
+        shadowView.layer.shadowPath = UIBezierPath(rect: shadowPathRect).cgPath
     }
 
     override func viewDidAppear(_ animated: Bool) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7825)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17459)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Make the shadow of the header view be visible only to the bottom.

![demo](https://github.com/mozilla-mobile/firefox-ios/assets/51127880/42a6acf9-05ed-4ad0-bb51-c4209b80cf5f)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

