### PR TITLE
Bugfix FXIOS-6943 [v122] Listen for updates to the state from the tab tray view controller

### DIFF
--- a/Client/Coordinators/QRCode/QRCodeCoordinator.swift
+++ b/Client/Coordinators/QRCode/QRCodeCoordinator.swift
@@ -35,6 +35,5 @@ class QRCodeCoordinator: BaseCoordinator, QRCodeDismissHandler {
 
     func dismiss(_ completion: (() -> Void)?) {
         router.dismiss(animated: true, completion: completion)
-        parentCoordinator?.didFinish(from: self)
     }
 }

--- a/Client/Coordinators/QRCode/QRCodeCoordinator.swift
+++ b/Client/Coordinators/QRCode/QRCodeCoordinator.swift
@@ -35,5 +35,6 @@ class QRCodeCoordinator: BaseCoordinator, QRCodeDismissHandler {
 
     func dismiss(_ completion: (() -> Void)?) {
         router.dismiss(animated: true, completion: completion)
+        parentCoordinator?.didFinish(from: self)
     }
 }

--- a/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -11,6 +11,10 @@ class TabManagerMiddleware {
     var tabManagers: [WindowUUID: TabManager] = [:]
     var selectedPanel: TabTrayPanelType = .tabs
 
+    var normalTabsCount: String {
+        (defaultTabManager.normalTabs.count < 100) ? defaultTabManager.normalTabs.count.description : "\u{221E}"
+    }
+
     lazy var tabsPanelProvider: Middleware<AppState> = { state, action in
         switch action {
         case TabTrayAction.tabTrayDidLoad(let panelType):
@@ -108,17 +112,17 @@ class TabManagerMiddleware {
         let tabsCount = refreshTabs(for: isPrivate).count
         return TabTrayModel(isPrivateMode: isPrivate,
                             selectedPanel: panelType,
-                            normalTabsCount: "\(tabsCount)")
+                            normalTabsCount: normalTabsCount)
     }
 
     func getTabsDisplayModel(for isPrivateMode: Bool) -> TabDisplayModel {
         let tabs = refreshTabs(for: isPrivateMode)
         let inactiveTabs = refreshInactiveTabs(for: isPrivateMode)
-        let isInactiveTabsExpanded = !isPrivateMode && !inactiveTabs.isEmpty
         let tabDisplayModel = TabDisplayModel(isPrivateMode: isPrivateMode,
                                               tabs: tabs,
+                                              normalTabsCount: normalTabsCount,
                                               inactiveTabs: inactiveTabs,
-                                              isInactiveTabsExpanded: isInactiveTabsExpanded)
+                                              isInactiveTabsExpanded: false)
         return tabDisplayModel
     }
 
@@ -165,7 +169,7 @@ class TabManagerMiddleware {
     }
 
     private func closeTab(with tabUUID: String) async -> Bool {
-        let isLastTab = defaultTabManager.tabs.count == 1
+        let isLastTab = defaultTabManager.normalTabs.count == 1
         await defaultTabManager.removeTab(tabUUID)
         return isLastTab
     }

--- a/Client/Frontend/Browser/Tabs/Models/TabDisplayModel.swift
+++ b/Client/Frontend/Browser/Tabs/Models/TabDisplayModel.swift
@@ -7,11 +7,7 @@ import Foundation
 struct TabDisplayModel: Equatable {
     var isPrivateMode: Bool
     var tabs: [TabModel]
-    var isPrivateTabsEmpty: Bool {
-        guard isPrivateMode else { return false }
-        return tabs.isEmpty
-    }
-
+    var normalTabsCount: String
     // MARK: Inactive tabs
     var inactiveTabs: [InactiveTabsModel]
     var isInactiveTabsExpanded: Bool

--- a/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
+++ b/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
@@ -14,9 +14,6 @@ struct TabTrayState: ScreenState, Equatable {
     var isPrivateMode: Bool
     var selectedPanel: TabTrayPanelType
     var shouldDismiss: Bool
-
-    var layout: TabTrayLayoutType = .compact
-    // TODO: FXIOS-7359 Move logic to show "\u{221E}" over 100 tabs to reducer
     var normalTabsCount: String
     var navigationTitle: String {
         return selectedPanel.navTitle
@@ -74,7 +71,7 @@ struct TabTrayState: ScreenState, Equatable {
             let panelType = tabState.isPrivateMode ? TabTrayPanelType.privateTabs : TabTrayPanelType.tabs
             return TabTrayState(isPrivateMode: tabState.isPrivateMode,
                                 selectedPanel: panelType,
-                                normalTabsCount: "\(tabState.tabs.count)")
+                                normalTabsCount: tabState.normalTabsCount)
         case TabTrayAction.dismissTabTray:
             return TabTrayState(isPrivateMode: state.isPrivateMode,
                                 selectedPanel: state.selectedPanel,
@@ -83,11 +80,5 @@ struct TabTrayState: ScreenState, Equatable {
         default:
             return state
         }
-    }
-
-    static func == (lhs: TabTrayState, rhs: TabTrayState) -> Bool {
-        return lhs.isPrivateMode == rhs.isPrivateMode
-        && lhs.selectedPanel == rhs.selectedPanel
-        && lhs.layout == rhs.layout
     }
 }

--- a/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
+++ b/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
@@ -67,7 +67,7 @@ struct TabsPanelState: ScreenState, Equatable {
             return TabsPanelState(isPrivateMode: state.isPrivateMode,
                                   tabs: state.tabs,
                                   inactiveTabs: inactiveTabs,
-                                  isInactiveTabsExpanded: !inactiveTabs.isEmpty)
+                                  isInactiveTabsExpanded: state.isInactiveTabsExpanded)
         default: return state
         }
     }

--- a/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -262,8 +262,9 @@ class TabTrayViewController: UIViewController,
     func newState(state: TabTrayState) {
         tabTrayState = state
 
+        updateNormalTabsCounter()
         if tabTrayState.shouldDismiss {
-            dismissVC()
+            delegate?.didFinish()
         }
     }
 
@@ -308,6 +309,13 @@ class TabTrayViewController: UIViewController,
 
     private func updateTitle() {
         navigationItem.title = tabTrayState.navigationTitle
+    }
+
+    private func updateNormalTabsCounter() {
+        countLabel.text = tabTrayState.normalTabsCount
+        guard !isRegularLayout,
+              let image = UIImage(named: ImageIdentifiers.navTabCounter) else { return }
+        segmentedControl.setImage(image.overlayWith(image: countLabel), forSegmentAt: 0)
     }
 
     private func setupForiPad() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabsPanelStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabsPanelStateTests.swift
@@ -25,8 +25,10 @@ final class TabPanelStateTests: XCTestCase {
         let initialState = createInitialState()
         XCTAssertTrue(initialState.tabs.isEmpty)
         let reducer = tabsPanelReducer()
+        let tabs = createTabs()
         let tabDisplayModel = TabDisplayModel(isPrivateMode: false,
-                                              tabs: createTabs(),
+                                              tabs: tabs,
+                                              normalTabsCount: "\(tabs.count)",
                                               inactiveTabs: [InactiveTabsModel](),
                                               isInactiveTabsExpanded: false)
         let newState = reducer(initialState, TabPanelAction.didLoadTabPanel(tabDisplayModel))


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6943)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15421)

## :bulb: Description
Tab tray refactor multiple bug fixes:
- Use normal tabs count to for regular tabs segment section
- Fix close last tab to count only for regular tabs (ignore private tabs)
- Dismiss Tab tray through Coordinator instead of dismissing View controller directly 
- Close inactive tabs by default
- Remove call to `parentCoordinator?.didFinish(from: self)` from `QRCodeCoordinator` because it was dismissing the tab tray too soon when using the QR code flow. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

