### PR TITLE
Refactor FXIOS-7188 [v122] Update felt privacy strings to new versions

### DIFF
--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -1690,7 +1690,7 @@ extension String {
                 value: "Quick-Search Engines",
                 comment: "Title for quick-search engines settings section in the Search page in the Settings menu.")
             public static let PrivateSessionTitle = MZLocalizedString(
-                key: "Settings.Search.PrivateSession.Title.v121",
+                key: "Settings.Search.PrivateSession.Title.v122",
                 tableName: "Settings",
                 value: "Private Browsing",
                 comment: "Title for the `Private Session` settings section in the Search page in the Settings menu.")

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -723,9 +723,11 @@ extension String {
                 tableName: "FirefoxHomepage",
                 value: "Who might be able to see my activity?",
                 comment: "The link for the card that educates users about how private mode works. The link redirects to an external site for more information. The card shows up on the homepage when in the new privacy mode.")
+        }
 
+        public struct FeltDeletion {
             public static let ToastTitle = MZLocalizedString(
-                key: "FirefoxHomepage.FeltPrivacyUI.Link.v122",
+                key: "FirefoxHomepage.FeltDeletion.Link.v122",
                 tableName: "FirefoxHomepage",
                 value: "Private Browsing Data Erased",
                 comment: "When the user ends their private session, their are returned to the private mode homepage, and a toastbar popus confirming that their data has been erased. This is the label for that toast.")

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -1695,7 +1695,7 @@ extension String {
                 value: "Private Browsing",
                 comment: "Title for the `Private Session` settings section in the Search page in the Settings menu.")
             public static let PrivateSessionSetting = MZLocalizedString(
-                key: "Settings.Search.PrivateSession.Setting.v121",
+                key: "Settings.Search.PrivateSession.Setting.v122",
                 tableName: "Settings",
                 value: "Show Suggestions in Private Browsing",
                 comment: "Label for toggle. Explains that in private browsing mode, the search suggestions which appears at the top of the search bar, can be toggled on or off. Located in the Private Session section in the Search page in the Settings menu.")

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -82,6 +82,30 @@ extension String {
                 value: "Restore tabs",
                 comment: "The title for the affirmative action of the restore tabs pop-up alert. This alert shows when opening up Firefox after it crashed, and will restore existing tabs.")
         }
+
+        public struct FeltDeletion {
+            public static let Title = MZLocalizedString(
+                key: "Alerts.FeltDeletion.Title.v122",
+                tableName: "Alerts",
+                value: "End your private session?",
+                comment: "When tapping the fire icon in private mode, an alert comes up asking to confirm if you want to delete all browsing data and end your private session. This is the title for the alert.")
+            public static let Body = MZLocalizedString(
+                key: "Alerts.FeltDeletion.Body.v122",
+                tableName: "Alerts",
+                value: "Close all private tabs and delete history, cookies, and all other site data.",
+                comment: "When tapping the fire icon in private mode, an alert comes up asking to confirm if you want to delete all browsing data and end your private session. This is the body text for the alert.")
+            public static let ConfirmButton = MZLocalizedString(
+                key: "Alerts.FeltDeletion.Button.Confirm.v122",
+                tableName: "Alerts",
+                value: "Delete session data",
+                comment: "When tapping the fire icon in private mode, an alert comes up asking to confirm if you want to delete all browsing data and end your private session. This is the affirmative action for the alert, confirming that you do want to do that.")
+            public static let CancelButton = MZLocalizedString(
+                key: "Alerts.FeltDeletion.Button.Cancel.v122",
+                tableName: "Alerts",
+                value: "Cancel",
+                comment: "When tapping the fire icon in private mode, an alert comes up asking to confirm if you want to delete all browsing data and end your private session. This is the cancel action for the alert, cancelling ending your session.")
+
+        }
     }
 }
 

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -104,7 +104,6 @@ extension String {
                 tableName: "Alerts",
                 value: "Cancel",
                 comment: "When tapping the fire icon in private mode, an alert comes up asking to confirm if you want to delete all browsing data and end your private session. This is the cancel action for the alert, cancelling ending your session.")
-
         }
     }
 }
@@ -219,7 +218,7 @@ extension String {
                 value: "Open Review Checker",
                 comment: "Contextual hints are little popups that appear for the users informing them of new features. This is a call to action for the popup that appears after the user has opted in for the Shopping feature. It indicates that a user can directly open the review checker by tapping the text of the action.")
         }
