### PR TITLE
Bugfix FXIOS-7852 [v122] search widget should focus url bar

### DIFF
--- a/Client/Coordinators/Router/RouteBuilder.swift
+++ b/Client/Coordinators/Router/RouteBuilder.swift
@@ -65,11 +65,11 @@ final class RouteBuilder {
 
             case .widgetSmallQuickLinkOpenUrl:
                 // Widget Quick links - small - open url private or regular
-                return .search(url: urlQuery, isPrivate: isPrivate)
+                return .search(url: urlQuery, isPrivate: isPrivate, options: [.focusLocationField])
 
             case .widgetMediumQuickLinkOpenUrl:
                 // Widget Quick Actions - medium - open url private or regular
-                return .search(url: urlQuery, isPrivate: isPrivate)
+                return .search(url: urlQuery, isPrivate: isPrivate, options: [.focusLocationField])
 
             case .widgetSmallQuickLinkOpenCopied, .widgetMediumQuickLinkOpenCopied:
                 // Widget Quick links - medium - open copied url

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteTests.swift
@@ -203,7 +203,7 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .search(url: URL(string: "https://google.com"), isPrivate: true))
+        XCTAssertEqual(route, .search(url: URL(string: "https://google.com"), isPrivate: true, options: [.focusLocationField]))
     }
 
     func testWidgetMediumQuicklinkOpenUrlWithoutPrivateFlag() {
@@ -212,7 +212,7 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .search(url: URL(string: "https://google.com"), isPrivate: false))
+        XCTAssertEqual(route, .search(url: URL(string: "https://google.com"), isPrivate: false, options: [.focusLocationField]))
     }
 
     func testWidgetSmallQuicklinkOpenCopied() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7852)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17530)

## :bulb: Description
Adjust search widget to focus URL bar, related to discussion in [Slack thread](https://mozilla.slack.com/archives/C05C9RET70F/p1701278198098089)

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

