### PR TITLE
Fix MTE-2029 [v123] testSharePageWithShareSheetOptions in Ipad

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
@@ -72,9 +72,6 @@ class PhotonActionSheetTests: BaseTestCase {
         mozWaitForElementToExist(app.collectionViews.cells["Copy"], timeout: TIMEOUT)
 
         var  fennecElement = app.collectionViews.scrollViews.cells.elementContainingText("Fennec")
-        if iPad() {
-            fennecElement = app.collectionViews.scrollViews.cells.element(boundBy: 2)
-        }
         mozWaitForElementToExist(fennecElement, timeout: 5)
         fennecElement.tap()
         mozWaitForElementToExist(app.navigationBars["ShareTo.ShareView"])

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
@@ -71,7 +71,7 @@ class PhotonActionSheetTests: BaseTestCase {
         mozWaitForElementToExist(app.otherElements["ActivityListView"].otherElements["example.com"])
         mozWaitForElementToExist(app.collectionViews.cells["Copy"], timeout: TIMEOUT)
 
-        var  fennecElement = app.collectionViews.scrollViews.cells.elementContainingText("Fennec")
+        let fennecElement = app.collectionViews.scrollViews.cells.elementContainingText("Fennec")
         mozWaitForElementToExist(fennecElement, timeout: 5)
         fennecElement.tap()
         mozWaitForElementToExist(app.navigationBars["ShareTo.ShareView"])


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2029)
## :bulb: Description
Fix for testSharePageWithShareSheetOptions on iPad. Removed the condition. 
Now the element applies for both devices.

