### PR TITLE
Bugfix FXIOS-7830 [v121] [regression] After “open in new tab”, the current tab’s title changes to match the new tab’s title

### DIFF
--- a/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -898,7 +898,7 @@ extension LegacyTabManager: WKNavigationDelegate {
                 return
             }
 
-            if let title = webView.title {
+            if let title = webView.title, selectedTab?.webView == webView {
                 selectedTab?.lastTitle = title
             }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7830)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17474)

## :bulb: Description
- Add check to avoid changing title from wrong tab

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

