### PR TITLE
Bugfix FXIOS-7706 [v122] Fix deprecation warning in ToastView animation

### DIFF
--- a/Client/Frontend/Autofill/CreditCard/ViewComponents/ToastView.swift
+++ b/Client/Frontend/Autofill/CreditCard/ViewComponents/ToastView.swift
@@ -23,11 +23,12 @@ struct ToastView: View {
     }
 
     var body: some View {
-        VStack {
+        withAnimation(.default) {
+            VStack {
+            }
+            .toast(toastView: toast, isShowing: $isShowing)
+            .transition(AnyTransition.move(edge: .bottom))
         }
-        .toast(toastView: toast, isShowing: $isShowing)
-        .animation(.default)
-        .transition(AnyTransition.move(edge: .bottom))
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7706)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17186)

## :bulb: Description

Use withAnimation(_:_:) instead of deprecated animation(_:) method

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

