### PR TITLE
Fix MTE-2031 [v123] drag and drop tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DragAndDropTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DragAndDropTests.swift
@@ -126,10 +126,21 @@ private extension BaseTestCase {
     }
 
     func dragAndDrop(dragElement: XCUIElement, dropOnElement: XCUIElement) {
+        var nrOfAttempts = 0
+        mozWaitForElementToExist(dropOnElement)
         dragElement.press(forDuration: 1.5, thenDragTo: dropOnElement)
+        mozWaitForElementToExist(dragElement)
+        // Repeat the action in case the first drag and drop attempt was not successfull
+        while dragElement.isLeftOf(rightElement: dropOnElement) && nrOfAttempts < 4 {
+            dragElement.press(forDuration: 1.5, thenDragTo: dropOnElement)
+            nrOfAttempts = nrOfAttempts + 1
+            mozWaitForElementToExist(dragElement)
+        }
     }
 
     func checkTabsOrder(dragAndDropTab: Bool, firstTab: String, secondTab: String) {
+        mozWaitForElementToExist(app.collectionViews.cells.element(boundBy: 0))
+        mozWaitForElementToExist(app.collectionViews.cells.element(boundBy: 1))
         let firstTabCell = app.collectionViews.cells.element(boundBy: 0).label
         let secondTabCell = app.collectionViews.cells.element(boundBy: 1).label
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2031)

## :bulb: Description
This PR fixes testRearrangeTabsTabTray and testDragAndDropHomeTabTabsTray tests.
These are flaky tests and the failing is caused by the fact that the drag and drop action is not performed successfully all the time.
The solution was to add a retry when that happens. Below you can find the results of 50 runs locally.
 
<img width="731" alt="Screenshot 2023-12-21 at 17 01 56" src="https://github.com/mozilla-mobile/firefox-ios/assets/134391433/be9bd1c0-2508-4658-9588-c4791d0d1ece">
<img width="994" alt="Screenshot 2023-12-21 at 17 01 34" src="https://github.com/mozilla-mobile/firefox-ios/assets/134391433/4bd5b0f8-c9ac-4206-8cf2-e877f3000ab7">


