### PR TITLE
Refactor FXIOS-7940 [v122] Remove SnapKit from webview delegates

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -120,9 +120,13 @@ extension BrowserViewController: WKUIDelegate {
                 let clonedWebView = WKWebView(frame: webView.frame, configuration: webView.configuration)
 
                 previewViewController.view.addSubview(clonedWebView)
-                clonedWebView.snp.makeConstraints { make in
-                    make.edges.equalTo(previewViewController.view)
-                }
+                NSLayoutConstraint.activate([
+                    clonedWebView.topAnchor.constraint(equalTo: previewViewController.view.topAnchor),
+                    clonedWebView.leadingAnchor.constraint(equalTo: previewViewController.view.leadingAnchor),
+                    clonedWebView.trailingAnchor.constraint(equalTo: previewViewController.view.trailingAnchor),
+                    clonedWebView.bottomAnchor.constraint(equalTo: previewViewController.view.bottomAnchor)
+                ])
+                clonedWebView.translatesAutoresizingMaskIntoConstraints = false
 
                 clonedWebView.load(URLRequest(url: url))
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7940)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17708)

## :bulb: Description
- Remove SnapKit from BrowserViewController+WebviewDelegates and replace with normal constraints. 
- The primary focus is on optimizing the layout constraints within the BrowserViewController+WebviewDelegates file, specifically targeting the clonedWebView.snp.makeConstraints section.

| Portrait  | Landscape | 
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2023-12-13 at 13 19 01](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/5645b8fd-a231-4b38-88a0-ae69276ba487) | ![Simulator Screenshot - iPhone 15 Pro - 2023-12-13 at 13 19 10](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/a7de717e-5b87-4561-bc85-d911487813a1) |

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods