### PR TITLE
Refactor FXIOS-6942 Listen for updates to the state from the sync tabs view controller

### DIFF
--- a/Client/Frontend/Browser/Tabs/Action/RemoteTabsPanelAction.swift
+++ b/Client/Frontend/Browser/Tabs/Action/RemoteTabsPanelAction.swift
@@ -12,7 +12,6 @@ enum RemoteTabsPanelAction: Action {
     case refreshTabs
     case refreshDidBegin
     case refreshDidFail(RemoteTabsPanelEmptyStateReason)
-    case cachedTabsAvailable(RemoteTabsPanelCachedResults)
     case refreshDidSucceed([ClientAndTabs])
     case openSelectedURL(URL)
 }

--- a/Client/Frontend/Browser/Tabs/Action/TabTrayAction.swift
+++ b/Client/Frontend/Browser/Tabs/Action/TabTrayAction.swift
@@ -11,4 +11,5 @@ enum TabTrayAction: Action {
     // Middleware actions
     case didLoadTabTray(TabTrayModel)
     case dismissTabTray
+    case firefoxAccountChanged(Bool)
 }

--- a/Client/Frontend/Browser/Tabs/Middleware/RemoteTabsPanelMiddleware.swift
+++ b/Client/Frontend/Browser/Tabs/Middleware/RemoteTabsPanelMiddleware.swift
@@ -54,11 +54,11 @@ class RemoteTabsPanelMiddleware {
             // in the middle of a refresh (pull-to-refresh shouldn't trigger a new update etc.)
             store.dispatch(RemoteTabsPanelAction.refreshDidBegin)
 
-            getRemoteTabs()
+            getCachedRemoteTabs()
         }
     }
 
