### PR TITLE
Fix MTE-1946 [v122] testOpenTabsInSearchSuggestions smoke test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -282,7 +282,7 @@ class BaseTestCase: XCTestCase {
     }
 
     func waitForTabsButton() {
-        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 15)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: TIMEOUT)
     }
 
     func unlockLoginsView() {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -1031,6 +1031,7 @@ extension MMNavigator where T == FxUserState {
     func createNewTab() {
         let app = XCUIApplication()
         self.goto(TabTray)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.TabTray.newTabButton], timeout: TIMEOUT)
         app.buttons[AccessibilityIdentifiers.TabTray.newTabButton].tap()
         self.nowAt(NewTabScreen)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -267,6 +267,7 @@ class SearchTests: BaseTestCase {
         }
     }
 
+    // https://testrail.stage.mozaws.net/index.php?/cases/view/2306989
     // Smoketest
     func testOpenTabsInSearchSuggestions() {
         // Go to localhost website and check the page displays correctly
@@ -276,6 +277,7 @@ class SearchTests: BaseTestCase {
         validateSearchSuggestionText(typeText: "localhost")
         restartInBackground()
         // Open new tab
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton], timeout: TIMEOUT)
         navigator.performAction(Action.CloseURLBarOpen)
         waitForTabsButton()
         validateSearchSuggestionText(typeText: "localhost")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1946)

## :bulb: Description
This PR attempts to fix testOpenTabsInSearchSuggestions smoke test that keep failing intermittently.
Run the test 100 times locally. No failure.
<img width="829" alt="Screenshot 2023-12-12 at 14 24 11" src="https://github.com/mozilla-mobile/firefox-ios/assets/134391433/7dec5d5a-f580-4310-9657-7b5c26f96363">
<img width="583" alt="Screenshot 2023-12-12 at 14 24 41" src="https://github.com/mozilla-mobile/firefox-ios/assets/134391433/2529b790-c5b8-43ea-95d5-4cc3aa7cb291">


