### PR TITLE
Refactor FXIOS-7798 [v122] Remove hardcoded window UUID (Multi-window support)

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -8,6 +8,7 @@ import CoreSpotlight
 import UIKit
 import Common
 import Glean
+import TabDataStore
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
     let logger = DefaultLogger.shared
@@ -30,6 +31,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     lazy var ratingPromptManager = RatingPromptManager(profile: profile)
     lazy var appSessionManager: AppSessionProvider = AppSessionManager()
     lazy var notificationSurfaceManager = NotificationSurfaceManager()
+    lazy var tabDataStore = DefaultTabDataStore()
     lazy var windowManager = WindowManagerImplementation()
 
     private var shutdownWebServer: DispatchSourceTimer?

--- a/Client/Application/DependencyHelper.swift
+++ b/Client/Application/DependencyHelper.swift
@@ -5,6 +5,7 @@
 import Storage
 import Shared
 import Common
+import TabDataStore
 
 class DependencyHelper {
     func bootstrapDependencies() {
@@ -27,6 +28,9 @@ class DependencyHelper {
 
         let downloadQueue: DownloadQueue = appDelegate.appSessionManager.downloadQueue
         AppContainer.shared.register(service: downloadQueue)
+
+        let tabDataStore: TabDataStore = appDelegate.tabDataStore
+        AppContainer.shared.register(service: tabDataStore)
 
         let windowManager: WindowManager = appDelegate.windowManager
         AppContainer.shared.register(service: windowManager)

--- a/Client/Application/WindowManager.swift
+++ b/Client/Application/WindowManager.swift
@@ -8,15 +8,24 @@ import Common
 /// General window management class that provides some basic coordination and
 /// state management for multiple windows shared across a single running app.
 protocol WindowManager {
-    // Managing and checking the active iPad window
+
+    /// The UUID of the active window (there is always at least 1, except in
+    /// the earliest stages of app startup lifecycle)
     var activeWindow: WindowUUID { get set }
+    
+    /// A collection of all open windows and their related metadata.
     var windows: [WindowUUID: AppWindowInfo] { get }
 
-    // Managing TabManagers associated with windows
+    /// Signals the WindowManager that a new browser window has been configured.
+    /// - Parameter windowInfo: the information for the window.
+    /// - Parameter uuid: the window's unique ID.
+    func newBrowserWindowConfigured(_ windowInfo: AppWindowInfo, uuid: WindowUUID)
+    
+    /// Convenience. Returns the TabManager for a specific window.
     func tabManager(for windowUUID: WindowUUID) -> TabManager
-    func tabManagerDidConnectToBrowserWindow(_ tabManager: TabManager)
-
-    // Closing windows
+    
+    /// Signals the WindowManager that a window was closed.
+    /// - Parameter uuid: the ID of the window.
     func windowDidClose(uuid: WindowUUID)
 }
 
@@ -42,11 +51,8 @@ final class WindowManagerImplementation: WindowManager {
 
     // MARK: - Public API
 
-    func tabManagerDidConnectToBrowserWindow(_ tabManager: TabManager) {
-        let uuid = tabManager.windowUUID
-        guard var info = window(for: uuid, createIfNeeded: true) else { fatalError() }
-        info.tabManager = tabManager
-        updateWindow(info, for: uuid)
+    func newBrowserWindowConfigured(_ windowInfo: AppWindowInfo, uuid: WindowUUID) {
+        updateWindow(windowInfo, for: uuid)
     }
 
     func tabManager(for windowUUID: WindowUUID) -> TabManager {

--- a/Client/Application/WindowManager.swift
+++ b/Client/Application/WindowManager.swift
@@ -8,11 +8,10 @@ import Common
 /// General window management class that provides some basic coordination and
 /// state management for multiple windows shared across a single running app.
 protocol WindowManager {
-
     /// The UUID of the active window (there is always at least 1, except in
     /// the earliest stages of app startup lifecycle)
     var activeWindow: WindowUUID { get set }
-    
+
     /// A collection of all open windows and their related metadata.
     var windows: [WindowUUID: AppWindowInfo] { get }
 
@@ -20,10 +19,10 @@ protocol WindowManager {
     /// - Parameter windowInfo: the information for the window.
     /// - Parameter uuid: the window's unique ID.
     func newBrowserWindowConfigured(_ windowInfo: AppWindowInfo, uuid: WindowUUID)
-    
+
     /// Convenience. Returns the TabManager for a specific window.
     func tabManager(for windowUUID: WindowUUID) -> TabManager
-    
+
     /// Signals the WindowManager that a window was closed.
     /// - Parameter uuid: the ID of the window.
     func windowDidClose(uuid: WindowUUID)

--- a/Client/Application/WindowManager.swift
+++ b/Client/Application/WindowManager.swift
@@ -29,7 +29,14 @@ protocol WindowManager {
     /// - Parameter uuid: the ID of the window.
     func windowDidClose(uuid: WindowUUID)
 
+    /// Supplies the UUID for the next window the iOS app should open. This
+    /// corresponds with the window tab data saved to disk, or, if no data is
+    /// available it provides a new UUID for the window.
+    /// - Returns: a UUID for the next window to be opened.
     func nextAvailableWindowUUID() -> WindowUUID
+
+    /// Resets all windows. Typically this should not be needed in the Client.
+    func reset()
 }
 
 /// Captures state and coordinator references specific to one particular app window.
@@ -69,6 +76,10 @@ final class WindowManagerImplementation: WindowManager {
 
     func windowDidClose(uuid: WindowUUID) {
         updateWindow(nil, for: uuid)
+    }
+
+    func reset() {
+        windows.removeAll()
     }
 
     func nextAvailableWindowUUID() -> WindowUUID {

--- a/Client/Application/WindowManager.swift
+++ b/Client/Application/WindowManager.swift
@@ -34,9 +34,6 @@ protocol WindowManager {
     /// available it provides a new UUID for the window.
     /// - Returns: a UUID for the next window to be opened.
     func nextAvailableWindowUUID() -> WindowUUID
-
-    /// Resets all windows. Typically this should not be needed in the Client.
-    func reset()
 }
 
 /// Captures state and coordinator references specific to one particular app window.
@@ -76,10 +73,6 @@ final class WindowManagerImplementation: WindowManager {
 
     func windowDidClose(uuid: WindowUUID) {
         updateWindow(nil, for: uuid)
-    }
-
-    func reset() {
-        windows.removeAll()
     }
 
     func nextAvailableWindowUUID() -> WindowUUID {

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -53,7 +53,8 @@ class BrowserCoordinator: BaseCoordinator,
         self.glean = glean
         super.init(router: router)
 
-        windowManager.tabManagerDidConnectToBrowserWindow(tabManager)
+        windowManager.newBrowserWindowConfigured(AppWindowInfo(tabManager: tabManager), uuid: tabManager.windowUUID)
+
         // TODO [7856]: Additional telemetry updates forthcoming once iPad multi-window enabled.
         // For now, we only have a single BVC and TabManager. Plug it into our TelemetryWrapper:
         TelemetryWrapper.shared.defaultTabManager = tabManager

--- a/Client/Coordinators/Browser/BrowserWindow.swift
+++ b/Client/Coordinators/Browser/BrowserWindow.swift
@@ -9,8 +9,3 @@ import Foundation
 /// manages its own unique set of tabs. Multiple Firefox windows
 /// can be run side-by-side on iPad (once multi-window is enabled). [FXIOS-7349]
 public typealias WindowUUID = UUID
-
-extension WindowUUID {
-    // TODO: [FXIOS-7798] Temporary. Part of WIP iPad multi-window epic.
-    public static let defaultSingleWindowUUID = UUID(uuidString: "44BA0B7D-097A-484D-8358-91A6E374451D")!
-}

--- a/Client/Coordinators/Scene/SceneCoordinator.swift
+++ b/Client/Coordinators/Scene/SceneCoordinator.swift
@@ -13,17 +13,18 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
     let windowUUID: WindowUUID
     private let screenshotService: ScreenshotService
     private let sceneContainer: SceneContainer
+    private let windowManager: WindowManager
 
     init(scene: UIScene,
          sceneSetupHelper: SceneSetupHelper = SceneSetupHelper(),
          screenshotService: ScreenshotService = ScreenshotService(),
-         sceneContainer: SceneContainer = SceneContainer()) {
+         sceneContainer: SceneContainer = SceneContainer(),
+         windowManager: WindowManager = AppContainer.shared.resolve()) {
         self.window = sceneSetupHelper.configureWindowFor(scene, screenshotServiceDelegate: screenshotService)
         self.screenshotService = screenshotService
         self.sceneContainer = sceneContainer
-
-        // TODO: [FXIOS-7798] Update for iPad multi-window. Default to single-window UUID for now.
-        self.windowUUID = .defaultSingleWindowUUID
+        self.windowManager = windowManager
+        self.windowUUID = windowManager.nextAvailableWindowUUID()
 
         let navigationController = sceneSetupHelper.createNavigationController()
         let router = DefaultRouter(navigationController: navigationController)

--- a/Client/TabManagement/TabMigrationUtility.swift
+++ b/Client/TabManagement/TabMigrationUtility.swift
@@ -9,7 +9,7 @@ import TabDataStore
 protocol TabMigrationUtility {
     var shouldRunMigration: Bool { get }
     var legacyTabs: [LegacySavedTab] { get set }
-    func runMigration() async -> WindowData
+    func runMigration(for windowUUID: WindowUUID) async -> WindowData
 }
 
 class DefaultTabMigrationUtility: TabMigrationUtility {
@@ -22,7 +22,7 @@ class DefaultTabMigrationUtility: TabMigrationUtility {
     var legacyTabs = [LegacySavedTab]()
 
     init(profile: Profile = AppContainer.shared.resolve(),
-         tabDataStore: TabDataStore = DefaultTabDataStore(),
+         tabDataStore: TabDataStore = AppContainer.shared.resolve(),
          logger: Logger = DefaultLogger.shared,
          legacyTabDataRetriever: LegacyTabDataRetriever = LegacyTabDataRetrieverImplementation()) {
         self.prefs = profile.prefs
@@ -62,7 +62,7 @@ class DefaultTabMigrationUtility: TabMigrationUtility {
         }
     }
 
-    func runMigration() async -> WindowData {
+    func runMigration(for windowUUID: WindowUUID) async -> WindowData {
         logger.log("Begin tab migration with legacy tab count \(legacyTabs.count)",
                    level: .debug,
                    category: .tabs)
@@ -94,7 +94,7 @@ class DefaultTabMigrationUtility: TabMigrationUtility {
             tabsToMigrate.append(tabData)
         }
 
-        let windowData = WindowData(id: .defaultSingleWindowUUID,
+        let windowData = WindowData(id: windowUUID,
                                     isPrimary: true,
                                     activeTabId: selectTabUUID ?? UUID(),
                                     tabData: tabsToMigrate)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
@@ -16,13 +16,14 @@ class DependencyHelperMock {
         )
         AppContainer.shared.register(service: profile)
 
+        let windowUUID = WindowUUID()
         let tabManager: TabManager = injectedTabManager ?? TabManagerImplementation(
             profile: profile,
             imageStore: DefaultDiskImageStore(
                 files: profile.files,
                 namespace: "TabManagerScreenshots",
                 quality: UIConstants.ScreenshotQuality),
-            uuid: .defaultSingleWindowUUID
+            uuid: windowUUID
         )
 
         let appSessionProvider: AppSessionProvider = AppSessionManager()
@@ -39,9 +40,7 @@ class DependencyHelperMock {
 
         let windowManager: WindowManager = WindowManagerImplementation()
         AppContainer.shared.register(service: windowManager)
-        // Register TabManager with Redux for primary app window
-        let uuid = tabManager.windowUUID
-        windowManager.newBrowserWindowConfigured(AppWindowInfo(tabManager: tabManager), uuid: uuid)
+        windowManager.newBrowserWindowConfigured(AppWindowInfo(tabManager: tabManager), uuid: windowUUID)
 
         // Tell the container we are done registering
         AppContainer.shared.bootstrap()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
@@ -5,6 +5,7 @@
 import Common
 import Shared
 import Storage
+import TabDataStore
 @testable import Client
 
 class DependencyHelperMock {
@@ -15,6 +16,9 @@ class DependencyHelperMock {
             localName: "profile"
         )
         AppContainer.shared.register(service: profile)
+
+        let tabDataStore: TabDataStore = MockTabDataStore()
+        AppContainer.shared.register(service: tabDataStore)
 
         let windowUUID = WindowUUID()
         let tabManager: TabManager = injectedTabManager ?? TabManagerImplementation(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
@@ -40,7 +40,8 @@ class DependencyHelperMock {
         let windowManager: WindowManager = WindowManagerImplementation()
         AppContainer.shared.register(service: windowManager)
         // Register TabManager with Redux for primary app window
-        windowManager.tabManagerDidConnectToBrowserWindow(tabManager)
+        let uuid = tabManager.windowUUID
+        windowManager.newBrowserWindowConfigured(AppWindowInfo(tabManager: tabManager), uuid: uuid)
 
         // Tell the container we are done registering
         AppContainer.shared.bootstrap()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
@@ -19,7 +19,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         profile = MockProfile()
-        tabManager = TabManagerImplementation(profile: profile, imageStore: nil, uuid: .defaultSingleWindowUUID)
+        tabManager = TabManagerImplementation(profile: profile, imageStore: nil)
         subject = BrowserViewController(profile: profile, tabManager: tabManager)
         tabManagerDelegate = TabManagerNavDelegate()
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/HomepageViewControllerTests.swift
@@ -24,7 +24,7 @@ class HomepageViewControllerTests: XCTestCase {
     }
 
     func testHomepageViewController_simpleCreation_hasNoLeaks() {
-        let tabManager = TabManagerImplementation(profile: profile, imageStore: nil, uuid: .defaultSingleWindowUUID)
+        let tabManager = TabManagerImplementation(profile: profile, imageStore: nil)
         let urlBar = URLBarView(profile: profile)
         let overlayManager = MockOverlayModeManager()
         overlayManager.setURLBar(urlBarView: urlBar)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
@@ -28,7 +28,7 @@ class JumpBackInViewModelTests: XCTestCase {
         mockTabManager = MockTabManager()
         stubBrowserViewController = BrowserViewController(
             profile: mockProfile,
-            tabManager: TabManagerImplementation(profile: mockProfile, imageStore: nil, uuid: .defaultSingleWindowUUID)
+            tabManager: TabManagerImplementation(profile: mockProfile, imageStore: nil)
         )
 
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: mockProfile)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/GridTabViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/GridTabViewControllerTests.swift
@@ -13,7 +13,7 @@ final class LegacyGridTabViewControllerTests: XCTestCase {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         profile = MockProfile()
-        manager = TabManagerImplementation(profile: profile, imageStore: nil, uuid: .defaultSingleWindowUUID)
+        manager = TabManagerImplementation(profile: profile, imageStore: nil)
     }
 
     override func tearDown() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/HistoryHighlights/HistoryHighlightsManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/HistoryHighlights/HistoryHighlightsManagerTests.swift
@@ -21,7 +21,7 @@ class HistoryHighlightsTests: XCTestCase {
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
         DependencyHelperMock().bootstrapDependencies()
         profile.reopen()
-        let tabManager = TabManagerImplementation(profile: profile, imageStore: nil, uuid: .defaultSingleWindowUUID)
+        let tabManager = TabManagerImplementation(profile: profile, imageStore: nil)
         entryProvider = HistoryHighlightsTestEntryProvider(with: profile, and: tabManager)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/AppSettingsTableViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/AppSettingsTableViewControllerTests.swift
@@ -17,7 +17,7 @@ class AppSettingsTableViewControllerTests: XCTestCase {
         DependencyHelperMock().bootstrapDependencies()
         self.profile = MockProfile()
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
-        self.tabManager = TabManagerImplementation(profile: profile, imageStore: nil, uuid: .defaultSingleWindowUUID)
+        self.tabManager = TabManagerImplementation(profile: profile, imageStore: nil)
         self.appAuthenticator = MockAppAuthenticator()
         self.delegate = MockSettingsFlowDelegate()
         self.applicationHelper = MockApplicationHelper()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/StartAtHomeHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/StartAtHomeHelperTests.swift
@@ -18,7 +18,7 @@ class StartAtHomeHelperTests: XCTestCase {
 
         DependencyHelperMock().bootstrapDependencies()
         profile = MockProfile()
-        tabManager = TabManagerImplementation(profile: profile, imageStore: nil, uuid: .defaultSingleWindowUUID)
+        tabManager = TabManagerImplementation(profile: profile, imageStore: nil)
 
         DependencyHelperMock().bootstrapDependencies()
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Legacy/TabsQuantityTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Legacy/TabsQuantityTelemetryTests.swift
@@ -32,7 +32,6 @@ class TabsQuantityTelemetryTests: XCTestCase {
     func testTrackTabsQuantity_withNormalTab_gleanIsCalled() {
         let tabManager = TabManagerImplementation(profile: profile,
                                                   imageStore: nil,
-                                                  uuid: .defaultSingleWindowUUID,
                                                   inactiveTabsManager: inactiveTabsManager)
 
         let tab = tabManager.addTab()
@@ -51,7 +50,7 @@ class TabsQuantityTelemetryTests: XCTestCase {
     }
 
     func testTrackTabsQuantity_withPrivateTab_gleanIsCalled() {
-        let tabManager = TabManagerImplementation(profile: profile, imageStore: nil, uuid: .defaultSingleWindowUUID)
+        let tabManager = TabManagerImplementation(profile: profile, imageStore: nil)
         tabManager.addTab(isPrivate: true)
 
         TabsQuantityTelemetry.trackTabsQuantity(tabManager: tabManager)
@@ -68,7 +67,6 @@ class TabsQuantityTelemetryTests: XCTestCase {
     func testTrackTabsQuantity_ensureNoInactiveTabs_gleanIsCalled() {
         let tabManager = TabManagerImplementation(profile: profile,
                                                   imageStore: nil,
-                                                  uuid: .defaultSingleWindowUUID,
                                                   inactiveTabsManager: inactiveTabsManager)
         let tab = tabManager.addTab()
         inactiveTabsManager.activeTabs = [tab]

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Mocks/MockTabDataStore.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Mocks/MockTabDataStore.swift
@@ -11,6 +11,10 @@ class MockTabDataStore: TabDataStore {
     var fetchTabWindowData: WindowData?
     var saveWindowData: WindowData?
 
+    func fetchWindowDataUUIDs() -> [UUID] {
+        return []
+    }
+
     func fetchWindowData() async -> WindowData? {
         fetchWindowDataCalledCount += 1
         return fetchTabWindowData

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Mocks/MockTabDataStore.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Mocks/MockTabDataStore.swift
@@ -10,9 +10,10 @@ class MockTabDataStore: TabDataStore {
     var saveWindowDataCalledCount = 0
     var fetchTabWindowData: WindowData?
     var saveWindowData: WindowData?
+    private var persistedTabWindowUUIDs: [UUID] = []
 
     func fetchWindowDataUUIDs() -> [UUID] {
-        return []
+        return persistedTabWindowUUIDs
     }
 
     func fetchWindowData() async -> WindowData? {
@@ -26,4 +27,15 @@ class MockTabDataStore: TabDataStore {
     }
 
     func clearAllWindowsData() async {}
+}
+
+// Utilities for mocking available tab window UUIDs in unit tests.
+extension MockTabDataStore {
+    func resetMockTabWindowUUIDs() {
+        persistedTabWindowUUIDs.removeAll()
+    }
+
+    func injectMockTabWindowUUID(_ uuid: UUID) {
+        persistedTabWindowUUIDs.append(uuid)
+    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -7,9 +7,11 @@ import XCTest
 import TabDataStore
 import WebKit
 import Shared
+import Common
 @testable import Client
 
 class TabManagerTests: XCTestCase {
+    var tabWindowUUID: WindowUUID!
     var mockTabStore: MockTabDataStore!
     var mockSessionStore: MockTabSessionStore!
     var mockProfile: MockProfile!
@@ -19,7 +21,11 @@ class TabManagerTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+
         DependencyHelperMock().bootstrapDependencies()
+        let uuid = (AppContainer.shared.resolve() as TabManager).windowUUID
+        // For this test suite, use a consistent window UUID for all test cases
+        tabWindowUUID = uuid
         mockProfile = MockProfile()
         mockDiskImageStore = MockDiskImageStore()
         mockTabStore = MockTabDataStore()
@@ -172,7 +178,7 @@ class TabManagerTests: XCTestCase {
     private func createSubject() -> TabManagerImplementation {
         let subject = TabManagerImplementation(profile: mockProfile,
                                                imageStore: mockDiskImageStore,
-                                               uuid: .defaultSingleWindowUUID,
+                                               uuid: tabWindowUUID,
                                                tabDataStore: mockTabStore,
                                                tabSessionStore: mockSessionStore)
         trackForMemoryLeaks(subject)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -23,9 +23,12 @@ class TabManagerTests: XCTestCase {
         super.setUp()
 
         DependencyHelperMock().bootstrapDependencies()
-        let uuid = (AppContainer.shared.resolve() as TabManager).windowUUID
+
         // For this test suite, use a consistent window UUID for all test cases
+        let windowManager: WindowManager = AppContainer.shared.resolve()
+        let uuid = windowManager.activeWindow
         tabWindowUUID = uuid
+
         mockProfile = MockProfile()
         mockDiskImageStore = MockDiskImageStore()
         mockTabStore = MockTabDataStore()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabMigrationUtilityTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabMigrationUtilityTests.swift
@@ -11,9 +11,11 @@ class TabMigrationUtilityTests: XCTestCase {
     var tabDataStore: MockTabDataStore!
     let sleepTime: UInt64 = 1 * NSEC_PER_SEC
     let selectedTabUUID = UUID(uuidString: "1CEBD34D-44E5-41F8-A686-4EA8C284A5CE")
+    private var tabDataWindowUUID: WindowUUID!
 
     override func setUp() {
         super.setUp()
+        tabDataWindowUUID = WindowUUID()
         profile = MockProfile()
         tabDataStore = MockTabDataStore()
     }
@@ -27,40 +29,40 @@ class TabMigrationUtilityTests: XCTestCase {
     func testShouldRunMigration_OnlyOnce() async {
         let subject = createSubject()
         XCTAssertTrue(subject.shouldRunMigration)
-        _ = await subject.runMigration()
+        _ = await subject.runMigration(for: tabDataWindowUUID)
         XCTAssertFalse(subject.shouldRunMigration)
     }
 
     func testRunMigration_SaveDataCalled() async {
         let subject = createSubject()
-        _ = await subject.runMigration()
+        _ = await subject.runMigration(for: tabDataWindowUUID)
         XCTAssertEqual(tabDataStore.saveWindowDataCalledCount, 1)
     }
 
     func testRunMigration_SameAmountOfTabs() async {
         var subject = createSubject()
         subject.legacyTabs = buildSavedTab(amountOfTabs: 3)
-        let windowData = await subject.runMigration()
+        let windowData = await subject.runMigration(for: tabDataWindowUUID)
         XCTAssertEqual(windowData.tabData.count, subject.legacyTabs.count)
     }
 
     func testRunMigration_EmptyTabs() async {
         let subject = createSubject()
-        let windowData = await subject.runMigration()
+        let windowData = await subject.runMigration(for: tabDataWindowUUID)
         XCTAssertEqual(windowData.tabData.count, 0)
     }
 
     func testRunMigration_FirstTabAsSelected() async {
         var subject = createSubject()
         subject.legacyTabs = buildSavedTab(amountOfTabs: 3)
-        let windowData = await subject.runMigration()
+        let windowData = await subject.runMigration(for: tabDataWindowUUID)
         XCTAssertEqual(windowData.activeTabId, selectedTabUUID)
     }
 
     func testRunMigration_AllTabDataIsMigrated() async {
         var subject = createSubject()
         subject.legacyTabs = buildSavedTab(amountOfTabs: 1)
-        let windowData = await subject.runMigration()
+        let windowData = await subject.runMigration(for: tabDataWindowUUID)
 
         let migratedTab = windowData.tabData[0]
         XCTAssertEqual(migratedTab.id, selectedTabUUID)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabToolbarHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabToolbarHelperTests.swift
@@ -124,7 +124,7 @@ class MockTabToolbar: TabToolbarProtocol {
 
     init() {
         profile = MockProfile()
-        tabManager = TabManagerImplementation(profile: profile, imageStore: nil, uuid: .defaultSingleWindowUUID)
+        tabManager = TabManagerImplementation(profile: profile, imageStore: nil)
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
         _tabToolBarDelegate = BrowserViewController(profile: profile, tabManager: tabManager)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/Legacy/LegacyTabTrayViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/Legacy/LegacyTabTrayViewControllerTests.swift
@@ -23,7 +23,7 @@ final class LegacyTabTrayViewControllerTests: XCTestCase {
 
         DependencyHelperMock().bootstrapDependencies()
         profile = MockProfile()
-        manager = TabManagerImplementation(profile: profile, imageStore: nil, uuid: .defaultSingleWindowUUID)
+        manager = TabManagerImplementation(profile: profile, imageStore: nil)
         urlBar = MockURLBarView()
         overlayManager = MockOverlayModeManager()
         overlayManager.setURLBar(urlBarView: urlBar)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WindowManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WindowManagerTests.swift
@@ -168,6 +168,7 @@ class WindowManagerTests: XCTestCase {
 
     private func createSubject() -> WindowManager {
         let manager: WindowManager = AppContainer.shared.resolve()
+        manager.reset()
         return manager
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WindowManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WindowManagerTests.swift
@@ -28,7 +28,7 @@ class WindowManagerTests: XCTestCase {
 
         // Connect TabManager and browser to app window
         let uuid = tabManager.windowUUID
-        subject.tabManagerDidConnectToBrowserWindow(tabManager)
+        subject.newBrowserWindowConfigured(AppWindowInfo(tabManager: tabManager), uuid: uuid)
 
         // Expect 1 app window is now configured
         XCTAssertEqual(1, subject.windows.count)
@@ -44,13 +44,13 @@ class WindowManagerTests: XCTestCase {
 
         // Connect first TabManager and browser to app window
         let firstWindowUUID = tabManager.windowUUID
-        subject.tabManagerDidConnectToBrowserWindow(tabManager)
+        subject.newBrowserWindowConfigured(AppWindowInfo(tabManager: tabManager), uuid: firstWindowUUID)
         // Expect 1 app window is now configured
         XCTAssertEqual(1, subject.windows.count)
 
         // Connect second TabManager and browser to another window
         let secondWindowUUID = secondTabManager.windowUUID
-        subject.tabManagerDidConnectToBrowserWindow(secondTabManager)
+        subject.newBrowserWindowConfigured(AppWindowInfo(tabManager: secondTabManager), uuid: secondWindowUUID)
 
         // Expect 2 app windows are now configured
         XCTAssertEqual(2, subject.windows.count)
@@ -70,8 +70,8 @@ class WindowManagerTests: XCTestCase {
         // Configure two app windows
         let firstWindowUUID = tabManager.windowUUID
         let secondWindowUUID = secondTabManager.windowUUID
-        subject.tabManagerDidConnectToBrowserWindow(tabManager)
-        subject.tabManagerDidConnectToBrowserWindow(secondTabManager)
+        subject.newBrowserWindowConfigured(AppWindowInfo(tabManager: tabManager), uuid: firstWindowUUID)
+        subject.newBrowserWindowConfigured(AppWindowInfo(tabManager: secondTabManager), uuid: secondWindowUUID)
 
         XCTAssertEqual(subject.activeWindow, firstWindowUUID)
         subject.activeWindow = secondWindowUUID
@@ -84,8 +84,8 @@ class WindowManagerTests: XCTestCase {
         // Configure two app windows
         let firstWindowUUID = tabManager.windowUUID
         let secondWindowUUID = secondTabManager.windowUUID
-        subject.tabManagerDidConnectToBrowserWindow(tabManager)
-        subject.tabManagerDidConnectToBrowserWindow(secondTabManager)
+        subject.newBrowserWindowConfigured(AppWindowInfo(tabManager: tabManager), uuid: firstWindowUUID)
+        subject.newBrowserWindowConfigured(AppWindowInfo(tabManager: secondTabManager), uuid: secondWindowUUID)
 
         // Check that first window is the active window
         XCTAssertEqual(2, subject.windows.count)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WindowManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WindowManagerTests.swift
@@ -167,8 +167,9 @@ class WindowManagerTests: XCTestCase {
     // MARK: - Test Subject
 
     private func createSubject() -> WindowManager {
-        let manager: WindowManager = AppContainer.shared.resolve()
-        manager.reset()
-        return manager
+        // For this test case, we create a new WindowManager that we can
+        // modify and reset between each test case as needed, without
+        // impacting other tests that may use the shared AppContainer.
+        return WindowManagerImplementation()
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WindowManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WindowManagerTests.swift
@@ -21,7 +21,7 @@ class WindowManagerTests: XCTestCase {
 
     override func tearDown() {
         super.tearDown()
-        AppContainer.shared.reset()
+        DependencyHelperMock().reset()
     }
 
     func testConfiguringAndConnectingSingleAppWindow() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7798)

## :bulb: Description

Additional early refactors to help move towards supporting multiple windows on iPad.

Changes in this PR:
- Removes the hardcoded/static window UUID used previously (except for UI tests, which will continue to use it for now)
- Adds new functionality to `WindowManager` to help it coordinate window UUIDs during `UIScene` configuration + app startup
- Moves `DefaultTabDataStore` into ubiquitous `AppContainer` to ensure we're always sharing the same instance (since the collective window data should always be managed by the same data store actor)
- Some add'tl unit test updates and related refactors

### More Info

👉 This is a pure refactor and should have no impact to functionality on `main`.
👉 If existing `WindowData` is already saved on a device using the former hardcoded UUID, the app will simply open that data and continue to use that UUID during launch.
👉 For new app installs, the UUID of the first new browser window will be randomly-generated since we are no longer hardcoding the value.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

