### PR TITLE
Add FXIOS-7952 [v122]  Homepage - Missing long press on Jump Back, Recently Saved - Recently Visited

### DIFF
--- a/Client/Frontend/Home/HomepageContextMenuHelper.swift
+++ b/Client/Frontend/Home/HomepageContextMenuHelper.swift
@@ -53,6 +53,10 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
             actions = topSitesActions
         } else if sectionType == .pocket, let pocketActions = getPocketActions(site: site, with: sourceView) {
             actions = pocketActions
+        } else if sectionType == .recentlySaved, let recentlySavedActions = getRecentlySavedActions(site: site, with: sourceView) {
+            actions = recentlySavedActions
+        } else if sectionType == .jumpBackIn, let jumpBackInActions = getJumpBackInActions(site: site, with: sourceView) {
+            actions = jumpBackInActions
         }
 
         return actions
@@ -72,7 +76,7 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
                                sectionType: HomepageSectionType
     ) -> [PhotonRowActions]? {
         guard sectionType == .historyHighlights,
-              let highlightsActions = getHistoryHighlightsActions(for: highlightItem)
+              let highlightsActions = getHistoryHighlightsActions(for: highlightItem, with: sourceView)
         else { return nil }
 
         return highlightsActions
@@ -88,17 +92,45 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
 
     // MARK: - History Highlights
 
-    private func getHistoryHighlightsActions(for highlightItem: HighlightItem) -> [PhotonRowActions]? {
-        return [SingleActionViewModel(title: .RemoveContextMenuTitle,
-                                      iconString: StandardImageIdentifiers.Large.cross,
-                                      tapHandler: { _ in
-            self.viewModel.historyHighlightsViewModel.delete(highlightItem)
-            self.sendHistoryHighlightContextualTelemetry(type: .remove)
-        }).items]
+    private func getHistoryHighlightsActions(for highlightItem: HighlightItem, with sourceView: UIView?) -> [PhotonRowActions]? {
+        guard let siteURL = highlightItem.siteUrl else { return nil }
+
+        let site = Site(url: siteURL.absoluteString, title: highlightItem.displayTitle)
+        let openInNewTabAction = getOpenInNewTabAction(siteURL: siteURL, sectionType: .historyHighlights)
+        let openInNewPrivateTabAction = getOpenInNewPrivateTabAction(siteURL: siteURL, sectionType: .historyHighlights)
+        let shareAction = getShareAction(site: site, sourceView: sourceView)
+        let bookmarkAction = getBookmarkAction(site: site)
+
+        return [openInNewTabAction, openInNewPrivateTabAction, bookmarkAction, shareAction]
+    }
+
+    // MARK: Jump Back In
+
+    private func getJumpBackInActions(site: Site, with sourceView: UIView?) -> [PhotonRowActions]? {
+        guard let siteURL = site.url.asURL else { return nil }
+
+        let openInNewTabAction = getOpenInNewTabAction(siteURL: siteURL, sectionType: .recentlySaved)
+        let openInNewPrivateTabAction = getOpenInNewPrivateTabAction(siteURL: siteURL, sectionType: .recentlySaved)
+        let shareAction = getShareAction(site: site, sourceView: sourceView)
+        let bookmarkAction = getBookmarkAction(site: site)
+
+        return [openInNewTabAction, openInNewPrivateTabAction, bookmarkAction, shareAction]
+    }
+
+    // MARK: Recently Saved
+
+    private func getRecentlySavedActions(site: Site, with sourceView: UIView?) -> [PhotonRowActions]? {
+        guard let siteURL = site.url.asURL else { return nil }
+
+        let openInNewTabAction = getOpenInNewTabAction(siteURL: siteURL, sectionType: .recentlySaved)
+        let openInNewPrivateTabAction = getOpenInNewPrivateTabAction(siteURL: siteURL, sectionType: .recentlySaved)
+        let shareAction = getShareAction(site: site, sourceView: sourceView)
+        let bookmarkAction = getBookmarkAction(site: site)
+
+        return [openInNewTabAction, openInNewPrivateTabAction, bookmarkAction, shareAction]
     }
 
     // MARK: - Pocket
-
     private func getPocketActions(site: Site, with sourceView: UIView?) -> [PhotonRowActions]? {
         guard let siteURL = site.url.asURL else { return nil }
 

--- a/Client/Frontend/Home/HomepageContextMenuHelper.swift
+++ b/Client/Frontend/Home/HomepageContextMenuHelper.swift
@@ -109,8 +109,8 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
     private func getJumpBackInActions(site: Site, with sourceView: UIView?) -> [PhotonRowActions]? {
         guard let siteURL = site.url.asURL else { return nil }
 
-        let openInNewTabAction = getOpenInNewTabAction(siteURL: siteURL, sectionType: .recentlySaved)
-        let openInNewPrivateTabAction = getOpenInNewPrivateTabAction(siteURL: siteURL, sectionType: .recentlySaved)
+        let openInNewTabAction = getOpenInNewTabAction(siteURL: siteURL, sectionType: .jumpBackIn)
+        let openInNewPrivateTabAction = getOpenInNewPrivateTabAction(siteURL: siteURL, sectionType: .jumpBackIn)
         let shareAction = getShareAction(site: site, sourceView: sourceView)
         let bookmarkAction = getBookmarkAction(site: site)
 

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -535,9 +535,17 @@ private extension HomepageViewController {
             self?.openBookmarks(button)
         }
 
+        viewModel.recentlySavedViewModel.onLongPressTileAction = { [weak self] (site, sourceView) in
+            self?.contextMenuHelper.presentContextMenu(for: site, with: sourceView, sectionType: .recentlySaved)
+        }
+
         // Jumpback in
         viewModel.jumpBackInViewModel.headerButtonAction = { [weak self] button in
             self?.openTabTray(button)
+        }
+
+        viewModel.jumpBackInViewModel.onLongPressTileAction = { [weak self] (site, sourceView) in
+            self?.contextMenuHelper.presentContextMenu(for: site, with: sourceView, sectionType: .recentlySaved)
         }
 
         viewModel.jumpBackInViewModel.syncedTabsShowAllAction = { [weak self] in

--- a/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -21,6 +21,7 @@ class JumpBackInViewModel: FeatureFlaggable {
     var headerButtonAction: ((UIButton) -> Void)?
     var syncedTabsShowAllAction: (() -> Void)?
     var openSyncedTabAction: ((URL) -> Void)?
+    var onLongPressTileAction: ((Site, UIView?) -> Void)?
     var prepareContextualHint: ((SyncedTabCell) -> Void)?
 
     weak var delegate: HomepageDataModelDelegate?
@@ -426,6 +427,22 @@ extension JumpBackInViewModel: HomepageSectionHandler {
             // SyncedTab cell
             // do nothing, will be handled in cell depending on area tapped
         }
+    }
+
+    func handleLongPress(with collectionView: UICollectionView, indexPath: IndexPath) {
+        guard let tileLongPressedHandler = onLongPressTileAction else { return }
+
+        var site = Site(url: "", title: "")
+        if let jumpBackInItemRow = sectionLayout.indexOfJumpBackInItem(for: indexPath) {
+            if let item = jumpBackInList.tabs[safe: jumpBackInItemRow] {
+                site = Site(url: item.url?.absoluteString ?? "", title: item.title ?? "")
+            }
+        } else if hasSyncedTab {
+            site = Site(url: mostRecentSyncedTab?.tab.URL.absoluteString ?? "", title: mostRecentSyncedTab?.tab.title ?? "")
+        }
+
+        let sourceView = collectionView.cellForItem(at: indexPath)
+        tileLongPressedHandler(site, sourceView)
     }
 }
 

--- a/Client/Frontend/Home/RecentlySaved/RecentlySavedViewModel.swift
+++ b/Client/Frontend/Home/RecentlySaved/RecentlySavedViewModel.swift
@@ -31,6 +31,7 @@ class RecentlySavedViewModel {
     private var recentItems = [RecentlySavedItem]()
     private var wallpaperManager: WallpaperManager
     var headerButtonAction: ((UIButton) -> Void)?
+    var onLongPressTileAction: ((Site, UIView?) -> Void)?
 
     weak var delegate: HomepageDataModelDelegate?
 
@@ -162,6 +163,15 @@ extension RecentlySavedViewModel: HomepageSectionHandler {
                                          value: .recentlySavedReadingListAction,
                                          extras: TelemetryWrapper.getOriginExtras(isZeroSearch: isZeroSearch))
         }
+    }
+
+    func handleLongPress(with collectionView: UICollectionView, indexPath: IndexPath) {
+        guard let onLongPressTileAction = onLongPressTileAction else { return }
+
+        let site = Site(url: recentItems[indexPath.row].url,
+                        title: recentItems[indexPath.row].title)
+        let sourceView = collectionView.cellForItem(at: indexPath)
+        onLongPressTileAction(site, sourceView)
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7952)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17731)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Connected the long press gesture recognizer to the existing actions defined in the `HomepageContextMenuHelper`
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods