### PR TITLE
Refactor FXIOS-7889 [v123] Decouple BackForwardListViewController from BVC

### DIFF
--- a/Client/Frontend/Browser/BackForwardListViewController.swift
+++ b/Client/Frontend/Browser/BackForwardListViewController.swift
@@ -12,7 +12,7 @@ private struct BackForwardViewUX {
     static let RowHeight: CGFloat = 50
 }
 
-/// Provides information about the size of various BrowserViewController subviews.
+/// Provides information about the size of various BrowserViewController's subviews.
 protocol BrowserViewControllerFrameInfoProvider: AnyObject {
     func getBottomContainerSize() -> CGSize
 

--- a/Client/Frontend/Browser/BackForwardListViewController.swift
+++ b/Client/Frontend/Browser/BackForwardListViewController.swift
@@ -13,12 +13,12 @@ private struct BackForwardViewUX {
 }
 
 /// Provides information about the size of various BrowserViewController's subviews.
-protocol BrowserViewControllerFrameInfoProvider: AnyObject {
+protocol BrowserFrameInfoProvider: AnyObject {
     func getBottomContainerSize() -> CGSize
 
     func getHeaderSize() -> CGSize
 
-    func getOverKeyoboardContainerSize() -> CGSize
+    func getOverKeyboardContainerSize() -> CGSize
 }
 
 class BackForwardListViewController: UIViewController,
@@ -54,7 +54,7 @@ class BackForwardListViewController: UIViewController,
     lazy var shadow: UIView = .build { _ in }
 
     var tabManager: TabManager!
-    weak var browserViewControllerFrameInfoProvider: BrowserViewControllerFrameInfoProvider?
+    weak var browserFrameInfoProvider: BrowserFrameInfoProvider?
     var currentItem: WKBackForwardListItem?
     var listData = [WKBackForwardListItem]()
 
@@ -172,7 +172,6 @@ class BackForwardListViewController: UIViewController,
 
     override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
         super.willTransition(to: newCollection, with: coordinator)
-        guard let _ = browserViewControllerFrameInfoProvider else { return }
         if shouldShowToolbarForTraitCollection(newCollection) != snappedToBottom, !isBottomSearchBar {
             if snappedToBottom {
                 tableViewBottomAnchor.constant = 0
@@ -196,14 +195,14 @@ class BackForwardListViewController: UIViewController,
     }
 
     func remakeVerticalConstraints() {
-        guard let browserFrameInfo = browserViewControllerFrameInfoProvider else { return }
+        guard let browserFrameInfo = browserFrameInfoProvider else { return }
         for constraint in self.verticalConstraints {
             constraint.isActive = false
         }
         self.verticalConstraints = []
         if snappedToBottom {
-            let keyboardContainerHeight = browserFrameInfo.getOverKeyoboardContainerSize().height // bvc.overKeyboardContainer.frame.height
-            let toolbarContainerheight = browserFrameInfo.getBottomContainerSize().height // bvc.bottomContainer.frame.height
+            let keyboardContainerHeight = browserFrameInfo.getOverKeyboardContainerSize().height
+            let toolbarContainerheight = browserFrameInfo.getBottomContainerSize().height
             let offset = keyboardContainerHeight + toolbarContainerheight
             tableViewBottomAnchor = tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -offset)
             let constraints: [NSLayoutConstraint] = [
@@ -215,7 +214,7 @@ class BackForwardListViewController: UIViewController,
             verticalConstraints += constraints
         } else {
             let statusBarHeight = UIWindow.keyWindow?.windowScene?.statusBarManager?.statusBarFrame.height ?? 0
-            tableViewTopAnchor = tableView.topAnchor.constraint(equalTo: view.topAnchor, constant: browserFrameInfo.getHeaderSize().height + statusBarHeight) // bvc.header.frame.height + statusBarHeight)
+            tableViewTopAnchor = tableView.topAnchor.constraint(equalTo: view.topAnchor, constant: browserFrameInfo.getHeaderSize().height + statusBarHeight)
             let constraints: [NSLayoutConstraint] = [
                 tableViewTopAnchor,
                 shadow.topAnchor.constraint(equalTo: tableView.bottomAnchor),

--- a/Client/Frontend/Browser/BackForwardListViewController.swift
+++ b/Client/Frontend/Browser/BackForwardListViewController.swift
@@ -12,11 +12,21 @@ private struct BackForwardViewUX {
     static let RowHeight: CGFloat = 50
 }
 
+/// Provides information about the size of various BrowserViewController subviews.
+protocol BrowserViewControllerFrameInfoProvider: AnyObject {
+    func getBottomContainerSize() -> CGSize
+
+    func getHeaderSize() -> CGSize
+
+    func getOverKeyoboardContainerSize() -> CGSize
+}
+
 class BackForwardListViewController: UIViewController,
                                      UITableViewDataSource,
                                      UITableViewDelegate,
                                      UIGestureRecognizerDelegate,
-                                     Themeable {
+                                     Themeable,
+                                     SearchBarLocationProvider {
     private var profile: Profile
     private lazy var sites = [String: Site]()
     private var dismissing = false
@@ -44,7 +54,7 @@ class BackForwardListViewController: UIViewController,
     lazy var shadow: UIView = .build { _ in }
 
     var tabManager: TabManager!
-    weak var bvc: BrowserViewController?
+    weak var browserViewControllerFrameInfoProvider: BrowserViewControllerFrameInfoProvider?
     var currentItem: WKBackForwardListItem?
     var listData = [WKBackForwardListItem]()
 
@@ -89,8 +99,7 @@ class BackForwardListViewController: UIViewController,
         view.addSubview(shadow)
         view.addSubview(tableView)
 
-        let toolBarShouldShow = bvc?.shouldShowToolbarForTraitCollection(traitCollection) ?? false
-        let isBottomSearchBar = bvc?.isBottomSearchBar ?? false
+        let toolBarShouldShow = shouldShowToolbarForTraitCollection(traitCollection)
         snappedToBottom = toolBarShouldShow || isBottomSearchBar
         tableViewHeightAnchor = tableView.heightAnchor.constraint(equalToConstant: 0)
         NSLayoutConstraint.activate([
@@ -103,6 +112,10 @@ class BackForwardListViewController: UIViewController,
         ])
         remakeVerticalConstraints()
         view.layoutIfNeeded()
+    }
+
+    private func shouldShowToolbarForTraitCollection(_ previousTraitCollection: UITraitCollection) -> Bool {
+        return previousTraitCollection.verticalSizeClass != .compact && previousTraitCollection.horizontalSizeClass != .regular
     }
 
     func applyTheme() {
@@ -159,8 +172,8 @@ class BackForwardListViewController: UIViewController,
 
     override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
         super.willTransition(to: newCollection, with: coordinator)
-        guard let bvc = self.bvc else { return }
-        if bvc.shouldShowToolbarForTraitCollection(newCollection) != snappedToBottom, !bvc.isBottomSearchBar {
+        guard let _ = browserViewControllerFrameInfoProvider else { return }
+        if shouldShowToolbarForTraitCollection(newCollection) != snappedToBottom, !isBottomSearchBar {
             if snappedToBottom {
                 tableViewBottomAnchor.constant = 0
             } else {
@@ -183,14 +196,14 @@ class BackForwardListViewController: UIViewController,
     }
 
     func remakeVerticalConstraints() {
-        guard let bvc = self.bvc else { return }
+        guard let browserFrameInfo = browserViewControllerFrameInfoProvider else { return }
         for constraint in self.verticalConstraints {
             constraint.isActive = false
         }
         self.verticalConstraints = []
         if snappedToBottom {
-            let keyboardContainerHeight = bvc.overKeyboardContainer.frame.height
-            let toolbarContainerheight = bvc.bottomContainer.frame.height
+            let keyboardContainerHeight = browserFrameInfo.getOverKeyoboardContainerSize().height // bvc.overKeyboardContainer.frame.height
+            let toolbarContainerheight = browserFrameInfo.getBottomContainerSize().height // bvc.bottomContainer.frame.height
             let offset = keyboardContainerHeight + toolbarContainerheight
             tableViewBottomAnchor = tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -offset)
             let constraints: [NSLayoutConstraint] = [
@@ -202,7 +215,7 @@ class BackForwardListViewController: UIViewController,
             verticalConstraints += constraints
         } else {
             let statusBarHeight = UIWindow.keyWindow?.windowScene?.statusBarManager?.statusBarFrame.height ?? 0
-            tableViewTopAnchor = tableView.topAnchor.constraint(equalTo: view.topAnchor, constant: bvc.header.frame.height + statusBarHeight)
+            tableViewTopAnchor = tableView.topAnchor.constraint(equalTo: view.topAnchor, constant: browserFrameInfo.getHeaderSize().height + statusBarHeight) // bvc.header.frame.height + statusBarHeight)
             let constraints: [NSLayoutConstraint] = [
                 tableViewTopAnchor,
                 shadow.topAnchor.constraint(equalTo: tableView.bottomAnchor),

--- a/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -193,7 +193,7 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
         if let backForwardList = tabManager.selectedTab?.webView?.backForwardList {
             let backForwardViewController = BackForwardListViewController(profile: profile, backForwardList: backForwardList)
             backForwardViewController.tabManager = tabManager
-            backForwardViewController.browserViewControllerFrameUpdateDelegate = self
+            backForwardViewController.browserViewControllerFrameInfoProvider = self
             backForwardViewController.modalPresentationStyle = .overCurrentContext
             backForwardViewController.backForwardTransitionDelegate = BackForwardListAnimator()
             self.present(backForwardViewController, animated: true, completion: nil)

--- a/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -193,7 +193,7 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
         if let backForwardList = tabManager.selectedTab?.webView?.backForwardList {
             let backForwardViewController = BackForwardListViewController(profile: profile, backForwardList: backForwardList)
             backForwardViewController.tabManager = tabManager
-            backForwardViewController.bvc = self
+            backForwardViewController.browserViewControllerFrameUpdateDelegate = self
             backForwardViewController.modalPresentationStyle = .overCurrentContext
             backForwardViewController.backForwardTransitionDelegate = BackForwardListAnimator()
             self.present(backForwardViewController, animated: true, completion: nil)

--- a/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -193,7 +193,7 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
         if let backForwardList = tabManager.selectedTab?.webView?.backForwardList {
             let backForwardViewController = BackForwardListViewController(profile: profile, backForwardList: backForwardList)
             backForwardViewController.tabManager = tabManager
-            backForwardViewController.browserViewControllerFrameInfoProvider = self
+            backForwardViewController.browserFrameInfoProvider = self
             backForwardViewController.modalPresentationStyle = .overCurrentContext
             backForwardViewController.backForwardTransitionDelegate = BackForwardListAnimator()
             self.present(backForwardViewController, animated: true, completion: nil)

--- a/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1916,7 +1916,7 @@ class BrowserViewController: UIViewController,
         }
     }
 
-    // MARK: - BrowserViewControllerUpdateDelegate
+    // MARK: - BrowserViewControllerFrameInfoProvider
 
     func getHeaderSize() -> CGSize {
         return header.frame.size

--- a/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -22,7 +22,8 @@ class BrowserViewController: UIViewController,
                              LibraryPanelDelegate,
                              RecentlyClosedPanelDelegate,
                              QRCodeViewControllerDelegate,
-                             StoreSubscriber {
+                             StoreSubscriber,
+                             BrowserViewControllerFrameInfoProvider {
     private enum UX {
         static let ShowHeaderTapAreaHeight: CGFloat = 32
         static let ActionSheetTitleMaxLength = 120
@@ -1913,6 +1914,20 @@ class BrowserViewController: UIViewController,
         default:
             defaultAction()
         }
+    }
+
+    // MARK: - BrowserViewControllerUpdateDelegate
+
+    func getHeaderSize() -> CGSize {
+        return header.frame.size
+    }
+
+    func getBottomContainerSize() -> CGSize {
+        return bottomContainer.frame.size
+    }
+
+    func getOverKeyoboardContainerSize() -> CGSize {
+        return overKeyboardContainer.frame.size
     }
 }
 

--- a/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -23,7 +23,7 @@ class BrowserViewController: UIViewController,
                              RecentlyClosedPanelDelegate,
                              QRCodeViewControllerDelegate,
                              StoreSubscriber,
-                             BrowserViewControllerFrameInfoProvider {
+                             BrowserFrameInfoProvider {
     private enum UX {
         static let ShowHeaderTapAreaHeight: CGFloat = 32
         static let ActionSheetTitleMaxLength = 120
@@ -1916,7 +1916,7 @@ class BrowserViewController: UIViewController,
         }
     }
 
-    // MARK: - BrowserViewControllerFrameInfoProvider
+    // MARK: - BrowserFrameInfoProvider
 
     func getHeaderSize() -> CGSize {
         return header.frame.size
@@ -1926,7 +1926,7 @@ class BrowserViewController: UIViewController,
         return bottomContainer.frame.size
     }
 
-    func getOverKeyoboardContainerSize() -> CGSize {
+    func getOverKeyboardContainerSize() -> CGSize {
         return overKeyboardContainer.frame.size
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7889)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17624)

## :bulb: Description

Decouple `BackForewardListViewController` from `BVC`. The decouple was simply done by adding the protocol conformance of `SearchBarLocationProvider` and by replacing the `BVC` with an abstraction of it, that has the ability to provide information of BVC's subviews frame. If you have better solution let me know, thank you.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

