### PR TITLE
Bugfix FXIOS-7946 [v122] FxA signin using QR code gets dismissed before finishing the flow

### DIFF
--- a/Client/Coordinators/TabTray/TabTrayCoordinator.swift
+++ b/Client/Coordinators/TabTray/TabTrayCoordinator.swift
@@ -15,8 +15,7 @@ protocol TabTrayNavigationHandler: AnyObject {
 class TabTrayCoordinator: BaseCoordinator,
                           ParentCoordinatorDelegate,
                           TabTrayViewControllerDelegate,
-                          TabTrayNavigationHandler,
-                          QRCodeNavigationHandler {
+                          TabTrayNavigationHandler {
     private var tabTrayViewController: TabTrayViewController!
     private var profile: Profile
     weak var parentCoordinator: TabTrayCoordinatorDelegate?
@@ -77,7 +76,6 @@ class TabTrayCoordinator: BaseCoordinator,
                                                           router: router)
         add(child: remoteTabsCoordinator)
         remoteTabsCoordinator.parentCoordinator = self
-        remoteTabsCoordinator.qrCodeNavigationHandler = self
         (navigationController.topViewController as? RemoteTabsPanel)?.remoteTabsDelegate = remoteTabsCoordinator
     }
 
@@ -90,18 +88,5 @@ class TabTrayCoordinator: BaseCoordinator,
     // MARK: - TabTrayViewControllerDelegate
     func didFinish() {
         parentCoordinator?.didDismissTabTray(from: self)
-    }
-
-    // MARK: - QRCodeNavigationHandler
-    func showQRCode(delegate: QRCodeViewControllerDelegate, rootNavigationController: UINavigationController?) {
-        var coordinator: QRCodeCoordinator
-        if let qrCodeCoordinator = childCoordinators.first(where: { $0 is QRCodeCoordinator }) as? QRCodeCoordinator {
-            coordinator = qrCodeCoordinator
-        } else {
-            let router = rootNavigationController != nil ? DefaultRouter(navigationController: rootNavigationController!) : router
-            coordinator = QRCodeCoordinator(parentCoordinator: self, router: router)
-            add(child: coordinator)
-        }
-        coordinator.showQRCode(delegate: delegate)
     }
 }

--- a/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
+++ b/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
@@ -619,7 +619,6 @@ extension LegacyGridTabViewController: TabDisplayCompletionDelegate, RecentlyClo
         dismissTabTray()
     }
 
-    @discardableResult
     func openRecentlyClosedSiteInNewTab(_ url: URL, isPrivate: Bool) {
         TelemetryWrapper.recordEvent(category: .action,
                                      method: .tap,

--- a/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -109,10 +109,9 @@ class TabManagerMiddleware {
         selectedPanel = panelType
 
         let isPrivate = panelType == .privateTabs
-        let tabsCount = refreshTabs(for: isPrivate).count
         return TabTrayModel(isPrivateMode: isPrivate,
                             selectedPanel: panelType,
-                            normalTabsCount: normalTabsCount)
+                            normalTabsCount: normalTabsCountText)
     }
 
     func getTabsDisplayModel(for isPrivateMode: Bool) -> TabDisplayModel {
@@ -120,7 +119,7 @@ class TabManagerMiddleware {
         let inactiveTabs = refreshInactiveTabs(for: isPrivateMode)
         let tabDisplayModel = TabDisplayModel(isPrivateMode: isPrivateMode,
                                               tabs: tabs,
-                                              normalTabsCount: normalTabsCount,
+                                              normalTabsCount: normalTabsCountText,
                                               inactiveTabs: inactiveTabs,
                                               isInactiveTabsExpanded: false)
         return tabDisplayModel

--- a/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -10,12 +10,12 @@ class TabManagerMiddleware {
     var selectedPanel: TabTrayPanelType = .tabs
     private let windowManager: WindowManager
 
-    init(windowManager: WindowManager = AppContainer.shared.resolve()) {
-        self.windowManager = windowManager
+    var normalTabsCountText: String {
+        (defaultTabManager.normalTabs.count < 100) ? defaultTabManager.normalTabs.count.description : "\u{221E}"
     }
 
-    var normalTabsCount: String {
-        (defaultTabManager.normalTabs.count < 100) ? defaultTabManager.normalTabs.count.description : "\u{221E}"
+    init(windowManager: WindowManager = AppContainer.shared.resolve()) {
+        self.windowManager = windowManager
     }
 
     lazy var tabsPanelProvider: Middleware<AppState> = { state, action in

--- a/Client/Frontend/Fakespot/FakespotViewModel.swift
+++ b/Client/Frontend/Fakespot/FakespotViewModel.swift
@@ -389,7 +389,7 @@ class FakespotViewModel {
                 )
             )
 
-            guard let product else { return }
+            guard product != nil else { return }
             if productAds.isEmpty {
                 recordSurfaceNoAdsAvailableTelemetry()
             } else {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/TabTray/RemoteTabsCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/TabTray/RemoteTabsCoordinatorTests.swift
@@ -9,6 +9,7 @@ final class RemoteTabsCoordinatorTests: XCTestCase {
     private var mockProfile: MockProfile!
     private var mockRouter: MockRouter!
     private var mockApplicationHelper: MockApplicationHelper!
+    private var qrDelegate: MockQRCodeViewControllerDelegate!
 
     override func setUp() {
         super.setUp()
@@ -16,6 +17,7 @@ final class RemoteTabsCoordinatorTests: XCTestCase {
         mockProfile = MockProfile()
         mockRouter = MockRouter(navigationController: MockNavigationController())
         mockApplicationHelper = MockApplicationHelper()
+        qrDelegate = MockQRCodeViewControllerDelegate()
     }
 
     override func tearDown() {
@@ -23,6 +25,7 @@ final class RemoteTabsCoordinatorTests: XCTestCase {
         mockProfile = nil
         mockRouter = nil
         mockApplicationHelper = nil
+        qrDelegate = nil
         DependencyHelperMock().reset()
     }
 
@@ -44,6 +47,26 @@ final class RemoteTabsCoordinatorTests: XCTestCase {
         subject.presentFxAccountSettings()
 
         XCTAssertEqual(mockApplicationHelper.openURLCalled, 1)
+    }
+
+    func testPresentQRCode() {
+        let subject = createSubject()
+        subject.showQRCode(delegate: qrDelegate)
+
+        XCTAssertEqual(mockRouter.presentCalled, 1)
+    }
+
+    func testDidFinishCalled() {
+        let subject = createSubject()
+        subject.showQRCode(delegate: qrDelegate)
+
+        guard let qrCodeCoordinator = subject.childCoordinators.first(where: { $0 is QRCodeCoordinator }) as? QRCodeCoordinator else {
+            XCTFail("QRCodeCoordinator expected to be found")
+            return
+        }
+
+        subject.didFinish(from: qrCodeCoordinator)
+        XCTAssertEqual(subject.childCoordinators.count, 0)
     }
 
     // MARK: - Helpers

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/TabTray/TabTrayCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/TabTray/TabTrayCoordinatorTests.swift
@@ -9,7 +9,6 @@ final class TabTrayCoordinatorTests: XCTestCase {
     private var mockRouter: MockRouter!
     private var profile: MockProfile!
     private var parentCoordinator: MockTabTrayCoordinatorDelegate!
-    private var qrDelegate: MockQRCodeViewControllerDelegate!
 
     override func setUp() {
         super.setUp()
@@ -17,7 +16,6 @@ final class TabTrayCoordinatorTests: XCTestCase {
         mockRouter = MockRouter(navigationController: MockNavigationController())
         profile = MockProfile()
         parentCoordinator = MockTabTrayCoordinatorDelegate()
-        qrDelegate = MockQRCodeViewControllerDelegate()
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: MockProfile())
     }
 
@@ -26,7 +24,6 @@ final class TabTrayCoordinatorTests: XCTestCase {
         mockRouter = nil
         profile = nil
         parentCoordinator = nil
-        qrDelegate = nil
         DependencyHelperMock().reset()
     }
 
@@ -61,20 +58,12 @@ final class TabTrayCoordinatorTests: XCTestCase {
         XCTAssertEqual(mockRouter.setRootViewControllerCalled, 1)
     }
 
-    func testDismissCalled() {
+    func testDidFinishCalled() {
         let subject = createSubject()
         subject.start(panelType: .tabs, navigationController: UINavigationController())
         subject.didFinish()
 
         XCTAssertEqual(parentCoordinator.didDismissWasCalled, 1)
-    }
-
-    func testPresentQRCode() {
-        let subject = createSubject()
-        subject.start(panelType: .syncedTabs, navigationController: UINavigationController())
-        subject.showQRCode(delegate: qrDelegate)
-
-        XCTAssertEqual(mockRouter.presentCalled, 1)
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7946)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17718)

## :bulb: Description
- Move QRCode flow presentation to RemoteTabsCoordinator 
- Update var name 
- Fix unit test

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

