### PR TITLE
Remove FXIOS-7926 [v122] Remove Tab.isRestoring as it's always false anyway

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1310,7 +1310,7 @@ class BrowserViewController: UIViewController,
             if tab.url?.origin == webView.url?.origin {
                 tab.url = webView.url
 
-                if tab === tabManager.selectedTab && !tab.isRestoring {
+                if tab === tabManager.selectedTab {
                     updateUIForReaderHomeStateForTab(tab)
                 }
                 // Catch history pushState navigation, but ONLY for same origin navigation,
@@ -2419,8 +2419,6 @@ extension BrowserViewController: KeyboardHelperDelegate {
 
 extension BrowserViewController: SessionRestoreHelperDelegate {
     func sessionRestoreHelper(_ helper: SessionRestoreHelper, didRestoreSessionForTab tab: Tab) {
-        tab.isRestoring = false
-
         if let tab = tabManager.selectedTab, tab.webView === tab.webView {
             updateUIForReaderHomeStateForTab(tab)
         }

--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -890,8 +890,6 @@ extension LegacyTabDisplayManager: TabManagerDelegate {
     }
 
     func tabManager(_ tabManager: TabManager, didAddTab tab: Tab, placeNextToParentTab: Bool, isRestoring: Bool) {
-        guard !isRestoring else { return }
-
         if cancelDragAndGestures() {
             refreshStore()
             return

--- a/Client/TabManagement/Tab.swift
+++ b/Client/TabManagement/Tab.swift
@@ -198,7 +198,7 @@ class Tab: NSObject, ThemeApplicable {
         // If the webView doesn't give a title. check the URL to see if it's our Home URL, with no sessionData on this tab.
         // When picking a display title. Tabs with sessionData are pending a restore so show their old title.
         // To prevent flickering of the display title. If a tab is restoring make sure to use its lastTitle.
-        if let url = self.url, InternalURL(url)?.isAboutHomeURL ?? false, sessionData == nil, !isRestoring {
+        if let url = self.url, InternalURL(url)?.isAboutHomeURL ?? false, sessionData == nil {
             return .AppMenu.AppMenuOpenHomePageTitleString
         }
 
@@ -260,7 +260,6 @@ class Tab: NSObject, ThemeApplicable {
         }
     }
     fileprivate var lastRequest: URLRequest?
-    var isRestoring = false
     var pendingScreenshot = false
     var url: URL? {
         didSet {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7926)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17684)

## :bulb: Description
Remove `isRestoring` as it's always false anyway due to recent changes in the tab manager area

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods