### PR TITLE
Refactor FXIOS-8021 [v123] Remove SnapKit from topTouchArea

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -118,7 +118,10 @@ class BrowserViewController: UIViewController,
         return searchBarPosition == .bottom
     }()
 
-    private var topTouchArea: UIButton!
+    private lazy var topTouchArea: UIButton = .build { topTouchArea in
+        topTouchArea.isAccessibilityElement = false
+        topTouchArea.addTarget(self, action: #selector(self.tappedTopArea), for: .touchUpInside)
+    }
 
     var topTabsVisible: Bool {
         return topTabsViewController != nil
@@ -634,9 +637,6 @@ class BrowserViewController: UIViewController,
 
         contentStackView.addArrangedSubview(contentContainer)
 
-        topTouchArea = UIButton()
-        topTouchArea.isAccessibilityElement = false
-        topTouchArea.addTarget(self, action: #selector(tappedTopArea), for: .touchUpInside)
         view.addSubview(topTouchArea)
 
         // Work around for covering the non-clipped web view content
@@ -849,10 +849,12 @@ class BrowserViewController: UIViewController,
     override func updateViewConstraints() {
         super.updateViewConstraints()
 
-        topTouchArea.snp.remakeConstraints { make in
-            make.top.left.right.equalTo(view)
-            make.height.equalTo(UX.ShowHeaderTapAreaHeight)
-        }
+        NSLayoutConstraint.activate([
+            topTouchArea.topAnchor.constraint(equalTo: view.topAnchor),
+            topTouchArea.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            topTouchArea.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            topTouchArea.heightAnchor.constraint(equalToConstant: UX.ShowHeaderTapAreaHeight)
+        ])
 
         readerModeBar?.snp.remakeConstraints { make in
             make.height.equalTo(UIConstants.ToolbarHeight)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8021)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17892)

## :bulb: Description
- This pull request addresses the reported issue by eliminating the usage of SnapKit for constraints related to topTouchArea in the BrowserViewController.swift file. 
- The change replaces the line, `topTouchArea.snp.remakeConstraints`, with standard NSLayoutConstraint code.

| Portrait  | Landscape | 
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2023-12-22 at 10 21 41](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/80b45a26-14c4-4711-a768-b79ccdca9295) | ![Simulator Screenshot - iPhone 15 Pro - 2023-12-22 at 10 21 43](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/f3c4e86d-3e5a-4694-8bc3-76ea10691e15) |


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods