### PR TITLE
Refactor [v123] Adapt codeowners path

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,8 +7,8 @@
 # When someone opens a pull request that only modifies those folders / files, 
 # only @mozilla-mobile/fxios-automation and not the global
 # owners will be requested for a review.
-/Tests/UITests @mozilla-mobile/fxios-automation-1
-/Tests/XCUITests @mozilla-mobile/fxios-automation-1
+/firefox-ios/firefox-ios-tests/Tests/UITests @mozilla-mobile/fxios-automation-1
+/firefox-ios/firefox-ios-tests/Tests/XCUITests @mozilla-mobile/fxios-automation-1
 bitrise.yml @mozilla-mobile/fxios-automation-1
 .taskcluster.yml @mozilla-mobile/fxios-automation-1
 /taskcluster @mozilla-mobile/fxios-automation-1


### PR DESCRIPTION
## :scroll: Tickets
No ticket

## :bulb: Description
Adapt CODEOWNERS path to reflect the location of the tests file. I realized now we forgot to adjust this path a couple weeks back.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

