### PR TITLE
Add FXIOS-7187 [v122] New private homepage for felt privacy

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -570,6 +570,8 @@
 		8A093D7F2A4B3E7D0099ABA5 /* GeneralSettingsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A093D7E2A4B3E7D0099ABA5 /* GeneralSettingsDelegate.swift */; };
 		8A093D812A4B58330099ABA5 /* MockSettingsFlowDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A093D802A4B58330099ABA5 /* MockSettingsFlowDelegate.swift */; };
 		8A093D832A4B68940099ABA5 /* PrivacySettingsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A093D822A4B68940099ABA5 /* PrivacySettingsDelegate.swift */; };
+		8A0A1BA02B2200FD00E8706F /* PrivateHomepageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0A1B9F2B2200FD00E8706F /* PrivateHomepageViewController.swift */; };
+		8A0A1BA32B22030100E8706F /* PrivateMessageCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0A1BA22B22030100E8706F /* PrivateMessageCardCell.swift */; };
 		8A0D32842A61E1CC007D976D /* StatusBarOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0D32832A61E1CC007D976D /* StatusBarOverlay.swift */; };
 		8A11C80F2731916E00AC7318 /* defaultOnlyTestList.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A11C80D2731916E00AC7318 /* defaultOnlyTestList.json */; };
 		8A11C8112731CFD700AC7318 /* ReaderModeStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A11C8102731CFD700AC7318 /* ReaderModeStyleTests.swift */; };
@@ -662,6 +664,7 @@
 		8A6E13982A71BA4E00A88FA8 /* TabWebViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6E13972A71BA4E00A88FA8 /* TabWebViewTests.swift */; };
 		8A6E139C2A71BB5700A88FA8 /* LegacyTabCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6E139B2A71BB5700A88FA8 /* LegacyTabCellTests.swift */; };
 		8A6E139E2A71C78A00A88FA8 /* GridTabViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6E139D2A71C78A00A88FA8 /* GridTabViewControllerTests.swift */; };
+		8A6E8DEB2B275BA9000C4301 /* PrivateHomepageViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6E8DE92B275B49000C4301 /* PrivateHomepageViewControllerTests.swift */; };
 		8A720C5E2A4C85DA0003018A /* AccountSettingsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A720C5D2A4C85DA0003018A /* AccountSettingsDelegate.swift */; };
 		8A720C602A4C8B700003018A /* SharedSettingsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A720C5F2A4C8B700003018A /* SharedSettingsDelegate.swift */; };
 		8A720C622A4CBB370003018A /* SupportSettingsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A720C612A4CBB370003018A /* SupportSettingsDelegate.swift */; };
