### PR TITLE
Add FXIOS-7801 [v122] Add ads events recording API endpoint

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -811,6 +811,7 @@
 		8AFCE50729DE0CD500B1B253 /* LaunchCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFCE50629DE0CD500B1B253 /* LaunchCoordinatorTests.swift */; };
 		8AFCE50929DE136300B1B253 /* MockLaunchFinishedLoadingDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFCE50829DE136300B1B253 /* MockLaunchFinishedLoadingDelegate.swift */; };
 		8AFE4C2127480D0C00B97C65 /* LegacyTabTrayViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFE4C2027480D0B00B97C65 /* LegacyTabTrayViewControllerTests.swift */; };
+		8C29627C2B1F473800571655 /* AdEventsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C29627B2B1F473800571655 /* AdEventsResponse.swift */; };
 		8C44A9D22A6A99FE009A1AA7 /* ShoppingProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C44A9D12A6A99FE009A1AA7 /* ShoppingProduct.swift */; };
 		8C6F94652A972EB300415FF6 /* FakespotAdjustRatingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C6F94632A972EB300415FF6 /* FakespotAdjustRatingView.swift */; };
 		8C6F94662A972EB300415FF6 /* FakespotStarRatingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C6F94642A972EB300415FF6 /* FakespotStarRatingView.swift */; };
@@ -5395,6 +5396,7 @@
 		8BFA4413BB71963DB0E69F82 /* ses */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ses; path = ses.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
 		8BFD47109E07F897D604AEBE /* uz */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uz; path = uz.lproj/ClearPrivateData.strings; sourceTree = "<group>"; };
 		8C264BF5A1C7B2B6378D4DFF /* fa */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fa; path = fa.lproj/Today.strings; sourceTree = "<group>"; };
+		8C29627B2B1F473800571655 /* AdEventsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdEventsResponse.swift; sourceTree = "<group>"; };
 		8C44A9D12A6A99FE009A1AA7 /* ShoppingProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoppingProduct.swift; sourceTree = "<group>"; };
 		8C514AFEABEF8DE46CE7B8D4 /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
 		8C6DA7D02A6FE78F00DE264F /* ShoppingProductTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoppingProductTests.swift; sourceTree = "<group>"; };
@@ -9168,6 +9170,7 @@
 				8C92DE922A7128DE0090BD28 /* ProductAdsResponse.swift */,
 				8CCCB08A2AE26B5C0073ADB9 /* ReportResponse.swift */,
 				8C92DE902A7128CB0090BD28 /* ProductAnalysisResponse.swift */,
+				8C29627B2B1F473800571655 /* AdEventsResponse.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -13137,6 +13140,7 @@
 				D0E55C4F1FB4FD23006DC274 /* FormPostHelper.swift in Sources */,
 				E118B9292862674E00C84831 /* LegacyInactiveTabItemCellModel.swift in Sources */,
 				C88E7A552A0553180072E638 /* OnboardingViewModel.swift in Sources */,
+				8C29627C2B1F473800571655 /* AdEventsResponse.swift in Sources */,
 				962021E128B8078400BDF3D9 /* ContextualHintCopyProvider.swift in Sources */,
 				8AE1E1D227B1ADC40024C45E /* TopBottomInterchangeable.swift in Sources */,
 				8A7653BD28A2C61D00924ABF /* PocketDataAdaptor.swift in Sources */,

--- a/Client/Frontend/Fakespot/Client/FakeSpotClient.swift
+++ b/Client/Frontend/Fakespot/Client/FakeSpotClient.swift
@@ -48,6 +48,15 @@ protocol FakespotClientType {
     /// - Throws: `FakeSpotClientError.invalidURL` if the API endpoint URL is missing or invalid,
     ///           and any other errors that may occur during the API request.
     func reportProductBackInStock(productId: String, website: String) async throws -> ReportResponse
+
+    /// Reports an advertising event with specified details to the API.
+    /// - Parameters:
+    ///   - eventName: The name of the advertising event.
+    ///   - eventSource: The source of the advertising event.
+    ///   - aidvs: An array of strings representing additional identifiers for the event.
+    /// - Returns: An `AdEventsResponse` object containing the response data.
+    /// - Throws: `FakeSpotClientError.invalidURL` if the ad recording endpoint URL is invalid or not set.
+    func reportAdEvent(eventName: String, eventSource: String, aidvs: [String]) async throws -> AdEventsResponse
 }
 
 /// An enumeration representing different environments for the Fakespot client.
@@ -109,6 +118,15 @@ enum FakespotEnvironment {
         }
     }
 
+    var adRecordingEndpoint: URL? {
+        switch self {
+        case .staging:
+            return URL(string: "https://staging-partner-ads.fakespot.io/api/v1/fx/events")
+        case .prod:
+            return URL(string: "https://pe.fakespot.com/api/v1/fx/events")
+        }
+    }
+
     /// Returns the configuration URL based on the selected environment.
     var config: URL? {
         switch self {
@@ -152,8 +170,14 @@ struct FakespotClient: FakespotClientType {
             throw FakeSpotClientError.invalidURL
         }
 
+        // Prepare the request body
+        let requestBody = [
+            "website": website,
+            "product_id": productId
+        ]
+
         // Perform the async API request and get the data
-        return try await fetch(ProductAnalysisStatusResponse.self, url: endpointURL, productId: productId, website: website)
+        return try await fetch(ProductAnalysisStatusResponse.self, url: endpointURL, requestBody: requestBody)
     }
 
     /// Trigger product analyze for a given product ID and website.
@@ -163,8 +187,14 @@ struct FakespotClient: FakespotClientType {
             throw FakeSpotClientError.invalidURL
         }
 
+        // Prepare the request body
+        let requestBody = [
+            "website": website,
+            "product_id": productId
+        ]
+
         // Perform the async API request and get the data
-        return try await fetch(ProductAnalyzeResponse.self, url: endpointURL, productId: productId, website: website)
+        return try await fetch(ProductAnalyzeResponse.self, url: endpointURL, requestBody: requestBody)
     }
 
     /// Fetches product analysis data for a given product ID and website.
