### PR TITLE
Refactor FXIOS-7883 [v122] Move contextual id away from sponsored tile telemetry

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -694,6 +694,8 @@
 		8A93F87029D3A597004159D9 /* SceneCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A93F86F29D3A597004159D9 /* SceneCoordinator.swift */; };
 		8A93F87229D3A5AD004159D9 /* BrowserCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A93F87129D3A5AD004159D9 /* BrowserCoordinator.swift */; };
 		8A93F87429D3A5C1004159D9 /* LaunchCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A93F87329D3A5C1004159D9 /* LaunchCoordinator.swift */; };
+		8A95FF642B1E969E00AC303D /* TelemetryContextualIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A95FF632B1E969E00AC303D /* TelemetryContextualIdentifier.swift */; };
+		8A95FF672B1E97A800AC303D /* TelemetryContextualIdentifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A95FF652B1E977E00AC303D /* TelemetryContextualIdentifierTests.swift */; };
 		8A96C4BB28F9E7B300B75884 /* XCTestCaseRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A96C4BA28F9E7B300B75884 /* XCTestCaseRootViewController.swift */; };
 		8A9AC465276CEC4E0047F5B0 /* JumpBackInCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9AC464276CEC4E0047F5B0 /* JumpBackInCell.swift */; };
 		8A9AC46B276D11280047F5B0 /* PocketViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9AC46A276D11280047F5B0 /* PocketViewModel.swift */; };
@@ -5265,6 +5267,8 @@
 		8A93F86F29D3A597004159D9 /* SceneCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneCoordinator.swift; sourceTree = "<group>"; };
 		8A93F87129D3A5AD004159D9 /* BrowserCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserCoordinator.swift; sourceTree = "<group>"; };
 		8A93F87329D3A5C1004159D9 /* LaunchCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchCoordinator.swift; sourceTree = "<group>"; };
+		8A95FF632B1E969E00AC303D /* TelemetryContextualIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryContextualIdentifier.swift; sourceTree = "<group>"; };
+		8A95FF652B1E977E00AC303D /* TelemetryContextualIdentifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryContextualIdentifierTests.swift; sourceTree = "<group>"; };
 		8A96C4B828F9DD8700B75884 /* ThemableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemableTests.swift; sourceTree = "<group>"; };
 		8A96C4BA28F9E7B300B75884 /* XCTestCaseRootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestCaseRootViewController.swift; sourceTree = "<group>"; };
 		8A99DB9727C6DD3E007EA6BD /* is */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = is; path = "is.lproj/Default Browser.strings"; sourceTree = "<group>"; };
@@ -10694,6 +10698,7 @@
 				8AD08D1427E9198E00B8E907 /* TabsQuantityTelemetry.swift */,
 				EBF47E6F1F7979DF00899189 /* TelemetryWrapper.swift */,
 				8ADC2A132A33762900543DAA /* ReferringPage.swift */,
+				8A95FF632B1E969E00AC303D /* TelemetryContextualIdentifier.swift */,
 			);
 			path = Telemetry;
 			sourceTree = "<group>";
@@ -10942,6 +10947,7 @@
 				8AA6ADB42742B567004EEE23 /* TelemetryWrapperTests.swift */,
 				0BA8964A1A250E6500C1010C /* TestBookmarks.swift */,
 				4A59BF410BBD9B3BE71F4C7C /* TestHistory.swift */,
+				8A95FF652B1E977E00AC303D /* TelemetryContextualIdentifierTests.swift */,
 				8A33222027DFE64C008F809E /* TestingHelperClasses */,
 				E1D8BC7921FF7A0000B100BD /* TPStatsBlocklistsTests.swift */,
 				8A1E3BE028CBAC1F003388C4 /* Utils */,
@@ -13268,6 +13274,7 @@
 				E1442FD1294782D9003680B0 /* UIModalPresentationStyle+Photon.swift in Sources */,
 				E1ADE23E2B06559500FD17AA /* FakespotAction.swift in Sources */,
 				5A32C2B62AD8517200A9B5A4 /* MetricKitWrapper.swift in Sources */,
+				8A95FF642B1E969E00AC303D /* TelemetryContextualIdentifier.swift in Sources */,
 				D3FEC38D1AC4B42F00494F45 /* AutocompleteTextField.swift in Sources */,
 				8A19ACAE2A329058001C2147 /* PasswordManagerSetting.swift in Sources */,
 				AB03032C2AB47AF300DCD8EF /* FakespotOptInCardViewModel.swift in Sources */,
@@ -13691,6 +13698,7 @@
 				8A7A26E129D4785900EA76F1 /* MockRouter.swift in Sources */,
 				965C3C96293431FC006499ED /* MockLaunchSessionProvider.swift in Sources */,
 				C869915628917803007ACC5C /* WallpaperJSONTestProvider.swift in Sources */,
+				8A95FF672B1E97A800AC303D /* TelemetryContextualIdentifierTests.swift in Sources */,
 				965C3C9829343445006499ED /* MockAppSessionManager.swift in Sources */,
 				8AFCE50929DE136300B1B253 /* MockLaunchFinishedLoadingDelegate.swift in Sources */,
 				8AE1E1DB27B1C1320024C45E /* SearchBarSettingsViewModelTests.swift in Sources */,

--- a/Client/Telemetry/SponsoredTileTelemetry.swift
+++ b/Client/Telemetry/SponsoredTileTelemetry.swift
@@ -7,33 +7,9 @@ import Glean
 
 // Telemetry for the Sponsored tiles located in the Top sites on the Firefox home page
 // Using Pings to send the telemetry events
-class SponsoredTileTelemetry {
+struct SponsoredTileTelemetry {
     // Source is only new tab at the moment, more source could be added later
     static let source = "newtab"
-
-    enum UserDefaultsKey: String {
-        case keyContextId = "com.moz.contextId.key"
-    }
-
-    static var contextId: String? {
-        get { UserDefaults.standard.object(forKey: UserDefaultsKey.keyContextId.rawValue) as? String }
-        set { UserDefaults.standard.set(newValue, forKey: UserDefaultsKey.keyContextId.rawValue) }
-    }
-
-    static func clearUserDefaults() {
-        SponsoredTileTelemetry.contextId = nil
-    }
-
-    static func setupContextId() {
-        // Use existing client UUID, if doesn't exists create a new one
-        if let stringContextId = contextId, let clientUUID = UUID(uuidString: stringContextId) {
-            GleanMetrics.TopSites.contextId.set(clientUUID)
-        } else {
-            let newUUID = UUID()
-            GleanMetrics.TopSites.contextId.set(newUUID)
-            contextId = newUUID.uuidString
-        }
-    }
 
     static func sendImpressionTelemetry(tile: SponsoredTile, position: Int) {
         let extra = GleanMetrics.TopSites.ContileImpressionExtra(position: Int32(position), source: SponsoredTileTelemetry.source)

--- a/Client/Telemetry/TelemetryContextualIdentifier.swift
+++ b/Client/Telemetry/TelemetryContextualIdentifier.swift
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Glean
+
+// Contextual identifier used for the sponsored tiles in top sites and the suggestions in the search view
+struct TelemetryContextualIdentifier {
+    enum UserDefaultsKey: String {
+        case keyContextId = "com.moz.contextId.key"
+    }
+
+    static var contextId: String? {
+        get { UserDefaults.standard.object(forKey: UserDefaultsKey.keyContextId.rawValue) as? String }
+        set { UserDefaults.standard.set(newValue, forKey: UserDefaultsKey.keyContextId.rawValue) }
+    }
+
+    static func clearUserDefaults() {
+        TelemetryContextualIdentifier.contextId = nil
+    }
+
+    static func setupContextId() {
+        // Use existing client UUID, if doesn't exists create a new one
+        if let stringContextId = contextId, let clientUUID = UUID(uuidString: stringContextId) {
+            GleanMetrics.TopSites.contextId.set(clientUUID)
+        } else {
+            let newUUID = UUID()
+            GleanMetrics.TopSites.contextId.set(newUUID)
+            contextId = newUUID.uuidString
+        }
+    }
+}

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -177,7 +177,7 @@ class TelemetryWrapper: TelemetryWrapperProtocol, FeatureFlaggable {
         // Save the profile so we can record settings from it when the notification below fires.
         self.profile = profile
 
-        SponsoredTileTelemetry.setupContextId()
+        TelemetryContextualIdentifier.setupContextId()
 
         // Register an observer to record settings and other metrics that are more appropriate to
         // record on going to background rather than during initialization.

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/SponsoredTileTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/SponsoredTileTelemetryTests.swift
@@ -18,33 +18,10 @@ class SponsoredTileTelemetryTests: XCTestCase {
         clearTest()
     }
 
-    // MARK: Context id
-
-    func testContextId_isNilByDefault() {
-        XCTAssertNil(SponsoredTileTelemetry.contextId)
-    }
-
-    func testContextId_isCreated() {
-        SponsoredTileTelemetry.setupContextId()
-        XCTAssertNotNil(SponsoredTileTelemetry.contextId)
-    }
-
-    func testContextId_isReusedAfterCreation() {
-        SponsoredTileTelemetry.setupContextId()
-        let contextId = SponsoredTileTelemetry.contextId
-        SponsoredTileTelemetry.setupContextId()
-        XCTAssertEqual(contextId, SponsoredTileTelemetry.contextId)
-    }
-
-    func testTelemetryWrapper_setsContextId() {
-        TelemetryWrapper.shared.setup(profile: MockProfile())
-        XCTAssertNotNil(SponsoredTileTelemetry.contextId)
-    }
-
     // MARK: Impression
 
     func testImpressionTopSite() {
-        SponsoredTileTelemetry.setupContextId()
+        TelemetryContextualIdentifier.setupContextId()
         let contile = ContileProviderMock.defaultSuccessData[0]
         let topSite = SponsoredTile(contile: contile)
 
@@ -75,7 +52,7 @@ class SponsoredTileTelemetryTests: XCTestCase {
     // MARK: Click
 
     func testClickTopSite() {
-        SponsoredTileTelemetry.setupContextId()
+        TelemetryContextualIdentifier.setupContextId()
         let contile = ContileProviderMock.defaultSuccessData[1]
         let topSite = SponsoredTile(contile: contile)
 
@@ -104,13 +81,13 @@ class SponsoredTileTelemetryTests: XCTestCase {
 
     // MARK: ContexId
     func testContextIdImpressionTopSite() {
-        SponsoredTileTelemetry.setupContextId()
+        TelemetryContextualIdentifier.setupContextId()
         let contile = ContileProviderMock.defaultSuccessData[0]
         let topSite = SponsoredTile(contile: contile)
 
         let expectation = expectation(description: "The top sites ping was sent")
         GleanMetrics.Pings.shared.topsitesImpression.testBeforeNextSubmit { _ in
-            guard let contextId =  SponsoredTileTelemetry.contextId,
+            guard let contextId = TelemetryContextualIdentifier.contextId,
                     let uuid = UUID(uuidString: contextId) else {
                 XCTFail("Expected contextId to be configured")
                 return
@@ -125,13 +102,12 @@ class SponsoredTileTelemetryTests: XCTestCase {
         SponsoredTileTelemetry.sendImpressionTelemetry(tile: topSite, position: 2)
         waitForExpectations(timeout: 5.0)
     }
-}
 
-// MARK: Helper methods
-extension SponsoredTileTelemetryTests {
+    // MARK: Helper methods
+
     func clearTest() {
         Glean.shared.resetGlean(clearStores: true)
         Glean.shared.enableTestingMode()
-        SponsoredTileTelemetry.clearUserDefaults()
+        TelemetryContextualIdentifier.clearUserDefaults()
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryContextualIdentifierTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryContextualIdentifierTests.swift
@@ -1,0 +1,49 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+
+import Glean
+import XCTest
+
+class TelemetryContextualIdentifierTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        clearTest()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        clearTest()
+    }
+
+    // MARK: Context id
+
+    func testContextId_isNilByDefault() {
+        XCTAssertNil(TelemetryContextualIdentifier.contextId)
+    }
+
+    func testContextId_isCreated() {
+        TelemetryContextualIdentifier.setupContextId()
+        XCTAssertNotNil(TelemetryContextualIdentifier.contextId)
+    }
+
+    func testContextId_isReusedAfterCreation() {
+        TelemetryContextualIdentifier.setupContextId()
+        let contextId = TelemetryContextualIdentifier.contextId
+        TelemetryContextualIdentifier.setupContextId()
+        XCTAssertEqual(contextId, TelemetryContextualIdentifier.contextId)
+    }
+
+    func testTelemetryWrapper_setsContextId() {
+        TelemetryWrapper.shared.setup(profile: MockProfile())
+        XCTAssertNotNil(TelemetryContextualIdentifier.contextId)
+    }
+
+    // MARK: Helper methods
+    func clearTest() {
+        Glean.shared.resetGlean(clearStores: true)
+        TelemetryContextualIdentifier.clearUserDefaults()
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7883)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17600)

## :bulb: Description
Move contextual id away from sponsored tile telemetry as it needs to be used in other places in the app (see related PR in task)

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

