### PR TITLE
Refactor MTE-1983 [v123] Follow up: fix typo in github action

### DIFF
--- a/.github/workflows/firefox-ios-update-effective-tld-names-file.yml
+++ b/.github/workflows/firefox-ios-update-effective-tld-names-file.yml
@@ -31,7 +31,7 @@ jobs:
 
         curl -o tmp.dat  "https://raw.githubusercontent.com/publicsuffix/list/master/public_suffix_list.dat"
 
-        file_in_repo=firefox-io/Shared/effective_tld_names.dat
+        file_in_repo=firefox-ios/Shared/effective_tld_names.dat
 
         files_diff=$(cmp --silent tmp.dat $file_in_repo && echo '### SUCCESS: Files Are Identical! ###' || echo '### WARNING: Files Are Different! ###')
 

--- a/taskcluster/ffios_taskgraph/screenshots_locales.py
+++ b/taskcluster/ffios_taskgraph/screenshots_locales.py
@@ -15,7 +15,7 @@ def get_screenshots_locales():
     config = {"locales": []}
 
     # Check all *.lproj files as there is one per locale
-    for file in os.listdir(os.path.join(project_dir, 'Client')):
+    for file in os.listdir(os.path.join(project_dir, 'firefox-ios/Client')):
         if file.endswith(".lproj"):
                 config["locales"].append(file)
 


### PR DESCRIPTION
## :scroll: Tickets
There is a typo in the effective tld names update github action. Missing an `s`


## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

