### PR TITLE
Refactor FXIOS-7891 [v122] Clean up if available code

### DIFF
--- a/BrowserKit/Sources/Common/Logger/CrashManager.swift
+++ b/BrowserKit/Sources/Common/Logger/CrashManager.swift
@@ -104,9 +104,7 @@ public class DefaultCrashManager: CrashManager {
             options.enableFileIOTracing = false
             options.enableNetworkTracking = false
             options.enableAppHangTracking = self.shouldEnableAppHangTracking
-            if #available(iOS 15.0, *) {
-                options.enableMetricKit = self.shouldEnableMetricKit
-            }
+            options.enableMetricKit = self.shouldEnableMetricKit
             options.enableCaptureFailedRequests = false
             options.enableSwizzling = false
             options.beforeBreadcrumb = { crumb in

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -362,12 +362,9 @@ extension BrowserViewController {
             UIKeyCommand(action: #selector(showTabTrayKeyCommand), input: "\\", modifierFlags: [.command, .shift]),
         ]
 
-        // In iOS 15+, certain keys events are delivered to the text input or focus systems first, unless specified otherwise
-        if #available(iOS 15, *) {
-            searchLocationCommands.forEach { $0.wantsPriorityOverSystemBehavior = true }
-            overridesTextEditing.forEach { $0.wantsPriorityOverSystemBehavior = true }
-            windowShortcuts.forEach { $0.wantsPriorityOverSystemBehavior = true }
-        }
+        searchLocationCommands.forEach { $0.wantsPriorityOverSystemBehavior = true }
+        overridesTextEditing.forEach { $0.wantsPriorityOverSystemBehavior = true }
+        windowShortcuts.forEach { $0.wantsPriorityOverSystemBehavior = true }
 
         let commands = [
             UIKeyCommand(action: #selector(undoLastTabClosedKeyCommand), input: "t", modifierFlags: [.command, .shift]),

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -112,9 +112,7 @@ class SearchViewController: SiteTableViewController,
         self.highlightManager = highlightManager
         super.init(profile: profile)
 
-        if #available(iOS 15.0, *) {
-            tableView.sectionHeaderTopPadding = 0
-        }
+        tableView.sectionHeaderTopPadding = 0
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Client/Frontend/Browser/TabTrayController+KeyCommands.swift
+++ b/Client/Frontend/Browser/TabTrayController+KeyCommands.swift
@@ -22,11 +22,7 @@ extension LegacyGridTabViewController {
             UIKeyCommand(input: UIKeyCommand.inputDownArrow, modifierFlags: [], action: #selector(didChangeSelectedTabKeyCommand(sender:))),
             UIKeyCommand(input: UIKeyCommand.inputUpArrow, modifierFlags: [], action: #selector(didChangeSelectedTabKeyCommand(sender:))),
         ]
-
-        // In iOS 15+, certain keys events are delivered to the text input or focus systems first, unless specified otherwise
-        if #available(iOS 15, *) {
-            arrowKeysCommands.forEach { $0.wantsPriorityOverSystemBehavior = true }
-        }
+        arrowKeysCommands.forEach { $0.wantsPriorityOverSystemBehavior = true }
 
         return commands + arrowKeysCommands
     }

--- a/Client/Frontend/Browser/Tabs/Legacy/LegacyRemoteTabsPanel.swift
+++ b/Client/Frontend/Browser/Tabs/Legacy/LegacyRemoteTabsPanel.swift
@@ -172,9 +172,7 @@ class LegacyRemoteTabsTableViewController: UITableViewController, Themeable {
         tableView.separatorInset = .zero
         tableView.alwaysBounceVertical = false
 
-        if #available(iOS 15.0, *) {
-            tableView.sectionHeaderTopPadding = 0.0
-        }
+        tableView.sectionHeaderTopPadding = 0.0
 
         tableView.delegate = nil
         tableView.dataSource = nil

--- a/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
+++ b/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsTableViewController.swift
@@ -64,9 +64,7 @@ class RemoteTabsTableViewController: UITableViewController,
         tableView.separatorInset = .zero
         tableView.alwaysBounceVertical = false
 
-        if #available(iOS 15.0, *) {
-            tableView.sectionHeaderTopPadding = 0.0
-        }
+        tableView.sectionHeaderTopPadding = 0.0
 
         tableView.accessibilityIdentifier = AccessibilityIdentifiers.TabTray.syncedTabs
 

--- a/Client/Frontend/Library/Downloads/DownloadsPanel.swift
+++ b/Client/Frontend/Library/Downloads/DownloadsPanel.swift
@@ -42,9 +42,8 @@ class DownloadsPanel: UIViewController,
         tableView.keyboardDismissMode = .onDrag
         tableView.accessibilityIdentifier = "DownloadsTable"
         tableView.cellLayoutMarginsFollowReadableWidth = false
-        if #available(iOS 15.0, *) {
-            tableView.sectionHeaderTopPadding = 0.0
-        }
+        tableView.sectionHeaderTopPadding = 0.0
+
         // Set an empty footer to prevent empty cells from appearing in the list.
         tableView.tableFooterView = UIView()
     }

