### PR TITLE
Bump [v122] Update Sentry to version 8.17.1

### DIFF
--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
             exact: "2.0.0"),
         .package(
             url: "https://github.com/getsentry/sentry-cocoa.git",
-            exact: "8.17.0"),
+            exact: "8.17.1"),
     ],
     targets: [
         .target(

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -19887,7 +19887,7 @@
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa.git";
 			requirement = {
 				kind = exactVersion;
-				version = 8.17.0;
+				version = 8.17.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "a3e15ba9fd6c8efc6515ad9d6f3337bb2dc2e1e3",
-        "version" : "8.17.0"
+        "revision" : "74cf23b2946c92550fb1185612077151497e648e",
+        "version" : "8.17.1"
       }
     },
     {


### PR DESCRIPTION
Changelog: https://github.com/getsentry/sentry-cocoa/releases/tag/8.17.1

If whoever reviews this could also looking at the Focus bump (https://github.com/mozilla-mobile/focus-ios/pull/3932), I would also appreciate it!