### PR TITLE
Refactor FXIOS-8009 [v121] Fix InsetButton warnings

### DIFF
--- a/firefox-ios/Client/Frontend/Widgets/InsetButton.swift
+++ b/firefox-ios/Client/Frontend/Widgets/InsetButton.swift
@@ -7,8 +7,17 @@
  */
 class InsetButton: UIButton {
     override var intrinsicContentSize: CGSize {
-        let size = super.intrinsicContentSize
-        return CGSize(width: size.width + titleEdgeInsets.left + titleEdgeInsets.right,
-                      height: size.height + titleEdgeInsets.top + titleEdgeInsets.bottom)
+        guard let title = titleLabel, let configuration else {
+            return super.intrinsicContentSize
+        }
+
+        let widthContentInset = configuration.contentInsets.leading + configuration.contentInsets.trailing
+        let heightContentInset = configuration.contentInsets.top + configuration.contentInsets.bottom
+
+        let availableWidth = frame.width - widthContentInset
+        let size = title.sizeThatFits(CGSize(width: availableWidth, height: .greatestFiniteMagnitude))
+
+        return CGSize(width: size.width + widthContentInset,
+                      height: size.height + heightContentInset)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8009)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17880)

## :bulb: Description
- This pull request resolves warnings in the InsetButton class, which is used in two places under the URLBarView
- The warnings were related to the deprecation of the 'titleEdgeInsets' property in iOS 15.0

| Portrait  | Landscape | 
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2023-12-22 at 14 36 38](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/ac460025-b092-4adc-bdf0-01df3c463b96) | ![Simulator Screenshot - iPhone 15 Pro - 2023-12-22 at 14 36 41](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/296dc245-ac07-4524-a23c-028d6689b35e) |

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods