### PR TITLE
Add FXIOS-7935 [v123] Add support for multiple message handlers per content script

### DIFF
--- a/firefox-ios/Client/ContentBlocker/TabContentBlocker.swift
+++ b/firefox-ios/Client/ContentBlocker/TabContentBlocker.swift
@@ -56,8 +56,8 @@ class TabContentBlocker {
         NotificationCenter.default.addObserver(self, selector: #selector(notifiedTabSetupRequired), name: .contentBlockerTabSetupRequired, object: nil)
     }
 
-    func scriptMessageHandlerName() -> String? {
-        return "trackingProtectionStats"
+    func scriptMessageHandlerNames() -> [String]? {
+        return ["trackingProtectionStats"]
     }
 
     class func prefsChanged() {

--- a/firefox-ios/Client/Frontend/Browser/FaviconManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/FaviconManager.swift
@@ -32,8 +32,8 @@ class FaviconManager: TabContentScript {
         return "FaviconsManager"
     }
 
-    func scriptMessageHandlerName() -> String? {
-        return "faviconsMessageHandler"
+    func scriptMessageHandlerNames() -> [String]? {
+        return ["faviconsMessageHandler"]
     }
 
     fileprivate func loadFavicons(_ tab: Tab, profile: Profile, favicons: [Favicon]) -> Deferred<[Maybe<Favicon>]> {

--- a/firefox-ios/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
+++ b/firefox-ios/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
@@ -298,8 +298,8 @@ extension ErrorPageHelper: TabContentScript {
         return "ErrorPageHelper"
     }
 
-    func scriptMessageHandlerName() -> String? {
-        return "errorPageHelperMessageManager"
+    func scriptMessageHandlerNames() -> [String]? {
+        return ["errorPageHelperMessageManager"]
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {

--- a/firefox-ios/Client/Frontend/Reader/ReaderMode.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReaderMode.swift
@@ -291,8 +291,8 @@ class ReaderMode: TabContentScript {
         self.logger = logger
     }
 
-    func scriptMessageHandlerName() -> String? {
-        return "readerModeMessageHandler"
+    func scriptMessageHandlerNames() -> [String]? {
+        return ["readerModeMessageHandler"]
     }
 
     fileprivate func handleReaderPageEvent(_ readerPageEvent: ReaderPageEvent) {

--- a/firefox-ios/Client/Frontend/TabContentsScripts/ContextMenuHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/ContextMenuHelper.swift
@@ -29,8 +29,8 @@ extension ContextMenuHelper: TabContentScript {
         return "ContextMenuHelper"
     }
 
-    func scriptMessageHandlerName() -> String? {
-        return "contextMenuMessageHandler"
+    func scriptMessageHandlerNames() -> [String]? {
+        return ["contextMenuMessageHandler"]
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {

--- a/firefox-ios/Client/Frontend/TabContentsScripts/DownloadContentScript.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/DownloadContentScript.swift
@@ -28,8 +28,8 @@ class DownloadContentScript: TabContentScript {
         self.notificationCenter = notificationCenter
     }
 
-    func scriptMessageHandlerName() -> String? {
-        return "downloadManager"
+    func scriptMessageHandlerNames() -> [String]? {
+        return ["downloadManager"]
     }
 
     /// This function handles blob downloads

--- a/firefox-ios/Client/Frontend/TabContentsScripts/FindInPageHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/FindInPageHelper.swift
@@ -23,8 +23,8 @@ class FindInPageHelper: TabContentScript {
         self.tab = tab
     }
 
-    func scriptMessageHandlerName() -> String? {
-        return "findInPageHandler"
+    func scriptMessageHandlerNames() -> [String]? {
+        return ["findInPageHandler"]
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {

--- a/firefox-ios/Client/Frontend/TabContentsScripts/FocusHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/FocusHelper.swift
@@ -21,8 +21,8 @@ class FocusHelper: TabContentScript {
         return "FocusHelper"
     }
 
-    func scriptMessageHandlerName() -> String? {
-        return "focusHelper"
+    func scriptMessageHandlerNames() -> [String]? {
+        return ["focusHelper"]
     }
 
     func userContentController(_ userContentController: WKUserContentController,

--- a/firefox-ios/Client/Frontend/TabContentsScripts/FormAutofillHelper/FormAutofillHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/FormAutofillHelper/FormAutofillHelper.swift
@@ -35,7 +35,7 @@ class FormAutofillHelper: TabContentScript {
     // MARK: - Script Message Handler
 
     func scriptMessageHandlerNames() -> [String]? {
-        return ["addressMessageHandler", "creditCardMessageHandler"]
+        return ["addressFormMessageHandler", "creditCardFormMessageHandler"]
     }
 
     // MARK: - Deinitialization

--- a/firefox-ios/Client/Frontend/TabContentsScripts/FormAutofillHelper/FormAutofillHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/FormAutofillHelper/FormAutofillHelper.swift
@@ -34,8 +34,8 @@ class FormAutofillHelper: TabContentScript {
 
     // MARK: - Script Message Handler
 
-    func scriptMessageHandlerName() -> String? {
-        return "creditCardMessageHandler"
+    func scriptMessageHandlerNames() -> [String]? {
+        return ["addressMessageHandler", "creditCardMessageHandler"]
     }
 
     // MARK: - Deinitialization

--- a/firefox-ios/Client/Frontend/TabContentsScripts/FormPostHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/FormPostHelper.swift
@@ -66,8 +66,8 @@ class FormPostHelper: TabContentScript {
         return "FormPostHelper"
     }
 
-    func scriptMessageHandlerName() -> String? {
-        return "formPostHelper"
+    func scriptMessageHandlerNames() -> [String]? {
+        return ["formPostHelper"]
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {

--- a/firefox-ios/Client/Frontend/TabContentsScripts/LocalRequestHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/LocalRequestHelper.swift
@@ -7,8 +7,8 @@ import WebKit
 import Shared
 
 class LocalRequestHelper: TabContentScript {
-    func scriptMessageHandlerName() -> String? {
-        return "localRequestHelper"
+    func scriptMessageHandlerNames() -> [String]? {
+        return ["localRequestHelper"]
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {

--- a/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
@@ -29,8 +29,8 @@ class LoginsHelper: TabContentScript {
         self.theme = theme
     }
 
-    func scriptMessageHandlerName() -> String? {
-        return "loginsManagerMessageHandler"
+    func scriptMessageHandlerNames() -> [String]? {
+        return ["loginsManagerMessageHandler"]
     }
 
     private func getOrigin(_ uriString: String, allowJS: Bool = false) -> String? {

--- a/firefox-ios/Client/Frontend/TabContentsScripts/NightModeHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/NightModeHelper.swift
@@ -23,8 +23,8 @@ class NightModeHelper: TabContentScript {
         return "NightMode"
     }
 
-    func scriptMessageHandlerName() -> String? {
-        return "NightMode"
+    func scriptMessageHandlerNames() -> [String]? {
+        return ["NightMode"]
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {

--- a/firefox-ios/Client/Frontend/TabContentsScripts/NoImageModeHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/NoImageModeHelper.swift
@@ -21,8 +21,8 @@ class NoImageModeHelper: TabContentScript {
         return "NoImageMode"
     }
 
-    func scriptMessageHandlerName() -> String? {
-        return "NoImageMode"
+    func scriptMessageHandlerNames() -> [String]? {
+        return ["NoImageMode"]
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {

--- a/firefox-ios/Client/Frontend/TabContentsScripts/PrintHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/PrintHelper.swift
@@ -17,8 +17,8 @@ class PrintHelper: TabContentScript {
         self.tab = tab
     }
 
-    func scriptMessageHandlerName() -> String? {
-        return "printHandler"
+    func scriptMessageHandlerNames() -> [String]? {
+        return ["printHandler"]
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {

--- a/firefox-ios/Client/Frontend/TabContentsScripts/SessionRestoreHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/SessionRestoreHelper.swift
@@ -17,8 +17,8 @@ class SessionRestoreHelper: TabContentScript {
         self.tab = tab
     }
 
-    func scriptMessageHandlerName() -> String? {
-        return "sessionRestoreHelper"
+    func scriptMessageHandlerNames() -> [String]? {
+        return ["sessionRestoreHelper"]
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AutofillAtDocumentStart/FormAutofillHelper.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AutofillAtDocumentStart/FormAutofillHelper.js
@@ -32,8 +32,9 @@ const creditCardSendMessage = sendMessage(
   window.webkit.messageHandlers.creditCardMessageHandler
 );
 
-// TODO: FXCM-703: Define this method for address autofill
-const addressSendMessage = sendMessage();
+const addressSendMessage = sendMessage(
+  window.webkit.messageHandlers.addressMessageHandler
+);
 
 // Note: We expect all values to be string based
 const sendCaptureCreditCardFormMessage = creditCardSendMessage(

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AutofillAtDocumentStart/FormAutofillHelper.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AutofillAtDocumentStart/FormAutofillHelper.js
@@ -29,11 +29,11 @@ const sendMessage =
     });
 
 const creditCardSendMessage = sendMessage(
-  window.webkit.messageHandlers.creditCardMessageHandler
+  window.webkit.messageHandlers.creditCardFormMessageHandler
 );
 
 const addressSendMessage = sendMessage(
-  window.webkit.messageHandlers.addressMessageHandler
+  window.webkit.messageHandlers.addressFormMessageHandler
 );
 
 // Note: We expect all values to be string based

--- a/firefox-ios/Client/Telemetry/AdsTelemetryHelper.swift
+++ b/firefox-ios/Client/Telemetry/AdsTelemetryHelper.swift
@@ -107,8 +107,8 @@ class AdsTelemetryHelper: TabContentScript {
         self.tab = tab
     }
 
-    func scriptMessageHandlerName() -> String? {
-        return "adsMessageHandler"
+    func scriptMessageHandlerNames() -> [String]? {
+        return ["adsMessageHandler"]
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7935)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17696)


## :bulb: Description
This PR:
- Adds support for multiple message handlers per content script.
- Refactors code to use `scriptMessageHandlerNames` instead `scriptMessageHandlerName`
- Introduces new `addressMessageHandler` that will be used for address autofill

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] ~~Wrote unit tests and/or ensured the tests suite is passing~~
- [ ] ~~When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)~~
- [ ] ~~If needed I updated documentation / comments for complex code and public methods~~

