### PR TITLE
Added FXIOS-7859 [v123] Show share sheet from tab peek

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Redux
+import Storage
 
 enum ToastType: Equatable {
     case singleTab
@@ -61,6 +62,7 @@ enum TabPanelAction: Action {
     case selectTab(String)
     case showToast(ToastType)
     case hideUndoToast
+    case showShareSheet(URL)
 
     // Middleware actions
     case didLoadTabPanel(TabDisplayModel)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -372,7 +372,13 @@ class TabManagerMiddleware {
                                      value: .tabTray)
     }
 
-    private func sendToDevice(tabID: String) {}
+    private func sendToDevice(tabID: String) {
+        guard let tabToShare = defaultTabManager.getTabForUUID(uuid: tabID),
+              let url = tabToShare.url
+        else { return }
+
+        store.dispatch(TabPanelAction.showShareSheet(url))
+    }
 
     private func copyURL(tabID: String) {
         UIPasteboard.general.url = defaultTabManager.selectedTab?.canonicalURL

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Redux
+import Storage
 
 enum TabTrayLayoutType: Equatable {
     case regular // iPad
@@ -16,6 +17,7 @@ struct TabTrayState: ScreenState, Equatable {
     var normalTabsCount: String
     var hasSyncableAccount: Bool
     var shouldDismiss: Bool
+    var shareURL: URL?
 
     var navigationTitle: String {
         return selectedPanel.navTitle
@@ -35,7 +37,8 @@ struct TabTrayState: ScreenState, Equatable {
                   selectedPanel: panelState.selectedPanel,
                   normalTabsCount: panelState.normalTabsCount,
                   hasSyncableAccount: panelState.hasSyncableAccount,
-                  shouldDismiss: panelState.shouldDismiss)
+                  shouldDismiss: panelState.shouldDismiss,
+                  shareURL: panelState.shareURL)
     }
 
     init() {
@@ -56,12 +59,14 @@ struct TabTrayState: ScreenState, Equatable {
          selectedPanel: TabTrayPanelType,
          normalTabsCount: String,
          hasSyncableAccount: Bool,
-         shouldDismiss: Bool = false) {
+         shouldDismiss: Bool = false,
+         shareURL: URL? = nil) {
         self.isPrivateMode = isPrivateMode
         self.selectedPanel = selectedPanel
         self.normalTabsCount = normalTabsCount
         self.hasSyncableAccount = hasSyncableAccount
         self.shouldDismiss = shouldDismiss
+        self.shareURL = shareURL
     }
 
     static let reducer: Reducer<Self> = { state, action in
@@ -93,6 +98,12 @@ struct TabTrayState: ScreenState, Equatable {
                                     selectedPanel: state.selectedPanel,
                                     normalTabsCount: state.normalTabsCount,
                                     hasSyncableAccount: isSyncAccountEnabled)
+        case TabPanelAction.showShareSheet(let shareURL):
+            return TabTrayState(isPrivateMode: state.isPrivateMode,
+                                selectedPanel: state.selectedPanel,
+                                normalTabsCount: state.normalTabsCount,
+                                hasSyncableAccount: state.hasSyncableAccount,
+                                shareURL: shareURL)
         default:
             return state
         }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanel.swift
@@ -8,9 +8,9 @@ import Storage
 import UIKit
 
 class TabDisplayPanel: UIViewController,
-                                Themeable,
-                                EmptyPrivateTabsViewDelegate,
-                                StoreSubscriber {
+                       Themeable,
+                       EmptyPrivateTabsViewDelegate,
+                       StoreSubscriber {
     typealias SubscriberStateType = TabsPanelState
     var notificationCenter: NotificationProtocol
     var themeManager: ThemeManager
@@ -18,7 +18,7 @@ class TabDisplayPanel: UIViewController,
 
     // MARK: UI elements
     private lazy var tabDisplayView: TabDisplayView = {
-        let view = TabDisplayView(state: self.tabsState, tabPeekDelegate: self)
+        let view = TabDisplayView(state: self.tabsState)
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
@@ -38,10 +38,6 @@ class TabDisplayPanel: UIViewController,
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    deinit {
-        unsubscribeFromRedux()
     }
 
     override func viewDidLoad() {
@@ -127,12 +123,4 @@ class TabDisplayPanel: UIViewController,
     func didTapLearnMore(urlRequest: URLRequest) {
         store.dispatch(TabPanelAction.learnMorePrivateMode(urlRequest))
     }
-}
-
-extension TabDisplayPanel: LegacyTabPeekDelegate {
-    func tabPeekDidAddToReadingList(_ tab: Tab) -> ReadingListItem? { return nil }
-    func tabPeekDidAddBookmark(_ tab: Tab) {}
-    func tabPeekRequestsPresentationOf(_ viewController: UIViewController) {}
-    func tabPeekDidCloseTab(_ tab: Tab) {}
-    func tabPeekDidCopyUrl() {}
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -25,7 +25,6 @@ class TabDisplayView: UIView,
     private(set) var tabsState: TabsPanelState
     private var inactiveTabsSectionManager: InactiveTabsSectionManager
     private var tabsSectionManager: TabsSectionManager
-    private weak var tabPeekDelegate: LegacyTabPeekDelegate?
     var theme: Theme?
 
     private var shouldHideInactiveTabs: Bool {
@@ -60,9 +59,8 @@ class TabDisplayView: UIView,
         return collectionView
     }()
 
-    public init(state: TabsPanelState, tabPeekDelegate: LegacyTabPeekDelegate?) {
+    public init(state: TabsPanelState) {
         self.tabsState = state
-        self.tabPeekDelegate = tabPeekDelegate
         self.inactiveTabsSectionManager = InactiveTabsSectionManager()
         self.tabsSectionManager = TabsSectionManager()
         super.init(frame: .zero)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -6,6 +6,7 @@ import Common
 import Foundation
 import Storage
 import Redux
+import Shared
 
 protocol TabTrayController: UIViewController,
                             UIAdaptivePresentationControllerDelegate,
@@ -264,6 +265,12 @@ class TabTrayViewController: UIViewController,
 
         if tabTrayState.shouldDismiss {
             dismissVC()
+        }
+        if let url = tabTrayState.shareURL {
+            navigationHandler?.shareTab(url: url, sourceView: self.view)
+
+            // Reload to clear the share sheet item
+            store.dispatch(TabTrayAction.tabTrayDidLoad(tabTrayState.selectedPanel))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Extensions/DevicePickerViewController.swift
+++ b/firefox-ios/Client/Frontend/Extensions/DevicePickerViewController.swift
@@ -64,7 +64,7 @@ class DevicePickerViewController: UITableViewController {
     // url later. Currently used only when sharing an item from the Tab Tray from a Preview Action.
     var shareItem: ShareItem?
 
-    init(profile: Profile) {
+    init(profile: Profile = AppContainer.shared.resolve()) {
         self.profile = profile
 
         super.init(nibName: nil, bundle: nil)

--- a/firefox-ios/Storage/Sharing.swift
+++ b/firefox-ios/Storage/Sharing.swift
@@ -7,7 +7,7 @@ import Shared
 
 // A small structure to encapsulate all the possible data that we can get
 // from an application sharing a web page or a URL.
-public struct ShareItem {
+public struct ShareItem: Equatable {
     public let url: String
     public let title: String?
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabDisplayViewTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabDisplayViewTests.swift
@@ -112,7 +112,7 @@ final class TabDisplayViewTests: XCTestCase {
                                       inactiveTabs: inactiveTabs,
                                       isInactiveTabsExpanded: isInactiveTabsExpanded)
 
-        let subject = TabDisplayView(state: tabState, tabPeekDelegate: nil)
+        let subject = TabDisplayView(state: tabState)
         trackForMemoryLeaks(subject, file: file, line: line)
         return subject
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7859)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17546)

## :bulb: Description
Shows the share sheet from the tab peek options on the new tab tray

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

