### PR TITLE
Add FXIOS-7997 [v122] CFR for fire button

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -7,6 +7,26 @@ import Shared
 import UIKit
 
 extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
+    // MARK: Data Clearance CFR / Contextual Hint
+    func toolBarPresentCFR(at sourceView: UIView) {
+        configureDataClearanceContextVC(at: sourceView)
+    }
+
+    private func configureDataClearanceContextVC(at sourceView: UIView) {
+        dataClearanceContextHintVC.configure(
+            anchor: sourceView,
+            withArrowDirection: topTabsVisible ? .up : .down,
+            andDelegate: self,
+            presentedUsing: { self.presentDataClearanceContextualHint() },
+            andActionForButton: { },
+            overlayState: overlayManager)
+    }
+
+    private func presentDataClearanceContextualHint() {
+        present(dataClearanceContextHintVC, animated: true)
+        UIAccessibility.post(notification: .layoutChanged, argument: dataClearanceContextHintVC)
+    }
+
     func tabToolbarDidPressHome(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
         updateZoomPageBarVisibility(visible: false)
         userHasPressedHomeButton = true

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -8,13 +8,9 @@ import UIKit
 
 extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
     // MARK: Data Clearance CFR / Contextual Hint
-    func toolBarPresentCFR(at sourceView: UIView) {
-        configureDataClearanceContextVC(at: sourceView)
-    }
-
-    private func configureDataClearanceContextVC(at sourceView: UIView) {
+    func configureDataClearanceContextualHint() {
         dataClearanceContextHintVC.configure(
-            anchor: sourceView,
+            anchor: navigationToolbar.multiStateButton,
             withArrowDirection: topTabsVisible ? .up : .down,
             andDelegate: self,
             presentedUsing: { self.presentDataClearanceContextualHint() },

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1305,14 +1305,10 @@ class BrowserViewController: UIViewController,
         let showFireButton = featureFlags.isFeatureEnabled(.feltPrivacyFeltDeletion, checking: .buildOnly) && showDataClearanceFlow
         guard !showFireButton else {
             navigationToolbar.updateMiddleButtonState(.fire)
-            prepareDataClearanceContextualHintForFireButton()
+            configureDataClearanceContextualHint()
             return
         }
         navigationToolbar.updateMiddleButtonState(state)
-    }
-
-    private func prepareDataClearanceContextualHintForFireButton() {
-        toolBarPresentCFR(at: navigationToolbar.multiStateButton)
     }
 
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -64,6 +64,7 @@ class BrowserViewController: UIViewController,
     var overlayManager: OverlayModeManager
     var appAuthenticator: AppAuthenticationProtocol
     var toolbarContextHintVC: ContextualHintViewController
+    var dataClearanceContextHintVC: ContextualHintViewController
     let shoppingContextHintVC: ContextualHintViewController
     private var backgroundTabLoader: DefaultBackgroundTabLoader
 
@@ -210,6 +211,11 @@ class BrowserViewController: UIViewController,
         let shoppingViewProvider = ContextualHintViewProvider(forHintType: .shoppingExperience,
                                                               with: profile)
         shoppingContextHintVC = ContextualHintViewController(with: shoppingViewProvider)
+        let dataClearanceViewProvider = ContextualHintViewProvider(
+            forHintType: .dataClearance,
+            with: profile
+        )
+        self.dataClearanceContextHintVC = ContextualHintViewController(with: dataClearanceViewProvider)
         self.backgroundTabLoader = DefaultBackgroundTabLoader(tabQueue: profile.queue)
         super.init(nibName: nil, bundle: nil)
         didInit()
@@ -498,7 +504,9 @@ class BrowserViewController: UIViewController,
                 dismissFakespotIfNeeded()
             }
 
+            // Update states for felt privacy
             updateInContentHomePanel(tabManager.selectedTab?.url)
+            setupMiddleButtonStatus(isLoading: false)
         }
     }
 
