### PR TITLE
Refactor FXIOS-7863 [v122] Remove TabManagerMiddleware dependency on global TabManager

### DIFF
--- a/BrowserKit/Sources/TabDataStore/WindowData.swift
+++ b/BrowserKit/Sources/TabDataStore/WindowData.swift
@@ -6,7 +6,7 @@ import Foundation
 
 public struct WindowData: Codable {
     // TODO: [7798] Part of WIP iPad multi-window epic.
-    public static let DefaultSingleWindowUUID = UUID(uuidString:"44BA0B7D-097A-484D-8358-91A6E374451D")!
+    public static let DefaultSingleWindowUUID = UUID(uuidString: "44BA0B7D-097A-484D-8358-91A6E374451D")!
 
     public let id: UUID
     public let isPrimary: Bool

--- a/BrowserKit/Sources/TabDataStore/WindowData.swift
+++ b/BrowserKit/Sources/TabDataStore/WindowData.swift
@@ -5,6 +5,9 @@
 import Foundation
 
 public struct WindowData: Codable {
+    // TODO: [7798] Part of WIP iPad multi-window epic.
+    public static let DefaultSingleWindowUUID = UUID(uuidString:"44BA0B7D-097A-484D-8358-91A6E374451D")!
+
     public let id: UUID
     public let isPrimary: Bool
     public let activeTabId: UUID

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		1D3C90882ACE1AF400304C87 /* RemoteTabPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3C90872ACE1AF400304C87 /* RemoteTabPanelTests.swift */; };
 		1D5CBF492B17E3CB0001D033 /* NotificationPayloads.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D5CBF482B17E3CB0001D033 /* NotificationPayloads.swift */; };
 		1D5CBF4A2B17E3CB0001D033 /* NotificationPayloads.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D5CBF482B17E3CB0001D033 /* NotificationPayloads.swift */; };
+		1D5CBF4C2B1A76B20001D033 /* TabManagerAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D5CBF4B2B1A76B20001D033 /* TabManagerAction.swift */; };
 		1D69FF8D27B17286001F660E /* HomeLogoHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D69FF8C27B17285001F660E /* HomeLogoHeaderCell.swift */; };
 		1D7B78972ADF32590011E9F2 /* EventQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D7B78962ADF32590011E9F2 /* EventQueue.swift */; };
 		1D7B78992ADF328E0011E9F2 /* AppEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D7B78982ADF328E0011E9F2 /* AppEvent.swift */; };
@@ -2123,6 +2124,7 @@
 		1D2F68B02ACCA22000524B92 /* RemoteTabsEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabsEmptyView.swift; sourceTree = "<group>"; };
 		1D3C90872ACE1AF400304C87 /* RemoteTabPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabPanelTests.swift; sourceTree = "<group>"; };
 		1D5CBF482B17E3CB0001D033 /* NotificationPayloads.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPayloads.swift; sourceTree = "<group>"; };
+		1D5CBF4B2B1A76B20001D033 /* TabManagerAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerAction.swift; sourceTree = "<group>"; };
 		1D69FF8C27B17285001F660E /* HomeLogoHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeLogoHeaderCell.swift; sourceTree = "<group>"; };
 		1D774B3D9C6E21B77FB7B38F /* kab */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kab; path = kab.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
 		1D7B78962ADF32590011E9F2 /* EventQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventQueue.swift; sourceTree = "<group>"; };
@@ -7551,6 +7553,7 @@
 			children = (
 				219914042AF963F900153598 /* TabTrayAction.swift */,
 				219935E82B070F9000E5966F /* TabPanelAction.swift */,
+				1D5CBF4B2B1A76B20001D033 /* TabManagerAction.swift */,
 			);
 			path = Action;
 			sourceTree = "<group>";
@@ -12730,6 +12733,7 @@
 				E18259DF29B25E4F00E6BE76 /* UserNotificationCenterProtocol.swift in Sources */,
 				DFFC9AD12A681FA0002A6AAD /* NimbusFakespotFeatureLayer.swift in Sources */,
 				1DEBC55E2AC4ED70006E4801 /* RemoteTabsPanel.swift in Sources */,
