### PR TITLE
Refactor FXIOS-8014 [v123] Replace continueButton and learnMoreButton with PrimaryRoundedButton and LinkButton Components

### DIFF
--- a/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
@@ -5,6 +5,7 @@
 import Common
 import UIKit
 import Shared
+import ComponentLibrary
 
 class PasswordManagerOnboardingViewController: SettingsViewController {
     private struct UX {
@@ -26,13 +27,13 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
         label.numberOfLines = UX.maxLabelLines
     }
 
-    private lazy var learnMoreButton: UIButton = .build { button in
+    private lazy var learnMoreButton: LinkButton = .build { button in
         button.setTitle(.LoginsOnboardingLearnMoreButtonTitle, for: .normal)
         button.addTarget(self, action: #selector(self.learnMoreButtonTapped), for: .touchUpInside)
         button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: UX.fontSize)
     }
 
-    private lazy var continueButton: UIButton = .build { button in
+    private lazy var continueButton: PrimaryRoundedButton = .build { button in
         button.layer.cornerRadius = UX.buttonCornerRadius
         button.setTitle(.LoginsOnboardingContinueButtonTitle, for: .normal)
         button.accessibilityIdentifier = AccessibilityIdentifiers.Settings.Passwords.onboardingContinue
@@ -135,5 +136,6 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
         let currentTheme = themeManager.currentTheme.colors
         learnMoreButton.setTitleColor(currentTheme.actionPrimary, for: .normal)
         continueButton.backgroundColor = currentTheme.actionPrimary
+        continueButton.applyTheme(theme: themeManager.currentTheme)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8014)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17885)

## :bulb: Description
- Implementing the use of '**PrimaryRoundedButton**' and '**LinkButton**' components from our Component Library to replace the current UI elements, enhancing maintainability.

| Portrait  | Landscape | 
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2023-12-22 at 23 39 27](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/a3dc7e3a-1e03-4ba3-8bd5-3071216ff6a5) | ![Simulator Screenshot - iPhone 15 Pro - 2023-12-22 at 23 39 30](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/932e82c9-eec4-4577-acae-004c9e71e523) |


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods