### PR TITLE
Refactor FXIOS-7864 [v122]  Renaming and refactor of CreditCardHellper

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -25,7 +25,7 @@
 		0B75AEA91AC20FB20015E5DC /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B8E0FF31A932BD500161DC3 /* ImageIO.framework */; };
 		0B7C1E951F6097AD006A8869 /* TrackingProtectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7C1E941F6097AD006A8869 /* TrackingProtectionTests.swift */; };
 		0B8E0FF41A932BD500161DC3 /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B8E0FF31A932BD500161DC3 /* ImageIO.framework */; };
-		0BA02DB22942605600C92603 /* CreditCardHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA02DB12942605600C92603 /* CreditCardHelper.swift */; };
+		0BA02DB22942605600C92603 /* FormAutofillHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA02DB12942605600C92603 /* FormAutofillHelper.swift */; };
 		0BA1E00E1B03FB0B007675AF /* NetError.html in Resources */ = {isa = PBXBuildFile; fileRef = 0BA1E00D1B03FB0B007675AF /* NetError.html */; };
 		0BA1E0301B051A07007675AF /* NetError.css in Resources */ = {isa = PBXBuildFile; fileRef = 0BA1E02F1B051A07007675AF /* NetError.css */; };
 		0BA8964B1A250E6500C1010C /* ProfileTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA896491A250E6500C1010C /* ProfileTest.swift */; };
@@ -887,6 +887,11 @@
 		B15058812AA0A878008B7382 /* OpeningScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15058802AA0A878008B7382 /* OpeningScreenTests.swift */; };
 		B2999FED2B044A5900F0FEC1 /* UnencryptedCreditCardFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2999FEC2B044A5900F0FEC1 /* UnencryptedCreditCardFields.swift */; };
 		B2999FEF2B044B4E00F0FEC1 /* RustAutofillEncryptionKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2999FEE2B044B4E00F0FEC1 /* RustAutofillEncryptionKeys.swift */; };
+		B2999FF12B194A5800F0FEC1 /* CreditCardPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2999FF02B194A5800F0FEC1 /* CreditCardPayload.swift */; };
+		B2999FF32B194A8300F0FEC1 /* FillCreditCardForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2999FF22B194A8300F0FEC1 /* FillCreditCardForm.swift */; };
+		B2999FF52B194AB200F0FEC1 /* FormAutofillHelperError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2999FF42B194AB200F0FEC1 /* FormAutofillHelperError.swift */; };
+		B2999FF72B194ADE00F0FEC1 /* FormAutofillPayloadType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2999FF62B194ADE00F0FEC1 /* FormAutofillPayloadType.swift */; };
+		B2999FFA2B1A3E0700F0FEC1 /* AddressAutofillPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2999FF92B1A3E0700F0FEC1 /* AddressAutofillPayload.swift */; };
 		B640467E29B9B58200C5C7B6 /* TabLocationViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B640467D29B9B58200C5C7B6 /* TabLocationViewTests.swift */; };
 		BCFF93EE2AAA9F6E005B5B71 /* RustFirefoxSuggest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF93ED2AAA9C47005B5B71 /* RustFirefoxSuggest.swift */; };
 		BCFF93F02AABA55A005B5B71 /* BackgroundFirefoxSuggestIngestUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF93EF2AAB97A8005B5B71 /* BackgroundFirefoxSuggestIngestUtility.swift */; };
