### PR TITLE
Refactor FXIOS-7914 [v122] Update DependencyHelperMock, fix unit test dependency crash

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
@@ -23,7 +23,6 @@ class DependencyHelperMock {
                 namespace: "TabManagerScreenshots",
                 quality: UIConstants.ScreenshotQuality)
         )
-        AppContainer.shared.register(service: tabManager)
 
         let appSessionProvider: AppSessionProvider = AppSessionManager()
         AppContainer.shared.register(service: appSessionProvider)
@@ -39,6 +38,11 @@ class DependencyHelperMock {
 
         // Tell the container we are done registering
         AppContainer.shared.bootstrap()
+
+        // Register TabManager with Redux for the current app scene
+        // Hardcoded UUID here is temporary; will be removed once PR #17661 is merged
+        let defaultSceneUUID = UUID(uuidString: "44BA0B7D-097A-484D-8358-91A6E374451D")!
+        store.dispatch(TabManagerAction.tabManagerDidConnectToScene(tabManager, defaultSceneUUID))
     }
 
     func reset() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7914)

## :bulb: Description

This PR updates `DependencyHelperMock` to remove the `TabManager` from our `AppContainer` (which is how the client now works) and ensures that the manager is registered with Redux for the default app scene.

Some aspects of our dependency management and the architecture around `TabManager` and Redux are in flux currently and so some of this may be changing soon.

Related: hardcoded UUID here can be removed as part of https://github.com/mozilla-mobile/firefox-ios/pull/17661, since that is now injected into the `TabManager` itself.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

