### PR TITLE
Refactor EXP-4109 [v121] Add string-alias types to messaging and onboarding FML files

### DIFF
--- a/nimbus-features/messagingFeature.yaml
+++ b/nimbus-features/messagingFeature.yaml
@@ -140,8 +140,6 @@ features:
             URGENT:
               priority: 100
               max-display-count: 10
-      - channel: release
-        value:
           messages:
             default-browser:
               surface: new-tab-card

--- a/nimbus-features/messagingFeature.yaml
+++ b/nimbus-features/messagingFeature.yaml
@@ -30,7 +30,8 @@ features:
           A growable collection of messages, where the
           Key is the message identifier and the value
           is its associated MessageData.
-        type: Map<String, MessageData>
+        type: Map<MessageKey, MessageData>
+        string-alias: MessageKey
         default: {}
 
       triggers:
@@ -38,19 +39,22 @@ features:
           A collection of out the box trigger
           expressions. Each entry maps to a
           valid JEXL expression.
-        type: Map<String, String>
+        type: Map<TriggerName, String>
+        string-alias: TriggerName
         default: {}
 
       styles:
         description: >
           A map of styles to configure message
           appearance.
-        type: Map<String, StyleData>
+        type: Map<StyleName, StyleData>
+        string-alias: StyleName
         default: {}
 
       actions:
-        type: Map<String, String>
+        type: Map<ActionName, String>
         description: A growable map of action URLs.
+        string-alias: ActionName
         default: {}
 
       on-control:
@@ -58,8 +62,14 @@ features:
         description: What should be displayed when a control message is selected.
         default: show-next-message
 
+      $$experiment::
+        type: ExperimentSlug
+        string-alias: ExperimentSlug
+        description: Not to be set by experiment.
+        default: "{experiment}"
+
       message-under-experiment:
-        type: Option<String>
+        type: Option<MessageKey>
         description: 'Deprecated. Please use "experiment": "{experiment}" instead.'
         default: null
 
@@ -130,6 +140,8 @@ features:
             URGENT:
               priority: 100
               max-display-count: 10
+      - channel: release
+        value:
           messages:
             default-browser:
               surface: new-tab-card
@@ -164,6 +176,8 @@ objects:
       and call to action.
     fields:
       action:
+        # We would like this to be of ActionName type, but it accepts https:// URLs
+        # so changing this would be a breaking change.
         type: String
         description: >
           A URL of a page or a deeplink.
@@ -190,13 +204,13 @@ objects:
           is present, the whole message is clickable.
         default: null
       style:
-        type: String
+        type: StyleName
         description: >
           The style as described in a
           `StyleData` from the styles table.
         default: DEFAULT
       trigger:
-        type: List<String>
+        type: List<TriggerName>
         description: >
           A list of strings corresponding to
           targeting expressions. The message will be
@@ -207,7 +221,7 @@ objects:
         description: Each message will tell us the surface it is targeting with this.
         default: Unknown
       experiment:
-        type: Option<String>
+        type: Option<ExperimentSlug>
         description: The experiment slug that this message is involved in.
         default: null
 

--- a/nimbus-features/onboardingFrameworkFeature.yaml
+++ b/nimbus-features/onboardingFrameworkFeature.yaml
@@ -10,12 +10,14 @@ features:
           A collection of out the box conditional expressions to be
           used in determining whether a card should show or not.
           Each entry maps to a valid JEXL expression.
-        type: Map<String, String>
+        type: Map<ConditionName, String>
+        string-alias: ConditionName
         default: {}
       cards:
         description: >
           The list of available cards for onboarding.
-        type: Map<String, NimbusOnboardingCardData>
+        type: Map<NimbusOnboardingCardKey, NimbusOnboardingCardData>
+        string-alias: NimbusOnboardingCardKey
         default: {}
       dismissable:
         description: >
@@ -167,17 +169,17 @@ objects:
           popup information
         default: null
       prerequisites:
-        type: List<String>
+        type: List<ConditionName>
         description: >
-          A list of strings corresponding to targeting expressions.
+          A list of ConditionName strings corresponding to targeting expressions.
           The card will be shown if all expressions `true` and if
           no expressions in the `disqualifiers` table are true, or
           if the `disqualifiers` table is empty.
         default: []
       disqualifiers:
-        type: List<String>
+        type: List<ConditionName>
         description: >
-          A list of strings corresponding to targeting expressions.
+          A list of ConditionName strings corresponding to targeting expressions.
           The card will not be shown if any expression is `true`.
         default: []
       type:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/EXP-4109)

Relates to [ EXP-4109](https://mozilla-hub.atlassian.net/browse/EXP-4109).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

## :bulb: Description

This small PR makes no changes to Swift, but changes `String` types in FML to new [`string-alias` types](https://experimenter.info/fml/string-alias/).

This is intended to improve the UI of the experimenter branch configuration screen.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

