### PR TITLE
Add FXIOS-7842 [v122] Adjust homepage logo header for private mode

### DIFF
--- a/Client/Frontend/Home/LogoHeader/HomeLogoHeaderCell.swift
+++ b/Client/Frontend/Home/LogoHeader/HomeLogoHeaderCell.swift
@@ -39,6 +39,8 @@ class HomeLogoHeaderCell: UICollectionViewCell, ReusableCell {
     private lazy var logoTextImage: UIImageView = .build { imageView in
         imageView.contentMode = .scaleAspectFit
         imageView.accessibilityIdentifier = a11y.logoText
+        imageView.accessibilityLabel = AppName.shortName.rawValue
+        imageView.isAccessibilityElement = true
     }
 
     private lazy var containerView: UIView = .build { view in

--- a/Client/Frontend/Home/LogoHeader/HomeLogoHeaderCell.swift
+++ b/Client/Frontend/Home/LogoHeader/HomeLogoHeaderCell.swift
@@ -63,7 +63,7 @@ class HomeLogoHeaderCell: UICollectionViewCell, ReusableCell {
         contentView.addSubview(containerView)
 
         // TODO: Felt Privacy - Private mode in Redux to follow
-        let isiPadAndPrivate = UIDevice.current.userInterfaceIdiom == .pad && true
+        let isiPadAndPrivate = UIDevice.current.userInterfaceIdiom == .pad && false
         let logoSizeConstant = isiPadAndPrivate ? UX.Logo.iPadImageSize : UX.Logo.iPhoneImageSize
 
         NSLayoutConstraint.activate([

--- a/Client/Frontend/Home/LogoHeader/HomeLogoHeaderCell.swift
+++ b/Client/Frontend/Home/LogoHeader/HomeLogoHeaderCell.swift
@@ -9,16 +9,20 @@ import UIKit
 
 class HomeLogoHeaderCell: UICollectionViewCell, ReusableCell {
     private struct UX {
+        static let iPadAdjustment: CGFloat = -40
         struct Logo {
-            static let imageSize: CGFloat = 40
-            static let topConstant: CGFloat = 32
+            static let iPhoneImageSize: CGFloat = 40
+            static let iPadImageSize: CGFloat = 75
+            static let iPhoneTopConstant: CGFloat = 32
+            static let iPadTopConstant: CGFloat = 70
             static let bottomConstant: CGFloat = -10
         }
 
         struct TextImage {
-            static let imageWidth: CGFloat = 70
-            static let imageHeight: CGFloat = 40
-            static let leadingConstant: CGFloat = 9
+            static let iPhoneWidth: CGFloat = 70
+            static let iPadWidth: CGFloat = 133
+            static let iPhoneLeadingConstant: CGFloat = 9
+            static let iPadLeadingConstant: CGFloat = 17
             static let trailingConstant: CGFloat = -15
         }
     }

--- a/Client/Frontend/Home/LogoHeader/HomeLogoHeaderCell.swift
+++ b/Client/Frontend/Home/LogoHeader/HomeLogoHeaderCell.swift
@@ -30,15 +30,19 @@ class HomeLogoHeaderCell: UICollectionViewCell, ReusableCell {
     typealias a11y = AccessibilityIdentifiers.FirefoxHomepage.OtherButtons
 
     // MARK: - UI Elements
-    lazy var logoImage: UIImageView = .build { imageView in
+    private lazy var logoImage: UIImageView = .build { imageView in
         imageView.image = UIImage(imageLiteralResourceName: ImageIdentifiers.homeHeaderLogoBall)
         imageView.contentMode = .scaleAspectFit
         imageView.accessibilityIdentifier = a11y.logoImage
     }
 
-    lazy var logoTextImage: UIImageView = .build { imageView in
+    private lazy var logoTextImage: UIImageView = .build { imageView in
         imageView.contentMode = .scaleAspectFit
         imageView.accessibilityIdentifier = a11y.logoText
+    }
+
+    private lazy var containerView: UIView = .build { view in
+        view.backgroundColor = .clear
     }
 
     // MARK: - Initializers
@@ -54,26 +58,53 @@ class HomeLogoHeaderCell: UICollectionViewCell, ReusableCell {
     // MARK: - UI Setup
     func setupView() {
         contentView.backgroundColor = .clear
-        contentView.addSubview(logoImage)
-        contentView.addSubview(logoTextImage)
+        containerView.addSubview(logoImage)
+        containerView.addSubview(logoTextImage)
+        contentView.addSubview(containerView)
+
+        // TODO: Felt Privacy - Private mode in Redux to follow
+        let isiPadAndPrivate = UIDevice.current.userInterfaceIdiom == .pad && true
+        let logoSizeConstant = isiPadAndPrivate ? UX.Logo.iPadImageSize : UX.Logo.iPhoneImageSize
 
         NSLayoutConstraint.activate([
-            logoImage.topAnchor.constraint(equalTo: contentView.topAnchor,
-                                           constant: UX.Logo.topConstant),
-            logoImage.widthAnchor.constraint(equalToConstant: UX.Logo.imageSize),
-            logoImage.heightAnchor.constraint(equalToConstant: UX.Logo.imageSize),
-            logoImage.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            containerView.topAnchor.constraint(
+                equalTo: contentView.topAnchor,
+                constant: isiPadAndPrivate ? UX.Logo.iPadTopConstant : UX.Logo.iPhoneTopConstant),
+            containerView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor,
+                                                  constant: UX.Logo.bottomConstant),
+
+            logoImage.topAnchor.constraint(equalTo: containerView.topAnchor),
+            logoImage.widthAnchor.constraint(equalToConstant: logoSizeConstant),
+            logoImage.heightAnchor.constraint(equalToConstant: logoSizeConstant),
+            logoImage.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
             logoImage.bottomAnchor.constraint(equalTo: contentView.bottomAnchor,
                                               constant: UX.Logo.bottomConstant),
 
-            logoTextImage.widthAnchor.constraint(equalToConstant: UX.TextImage.imageWidth),
-            logoTextImage.heightAnchor.constraint(equalToConstant: UX.TextImage.imageHeight),
-            logoTextImage.leadingAnchor.constraint(equalTo: logoImage.trailingAnchor,
-                                                   constant: UX.TextImage.leadingConstant),
-            logoTextImage.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor,
-                                                    constant: UX.TextImage.trailingConstant),
+            logoTextImage.widthAnchor.constraint(
+                equalToConstant: isiPadAndPrivate ? UX.TextImage.iPadWidth : UX.TextImage.iPhoneWidth),
+            logoTextImage.heightAnchor.constraint(equalTo: logoImage.heightAnchor),
+            logoTextImage.leadingAnchor.constraint(
+                equalTo: logoImage.trailingAnchor,
+                constant: isiPadAndPrivate ? UX.TextImage.iPadLeadingConstant : UX.TextImage.iPhoneLeadingConstant),
+            logoTextImage.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
             logoTextImage.centerYAnchor.constraint(equalTo: logoImage.centerYAnchor)
         ])
+
+        if isiPadAndPrivate {
+            NSLayoutConstraint.activate([
+                containerView.centerXAnchor.constraint(
+                    equalTo: contentView.centerXAnchor,
+                    constant: UX.iPadAdjustment
+                ),
+            ])
+        } else {
+            NSLayoutConstraint.activate([
+                containerView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+                containerView.trailingAnchor.constraint(
+                    lessThanOrEqualTo: contentView.trailingAnchor,
+                    constant: UX.TextImage.trailingConstant),
+            ])
+        }
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7842)

## :bulb: Description
If in private mode & on iPad, the logo will look like this. Private mode is not yet globally available, so in the screenshot we're not in private mode; it's just for demo purposes.

![Simulator Screenshot - iPad Pro (11-inch) (4th generation) - 2023-11-28 at 16 21 04](https://github.com/mozilla-mobile/firefox-ios/assets/11182210/4a459e48-6929-40b2-b7db-64ee681b188a)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

