### PR TITLE
Bugfix FXIOS-6672 [v123] Awesomebar.location telemetry does not add up to 100

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -389,6 +389,7 @@ class BrowserViewController: UIViewController,
         tabManager.preserveTabs()
         // TODO: [FXIOS-7856] Some additional updates for telemetry forthcoming, once iPad multi-window is enabled.
         TabsQuantityTelemetry.trackTabsQuantity(tabManager: tabManager)
+        SearchBarSettingsViewModel.recordLocationTelemetry(for: isBottomSearchBar ? .bottom : .top)
     }
 
     @objc


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6672)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15348)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Added another trigger for the awesomebar.location telemetry event when the app goes to background so it covers the cases when the app is used between days which makes `viewDidLoad()` not get called again. I put this in the going to background handling because you will always go to background after the app is in foreground but if the app goes to background after midnight it's not 100% it will come back to foreground the same day.
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

