### PR TITLE
Refactor FXIOS-7886 [v122] Fix kUTTypeText and kUTTypeURL deprecations

### DIFF
--- a/Client/Helpers/UserActivityHandler.swift
+++ b/Client/Helpers/UserActivityHandler.swift
@@ -89,7 +89,7 @@ extension UserActivityHandler {
         let spotlightConfig = FxNimbus.shared.features.spotlightSearch.value()
         if !spotlightConfig.enabled { return }
 
-        let attributeSet = CSSearchableItemAttributeSet(itemContentType: kUTTypeText as String)
+        let attributeSet = CSSearchableItemAttributeSet(itemContentType: UTType.text.identifier as String)
         attributeSet.title = page.title
 
         switch spotlightConfig.searchableContent {

--- a/Client/Helpers/UserActivityHandler.swift
+++ b/Client/Helpers/UserActivityHandler.swift
@@ -89,7 +89,7 @@ extension UserActivityHandler {
         let spotlightConfig = FxNimbus.shared.features.spotlightSearch.value()
         if !spotlightConfig.enabled { return }
 
-        let attributeSet = CSSearchableItemAttributeSet(itemContentType: UTType.text.identifier as String)
+        let attributeSet = CSSearchableItemAttributeSet(itemContentType: UTType.text.identifier)
         attributeSet.title = page.title
 
         switch spotlightConfig.searchableContent {

--- a/Storage/ExtensionUtils.swift
+++ b/Storage/ExtensionUtils.swift
@@ -4,17 +4,18 @@
 
 import UIKit
 import MobileCoreServices
+import UniformTypeIdentifiers
 
 extension NSItemProvider {
-    var isText: Bool { return hasItemConformingToTypeIdentifier(String(kUTTypeText)) }
-    var isUrl: Bool { return hasItemConformingToTypeIdentifier(String(kUTTypeURL)) }
+    var isText: Bool { return hasItemConformingToTypeIdentifier(String(UTType.text.identifier)) }
+    var isUrl: Bool { return hasItemConformingToTypeIdentifier(String(UTType.url.identifier)) }
 
     func processText(completion: CompletionHandler?) {
-        loadItem(forTypeIdentifier: String(kUTTypeText), options: nil, completionHandler: completion)
+        loadItem(forTypeIdentifier: String(UTType.text.identifier), options: nil, completionHandler: completion)
     }
 
     func processUrl(completion: CompletionHandler?) {
-        loadItem(forTypeIdentifier: String(kUTTypeURL), options: nil, completionHandler: completion)
+        loadItem(forTypeIdentifier: String(UTType.url.identifier), options: nil, completionHandler: completion)
     }
 }
 

--- a/Storage/ExtensionUtils.swift
+++ b/Storage/ExtensionUtils.swift
@@ -7,15 +7,15 @@ import MobileCoreServices
 import UniformTypeIdentifiers
 
 extension NSItemProvider {
-    var isText: Bool { return hasItemConformingToTypeIdentifier(String(UTType.text.identifier)) }
-    var isUrl: Bool { return hasItemConformingToTypeIdentifier(String(UTType.url.identifier)) }
+    var isText: Bool { return hasItemConformingToTypeIdentifier(UTType.text.identifier) }
+    var isUrl: Bool { return hasItemConformingToTypeIdentifier(UTType.url.identifier) }
 
     func processText(completion: CompletionHandler?) {
-        loadItem(forTypeIdentifier: String(UTType.text.identifier), options: nil, completionHandler: completion)
+        loadItem(forTypeIdentifier: UTType.text.identifier, options: nil, completionHandler: completion)
     }
 
     func processUrl(completion: CompletionHandler?) {
-        loadItem(forTypeIdentifier: String(UTType.url.identifier), options: nil, completionHandler: completion)
+        loadItem(forTypeIdentifier: UTType.url.identifier, options: nil, completionHandler: completion)
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7886)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17609)

## :bulb: Description
This PR addresses the deprecation warnings related to 'kUTTypeText' and 'kUTTypeURL' in iOS 15.0. Now, UTTypeText and UTTypeURL (or UTType.text and UTType.url in Swift) are used to replace the deprecated constants.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods