### PR TITLE
Bugfix FXIOS-7836 [v122] Recently-closed tabs: fix encoding/decoding

### DIFF
--- a/Storage/RecentlyClosedTabs.swift
+++ b/Storage/RecentlyClosedTabs.swift
@@ -13,11 +13,11 @@ open class ClosedTabsStore {
     }
 
     open lazy var tabs: [ClosedTab] = {
-        guard let tabsArray: Data = self.prefs.objectForKey(KeyedArchiverKeys.recentlyClosedTabs.rawValue) as Any? as? Data,
-              let unarchiver = try? NSKeyedUnarchiver(forReadingFrom: tabsArray),
-              let unarchivedArray = unarchiver.decodeObject(of: [NSArray.self, ClosedTab.self], forKey: KeyedArchiverKeys.recentlyClosedTabs.rawValue) as? [ClosedTab]
+        guard let tabsData: Data = self.prefs.objectForKey(KeyedArchiverKeys.recentlyClosedTabs.rawValue) as Any? as? Data,
+              let unarchivedTabs = try? NSKeyedUnarchiver
+            .unarchivedObject(ofClasses: [NSArray.self, ClosedTab.self], from: tabsData) as? [ClosedTab]
         else { return [] }
-        return unarchivedArray
+        return unarchivedTabs
     }()
 
     public init(prefs: Prefs) {
@@ -75,17 +75,16 @@ open class ClosedTab: NSObject, NSSecureCoding {
         super.init()
     }
 
-    public required convenience init?(coder: NSCoder) {
-        guard let url = coder.decodeObject(forKey: CodingKeys.url.rawValue) as? URL,
-              let title = coder.decodeObject(forKey: CodingKeys.title.rawValue) as? String,
+    public required init?(coder: NSCoder) {
+        guard let url = coder.decodeObject(of: [NSURL.self], forKey: CodingKeys.url.rawValue) as? URL,
+              let title = coder.decodeObject(of: [NSString.self], forKey: CodingKeys.title.rawValue) as? String,
               let date = coder.decodeObject(forKey: CodingKeys.lastExecutedTime.rawValue) as? Timestamp
         else { return nil }
 
-        self.init(
-            url: url,
-            title: title,
-            lastExecutedTime: date
-        )
+        self.title = title
+        self.url = url
+        self.lastExecutedTime = date
+        super.init()
     }
 
     open func encode(with coder: NSCoder) {

--- a/Storage/RecentlyClosedTabs.swift
+++ b/Storage/RecentlyClosedTabs.swift
@@ -58,7 +58,8 @@ open class ClosedTabsStore {
     }
 }
 
-open class ClosedTab: NSObject, NSCoding {
+open class ClosedTab: NSObject, NSSecureCoding {
+    public static var supportsSecureCoding: Bool { return true }
     enum CodingKeys: String {
         case url, title, lastExecutedTime
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7836)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17486)

## :bulb: Description

This fixes some issues (including adoption of NSSecureCoding) that were preventing recently-closed tabs from being encoded and decoded. It also avoids a related non-fatal error that was being thrown during encoding.

The iOS client attempts to persist/restore recently-closed tabs between app launches but for some time now that appears to have not been working. I'm not sure if perhaps this was a longstanding bug and users just assumed that Recently-Closed tabs weren't tracked between app launches. But that should now be working correctly.

![image](https://github.com/mozilla-mobile/firefox-ios/assets/145381717/5bb9524d-e71e-4b36-847e-2bc4ef25a767)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