@@ -1963,7 +1968,7 @@
 		0B8E0FF31A932BD500161DC3 /* ImageIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ImageIO.framework; path = System/Library/Frameworks/ImageIO.framework; sourceTree = SDKROOT; };
 		0B98487A9E51F379857B3592 /* hi-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "hi-IN"; path = "hi-IN.lproj/ErrorPages.strings"; sourceTree = "<group>"; };
 		0B9D40781E8D5AC80059E664 /* XCUITests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCUITests-Bridging-Header.h"; sourceTree = "<group>"; };
-		0BA02DB12942605600C92603 /* CreditCardHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditCardHelper.swift; sourceTree = "<group>"; };
+		0BA02DB12942605600C92603 /* FormAutofillHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormAutofillHelper.swift; sourceTree = "<group>"; };
 		0BA049CE9929DAA536A2CB2F /* es-MX */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-MX"; path = "es-MX.lproj/3DTouchActions.strings"; sourceTree = "<group>"; };
 		0BA1E00D1B03FB0B007675AF /* NetError.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = NetError.html; sourceTree = "<group>"; };
 		0BA1E02F1B051A07007675AF /* NetError.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; path = NetError.css; sourceTree = "<group>"; };
@@ -5716,6 +5721,11 @@
 		B2944B3EAFB1DA22E7F28520 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Shared.strings; sourceTree = "<group>"; };
 		B2999FEC2B044A5900F0FEC1 /* UnencryptedCreditCardFields.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnencryptedCreditCardFields.swift; sourceTree = "<group>"; };
 		B2999FEE2B044B4E00F0FEC1 /* RustAutofillEncryptionKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustAutofillEncryptionKeys.swift; sourceTree = "<group>"; };
+		B2999FF02B194A5800F0FEC1 /* CreditCardPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditCardPayload.swift; sourceTree = "<group>"; };
+		B2999FF22B194A8300F0FEC1 /* FillCreditCardForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FillCreditCardForm.swift; sourceTree = "<group>"; };
+		B2999FF42B194AB200F0FEC1 /* FormAutofillHelperError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormAutofillHelperError.swift; sourceTree = "<group>"; };
+		B2999FF62B194ADE00F0FEC1 /* FormAutofillPayloadType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormAutofillPayloadType.swift; sourceTree = "<group>"; };
+		B2999FF92B1A3E0700F0FEC1 /* AddressAutofillPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressAutofillPayload.swift; sourceTree = "<group>"; };
 		B2BA445A91E19959BA9FDED7 /* mr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = mr; path = mr.lproj/FindInPage.strings; sourceTree = "<group>"; };
 		B2C74A199A0619104A7635EC /* bs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bs; path = bs.lproj/ClearPrivateData.strings; sourceTree = "<group>"; };
 		B2CD44128F18BC81432BBB4C /* gu-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "gu-IN"; path = "gu-IN.lproj/Search.strings"; sourceTree = "<group>"; };
@@ -8867,6 +8877,7 @@
 		8AD40FB827BAD1DD00672675 /* TabContentsScripts */ = {
 			isa = PBXGroup;
 			children = (
+				B2999FF82B194B3D00F0FEC1 /* FormAutofillHelper */,
 				D0FCF7F41FE45842004A7995 /* UserScriptManager.swift */,
 				D3B6923E1B9F9A58004B87A4 /* FindInPageHelper.swift */,
 				D01017F4219CB6BD009CBB5A /* DownloadContentScript.swift */,
@@ -8879,7 +8890,6 @@
 				F35B8D2C1D6383E9008E3D61 /* SessionRestoreHelper.swift */,
 				D0E55C4E1FB4FD23006DC274 /* FormPostHelper.swift */,
 				39F4C1092045DB2E00746155 /* FocusHelper.swift */,
-				0BA02DB12942605600C92603 /* CreditCardHelper.swift */,
 			);
 			path = TabContentsScripts;
 			sourceTree = "<group>";
@@ -9205,6 +9215,19 @@
 				ABEF80D42A254185003F52C4 /* CreditCardBottomSheetFooterView.swift */,
 			);
 			path = CreditCardBottomSheet;