-        
+
         public struct FeltDeletion {
             public static let Body = MZLocalizedString(
                 key: "ContextualHints.FeltDeletion.Body.v122",

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -715,7 +715,7 @@ extension String {
             public static let Body = MZLocalizedString(
                 key: "FirefoxHomepage.FeltPrivacyUI.Body.v122",
                 tableName: "FirefoxHomepage",
-                value: "%@ deletes your cookies, history, and site data when you close all your private windows.",
+                value: "%@ deletes your cookies, history, and site data when you close all your private tabs.",
                 comment: "The body of the message for the card that educates users about how private mode works. The card shows up on the homepage when in the new privacy mode. Placeholder refers to app name.")
 
             public static let Link = MZLocalizedString(

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -219,6 +219,14 @@ extension String {
                 value: "Open Review Checker",
                 comment: "Contextual hints are little popups that appear for the users informing them of new features. This is a call to action for the popup that appears after the user has opted in for the Shopping feature. It indicates that a user can directly open the review checker by tapping the text of the action.")
         }
+        
+        public struct FeltDeletion {
+            public static let Body = MZLocalizedString(
+                key: "ContextualHints.FeltDeletion.Body.v122",
+                tableName: "ContextualHints",
+                value: "Tap here to start a fresh private session. Delete your history, cookies  — everything.",
+                comment: "Contextual hints are little popups that appear for the users informing them of new features. This is a call to action for the popup that appears to educate users about what the fire button in the toolbar does, when in private mode.")
+        }
     }
 }
 
@@ -699,22 +707,28 @@ extension String {
 
         public struct FeltPrivacyUI {
             public static let Title = MZLocalizedString(
-                key: "FeltPrivacyUI.Title.v121",
+                key: "FirefoxHomepage.FeltPrivacyUI.Title.v122",
                 tableName: "FirefoxHomepage",
                 value: "Leave no traces on this device",
                 comment: "The title for the card that educates users about how private mode works. The card shows up on the homepage when in the new privacy mode.")
 
             public static let Body = MZLocalizedString(
-                key: "FeltPrivacyUI.Body.v121",
+                key: "FirefoxHomepage.FeltPrivacyUI.Body.v122",
                 tableName: "FirefoxHomepage",
                 value: "%@ deletes your cookies, history, and site data when you close all your private windows.",
                 comment: "The body of the message for the card that educates users about how private mode works. The card shows up on the homepage when in the new privacy mode. Placeholder refers to app name.")
 
             public static let Link = MZLocalizedString(
-                key: "FeltPrivacyUI.Link.v121",
+                key: "FirefoxHomepage.FeltPrivacyUI.Link.v122",
                 tableName: "FirefoxHomepage",
                 value: "Who might be able to see my activity?",
                 comment: "The link for the card that educates users about how private mode works. The link redirects to an external site for more information. The card shows up on the homepage when in the new privacy mode.")
+
+            public static let ToastTitle = MZLocalizedString(
+                key: "FirefoxHomepage.FeltPrivacyUI.Link.v122",
+                tableName: "FirefoxHomepage",
+                value: "Private Browsing Data Erased",
+                comment: "When the user ends their private session, their are returned to the private mode homepage, and a toastbar popus confirming that their data has been erased. This is the label for that toast.")
         }
     }
 }
@@ -1678,12 +1692,12 @@ extension String {
             public static let PrivateSessionTitle = MZLocalizedString(
                 key: "Settings.Search.PrivateSession.Title.v121",
                 tableName: "Settings",
-                value: "Private Session",
+                value: "Private Browsing",
                 comment: "Title for the `Private Session` settings section in the Search page in the Settings menu.")
             public static let PrivateSessionSetting = MZLocalizedString(
                 key: "Settings.Search.PrivateSession.Setting.v121",
                 tableName: "Settings",
-                value: "Turn off suggestions in private browsing",
+                value: "Show Suggestions in Private Browsing",
                 comment: "Label for toggle. Explains that in private browsing mode, the search suggestions which appears at the top of the search bar, can be toggled on or off. Located in the Private Session section in the Search page in the Settings menu.")
 
             public struct AccessibilityLabels {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7188)

## :bulb: Description
Note: the 121 versions were not in use in prod, so, as per @Delphine's advice, I'm just updating the identifiers of the strings I'm changing.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