--- a/Client/Frontend/Library/HistoryPanel/GeneralizedTableView/SearchGroupedItemsViewController.swift
+++ b/Client/Frontend/Library/HistoryPanel/GeneralizedTableView/SearchGroupedItemsViewController.swift
@@ -35,9 +35,7 @@ class SearchGroupedItemsViewController: UIViewController, UITableViewDelegate, T
         tableView.register(OneLineTableViewCell.self, forCellReuseIdentifier: OneLineTableViewCell.cellIdentifier)
         tableView.register(TwoLineImageOverlayCell.self, forCellReuseIdentifier: TwoLineImageOverlayCell.cellIdentifier)
 
-        if #available(iOS 15.0, *) {
-            tableView.sectionHeaderTopPadding = 0
-        }
+        tableView.sectionHeaderTopPadding = 0
     }
 
     private lazy var doneButton: UIBarButtonItem =  {

--- a/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -122,9 +122,7 @@ class HistoryPanel: UIViewController,
         tableView.register(SiteTableViewHeader.self,
                            forHeaderFooterViewReuseIdentifier: SiteTableViewHeader.cellIdentifier)
 
-        if #available(iOS 15.0, *) {
-            tableView.sectionHeaderTopPadding = 0
-        }
+        tableView.sectionHeaderTopPadding = 0
     }
 
     lazy var longPressRecognizer: UILongPressGestureRecognizer = {

--- a/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -301,10 +301,8 @@ class LibraryViewController: UIViewController, Themeable {
         standardAppearance.backgroundColor = themeManager.currentTheme.colors.layer1
         navigationController?.toolbar.standardAppearance = standardAppearance
         navigationController?.toolbar.compactAppearance = standardAppearance
-        if #available(iOS 15.0, *) {
-            navigationController?.toolbar.scrollEdgeAppearance = standardAppearance
-            navigationController?.toolbar.compactScrollEdgeAppearance = standardAppearance
-        }
+        navigationController?.toolbar.scrollEdgeAppearance = standardAppearance
+        navigationController?.toolbar.compactScrollEdgeAppearance = standardAppearance
         navigationController?.toolbar.tintColor = themeManager.currentTheme.colors.actionPrimary
     }
 

--- a/Client/Frontend/PasswordManagement/PasswordManagerListViewController.swift
+++ b/Client/Frontend/PasswordManagement/PasswordManagerListViewController.swift
@@ -67,10 +67,7 @@ class PasswordManagerListViewController: SensitiveViewController, Themeable {
         tableView.allowsMultipleSelectionDuringEditing = true
         tableView.delegate = self
         tableView.tableFooterView = UIView()
-
-        if #available(iOS 15.0, *) {
-            tableView.sectionHeaderTopPadding = 0
-        }
+        tableView.sectionHeaderTopPadding = 0
 
         // Setup the Search Controller
         searchController.searchBar.autocapitalizationType = .none

