### PR TITLE
Add FXIOS-7408 [v122] Implement `UILargeContentViewer` and related protocols for URL bar, tab bar and tab location view

### DIFF
--- a/Client/Frontend/Browser/TabTrayButtonExtensions.swift
+++ b/Client/Frontend/Browser/TabTrayButtonExtensions.swift
@@ -13,6 +13,9 @@ class PrivateModeButton: ToggleButton, PrivateModeUI {
         accessibilityHint = .TabTrayToggleAccessibilityHint
         let maskImage = UIImage(named: ImageIdentifiers.privateMaskSmall)?.withRenderingMode(.alwaysTemplate)
         setImage(maskImage, for: [])
+        showsLargeContentViewer = true
+        largeContentTitle = .TabTrayToggleAccessibilityLabel
+        largeContentImage = maskImage
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Client/Frontend/Browser/TopTabCell.swift
+++ b/Client/Frontend/Browser/TopTabCell.swift
@@ -65,10 +65,16 @@ class TopTabCell: UICollectionViewCell, ThemeApplicable, LegacyTabTrayCell, Reus
 
         titleText.text = tab.getTabTrayTitle()
         accessibilityLabel = getA11yTitleLabel(tab: tab)
+        showsLargeContentViewer = true
+        largeContentTitle = tab.getTabTrayTitle()
         isAccessibilityElement = true
 
         closeButton.accessibilityLabel = String(format: .TopSitesRemoveButtonAccessibilityLabel,
                                                 self.titleText.text ?? "")
+        closeButton.showsLargeContentViewer = true
+        closeButton.largeContentTitle = .TopSitesRemoveButtonLargeContentTitle
+        closeButton.largeContentImage = UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross)
+        closeButton.scalesLargeContentImage = true
 
         let hideCloseButton = frame.width < 148 && !selected
         closeButton.isHidden = hideCloseButton

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -57,6 +57,7 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable {
         button.semanticContentAttribute = .forceLeftToRight
         button.addTarget(self, action: #selector(TopTabsViewController.tabsTrayTapped), for: .touchUpInside)
         button.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.tabsButton
+        button.showsLargeContentViewer = true
     }
 
     private lazy var newTab: UIButton = .build { button in
@@ -64,6 +65,9 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable {
         button.semanticContentAttribute = .forceLeftToRight
         button.addTarget(self, action: #selector(TopTabsViewController.newTabTapped), for: .touchUpInside)
         button.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.addNewTabButton
+        button.accessibilityLabel = .AddTabAccessibilityLabel
+        button.showsLargeContentViewer = true
+        button.largeContentTitle = .AddTabAccessibilityLabel
     }
 
     lazy var privateModeButton: PrivateModeButton = {
@@ -72,6 +76,7 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable {
         privateModeButton.accessibilityIdentifier = AccessibilityIdentifiers.Browser.TopTabs.privateModeButton
         privateModeButton.addTarget(self, action: #selector(TopTabsViewController.togglePrivateModeTapped), for: .touchUpInside)
         privateModeButton.translatesAutoresizingMaskIntoConstraints = false
+        privateModeButton.showsLargeContentViewer = true
         return privateModeButton
     }()
 
@@ -153,6 +158,9 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable {
         // links onto the "New Tab" button.
         let dropInteraction = UIDropInteraction(delegate: topTabDisplayManager)
         newTab.addInteraction(dropInteraction)
+
+        let uiLargeContentViewInteraction = UILargeContentViewerInteraction()
+        view.addInteraction(uiLargeContentViewInteraction)
 
         tabsButton.applyTheme(theme: themeManager.currentTheme)
         applyUIMode(isPrivate: tabManager.selectedTab?.isPrivate ?? false, theme: themeManager.currentTheme)

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -1816,6 +1816,11 @@ extension String {
         tableName: nil,
         value: "Remove page — %@",
         comment: "Button shown in editing mode to remove this site from the top sites panel.")
+    public static let TopSitesRemoveButtonLargeContentTitle = MZLocalizedString(
+        key: "TopSites.RemoveButton.LargeContentTitle.v122",
+        tableName: "TabLocation",
+        value: "Remove page",
+        comment: "Large content title for the button shown in editing mode to remove this site from the top sites panel.")
 }
 
 // MARK: - Activity Stream
@@ -4701,6 +4706,26 @@ extension String {
         tableName: "TabLocation",
         value: "Secure connection. Enhanced Tracking Protection is off.",
         comment: "Accessibility label for the security icon in url bar")
+    public static let TabLocationLockButtonLargeContentTitle = MZLocalizedString(
+        key: "TabLocation.LockButton.LargeContentTitle.v122",
+        tableName: "TabLocation",
+        value: "Tracking Protection",
+        comment: "Large content title for the lock button. This title is displayed when using accessible font sizes is enabled")
+    public static let TabLocationLockButtonAccessibilityLabel = MZLocalizedString(
+        key: "TabLocation.LockButton.AccessibilityLabel.v122",
+        tableName: "TabLocation",
+        value: "Tracking Protection",
+        comment: "Accessibility label for the lock / tracking protection button on the URL bar")
+    public static let TabLocationShareButtonLargeContentTitle = MZLocalizedString(
+        key: "TabLocation.ShareButton.AccessibilityLabel.v122",
+        tableName: "TabLocation",
+        value: "Share",
+        comment: "Large content title for the share button. This title is displayed when using accessible font sizes is enabled")
+    public static let TabsButtonShowTabsLargeContentTitle = MZLocalizedString(
+        key: "TabsButton.Accessibility.LargeContentTitle.v122",
+        tableName: "TabLocation",
+        value: "Show Tabs, %@",
+        comment: "Large content title for the tabs button. The argument is the number of open tabs or an infinity symbol. This title is displayed when using accessible font sizes is enabled.")
 }
 
 // MARK: - TabPeekViewController

--- a/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -103,6 +103,10 @@ class TabLocationView: UIView, FeatureFlaggable {
         trackingProtectionButton.addTarget(self, action: #selector(self.didPressTPShieldButton(_:)), for: .touchUpInside)
         trackingProtectionButton.clipsToBounds = false
         trackingProtectionButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.trackingProtection
+        trackingProtectionButton.showsLargeContentViewer = true
+        trackingProtectionButton.largeContentImage = .templateImageNamed(StandardImageIdentifiers.Large.lock)
+        trackingProtectionButton.largeContentTitle = .TabLocationLockButtonLargeContentTitle
+        trackingProtectionButton.accessibilityLabel = .TabLocationLockButtonAccessibilityLabel
     }
 
     lazy var shareButton: ShareButton = .build { shareButton in
@@ -111,15 +115,23 @@ class TabLocationView: UIView, FeatureFlaggable {
         shareButton.contentHorizontalAlignment = .center
         shareButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.shareButton
         shareButton.accessibilityLabel = .TabLocationShareAccessibilityLabel
+        shareButton.showsLargeContentViewer = true
+        shareButton.largeContentImage = .templateImageNamed(ImageIdentifiers.share)
+        shareButton.largeContentTitle = .TabLocationShareButtonLargeContentTitle
     }
 
     private lazy var shoppingButton: UIButton = .build { button in
+        let image = UIImage(named: StandardImageIdentifiers.Large.shopping)
+
         button.addTarget(self, action: #selector(self.didPressShoppingButton(_:)), for: .touchUpInside)
         button.isHidden = true
-        button.setImage(UIImage(named: StandardImageIdentifiers.Large.shopping)?.withRenderingMode(.alwaysTemplate), for: .normal)
+        button.setImage(image?.withRenderingMode(.alwaysTemplate), for: .normal)
         button.imageView?.contentMode = .scaleAspectFit
         button.accessibilityLabel = .TabLocationShoppingAccessibilityLabel
         button.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.shoppingButton
+        button.showsLargeContentViewer = true
+        button.largeContentTitle = .TabLocationShoppingAccessibilityLabel
+        button.largeContentImage = image
     }
 
     private lazy var readerModeButton: ReaderModeButton = .build { readerModeButton in
@@ -136,6 +148,9 @@ class TabLocationView: UIView, FeatureFlaggable {
                 name: .TabLocationReaderModeAddToReadingListAccessibilityLabel,
                 target: self,
                 selector: #selector(self.readerModeCustomAction))]
+        readerModeButton.showsLargeContentViewer = true
+        readerModeButton.largeContentTitle = .TabLocationReaderModeAccessibilityLabel
+        readerModeButton.largeContentImage = .templateImageNamed("reader")
     }
 
     lazy var reloadButton: StatefulButton = {
@@ -149,6 +164,8 @@ class TabLocationView: UIView, FeatureFlaggable {
         reloadButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.reloadButton
         reloadButton.isAccessibilityElement = true
         reloadButton.translatesAutoresizingMaskIntoConstraints = false
+        reloadButton.showsLargeContentViewer = true
+        reloadButton.largeContentTitle = .TabLocationReloadAccessibilityLabel
         return reloadButton
     }()
 

--- a/Client/Frontend/Toolbar+URLBar/TabToolbar.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabToolbar.swift
@@ -131,6 +131,12 @@ extension TabToolbar: TabToolbarProtocol {
     func updateTabCount(_ count: Int, animated: Bool) {
         tabsButton.updateTabCount(count, animated: animated)
     }
+
+    func addUILargeContentViewInteraction(
+        interaction: UILargeContentViewerInteraction
+    ) {
+        addInteraction(interaction)
+    }
 }
 
 // MARK: - Theme protocols

--- a/Client/Frontend/Toolbar+URLBar/TabToolbarHelper.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabToolbarHelper.swift
@@ -26,6 +26,7 @@ protocol TabToolbarProtocol: AnyObject {
     func updateTabCount(_ count: Int, animated: Bool)
     func privateModeBadge(visible: Bool)
     func warningMenuBadge(setVisible: Bool)
+    func addUILargeContentViewInteraction(interaction: UILargeContentViewerInteraction)
 }
 
 protocol TabToolbarDelegate: AnyObject {
@@ -60,6 +61,7 @@ open class TabToolbarHelper: NSObject {
     let ImageSearch = UIImage.templateImageNamed("search")
     let ImageNewTab = UIImage.templateImageNamed(StandardImageIdentifiers.Large.plus)
     let ImageHome = UIImage.templateImageNamed(StandardImageIdentifiers.Large.home)
+    let ImageBookmark = UIImage.templateImageNamed(StandardImageIdentifiers.Large.bookmarkTrayFill)
 
     func setMiddleButtonState(_ state: MiddleButtonState) {
         let device = UIDevice.current.userInterfaceIdiom
@@ -68,20 +70,28 @@ open class TabToolbarHelper: NSObject {
             middleButtonState = .search
             toolbar.multiStateButton.setImage(ImageSearch, for: .normal)
             toolbar.multiStateButton.accessibilityLabel = .TabToolbarSearchAccessibilityLabel
+            toolbar.multiStateButton.largeContentTitle = .TabToolbarSearchAccessibilityLabel
+            toolbar.multiStateButton.largeContentImage = ImageSearch
             toolbar.multiStateButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.searchButton
         case (.reload, .pad):
             middleButtonState = .reload
             toolbar.multiStateButton.setImage(ImageReload, for: .normal)
             toolbar.multiStateButton.accessibilityLabel = .TabToolbarReloadAccessibilityLabel
+            toolbar.multiStateButton.largeContentTitle = .TabToolbarReloadAccessibilityLabel
+            toolbar.multiStateButton.largeContentImage = ImageReload
             toolbar.multiStateButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.reloadButton
         case (.stop, .pad):
             middleButtonState = .stop
             toolbar.multiStateButton.setImage(ImageStop, for: .normal)
             toolbar.multiStateButton.accessibilityLabel = .TabToolbarStopAccessibilityLabel
+            toolbar.multiStateButton.largeContentTitle = .TabToolbarStopAccessibilityLabel
+            toolbar.multiStateButton.largeContentImage = ImageStop
             toolbar.multiStateButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.stopButton
         default:
             toolbar.multiStateButton.setImage(ImageHome, for: .normal)
             toolbar.multiStateButton.accessibilityLabel = .TabToolbarHomeAccessibilityLabel
+            toolbar.multiStateButton.largeContentImage = ImageHome
+            toolbar.multiStateButton.largeContentTitle = .TabToolbarHomeAccessibilityLabel
             toolbar.multiStateButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.homeButton
             middleButtonState = .home
         }
@@ -90,14 +100,22 @@ open class TabToolbarHelper: NSObject {
     // Default state as reload
     var middleButtonState: MiddleButtonState = .home
 
+    private var longPressGestureRecognizers: [UILongPressGestureRecognizer] = []
+    private let uiLargeContentViewInteraction: UILargeContentViewerInteraction = .init()
+
     init(toolbar: TabToolbarProtocol) {
         self.toolbar = toolbar
         super.init()
 
+        toolbar.addUILargeContentViewInteraction(interaction: uiLargeContentViewInteraction)
+
         toolbar.backButton.setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Large.back)?.imageFlippedForRightToLeftLayoutDirection(), for: .normal)
         toolbar.backButton.accessibilityLabel = .TabToolbarBackAccessibilityLabel
         toolbar.backButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.backButton
+        toolbar.backButton.showsLargeContentViewer = true
+        toolbar.backButton.largeContentTitle = .TabToolbarBackAccessibilityLabel
         let longPressGestureBackButton = UILongPressGestureRecognizer(target: self, action: #selector(didLongPressBack))
+        longPressGestureRecognizers.append(longPressGestureBackButton)
         toolbar.backButton.addGestureRecognizer(longPressGestureBackButton)
         toolbar.backButton.addTarget(self, action: #selector(didClickBack), for: .touchUpInside)
 
@@ -106,50 +124,88 @@ open class TabToolbarHelper: NSObject {
             for: .normal)
         toolbar.forwardButton.accessibilityLabel = .TabToolbarForwardAccessibilityLabel
         toolbar.forwardButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.forwardButton
+        toolbar.forwardButton.showsLargeContentViewer = true
+        toolbar.forwardButton.largeContentTitle = .TabToolbarForwardAccessibilityLabel
         let longPressGestureForwardButton = UILongPressGestureRecognizer(target: self, action: #selector(didLongPressForward))
+        longPressGestureRecognizers.append(longPressGestureForwardButton)
+
         toolbar.forwardButton.addGestureRecognizer(longPressGestureForwardButton)
         toolbar.forwardButton.addTarget(self, action: #selector(didClickForward), for: .touchUpInside)
 
         if UIDevice.current.userInterfaceIdiom == .phone {
-            toolbar.multiStateButton.setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Large.home), for: .normal)
+            toolbar.multiStateButton.setImage(ImageHome, for: .normal)
         } else {
-            toolbar.multiStateButton.setImage(UIImage.templateImageNamed("nav-refresh"), for: .normal)
+            toolbar.multiStateButton.setImage(ImageReload, for: .normal)
         }
         toolbar.multiStateButton.accessibilityLabel = .TabToolbarReloadAccessibilityLabel
+        toolbar.multiStateButton.showsLargeContentViewer = true
 
         let longPressMultiStateButton = UILongPressGestureRecognizer(target: self, action: #selector(didLongPressMultiStateButton))
+        longPressMultiStateButton.delegate = self
         toolbar.multiStateButton.addGestureRecognizer(longPressMultiStateButton)
-
         toolbar.multiStateButton.addTarget(self, action: #selector(didPressMultiStateButton), for: .touchUpInside)
+        longPressGestureRecognizers.append(longPressMultiStateButton)
 
         toolbar.tabsButton.addTarget(self, action: #selector(didClickTabs), for: .touchUpInside)
         let longPressGestureTabsButton = UILongPressGestureRecognizer(target: self, action: #selector(didLongPressTabs))
         toolbar.tabsButton.addGestureRecognizer(longPressGestureTabsButton)
         toolbar.tabsButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.tabsButton
+        toolbar.tabsButton.showsLargeContentViewer = true
+        toolbar.tabsButton.largeContentTitle = .TabsButtonShowTabsAccessibilityLabel
+        longPressGestureRecognizers.append(longPressGestureTabsButton)
 
         toolbar.addNewTabButton.setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Large.plus), for: .normal)
         toolbar.addNewTabButton.accessibilityLabel = .AddTabAccessibilityLabel
+        toolbar.addNewTabButton.showsLargeContentViewer = true
+        toolbar.addNewTabButton.largeContentTitle = .AddTabAccessibilityLabel
         toolbar.addNewTabButton.addTarget(self, action: #selector(didClickAddNewTab), for: .touchUpInside)
         toolbar.addNewTabButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.addNewTabButton
 
+        let appMenuImage = UIImage.templateImageNamed(StandardImageIdentifiers.Large.appMenu)
         toolbar.appMenuButton.contentMode = .center
-        toolbar.appMenuButton.setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Large.appMenu), for: .normal)
+        toolbar.appMenuButton.showsLargeContentViewer = true
+        toolbar.appMenuButton.largeContentTitle = .AppMenu.Toolbar.MenuButtonAccessibilityLabel
+        toolbar.appMenuButton.largeContentImage = appMenuImage
+        toolbar.appMenuButton.setImage(appMenuImage, for: .normal)
         toolbar.appMenuButton.accessibilityLabel = .AppMenu.Toolbar.MenuButtonAccessibilityLabel
         toolbar.appMenuButton.addTarget(self, action: #selector(didClickMenu), for: .touchUpInside)
         toolbar.appMenuButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.settingsMenuButton
 
         toolbar.homeButton.contentMode = .center
-        toolbar.homeButton.setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Large.home), for: .normal)
+        toolbar.homeButton.showsLargeContentViewer = true
+        toolbar.homeButton.largeContentImage = ImageHome
+        toolbar.homeButton.largeContentTitle = .TabToolbarHomeAccessibilityLabel
+        toolbar.homeButton.setImage(ImageHome, for: .normal)
         toolbar.homeButton.accessibilityLabel = .AppMenu.Toolbar.HomeMenuButtonAccessibilityLabel
         toolbar.homeButton.addTarget(self, action: #selector(didClickHome), for: .touchUpInside)
         toolbar.homeButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.homeButton
 
         toolbar.bookmarksButton.contentMode = .center
-        toolbar.bookmarksButton.setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Large.bookmarkTrayFill),
-                                         for: .normal)
+        toolbar.bookmarksButton.showsLargeContentViewer = true
+        toolbar.bookmarksButton.largeContentImage = ImageBookmark
+        toolbar.bookmarksButton.largeContentTitle = .AppMenu.Toolbar.BookmarksButtonAccessibilityLabel
+        toolbar.bookmarksButton.setImage(ImageBookmark, for: .normal)
         toolbar.bookmarksButton.accessibilityLabel = .AppMenu.Toolbar.BookmarksButtonAccessibilityLabel
         toolbar.bookmarksButton.addTarget(self, action: #selector(didClickLibrary), for: .touchUpInside)
         toolbar.bookmarksButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.bookmarksButton
+
+        // The default long press duration is 0.5.  Here we extend it if
+        // UILargeContentViewInteraction is enabled to allow the large content
+        // viewer time to display the content
+        let longPressDuration = UILargeContentViewerInteraction.isEnabled ? 1.5 : 0.5
+        longPressGestureRecognizers.forEach { gesture in
+            gesture.minimumPressDuration = longPressDuration
+            gesture.delegate = self
+        }
+        NotificationCenter.default.addObserver(
+            forName: UILargeContentViewerInteraction.enabledStatusDidChangeNotification,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            self?.longPressGestureRecognizers.forEach { gesture in
+                gesture.minimumPressDuration = longPressDuration
+            }
+        }
     }
 
     func didClickBack() {
@@ -160,6 +216,7 @@ open class TabToolbarHelper: NSObject {
     func didLongPressBack(_ recognizer: UILongPressGestureRecognizer) {
         if recognizer.state == .began {
             toolbar.tabToolbarDelegate?.tabToolbarDidLongPressBack(toolbar, button: toolbar.backButton)
+            uiLargeContentViewInteraction.gestureRecognizerForExclusionRelationship.state = .cancelled
             TelemetryWrapper.recordEvent(category: .action, method: .press, object: .navigateTabHistoryBack)
         }
     }
@@ -171,6 +228,7 @@ open class TabToolbarHelper: NSObject {
     func didLongPressTabs(_ recognizer: UILongPressGestureRecognizer) {
         if recognizer.state == .began {
             toolbar.tabToolbarDelegate?.tabToolbarDidLongPressTabs(toolbar, button: toolbar.tabsButton)
+            uiLargeContentViewInteraction.gestureRecognizerForExclusionRelationship.state = .cancelled
         }
     }
 
@@ -182,6 +240,7 @@ open class TabToolbarHelper: NSObject {
     func didLongPressForward(_ recognizer: UILongPressGestureRecognizer) {
         if recognizer.state == .began {
             toolbar.tabToolbarDelegate?.tabToolbarDidLongPressForward(toolbar, button: toolbar.forwardButton)
+            uiLargeContentViewInteraction.gestureRecognizerForExclusionRelationship.state = .cancelled
             TelemetryWrapper.recordEvent(category: .action, method: .press, object: .navigateTabHistoryForward)
         }
     }
@@ -226,5 +285,15 @@ open class TabToolbarHelper: NSObject {
                 toolbar.tabToolbarDelegate?.tabToolbarDidLongPressReload(toolbar, button: toolbar.multiStateButton)
             }
         }
+    }
+}
+
+extension TabToolbarHelper: UIGestureRecognizerDelegate {
+    public func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        longPressGestureRecognizers.contains { $0 == gestureRecognizer }
+            && otherGestureRecognizer == uiLargeContentViewInteraction.gestureRecognizerForExclusionRelationship
     }
 }

--- a/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -136,21 +136,29 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
 
     fileprivate lazy var cancelButton: UIButton = {
         let cancelButton = InsetButton()
-        cancelButton.setImage(
-            UIImage.templateImageNamed(StandardImageIdentifiers.Large.chevronLeft)?.imageFlippedForRightToLeftLayoutDirection(),
-            for: .normal)
+        let flippedChevron = UIImage.templateImageNamed(StandardImageIdentifiers.Large.chevronLeft)?
+            .imageFlippedForRightToLeftLayoutDirection()
+
+        cancelButton.setImage(flippedChevron, for: .normal)
         cancelButton.accessibilityIdentifier = AccessibilityIdentifiers.Browser.UrlBar.cancelButton
         cancelButton.accessibilityLabel = AccessibilityIdentifiers.GeneralizedIdentifiers.back
         cancelButton.addTarget(self, action: #selector(didClickCancel), for: .touchUpInside)
         cancelButton.alpha = 0
+        cancelButton.showsLargeContentViewer = true
+        cancelButton.largeContentTitle = AccessibilityIdentifiers.GeneralizedIdentifiers.back
+        cancelButton.largeContentImage = flippedChevron
         return cancelButton
     }()
 
     fileprivate lazy var showQRScannerButton: InsetButton = {
         let button = InsetButton()
-        button.setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Large.qrCode), for: .normal)
+        let qrCodeImage = UIImage.templateImageNamed(StandardImageIdentifiers.Large.qrCode)
+        button.setImage(qrCodeImage, for: .normal)
         button.accessibilityIdentifier = AccessibilityIdentifiers.Browser.UrlBar.scanQRCodeButton
         button.accessibilityLabel = .ScanQRCodeViewTitle
+        button.showsLargeContentViewer = true
+        button.largeContentTitle = .ScanQRCodeViewTitle
+        button.largeContentImage = qrCodeImage
         button.clipsToBounds = false
         button.addTarget(self, action: #selector(showQRScanner), for: .touchUpInside)
         button.setContentHuggingPriority(UILayoutPriority(rawValue: 1000), for: .horizontal)
@@ -173,6 +181,7 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
         searchIconImageView.contentMode = .scaleAspectFit
         searchIconImageView.layer.cornerRadius = 5
         searchIconImageView.clipsToBounds = true
+        searchIconImageView.showsLargeContentViewer = true
         return searchIconImageView
     }()
 
@@ -230,6 +239,8 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
 
     func searchEnginesDidUpdate() {
         self.searchIconImageView.image = profile.searchEngines.defaultEngine?.image
+        self.searchIconImageView.largeContentTitle = profile.searchEngines.defaultEngine?.shortName
+        self.searchIconImageView.largeContentImage = nil
     }
 
     fileprivate func commonInit() {
@@ -704,6 +715,12 @@ extension URLBarView: TabToolbarProtocol {
         set {
             super.accessibilityElements = newValue
         }
+    }
+
+    func addUILargeContentViewInteraction(
+        interaction: UILargeContentViewerInteraction
+    ) {
+        addInteraction(interaction)
     }
 }
 

--- a/Client/Frontend/Widgets/TabsButton.swift
+++ b/Client/Frontend/Widgets/TabsButton.swift
@@ -137,6 +137,7 @@ class TabsButton: UIButton, ThemeApplicable {
             if let clone = self.clonedTabsButton {
                 clone.countLabel.text = countToBe
                 clone.accessibilityValue = countToBe
+                clone.largeContentTitle = String(format: .TabsButtonShowTabsLargeContentTitle, countToBe)
             }
             return
         }
@@ -154,6 +155,7 @@ class TabsButton: UIButton, ThemeApplicable {
         newTabsButton.addTarget(self, action: #selector(cloneDidClickTabs), for: .touchUpInside)
         newTabsButton.countLabel.text = countToBe
         newTabsButton.accessibilityValue = countToBe
+        newTabsButton.largeContentTitle = String(format: .TabsButtonShowTabsLargeContentTitle, countToBe)
         newTabsButton.insideButton.frame = self.insideButton.frame
         newTabsButton.snp.removeConstraints()
         self.addSubview(newTabsButton)
@@ -194,6 +196,7 @@ class TabsButton: UIButton, ThemeApplicable {
                 self.insideButton.layer.transform = CATransform3DIdentity
             }
             self.accessibilityLabel = .TabsButtonShowTabsAccessibilityLabel
+            self.largeContentTitle = String(format: .TabsButtonShowTabsLargeContentTitle, self.countToBe)
             self.countLabel.text = self.countToBe
             self.accessibilityValue = self.countToBe
             self.isUpdatingTabCount = false

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabToolbarHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabToolbarHelperTests.swift
@@ -146,4 +146,6 @@ class MockTabToolbar: TabToolbarProtocol {
     func appMenuBadge(setVisible: Bool) { }
 
     func warningMenuBadge(setVisible: Bool) { }
+
+    func addUILargeContentViewInteraction(interaction: UILargeContentViewerInteraction) { }
 }


### PR DESCRIPTION
## :scroll: Tickets

[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7408)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16422)

## :bulb: Description

I've added large text support for the buttons that can't grow in size on the tab bar (on the phone in portrait orientation), the tab location view (iPad orientations and other phone orientations) and the URL Bar view (iPad orientations and other phone orientations).

There are several buttons to test:

* Back button
* Forward button
* Multistate button (Home / Search / Reload)
* Tabs button
* Menu button
* Add new tab button
* Search button
* Stop button
* Close tab button (on iPad)
* Bookmarks button
* Share button
* Tracking Protection button (lock icon)
* Reload button
* Privacy mode button
* Reader view button
* QR Code button
* Back button when focused on the search bar
* Search engine button

Note that some of these button have long press gesture recognizers attached.  For the large content viewer to display and the long press gesture recognizers to work as expected, `TabToolbarHelper` now holds a reference to the gesture recognizers and implements the `UIGestureRecognizerDelegate`.  When long pressing on these buttons, you should initially see the large content viewer and then the original long press gesture should activate.  Note the original long press will only work if your touch doesn't leave the original button's view.

In a few places, I've reused an existing accessibility label as a large content title.  

___Question___:  Should I create new localized strings instead of reusing an existing accessibility label

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods