### PR TITLE
Refactor FXIOS-7702 [v122] Update SecondaryRoundedButton to use the new ResizableButton class

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
@@ -20,15 +20,9 @@ public class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
         )
     }
 
-    private var highlightedTintColor: UIColor!
-    private var normalTintColor: UIColor!
-    private var foregroundColorForState: ((UIControl.State) -> UIColor)?
-
-    override open var isHighlighted: Bool {
-        didSet {
-            backgroundColor = isHighlighted ? highlightedTintColor : normalTintColor
-        }
-    }
+    private var highlightedBackgroundColor: UIColor!
+    private var normalBackgroundColor: UIColor!
+    private var foregroundColor: UIColor!
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -46,9 +40,11 @@ public class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
         guard var updatedConfiguration = configuration else {
             return
         }
-        let foregroundColor = foregroundColorForState?(state)
+        let newBackgroundColor = state == .highlighted ? highlightedBackgroundColor : normalBackgroundColor
 
         updatedConfiguration.baseForegroundColor = foregroundColor
+        backgroundColor = newBackgroundColor
+
         configuration = updatedConfiguration
     }
 
@@ -72,19 +68,10 @@ public class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
     // MARK: ThemeApplicable
 
     public func applyTheme(theme: Theme) {
-        guard var updatedConfiguration = configuration else {
-            return
-        }
+        highlightedBackgroundColor = theme.colors.actionSecondaryHover
+        normalBackgroundColor = theme.colors.actionSecondary
+        foregroundColor = theme.colors.textInverted
 
-        highlightedTintColor = theme.colors.actionSecondaryHover
-        normalTintColor = theme.colors.actionSecondary
-        backgroundColor = normalTintColor
-
-        foregroundColorForState = { _ in
-            // For this button, all states should use colors.textOnLight
-            theme.colors.textOnLight
-        }
-        updatedConfiguration.baseForegroundColor = foregroundColorForState?(state)
-        configuration = updatedConfiguration
+        setNeedsUpdateConfiguration()
     }
 }

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
@@ -42,11 +42,11 @@ public class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
             return
         }
 
-        switch state {
+        updatedConfiguration.background.backgroundColor = switch state {
         case [.highlighted]:
-            updatedConfiguration.background.backgroundColor = highlightedBackgroundColor
+            highlightedBackgroundColor
         default:
-            updatedConfiguration.background.backgroundColor = normalBackgroundColor
+            normalBackgroundColor
         }
         updatedConfiguration.baseForegroundColor = foregroundColor
 

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
@@ -42,7 +42,7 @@ public class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
         fatalError("init(coder:) has not been implemented")
     }
 
-    public override func updateConfiguration() {
+    override public func updateConfiguration() {
         guard var updatedConfiguration = configuration else {
             return
         }

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
@@ -28,8 +28,6 @@ public class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
         super.init(frame: frame)
 
         configuration = UIButton.Configuration.filled()
-        layer.cornerRadius = UX.buttonCornerRadius
-        titleLabel?.textAlignment = .center
         titleLabel?.adjustsFontForContentSizeCategory = true
     }
 

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
@@ -48,14 +48,6 @@ public class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
         }
         updatedConfiguration.baseForegroundColor = foregroundColor
 
-        configuration = updatedConfiguration
-    }
-
-    public func configure(viewModel: SecondaryRoundedButtonViewModel) {
-        guard var updatedConfiguration = configuration else {
-            return
-        }
-
         updatedConfiguration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
             var container = incoming
 
@@ -65,6 +57,14 @@ public class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
                 size: UX.buttonFontSize
             )
             return container
+        }
+
+        configuration = updatedConfiguration
+    }
+
+    public func configure(viewModel: SecondaryRoundedButtonViewModel) {
+        guard var updatedConfiguration = configuration else {
+            return
         }
 
         updatedConfiguration.contentInsets = UX.contentInsets

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
@@ -58,10 +58,17 @@ public class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
             return
         }
 
