### PR TITLE
Refactor FXIOS-8019 [v123] Remove SnapKit from statusBarOverlay

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -738,10 +738,19 @@ class BrowserViewController: UIViewController,
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        statusBarOverlay.snp.remakeConstraints { make in
-            make.top.left.right.equalTo(self.view)
-            make.height.equalTo(self.view.safeAreaInsets.top)
-        }
+        // Remove existing constraints
+        statusBarOverlay.removeConstraints(statusBarOverlay.constraints)
+
+        // Set new constraints for the statusBarOverlay
+        NSLayoutConstraint.activate([
+            statusBarOverlay.topAnchor.constraint(equalTo: view.topAnchor),
+            statusBarOverlay.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            statusBarOverlay.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            statusBarOverlay.heightAnchor.constraint(equalToConstant: view.safeAreaInsets.top)
+        ])
+
+        // Ensure the layout is updated immediately
+        view.layoutIfNeeded()
 
         showQueuedAlertIfAvailable()
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8019)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17890)

## :bulb: Description
- This pull request resolves the reported issue by removing SnapKit usage for constraints associated with statusBarOverlay in the BrowserViewController.swift file. 
- The modification replaces the SnapKit in line, 'statusBarOverlay.snp.remakeConstraints', with standard NSLayoutConstraint code.

| Portrait  | Landscape | 
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2023-12-22 at 13 58 17](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/bc2aa7b6-b0c7-4f70-8c45-b9896a80ef1f) | ![Simulator Screenshot - iPhone 15 Pro - 2023-12-22 at 13 58 20](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/73473e53-f161-400b-b807-dca855470b98) |


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods