### PR TITLE
Bugfix MTE-1944 [v122] Update TopTabsTest

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TopTabsTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TopTabsTest.swift
@@ -60,7 +60,7 @@ class TopTabsTest: BaseTestCase {
 
         // Open tab tray to check that both tabs are there
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
-        mozWaitForElementToExist(app.cells.staticTexts["Example Domain"])
+        mozWaitForElementToExist(app.cells.staticTexts["Example Domains"])
         if !app.cells.staticTexts["Example Domains"].exists {
             navigator.goto(TabTray)
             app.cells.staticTexts["Examples Domain"].firstMatch.tap()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1944)

## :bulb: Description
https://github.com/mozilla-mobile/firefox-ios/pull/17441 introduced a change that uses a different string as the title in the tabs page. The "Example Domain" page is now "Example Domains" page (note the "s").

![Simulator Screenshot - iPhone 15 - 2023-11-23 at 17 24 56](https://github.com/mozilla-mobile/firefox-ios/assets/1740517/59e4ecbb-b539-490c-94aa-bac19bc0916c)

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

