### PR TITLE
Bugfix FXIOS-7854 [v122] Widgets have a white or black outline

### DIFF
--- a/WidgetKit/SearchQuickLinksMedium/SearchQuickLinks.swift
+++ b/WidgetKit/SearchQuickLinksMedium/SearchQuickLinks.swift
@@ -53,6 +53,7 @@ struct SearchQuickLinksWidget: Widget {
         StaticConfiguration(kind: kind, provider: Provider()) { entry in
             SearchQuickLinksEntryView()
         }
+        .contentMarginsDisabled()
         .supportedFamilies([.systemMedium])
         .configurationDisplayName(String.QuickActionsGalleryTitlev2)
         .description(String.FirefoxShortcutGalleryDescription)

--- a/WidgetKit/SearchQuickLinksSmall/SmallQuickLink.swift
+++ b/WidgetKit/SearchQuickLinksSmall/SmallQuickLink.swift
@@ -51,6 +51,7 @@ struct SmallQuickLinkWidget: Widget {
         .supportedFamilies([.systemSmall])
         .configurationDisplayName(String.QuickActionsGalleryTitle)
         .description(String.QuickActionGalleryDescription)
+        .contentMarginsDisabled()
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7854)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17535)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

iOS 17 added content margins to widgets causing an outline. Luckily, the modifier to disable them is available for iOS 15+ so it's only a minor change.

![image](https://github.com/mozilla-mobile/firefox-ios/assets/650804/feb51042-c7d9-4214-a39c-bd7fc3368ff9)


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

