### PR TITLE
Add FXIOS-7859 [v122] Replace Legacy tab peek in new code

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -455,6 +455,7 @@
 		5A47CFF52860FB8900B2B7BF /* AppLaunchUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A47CFF42860FB8900B2B7BF /* AppLaunchUtil.swift */; };
 		5A5AB980296CA03500485E06 /* SiteImageView in Frameworks */ = {isa = PBXBuildFile; productRef = 5A5AB97F296CA03500485E06 /* SiteImageView */; };
 		5A64225129CB506500EEC3E5 /* LegacyTabManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A64225029CB506500EEC3E5 /* LegacyTabManager.swift */; };
+		5A679E4B2B239FAE004F2B0D /* TabPeekViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A679E4A2B239FAE004F2B0D /* TabPeekViewController.swift */; };
 		5A68F0AB2AF2E5E00089AC62 /* TabDataStore in Frameworks */ = {isa = PBXBuildFile; productRef = 5A68F0AA2AF2E5E00089AC62 /* TabDataStore */; };
 		5A70EF0E295DFCCF00790249 /* Common in Frameworks */ = {isa = PBXBuildFile; productRef = 5A70EF0D295DFCCF00790249 /* Common */; };
 		5A70EF10295DFD4900790249 /* Common in Frameworks */ = {isa = PBXBuildFile; productRef = 5A70EF0F295DFD4900790249 /* Common */; };
@@ -544,7 +545,7 @@
 		7B4980A81CE363ED0017547C /* Settings.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7B4980A71CE363ED0017547C /* Settings.xcassets */; };
 		7B844E3D1BBDDB9D00E733A2 /* ChevronView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B844E3C1BBDDB9D00E733A2 /* ChevronView.swift */; };
 		7B8A47F61D01D3B400C07734 /* PassKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B8A47F51D01D3B400C07734 /* PassKit.framework */; };
-		7BA0601B1C0F4DE200DFADB6 /* TabPeekViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA0601A1C0F4DE200DFADB6 /* TabPeekViewController.swift */; };
+		7BA0601B1C0F4DE200DFADB6 /* LegacyTabPeekViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA0601A1C0F4DE200DFADB6 /* LegacyTabPeekViewController.swift */; };
 		7BA8D1C71BA037F500C8AE9E /* DownloadHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA8D1C61BA037F500C8AE9E /* DownloadHelper.swift */; };
 		7BEB64441C7345600092C02E /* L10nSuite2SnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3632D31C2983F000D12AF9 /* L10nSuite2SnapshotTests.swift */; };
 		7BEB64451C7345600092C02E /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B60B0071BDE3AE10090C984 /* SnapshotHelper.swift */; };
@@ -4772,6 +4773,7 @@
 		5A47CFF42860FB8900B2B7BF /* AppLaunchUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLaunchUtil.swift; sourceTree = "<group>"; };
 		5A64225029CB506500EEC3E5 /* LegacyTabManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyTabManager.swift; sourceTree = "<group>"; };
 		5A65BE172928619E00E841A7 /* BrowserKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = BrowserKit; sourceTree = "<group>"; };
+		5A679E4A2B239FAE004F2B0D /* TabPeekViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabPeekViewController.swift; sourceTree = "<group>"; };
 		5A70EF18295E2E1600790249 /* DependencyHelperMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyHelperMock.swift; sourceTree = "<group>"; };
 		5A70EF1C295E3C3500790249 /* TestSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSetup.swift; sourceTree = "<group>"; };
 		5A70EF1E295E3DFC00790249 /* UnitTestAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitTestAppDelegate.swift; sourceTree = "<group>"; };
@@ -5054,7 +5056,7 @@
 		7B844E3C1BBDDB9D00E733A2 /* ChevronView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChevronView.swift; sourceTree = "<group>"; };
 		7B864D89B9D9C309484081D1 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		7B8A47F51D01D3B400C07734 /* PassKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PassKit.framework; path = System/Library/Frameworks/PassKit.framework; sourceTree = SDKROOT; };
-		7BA0601A1C0F4DE200DFADB6 /* TabPeekViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabPeekViewController.swift; sourceTree = "<group>"; };
+		7BA0601A1C0F4DE200DFADB6 /* LegacyTabPeekViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyTabPeekViewController.swift; sourceTree = "<group>"; };
 		7BA34E6CB59CF71C21C42BB3 /* es-AR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-AR"; path = "es-AR.lproj/FindInPage.strings"; sourceTree = "<group>"; };
 		7BA8D1C61BA037F500C8AE9E /* DownloadHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DownloadHelper.swift; sourceTree = "<group>"; };
 		7BB34A09A04DA7D6B5600019 /* ses */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ses; path = ses.lproj/Search.strings; sourceTree = "<group>"; };
@@ -10250,7 +10252,8 @@
 				3BF56D261CDBBE1F00AC4D75 /* SimpleToast.swift */,
 				E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */,
 				213B67A527CE682B000542F5 /* StartAtHomeHelper.swift */,
-				7BA0601A1C0F4DE200DFADB6 /* TabPeekViewController.swift */,
+				7BA0601A1C0F4DE200DFADB6 /* LegacyTabPeekViewController.swift */,
+				5A679E4A2B239FAE004F2B0D /* TabPeekViewController.swift */,
 				DD31E0FA1B382B520077078A /* TabPrintPageRenderer.swift */,
 				E698FFD91B4AADF40001F623 /* TabScrollController.swift */,
 				396CDB54203C5B870034A3A3 /* TabTrayController+KeyCommands.swift */,
@@ -13115,6 +13118,7 @@
 				C4E3983D1D21F1E7004E89BA /* TopTabCell.swift in Sources */,
 				210E0EBA298D9D6400BB4F33 /* OpenSearchEngine.swift in Sources */,
 				FA9293D41D6580E100AC8D33 /* QRCodeViewController.swift in Sources */,
+				5A679E4B2B239FAE004F2B0D /* TabPeekViewController.swift in Sources */,
 				2178A6A0291454B5002EC290 /* ReaderModeThemeButton.swift in Sources */,
 				39F4C10A2045DB2E00746155 /* FocusHelper.swift in Sources */,
 				E4CD9F2D1A6DC91200318571 /* TabLocationView.swift in Sources */,
@@ -13303,7 +13307,7 @@
 				C8E531C829E5EB6100E03FEF /* RouteBuilder.swift in Sources */,
 				D3972BF41C22412B00035B87 /* TitleActivityItemProvider.swift in Sources */,
 				D38A1BEE1A9FA2CA00F6A386 /* SiteTableViewController.swift in Sources */,
-				7BA0601B1C0F4DE200DFADB6 /* TabPeekViewController.swift in Sources */,
+				7BA0601B1C0F4DE200DFADB6 /* LegacyTabPeekViewController.swift in Sources */,
 				212985E42A6F078800546684 /* ScreenState.swift in Sources */,
 				D51EA5BA26406A0000334331 /* ExperimentsBranchesViewController.swift in Sources */,
 				C84655F728879EF100861B4A /* WallpaperManager.swift in Sources */,

