### PR TITLE
Refactor FXIOS-7849 [v122] Minor cleanup: remove SentTabs string literals

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -54,6 +54,8 @@
 		1D2F68AF2ACB272500524B92 /* RemoteTabsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2F68AE2ACB272500524B92 /* RemoteTabsTableViewController.swift */; };
 		1D2F68B12ACCA22000524B92 /* RemoteTabsEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2F68B02ACCA22000524B92 /* RemoteTabsEmptyView.swift */; };
 		1D3C90882ACE1AF400304C87 /* RemoteTabPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3C90872ACE1AF400304C87 /* RemoteTabPanelTests.swift */; };
+		1D5CBF492B17E3CB0001D033 /* NotificationPayloads.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D5CBF482B17E3CB0001D033 /* NotificationPayloads.swift */; };
+		1D5CBF4A2B17E3CB0001D033 /* NotificationPayloads.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D5CBF482B17E3CB0001D033 /* NotificationPayloads.swift */; };
 		1D69FF8D27B17286001F660E /* HomeLogoHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D69FF8C27B17285001F660E /* HomeLogoHeaderCell.swift */; };
 		1D7B78972ADF32590011E9F2 /* EventQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D7B78962ADF32590011E9F2 /* EventQueue.swift */; };
 		1D7B78992ADF328E0011E9F2 /* AppEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D7B78982ADF328E0011E9F2 /* AppEvent.swift */; };
@@ -2119,6 +2121,7 @@
 		1D2F68AE2ACB272500524B92 /* RemoteTabsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabsTableViewController.swift; sourceTree = "<group>"; };
 		1D2F68B02ACCA22000524B92 /* RemoteTabsEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabsEmptyView.swift; sourceTree = "<group>"; };
 		1D3C90872ACE1AF400304C87 /* RemoteTabPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabPanelTests.swift; sourceTree = "<group>"; };
+		1D5CBF482B17E3CB0001D033 /* NotificationPayloads.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPayloads.swift; sourceTree = "<group>"; };
 		1D69FF8C27B17285001F660E /* HomeLogoHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeLogoHeaderCell.swift; sourceTree = "<group>"; };
 		1D774B3D9C6E21B77FB7B38F /* kab */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kab; path = kab.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
 		1D7B78962ADF32590011E9F2 /* EventQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventQueue.swift; sourceTree = "<group>"; };
@@ -7956,6 +7959,7 @@
 			children = (
 				397848DF1ED86605004C0C0B /* Info.plist */,
 				397848DD1ED86605004C0C0B /* NotificationService.swift */,
+				1D5CBF482B17E3CB0001D033 /* NotificationPayloads.swift */,
 			);
 			path = NotificationService;
 			sourceTree = "<group>";
@@ -12453,6 +12457,7 @@
 				45355B232A269E7100B1EA8E /* Autopush.swift in Sources */,
 				45355B262A269EAC00B1EA8E /* PushConfiguration.swift in Sources */,
 				396E38CC1EE0816C00CC180F /* Profile.swift in Sources */,
+				1D5CBF4A2B17E3CB0001D033 /* NotificationPayloads.swift in Sources */,
 				1D1933792AF2C8CF005089C9 /* AppEvent.swift in Sources */,
 				396E38DD1EE081DA00CC180F /* SyncDisplayState.swift in Sources */,
 				1D1933762AF2C8C9005089C9 /* EventQueue.swift in Sources */,
@@ -12888,6 +12893,7 @@
 				C84656012887A0F700861B4A /* WallpaperMetadataUtility.swift in Sources */,
 				E1B04A9D28E20A8300670E54 /* InstructionsView.swift in Sources */,
 				D3B6923D1B9F9444004B87A4 /* FindInPageBar.swift in Sources */,
+				1D5CBF492B17E3CB0001D033 /* NotificationPayloads.swift in Sources */,
 				2F44FC721A9E840300FD20CC /* SettingsNavigationController.swift in Sources */,
 				D0E89A2920910917001CE5C7 /* DownloadsPanel.swift in Sources */,
 				D3BA7E0E1B0E934F00153782 /* ContextMenuHelper.swift in Sources */,

--- a/Client/Application/SceneDelegate.swift
+++ b/Client/Application/SceneDelegate.swift
@@ -137,8 +137,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         // Check if our connection options include a user response to a push
         // notification that is for Sent Tabs. If so, route the related tab URLs.
+        let sentTabsKey = NotificationSentTabs.sentTabsKey
         if let notification = connectionOptions.notificationResponse?.notification,
-           let userInfo = notification.request.content.userInfo["sentTabs"] as? [[String: Any]] {
+           let userInfo = notification.request.content.userInfo[sentTabsKey] as? [[String: Any]] {
             handleConnectionOptionsSentTabs(userInfo)
         }
     }

--- a/Extensions/NotificationService/NotificationPayloads.swift
+++ b/Extensions/NotificationService/NotificationPayloads.swift
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+struct NotificationSentTabs {
+    static let sentTabsKey = "sentTabs"
+
+    struct Payload {
+        static let titleKey = "title"
+        static let urlKey = "url"
+        static let displayURLKey = "displayURL"
+        static let deviceNameKey = "deviceName"
+    }
+}

--- a/Extensions/NotificationService/NotificationService.swift
+++ b/Extensions/NotificationService/NotificationService.swift
@@ -174,18 +174,18 @@ class SyncDataDisplay {
     }
 
     func displayNewSentTabNotification(tab: [String: String]) {
-        if let urlString = tab["url"],
+        if let urlString = tab[NotificationSentTabs.Payload.urlKey],
             let url = URL(string: urlString, invalidCharacters: false),
             url.isWebPage(),
-            let title = tab["title"] {
+            let title = tab[NotificationSentTabs.Payload.titleKey] {
             let tab = [
-                "title": title,
-                "url": url.absoluteString,
-                "displayURL": url.absoluteDisplayExternalString,
-                "deviceName": nil
+                NotificationSentTabs.Payload.titleKey: title,
+                NotificationSentTabs.Payload.urlKey: url.absoluteString,
+                NotificationSentTabs.Payload.displayURLKey: url.absoluteDisplayExternalString,
+                NotificationSentTabs.Payload.deviceNameKey: nil
             ] as NSDictionary
 
-            notificationContent.userInfo["sentTabs"] = [tab] as NSArray
+            notificationContent.userInfo[NotificationSentTabs.sentTabsKey] = [tab] as NSArray
 
             presentNotification(title: .SentTab_TabArrivingNotification_NoDevice_title, body: url.absoluteDisplayExternalString)
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7849)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17528)

## :bulb: Description

Minor cleanup to DRY out string literals used for APNS SentTabs.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

