### PR TITLE
Bugfix FXIOS-7968 [v122] Change private browsing suggestions toggle to be OFF by default

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
@@ -395,8 +395,8 @@ extension BrowserViewController: URLBarDelegate {
     private var shouldDisableSearchSuggestsForPrivateMode: Bool {
         let featureFlagEnabled = featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly)
         let isPrivateTab = tabManager.selectedTab?.isPrivate ?? false
-        let isSettingEnabled = profile.prefs.boolForKey(PrefsKeys.SearchSettings.disablePrivateModeSearchSuggestions) ?? true
-        return featureFlagEnabled && isPrivateTab && isSettingEnabled
+        let isSettingEnabled = profile.prefs.boolForKey(PrefsKeys.SearchSettings.showPrivateModeSearchSuggestions) ?? false
+        return featureFlagEnabled && isPrivateTab && !isSettingEnabled
     }
 
     // Determines the view user should see when editing the url bar

--- a/Client/Frontend/Browser/SearchEngines/SearchEngines.swift
+++ b/Client/Frontend/Browser/SearchEngines/SearchEngines.swift
@@ -45,7 +45,7 @@ class SearchEngines {
         self.prefs = prefs
         // By default, show search suggestions
         self.shouldShowSearchSuggestions = prefs.boolForKey(showSearchSuggestions) ?? true
-        self.shouldDisablePrivateModeSearchSuggestions = prefs.boolForKey(PrefsKeys.SearchSettings.disablePrivateModeSearchSuggestions) ?? true
+        self.shouldShowPrivateModeSearchSuggestions = prefs.boolForKey(PrefsKeys.SearchSettings.showPrivateModeSearchSuggestions) ?? false
         self.fileAccessor = files
         self.engineProvider = engineProvider
         self.orderedEngines = []
@@ -101,9 +101,9 @@ class SearchEngines {
         }
     }
 
-    var shouldDisablePrivateModeSearchSuggestions: Bool {
+    var shouldShowPrivateModeSearchSuggestions: Bool {
         didSet {
-            self.prefs.setObject(shouldDisablePrivateModeSearchSuggestions, forKey: PrefsKeys.SearchSettings.disablePrivateModeSearchSuggestions)
+            self.prefs.setObject(shouldShowPrivateModeSearchSuggestions, forKey: PrefsKeys.SearchSettings.showPrivateModeSearchSuggestions)
         }
     }
 

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -163,8 +163,8 @@ class SearchSettingsTableViewController: ThemedTableViewController, FeatureFlagg
             cell.textLabel?.numberOfLines = 0
             let toggle = ThemedSwitch()
             toggle.applyTheme(theme: themeManager.currentTheme)
-            toggle.addTarget(self, action: #selector(didToggleDisableSearchSuggestionsInPrivateMode), for: .valueChanged)
-            toggle.isOn = model.shouldDisablePrivateModeSearchSuggestions
+            toggle.addTarget(self, action: #selector(didToggleShowSearchSuggestionsInPrivateMode), for: .valueChanged)
+            toggle.isOn = model.shouldShowPrivateModeSearchSuggestions
             cell.editingAccessoryView = toggle
             cell.selectionStyle = .none
             cell.accessibilityIdentifier = AccessibilityIdentifiers.Settings.Search.disableSearchSuggestsInPrivateMode
@@ -388,8 +388,8 @@ extension SearchSettingsTableViewController {
     }
 
     @objc
-    func didToggleDisableSearchSuggestionsInPrivateMode(_ toggle: ThemedSwitch) {
-        model.shouldDisablePrivateModeSearchSuggestions = toggle.isOn
+    func didToggleShowSearchSuggestionsInPrivateMode(_ toggle: ThemedSwitch) {
+        model.shouldShowPrivateModeSearchSuggestions = toggle.isOn
     }
 
     func cancel() {

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -79,7 +79,7 @@ public struct PrefsKeys {
     }
 
     public struct SearchSettings {
-        public static let disablePrivateModeSearchSuggestions = "DisablePrivateModeSearchSuggestionsKey"
+        public static let showPrivateModeSearchSuggestions = "ShowPrivateModeSearchSuggestionsKey"
     }
 
     public struct UserFeatureFlagPrefs {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEnginesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEnginesTests.swift
@@ -160,20 +160,20 @@ class SearchEnginesTests: XCTestCase {
         XCTAssertFalse(engines.shouldShowSearchSuggestions)
     }
 
-    func testDisableSearchSuggestionSettingsInPrivateMode() {
+    func testShowSearchSuggestionSettingsInPrivateMode() {
         // Disable search suggestions by default
-        XCTAssertTrue(engines.shouldDisablePrivateModeSearchSuggestions)
-        XCTAssertNil(profile.prefs.boolForKey(PrefsKeys.SearchSettings.disablePrivateModeSearchSuggestions))
+        XCTAssertFalse(engines.shouldShowPrivateModeSearchSuggestions)
+        XCTAssertNil(profile.prefs.boolForKey(PrefsKeys.SearchSettings.showPrivateModeSearchSuggestions))
 
         // Turn off setting
-        engines.shouldDisablePrivateModeSearchSuggestions = false
-        XCTAssertFalse(engines.shouldDisablePrivateModeSearchSuggestions)
-        XCTAssertEqual(profile.prefs.boolForKey(PrefsKeys.SearchSettings.disablePrivateModeSearchSuggestions), false)
+        engines.shouldShowPrivateModeSearchSuggestions = false
+        XCTAssertFalse(engines.shouldShowPrivateModeSearchSuggestions)
+        XCTAssertEqual(profile.prefs.boolForKey(PrefsKeys.SearchSettings.showPrivateModeSearchSuggestions), false)
 
         // Turn on setting
-        engines.shouldDisablePrivateModeSearchSuggestions = true
-        XCTAssertTrue(engines.shouldDisablePrivateModeSearchSuggestions)
-        XCTAssertEqual(profile.prefs.boolForKey(PrefsKeys.SearchSettings.disablePrivateModeSearchSuggestions), true)
+        engines.shouldShowPrivateModeSearchSuggestions = true
+        XCTAssertTrue(engines.shouldShowPrivateModeSearchSuggestions)
+        XCTAssertEqual(profile.prefs.boolForKey(PrefsKeys.SearchSettings.showPrivateModeSearchSuggestions), true)
     }
 
     func testGetOrderedEngines() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7968)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17763)

## :bulb: Description
Change private browsing suggestions toggle to be OFF by default and update variable names to match string update

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

# Screenshots
| Before | After |
| --- | --- |
| <img width="281" alt="image" src="https://github.com/mozilla-mobile/firefox-ios/assets/6743397/6ded558d-44e8-4b13-96cb-fdf3fd35ddc2">| <img width="355" alt="image" src="https://github.com/mozilla-mobile/firefox-ios/assets/6743397/cf09b0d9-90a1-402a-a638-90cbe098c621"> | 
