### PR TITLE
Bugfix FXIOS-7733 [v122] Take indentation level into account for OneLineTableViewCell

### DIFF
--- a/Client/Frontend/Widgets/OneLineTableViewCell.swift
+++ b/Client/Frontend/Widgets/OneLineTableViewCell.swift
@@ -72,6 +72,18 @@ class OneLineTableViewCell: UITableViewCell,
                             right: 0)
     }
 
+    /// Holds a reference to the left image view's leading constraint so we can update
+    /// its constant when modifying this cell's ``indentationLevel`` value.
+    private var leftImageViewLeadingConstraint: NSLayoutConstraint?
+
+    override var indentationLevel: Int {
+        didSet {
+            // Update the leading constraint based on this cell's indentationLevel value,
+            // adding 1 since the default indentation is 0.
+            leftImageViewLeadingConstraint?.constant = UX.borderViewMargin * CGFloat(1 + indentationLevel)
+        }
+    }
+
     private func setupLayout() {
         separatorInset = defaultSeparatorInset
         selectionStyle = .default
@@ -86,6 +98,12 @@ class OneLineTableViewCell: UITableViewCell,
         let containerViewTrailingAnchor = accessoryView?.leadingAnchor ?? contentView.trailingAnchor
         let midViewLeadingMargin: CGFloat = shouldLeftAlignTitle ? UX.shortLeadingMargin : UX.longLeadingMargin
 
+        // Keep a reference to the left image's leading constraint to be able to update its value when
+        // modifying this cell's indentationLevel value
+        leftImageViewLeadingConstraint = leftImageView.leadingAnchor.constraint(
+            equalTo: containerView.leadingAnchor,
+            constant: UX.borderViewMargin
+        )
         NSLayoutConstraint.activate([
             containerView.topAnchor.constraint(equalTo: contentView.topAnchor,
                                                constant: UX.verticalMargin),
@@ -94,9 +112,8 @@ class OneLineTableViewCell: UITableViewCell,
                                                   constant: -UX.verticalMargin),
             containerView.trailingAnchor.constraint(equalTo: containerViewTrailingAnchor),
 
+            leftImageViewLeadingConstraint,
             leftImageView.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
-            leftImageView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor,
-                                                   constant: UX.borderViewMargin),
             leftImageView.widthAnchor.constraint(equalToConstant: UX.leftImageViewSize),
             leftImageView.heightAnchor.constraint(equalToConstant: UX.leftImageViewSize),
             leftImageView.trailingAnchor.constraint(equalTo: titleLabel.leadingAnchor,
@@ -113,7 +130,7 @@ class OneLineTableViewCell: UITableViewCell,
             bottomSeparatorView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
             bottomSeparatorView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
             bottomSeparatorView.heightAnchor.constraint(equalToConstant: UX.separatorViewHeight)
-        ])
+        ].compactMap { $0 })
 
         selectedBackgroundView = selectedView
     }


### PR DESCRIPTION
## :scroll: Tickets
- [Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7733)
- Github issues: 
  - https://github.com/mozilla-mobile/firefox-ios/issues/17249
  - https://github.com/mozilla-mobile/firefox-ios/issues/13054

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

Fixes the indentation issue with the bookmark folders tree structure. The code was already there for updating each item's indentation level but this value was not taken into account in the cell's layout. The proposed fix is the following:

- Keep a reference to the cell's leading margin constraint
- Update the constraint's constant value when setting the cell's `indentationLevel` property using `didSet` (could also be done in the cell's `configure(viewModel:)` method but since the indentation level is not part of the view model I think it makes sense to keep both separated)
- I've used `UX.borderViewMargin` multiplied by the indentation level as a constant value.

<details><summary>**Expand to see screenshots of the result**</summary>

| Before | After |
| --------------- | --------------- |
|  ![Simulator Screenshot - iPhone 15 Pro - 2023-11-28 at 17 09 28](https://github.com/mozilla-mobile/firefox-ios/assets/19548672/8ef5f5a8-10c7-4ead-a5a9-aabe2b58c543) | ![Simulator Screenshot - iPhone 15 Pro - 2023-11-28 at 17 07 21](https://github.com/mozilla-mobile/firefox-ios/assets/19548672/18f4b75e-c000-456e-9389-65665c08b3c4) |

</details> 

This is my first time contributing so please don't hesitate to tell me if something's wrong or if the code doesn't meet your style 🙂 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