--- a/Client/Frontend/Settings/SettingsNavigationController.swift
+++ b/Client/Frontend/Settings/SettingsNavigationController.swift
@@ -51,9 +51,7 @@ class ThemedNavigationController: DismissableNavigationViewController, Themeable
         navigationBar.standardAppearance = standardAppearance
         navigationBar.compactAppearance = standardAppearance
         navigationBar.scrollEdgeAppearance = standardAppearance
-        if #available(iOS 15.0, *) {
-            navigationBar.compactScrollEdgeAppearance = standardAppearance
-        }
+        navigationBar.compactScrollEdgeAppearance = standardAppearance
         navigationBar.tintColor = theme.colors.actionPrimary
     }
 

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -100,11 +100,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
             UIKeyCommand(input: UIKeyCommand.inputRightArrow, modifierFlags: [], action: #selector(self.handleKeyCommand(sender:))),
             UIKeyCommand(input: UIKeyCommand.inputEscape, modifierFlags: [], action: #selector(self.handleKeyCommand(sender:))),
         ]
-
-        // In iOS 15+, certain keys events are delivered to the text input or focus systems first, unless specified otherwise
-        if #available(iOS 15, *) {
-            arrowKeysCommands.forEach { $0.wantsPriorityOverSystemBehavior = true }
-        }
+        arrowKeysCommands.forEach { $0.wantsPriorityOverSystemBehavior = true }
 
         return arrowKeysCommands + commands
     }

--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -45,10 +45,7 @@ class SiteTableViewController: UIViewController,
 
         // Set an empty footer to prevent empty cells from appearing in the list.
         table.tableFooterView = UIView()
-
-        if #available(iOS 15.0, *) {
-            table.sectionHeaderTopPadding = 0
-        }
+        table.sectionHeaderTopPadding = 0
     }
 
     override private init(nibName: String?, bundle: Bundle?) {

--- a/Client/Frontend/Widgets/ThemedDefaultNavigationController.swift
+++ b/Client/Frontend/Widgets/ThemedDefaultNavigationController.swift
@@ -41,9 +41,7 @@ class ThemedDefaultNavigationController: DismissableNavigationViewController, Th
         navigationBar.standardAppearance = standardAppearance
         navigationBar.compactAppearance = standardAppearance
         navigationBar.scrollEdgeAppearance = standardAppearance
-        if #available(iOS 15.0, *) {
-            navigationBar.compactScrollEdgeAppearance = standardAppearance
-        }
+        navigationBar.compactScrollEdgeAppearance = standardAppearance
         navigationBar.tintColor = themeManager.currentTheme.colors.textPrimary
     }
 
@@ -56,10 +54,8 @@ class ThemedDefaultNavigationController: DismissableNavigationViewController, Th
 
         toolbar.standardAppearance = standardAppearance
         toolbar.compactAppearance = standardAppearance
-        if #available(iOS 15.0, *) {
-            toolbar.scrollEdgeAppearance = standardAppearance
-            toolbar.compactScrollEdgeAppearance = standardAppearance
-        }
+        toolbar.scrollEdgeAppearance = standardAppearance
+        toolbar.compactScrollEdgeAppearance = standardAppearance
         toolbar.tintColor = themeManager.currentTheme.colors.textPrimary
     }
 

