### PR TITLE
Bump [v122] Update Sentry to version 8.17.0

### DIFF
--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
             exact: "2.0.0"),
         .package(
             url: "https://github.com/getsentry/sentry-cocoa.git",
-            exact: "8.13.1"),
+            exact: "8.17.0"),
     ],
     targets: [
         .target(

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -19881,7 +19881,7 @@
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa.git";
 			requirement = {
 				kind = exactVersion;
-				version = 8.13.1;
+				version = 8.17.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "7b0d185631a6d4b7756468efa464a68725c061d2",
-        "version" : "8.13.1"
+        "revision" : "a3e15ba9fd6c8efc6515ad9d6f3337bb2dc2e1e3",
+        "version" : "8.17.0"
       }
     },
     {


### PR DESCRIPTION
Changelogs since the previous update (8.13.1):
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.14.0
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.14.1
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.15.0
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.15.1
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.15.2
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.16.0
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.16.1
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.17.0