### PR TITLE
Refactor FXIOS-7906 [v123] Implement reload in WKEngineSession

### DIFF
--- a/BrowserKit/.swiftpm/xcode/xcshareddata/xcschemes/WebEngine.xcscheme
+++ b/BrowserKit/.swiftpm/xcode/xcshareddata/xcschemes/WebEngine.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1410"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "WebEngine"
+               BuildableName = "WebEngine"
+               BlueprintName = "WebEngine"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "WebEngine"
+            BuildableName = "WebEngine"
+            BlueprintName = "WebEngine"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </CodeCoverageTargets>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "WebEngineTests"
+               BuildableName = "WebEngineTests"
+               BlueprintName = "WebEngineTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "WebEngine"
+            BuildableName = "WebEngine"
+            BlueprintName = "WebEngine"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineInfo.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineInfo.swift
@@ -7,4 +7,6 @@ import Foundation
 /// The specific information related to the WK session and view
 struct WKEngineInfo {
     static var webserverPort = 6571
+
+    static let apostropheEncoded = "%27"
 }

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineInfo.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineInfo.swift
@@ -7,6 +7,4 @@ import Foundation
 /// The specific information related to the WK session and view
 struct WKEngineInfo {
     static var webserverPort = 6571
-
-    static let apostropheEncoded = "%27"
 }

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -45,6 +45,7 @@ class WKEngineSession: EngineSession {
            let localReaderModeURL = syncedReaderModeURL.encodeReaderModeURL(WKEngineWebServer.shared.baseReaderModeURL()) {
             let readerModeRequest = URLRequest(url: localReaderModeURL)
             webView.load(readerModeRequest)
+            logger.log("Loaded reader mode request", level: .debug, category: .webview)
             return
         }
 
@@ -55,23 +56,40 @@ class WKEngineSession: EngineSession {
             webView.loadFileURL(url, allowingReadAccessTo: url.deletingLastPathComponent())
             return
         }
+
         webView.load(request)
+        logger.log("Loaded request", level: .debug, category: .webview)
     }
 
     func stopLoading() {
         webView.stopLoading()
+        logger.log("Stop loading", level: .debug, category: .webview)
     }
 
     func reload() {
-        // TODO: FXIOS-7906 #17650 Handle reload in WKEngineSession
+        // If the current page is an error page load the original URL
+        if let url = webView.url,
+            let internalUrl = WKInternalURL(url),
+            let page = internalUrl.originalURLFromErrorPage {
+            webView.replaceLocation(with: page)
+            logger.log("Reloaded webview as error page", level: .debug, category: .webview)
+            return
+        }
+
+        // Reloads the current webpage, and performs end-to-end revalidation of the content 
+        // using cache-validating conditionals, if possible.
+        webView.reloadFromOrigin()
+        logger.log("Reloaded webview from origin", level: .debug, category: .webview)
     }
 
     func goBack() {
         _ = webView.goBack()
+        logger.log("Go back", level: .debug, category: .webview)
     }
 
     func goForward() {
         _ = webView.goForward()
+        logger.log("Go forward", level: .debug, category: .webview)
     }
 
     func goToHistoryIndex(index: Int) {

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
@@ -100,7 +100,8 @@ extension WKEngineWebView {
     }
 
     func replaceLocation(with url: URL) {
-        let safeUrl = url.absoluteString.replacingOccurrences(of: "'", with: WKEngineInfo.apostropheEncoded)
+        let charactersToReplace = CharacterSet(charactersIn: "'")
+        let safeUrl = url.absoluteString.addingPercentEncoding(withAllowedCharacters: charactersToReplace.inverted)
         evaluateJavascriptInDefaultContentWorld("location.replace('\(safeUrl)')")
     }
 }

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
@@ -33,9 +33,6 @@ protocol WKEngineWebView {
                      allowingReadAccessTo readAccessURL: URL) -> WKNavigation?
 
     @discardableResult
-    func reload() -> WKNavigation?
-
-    @discardableResult
     func reloadFromOrigin() -> WKNavigation?
 
     func stopLoading()
@@ -53,6 +50,12 @@ protocol WKEngineWebView {
 
     func removeAllUserScripts()
     func removeFromSuperview()
+
+    // MARK: Custom WKEngineView functions
+
+    /// Use JS to redirect the page without adding a history entry
+    /// - Parameter url: The URL to replace the location with
+    func replaceLocation(with url: URL)
 }
 
 extension WKEngineWebView {
@@ -96,7 +99,6 @@ extension WKEngineWebView {
         }
     }
 
-    /// Use JS to redirect the page without adding a history entry
     func replaceLocation(with url: URL) {
         let safeUrl = url.absoluteString.replacingOccurrences(of: "'", with: WKEngineInfo.apostropheEncoded)
         evaluateJavascriptInDefaultContentWorld("location.replace('\(safeUrl)')")

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
@@ -18,6 +18,7 @@ protocol WKEngineWebView {
     var allowsBackForwardNavigationGestures: Bool { get set }
     var allowsLinkPreview: Bool { get set }
     var backgroundColor: UIColor? { get set }
+    var url: URL? { get }
 
     @available(iOS 16.4, *)
     var isInspectable: Bool { get set }
@@ -30,6 +31,12 @@ protocol WKEngineWebView {
     @discardableResult
     func loadFileURL(_ URL: URL,
                      allowingReadAccessTo readAccessURL: URL) -> WKNavigation?
+
+    @discardableResult
+    func reload() -> WKNavigation?
+
+    @discardableResult
+    func reloadFromOrigin() -> WKNavigation?
 
     func stopLoading()
 
@@ -87,6 +94,12 @@ extension WKEngineWebView {
                 completion(nil, error)
             }
         }
+    }
+
+    /// Use JS to redirect the page without adding a history entry
+    func replaceLocation(with url: URL) {
+        let safeUrl = url.absoluteString.replacingOccurrences(of: "'", with: WKEngineInfo.apostropheEncoded)
+        evaluateJavascriptInDefaultContentWorld("location.replace('\(safeUrl)')")
     }
 }
 

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
@@ -101,7 +101,9 @@ extension WKEngineWebView {
 
     func replaceLocation(with url: URL) {
         let charactersToReplace = CharacterSet(charactersIn: "'")
-        let safeUrl = url.absoluteString.addingPercentEncoding(withAllowedCharacters: charactersToReplace.inverted)
+        guard let safeUrl = url.absoluteString.addingPercentEncoding(withAllowedCharacters: charactersToReplace.inverted) else {
+            return
+        }
         evaluateJavascriptInDefaultContentWorld("location.replace('\(safeUrl)')")
     }
 }

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKInternalURL.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKInternalURL.swift
@@ -21,7 +21,6 @@ final class WKInternalURL: InternalURL {
     enum Path: String {
         case errorpage
         func matches(_ string: String) -> Bool {
-            print("Laurie - \(self.rawValue)")
             return string.range(of: "/?\(self.rawValue)",
                                 options: .regularExpression,
                                 range: nil,

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKInternalURL.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKInternalURL.swift
@@ -87,12 +87,7 @@ final class WKInternalURL: InternalURL {
     }
 
     var originalURLFromErrorPage: URL? {
-        if let urlParam = extractedUrlParam,
-           let nested = WKInternalURL(urlParam),
-           nested.isErrorPage {
-            return nested.extractedUrlParam
-        }
-        return nil
+        return isErrorPage ? extractedUrlParam : nil
     }
 
     private var extractedUrlParam: URL? {

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKInternalURL.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKInternalURL.swift
@@ -21,7 +21,11 @@ final class WKInternalURL: InternalURL {
     enum Path: String {
         case errorpage
         func matches(_ string: String) -> Bool {
-            return string.range(of: "/?\(self.rawValue)", options: .regularExpression, range: nil, locale: nil) != nil
+            print("Laurie - \(self.rawValue)")
+            return string.range(of: "/?\(self.rawValue)",
+                                options: .regularExpression,
+                                range: nil,
+                                locale: nil) != nil
         }
     }
 
@@ -83,7 +87,9 @@ final class WKInternalURL: InternalURL {
     }
 
     var originalURLFromErrorPage: URL? {
-        if let urlParam = extractedUrlParam, let nested = WKInternalURL(urlParam), nested.isErrorPage {
+        if let urlParam = extractedUrlParam,
+           let nested = WKInternalURL(urlParam),
+           nested.isErrorPage {
             return nested.extractedUrlParam
         }
         return nil
@@ -97,7 +103,6 @@ final class WKInternalURL: InternalURL {
     }
 
     private var isErrorPage: Bool {
-        let path = extractedUrlParam?.path
-        return WKInternalURL.Path.errorpage.matches(path ?? "")
+        return WKInternalURL.Path.errorpage.matches(url.path)
     }
 }

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKInternalURL.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKInternalURL.swift
@@ -81,4 +81,23 @@ final class WKInternalURL: InternalURL {
         let query = url.getQuery()
         return query[WKInternalURL.Param.uuidkey.rawValue] == WKInternalURL.uuid
     }
+
+    var originalURLFromErrorPage: URL? {
+        if let urlParam = extractedUrlParam, let nested = WKInternalURL(urlParam), nested.isErrorPage {
+            return nested.extractedUrlParam
+        }
+        return nil
+    }
+
+    private var extractedUrlParam: URL? {
+        if let nestedUrl = url.getQuery()[WKInternalURL.Param.url.rawValue]?.removingPercentEncoding {
+            return URL(string: nestedUrl, invalidCharacters: false)
+        }
+        return nil
+    }
+
+    private var isErrorPage: Bool {
+        let path = extractedUrlParam?.path
+        return WKInternalURL.Path.errorpage.matches(path ?? "")
+    }
 }

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebView.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebView.swift
@@ -25,8 +25,6 @@ class MockWKEngineWebView: WKEngineWebView {
     var removeAllUserScriptsCalled = 0
     var removeFromSuperviewCalled = 0
 
-    var loadRequest: URLRequest?
-    var loadFileURL: URL?
     var loadFileReadAccessURL: URL?
 
     required init?(frame: CGRect,

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebView.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebView.swift
@@ -7,6 +7,7 @@ import WebKit
 @testable import WebEngine
 
 class MockWKEngineWebView: WKEngineWebView {
+    var url: URL?
     var navigationDelegate: WKNavigationDelegate?
     var allowsBackForwardNavigationGestures = true
     var allowsLinkPreview = true
@@ -16,6 +17,8 @@ class MockWKEngineWebView: WKEngineWebView {
     // MARK: Test properties
     var loadCalled = 0
     var loadFileURLCalled = 0
+    var reloadFromOriginCalled = 0
+    var replaceLocationCalled = 0
     var stopLoadingCalled = 0
     var goBackCalled = 0
     var goForwardCalled = 0
@@ -30,16 +33,26 @@ class MockWKEngineWebView: WKEngineWebView {
                    configurationProvider: WKEngineConfigurationProvider) {}
 
     func load(_ request: URLRequest) -> WKNavigation? {
-        loadRequest = request
+        url = request.url
         loadCalled += 1
         return nil
     }
 
     func loadFileURL(_ URL: URL, allowingReadAccessTo readAccessURL: URL) -> WKNavigation? {
-        loadFileURL = URL
+        url = URL
         loadFileReadAccessURL = readAccessURL
         loadFileURLCalled += 1
         return nil
+    }
+
+    func reloadFromOrigin() -> WKNavigation? {
+        reloadFromOriginCalled += 1
+        return nil
+    }
+
+    func replaceLocation(with url: URL) {
+        self.url = url
+        replaceLocationCalled += 1
     }
 
     func stopLoading() {

--- a/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
@@ -49,7 +49,7 @@ final class WKEngineSessionTests: XCTestCase {
         subject?.load(url: url)
 
         XCTAssertEqual(webViewProvider.webView.loadCalled, 1)
-        XCTAssertEqual(webViewProvider.webView.loadRequest?.url?.absoluteString, "https://example.com")
+        XCTAssertEqual(webViewProvider.webView.url?.absoluteString, url)
     }
 
     func testLoadURLGivenReaderModeURLThenLoad() {
@@ -103,6 +103,29 @@ final class WKEngineSessionTests: XCTestCase {
         subject?.goForward()
 
         XCTAssertEqual(webViewProvider.webView.goForwardCalled, 1)
+    }
+
+    // MARK: Reload
+
+    func testReloadThenCallsReloadFromOrigin() {
+        let subject = createSubject()
+
+        subject?.reload()
+
+        XCTAssertEqual(webViewProvider.webView.reloadFromOriginCalled, 1)
+    }
+
+    func testReloadWhenErrorPageThenReplaceLocation() {
+        let subject = createSubject()
+        let errorPageURL = "errorpage"
+        let internalURL = "internal://local/errorpage?url=\(errorPageURL)"
+        subject?.load(url: internalURL)
+
+        subject?.reload()
+
+        XCTAssertEqual(webViewProvider.webView.reloadFromOriginCalled, 0)
+        XCTAssertEqual(webViewProvider.webView.replaceLocationCalled, 1)
+        XCTAssertEqual(webViewProvider.webView.url?.absoluteString, errorPageURL)
     }
 
     // MARK: Helper

--- a/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
@@ -59,7 +59,7 @@ final class WKEngineSessionTests: XCTestCase {
         subject?.load(url: url)
 
         XCTAssertEqual(webViewProvider.webView.loadCalled, 1)
-        XCTAssertEqual(webViewProvider.webView.loadRequest?.url?.absoluteString,
+        XCTAssertEqual(webViewProvider.webView.url?.absoluteString,
                        "http://localhost:0/reader-mode/page?url=http%3A%2F%2Fexample%2Ecom")
     }
 
@@ -71,7 +71,7 @@ final class WKEngineSessionTests: XCTestCase {
 
         XCTAssertEqual(webViewProvider.webView.loadCalled, 0)
         XCTAssertEqual(webViewProvider.webView.loadFileURLCalled, 1)
-        XCTAssertEqual(webViewProvider.webView.loadFileURL?.absoluteString, "file://path/to/abc/dirA/A.html")
+        XCTAssertEqual(webViewProvider.webView.url?.absoluteString, "file://path/to/abc/dirA/A.html")
         XCTAssertEqual(webViewProvider.webView.loadFileReadAccessURL?.absoluteString, "file://path/to/abc/dirA/")
     }
 

--- a/BrowserKit/Tests/WebEngineTests/WKInternalURLTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKInternalURLTests.swift
@@ -80,7 +80,7 @@ final class WKInternalURLTests: XCTestCase {
     // MARK: Original URL from Error page
 
     func testOriginalURLFromErrorPageWhenInternalErrorPageThenErrorPageURL() {
-        let expectedURL = "/errorpage"
+        let expectedURL = "www.example.com"
         let url = URL(string: "internal://local/errorpage?url=\(expectedURL)")!
 
         let subject = WKInternalURL(url)

--- a/BrowserKit/Tests/WebEngineTests/WKInternalURLTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKInternalURLTests.swift
@@ -76,4 +76,28 @@ final class WKInternalURLTests: XCTestCase {
 
         XCTAssertFalse(subject.isAuthorized)
     }
+
+    // MARK: Original URL from Error page
+
+    func testOriginalURLFromErrorPageWhenInternalErrorPageThenErrorPageURL() {
+        let expectedURL = "/errorpage"
+        let url = URL(string: "internal://local/errorpage?url=\(expectedURL)")!
+
+        let subject = WKInternalURL(url)
+        XCTAssertEqual(subject?.originalURLFromErrorPage, URL(string: expectedURL)!)
+    }
+
+    func testOriginalURLFromErrorPageWhenNoParamThenNil() {
+        let url = URL(string: "internal://local/errorpage")!
+
+        let subject = WKInternalURL(url)
+        XCTAssertNil(subject?.originalURLFromErrorPage)
+    }
+
+    func testOriginalURLFromErrorPageWhenEmptyParamURLHasNoParamThenNil() {
+        let url = URL(string: "internal://local/errorpage?url=")!
+
+        let subject = WKInternalURL(url)
+        XCTAssertNil(subject?.originalURLFromErrorPage)
+    }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7906)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17650)

## :bulb: Description
- Implement reload in WKEngineSession and created unit tests for it
- Added `originalURLFromErrorPage` in `WKInternalIURL` based in our existing code and created unit tests for it 
- Added some logs in WKEngineSession at the same time.
- Added the necessary scheme to test WebEngine easily (I was testing through the Client target before, but it's kind of slow).

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

