### PR TITLE
Refactor FXIOS-7356 [v122] Create TabManager Middleware

### DIFF
--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -514,7 +514,8 @@ class BrowserCoordinator: BaseCoordinator,
         navigationController.modalPresentationStyle = modalPresentationStyle
 
         let tabTrayCoordinator = TabTrayCoordinator(
-            router: DefaultRouter(navigationController: navigationController)
+            router: DefaultRouter(navigationController: navigationController),
+            tabTraySection: selectedPanel
         )
         tabTrayCoordinator.parentCoordinator = self
         add(child: tabTrayCoordinator)

--- a/Client/Coordinators/TabTray/TabTrayCoordinator.swift
+++ b/Client/Coordinators/TabTray/TabTrayCoordinator.swift
@@ -15,7 +15,6 @@ protocol TabTrayNavigationHandler: AnyObject {
 class TabTrayCoordinator: BaseCoordinator, TabTrayViewControllerDelegate, TabTrayNavigationHandler {
     private var tabTrayViewController: TabTrayViewController!
     weak var parentCoordinator: TabTrayCoordinatorDelegate?
-//    private var selectedTab: TabTrayPanelType
 
     init(router: Router,
          tabTraySection: TabTrayPanelType) {

--- a/Client/Coordinators/TabTray/TabTrayCoordinator.swift
+++ b/Client/Coordinators/TabTray/TabTrayCoordinator.swift
@@ -15,14 +15,16 @@ protocol TabTrayNavigationHandler: AnyObject {
 class TabTrayCoordinator: BaseCoordinator, TabTrayViewControllerDelegate, TabTrayNavigationHandler {
     private var tabTrayViewController: TabTrayViewController!
     weak var parentCoordinator: TabTrayCoordinatorDelegate?
+//    private var selectedTab: TabTrayPanelType
 
-    init(router: Router) {
+    init(router: Router,
+         tabTraySection: TabTrayPanelType) {
         super.init(router: router)
-        initializeTabTrayViewController()
+        initializeTabTrayViewController(selectedTab: tabTraySection)
     }
 
-    private func initializeTabTrayViewController() {
-        tabTrayViewController = TabTrayViewController(delegate: self)
+    private func initializeTabTrayViewController(selectedTab: TabTrayPanelType) {
+        tabTrayViewController = TabTrayViewController(delegate: self, selectedTab: selectedTab)
         router.setRootViewController(tabTrayViewController)
         tabTrayViewController.childPanelControllers = makeChildPanels()
         tabTrayViewController.navigationHandler = self

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
@@ -105,7 +105,8 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
 
     func tabToolbarDidPressTabs(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
         updateZoomPageBarVisibility(visible: false)
-        showTabTray()
+        let segmentToFocus = tabManager.selectedTab?.isPrivate ?? false ? TabTrayPanelType.privateTabs : TabTrayPanelType.tabs
+        showTabTray(focusedSegment: segmentToFocus)
         TelemetryWrapper.recordEvent(category: .action, method: .press, object: .tabToolbar, value: .tabView)
     }
 

--- a/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
+++ b/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
@@ -18,6 +18,7 @@ enum TabPanelAction: Action {
 
     // Middleware actions
     case didLoadTabPanel(TabDisplayModel)
+//    case newTabWasAdded(TabModel, Int)
     // Response to all user actions involving tabs ex: add, close and close all tabs
     case refreshTab([TabModel])
     case refreshInactiveTabs([InactiveTabsModel])

--- a/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
+++ b/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
@@ -8,7 +8,7 @@ enum TabPanelAction: Action {
     case tabPanelDidLoad(Bool)
     case tabPanelDidAppear(Bool)
     case addNewTab(Bool)
-    case closeTab(Int)
+    case closeTab(String)
     case closeAllTabs
     case moveTab(Int, Int)
     case toggleInactiveTabs
@@ -18,7 +18,6 @@ enum TabPanelAction: Action {
 
     // Middleware actions
     case didLoadTabPanel(TabDisplayModel)
-//    case newTabWasAdded(TabModel, Int)
     // Response to all user actions involving tabs ex: add, close and close all tabs
     case refreshTab([TabModel])
     case refreshInactiveTabs([InactiveTabsModel])

--- a/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
+++ b/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
@@ -7,14 +7,14 @@ import Redux
 enum TabPanelAction: Action {
     case tabPanelDidLoad(Bool)
     case tabPanelDidAppear(Bool)
-    case addNewTab(Bool)
+    case addNewTab(URLRequest?, Bool)
     case closeTab(String)
     case closeAllTabs
     case moveTab(Int, Int)
     case toggleInactiveTabs
     case closeInactiveTabs(Int)
     case closeAllInactiveTabs
-    case learnMorePrivateMode
+    case learnMorePrivateMode(URLRequest)
     case selectTab(String)
 
     // Middleware actions

--- a/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
+++ b/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
@@ -15,6 +15,7 @@ enum TabPanelAction: Action {
     case closeInactiveTabs(Int)
     case closeAllInactiveTabs
     case learnMorePrivateMode
+    case selectTab(String)
 
     // Middleware actions
     case didLoadTabPanel(TabDisplayModel)

--- a/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
+++ b/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
@@ -288,9 +288,7 @@ class LegacyGridTabViewController: UIViewController,
     }
 
     func openNewTab(_ request: URLRequest? = nil, isPrivate: Bool) {
-        if tabDisplayManager.isDragging {
-            return
-        }
+        guard !tabDisplayManager.isDragging else { return }
 
         // Ensure Firefox home page is refreshed if privacy mode was changed
         if tabManager.selectedTab?.isPrivate != isPrivate {

--- a/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
+++ b/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
@@ -44,6 +44,12 @@ struct TabTrayState: ScreenState, Equatable {
                   normalTabsCount: "0")
     }
 
+    init(panelType: TabTrayPanelType) {
+        self.init(isPrivateMode: panelType == .privateTabs,
+                  selectedPanel: panelType,
+                  normalTabsCount: "0")
+    }
+
     init(isPrivateMode: Bool,
          selectedPanel: TabTrayPanelType,
          normalTabsCount: String,

--- a/Client/Frontend/Browser/Tabs/TabManagerMiddleware.swift
+++ b/Client/Frontend/Browser/Tabs/TabManagerMiddleware.swift
@@ -65,6 +65,10 @@ class TabManagerMiddleware {
                 }
             }
 
+        case TabPanelAction.selectTab(let tabUUID):
+            self.selectTab(for: tabUUID)
+            store.dispatch(TabTrayAction.dismissTabTray)
+
         case TabPanelAction.closeAllInactiveTabs:
             self.closeAllInactiveTabs()
             store.dispatch(TabPanelAction.refreshInactiveTabs(self.inactiveTabs))
@@ -155,5 +159,11 @@ class TabManagerMiddleware {
 
     private func didTapLearnMoreAboutPrivate() {
         addNewTab(true)
+    }
+
+    private func selectTab(for tabUUID: String) {
+        guard let tab = tabManager.getTabForUUID(uuid: tabUUID) else { return }
+
+        tabManager.selectTab(tab)
     }
 }

--- a/Client/Frontend/Browser/Tabs/TabManagerMiddleware.swift
+++ b/Client/Frontend/Browser/Tabs/TabManagerMiddleware.swift
@@ -29,9 +29,9 @@ class TabManagerMiddleware {
             let tabState = self.getTabsDisplayModel(for: isPrivate)
             store.dispatch(TabPanelAction.didLoadTabPanel(tabState))
 
-        case TabPanelAction.addNewTab(let isPrivate):
-            self.addNewTab(isPrivate)
-            let tabs = self.refreshTabs(for: isPrivate)
+        case TabPanelAction.addNewTab(let urlRequest, let isPrivateMode):
+            self.addNewTab(with: urlRequest, isPrivate: isPrivateMode)
+            let tabs = self.refreshTabs(for: isPrivateMode)
             store.dispatch(TabPanelAction.refreshTab(tabs))
             store.dispatch(TabTrayAction.dismissTabTray)
 
@@ -77,8 +77,8 @@ class TabManagerMiddleware {
             self.closeInactiveTab(for: index)
             store.dispatch(TabPanelAction.refreshInactiveTabs(self.inactiveTabs))
 
-        case TabPanelAction.learnMorePrivateMode:
-            self.didTapLearnMoreAboutPrivate()
+        case TabPanelAction.learnMorePrivateMode(let urlRequest):
+            self.didTapLearnMoreAboutPrivate(with: urlRequest)
             let tabs = self.refreshTabs(for: true)
             store.dispatch(TabPanelAction.refreshTab(tabs))
             store.dispatch(TabTrayAction.dismissTabTray)
@@ -127,10 +127,9 @@ class TabManagerMiddleware {
         return tabs
     }
 
-    private func addNewTab(_ isPrivate: Bool) {
-        // TODO: Add a guard to check if is dragging as per Legacy
-        // TODO: Add request
-        let tab = tabManager.addTab(nil, isPrivate: isPrivate)
+    private func addNewTab(with urlRequest: URLRequest?, isPrivate: Bool) {
+        // TODO: Add a guard to check if is dragging as per Legacy code
+        let tab = tabManager.addTab(urlRequest, isPrivate: isPrivate)
         tabManager.selectTab(tab)
     }
 
@@ -157,8 +156,8 @@ class TabManagerMiddleware {
         inactiveTabs.remove(at: index)
     }
 
-    private func didTapLearnMoreAboutPrivate() {
-        addNewTab(true)
+    private func didTapLearnMoreAboutPrivate(with urlRequest: URLRequest) {
+        addNewTab(with: urlRequest, isPrivate: true)
     }
 
     private func selectTab(for tabUUID: String) {

--- a/Client/Frontend/Browser/Tabs/Views/TabCell.swift
+++ b/Client/Frontend/Browser/Tabs/Views/TabCell.swift
@@ -154,8 +154,7 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
     }
 
     private func configureScreenshot(tabModel: TabModel) {
-        // Regular screenshot for home or internal url when
-        // tab has home screenshot
+        // Regular screenshot for home or internal url when tab has home screenshot
         guard !hasHomeScreenshot(tabModel: tabModel) else {
             let defaultImage = UIImage(named: StandardImageIdentifiers.Large.globe)?
                 .withRenderingMode(.alwaysTemplate)
@@ -164,8 +163,7 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
             return
         }
 
-        // Favicon or letter image when home screenshot is present for
-        // a regular (non-internal) url
+        // Favicon or letter image when home screenshot is present for a regular (non-internal) url
         if let url = tabModel.url,
            !url.absoluteString.starts(with: "internal"),
            tabModel.hasHomeScreenshot {

--- a/Client/Frontend/Browser/Tabs/Views/TabCell.swift
+++ b/Client/Frontend/Browser/Tabs/Views/TabCell.swift
@@ -9,7 +9,7 @@ import Shared
 import SiteImageView
 
 protocol TabCellDelegate: AnyObject {
-    func tabCellDidClose(_ cell: TabCell)
+    func tabCellDidClose(for tabUUID: String)
 }
 
 /// WIP. Brings over much of the existing functionality from LegacyTabCell but has been
@@ -130,7 +130,8 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
 
     @objc
     func close() {
-        delegate?.tabCellDidClose(self)
+        guard let tabModel = tabModel else { return }
+        delegate?.tabCellDidClose(for: tabModel.tabUUID)
     }
 
     // MARK: - Configuration

--- a/Client/Frontend/Browser/Tabs/Views/TabCell.swift
+++ b/Client/Frontend/Browser/Tabs/Views/TabCell.swift
@@ -145,29 +145,38 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         smallFaviconView.tintColor = theme.colors.textPrimary
     }
 
+    private func hasHomeScreenshot(tabModel: TabModel) -> Bool {
+        guard let url = tabModel.url,
+              url.absoluteString.starts(with: "internal"),
+            tabModel.screenshot != nil, tabModel.hasHomeScreenshot else { return false }
+
+        return true
+    }
+
     private func configureScreenshot(tabModel: TabModel) {
-        if let url = tabModel.url,
-           let tabScreenshot = tabModel.screenshot,
-           url.absoluteString.starts(with: "internal"),
-           tabModel.hasHomeScreenshot {
-            // Regular screenshot for home or internal url when
-            // tab has home screenshot
+        // Regular screenshot for home or internal url when
+        // tab has home screenshot
+        guard !hasHomeScreenshot(tabModel: tabModel) else {
             let defaultImage = UIImage(named: StandardImageIdentifiers.Large.globe)?
                 .withRenderingMode(.alwaysTemplate)
             smallFaviconView.manuallySetImage(defaultImage ?? UIImage())
-            screenshotView.image = tabScreenshot
-        } else if let url = tabModel.url,
-                  !url.absoluteString.starts(with: "internal"),
-                  tabModel.hasHomeScreenshot {
-            // Favicon or letter image when home screenshot is present for
-            // a regular (non-internal) url
+            screenshotView.image = tabModel.screenshot
+            return
+        }
 
+        // Favicon or letter image when home screenshot is present for
+        // a regular (non-internal) url
+        if let url = tabModel.url,
+           !url.absoluteString.starts(with: "internal"),
+           tabModel.hasHomeScreenshot {
             let defaultImage = UIImage(named: StandardImageIdentifiers.Large.globe)?.withRenderingMode(.alwaysTemplate)
             smallFaviconView.manuallySetImage(defaultImage ?? UIImage())
             faviconBG.isHidden = false
             screenshotView.image = nil
-        } else if let tabScreenshot = tabModel.screenshot {
-            // Tab screenshot when available
+        }
+
+        // Use Tab screenshot when available
+        if let tabScreenshot = tabModel.screenshot {
             screenshotView.image = tabScreenshot
         } else {
             // Favicon or letter image when tab screenshot isn't available

--- a/Client/Frontend/Browser/Tabs/Views/TabDisplayPanel.swift
+++ b/Client/Frontend/Browser/Tabs/Views/TabDisplayPanel.swift
@@ -120,7 +120,7 @@ class TabDisplayPanel: UIViewController,
 
     // MARK: EmptyPrivateTabsViewDelegate
     func didTapLearnMore(urlRequest: URLRequest) {
-        store.dispatch(TabPanelAction.learnMorePrivateMode)
+        store.dispatch(TabPanelAction.learnMorePrivateMode(urlRequest))
     }
 }
 

--- a/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
+import Redux
 import UIKit
 
 class TabDisplayView: UIView,
@@ -223,6 +224,12 @@ class TabDisplayView: UIView,
             cell.configure(with: tabState, theme: theme, delegate: self)
             return cell
         }
+    }
+
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        // TODO: Add guard to handle inactive tabs
+        let tabUUID = tabsState.tabs[indexPath.row].tabUUID
+        store.dispatch(TabPanelAction.selectTab(tabUUID))
     }
 
     func collectionView(_ collectionView: UICollectionView,

--- a/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -245,9 +245,8 @@ class TabDisplayView: UIView,
     }
 
     // MARK: - TabCellDelegate
-    func tabCellDidClose(_ cell: TabCell) {
-        guard let indexPath = collectionView.indexPath(for: cell) else { return }
-        store.dispatch(TabPanelAction.closeTab(indexPath.row))
+    func tabCellDidClose(for tabUUID: String) {
+        store.dispatch(TabPanelAction.closeTab(tabUUID))
     }
 }
 

--- a/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -181,9 +181,10 @@ class TabTrayViewController: UIViewController,
     }
 
     init(delegate: TabTrayViewControllerDelegate,
+         selectedTab: TabTrayPanelType,
          themeManager: ThemeManager = AppContainer.shared.resolve(),
          and notificationCenter: NotificationProtocol = NotificationCenter.default) {
-        self.tabTrayState = TabTrayState()
+        self.tabTrayState = TabTrayState(panelType: selectedTab)
         self.delegate = delegate
         self.themeManager = themeManager
         self.notificationCenter = notificationCenter
@@ -295,7 +296,6 @@ class TabTrayViewController: UIViewController,
             navigationToolbar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             navigationToolbar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             navigationToolbar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            // TODO: FXIOS-6926 Remove priority once collection view layout is configured
             navigationToolbar.bottomAnchor.constraint(equalTo: containerView.topAnchor).priority(.defaultLow),
 
             containerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
@@ -383,6 +383,7 @@ class TabTrayViewController: UIViewController,
 
         guard let currentPanel = currentPanel else { return }
 
+        segmentedControl.selectedSegmentIndex = panelType.rawValue
         updateTitle()
         updateLayout()
         hideCurrentPanel()

--- a/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -436,7 +436,7 @@ class TabTrayViewController: UIViewController,
 
     @objc
     private func newTabButtonTapped() {
-        store.dispatch(TabPanelAction.addNewTab(tabTrayState.isPrivateMode))
+        store.dispatch(TabPanelAction.addNewTab(nil, tabTrayState.isPrivateMode))
     }
 
     @objc

--- a/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -631,8 +631,9 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     }
 
     @MainActor
-    func removeAllTabs() async {
-        for tab in tabs {
+    func removeAllTabs(isPrivateMode: Bool) async {
+        let currentModeTabs = tabs.filter {$0.isPrivate == isPrivateMode}
+        for tab in currentModeTabs {
             await self.removeTab(tab.tabUUID)
         }
         storeChanges()

--- a/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -630,6 +630,14 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         storeChanges()
     }
 
+    @MainActor
+    func removeAllTabs() async {
+        for tab in tabs {
+            await self.removeTab(tab.tabUUID)
+        }
+        storeChanges()
+    }
+
     func backgroundRemoveAllTabs(isPrivate: Bool = false,
                                  didClearTabs: @escaping (_ tabsToRemove: [Tab],
                                                           _ isPrivate: Bool,

--- a/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -567,6 +567,23 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         )
     }
 
+    @MainActor
+    func removeTab(_ tabUUID: String) async {
+        guard let index = tabs.firstIndex(where: { $0.tabUUID == tabUUID }) else { return }
+
+        let tab = tabs[index]
+        let viableTabsIndex = deletedIndexForViableTabs(tab)
+        self.removeTab(tab, flushToDisk: true)
+        self.updateIndexAfterRemovalOf(tab, deletedIndex: index, viableTabsIndex: viableTabsIndex)
+
+        TelemetryWrapper.recordEvent(
+            category: .action,
+            method: .close,
+            object: .tab,
+            value: tab.isPrivate ? .privateTab : .normalTab
+        )
+    }
+
     /// Remove a tab, will notify delegate of the tab removal
     /// - Parameters:
     ///   - tab: the tab to remove

--- a/Client/TabManagement/TabManager.swift
+++ b/Client/TabManagement/TabManager.swift
@@ -32,6 +32,7 @@ protocol TabManager: AnyObject {
     func addTab(_ request: URLRequest?, afterTab: Tab?, isPrivate: Bool) -> Tab
     func addTabsForURLs(_ urls: [URL], zombie: Bool, shouldSelectTab: Bool)
     func removeTab(_ tab: Tab, completion: (() -> Void)?)
+    func removeTab(_ tabUUID: String) async
     func removeTabs(_ tabs: [Tab])
     func undoCloseTab(tab: Tab, position: Int?)
     func getMostRecentHomepageTab() -> Tab?

--- a/Client/TabManagement/TabManager.swift
+++ b/Client/TabManagement/TabManager.swift
@@ -34,7 +34,7 @@ protocol TabManager: AnyObject {
     func removeTab(_ tab: Tab, completion: (() -> Void)?)
     func removeTab(_ tabUUID: String) async
     func removeTabs(_ tabs: [Tab])
-    func removeAllTabs() async
+    func removeAllTabs(isPrivateMode: Bool) async
     func undoCloseTab(tab: Tab, position: Int?)
     func getMostRecentHomepageTab() -> Tab?
     func getTabFor(_ url: URL) -> Tab?

--- a/Client/TabManagement/TabManager.swift
+++ b/Client/TabManagement/TabManager.swift
@@ -34,6 +34,7 @@ protocol TabManager: AnyObject {
     func removeTab(_ tab: Tab, completion: (() -> Void)?)
     func removeTab(_ tabUUID: String) async
     func removeTabs(_ tabs: [Tab])
+    func removeAllTabs() async
     func undoCloseTab(tab: Tab, position: Int?)
     func getMostRecentHomepageTab() -> Tab?
     func getTabFor(_ url: URL) -> Tab?

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/TabTray/TabTrayCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/TabTray/TabTrayCoordinatorTests.swift
@@ -61,9 +61,11 @@ final class TabTrayCoordinatorTests: XCTestCase {
     }
 
     // MARK: - Helpers
-    private func createSubject(file: StaticString = #file,
+    private func createSubject(panelType: TabTrayPanelType = .tabs,
+                               file: StaticString = #file,
                                line: UInt = #line) -> TabTrayCoordinator {
-        let subject = TabTrayCoordinator(router: mockRouter)
+        let subject = TabTrayCoordinator(router: mockRouter,
+                                         tabTraySection: panelType)
 
         trackForMemoryLeaks(subject, file: file, line: line)
         return subject

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -75,6 +75,10 @@ class MockTabManager: TabManager {
 
     func removeTabs(_ tabs: [Tab]) {}
 
+    func removeTab(_ tabUUID: String) async {}
+
+    func removeAllTabs(isPrivateMode: Bool) async {}
+
     func undoCloseTab(tab: Client.Tab, position: Int?) {}
 
     func getTabFor(_ url: URL) -> Tab? {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabCellTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabCellTests.swift
@@ -65,7 +65,7 @@ class TabCellTests: XCTestCase {
 class MockTabCellDelegate: TabCellDelegate {
     var tabCellClosedCounter = 0
 
-    func tabCellDidClose(_ cell: TabCell) {
+    func tabCellDidClose(for tabUUID: String) {
         tabCellClosedCounter += 1
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabTrayViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabTrayViewControllerTests.swift
@@ -88,7 +88,7 @@ final class TabTrayViewControllerTests: XCTestCase {
     private func createSubject(selectedSegment: TabTrayPanelType = .tabs,
                                file: StaticString = #file,
                                line: UInt = #line) -> TabTrayViewController {
-        let subject = TabTrayViewController(delegate: delegate)
+        let subject = TabTrayViewController(delegate: delegate, selectedTab: selectedSegment)
         subject.childPanelControllers = makeChildPanels()
         subject.setupOpenPanel(panelType: selectedSegment)
         let navigationController = createNavigationController(root: subject)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7356)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16298)

## :bulb: Description
- Middleware integration part1, there are multiple actions in the tab tray so I will group them by related actions this PR includes:
- Load regular/private tabs
- Add regular/private new tab
- Close regular/private tab without undo option
- Close all regular/private tabs without undo option
- Move regular/private tab
- Open new tab when user selects learn more about privacy on Private tabs

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods


