### PR TITLE
Refactor FXIOS-7324 [v121.1] Add missing credit card option for FxA syncing in the choose what to sync list

### DIFF
--- a/RustFxA/FxAWebViewModel.swift
+++ b/RustFxA/FxAWebViewModel.swift
@@ -28,7 +28,7 @@ private enum RemoteCommand: String {
     case profileChanged = "profile:change"
 }
 
-class FxAWebViewModel {
+class FxAWebViewModel: FeatureFlaggable {
     fileprivate let pageType: FxAPageType
     fileprivate let profile: Profile
     fileprivate var deepLinkParams: FxALaunchParams
@@ -205,6 +205,8 @@ extension FxAWebViewModel {
     /// user info (for settings), or by passing CWTS setup info (in case the user is
     /// signing up for an account). This latter case is also used for the sign-in state.
     private func onSessionStatus(id: Int, webView: WKWebView) {
+        let autofillCreditCardStatus = featureFlags.isFeatureEnabled(.creditCardAutofillStatus, checking: .buildOnly)
+        let creditCardCapability =  autofillCreditCardStatus ? ", \"creditcards\"" : ""
         guard let fxa = profile.rustFxA.accountManager else { return }
         let cmd = "fxaccounts:fxa_status"
         let typeId = "account_updates"
@@ -229,7 +231,7 @@ extension FxAWebViewModel {
         case .emailLoginFlow, .qrCode:
             data = """
                     { capabilities:
-                        { choose_what_to_sync: true, engines: ["bookmarks", "history", "tabs", "passwords", "creditcards"] },
+                        { choose_what_to_sync: true, engines: ["bookmarks", "history", "tabs", "passwords"\(creditCardCapability)] },
                     }
                 """
         }

--- a/RustFxA/FxAWebViewModel.swift
+++ b/RustFxA/FxAWebViewModel.swift
@@ -229,7 +229,7 @@ extension FxAWebViewModel {
         case .emailLoginFlow, .qrCode:
             data = """
                     { capabilities:
-                        { choose_what_to_sync: true, engines: ["bookmarks", "history", "tabs", "passwords"] },
+                        { choose_what_to_sync: true, engines: ["bookmarks", "history", "tabs", "passwords", "creditcards"] },
                     }
                 """
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket - 7324](https://mozilla-hub.atlassian.net/browse/FXIOS-7324)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Added missing credit card option for FxA syncing in the choose what to sync list.

You can test this by simply trying to create a new account. 
﻿
<img width="307" alt="Screenshot 2023-12-07 at 3 44 09 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/8919439/c1d23934-1cf0-421b-95f5-c06bb1f0316f">'

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

