### PR TITLE
Revert FXIOS-8052 [v121] logins key logic updates

### DIFF
--- a/firefox-ios/Shared/Prefs.swift
+++ b/firefox-ios/Shared/Prefs.swift
@@ -12,7 +12,6 @@ public struct PrefsKeys {
 
     // Global sync state for rust sync manager
     public static let RustSyncManagerPersistedState = "rustSyncManagerPersistedStateKey"
-    public static let HasVerifiedRustLogins = "hasVerifiedRustLogins"
 
     public static let KeyLastSyncFinishTime = "lastSyncFinishTime"
     public static let KeyDefaultHomePageURL = "KeyDefaultHomePageURL"

--- a/firefox-ios/Storage/Rust/RustLogins.swift
+++ b/firefox-ios/Storage/Rust/RustLogins.swift
@@ -355,9 +355,8 @@ public extension LoginEntry {
 }
 
 public enum LoginEncryptionKeyError: Error {
-    case noKeyCreated
     case illegalState
-    case dbRecordCountVerificationError(String)
+    case noKeyCreated
 }
 
 public class RustLoginEncryptionKeys {
@@ -536,72 +535,6 @@ public class RustLogins {
         }
     }
 
-    private func deleteInvalidLogins(key: String,
-                                     logins: [EncryptedLogin],
-                                     completion: @escaping (Bool) -> Void) {
-        // Create a list of IDs from saved logins that can't be decrypted
-        let loginsToDelete = logins
-            .filter { (try? decryptLogin(login: $0, encryptionKey: key)) == nil }
-            .map { $0.record.id }
-
-        // Delete all the logins that can't be decrypted
-        self.deleteLogins(ids: loginsToDelete).upon { deleteResults in
-            var verified = true
-            for result in deleteResults {
-                if case let .failure(err) = result {
-                    let errMsg = "Login could not be deleted during verification"
-                    self.logger.log(errMsg,
-                                    level: .warning,
-                                    category: .storage,
-                                    description: err.localizedDescription)
-                    verified = false
-                }
-            }
-            completion(verified)
-        }
-    }
-
-    public func verifyLogins(completion: @escaping (Bool) -> Void) {
-        queue.async {
-            self.listLogins().upon { loginResult in
-                switch loginResult {
-                case let .failure(error):
-                    self.logger.log("Logins could not be retrieved for verification",
-                                    level: .warning,
-                                    category: .storage,
-                                    description: error.localizedDescription)
-                    completion(false)
-                    return
-                case let .success(logins):
-                    guard !logins.isEmpty else {
-                        // If there are no logins we don't need to go through this verification
-                        // process in the future so we return true.
-                        completion(true)
-                        return
-                    }
-
-                    let rustKeys = RustLoginEncryptionKeys()
-                    guard let key = rustKeys.keychain.string(forKey: rustKeys.loginPerFieldKeychainKey) else {
-                        // If the key is missing during the verification process, we wipe the database and
-                        // recreate the key.
-                        self.resetLoginsAndKey(rustKeys: rustKeys) { resetResult in
-                            if case let .failure(error) = resetResult {
-                                self.logger.log("Logins and key could not be reset during verification",
-                                                level: .warning,
-                                                category: .storage,
-                                                description: error.localizedDescription)
-                            }
-                            return
-                        }
-                        completion(false)
-                        return
-                    }
-                    self.deleteInvalidLogins(key: key, logins: logins, completion: completion)
-                }
-            }
-        }
-    }
-
     private func close() -> NSError? {
         storage = nil
         isOpen = false
@@ -747,20 +680,15 @@ public class RustLogins {
                 return
             }
 
-            self.getStoredKey { result in
-                switch result {
-                case .success(let key):
-                    do {
-                        let id = try self.storage?.add(login: login, encryptionKey: key).record.id
-                        deferred.fill(Maybe(success: id!))
-                    } catch let err as NSError {
-                        deferred.fill(Maybe(failure: err))
-                    }
-                case .failure(let err):
-                    deferred.fill(Maybe(failure: err))
-                }
+            do {
+                let key = try self.getStoredKey()
+                let id = try self.storage?.add(login: login, encryptionKey: key).record.id
+                deferred.fill(Maybe(success: id!))
+            } catch let err as NSError {
+                deferred.fill(Maybe(failure: err))
             }
         }
+
         return deferred
     }
 
@@ -795,18 +723,12 @@ public class RustLogins {
                 return
             }
 
-            self.getStoredKey { result in
-                switch result {
-                case .success(let key):
-                    do {
-                        _ = try self.storage?.update(id: id, login: login, encryptionKey: key)
-                        deferred.fill(Maybe(success: ()))
-                    } catch let err as NSError {
-                        deferred.fill(Maybe(failure: err))
-                    }
-                case .failure(let err):
-                    deferred.fill(Maybe(failure: err))
-                }
+            do {
+                let key = try self.getStoredKey()
+                _ = try self.storage?.update(id: id, login: login, encryptionKey: key)
+                deferred.fill(Maybe(success: ()))
+            } catch let err as NSError {
+                deferred.fill(Maybe(failure: err))
             }
         }
 
@@ -865,107 +787,75 @@ public class RustLogins {
         }
     }
 
-    private func resetLoginsAndKey(rustKeys: RustLoginEncryptionKeys,
-                                   completion: @escaping (Result<String, NSError>) -> Void) {
-        self.wipeLocalEngine().upon { result in
-            guard result.isSuccess else {
-                completion(.failure(result.failureValue! as NSError))
-                return
-            }
-
-            do {
-                let key = try rustKeys.createAndStoreKey()
-                completion(.success(key))
-            } catch let error as NSError {
-                self.logger.log("Error creating logins encryption key",
-                                level: .warning,
-                                category: .storage,
-                                description: error.localizedDescription)
-                completion(.failure(error))
-            }
-        }
-    }
-
-    public func getStoredKey(completion: @escaping (Result<String, NSError>) -> Void) {
+    public func getStoredKey() throws -> String {
         let rustKeys = RustLoginEncryptionKeys()
         let key = rustKeys.keychain.string(forKey: rustKeys.loginPerFieldKeychainKey)
         let encryptedCanaryPhrase = rustKeys.keychain.string(forKey: rustKeys.canaryPhraseKey)
 
         switch(key, encryptedCanaryPhrase) {
         case (.some(key), .some(encryptedCanaryPhrase)):
+            // We expected the key to be present, and it is.
             do {
                 let canaryIsValid = try checkCanary(
                     canary: encryptedCanaryPhrase!,
                     text: rustKeys.canaryPhrase,
                     encryptionKey: key!)
-
                 if canaryIsValid {
-                    completion(.success(key!))
+                    return key!
                 } else {
                     logger.log("Logins key was corrupted, new one generated",
                                level: .warning,
                                category: .storage)
                     GleanMetrics.LoginsStoreKeyRegeneration.corrupt.record()
-                    self.resetLoginsAndKey(rustKeys: rustKeys, completion: completion)
+                    _ = self.wipeLocalEngine()
+
+                    return try rustKeys.createAndStoreKey()
                 }
             } catch let error as NSError {
-                logger.log("Error validating logins encryption key",
+                logger.log("Error retrieving logins encryption key",
                            level: .warning,
                            category: .storage,
                            description: error.localizedDescription)
-                completion(.failure(error))
             }
         case (.some(key), .none):
             // The key is present, but we didn't expect it to be there.
+            do {
+                logger.log("Logins key lost due to storage malfunction, new one generated",
+                           level: .warning,
+                           category: .storage)
+                GleanMetrics.LoginsStoreKeyRegeneration.other.record()
+                _ = self.wipeLocalEngine()
 
-            logger.log("Logins key lost due to storage malfunction, new one generated",
-                       level: .warning,
-                       category: .storage)
-            GleanMetrics.LoginsStoreKeyRegeneration.other.record()
-            self.resetLoginsAndKey(rustKeys: rustKeys, completion: completion)
+                return try rustKeys.createAndStoreKey()
+            } catch let error as NSError {
+                throw error
+            }
         case (.none, .some(encryptedCanaryPhrase)):
             // We expected the key to be present, but it's gone missing on us.
+            do {
+                logger.log("Logins key lost, new one generated",
+                           level: .warning,
+                           category: .storage)
+                GleanMetrics.LoginsStoreKeyRegeneration.lost.record()
+                _ = self.wipeLocalEngine()
 
-            logger.log("Logins key lost, new one generated",
-                       level: .warning,
-                       category: .storage)
-            GleanMetrics.LoginsStoreKeyRegeneration.lost.record()
-            self.resetLoginsAndKey(rustKeys: rustKeys, completion: completion)
+                return try rustKeys.createAndStoreKey()
+            } catch let error as NSError {
+                throw error
+            }
         case (.none, .none):
-            // We didn't expect the key to be present, which either means this is a first-time
-            // call or the key data has been cleared from the keychain.
-
-            self.hasSyncedLogins().upon { result in
-                guard result.failureValue == nil else {
-                    completion(.failure(result.failureValue! as NSError))
-                    return
-                }
-
-                guard let hasLogins = result.successValue else {
-                    let msg = "Failed to verify logins count before attempting to reset key"
-                    completion(.failure(LoginEncryptionKeyError.dbRecordCountVerificationError(msg) as NSError))
-                    return
-                }
-
-                if hasLogins {
-                    // Since the key data isn't present and we have login records in
-                    // the database, we both clear the databbase and the reset the key.
-                    GleanMetrics.LoginsStoreKeyRegeneration.keychainDataLost.record()
-                    self.resetLoginsAndKey(rustKeys: rustKeys, completion: completion)
-                } else {
-                    // There are no records in the database so we don't need to wipe any
-                    // existing login records. We just need to create a new key.
-                    do {
-                        let key = try rustKeys.createAndStoreKey()
-                        completion(.success(key))
-                    } catch let error as NSError {
-                        completion(.failure(error))
-                    }
-                }
+            // We didn't expect the key to be present, and it's not (which is the case for first-time calls).
+            do {
+                return try rustKeys.createAndStoreKey()
+            } catch let error as NSError {
+                throw error
             }
         default:
             // If none of the above cases apply, we're in a state that shouldn't be possible but is disallowed nonetheless
-            completion(.failure(LoginEncryptionKeyError.illegalState as NSError))
+            throw LoginEncryptionKeyError.illegalState
         }
+
+        // This must be declared again for Swift's sake even though the above switch statement handles all cases
+        throw LoginEncryptionKeyError.illegalState
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/PasswordManagerViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/PasswordManagerViewModelTests.swift
@@ -44,19 +44,14 @@ class PasswordManagerViewModelTests: XCTestCase {
                 "username": "username\(i)",
                 "password": "password\(i)"
             ])
-            let addExp = expectation(description: "\(#function)\(#line)")
-            self.viewModel.profile.logins.addLogin(login: login).upon { addResult in
-                XCTAssertTrue(addResult.isSuccess)
-                XCTAssertNotNil(addResult.successValue)
-                addExp.fulfill()
-            }
+            let addResult = self.viewModel.profile.logins.addLogin(login: login)
+            XCTAssertTrue(addResult.value.isSuccess)
+            XCTAssertNotNil(addResult.value.successValue)
         }
 
         let logins = self.viewModel.profile.logins.listLogins().value
         XCTAssertTrue(logins.isSuccess)
         XCTAssertNotNil(logins.successValue)
-
-        waitForExpectations(timeout: 10, handler: nil)
     }
 
     func testQueryLogins() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/RustSyncManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/RustSyncManagerTests.swift
@@ -54,7 +54,6 @@ class RustSyncManagerTests: XCTestCase {
 
     func testGetEnginesAndKeys() {
         let engines: [RustSyncManagerAPI.TogglableEngine] = [.bookmarks, .creditcards, .history, .passwords, .tabs]
-
         rustSyncManager.getEnginesAndKeys(engines: engines) { (engines, keys) in
             XCTAssertEqual(engines.count, 5)
 

--- a/firefox-ios/firefox-ios-tests/Tests/UnitTest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/UnitTest.xctestplan
@@ -96,7 +96,6 @@
       "skippedTests" : [
         "ETPCoverSheetTests",
         "IntroViewControllerTests\/testBasicSetupReturnsExpectedItems()",
-        "RustSyncManagerTests\/testGetEnginesAndKeys()",
         "RustSyncManagerTests\/testGetEnginesAndKeysWithNoKey()",
         "RustSyncManagerTests\/testUpdateEnginePrefs_bookmarksEnabled()",
         "TabManagerTests\/testDeleteSelectedTab()",
@@ -120,7 +119,6 @@
     },
     {
       "skippedTests" : [
-        "RustLoginsTests\/testGetStoredKeyWithKeychainReset()",
         "RustLoginsTests\/testUpdateLogin()",
         "TestBrowserDB\/testMovesDB()"
       ],


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO](https://mozilla-hub.atlassian.net/browse/FXIOS-8052))
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17956)

## :bulb: Description
Reverting PR #16973 and PR #17355 which update the logins key logic in response to reported issues with logins syncing in v121.

Note: Added "do not merge" to the PR title because I would like other members of the sync and iOS team to agree that this is the next step.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

