### PR TITLE
Refactor FXIOS-7699 [v122] Start migration to using UIButton.Configuration for buttons styling

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/ActionButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/ActionButton.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-public class ActionButton: ResizableButton {
+public class ActionButton: LegacyResizableButton {
     public var touchUpAction: ((UIButton) -> Void)? {
         didSet {
             setupButton()

--- a/BrowserKit/Sources/ComponentLibrary/ActionFooterView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/ActionFooterView.swift
@@ -44,7 +44,7 @@ public final class ActionFooterView: UIView, ThemeApplicable {
         label.adjustsFontForContentSizeCategory = true
     }
 
-    private lazy var linkButton: ResizableButton = .build { button in
+    private lazy var linkButton: LegacyResizableButton = .build { button in
         button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(
             withTextStyle: .footnote,
             size: UX.buttonSize)

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/LegacyResizableButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/LegacyResizableButton.swift
@@ -4,7 +4,11 @@
 
 import UIKit
 
-open class ResizableButton: UIButton {
+/// Deprecated base button class that use content, image and title edge insets.
+/// Should be replaced gradually with ``ResizableButton``, using UIButton.Configuration instead.
+@available(*, deprecated, renamed: "ResizableButton",
+            message: "Should be replaced with ResizableButton, using UIButton.Configuration")
+open class LegacyResizableButton: UIButton {
     public struct UX {
         public static let buttonEdgeSpacing: CGFloat = 8
     }

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/PrimaryRoundedButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/PrimaryRoundedButton.swift
@@ -5,7 +5,7 @@
 import Common
 import UIKit
 
-public class PrimaryRoundedButton: ResizableButton, ThemeApplicable {
+public class PrimaryRoundedButton: LegacyResizableButton, ThemeApplicable {
     private struct UX {
         static let buttonCornerRadius: CGFloat = 12
         static let buttonVerticalInset: CGFloat = 12

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/ResizableButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/ResizableButton.swift
@@ -1,0 +1,72 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+
+open class ResizableButton: UIButton {
+    public struct UX {
+        public static let buttonEdgeSpacing: CGFloat = 8
+    }
+
+    public var buttonEdgeSpacing: CGFloat = UX.buttonEdgeSpacing {
+        didSet {
+            updateContentInsets()
+        }
+    }
+
+    override public init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+
+    public required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override public var intrinsicContentSize: CGSize {
+        guard let title = titleLabel, let configuration else {
+            return super.intrinsicContentSize
+        }
+
+        let imagePadding = configuration.imagePadding
+        let widthContentInset = configuration.contentInsets.leading + configuration.contentInsets.trailing
+        let heightContentInset = configuration.contentInsets.top + configuration.contentInsets.bottom
+
+        var availableWidth = frame.width - widthContentInset
+        if let imageWidth = image(for: [])?.size.width {
+            availableWidth = availableWidth - imageWidth - imagePadding
+        }
+
+        let size = title.sizeThatFits(CGSize(width: availableWidth, height: .greatestFiniteMagnitude))
+        return CGSize(width: size.width + widthContentInset,
+                      height: size.height + heightContentInset)
+    }
+
+    override public func layoutSubviews() {
+        super.layoutSubviews()
+        guard let title = titleLabel else { return }
+
+        titleLabel?.preferredMaxLayoutWidth = title.frame.size.width
+    }
+
+    private func commonInit() {
+        titleLabel?.numberOfLines = 0
+        titleLabel?.adjustsFontForContentSizeCategory = true
+        adjustsImageSizeForAccessibilityContentSizeCategory = true
+
+        configuration = UIButton.Configuration.plain()
+        configuration?.titleLineBreakMode = .byWordWrapping
+        updateContentInsets()
+    }
+
+    private func updateContentInsets() {
+        configuration?.contentInsets = NSDirectionalEdgeInsets(
+            top: 0,
+            leading: buttonEdgeSpacing,
+            bottom: 0,
+            trailing: buttonEdgeSpacing
+        )
+    }
+}

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
@@ -5,7 +5,7 @@
 import Common
 import UIKit
 
-public class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
+public class SecondaryRoundedButton: LegacyResizableButton, ThemeApplicable {
     private struct UX {
         static let buttonCornerRadius: CGFloat = 12
         static let buttonVerticalInset: CGFloat = 12

--- a/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetFooterView.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetFooterView.swift
@@ -17,7 +17,7 @@ class CreditCardBottomSheetFooterView: UITableViewHeaderFooterView, ReusableCell
         static let titleVerticalLongPadding: CGFloat = 20
     }
 
-    public lazy var manageCardsButton: ResizableButton = .build { button in
+    public lazy var manageCardsButton: LegacyResizableButton = .build { button in
         button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(
             withTextStyle: .callout,
             size: UX.manageCardsButtonFontSize)

--- a/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
+++ b/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
@@ -81,7 +81,7 @@ class CreditCardBottomSheetViewController: UIViewController, UITableViewDelegate
         stack.spacing = UX.buttonsSpacing
     }
 
-    private lazy var yesButton: ResizableButton = .build { button in
+    private lazy var yesButton: LegacyResizableButton = .build { button in
         button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(
             withTextStyle: .headline,
             size: UX.yesButtonFontSize)

--- a/Client/Frontend/Browser/Tabs/Views/RemoteTabsEmptyView.swift
+++ b/Client/Frontend/Browser/Tabs/Views/RemoteTabsEmptyView.swift
@@ -52,7 +52,7 @@ class RemoteTabsEmptyView: UIView, ThemeApplicable {
         label.textAlignment = .center
     }
 
-    private let signInButton: ResizableButton = .build { button in
+    private let signInButton: LegacyResizableButton = .build { button in
         button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .callout,
                                                                          size: UX.buttonSizeFont)
         button.setTitle(.Settings.Sync.ButtonTitle, for: [])

--- a/Client/Frontend/Browser/Tabs/Views/RemoteTabsErrorCell.swift
+++ b/Client/Frontend/Browser/Tabs/Views/RemoteTabsErrorCell.swift
@@ -52,7 +52,7 @@ class RemoteTabsErrorCell: UITableViewCell, ReusableCell, ThemeApplicable {
         label.textAlignment = .center
     }
 
-    private let signInButton: ResizableButton = .build { button in
+    private let signInButton: LegacyResizableButton = .build { button in
         button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .callout,
                                                                          size: UX.buttonSizeFont)
         button.setTitle(.Settings.Sync.ButtonTitle, for: [])

--- a/Client/Frontend/Fakespot/Views/FakespotMessageCardView.swift
+++ b/Client/Frontend/Fakespot/Views/FakespotMessageCardView.swift
@@ -153,7 +153,7 @@ final class FakespotMessageCardView: UIView, ThemeApplicable, Notifiable {
         label.setContentCompressionResistancePriority(.required, for: .vertical)
     }
 
-    private lazy var linkButton: ResizableButton = .build { button in
+    private lazy var linkButton: LegacyResizableButton = .build { button in
         button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(
             withTextStyle: .caption1,
             size: UX.linkFontSize)
@@ -163,7 +163,7 @@ final class FakespotMessageCardView: UIView, ThemeApplicable, Notifiable {
         button.titleLabel?.adjustsFontForContentSizeCategory = true
     }
 
-    private lazy var primaryButton: ResizableButton = .build { button in
+    private lazy var primaryButton: LegacyResizableButton = .build { button in
         button.titleLabel?.font = DefaultDynamicFontHelper.preferredBoldFont(
             withTextStyle: .callout,
             size: UX.buttonFontSize)

--- a/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionCell.swift
+++ b/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionCell.swift
@@ -25,9 +25,9 @@ class CustomizeHomepageSectionCell: UICollectionViewCell, ReusableCell {
         button.layer.cornerRadius = UX.buttonCornerRadius
         button.accessibilityIdentifier = a11y.customizeHome
         button.contentEdgeInsets = UIEdgeInsets(top: UX.buttonVerticalInset,
-                                                left: ResizableButton.UX.buttonEdgeSpacing,
+                                                left: LegacyResizableButton.UX.buttonEdgeSpacing,
                                                 bottom: UX.buttonVerticalInset,
-                                                right: ResizableButton.UX.buttonEdgeSpacing)
+                                                right: LegacyResizableButton.UX.buttonEdgeSpacing)
     }
 
     // MARK: - Initializers

--- a/Client/Frontend/Onboarding/ViewControllers/OnboardingInstructionPopupViewController.swift
+++ b/Client/Frontend/Onboarding/ViewControllers/OnboardingInstructionPopupViewController.swift
@@ -64,7 +64,7 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
         stack.spacing = UX.textStackViewSpacing
     }
 
-    private lazy var primaryButton: ResizableButton = .build { button in
+    private lazy var primaryButton: LegacyResizableButton = .build { button in
         button.titleLabel?.font = DefaultDynamicFontHelper.preferredBoldFont(
             withTextStyle: .callout,
             size: UX.buttonFontSize)

--- a/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsHeaderView.swift
+++ b/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsHeaderView.swift
@@ -46,7 +46,7 @@ class WallpaperSettingsHeaderView: UICollectionReusableView, ReusableCell {
         label.numberOfLines = 0
     }
 
-    private lazy var learnMoreButton: ResizableButton = .build { button in
+    private lazy var learnMoreButton: LegacyResizableButton = .build { button in
         button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 12.0)
         button.contentHorizontalAlignment = .leading
         button.buttonEdgeSpacing = 0

--- a/Client/Frontend/SurveySurface/SurveySurfaceViewController.swift
+++ b/Client/Frontend/SurveySurface/SurveySurfaceViewController.swift
@@ -74,7 +74,7 @@ class SurveySurfaceViewController: UIViewController, Themeable {
         label.alpha = 0.0
     }
 
-    private lazy var takeSurveyButton: ResizableButton = .build { button in
+    private lazy var takeSurveyButton: LegacyResizableButton = .build { button in
         button.titleLabel?.font = DefaultDynamicFontHelper.preferredBoldFont(
             withTextStyle: .callout,
             size: UX.buttonFontSize)
@@ -90,7 +90,7 @@ class SurveySurfaceViewController: UIViewController, Themeable {
         button.alpha = 0.0
     }
 
-    private lazy var dismissSurveyButton: ResizableButton = .build { button in
+    private lazy var dismissSurveyButton: LegacyResizableButton = .build { button in
         button.titleLabel?.font = DefaultDynamicFontHelper.preferredBoldFont(
             withTextStyle: .callout,
             size: UX.buttonFontSize)

--- a/test-fixtures/generate-metrics.sh
+++ b/test-fixtures/generate-metrics.sh
@@ -4,8 +4,8 @@ set -e
 
 BUILD_LOG_FILE="$1"
 TYPE_LOG_FILE="$2"
-THRESHOLD_UNIT_TEST=91
-THRESHOLD_XCUITEST=91
+THRESHOLD_UNIT_TEST=77
+THRESHOLD_XCUITEST=77
 
 WARNING_COUNT=$(grep -E -v "SourcePackages/checkouts" "$BUILD_LOG_FILE" | grep -E "(^|:)[0-9]+:[0-9]+:|warning:|ld: warning:|<unknown>:0: warning:|fatal|===" | uniq | wc -l)
 


### PR DESCRIPTION
## :scroll: Tickets

This PR is linked to the following ticket and issue but **it is just preparatory work, it does not resolve them yet**: 

- [FXIOS-7699](https://mozilla-hub.atlassian.net/browse/FXIOS-7699): https://github.com/mozilla-mobile/firefox-ios/issues/17179

## :bulb: Description

This PR is the first step to using `UIButton.Configuration` for managing button styling since using content, title and image edge insets is now deprecated. Here we introduce a new `ResizableButton` class that use this new configuration paradigm, and the old class has been renamed `LegacyResizableButton`. The next steps will be to gradually migrate all usages of this base class to use the new class one at a time.

This PR follows the dicussion here: #17558 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

