### PR TITLE
Bugfix FXIOS-7803 [v122] Address bar icons overlap

### DIFF
--- a/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -50,6 +50,7 @@ class TabLocationView: UIView, FeatureFlaggable {
 
     var url: URL? {
         didSet {
+            hideButtons()
             updateTextWithURL()
             trackingProtectionButton.isHidden = !isValidHttpUrlProtocol
             shareButton.isHidden = !(shouldEnableShareButtonFeature && isValidHttpUrlProtocol)
@@ -341,6 +342,12 @@ class TabLocationView: UIView, FeatureFlaggable {
                     .TabLocationETPOffSecureAccessibilityLabel : .TabLocationETPOffNotSecureAccessibilityLabel
             }
         }
+    }
+
+    // Fixes: https://github.com/mozilla-mobile/firefox-ios/issues/17403
+    private func hideButtons() {
+        [shoppingButton, shareButton, readerModeButton]
+            .forEach { $0.isHidden = true }
     }
 }
 

--- a/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -346,8 +346,7 @@ class TabLocationView: UIView, FeatureFlaggable {
 
     // Fixes: https://github.com/mozilla-mobile/firefox-ios/issues/17403
     private func hideButtons() {
-        [shoppingButton, shareButton, readerModeButton]
-            .forEach { $0.isHidden = true }
+        [shoppingButton, shareButton].forEach { $0.isHidden = true }
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7803)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17403)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

- When a URL changes, the views in the `tabLocationView` need to check whether they should still be visible or not. Even though, for example, `shoppingButton.isHidden` is set to `false`, for some reason, it still remains in the true state, creating this overlapping problem.
- Hiding the buttons before the checks start seems to solve the problem.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

