### PR TITLE
Add FXIOS-7752 [v122] Add telemetry for surface ads clicked

### DIFF
--- a/firefox-ios/Client/Frontend/Fakespot/FakespotViewController.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotViewController.swift
@@ -460,6 +460,7 @@ class FakespotViewController:
             var viewModel = FakespotAdViewModel(productAdsData: adData)
             viewModel.onTapProductLink = { [weak self] in
                 self?.viewModel.addTab(url: adData.url)
+                self?.viewModel.recordSurfaceAdsClickedTelemetry()
                 self?.viewModel.reportAdEvent(eventName: .trustedDealsLinkClicked, aid: adData.aid)
                 store.dispatch(FakespotAction.setAppearanceTo(false))
             }

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotViewModel.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotViewModel.swift
@@ -557,6 +557,15 @@ class FakespotViewModel {
         }
     }
 
+    public func recordSurfaceAdsClickedTelemetry() {
+        TelemetryWrapper.recordEvent(
+            category: .action,
+            method: .view,
+            object: .shoppingBottomSheet,
+            value: .surfaceAdsClicked
+        )
+    }
+
     private static func recordNoReviewReliabilityAvailableTelemetry() {
         TelemetryWrapper.recordEvent(
             category: .action,

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -673,6 +673,7 @@ extension TelemetryWrapper {
         case searchSuggestion = "search-suggestion"
         case searchHighlights = "search-highlights"
         case shoppingCFRsDisplayed = "shopping-cfrs-displayed"
+        case surfaceAdsClicked = "surface-ads-clicked"
         case shoppingAdsExposure = "shopping-ads-exposure"
         case shoppingAdsImpression = "shopping-ads-impression"
         case shoppingNoAdsAvailable = "shopping-no-ads-available"
@@ -1167,6 +1168,8 @@ extension TelemetryWrapper {
             }
 
         // MARK: Shopping Experience (Fakespot)
+        case (.action, .view, .shoppingBottomSheet, .surfaceAdsClicked, _):
+            GleanMetrics.Shopping.surfaceAdsClicked.record()
         case (.action, .tap, .shoppingButton, _, _):
             GleanMetrics.Shopping.addressBarIconClicked.record()
         case (.action, .view, .shoppingBottomSheet, .shoppingAdsExposure, _):

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -727,7 +727,7 @@ shopping:
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/7752
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/17746
+      - https://github.com/mozilla-mobile/firefox-ios/pull/17861
     data_sensitivity:
       - interaction
     expires: "2024-06-01"

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -720,6 +720,22 @@ shopping:
     send_in_pings:
       - events
 
+  surface_ads_clicked:
+    type: event
+    description: |
+      An ad shown in the fakespot bar was clicked.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/7752
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/17746
+    data_sensitivity:
+      - interaction
+    expires: "2024-06-01"
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    send_in_pings:
+      - events
+
   address_bar_icon_clicked:
     type: event
     description: |

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -473,6 +473,18 @@ class TelemetryWrapperTests: XCTestCase {
         )
     }
 
+    func test_surfaceAdsClicked_GleanIsCalled() {
+        TelemetryWrapper.recordEvent(
+            category: .action,
+            method: .view,
+            object: .shoppingBottomSheet,
+            value: .surfaceAdsClicked
+        )
+        testEventMetricRecordingSuccess(
+            metric: GleanMetrics.Shopping.surfaceAdsClicked
+        )
+    }
+
     // MARK: - Onboarding
     func test_onboardingSelectWallpaperWithExtras_GleanIsCalled() {
         let wallpaperNameKey = TelemetryWrapper.EventExtraKey.wallpaperName.rawValue


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7752)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17300)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
The primary objective of this feature is to collect detailed information on which ads are clicked.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