+			sourceTree = "<group>";
+		};
+		B2999FF82B194B3D00F0FEC1 /* FormAutofillHelper */ = {
+			isa = PBXGroup;
+			children = (
+				0BA02DB12942605600C92603 /* FormAutofillHelper.swift */,
+				B2999FF02B194A5800F0FEC1 /* CreditCardPayload.swift */,
+				B2999FF92B1A3E0700F0FEC1 /* AddressAutofillPayload.swift */,
+				B2999FF22B194A8300F0FEC1 /* FillCreditCardForm.swift */,
+				B2999FF42B194AB200F0FEC1 /* FormAutofillHelperError.swift */,
+				B2999FF62B194ADE00F0FEC1 /* FormAutofillPayloadType.swift */,
+			);
+			path = FormAutofillHelper;
 			sourceTree = "<group>";
 		};
 		C22753422A3CA25100B9C0D1 /* WebsiteDataManagement */ = {
@@ -12686,6 +12709,7 @@
 				CAA3B7E62497DCB60094E3C1 /* LoginDataSource.swift in Sources */,
 				8ADC2A1B2A33998100543DAA /* AppStoreReviewSetting.swift in Sources */,
 				8A5D1CA82A30D6D3005AD35C /* HomeSetting.swift in Sources */,
+				B2999FFA2B1A3E0700F0FEC1 /* AddressAutofillPayload.swift in Sources */,
 				1DFE57FF27BAE3150025DE58 /* HomepageSectionType.swift in Sources */,
 				C2D1A10D2A66C70000205DCC /* BookmarksCoordinator.swift in Sources */,
 				396E38F11EE0C8EC00CC180F /* FxAPushMessageHandler.swift in Sources */,
@@ -12848,6 +12872,7 @@
 				C8BD87622A0C257C00CD803A /* OnboardingCardInfoModelProtocol.swift in Sources */,
 				DA27EEDB28BADF4700DD6F5D /* MenuBuilderHelper.swift in Sources */,
 				E16AD22C2A8A7AE800F0AA58 /* FakespotHighlightsCardView.swift in Sources */,
+				B2999FF12B194A5800F0FEC1 /* CreditCardPayload.swift in Sources */,
 				E1877A81286E0EFD00F5BDF2 /* WebViewNavigationHandler.swift in Sources */,
 				274A36CC239EB99400A21587 /* LibraryPanelContextMenu.swift in Sources */,
 				D314E7F71A37B98700426A76 /* TabToolbar.swift in Sources */,
@@ -12937,6 +12962,7 @@
 				AB65F8B12AFA38E90088D6FC /* FakespotImageLoadingView.swift in Sources */,
 				5A70EF21295E3E0B00790249 /* UnitTestSceneDelegate.swift in Sources */,
 				2C49854E206173C800893DAE /* photon-colors.swift in Sources */,
+				B2999FF72B194ADE00F0FEC1 /* FormAutofillPayloadType.swift in Sources */,
 				8A285B08294A5D4C00149B0F /* HomepageHeroImageViewModel.swift in Sources */,
 				8C92DE8B2A711ED60090BD28 /* FakespotClient.swift in Sources */,
 				8AC1065F28D0CD700013263A /* OpenQLPreviewHelper.swift in Sources */,
@@ -12961,6 +12987,7 @@
 				C22753402A3C9E1300B9C0D1 /* WebsiteDataManagementViewModel.swift in Sources */,
 				2F44FCC71A9E8CF500FD20CC /* SearchSettingsTableViewController.swift in Sources */,
 				8AD3271527E3B45D00EAF033 /* SponsoredTile.swift in Sources */,
+				B2999FF32B194A8300F0FEC1 /* FillCreditCardForm.swift in Sources */,
 				5A64225129CB506500EEC3E5 /* LegacyTabManager.swift in Sources */,
 				8A93F86029D36EBD004159D9 /* Router.swift in Sources */,
 				C8417D222657F0600010B877 /* LibraryViewModel.swift in Sources */,
@@ -12979,6 +13006,7 @@
 				E1442FD4294782D9003680B0 /* URL+Mail.swift in Sources */,
 				9636D92827F5D72D00771F5E /* GleanPlumbMessageManager.swift in Sources */,
 				C80685D126A0C93900DCD895 /* UserResearch.swift in Sources */,
+				B2999FF52B194AB200F0FEC1 /* FormAutofillHelperError.swift in Sources */,
 				8AED23C527AC1F9500DE7E97 /* BaseContentStackView.swift in Sources */,
 				C8699131289176A5007ACC5C /* WallpaperNetworking.swift in Sources */,
 				5A271ABD2860B0D700471CE4 /* WebServerUtil.swift in Sources */,
@@ -13191,7 +13219,7 @@
 				EBE26B57220C959D00D1D99A /* BrowserViewController+TabToolbarDelegate.swift in Sources */,
 				8A3EF7F02A2FCF3100796E3A /* HiddenSettings.swift in Sources */,
 				AB03032B2AB47AF300DCD8EF /* FakespotOptInCardView.swift in Sources */,
-				0BA02DB22942605600C92603 /* CreditCardHelper.swift in Sources */,
+				0BA02DB22942605600C92603 /* FormAutofillHelper.swift in Sources */,
 				8A19ACB82A329128001C2147 /* PrivacyPolicySetting.swift in Sources */,
 				E68AEDB01B18F81A00133D99 /* SwipeAnimator.swift in Sources */,
 				1DDE3DB32AC34E1E0039363B /* TabCell.swift in Sources */,

--- a/Client/Coordinators/CredentialAutofillCoordinator.swift
+++ b/Client/Coordinators/CredentialAutofillCoordinator.swift
@@ -83,10 +83,10 @@ class CredentialAutofillCoordinator: BaseCoordinator {
                 self.parentCoordinator?.didFinish(from: self)
                 return
             }
-            CreditCardHelper.injectCardInfo(logger: self.logger,
-                                            card: plainTextCard,
-                                            tab: currentTab,
-                                            frame: frame) { error in
+            FormAutofillHelper.injectCardInfo(logger: self.logger,
+                                              card: plainTextCard,
+                                              tab: currentTab,
+                                              frame: frame) { error in
                 guard let error = error else {
                     return
                 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1753,10 +1753,10 @@ class BrowserViewController: UIViewController,
                 self?.showCreditCardAutofillSheet(fieldValues: fieldValues)
                 break
             case .fillAddressForm:
-                // TODO: FXIOS-7670
+                // TODO: FXIOS-7670 Address Autofill UX
                 return
             case .captureAddressForm:
-                // TODO: FXIOS-7670
+                // TODO: FXIOS-7670 Address Autofill UX
                 return
             }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1723,9 +1723,9 @@ class BrowserViewController: UIViewController,
 
         let autofillCreditCardStatus = featureFlags.isFeatureEnabled(
             .creditCardAutofillStatus, checking: .buildOnly)
-        let creditCardHelper = CreditCardHelper(tab: tab)
-        tab.addContentScript(creditCardHelper, name: CreditCardHelper.name())
-        creditCardHelper.foundFieldValues = { [weak self] fieldValues, type, frame in
+        let formAutofillHelper = FormAutofillHelper(tab: tab)
+        tab.addContentScript(formAutofillHelper, name: FormAutofillHelper.name())
+        formAutofillHelper.foundFieldValues = { [weak self] fieldValues, type, frame in
             guard let tabWebView = tab.webView,
                   let type = type,
                   userDefaults.object(forKey: keyCreditCardAutofill) as? Bool ?? true
@@ -1752,6 +1752,12 @@ class BrowserViewController: UIViewController,
             case .formSubmit:
                 self?.showCreditCardAutofillSheet(fieldValues: fieldValues)
                 break
+            case .fillAddressForm:
+                // TODO: FXIOS-7670
+                return
+            case .captureAddressForm:
+                // TODO: FXIOS-7670
+                return
             }
 
             tabWebView.accessoryView.savedCardsClosure = {

--- a/Client/Frontend/TabContentsScripts/FormAutofillHelper/AddressAutofillPayload.swift
+++ b/Client/Frontend/TabContentsScripts/FormAutofillHelper/AddressAutofillPayload.swift
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+// TO DO: FXIOS-7872
+// struct AddressAutofillPayload: Codable {
+//     enum CodingKeys: String, CodingKey, CaseIterable {
+//     }
+// }

--- a/Client/Frontend/TabContentsScripts/FormAutofillHelper/AddressAutofillPayload.swift
+++ b/Client/Frontend/TabContentsScripts/FormAutofillHelper/AddressAutofillPayload.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-// TO DO: FXIOS-7872
+// TO DO: FXIOS-7872 Implement Address Autofill Payloads
 // struct AddressAutofillPayload: Codable {
 //     enum CodingKeys: String, CodingKey, CaseIterable {
 //     }

--- a/Client/Frontend/TabContentsScripts/FormAutofillHelper/CreditCardPayload.swift
+++ b/Client/Frontend/TabContentsScripts/FormAutofillHelper/CreditCardPayload.swift
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+struct CreditCardPayload: Codable {
+    let ccNumber: String
+    let ccExpMonth: String
+    let ccExpYear: String
+    let ccName: String
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case ccNumber = "cc-number"
+        case ccExpMonth = "cc-exp-month"
+        case ccExpYear = "cc-exp-year"
+        case ccName = "cc-name"
+    }
+}

--- a/Client/Frontend/TabContentsScripts/FormAutofillHelper/FillCreditCardForm.swift
+++ b/Client/Frontend/TabContentsScripts/FormAutofillHelper/FillCreditCardForm.swift
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+struct FillCreditCardForm: Codable {
+    let creditCardPayload: CreditCardPayload
+    let type: String
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case creditCardPayload = "payload"
+        case type = "type"
+    }
+}

--- a/Client/Frontend/TabContentsScripts/FormAutofillHelper/FormAutofillHelperError.swift
+++ b/Client/Frontend/TabContentsScripts/FormAutofillHelper/FormAutofillHelperError.swift
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// `FormAutofillHelperError` enumerates possible errors that may occur during  Autofill information injection
+/// within the `FormAutofillHelper` class. This conforms to the Swift `Error` protocol, allowing for structured
+/// error handling and providing clear and specific indications of potential issues in the injection process.
+enum FormAutofillHelperError: Error {
+    /// Indicates an issue with the injection process in the context of the `FormAutofillHelper` class.
+    case injectionIssue
+
+    /// Indicates that the credit card information provided for injection contains invalid or missing fields.
+    case injectionInvalidFields
+
+    /// Indicates an issue with the generation or serialization of the JSON payload during the injection process.
+    case injectionInvalidJSON
+}

--- a/Client/Frontend/TabContentsScripts/FormAutofillHelper/FormAutofillPayloadType.swift
+++ b/Client/Frontend/TabContentsScripts/FormAutofillHelper/FormAutofillPayloadType.swift
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// `FormAutofillPayloadType` enumerates the different types of payloads that the `FormAutofillHelper` class
+/// may encounter during the autofill process. Each case represents a specific action related to credit card
+/// or address form interaction, providing a clear and structured way to identify and handle different payload scenarios.
+enum FormAutofillPayloadType: String {
+    /// Indicates a payload type for capturing credit card information from a form submission.
+    case formSubmit = "capture-credit-card-form"
+
+    /// Indicates a payload type for filling credit card information into a form.
+    case formInput = "fill-credit-card-form"
+
+    /// Indicates a payload type for filling address information into a form.
+    case fillAddressForm = "fill-address-form"
+
+    /// Indicates a payload type for capturing address information from a form submission.
+    case captureAddressForm = "capture-address-form"
+}

--- a/Client/TabManagement/Tab.swift
+++ b/Client/TabManagement/Tab.swift
@@ -983,19 +983,19 @@ class TabWebView: WKWebView, MenuHelperInterface, ThemeApplicable {
 
         accessoryView.previousClosure = { [weak self] in
             guard let self else { return }
-            CreditCardHelper.focusPreviousInputField(tabWebView: self,
+            FormAutofillHelper.focusPreviousInputField(tabWebView: self,
                                                      logger: self.logger)
         }
 
         accessoryView.nextClosure = { [weak self] in
             guard let self else { return }
-            CreditCardHelper.focusNextInputField(tabWebView: self,
+            FormAutofillHelper.focusNextInputField(tabWebView: self,
                                                  logger: self.logger)
         }
 
         accessoryView.doneClosure = { [weak self] in
             guard let self else { return }
-            CreditCardHelper.blurActiveElement(tabWebView: self, logger: self.logger)
+            FormAutofillHelper.blurActiveElement(tabWebView: self, logger: self.logger)
             self.endEditing(true)
         }
     }

--- a/Client/TabManagement/Tab.swift
+++ b/Client/TabManagement/Tab.swift
@@ -984,13 +984,13 @@ class TabWebView: WKWebView, MenuHelperInterface, ThemeApplicable {
         accessoryView.previousClosure = { [weak self] in
             guard let self else { return }
             FormAutofillHelper.focusPreviousInputField(tabWebView: self,
-                                                     logger: self.logger)
+                                                       logger: self.logger)
         }
 
         accessoryView.nextClosure = { [weak self] in
             guard let self else { return }
             FormAutofillHelper.focusNextInputField(tabWebView: self,
-                                                 logger: self.logger)
+                                                   logger: self.logger)
         }
 
         accessoryView.doneClosure = { [weak self] in

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardHelperTests.swift
@@ -10,8 +10,8 @@ import Shared
 import Common
 import Storage
 
-class CreditCardHelperTests: XCTestCase {
-    var creditCardHelper: CreditCardHelper!
+class FormAutofillHelperTests: XCTestCase {
+    var formAutofillHelper: FormAutofillHelper!
     var tab: Tab!
     var profile: MockProfile!
     var validMockWKMessage: MockWKScriptMessage!
@@ -49,7 +49,7 @@ class CreditCardHelperTests: XCTestCase {
         DependencyHelperMock().bootstrapDependencies()
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
         tab = Tab(profile: profile, configuration: WKWebViewConfiguration())
-        creditCardHelper = CreditCardHelper(tab: tab)
+        formAutofillHelper = FormAutofillHelper(tab: tab)
         guard let jsonData = validMockPayloadJson.data(using: .utf8),
               let dictionary = try? JSONSerialization.jsonObject(
                 with: jsonData,
@@ -75,7 +75,7 @@ class CreditCardHelperTests: XCTestCase {
         profile = nil
         DependencyHelperMock().reset()
         tab = nil
-        creditCardHelper = nil
+        formAutofillHelper = nil
         validMockWKMessage = nil
         validPayloadCaptureMockWKMessage = nil
     }
@@ -89,7 +89,7 @@ class CreditCardHelperTests: XCTestCase {
                                                ccExpMonth: 12,
                                                ccExpYear: 2023,
                                                ccType: "VISA")
-        let json = CreditCardHelper.injectionJSONBuilder(card: card)
+        let json = FormAutofillHelper.injectionJSONBuilder(card: card)
         XCTAssertEqual(json["cc-name"] as? String, "John Doe")
         XCTAssertEqual(json["cc-number"] as? String, "1234567812345678")
         XCTAssertEqual(json["cc-exp-month"] as? String, "12")
@@ -104,7 +104,7 @@ class CreditCardHelperTests: XCTestCase {
                                                ccExpMonth: 12,
                                                ccExpYear: 2023,
                                                ccType: "VISA")
-        let json = CreditCardHelper.injectionJSONBuilder(card: card)
+        let json = FormAutofillHelper.injectionJSONBuilder(card: card)
         XCTAssertEqual(json["cc-name"] as? String, "&lt;John Doe&gt;")
         XCTAssertEqual(json["cc-number"] as? String, "1234567812345678")
         XCTAssertEqual(json["cc-exp-month"] as? String, "12")
@@ -119,7 +119,7 @@ class CreditCardHelperTests: XCTestCase {
                                                ccExpMonth: 12,
                                                ccExpYear: 2023,
                                                ccType: "VISA")
-        let json = CreditCardHelper.injectionJSONBuilder(card: card)
+        let json = FormAutofillHelper.injectionJSONBuilder(card: card)
         XCTAssertEqual(json["cc-name"] as? String, "&lt;script&gt;alert(&#39;XSS&#39;)&lt;/script&gt;")
         XCTAssertEqual(json["cc-number"] as? String, "1234567812345678")
         XCTAssertEqual(json["cc-exp-month"] as? String, "12")
@@ -134,7 +134,7 @@ class CreditCardHelperTests: XCTestCase {
                                                ccExpMonth: 12,
                                                ccExpYear: 2023,
                                                ccType: "VISA")
-        let json = CreditCardHelper.injectionJSONBuilder(card: card)
+        let json = FormAutofillHelper.injectionJSONBuilder(card: card)
         XCTAssertEqual(json["cc-name"] as? String, "&amp;quot;John Doe&amp;quot;")
         XCTAssertEqual(json["cc-number"] as? String, "1234567812345678")
         XCTAssertEqual(json["cc-exp-month"] as? String, "12")
@@ -143,15 +143,15 @@ class CreditCardHelperTests: XCTestCase {
     }
 
     func test_getValidPayloadData() {
-        XCTAssertNotNil(creditCardHelper.getValidPayloadData(from: validMockWKMessage))
-        XCTAssertNotNil(creditCardHelper.getValidPayloadData(from: validPayloadCaptureMockWKMessage))
+        XCTAssertNotNil(formAutofillHelper.getValidPayloadData(from: validMockWKMessage))
+        XCTAssertNotNil(formAutofillHelper.getValidPayloadData(from: validPayloadCaptureMockWKMessage))
     }
 
     func test_parseFieldType_valid() {
-        let messageBodyDict = creditCardHelper.getValidPayloadData(from: validMockWKMessage)
-        let messageFields = creditCardHelper.parseFieldType(messageBody: messageBodyDict!)
+        let messageBodyDict = formAutofillHelper.getValidPayloadData(from: validMockWKMessage)
+        let messageFields = formAutofillHelper.parseFieldType(messageBody: messageBodyDict!)
         XCTAssertNotNil(messageFields)
-        XCTAssertEqual(messageFields!.type, CreditCardPayloadType.formInput.rawValue)
+        XCTAssertEqual(messageFields!.type, FormAutofillPayloadType.formInput.rawValue)
         XCTAssertEqual(messageFields!.creditCardPayload.ccExpMonth, "03")
         XCTAssertEqual(messageFields!.creditCardPayload.ccExpYear, "2999")
         XCTAssertEqual(messageFields!.creditCardPayload.ccName, "Josh Moustache")
@@ -159,10 +159,10 @@ class CreditCardHelperTests: XCTestCase {
     }
 
     func test_parseFieldCaptureJsonType_valid() {
-        let messageBodyDict = creditCardHelper.getValidPayloadData(from: validPayloadCaptureMockWKMessage)
-        let messageFields = creditCardHelper.parseFieldType(messageBody: messageBodyDict!)
+        let messageBodyDict = formAutofillHelper.getValidPayloadData(from: validPayloadCaptureMockWKMessage)
+        let messageFields = formAutofillHelper.parseFieldType(messageBody: messageBodyDict!)
         XCTAssertNotNil(messageFields)
-        XCTAssertEqual(messageFields!.type, CreditCardPayloadType.formSubmit.rawValue)
+        XCTAssertEqual(messageFields!.type, FormAutofillPayloadType.formSubmit.rawValue)
         XCTAssertEqual(messageFields!.creditCardPayload.ccExpMonth, "03")
         XCTAssertEqual(messageFields!.creditCardPayload.ccExpYear, "2999")
         XCTAssertEqual(messageFields!.creditCardPayload.ccName, "Josh Moustache")
@@ -172,10 +172,10 @@ class CreditCardHelperTests: XCTestCase {
     // MARK: Retrieval
 
     func test_getFieldTypeValues() {
-        let messageBodyDict = creditCardHelper.getValidPayloadData(from: validMockWKMessage)
-        let messageFields = creditCardHelper.parseFieldType(messageBody: messageBodyDict!)
+        let messageBodyDict = formAutofillHelper.getValidPayloadData(from: validMockWKMessage)
+        let messageFields = formAutofillHelper.parseFieldType(messageBody: messageBodyDict!)
         XCTAssertNotNil(messageFields)
-        let fieldValues = creditCardHelper.getFieldTypeValues(payload: messageFields!.creditCardPayload)
+        let fieldValues = formAutofillHelper.getFieldTypeValues(payload: messageFields!.creditCardPayload)
         XCTAssertEqual(fieldValues.ccExpMonth, 3)
         XCTAssertEqual(fieldValues.ccExpYear, 2999)
         XCTAssertEqual(fieldValues.ccName, "Josh Moustache")
@@ -185,17 +185,17 @@ class CreditCardHelperTests: XCTestCase {
 
     // MARK: Leaks
 
-    func test_creditCardHelper_basicCreation_doesntLeak() {
-        let subject = CreditCardHelper(tab: tab)
+    func test_formAutofillHelper_basicCreation_doesntLeak() {
+        let subject = FormAutofillHelper(tab: tab)
         trackForMemoryLeaks(subject)
     }
 
-    func test_creditCardHelper_foundFieldValuesClosure_doesntLeak() {
+    func test_formAutofillHelper_foundFieldValuesClosure_doesntLeak() {
         let tab = Tab(profile: profile, configuration: WKWebViewConfiguration())
-        let subject = CreditCardHelper(tab: tab)
+        let subject = FormAutofillHelper(tab: tab)
         trackForMemoryLeaks(subject)
         tab.createWebview()
-        tab.addContentScript(subject, name: CreditCardHelper.name())
+        tab.addContentScript(subject, name: FormAutofillHelper.name())
 
         subject.foundFieldValues = { fieldValues, type, frame in
             guard let tabWebView = tab.webView else { return }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardHelperTests.swift
@@ -185,7 +185,7 @@ class FormAutofillHelperTests: XCTestCase {
 
     // MARK: Leaks
 
-    func test_formAutofillHelper_basicCreation_doesntLeak() {
+    func testFormAutofillHelperBasicCreationDoesntLeak() {
         let subject = FormAutofillHelper(tab: tab)
         trackForMemoryLeaks(subject)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7864)

## :bulb: Description
Refactored the CreditCardHelper class, renaming it to FormAutofillHelper, and created new files for CreditCardPayload, AddressAutofillPayload, FillCreditCardForm, FormAutofillHelperError, and FormAutofillPayloadType. This separation of concerns aims to achieve cleaner code by organizing related functionalities into distinct files.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