-    private func getRemoteTabs() {
+    private func geCachedtRemoteTabs() {
         profile.getCachedClientsAndTabs { result in
             guard let clientAndTabs = result else {
                 store.dispatch(RemoteTabsPanelAction.refreshDidFail(.failedToSync))

--- a/Client/Frontend/Browser/Tabs/Middleware/RemoteTabsPanelMiddleware.swift
+++ b/Client/Frontend/Browser/Tabs/Middleware/RemoteTabsPanelMiddleware.swift
@@ -58,7 +58,7 @@ class RemoteTabsPanelMiddleware {
         }
     }
 
-    private func geCachedtRemoteTabs() {
+    private func getCachedRemoteTabs() {
         profile.getCachedClientsAndTabs { result in
             guard let clientAndTabs = result else {
                 store.dispatch(RemoteTabsPanelAction.refreshDidFail(.failedToSync))
@@ -87,7 +87,7 @@ class RemoteTabsPanelMiddleware {
         switch notification.name {
         case .FirefoxAccountChanged,
                 .ProfileDidFinishSyncing:
-            getRemoteTabs()
+            getCachedRemoteTabs()
             store.dispatch(TabTrayAction.firefoxAccountChanged(hasSyncableAccount))
         default: break
         }

--- a/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -111,7 +111,8 @@ class TabManagerMiddleware {
         let isPrivate = panelType == .privateTabs
         return TabTrayModel(isPrivateMode: isPrivate,
                             selectedPanel: panelType,
-                            normalTabsCount: normalTabsCountText)
+                            normalTabsCount: normalTabsCountText,
+                            hasSyncableAccount: false)
     }
 
     func getTabsDisplayModel(for isPrivateMode: Bool) -> TabDisplayModel {

--- a/Client/Frontend/Browser/Tabs/Models/TabTrayModel.swift
+++ b/Client/Frontend/Browser/Tabs/Models/TabTrayModel.swift
@@ -8,4 +8,5 @@ struct TabTrayModel: Equatable {
     var isPrivateMode: Bool
     var selectedPanel: TabTrayPanelType
     var normalTabsCount: String
+    var hasSyncableAccount: Bool
 }

--- a/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
+++ b/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
@@ -82,10 +82,6 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
 
     static let reducer: Reducer<Self> = { state, action in
         switch action {
-        case RemoteTabsPanelAction.refreshTabs:
-            // No change to state until middleware performs necessary logic to
-            // determine whether we can sync account
-            return state
         case RemoteTabsPanelAction.refreshDidBegin:
             let newState = RemoteTabsPanelState(refreshState: .refreshing,
                                                 allowsRefresh: state.allowsRefresh,
@@ -101,14 +97,15 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
                                                 showingEmptyState: reason)
             return newState
         case RemoteTabsPanelAction.refreshDidSucceed(let newClientAndTabs):
-            // Send client and tabs state, ensure empty state is nil and refresh is idle
+            print("YRD refreshDidSucceed \(newClientAndTabs.count)")
             let newState = RemoteTabsPanelState(refreshState: .idle,
                                                 allowsRefresh: true,
                                                 clientAndTabs: newClientAndTabs,
                                                 showingEmptyState: nil)
             return newState
         case RemoteTabsPanelAction.cachedTabsAvailable(let cachedResults):
-            let newState = RemoteTabsPanelState(refreshState: cachedResults.isUpdating ? .refreshing : .idle,
+            print("YRD cachedTabsAvailable \(cachedResults.clientAndTabs.count)")
+            let newState = RemoteTabsPanelState(refreshState: .idle,
                                                 allowsRefresh: true,
                                                 clientAndTabs: cachedResults.clientAndTabs,
                                                 showingEmptyState: nil)

--- a/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
+++ b/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
@@ -97,17 +97,9 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
                                                 showingEmptyState: reason)
             return newState
         case RemoteTabsPanelAction.refreshDidSucceed(let newClientAndTabs):
-            print("YRD refreshDidSucceed \(newClientAndTabs.count)")
             let newState = RemoteTabsPanelState(refreshState: .idle,
                                                 allowsRefresh: true,
                                                 clientAndTabs: newClientAndTabs,
-                                                showingEmptyState: nil)
-            return newState
-        case RemoteTabsPanelAction.cachedTabsAvailable(let cachedResults):
-            print("YRD cachedTabsAvailable \(cachedResults.clientAndTabs.count)")
-            let newState = RemoteTabsPanelState(refreshState: .idle,
-                                                allowsRefresh: true,
-                                                clientAndTabs: cachedResults.clientAndTabs,
                                                 showingEmptyState: nil)
             return newState
         default:

--- a/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
+++ b/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
@@ -88,7 +88,7 @@ struct TabTrayState: ScreenState, Equatable {
                                 normalTabsCount: state.normalTabsCount,
                                 hasSyncableAccount: state.hasSyncableAccount,
                                 shouldDismiss: true)
-        case TabTrayAction.syncStateChanged(let isSyncAccountEnabled):
+        case TabTrayAction.firefoxAccountChanged(let isSyncAccountEnabled):
                 return TabTrayState(isPrivateMode: state.isPrivateMode,
                                     selectedPanel: state.selectedPanel,
                                     normalTabsCount: state.normalTabsCount,

--- a/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
+++ b/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
@@ -13,8 +13,10 @@ enum TabTrayLayoutType: Equatable {
 struct TabTrayState: ScreenState, Equatable {
     var isPrivateMode: Bool
     var selectedPanel: TabTrayPanelType
-    var shouldDismiss: Bool
     var normalTabsCount: String
+    var hasSyncableAccount: Bool
+    var shouldDismiss: Bool
+
     var navigationTitle: String {
         return selectedPanel.navTitle
     }
@@ -32,28 +34,33 @@ struct TabTrayState: ScreenState, Equatable {
         self.init(isPrivateMode: panelState.isPrivateMode,
                   selectedPanel: panelState.selectedPanel,
                   normalTabsCount: panelState.normalTabsCount,
+                  hasSyncableAccount: panelState.hasSyncableAccount,
                   shouldDismiss: panelState.shouldDismiss)
     }
 
     init() {
         self.init(isPrivateMode: false,
                   selectedPanel: .tabs,
-                  normalTabsCount: "0")
+                  normalTabsCount: "0",
+                  hasSyncableAccount: false)
     }
 
     init(panelType: TabTrayPanelType) {
         self.init(isPrivateMode: panelType == .privateTabs,
                   selectedPanel: panelType,
-                  normalTabsCount: "0")
+                  normalTabsCount: "0",
+                  hasSyncableAccount: false)
     }
 
     init(isPrivateMode: Bool,
          selectedPanel: TabTrayPanelType,
          normalTabsCount: String,
+         hasSyncableAccount: Bool,
          shouldDismiss: Bool = false) {
         self.isPrivateMode = isPrivateMode
         self.selectedPanel = selectedPanel
         self.normalTabsCount = normalTabsCount
+        self.hasSyncableAccount = hasSyncableAccount
         self.shouldDismiss = shouldDismiss
     }
 
@@ -62,21 +69,30 @@ struct TabTrayState: ScreenState, Equatable {
         case TabTrayAction.didLoadTabTray(let tabTrayModel):
             return TabTrayState(isPrivateMode: tabTrayModel.isPrivateMode,
                                 selectedPanel: tabTrayModel.selectedPanel,
-                                normalTabsCount: tabTrayModel.normalTabsCount)
+                                normalTabsCount: tabTrayModel.normalTabsCount,
+                                hasSyncableAccount: tabTrayModel.hasSyncableAccount)
         case TabTrayAction.changePanel(let panelType):
             return TabTrayState(isPrivateMode: panelType == .privateTabs,
                                 selectedPanel: panelType,
-                                normalTabsCount: state.normalTabsCount)
+                                normalTabsCount: state.normalTabsCount,
+                                hasSyncableAccount: state.hasSyncableAccount)
         case TabPanelAction.didLoadTabPanel(let tabState):
             let panelType = tabState.isPrivateMode ? TabTrayPanelType.privateTabs : TabTrayPanelType.tabs
             return TabTrayState(isPrivateMode: tabState.isPrivateMode,
                                 selectedPanel: panelType,
-                                normalTabsCount: tabState.normalTabsCount)
+                                normalTabsCount: tabState.normalTabsCount,
+                                hasSyncableAccount: state.hasSyncableAccount)
         case TabTrayAction.dismissTabTray:
             return TabTrayState(isPrivateMode: state.isPrivateMode,
                                 selectedPanel: state.selectedPanel,
                                 normalTabsCount: state.normalTabsCount,
+                                hasSyncableAccount: state.hasSyncableAccount,
                                 shouldDismiss: true)
+        case TabTrayAction.syncStateChanged(let isSyncAccountEnabled):
+                return TabTrayState(isPrivateMode: state.isPrivateMode,
+                                    selectedPanel: state.selectedPanel,
+                                    normalTabsCount: state.normalTabsCount,
+                                    hasSyncableAccount: isSyncAccountEnabled)
         default:
             return state
         }

--- a/Client/Frontend/Browser/Tabs/TabTrayFlagManager.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayFlagManager.swift
@@ -7,7 +7,8 @@ import Foundation
 /// This is a temporary struct made to manage the feature flag for convenience
 struct TabTrayFlagManager {
     static var isRefactorEnabled: Bool {
-        return LegacyFeatureFlagsManager.shared.isFeatureEnabled(.tabTrayRefactor,
-                                                                 checking: .buildOnly)
+        return true
+//        LegacyFeatureFlagsManager.shared.isFeatureEnabled(.tabTrayRefactor,
+//                                                                 checking: .buildOnly)
     }
 }

--- a/Client/Frontend/Browser/Tabs/TabTrayFlagManager.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayFlagManager.swift
@@ -7,8 +7,7 @@ import Foundation
 /// This is a temporary struct made to manage the feature flag for convenience
 struct TabTrayFlagManager {
     static var isRefactorEnabled: Bool {
-        return true
-//        LegacyFeatureFlagsManager.shared.isFeatureEnabled(.tabTrayRefactor,
-//                                                                 checking: .buildOnly)
+        return LegacyFeatureFlagsManager.shared.isFeatureEnabled(.tabTrayRefactor,
+                                                                 checking: .buildOnly)
     }
 }

--- a/Client/Frontend/Browser/Tabs/Views/RemoteTabsPanel.swift
+++ b/Client/Frontend/Browser/Tabs/Views/RemoteTabsPanel.swift
@@ -42,8 +42,6 @@ class RemoteTabsPanel: UIViewController,
         super.init(nibName: nil, bundle: nil)
 
         self.tableViewController.remoteTabsPanel = self
-
-        observeNotifications()
     }
 
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
@@ -66,28 +64,6 @@ class RemoteTabsPanel: UIViewController,
         store.dispatch(RemoteTabsPanelAction.refreshTabs)
     }
 
-    private func observeNotifications() {
-        // TODO: State to be provided by forthcoming Redux updates. TBD.
-        // For now, continue to observe notifications.
-        let notificationCenter = NotificationCenter.default
-        notificationCenter.addObserver(self,
-                                       selector: #selector(notificationReceived),
-                                       name: .FirefoxAccountChanged,
-                                       object: nil)
-        notificationCenter.addObserver(self,
-                                       selector: #selector(notificationReceived),
-                                       name: .ProfileDidFinishSyncing,
-                                       object: nil)
-    }
-
-    @objc
-    func notificationReceived(_ notification: Notification) {
-        let name = notification.name
-        if name == .FirefoxAccountChanged || name == .ProfileDidFinishSyncing {
-            refreshTabs()
-        }
-    }
-
     // MARK: - View & Layout
 
     override func viewDidLoad() {
@@ -97,11 +73,6 @@ class RemoteTabsPanel: UIViewController,
         setupLayout()
         subscribeToRedux()
         applyTheme()
-    }
-
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        refreshTabs()
     }
 
     private func setupLayout() {

--- a/Client/Frontend/Browser/Tabs/Views/RemoteTabsTableViewController.swift
+++ b/Client/Frontend/Browser/Tabs/Views/RemoteTabsTableViewController.swift
@@ -108,17 +108,12 @@ class RemoteTabsTableViewController: UITableViewController,
             configureEmptyView()
         }
 
-        if state.refreshState != .refreshing {
+        if state.refreshState == .refreshing {
+            print("YRD start refreshing")
+            beginRefreshing()
+        } else {
+            print("YRD stop refreshing")
             endRefreshing()
-        }
-
-        // Add a refresh control if the user is logged in and the control
-        // was not added before. If the user is not logged in, remove any
-        // existing control.
-        if state.allowsRefresh && refreshControl == nil {
-            addRefreshControl()
-        } else if !state.allowsRefresh {
-            removeRefreshControl()
         }
 
         tableView.reloadData()
@@ -162,6 +157,13 @@ class RemoteTabsTableViewController: UITableViewController,
         }
         refreshControl?.beginRefreshing()
         remoteTabsPanel?.tableViewControllerDidPullToRefresh()
+    }
+
+    private func beginRefreshing() {
+        if state.allowsRefresh && refreshControl == nil {
+            addRefreshControl()
+            refreshControl?.beginRefreshing()
+        }
     }
 
     private func endRefreshing() {

--- a/Client/Frontend/Browser/Tabs/Views/RemoteTabsTableViewController.swift
+++ b/Client/Frontend/Browser/Tabs/Views/RemoteTabsTableViewController.swift
@@ -51,6 +51,26 @@ class RemoteTabsTableViewController: UITableViewController,
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        setupLayout()
+        listenForThemeChange(view)
+        applyTheme()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        (navigationController as? ThemedNavigationController)?.applyTheme()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        if refreshControl != nil {
+            removeRefreshControl()
+        }
+    }
+
+    // MARK: - UI
+
+    private func setupLayout() {
         tableView.addGestureRecognizer(longPressRecognizer)
         tableView.register(SiteTableViewHeader.self,
                            forHeaderFooterViewReuseIdentifier: SiteTableViewHeader.cellIdentifier)
@@ -76,47 +96,33 @@ class RemoteTabsTableViewController: UITableViewController,
             emptyView.trailingAnchor.constraint(equalTo: tableView.trailingAnchor),
         ])
 
-        listenForThemeChange(view)
-        applyTheme()
-
         reloadUI()
+        addRefreshControl()
     }
-
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        (navigationController as? ThemedNavigationController)?.applyTheme()
-    }
-
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        if refreshControl != nil {
-            removeRefreshControl()
-        }
-    }
-
-    // MARK: - UI
 
     func newState(state: RemoteTabsPanelState) {
         self.state = state
         reloadUI()
     }
 
-    func reloadUI() {
+    private func reloadUI() {
         emptyView.isHidden = !isShowingEmptyView
 
-        if isShowingEmptyView {
+        guard !isShowingEmptyView else {
             configureEmptyView()
+            return
         }
 
-        if state.refreshState == .refreshing {
-            print("YRD start refreshing")
-            beginRefreshing()
-        } else {
-            print("YRD stop refreshing")
-            endRefreshing()
-        }
-
+        updateRefreshControl()
         tableView.reloadData()
+    }
+
+    private func updateRefreshControl() {
+        if state.refreshState == .refreshing {
+            refreshControl?.beginRefreshing()
+        } else {
+            refreshControl?.endRefreshing()
+        }
     }
 
     func applyTheme() {

--- a/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -56,13 +56,6 @@ class TabTrayViewController: UIViewController,
         return layout == .regular
     }
 
-    var hasSyncableAccount: Bool {
-        // Temporary. Added for early testing.
-        // Eventually we will update this to use Redux state. -mr
-        guard let profile = (UIApplication.shared.delegate as? AppDelegate)?.profile else { return false }
-        return profile.hasSyncableAccount()
-    }
-
     var currentPanel: UINavigationController? {
         guard !childPanelControllers.isEmpty else { return nil }
         let index = tabTrayState.selectedPanel.rawValue
@@ -166,13 +159,14 @@ class TabTrayViewController: UIViewController,
     }()
 
     private lazy var bottomToolbarItemsForSync: [UIBarButtonItem] = {
-        guard hasSyncableAccount else { return [] }
+        print("YRD bottomToolbarItemsForSync \(tabTrayState.hasSyncableAccount)")
+        guard tabTrayState.hasSyncableAccount else { return [] }
 
         return [flexibleSpace, syncTabButton]
     }()
 
     private var rightBarButtonItemsForSync: [UIBarButtonItem] {
-        if hasSyncableAccount {
+        if tabTrayState.hasSyncableAccount {
             return [doneButton, fixedSpace, syncTabButton]
         } else {
             return [doneButton]
@@ -227,6 +221,7 @@ class TabTrayViewController: UIViewController,
         super.viewDidDisappear(animated)
 
         unsubscribeFromRedux()
+        delegate?.didFinish()
     }
 
     private func updateLayout() {
@@ -262,7 +257,8 @@ class TabTrayViewController: UIViewController,
     func newState(state: TabTrayState) {
         tabTrayState = state
 
-        updateNormalTabsCounter()
+        print("YRD hasSync \(state.hasSyncableAccount)")
+        reloadView()
         if tabTrayState.shouldDismiss {
             delegate?.didFinish()
         }
@@ -286,6 +282,12 @@ class TabTrayViewController: UIViewController,
             return
         }
         setupForiPad()
+    }
+
+    private func reloadView() {
+        updateTitle()
+        updateToolbarItems()
+        updateNormalTabsCounter()
     }
 
     private func setupForiPhone() {

--- a/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -159,9 +159,6 @@ class TabTrayViewController: UIViewController,
     }()
 
     private lazy var bottomToolbarItemsForSync: [UIBarButtonItem] = {
-        print("YRD bottomToolbarItemsForSync \(tabTrayState.hasSyncableAccount)")
-        guard tabTrayState.hasSyncableAccount else { return [] }
-
         return [flexibleSpace, syncTabButton]
     }()
 
@@ -257,7 +254,6 @@ class TabTrayViewController: UIViewController,
     func newState(state: TabTrayState) {
         tabTrayState = state
 
-        print("YRD hasSync \(state.hasSyncableAccount)")
         reloadView()
         if tabTrayState.shouldDismiss {
             delegate?.didFinish()
@@ -344,8 +340,13 @@ class TabTrayViewController: UIViewController,
             return
         }
 
-        let toolbarItems = tabTrayState.isSyncTabsPanel ? bottomToolbarItemsForSync : bottomToolbarItems
+        let toolbarItems = tabTrayState.isSyncTabsPanel ? bottomToolBarForSync() : bottomToolbarItems
         setToolbarItems(toolbarItems, animated: true)
+    }
+
+    private func bottomToolBarForSync() -> [UIBarButtonItem] {
+        guard tabTrayState.hasSyncableAccount else { return [] }
+        return bottomToolbarItemsForSync
     }
 
     private func setupToolbarForIpad() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/RemoteTabPanelStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/RemoteTabPanelStateTests.swift
@@ -49,21 +49,6 @@ final class RemoteTabPanelStateTests: XCTestCase {
         XCTAssertEqual(newState.clientAndTabs.first!.tabs.count, 2)
     }
 
-    func testTabsCachedResultAvailableStateChange() {
-        let initialState = createSubject()
-        let reducer = remoteTabsPanelReducer()
-        let testTabs = generateOneClientTwoTabs()
-        let cachedResult = RemoteTabsPanelCachedResults(clientAndTabs: testTabs,
-                                                        isUpdating: false)
-
-        XCTAssertEqual(initialState.clientAndTabs.count, 0)
-
-        let newState = reducer(initialState, RemoteTabsPanelAction.cachedTabsAvailable(cachedResult))
-
-        XCTAssertEqual(newState.clientAndTabs.count, 1)
-        XCTAssertEqual(newState.clientAndTabs.first!.tabs.count, 2)
-    }
-
     func testTabsRefreshFailedStateChange() {
         let initialState = createSubject()
         let reducer = remoteTabsPanelReducer()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6942)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15420)

## :bulb: Description
- Remove Profile and Notification from ViewController and move to RemoteTabsPanelMiddleware
- Refactor request to remote tabs and update state based on changes of FirefoxAccount
- Refactor actions and view reload based on new state
- Show/hide Sync tabs bottom toolbar button based on hasSyncAccountEnabled

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

