### PR TITLE
Refactor FXIOS-8000 [v123] Remove Redux unsubscribe (BVC)

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -219,10 +219,6 @@ class BrowserViewController: UIViewController,
         fatalError("init(coder:) has not been implemented")
     }
 
-    deinit {
-        unsubscribeFromRedux()
-    }
-
     override var prefersStatusBarHidden: Bool {
         return false
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8000)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17852)

## :bulb: Description

Summary of context:

- Unsubscribing from Redux store explicitly as part of `deinit` is not needed, the `Store` holds weak references to subscribers and auto-removes them
- It isn't typically problematic to explicitly unsubscribe, however in some scenarios it can cause issues
- During CI tests if you `nil` out BVC it will attempt to unsubscribe from `Redux` which references `store`. This means that the Redux store will actually be created if it doesn't already exist. This, in turn, triggers the initializers of several Redux middlewares which have dependencies that are expected to be available in `AppContainer`. This creates a hidden ordering dependency during `deinit`, and if you clear the `AppContainer` in a test case tear down before the BVC is nil'd out, you'll crash on CI. 💥 
- The change here just removes the explicit unsubscribe in BVC to avoid the above.
- We are unsubscribing in `deinit` in a few other classes also, however as those are not as ubiquitous as BVC and not instantiated in as many test cases, I have left those alone until we identify a specific reason to change them.

**TL;DR:**
Unsubscribing from Redux during `deinit` is not explicitly needed and can in some situations cause problems in our CI tests.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

