### PR TITLE
BugFix FXIOS-7942-7943 [v122] QRCodeViewController not presented in LegacyTabTray and in MainMenuActionHelper

### DIFF
--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -508,15 +508,16 @@ class BrowserCoordinator: BaseCoordinator,
         return bottomSheetCoordinator
     }
 
-    func showQRCode() {
+    func showQRCode(delegate: QRCodeViewControllerDelegate, rootNavigationController: UINavigationController?) {
         var coordinator: QRCodeCoordinator
         if let qrCodeCoordinator = childCoordinators.first(where: { $0 is QRCodeCoordinator }) as? QRCodeCoordinator {
             coordinator = qrCodeCoordinator
         } else {
+            let router = rootNavigationController != nil ? DefaultRouter(navigationController: rootNavigationController!) : router
             coordinator = QRCodeCoordinator(parentCoordinator: self, router: router)
             add(child: coordinator)
         }
-        coordinator.showQRCode(delegate: browserViewController)
+        coordinator.showQRCode(delegate: delegate)
     }
 
     func showTabTray(selectedPanel: TabTrayPanelType) {

--- a/Client/Coordinators/Browser/BrowserNavigationHandler.swift
+++ b/Client/Coordinators/Browser/BrowserNavigationHandler.swift
@@ -6,7 +6,7 @@ import Foundation
 import Storage
 import WebKit
 
-protocol BrowserNavigationHandler: AnyObject {
+protocol BrowserNavigationHandler: AnyObject, QRCodeNavigationHandler {
     /// Asks to show a settings page, can be a general settings page or a child page
     /// - Parameter settings: The settings route we're trying to get to
     func show(settings: Route.SettingsSection)
@@ -73,9 +73,6 @@ protocol BrowserNavigationHandler: AnyObject {
 
     /// Shows the Tab Tray View Controller.
     func showTabTray(selectedPanel: TabTrayPanelType)
-
-    /// Shows the QRCode View Controller.
-    func showQRCode()
 }
 
 extension BrowserNavigationHandler {

--- a/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
@@ -46,14 +46,14 @@ extension BrowserViewController: URLBarDelegate {
 
     private func showLegacyTabTrayViewController(withFocusOnUnselectedTab tabToFocus: Tab? = nil,
                                                  focusedSegment: TabTrayPanelType? = nil) {
-        self.tabTrayViewController = LegacyTabTrayViewController(
+        tabTrayViewController = LegacyTabTrayViewController(
             tabTrayDelegate: self,
             profile: profile,
             tabToFocus: tabToFocus,
             tabManager: tabManager,
             overlayManager: overlayManager,
             focusedSegment: focusedSegment)
-
+        (tabTrayViewController as? LegacyTabTrayViewController)?.qrCodeNavigationHandler = navigationHandler
         tabTrayViewController?.openInNewTab = { url, isPrivate in
             let tab = self.tabManager.addTab(URLRequest(url: url), afterTab: self.tabManager.selectedTab, isPrivate: isPrivate)
             // If we are showing toptabs a user can just use the top tab bar
@@ -167,7 +167,7 @@ extension BrowserViewController: URLBarDelegate {
 
     func urlBarDidPressQRButton(_ urlBar: URLBarView) {
         if CoordinatorFlagManager.isQRCodeCoordinatorEnabled {
-            navigationHandler?.showQRCode()
+            navigationHandler?.showQRCode(delegate: self)
         } else {
             let qrCodeViewController = QRCodeViewController()
             qrCodeViewController.qrCodeDelegate = self

--- a/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1405,6 +1405,7 @@ class BrowserViewController: UIViewController,
                                                                                       flowType: flowType,
                                                                                       referringPage: referringPage,
                                                                                       profile: profile)
+        (vcToPresent as? FirefoxAccountSignInViewController)?.qrCodeNavigationHandler = navigationHandler
         presentThemedViewController(navItemLocation: .Left,
                                     navItemText: .Close,
                                     vcBeingPresented: vcToPresent,
@@ -1437,7 +1438,7 @@ class BrowserViewController: UIViewController,
 
     func handleQRCode() {
         if CoordinatorFlagManager.isQRCodeCoordinatorEnabled {
-            navigationHandler?.showQRCode()
+            navigationHandler?.showQRCode(delegate: self)
         } else {
             let qrCodeViewController = QRCodeViewController()
             qrCodeViewController.qrCodeDelegate = self

--- a/Client/Frontend/Browser/Tabs/Legacy/LegacyTabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/Legacy/LegacyTabTrayViewController.swift
@@ -36,6 +36,7 @@ class LegacyTabTrayViewController: UIViewController, Themeable, TabTrayControlle
     var nimbus: FxNimbus
     var themeManager: ThemeManager
     var themeObserver: NSObjectProtocol?
+    weak var qrCodeNavigationHandler: QRCodeNavigationHandler?
 
     // MARK: - UI Elements
     private var titleWidthConstraint: NSLayoutConstraint?
@@ -615,6 +616,7 @@ extension LegacyTabTrayViewController: RemotePanelDelegate {
                                                                                      flowType: .emailLoginFlow,
                                                                                      referringPage: .tabTray,
                                                                                      profile: viewModel.profile)
+        (controller as? FirefoxAccountSignInViewController)?.qrCodeNavigationHandler = qrCodeNavigationHandler
         (controller as? FirefoxAccountSignInViewController)?.shouldReload = { [weak self] in
             self?.viewModel.reloadRemoteTabs()
         }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -234,8 +234,8 @@ final class BrowserCoordinatorTests: XCTestCase {
 
     func testShowQRCode_addsQRCodeCoordinator() {
         let subject = createSubject()
-
-        subject.showQRCode()
+        let delegate = MockQRCodeViewControllerDelegate()
+        subject.showQRCode(delegate: delegate)
 
         XCTAssertEqual(subject.childCoordinators.count, 1)
         XCTAssertTrue(subject.childCoordinators.first is QRCodeCoordinator)
@@ -243,8 +243,8 @@ final class BrowserCoordinatorTests: XCTestCase {
 
     func testShowQRCode_presentsQRCodeNavigationController() {
         let subject = createSubject()
-
-        subject.showQRCode()
+        let delegate = MockQRCodeViewControllerDelegate()
+        subject.showQRCode(delegate: delegate)
 
         XCTAssertEqual(mockRouter.presentCalled, 1)
         XCTAssertTrue(mockRouter.presentedViewController is QRCodeNavigationController)


### PR DESCRIPTION
## :scroll: Tickets
### LegacyTabTrayViewController
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7942)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17714)

### MainMenuActionHelper
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7943)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17715)

## :bulb: Description
Bug fix `QRCodeViewController` not being presented when pressing Ready to Scan in the Fx A sign in view controller presented from the MainMenu and `LegacyTabTrayViewController`

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

