### PR TITLE
Refactor FXIOS-8020 [v123] Remove SnapKit from webViewContainerBackdrop

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -124,7 +124,9 @@ class BrowserViewController: UIViewController,
         return topTabsViewController != nil
     }
     // Backdrop used for displaying greyed background for private tabs
-    var webViewContainerBackdrop: UIView!
+    private lazy var webViewContainerBackdrop: UIView = .build { containerBackdrop in
+        containerBackdrop.alpha = 0
+    }
     var keyboardBackdrop: UIView?
 
     var scrollController = TabScrollingController()
@@ -627,10 +629,7 @@ class BrowserViewController: UIViewController,
     }
 
     func addSubviews() {
-        webViewContainerBackdrop = UIView()
-        webViewContainerBackdrop.alpha = 0
-        view.addSubview(webViewContainerBackdrop)
-        view.addSubview(contentStackView)
+        view.addSubviews(webViewContainerBackdrop, contentStackView)
 
         contentStackView.addArrangedSubview(contentContainer)
 
@@ -817,9 +816,12 @@ class BrowserViewController: UIViewController,
             urlBarHeightConstraint = make.height.equalTo(UIConstants.TopToolbarHeightMax).constraint
         }
 
-        webViewContainerBackdrop.snp.makeConstraints { make in
-            make.edges.equalTo(view)
-        }
+        NSLayoutConstraint.activate([
+            webViewContainerBackdrop.topAnchor.constraint(equalTo: view.topAnchor),
+            webViewContainerBackdrop.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            webViewContainerBackdrop.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            webViewContainerBackdrop.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
 
         NSLayoutConstraint.activate([
             contentStackView.topAnchor.constraint(equalTo: header.bottomAnchor),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8020)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17891)

## :bulb: Description
- This pull request addresses the reported issue by eliminating the usage of SnapKit for constraints related to webViewContainerBackdrop in the BrowserViewController.swift file. 
- The change replaces the line, `webViewContainerBackdrop.snp.makeConstraints`, with standard NSLayoutConstraint code.

| Portrait  | Landscape | 
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2023-12-22 at 10 46 40](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/5077c6ab-720e-4814-b761-53cc5c1af25b) | ![Simulator Screenshot - iPhone 15 Pro - 2023-12-22 at 10 46 58](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/31cefe4e-789f-4c51-89fe-c698f00dcc47) |


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods