### PR TITLE
Refactor FXIOS-7995 [v123] Improve PasswordManagerOnboardingViewController

### DIFF
--- a/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
@@ -5,38 +5,45 @@
 import Common
 import UIKit
 import Shared
+import ComponentLibrary
 
 class PasswordManagerOnboardingViewController: SettingsViewController {
-    private var onboardingMessageLabel: UILabel = {
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
+    private struct UX {
+        static let fontSize: CGFloat = 19
+        static let maxLabelLines: Int = 0
+        static let buttonCornerRadius: CGFloat = 8
+        static let defaultContentSize: CGFloat = 0
+        static let leadingContentSize: CGFloat = 15
+        static let standardSpacing: CGFloat = 20
+        static let continueButtonHeight: CGFloat = 44
+        static let buttonHorizontalPadding: CGFloat = 35
+        static let continueButtonMaxWidth: CGFloat = 360
+    }
+
+    private var onboardingMessageLabel: UILabel = . build { label in
         label.text = .Settings.Passwords.OnboardingMessage
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 19)
+        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: UX.fontSize)
         label.textAlignment = .center
-        label.numberOfLines = 0
-        return label
-    }()
+        label.numberOfLines = UX.maxLabelLines
+    }
 
-    private lazy var learnMoreButton: UIButton = {
-        let button = UIButton(type: .system)
-        button.translatesAutoresizingMaskIntoConstraints = false
+    private lazy var learnMoreButton: UIButton = .build { button in
         button.setTitle(.LoginsOnboardingLearnMoreButtonTitle, for: .normal)
-        button.addTarget(self, action: #selector(learnMoreButtonTapped), for: .touchUpInside)
-        button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 19)
-        return button
-    }()
+        button.addTarget(self, action: #selector(self.learnMoreButtonTapped), for: .touchUpInside)
+        button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: UX.fontSize)
+    }
 
-    private lazy var continueButton: UIButton = {
-        let button = UIButton(type: .custom)
-        button.translatesAutoresizingMaskIntoConstraints = false
-        button.layer.cornerRadius = 8
+    private lazy var continueButton: PrimaryRoundedButton = .build { button in
+        button.layer.cornerRadius = UX.buttonCornerRadius
         button.setTitle(.LoginsOnboardingContinueButtonTitle, for: .normal)
         button.accessibilityIdentifier = AccessibilityIdentifiers.Settings.Passwords.onboardingContinue
         button.titleLabel?.font = LegacyDynamicFontHelper().MediumSizeBoldFontAS
-        button.titleEdgeInsets = UIEdgeInsets(top: 0, left: 15, bottom: 0, right: 0)
-        button.addTarget(self, action: #selector(proceedButtonTapped), for: .touchUpInside)
-        return button
-    }()
+        button.configuration?.contentInsets = NSDirectionalEdgeInsets(top: UX.defaultContentSize,
+                                                                      leading: UX.leadingContentSize,
+                                                                      bottom: UX.defaultContentSize,
+                                                                      trailing: UX.defaultContentSize)
+        button.addTarget(self, action: #selector(self.proceedButtonTapped), for: .touchUpInside)
+    }
 
     weak var coordinator: PasswordManagerFlowDelegate?
     private var appAuthenticator: AppAuthenticationProtocol
@@ -59,22 +66,32 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
 
         self.view.addSubviews(onboardingMessageLabel, learnMoreButton, continueButton)
 
-        NSLayoutConstraint.activate([
-            onboardingMessageLabel.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
-            onboardingMessageLabel.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
-            onboardingMessageLabel.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
-            onboardingMessageLabel.centerYAnchor.constraint(equalTo: self.view.centerYAnchor),
+        NSLayoutConstraint.activate(
+            [
+                onboardingMessageLabel.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor, constant: UX.standardSpacing),
+                onboardingMessageLabel.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor, constant: -UX.standardSpacing),
+                onboardingMessageLabel.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+                onboardingMessageLabel.centerYAnchor.constraint(equalTo: self.view.centerYAnchor),
 
-            learnMoreButton.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
-            learnMoreButton.topAnchor.constraint(equalTo: onboardingMessageLabel.safeAreaLayoutGuide.bottomAnchor, constant: 20),
+                learnMoreButton.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+                learnMoreButton.topAnchor.constraint(equalTo: onboardingMessageLabel.safeAreaLayoutGuide.bottomAnchor, constant: UX.standardSpacing),
 
-            continueButton.bottomAnchor.constraint(equalTo: self.view.layoutMarginsGuide.bottomAnchor, constant: -20),
-            continueButton.heightAnchor.constraint(equalToConstant: 44),
-            continueButton.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
-            continueButton.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor, constant: 35, priority: .defaultHigh),
-            continueButton.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor, constant: -35, priority: .defaultHigh),
-            continueButton.widthAnchor.constraint(lessThanOrEqualToConstant: 360)
-        ])
+                continueButton.bottomAnchor.constraint(equalTo: self.view.layoutMarginsGuide.bottomAnchor, constant: -UX.standardSpacing),
+                continueButton.heightAnchor.constraint(equalToConstant: UX.continueButtonHeight),
+                continueButton.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+                continueButton.leadingAnchor.constraint(
+                    equalTo: self.view.safeAreaLayoutGuide.leadingAnchor,
+                    constant: UX.buttonHorizontalPadding,
+                    priority: .defaultHigh
+                ),
+                continueButton.trailingAnchor.constraint(
+                    equalTo: self.view.safeAreaLayoutGuide.trailingAnchor,
+                    constant: -UX.buttonHorizontalPadding,
+                    priority: .defaultHigh
+                ),
+                continueButton.widthAnchor.constraint(lessThanOrEqualToConstant: UX.continueButtonMaxWidth)
+            ]
+        )
     }
 
     @objc

