### PR TITLE
Bugfix FXIOS-8007 [v123] Replaced SecTrustGetCertificateAtIndex with SecTrustCopyCertificateChain

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -904,8 +904,8 @@ private extension BrowserViewController {
         let origin = "\(challenge.protectionSpace.host):\(challenge.protectionSpace.port)"
 
         guard let trust = challenge.protectionSpace.serverTrust,
-              let cert = SecTrustGetCertificateAtIndex(trust, 0),
-              profile.certStore.containsCertificate(cert, forOrigin: origin)
+              let cert = SecTrustCopyCertificateChain(trust) as? [SecCertificate],
+              profile.certStore.containsCertificate(cert[0], forOrigin: origin)
         else {
             completionHandler(.performDefaultHandling, nil)
             return


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8007)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17877)

## :bulb: Description
Replaced `SecTrustGetCertificateAtIndex` with `SecTrustCopyCertificateChain` in `BrowserViewController+WebViewDelegates`

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

