### PR TITLE
Add FXIOS-8005 [v122] Footer to Show Suggestions setting

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -271,7 +271,7 @@ class SearchSettingsTableViewController: ThemedTableViewController, FeatureFlagg
     }
 
     override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return 0
+        return UITableView.automaticDimension
     }
 
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
@@ -285,7 +285,10 @@ class SearchSettingsTableViewController: ThemedTableViewController, FeatureFlagg
 
     override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         guard let footerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: ThemedTableSectionHeaderFooterView.cellIdentifier) as? ThemedTableSectionHeaderFooterView else { return nil }
-
+        if case .defaultEngine = Section(rawValue: section) {
+            footerView.titleLabel.text = .Settings.Search.DefaultSearchEngineFooter
+            footerView.titleAlignment = .top
+        }
         footerView.applyTheme(theme: themeManager.currentTheme)
         return footerView
     }

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -1685,6 +1685,11 @@ extension String {
                 tableName: "Settings",
                 value: "Default Search Engine",
                 comment: "Title for the `default search engine` settings section in the Search page in the Settings menu.")
+            public static let DefaultSearchEngineFooter = MZLocalizedString(
+                key: "Settings.Search.DefaultSearchEngine.Footer.v122",
+                tableName: "Settings",
+                value: "Results from searches, history, bookmarks, and more",
+                comment: "Footer for for the `default search engine` settings section in the Search Settings page, which explains in more details what the `Show Search Suggestions` setting includes.")
             public static let QuickSearchEnginesTitle = MZLocalizedString(
                 key: "Settings.Search.QuickEnginesTitle.v121",
                 tableName: "Settings",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8005)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17867)

## :bulb: Description
Add footer to default engine section in search settings page to describe the show suggestions results more clearly.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

## Screenshots
| iPhone | iPad |
| --- | --- |
|![simulator_screenshot_4279D02F-C8BF-4FF3-B131-E2B4B904945B](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/ff139fde-53d1-4a86-bba2-e853bbad8dfa)|![Simulator Screenshot - iPad Pro (11-inch) (4th generation) - 2023-12-21 at 12 57 43](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/a8eaa4ea-3e71-4d14-9dbf-d5272a68b890)|