### PR TITLE
Bugfix FXIOS-6685 [v122] Search is not correctly aligned in RTL locale (ar) 

### DIFF
--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -87,7 +87,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
         autocapitalizationType = .none
         returnKeyType = .go
         clearButtonMode = .whileEditing
-        textAlignment = .left
+        textAlignment = effectiveUserInterfaceLayoutDirection == .leftToRight ? .natural : .right
     }
 
     override var keyCommands: [UIKeyCommand]? {
@@ -268,7 +268,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
         label.accessibilityIdentifier = "autocomplete"
         label.backgroundColor = self.backgroundColor
         label.textColor = self.textColor
-        label.textAlignment = .left
+        label.textAlignment = .natural
 
         let enteredTextSize = self.attributedText?.boundingRect(with: self.frame.size, options: NSStringDrawingOptions.usesLineFragmentOrigin, context: nil)
         frame.origin.x = (enteredTextSize?.width.rounded() ?? 0) + textRect(forBounds: bounds).origin.x


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6685)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14919)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

