### PR TITLE
Disabled MTE-2024 [v123] flaky tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DesktopModeTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DesktopModeTests.swift
@@ -32,15 +32,16 @@ class DesktopModeTestsIpad: IpadOnlyTestCase {
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
 
-        navigator.performAction(Action.AcceptRemovingAllTabs)
-        waitUntilPageLoad()
-
-        // Covering scenario that when closing a tab and re-opening should preserve Mobile mode
-        navigator.nowAt(NewTabScreen)
-        navigator.createNewTab()
-        navigator.openURL(path(forTestPage: "test-user-agent.html"))
-        waitUntilPageLoad()
-        XCTAssert(app.webViews.staticTexts.matching(identifier: "MOBILE_UA").count > 0)
+        // Disabling next steps due to https://github.com/mozilla-mobile/firefox-ios/issues/16810 crash
+//        navigator.performAction(Action.AcceptRemovingAllTabs)
+//        waitUntilPageLoad()
+//
+//        // Covering scenario that when closing a tab and re-opening should preserve Mobile mode
+//        navigator.nowAt(NewTabScreen)
+//        navigator.createNewTab()
+//        navigator.openURL(path(forTestPage: "test-user-agent.html"))
+//        waitUntilPageLoad()
+//        XCTAssert(app.webViews.staticTexts.matching(identifier: "MOBILE_UA").count > 0)
     }
 }
 
@@ -210,14 +211,15 @@ class DesktopModeTestsIphone: IphoneOnlyTestCase {
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
 
-        navigator.performAction(Action.AcceptRemovingAllTabs)
-        waitUntilPageLoad()
-        navigator.nowAt(NewTabScreen)
-        // Covering scenario that when closing a tab and re-opening should preserve Desktop mode
-        navigator.createNewTab()
-        navigator.openURL(path(forTestPage: "test-user-agent.html"))
-        waitUntilPageLoad()
-        XCTAssert(app.webViews.staticTexts.matching(identifier: "DESKTOP_UA").count > 0)
+        // Disabling next steps due to https://github.com/mozilla-mobile/firefox-ios/issues/16810 crash
+//        navigator.performAction(Action.AcceptRemovingAllTabs)
+//        waitUntilPageLoad()
+//        navigator.nowAt(NewTabScreen)
+//        // Covering scenario that when closing a tab and re-opening should preserve Desktop mode
+//        navigator.createNewTab()
+//        navigator.openURL(path(forTestPage: "test-user-agent.html"))
+//        waitUntilPageLoad()
+//        XCTAssert(app.webViews.staticTexts.matching(identifier: "DESKTOP_UA").count > 0)
     }
 }
 // swiftlint:enable empty_count

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
@@ -71,9 +71,9 @@ class PhotonActionSheetTests: BaseTestCase {
         mozWaitForElementToExist(app.otherElements["ActivityListView"].otherElements["example.com"])
         mozWaitForElementToExist(app.collectionViews.cells["Copy"], timeout: TIMEOUT)
 
-        var  fennecElement = app.collectionViews.scrollViews.cells.element(boundBy: 2)
+        var  fennecElement = app.collectionViews.scrollViews.cells.elementContainingText("Fennec")
         if iPad() {
-            fennecElement = app.collectionViews.scrollViews.cells.element(boundBy: 1)
+            fennecElement = app.collectionViews.scrollViews.cells.element(boundBy: 2)
         }
         mozWaitForElementToExist(fennecElement, timeout: 5)
         fennecElement.tap()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ReadingListTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ReadingListTests.swift
@@ -192,8 +192,9 @@ class ReadingListTests: BaseTestCase {
         updateScreenGraph()
         // Now there should be two tabs open
         navigator.goto(HomePanelsScreen)
-        let numTabAfter = app.buttons["Show Tabs"].value as? String
-        XCTAssertEqual(numTabAfter, "2")
+        // Disabling validation of tab count until https://github.com/mozilla-mobile/firefox-ios/issues/17579 is fixed
+//        let numTabAfter = app.buttons["Show Tabs"].value as? String
+//        XCTAssertEqual(numTabAfter, "2")
     }
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2307001

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TopTabsTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TopTabsTest.swift
@@ -148,26 +148,27 @@ class TopTabsTest: BaseTestCase {
         }
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
 
+        // Disabling next steps due to https://github.com/mozilla-mobile/firefox-ios/issues/16810 crash
         // Close all tabs, undo it and check that the number of tabs is correct
-        navigator.performAction(Action.AcceptRemovingAllTabs)
-
-        mozWaitForElementToExist(app.otherElements.buttons.staticTexts["Undo"])
-        app.otherElements.buttons.staticTexts["Undo"].tap()
-
-        mozWaitForElementToExist(app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell], timeout: 5)
-        navigator.nowAt(BrowserTab)
-        if !iPad() {
-            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 5)
-        }
-
-        if iPad() {
-            navigator.goto(TabTray)
-        } else {
-            navigator.performAction(Action.CloseURLBarOpen)
-        }
-        checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
-
-        mozWaitForElementToExist(app.cells.staticTexts[urlLabel])
+//        navigator.performAction(Action.AcceptRemovingAllTabs)
+//
+//        mozWaitForElementToExist(app.otherElements.buttons.staticTexts["Undo"])
+//        app.otherElements.buttons.staticTexts["Undo"].tap()
+//
+//        mozWaitForElementToExist(app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell], timeout: 5)
+//        navigator.nowAt(BrowserTab)
+//        if !iPad() {
+//            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 5)
+//        }
+//
+//        if iPad() {
+//            navigator.goto(TabTray)
+//        } else {
+//            navigator.performAction(Action.CloseURLBarOpen)
+//        }
+//        checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
+//
+//        mozWaitForElementToExist(app.cells.staticTexts[urlLabel])
     }
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2354473
@@ -222,14 +223,15 @@ class TopTabsTest: BaseTestCase {
         navigator.nowAt(NewTabScreen)
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
 
+        // Disabling next steps due to https://github.com/mozilla-mobile/firefox-ios/issues/16810 crash
         // Close all tabs and check that the number of tabs is correct
-        navigator.performAction(Action.AcceptRemovingAllTabs)
-        if !iPad() {
-            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton])
-        }
-        navigator.nowAt(NewTabScreen)
-        checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
-        mozWaitForElementToExist(app.cells.staticTexts["Homepage"])
+//        navigator.performAction(Action.AcceptRemovingAllTabs)
+//        if !iPad() {
+//            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton])
+//        }
+//        navigator.nowAt(NewTabScreen)
+//        checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
+//        mozWaitForElementToExist(app.cells.staticTexts["Homepage"])
     }
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2354580


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2024)

## :bulb: Description
Disabled the flaky tests affected by:
https://github.com/mozilla-mobile/firefox-ios/issues/17579
https://github.com/mozilla-mobile/firefox-ios/issues/16810
Included a fix for testSharePageWithShareSheetOptions that started to fail because the position of the element on the page has changed.
