### PR TITLE
Bugfix FXIOS-7497 [v122] Scroll position is reset to the top of previous page when navigating back

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1292,7 +1292,9 @@ class BrowserViewController: UIViewController,
             guard let loading = change?[.newKey] as? Bool else { break }
             setupMiddleButtonStatus(isLoading: loading)
             setupLoadingSpinnerFor(webView, isLoading: loading)
-
+            if self.scrollController.contentOffsetBeforeLoadingWebsite == CGPoint.zero {
+                self.scrollController.contentOffsetBeforeLoadingWebsite = self.tabManager.selectedTab?.webView?.scrollView.contentOffset ?? CGPoint.zero
+            }
         case .URL:
             // Special case for "about:blank" popups, if the webView.url is nil, keep the tab url as "about:blank"
             if tab.url?.absoluteString == "about:blank" && webView.url == nil {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7497)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16643)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Tried another approach using magic numbers because the scrollView's contentOffset y coord had the same value regardless of the device on a faulty reset, where I'm saving the contentOffset when a page loading event happens and then when the scrollViewDidScroll delegate method gets called I'm checking if the contentOffset has the same value as the reset point y coord and if so, change it back to the value we saved during loading. This still doesn't work every time and can cause the scroll to happen when going forward in some cases but it has a much higher success rate than the other methods I tried. CC: @yoanarios 
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

https://github.com/mozilla-mobile/firefox-ios/assets/126153378/eeadea4d-2707-413f-afdb-b0b8f4227835

