### PR TITLE
Add FXIOS-4982 [v123] Accessibility Magic Tap should launch/hide Reader View

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1239,6 +1239,14 @@ class BrowserViewController: UIViewController,
         }
     }
 
+    override func accessibilityPerformMagicTap() -> Bool {
+        if !urlBar.locationView.readerModeButton.isHidden {
+            self.urlBar.tabLocationViewDidTapReaderMode(self.urlBar.locationView)
+            return true
+        }
+        return false
+    }
+
     override func accessibilityPerformEscape() -> Bool {
         if overlayManager.inOverlayMode {
             overlayManager.finishEditing(shouldCancelLoading: true)

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -134,7 +134,7 @@ class TabLocationView: UIView, FeatureFlaggable {
         button.largeContentImage = image
     }
 
-    private lazy var readerModeButton: ReaderModeButton = .build { readerModeButton in
+    private(set) lazy var readerModeButton: ReaderModeButton = .build { readerModeButton in
         readerModeButton.addTarget(self, action: #selector(self.tapReaderModeButton), for: .touchUpInside)
         readerModeButton.addGestureRecognizer(
             UILongPressGestureRecognizer(target: self,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-2108)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/4982)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

