### PR TITLE
Remove FXIOS-7865 [v122] Unused function in homepage

### DIFF
--- a/Client/Frontend/Home/HomepageContextMenuHelper.swift
+++ b/Client/Frontend/Home/HomepageContextMenuHelper.swift
@@ -12,7 +12,6 @@ protocol HomepageContextMenuHelperDelegate: UIViewController {
     func presentWithModalDismissIfNeeded(_ viewController: UIViewController, animated: Bool)
     func homePanelDidRequestToOpenInNewTab(_ url: URL, isPrivate: Bool, selectNewTab: Bool)
     func homePanelDidRequestToOpenSettings(at settingsPage: Route.SettingsSection)
-    func showToast(message: String)
 }
 // swiftlint:enable class_delegate_protocol
 

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -713,10 +713,6 @@ extension HomepageViewController: HomepageContextMenuHelperDelegate {
     func homePanelDidRequestToOpenSettings(at settingsPage: Route.SettingsSection) {
         homePanelDelegate?.homePanelDidRequestToOpenSettings(at: settingsPage)
     }
-
-    func showToast(message: String) {
-        SimpleToast().showAlertWithText(message, bottomContainer: view, theme: themeManager.currentTheme)
-    }
 }
 
 // MARK: - Status Bar Background


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7865)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17559)

## :bulb: Description
Small PR to remove unused show toast function discovered while doing investigation work. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

