### PR TITLE
Refactor FXIOS-7869 [v122] Rename TabPeek to legacy

### DIFF
--- a/Client/Frontend/Browser/TabPeekViewController.swift
+++ b/Client/Frontend/Browser/TabPeekViewController.swift
@@ -8,7 +8,7 @@ import Shared
 import Storage
 import WebKit
 
-protocol TabPeekDelegate: AnyObject {
+protocol LegacyTabPeekDelegate: AnyObject {
     @discardableResult
     func tabPeekDidAddToReadingList(_ tab: Tab) -> ReadingListItem?
     func tabPeekDidAddBookmark(_ tab: Tab)
@@ -17,10 +17,10 @@ protocol TabPeekDelegate: AnyObject {
     func tabPeekDidCopyUrl()
 }
 
-class TabPeekViewController: UIViewController, WKNavigationDelegate {
+class LegacyTabPeekViewController: UIViewController, WKNavigationDelegate {
     weak var tab: Tab?
 
-    private weak var delegate: TabPeekDelegate?
+    private weak var delegate: LegacyTabPeekDelegate?
     private var fxaDevicePicker: UINavigationController?
     private var isBookmarked = false
     private var isInReadingList = false
@@ -110,7 +110,7 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
         return UIMenu(title: "", children: actions)
     }
 
-    init(tab: Tab?, delegate: TabPeekDelegate?) {
+    init(tab: Tab?, delegate: LegacyTabPeekDelegate?) {
         self.tab = tab
         self.delegate = delegate
         super.init(nibName: nil, bundle: nil)

--- a/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
+++ b/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
@@ -576,8 +576,8 @@ extension LegacyGridTabViewController: LegacyTabCellDelegate {
     }
 }
 
-// MARK: - TabPeekDelegate
-extension LegacyGridTabViewController: TabPeekDelegate {
+// MARK: - LegacyTabPeekDelegate
+extension LegacyGridTabViewController: LegacyTabPeekDelegate {
     func tabPeekDidAddBookmark(_ tab: Tab) {
         delegate?.tabTrayDidAddBookmark(tab)
     }

--- a/Client/Frontend/Browser/Tabs/Legacy/LegacyTabLayoutDelegate.swift
+++ b/Client/Frontend/Browser/Tabs/Legacy/LegacyTabLayoutDelegate.swift
@@ -6,7 +6,7 @@ import UIKit
 
 class LegacyTabLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayout, UIGestureRecognizerDelegate {
     weak var tabSelectionDelegate: TabSelectionDelegate?
-    weak var tabPeekDelegate: TabPeekDelegate?
+    weak var tabPeekDelegate: LegacyTabPeekDelegate?
     var lastYOffset: CGFloat = 0
     var tabDisplayManager: LegacyTabDisplayManager
 
@@ -149,7 +149,7 @@ class LegacyTabLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayout, UIG
               let tab = tabDisplayManager.dataStore.at(indexPath.row)
         else { return nil }
 
-        let tabVC = TabPeekViewController(tab: tab, delegate: tabPeekDelegate)
+        let tabVC = LegacyTabPeekViewController(tab: tab, delegate: tabPeekDelegate)
         if let browserProfile = tabDisplayManager.profile as? BrowserProfile,
            let pickerDelegate = tabPeekDelegate as? DevicePickerViewControllerDelegate {
             tabVC.setState(withProfile: browserProfile, clientPickerDelegate: pickerDelegate)

--- a/Client/Frontend/Browser/Tabs/Views/TabDisplayPanel.swift
+++ b/Client/Frontend/Browser/Tabs/Views/TabDisplayPanel.swift
@@ -130,7 +130,7 @@ class TabDisplayPanel: UIViewController,
     }
 }
 
-extension TabDisplayPanel: TabPeekDelegate {
+extension TabDisplayPanel: LegacyTabPeekDelegate {
     func tabPeekDidAddToReadingList(_ tab: Tab) -> ReadingListItem? { return nil }
     func tabPeekDidAddBookmark(_ tab: Tab) {}
     func tabPeekRequestsPresentationOf(_ viewController: UIViewController) {}

--- a/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -25,7 +25,7 @@ class TabDisplayView: UIView,
     private(set) var tabsState: TabsPanelState
     private var inactiveTabsSectionManager: InactiveTabsSectionManager
     private var tabsSectionManager: TabsSectionManager
-    private weak var tabPeekDelegate: TabPeekDelegate?
+    private weak var tabPeekDelegate: LegacyTabPeekDelegate?
     var theme: Theme?
 
     private var shouldHideInactiveTabs: Bool {
@@ -60,7 +60,7 @@ class TabDisplayView: UIView,
         return collectionView
     }()
 
-    public init(state: TabsPanelState, tabPeekDelegate: TabPeekDelegate?) {
+    public init(state: TabsPanelState, tabPeekDelegate: LegacyTabPeekDelegate?) {
         self.tabsState = state
         self.tabPeekDelegate = tabPeekDelegate
         self.inactiveTabsSectionManager = InactiveTabsSectionManager()
@@ -244,7 +244,7 @@ class TabDisplayView: UIView,
         else { return nil }
 
         // TODO: Add browserProfile and clientPickerDelegate
-        let tabVC = TabPeekViewController(tab: nil, delegate: tabPeekDelegate)
+        let tabVC = LegacyTabPeekViewController(tab: nil, delegate: tabPeekDelegate)
         return UIContextMenuConfiguration(identifier: nil,
                                           previewProvider: { return tabVC },
                                           actionProvider: tabVC.contextActions(defaultActions:))


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7859)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17546)

## :bulb: Description
Rename the TabPeek classes to legacy to prep for the new version.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

