### PR TITLE
Refactor FXIOS-7885 [v123] [Multi-window] Shared DiskImageStore for iPad windows

### DIFF
--- a/firefox-ios/Client/Application/DependencyHelper.swift
+++ b/firefox-ios/Client/Application/DependencyHelper.swift
@@ -17,6 +17,12 @@ class DependencyHelper {
         let profile: Profile = appDelegate.profile
         AppContainer.shared.register(service: profile)
 
+        let diskImageStore: DiskImageStore =
+        DefaultDiskImageStore(files: profile.files,
+                              namespace: TabManagerConstants.tabScreenshotNamespace,
+                              quality: UIConstants.ScreenshotQuality)
+        AppContainer.shared.register(service: diskImageStore)
+
         let appSessionProvider: AppSessionProvider = appDelegate.appSessionManager
         AppContainer.shared.register(service: appSessionProvider)
 

--- a/firefox-ios/Client/Coordinators/Scene/SceneCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Scene/SceneCoordinator.swift
@@ -114,29 +114,16 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
                    level: .info,
                    category: .coordinator)
 
+        let tabManager = TabManagerImplementation(profile: AppContainer.shared.resolve(), uuid: windowUUID)
         let browserCoordinator = BrowserCoordinator(router: router,
                                                     screenshotService: screenshotService,
-                                                    tabManager: createWindowTabManager(for: windowUUID))
+                                                    tabManager: tabManager)
         add(child: browserCoordinator)
         browserCoordinator.start(with: launchType)
 
         if let savedRoute {
             browserCoordinator.findAndHandle(route: savedRoute)
         }
-    }
-
-    private func createWindowTabManager(for windowUUID: WindowUUID) -> TabManager {
-        let profile: Profile = AppContainer.shared.resolve()
-        let imageStore = defaultDiskImageStoreForSceneTabManager()
-        return TabManagerImplementation(profile: profile, imageStore: imageStore, uuid: windowUUID)
-    }
-
-    private func defaultDiskImageStoreForSceneTabManager() -> DefaultDiskImageStore {
-        let profile: Profile = AppContainer.shared.resolve()
-        // TODO: [FXIOS-7885] Once iPad multi-window enabled each TabManager will likely share same default image store.
-        return DefaultDiskImageStore(files: profile.files,
-                                     namespace: "TabManagerScreenshots",
-                                     quality: UIConstants.ScreenshotQuality)
     }
 
     // MARK: - LaunchCoordinatorDelegate

--- a/firefox-ios/Client/TabManagement/TabManager.swift
+++ b/firefox-ios/Client/TabManagement/TabManager.swift
@@ -8,6 +8,10 @@ import WebKit
 import Storage
 import Shared
 