--- a/Client/Frontend/Browser/LegacyTabPeekViewController.swift
+++ b/Client/Frontend/Browser/LegacyTabPeekViewController.swift
@@ -1,0 +1,230 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import UIKit
+import Shared
+import Storage
+import WebKit
+
+protocol LegacyTabPeekDelegate: AnyObject {
+    @discardableResult
+    func tabPeekDidAddToReadingList(_ tab: Tab) -> ReadingListItem?
+    func tabPeekDidAddBookmark(_ tab: Tab)
+    func tabPeekRequestsPresentationOf(_ viewController: UIViewController)
+    func tabPeekDidCloseTab(_ tab: Tab)
+    func tabPeekDidCopyUrl()
+}
+
+class LegacyTabPeekViewController: UIViewController, WKNavigationDelegate {
+    weak var tab: Tab?
+
+    private weak var delegate: LegacyTabPeekDelegate?
+    private var fxaDevicePicker: UINavigationController?
+    private var isBookmarked = false
+    private var isInReadingList = false
+    private var hasRemoteClients = false
+    private var ignoreURL = false
+
+    private var screenShot: UIImageView?
+    private var previewAccessibilityLabel: String!
+    private var webView: WKWebView?
+
+    // Preview action items.
+    override var previewActionItems: [UIPreviewActionItem] { return previewActions }
+
+    lazy var previewActions: [UIPreviewActionItem] = {
+        var actions = [UIPreviewActionItem]()
+
+        let urlIsTooLongToSave = self.tab?.urlIsTooLong ?? false
+        let isHomeTab = self.tab?.isFxHomeTab ?? false
+        if !self.ignoreURL && !urlIsTooLongToSave {
+            if !self.isBookmarked && !isHomeTab {
+                actions.append(UIPreviewAction(title: .TabPeekAddToBookmarks, style: .default) { [weak self] previewAction, viewController in
+                    guard let wself = self, let tab = wself.tab else { return }
+                    wself.delegate?.tabPeekDidAddBookmark(tab)
+                })
+            }
+            if self.hasRemoteClients {
+                actions.append(UIPreviewAction(title: .AppMenu.TouchActions.SendToDeviceTitle, style: .default) { [weak self] previewAction, viewController in
+                    guard let wself = self, let clientPicker = wself.fxaDevicePicker else { return }
+                    wself.delegate?.tabPeekRequestsPresentationOf(clientPicker)
+                })
+            }
+            // only add the copy URL action if we don't already have 3 items in our list
+            // as we are only allowed 4 in total and we always want to display close tab
+            if actions.count < 3 {
+                actions.append(UIPreviewAction(title: .TabPeekCopyUrl, style: .default) { [weak self] previewAction, viewController in
+                    guard let wself = self, let url = wself.tab?.canonicalURL else { return }
+
+                    UIPasteboard.general.url = url
+                    wself.delegate?.tabPeekDidCopyUrl()
+                })
+            }
+        }
+        actions.append(UIPreviewAction(title: .TabPeekCloseTab, style: .destructive) { [weak self] previewAction, viewController in
+            guard let wself = self, let tab = wself.tab else { return }
+            wself.delegate?.tabPeekDidCloseTab(tab)
+        })
+
+        return actions
+    }()
+
+    func contextActions(defaultActions: [UIMenuElement]) -> UIMenu {
+        var actions = [UIAction]()
+
+        let urlIsTooLongToSave = self.tab?.urlIsTooLong ?? false
+        let isHomeTab = self.tab?.isFxHomeTab ?? false
+        if !self.ignoreURL && !urlIsTooLongToSave {
+            if !self.isBookmarked && !isHomeTab {
+                actions.append(UIAction(title: .TabPeekAddToBookmarks,
+                                        image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.bookmark),
+                                        identifier: nil) { [weak self] _ in
+                    guard let wself = self, let tab = wself.tab else { return }
+                    wself.delegate?.tabPeekDidAddBookmark(tab)
+                })
+            }
+            if self.hasRemoteClients {
+                actions.append(UIAction(title: .AppMenu.TouchActions.SendToDeviceTitle, image: UIImage.templateImageNamed("menu-Send"), identifier: nil) { [weak self] _ in
+                    guard let wself = self, let clientPicker = wself.fxaDevicePicker else { return }
+                    wself.delegate?.tabPeekRequestsPresentationOf(clientPicker)
+                })
+            }
+            actions.append(UIAction(title: .TabPeekCopyUrl,
+                                    image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.link),
+                                    identifier: nil) { [weak self] _ in
+                guard let wself = self, let url = wself.tab?.canonicalURL else { return }
+
+                UIPasteboard.general.url = url
+                wself.delegate?.tabPeekDidCopyUrl()
+            })
+        }
+        actions.append(UIAction(title: .TabPeekCloseTab,
+                                image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross),
+                                identifier: nil) { [weak self] _ in
+            guard let wself = self, let tab = wself.tab else { return }
+            wself.delegate?.tabPeekDidCloseTab(tab)
+        })
+
+        return UIMenu(title: "", children: actions)
+    }
+
+    init(tab: Tab?, delegate: LegacyTabPeekDelegate?) {
+        self.tab = tab
+        self.delegate = delegate
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        webView?.navigationDelegate = nil
+        self.webView = nil
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        if let webViewAccessibilityLabel = tab?.webView?.accessibilityLabel {
+            previewAccessibilityLabel = String(format: .TabPeekPreviewAccessibilityLabel, webViewAccessibilityLabel)
+        }
+        // if there is no screenshot, load the URL in a web page
+        // otherwise just show the screenshot
+        if let screenshot = tab?.screenshot {
+            setupWithScreenshot(screenshot)
+        } else {
+            setupWebView(tab?.webView)
+        }
+    }
+
+    private func setupWithScreenshot(_ screenshot: UIImage) {
+        let imageView: UIImageView = .build { imageView in
+            imageView.image = screenshot
+        }
+        view.addSubview(imageView)
+
+        NSLayoutConstraint.activate([
+            imageView.topAnchor.constraint(equalTo: view.topAnchor),
+            imageView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            imageView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            imageView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+
+        screenShot = imageView
+        screenShot?.accessibilityLabel = previewAccessibilityLabel
+    }
+
+    private func setupWebView(_ webView: WKWebView?) {
+        guard let webView = webView,
+              let url = webView.url,
+              !isIgnoredURL(url)
+        else { return }
+
+        let clonedWebView = WKWebView(frame: webView.frame, configuration: webView.configuration)
+        clonedWebView.translatesAutoresizingMaskIntoConstraints = false
+        clonedWebView.allowsLinkPreview = false
+        clonedWebView.accessibilityLabel = previewAccessibilityLabel
+        view.addSubview(clonedWebView)
+
+        NSLayoutConstraint.activate([
+            clonedWebView.topAnchor.constraint(equalTo: view.topAnchor),
+            clonedWebView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            clonedWebView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            clonedWebView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+
+        clonedWebView.navigationDelegate = self
+        self.webView = clonedWebView
+        clonedWebView.load(URLRequest(url: url))
+    }
+
+    func setState(withProfile browserProfile: BrowserProfile,
+                  clientPickerDelegate: DevicePickerViewControllerDelegate) {
+        guard let tab = self.tab,
+              let displayURL = tab.url?.absoluteString,
+              !displayURL.isEmpty
+        else { return }
+
+        ensureMainThread { [weak self] in
+            guard let self = self else { return }
+
+            browserProfile.places.isBookmarked(url: displayURL) >>== { isBookmarked in
+                self.isBookmarked = isBookmarked
+            }
+            browserProfile.tabs.getClientGUIDs { (result, error) in
+                guard let clientGUIDs = result else { return }
+
+                self.hasRemoteClients = !clientGUIDs.isEmpty
+
+                DispatchQueue.main.async {
+                    self.createDevicePicker(withProfile: browserProfile,
+                                            clientPickerDelegate: clientPickerDelegate)
+                }
+            }
+
+            let result = browserProfile.readingList.getRecordWithURL(displayURL).value.successValue
+
+            self.isInReadingList = !(result?.url.isEmpty ?? true)
+            self.ignoreURL = isIgnoredURL(displayURL)
+        }
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        screenShot?.removeFromSuperview()
+        screenShot = nil
+    }
+
+    private func createDevicePicker(withProfile browserProfile: BrowserProfile,
+                                    clientPickerDelegate: DevicePickerViewControllerDelegate) {
+            let clientPickerController = DevicePickerViewController(profile: browserProfile)
+            clientPickerController.pickerDelegate = clientPickerDelegate
+            clientPickerController.profile = browserProfile
+            if let url = tab?.url?.absoluteString {
+                clientPickerController.shareItem = ShareItem(url: url, title: tab?.title ?? "")
+            }
+            self.fxaDevicePicker = UINavigationController(rootViewController: clientPickerController)
+    }
+}

--- a/Client/Frontend/Browser/TabPeekViewController.swift
+++ b/Client/Frontend/Browser/TabPeekViewController.swift
@@ -2,117 +2,27 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import Common
 import UIKit
-import Shared
-import Storage
+import Common
 import WebKit
 
-protocol LegacyTabPeekDelegate: AnyObject {
-    @discardableResult
-    func tabPeekDidAddToReadingList(_ tab: Tab) -> ReadingListItem?
-    func tabPeekDidAddBookmark(_ tab: Tab)
-    func tabPeekRequestsPresentationOf(_ viewController: UIViewController)
-    func tabPeekDidCloseTab(_ tab: Tab)
-    func tabPeekDidCopyUrl()
-}
+class TabPeekViewController: UIViewController {
+    weak var tab: Tab? // Tab ID, screenshot, webview accessiblity label
 
-class LegacyTabPeekViewController: UIViewController, WKNavigationDelegate {
-    weak var tab: Tab?
-
-    private weak var delegate: LegacyTabPeekDelegate?
-    private var fxaDevicePicker: UINavigationController?
+    private var previewAccessibilityLabel: String!
+    private var ignoreURL = false
     private var isBookmarked = false
     private var isInReadingList = false
     private var hasRemoteClients = false
-    private var ignoreURL = false
-
-    private var screenShot: UIImageView?
-    private var previewAccessibilityLabel: String!
-    private var webView: WKWebView?
-
-    // Preview action items.
-    override var previewActionItems: [UIPreviewActionItem] { return previewActions }
-
-    lazy var previewActions: [UIPreviewActionItem] = {
-        var actions = [UIPreviewActionItem]()
-
-        let urlIsTooLongToSave = self.tab?.urlIsTooLong ?? false
-        let isHomeTab = self.tab?.isFxHomeTab ?? false
-        if !self.ignoreURL && !urlIsTooLongToSave {
-            if !self.isBookmarked && !isHomeTab {
-                actions.append(UIPreviewAction(title: .TabPeekAddToBookmarks, style: .default) { [weak self] previewAction, viewController in
-                    guard let wself = self, let tab = wself.tab else { return }
-                    wself.delegate?.tabPeekDidAddBookmark(tab)
-                })
-            }
-            if self.hasRemoteClients {
-                actions.append(UIPreviewAction(title: .AppMenu.TouchActions.SendToDeviceTitle, style: .default) { [weak self] previewAction, viewController in
-                    guard let wself = self, let clientPicker = wself.fxaDevicePicker else { return }
-                    wself.delegate?.tabPeekRequestsPresentationOf(clientPicker)
-                })
-            }
-            // only add the copy URL action if we don't already have 3 items in our list
-            // as we are only allowed 4 in total and we always want to display close tab
-            if actions.count < 3 {
-                actions.append(UIPreviewAction(title: .TabPeekCopyUrl, style: .default) { [weak self] previewAction, viewController in
-                    guard let wself = self, let url = wself.tab?.canonicalURL else { return }
-
-                    UIPasteboard.general.url = url
-                    wself.delegate?.tabPeekDidCopyUrl()
-                })
-            }
-        }
-        actions.append(UIPreviewAction(title: .TabPeekCloseTab, style: .destructive) { [weak self] previewAction, viewController in
-            guard let wself = self, let tab = wself.tab else { return }
-            wself.delegate?.tabPeekDidCloseTab(tab)
-        })
-
-        return actions
-    }()
 
     func contextActions(defaultActions: [UIMenuElement]) -> UIMenu {
-        var actions = [UIAction]()
-
-        let urlIsTooLongToSave = self.tab?.urlIsTooLong ?? false
-        let isHomeTab = self.tab?.isFxHomeTab ?? false
-        if !self.ignoreURL && !urlIsTooLongToSave {
-            if !self.isBookmarked && !isHomeTab {
-                actions.append(UIAction(title: .TabPeekAddToBookmarks,
-                                        image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.bookmark),
-                                        identifier: nil) { [weak self] _ in
-                    guard let wself = self, let tab = wself.tab else { return }
-                    wself.delegate?.tabPeekDidAddBookmark(tab)
-                })
-            }
-            if self.hasRemoteClients {
-                actions.append(UIAction(title: .AppMenu.TouchActions.SendToDeviceTitle, image: UIImage.templateImageNamed("menu-Send"), identifier: nil) { [weak self] _ in
-                    guard let wself = self, let clientPicker = wself.fxaDevicePicker else { return }
-                    wself.delegate?.tabPeekRequestsPresentationOf(clientPicker)
-                })
-            }
-            actions.append(UIAction(title: .TabPeekCopyUrl,
-                                    image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.link),
-                                    identifier: nil) { [weak self] _ in
-                guard let wself = self, let url = wself.tab?.canonicalURL else { return }
-
-                UIPasteboard.general.url = url
-                wself.delegate?.tabPeekDidCopyUrl()
-            })
-        }
-        actions.append(UIAction(title: .TabPeekCloseTab,
-                                image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross),
-                                identifier: nil) { [weak self] _ in
-            guard let wself = self, let tab = wself.tab else { return }
-            wself.delegate?.tabPeekDidCloseTab(tab)
-        })
-
-        return UIMenu(title: "", children: actions)
+        return makeMenuActions()
     }
 
-    init(tab: Tab?, delegate: LegacyTabPeekDelegate?) {
+    // MARK: - Lifecycle methods
+
+    init(tab: Tab?) {
         self.tab = tab
-        self.delegate = delegate
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -120,25 +30,16 @@ class LegacyTabPeekViewController: UIViewController, WKNavigationDelegate {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        webView?.navigationDelegate = nil
-        self.webView = nil
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
         if let webViewAccessibilityLabel = tab?.webView?.accessibilityLabel {
             previewAccessibilityLabel = String(format: .TabPeekPreviewAccessibilityLabel, webViewAccessibilityLabel)
         }
-        // if there is no screenshot, load the URL in a web page
-        // otherwise just show the screenshot
-        if let screenshot = tab?.screenshot {
-            setupWithScreenshot(screenshot)
-        } else {
-            setupWebView(tab?.webView)
-        }
+
+        setupWithScreenshot(tab?.screenshot ?? UIImage())
     }
+
+    // MARK: - Private helper methods
 
     private func setupWithScreenshot(_ screenshot: UIImage) {
         let imageView: UIImageView = .build { imageView in
@@ -153,78 +54,39 @@ class LegacyTabPeekViewController: UIViewController, WKNavigationDelegate {
             imageView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
 
-        screenShot = imageView
-        screenShot?.accessibilityLabel = previewAccessibilityLabel
+        screenshot.accessibilityLabel = previewAccessibilityLabel
     }
 
-    private func setupWebView(_ webView: WKWebView?) {
-        guard let webView = webView,
-              let url = webView.url,
-              !isIgnoredURL(url)
-        else { return }
+    private func makeMenuActions() -> UIMenu {
+        var actions = [UIAction]()
 
-        let clonedWebView = WKWebView(frame: webView.frame, configuration: webView.configuration)
-        clonedWebView.translatesAutoresizingMaskIntoConstraints = false
-        clonedWebView.allowsLinkPreview = false
-        clonedWebView.accessibilityLabel = previewAccessibilityLabel
-        view.addSubview(clonedWebView)
-
-        NSLayoutConstraint.activate([
-            clonedWebView.topAnchor.constraint(equalTo: view.topAnchor),
-            clonedWebView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            clonedWebView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            clonedWebView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-        ])
-
-        clonedWebView.navigationDelegate = self
-        self.webView = clonedWebView
-        clonedWebView.load(URLRequest(url: url))
-    }
-
-    func setState(withProfile browserProfile: BrowserProfile,
-                  clientPickerDelegate: DevicePickerViewControllerDelegate) {
-        guard let tab = self.tab,
-              let displayURL = tab.url?.absoluteString,
-              !displayURL.isEmpty
-        else { return }
-
-        ensureMainThread { [weak self] in
-            guard let self = self else { return }
-
-            browserProfile.places.isBookmarked(url: displayURL) >>== { isBookmarked in
-                self.isBookmarked = isBookmarked
+        let urlIsTooLongToSave = self.tab?.urlIsTooLong ?? false
+        let isHomeTab = self.tab?.isFxHomeTab ?? false
+        if !self.ignoreURL && !urlIsTooLongToSave {
+            if !self.isBookmarked && !isHomeTab {
+                actions.append(UIAction(title: .TabPeekAddToBookmarks,
+                                        image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.bookmark),
+                                        identifier: nil) { _ in
+                    return
+                })
             }
-            browserProfile.tabs.getClientGUIDs { (result, error) in
-                guard let clientGUIDs = result else { return }
-
-                self.hasRemoteClients = !clientGUIDs.isEmpty
-
-                DispatchQueue.main.async {
-                    self.createDevicePicker(withProfile: browserProfile,
-                                            clientPickerDelegate: clientPickerDelegate)
-                }
+            if self.hasRemoteClients {
+                actions.append(UIAction(title: .AppMenu.TouchActions.SendToDeviceTitle, image: UIImage.templateImageNamed("menu-Send"), identifier: nil) { _ in
+                    return
+                })
             }
-
-            let result = browserProfile.readingList.getRecordWithURL(displayURL).value.successValue
-
-            self.isInReadingList = !(result?.url.isEmpty ?? true)
-            self.ignoreURL = isIgnoredURL(displayURL)
+            actions.append(UIAction(title: .TabPeekCopyUrl,
+                                    image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.link),
+                                    identifier: nil) { _ in
+                return
+            })
         }
-    }
+        actions.append(UIAction(title: .TabPeekCloseTab,
+                                image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross),
+                                identifier: nil) { _ in
+            return
+        })
 
-    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        screenShot?.removeFromSuperview()
-        screenShot = nil
-    }
-
-    private func createDevicePicker(withProfile browserProfile: BrowserProfile,
-                                    clientPickerDelegate: DevicePickerViewControllerDelegate) {
-            let clientPickerController = DevicePickerViewController(profile: browserProfile)
-            clientPickerController.pickerDelegate = clientPickerDelegate
-            clientPickerController.profile = browserProfile
-            if let url = tab?.url?.absoluteString {
-                clientPickerController.shareItem = ShareItem(url: url, title: tab?.title ?? "")
-            }
-            self.fxaDevicePicker = UINavigationController(rootViewController: clientPickerController)
+        return UIMenu(title: "", children: actions)
     }
 }

--- a/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -244,7 +244,7 @@ class TabDisplayView: UIView,
         else { return nil }
 
         // TODO: Add browserProfile and clientPickerDelegate
-        let tabVC = LegacyTabPeekViewController(tab: nil, delegate: tabPeekDelegate)
+        let tabVC = TabPeekViewController(tab: nil)
         return UIContextMenuConfiguration(identifier: nil,
                                           previewProvider: { return tabVC },
                                           actionProvider: tabVC.contextActions(defaultActions:))


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7859)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17546)

## :bulb: Description
Add new TabPeekViewController and show from the new tab tray
Next PR will wire up the redux events

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

