### PR TITLE
Refactor FXIOS-7890 [v122] Review Checker's advertised products' price should be formatted with "$", not "USD" prefix

### DIFF
--- a/Client/Frontend/Fakespot/Views/FakespotAdView.swift
+++ b/Client/Frontend/Fakespot/Views/FakespotAdView.swift
@@ -147,7 +147,7 @@ class FakespotAdView: UIView, Notifiable, ThemeApplicable, UITextViewDelegate {
         footerLabel.text = viewModel.footerText
         footerLabel.accessibilityIdentifier = viewModel.footerA11yId
 
-        priceLabel.text = productAdsData.currency + productAdsData.price
+        priceLabel.text = viewModel.formattedPrice
         priceLabel.accessibilityIdentifier = viewModel.priceA11yId
 
         starRatingView.rating = productAdsData.adjustedRating

--- a/Client/Frontend/Fakespot/Views/FakespotAdView.swift
+++ b/Client/Frontend/Fakespot/Views/FakespotAdView.swift
@@ -23,6 +23,22 @@ struct FakespotAdViewModel {
     var dismissViewController: (() -> Void)?
     let productAdsData: ProductAdsResponse
 
+    var formattedPrice: String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.minimumFractionDigits = 2
+        formatter.maximumFractionDigits = 2
+        formatter.currencyCode = productAdsData.currency
+
+        let fallBackPrice = productAdsData.currency + productAdsData.price
+
+        guard let price = Double(productAdsData.price) else {
+            return fallBackPrice
+        }
+
+        return formatter.string(from: NSNumber(value: price)) ?? fallBackPrice
+    }
+
     // MARK: Init
     init(tabManager: TabManager = AppContainer.shared.resolve(),
          productAdsData: ProductAdsResponse) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7890)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17627)

## :bulb: Description
Formats the ad price according to the users preferences set on the phone.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

