### PR TITLE
Add FXIOS-7994 [v122] Data clearance check to redux

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -8,6 +8,7 @@ import Redux
 struct BrowserViewControllerState: ScreenState, Equatable {
     var searchScreenState: SearchScreenState
     var usePrivateHomepage: Bool
+    var showDataClearanceFlow: Bool
     var fakespotState: FakespotState
 
     init(_ appState: AppState) {
@@ -21,6 +22,7 @@ struct BrowserViewControllerState: ScreenState, Equatable {
 
         self.init(searchScreenState: bvcState.searchScreenState,
                   usePrivateHomepage: bvcState.usePrivateHomepage,
+                  showDataClearanceFlow: bvcState.showDataClearanceFlow,
                   fakespotState: bvcState.fakespotState)
     }
 
@@ -28,16 +30,19 @@ struct BrowserViewControllerState: ScreenState, Equatable {
         self.init(
             searchScreenState: SearchScreenState(),
             usePrivateHomepage: false,
+            showDataClearanceFlow: false,
             fakespotState: FakespotState())
     }
 
     init(
         searchScreenState: SearchScreenState,
         usePrivateHomepage: Bool,
+        showDataClearanceFlow: Bool,
         fakespotState: FakespotState
     ) {
         self.searchScreenState = searchScreenState
         self.usePrivateHomepage = usePrivateHomepage
+        self.showDataClearanceFlow = showDataClearanceFlow
         self.fakespotState = fakespotState
     }
 
@@ -47,6 +52,7 @@ struct BrowserViewControllerState: ScreenState, Equatable {
             return BrowserViewControllerState(
                 searchScreenState: SearchScreenState(inPrivateMode: privacyState),
                 usePrivateHomepage: privacyState,
+                showDataClearanceFlow: privacyState,
                 fakespotState: state.fakespotState)
         case FakespotAction.pressedShoppingButton,
             FakespotAction.show,
@@ -58,6 +64,7 @@ struct BrowserViewControllerState: ScreenState, Equatable {
             return BrowserViewControllerState(
                 searchScreenState: state.searchScreenState,
                 usePrivateHomepage: state.usePrivateHomepage,
+                showDataClearanceFlow: state.showDataClearanceFlow,
                 fakespotState: FakespotState.reducer(state.fakespotState, action))
         default:
             return state

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1280,9 +1280,8 @@ class BrowserViewController: UIViewController,
     }
 
     private func handleMiddleButtonState(_ state: MiddleButtonState) {
-        // TODO: Use REDUX to show felt deletion https://mozilla-hub.atlassian.net/browse/FXIOS-7994
-        let isPrivate = tabManager.selectedTab?.isPrivate ?? false
-        let showFireIcon = featureFlags.isFeatureEnabled(.feltPrivacyFeltDeletion, checking: .buildOnly) && isPrivate
+        let showDataClearanceFlow = browserViewControllerState?.showDataClearanceFlow ?? false
+        let showFireIcon = featureFlags.isFeatureEnabled(.feltPrivacyFeltDeletion, checking: .buildOnly) && showDataClearanceFlow
         guard !showFireIcon else {
             navigationToolbar.updateMiddleButtonState(.fire)
             return

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -166,7 +166,7 @@ final class NimbusFeatureFlagLayer {
 
         switch featureID {
         case .feltPrivacySimplifiedUI: return config.simplifiedUiEnabled
-        case .feltPrivacyFeltDeletion: return config.feltDeletionEnabled
+        case .feltPrivacyFeltDeletion: return config.feltDeletionEnabled && config.simplifiedUiEnabled
         default: return false
         }
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7994)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17838)

## :bulb: Description
Add check to show data clearance flow using Redux based on whether user is in private mode. 
Confirmed with Andy that the felt deletion flow will exists only if the simplified UI flow exists. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

