### PR TITLE
Bugfix MTE-1938 [v123] Ensure SyncIntegrationTests directory is used

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/tps.py
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/tps.py
@@ -22,6 +22,8 @@ class TPS(object):
         self.firefox_log.write(line.decode() + '\n')
 
     def run(self, test, phase='phase1', ignore_unused_engines=True):
+        if "SyncIntegrationTests" not in os.getcwd():
+            os.chdir("firefox-ios-tests/Tests/SyncIntegrationTests")
         self.profile.set_preferences({
             'testing.tps.testFile': os.path.abspath(test),
             'testing.tps.testPhase': phase,

--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/xcodebuild.py
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/xcodebuild.py
@@ -57,11 +57,11 @@ class XCodeBuild(object):
                 cwd=os.chdir("../../.."),
                 stderr=subprocess.STDOUT,
                 universal_newlines=True)
-            os.chdir("firefox-ios-tests/Tests/SyncIntegrationTests")
         except subprocess.CalledProcessError as e:
             out = e.output
             raise
         finally:
             with open(self.log, 'w') as f:
                 f.write(out)
+            os.chdir("firefox-ios-tests/Tests/SyncIntegrationTests")
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-1938)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Roughly after the start of the test files were reorganized, some tests fail in bulk due to the `.js` files for TPS was not found. Let's ensure that we navigate back to the `SyncIntegrationTests` directory even after a test has failed.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

