### PR TITLE
Refactor FXIOS-7808 [v122] Refactors to AppEvent for window UUIDs and iPad multi-window support

### DIFF
--- a/BrowserKit/Sources/TabDataStore/WindowData.swift
+++ b/BrowserKit/Sources/TabDataStore/WindowData.swift
@@ -5,9 +5,6 @@
 import Foundation
 
 public struct WindowData: Codable {
-    // TODO: [7798] Part of WIP iPad multi-window epic.
-    public static let DefaultSingleWindowUUID = UUID(uuidString: "44BA0B7D-097A-484D-8358-91A6E374451D")!
-
     public let id: UUID
     public let isPrimary: Bool
     public let activeTabId: UUID

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -63,6 +63,10 @@
 		1D7B789F2AE088930011E9F2 /* EventQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D7B789E2AE088930011E9F2 /* EventQueueTests.swift */; };
 		1D8487B42AD0C6C100F7527C /* RemoteTabsPanelMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8487B32AD0C6C100F7527C /* RemoteTabsPanelMiddleware.swift */; };
 		1D8487B62AD6038100F7527C /* RemoteTabPanelStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8487B52AD6038100F7527C /* RemoteTabPanelStateTests.swift */; };
+		1D969C702B21322B004255B1 /* BrowserWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D969C6F2B21322B004255B1 /* BrowserWindow.swift */; };
+		1D969C712B2132B6004255B1 /* BrowserWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D969C6F2B21322B004255B1 /* BrowserWindow.swift */; };
+		1D969C722B2132B7004255B1 /* BrowserWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D969C6F2B21322B004255B1 /* BrowserWindow.swift */; };
+		1D969C732B2132B7004255B1 /* BrowserWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D969C6F2B21322B004255B1 /* BrowserWindow.swift */; };
 		1D9E1FE524FEF56C006E561D /* TopSites in Resources */ = {isa = PBXBuildFile; fileRef = 3BC659481E5BA4AE006D560F /* TopSites */; };
 		1DA3CE5D24EEE73100422BB2 /* OpenTabsWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA3CE5C24EEE73100422BB2 /* OpenTabsWidget.swift */; };
 		1DA3CE5F24EEE7C600422BB2 /* LegacyTabDataRetriever.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA3CE5E24EEE7C600422BB2 /* LegacyTabDataRetriever.swift */; };
@@ -2157,6 +2161,7 @@
 		1D8487B32AD0C6C100F7527C /* RemoteTabsPanelMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabsPanelMiddleware.swift; sourceTree = "<group>"; };
 		1D8487B52AD6038100F7527C /* RemoteTabPanelStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabPanelStateTests.swift; sourceTree = "<group>"; };
 		1D90440B860A503D4DBA4213 /* cy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cy; path = cy.lproj/Storage.strings; sourceTree = "<group>"; };
+		1D969C6F2B21322B004255B1 /* BrowserWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserWindow.swift; sourceTree = "<group>"; };
 		1DA24C60879E7D4B2073FD63 /* kab */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kab; path = kab.lproj/Search.strings; sourceTree = "<group>"; };
 		1DA3CE5C24EEE73100422BB2 /* OpenTabsWidget.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenTabsWidget.swift; sourceTree = "<group>"; };
 		1DA3CE5E24EEE7C600422BB2 /* LegacyTabDataRetriever.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyTabDataRetriever.swift; sourceTree = "<group>"; };
@@ -9218,6 +9223,7 @@
 				8A19ACAA2A32895E001C2147 /* BrowserNavigationHandler.swift */,
 				8A93F87129D3A5AD004159D9 /* BrowserCoordinator.swift */,
 				8AF99B4E29EF1BA700108DEC /* BrowserDelegate.swift */,
+				1D969C6F2B21322B004255B1 /* BrowserWindow.swift */,
 			);
 			path = Browser;
 			sourceTree = "<group>";
@@ -12635,6 +12641,7 @@
 				1D1933792AF2C8CF005089C9 /* AppEvent.swift in Sources */,
 				396E38DD1EE081DA00CC180F /* SyncDisplayState.swift in Sources */,
 				1D1933762AF2C8C9005089C9 /* EventQueue.swift in Sources */,
+				1D969C712B2132B6004255B1 /* BrowserWindow.swift in Sources */,
 				6025B10E267B6C7F00F59F6B /* LoginRecordExtension.swift in Sources */,
 				396E38F21EE0C8ED00CC180F /* FxAPushMessageHandler.swift in Sources */,
 				F8A0B08329AD64790091C75B /* RustSyncManager.swift in Sources */,
@@ -12801,6 +12808,7 @@
 				6025B111267B6EE100F59F6B /* CredentialWelcomeViewController.swift in Sources */,
 				1D1933742AF2C8C8005089C9 /* EventQueue.swift in Sources */,
 				C87DF962267246730097E707 /* photon-colors.swift in Sources */,
+				1D969C732B2132B7004255B1 /* BrowserWindow.swift in Sources */,
 				6025B10A267B6BB300F59F6B /* SelectPasswordCell.swift in Sources */,
 				8AB8574127D9630E0075C173 /* LegacyTheme.swift in Sources */,
 				1D1933772AF2C8CE005089C9 /* AppEvent.swift in Sources */,
@@ -13450,6 +13458,7 @@
 				D5D052D92645ABF400759F85 /* ExperimentsSettingsView.swift in Sources */,
 				8AE0BF4F2819B10E00F33EC4 /* TopSitesSettingsViewController.swift in Sources */,
 				8A8DDEBF276259A900E7B97A /* RatingPromptManager.swift in Sources */,
+				1D969C702B21322B004255B1 /* BrowserWindow.swift in Sources */,
 				8AB8571D27D929350075C173 /* TopSitesViewModel.swift in Sources */,
 				8A93F85E29D36DA9004159D9 /* Coordinator.swift in Sources */,
 				1D2F68B12ACCA22000524B92 /* RemoteTabsEmptyView.swift in Sources */,
@@ -13897,6 +13906,7 @@
 				E1CD81BA290C4ED900124B27 /* AccessibilityIdentifiers.swift in Sources */,
 				E1CD81BF290C5C9500124B27 /* DevicePickerTableViewHeaderCell.swift in Sources */,
 				1D1933782AF2C8CE005089C9 /* AppEvent.swift in Sources */,
+				1D969C722B2132B7004255B1 /* BrowserWindow.swift in Sources */,
 				1D1933752AF2C8C9005089C9 /* EventQueue.swift in Sources */,
 				E41A7D4B1A1BE04500245963 /* InitialViewController.swift in Sources */,
 			);

--- a/Client/Application/SceneDelegate.swift
+++ b/Client/Application/SceneDelegate.swift
@@ -43,10 +43,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         routeBuilder.configure(isPrivate: UserDefaults.standard.bool(forKey: PrefsKeys.LastSessionWasPrivate),
                                prefs: profile.prefs)
 
-        sceneCoordinator = SceneCoordinator(scene: scene)
-        sceneCoordinator?.start()
+        let sceneCoordinator = SceneCoordinator(scene: scene)
+        self.sceneCoordinator = sceneCoordinator
+        sceneCoordinator.start()
 
-        AppEventQueue.wait(for: [.startupFlowComplete, .tabRestoration]) { [weak self] in
+        AppEventQueue.wait(for: [.startupFlowComplete, .tabRestoration(sceneCoordinator.windowUUID)]) { [weak self] in
             self?.handle(connectionOptions: connectionOptions)
         }
     }

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -358,6 +358,7 @@ class BrowserCoordinator: BaseCoordinator,
         browserViewController.openRecentlyClosedSiteInSameTab(url)
     }
 
+    @discardableResult
     func openRecentlyClosedSiteInNewTab(_ url: URL, isPrivate: Bool) -> WindowUUID {
         browserViewController.openRecentlyClosedSiteInNewTab(url, isPrivate: isPrivate)
         // TODO: [FXIOS-7349] Updates to Recently Closed for iPad multi-window forthcoming.

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -318,7 +318,7 @@ class BrowserCoordinator: BaseCoordinator,
 
             let libraryCoordinator = LibraryCoordinator(
                 router: DefaultRouter(navigationController: navigationController),
-                tabManager: browserViewController.tabManager
+                tabManager: tabManager
             )
             libraryCoordinator.parentCoordinator = self
             add(child: libraryCoordinator)

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -360,7 +360,7 @@ class BrowserCoordinator: BaseCoordinator,
 
     func openRecentlyClosedSiteInNewTab(_ url: URL, isPrivate: Bool) -> WindowUUID {
         browserViewController.openRecentlyClosedSiteInNewTab(url, isPrivate: isPrivate)
-        // TODO: [7349] Updates to Recently Closed for iPad multi-window forthcoming.
+        // TODO: [FXIOS-7349] Updates to Recently Closed for iPad multi-window forthcoming.
         return tabManager.windowUUID
     }
 

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -68,8 +68,7 @@ class BrowserCoordinator: BaseCoordinator,
     private func tabManagerDidConnectToScene() {
         // [7863] [WIP] Redux: connect this Browser's TabManager to associated window scene
         guard ReduxFlagManager.isReduxEnabled else { return }
-        let sceneUUID = WindowData.DefaultSingleWindowUUID
-        store.dispatch(TabManagerAction.tabManagerDidConnectToScene(tabManager, sceneUUID))
+        store.dispatch(TabManagerAction.tabManagerDidConnectToScene(tabManager))
 
         // TODO [7856]: Additional telemetry updates forthcoming once iPad multi-window enabled.
         // For now, we only have a single BVC and TabManager. Plug it into our TelemetryWrapper:
@@ -359,8 +358,10 @@ class BrowserCoordinator: BaseCoordinator,
         browserViewController.openRecentlyClosedSiteInSameTab(url)
     }
 
-    func openRecentlyClosedSiteInNewTab(_ url: URL, isPrivate: Bool) {
+    func openRecentlyClosedSiteInNewTab(_ url: URL, isPrivate: Bool) -> WindowUUID {
         browserViewController.openRecentlyClosedSiteInNewTab(url, isPrivate: isPrivate)
+        // TODO: [7349] Updates to Recently Closed for iPad multi-window forthcoming.
+        return tabManager.windowUUID
     }
 
     func libraryPanelDidRequestToOpenInNewTab(_ url: URL, isPrivate: Bool) {

--- a/Client/Coordinators/Browser/BrowserWindow.swift
+++ b/Client/Coordinators/Browser/BrowserWindow.swift
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// A unique identifier for a particular window in Firefox iOS.
+/// On iPad this UUID corresponds to an individual window which
+/// manages its own unique set of tabs. Multiple Firefox windows
+/// can be run side-by-side on iPad (once multi-window is enabled). [FXIOS-7349]
+public typealias WindowUUID = UUID
+
+extension WindowUUID {
+    // TODO: [7798] Part of WIP iPad multi-window epic.
+    public static let defaultSingleWindowUUID = UUID(uuidString: "44BA0B7D-097A-484D-8358-91A6E374451D")!
+}

--- a/Client/Coordinators/Browser/BrowserWindow.swift
+++ b/Client/Coordinators/Browser/BrowserWindow.swift
@@ -11,6 +11,6 @@ import Foundation
 public typealias WindowUUID = UUID
 
 extension WindowUUID {
-    // [7798] Temporary. Part of WIP iPad multi-window epic.
+    // TODO: [FXIOS-7798] Temporary. Part of WIP iPad multi-window epic.
     public static let defaultSingleWindowUUID = UUID(uuidString: "44BA0B7D-097A-484D-8358-91A6E374451D")!
 }

--- a/Client/Coordinators/Browser/BrowserWindow.swift
+++ b/Client/Coordinators/Browser/BrowserWindow.swift
@@ -11,6 +11,6 @@ import Foundation
 public typealias WindowUUID = UUID
 
 extension WindowUUID {
-    // TODO: [7798] Part of WIP iPad multi-window epic.
+    // [7798] Temporary. Part of WIP iPad multi-window epic.
     public static let defaultSingleWindowUUID = UUID(uuidString: "44BA0B7D-097A-484D-8358-91A6E374451D")!
 }

--- a/Client/Coordinators/Scene/SceneCoordinator.swift
+++ b/Client/Coordinators/Scene/SceneCoordinator.swift
@@ -22,7 +22,7 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
         self.screenshotService = screenshotService
         self.sceneContainer = sceneContainer
 
-        // TODO: [7798] Update for iPad multi-window. Default to single-window UUID for now.
+        // TODO: [FXIOS-7798] Update for iPad multi-window. Default to single-window UUID for now.
         self.windowUUID = .defaultSingleWindowUUID
 
         let navigationController = sceneSetupHelper.createNavigationController()
@@ -128,7 +128,7 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
 
     private func defaultDiskImageStoreForSceneTabManager() -> DefaultDiskImageStore {
         let profile: Profile = AppContainer.shared.resolve()
-        // TODO: [7885] Once iPad multi-window enabled each TabManager will likely share same default image store.
+        // TODO: [FXIOS-7885] Once iPad multi-window enabled each TabManager will likely share same default image store.
         return DefaultDiskImageStore(files: profile.files,
                                      namespace: "TabManagerScreenshots",
                                      quality: UIConstants.ScreenshotQuality)

--- a/Client/Coordinators/Scene/SceneCoordinator.swift
+++ b/Client/Coordinators/Scene/SceneCoordinator.swift
@@ -122,15 +122,16 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
 
     private func createWindowTabManager(for windowUUID: WindowUUID) -> TabManager {
         let profile: Profile = AppContainer.shared.resolve()
+        let imageStore = defaultDiskImageStoreForSceneTabManager()
+        return TabManagerImplementation(profile: profile, imageStore: imageStore, uuid: windowUUID)
+    }
+
+    private func defaultDiskImageStoreForSceneTabManager() -> DefaultDiskImageStore {
+        let profile: Profile = AppContainer.shared.resolve()
         // TODO: [7885] Once iPad multi-window enabled each TabManager will likely share same default image store.
-        let imageStore = DefaultDiskImageStore(
-            files: profile.files,
-            namespace: "TabManagerScreenshots",
-            quality: UIConstants.ScreenshotQuality)
-        let tabManager = TabManagerImplementation(profile: profile,
-                                                  imageStore: imageStore,
-                                                  uuid: windowUUID)
-        return tabManager
+        return DefaultDiskImageStore(files: profile.files,
+                                     namespace: "TabManagerScreenshots",
+                                     quality: UIConstants.ScreenshotQuality)
     }
 
     // MARK: - LaunchCoordinatorDelegate

--- a/Client/Coordinators/Scene/SceneCoordinator.swift
+++ b/Client/Coordinators/Scene/SceneCoordinator.swift
@@ -7,11 +7,10 @@ import UIKit
 import Shared
 import Storage
 
-typealias SceneUUID = UUID
-
 /// Each scene has it's own scene coordinator, which is the root coordinator for a scene.
 class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinishedLoadingDelegate {
     var window: UIWindow?
+    let windowUUID: WindowUUID
     private let screenshotService: ScreenshotService
     private let sceneContainer: SceneContainer
 
@@ -22,6 +21,10 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
         self.window = sceneSetupHelper.configureWindowFor(scene, screenshotServiceDelegate: screenshotService)
         self.screenshotService = screenshotService
         self.sceneContainer = sceneContainer
+
+        // TODO: [7798] Update for iPad multi-window. Default to single-window UUID for now.
+        self.windowUUID = .defaultSingleWindowUUID
+
         let navigationController = sceneSetupHelper.createNavigationController()
         let router = DefaultRouter(navigationController: navigationController)
         super.init(router: router)
@@ -106,23 +109,28 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
                    level: .info,
                    category: .coordinator)
 
-        // Create the TabManager instance that will be associated with this browser
-        let profile: Profile = AppContainer.shared.resolve()
-        // TODO: [7885] Once iPad multi-window enabled each TabManager will likely share same default image store.
-        let imageStore = DefaultDiskImageStore(
-            files: profile.files,
-            namespace: "TabManagerScreenshots",
-            quality: UIConstants.ScreenshotQuality)
-        let tabManager = TabManagerImplementation(profile: profile, imageStore: imageStore)
         let browserCoordinator = BrowserCoordinator(router: router,
                                                     screenshotService: screenshotService,
-                                                    tabManager: tabManager)
+                                                    tabManager: createWindowTabManager(for: windowUUID))
         add(child: browserCoordinator)
         browserCoordinator.start(with: launchType)
 
         if let savedRoute {
             browserCoordinator.findAndHandle(route: savedRoute)
         }
+    }
+
+    private func createWindowTabManager(for windowUUID: WindowUUID) -> TabManager {
+        let profile: Profile = AppContainer.shared.resolve()
+        // TODO: [7885] Once iPad multi-window enabled each TabManager will likely share same default image store.
+        let imageStore = DefaultDiskImageStore(
+            files: profile.files,
+            namespace: "TabManagerScreenshots",
+            quality: UIConstants.ScreenshotQuality)
+        let tabManager = TabManagerImplementation(profile: profile,
+                                                  imageStore: imageStore,
+                                                  uuid: windowUUID)
+        return tabManager
     }
 
     // MARK: - LaunchCoordinatorDelegate

--- a/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -237,7 +237,7 @@ class BrowserViewController: UIViewController,
         let tabWindowUUID = tabManager.windowUUID
         AppEventQueue.wait(for: [.startupFlowComplete, .tabRestoration(tabWindowUUID)]) { [weak self] in
             // Ensure we call into didBecomeActive at least once during startup flow (if needed)
-            guard !AppEventQueue.activityIsCompleted(.browserDidBecomeActive(tabWindowUUID)) else { return }
+            guard !AppEventQueue.activityIsCompleted(.browserUpdatedForAppActivation(tabWindowUUID)) else { return }
             self?.browserDidBecomeActive()
         }
     }
@@ -438,8 +438,8 @@ class BrowserViewController: UIViewController,
 
     func browserDidBecomeActive() {
         let uuid = tabManager.windowUUID
-        AppEventQueue.started(.browserDidBecomeActive(uuid))
-        defer { AppEventQueue.completed(.browserDidBecomeActive(uuid)) }
+        AppEventQueue.started(.browserUpdatedForAppActivation(uuid))
+        defer { AppEventQueue.completed(.browserUpdatedForAppActivation(uuid)) }
 
         // Update lock icon without redrawing the whole locationView
         if let tab = tabManager.selectedTab {

--- a/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1873,6 +1873,7 @@ class BrowserViewController: UIViewController,
         tabTrayOpenRecentlyClosedTab(url)
     }
 
+    @discardableResult
     func openRecentlyClosedSiteInNewTab(_ url: URL, isPrivate: Bool) -> WindowUUID {
         tabManager.selectTab(tabManager.addTab(URLRequest(url: url)))
         return tabManager.windowUUID

--- a/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -381,7 +381,7 @@ class BrowserViewController: UIViewController,
         // Formerly these calls were run during AppDelegate.didEnterBackground(), but we have
         // individual TabManager instances for each BVC, so we perform these here instead.
         tabManager.preserveTabs()
-        // TODO: [7856] Some additional updates for telemetry forthcoming, once iPad multi-window is enabled.
+        // TODO: [FXIOS-7856] Some additional updates for telemetry forthcoming, once iPad multi-window is enabled.
         TabsQuantityTelemetry.trackTabsQuantity(tabManager: tabManager)
     }
 

--- a/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -234,9 +234,10 @@ class BrowserViewController: UIViewController,
         tabManager.addDelegate(self)
         tabManager.addNavigationDelegate(self)
         downloadQueue.delegate = self
-        AppEventQueue.wait(for: [.startupFlowComplete, .tabRestoration]) { [weak self] in
+        let tabWindowUUID = tabManager.windowUUID
+        AppEventQueue.wait(for: [.startupFlowComplete, .tabRestoration(tabWindowUUID)]) { [weak self] in
             // Ensure we call into didBecomeActive at least once during startup flow (if needed)
-            guard !AppEventQueue.activityIsCompleted(.browserDidBecomeActive) else { return }
+            guard !AppEventQueue.activityIsCompleted(.browserDidBecomeActive(tabWindowUUID)) else { return }
             self?.browserDidBecomeActive()
         }
     }
@@ -436,8 +437,9 @@ class BrowserViewController: UIViewController,
     }
 
     func browserDidBecomeActive() {
-        AppEventQueue.started(.browserDidBecomeActive)
-        defer { AppEventQueue.completed(.browserDidBecomeActive) }
+        let uuid = tabManager.windowUUID
+        AppEventQueue.started(.browserDidBecomeActive(uuid))
+        defer { AppEventQueue.completed(.browserDidBecomeActive(uuid)) }
 
         // Update lock icon without redrawing the whole locationView
         if let tab = tabManager.selectedTab {
@@ -449,7 +451,7 @@ class BrowserViewController: UIViewController,
 
         // When, for example, you "Load in Background" via the share sheet, the tab is added to `Profile`'s `TabQueue`.
         // Make sure that our startup flow is completed and other tabs have been restored before we load.
-        AppEventQueue.wait(for: [.startupFlowComplete, .tabRestoration]) { [weak self] in
+        AppEventQueue.wait(for: [.startupFlowComplete, .tabRestoration(tabManager.windowUUID)]) { [weak self] in
             self?.backgroundTabLoader.loadBackgroundTabs()
         }
     }
@@ -958,7 +960,7 @@ class BrowserViewController: UIViewController,
                 self.isCrashAlertShowing = false
                 self.tabManager.selectTab(self.tabManager.addTab())
                 self.openUrlAfterRestore()
-                AppEventQueue.signal(event: .tabRestoration)
+                AppEventQueue.signal(event: .tabRestoration(self.tabManager.windowUUID))
             }
         )
         self.present(alert, animated: true, completion: nil)
@@ -1871,8 +1873,9 @@ class BrowserViewController: UIViewController,
         tabTrayOpenRecentlyClosedTab(url)
     }
 
-    func openRecentlyClosedSiteInNewTab(_ url: URL, isPrivate: Bool) {
+    func openRecentlyClosedSiteInNewTab(_ url: URL, isPrivate: Bool) -> WindowUUID {
         tabManager.selectTab(tabManager.addTab(URLRequest(url: url)))
+        return tabManager.windowUUID
     }
 
     // MARK: - QRCodeViewControllerDelegate

--- a/Client/Frontend/Browser/Event Queue/AppEvent.swift
+++ b/Client/Frontend/Browser/Event Queue/AppEvent.swift
@@ -25,7 +25,7 @@ public enum AppEvent: AppEventType {
     // MARK: - Browser Events
 
     // Activities: Browser
-    case browserDidBecomeActive(WindowUUID)
+    case browserUpdatedForAppActivation(WindowUUID)
 
     // Activites: Tabs
     case tabRestoration(WindowUUID)

--- a/Client/Frontend/Browser/Event Queue/AppEvent.swift
+++ b/Client/Frontend/Browser/Event Queue/AppEvent.swift
@@ -4,9 +4,12 @@
 
 import Foundation
 
+/// Base event type protocol. Conforming types must be hashable.
 public protocol AppEventType: Hashable { }
 
 public enum AppEvent: AppEventType {
+    // MARK: - Global App Events
+
     // Events: Startup flow
     case startupFlowComplete
 
@@ -19,10 +22,12 @@ public enum AppEvent: AppEventType {
     // Activities: Profile Syncing
     case profileSyncing
 
+    // MARK: - Browser Events
+
     // Activities: Browser
-    case browserDidBecomeActive
+    case browserDidBecomeActive(WindowUUID)
 
     // Activites: Tabs
-    case tabRestoration
-    case selectTab(URL)
+    case tabRestoration(WindowUUID)
+    case selectTab(URL, WindowUUID)
 }

--- a/Client/Frontend/Browser/Tabs/Action/TabManagerAction.swift
+++ b/Client/Frontend/Browser/Tabs/Action/TabManagerAction.swift
@@ -5,5 +5,5 @@
 import Redux
 
 enum TabManagerAction: Action {
-    case tabManagerDidConnectToScene(TabManager, SceneUUID)
+    case tabManagerDidConnectToScene(TabManager)
 }

--- a/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
+++ b/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
@@ -619,6 +619,7 @@ extension LegacyGridTabViewController: TabDisplayCompletionDelegate, RecentlyClo
         dismissTabTray()
     }
 
+    @discardableResult
     func openRecentlyClosedSiteInNewTab(_ url: URL, isPrivate: Bool) -> WindowUUID {
         TelemetryWrapper.recordEvent(category: .action,
                                      method: .tap,

--- a/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
+++ b/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
@@ -627,7 +627,7 @@ extension LegacyGridTabViewController: TabDisplayCompletionDelegate, RecentlyClo
                                      extras: nil)
         openNewTab(URLRequest(url: url), isPrivate: isPrivate)
         dismissTabTray()
-        // TODO: [7349] Updates to Recently Closed for iPad multi-window forthcoming.
+        // TODO: [FXIOS-7349] Updates to Recently Closed for iPad multi-window forthcoming.
         return tabManager.windowUUID
     }
 

--- a/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
+++ b/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
@@ -619,7 +619,7 @@ extension LegacyGridTabViewController: TabDisplayCompletionDelegate, RecentlyClo
         dismissTabTray()
     }
 
-    func openRecentlyClosedSiteInNewTab(_ url: URL, isPrivate: Bool) {
+    func openRecentlyClosedSiteInNewTab(_ url: URL, isPrivate: Bool) -> WindowUUID {
         TelemetryWrapper.recordEvent(category: .action,
                                      method: .tap,
                                      object: .inactiveTabTray,
@@ -627,6 +627,8 @@ extension LegacyGridTabViewController: TabDisplayCompletionDelegate, RecentlyClo
                                      extras: nil)
         openNewTab(URLRequest(url: url), isPrivate: isPrivate)
         dismissTabTray()
+        // TODO: [7349] Updates to Recently Closed for iPad multi-window forthcoming.
+        return tabManager.windowUUID
     }
 
     // TabDisplayCompletionDelegate

--- a/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -8,7 +8,7 @@ import TabDataStore
 
 class TabManagerMiddleware {
     // TODO: [7863] Part of ongoing WIP for Redux + iPad Multi-window.
-    var tabManagers: [SceneUUID: TabManager] = [:]
+    var tabManagers: [WindowUUID: TabManager] = [:]
     var selectedPanel: TabTrayPanelType = .tabs
 
     lazy var tabsPanelProvider: Middleware<AppState> = { state, action in
@@ -93,8 +93,9 @@ class TabManagerMiddleware {
             self.addNewTab(with: urlRequest, isPrivate: false)
             store.dispatch(TabTrayAction.dismissTabTray)
 
-        case TabManagerAction.tabManagerDidConnectToScene(let manager, let sceneUUID):
-            self.setTabManager(manager, for: sceneUUID)
+        case TabManagerAction.tabManagerDidConnectToScene(let manager):
+            self.setTabManager(manager, for: manager.windowUUID)
+
         default:
             break
         }
@@ -191,16 +192,16 @@ class TabManagerMiddleware {
         defaultTabManager.selectTab(tab)
     }
 
-    private func setTabManager(_ tabManager: TabManager, for sceneUUID: SceneUUID) {
-        tabManagers[sceneUUID] = tabManager
+    private func setTabManager(_ tabManager: TabManager, for windowUUID: WindowUUID) {
+        tabManagers[windowUUID] = tabManager
     }
 
-    private func removeTabManager(_ tabManager: TabManager, for sceneUUID: SceneUUID) {
-        tabManagers.removeValue(forKey: sceneUUID)
+    private func removeTabManager(_ tabManager: TabManager, for windowUUID: WindowUUID) {
+        tabManagers.removeValue(forKey: windowUUID)
     }
 
     private var defaultTabManager: TabManager {
         // TODO: [7863] Temporary. WIP for Redux + iPad Multi-window.
-        return tabManagers[WindowData.DefaultSingleWindowUUID]!
+        return tabManagers[.defaultSingleWindowUUID]!
     }
 }

--- a/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -7,7 +7,7 @@ import Redux
 import TabDataStore
 
 class TabManagerMiddleware {
-    // TODO: [7863] Part of ongoing WIP for Redux + iPad Multi-window.
+    // TODO: [FXIOS-7863] Part of ongoing WIP for Redux + iPad Multi-window.
     var tabManagers: [WindowUUID: TabManager] = [:]
     var selectedPanel: TabTrayPanelType = .tabs
 
@@ -201,7 +201,7 @@ class TabManagerMiddleware {
     }
 
     private var defaultTabManager: TabManager {
-        // TODO: [7863] Temporary. WIP for Redux + iPad Multi-window.
+        // TODO: [FXIOS-7863] Temporary. WIP for Redux + iPad Multi-window.
         return tabManagers[.defaultSingleWindowUUID]!
     }
 }

--- a/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
+++ b/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
@@ -19,6 +19,7 @@ protocol RecentlyClosedPanelDelegate: AnyObject {
     ///   - url: the URL to open.
     ///   - isPrivate: private mode.
     /// - Returns: the identifier of the iPad window (if applicable) that the tab will be opened in.
+    @discardableResult
     func openRecentlyClosedSiteInNewTab(_ url: URL, isPrivate: Bool) -> WindowUUID
     func openRecentlyClosedSiteInSameTab(_ url: URL)
 }

--- a/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
+++ b/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
@@ -14,8 +14,13 @@ private struct RecentlyClosedPanelUX {
 }
 
 protocol RecentlyClosedPanelDelegate: AnyObject {
+    /// Opens the provided URL in a new tab.
+    /// - Parameters:
+    ///   - url: the URL to open.
+    ///   - isPrivate: private mode.
+    /// - Returns: the identifier of the iPad window (if applicable) that the tab will be opened in.
+    func openRecentlyClosedSiteInNewTab(_ url: URL, isPrivate: Bool) -> WindowUUID
     func openRecentlyClosedSiteInSameTab(_ url: URL)
-    func openRecentlyClosedSiteInNewTab(_ url: URL, isPrivate: Bool)
 }
 
 class RecentlyClosedTabsPanel: UIViewController, LibraryPanel, Themeable {
@@ -119,7 +124,8 @@ class RecentlyClosedTabsPanelSiteTableViewController: SiteTableViewController {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         let url = recentlyClosedTabs[indexPath.row].url
-        recentlyClosedTabsDelegate?.openRecentlyClosedSiteInNewTab(url, isPrivate: false)
+        guard let tabWindowUUID = recentlyClosedTabsDelegate?
+            .openRecentlyClosedSiteInNewTab(url, isPrivate: false) else { return }
 
         // The code above creates new tab and selects it, but TabManagerImplementation.selectTab()
         // currently performs the actual selection update asynchronously via Swift Async + Task/Await.
@@ -129,7 +135,7 @@ class RecentlyClosedTabsPanelSiteTableViewController: SiteTableViewController {
         // is avoided by making sure we wait for our expected tab above to be selected before
         // notifying our library panel delegate. [FXIOS-7741]
 
-        AppEventQueue.wait(for: .selectTab(url)) {
+        AppEventQueue.wait(for: .selectTab(url, tabWindowUUID)) {
             let visitType = VisitType.typed    // Means History, too.
             self.libraryPanelDelegate?.libraryPanel(didSelectURL: url, visitType: visitType)
         }

--- a/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -67,6 +67,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     // MARK: - Variables
     private let tabEventHandlers: [TabEventHandler]
     let profile: Profile
+    let windowUUID: WindowUUID
     var isRestoringTabs = false
     var tabRestoreHasFinished = false
     var tabs = [Tab]()
@@ -155,8 +156,10 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     // MARK: - Initializer
 
     init(profile: Profile,
+         uuid: WindowUUID,
          logger: Logger = DefaultLogger.shared
     ) {
+        self.windowUUID = uuid
         self.profile = profile
         self.navDelegate = TabManagerNavDelegate()
         self.tabEventHandlers = TabEventHandlers.create(with: profile)

--- a/Client/TabManagement/TabManager.swift
+++ b/Client/TabManagement/TabManager.swift
@@ -10,6 +10,7 @@ import Shared
 
 // MARK: - TabManager protocol
 protocol TabManager: AnyObject {
+    var windowUUID: WindowUUID { get }
     var isRestoringTabs: Bool { get }
     var delaySelectingNewPopupTab: TimeInterval { get }
     var recentlyAccessedNormalTabs: [Tab] { get }

--- a/Client/TabManagement/TabManagerImplementation.swift
+++ b/Client/TabManagement/TabManagerImplementation.swift
@@ -228,7 +228,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
         Task {
             // This value should never be nil but we need to still treat it as if it can be nil until the old code is removed
             let activeTabID = UUID(uuidString: self.selectedTab?.tabUUID ?? "") ?? UUID()
-            // TODO: [7798] Hard coding the window ID until we later add multi-window support
+            // TODO: [FXIOS-7798] Hard coding the window ID until we later add multi-window support
             let windowData = WindowData(id: .defaultSingleWindowUUID,
                                         activeTabId: activeTabID,
                                         tabData: self.generateTabDataForSaving())

--- a/Client/TabManagement/TabManagerImplementation.swift
+++ b/Client/TabManagement/TabManagerImplementation.swift
@@ -27,6 +27,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
     init(profile: Profile,
          imageStore: DiskImageStore?,
          logger: Logger = DefaultLogger.shared,
+         uuid: WindowUUID,
          tabDataStore: TabDataStore = DefaultTabDataStore(),
          tabSessionStore: TabSessionStore = DefaultTabSessionStore(),
          tabMigration: TabMigrationUtility = DefaultTabMigrationUtility(),
@@ -38,7 +39,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
             self.tabMigration = tabMigration
             self.notificationCenter = notificationCenter
             self.inactiveTabsManager = inactiveTabsManager
-            super.init(profile: profile)
+            super.init(profile: profile, uuid: uuid)
 
             setupNotifications(forObserver: self,
                                observing: [UIApplication.willResignActiveNotification])
@@ -71,7 +72,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
         }
 
         isRestoringTabs = true
-        AppEventQueue.started(.tabRestoration)
+        AppEventQueue.started(.tabRestoration(windowUUID))
 
         guard tabMigration.shouldRunMigration else {
             logger.log("Not running the migration",
@@ -108,7 +109,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
         defer {
             isRestoringTabs = false
             tabRestoreHasFinished = true
-            AppEventQueue.completed(.tabRestoration)
+            AppEventQueue.completed(.tabRestoration(windowUUID))
         }
 
         let nonPrivateTabs = window?.tabData.filter { !$0.isPrivate }
@@ -228,7 +229,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
             // This value should never be nil but we need to still treat it as if it can be nil until the old code is removed
             let activeTabID = UUID(uuidString: self.selectedTab?.tabUUID ?? "") ?? UUID()
             // TODO: [7798] Hard coding the window ID until we later add multi-window support
-            let windowData = WindowData(id: WindowData.DefaultSingleWindowUUID,
+            let windowData = WindowData(id: .defaultSingleWindowUUID,
                                         activeTabId: activeTabID,
                                         tabData: self.generateTabDataForSaving())
             await tabDataStore.saveWindowData(window: windowData, forced: forced)
@@ -354,12 +355,12 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
 
     private func willSelectTab(_ url: URL?) {
         guard let url else { return }
-        AppEventQueue.started(.selectTab(url))
+        AppEventQueue.started(.selectTab(url, windowUUID))
     }
 
     private func didSelectTab(_ url: URL?) {
         guard let url else { return }
-        AppEventQueue.completed(.selectTab(url))
+        AppEventQueue.completed(.selectTab(url, windowUUID))
     }
 
     @MainActor

--- a/Client/TabManagement/TabMigrationUtility.swift
+++ b/Client/TabManagement/TabMigrationUtility.swift
@@ -94,7 +94,7 @@ class DefaultTabMigrationUtility: TabMigrationUtility {
             tabsToMigrate.append(tabData)
         }
 
-        let windowData = WindowData(id: WindowData.DefaultSingleWindowUUID,
+        let windowData = WindowData(id: .defaultSingleWindowUUID,
                                     isPrimary: true,
                                     activeTabId: selectTabUUID ?? UUID(),
                                     tabData: tabsToMigrate)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockLibraryCoordinatorDelegate.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockLibraryCoordinatorDelegate.swift
@@ -36,7 +36,8 @@ class MockLibraryCoordinatorDelegate: LibraryCoordinatorDelegate, LibraryPanelDe
         didOpenRecentlyClosedSiteInSameTab += 1
     }
 
-    func openRecentlyClosedSiteInNewTab(_ url: URL, isPrivate: Bool) {
+    func openRecentlyClosedSiteInNewTab(_ url: URL, isPrivate: Bool) -> WindowUUID {
         didOpenRecentlyClosedSiteInNewTab += 1
+        return .defaultSingleWindowUUID
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
@@ -43,7 +43,7 @@ class DependencyHelperMock {
         // Register TabManager with Redux for the current app scene
         // Hardcoded UUID here is temporary; will be removed once PR #17661 is merged
         let defaultSceneUUID = UUID(uuidString: "44BA0B7D-097A-484D-8358-91A6E374451D")!
-        store.dispatch(TabManagerAction.tabManagerDidConnectToScene(tabManager, defaultSceneUUID))
+        store.dispatch(TabManagerAction.tabManagerDidConnectToScene(tabManager))
     }
 
     func reset() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
@@ -21,7 +21,8 @@ class DependencyHelperMock {
             imageStore: DefaultDiskImageStore(
                 files: profile.files,
                 namespace: "TabManagerScreenshots",
-                quality: UIConstants.ScreenshotQuality)
+                quality: UIConstants.ScreenshotQuality),
+            uuid: .defaultSingleWindowUUID
         )
 
         let appSessionProvider: AppSessionProvider = AppSessionManager()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
@@ -19,7 +19,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         profile = MockProfile()
-        tabManager = TabManagerImplementation(profile: profile, imageStore: nil)
+        tabManager = TabManagerImplementation(profile: profile, imageStore: nil, uuid: .defaultSingleWindowUUID)
         subject = BrowserViewController(profile: profile, tabManager: tabManager)
         tabManagerDelegate = TabManagerNavDelegate()
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/HomepageViewControllerTests.swift
@@ -24,7 +24,7 @@ class HomepageViewControllerTests: XCTestCase {
     }
 
     func testHomepageViewController_simpleCreation_hasNoLeaks() {
-        let tabManager = TabManagerImplementation(profile: profile, imageStore: nil)
+        let tabManager = TabManagerImplementation(profile: profile, imageStore: nil, uuid: .defaultSingleWindowUUID)
         let urlBar = URLBarView(profile: profile)
         let overlayManager = MockOverlayModeManager()
         overlayManager.setURLBar(urlBarView: urlBar)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
@@ -28,7 +28,7 @@ class JumpBackInViewModelTests: XCTestCase {
         mockTabManager = MockTabManager()
         stubBrowserViewController = BrowserViewController(
             profile: mockProfile,
-            tabManager: TabManagerImplementation(profile: mockProfile, imageStore: nil)
+            tabManager: TabManagerImplementation(profile: mockProfile, imageStore: nil, uuid: .defaultSingleWindowUUID)
         )
 
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: mockProfile)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/GridTabViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/GridTabViewControllerTests.swift
@@ -13,7 +13,7 @@ final class LegacyGridTabViewControllerTests: XCTestCase {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         profile = MockProfile()
-        manager = TabManagerImplementation(profile: profile, imageStore: nil)
+        manager = TabManagerImplementation(profile: profile, imageStore: nil, uuid: .defaultSingleWindowUUID)
     }
 
     override func tearDown() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/HistoryHighlights/HistoryHighlightsManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/HistoryHighlights/HistoryHighlightsManagerTests.swift
@@ -21,7 +21,7 @@ class HistoryHighlightsTests: XCTestCase {
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
         DependencyHelperMock().bootstrapDependencies()
         profile.reopen()
-        let tabManager = TabManagerImplementation(profile: profile, imageStore: nil)
+        let tabManager = TabManagerImplementation(profile: profile, imageStore: nil, uuid: .defaultSingleWindowUUID)
         entryProvider = HistoryHighlightsTestEntryProvider(with: profile, and: tabManager)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -8,6 +8,7 @@ import WebKit
 @testable import Client
 
 class MockTabManager: TabManager {
+    let windowUUID: WindowUUID = .defaultSingleWindowUUID
     var isRestoringTabs = false
     var selectedTab: Tab?
     var backupCloseTab: Client.BackupCloseTab?

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/AppSettingsTableViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/AppSettingsTableViewControllerTests.swift
@@ -17,7 +17,7 @@ class AppSettingsTableViewControllerTests: XCTestCase {
         DependencyHelperMock().bootstrapDependencies()
         self.profile = MockProfile()
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
-        self.tabManager = TabManagerImplementation(profile: profile, imageStore: nil)
+        self.tabManager = TabManagerImplementation(profile: profile, imageStore: nil, uuid: .defaultSingleWindowUUID)
         self.appAuthenticator = MockAppAuthenticator()
         self.delegate = MockSettingsFlowDelegate()
         self.applicationHelper = MockApplicationHelper()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/StartAtHomeHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/StartAtHomeHelperTests.swift
@@ -18,7 +18,7 @@ class StartAtHomeHelperTests: XCTestCase {
 
         DependencyHelperMock().bootstrapDependencies()
         profile = MockProfile()
-        tabManager = TabManagerImplementation(profile: profile, imageStore: nil)
+        tabManager = TabManagerImplementation(profile: profile, imageStore: nil, uuid: .defaultSingleWindowUUID)
 
         DependencyHelperMock().bootstrapDependencies()
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Legacy/TabsQuantityTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Legacy/TabsQuantityTelemetryTests.swift
@@ -32,6 +32,7 @@ class TabsQuantityTelemetryTests: XCTestCase {
     func testTrackTabsQuantity_withNormalTab_gleanIsCalled() {
         let tabManager = TabManagerImplementation(profile: profile,
                                                   imageStore: nil,
+                                                  uuid: .defaultSingleWindowUUID,
                                                   inactiveTabsManager: inactiveTabsManager)
 
         let tab = tabManager.addTab()
@@ -50,7 +51,7 @@ class TabsQuantityTelemetryTests: XCTestCase {
     }
 
     func testTrackTabsQuantity_withPrivateTab_gleanIsCalled() {
-        let tabManager = TabManagerImplementation(profile: profile, imageStore: nil)
+        let tabManager = TabManagerImplementation(profile: profile, imageStore: nil, uuid: .defaultSingleWindowUUID)
         tabManager.addTab(isPrivate: true)
 
         TabsQuantityTelemetry.trackTabsQuantity(tabManager: tabManager)
@@ -67,6 +68,7 @@ class TabsQuantityTelemetryTests: XCTestCase {
     func testTrackTabsQuantity_ensureNoInactiveTabs_gleanIsCalled() {
         let tabManager = TabManagerImplementation(profile: profile,
                                                   imageStore: nil,
+                                                  uuid: .defaultSingleWindowUUID,
                                                   inactiveTabsManager: inactiveTabsManager)
         let tab = tabManager.addTab()
         inactiveTabsManager.activeTabs = [tab]

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -172,6 +172,7 @@ class TabManagerTests: XCTestCase {
     private func createSubject() -> TabManagerImplementation {
         let subject = TabManagerImplementation(profile: mockProfile,
                                                imageStore: mockDiskImageStore,
+                                               uuid: .defaultSingleWindowUUID,
                                                tabDataStore: mockTabStore,
                                                tabSessionStore: mockSessionStore)
         trackForMemoryLeaks(subject)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabToolbarHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabToolbarHelperTests.swift
@@ -124,7 +124,7 @@ class MockTabToolbar: TabToolbarProtocol {
 
     init() {
         profile = MockProfile()
-        tabManager = TabManagerImplementation(profile: profile, imageStore: nil)
+        tabManager = TabManagerImplementation(profile: profile, imageStore: nil, uuid: .defaultSingleWindowUUID)
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
         _tabToolBarDelegate = BrowserViewController(profile: profile, tabManager: tabManager)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/Legacy/LegacyTabTrayViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/Legacy/LegacyTabTrayViewControllerTests.swift
@@ -23,7 +23,7 @@ final class LegacyTabTrayViewControllerTests: XCTestCase {
 
         DependencyHelperMock().bootstrapDependencies()
         profile = MockProfile()
-        manager = TabManagerImplementation(profile: profile, imageStore: nil)
+        manager = TabManagerImplementation(profile: profile, imageStore: nil, uuid: .defaultSingleWindowUUID)
         urlBar = MockURLBarView()
         overlayManager = MockOverlayModeManager()
         overlayManager.setURLBar(urlBarView: urlBar)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7808)

## :bulb: Description

This PR includes additional early refactors to pave the way for upcoming changes to support multiple concurrent Firefox windows on iPad:
- Updates `AppEvent` (for event queue) to be window-specific, since we will soon have identical events being posted across multiple scenes/windows
- Adds code to initialize and inject each window (scene) with a unique ID and pass that along to the associated `TabManager` _(for now, this is still the same hardcoded UUID that we have been using, but will eventually be updated)_
- Minor refactors to `RecentlyClosedPanelDelegate` that are needed for it to continue using the Event Queue; aspects of this are still in flux, and there is more work forthcoming in that area

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

