### PR TITLE
Bugfix FXIOS-7875 [v122] Empty Private tabs: fade-in animation

### DIFF
--- a/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
+++ b/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
@@ -284,7 +284,13 @@ class LegacyGridTabViewController: UIViewController,
 
         tabDisplayManager.togglePrivateMode(isOn: !tabDisplayManager.isPrivate, createTabOnEmptyPrivateMode: false)
 
+        emptyPrivateTabsView.alpha = 0.0
         emptyPrivateTabsView.isHidden = !privateTabsAreEmpty
+        if privateTabsAreEmpty {
+            UIView.animate(withDuration: 0.2) { [weak self] in
+                self?.emptyPrivateTabsView.alpha = 1.0
+            }
+        }
     }
 
     func openNewTab(_ request: URLRequest? = nil, isPrivate: Bool) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7875)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17578)

## :bulb: Description

Minor fix to improve animation when switching panels in tab tray. Previously the empty Private view would immediately appear, overlapping the previous tab content.

### Before

https://github.com/mozilla-mobile/firefox-ios/assets/145381717/909699b4-39cd-4ad5-97da-fa176dc08de3

### After (iPad & iPhone)

https://github.com/mozilla-mobile/firefox-ios/assets/145381717/0678aba8-85cf-4422-86f5-1699694f6ff7

https://github.com/mozilla-mobile/firefox-ios/assets/145381717/b821680c-5e67-461f-9001-e1ab9e71cf90

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

