### PR TITLE
Refactor FXIOS-8018 [v123] Remove Deferred usage from InitialViewController

### DIFF
--- a/firefox-ios/Extensions/ShareTo/InitialViewController.swift
+++ b/firefox-ios/Extensions/ShareTo/InitialViewController.swift
@@ -49,21 +49,23 @@ class InitialViewController: UIViewController {
 
         self.view.alpha = 0
 
-        getShareItem().uponQueue(.main) { shareItem in
-            guard let shareItem = shareItem else {
-                let alert = UIAlertController(title: .SendToErrorTitle, message: .SendToErrorMessage, preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: .SendToErrorOKButton, style: .default) { _ in self.finish(afterDelay: 0) })
-                self.present(alert, animated: true, completion: nil)
-                return
+        DispatchQueue.main.async {
+            self.getShareItem { shareItem in
+                guard let shareItem = shareItem else {
+                    let alert = UIAlertController(title: .SendToErrorTitle, message: .SendToErrorMessage, preferredStyle: .alert)
+                    alert.addAction(UIAlertAction(title: .SendToErrorOKButton, style: .default) { _ in self.finish(afterDelay: 0) })
+                    self.present(alert, animated: true, completion: nil)
+                    return
+                }
+
+                // This is the view controller for the popup dialog
+                let shareController = ShareViewController()
+                shareController.delegate = self
+                shareController.shareItem = shareItem
+                self.shareViewController = shareController
+
+                self.embedController = EmbeddedNavController(isSearchMode: !shareItem.isUrlType(), parent: self, rootViewController: shareController)
             }
-
-            // This is the view controller for the popup dialog
-            let shareController = ShareViewController()
-            shareController.delegate = self
-            shareController.shareItem = shareItem
-            self.shareViewController = shareController
-
-            self.embedController = EmbeddedNavController(isSearchMode: !shareItem.isUrlType(), parent: self, rootViewController: shareController)
         }
     }
 
@@ -78,17 +80,15 @@ class InitialViewController: UIViewController {
         }
     }
 
-    func getShareItem() -> Deferred<ExtensionUtils.ExtractedShareItem?> {
-        let deferred = Deferred<ExtensionUtils.ExtractedShareItem?>()
+    func getShareItem(completion: @escaping (ExtensionUtils.ExtractedShareItem?) -> Void) {
         ExtensionUtils.extractSharedItem(fromExtensionContext: extensionContext) { item, error in
             if let item = item, error == nil {
-                deferred.fill(item)
+                completion(item)
             } else {
-                deferred.fill(nil)
+                completion(nil)
                 self.extensionContext?.cancelRequest(withError: CocoaError(.keyValueValidation))
             }
         }
-        return deferred
     }
 
     override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {

--- a/firefox-ios/Extensions/ShareTo/InitialViewController.swift
+++ b/firefox-ios/Extensions/ShareTo/InitialViewController.swift
@@ -49,8 +49,8 @@ class InitialViewController: UIViewController {
 
         self.view.alpha = 0
 
-        DispatchQueue.main.async {
-            self.getShareItem { shareItem in
+        self.getShareItem { shareItem in
+            DispatchQueue.main.async {
                 guard let shareItem = shareItem else {
                     let alert = UIAlertController(title: .SendToErrorTitle, message: .SendToErrorMessage, preferredStyle: .alert)
                     alert.addAction(UIAlertAction(title: .SendToErrorOKButton, style: .default) { _ in self.finish(afterDelay: 0) })


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8018)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17889)

## :bulb: Description
- Replaced the **`Deferred<ExtensionUtils.ExtractedShareItem?>`** return type in **`getShareItem`** with a completion handler.
- Refactored the extraction of shared items to use a callback for asynchronous handling.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

