### PR TITLE
Bugfix FXIOS-7874 [v120] homepage crash

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataAdaptorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataAdaptorTests.swift
@@ -57,10 +57,9 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
     func testCalculateTopSitesData_hasGoogleTopSite_googlePrefsNil() {
         let subject = createSubject()
 
-        subject.recalculateTopSiteData(for: 6)
+        let data = subject.getTopSitesData()
 
         // We test that without a pref, google is added
-        let data = subject.getTopSitesData()
         XCTAssertTrue(data[0].isGoogleURL)
         XCTAssertTrue(data[0].isGoogleGUID)
     }
@@ -68,10 +67,9 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
     func testCalculateTopSitesData_hasGoogleTopSiteWithPinnedCount_googlePrefsNil() {
         let subject = createSubject(addPinnedSiteCount: 3)
 
-        subject.recalculateTopSiteData(for: 1)
+        let data = subject.getTopSitesData()
 
         // We test that without a pref, google is added even with pinned tiles
-        let data = subject.getTopSitesData()
         XCTAssertTrue(data[0].isGoogleURL)
         XCTAssertTrue(data[0].isGoogleGUID)
     }
@@ -81,10 +79,9 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
         profile.prefs.setBool(true, forKey: PrefsKeys.GoogleTopSiteAddedKey)
         profile.prefs.setBool(true, forKey: PrefsKeys.GoogleTopSiteHideKey)
 
-        subject.recalculateTopSiteData(for: 1)
+        let data = subject.getTopSitesData()
 
         // We test that having more pinned than available tiles, google tile isn't put in
-        let data = subject.getTopSitesData()
         XCTAssertFalse(data[0].isGoogleURL)
         XCTAssertFalse(data[0].isGoogleGUID)
     }
@@ -94,9 +91,8 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
     func testCalculateTopSitesData_pinnedSites() {
         let subject = createSubject(addPinnedSiteCount: 3)
 
-        subject.recalculateTopSiteData(for: 6)
-
         let data = subject.getTopSitesData()
+
         XCTAssertEqual(data.count, 14)
         XCTAssertTrue(data[0].isPinned)
     }
@@ -118,9 +114,8 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
         let expectedContileResult = ContileProviderMock.getContiles(contilesCount: 1)
         let subject = createSubject(expectedContileResult: ContileResult.success(expectedContileResult))
 
-        subject.recalculateTopSiteData(for: 6)
-
         let data = subject.getTopSitesData()
+
         XCTAssertEqual(data.count, 12, "Expects 1 google site, 1 contile, 10 history sites")
     }
 
@@ -128,9 +123,8 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
         let expectedContileResult = ContileProviderMock.getContiles(contilesCount: 1)
         let subject = createSubject(expectedContileResult: ContileResult.success(expectedContileResult))
 
-        subject.recalculateTopSiteData(for: 6)
-
         let data = subject.getTopSitesData()
+
         XCTAssertTrue(data[0].isGoogleURL)
         XCTAssertTrue(data[1].isSponsoredTile)
         XCTAssertFalse(data[2].isSponsoredTile)
@@ -140,9 +134,8 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
         let expectedContileResult = ContileResult.failure(ContileProvider.Error.noDataAvailable)
         let subject = createSubject(expectedContileResult: expectedContileResult)
 
-        subject.recalculateTopSiteData(for: 6)
-
         let data = subject.getTopSitesData()
+
         XCTAssertTrue(data[0].isGoogleURL)
         XCTAssertFalse(data[1].isSponsoredTile)
         XCTAssertFalse(data[2].isSponsoredTile)
@@ -152,9 +145,8 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
         let expectedContileResult = ContileResult.success([])
         let subject = createSubject(expectedContileResult: expectedContileResult)
 
-        subject.recalculateTopSiteData(for: 6)
-
         let data = subject.getTopSitesData()
+
         XCTAssertTrue(data[0].isGoogleURL)
         XCTAssertFalse(data[1].isSponsoredTile)
         XCTAssertFalse(data[2].isSponsoredTile)
@@ -165,8 +157,8 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
         let expectedContileResult = ContileProviderMock.getContiles(contilesCount: 3)
         let subject = createSubject(expectedContileResult: ContileResult.success(expectedContileResult))
 
-        subject.recalculateTopSiteData(for: 6)
         let data = subject.getTopSitesData()
+
         XCTAssertTrue(data[0].isGoogleURL)
         XCTAssertTrue(data[1].isSponsoredTile)
         XCTAssertTrue(data[2].isSponsoredTile)
@@ -178,9 +170,8 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
                                                                     duplicateFirstTile: true,
                                                                     pinnedDuplicateTile: true)
         let subject = createSubject(addPinnedSiteCount: 1, expectedContileResult: ContileResult.success(expectedContileResult))
-        subject.recalculateTopSiteData(for: 6)
-
         let data = subject.getTopSitesData()
+
         XCTAssertTrue(data[0].isGoogleURL)
         XCTAssertFalse(data[1].isSponsoredTile)
         XCTAssertFalse(data[2].isSponsoredTile)
@@ -190,10 +181,8 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
         let expectedContileResult = ContileProviderMock.getContiles(contilesCount: 1,
                                                                     duplicateFirstTile: true)
         let subject = createSubject(addPinnedSiteCount: 1, expectedContileResult: ContileResult.success(expectedContileResult))
-
-        subject.recalculateTopSiteData(for: 6)
-
         let data = subject.getTopSitesData()
+
         XCTAssertTrue(data[0].isGoogleURL)
         XCTAssertTrue(data[1].isSponsoredTile)
         XCTAssertFalse(data[2].isSponsoredTile)
