### PR TITLE
Bugfix FXIOS-7984 [v121]: Makes sure networking is enabled in ShareTo

### DIFF
--- a/firefox-ios/Extensions/ShareTo/ShareViewController.swift
+++ b/firefox-ios/Extensions/ShareTo/ShareViewController.swift
@@ -106,6 +106,7 @@ class ShareViewController: UIViewController {
         }
 
         let profile = BrowserProfile(localName: "profile")
+        Viaduct.shared.useReqwestBackend()
         RustFirefoxAccounts.startup(prefs: profile.prefs) { _ in }
     }
 


### PR DESCRIPTION
Viaduct (the networking library used by application services) was not initialized in the Share extension. This adds initialization of Viaduct before initializing the extension.

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7984 )
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17789)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