@@ -1294,12 +1302,17 @@ class BrowserViewController: UIViewController,
 
     private func handleMiddleButtonState(_ state: MiddleButtonState) {
         let showDataClearanceFlow = browserViewControllerState?.showDataClearanceFlow ?? false
-        let showFireIcon = featureFlags.isFeatureEnabled(.feltPrivacyFeltDeletion, checking: .buildOnly) && showDataClearanceFlow
-        guard !showFireIcon else {
+        let showFireButton = featureFlags.isFeatureEnabled(.feltPrivacyFeltDeletion, checking: .buildOnly) && showDataClearanceFlow
+        guard !showFireButton else {
             navigationToolbar.updateMiddleButtonState(.fire)
+            prepareDataClearanceContextualHintForFireButton()
             return
         }
         navigationToolbar.updateMiddleButtonState(state)
+    }
+
+    private func prepareDataClearanceContextualHintForFireButton() {
+        toolBarPresentCFR(at: navigationToolbar.multiStateButton)
     }
 
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {

--- a/firefox-ios/Client/Frontend/ContextualHint/ContextualHintCopyProvider.swift
+++ b/firefox-ios/Client/Frontend/ContextualHint/ContextualHintCopyProvider.swift
@@ -53,6 +53,8 @@ struct ContextualHintCopyProvider: FeatureFlaggable {
         var descriptionCopy = ""
 
         switch hint {
+        case .dataClearance:
+            descriptionCopy = CFRStrings.FeltDeletion.Body
         case .inactiveTabs:
             descriptionCopy = CFRStrings.TabsTray.InactiveTabs.Body
 
@@ -76,6 +78,8 @@ struct ContextualHintCopyProvider: FeatureFlaggable {
         var actionCopy: String
 
         switch hint {
+        case .dataClearance:
+            actionCopy = ""
         case .inactiveTabs:
             actionCopy = CFRStrings.TabsTray.InactiveTabs.Action
         case .toolbarLocation:

--- a/firefox-ios/Client/Frontend/ContextualHint/ContextualHintEligibilityUtility.swift
+++ b/firefox-ios/Client/Frontend/ContextualHint/ContextualHintEligibilityUtility.swift
@@ -36,6 +36,8 @@ struct ContextualHintEligibilityUtility: ContextualHintEligibilityUtilityProtoco
         var hintTypeShouldBePresented = false
 
         switch hintType {
+        case .dataClearance:
+            hintTypeShouldBePresented = true
         case .jumpBackIn:
             hintTypeShouldBePresented = canJumpBackInBePresented
         case .jumpBackInSyncedTab:

--- a/firefox-ios/Client/Frontend/ContextualHint/ContextualHintPrefsKeysProvider.swift
+++ b/firefox-ios/Client/Frontend/ContextualHint/ContextualHintPrefsKeysProvider.swift
@@ -14,6 +14,7 @@ extension ContextualHintPrefsKeysProvider {
 
     func prefsKey(for hintType: ContextualHintType) -> String {
         switch hintType {
+        case .dataClearance: return CFRPrefsKeys.dataClearanceKey.rawValue
         case .inactiveTabs: return CFRPrefsKeys.inactiveTabsKey.rawValue
         case .jumpBackIn: return CFRPrefsKeys.jumpBackinKey.rawValue
         case .jumpBackInSyncedTab: return CFRPrefsKeys.jumpBackInSyncedTabKey.rawValue

--- a/firefox-ios/Client/Frontend/ContextualHint/ContextualHintViewProvider.swift
+++ b/firefox-ios/Client/Frontend/ContextualHint/ContextualHintViewProvider.swift
@@ -18,6 +18,7 @@ enum ContextualHintType: String {
     case inactiveTabs = "InactiveTabs"
     case toolbarLocation = "ToolbarLocation"
     case shoppingExperience = "ShoppingExperience"
+    case dataClearance = "DataClearance"
 }
 
 class ContextualHintViewProvider: ContextualHintPrefsKeysProvider, SearchBarLocationProvider {

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/TabToolbarHelper.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/TabToolbarHelper.swift
@@ -30,6 +30,7 @@ protocol TabToolbarProtocol: AnyObject {
 }
 
 protocol TabToolbarDelegate: AnyObject {
+    func toolBarPresentCFR(at sourceView: UIView)
     func tabToolbarDidPressBack(_ tabToolbar: TabToolbarProtocol, button: UIButton)
     func tabToolbarDidPressForward(_ tabToolbar: TabToolbarProtocol, button: UIButton)
     func tabToolbarDidLongPressBack(_ tabToolbar: TabToolbarProtocol, button: UIButton)

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/TabToolbarHelper.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/TabToolbarHelper.swift
@@ -30,7 +30,7 @@ protocol TabToolbarProtocol: AnyObject {
 }
 
 protocol TabToolbarDelegate: AnyObject {
-    func toolBarPresentCFR(at sourceView: UIView)
+    func configureDataClearanceContextualHint()
     func tabToolbarDidPressBack(_ tabToolbar: TabToolbarProtocol, button: UIButton)
     func tabToolbarDidPressForward(_ tabToolbar: TabToolbarProtocol, button: UIButton)
     func tabToolbarDidLongPressBack(_ tabToolbar: TabToolbarProtocol, button: UIButton)

--- a/firefox-ios/Shared/Prefs.swift
+++ b/firefox-ios/Shared/Prefs.swift
@@ -92,6 +92,7 @@ public struct PrefsKeys {
 
     // Firefox contextual hint
     public enum ContextualHints: String, CaseIterable {
+        case dataClearanceKey = "ContextualHintDataClearance"
         case jumpBackinKey = "ContextualHintJumpBackin"
         case jumpBackInConfiguredKey = "JumpBackInConfigured"
         case jumpBackInSyncedTabKey = "ContextualHintJumpBackInSyncedTab"

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ContextualHints/ContextualHintEligibilityUtilityTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ContextualHints/ContextualHintEligibilityUtilityTests.swift
@@ -53,6 +53,19 @@ class ContextualHintEligibilityUtilityTests: XCTestCase {
         XCTAssertTrue(result)
     }
 
+    func test_shouldPresentDataClearanceHint() {
+        let result = subject.canPresent(.dataClearance)
+        XCTAssertTrue(result)
+    }
+
+    func test_shouldPresentDataClearanceHint_WithiPad() {
+        subject = ContextualHintEligibilityUtility(with: profile,
+                                                   overlayState: nil,
+                                                   device: MockUIDevice(isIpad: true))
+        let result = subject.canPresent(.dataClearance)
+        XCTAssertTrue(result)
+    }
+
     // MARK: Jump Back in and Synced tabs
     func test_shouldPresentJumpBackHint() {
         subject = ContextualHintEligibilityUtility(with: profile,
@@ -135,6 +148,13 @@ class ContextualHintEligibilityUtilityTests: XCTestCase {
         profile.prefs.setBool(true, forKey: CFRPrefsKeys.inactiveTabsKey.rawValue)
 
         let result = subject.canPresent(.inactiveTabs)
+        XCTAssertFalse(result)
+    }
+
+    func test_shouldNotPresentDataClearanceHint() {
+        profile.prefs.setBool(true, forKey: CFRPrefsKeys.dataClearanceKey.rawValue)
+
+        let result = subject.canPresent(.dataClearance)
         XCTAssertFalse(result)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ContextualHints/ContextualHintViewProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ContextualHints/ContextualHintViewProviderTests.swift
@@ -15,6 +15,7 @@ class ContextualHintViewProviderTests: XCTestCase {
     override func setUp() {
         super.setUp()
         profile = MockProfile()
+        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
     }
 
     override func tearDown() {
@@ -23,6 +24,30 @@ class ContextualHintViewProviderTests: XCTestCase {
     }
 
     // MARK: Mark Contextual Hint Configuration
+
+    func test_dataClearanceConfiguration() {
+        let subject = ContextualHintViewProvider(forHintType: .dataClearance, with: profile)
+        XCTAssertTrue(subject.shouldPresentContextualHint())
+        XCTAssertFalse(subject.isActionType)
+    }
+
+    func test_markContextualHintPresented_setPrefsTrue() {
+        let subject = ContextualHintViewProvider(forHintType: .dataClearance, with: profile)
+        subject.markContextualHintPresented()
+        XCTAssertTrue(profile.prefs.boolForKey(CFRPrefsKeys.dataClearanceKey.rawValue)!)
+    }
+
+    func test_markContextualHintConfiguration_withDataClearanceTrue_doesNotSetPrefs() {
+        let subject = ContextualHintViewProvider(forHintType: .dataClearance, with: profile)
+        subject.markContextualHintConfiguration(configured: true)
+        XCTAssertNil(profile.prefs.boolForKey(CFRPrefsKeys.dataClearanceKey.rawValue))
+    }
+
+    func test_markContextualHintConfiguration_withDataClearanceFalse_doesNotSetPrefs() {
+        let subject = ContextualHintViewProvider(forHintType: .dataClearance, with: profile)
+        subject.markContextualHintConfiguration(configured: false)
+        XCTAssertNil(profile.prefs.boolForKey(CFRPrefsKeys.dataClearanceKey.rawValue))
+    }
 
     func testJumpBackInSyncTabConfiguredTrue() {
         let subject = ContextualHintViewProvider(forHintType: .jumpBackInSyncedTab, with: profile)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7997)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17568)

## :bulb: Description
Add CFR / Contextual Hint to better inform the user on the fire button feature.

Given that the user access the private mode
When the user opens the app for the first time and access a private tab
Then the user will see a CFR message (see message on design). The CFR message should close when the user taps (interact) with it.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

## Screenshots
| iPhone | iPad |
| --- | --- |
| ![simulator_screenshot_9CB9DFD3-3D8B-4135-8C9D-9470BF8CA45E](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/28a22cfa-0fdc-47aa-bdee-b8739cdb9610) | ![simulator_screenshot_4819AB10-E1FA-4E1A-961F-81DD4314EE0F](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/94ac4c49-87af-495c-aa56-65371a4b7525) |
**Accessibility**
| iPhone | iPad |
| --- | --- |
| ![simulator_screenshot_9DAF2C9A-372E-4290-930F-9A35DC7B4849](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/a79bad6d-a634-46f2-bdfe-099b1c3cbece)|![simulator_screenshot_BC4355F7-8E1B-41C7-B6F2-CDC7AA441078](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/b3bea4ff-03ea-4989-abd1-ce2ac9743e9d)|