### PR TITLE
Refactor FXIOS-17919 [v123] Fix github action update credential provider

### DIFF
--- a/.github/workflows/firefox-ios-update_credential_provider_script.yml
+++ b/.github/workflows/firefox-ios-update_credential_provider_script.yml
@@ -27,7 +27,7 @@ jobs:
         pip install -r ./test-fixtures/requirements.txt
     - name: Modify credential provider script
       run: |
-        python Client/Assets/CC_Script/CC_Python_Update.py
+        python firefox-ios/Client/Assets/CC_Script/CC_Python_Update.py
     - name: Commit and push credential provider changed
       run: |-
         git diff

--- a/firefox-ios/Client/Assets/CC_Script/CC_Python_Update.py
+++ b/firefox-ios/Client/Assets/CC_Script/CC_Python_Update.py
@@ -4,7 +4,7 @@ import shutil
 import os
 
 MOZILLA_CENTRAL_URL = "https://hg.mozilla.org/mozilla-central/raw-file/tip/"
-GITHUB_ACTIONS_PATH = "./Client/Assets/CC_Script/"
+GITHUB_ACTIONS_PATH = "./firefox-ios/Client/Assets/CC_Script/"
 GITHUB_ACTIONS_TMP_PATH = f"{GITHUB_ACTIONS_PATH}tmp/"
 
 


### PR DESCRIPTION
## :scroll: Tickets
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17919)
When moving all files into firefox-ios folder, we forgot to update the github action to automatically update content provider script. This PR fixes it

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

