### PR TITLE
Bugfix FXIOS-7985 [v122] Display 3 lines of title for ads

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/Buttons/LinkButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/LinkButton.swift
@@ -6,9 +6,11 @@ import Common
 import UIKit
 
 public class LinkButton: UIButton, ThemeApplicable {
-    var foregroundColorForState: ((UIControl.State) -> UIColor)?
-    var numberOfLines = 0
+    private var numberOfLines = 0
     private var previousFrame: CGRect = .zero
+    private var foregroundColorNormal: UIColor = .clear
+    private var foregroundColorHighlighted: UIColor = .clear
+    private var backgroundColorNormal: UIColor = .clear
 
     public override var frame: CGRect {
         didSet {
@@ -57,13 +59,18 @@ public class LinkButton: UIButton, ThemeApplicable {
     }
 
     override public func updateConfiguration() {
-        guard let config = configuration else {
+        guard var updatedConfiguration = configuration else {
             return
         }
-        var updatedConfiguration = config
-        let foregroundColor = foregroundColorForState?(state)
 
-        updatedConfiguration.baseForegroundColor = foregroundColor
+        switch state {
+        case [.highlighted]:
+            updatedConfiguration.baseForegroundColor = foregroundColorHighlighted
+        default:
+            updatedConfiguration.baseForegroundColor = foregroundColorNormal
+        }
+
+        updatedConfiguration.background.backgroundColor = backgroundColorNormal
         configuration = updatedConfiguration
     }
 
@@ -97,19 +104,9 @@ public class LinkButton: UIButton, ThemeApplicable {
     // MARK: ThemeApplicable
 
     public func applyTheme(theme: Theme) {
-        var updatedConfiguration = configuration
-
-        foregroundColorForState = { state in
-            switch state {
-            case [.highlighted]:
-                return theme.colors.actionPrimaryHover
-            default:
-                return theme.colors.textAccent
-            }
-        }
-
-        updatedConfiguration?.baseForegroundColor = foregroundColorForState?(state)
-        updatedConfiguration?.baseBackgroundColor = .clear
-        configuration = updatedConfiguration
+        foregroundColorNormal = theme.colors.textAccent
+        foregroundColorHighlighted = theme.colors.actionPrimaryHover
+        backgroundColorNormal = .clear
+        setNeedsUpdateConfiguration()
     }
 }

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/LinkButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/LinkButton.swift
@@ -7,15 +7,22 @@ import UIKit
 
 public class LinkButton: UIButton, ThemeApplicable {
     var foregroundColorForState: ((UIControl.State) -> UIColor)?
+    var numberOfLines = 0
+    private var previousFrame: CGRect = .zero
+
+    public override var frame: CGRect {
+        didSet {
+            guard previousFrame != frame, numberOfLines > 0 else { return }
+
+            previousFrame = frame
+            invalidateIntrinsicContentSize()
+        }
+    }
 
     override init(frame: CGRect) {
         super.init(frame: frame)
 
         configuration = UIButton.Configuration.plain()
-        backgroundColor = .clear
-        titleLabel?.adjustsFontForContentSizeCategory = true
-        titleLabel?.numberOfLines = 0
-        titleLabel?.lineBreakMode = .byWordWrapping
     }
 
     public func configure(viewModel: LinkButtonViewModel) {
@@ -23,8 +30,6 @@ public class LinkButton: UIButton, ThemeApplicable {
             return
         }
         var updatedConfiguration = config
-
-        accessibilityIdentifier = viewModel.a11yIdentifier
 
         updatedConfiguration.title = viewModel.title
         updatedConfiguration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
@@ -34,9 +39,16 @@ public class LinkButton: UIButton, ThemeApplicable {
             return outgoing
         }
         updatedConfiguration.contentInsets = viewModel.contentInsets
-        configuration = updatedConfiguration
 
+        accessibilityIdentifier = viewModel.a11yIdentifier
         contentHorizontalAlignment = viewModel.contentHorizontalAlignment
+
+        if viewModel.numberOfLines > 0 {
+            updatedConfiguration.titleLineBreakMode = .byTruncatingTail
+            self.numberOfLines = viewModel.numberOfLines
+        }
+
+        configuration = updatedConfiguration
         layoutIfNeeded()
     }
 
@@ -55,6 +67,33 @@ public class LinkButton: UIButton, ThemeApplicable {
         configuration = updatedConfiguration
     }
 
+    override public func layoutSubviews() {
+        super.layoutSubviews()
+
+        guard let titleLabel, numberOfLines > 0 else { return }
+
+        titleLabel.numberOfLines = numberOfLines
+        sizeToFit()
+    }
+
+    override public var intrinsicContentSize: CGSize {
+        guard let title = titleLabel,
+              let configuration,
+              numberOfLines > 0
+        else {
+            return super.intrinsicContentSize
+        }
+
+        let widthContentInset = configuration.contentInsets.leading + configuration.contentInsets.trailing
+        let heightContentInset = configuration.contentInsets.top + configuration.contentInsets.bottom
+
+        let availableWidth = frame.width - widthContentInset
+        let size = title.sizeThatFits(CGSize(width: availableWidth, height: .greatestFiniteMagnitude))
+
+        return CGSize(width: size.width + widthContentInset,
+                      height: size.height + heightContentInset)
+    }
+
     // MARK: ThemeApplicable
 
     public func applyTheme(theme: Theme) {
@@ -70,6 +109,7 @@ public class LinkButton: UIButton, ThemeApplicable {
         }
 
         updatedConfiguration?.baseForegroundColor = foregroundColorForState?(state)
+        updatedConfiguration?.baseBackgroundColor = .clear
         configuration = updatedConfiguration
     }
 }

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/LinkButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/LinkButton.swift
@@ -5,23 +5,10 @@
 import Common
 import UIKit
 
-public class LinkButton: UIButton, ThemeApplicable {
-    private var numberOfLines = 0
-    private var previousFrame: CGRect = .zero
+open class LinkButton: UIButton, ThemeApplicable {
     private var foregroundColorNormal: UIColor = .clear
     private var foregroundColorHighlighted: UIColor = .clear
     private var backgroundColorNormal: UIColor = .clear
-
-    override public var frame: CGRect {
-        didSet {
-            // invalidate intrinsic content size so that we calculate it correctly
-            // when not the full button text should be shown
-            guard previousFrame != frame, numberOfLines > 0 else { return }
-
-            previousFrame = frame
-            invalidateIntrinsicContentSize()
-        }
-    }
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -29,7 +16,7 @@ public class LinkButton: UIButton, ThemeApplicable {
         configuration = UIButton.Configuration.plain()
     }
 
-    public func configure(viewModel: LinkButtonViewModel) {
+    open func configure(viewModel: LinkButtonViewModel) {
         guard let config = configuration else {
             return
         }
@@ -47,16 +34,11 @@ public class LinkButton: UIButton, ThemeApplicable {
         accessibilityIdentifier = viewModel.a11yIdentifier
         contentHorizontalAlignment = viewModel.contentHorizontalAlignment
 
-        if viewModel.numberOfLines > 0 {
-            updatedConfiguration.titleLineBreakMode = .byTruncatingTail
-            self.numberOfLines = viewModel.numberOfLines
-        }
-
         configuration = updatedConfiguration
         layoutIfNeeded()
     }
 
-    required init?(coder aDecoder: NSCoder) {
+    public required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
@@ -74,36 +56,6 @@ public class LinkButton: UIButton, ThemeApplicable {
 
         updatedConfiguration.background.backgroundColor = backgroundColorNormal
         configuration = updatedConfiguration
-    }
-
-    override public func layoutSubviews() {
-        super.layoutSubviews()
-
-        guard let titleLabel, numberOfLines > 0 else { return }
-
-        // hack to be able to restrict the number of lines displayed
-        titleLabel.numberOfLines = numberOfLines
-        sizeToFit()
-    }
-
-    override public var intrinsicContentSize: CGSize {
-        // will only be calculated when the number of lines displayed is restricted
-        // without autolayout is not working correctly
-        guard let title = titleLabel,
-              let configuration,
-              numberOfLines > 0
-        else {
-            return super.intrinsicContentSize
-        }
-
-        let widthContentInset = configuration.contentInsets.leading + configuration.contentInsets.trailing
-        let heightContentInset = configuration.contentInsets.top + configuration.contentInsets.bottom
-
-        let availableWidth = frame.width - widthContentInset
-        let size = title.sizeThatFits(CGSize(width: availableWidth, height: .greatestFiniteMagnitude))
-
-        return CGSize(width: size.width + widthContentInset,
-                      height: size.height + heightContentInset)
     }
 
     // MARK: ThemeApplicable

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/LinkButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/LinkButton.swift
@@ -12,8 +12,10 @@ public class LinkButton: UIButton, ThemeApplicable {
     private var foregroundColorHighlighted: UIColor = .clear
     private var backgroundColorNormal: UIColor = .clear
 
-    public override var frame: CGRect {
+    override public var frame: CGRect {
         didSet {
+            // invalidate intrinsic content size so that we calculate it correctly
+            // when not the full button text should be shown
             guard previousFrame != frame, numberOfLines > 0 else { return }
 
             previousFrame = frame
@@ -79,11 +81,14 @@ public class LinkButton: UIButton, ThemeApplicable {
 
         guard let titleLabel, numberOfLines > 0 else { return }
 
+        // hack to be able to restrict the number of lines displayed
         titleLabel.numberOfLines = numberOfLines
         sizeToFit()
     }
 
     override public var intrinsicContentSize: CGSize {
+        // will only be calculated when the number of lines displayed is restricted
+        // without autolayout is not working correctly
         guard let title = titleLabel,
               let configuration,
               numberOfLines > 0

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/LinkButtonViewModel.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/LinkButtonViewModel.swift
@@ -17,7 +17,6 @@ public struct LinkButtonViewModel {
     public let fontSize: CGFloat
     public let contentInsets: NSDirectionalEdgeInsets
     public let contentHorizontalAlignment: UIControl.ContentHorizontalAlignment
-    public let numberOfLines: Int
 
     public init(title: String,
                 a11yIdentifier: String,
@@ -26,13 +25,11 @@ public struct LinkButtonViewModel {
                                                                                  leading: UX.horizontalInset,
                                                                                  bottom: UX.verticalInset,
                                                                                  trailing: UX.horizontalInset),
-                contentHorizontalAlignment: UIControl.ContentHorizontalAlignment = .leading,
-                numberOfLines: Int = 0) {
+                contentHorizontalAlignment: UIControl.ContentHorizontalAlignment = .leading) {
         self.title = title
         self.a11yIdentifier = a11yIdentifier
         self.fontSize = fontSize
         self.contentInsets = contentInsets
         self.contentHorizontalAlignment = contentHorizontalAlignment
-        self.numberOfLines = numberOfLines
     }
 }

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/LinkButtonViewModel.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/LinkButtonViewModel.swift
@@ -17,6 +17,7 @@ public struct LinkButtonViewModel {
     public let fontSize: CGFloat
     public let contentInsets: NSDirectionalEdgeInsets
     public let contentHorizontalAlignment: UIControl.ContentHorizontalAlignment
+    public let numberOfLines: Int
 
     public init(title: String,
                 a11yIdentifier: String,
@@ -25,11 +26,13 @@ public struct LinkButtonViewModel {
                                                                                  leading: UX.horizontalInset,
                                                                                  bottom: UX.verticalInset,
                                                                                  trailing: UX.horizontalInset),
-                contentHorizontalAlignment: UIControl.ContentHorizontalAlignment = .leading) {
+                contentHorizontalAlignment: UIControl.ContentHorizontalAlignment = .leading,
+                numberOfLines: Int = 0) {
         self.title = title
         self.a11yIdentifier = a11yIdentifier
         self.fontSize = fontSize
         self.contentInsets = contentInsets
         self.contentHorizontalAlignment = contentHorizontalAlignment
+        self.numberOfLines = numberOfLines
     }
 }

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -1333,6 +1333,7 @@
 		E12BD0AE28AC38480029AAF0 /* UIImage+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12BD0AD28AC38480029AAF0 /* UIImage+Extension.swift */; };
 		E12BD0B028AC3A7E0029AAF0 /* UIEdgeInsets+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12BD0AF28AC3A7E0029AAF0 /* UIEdgeInsets+Extension.swift */; };
 		E1312FD129D237EE008DDA85 /* NotificationSurfaceManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1312FD029D237EE008DDA85 /* NotificationSurfaceManagerTests.swift */; };
+		E134D5802B31FF3100C6B17B /* FakespotAdLinkButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E134D57F2B31FF3000C6B17B /* FakespotAdLinkButton.swift */; };
 		E136D41A2B19D35D003D0302 /* EmbeddedNavController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E136D4192B19D35D003D0302 /* EmbeddedNavController.swift */; };
 		E1380B8D2AEA897C00630AFA /* SidebarEnabledView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1380B8C2AEA897C00630AFA /* SidebarEnabledView.swift */; };
 		E1390FB628B040E900C9EF3E /* WallpaperSelectorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1390FB528B040E900C9EF3E /* WallpaperSelectorViewModelTests.swift */; };
@@ -6991,6 +6992,7 @@
 		E12BD0AD28AC38480029AAF0 /* UIImage+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Extension.swift"; sourceTree = "<group>"; };
 		E12BD0AF28AC3A7E0029AAF0 /* UIEdgeInsets+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIEdgeInsets+Extension.swift"; sourceTree = "<group>"; };
 		E1312FD029D237EE008DDA85 /* NotificationSurfaceManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSurfaceManagerTests.swift; sourceTree = "<group>"; };
+		E134D57F2B31FF3000C6B17B /* FakespotAdLinkButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakespotAdLinkButton.swift; sourceTree = "<group>"; };
 		E136D4192B19D35D003D0302 /* EmbeddedNavController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddedNavController.swift; sourceTree = "<group>"; };
 		E1380B8C2AEA897C00630AFA /* SidebarEnabledView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarEnabledView.swift; sourceTree = "<group>"; };
 		E1390FB528B040E900C9EF3E /* WallpaperSelectorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperSelectorViewModelTests.swift; sourceTree = "<group>"; };
@@ -10611,6 +10613,7 @@
 				AB0303292AB47AF300DCD8EF /* FakespotOptInCardView.swift */,
 				DF529EA02AB1B421003C5373 /* FakespotReliabilityScoreView.swift */,
 				AB6FEA1F2AEA5CA200E7B2F2 /* FakespotAdView.swift */,
+				E134D57F2B31FF3000C6B17B /* FakespotAdLinkButton.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -13700,6 +13703,7 @@
 				D863C8F21F68BFC20058D95F /* GradientProgressBar.swift in Sources */,
 				C8445A14264428DC00B83F53 /* LibraryPanelViewState.swift in Sources */,
 				D5D052D92645ABF400759F85 /* ExperimentsSettingsView.swift in Sources */,
+				E134D5802B31FF3100C6B17B /* FakespotAdLinkButton.swift in Sources */,
 				8AE0BF4F2819B10E00F33EC4 /* TopSitesSettingsViewController.swift in Sources */,
 				8A8DDEBF276259A900E7B97A /* RatingPromptManager.swift in Sources */,
 				1D969C702B21322B004255B1 /* BrowserWindow.swift in Sources */,

--- a/Client/Frontend/Fakespot/Views/FakespotAdLinkButton.swift
+++ b/Client/Frontend/Fakespot/Views/FakespotAdLinkButton.swift
@@ -6,14 +6,15 @@ import UIKit
 import ComponentLibrary
 
 class FakespotAdLinkButton: LinkButton {
-    private var numberOfLines = 0
+    private struct UX {
+        static let numberOfLines: Int = 3
+    }
+
     private var previousFrame: CGRect = .zero
 
     override public var frame: CGRect {
         didSet {
-            // invalidate intrinsic content size so that we calculate it correctly
-            // when not the full button text should be shown
-            guard previousFrame != frame, numberOfLines > 0 else { return }
+            guard previousFrame != frame else { return }
 
             previousFrame = frame
             invalidateIntrinsicContentSize()
@@ -26,12 +27,9 @@ class FakespotAdLinkButton: LinkButton {
         guard let config = configuration else {
             return
         }
-        var updatedConfiguration = config
 
-        if viewModel.numberOfLines > 0 {
-            updatedConfiguration.titleLineBreakMode = .byTruncatingTail
-            self.numberOfLines = viewModel.numberOfLines
-        }
+        var updatedConfiguration = config
+        updatedConfiguration.titleLineBreakMode = .byTruncatingTail
 
         configuration = updatedConfiguration
         layoutIfNeeded()
@@ -40,19 +38,16 @@ class FakespotAdLinkButton: LinkButton {
     override public func layoutSubviews() {
         super.layoutSubviews()
 
-        guard let titleLabel, numberOfLines > 0 else { return }
+        guard let titleLabel else { return }
 
         // hack to be able to restrict the number of lines displayed
-        titleLabel.numberOfLines = numberOfLines
+        titleLabel.numberOfLines = UX.numberOfLines
         sizeToFit()
     }
 
     override public var intrinsicContentSize: CGSize {
-        // will only be calculated when the number of lines displayed is restricted
-        // without autolayout is not working correctly
         guard let title = titleLabel,
-              let configuration,
-              numberOfLines > 0
+              let configuration
         else {
             return super.intrinsicContentSize
         }

--- a/Client/Frontend/Fakespot/Views/FakespotAdLinkButton.swift
+++ b/Client/Frontend/Fakespot/Views/FakespotAdLinkButton.swift
@@ -1,0 +1,69 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import ComponentLibrary
+
+class FakespotAdLinkButton: LinkButton {
+    private var numberOfLines = 0
+    private var previousFrame: CGRect = .zero
+
+    override public var frame: CGRect {
+        didSet {
+            // invalidate intrinsic content size so that we calculate it correctly
+            // when not the full button text should be shown
+            guard previousFrame != frame, numberOfLines > 0 else { return }
+
+            previousFrame = frame
+            invalidateIntrinsicContentSize()
+        }
+    }
+
+    override public func configure(viewModel: LinkButtonViewModel) {
+        super.configure(viewModel: viewModel)
+
+        guard let config = configuration else {
+            return
+        }
+        var updatedConfiguration = config
+
+        if viewModel.numberOfLines > 0 {
+            updatedConfiguration.titleLineBreakMode = .byTruncatingTail
+            self.numberOfLines = viewModel.numberOfLines
+        }
+
+        configuration = updatedConfiguration
+        layoutIfNeeded()
+    }
+
+    override public func layoutSubviews() {
+        super.layoutSubviews()
+
+        guard let titleLabel, numberOfLines > 0 else { return }
+
+        // hack to be able to restrict the number of lines displayed
+        titleLabel.numberOfLines = numberOfLines
+        sizeToFit()
+    }
+
+    override public var intrinsicContentSize: CGSize {
+        // will only be calculated when the number of lines displayed is restricted
+        // without autolayout is not working correctly
+        guard let title = titleLabel,
+              let configuration,
+              numberOfLines > 0
+        else {
+            return super.intrinsicContentSize
+        }
+
+        let widthContentInset = configuration.contentInsets.leading + configuration.contentInsets.trailing
+        let heightContentInset = configuration.contentInsets.top + configuration.contentInsets.bottom
+
+        let availableWidth = frame.width - widthContentInset
+        let size = title.sizeThatFits(CGSize(width: availableWidth, height: .greatestFiniteMagnitude))
+
+        return CGSize(width: size.width + widthContentInset,
+                      height: size.height + heightContentInset)
+    }
+}

--- a/Client/Frontend/Fakespot/Views/FakespotAdView.swift
+++ b/Client/Frontend/Fakespot/Views/FakespotAdView.swift
@@ -144,7 +144,7 @@ class FakespotAdView: UIView, Notifiable, ThemeApplicable, UITextViewDelegate {
                                                             weight: .semibold)
         label.numberOfLines = 0
     }
-    private lazy var productLinkButton: LinkButton = .build { button in
+    private lazy var productLinkButton: FakespotAdLinkButton = .build { button in
         button.addTarget(self, action: #selector(self.didTapProductLink), for: .touchUpInside)
     }
 

--- a/Client/Frontend/Fakespot/Views/FakespotAdView.swift
+++ b/Client/Frontend/Fakespot/Views/FakespotAdView.swift
@@ -200,8 +200,7 @@ class FakespotAdView: UIView, Notifiable, ThemeApplicable, UITextViewDelegate {
             title: productAdsData.name,
             a11yIdentifier: viewModel.productTitleA11yId,
             fontSize: UX.linkFontSize,
-            contentInsets: UX.linkInsets,
-            numberOfLines: 3
+            contentInsets: UX.linkInsets
         )
         productLinkButton.configure(viewModel: productLinkButtonViewModel)
         gradeReliabilityScoreView.configure(grade: productAdsData.grade)

--- a/Client/Frontend/Fakespot/Views/FakespotAdView.swift
+++ b/Client/Frontend/Fakespot/Views/FakespotAdView.swift
@@ -200,7 +200,8 @@ class FakespotAdView: UIView, Notifiable, ThemeApplicable, UITextViewDelegate {
             title: productAdsData.name,
             a11yIdentifier: viewModel.productTitleA11yId,
             fontSize: UX.linkFontSize,
-            contentInsets: UX.linkInsets
+            contentInsets: UX.linkInsets,
+            numberOfLines: 3
         )
         productLinkButton.configure(viewModel: productLinkButtonViewModel)
         gradeReliabilityScoreView.configure(grade: productAdsData.grade)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7985)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17791)

## :bulb: Description
Restricts the number of lines for the ad link. By default the LinkButton will show all content. Restricting the number of lines when using UIButton.Configuration only works with a hacky solution which is not used when `numberOfLines = 0`.

![Simulator Screenshot - iPhone 15 Pro Max - 2023-12-19 at 14 05 06](https://github.com/mozilla-mobile/firefox-ios/assets/4530/682722dc-6c22-41ab-b68f-4ec6c7b09300)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

