### PR TITLE
Add FXIOS-7183 [v122] Private mode search suggestions toggle in settings

### DIFF
--- a/Client/Application/AccessibilityIdentifiers.swift
+++ b/Client/Application/AccessibilityIdentifiers.swift
@@ -119,6 +119,10 @@ public struct AccessibilityIdentifiers {
         public static let back = "Back"
     }
 
+    struct PrivateMode {
+        static let dimmingView = "PrivateMode.DimmingView"
+    }
+
     struct Shopping {
         static let sheetHeaderTitle = "Shopping.Sheet.HeaderTitle"
         static let sheetHeaderBetaLabel = "Shopping.Sheet.HeaderBetaLabel"
@@ -409,6 +413,7 @@ public struct AccessibilityIdentifiers {
             static let searchNavigationBar = "Search"
             static let deleteMozillaEngine = "Remove Mozilla Engine"
             static let deleteButton = "Delete"
+            static let disableSearchSuggestsInPrivateMode = "PrivateMode.DisableSearchSuggests"
         }
 
         struct AdvancedAccountSettings {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -92,6 +92,7 @@ class BrowserViewController: UIViewController,
     // Overlay dimming view for private mode
     lazy var privateModeDimmingView: UIView = .build { view in
         view.backgroundColor = self.themeManager.currentTheme.colors.layerScrim
+        view.accessibilityIdentifier = AccessibilityIdentifiers.PrivateMode.dimmingView
     }
 
     // BottomContainer stack view contains toolbar
@@ -653,8 +654,6 @@ class BrowserViewController: UIViewController,
 
     // Configure dimming view to show for private mode
     func configureDimmingView() {
-        guard featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly) else { return }
-
         if let selectedTab = tabManager.selectedTab, selectedTab.isPrivate {
             view.addSubview(privateModeDimmingView)
             view.bringSubviewToFront(privateModeDimmingView)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -299,9 +299,7 @@ extension BrowserViewController: URLBarDelegate {
         if text.isEmpty {
             hideSearchController()
         } else {
-            configureDimmingView()
-            // TODO: Show / Hide Search Controller based on Setting - https://mozilla-hub.atlassian.net/browse/FXIOS-7182
-            showSearchController()
+            configureOverlayView()
         }
 
         searchController?.searchQuery = text
@@ -312,9 +310,7 @@ extension BrowserViewController: URLBarDelegate {
         if text.isEmpty {
             hideSearchController()
         } else {
-            configureDimmingView()
-            // TODO: Show / Hide Search Controller based on Setting - https://mozilla-hub.atlassian.net/browse/FXIOS-7182
-            showSearchController()
+            configureOverlayView()
         }
         urlBar.locationTextField?.applyUIMode(isPrivate: tabManager.selectedTab?.isPrivate ?? false, theme: self.themeManager.currentTheme)
         searchController?.searchQuery = text
@@ -404,5 +400,23 @@ extension BrowserViewController: URLBarDelegate {
 
     func urlBarDidBeginDragInteraction(_ urlBar: URLBarView) {
         dismissVisibleMenus()
+    }
+
+    private var shouldDisableSearchSuggestsForPrivateMode: Bool {
+        let featureFlagEnabled = featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly)
+        let isPrivateTab = tabManager.selectedTab?.isPrivate ?? false
+        let isSettingEnabled = profile.prefs.boolForKey(PrefsKeys.SearchSettings.disablePrivateModeSearchSuggestions) ?? true
+        return featureFlagEnabled && isPrivateTab && isSettingEnabled
+    }
+
+    // Determines the view user should see when editing the url bar
+    // Dimming view appears if private mode search suggest is disabled
+    // Otherwise shows search suggests screen
+    private func configureOverlayView() {
+        if shouldDisableSearchSuggestsForPrivateMode {
+            configureDimmingView()
+        } else {
+            showSearchController()
+        }
     }
 }

--- a/Client/Frontend/Browser/SearchEngines/SearchEngines.swift
+++ b/Client/Frontend/Browser/SearchEngines/SearchEngines.swift
@@ -20,8 +20,7 @@ protocol SearchEngineDelegate: AnyObject {
 /// The first search engine is distinguished and labeled the "default" search engine; it can never be
 /// disabled.  Search suggestions should always be sourced from the default search engine.
 /// 
-/// Two additional bits of information are maintained: whether the user should be shown "opt-in to
-/// search suggestions" UI, and whether search suggestions are enabled.
+/// Two additional bits of information are maintained: whether search suggestions are enabled and whether search suggestions in private mode is disabled
 ///
 /// Consumers will almost always use `defaultEngine` if they want a single search engine, and
 /// `quickSearchEngines()` if they want a list of enabled quick search engines (possibly empty,
@@ -35,7 +34,6 @@ class SearchEngines {
     private let fileAccessor: FileAccessor
     private let orderedEngineNames = "search.orderedEngineNames"
     private let disabledEngineNames = "search.disabledEngineNames"
-    private let showSearchSuggestionsOptIn = "search.suggestions.showOptIn"
     private let showSearchSuggestions = "search.suggestions.show"
     private let customSearchEnginesFileName = "customEngines.plist"
     private var engineProvider: SearchEngineProvider
@@ -47,6 +45,7 @@ class SearchEngines {
         self.prefs = prefs
         // By default, show search suggestions
         self.shouldShowSearchSuggestions = prefs.boolForKey(showSearchSuggestions) ?? true
+        self.shouldDisablePrivateModeSearchSuggestions = prefs.boolForKey(PrefsKeys.SearchSettings.disablePrivateModeSearchSuggestions) ?? true
         self.fileAccessor = files
         self.engineProvider = engineProvider
         self.orderedEngines = []
@@ -99,6 +98,12 @@ class SearchEngines {
     var shouldShowSearchSuggestions: Bool {
         didSet {
             self.prefs.setObject(shouldShowSearchSuggestions, forKey: showSearchSuggestions)
+        }
+    }
+
+    var shouldDisablePrivateModeSearchSuggestions: Bool {
+        didSet {
+            self.prefs.setObject(shouldDisablePrivateModeSearchSuggestions, forKey: PrefsKeys.SearchSettings.disablePrivateModeSearchSuggestions)
         }
     }
 

--- a/Shared/NotificationConstants.swift
+++ b/Shared/NotificationConstants.swift
@@ -97,5 +97,8 @@ extension Notification.Name {
     public static let ReadingListUpdated = Notification.Name("ReadingListUpdated")
     public static let TopSitesUpdated = Notification.Name("TopSitesUpdated")
     public static let HistoryUpdated = Notification.Name("HistoryUpdated")
+
+    // Search
     public static let DefaultSearchEngineUpdated = Notification.Name("DefaultSearchEngineUpdated")
+    public static let DisablePrivateModeSearchSuggests = Notification.Name("DisablePrivateModeSearchSuggests")
 }

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -78,6 +78,10 @@ public struct PrefsKeys {
         public static let SearchBarPosition = "SearchBarPositionUsersPrefsKey"
     }
 
+    public struct SearchSettings {
+        public static let disablePrivateModeSearchSuggestions = "DisablePrivateModeSearchSuggestionsKey"
+    }
+
     public struct UserFeatureFlagPrefs {
         public static let ASPocketStories = "ASPocketStoriesUserPrefsKey"
         public static let RecentlySavedSection = "RecentlySavedSectionUserPrefsKey"

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEnginesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEnginesTests.swift
@@ -160,6 +160,22 @@ class SearchEnginesTests: XCTestCase {
         XCTAssertFalse(engines.shouldShowSearchSuggestions)
     }
 
+    func testDisableSearchSuggestionSettingsInPrivateMode() {
+        // Disable search suggestions by default
+        XCTAssertTrue(engines.shouldDisablePrivateModeSearchSuggestions)
+        XCTAssertNil(profile.prefs.boolForKey(PrefsKeys.SearchSettings.disablePrivateModeSearchSuggestions))
+
+        // Turn off setting
+        engines.shouldDisablePrivateModeSearchSuggestions = false
+        XCTAssertFalse(engines.shouldDisablePrivateModeSearchSuggestions)
+        XCTAssertEqual(profile.prefs.boolForKey(PrefsKeys.SearchSettings.disablePrivateModeSearchSuggestions), false)
+
+        // Turn on setting
+        engines.shouldDisablePrivateModeSearchSuggestions = true
+        XCTAssertTrue(engines.shouldDisablePrivateModeSearchSuggestions)
+        XCTAssertEqual(profile.prefs.boolForKey(PrefsKeys.SearchSettings.disablePrivateModeSearchSuggestions), true)
+    }
+
     func testGetOrderedEngines() {
         // Verify that the set of shipped engines includes the expected subset.
         let expectation = expectation(description: "Completed parse engines")

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -280,4 +280,86 @@ class SearchTests: BaseTestCase {
         waitForTabsButton()
         validateSearchSuggestionText(typeText: "localhost")
     }
+// TODO: Add UI Tests back when felt privay simplified UI feature flag is enabled or when we support feature flags for tests
+//    func testPrivateModeSearchSuggestsOnOffAndGeneralSearchSuggestsOn() {
+//        navigator.nowAt(NewTabScreen)
+//        navigator.goto(SearchSettings)
+//        navigator.nowAt(SearchSettings)
+//
+//        // By default, disable search suggest in private mode
+//        let privateModeSearchSuggestSwitch = app.otherElements.tables.cells[AccessibilityIdentifiers.Settings.Search.disableSearchSuggestsInPrivateMode]
+//        mozWaitForElementToExist(privateModeSearchSuggestSwitch)
+//
+//        app.navigationBars["Search"].buttons["Settings"].tap()
+//        app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].tap()
+//
+//        navigator.nowAt(NewTabScreen)
+//        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
+//        navigator.goto(URLBarOpen)
+//        app.textFields["address"].typeText("ex")
+//
+//        let dimmingView = app.otherElements[AccessibilityIdentifiers.PrivateMode.dimmingView]
+//        mozWaitForElementToExist(dimmingView)
+//
+//        // Enable search suggest in private mode
+//        navigator.goto(SearchSettings)
+//        navigator.nowAt(SearchSettings)
+//
+//        mozWaitForElementToNotExist(app.tables["SiteTable"])
+//        mozWaitForElementToExist(privateModeSearchSuggestSwitch)
+//        privateModeSearchSuggestSwitch.tap()
+//
+//        app.navigationBars["Search"].buttons["Settings"].tap()
+//        app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].tap()
+//
+//        navigator.nowAt(NewTabScreen)
+//        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
+//        navigator.goto(URLBarOpen)
+//        app.textFields["address"].typeText("ex")
+//
+//        mozWaitForElementToNotExist(dimmingView)
+//        mozWaitForElementToExist(app.tables["SiteTable"])
+//    }
+//
+//    func testPrivateModeSearchSuggestsOnOffAndGeneralSearchSuggestsOff() {
+//        // Disable general search suggests
+//        suggestionsOnOff()
+//        navigator.nowAt(NewTabScreen)
+//        navigator.goto(SearchSettings)
+//        navigator.nowAt(SearchSettings)
+//
+//        // By default, disable search suggest in private mode
+//        let privateModeSearchSuggestSwitch = app.otherElements.tables.cells[AccessibilityIdentifiers.Settings.Search.disableSearchSuggestsInPrivateMode]
+//        mozWaitForElementToExist(privateModeSearchSuggestSwitch)
+//
+//        app.navigationBars["Search"].buttons["Settings"].tap()
+//        app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].tap()
+//
+//        navigator.nowAt(NewTabScreen)
+//        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
+//        navigator.goto(URLBarOpen)
+//        app.textFields["address"].typeText("ex")
+//
+//        let dimmingView = app.otherElements[AccessibilityIdentifiers.PrivateMode.dimmingView]
+//        mozWaitForElementToExist(dimmingView)
+//
+//        // Enable search suggest in private mode
+//        navigator.goto(SearchSettings)
+//        navigator.nowAt(SearchSettings)
+//
+//        mozWaitForElementToNotExist(app.tables["SiteTable"])
+//        mozWaitForElementToExist(privateModeSearchSuggestSwitch)
+//        privateModeSearchSuggestSwitch.tap()
+//
+//        app.navigationBars["Search"].buttons["Settings"].tap()
+//        app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].tap()
+//
+//        navigator.nowAt(NewTabScreen)
+//        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
+//        navigator.goto(URLBarOpen)
+//        app.textFields["address"].typeText("ex")
+//
+//        mozWaitForElementToNotExist(dimmingView)
+//        mozWaitForElementToExist(app.tables["SiteTable"])
+//    }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7183)

## :bulb: Description
Add new Private Mode Search Suggestions toggle in search settings
Disable search suggestions by default under private session section

Note: Strings need to be updated for the toggle button to match new designs

## Test Steps
Open up `feltPrivacyFeature.yaml` in `nimbus-features` in repo.
Change the value for `simplified-ui-enabled: true` under `developer` 
Verify that the toggle feature appears and work as expected.

**Expected Behavior:** Disabling search suggests in private mode should show dimming view; otherwise we see the search screen.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods


https://github.com/mozilla-mobile/firefox-ios/assets/6743397/9d31aab0-a95e-471d-ac80-83e1f704148f


