### PR TITLE
Bugfix FXIOS-7530 [v122] Fix UnsafeRawPointer warnings for objc_setAssociatedObject

### DIFF
--- a/Client/TabManagement/TabEventHandler.swift
+++ b/Client/TabManagement/TabEventHandler.swift
@@ -155,7 +155,8 @@ extension TabEvent {
 private let center = NotificationCenter()
 
 private struct AssociatedKeys {
-    static var key = "observers"
+    // This property's address will be used as a unique address for the associated object's handle
+    static var observers: UInt8 = 0
 }
 
 private class ObserverWrapper: NSObject {
@@ -185,6 +186,6 @@ extension TabEventHandler {
             }
         }
 
-        objc_setAssociatedObject(observer, &AssociatedKeys.key, wrapper, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        objc_setAssociatedObject(observer, &AssociatedKeys.observers, wrapper, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
     }
 }

--- a/Shared/Extensions/UIBarButtonItemExtensions.swift
+++ b/Shared/Extensions/UIBarButtonItemExtensions.swift
@@ -14,7 +14,8 @@ extension UIBarButtonItem {
     }
 
     private struct AssociatedKeys {
-        static var targetClosure = "targetClosure"
+        // This property's address will be used as a unique address for the associated object's handle
+        static var targetClosure: UInt8 = 0
     }
 
     private var targetClosure: ((UIBarButtonItem) -> Void)? {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7530)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16727)

## :bulb: Description

Those warnings were the cause of passing an inout `String` type as a key to `objc_set/getAssociatedObject`, but this key variable does not need to be a string so replacing it with a `UInt8` type resolves the warning. Since the value of the key itself does not matter here but the address does, the property name is enough to serve as a unique key together with an arbitrary value.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

