### PR TITLE
Refactor FXIOS-7860 [v122] Add support for undo close tabs actions in middleware and listen for updates

### DIFF
--- a/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
+++ b/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
@@ -14,6 +14,7 @@ enum TabPanelAction: Action {
     case moveTab(Int, Int)
     case toggleInactiveTabs
     case closeInactiveTabs(String)
+    case undoCloseInactiveTab
     case closeAllInactiveTabs
     case learnMorePrivateMode(URLRequest)
     case selectTab(String)

--- a/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
+++ b/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
@@ -9,6 +9,7 @@ enum TabPanelAction: Action {
     case tabPanelDidAppear(Bool)
     case addNewTab(URLRequest?, Bool)
     case closeTab(String)
+    case undoClose
     case closeAllTabs
     case moveTab(Int, Int)
     case toggleInactiveTabs
@@ -16,10 +17,11 @@ enum TabPanelAction: Action {
     case closeAllInactiveTabs
     case learnMorePrivateMode(URLRequest)
     case selectTab(String)
+    case showUndoToast(UndoToastType)
+    case hideUndoToast
 
     // Middleware actions
     case didLoadTabPanel(TabDisplayModel)
-    // Response to all user actions involving tabs ex: add, close and close all tabs
-    case refreshTab([TabModel])
+    case refreshTab([TabModel]) // Response to all user actions involving tabs ex: add, close and close all tabs
     case refreshInactiveTabs([InactiveTabsModel])
 }

--- a/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
+++ b/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
@@ -4,6 +4,38 @@
 
 import Redux
 
+enum UndoToastType: Equatable {
+    case singleTab
+    case allTabs(count: Int)
+    case singleInactiveTabs
+    case allInactiveTabs(count: Int)
+
+    var title: String {
+        switch self {
+        case .singleTab, .singleInactiveTabs:
+            return .TabsTray.CloseTabsToast.SingleTabTitle
+        case let .allInactiveTabs(tabsCount),
+            let .allTabs(count: tabsCount):
+            return String.localizedStringWithFormat(
+                .TabsTray.CloseTabsToast.Title,
+                tabsCount)
+        }
+    }
+
+    var buttonText: String {
+        return .TabsTray.CloseTabsToast.Action
+    }
+
+    var reduxAction: TabPanelAction {
+        switch self {
+        case .singleTab: return .undoClose
+        case .singleInactiveTabs: return .undoCloseInactiveTab
+        case .allTabs: return .undoCloseAllTabs
+        case .allInactiveTabs: return .undoCloseAllInactiveTabs
+        }
+    }
+}
+
 enum TabPanelAction: Action {
     case tabPanelDidLoad(Bool)
     case tabPanelDidAppear(Bool)
@@ -11,11 +43,13 @@ enum TabPanelAction: Action {
     case closeTab(String)
     case undoClose
     case closeAllTabs
+    case undoCloseAllTabs
     case moveTab(Int, Int)
     case toggleInactiveTabs
     case closeInactiveTabs(String)
     case undoCloseInactiveTab
     case closeAllInactiveTabs
+    case undoCloseAllInactiveTabs
     case learnMorePrivateMode(URLRequest)
     case selectTab(String)
     case showUndoToast(UndoToastType)

--- a/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
+++ b/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
@@ -17,29 +17,6 @@ protocol TabTrayDelegate: AnyObject {
     func tabTrayDidCloseLastTab(toast: ButtonToast)
 }
 
-enum UndoToastType: Equatable {
-    case singleTab
-    case allTabs(count: Int)
-    case singleInactiveTabs
-    case inactiveTabs(count: Int)
-
-    var title: String {
-        switch self {
-        case .singleTab, .singleInactiveTabs:
-            return .TabsTray.CloseTabsToast.SingleTabTitle
-        case let .inactiveTabs(tabsCount),
-            let .allTabs(count: tabsCount):
-            return String.localizedStringWithFormat(
-                .TabsTray.CloseTabsToast.Title,
-                tabsCount)
-        }
-    }
-
-    var buttonText: String {
-        return .TabsTray.CloseTabsToast.Action
-    }
-}
-
 class LegacyGridTabViewController: UIViewController,
                                    TabTrayViewDelegate,
                                    Themeable,
@@ -738,7 +715,7 @@ extension LegacyGridTabViewController: InactiveTabsCFRProtocol {
     }
 
     func presentUndoToast(tabsCount: Int, completion: @escaping (Bool) -> Void) {
-        presentUndoToast(toastType: .inactiveTabs(count: tabsCount),
+        presentUndoToast(toastType: .allInactiveTabs(count: tabsCount),
                          completion: completion)
     }
 

--- a/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
+++ b/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
@@ -17,6 +17,29 @@ protocol TabTrayDelegate: AnyObject {
     func tabTrayDidCloseLastTab(toast: ButtonToast)
 }
 
+enum UndoToastType: Equatable {
+    case singleTab
+    case allTabs(count: Int)
+    case singleInactiveTabs
+    case inactiveTabs(count: Int)
+
+    var title: String {
+        switch self {
+        case .singleTab, .singleInactiveTabs:
+            return .TabsTray.CloseTabsToast.SingleTabTitle
+        case let .inactiveTabs(tabsCount),
+            let .allTabs(count: tabsCount):
+            return String.localizedStringWithFormat(
+                .TabsTray.CloseTabsToast.Title,
+                tabsCount)
+        }
+    }
+
+    var buttonText: String {
+        return .TabsTray.CloseTabsToast.Action
+    }
+}
+
 class LegacyGridTabViewController: UIViewController,
                                    TabTrayViewDelegate,
                                    Themeable,
@@ -36,29 +59,6 @@ class LegacyGridTabViewController: UIViewController,
         static let menuFixedWidth: CGFloat = 320
         static let undoToastDelay = DispatchTimeInterval.seconds(0)
         static let undoToastDuration = DispatchTimeInterval.seconds(3)
-    }
-
-    enum UndoToastType {
-        case singleTab
-        case inactiveTabs(count: Int)
-
-        var title: String {
-            switch self {
-            case .singleTab:
-                return .TabsTray.CloseTabsToast.SingleTabTitle
-            case let .inactiveTabs(tabsCount):
-                return String.localizedStringWithFormat(
-                    .TabsTray.CloseTabsToast.Title,
-                    tabsCount)
-            }
-        }
-
-        var buttonText: String {
-            switch self {
-            case .singleTab, .inactiveTabs:
-                return .TabsTray.CloseTabsToast.Action
-            }
-        }
     }
 
     let tabManager: TabManager

--- a/Client/Frontend/Browser/Tabs/Models/TabDisplayModel.swift
+++ b/Client/Frontend/Browser/Tabs/Models/TabDisplayModel.swift
@@ -8,7 +8,7 @@ struct TabDisplayModel: Equatable {
     var isPrivateMode: Bool
     var tabs: [TabModel]
     var normalTabsCount: String
-    // MARK: Inactive tabs
     var inactiveTabs: [InactiveTabsModel]
     var isInactiveTabsExpanded: Bool
+    var undoCloseType: UndoToastType?
 }

--- a/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
+++ b/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
@@ -8,14 +8,14 @@ import Redux
 struct TabsPanelState: ScreenState, Equatable {
     var isPrivateMode: Bool
     var tabs: [TabModel]
+    var inactiveTabs: [InactiveTabsModel]
+    var isInactiveTabsExpanded: Bool
+    var undoToastType: UndoToastType?
+
     var isPrivateTabsEmpty: Bool {
         guard isPrivateMode else { return false }
         return tabs.isEmpty
     }
-
-    // MARK: Inactive tabs
-    var inactiveTabs: [InactiveTabsModel]
-    var isInactiveTabsExpanded: Bool
 
     init(_ appState: AppState) {
         guard let panelState = store.state.screenState(TabsPanelState.self, for: .tabsPanel) else {
@@ -26,24 +26,28 @@ struct TabsPanelState: ScreenState, Equatable {
         self.init(isPrivateMode: panelState.isPrivateMode,
                   tabs: panelState.tabs,
                   inactiveTabs: panelState.inactiveTabs,
-                  isInactiveTabsExpanded: panelState.isInactiveTabsExpanded)
+                  isInactiveTabsExpanded: panelState.isInactiveTabsExpanded,
+                  undoToastType: panelState.undoToastType)
     }
 
     init(isPrivateMode: Bool = false) {
         self.init(isPrivateMode: isPrivateMode,
                   tabs: [TabModel](),
                   inactiveTabs: [InactiveTabsModel](),
-                  isInactiveTabsExpanded: false)
+                  isInactiveTabsExpanded: false,
+                  undoToastType: nil)
     }
 
     init(isPrivateMode: Bool,
          tabs: [TabModel],
          inactiveTabs: [InactiveTabsModel],
-         isInactiveTabsExpanded: Bool) {
+         isInactiveTabsExpanded: Bool,
+         undoToastType: UndoToastType? = nil) {
         self.isPrivateMode = isPrivateMode
         self.tabs = tabs
         self.inactiveTabs = inactiveTabs
         self.isInactiveTabsExpanded = isInactiveTabsExpanded
+        self.undoToastType = undoToastType
     }
 
     static let reducer: Reducer<Self> = { state, action in
@@ -54,6 +58,7 @@ struct TabsPanelState: ScreenState, Equatable {
                                   inactiveTabs: tabsModel.inactiveTabs,
                                   isInactiveTabsExpanded: tabsModel.isInactiveTabsExpanded)
         case TabPanelAction.refreshTab(let tabs):
+            print("YRD refreshTabs")
             return TabsPanelState(isPrivateMode: state.isPrivateMode,
                                   tabs: tabs,
                                   inactiveTabs: state.inactiveTabs,
@@ -68,6 +73,18 @@ struct TabsPanelState: ScreenState, Equatable {
                                   tabs: state.tabs,
                                   inactiveTabs: inactiveTabs,
                                   isInactiveTabsExpanded: state.isInactiveTabsExpanded)
+        case TabPanelAction.showUndoToast(let type):
+            return TabsPanelState(isPrivateMode: state.isPrivateMode,
+                                  tabs: state.tabs,
+                                  inactiveTabs: state.inactiveTabs,
+                                  isInactiveTabsExpanded: state.isInactiveTabsExpanded,
+                                  undoToastType: type)
+        case TabPanelAction.hideUndoToast:
+            return TabsPanelState(isPrivateMode: state.isPrivateMode,
+                                  tabs: state.tabs,
+                                  inactiveTabs: state.inactiveTabs,
+                                  isInactiveTabsExpanded: state.isInactiveTabsExpanded,
+                                  undoToastType: nil)
         default: return state
         }
     }

--- a/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
+++ b/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
@@ -58,7 +58,6 @@ struct TabsPanelState: ScreenState, Equatable {
                                   inactiveTabs: tabsModel.inactiveTabs,
                                   isInactiveTabsExpanded: tabsModel.isInactiveTabsExpanded)
         case TabPanelAction.refreshTab(let tabs):
-            print("YRD refreshTabs")
             return TabsPanelState(isPrivateMode: state.isPrivateMode,
                                   tabs: tabs,
                                   inactiveTabs: state.inactiveTabs,

--- a/Client/Frontend/Browser/Tabs/Views/TabDisplayPanel.swift
+++ b/Client/Frontend/Browser/Tabs/Views/TabDisplayPanel.swift
@@ -164,19 +164,10 @@ class TabDisplayPanel: UIViewController,
             store.dispatch(TabPanelAction.hideUndoToast)
             presentUndoToast(toastType: undoType) { undoClose in
                 if undoClose {
-                    let undoAction = self.getUndoAction(undoType)
-                    store.dispatch(undoAction)
+                    store.dispatch(undoType.reduxAction)
                 }
                 self.shownToast = nil
             }
-        }
-    }
-
-    private func getUndoAction(_ undoType: UndoToastType) -> TabPanelAction {
-        switch undoType {
-        case .singleTab: return .undoClose
-        case .singleInactiveTabs: return .undoCloseInactiveTab
-        default: return .undoClose
         }
     }
 

--- a/Client/Frontend/Browser/Tabs/Views/TabDisplayPanel.swift
+++ b/Client/Frontend/Browser/Tabs/Views/TabDisplayPanel.swift
@@ -159,15 +159,24 @@ class TabDisplayPanel: UIViewController,
         shouldShowEmptyView(tabsState.isPrivateTabsEmpty)
 
         // Avoid showing toast multiple times
-        if let undoType = tabsState.undoToastType, 
+        if let undoType = tabsState.undoToastType,
             shownToast == nil {
-            print("YRD presentUndoToast")
             store.dispatch(TabPanelAction.hideUndoToast)
             presentUndoToast(toastType: undoType) { undoClose in
                 if undoClose {
-                    store.dispatch(TabPanelAction.undoClose)
+                    let undoAction = self.getUndoAction(undoType)
+                    store.dispatch(undoAction)
                 }
+                self.shownToast = nil
             }
+        }
+    }
+
+    private func getUndoAction(_ undoType: UndoToastType) -> TabPanelAction {
+        switch undoType {
+        case .singleTab: return .undoClose
+        case .singleInactiveTabs: return .undoCloseInactiveTab
+        default: return .undoClose
         }
     }
 

--- a/Client/Frontend/Browser/Tabs/Views/TabDisplayPanel.swift
+++ b/Client/Frontend/Browser/Tabs/Views/TabDisplayPanel.swift
@@ -12,9 +12,15 @@ class TabDisplayPanel: UIViewController,
                                 EmptyPrivateTabsViewDelegate,
                                 StoreSubscriber {
     typealias SubscriberStateType = TabsPanelState
+    struct UX {
+        static let undoToastDelay = DispatchTimeInterval.seconds(0)
+        static let undoToastDuration = DispatchTimeInterval.seconds(3)
+    }
+
     var notificationCenter: NotificationProtocol
     var themeManager: ThemeManager
     var themeObserver: NSObjectProtocol?
+    var tabsState: TabsPanelState
 
     // MARK: UI elements
     private lazy var tabDisplayView: TabDisplayView = {
@@ -24,8 +30,11 @@ class TabDisplayPanel: UIViewController,
     }()
     private var backgroundPrivacyOverlay: UIView = .build()
     private lazy var emptyPrivateTabsView: EmptyPrivateTabsView = .build()
+    var shownToast: Toast?
 
-    var tabsState: TabsPanelState
+    var toolbarHeight: CGFloat {
+        return !shouldUseiPadSetup() ? view.safeAreaInsets.bottom : 0
+    }
 
     init(isPrivateMode: Bool,
          notificationCenter: NotificationProtocol = NotificationCenter.default,
@@ -101,6 +110,34 @@ class TabDisplayPanel: UIViewController,
         emptyPrivateTabsView.applyTheme(themeManager.currentTheme)
     }
 
+    private func presentUndoToast(toastType: UndoToastType,
+                                  completion: @escaping (Bool) -> Void) {
+        if let currentToast = shownToast {
+            currentToast.dismiss(false)
+        }
+
+        let viewModel = ButtonToastViewModel(
+            labelText: toastType.title,
+            buttonText: toastType.buttonText)
+        let toast = ButtonToast(viewModel: viewModel,
+                                theme: themeManager.currentTheme,
+                                completion: { buttonPressed in
+            completion(buttonPressed)
+        })
+
+        toast.showToast(viewController: self,
+                        delay: UX.undoToastDelay,
+                        duration: UX.undoToastDuration) { toast in
+            [
+                toast.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+                toast.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+                toast.bottomAnchor.constraint(equalTo: self.view.bottomAnchor,
+                                              constant: -self.toolbarHeight)
+            ]
+        }
+        shownToast = toast
+    }
+
     // MARK: - Redux
 
     func subscribeToRedux() {
@@ -120,6 +157,18 @@ class TabDisplayPanel: UIViewController,
         tabsState = state
         tabDisplayView.newState(state: tabsState)
         shouldShowEmptyView(tabsState.isPrivateTabsEmpty)
+
+        // Avoid showing toast multiple times
+        if let undoType = tabsState.undoToastType, 
+            shownToast == nil {
+            print("YRD presentUndoToast")
+            store.dispatch(TabPanelAction.hideUndoToast)
+            presentUndoToast(toastType: undoType) { undoClose in
+                if undoClose {
+                    store.dispatch(TabPanelAction.undoClose)
+                }
+            }
+        }
     }
 
     // MARK: EmptyPrivateTabsViewDelegate

--- a/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -75,6 +75,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     var selectedIndex: Int { return _selectedIndex }
     let logger: Logger
     var backupCloseTab: BackupCloseTab?
+    var backupCloseTabs = [Tab]()
 
     var tabDisplayType: TabDisplayType = .TabGrid
     let delaySelectingNewPopupTab: TimeInterval = 0.1
@@ -633,6 +634,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         storeChanges()
     }
 
+    // TODO: FXIOS-XXXX Remove when cleaning Legacy Tab Tray
     @MainActor
     func removeAllTabs(isPrivateMode: Bool) async {
         let currentModeTabs = tabs.filter { $0.isPrivate == isPrivateMode }
@@ -648,6 +650,9 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     func getInactiveTabs() -> [Tab] {
         return inactiveTabs
     }
+
+    @MainActor
+    func undoCloseInactiveTabs() { fatalError("should never be called") }
 
     func backgroundRemoveAllTabs(isPrivate: Bool = false,
                                  didClearTabs: @escaping (_ tabsToRemove: [Tab],

--- a/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -634,7 +634,6 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         storeChanges()
     }
 
-    // TODO: FXIOS-XXXX Remove when cleaning Legacy Tab Tray
     @MainActor
     func removeAllTabs(isPrivateMode: Bool) async {
         let currentModeTabs = tabs.filter { $0.isPrivate == isPrivateMode }

--- a/Client/TabManagement/TabManager.swift
+++ b/Client/TabManagement/TabManager.swift
@@ -18,6 +18,7 @@ protocol TabManager: AnyObject {
     var count: Int { get }
     var selectedTab: Tab? { get }
     var backupCloseTab: BackupCloseTab? { get set }
+    var backupCloseTabs: [Tab] { get set }
     var normalTabs: [Tab] { get }
     var normalActiveTabs: [Tab] { get }
     var inactiveTabs: [Tab] { get }
@@ -67,6 +68,7 @@ protocol TabManager: AnyObject {
     func removeAllTabs(isPrivateMode: Bool) async
     func getInactiveTabs() -> [Tab]
     func removeAllInactiveTabs() async
+    func undoCloseInactiveTabs()
 }
 
 extension TabManager {

--- a/Client/TabManagement/TabManagerImplementation.swift
+++ b/Client/TabManagement/TabManagerImplementation.swift
@@ -445,11 +445,19 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
 
     @MainActor
     override func removeAllInactiveTabs() async {
-        let currentModeTabs = getInactiveTabs()
+        backupCloseTabs = getInactiveTabs()
+        let currentModeTabs = backupCloseTabs
         for tab in currentModeTabs {
             await self.removeTab(tab.tabUUID)
         }
         storeChanges()
+    }
+
+    @MainActor
+    override func undoCloseInactiveTabs() {
+        tabs.append(contentsOf: backupCloseTabs)
+        storeChanges()
+        backupCloseTabs = [Tab]()
     }
 
     // MARK: - Notifiable

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -11,7 +11,8 @@ class MockTabManager: TabManager {
     let windowUUID = WindowUUID()
     var isRestoringTabs = false
     var selectedTab: Tab?
-    var backupCloseTab: Client.BackupCloseTab?
+    var backupCloseTab: BackupCloseTab?
+    var backupCloseTabs = [Tab]()
 
     var nextRecentlyAccessedNormalTabs = [Tab]()
 
@@ -141,8 +142,10 @@ class MockTabManager: TabManager {
 
     // MARK: - Inactive tabs
     func getInactiveTabs() -> [Tab] {
-        return [Tab]()
+        return inactiveTabs
     }
 
     func removeAllInactiveTabs() async {}
+
+    func undoCloseInactiveTabs() {}
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7860)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17547)

## :bulb: Description
Support for undo actions:
-  Close single tab (except last regular tab)
- Close single inactive tab
- Close all inactive tabs
TODO: Handle close all tabs and last regular tab

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

