### PR TITLE
Bugfix FXIOS-3653 [v123] Adjust row count for Top Site section on home page depending on font sizes

### DIFF
--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -103,7 +103,8 @@ class HomepageViewController:
         setupNotifications(forObserver: self,
                            observing: [.HomePanelPrefsChanged,
                                        .TabsPrivacyModeChanged,
-                                       .WallpaperDidChange])
+                                       .WallpaperDidChange,
+                                       .DynamicFontChanged])
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -187,6 +188,7 @@ class HomepageViewController:
 
         if previousTraitCollection?.horizontalSizeClass != traitCollection.horizontalSizeClass
             || previousTraitCollection?.verticalSizeClass != traitCollection.verticalSizeClass {
+            view.layoutIfNeeded()
             reloadOnRotation(newSize: view.frame.size)
         }
     }
@@ -784,7 +786,8 @@ extension HomepageViewController: Notifiable {
                 self.adjustPrivacySensitiveSections(notification: notification)
 
             case .HomePanelPrefsChanged,
-                    .WallpaperDidChange:
+                    .WallpaperDidChange,
+                    .DynamicFontChanged:
                 self.reloadView()
 
             default: break

--- a/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -9,7 +9,18 @@ import Storage
 
 class TopSitesViewModel {
     struct UX {
-        static let cellEstimatedSize = CGSize(width: 85, height: 94)
+        static var cellEstimatedSize: CGSize {
+            let width: CGFloat
+            switch UIApplication.shared.preferredContentSizeCategory {
+            case .unspecified, .extraSmall, .small, .medium, .large, .extraLarge, .extraExtraLarge, .extraExtraExtraLarge:
+                width = 80
+            case .accessibilityMedium, .accessibilityLarge, .accessibilityExtraLarge:
+                width = 115
+            default:
+                width = 140
+            }
+            return CGSize(width: width, height: 94)
+        }
         static let cardSpacing: CGFloat = 16
         static let minCards: Int = 4
     }

--- a/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -22,7 +22,7 @@ class TopSitesViewModel {
             return CGSize(width: width, height: 94)
         }
         static let cardSpacing: CGFloat = 16
-        static let minCards: Int = 4
+        static let minCards: Int = 2
     }
 
     weak var delegate: HomepageDataModelDelegate?

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesRowCountSettingsController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesRowCountSettingsController.swift
@@ -8,7 +8,7 @@ import Shared
 class TopSitesRowCountSettingsController: SettingsTableViewController {
     let prefs: Prefs
     var numberOfRows: Int32
-    static let defaultNumberOfRows: Int32 = 2
+    static let defaultNumberOfRows: Int32 = 4
 
     init(prefs: Prefs) {
         self.prefs = prefs

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesRowCountSettingsController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesRowCountSettingsController.swift
@@ -8,7 +8,7 @@ import Shared
 class TopSitesRowCountSettingsController: SettingsTableViewController {
     let prefs: Prefs
     var numberOfRows: Int32
-    static let defaultNumberOfRows: Int32 = 4
+    static let defaultNumberOfRows: Int32 = 2
 
     init(prefs: Prefs) {
         self.prefs = prefs


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-3653)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/9826)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
### Before PR
<img width="545" alt="Screenshot 2024-01-04 at 7 01 03 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/15265718/6a7be999-7736-4997-9b71-626009a5c396">

### After PR
<img width="545" alt="Screenshot 2024-01-04 at 7 09 45 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/15265718/71965c04-a3cb-41df-b388-6a9b3122bf6e">

Note, here only 4 cells are visible since from settings the number of rows on the homepage was set as 2.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

