### PR TITLE
Refactor FXIOS-7713 [v122] Remove legacy theme manager usage from BookmarksFolderCell

### DIFF
--- a/Client/Frontend/Library/Bookmarks/BookmarksFolderCell.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarksFolderCell.swift
@@ -87,20 +87,10 @@ extension BookmarkItemData: BookmarksFolderCell {
 // MARK: FxBookmarkNode viewModel helper
 extension FxBookmarkNode {
     var leftImageView: UIImage? {
-        return LegacyThemeManager.instance.currentName == .dark ? bookmarkFolderIconDark : bookmarkFolderIconNormal
+        return UIImage(named: StandardImageIdentifiers.Large.folder)?.withRenderingMode(.alwaysTemplate)
     }
 
     var chevronImage: UIImage? {
         return UIImage(named: StandardImageIdentifiers.Large.chevronRight)?.withRenderingMode(.alwaysTemplate)
-    }
-
-    private var bookmarkFolderIconNormal: UIImage? {
-        return UIImage(named: StandardImageIdentifiers.Large.folder)?
-            .tinted(withColor: UIColor.Photon.Grey90)
-    }
-
-    private var bookmarkFolderIconDark: UIImage? {
-        return UIImage(named: StandardImageIdentifiers.Large.folder)?
-            .tinted(withColor: UIColor.Photon.Grey10)
     }
 }

--- a/Client/Frontend/Widgets/OneLineTableViewCell.swift
+++ b/Client/Frontend/Widgets/OneLineTableViewCell.swift
@@ -166,5 +166,6 @@ class OneLineTableViewCell: UITableViewCell,
         titleLabel.textColor = theme.colors.textPrimary
         bottomSeparatorView.backgroundColor = theme.colors.borderPrimary
         accessoryView?.tintColor = theme.colors.actionSecondary
+        leftImageView.tintColor = theme.colors.textPrimary
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7713)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17203)

## :bulb: Description

- Return a single image with rendering mode `.alwaysTemplate` instead of two tinted variants based on legacy theme
- Apply `tintColor` on image view instead, in the cell's `applyTheme` method

| | Before | After |
| :-: | :-: | :-: |
| Dark | ![Simulator Screenshot - iPhone 15 Pro - 2023-12-05 at 16 09 33](https://github.com/mozilla-mobile/firefox-ios/assets/19548672/387d0df9-d3a6-4753-9544-01c844bed686) | ![Simulator Screenshot - iPhone 15 Pro - 2023-12-05 at 16 16 27](https://github.com/mozilla-mobile/firefox-ios/assets/19548672/693b63d0-dcfa-4d7a-a12d-216667f7a102) |
| Light | ![Simulator Screenshot - iPhone 15 Pro - 2023-12-05 at 16 10 08](https://github.com/mozilla-mobile/firefox-ios/assets/19548672/18ed6df4-b9ef-4612-8df2-3da055993fa9) | ![Simulator Screenshot - iPhone 15 Pro - 2023-12-05 at 16 15 49](https://github.com/mozilla-mobile/firefox-ios/assets/19548672/fd685768-b9ba-4e1b-bd86-d986d2b920b2) |







## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

