### PR TITLE
Bugfix FXIOS-7832 [v121] Fix overlay mode on ipad attempt number 2

### DIFF
--- a/Client/Frontend/Browser/Tabs/Legacy/LegacyTabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/Legacy/LegacyTabTrayViewController.swift
@@ -558,7 +558,9 @@ extension LegacyTabTrayViewController {
     func didTapAddTab(_ sender: UIBarButtonItem) {
         notificationCenter.post(name: .TabsTrayDidClose)
         viewModel.didTapAddTab(sender)
-        self.dismiss(animated: true, completion: nil)
+        self.dismiss(animated: true) {
+            self.viewModel.didDismiss()
+        }
     }
 
     @objc

--- a/Client/Frontend/Browser/Tabs/Legacy/LegacyTabTrayViewModel.swift
+++ b/Client/Frontend/Browser/Tabs/Legacy/LegacyTabTrayViewModel.swift
@@ -63,12 +63,15 @@ extension LegacyTabTrayViewModel {
     @objc
     func didTapAddTab(_ sender: UIBarButtonItem) {
         tabTrayView.performToolbarAction(.addTab, sender: sender)
-        overlayManager.openNewTab(url: nil,
-                                  newTabSettings: NewTabAccessors.getNewTabPage(profile.prefs))
     }
 
     @objc
     func didTapSyncTabs(_ sender: UIBarButtonItem) {
         reloadRemoteTabs()
+    }
+
+    func didDismiss() {
+        overlayManager.openNewTab(url: nil,
+                                  newTabSettings: NewTabAccessors.getNewTabPage(profile.prefs))
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/Legacy/LegacyTabTrayViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/Legacy/LegacyTabTrayViewControllerTests.swift
@@ -79,13 +79,4 @@ final class LegacyTabTrayViewControllerTests: XCTestCase {
         let privateState = UserDefaults.standard.bool(forKey: PrefsKeys.LastSessionWasPrivate)
         XCTAssertFalse(privateState)
     }
-
-    func testInOverlayMode_ForHomepageNewTabSettings() {
-        tabTray.viewModel.segmentToFocus = TabTrayPanelType.privateTabs
-        tabTray.viewDidLoad()
-        profile.prefs.setString(NewTabPage.topSites.rawValue, forKey: NewTabAccessors.NewTabPrefKey)
-        tabTray.viewModel.didTapAddTab(UIBarButtonItem())
-
-        XCTAssertTrue(tabTray.viewModel.overlayManager.inOverlayMode)
-    }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7832)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17476)

## :bulb: Description
The previous PR didn't catch all cases. This should work better now as it doesn't trigger overlay mode until the VC has finished it's dismiss animation.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

