### PR TITLE
Add FXIOS-7944 [v122] Add Webview telemetry for failures

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -122,6 +122,7 @@ excluded: # paths to ignore during linting. Takes precedence over `included`.
   # so must be excluded due to file_header rule
   - firefox-ios/Package.swift
   - BrowserKit/Package.swift
+  - BrowserKit/.build/
   - firefox-ios/Client/ContentBlocker/ContentBlockerGenerator/Package.swift
   - Package.swift
   

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -49,10 +49,15 @@ extension BrowserViewController: WKUIDelegate {
     ) {
         let messageAlert = MessageAlert(message: message, frame: frame)
         if shouldDisplayJSAlertForWebView(webView) {
+            logger.log("Javascript message alert will be presented.", level: .info, category: .webview)
+
             present(messageAlert.alertController(), animated: true) {
                 completionHandler()
+                self.logger.log("Javascript message alert was completed.", level: .info, category: .webview)
             }
         } else if let promptingTab = tabManager[webView] {
+            logger.log("Javascript message alert is queued.", level: .info, category: .webview)
+
             promptingTab.queueJavascriptAlertPrompt(messageAlert)
             completionHandler()
         }
@@ -66,11 +71,16 @@ extension BrowserViewController: WKUIDelegate {
     ) {
         let confirmAlert = ConfirmPanelAlert(message: message,
                                              frame: frame) { confirm in
+            self.logger.log("Javascript confirm panel was completed.", level: .info, category: .webview)
             completionHandler(confirm)
         }
         if shouldDisplayJSAlertForWebView(webView) {
+            logger.log("Javascript confirm panel alert will be presented.", level: .info, category: .webview)
+
             present(confirmAlert.alertController(), animated: true)
         } else if let promptingTab = tabManager[webView] {
+            logger.log("Javascript confirm panel alert is queued.", level: .info, category: .webview)
+
             promptingTab.queueJavascriptAlertPrompt(confirmAlert)
         }
     }
@@ -85,11 +95,16 @@ extension BrowserViewController: WKUIDelegate {
         let textInputAlert = TextInputAlert(message: prompt,
                                             frame: frame,
                                             defaultText: defaultText) { confirm in
+            self.logger.log("Javascript text input alert was completed.", level: .info, category: .webview)
             completionHandler(confirm)
         }
         if shouldDisplayJSAlertForWebView(webView) {
+            logger.log("Javascript text input alert will be presented.", level: .info, category: .webview)
+
             present(textInputAlert.alertController(), animated: true)
         } else if let promptingTab = tabManager[webView] {
+            logger.log("Javascript text input alert is queued.", level: .info, category: .webview)
+
             promptingTab.queueJavascriptAlertPrompt(textInputAlert)
         }
     }
@@ -373,7 +388,8 @@ extension BrowserViewController: WKUIDelegate {
 }
 
 // MARK: - WKNavigationDelegate
-extension BrowserViewController: WKNavigationDelegate {
+extension BrowserViewController: WKNavigationDelegate
+{
     func webView(_ webView: WKWebView, didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation!) {
         guard let tab = tabManager[webView] else { return }
 
@@ -666,12 +682,37 @@ extension BrowserViewController: WKNavigationDelegate {
         decisionHandler(.allow)
     }
 
+    /// Tells the delegate that an error occurred during navigation.
+    func webView(
+        _ webView: WKWebView,
+        didFail navigation: WKNavigation!,
+        withError error: Error
+    ) {
+        logger.log("Error occurred during navigation.",
+                   level: .warning,
+                   category: .webview)
+
+        TelemetryWrapper.shared.recordEvent(category: .information, 
+                                            method: .error,
+                                            object: .webview,
+                                            value: .webviewFail)
+    }
+
     /// Invoked when an error occurs while starting to load data for the main frame.
     func webView(
         _ webView: WKWebView,
         didFailProvisionalNavigation navigation: WKNavigation!,
         withError error: Error
     ) {
+        logger.log("Error occurred during the early navigation process.",
+                   level: .warning,
+                   category: .webview)
+
+        TelemetryWrapper.shared.recordEvent(category: .information,
+                                            method: .error,
+                                            object: .webview,
+                                            value: .webviewFailProvisional)
+
         // Ignore the "Frame load interrupted" error that is triggered when we cancel a request
         // to open an external application and hand it over to UIApplication.openURL(). The result
         // will be that we switch to the external app, for example the app store, while keeping the

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -388,8 +388,7 @@ extension BrowserViewController: WKUIDelegate {
 }
 
 // MARK: - WKNavigationDelegate
-extension BrowserViewController: WKNavigationDelegate
-{
+extension BrowserViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView, didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation!) {
         guard let tab = tabManager[webView] else { return }
 
@@ -692,7 +691,7 @@ extension BrowserViewController: WKNavigationDelegate
                    level: .warning,
                    category: .webview)
 
-        TelemetryWrapper.shared.recordEvent(category: .information, 
+        TelemetryWrapper.shared.recordEvent(category: .information,
                                             method: .error,
                                             object: .webview,
                                             value: .webviewFail)

--- a/firefox-ios/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
+++ b/firefox-ios/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
@@ -277,7 +277,7 @@ class ErrorPageHelper {
                                                 method: .error,
                                                 object: .webview,
                                                 value: .webviewShowErrorPage,
-                                                extras: [TelemetryWrapper.EventExtraKey.errorCode.rawValue :"\(error.code)"])
+                                                extras: [TelemetryWrapper.EventExtraKey.errorCode.rawValue: "\(error.code)"])
 
             if let internalUrl = InternalURL(webViewUrl), internalUrl.isSessionRestore, let page = InternalURL.authorize(url: urlWithQuery) {
                 // A session restore page is already on the history stack, so don't load another page on the history stack.

--- a/firefox-ios/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
+++ b/firefox-ios/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
@@ -271,13 +271,13 @@ class ErrorPageHelper {
             logger.log("An error page will show.",
                        level: .info,
                        category: .webview,
-                       extra: ["Error code" : "\(error.code)"])
+                       extra: ["Error code": "\(error.code)"])
 
             TelemetryWrapper.shared.recordEvent(category: .information,
                                                 method: .error,
                                                 object: .webview,
                                                 value: .webviewShowErrorPage,
-                                                extras: [TelemetryWrapper.EventExtraKey.errorCode.rawValue : "\(error.code)"])
+                                                extras: [TelemetryWrapper.EventExtraKey.errorCode.rawValue :"\(error.code)"])
 
             if let internalUrl = InternalURL(webViewUrl), internalUrl.isSessionRestore, let page = InternalURL.authorize(url: urlWithQuery) {
                 // A session restore page is already on the history stack, so don't load another page on the history stack.

--- a/firefox-ios/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
+++ b/firefox-ios/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
 import WebKit
 import GCDWebServers
@@ -224,9 +225,12 @@ class ErrorPageHandler: InternalSchemeResponse {
 
 class ErrorPageHelper {
     fileprivate weak var certStore: CertStore?
+    private var logger: Logger
 
-    init(certStore: CertStore?) {
+    init(certStore: CertStore?,
+         logger: Logger = DefaultLogger.shared) {
         self.certStore = certStore
+        self.logger = logger
     }
 
     func loadPage(_ error: NSError, forUrl url: URL, inWebView webView: WKWebView) {
@@ -264,6 +268,17 @@ class ErrorPageHelper {
 
         components.queryItems = queryItems
         if let urlWithQuery = components.url {
+            logger.log("An error page will show.",
+                       level: .info,
+                       category: .webview,
+                       extra: ["Error code" : "\(error.code)"])
+
+            TelemetryWrapper.shared.recordEvent(category: .information,
+                                                method: .error,
+                                                object: .webview,
+                                                value: .webviewShowErrorPage,
+                                                extras: [TelemetryWrapper.EventExtraKey.errorCode.rawValue : "\(error.code)"])
+
             if let internalUrl = InternalURL(webViewUrl), internalUrl.isSessionRestore, let page = InternalURL.authorize(url: urlWithQuery) {
                 // A session restore page is already on the history stack, so don't load another page on the history stack.
                 webView.replaceLocation(with: page)

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -4918,7 +4918,7 @@ webview:
   did_fail_provisional:
     type: event
     description: |
-      Recorded when an error occurs while starting to load data for the main frame, so early navigation.
+      Recorded when an error occurs on early webview navigation.
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/17716
     data_reviews:

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -4922,7 +4922,7 @@ webview:
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/17716
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/17910
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
@@ -4933,7 +4933,7 @@ webview:
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/17716
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/17910
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
@@ -4949,7 +4949,7 @@ webview:
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/17716
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/17910
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -4914,6 +4914,46 @@ app_errors:
       - fx-ios-data-stewards@mozilla.com
     expires: never
 
+webview:
+  did_fail_provisional:
+    type: event
+    description: |
+      Recorded when an error occurs while starting to load data for the main frame, so early navigation.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/17716
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+  did_fail:
+    type: event
+    description: |
+      Recorded when an error occurred during navigation.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/17716
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+  show_error_page:
+    type: event
+    extra_keys:
+      error_code:
+        type: string
+        description: |
+          The error code number
+    description: |
+      Recorded when an error page is shown on the webview.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/17716
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+
 fx_suggest:
   ping_type:
     type: string

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -997,6 +997,7 @@ class TelemetryWrapperTests: XCTestCase {
                                           object: .recordSearch,
                                           extras: extras)
     }
+
     func test_RecordSearch_GleanIsCalledSearchQuickSearch() {
         let extras = [TelemetryWrapper.EventExtraKey.recordSearchLocation.rawValue: "quickSearch",
                       TelemetryWrapper.EventExtraKey.recordSearchEngineID.rawValue: "default"] as [String: Any]
@@ -1004,6 +1005,34 @@ class TelemetryWrapperTests: XCTestCase {
                                           method: .tap,
                                           object: .recordSearch,
                                           extras: extras)
+    }
+
+    // MARK: - Webview
+
+    func testRecordWebviewWhenDidFailThenGleanIsCalled() {
+        TelemetryWrapper.gleanRecordEvent(category: .information,
+                                          method: .error,
+                                          object: .webview,
+                                          value: .webviewFail)
+        testEventMetricRecordingSuccess(metric: GleanMetrics.Webview.didFail)
+    }
+
+    func testRecordWebviewWhenDidFailProvisionalThenGleanIsCalled() {
+        TelemetryWrapper.gleanRecordEvent(category: .information,
+                                          method: .error,
+                                          object: .webview,
+                                          value: .webviewFailProvisional)
+        testEventMetricRecordingSuccess(metric: GleanMetrics.Webview.didFailProvisional)
+    }
+
+    func testRecordWebviewWhenDidShowErrorThenGleanIsCalled() {
+        let extra = [TelemetryWrapper.EventExtraKey.errorCode.rawValue: "403"]
+        TelemetryWrapper.gleanRecordEvent(category: .information,
+                                          method: .error,
+                                          object: .webview,
+                                          value: .webviewShowErrorPage,
+                                          extras: extra)
+        testEventMetricRecordingSuccess(metric: GleanMetrics.Webview.showErrorPage)
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7944)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17716)

## :bulb: Description
Add Web View telemetry for failures + some logs related to JavaScript and failure points that can help us debug some crashes in Sentry.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

