### PR TITLE
Remove FXIOS-7248 [v122] Remove send to device delegate from homepage, not used anymore

### DIFF
--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -97,14 +97,12 @@ class BrowserCoordinator: BaseCoordinator,
                       toastContainer: UIView,
                       homepanelDelegate: HomePanelDelegate,
                       libraryPanelDelegate: LibraryPanelDelegate,
-                      sendToDeviceDelegate: HomepageViewController.SendToDeviceDelegate,
                       statusBarScrollDelegate: StatusBarScrollDelegate,
                       overlayManager: OverlayModeManager) {
         let homepageController = getHomepage(inline: inline,
                                              toastContainer: toastContainer,
                                              homepanelDelegate: homepanelDelegate,
                                              libraryPanelDelegate: libraryPanelDelegate,
-                                             sendToDeviceDelegate: sendToDeviceDelegate,
                                              statusBarScrollDelegate: statusBarScrollDelegate,
                                              overlayManager: overlayManager)
 
@@ -142,7 +140,6 @@ class BrowserCoordinator: BaseCoordinator,
                              toastContainer: UIView,
                              homepanelDelegate: HomePanelDelegate,
                              libraryPanelDelegate: LibraryPanelDelegate,
-                             sendToDeviceDelegate: HomepageViewController.SendToDeviceDelegate,
                              statusBarScrollDelegate: StatusBarScrollDelegate,
                              overlayManager: OverlayModeManager) -> HomepageViewController {
         if let homepageViewController = homepageViewController {
@@ -156,7 +153,6 @@ class BrowserCoordinator: BaseCoordinator,
                 overlayManager: overlayManager)
             homepageViewController.homePanelDelegate = homepanelDelegate
             homepageViewController.libraryPanelDelegate = libraryPanelDelegate
-            homepageViewController.sendToDeviceDelegate = sendToDeviceDelegate
             homepageViewController.statusBarScrollDelegate = statusBarScrollDelegate
             homepageViewController.browserNavigationHandler = self
 

--- a/Client/Coordinators/Browser/BrowserDelegate.swift
+++ b/Client/Coordinators/Browser/BrowserDelegate.swift
@@ -12,14 +12,12 @@ protocol BrowserDelegate: AnyObject {
     ///   - toastContainer: The container view for alert shown from share extension in the home page context menu
     ///   - homepanelDelegate: The homepanel delegate for the homepage
     ///   - libraryPanelDelegate:  The library panel delegate for the homepage
-    ///   - sendToDeviceDelegate: The send to device delegate for the homepage
     ///   - statusBarScrollDelegate: The delegate that takes care of the status bar overlay scroll
     ///   - overlayManager: The overlay manager for the homepage
     func showHomepage(inline: Bool,
                       toastContainer: UIView,
                       homepanelDelegate: HomePanelDelegate,
                       libraryPanelDelegate: LibraryPanelDelegate,
-                      sendToDeviceDelegate: HomepageViewController.SendToDeviceDelegate,
                       statusBarScrollDelegate: StatusBarScrollDelegate,
                       overlayManager: OverlayModeManager)
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1026,7 +1026,6 @@ class BrowserViewController: UIViewController,
                                       toastContainer: contentContainer,
                                       homepanelDelegate: self,
                                       libraryPanelDelegate: self,
-                                      sendToDeviceDelegate: self,
                                       statusBarScrollDelegate: statusBarOverlay,
                                       overlayManager: overlayManager)
     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1563,28 +1563,6 @@ class BrowserViewController: UIViewController,
         return navigationController?.topViewController?.presentedViewController as? JSPromptAlertController != nil
     }
 
-    private func showSendToDevice() {
-        guard let selectedTab = tabManager.selectedTab,
-              let url = selectedTab.canonicalURL?.displayURL
-        else { return }
-
-        let themeColors = themeManager.currentTheme.colors
-        let colors = SendToDeviceHelper.Colors(defaultBackground: themeColors.layer1,
-                                               textColor: themeColors.textPrimary,
-                                               iconColor: themeColors.iconPrimary)
-        let shareItem = ShareItem(url: url.absoluteString,
-                                  title: selectedTab.title)
-
-        let helper = SendToDeviceHelper(shareItem: shareItem,
-                                        profile: profile,
-                                        colors: colors,
-                                        delegate: self)
-        let viewController = helper.initialViewController()
-
-        TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .sendToDevice)
-        showViewController(viewController: viewController)
-    }
-
     fileprivate func postLocationChangeNotificationForTab(_ tab: Tab, navigation: WKNavigation?) {
         let notificationCenter = NotificationCenter.default
         var info = [AnyHashable: Any]()

--- a/Client/Frontend/Home/HomepageContextMenuHelper.swift
+++ b/Client/Frontend/Home/HomepageContextMenuHelper.swift
@@ -9,7 +9,6 @@ import Storage
 
 // swiftlint:disable class_delegate_protocol
 protocol HomepageContextMenuHelperDelegate: UIViewController {
-    func presentWithModalDismissIfNeeded(_ viewController: UIViewController, animated: Bool)
     func homePanelDidRequestToOpenInNewTab(_ url: URL, isPrivate: Bool, selectNewTab: Bool)
     func homePanelDidRequestToOpenSettings(at settingsPage: Route.SettingsSection)
 }
@@ -23,10 +22,8 @@ extension HomepageContextMenuHelperDelegate {
 
 class HomepageContextMenuHelper: HomepageContextMenuProtocol {
     typealias ContextHelperDelegate = HomepageContextMenuHelperDelegate & UIPopoverPresentationControllerDelegate
-    typealias SendToDeviceDelegate = InstructionsViewDelegate & DevicePickerViewControllerDelegate
     private var viewModel: HomepageViewModel
     private let toastContainer: UIView
-    weak var sendToDeviceDelegate: SendToDeviceDelegate?
     weak var browserNavigationHandler: BrowserNavigationHandler?
     weak var delegate: ContextHelperDelegate?
     var getPopoverSourceRect: ((UIView?) -> CGRect)?
@@ -189,25 +186,6 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
                 toastContainer: self.toastContainer,
                 popoverArrowDirection: [.up, .down, .left])
         }).items
-    }
-
-    private func showSendToDevice(site: Site) {
-        guard let delegate = sendToDeviceDelegate else { return }
-
-        let themeColors = viewModel.theme.colors
-
-        let colors = SendToDeviceHelper.Colors(defaultBackground: themeColors.layer1,
-                                               textColor: themeColors.textPrimary,
-                                               iconColor: themeColors.iconPrimary)
-        let shareItem = ShareItem(url: site.url, title: site.title)
-        let helper = SendToDeviceHelper(shareItem: shareItem,
-                                        profile: viewModel.profile,
-                                        colors: colors,
-                                        delegate: delegate)
-        let viewController = helper.initialViewController()
-
-        TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .sendToDevice)
-        self.delegate?.presentWithModalDismissIfNeeded(viewController, animated: true)
     }
 
     // MARK: - Top sites

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -19,17 +19,11 @@ class HomepageViewController:
     // MARK: - Typealiases
 
     private typealias a11y = AccessibilityIdentifiers.FirefoxHomepage
-    typealias SendToDeviceDelegate = InstructionsViewDelegate & DevicePickerViewControllerDelegate
 
     // MARK: - Operational Variables
 
     weak var homePanelDelegate: HomePanelDelegate?
     weak var libraryPanelDelegate: LibraryPanelDelegate?
-    weak var sendToDeviceDelegate: SendToDeviceDelegate? {
-        didSet {
-            contextMenuHelper.sendToDeviceDelegate = sendToDeviceDelegate
-        }
-    }
 
     weak var browserNavigationHandler: BrowserNavigationHandler? {
         didSet {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -91,7 +91,6 @@ final class BrowserCoordinatorTests: XCTestCase {
                              toastContainer: UIView(),
                              homepanelDelegate: subject.browserViewController,
                              libraryPanelDelegate: subject.browserViewController,
-                             sendToDeviceDelegate: subject.browserViewController,
                              statusBarScrollDelegate: scrollDelegate,
                              overlayManager: overlayModeManager)
 
@@ -107,7 +106,6 @@ final class BrowserCoordinatorTests: XCTestCase {
                              toastContainer: UIView(),
                              homepanelDelegate: subject.browserViewController,
                              libraryPanelDelegate: subject.browserViewController,
-                             sendToDeviceDelegate: subject.browserViewController,
                              statusBarScrollDelegate: scrollDelegate,
                              overlayManager: overlayModeManager)
         let firstHomepage = subject.homepageViewController
@@ -117,7 +115,6 @@ final class BrowserCoordinatorTests: XCTestCase {
                              toastContainer: UIView(),
                              homepanelDelegate: subject.browserViewController,
                              libraryPanelDelegate: subject.browserViewController,
-                             sendToDeviceDelegate: subject.browserViewController,
                              statusBarScrollDelegate: scrollDelegate,
                              overlayManager: overlayModeManager)
         let secondHomepage = subject.homepageViewController


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7248)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16074)

## :bulb: Description
Remove send to device delegate from homepage, not used anymore from the homepage contextual menu 👍 

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

