### PR TITLE
Bugfix FXIOS-7854 [v122] Widgets have a white or black outline (part 2)

### DIFF
--- a/WidgetKit/OpenTabs/OpenTabsWidget.swift
+++ b/WidgetKit/OpenTabs/OpenTabsWidget.swift
@@ -17,6 +17,7 @@ struct OpenTabsWidget: Widget {
         .supportedFamilies([.systemMedium, .systemLarge])
         .configurationDisplayName(String.QuickViewGalleryTitle)
         .description(String.QuickViewGalleryDescriptionV2)
+        .contentMarginsDisabled()
     }
 }
 

--- a/WidgetKit/TopSites/TopSitesWidget.swift
+++ b/WidgetKit/TopSites/TopSitesWidget.swift
@@ -16,6 +16,7 @@ struct TopSitesWidget: Widget {
         .supportedFamilies([.systemMedium])
         .configurationDisplayName(String.TopSitesGalleryTitleV2)
         .description(String.TopSitesGalleryDescription)
+        .contentMarginsDisabled()
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7854)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17535)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Accidentally forgot two widgets in the already merged PR. 😨 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

