### PR TITLE
Add FXIOS-7192 [v122] Private mode homepage card link

### DIFF
--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -20,7 +20,9 @@ class BrowserCoordinator: BaseCoordinator,
                           FakespotCoordinatorDelegate,
                           ParentCoordinatorDelegate,
                           TabManagerDelegate,
-                          TabTrayCoordinatorDelegate {
+                          TabTrayCoordinatorDelegate,
+                          PrivateHomepageDelegate {
+
     var browserViewController: BrowserViewController
     var webviewController: WebviewViewController?
     var homepageViewController: HomepageViewController?
@@ -114,13 +116,20 @@ class BrowserCoordinator: BaseCoordinator,
         screenshotService.screenshotableView = nil
     }
 
-    func showPrivateHomepage() {
-        let privateHomepageController = PrivateHomepageViewController()
+    func showPrivateHomepage(overlayManager: OverlayModeManager) {
+        let privateHomepageController = PrivateHomepageViewController(overlayManager: overlayManager)
+        privateHomepageController.parentCoordinator = self
         guard browserViewController.embedContent(privateHomepageController) else {
             logger.log("Unable to embed private homepage", level: .debug, category: .coordinator)
             return
         }
         self.privateViewController = privateHomepageController
+    }
+
+    // MARK: - PrivateHomepageDelegate
+
+    func homePanelDidRequestToOpenInNewTab(with url: URL, isPrivate: Bool, selectNewTab: Bool) {
+        browserViewController.homePanelDidRequestToOpenInNewTab(url, isPrivate: isPrivate, selectNewTab: selectNewTab)
     }
 
     func show(webView: WKWebView) {

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -22,7 +22,6 @@ class BrowserCoordinator: BaseCoordinator,
                           TabManagerDelegate,
                           TabTrayCoordinatorDelegate,
                           PrivateHomepageDelegate {
-
     var browserViewController: BrowserViewController
     var webviewController: WebviewViewController?
     var homepageViewController: HomepageViewController?

--- a/Client/Coordinators/Browser/BrowserDelegate.swift
+++ b/Client/Coordinators/Browser/BrowserDelegate.swift
@@ -22,7 +22,7 @@ protocol BrowserDelegate: AnyObject {
                       overlayManager: OverlayModeManager)
 
     /// Show the private homepage to the user as part of felt privacy
-    func showPrivateHomepage()
+    func showPrivateHomepage(overlayManager: OverlayModeManager)
 
     /// Show the webview to navigate
     /// - Parameter webView: When nil, will show the already existing webview

--- a/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1021,7 +1021,9 @@ class BrowserViewController: UIViewController,
     /// it's the zero search page, aka when the home page is shown by clicking the url bar from a loaded web page.
     func showEmbeddedHomepage(inline: Bool) {
         guard let isPrivate = browserViewControllerState?.usePrivateHomepage, !isPrivate else {
-            browserDelegate?.showPrivateHomepage()
+            browserDelegate?.showPrivateHomepage(
+                overlayManager: overlayManager
+            )
             return
         }
 

--- a/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1021,9 +1021,7 @@ class BrowserViewController: UIViewController,
     /// it's the zero search page, aka when the home page is shown by clicking the url bar from a loaded web page.
     func showEmbeddedHomepage(inline: Bool) {
         guard let isPrivate = browserViewControllerState?.usePrivateHomepage, !isPrivate else {
-            browserDelegate?.showPrivateHomepage(
-                overlayManager: overlayManager
-            )
+            browserDelegate?.showPrivateHomepage(overlayManager: overlayManager)
             return
         }
 

--- a/Client/Frontend/Home/PrivateHome/PrivateMessageCardCell.swift
+++ b/Client/Frontend/Home/PrivateHome/PrivateMessageCardCell.swift
@@ -9,6 +9,7 @@ import ComponentLibrary
 // UI element used to describe details about private browsing on the private firefox homepage
 class PrivateMessageCardCell: UIView, ThemeApplicable {
     typealias a11y = AccessibilityIdentifiers.PrivateMode.Homepage
+    var privateBrowsingLinkTapped: (() -> Void)?
 
     struct PrivateMessageCard: Hashable {
         let title: String
@@ -62,6 +63,12 @@ class PrivateMessageCardCell: UIView, ThemeApplicable {
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = a11y.link
         label.accessibilityTraits.insert(.link)
+        label.isUserInteractionEnabled = true
+    }
+
+    @objc
+    func linkTapped(_ sender: UITapGestureRecognizer) {
+        privateBrowsingLinkTapped?()
     }
 
     override init(frame: CGRect) {
@@ -77,6 +84,9 @@ class PrivateMessageCardCell: UIView, ThemeApplicable {
         headerLabel.text = item.title
         bodyLabel.text = item.body
         linkLabel.attributedText = getUnderlineText(for: item.link)
+
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(self.linkTapped(_:)))
+        linkLabel.addGestureRecognizer(tapGesture)
 
         let cardModel = ShadowCardViewModel(view: mainView, a11yId: a11y.card)
         cardContainer.configure(cardModel)

--- a/Shared/SupportUtils.swift
+++ b/Shared/SupportUtils.swift
@@ -8,6 +8,11 @@ import UIKit
 
 /// Utility functions related to SUMO and Webcompat
 public struct SupportUtils {
+    public static var URLForPrivateBrowsingLearnMore: URL? {
+        // Returns the predefined URL associated to private homepage message card learn more action.
+        return URL(string: "https://support.mozilla.org/en-US/kb/common-myths-about-private-browsing?as=u&utm_source=inproduct")
+    }
+
     public static var URLForWhatsNew: URL? {
         // Returns the predefined URL associated to what's new button action.
         return URL(string: "https://www.mozilla.org/en-US/firefox/ios/notes/")

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/PrivateHomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/PrivateHomepageViewControllerTests.swift
@@ -18,7 +18,8 @@ final class PrivateHomepageViewControllerTests: XCTestCase {
     }
 
     func testPrivateHomepageViewController_simpleCreation_hasNoLeaks() {
-        let privateHomeViewController = PrivateHomepageViewController()
+        let overlayManager = MockOverlayModeManager()
+        let privateHomeViewController = PrivateHomepageViewController(overlayManager: overlayManager)
 
         trackForMemoryLeaks(privateHomeViewController)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7192)

## :bulb: Description
Add navigation for opening help page in a new tab.

Given that the user is on the private homepage,
when the user taps on the link,
then they should be navigated to the following help page: [Common Myths about Private Browsing | Firefox Help]
(https://support.mozilla.org/en-US/kb/common-myths-about-private-browsing?as=u&utm_source=inproduct)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

# Screenshots 

https://github.com/mozilla-mobile/firefox-ios/assets/6743397/63bd074c-f9cc-4a1b-b122-d57a3569e9ee