+enum TabManagerConstants {
+    static let tabScreenshotNamespace = "TabManagerScreenshots"
+}
+
 // MARK: - TabManager protocol
 protocol TabManager: AnyObject {
     var windowUUID: WindowUUID { get }

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -25,7 +25,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
     }
 
     init(profile: Profile,
-         imageStore: DiskImageStore?,
+         imageStore: DiskImageStore = AppContainer.shared.resolve(),
          logger: Logger = DefaultLogger.shared,
          uuid: WindowUUID = WindowUUID(),
          tabDataStore: TabDataStore = AppContainer.shared.resolve(),

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
@@ -20,15 +20,15 @@ class DependencyHelperMock {
         let tabDataStore: TabDataStore = MockTabDataStore()
         AppContainer.shared.register(service: tabDataStore)
 
+        let diskImageStore: DiskImageStore = DefaultDiskImageStore(
+            files: profile.files,
+            namespace: TabManagerConstants.tabScreenshotNamespace,
+            quality: UIConstants.ScreenshotQuality)
+        AppContainer.shared.register(service: diskImageStore)
+
         let windowUUID = WindowUUID()
-        let tabManager: TabManager = injectedTabManager ?? TabManagerImplementation(
-            profile: profile,
-            imageStore: DefaultDiskImageStore(
-                files: profile.files,
-                namespace: "TabManagerScreenshots",
-                quality: UIConstants.ScreenshotQuality),
-            uuid: windowUUID
-        )
+        let tabManager: TabManager =
+        injectedTabManager ?? TabManagerImplementation(profile: profile, uuid: windowUUID)
 
         let appSessionProvider: AppSessionProvider = AppSessionManager()
         AppContainer.shared.register(service: appSessionProvider)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
@@ -19,7 +19,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         profile = MockProfile()
-        tabManager = TabManagerImplementation(profile: profile, imageStore: nil)
+        tabManager = TabManagerImplementation(profile: profile)
         subject = BrowserViewController(profile: profile, tabManager: tabManager)
         tabManagerDelegate = TabManagerNavDelegate()
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/HomepageViewControllerTests.swift
@@ -24,7 +24,7 @@ class HomepageViewControllerTests: XCTestCase {
     }
 
     func testHomepageViewController_simpleCreation_hasNoLeaks() {
-        let tabManager = TabManagerImplementation(profile: profile, imageStore: nil)
+        let tabManager = TabManagerImplementation(profile: profile)
         let urlBar = URLBarView(profile: profile)
         let overlayManager = MockOverlayModeManager()
         overlayManager.setURLBar(urlBarView: urlBar)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
@@ -36,11 +36,11 @@ class JumpBackInViewModelTests: XCTestCase {
 
     override func tearDown() {
         super.tearDown()
-        AppContainer.shared.reset()
         adaptor = nil
         stubBrowserViewController = nil
         mockTabManager = nil
         mockProfile = nil
+        AppContainer.shared.reset()
     }
 
     // MARK: - Switch to tab

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
@@ -28,7 +28,7 @@ class JumpBackInViewModelTests: XCTestCase {
         mockTabManager = MockTabManager()
         stubBrowserViewController = BrowserViewController(
             profile: mockProfile,
-            tabManager: TabManagerImplementation(profile: mockProfile, imageStore: nil)
+            tabManager: TabManagerImplementation(profile: mockProfile)
         )
 
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: mockProfile)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/GridTabViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/GridTabViewControllerTests.swift
@@ -13,7 +13,7 @@ final class LegacyGridTabViewControllerTests: XCTestCase {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         profile = MockProfile()
-        manager = TabManagerImplementation(profile: profile, imageStore: nil)
+        manager = TabManagerImplementation(profile: profile)
     }
 
     override func tearDown() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/HistoryHighlights/HistoryHighlightsManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/HistoryHighlights/HistoryHighlightsManagerTests.swift
@@ -21,7 +21,7 @@ class HistoryHighlightsTests: XCTestCase {
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
         DependencyHelperMock().bootstrapDependencies()
         profile.reopen()
-        let tabManager = TabManagerImplementation(profile: profile, imageStore: nil)
+        let tabManager = TabManagerImplementation(profile: profile)
         entryProvider = HistoryHighlightsTestEntryProvider(with: profile, and: tabManager)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/AppSettingsTableViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/AppSettingsTableViewControllerTests.swift
@@ -17,7 +17,7 @@ class AppSettingsTableViewControllerTests: XCTestCase {
         DependencyHelperMock().bootstrapDependencies()
         self.profile = MockProfile()
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
-        self.tabManager = TabManagerImplementation(profile: profile, imageStore: nil)
+        self.tabManager = TabManagerImplementation(profile: profile)
         self.appAuthenticator = MockAppAuthenticator()
         self.delegate = MockSettingsFlowDelegate()
         self.applicationHelper = MockApplicationHelper()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/StartAtHomeHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/StartAtHomeHelperTests.swift
@@ -18,7 +18,7 @@ class StartAtHomeHelperTests: XCTestCase {
 
         DependencyHelperMock().bootstrapDependencies()
         profile = MockProfile()
-        tabManager = TabManagerImplementation(profile: profile, imageStore: nil)
+        tabManager = TabManagerImplementation(profile: profile)
 
         DependencyHelperMock().bootstrapDependencies()
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Legacy/TabEventHandlerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Legacy/TabEventHandlerTests.swift
@@ -27,7 +27,7 @@ class TabEventHandlerTests: XCTestCase {
     func testBlankPopupURL() throws {
         throw XCTSkip("Test doesn't complete anymore, was probably relying on behavior from setup in App delegate")
 //        let profile = MockProfile()
-//        let manager = TabManager(profile: profile, imageStore: nil)
+//        let manager = TabManager(profile: profile)
 //
 //        // Hide intro so it is easier to see the test running and debug it
 //        IntroScreenManager(prefs: profile.prefs).didSeeIntroScreen()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Legacy/TabsQuantityTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Legacy/TabsQuantityTelemetryTests.swift
@@ -31,7 +31,6 @@ class TabsQuantityTelemetryTests: XCTestCase {
 
     func testTrackTabsQuantity_withNormalTab_gleanIsCalled() {
         let tabManager = TabManagerImplementation(profile: profile,
-                                                  imageStore: nil,
                                                   inactiveTabsManager: inactiveTabsManager)
 
         let tab = tabManager.addTab()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Legacy/TabsQuantityTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Legacy/TabsQuantityTelemetryTests.swift
@@ -65,7 +65,6 @@ class TabsQuantityTelemetryTests: XCTestCase {
 
     func testTrackTabsQuantity_ensureNoInactiveTabs_gleanIsCalled() {
         let tabManager = TabManagerImplementation(profile: profile,
-                                                  imageStore: nil,
                                                   inactiveTabsManager: inactiveTabsManager)
         let tab = tabManager.addTab()
         inactiveTabsManager.activeTabs = [tab]

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Legacy/TabsQuantityTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Legacy/TabsQuantityTelemetryTests.swift
@@ -50,7 +50,7 @@ class TabsQuantityTelemetryTests: XCTestCase {
     }
 
     func testTrackTabsQuantity_withPrivateTab_gleanIsCalled() {
-        let tabManager = TabManagerImplementation(profile: profile, imageStore: nil)
+        let tabManager = TabManagerImplementation(profile: profile)
         tabManager.addTab(isPrivate: true)
 
         TabsQuantityTelemetry.trackTabsQuantity(tabManager: tabManager)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabToolbarHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabToolbarHelperTests.swift
@@ -124,7 +124,7 @@ class MockTabToolbar: TabToolbarProtocol {
 
     init() {
         profile = MockProfile()
-        tabManager = TabManagerImplementation(profile: profile, imageStore: nil)
+        tabManager = TabManagerImplementation(profile: profile)
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
         _tabToolBarDelegate = BrowserViewController(profile: profile, tabManager: tabManager)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/Legacy/LegacyTabTrayViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/Legacy/LegacyTabTrayViewControllerTests.swift
@@ -23,7 +23,7 @@ final class LegacyTabTrayViewControllerTests: XCTestCase {
 
         DependencyHelperMock().bootstrapDependencies()
         profile = MockProfile()
-        manager = TabManagerImplementation(profile: profile, imageStore: nil)
+        manager = TabManagerImplementation(profile: profile)
         urlBar = MockURLBarView()
         overlayManager = MockOverlayModeManager()
         overlayManager.setURLBar(urlBarView: urlBar)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7885)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17605)

## :bulb: Description

Minor refactor. Currently the iOS app provides a common `DefaultDiskImageStore` for saving/restoring tab screenshots, which is a Swift Async actor. To take advantage of its protections on mutable state the shared instance should be used by all iPad windows since tab screenshot storage is ubiquitous and global to the entire app.

### Note

This PR has the changes from [this branch](https://github.com/mozilla-mobile/firefox-ios/pull/17833) re-applied to `main` after the recent project reorg.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

