### PR TITLE
Refactor FXIOS-7980 [v123] Adjust load file URL in WKEngineSession

### DIFF
--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -51,9 +51,9 @@ class WKEngineSession: EngineSession {
         guard let url = URL(string: url) else { return }
         let request = URLRequest(url: url)
 
-        // TODO: FXIOS-7980 Review loadFileURL usage with isPrivileged
-        if let url = request.url, url.isFileURL, request.isPrivileged {
-            webView.loadFileURL(url, allowingReadAccessTo: url)
+        if let url = request.url, url.isFileURL {
+            webView.loadFileURL(url, allowingReadAccessTo: url.deletingLastPathComponent())
+            return
         }
         webView.load(request)
     }

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebView.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebView.swift
@@ -21,16 +21,23 @@ class MockWKEngineWebView: WKEngineWebView {
     var goForwardCalled = 0
     var removeAllUserScriptsCalled = 0
     var removeFromSuperviewCalled = 0
+    
+    var loadRequest: URLRequest?
+    var loadFileURL: URL?
+    var loadFileReadAccessURL: URL?
 
     required init?(frame: CGRect,
                    configurationProvider: WKEngineConfigurationProvider) {}
 
     func load(_ request: URLRequest) -> WKNavigation? {
+        loadRequest = request
         loadCalled += 1
         return nil
     }
 
     func loadFileURL(_ URL: URL, allowingReadAccessTo readAccessURL: URL) -> WKNavigation? {
+        loadFileURL = URL
+        loadFileReadAccessURL = readAccessURL
         loadFileURLCalled += 1
         return nil
     }

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebView.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebView.swift
@@ -21,7 +21,7 @@ class MockWKEngineWebView: WKEngineWebView {
     var goForwardCalled = 0
     var removeAllUserScriptsCalled = 0
     var removeFromSuperviewCalled = 0
-    
+
     var loadRequest: URLRequest?
     var loadFileURL: URL?
     var loadFileReadAccessURL: URL?

--- a/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
@@ -49,6 +49,7 @@ final class WKEngineSessionTests: XCTestCase {
         subject?.load(url: url)
 
         XCTAssertEqual(webViewProvider.webView.loadCalled, 1)
+        XCTAssertEqual(webViewProvider.webView.loadRequest?.url?.absoluteString, "https://example.com")
     }
 
     func testLoadURLGivenReaderModeURLThenLoad() {
@@ -58,16 +59,20 @@ final class WKEngineSessionTests: XCTestCase {
         subject?.load(url: url)
 
         XCTAssertEqual(webViewProvider.webView.loadCalled, 1)
+        XCTAssertEqual(webViewProvider.webView.loadRequest?.url?.absoluteString,
+                       "http://localhost:0/reader-mode/page?url=http%3A%2F%2Fexample%2Ecom")
     }
 
     func testLoadURLGivenFileURLThenLoadFileURL() {
         let subject = createSubject()
-        let url = "file:location"
+        let url = "file://path/to/abc/dirA/A.html"
 
         subject?.load(url: url)
 
-        // TODO: FXIOS-7980 Review loadFileURL usage with isPrivileged
-        XCTAssertEqual(webViewProvider.webView.loadCalled, 1)
+        XCTAssertEqual(webViewProvider.webView.loadCalled, 0)
+        XCTAssertEqual(webViewProvider.webView.loadFileURLCalled, 1)
+        XCTAssertEqual(webViewProvider.webView.loadFileURL?.absoluteString, "file://path/to/abc/dirA/A.html")
+        XCTAssertEqual(webViewProvider.webView.loadFileReadAccessURL?.absoluteString, "file://path/to/abc/dirA/")
     }
 
     // MARK: Stop URL


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7980)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17782)

## :bulb: Description
Adjust load file URL in WKEngineSession by removing the check to `request.isPrivileged`. In the Client we're currently never calling `loadFileURL` if for example we are loading a downloaded HTML or PDF file. This introduces issues where if I leave the app on a tab that has a local PDF or an HTML, then we never restore that tab as it should (since the local file is not reloaded, as we didn't use the proper API it seems). This will fix that issue. I am also ensuring the `allowingReadAccessTo` URL is in fact the folder in which the local files are located, as this can prevent otherwise further local file URLs from loading (so I am in fact loading as [this article](https://www.hackingwithswift.com/articles/112/the-ultimate-guide-to-wkwebview) is suggesting). 

I am on the fence whether I make this change on the Client side as well. Any opinions?

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

