### PR TITLE
Add FXIOS-7869 [v122] Delete data alert for fire icon

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -19,8 +19,47 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .home)
     }
 
+    // Presents alert to clear users private session data
     func tabToolbarDidPressFire(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
-        // TODO: Felt Deletion - https://mozilla-hub.atlassian.net/browse/FXIOS-7869
+        let alert = UIAlertController(
+            title: .Alerts.FeltDeletion.Title,
+            message: .Alerts.FeltDeletion.Body,
+            preferredStyle: .alert
+        )
+
+        let cancelAction = UIAlertAction(
+            title: .Alerts.FeltDeletion.CancelButton,
+            style: .cancel,
+            handler: nil
+        )
+
+        let deleteDataAction = UIAlertAction(
+            title: .Alerts.FeltDeletion.ConfirmButton,
+            style: .destructive,
+            handler: { [weak self] _ in
+                self?.closePrivateTabsAndOpenNewPrivateHomepage()
+                self?.showDataClearanceConfirmationToast()
+            }
+        )
+
+        alert.addAction(deleteDataAction)
+        alert.addAction(cancelAction)
+        present(alert, animated: true)
+    }
+
+    private func closePrivateTabsAndOpenNewPrivateHomepage() {
+        tabManager.removeTabs(tabManager.privateTabs)
+        tabManager.selectTab(tabManager.addTab(isPrivate: true))
+    }
+
+    private func showDataClearanceConfirmationToast() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            SimpleToast().showAlertWithText(
+                .FirefoxHomepage.FeltDeletion.ToastTitle,
+                bottomContainer: self.contentContainer,
+                theme: self.themeManager.currentTheme
+            )
+        }
     }
 
     func tabToolbarDidPressLibrary(_ tabToolbar: TabToolbarProtocol, button: UIButton) {

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/TabToolbar.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/TabToolbar.swift
@@ -14,6 +14,7 @@ class TabToolbar: UIView, SearchBarLocationProvider {
     let tabsButton = TabsButton()
     let addNewTabButton = ToolbarButton()
     let appMenuButton = ToolbarButton()
+    let homeButton = ToolbarButton()
     let bookmarksButton = ToolbarButton()
     let forwardButton = ToolbarButton()
     let backButton = ToolbarButton()
@@ -102,8 +103,6 @@ class TabToolbar: UIView, SearchBarLocationProvider {
 
 // MARK: - TabToolbarProtocol
 extension TabToolbar: TabToolbarProtocol {
-    var homeButton: ToolbarButton { multiStateButton }
-
     func privateModeBadge(visible: Bool) {
         privateModeBadge.show(visible)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket - Clearing Private Data](https://mozilla-hub.atlassian.net/browse/FXIOS-7996)
[Github issue - Add alert](https://github.com/mozilla-mobile/firefox-ios/issues/17569)
[Github issue - Open new private tab](https://github.com/mozilla-mobile/firefox-ios/issues/17574)
[Github issue - Present toast after deletion](https://github.com/mozilla-mobile/firefox-ios/issues/17570)

## :bulb: Description
Add alert to delete private session data after tapping on fire icon.

**Context: Clicking the fire button**
Given that user is in private mode and inside a private tab
When the user clicks the fire button
Then they should see an alert popping up with a display message and a confirmation to delete the session. 

**Context: Clicking “Delete session data” in the alert**
Given that user is getting an alert message to confirm the deletion or cancel
When the user clicks “Delete the session data”
Then the app should close all the private tabs and open a new clean private tab (homepage private tab)

**Context: Clicking “Cancel” in the alert**
Given that user is getting an alert message to confirm the deletion or cancel
When the user clicks “Cancel”
Then the app should cancel the action and hide the alert.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

## Screenshots
| Alert | Toast |
|---|---|
| ![simulator_screenshot_B104E6B0-FE0D-4E08-9FB6-B45C980CDA02](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/39d55f93-40b9-4ccc-9f12-7dd95159ebdb) | ![simulator_screenshot_A9551680-6AAD-4461-A0D1-D7ACC939FF8C](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/a5704dd8-4974-4983-818c-7c0a6f525d2d)|
