### PR TITLE
Bugfix FXIOS-7055 [v122] Add spacer to "use saved card" button

### DIFF
--- a/Client/AccessoryViewProvider.swift
+++ b/Client/AccessoryViewProvider.swift
@@ -15,6 +15,7 @@ class AccessoryViewProvider: UIView, Themeable {
         static let toolbarHeight: CGFloat = 50
         static let cornerRadius: CGFloat = 4
         static let cardImageViewSize: CGFloat = 24
+        static let fixedSpacerWidth: CGFloat = 10
         static let fixedSpacerHeight: CGFloat = 30
         static let fixedLeadingSpacerWidth: CGFloat = 2
         static let fixedTrailingSpacerWidth: CGFloat = 3
@@ -63,6 +64,13 @@ class AccessoryViewProvider: UIView, Themeable {
         return button
     }()
 
+    private lazy var fixedSpacer: UIBarButtonItem = {
+        let fixedSpacer = UIBarButtonItem(barButtonSystemItem: .fixedSpace,
+                                          target: nil,
+                                          action: nil)
+        fixedSpacer.width = CGFloat(UX.fixedSpacerWidth)
+        return fixedSpacer
+    }()
     private let flexibleSpacer = UIBarButtonItem(systemItem: .flexibleSpace)
 
     private let leadingFixedSpacer: UIView = .build()
@@ -163,7 +171,7 @@ class AccessoryViewProvider: UIView, Themeable {
             let cardStackViewForBarButton = UIBarButtonItem(customView: cardButtonStackView)
             cardStackViewForBarButton.accessibilityTraits = .button
             cardStackViewForBarButton.accessibilityLabel = .CreditCard.Settings.UseSavedCardFromKeyboard
-            toolbar.items = [previousButton, nextButton, cardStackViewForBarButton, flexibleSpacer, doneButton]
+            toolbar.items = [previousButton, nextButton, fixedSpacer, cardStackViewForBarButton, flexibleSpacer, doneButton]
             toolbar.accessibilityElements = [previousButton, nextButton, cardStackViewForBarButton, doneButton]
         } else {
             toolbar.items = [previousButton, nextButton, flexibleSpacer, doneButton]


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7055)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15682)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Added spacer of 10 points, also attached ss of the same, please suggest if this needs to be changed to some other value.
<img width="541" alt="Screenshot 2023-12-04 at 3 04 52 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/15265718/98e850c8-b1ed-4301-90db-9ec6c8e2551e">


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

