### PR TITLE
Refactor FXIOS-7579 [v121] Replace link button in FakespotReviewQualityCardViewModel

### DIFF
--- a/Client/Frontend/Fakespot/Views/FakespotReviewQualityCardView.swift
+++ b/Client/Frontend/Fakespot/Views/FakespotReviewQualityCardView.swift
@@ -186,14 +186,14 @@ final class FakespotReviewQualityCardView: UIView, Notifiable, ThemeApplicable {
         label.clipsToBounds = true
     }
 
-    private lazy var learnMoreButton: ResizableButton = .build { button in
+    private lazy var learnMoreButton: LinkButton = .build { button in
         button.contentHorizontalAlignment = .leading
         let title = String.localizedStringWithFormat(.Shopping.ReviewQualityCardLearnMoreButtonTitle,
                                                      FakespotName.shortName.rawValue)
         button.setTitle(title, for: .normal)
         button.accessibilityIdentifier = AccessibilityIdentifiers.Shopping.ReviewQualityCard.learnMoreButtonTitle
         button.titleLabel?.adjustsFontForContentSizeCategory = true
-        button.buttonEdgeSpacing = 0
+        button.configuration?.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
         button.titleLabel?.numberOfLines = 0
         button.addTarget(self, action: #selector(self.didTapLearnMore), for: .touchUpInside)
         button.titleLabel?.font = UX.baseFont


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7579)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16866)

## :bulb: Description
- Replace learnMoreButton type from ResizableButton to LinkButton

| Portrait  | Landscape | 
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2023-11-29 at 19 38 08](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/508a5671-e4bf-46bf-a2c1-4084a73a8b6c) | ![Simulator Screenshot - iPhone 15 Pro - 2023-11-29 at 19 38 16](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/afe0ef55-ecc8-4f7c-af4e-d5fe5d6562eb) |


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods