### PR TITLE
Bugfix FXIOS-7573 [v122] Share This Page and Secure Connection url bar buttons are not included in the logical focus order  

### DIFF
--- a/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -205,7 +205,7 @@ class TabLocationView: UIView, FeatureFlaggable {
 
     // MARK: - Accessibility
 
-    private lazy var _accessibilityElements = [urlTextField, shoppingButton, readerModeButton, reloadButton, trackingProtectionButton, shareButton]
+    private lazy var _accessibilityElements = [trackingProtectionButton, urlTextField, shoppingButton, readerModeButton, shareButton, reloadButton]
 
     override var accessibilityElements: [Any]? {
         get {


### PR DESCRIPTION
…are not included in the logical focus order

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7573)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16857)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