-        updatedConfiguration.setFont(DefaultDynamicFontHelper.preferredBoldFont(
-            withTextStyle: .callout,
-            size: UX.buttonFontSize
-        ))
+        updatedConfiguration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
+            var container = incoming
+
+            container.foregroundColor = updatedConfiguration.baseForegroundColor
+            container.font = DefaultDynamicFontHelper.preferredBoldFont(
+                withTextStyle: .callout,
+                size: UX.buttonFontSize
+            )
+            return container
+        }
+
         updatedConfiguration.contentInsets = UX.contentInsets
         updatedConfiguration.title = viewModel.title
         updatedConfiguration.titleAlignment = .center

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
@@ -27,6 +27,7 @@ public class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
+        configuration = UIButton.Configuration.filled()
         layer.cornerRadius = UX.buttonCornerRadius
         titleLabel?.textAlignment = .center
         titleLabel?.adjustsFontForContentSizeCategory = true
@@ -40,10 +41,14 @@ public class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
         guard var updatedConfiguration = configuration else {
             return
         }
-        let newBackgroundColor = state == .highlighted ? highlightedBackgroundColor : normalBackgroundColor
 
+        switch state {
+        case [.highlighted]:
+            updatedConfiguration.background.backgroundColor = highlightedBackgroundColor
+        default:
+            updatedConfiguration.background.backgroundColor = normalBackgroundColor
+        }
         updatedConfiguration.baseForegroundColor = foregroundColor
-        backgroundColor = newBackgroundColor
 
         configuration = updatedConfiguration
     }
@@ -59,6 +64,13 @@ public class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
         ))
         updatedConfiguration.contentInsets = UX.contentInsets
         updatedConfiguration.title = viewModel.title
+        updatedConfiguration.titleAlignment = .center
+
+        // Using a nil backgroundColorTransformer will just make the background view
+        // use configuration.background.backgroundColor without any transformation
+        updatedConfiguration.background.backgroundColorTransformer = nil
+        updatedConfiguration.background.cornerRadius = UX.buttonCornerRadius
+        updatedConfiguration.cornerStyle = .fixed
 
         accessibilityIdentifier = viewModel.a11yIdentifier
 
@@ -70,7 +82,7 @@ public class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
     public func applyTheme(theme: Theme) {
         highlightedBackgroundColor = theme.colors.actionSecondaryHover
         normalBackgroundColor = theme.colors.actionSecondary
-        foregroundColor = theme.colors.textInverted
+        foregroundColor = theme.colors.textOnLight
 
         setNeedsUpdateConfiguration()
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7702)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17182)

## :bulb: Description

This PR continues the migration to using `UIButton.Configuration` by dropping `LegacyResizableButton` and using `ResizableButton` instead as base class for `SecondaryRoundedButton`.

The various usages of this button are not doing further custom styling so there wasn't the need to change anything outside from `SecondaryRoundedButton.swift` but please do let me know if you think of some place I forgot to check :)

| | Before | After |
| :-: | :-: | :-: |
| Dark | ![Simulator Screenshot - iPhone 15 Pro - 2023-12-12 at 22 01 00](https://github.com/mozilla-mobile/firefox-ios/assets/19548672/f99f31a9-7d8c-4b28-9a53-d795066d96d7) | ![Simulator Screenshot - iPhone 15 Pro - 2023-12-12 at 22 04 04](https://github.com/mozilla-mobile/firefox-ios/assets/19548672/540beee9-d8fe-46e2-a7f9-bf220df0a0fe) |
| Light | ![Simulator Screenshot - iPhone 15 Pro - 2023-12-12 at 22 01 14](https://github.com/mozilla-mobile/firefox-ios/assets/19548672/70216f80-53c6-418b-9414-03eff8cd8d2b) | ![Simulator Screenshot - iPhone 15 Pro - 2023-12-12 at 22 04 18](https://github.com/mozilla-mobile/firefox-ios/assets/19548672/4518673e-13d8-4ef0-9047-be8fc81f2f7b) |

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