+				1D5CBF4C2B1A76B20001D033 /* TabManagerAction.swift in Sources */,
 				435D660523D794B90046EFA2 /* UpdateViewModel.swift in Sources */,
 				9658143C29FAB610007339BD /* CreditCardInputFieldHelper.swift in Sources */,
 				215B457F27D7FD4B00E5E800 /* LegacyTabGroupData.swift in Sources */,

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -52,7 +52,7 @@ class BrowserCoordinator: BaseCoordinator,
         self.wallpaperManager = wallpaperManager
         super.init(router: router)
 
-        connectTabManagerToScene()
+        tabManagerDidConnectToScene()
         browserViewController.browserDelegate = self
         browserViewController.navigationHandler = self
         tabManager.addDelegate(self)
@@ -68,7 +68,7 @@ class BrowserCoordinator: BaseCoordinator,
 
     // MARK: - Helper methods
 
-    private func connectTabManagerToScene() {
+    private func tabManagerDidConnectToScene() {
         // [7863] [WIP] Redux: connect this Browser's TabManager to associated window scene
         guard ReduxFlagManager.isReduxEnabled else { return }
         let sceneUUID = WindowData.DefaultSingleWindowUUID

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -24,7 +24,7 @@ class BrowserCoordinator: BaseCoordinator,
     var homepageViewController: HomepageViewController?
 
     private var profile: Profile
-    private let tabManager: TabManager
+    let tabManager: TabManager
     private let themeManager: ThemeManager
     private let screenshotService: ScreenshotService
     private let glean: GleanWrapper

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -7,6 +7,8 @@ import Foundation
 import WebKit
 import Shared
 import Storage
+import Redux
+import TabDataStore
 
 class BrowserCoordinator: BaseCoordinator,
                           LaunchCoordinatorDelegate,
@@ -24,7 +26,7 @@ class BrowserCoordinator: BaseCoordinator,
     var homepageViewController: HomepageViewController?
 
     private var profile: Profile
-    let tabManager: TabManager
+    private let tabManager: TabManager
     private let themeManager: ThemeManager
     private let screenshotService: ScreenshotService
     private let glean: GleanWrapper
@@ -50,6 +52,7 @@ class BrowserCoordinator: BaseCoordinator,
         self.wallpaperManager = wallpaperManager
         super.init(router: router)
 
+        connectTabManagerToScene()
         browserViewController.browserDelegate = self
         browserViewController.navigationHandler = self
         tabManager.addDelegate(self)
@@ -64,6 +67,13 @@ class BrowserCoordinator: BaseCoordinator,
     }
 
     // MARK: - Helper methods
+
+    private func connectTabManagerToScene() {
+        // [7863] [WIP] Redux: connect this Browser's TabManager to associated window scene
+        guard ReduxFlagManager.isReduxEnabled else { return }
+        let sceneUUID = WindowData.DefaultSingleWindowUUID
+        store.dispatch(TabManagerAction.tabManagerDidConnectToScene(tabManager, sceneUUID))
+    }
 
     private func startLaunch(with launchType: LaunchType) {
         let launchCoordinator = LaunchCoordinator(router: router)

--- a/Client/Coordinators/Scene/SceneCoordinator.swift
+++ b/Client/Coordinators/Scene/SceneCoordinator.swift
@@ -109,8 +109,10 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
 
         let browserCoordinator = BrowserCoordinator(router: router,
                                                     screenshotService: screenshotService)
-        let sceneUUID = WindowData.DefaultSingleWindowUUID
-        store.dispatch(TabManagerAction.tabManagerDidConnectToScene(browserCoordinator.tabManager, sceneUUID))
+        if ReduxFlagManager.isReduxEnabled {
+            let sceneUUID = WindowData.DefaultSingleWindowUUID
+            store.dispatch(TabManagerAction.tabManagerDidConnectToScene(browserCoordinator.tabManager, sceneUUID))
+        }
         add(child: browserCoordinator)
         browserCoordinator.start(with: launchType)
 

--- a/Client/Coordinators/Scene/SceneCoordinator.swift
+++ b/Client/Coordinators/Scene/SceneCoordinator.swift
@@ -5,6 +5,10 @@
 import Common
 import UIKit
 import Shared
+import Redux
+import TabDataStore
+
+typealias SceneUUID = UUID
 
 /// Each scene has it's own scene coordinator, which is the root coordinator for a scene.
 class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinishedLoadingDelegate {
@@ -105,6 +109,8 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
 
         let browserCoordinator = BrowserCoordinator(router: router,
                                                     screenshotService: screenshotService)
+        let sceneUUID = WindowData.DefaultSingleWindowUUID
+        store.dispatch(TabManagerAction.tabManagerDidConnectToScene(browserCoordinator.tabManager, sceneUUID))
         add(child: browserCoordinator)
         browserCoordinator.start(with: launchType)
 

--- a/Client/Coordinators/Scene/SceneCoordinator.swift
+++ b/Client/Coordinators/Scene/SceneCoordinator.swift
@@ -5,8 +5,6 @@
 import Common
 import UIKit
 import Shared
-import Redux
-import TabDataStore
 
 typealias SceneUUID = UUID
 
@@ -109,10 +107,6 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
 
         let browserCoordinator = BrowserCoordinator(router: router,
                                                     screenshotService: screenshotService)
-        if ReduxFlagManager.isReduxEnabled {
-            let sceneUUID = WindowData.DefaultSingleWindowUUID
-            store.dispatch(TabManagerAction.tabManagerDidConnectToScene(browserCoordinator.tabManager, sceneUUID))
-        }
         add(child: browserCoordinator)
         browserCoordinator.start(with: launchType)
 

--- a/Client/Frontend/Browser/Tabs/Action/TabManagerAction.swift
+++ b/Client/Frontend/Browser/Tabs/Action/TabManagerAction.swift
@@ -1,0 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Redux
+
+enum TabManagerAction: Action {
+    case tabManagerDidConnectToScene(TabManager, SceneUUID)
+}

--- a/Client/Frontend/Browser/Tabs/TabManagerMiddleware.swift
+++ b/Client/Frontend/Browser/Tabs/TabManagerMiddleware.swift
@@ -4,15 +4,13 @@
 
 import Common
 import Redux
+import TabDataStore
 
 class TabManagerMiddleware {
-    var tabManager: TabManager
+    // TODO: [7863] Part of ongoing WIP for Redux + iPad Multi-window.
+    private var tabManagers: [SceneUUID: TabManager] = [:]
     var inactiveTabs = [InactiveTabsModel]()
     var selectedPanel: TabTrayPanelType = .tabs
-
-    init(tabManager: TabManager = AppContainer.shared.resolve()) {
-        self.tabManager = tabManager
-    }
 
     lazy var tabsPanelProvider: Middleware<AppState> = { state, action in
         switch action {
@@ -83,6 +81,8 @@ class TabManagerMiddleware {
             store.dispatch(TabPanelAction.refreshTab(tabs))
             store.dispatch(TabTrayAction.dismissTabTray)
 
+        case TabManagerAction.tabManagerDidConnectToScene(let manager, let sceneUUID):
+            self.setTabManager(manager, for: sceneUUID)
         default:
             break
         }
@@ -110,7 +110,7 @@ class TabManagerMiddleware {
 
     private func refreshTabs(for isPrivate: Bool) -> [TabModel] {
         var tabs = [TabModel]()
-        let tabManagerTabs = tabManager.tabs.filter { $0.isPrivate == isPrivate }
+        let tabManagerTabs = defaultTabManager.tabs.filter { $0.isPrivate == isPrivate }
         tabManagerTabs.forEach { tab in
             let tabModel = TabModel(tabUUID: tab.tabUUID,
                                     isSelected: false,
@@ -129,22 +129,22 @@ class TabManagerMiddleware {
 
     private func addNewTab(with urlRequest: URLRequest?, isPrivate: Bool) {
         // TODO: Add a guard to check if is dragging as per Legacy code
-        let tab = tabManager.addTab(urlRequest, isPrivate: isPrivate)
-        tabManager.selectTab(tab)
+        let tab = defaultTabManager.addTab(urlRequest, isPrivate: isPrivate)
+        defaultTabManager.selectTab(tab)
     }
 
     private func moveTab(from originIndex: Int, to destinationIndex: Int) {
-        tabManager.moveTab(isPrivate: false, fromIndex: originIndex, toIndex: destinationIndex)
+        defaultTabManager.moveTab(isPrivate: false, fromIndex: originIndex, toIndex: destinationIndex)
     }
 
     private func closeTab(with tabUUID: String) async -> Bool {
-        let isLastTab = tabManager.tabs.count == 1
-        await tabManager.removeTab(tabUUID)
+        let isLastTab = defaultTabManager.tabs.count == 1
+        await defaultTabManager.removeTab(tabUUID)
         return isLastTab
     }
 
     private func closeAllTabs(isPrivateMode: Bool) async {
-        await tabManager.removeAllTabs(isPrivateMode: isPrivateMode)
+        await defaultTabManager.removeAllTabs(isPrivateMode: isPrivateMode)
         inactiveTabs.removeAll()
     }
 
@@ -161,8 +161,21 @@ class TabManagerMiddleware {
     }
 
     private func selectTab(for tabUUID: String) {
-        guard let tab = tabManager.getTabForUUID(uuid: tabUUID) else { return }
+        guard let tab = defaultTabManager.getTabForUUID(uuid: tabUUID) else { return }
 
-        tabManager.selectTab(tab)
+        defaultTabManager.selectTab(tab)
+    }
+
+    private func setTabManager(_ tabManager: TabManager, for sceneUUID: SceneUUID) {
+        tabManagers[sceneUUID] = tabManager
+    }
+
+    private func removeTabManager(_ tabManager: TabManager, for sceneUUID: SceneUUID) {
+        tabManagers.removeValue(forKey: sceneUUID)
+    }
+
+    private var defaultTabManager: TabManager {
+        // TODO: [7863] Temporary. WIP for Redux + iPad Multi-window.
+        return tabManagers[WindowData.DefaultSingleWindowUUID]!
     }
 }

--- a/Client/Frontend/Browser/Tabs/TabManagerMiddleware.swift
+++ b/Client/Frontend/Browser/Tabs/TabManagerMiddleware.swift
@@ -8,7 +8,7 @@ import TabDataStore
 
 class TabManagerMiddleware {
     // TODO: [7863] Part of ongoing WIP for Redux + iPad Multi-window.
-    private var tabManagers: [SceneUUID: TabManager] = [:]
+    var tabManagers: [SceneUUID: TabManager] = [:]
     var inactiveTabs = [InactiveTabsModel]()
     var selectedPanel: TabTrayPanelType = .tabs
 

--- a/Client/TabManagement/TabManagerImplementation.swift
+++ b/Client/TabManagement/TabManagerImplementation.swift
@@ -218,7 +218,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
         Task {
             // This value should never be nil but we need to still treat it as if it can be nil until the old code is removed
             let activeTabID = UUID(uuidString: self.selectedTab?.tabUUID ?? "") ?? UUID()
-            // Hard coding the window ID until we later add multi-window support
+            // TODO: [7798] Hard coding the window ID until we later add multi-window support
             let windowData = WindowData(id: WindowData.DefaultSingleWindowUUID,
                                         activeTabId: activeTabID,
                                         tabData: self.generateTabDataForSaving())

--- a/Client/TabManagement/TabManagerImplementation.swift
+++ b/Client/TabManagement/TabManagerImplementation.swift
@@ -219,7 +219,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
             // This value should never be nil but we need to still treat it as if it can be nil until the old code is removed
             let activeTabID = UUID(uuidString: self.selectedTab?.tabUUID ?? "") ?? UUID()
             // Hard coding the window ID until we later add multi-window support
-            let windowData = WindowData(id: UUID(uuidString: "44BA0B7D-097A-484D-8358-91A6E374451D")!,
+            let windowData = WindowData(id: WindowData.DefaultSingleWindowUUID,
                                         activeTabId: activeTabID,
                                         tabData: self.generateTabDataForSaving())
             await tabDataStore.saveWindowData(window: windowData, forced: forced)

--- a/Client/TabManagement/TabMigrationUtility.swift
+++ b/Client/TabManagement/TabMigrationUtility.swift
@@ -94,7 +94,7 @@ class DefaultTabMigrationUtility: TabMigrationUtility {
             tabsToMigrate.append(tabData)
         }
 
-        let windowData = WindowData(id: UUID(uuidString: "44BA0B7D-097A-484D-8358-91A6E374451D")!,
+        let windowData = WindowData(id: WindowData.DefaultSingleWindowUUID,
                                     isPrimary: true,
                                     activeTabId: selectTabUUID ?? UUID(),
                                     tabData: tabsToMigrate)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7863)

This removes the dependency that Redux `TabManagerMiddleware` has on the global shared `TabManager`, instead allowing it to be injected on a per-scene basis.

For current `main` these changes are a pure refactor and have no effect, but they are necessary to unblock forthcoming work for [iPad multi-window support](https://mozilla-hub.atlassian.net/browse/FXIOS-7349). Aspects of this are still in flux and some of the code here (default UUID etc.) will eventually be removed once multi-window is further along.

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

