### PR TITLE
Add FXIOS-6507 [v122] show of QRCodeViewController from QRCodeCoordinator to production code 

### DIFF
--- a/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -133,11 +133,12 @@ class LaunchCoordinator: BaseCoordinator,
 
     // MARK: - QRCodeNavigationHandler
 
-    func showQRCode(delegate: QRCodeViewControllerDelegate) {
+    func showQRCode(delegate: QRCodeViewControllerDelegate, rootNavigationController: UINavigationController?) {
         var coordinator: QRCodeCoordinator
         if let qrCodeCoordinator = childCoordinators.first(where: { $0 is QRCodeCoordinator }) as? QRCodeCoordinator {
             coordinator = qrCodeCoordinator
         } else {
+            let router = rootNavigationController != nil ? DefaultRouter(navigationController: rootNavigationController!) : router
             coordinator = QRCodeCoordinator(parentCoordinator: self, router: router)
             add(child: coordinator)
         }

--- a/Client/Coordinators/QRCode/QRCodeCoordinator.swift
+++ b/Client/Coordinators/QRCode/QRCodeCoordinator.swift
@@ -25,7 +25,10 @@ class QRCodeCoordinator: BaseCoordinator, QRCodeDismissHandler {
         qrCodeViewController.qrCodeDelegate = delegate
         qrCodeViewController.dismissHandler = self
         let navigationController = QRCodeNavigationController(rootViewController: qrCodeViewController)
-        router.present(navigationController, animated: true)
+        router.present(navigationController, animated: true) { [weak self] in
+            guard let self = self else { return }
+            self.parentCoordinator?.didFinish(from: self)
+        }
     }
 
     // MARK: - QRCodeDismissHandler

--- a/Client/Coordinators/QRCode/QRCodeCoordinator.swift
+++ b/Client/Coordinators/QRCode/QRCodeCoordinator.swift
@@ -4,7 +4,12 @@
 
 import Foundation
 
-class QRCodeCoordinator: BaseCoordinator {
+protocol QRCodeDismissHandler: AnyObject {
+    /// Dismisses the current presented QRCodeViewController
+    func dismiss(_ completion: (() -> Void)?)
+}
+
+class QRCodeCoordinator: BaseCoordinator, QRCodeDismissHandler {
     private weak var parentCoordinator: ParentCoordinatorDelegate?
 
     init(
@@ -18,10 +23,15 @@ class QRCodeCoordinator: BaseCoordinator {
     func showQRCode(delegate: QRCodeViewControllerDelegate) {
         let qrCodeViewController = QRCodeViewController()
         qrCodeViewController.qrCodeDelegate = delegate
+        qrCodeViewController.dismissHandler = self
         let navigationController = QRCodeNavigationController(rootViewController: qrCodeViewController)
-        router.present(navigationController, animated: true) { [weak self] in
-            guard let self = self else { return }
-            self.parentCoordinator?.didFinish(from: self)
-        }
+        router.present(navigationController, animated: true)
+    }
+
+    // MARK: - QRCodeDismissHandler
+
+    func dismiss(_ completion: (() -> Void)?) {
+        router.dismiss(animated: true, completion: completion)
+        parentCoordinator?.didFinish(from: self)
     }
 }

--- a/Client/Coordinators/QRCode/QRCodeNavigationHandler.swift
+++ b/Client/Coordinators/QRCode/QRCodeNavigationHandler.swift
@@ -6,5 +6,12 @@ import Foundation
 
 protocol QRCodeNavigationHandler: AnyObject {
     /// Shows the QRCodeViewController
-    func showQRCode(delegate: QRCodeViewControllerDelegate)
+    /// The root navigation controller is used when available to present the QRCodeViewController.
+    func showQRCode(delegate: QRCodeViewControllerDelegate, rootNavigationController: UINavigationController?)
+}
+
+extension QRCodeNavigationHandler {
+    func showQRCode(delegate: QRCodeViewControllerDelegate, rootNavigationController: UINavigationController? = nil) {
+        showQRCode(delegate: delegate, rootNavigationController: rootNavigationController)
+    }
 }

--- a/Client/Coordinators/SettingsCoordinator.swift
+++ b/Client/Coordinators/SettingsCoordinator.swift
@@ -202,11 +202,12 @@ class SettingsCoordinator: BaseCoordinator,
         passwordCoordinator.start(with: shouldShowOnboarding)
     }
 
-    func showQRCode(delegate: QRCodeViewControllerDelegate) {
+    func showQRCode(delegate: QRCodeViewControllerDelegate, rootNavigationController: UINavigationController?) {
         var coordinator: QRCodeCoordinator
         if let qrCodeCoordinator = childCoordinators.first(where: { $0 is QRCodeCoordinator }) as? QRCodeCoordinator {
             coordinator = qrCodeCoordinator
         } else {
+            let router = rootNavigationController != nil ? DefaultRouter(navigationController: rootNavigationController!) : router
             coordinator = QRCodeCoordinator(parentCoordinator: self, router: router)
             add(child: coordinator)
         }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1428,10 +1428,14 @@ class BrowserViewController: UIViewController,
     }
 
     func handleQRCode() {
-        let qrCodeViewController = QRCodeViewController()
-        qrCodeViewController.qrCodeDelegate = self
-        presentedViewController?.dismiss(animated: true)
-        present(UINavigationController(rootViewController: qrCodeViewController), animated: true, completion: nil)
+        if CoordinatorFlagManager.isQRCodeCoordinatorEnabled {
+            navigationHandler?.showQRCode()
+        } else {
+            let qrCodeViewController = QRCodeViewController()
+            qrCodeViewController.qrCodeDelegate = self
+            presentedViewController?.dismiss(animated: true)
+            present(UINavigationController(rootViewController: qrCodeViewController), animated: true, completion: nil)
+        }
     }
 
     func handleClosePrivateTabs() {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -180,10 +180,14 @@ extension BrowserViewController: URLBarDelegate {
     }
 
     func urlBarDidPressQRButton(_ urlBar: URLBarView) {
-        let qrCodeViewController = QRCodeViewController()
-        qrCodeViewController.qrCodeDelegate = self
-        let controller = QRCodeNavigationController(rootViewController: qrCodeViewController)
-        self.present(controller, animated: true, completion: nil)
+        if CoordinatorFlagManager.isQRCodeCoordinatorEnabled {
+            navigationHandler?.showQRCode()
+        } else {
+            let qrCodeViewController = QRCodeViewController()
+            qrCodeViewController.qrCodeDelegate = self
+            let controller = QRCodeNavigationController(rootViewController: qrCodeViewController)
+            self.present(controller, animated: true, completion: nil)
+        }
     }
 
     func urlBarDidTapShield(_ urlBar: URLBarView) {

--- a/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/RustFxA/FirefoxAccountSignInViewController.swift
@@ -244,7 +244,7 @@ class FirefoxAccountSignInViewController: UIViewController, Themeable {
     @objc
     func scanbuttonTapped(_ sender: UIButton) {
         if CoordinatorFlagManager.isQRCodeCoordinatorEnabled {
-            qrCodeNavigationHandler?.showQRCode(delegate: self)
+            qrCodeNavigationHandler?.showQRCode(delegate: self, rootNavigationController: navigationController)
         } else {
             let qrCodeVC = QRCodeViewController()
             qrCodeVC.qrCodeDelegate = self

--- a/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/RustFxA/FirefoxAccountSignInViewController.swift
@@ -243,10 +243,14 @@ class FirefoxAccountSignInViewController: UIViewController, Themeable {
     /// Scan QR code button tapped
     @objc
     func scanbuttonTapped(_ sender: UIButton) {
-        let qrCodeVC = QRCodeViewController()
-        qrCodeVC.qrCodeDelegate = self
+        if CoordinatorFlagManager.isQRCodeCoordinatorEnabled {
+            qrCodeNavigationHandler?.showQRCode(delegate: self)
+        } else {
+            let qrCodeVC = QRCodeViewController()
+            qrCodeVC.qrCodeDelegate = self
+            presentThemedViewController(navItemLocation: .Left, navItemText: .Close, vcBeingPresented: qrCodeVC, topTabsVisible: true)
+        }
         TelemetryWrapper.recordEvent(category: .firefoxAccount, method: .tap, object: .syncSignInScanQRCode)
-        presentThemedViewController(navItemLocation: .Left, navItemText: .Close, vcBeingPresented: qrCodeVC, topTabsVisible: true)
     }
 
     /// Use email login button tapped

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/QRCodeCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/QRCodeCoordinatorTests.swift
@@ -39,7 +39,7 @@ final class QRCodeCoordinatorTests: XCTestCase {
 
         guard let qrCodeViewController = (router.presentedViewController as? QRCodeNavigationController)?.topViewController as? QRCodeViewController
         else {
-            XCTFail("The QRCodeViewController has to exists")
+            XCTFail("The QRCodeViewController has to exist")
             return
         }
         XCTAssertTrue(qrCodeViewController.qrCodeDelegate is MockQRCodeViewControllerDelegate)
@@ -53,7 +53,7 @@ final class QRCodeCoordinatorTests: XCTestCase {
 
         guard let qrCodeViewController = (router.presentedViewController as? QRCodeNavigationController)?.topViewController as? QRCodeViewController
         else {
-            XCTFail("The QRCodeViewController has to exists")
+            XCTFail("The QRCodeViewController has to exist")
             return
         }
         XCTAssertTrue(qrCodeViewController.dismissHandler is QRCodeCoordinator)
@@ -67,7 +67,7 @@ final class QRCodeCoordinatorTests: XCTestCase {
 
         guard let qrCodeViewController = (router.presentedViewController as? QRCodeNavigationController)?.topViewController as? QRCodeViewController
         else {
-            XCTFail("The QRCodeViewController has to exists")
+            XCTFail("The QRCodeViewController has to exist")
             return
         }
         // Since there is no capture capture device set, the controller should call dismiss on viewDidLoad()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/QRCodeCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/QRCodeCoordinatorTests.swift
@@ -70,8 +70,19 @@ final class QRCodeCoordinatorTests: XCTestCase {
             XCTFail("The QRCodeViewController has to exist")
             return
         }
-        // Since there is no capture capture device set, the controller should call dismiss on viewDidLoad()
+        // Since there is no capture device set, the controller should call dismiss on viewDidLoad()
         qrCodeViewController.loadViewIfNeeded()
+        XCTAssertEqual(parentCoordinator.didFinishCalled, 1)
+    }
+
+    func testShowQRCode_callsDidFinishOnParentCoordinator_whenRouterCompletionIsCalled() {
+        let subject = createSubject()
+        let delegate = MockQRCodeViewControllerDelegate()
+
+        subject.showQRCode(delegate: delegate)
+
+        router.savedCompletion?()
+
         XCTAssertEqual(parentCoordinator.didFinishCalled, 1)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/QRCodeCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/QRCodeCoordinatorTests.swift
@@ -31,14 +31,47 @@ final class QRCodeCoordinatorTests: XCTestCase {
         XCTAssertTrue(router.presentedViewController is QRCodeNavigationController)
     }
 
+    func testShowQRCode_setsDelegate() {
+        let subject = createSubject()
+        let delegate = MockQRCodeViewControllerDelegate()
+
+        subject.showQRCode(delegate: delegate)
+
+        guard let qrCodeViewController = (router.presentedViewController as? QRCodeNavigationController)?.topViewController as? QRCodeViewController
+        else {
+            XCTFail("The QRCodeViewController has to exists")
+            return
+        }
+        XCTAssertTrue(qrCodeViewController.qrCodeDelegate is MockQRCodeViewControllerDelegate)
+    }
+
+    func testShowQRCode_setsDismissHandler() {
+        let subject = createSubject()
+        let delegate = MockQRCodeViewControllerDelegate()
+
+        subject.showQRCode(delegate: delegate)
+
+        guard let qrCodeViewController = (router.presentedViewController as? QRCodeNavigationController)?.topViewController as? QRCodeViewController
+        else {
+            XCTFail("The QRCodeViewController has to exists")
+            return
+        }
+        XCTAssertTrue(qrCodeViewController.dismissHandler is QRCodeCoordinator)
+    }
+
     func testShowQRCode_callsDidFinishOnParentCoordinator() {
         let subject = createSubject()
         let delegate = MockQRCodeViewControllerDelegate()
 
         subject.showQRCode(delegate: delegate)
-        router.savedCompletion?()
 
-        XCTAssertNotNil(router.savedCompletion)
+        guard let qrCodeViewController = (router.presentedViewController as? QRCodeNavigationController)?.topViewController as? QRCodeViewController
+        else {
+            XCTFail("The QRCodeViewController has to exists")
+            return
+        }
+        // Since there is no capture capture device set, the controller should call dismiss on viewDidLoad()
+        qrCodeViewController.loadViewIfNeeded()
         XCTAssertEqual(parentCoordinator.didFinishCalled, 1)
     }
 

--- a/nimbus-features/qrCodeCoordinatorRefactor.yaml
+++ b/nimbus-features/qrCodeCoordinatorRefactor.yaml
@@ -8,11 +8,11 @@ features:
         description: >
           Enables the feature
         type: Boolean
-        default: false
+        default: true
     defaults:
       - channel: beta
         value:
-          enabled: false
+          enabled: true
       - channel: developer
         value:
           enabled: true

--- a/nimbus-features/qrCodeCoordinatorRefactor.yaml
+++ b/nimbus-features/qrCodeCoordinatorRefactor.yaml
@@ -15,5 +15,5 @@ features:
           enabled: false
       - channel: developer
         value:
-          enabled: false
+          enabled: true
 


### PR DESCRIPTION
## :scroll: Tickets
### Add QRCodeCoordinator to production code.
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6507)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14601)

### Enable QRCodeCoordinatorRefactor feature by default.
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7445)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16490)

## :bulb: Description

Add `QRCodeCoordinator` to production code. Add `QRCodeDismissHandler` protocol to handle dismiss of `QRCodeViewController` from `QRCodeCoordinator`. Turn on by default QRCodeCoordinatorRefactor feature.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

