### PR TITLE
Refactor FXIOS-7953 [v123] [Multi-window] Refactors for handling clear history

### DIFF
--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -25,6 +25,9 @@ protocol WindowManager {
     /// Convenience. Returns the TabManager for a specific window.
     func tabManager(for windowUUID: WindowUUID) -> TabManager
 
+    /// Convenience. Returns all TabManagers for all open windows.
+    func allWindowTabManagers() -> [TabManager]
+
     /// Signals the WindowManager that a window was closed.
     /// - Parameter uuid: the ID of the window.
     func windowDidClose(uuid: WindowUUID)
@@ -69,6 +72,10 @@ final class WindowManagerImplementation: WindowManager {
     func tabManager(for windowUUID: WindowUUID) -> TabManager {
         guard let tabManager = window(for: windowUUID)?.tabManager else { fatalError("No tab manager for window UUID.") }
         return tabManager
+    }
+
+    func allWindowTabManagers() -> [TabManager] {
+        return windows.compactMap { uuid, window in window.tabManager }
     }
 
     func windowDidClose(uuid: WindowUUID) {

--- a/firefox-ios/Client/Coordinators/Library/LibraryCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/LibraryCoordinator.swift
@@ -47,7 +47,7 @@ class LibraryCoordinator: BaseCoordinator, LibraryPanelDelegate, LibraryNavigati
 
     private func makeChildPanels() -> [UINavigationController] {
         let bookmarksPanel = BookmarksPanel(viewModel: BookmarksPanelViewModel(profile: profile))
-        let historyPanel = HistoryPanel(profile: profile, tabManager: tabManager)
+        let historyPanel = HistoryPanel(profile: profile)
         let downloadsPanel = DownloadsPanel()
         let readingListPanel = ReadingListPanel(profile: profile)
         return [

--- a/firefox-ios/Client/Frontend/Library/ClearHistorySheetProvider.swift
+++ b/firefox-ios/Client/Frontend/Library/ClearHistorySheetProvider.swift
@@ -4,14 +4,15 @@
 
 import Foundation
 import WebKit
+import Common
 
 class ClearHistorySheetProvider {
     private let profile: Profile
-    private let tabManager: TabManager
+    private let windowManager: WindowManager
 
-    init(profile: Profile, tabManager: TabManager) {
+    init(profile: Profile, windowManager: WindowManager = AppContainer.shared.resolve()) {
         self.profile = profile
-        self.tabManager = tabManager
+        self.windowManager = windowManager
     }
 
     /// Present a prompt that will enable the user to choose how he wants to clear his recent history
@@ -90,7 +91,8 @@ class ClearHistorySheetProvider {
             let deletionUtilitiy = HistoryDeletionUtility(with: self.profile)
             deletionUtilitiy.deleteHistoryFrom(.allTime) { dateOption in
                 DispatchQueue.main.async {
-                    self.tabManager.clearAllTabsHistory()
+                    // Clear and reset tab history for all windows / tab managers
+                    self.windowManager.allWindowTabManagers().forEach { $0.clearAllTabsHistory() }
                 }
                 NotificationCenter.default.post(name: .PrivateDataClearedHistory, object: nil)
                 didComplete?(dateOption)

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -145,11 +145,10 @@ class HistoryPanel: UIViewController,
     // MARK: - Inits
 
     init(profile: Profile,
-         tabManager: TabManager,
          themeManager: ThemeManager = AppContainer.shared.resolve(),
          notificationCenter: NotificationProtocol = NotificationCenter.default,
          logger: Logger = DefaultLogger.shared) {
-        self.clearHistoryHelper = ClearHistorySheetProvider(profile: profile, tabManager: tabManager)
+        self.clearHistoryHelper = ClearHistorySheetProvider(profile: profile)
         self.viewModel = HistoryPanelViewModel(profile: profile)
         self.profile = profile
         self.state = .history(state: .mainView)
@@ -308,6 +307,7 @@ class HistoryPanel: UIViewController,
     }
 
     func handleNotifications(_ notification: Notification) {
+        // TODO: [FXIOS-7953, 7791] Needs updates for multi-window support.
         switch notification.name {
         case .FirefoxAccountChanged, .PrivateDataClearedHistory:
             viewModel.removeAllData()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/HistoryPanelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/HistoryPanelTests.swift
@@ -89,8 +89,7 @@ class HistoryPanelTests: XCTestCase {
     private func createSubject() -> HistoryPanel {
         let profile = MockProfile()
         let tabManager = MockTabManager()
-        let subject = HistoryPanel(profile: profile,
-                                   tabManager: tabManager)
+        let subject = HistoryPanel(profile: profile)
         trackForMemoryLeaks(subject)
         return subject
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WindowManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WindowManagerTests.swift
@@ -164,6 +164,31 @@ class WindowManagerTests: XCTestCase {
         XCTAssertNotEqual(result2, result3)
     }
 
+    func testAllWindowTabManagers() {
+        let subject = createSubject()
+
+        let tabManager1 = MockTabManager()
+        let tabManager2 = MockTabManager()
+
+        // Create two separate windows with associated Tab Managers
+        let uuid1 = subject.nextAvailableWindowUUID()
+        subject.newBrowserWindowConfigured(AppWindowInfo(tabManager: tabManager1), uuid: uuid1)
+        let uuid2 = subject.nextAvailableWindowUUID()
+        subject.newBrowserWindowConfigured(AppWindowInfo(tabManager: tabManager2), uuid: uuid2)
+
+        // Check that allWindowTabManagers returns both expected instances
+        var allTabManagers = subject.allWindowTabManagers()
+        XCTAssertEqual(allTabManagers.count, 2)
+        XCTAssert(allTabManagers.contains(where: { $0 === tabManager1 }))
+        XCTAssert(allTabManagers.contains(where: { $0 === tabManager2 }))
+
+        // Close first window and check that only the 2nd tab manager instance is returned
+        subject.windowDidClose(uuid: uuid1)
+        allTabManagers = subject.allWindowTabManagers()
+        XCTAssertEqual(allTabManagers.count, 1)
+        XCTAssert(tabManager2 === allTabManagers.first!)
+    }
+
     // MARK: - Test Subject
 
     private func createSubject() -> WindowManager {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7953)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17735)

## :bulb: Description

Minor refactor. Adds early support for handling clearing of History when multiple windows are open. Additional changes forthcoming, more work is still needed to update History panel for multi-window.

👉 Note: this refactor has no effects on normal "single window" mode (no changes to `main`).

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

