### PR TITLE
Bugfix MTE-1938 [v123] Update directory for the new directory structure

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/xcodebuild.py
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/xcodebuild.py
@@ -57,7 +57,7 @@ class XCodeBuild(object):
                 cwd=os.chdir("../../.."),
                 stderr=subprocess.STDOUT,
                 universal_newlines=True)
-            os.chdir("firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests")
+            os.chdir("firefox-ios-tests/Tests/SyncIntegrationTests")
         except subprocess.CalledProcessError as e:
             out = e.output
             raise

--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/xcodebuild.py
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/xcodebuild.py
@@ -54,7 +54,7 @@ class XCodeBuild(object):
         try:
             out = subprocess.check_output(
                 args,
-                cwd=os.chdir("../../../.."),
+                cwd=os.chdir("../../.."),
                 stderr=subprocess.STDOUT,
                 universal_newlines=True)
             os.chdir("firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1938)

## :bulb: Description
After the change in MTE-1938, the Sync Integration Tests are not running. The directory structure has been updated.

I have tested this change by running one of the tests:
```
pipenv run pytest test_integration.py::test_sync_bookmark_from_device
```

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

