### PR TITLE
BugFix FXIOS-8015 [v123] Replaced primaryButton in OnboardingInstructionPopupViewController to PrimaryRoundedButton

### DIFF
--- a/firefox-ios/Client/Frontend/Onboarding/ViewControllers/OnboardingInstructionPopupViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/ViewControllers/OnboardingInstructionPopupViewController.swift
@@ -167,8 +167,8 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
             contentStackView.trailingAnchor.constraint(equalTo: contentContainerView.trailingAnchor, constant: -trailingPadding),
             contentStackView.bottomAnchor.constraint(equalTo: contentContainerView.bottomAnchor, constant: -bottomPadding),
             textStackView.leadingAnchor.constraint(equalTo: contentStackView.leadingAnchor),
-            primaryButton.leadingAnchor.constraint(equalTo: contentStackView.leadingAnchor),
-            primaryButton.trailingAnchor.constraint(equalTo: contentStackView.trailingAnchor),
+            PrimaryRoundedButton.leadingAnchor.constraint(equalTo: contentStackView.leadingAnchor),
+            PrimaryRoundedButton.trailingAnchor.constraint(equalTo: contentStackView.trailingAnchor),
         ])
     }
 
@@ -182,7 +182,7 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
 
     private func updateLayout() {
         titleLabel.text = viewModel.title
-        primaryButton.setTitle(viewModel.buttonTitle, for: .normal)
+        PrimaryRoundedButton.setTitle(viewModel.buttonTitle, for: .normal)
     }
 
     private func addViewsToView() {
@@ -191,7 +191,7 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
         contentStackView.addArrangedSubview(titleLabel)
         numeratedLabels.forEach { textStackView.addArrangedSubview($0) }
         contentStackView.addArrangedSubview(textStackView)
-        contentStackView.addArrangedSubview(primaryButton)
+        contentStackView.addArrangedSubview(PrimaryRoundedButton)
 
         contentContainerView.addSubview(contentStackView)
         view.addSubview(contentContainerView)
@@ -250,8 +250,8 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
         titleLabel.textColor = theme.colors.textPrimary
         numeratedLabels.forEach { $0.textColor = theme.colors.textPrimary }
 
-        primaryButton.setTitleColor(theme.colors.textInverted, for: .normal)
-        primaryButton.backgroundColor = theme.colors.actionPrimary
+        PrimaryRoundedButton.setTitleColor(theme.colors.textInverted, for: .normal)
+        PrimaryRoundedButton.backgroundColor = theme.colors.actionPrimary
 
         view.backgroundColor = theme.colors.layer1
     }

--- a/firefox-ios/Client/Frontend/Onboarding/ViewControllers/OnboardingInstructionPopupViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/ViewControllers/OnboardingInstructionPopupViewController.swift
@@ -64,7 +64,7 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
         stack.spacing = UX.textStackViewSpacing
     }
 
-    private lazy var primaryButton: LegacyResizableButton = .build { button in
+    private lazy var PrimaryRoundedButton: LegacyResizableButton = .build { button in
         button.titleLabel?.font = DefaultDynamicFontHelper.preferredBoldFont(
             withTextStyle: .callout,
             size: UX.buttonFontSize)
@@ -72,7 +72,7 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
         button.titleLabel?.textAlignment = .center
         button.addTarget(self, action: #selector(self.primaryAction), for: .touchUpInside)
         button.titleLabel?.adjustsFontForContentSizeCategory = true
-        button.accessibilityIdentifier = "\(self.viewModel.a11yIdRoot).DefaultBrowserSettings.PrimaryButton"
+        button.accessibilityIdentifier = "\(self.viewModel.a11yIdRoot).DefaultBrowserSettings.PrimaryRoundedButton"
         button.contentEdgeInsets = UIEdgeInsets(top: UX.buttonVerticalInset,
                                                 left: UX.buttonHorizontalInset,
                                                 bottom: UX.buttonVerticalInset,

--- a/firefox-ios/Client/Frontend/Onboarding/ViewControllers/OnboardingInstructionPopupViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/ViewControllers/OnboardingInstructionPopupViewController.swift
@@ -73,10 +73,11 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
         button.addTarget(self, action: #selector(self.primaryAction), for: .touchUpInside)
         button.titleLabel?.adjustsFontForContentSizeCategory = true
         button.accessibilityIdentifier = "\(self.viewModel.a11yIdRoot).DefaultBrowserSettings.PrimaryRoundedButton"
-        button.contentEdgeInsets = UIEdgeInsets(top: UX.buttonVerticalInset,
-                                                left: UX.buttonHorizontalInset,
-                                                bottom: UX.buttonVerticalInset,
-                                                right: UX.buttonHorizontalInset)
+        button.configuration?.contentInsets = NSDirectionalEdgeInsets(
+                                                                  top: UX.buttonVerticalInset,
+                                                                  leading: UX.buttonHorizontalInset,
+                                                                   bottom: UX.buttonVerticalInset,
+                                                                   trailing: UX.buttonHorizontalInset)
     }
 
     var viewModel: OnboardingDefaultBrowserModelProtocol

--- a/firefox-ios/Client/Frontend/Onboarding/ViewControllers/OnboardingInstructionPopupViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/ViewControllers/OnboardingInstructionPopupViewController.swift
@@ -64,7 +64,7 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
         stack.spacing = UX.textStackViewSpacing
     }
 
-    private lazy var PrimaryButton: PrimaryRoundedButton = .build { button in
+    private lazy var primaryButton: PrimaryRoundedButton = .build { button in
         button.titleLabel?.font = DefaultDynamicFontHelper.preferredBoldFont(
             withTextStyle: .callout,
             size: UX.buttonFontSize)
@@ -167,8 +167,8 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
             contentStackView.trailingAnchor.constraint(equalTo: contentContainerView.trailingAnchor, constant: -trailingPadding),
             contentStackView.bottomAnchor.constraint(equalTo: contentContainerView.bottomAnchor, constant: -bottomPadding),
             textStackView.leadingAnchor.constraint(equalTo: contentStackView.leadingAnchor),
-            PrimaryButton.leadingAnchor.constraint(equalTo: contentStackView.leadingAnchor),
-            PrimaryButton.trailingAnchor.constraint(equalTo: contentStackView.trailingAnchor),
+            primaryButton.leadingAnchor.constraint(equalTo: contentStackView.leadingAnchor),
+            primaryButton.trailingAnchor.constraint(equalTo: contentStackView.trailingAnchor),
         ])
     }
 
@@ -182,7 +182,7 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
 
     private func updateLayout() {
         titleLabel.text = viewModel.title
-        PrimaryButton.setTitle(viewModel.buttonTitle, for: .normal)
+        primaryButton.setTitle(viewModel.buttonTitle, for: .normal)
     }
 
     private func addViewsToView() {
@@ -191,7 +191,7 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
         contentStackView.addArrangedSubview(titleLabel)
         numeratedLabels.forEach { textStackView.addArrangedSubview($0) }
         contentStackView.addArrangedSubview(textStackView)
-        contentStackView.addArrangedSubview(PrimaryButton)
+        contentStackView.addArrangedSubview(primaryButton)
 
         contentContainerView.addSubview(contentStackView)
         view.addSubview(contentContainerView)
@@ -250,9 +250,9 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
         titleLabel.textColor = theme.colors.textPrimary
         numeratedLabels.forEach { $0.textColor = theme.colors.textPrimary }
 
-        PrimaryButton.setTitleColor(theme.colors.textInverted, for: .normal)
-        PrimaryButton.backgroundColor = theme.colors.actionPrimary
-        PrimaryButton.applyTheme(theme: themeManager.currentTheme)
+        primaryButton.setTitleColor(theme.colors.textInverted, for: .normal)
+        primaryButton.backgroundColor = theme.colors.actionPrimary
+        primaryButton.applyTheme(theme: themeManager.currentTheme)
 
         view.backgroundColor = theme.colors.layer1
     }

--- a/firefox-ios/Client/Frontend/Onboarding/ViewControllers/OnboardingInstructionPopupViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/ViewControllers/OnboardingInstructionPopupViewController.swift
@@ -64,7 +64,7 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
         stack.spacing = UX.textStackViewSpacing
     }
 
-    private lazy var PrimaryRoundedButton: LegacyResizableButton = .build { button in
+    private lazy var PrimaryButton: PrimaryRoundedButton = .build { button in
         button.titleLabel?.font = DefaultDynamicFontHelper.preferredBoldFont(
             withTextStyle: .callout,
             size: UX.buttonFontSize)
@@ -167,8 +167,8 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
             contentStackView.trailingAnchor.constraint(equalTo: contentContainerView.trailingAnchor, constant: -trailingPadding),
             contentStackView.bottomAnchor.constraint(equalTo: contentContainerView.bottomAnchor, constant: -bottomPadding),
             textStackView.leadingAnchor.constraint(equalTo: contentStackView.leadingAnchor),
-            PrimaryRoundedButton.leadingAnchor.constraint(equalTo: contentStackView.leadingAnchor),
-            PrimaryRoundedButton.trailingAnchor.constraint(equalTo: contentStackView.trailingAnchor),
+            PrimaryButton.leadingAnchor.constraint(equalTo: contentStackView.leadingAnchor),
+            PrimaryButton.trailingAnchor.constraint(equalTo: contentStackView.trailingAnchor),
         ])
     }
 
@@ -182,7 +182,7 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
 
     private func updateLayout() {
         titleLabel.text = viewModel.title
-        PrimaryRoundedButton.setTitle(viewModel.buttonTitle, for: .normal)
+        PrimaryButton.setTitle(viewModel.buttonTitle, for: .normal)
     }
 
     private func addViewsToView() {
@@ -191,7 +191,7 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
         contentStackView.addArrangedSubview(titleLabel)
         numeratedLabels.forEach { textStackView.addArrangedSubview($0) }
         contentStackView.addArrangedSubview(textStackView)
-        contentStackView.addArrangedSubview(PrimaryRoundedButton)
+        contentStackView.addArrangedSubview(PrimaryButton)
 
         contentContainerView.addSubview(contentStackView)
         view.addSubview(contentContainerView)
@@ -250,8 +250,9 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
         titleLabel.textColor = theme.colors.textPrimary
         numeratedLabels.forEach { $0.textColor = theme.colors.textPrimary }
 
-        PrimaryRoundedButton.setTitleColor(theme.colors.textInverted, for: .normal)
-        PrimaryRoundedButton.backgroundColor = theme.colors.actionPrimary
+        PrimaryButton.setTitleColor(theme.colors.textInverted, for: .normal)
+        PrimaryButton.backgroundColor = theme.colors.actionPrimary
+        PrimaryButton.applyTheme(theme: themeManager.currentTheme)
 
         view.backgroundColor = theme.colors.layer1
     }


### PR DESCRIPTION
Replaced primaryButton in OnboardingInstructionPopupViewController to PrimaryRoundedButton.

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8015)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17886)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
 
Replaced primaryButton in OnboardingInstructionPopupViewController to PrimaryRoundedButton. Here's the code "
```swift
   private lazy var PrimaryRoundedButton: LegacyResizableButton = .build { button in
        button.titleLabel?.font = DefaultDynamicFontHelper.preferredBoldFont(
            withTextStyle: .callout,
            size: UX.buttonFontSize)
        button.layer.cornerRadius = UX.buttonCornerRadius
        button.titleLabel?.textAlignment = .center
        button.addTarget(self, action: #selector(self.primaryAction), for: .touchUpInside)
        button.titleLabel?.adjustsFontForContentSizeCategory = true
        button.accessibilityIdentifier = "\(self.viewModel.a11yIdRoot).DefaultBrowserSettings.PrimaryRoundedButton"
        button.contentEdgeInsets = UIEdgeInsets(top: UX.buttonVerticalInset,
                                                left: UX.buttonHorizontalInset,
                                                bottom: UX.buttonVerticalInset,
                                                right: UX.buttonHorizontalInset)
    }
```

