### PR TITLE
Refactor FXIOS-7797 [v123] iPad multi-window: restore tabs via UUID

### DIFF
--- a/BrowserKit/Sources/TabDataStore/TabDataStore.swift
+++ b/BrowserKit/Sources/TabDataStore/TabDataStore.swift
@@ -6,9 +6,10 @@ import Foundation
 import Common
 
 public protocol TabDataStore {
-    /// Fetches the previously saved window data (this contains the list of tabs) from disk, if it exists
+    /// Fetches the previously saved window data matching the provided UUID,
+    /// if it exists. This data contains the list of tabs.
     /// - Returns: The window data object if one was previously saved
-    func fetchWindowData() async -> WindowData?
+    func fetchWindowData(uuid: UUID) async -> WindowData?
 
     /// Saves the window data (contains the list of tabs) to disk
     /// - Parameter window: the window data object to be saved
@@ -47,12 +48,23 @@ public actor DefaultTabDataStore: TabDataStore {
 
     // MARK: Fetching Window Data
 
-    public func fetchWindowData() async -> WindowData? {
-        logger.log("Attempting to fetch window/tab data",
-                   level: .debug,
-                   category: .tabs)
-        let allWindows = await fetchAllWindowsData()
-        return allWindows.first
+    public func fetchWindowData(uuid: UUID) async -> WindowData? {
+        logger.log("Attempting to fetch window/tab data", level: .debug, category: .tabs)
+        do {
+            guard let fileURL = windowURLPath(for: uuid, isBackup: false),
+                  let windowData = parseWindowDataFile(fromURL: fileURL) else {
+                logger.log("Failed to open window/tab data for UUID: \(uuid)", level: .fatal, category: .tabs)
+                throw TabDataError.failedToFetchData
+            }
+            return windowData
+        } catch {
+            logger.log("Error fetching window data: UUID = \(uuid) Error = \(error)", level: .warning, category: .tabs)
+            guard let backupURL = windowURLPath(for: uuid, isBackup: false),
+                  let backupWindowData = parseWindowDataFile(fromURL: backupURL) else {
+                return nil
+            }
+            return backupWindowData
+        }
     }
 
     nonisolated public func fetchWindowDataUUIDs() -> [UUID] {
@@ -71,38 +83,8 @@ public actor DefaultTabDataStore: TabDataStore {
         }
     }
 
-    private func fetchAllWindowsData() async -> [WindowData] {
-        guard let directoryURL = fileManager.windowDataDirectory(isBackup: false) else {
-            logger.log("Could not resolve window data directory",
-                       level: .warning,
-                       category: .tabs)
-            return [WindowData]()
-        }
-
-        do {
-            let fileURLs = fileManager.contentsOfDirectory(at: directoryURL)
-            let windowsData = parseWindowDataFiles(fromURLs: fileURLs)
-            if windowsData.isEmpty {
-                if !fileURLs.isEmpty {
-                    // There was a file present but it failed to restore for some reason
-                    logger.log("Failed to open window/tab data",
-                               level: .fatal,
-                               category: .tabs)
-                }
-                throw TabDataError.failedToFetchData
-            }
-            return windowsData
-        } catch {
-            logger.log("Error fetching all window data: \(error)",
-                       level: .warning,
-                       category: .tabs)
-            guard let backupURL = fileManager.windowDataDirectory(isBackup: true) else {
-                return [WindowData]()
-            }
-            let fileURLs = fileManager.contentsOfDirectory(at: backupURL)
-            let windowsData = parseWindowDataFiles(fromURLs: fileURLs)
-            return windowsData
-        }
+    private func parseWindowDataFile(fromURL url: URL) -> WindowData? {
+        return parseWindowDataFiles(fromURLs: [url]).first
     }
 
     private func parseWindowDataFiles(fromURLs urlList: [URL]) -> [WindowData] {

--- a/BrowserKit/Sources/TabDataStore/TabDataStore.swift
+++ b/BrowserKit/Sources/TabDataStore/TabDataStore.swift
@@ -60,7 +60,7 @@ public actor DefaultTabDataStore: TabDataStore {
             return windowData
         } catch {
             logger.log("Error fetching window data: UUID = \(uuid) Error = \(error)", level: .warning, category: .tabs)
-            guard let backupURL = windowURLPath(for: uuid, isBackup: false),
+            guard let backupURL = windowURLPath(for: uuid, isBackup: true),
                   fileManager.fileExists(atPath: backupURL),
                   let backupWindowData = parseWindowDataFile(fromURL: backupURL) else {
                 return nil

--- a/BrowserKit/Sources/TabDataStore/TabDataStore.swift
+++ b/BrowserKit/Sources/TabDataStore/TabDataStore.swift
@@ -52,6 +52,7 @@ public actor DefaultTabDataStore: TabDataStore {
         logger.log("Attempting to fetch window/tab data", level: .debug, category: .tabs)
         do {
             guard let fileURL = windowURLPath(for: uuid, isBackup: false),
+                  fileManager.fileExists(atPath: fileURL),
                   let windowData = parseWindowDataFile(fromURL: fileURL) else {
                 logger.log("Failed to open window/tab data for UUID: \(uuid)", level: .fatal, category: .tabs)
                 throw TabDataError.failedToFetchData
@@ -60,6 +61,7 @@ public actor DefaultTabDataStore: TabDataStore {
         } catch {
             logger.log("Error fetching window data: UUID = \(uuid) Error = \(error)", level: .warning, category: .tabs)
             guard let backupURL = windowURLPath(for: uuid, isBackup: false),
+                  fileManager.fileExists(atPath: backupURL),
                   let backupWindowData = parseWindowDataFile(fromURL: backupURL) else {
                 return nil
             }

--- a/BrowserKit/Tests/TabDataStoreTests/TabDataStoreTests.swift
+++ b/BrowserKit/Tests/TabDataStoreTests/TabDataStoreTests.swift
@@ -9,6 +9,7 @@ import Common
 final class TabDataStoreTests: XCTestCase {
     private var mockFileManager: TabFileManagerMock!
     private let sleepTime: UInt64 = 1 * NSEC_PER_SEC
+    private var defaultTestTabWindowUUID = UUID(uuidString: "E3FF60DA-D1E7-407B-AA3B-130D48B3909D")!
 
     override func setUp() {
         super.setUp()
@@ -23,7 +24,7 @@ final class TabDataStoreTests: XCTestCase {
     // MARK: - Saving Data
 
     func testSaveWindowData_noWindowDataDirectory_returns() async throws {
-        let windowData = createMockWindow()
+        let windowData = createMockWindow(uuid: defaultTestTabWindowUUID)
         let subject = createSubject()
 
         await subject.saveWindowData(window: windowData, forced: false)
@@ -38,7 +39,7 @@ final class TabDataStoreTests: XCTestCase {
 
     func testSaveWindowData_createsDirectory_notForced() async throws {
         let subject = createSubject()
-        let windowData = createMockWindow()
+        let windowData = createMockWindow(uuid: defaultTestTabWindowUUID)
         mockFileManager.primaryDirectoryURL = URL(string: "some/directory")
         mockFileManager.pathContents = []
         mockFileManager.windowData = windowData
@@ -56,7 +57,7 @@ final class TabDataStoreTests: XCTestCase {
 
     func testSaveWindowDataWithBackup_doesntCreateDirectory_notForced() async throws {
         let subject = createSubject()
-        let windowData = createMockWindow()
+        let windowData = createMockWindow(uuid: defaultTestTabWindowUUID)
         mockFileManager.primaryDirectoryURL = URL(string: "some/directory1")
         mockFileManager.backupDirectoryURL = URL(string: "some/directory2")
         mockFileManager.pathContents = []
@@ -75,7 +76,7 @@ final class TabDataStoreTests: XCTestCase {
 
     func testSaveWindowDataForceAndNotForcedMix() async throws {
         let subject = createSubject()
-        let windowData = createMockWindow()
+        let windowData = createMockWindow(uuid: defaultTestTabWindowUUID)
         mockFileManager.primaryDirectoryURL = URL(string: "some/directory1")
         mockFileManager.backupDirectoryURL = URL(string: "some/directory2")
         mockFileManager.pathContents = []
@@ -99,9 +100,12 @@ final class TabDataStoreTests: XCTestCase {
     func testFetchWindowData_withoutDirectory_returnEmpty() async throws {
         let subject = createSubject()
 
-        let fetchedWindowData = await subject.fetchWindowData()
+        let fetchedWindowData = await subject.fetchWindowData(uuid: defaultTestTabWindowUUID)
 
-        XCTAssertEqual(mockFileManager.windowDataDirectoryCalledCount, 1)
+        // We expect two calls to windowDataDirectory since fetchWindowData
+        // will check first for the primary WindowData (for a given UUID)
+        // and then also check the backup URL location.
+        XCTAssertEqual(mockFileManager.windowDataDirectoryCalledCount, 2)
         XCTAssertEqual(mockFileManager.getWindowDataFromPathCalledCount, 0)
         XCTAssertNil(fetchedWindowData)
     }
@@ -110,7 +114,7 @@ final class TabDataStoreTests: XCTestCase {
         let subject = createSubject()
         mockFileManager.primaryDirectoryURL = URL(string: "some/directory")
 
-        let fetchedWindowData = await subject.fetchWindowData()
+        let fetchedWindowData = await subject.fetchWindowData(uuid: defaultTestTabWindowUUID)
 
         XCTAssertEqual(mockFileManager.windowDataDirectoryCalledCount, 2)
         XCTAssertEqual(mockFileManager.getWindowDataFromPathCalledCount, 0)
@@ -122,7 +126,7 @@ final class TabDataStoreTests: XCTestCase {
         mockFileManager.primaryDirectoryURL = URL(string: "some/directory")
         mockFileManager.backupDirectoryURL = URL(string: "some/directory")
 
-        let fetchedWindowData = await subject.fetchWindowData()
+        let fetchedWindowData = await subject.fetchWindowData(uuid: defaultTestTabWindowUUID)
 
         XCTAssertEqual(mockFileManager.windowDataDirectoryCalledCount, 2)
         XCTAssertEqual(mockFileManager.getWindowDataFromPathCalledCount, 0)
@@ -131,15 +135,16 @@ final class TabDataStoreTests: XCTestCase {
 
     func testFetchWindowData_withWindowData_returnFetchedWindow() async throws {
         let subject = createSubject()
-        let windowData = createMockWindow()
+        let windowData = createMockWindow(uuid: defaultTestTabWindowUUID)
         mockFileManager.primaryDirectoryURL = URL(string: "some/directory")
         mockFileManager.pathContents = [URL(string: "some/directory")!]
+        mockFileManager.fileExists = true
         mockFileManager.windowData = windowData
 
-        let fetchedWindowData = await subject.fetchWindowData()
+        let fetchedWindowData = await subject.fetchWindowData(uuid: defaultTestTabWindowUUID)
 
         XCTAssertEqual(mockFileManager.windowDataDirectoryCalledCount, 1)
-        XCTAssertEqual(mockFileManager.contentsOfDirectoryCalledCount, 1)
+        XCTAssertEqual(mockFileManager.contentsOfDirectoryCalledCount, 0)
         XCTAssertEqual(mockFileManager.getWindowDataFromPathCalledCount, 1)
         XCTAssertEqual(fetchedWindowData?.id, windowData.id)
     }
@@ -148,7 +153,7 @@ final class TabDataStoreTests: XCTestCase {
 
     func testPreserveBeforeRestore() async throws {
         let subject = createSubject()
-        let windowData = createMockWindow()
+        let windowData = createMockWindow(uuid: defaultTestTabWindowUUID)
         mockFileManager.primaryDirectoryURL = URL(string: "some/directory1")
         mockFileManager.backupDirectoryURL = URL(string: "some/directory2")
         mockFileManager.pathContents = [URL(string: "some/directory")!]
@@ -156,7 +161,7 @@ final class TabDataStoreTests: XCTestCase {
 
         await subject.saveWindowData(window: windowData, forced: false) // preserve
         try await Task.sleep(nanoseconds: sleepTime)
-        let fetchedWindowData = await subject.fetchWindowData() // restore
+        let fetchedWindowData = await subject.fetchWindowData(uuid: defaultTestTabWindowUUID) // restore
         try await Task.sleep(nanoseconds: sleepTime)
 
         XCTAssertEqual(fetchedWindowData?.id, windowData.id)
@@ -165,13 +170,13 @@ final class TabDataStoreTests: XCTestCase {
 
     func testRestoreBeforePreserve() async throws {
         let subject = createSubject()
-        let windowData = createMockWindow()
+        let windowData = createMockWindow(uuid: defaultTestTabWindowUUID)
         mockFileManager.primaryDirectoryURL = URL(string: "some/directory1")
         mockFileManager.backupDirectoryURL = URL(string: "some/directory2")
         mockFileManager.pathContents = [URL(string: "some/directory")!]
         mockFileManager.fileExists = true
 
-        let fetchedWindowData = await subject.fetchWindowData() // restore
+        let fetchedWindowData = await subject.fetchWindowData(uuid: defaultTestTabWindowUUID) // restore
         await subject.saveWindowData(window: windowData, forced: false) // preserve
         try await Task.sleep(nanoseconds: sleepTime)
 
@@ -180,8 +185,8 @@ final class TabDataStoreTests: XCTestCase {
 
     func testSavingTwiceReturnsMostRecentData() async throws {
         let subject = createSubject()
-        let windowData1 = createMockWindow()
-        let windowData2 = createMockWindow(uuidString: "ABFF60DA-D1E7-407B-AA3B-130D48B31012")
+        let windowData1 = createMockWindow(uuid: defaultTestTabWindowUUID)
+        let windowData2 = createMockWindow(uuid: UUID(uuidString: "ABFF60DA-D1E7-407B-AA3B-130D48B31012")!)
         mockFileManager.primaryDirectoryURL = URL(string: "some/directory1")
         mockFileManager.backupDirectoryURL = URL(string: "some/directory2")
         mockFileManager.pathContents = [URL(string: "some/directory")!]
@@ -191,7 +196,7 @@ final class TabDataStoreTests: XCTestCase {
         await subject.saveWindowData(window: windowData2, forced: false) // preserve
         try await Task.sleep(nanoseconds: sleepTime)
 
-        let fetchedWindowData = await subject.fetchWindowData() // restore
+        let fetchedWindowData = await subject.fetchWindowData(uuid: defaultTestTabWindowUUID) // restore
         try await Task.sleep(nanoseconds: sleepTime)
 
         XCTAssertEqual(fetchedWindowData?.id, windowData2.id)
@@ -231,11 +236,9 @@ final class TabDataStoreTests: XCTestCase {
         return tabs
     }
 
-    func createMockWindow(
-        uuidString: String = "E3FF60DA-D1E7-407B-AA3B-130D48B3909D"
-    ) -> WindowData {
+    func createMockWindow(uuid: UUID) -> WindowData {
         let tabs = createMockTabs()
-        return WindowData(id: UUID(uuidString: uuidString)!,
+        return WindowData(id: uuid,
                           isPrimary: true,
                           activeTabId: tabs[0].id,
                           tabData: tabs)

--- a/BrowserKit/Tests/TabDataStoreTests/TabDataStoreTests.swift
+++ b/BrowserKit/Tests/TabDataStoreTests/TabDataStoreTests.swift
@@ -9,7 +9,7 @@ import Common
 final class TabDataStoreTests: XCTestCase {
     private var mockFileManager: TabFileManagerMock!
     private let sleepTime: UInt64 = 1 * NSEC_PER_SEC
-    private var defaultTestTabWindowUUID = UUID(uuidString: "E3FF60DA-D1E7-407B-AA3B-130D48B3909D")!
+    private let defaultTestTabWindowUUID = UUID(uuidString: "E3FF60DA-D1E7-407B-AA3B-130D48B3909D")!
 
     override func setUp() {
         super.setUp()

--- a/BrowserKit/Tests/TabDataStoreTests/TabFileManagerTests.swift
+++ b/BrowserKit/Tests/TabDataStoreTests/TabFileManagerTests.swift
@@ -8,6 +8,7 @@ import XCTest
 import Common
 
 final class TabFileManagerTests: XCTestCase {
+    private var defaultTestTabWindowUUID = UUID(uuidString: "E3FF60DA-D1E7-407B-AA3B-130D48B3909D")!
     override func setUp() {
         super.setUp()
         BrowserKitInformation.shared.configure(buildChannel: .developer,
@@ -62,7 +63,7 @@ final class TabFileManagerTests: XCTestCase {
 
     func createMockWindow() -> WindowData {
         let tabs = createMockTabs()
-        return WindowData(id: UUID(uuidString: "E3FF60DA-D1E7-407B-AA3B-130D48B3909D")!,
+        return WindowData(id: defaultTestTabWindowUUID,
                           isPrimary: true,
                           activeTabId: tabs[0].id,
                           tabData: tabs)

--- a/BrowserKit/Tests/TabDataStoreTests/TabFileManagerTests.swift
+++ b/BrowserKit/Tests/TabDataStoreTests/TabFileManagerTests.swift
@@ -8,7 +8,7 @@ import XCTest
 import Common
 
 final class TabFileManagerTests: XCTestCase {
-    private var defaultTestTabWindowUUID = UUID(uuidString: "E3FF60DA-D1E7-407B-AA3B-130D48B3909D")!
+    private let defaultTestTabWindowUUID = UUID(uuidString: "E3FF60DA-D1E7-407B-AA3B-130D48B3909D")!
     override func setUp() {
         super.setUp()
         BrowserKitInformation.shared.configure(buildChannel: .developer,

--- a/Client/Application/WindowManager.swift
+++ b/Client/Application/WindowManager.swift
@@ -82,12 +82,14 @@ final class WindowManagerImplementation: WindowManager {
         // • If no saved windows (tab data), we generate a new UUID.
         // • If user has saved windows (tab data), we return the first available UUID
         //   not already associated with an open window.
-        // • If multiple window UUIDs are available, which is returned first is undefined.
-        //   TODO: [FXIOS-7929] ^ Temporary, part of ongoing multi-window work, eventually
+        // • If multiple window UUIDs are available, we currently return the first one
+        //   after sorting based on the uuid value.
+        //   TODO: [FXIOS-7929] This ^ is temporary, part of ongoing multi-window work, eventually
         //   we'll be updating this (to use `isPrimary` on WindowData etc). Forthcoming.
         let openWindowUUIDs = windows.keys
         let uuids = tabDataStore.fetchWindowDataUUIDs().filter { !openWindowUUIDs.contains($0) }
-        return uuids.first ?? WindowUUID()
+        let sortedUUIDs = uuids.sorted(by: { return $0.uuidString > $1.uuidString })
+        return sortedUUIDs.first ?? WindowUUID()
     }
 
     // MARK: - Internal Utilities

--- a/Client/Coordinators/Scene/SceneCoordinator.swift
+++ b/Client/Coordinators/Scene/SceneCoordinator.swift
@@ -24,6 +24,10 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
         self.screenshotService = screenshotService
         self.sceneContainer = sceneContainer
         self.windowManager = windowManager
+        // Note: this is where we singularly decide the UUID for this specific iOS browser window (UIScene).
+        // The logic is handled by `nextAvailableWindowUUID`, but this is the point at which a window's UUID
+        // is set; this same UUID will be injected throughout several of the window's related components
+        // such as its TabManager instance, which also has the window UUID property as a convenience.
         self.windowUUID = windowManager.nextAvailableWindowUUID()
 
         let navigationController = sceneSetupHelper.createNavigationController()

--- a/Client/TabManagement/TabManagerImplementation.swift
+++ b/Client/TabManagement/TabManagerImplementation.swift
@@ -99,7 +99,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
     private func restoreOnly() {
         tabs = [Tab]()
         Task {
-            await buildTabRestore(window: await self.tabDataStore.fetchWindowData())
+            await buildTabRestore(window: await self.tabDataStore.fetchWindowData(uuid: windowUUID))
             logger.log("Tabs restore ended after fetching window data", level: .debug, category: .tabs)
             logger.log("Normal tabs count; \(normalTabs.count), Inactive tabs count; \(inactiveTabs.count), Private tabs count; \(privateTabs.count)", level: .debug, category: .tabs)
         }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Mocks/MockTabDataStore.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Mocks/MockTabDataStore.swift
@@ -16,7 +16,7 @@ class MockTabDataStore: TabDataStore {
         return persistedTabWindowUUIDs
     }
 
-    func fetchWindowData() async -> WindowData? {
+    func fetchWindowData(uuid: UUID) async -> WindowData? {
         fetchWindowDataCalledCount += 1
         return fetchTabWindowData
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7797)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17393)

## :bulb: Description

Related: https://github.com/mozilla-mobile/firefox-ios/pull/17771.

This PR includes additional refactors as part of early work to support iPad multi-window. This updates tab restoration code to be based on UUID.

👉 For single-window usage in iOS (the default behavior on current `main`) this should impart no changes in behavior.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

