### PR TITLE
Bugfix FXIOS-7663 [v122] Fix "Now Now" to "Not Now"

### DIFF
--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -2099,7 +2099,7 @@ extension String {
     public static let LoginsHelperDontSaveButtonTitle = MZLocalizedString(
         key: "LoginsHelper.DontSave.Button.v122",
         tableName: "LoginsHelper",
-        value: "Now Now",
+        value: "Not Now",
         comment: "Button to not save the user's password in the logins helper")
     public static let LoginsHelperUpdateButtonTitle = MZLocalizedString(
         key: "LoginsHelper.Update.Button",
@@ -2109,7 +2109,7 @@ extension String {
     public static let LoginsHelperDontUpdateButtonTitle = MZLocalizedString(
         key: "LoginsHelper.DontUpdate.Button.v122",
         tableName: "LoginsHelper",
-        value: "Now Now",
+        value: "Not Now",
         comment: "Button to not update the user's password in the logins helper")
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7663)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17619)

## :bulb: Description
Fix strings.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

