### PR TITLE
Bugfix FXIOS-7977 [v122] Fakespot - Sidebar incorrectly opens on a non-PDP page after a specific scenario

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1670,6 +1670,9 @@ class BrowserViewController: UIViewController,
             return
         }
 
+        // Do not update Fakespot when we are not on a selected tab
+        guard tabManager.selectedTab == tab else { return }
+
         if contentStackView.isSidebarVisible {
             // Sidebar is visible, update content
             navigationHandler?.updateFakespotSidebar(productURL: url,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7977)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17776)

## :bulb: Description
Skips updating Fakespot if tab is not selected.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

