### PR TITLE
Refactor FXIOS-7937 [v123] Remove SnapKit from TextFieldTableViewCell

### DIFF
--- a/Client/Frontend/Library/Bookmarks/BookmarkDetailPanel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarkDetailPanel.swift
@@ -415,24 +415,20 @@ class BookmarkDetailPanel: SiteTableViewController {
 
         switch indexPath.row {
         case BookmarkDetailFieldsRow.title.rawValue:
-            if let bookmarkTitle = bookmarkItemOrFolderTitle {
                 cell.configureCell(
                     title: .BookmarkDetailFieldTitle,
-                    textFieldText: bookmarkTitle,
+                    textFieldText: bookmarkItemOrFolderTitle ?? "",
                     autocapitalizationType: .sentences,
                     keyboardType: .default
                 )
-            }
             return cell
         case BookmarkDetailFieldsRow.url.rawValue:
-            if let bookmarkURL = bookmarkItemURL {
                 cell.configureCell(
                     title: .BookmarkDetailFieldURL,
-                    textFieldText: bookmarkURL,
+                    textFieldText: bookmarkItemURL ?? "",
                     autocapitalizationType: .none,
                     keyboardType: .URL
                 )
-            }
             return cell
         default:
             return super.tableView(tableView, cellForRowAt: indexPath) // Should not happen.

--- a/Client/Frontend/Library/Bookmarks/BookmarkDetailPanel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarkDetailPanel.swift
@@ -415,20 +415,20 @@ class BookmarkDetailPanel: SiteTableViewController {
 
         switch indexPath.row {
         case BookmarkDetailFieldsRow.title.rawValue:
-                cell.configureCell(
-                    title: .BookmarkDetailFieldTitle,
-                    textFieldText: bookmarkItemOrFolderTitle ?? "",
-                    autocapitalizationType: .sentences,
-                    keyboardType: .default
-                )
+            cell.configureCell(
+                title: .BookmarkDetailFieldTitle,
+                textFieldText: bookmarkItemOrFolderTitle ?? "",
+                autocapitalizationType: .sentences,
+                keyboardType: .default
+            )
             return cell
         case BookmarkDetailFieldsRow.url.rawValue:
-                cell.configureCell(
-                    title: .BookmarkDetailFieldURL,
-                    textFieldText: bookmarkItemURL ?? "",
-                    autocapitalizationType: .none,
-                    keyboardType: .URL
-                )
+            cell.configureCell(
+                title: .BookmarkDetailFieldURL,
+                textFieldText: bookmarkItemURL ?? "",
+                autocapitalizationType: .none,
+                keyboardType: .URL
+            )
             return cell
         default:
             return super.tableView(tableView, cellForRowAt: indexPath) // Should not happen.

--- a/Client/Frontend/Library/Bookmarks/BookmarkDetailPanel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarkDetailPanel.swift
@@ -426,7 +426,12 @@ class BookmarkDetailPanel: SiteTableViewController {
             return cell
         case BookmarkDetailFieldsRow.url.rawValue:
             if let bookmarkURL = bookmarkItemURL {
-                cell.configureCell(title: .BookmarkDetailFieldURL, textFieldText: bookmarkURL, autocapitalizationType: .none, keyboardType: .URL)
+                cell.configureCell(
+                    title: .BookmarkDetailFieldURL,
+                    textFieldText: bookmarkURL,
+                    autocapitalizationType: .none,
+                    keyboardType: .URL
+                )
             }
             return cell
         default:

--- a/Client/Frontend/Library/Bookmarks/BookmarkDetailPanel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarkDetailPanel.swift
@@ -164,7 +164,7 @@ class BookmarkDetailPanel: SiteTableViewController {
 
         // Focus the keyboard on the first text field.
         if let firstTextFieldCell = tableView.visibleCells.first(where: { $0 is TextFieldTableViewCell }) as? TextFieldTableViewCell {
-            firstTextFieldCell.textField.becomeFirstResponder()
+            firstTextFieldCell.focusTextField()
         }
     }
 
@@ -415,16 +415,19 @@ class BookmarkDetailPanel: SiteTableViewController {
 
         switch indexPath.row {
         case BookmarkDetailFieldsRow.title.rawValue:
-            cell.titleLabel.text = .BookmarkDetailFieldTitle
-            cell.textField.text = bookmarkItemOrFolderTitle
-            cell.textField.autocapitalizationType = .sentences
-            cell.textField.keyboardType = .default
+            if let bookmarkTitle = bookmarkItemOrFolderTitle {
+                cell.configureCell(
+                    title: .BookmarkDetailFieldTitle,
+                    textFieldText: bookmarkTitle,
+                    autocapitalizationType: .sentences,
+                    keyboardType: .default
+                )
+            }
             return cell
         case BookmarkDetailFieldsRow.url.rawValue:
-            cell.titleLabel.text = .BookmarkDetailFieldURL
-            cell.textField.text = bookmarkItemURL
-            cell.textField.autocapitalizationType = .none
-            cell.textField.keyboardType = .URL
+            if let bookmarkURL = bookmarkItemURL {
+                cell.configureCell(title: .BookmarkDetailFieldURL, textFieldText: bookmarkURL, autocapitalizationType: .none, keyboardType: .URL)
+            }
             return cell
         default:
             return super.tableView(tableView, cellForRowAt: indexPath) // Should not happen.

--- a/Client/Frontend/Widgets/TextFieldTableViewCell.swift
+++ b/Client/Frontend/Widgets/TextFieldTableViewCell.swift
@@ -40,19 +40,16 @@ class TextFieldTableViewCell: UITableViewCell, ThemeApplicable {
 
     private func setupLayout() {
         titleLabel.font = UX.TitleLabelFont
-        guard let titleLabelSuperview = titleLabel.superview else { return }
-        NSLayoutConstraint.activate([
-            titleLabel.topAnchor.constraint(equalTo: titleLabelSuperview.topAnchor, constant: UX.VerticalMargin),
-            titleLabel.leadingAnchor.constraint(equalTo: titleLabelSuperview.leadingAnchor, constant: UX.HorizontalMargin),
-            titleLabel.trailingAnchor.constraint(equalTo: titleLabelSuperview.trailingAnchor, constant: -UX.HorizontalMargin)
-        ])
-
         textField.font = UX.TextFieldFont
-        guard let textFieldSuperview = textField.superview else { return }
+
         NSLayoutConstraint.activate([
-            textField.leadingAnchor.constraint(equalTo: textFieldSuperview.leadingAnchor, constant: UX.HorizontalMargin),
-            textField.trailingAnchor.constraint(equalTo: textFieldSuperview.trailingAnchor, constant: -UX.HorizontalMargin),
-            textField.bottomAnchor.constraint(equalTo: textFieldSuperview.bottomAnchor, constant: -UX.VerticalMargin)
+            titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: UX.VerticalMargin),
+            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: UX.HorizontalMargin),
+            titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -UX.HorizontalMargin),
+
+            textField.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: UX.HorizontalMargin),
+            textField.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -UX.HorizontalMargin),
+            textField.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -UX.VerticalMargin)
         ])
     }
 

--- a/Client/Frontend/Widgets/TextFieldTableViewCell.swift
+++ b/Client/Frontend/Widgets/TextFieldTableViewCell.swift
@@ -6,69 +6,74 @@ import Common
 import UIKit
 import Shared
 
-struct TextFieldTableViewCellUX {
-    static let HorizontalMargin: CGFloat = 16
-    static let VerticalMargin: CGFloat = 10
-    static let TitleLabelFont = UIFont.systemFont(ofSize: 12)
-    static let TextFieldFont = UIFont.systemFont(ofSize: 16)
-}
-
 protocol TextFieldTableViewCellDelegate: AnyObject {
     func textFieldTableViewCell(_ textFieldTableViewCell: TextFieldTableViewCell, didChangeText text: String)
 }
 
 class TextFieldTableViewCell: UITableViewCell, ThemeApplicable {
-    let titleLabel: UILabel
-    let textField: UITextField
+    private struct UX {
+        static let HorizontalMargin: CGFloat = 16
+        static let VerticalMargin: CGFloat = 10
+        static let TitleLabelFont = UIFont.systemFont(ofSize: 12)
+        static let TextFieldFont = UIFont.systemFont(ofSize: 16)
+    }
+
+    private lazy var titleLabel: UILabel = .build()
+    private lazy var textField: UITextField = .build()
 
     weak var delegate: TextFieldTableViewCellDelegate?
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        self.titleLabel = UILabel(frame: .zero)
-        self.textField = UITextField(frame: .zero)
-
         super.init(style: style, reuseIdentifier: reuseIdentifier)
 
-        self.contentView.addSubview(self.titleLabel)
-        self.contentView.addSubview(self.textField)
-        self.textField.addTarget(self, action: #selector(onTextFieldDidChangeText), for: .editingChanged)
+        contentView.addSubviews(titleLabel, textField)
+        textField.addTarget(self, action: #selector(onTextFieldDidChangeText), for: .editingChanged)
         self.selectionStyle = .none
         self.separatorInset = .zero
+
+        setupLayout()
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func layoutSubviews() {
-        super.layoutSubviews()
+    private func setupLayout() {
+        titleLabel.font = UX.TitleLabelFont
+        guard let titleLabelSuperview = titleLabel.superview else { return }
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: titleLabelSuperview.topAnchor, constant: UX.VerticalMargin),
+            titleLabel.leadingAnchor.constraint(equalTo: titleLabelSuperview.leadingAnchor, constant: UX.HorizontalMargin),
+            titleLabel.trailingAnchor.constraint(equalTo: titleLabelSuperview.trailingAnchor, constant: -UX.HorizontalMargin)
+        ])
 
-        titleLabel.font = TextFieldTableViewCellUX.TitleLabelFont
-        titleLabel.snp.remakeConstraints { make in
-            guard titleLabel.superview != nil else { return }
-
-            make.leading.equalTo(TextFieldTableViewCellUX.HorizontalMargin)
-            make.trailing.equalTo(-TextFieldTableViewCellUX.HorizontalMargin)
-            make.top.equalTo(TextFieldTableViewCellUX.VerticalMargin)
-        }
-
-        textField.font = TextFieldTableViewCellUX.TextFieldFont
-        textField.snp.remakeConstraints { make in
-            guard textField.superview != nil else { return }
-
-            make.leading.equalTo(TextFieldTableViewCellUX.HorizontalMargin)
-            make.trailing.equalTo(-TextFieldTableViewCellUX.HorizontalMargin)
-            make.bottom.equalTo(-TextFieldTableViewCellUX.VerticalMargin)
-        }
+        textField.font = UX.TextFieldFont
+        guard let textFieldSuperview = textField.superview else { return }
+        NSLayoutConstraint.activate([
+            textField.leadingAnchor.constraint(equalTo: textFieldSuperview.leadingAnchor, constant: UX.HorizontalMargin),
+            textField.trailingAnchor.constraint(equalTo: textFieldSuperview.trailingAnchor, constant: -UX.HorizontalMargin),
+            textField.bottomAnchor.constraint(equalTo: textFieldSuperview.bottomAnchor, constant: -UX.VerticalMargin)
+        ])
     }
 
-    // MARK: ThemeApplicable
+    func configureCell(title: String, textFieldText: String, autocapitalizationType: UITextAutocapitalizationType, keyboardType: UIKeyboardType) {
+        titleLabel.text = title
+        textField.text = textFieldText
+        textField.autocapitalizationType = autocapitalizationType
+        textField.keyboardType = keyboardType
+    }
 
+    func focusTextField() {
+        textField.becomeFirstResponder()
+    }
+
+    // MARK: - ThemeApplicable
     func applyTheme(theme: Theme) {
-        backgroundColor = theme.colors.layer5
-        titleLabel.textColor = theme.colors.textAccent
-        textField.textColor = theme.colors.textPrimary
-        textField.tintColor = theme.colors.actionPrimary
+        let colors = theme.colors
+        backgroundColor = colors.layer5
+        titleLabel.textColor = colors.textAccent
+        textField.textColor = colors.textPrimary
+        textField.tintColor = colors.actionPrimary
     }
 
     @objc


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7937)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17705)

## :bulb: Description
- This PR addresses the task of removing the SnapKit dependency from the `TextFieldTableViewCell` class. 
- The SnapKit constraints have been replaced with standard layout constraints.

| Portrait  | Landscape | 
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2023-12-14 at 10 58 11](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/c72b5f54-1448-40d1-a615-f3452590e419) | ![Simulator Screenshot - iPhone 15 Pro - 2023-12-14 at 10 58 16](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/3edea16b-f685-4513-acee-d2ea8103f6d6) |

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods