### PR TITLE
Bugfix FXIOS-7637 [v122] Card auto fill Add Credit Card fields are too small to easily tap on

### DIFF
--- a/Client/Frontend/Autofill/CreditCard/ViewComponents/CreditCardInputField.swift
+++ b/Client/Frontend/Autofill/CreditCard/ViewComponents/CreditCardInputField.swift
@@ -26,6 +26,7 @@ struct CreditCardInputField: View {
     }
     @ObservedObject var viewModel: CreditCardInputViewModel
     let inputFieldHelper: CreditCardInputFieldHelper
+    @FocusState private var isFocused: Bool
     @State var text: String = ""
     @State var shouldReveal = true {
         willSet(val) {
@@ -183,12 +184,16 @@ struct CreditCardInputField: View {
         })
         .preferredBodyFont(size: 17)
         .disabled(editMode)
-        .padding(.top, 7.5)
+        .padding(.vertical, 7.5)
         .foregroundColor(textFieldColor)
         .multilineTextAlignment(.leading)
         .keyboardType(keyboardType)
         .lineLimit(1)
         .frame(maxWidth: .infinity, alignment: .leading)
+        .focused($isFocused)
+        .onTapGesture {
+            isFocused = true
+        }
         .onChange(of: text) { [oldValue = text] newValue in
             handleTextInputWith(oldValue, and: newValue)
             viewModel.updateRightButtonState()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7637)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17026)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Bugfix FXIOS-17026 [v122] | Card auto fill Add Credit Card fields are too small to easily tap on

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