--- a/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
@@ -5,7 +5,6 @@
 import Common
 import UIKit
 import Shared
-import ComponentLibrary
 
 class PasswordManagerOnboardingViewController: SettingsViewController {
     private struct UX {

--- a/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
@@ -68,15 +68,27 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
 
         NSLayoutConstraint.activate(
             [
-                onboardingMessageLabel.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor, constant: UX.standardSpacing),
-                onboardingMessageLabel.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor, constant: -UX.standardSpacing),
+                onboardingMessageLabel.leadingAnchor.constraint(
+                    equalTo: self.view.safeAreaLayoutGuide.leadingAnchor,
+                    constant: UX.standardSpacing
+                ),
+                onboardingMessageLabel.trailingAnchor.constraint(
+                    equalTo: self.view.safeAreaLayoutGuide.trailingAnchor,
+                    constant: -UX.standardSpacing
+                ),
                 onboardingMessageLabel.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
                 onboardingMessageLabel.centerYAnchor.constraint(equalTo: self.view.centerYAnchor),
 
                 learnMoreButton.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
-                learnMoreButton.topAnchor.constraint(equalTo: onboardingMessageLabel.safeAreaLayoutGuide.bottomAnchor, constant: UX.standardSpacing),
+                learnMoreButton.topAnchor.constraint(
+                    equalTo: onboardingMessageLabel.safeAreaLayoutGuide.bottomAnchor,
+                    constant: UX.standardSpacing
+                ),
 
-                continueButton.bottomAnchor.constraint(equalTo: self.view.layoutMarginsGuide.bottomAnchor, constant: -UX.standardSpacing),
+                continueButton.bottomAnchor.constraint(
+                    equalTo: self.view.layoutMarginsGuide.bottomAnchor,
+                    constant: -UX.standardSpacing
+                ),
                 continueButton.heightAnchor.constraint(equalToConstant: UX.continueButtonHeight),
                 continueButton.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
                 continueButton.leadingAnchor.constraint(

--- a/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
@@ -33,7 +33,7 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
         button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: UX.fontSize)
     }
 
-    private lazy var continueButton: PrimaryRoundedButton = .build { button in
+    private lazy var continueButton: UIButton = .build { button in
         button.layer.cornerRadius = UX.buttonCornerRadius
         button.setTitle(.LoginsOnboardingContinueButtonTitle, for: .normal)
         button.accessibilityIdentifier = AccessibilityIdentifiers.Settings.Passwords.onboardingContinue
@@ -133,6 +133,8 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
 
     override func applyTheme() {
         super.applyTheme()
-        continueButton.backgroundColor = themeManager.currentTheme.colors.actionPrimary
+        let currentTheme = themeManager.currentTheme.colors
+        learnMoreButton.setTitleColor(currentTheme.actionPrimary, for: .normal)
+        continueButton.backgroundColor = currentTheme.actionPrimary
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7995)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17839)

## :bulb: Description
- Refactored UI element declarations in PasswordManagerOnboardingViewController using .build for cleaner syntax.
- Deprecated 'titleEdgeInsets' for continueButton and instead configured button properties directly.
- Introduced a private struct UX to centralize and organize constant values related to user experience.


| Portrait  | Landscape | 
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2023-12-21 at 09 36 50](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/789f5ba5-6dfd-4e12-b9a5-d90bd6836d75) | ![Simulator Screenshot - iPhone 15 Pro - 2023-12-21 at 09 37 13](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/a8a1bba2-5de0-4f34-bafd-c795c0c93fd0) |


| Portrait  | Landscape | 
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2023-12-21 at 09 37 11](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/61fdb781-d1f0-4681-89c4-c13fd266be51) | ![Simulator Screenshot - iPhone 15 Pro - 2023-12-21 at 09 37 13](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/34aa3ab4-4b51-4f1a-8b28-4ff17f05fcfb) |


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods