### PR TITLE
Refactor FXIOS-8044 [v123] Fix swiftlint relative path

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -103,28 +103,27 @@ analyzer_rules: # Rules run by `swiftlint analyze`
 excluded: # paths to ignore during linting. Takes precedence over `included`.
   - build/
   - .build/
-  - Client/Assets/Search/get_supported_locales.swift
-  - Client/Generated
-  - fastlane/
-  - FxA
-  - FxAClient
-  - Source/ExcludedFolder
-  - Source/ExcludedFile.swift
-  - Storage/ThirdParty/SwiftData.swift
-  - Sync/Generated/Metrics.swift
-  - Storage/Generated/Metrics.swift
-  - ThirdParty
+  - firefox-ios/Client/Assets/Search/get_supported_locales.swift
+  - firefox-ios/Client/Generated
+  - firefox-ios/fastlane/
+  - firefox-ios/FxA
+  - firefox-ios/FxAClient
+  - firefox-ios/Source/ExcludedFolder
+  - firefox-ios/Source/ExcludedFile.swift
+  - firefox-ios/Storage/ThirdParty/SwiftData.swift
+  - firefox-ios/Sync/Generated/Metrics.swift
+  - firefox-ios/Storage/Generated/Metrics.swift
+  - firefox-ios/ThirdParty
   - test-fixtures/tmp
-  - firefox-ios-tests/Tests/UITests/
+  - firefox-ios/firefox-ios-tests/Tests/UITests/
   - l10n-screenshots-dd/
   - DerivedData/
   # Package.swift files need a custom header for swift-tools-version
   # so must be excluded due to file_header rule
-  - Package.swift
+  - firefox-ios/Package.swift
   - BrowserKit/Package.swift
-  - Client/ContentBlocker/ContentBlockerGenerator/Package.swift
-  - Package.swift
-  
+  - firefox-ios/Client/ContentBlocker/ContentBlockerGenerator/Package.swift
+  - Package.swift 
 
 included:
   - /Users/vagrant/git

--- a/firefox-ios/.swiftlint.yml
+++ b/firefox-ios/.swiftlint.yml
@@ -103,26 +103,26 @@ analyzer_rules: # Rules run by `swiftlint analyze`
 excluded: # paths to ignore during linting. Takes precedence over `included`.
   - build/
   - .build/
-  - firefox-ios/Client/Assets/Search/get_supported_locales.swift
-  - firefox-ios/Client/Generated
-  - firefox-ios/fastlane/
-  - firefox-ios/FxA
-  - firefox-ios/FxAClient
-  - firefox-ios/Source/ExcludedFolder
-  - firefox-ios/Source/ExcludedFile.swift
-  - firefox-ios/Storage/ThirdParty/SwiftData.swift
-  - firefox-ios/Sync/Generated/Metrics.swift
-  - firefox-ios/Storage/Generated/Metrics.swift
-  - firefox-ios/ThirdParty
+  - Client/Assets/Search/get_supported_locales.swift
+  - Client/Generated
+  - fastlane/
+  - FxA
+  - FxAClient
+  - Source/ExcludedFolder
+  - Source/ExcludedFile.swift
+  - Storage/ThirdParty/SwiftData.swift
+  - Sync/Generated/Metrics.swift
+  - Storage/Generated/Metrics.swift
+  - ThirdParty
   - test-fixtures/tmp
-  - firefox-ios/firefox-ios-tests/Tests/UITests/
+  - firefox-ios-tests/Tests/UITests/
   - l10n-screenshots-dd/
   - DerivedData/
   # Package.swift files need a custom header for swift-tools-version
   # so must be excluded due to file_header rule
-  - firefox-ios/Package.swift
+  - Package.swift
   - BrowserKit/Package.swift
-  - firefox-ios/Client/ContentBlocker/ContentBlockerGenerator/Package.swift
+  - Client/ContentBlocker/ContentBlockerGenerator/Package.swift
   - Package.swift
   
 

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -12669,7 +12669,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]; then\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif which swiftlint > /dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]; then\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif which swiftlint > /dev/null; then\n    swiftlint --config \"../.swiftlint.yml\"\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 		E6639F191BF11E3A002D0853 /* Conditionally Add Settings Bundle */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -12669,8 +12669,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "
-";
+			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]; then\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif which swiftlint > /dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 		E6639F191BF11E3A002D0853 /* Conditionally Add Settings Bundle */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8044)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17931)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
During The Big Merge of 2023, `swiftlint.yml` was kept in place, but its content modified, which, in theory, is ok. 

The first issue was that the Client's call to swiftlint was missing. This part was easy to figure out. However, on running it, it seems that swiftlint doesn't run at the top level, but relative to the path wherein it was called. Experimentation with removing the swiftlint file around revealed that swiftlint, on being enabled in the build, was actually using some default configurations, which, in actually resulted in a ton of errors, due to said relative pathing issue.

By specifying a relative path in the Client's Switlint step, we're back to our original position in our swiftlint journey, with the only warnings being generated by non-swiftlint items.

This has been an learning journey.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

