### PR TITLE
Add FXIOS-7755 [v122] telemetry for fakespot enable ads switch

### DIFF
--- a/Client/Frontend/Fakespot/FakespotViewModel.swift
+++ b/Client/Frontend/Fakespot/FakespotViewModel.swift
@@ -356,6 +356,7 @@ class FakespotViewModel {
     func toggleAdsEnabled() {
         prefs.setBool(!areAdsEnabled, forKey: PrefsKeys.Shopping2023EnableAds)
 
+        recordAdsToggleTelemetry()
         // Make sure the view updates with the new ads setting
         onStateChange?()
     }
@@ -581,6 +582,17 @@ class FakespotViewModel {
             method: .view,
             object: .shoppingBottomSheet,
             extras: [TelemetryWrapper.ExtraKey.size.rawValue: state.rawValue]
+        )
+    }
+
+    func recordAdsToggleTelemetry() {
+        TelemetryWrapper.recordEvent(
+            category: .action,
+            method: .tap,
+            object: .shoppingAdsSettingToggle,
+            extras: [
+                TelemetryWrapper.ExtraKey.Shopping.adsSettingToggle.rawValue: areAdsEnabled
+            ]
         )
     }
 }

--- a/Client/Telemetry/TelemetryWrapper.swift
+++ b/Client/Telemetry/TelemetryWrapper.swift
@@ -388,6 +388,7 @@ extension TelemetryWrapper {
         case downloadLinkButton = "download-link-button"
         case downloadNowButton = "download-now-button"
         case downloadsPanel = "downloads-panel"
+        // MARK: Fakespot
         case shoppingButton = "shopping-button"
         case shoppingBottomSheet = "shopping-bottom-sheet"
         case shoppingProductPageVisits = "product_page_visits"
@@ -408,6 +409,7 @@ extension TelemetryWrapper {
         case shoppingNimbusDisabled = "shopping-nimbus-disabled"
         case shoppingComponentOptedOut = "shopping-component-opted-out"
         case shoppingUserHasOnboarded = "shopping-user-has-onboarded"
+        case shoppingAdsSettingToggle = "shopping-ads-setting-toggle"
         case keyCommand = "key-command"
         case locationBar = "location-bar"
         case messaging = "messaging"
@@ -765,6 +767,7 @@ extension TelemetryWrapper {
             case interactionWithALink = "interaction-with-a-link"
             case swipingTheSurfaceHandle = "swiping-the-surface-handle"
             case optingOutOfTheFeature = "opting-out-of-the-feature"
+            case adsSettingToggle = "ads-setting-toggle"
             case closeButton = "close-button"
             case isNimbusDisabled = "is-nimbus-disabled"
             case isComponentOptedOut = "is-component-opted-out"
@@ -1223,6 +1226,19 @@ extension TelemetryWrapper {
             GleanMetrics.Shopping.surfaceReanalyzeClicked.record()
         case (.action, .tap, .shoppingProductBackInStockButton, _, _):
             GleanMetrics.Shopping.surfaceReactivatedButtonClicked.record()
+        case(.action, .tap, .shoppingAdsSettingToggle, _, let extras):
+            if let isEnabled = extras?[EventExtraKey.Shopping.adsSettingToggle.rawValue]
+                as? Bool {
+                let isEnabledExtra = GleanMetrics.Shopping.SurfaceAdsSettingToggledExtra(isEnabled: isEnabled)
+                GleanMetrics.Shopping.surfaceAdsSettingToggled.record(isEnabledExtra)
+            } else {
+                recordUninstrumentedMetrics(
+                    category: category,
+                    method: method,
+                    object: object,
+                    value: value,
+                    extras: extras)
+            }
         case (.action, .navigate, .shoppingBottomSheet, _, _):
             GleanMetrics.Shopping.surfaceNoReviewReliabilityAvailable.record()
         case (.action, .view, .shoppingSurfaceStaleAnalysisShown, _, _):

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -962,8 +962,6 @@ shopping:
     type: event
     description: |
       Whether the user has opted in for ads
-    send_in_pings:
-      - events
     extra_keys:
       is_enabled:
         type: boolean
@@ -973,6 +971,7 @@ shopping:
       - https://github.com/mozilla-mobile/firefox-ios/issues/17303
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/17681
+    notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2024-06-01"
 

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -972,8 +972,7 @@ shopping:
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/17303
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/16685
-    notification_emails:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/17681
       - fx-ios-data-stewards@mozilla.com
     expires: "2024-06-01"
 

--- a/Client/metrics.yaml
+++ b/Client/metrics.yaml
@@ -958,6 +958,25 @@ shopping:
       - fx-ios-data-stewards@mozilla.com
     expires: "2024-06-01"
 
+  surface_ads_setting_toggled:
+    type: event
+    description: |
+      Whether the user has opted in for ads
+    send_in_pings:
+      - events
+    extra_keys:
+      is_enabled:
+        type: boolean
+        description: |
+          Is enabled when the user has opted in for ads
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/17303
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/16685
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2024-06-01"
+
 shopping.settings:
   nimbus_disabled_shopping:
     type: boolean

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -398,6 +398,14 @@ class TelemetryWrapperTests: XCTestCase {
         testEventMetricRecordingSuccess(metric: GleanMetrics.Shopping.surfaceStaleAnalysisShown)
     }
 
+    func test_shoppingAdsSettingToggle_GleanIsCalled() {
+        let isEnabled = TelemetryWrapper.EventExtraKey.Shopping.adsSettingToggle.rawValue
+        let extras = [isEnabled: true]
+        TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .shoppingAdsSettingToggle, extras: extras)
+
+        testEventMetricRecordingSuccess(metric: GleanMetrics.Shopping.surfaceAdsSettingToggled)
+    }
+
     func test_shoppingNimbusDisabled_GleanIsCalled() {
         TelemetryWrapper.recordEvent(
             category: .information,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7755)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17303)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Added a telemetry event on the fakespot Enable Ads switch
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