--- a/Client/Helpers/MenuBuilderHelper.swift
+++ b/Client/Helpers/MenuBuilderHelper.swift
@@ -25,22 +25,16 @@ class MenuBuilderHelper {
             UIKeyCommand(title: .KeyboardShortcuts.SelectLocationBar, action: #selector(BrowserViewController.selectLocationBarKeyCommand), input: "l", modifierFlags: .command, discoverabilityTitle: .KeyboardShortcuts.SelectLocationBar),
             UIKeyCommand(title: .KeyboardShortcuts.CloseCurrentTab, action: #selector(BrowserViewController.closeTabKeyCommand), input: "w", modifierFlags: .command, discoverabilityTitle: .KeyboardShortcuts.CloseCurrentTab),
         ])
-
-        if #available(iOS 15, *) {
-            fileMenu.children.forEach {
-                ($0 as! UIKeyCommand).wantsPriorityOverSystemBehavior = true
-            }
+        fileMenu.children.forEach {
+            ($0 as! UIKeyCommand).wantsPriorityOverSystemBehavior = true
         }
 
         let findMenu = UIMenu(options: .displayInline, children: [
             UIKeyCommand(title: .KeyboardShortcuts.Find, action: #selector(BrowserViewController.findInPageKeyCommand), input: "f", modifierFlags: .command, discoverabilityTitle: .KeyboardShortcuts.Find),
             UIKeyCommand(title: .KeyboardShortcuts.FindAgain, action: #selector(BrowserViewController.findInPageAgainKeyCommand), input: "g", modifierFlags: .command, discoverabilityTitle: .KeyboardShortcuts.FindAgain),
         ])
-
-        if #available(iOS 15, *) {
-            findMenu.children.forEach {
-                ($0 as! UIKeyCommand).wantsPriorityOverSystemBehavior = true
-            }
+        findMenu.children.forEach {
+            ($0 as! UIKeyCommand).wantsPriorityOverSystemBehavior = true
         }
 
         var viewMenuChildren: [UIMenuElement] = [
@@ -56,11 +50,8 @@ class MenuBuilderHelper {
         )
 
         let viewMenu = UIMenu(options: .displayInline, children: viewMenuChildren)
-
-        if #available(iOS 15, *) {
-            viewMenu.children.forEach {
-                ($0 as! UIKeyCommand).wantsPriorityOverSystemBehavior = true
-            }
+        viewMenu.children.forEach {
+            ($0 as! UIKeyCommand).wantsPriorityOverSystemBehavior = true
         }
 
         let historyMenu = UIMenu(title: .KeyboardShortcuts.Sections.History, identifier: MenuIdentifiers.history, options: .displayInline, children: [

--- a/Client/TabManagement/TabManagerImplementation.swift
+++ b/Client/TabManagement/TabManagerImplementation.swift
@@ -287,8 +287,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
     }
 
     private func saveCurrentTabSessionData() {
-        guard #available(iOS 15.0, *),
-              let selectedTab = self.selectedTab,
+        guard let selectedTab = self.selectedTab,
               let tabSession = selectedTab.webView?.interactionState as? Data,
               let tabID = UUID(uuidString: selectedTab.tabUUID)
         else { return }
@@ -394,13 +393,6 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
         // users's last state (Private vs Regular)
         UserDefaults.standard.set(selectedTab?.isPrivate ?? false,
                                   forKey: PrefsKeys.LastSessionWasPrivate)
-    }
-
-    private func shouldUseNewTabStore() -> Bool {
-        if #available(iOS 15, *) {
-            return true
-        }
-        return false
     }
 
     // MARK: - Screenshots

--- a/Shared/Extensions/WKWebViewExtensions.swift
+++ b/Shared/Extensions/WKWebViewExtensions.swift
@@ -12,12 +12,7 @@ extension WKWebView {
     /// - Parameters:
     ///     - javascript: String representing javascript to be evaluated
     public func evaluateJavascriptInDefaultContentWorld(_ javascript: String) {
-        // iOS 14.3 is required here because of a webkit bug in lower iOS versions with this API
-        if #available(iOS 14.3, *) {
-            self.evaluateJavaScript(javascript, in: nil, in: .defaultClient, completionHandler: { _ in })
-        } else {
-            self.evaluateJavaScript(javascript)
-        }
+        self.evaluateJavaScript(javascript, in: nil, in: .defaultClient, completionHandler: { _ in })
     }
 
     /// This calls different WebKit evaluateJavaScript functions depending on iOS version with a completion that passes a tuple with optional data or an optional error
@@ -27,19 +22,12 @@ extension WKWebView {
     ///     - javascript: String representing javascript to be evaluated
     ///     - completion: Tuple containing optional data and an optional error
     public func evaluateJavascriptInDefaultContentWorld(_ javascript: String, _ frame: WKFrameInfo? = nil, _ completion: @escaping (Any?, Error?) -> Void) {
-        // iOS 14.3 is required here because of a webkit bug in lower iOS versions with this API
-        if #available(iOS 14.3, *) {
-            self.evaluateJavaScript(javascript, in: frame, in: .defaultClient) { result in
-                switch result {
-                case .success(let value):
-                    completion(value, nil)
-                case .failure(let error):
-                    completion(nil, error)
-                }
-            }
-        } else {
-            self.evaluateJavaScript(javascript) { data, error  in
-                completion(data, error)
+        self.evaluateJavaScript(javascript, in: frame, in: .defaultClient) { result in
+            switch result {
+            case .success(let value):
+                completion(value, nil)
+            case .failure(let error):
+                completion(nil, error)
             }
         }
     }
@@ -47,40 +35,20 @@ extension WKWebView {
 
 extension WKUserContentController {
     public func addInDefaultContentWorld(scriptMessageHandler: WKScriptMessageHandler, name: String) {
-        // iOS 14.3 is required here because of a webkit bug in lower iOS versions with this API
-        if #available(iOS 14.3, *) {
-            add(scriptMessageHandler, contentWorld: .defaultClient, name: name)
-        } else {
-            add(scriptMessageHandler, name: name)
-        }
+        add(scriptMessageHandler, contentWorld: .defaultClient, name: name)
     }
 
     public func addInPageContentWorld(scriptMessageHandler: WKScriptMessageHandler, name: String) {
-        // iOS 14.3 is required here because of a webkit bug in lower iOS versions with this API
-        if #available(iOS 14.3, *) {
-            add(scriptMessageHandler, contentWorld: .page, name: name)
-        } else {
-            add(scriptMessageHandler, name: name)
-        }
+        add(scriptMessageHandler, contentWorld: .page, name: name)
     }
 }
 
 extension WKUserScript {
     public class func createInDefaultContentWorld(source: String, injectionTime: WKUserScriptInjectionTime, forMainFrameOnly: Bool) -> WKUserScript {
-        // iOS 14.3 is required here because of a webkit bug in lower iOS versions with this API
-        if #available(iOS 14.3, *) {
-            return WKUserScript(source: source, injectionTime: injectionTime, forMainFrameOnly: forMainFrameOnly, in: .defaultClient)
-        } else {
-            return WKUserScript(source: source, injectionTime: injectionTime, forMainFrameOnly: forMainFrameOnly)
-        }
+        return WKUserScript(source: source, injectionTime: injectionTime, forMainFrameOnly: forMainFrameOnly, in: .defaultClient)
     }
 
     public class func createInPageContentWorld(source: String, injectionTime: WKUserScriptInjectionTime, forMainFrameOnly: Bool) -> WKUserScript {
-        // iOS 14.3 is required here because of a webkit bug in lower iOS versions with this API
-        if #available(iOS 14.3, *) {
-            return WKUserScript(source: source, injectionTime: injectionTime, forMainFrameOnly: forMainFrameOnly, in: .page)
-        } else {
-            return WKUserScript(source: source, injectionTime: injectionTime, forMainFrameOnly: forMainFrameOnly)
-        }
+        return WKUserScript(source: source, injectionTime: injectionTime, forMainFrameOnly: forMainFrameOnly, in: .page)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7891)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17629)

## :bulb: Description
Clean up `#available(iOS` where we can since our `IPHONEOS_DEPLOYMENT_TARGET` is iOS 15.0.

Note that `Tab.swift` `isRestoring` is never set to true, so it seems we can remove it @OrlaM ?

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