@@ -5144,6 +5147,8 @@
 		8A093D7E2A4B3E7D0099ABA5 /* GeneralSettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsDelegate.swift; sourceTree = "<group>"; };
 		8A093D802A4B58330099ABA5 /* MockSettingsFlowDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSettingsFlowDelegate.swift; sourceTree = "<group>"; };
 		8A093D822A4B68940099ABA5 /* PrivacySettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacySettingsDelegate.swift; sourceTree = "<group>"; };
+		8A0A1B9F2B2200FD00E8706F /* PrivateHomepageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateHomepageViewController.swift; sourceTree = "<group>"; };
+		8A0A1BA22B22030100E8706F /* PrivateMessageCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateMessageCardCell.swift; sourceTree = "<group>"; };
 		8A0D32832A61E1CC007D976D /* StatusBarOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarOverlay.swift; sourceTree = "<group>"; };
 		8A0F46E89E106C66C6C29F07 /* bn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bn; path = bn.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		8A11C80D2731916E00AC7318 /* defaultOnlyTestList.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = defaultOnlyTestList.json; sourceTree = "<group>"; };
@@ -5239,6 +5244,7 @@
 		8A6E13972A71BA4E00A88FA8 /* TabWebViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabWebViewTests.swift; sourceTree = "<group>"; };
 		8A6E139B2A71BB5700A88FA8 /* LegacyTabCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyTabCellTests.swift; sourceTree = "<group>"; };
 		8A6E139D2A71C78A00A88FA8 /* GridTabViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridTabViewControllerTests.swift; sourceTree = "<group>"; };
+		8A6E8DE92B275B49000C4301 /* PrivateHomepageViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateHomepageViewControllerTests.swift; sourceTree = "<group>"; };
 		8A720C5D2A4C85DA0003018A /* AccountSettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSettingsDelegate.swift; sourceTree = "<group>"; };
 		8A720C5F2A4C8B700003018A /* SharedSettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedSettingsDelegate.swift; sourceTree = "<group>"; };
 		8A720C612A4CBB370003018A /* SupportSettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportSettingsDelegate.swift; sourceTree = "<group>"; };
@@ -8614,6 +8620,15 @@
 			path = Cell;
 			sourceTree = "<group>";
 		};
+		8A0A1BA12B22010200E8706F /* PrivateHome */ = {
+			isa = PBXGroup;
+			children = (
+				8A0A1B9F2B2200FD00E8706F /* PrivateHomepageViewController.swift */,
+				8A0A1BA22B22030100E8706F /* PrivateMessageCardCell.swift */,
+			);
+			path = PrivateHome;
+			sourceTree = "<group>";
+		};
 		8A171A6029F82AD90085770E /* Application */ = {
 			isa = PBXGroup;
 			children = (
@@ -10434,6 +10449,7 @@
 				E1AEC171286E0CF500062E29 /* HomepageViewControllerTests.swift */,
 				E1AEC172286E0CF500062E29 /* FirefoxHomeViewModelTests.swift */,
 				5A9A09D128AFD51900B6F51E /* MockHomepageDataModelDelegate.swift */,
+				8A6E8DE92B275B49000C4301 /* PrivateHomepageViewControllerTests.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -11163,6 +11179,7 @@
 		F84B22211A09122500AAB793 /* Home */ = {
 			isa = PBXGroup;
 			children = (
+				8A0A1BA12B22010200E8706F /* PrivateHome */,
 				C834ACD028D3ACA900203AD1 /* Blurrable.swift */,
 				8AB5958628412B620090F4AE /* CustomizeHome */,
 				DF036E41274FD3FC002E834E /* HistoryHighlights */,
@@ -12890,6 +12907,7 @@
 				E1877A832875DEDE00F5BDF2 /* SyncedTabCell.swift in Sources */,
 				21E77E522AA8BE5C00FABA10 /* TabTrayFlagManager.swift in Sources */,
 				CA8226F324C11DB7008A6F38 /* PasswordManagerTableViewCell.swift in Sources */,
+				8A0A1BA02B2200FD00E8706F /* PrivateHomepageViewController.swift in Sources */,
 				E4A960061ABB9C450069AD6F /* ReaderModeUtils.swift in Sources */,
 				8AD40FCB27BADC4B00672675 /* StatefulButton.swift in Sources */,
 				C84655E62887398700861B4A /* WallpaperCollection.swift in Sources */,
@@ -13380,6 +13398,7 @@
 				214EF4152AC5D5D0005BCCDA /* TabDisplayView.swift in Sources */,
 				2165B2C22860C2F4004C0786 /* AdjustTelemetryHelper.swift in Sources */,
 				8A2D593E27DC0AA100713EC9 /* TopSite.swift in Sources */,
+				8A0A1BA32B22030100E8706F /* PrivateMessageCardCell.swift in Sources */,
 				213BF7532AC21D1B00C53A64 /* TabDisplayPanel.swift in Sources */,
 				434E733725EED32E006D3BDE /* BrowserViewController+URLBarDelegate.swift in Sources */,
 				C88E7A5B2A0553510072E638 /* OnboardingLinkInfoModel.swift in Sources */,
@@ -13782,6 +13801,7 @@
 				C2D80BED2AAF3C6B00CDF7A9 /* MockBrowserCoordinator.swift in Sources */,
 				45D5EDC0292D619000311934 /* MockablePinnedSites.swift in Sources */,
 				5AE371852A4DD6FE0092A760 /* PasswordManagerCoordinatorDelegateMock.swift in Sources */,
+				8A6E8DEB2B275BA9000C4301 /* PrivateHomepageViewControllerTests.swift in Sources */,
 				8A93F86529D37331004159D9 /* DefaultRouterTests.swift in Sources */,
 				8AF10D8A29D713F50086351D /* LaunchScreenViewModelTests.swift in Sources */,
 				2F13E79B1AC0C02700D75081 /* StringExtensionsTests.swift in Sources */,

--- a/Client/Application/AccessibilityIdentifiers.swift
+++ b/Client/Application/AccessibilityIdentifiers.swift
@@ -120,6 +120,12 @@ public struct AccessibilityIdentifiers {
 
     struct PrivateMode {
         static let dimmingView = "PrivateMode.DimmingView"
+        struct Homepage {
+            static let title = "PrivateMode.Homepage.Title"
+            static let body = "PrivateMode.Homepage.Body"
+            static let link = "PrivateMode.Homepage.Link"
+            static let card = "PrivateMode.Homepage.MessageCard"
+        }
     }
 
     struct Shopping {

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -24,6 +24,7 @@ class BrowserCoordinator: BaseCoordinator,
     var browserViewController: BrowserViewController
     var webviewController: WebviewViewController?
     var homepageViewController: HomepageViewController?
+    var privateViewController: PrivateHomepageViewController?
 
     private var profile: Profile
     private let tabManager: TabManager
@@ -114,6 +115,15 @@ class BrowserCoordinator: BaseCoordinator,
         homepageController.scrollToTop()
         // We currently don't support full page screenshot of the homepage
         screenshotService.screenshotableView = nil
+    }
+
+    func showPrivateHomepage() {
+        let privateHomepageController = PrivateHomepageViewController()
+        guard browserViewController.embedContent(privateHomepageController) else {
+            logger.log("Unable to embed private homepage", level: .debug, category: .coordinator)
+            return
+        }
+        self.privateViewController = privateHomepageController
     }
 
     func show(webView: WKWebView) {

--- a/Client/Coordinators/Browser/BrowserDelegate.swift
+++ b/Client/Coordinators/Browser/BrowserDelegate.swift
@@ -21,6 +21,9 @@ protocol BrowserDelegate: AnyObject {
                       statusBarScrollDelegate: StatusBarScrollDelegate,
                       overlayManager: OverlayModeManager)
 
+    /// Show the private homepage to the user as part of felt privacy
+    func showPrivateHomepage()
+
     /// Show the webview to navigate
     /// - Parameter webView: When nil, will show the already existing webview
     func show(webView: WKWebView)

--- a/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1020,6 +1020,11 @@ class BrowserViewController: UIViewController,
     /// on the tab bar to open a new tab or by pressing the home page button on the tab bar. Inline is false when
     /// it's the zero search page, aka when the home page is shown by clicking the url bar from a loaded web page.
     func showEmbeddedHomepage(inline: Bool) {
+        guard let isPrivate = browserViewControllerState?.usePrivateHomepage, !isPrivate else {
+            browserDelegate?.showPrivateHomepage()
+            return
+        }
+
         hideReaderModeBar(animated: false)
 
         // Make sure reload button is hidden on homepage

--- a/Client/Frontend/Components/ContentContainer.swift
+++ b/Client/Frontend/Components/ContentContainer.swift
@@ -7,6 +7,7 @@ import UIKit
 enum ContentType {
     case webview
     case homepage
+    case privateHomepage
 }
 
 protocol ContentContainable: UIViewController {
@@ -26,6 +27,10 @@ class ContentContainer: UIView {
         return type == .homepage
     }
 
+    var hasPrivateHomepage: Bool {
+        return type == .privateHomepage
+    }
+
     /// Determine if the content can be added, making sure we only add once
     /// - Parameters:
     ///   - viewController: The view controller to add to the container
@@ -34,6 +39,8 @@ class ContentContainer: UIView {
         switch type {
         case .homepage:
             return !(content is HomepageViewController)
+        case .privateHomepage:
+            return !(content is PrivateHomepageViewController)
         case .webview:
             return !(content is WebviewViewController)
         case .none:
@@ -61,7 +68,7 @@ class ContentContainer: UIView {
     private func removePreviousContent() {
         // Only remove previous content when it's the homepage. We're not remving the webview controller for now
         // since if it's not loaded, the webview doesn't layout it's WKCompositingView which result in black screen
-        guard type == .homepage else { return }
+        guard hasHomepage || hasPrivateHomepage else { return }
         contentController?.willMove(toParent: nil)
         contentController?.view.removeFromSuperview()
         contentController?.removeFromParent()

--- a/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
+++ b/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
@@ -1,0 +1,132 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Common
+import UIKit
+import Shared
+
+// Displays the view for the private homepage when users create a new tab in private browsing
+final class PrivateHomepageViewController: UIViewController, ContentContainable, Themeable {
+    enum UX {
+        static let scrollContainerStackSpacing: CGFloat = 24
+        static let defaultScrollContainerPadding: CGFloat = 16
+        private static let iPadScrollContainerPadding: CGFloat = 164
+
+        static var scrollContainerPadding: CGFloat {
+            let isiPad = UIDevice.current.userInterfaceIdiom == .pad
+            return isiPad ? UX.iPadScrollContainerPadding : UX.defaultScrollContainerPadding
+        }
+    }
+
+    // MARK: ContentContainable Variables
+    var contentType: ContentType = .privateHomepage
+
+    // MARK: Theming Variables
+    var themeManager: Common.ThemeManager
+    var themeObserver: NSObjectProtocol?
+    var notificationCenter: Common.NotificationProtocol
+
+    // MARK: UI Elements
+    private lazy var gradient: CAGradientLayer = {
+        let gradient = CAGradientLayer()
+        gradient.type = .axial
+        gradient.startPoint = CGPoint(x: 1, y: 0)
+        gradient.endPoint = CGPoint(x: 0, y: 1)
+        gradient.locations = [0, 0.5, 1]
+        return gradient
+    }()
+
+    private let scrollView: UIScrollView = .build()
+
+    private lazy var scrollContainer: UIStackView = .build { stackView in
+        stackView.axis = .vertical
+        stackView.spacing = UX.scrollContainerStackSpacing
+    }
+
+    private lazy var privateMessageCardCell: PrivateMessageCardCell = {
+        let messageCard = PrivateMessageCardCell()
+        let messageCardModel = PrivateMessageCardCell.PrivateMessageCard(
+            title: .FirefoxHomepage.FeltPrivacyUI.Title,
+            body: String(format: .FirefoxHomepage.FeltPrivacyUI.Body, AppName.shortName.rawValue),
+            link: .FirefoxHomepage.FeltPrivacyUI.Link
+        )
+        messageCard.configure(with: messageCardModel, and: themeManager.currentTheme)
+        return messageCard
+    }()
+
+    private lazy var logoHeaderCell: HomeLogoHeaderCell = {
+        let logoHeader = HomeLogoHeaderCell()
+        logoHeader.applyTheme(theme: themeManager.currentTheme)
+        return logoHeader
+    }()
+
+    init(themeManager: ThemeManager = AppContainer.shared.resolve(),
+         notificationCenter: NotificationProtocol = NotificationCenter.default
+    ) {
+        self.themeManager = themeManager
+        self.notificationCenter = notificationCenter
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        setupLayout()
+
+        listenForThemeChange(view)
+        applyTheme()
+    }
+
+    private func setupLayout() {
+        scrollContainer.addArrangedSubview(logoHeaderCell.contentView)
+        scrollContainer.addArrangedSubview(privateMessageCardCell)
+        scrollContainer.accessibilityElements = [logoHeaderCell.contentView, privateMessageCardCell]
+
+        view.layer.addSublayer(gradient)
+        view.addSubview(scrollView)
+        scrollView.addSubview(scrollContainer)
+
+        let contentLayoutGuide = scrollView.contentLayoutGuide
+        let frameLayoutGuide = scrollView.frameLayoutGuide
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+
+            scrollContainer.topAnchor.constraint(equalTo: contentLayoutGuide.topAnchor,
+                                                 constant: UX.defaultScrollContainerPadding),
+            scrollContainer.bottomAnchor.constraint(equalTo: contentLayoutGuide.bottomAnchor,
+                                                    constant: -UX.defaultScrollContainerPadding),
+            scrollContainer.leadingAnchor.constraint(equalTo: contentLayoutGuide.leadingAnchor,
+                                                     constant: UX.scrollContainerPadding),
+            scrollContainer.trailingAnchor.constraint(equalTo: contentLayoutGuide.trailingAnchor,
+                                                      constant: -UX.scrollContainerPadding),
+
+            scrollContainer.widthAnchor.constraint(equalTo: frameLayoutGuide.widthAnchor,
+                                                   constant: -UX.scrollContainerPadding * 2),
+        ])
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        gradient.frame = view.bounds
+    }
+
+    func applyTheme() {
+        // TODO: Felt Privay - Theming System should be handled by Redux 
+        // https://mozilla-hub.atlassian.net/browse/FXIOS-7879
+        themeManager.changeCurrentTheme(.privateMode)
+        let theme = themeManager.currentTheme
+        gradient.colors = theme.colors.layerHomepage.cgColors
+        logoHeaderCell.applyTheme(theme: theme)
+        privateMessageCardCell.applyTheme(theme: theme)
+    }
+}

--- a/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
+++ b/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
@@ -127,6 +127,5 @@ final class PrivateHomepageViewController: UIViewController, ContentContainable,
         let theme = themeManager.currentTheme
         gradient.colors = theme.colors.layerHomepage.cgColors
         logoHeaderCell.applyTheme(theme: theme)
-        privateMessageCardCell.applyTheme(theme: theme)
     }
 }

--- a/Client/Frontend/Home/PrivateHome/PrivateMessageCardCell.swift
+++ b/Client/Frontend/Home/PrivateHome/PrivateMessageCardCell.swift
@@ -1,0 +1,120 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Common
+import ComponentLibrary
+
+// UI element used to describe details about private browsing on the private firefox homepage
+class PrivateMessageCardCell: UIView, ThemeApplicable {
+    typealias a11y = AccessibilityIdentifiers.PrivateMode.Homepage
+
+    struct PrivateMessageCard: Hashable {
+        let title: String
+        let body: String
+        let link: String
+    }
+
+    enum UX {
+        static let contentStackViewSpacing: CGFloat = 8
+        static let contentStackPadding: CGFloat = 16
+        static let labelFontSize: CGFloat = 15
+        static let actionButtonInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
+    }
+
+    private lazy var cardContainer: ShadowCardView = .build()
+
+    private lazy var mainView: UIView = .build()
+
+    private lazy var contentStackView: UIStackView = .build { stackView in
+        stackView.axis = .vertical
+        stackView.spacing = UX.contentStackViewSpacing
+    }
+
+    private lazy var headerLabel: UILabel = .build { label in
+        label.font = DefaultDynamicFontHelper.preferredFont(
+            withTextStyle: .headline,
+            size: UX.labelFontSize
+        )
+        label.numberOfLines = 0
+        label.adjustsFontForContentSizeCategory = true
+        label.accessibilityIdentifier = a11y.title
+        label.accessibilityTraits.insert(.header)
+    }
+
+    private lazy var bodyLabel: UILabel = .build { label in
+        label.font = DefaultDynamicFontHelper.preferredFont(
+            withTextStyle: .body,
+            size: UX.labelFontSize
+        )
+        label.numberOfLines = 0
+        label.adjustsFontForContentSizeCategory = true
+        label.accessibilityIdentifier = a11y.body
+    }
+
+    private lazy var linkLabel: UILabel = .build { label in
+        label.font = DefaultDynamicFontHelper.preferredFont(
+            withTextStyle: .body,
+            size: UX.labelFontSize
+        )
+        label.numberOfLines = 0
+        label.adjustsFontForContentSizeCategory = true
+        label.accessibilityIdentifier = a11y.link
+        label.accessibilityTraits.insert(.link)
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(with item: PrivateMessageCard, and theme: Theme) {
+        headerLabel.text = item.title
+        bodyLabel.text = item.body
+        linkLabel.attributedText = getUnderlineText(for: item.link)
+
+        let cardModel = ShadowCardViewModel(view: mainView, a11yId: a11y.card)
+        cardContainer.configure(cardModel)
+        applyTheme(theme: theme)
+    }
+
+    func applyTheme(theme: Theme) {
+        cardContainer.applyTheme(theme: theme)
+    }
+
+    private func setupLayout() {
+        addSubviews(cardContainer, mainView)
+        mainView.addSubview(contentStackView)
+        contentStackView.addArrangedSubview(headerLabel)
+        contentStackView.addArrangedSubview(bodyLabel)
+        contentStackView.addArrangedSubview(linkLabel)
+
+        NSLayoutConstraint.activate([
+            cardContainer.leadingAnchor.constraint(equalTo: leadingAnchor),
+            cardContainer.topAnchor.constraint(equalTo: topAnchor),
+            cardContainer.trailingAnchor.constraint(equalTo: trailingAnchor),
+            cardContainer.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            contentStackView.topAnchor.constraint(equalTo: cardContainer.topAnchor,
+                                                  constant: UX.contentStackPadding),
+            contentStackView.bottomAnchor.constraint(equalTo: cardContainer.bottomAnchor,
+                                                     constant: -UX.contentStackPadding),
+            contentStackView.leadingAnchor.constraint(equalTo: cardContainer.leadingAnchor,
+                                                      constant: UX.contentStackPadding),
+            contentStackView.trailingAnchor.constraint(equalTo: cardContainer.trailingAnchor,
+                                                       constant: -UX.contentStackPadding),
+        ])
+    }
+
+    private func getUnderlineText(for text: String) -> NSAttributedString {
+        let attributes: [NSAttributedString.Key: Any] = [
+            .underlineStyle: NSUnderlineStyle.single.rawValue
+        ]
+        return NSMutableAttributedString(string: text, attributes: attributes)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/PrivateHomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/PrivateHomepageViewControllerTests.swift
@@ -12,6 +12,11 @@ final class PrivateHomepageViewControllerTests: XCTestCase {
         DependencyHelperMock().bootstrapDependencies()
     }
 
+    override func tearDown() {
+        super.tearDown()
+        DependencyHelperMock().reset()
+    }
+
     func testPrivateHomepageViewController_simpleCreation_hasNoLeaks() {
         let privateHomeViewController = PrivateHomepageViewController()
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/PrivateHomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/PrivateHomepageViewControllerTests.swift
@@ -1,0 +1,20 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+@testable import Client
+
+final class PrivateHomepageViewControllerTests: XCTestCase {
+    override class func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+    }
+
+    func testPrivateHomepageViewController_simpleCreation_hasNoLeaks() {
+        let privateHomeViewController = PrivateHomepageViewController()
+
+        trackForMemoryLeaks(privateHomeViewController)
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7187)

## :bulb: Description
Add new private homepage

Context: User opens tab tray
Given that the user navigates to the private tab
When the user creates a new private tab,
then they should be able to see the new private homepage.

Context: User opens tab tray
Given that the user navigates to the normal tab, 
when the user creates a new tab
then they should not see the new private homepage.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

# Screenshots
| iPad | iPhone | 
| ---  | --- |
| ![image](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/06384964-9fe4-462a-8c9b-175c1f370fe8) | ![image](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/520f7e66-62f7-45d8-bb9c-781017393f18) |

**Accessibility**
| iPad | iPhone | 
| ---  | --- |
| ![simulator_screenshot_B4F30753-B7D0-46BB-96EF-ACC8F44FACD4](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/b5c44512-1f8a-4652-8c7b-db4b85ff0211) | ![simulator_screenshot_67F36B70-3244-4A79-B48E-01255B91EC4C](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/4b22f78d-2489-4aaa-875a-1420745dd0be) |