@@ -204,10 +193,8 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
                                                                     duplicateFirstTile: true,
                                                                     pinnedDuplicateTile: true)
         let subject = createSubject(addPinnedSiteCount: 1, expectedContileResult: ContileResult.success(expectedContileResult))
-
-        subject.recalculateTopSiteData(for: 6)
-
         let data = subject.getTopSitesData()
+
         XCTAssertTrue(data[0].isGoogleURL)
         XCTAssertTrue(data[1].isSponsoredTile)
         XCTAssertEqual(data[1].title, ContileProviderMock.defaultSuccessData[0].name)
@@ -221,9 +208,8 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
         profile.prefs.setBool(true, forKey: PrefsKeys.GoogleTopSiteAddedKey)
         profile.prefs.setBool(true, forKey: PrefsKeys.GoogleTopSiteHideKey)
 
-        subject.recalculateTopSiteData(for: 6)
-
         let data = subject.getTopSitesData()
+
         XCTAssertFalse(data[0].isGoogleURL)
         XCTAssertFalse(data[1].isSponsoredTile)
         XCTAssertFalse(data[2].isSponsoredTile)
@@ -232,10 +218,8 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
     func testCalculateTopSitesData_doesNotAddTileIfAllSpacesArePinnedAndGoogleIsThere() {
         let expectedContileResult = ContileResult.success([])
         let subject = createSubject(addPinnedSiteCount: 11, expectedContileResult: expectedContileResult)
-
-        subject.recalculateTopSiteData(for: 6)
-
         let data = subject.getTopSitesData()
+
         XCTAssertTrue(data[0].isGoogleURL)
         XCTAssertFalse(data[1].isSponsoredTile)
         XCTAssertFalse(data[2].isSponsoredTile)
@@ -305,10 +289,8 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
     // Sponsored > Frequency
     func testDuplicates_SponsoredTileHasPrecedenceOnFrequencyTiles() {
         let subject = createSubject(expectedContileResult: ContileResult.success([ContileProviderMock.duplicateTile]))
-
-        subject.recalculateTopSiteData(for: 6)
-
         let data = subject.getTopSitesData()
+
         XCTAssertTrue(data[0].isGoogleURL)
         XCTAssertEqual(data[1].title, ContileProviderMock.duplicateTile.name)
         XCTAssertTrue(data[1].isSponsoredTile)
@@ -320,9 +302,8 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
         let subject = createSubject(addPinnedSiteCount: 1,
                                     expectedContileResult: ContileResult.success([ContileProviderMock.pinnedDuplicateTile]))
 
-        subject.recalculateTopSiteData(for: 6)
-
         let data = subject.getTopSitesData()
+
         XCTAssertTrue(data[0].isGoogleURL)
         XCTAssertFalse(data[1].isSponsoredTile)
         XCTAssertTrue(data[1].isPinned)
@@ -334,10 +315,8 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
     func testDuplicates_PinnedTilesHasPrecedenceOnFrequencyTiles() {
         let expectedPinnedURL = String(format: ContileProviderMock.url, "0")
         let subject = createSubject(addPinnedSiteCount: 1, siteCount: 3, duplicatePinnedSiteURL: true)
-
-        subject.recalculateTopSiteData(for: 6)
-
         let data = subject.getTopSitesData()
+
         XCTAssertEqual(data.count, 4, "Should have 3 sites and 1 pinned")
         XCTAssertTrue(data[0].isGoogleURL)
 
@@ -361,9 +340,8 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
     func testDuplicates_PinnedTilesOfSameDomainIsntDeduped() {
         let subject = createSubject(addPinnedSiteCount: 2, siteCount: 0)
 
-        subject.recalculateTopSiteData(for: 6)
-
         let data = subject.getTopSitesData()
+
         XCTAssertEqual(data.count, 3, "Should have google site and 2 pinned sites")
         XCTAssertTrue(data[0].isGoogleURL)
 
@@ -388,8 +366,6 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
                                                   isCustomEngine: false)
         add(searchEngine: googleSearchEngine)
         let subject = createSubject()
-        subject.recalculateTopSiteData(for: 6)
-
         let data = subject.getTopSitesData()
 
         XCTAssertTrue(data[0].isGoogleURL)
@@ -405,9 +381,8 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
                                                       isCustomEngine: false)
         add(searchEngine: pinnedTileSearchEngine)
         let subject = createSubject(addPinnedSiteCount: 3)
-        subject.recalculateTopSiteData(for: 6)
-
         let data = subject.getTopSitesData()
+
         XCTAssertEqual(data.count, 14)
         XCTAssertTrue(data[0].isPinned)
     }
@@ -421,8 +396,6 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
                                                        isCustomEngine: false)
         add(searchEngine: historyTileSearchEngine)
         let subject = createSubject()
-        subject.recalculateTopSiteData(for: 6)
-
         let data = subject.getTopSitesData()
 
         XCTAssertEqual(data[1].title, "A title 0")
@@ -438,10 +411,8 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
         add(searchEngine: sponsoredTileSearchEngine)
         let expectedContileResult = ContileProviderMock.getContiles(contilesCount: 1)
         let subject = createSubject(expectedContileResult: ContileResult.success(expectedContileResult))
-
-        subject.recalculateTopSiteData(for: 6)
-
         let data = subject.getTopSitesData()
+
         XCTAssertTrue(data[0].isGoogleURL)
         XCTAssertFalse(data[1].isSponsoredTile)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7874)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17576)

## :bulb: Description
This PR updates the top sites data adapter to cache a larger number of top sites than is needed and then filters down based on the available room on the screen. This is to protect against the underlying data not being thread safe.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

