### PR TITLE
Refactor FXIOS-7936 [v122] HomeLogoHeaderCell to be reusable + adjust padding

### DIFF
--- a/Client/Frontend/Home/LogoHeader/HomeLogoHeaderCell.swift
+++ b/Client/Frontend/Home/LogoHeader/HomeLogoHeaderCell.swift
@@ -9,7 +9,6 @@ import UIKit
 
 class HomeLogoHeaderCell: UICollectionViewCell, ReusableCell {
     private struct UX {
-        static let iPadAdjustment: CGFloat = -40
         struct Logo {
             static let iPhoneImageSize: CGFloat = 40
             static let iPadImageSize: CGFloat = 75
@@ -65,7 +64,7 @@ class HomeLogoHeaderCell: UICollectionViewCell, ReusableCell {
         contentView.addSubview(containerView)
 
         // TODO: Felt Privacy - Private mode in Redux to follow
-        let isiPadAndPrivate = UIDevice.current.userInterfaceIdiom == .pad && false
+        let isiPadAndPrivate = UIDevice.current.userInterfaceIdiom == .pad && true
         let logoSizeConstant = isiPadAndPrivate ? UX.Logo.iPadImageSize : UX.Logo.iPhoneImageSize
         let topAnchorConstant = isiPadAndPrivate ? UX.Logo.iPadTopConstant : UX.Logo.iPhoneTopConstant
         let textImageWidthConstant = isiPadAndPrivate ? UX.TextImage.iPadWidth : UX.TextImage.iPhoneWidth
@@ -95,8 +94,7 @@ class HomeLogoHeaderCell: UICollectionViewCell, ReusableCell {
         if isiPadAndPrivate {
             NSLayoutConstraint.activate([
                 containerView.centerXAnchor.constraint(
-                    equalTo: contentView.centerXAnchor,
-                    constant: UX.iPadAdjustment
+                    equalTo: contentView.centerXAnchor
                 ),
             ])
         } else {

--- a/Client/Frontend/Home/LogoHeader/HomeLogoHeaderCell.swift
+++ b/Client/Frontend/Home/LogoHeader/HomeLogoHeaderCell.swift
@@ -64,7 +64,7 @@ class HomeLogoHeaderCell: UICollectionViewCell, ReusableCell {
         contentView.addSubview(containerView)
 
         // TODO: Felt Privacy - Private mode in Redux to follow
-        let isiPadAndPrivate = UIDevice.current.userInterfaceIdiom == .pad && true
+        let isiPadAndPrivate = UIDevice.current.userInterfaceIdiom == .pad && false
         let logoSizeConstant = isiPadAndPrivate ? UX.Logo.iPadImageSize : UX.Logo.iPhoneImageSize
         let topAnchorConstant = isiPadAndPrivate ? UX.Logo.iPadTopConstant : UX.Logo.iPhoneTopConstant
         let textImageWidthConstant = isiPadAndPrivate ? UX.TextImage.iPadWidth : UX.TextImage.iPhoneWidth

--- a/Client/Frontend/Home/LogoHeader/HomeLogoHeaderViewModel.swift
+++ b/Client/Frontend/Home/LogoHeader/HomeLogoHeaderViewModel.swift
@@ -42,11 +42,12 @@ extension HomeLogoHeaderViewModel: HomepageViewModelProtocol, FeatureFlaggable {
 
         let section = NSCollectionLayoutSection(group: group)
 
+        let leadingInset = HomepageViewModel.UX.leadingInset(traitCollection: traitCollection)
         section.contentInsets = NSDirectionalEdgeInsets(
             top: 0,
-            leading: HomepageViewModel.UX.standardInset,
+            leading: leadingInset,
             bottom: UX.bottomSpacing,
-            trailing: HomepageViewModel.UX.standardInset)
+            trailing: leadingInset)
 
         return section
     }

--- a/Client/Frontend/Home/LogoHeader/HomeLogoHeaderViewModel.swift
+++ b/Client/Frontend/Home/LogoHeader/HomeLogoHeaderViewModel.swift
@@ -42,12 +42,11 @@ extension HomeLogoHeaderViewModel: HomepageViewModelProtocol, FeatureFlaggable {
 
         let section = NSCollectionLayoutSection(group: group)
 
-        let leadingInset = HomepageViewModel.UX.leadingInset(traitCollection: traitCollection)
         section.contentInsets = NSDirectionalEdgeInsets(
             top: 0,
-            leading: leadingInset,
+            leading: HomepageViewModel.UX.standardInset,
             bottom: UX.bottomSpacing,
-            trailing: 0)
+            trailing: HomepageViewModel.UX.standardInset)
 
         return section
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7936)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Refactor HomeLogoHeaderCell to be more easily reusable by centering the logo within the view
Update padding adjustments after reviewing with design

**Testing Steps**
Open up `feltPrivacyFeature.yaml` in `nimbus-features` in repo.
Change the value for `simplified-ui-enabled: true` under developer
Set `isiPadAndPrivate` to true in `HomeLogoHeaderCell`

**Expected Behavior:** Design matches the screenshots attached below.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

# Screenshots
| iPhone | iPad |
| --- | --- |
| ![Simulator Screenshot - iPhone 15 - 2023-12-18 at 10 50 21](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/2612344c-0aae-4fe7-8eb5-f6b1402dc18b)|  ![Simulator Screenshot - iPad Pro (11-inch) (4th generation) - 2023-12-18 at 10 53 32](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/10fb6779-8ddf-4a0a-a632-8998c04517ea) |

**Multitasking**
| iPad - Compact | iPad - Regular |
| --- | --- |
|![Simulator Screenshot - iPad Pro (11-inch) (4th generation) - 2023-12-18 at 10 54 27](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/c1682cce-c155-446a-8286-d836e7021943)|![Simulator Screenshot - iPad Pro (11-inch) (4th generation) - 2023-12-18 at 10 54 22](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/66bfcec2-f888-487a-b963-ed855f1e7668)| 