### PR TITLE
Bugfix FXIOS-7554 [v122] [Revert] Close All Tabs Crash

### DIFF
--- a/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -153,10 +153,6 @@ class JumpBackInViewModel: FeatureFlaggable {
 // MARK: - Private: Prepare UI data
 private extension JumpBackInViewModel {
     private func refreshData(maxItemsToDisplay: JumpBackInDisplayGroupCount) {
-        Task { @MainActor [weak self] in
-            guard let self else { return }
-            self.recentTabs = await self.jumpBackInDataAdaptor.getRecentTabData()
-        }
         jumpBackInList = createJumpBackInList(
             from: recentTabs,
             withMaxTabsCount: maxItemsToDisplay.tabsCount


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7554)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16810)

## :bulb: Description

Reverts fix for FXIOS-7554 (#[16873](https://github.com/mozilla-mobile/firefox-ios/pull/16873)), based on current data it appears that this may have exacerbated the crash rate for users and so this revert should help improve stability until the underlying issue with the Jump Back In data model and collection view can be addressed directly.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