@@ -174,8 +204,14 @@ struct FakespotClient: FakespotClientType {
             throw FakeSpotClientError.invalidURL
         }
 
+        // Prepare the request body
+        let requestBody = [
+            "website": website,
+            "product_id": productId
+        ]
+
         // Perform the async API request and get the data
-        return try await fetch(ProductAnalysisResponse.self, url: endpointURL, productId: productId, website: website)
+        return try await fetch(ProductAnalysisResponse.self, url: endpointURL, requestBody: requestBody)
     }
 
     /// Fetches product ad data for a given product ID and website.
@@ -185,8 +221,14 @@ struct FakespotClient: FakespotClientType {
             throw FakeSpotClientError.invalidURL
         }
 
+        // Prepare the request body
+        let requestBody = [
+            "website": website,
+            "product_id": productId
+        ]
+
         // Perform the async API request and get the data
-        return try await fetch([ProductAdsResponse].self, url: endpointURL, productId: productId, website: website)
+        return try await fetch([ProductAdsResponse].self, url: endpointURL, requestBody: requestBody)
     }
 
     /// Reports product back in stock for a given product ID and website.
@@ -196,17 +238,36 @@ struct FakespotClient: FakespotClientType {
             throw FakeSpotClientError.invalidURL
         }
 
-        // Perform the async API request and get the data
-        return try await fetch(ReportResponse.self, url: endpointURL, productId: productId, website: website)
-    }
-
-    /// Asynchronous method to perform the API request and decode the response data.
-    private func fetch<T: Decodable>(_ type: T.Type, url: URL, productId: String, website: String) async throws -> T {
         // Prepare the request body
         let requestBody = [
             "website": website,
             "product_id": productId
         ]
+
+        // Perform the async API request and get the data
+        return try await fetch(ReportResponse.self, url: endpointURL, requestBody: requestBody)
+    }
+
+    /// Reports an advertising event with specified details to the API
+    func reportAdEvent(eventName: String, eventSource: String, aidvs: [String]) async throws -> AdEventsResponse {
+        // Define the API endpoint URL
+        guard let endpointURL = environment.adRecordingEndpoint else {
+            throw FakeSpotClientError.invalidURL
+        }
+
+        // Prepare the request body
+        let requestBody: [String : Any] = [
+            "event_name": eventName,
+            "event_source": eventSource,
+            "aidvs": aidvs
+        ]
+
+        // Perform the async API request and get the data
+        return try await fetch(AdEventsResponse.self, url: endpointURL, requestBody: requestBody)
+    }
+
+    /// Asynchronous method to perform the API request and decode the response data.
+    private func fetch<T: Decodable>(_ type: T.Type, url: URL, requestBody: [String: Any]) async throws -> T {
 
         // Serialize the request body to JSON data
         let jsonData = try JSONSerialization.data(withJSONObject: requestBody)
@@ -215,6 +276,7 @@ struct FakespotClient: FakespotClientType {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.httpBody = jsonData
 
         guard

--- a/Client/Frontend/Fakespot/Client/FakeSpotClient.swift
+++ b/Client/Frontend/Fakespot/Client/FakeSpotClient.swift
@@ -256,7 +256,7 @@ struct FakespotClient: FakespotClientType {
         }
 
         // Prepare the request body
-        let requestBody: [String : Any] = [
+        let requestBody: [String: Any] = [
             "event_name": eventName,
             "event_source": eventSource,
             "aidvs": aidvs
@@ -268,7 +268,6 @@ struct FakespotClient: FakespotClientType {
 
     /// Asynchronous method to perform the API request and decode the response data.
     private func fetch<T: Decodable>(_ type: T.Type, url: URL, requestBody: [String: Any]) async throws -> T {
-
         // Serialize the request body to JSON data
         let jsonData = try JSONSerialization.data(withJSONObject: requestBody)
 

--- a/Client/Frontend/Fakespot/Client/Response/AdEventsResponse.swift
+++ b/Client/Frontend/Fakespot/Client/Response/AdEventsResponse.swift
@@ -1,0 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+struct AdEventsResponse: Codable {
+    var additionalProperties: [String: String]
+}

--- a/Client/Frontend/Fakespot/ShoppingProduct.swift
+++ b/Client/Frontend/Fakespot/ShoppingProduct.swift
@@ -195,6 +195,10 @@ class ShoppingProduct: FeatureFlaggable, Equatable {
         return try await client.reportProductBackInStock(productId: product.id, website: product.host)
     }
 
+    func reportAdEvent(eventName: String, eventSource: String, aidvs: [String]) async throws -> AdEventsResponse {
+        return try await client.reportAdEvent(eventName: eventName, eventSource: eventSource, aidvs: aidvs)
+    }
+
     static func == (lhs: ShoppingProduct, rhs: ShoppingProduct) -> Bool {
         return lhs.product == rhs.product
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7801)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17399)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR introduces the new API endpoint FXIOS-7801 in version 122 of our application. The primary purpose of this endpoint is to enhance our ad tracking capabilities by enabling the recording of events related to advertisements.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

