### PR TITLE
Update FXIOS-8048 [v123] Settings screen with Address Autofill section

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -922,6 +922,7 @@
 		B12DDFED2A8DE825008CE9CF /* ToolbarMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12DDFEC2A8DE825008CE9CF /* ToolbarMenuTests.swift */; };
 		B15058812AA0A878008B7382 /* OpeningScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15058802AA0A878008B7382 /* OpeningScreenTests.swift */; };
 		B1664E9E2B163B7A005D4C71 /* CreditCardsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1664E9D2B163B7A005D4C71 /* CreditCardsTests.swift */; };
+		B26ADF852B339ED000C6E127 /* AddressAutofillSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = B26ADF842B339ED000C6E127 /* AddressAutofillSetting.swift */; };
 		B2999FED2B044A5900F0FEC1 /* UnencryptedCreditCardFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2999FEC2B044A5900F0FEC1 /* UnencryptedCreditCardFields.swift */; };
 		B2999FEF2B044B4E00F0FEC1 /* RustAutofillEncryptionKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2999FEE2B044B4E00F0FEC1 /* RustAutofillEncryptionKeys.swift */; };
 		B2999FF12B194A5800F0FEC1 /* CreditCardPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2999FF02B194A5800F0FEC1 /* CreditCardPayload.swift */; };
@@ -929,6 +930,9 @@
 		B2999FF52B194AB200F0FEC1 /* FormAutofillHelperError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2999FF42B194AB200F0FEC1 /* FormAutofillHelperError.swift */; };
 		B2999FF72B194ADE00F0FEC1 /* FormAutofillPayloadType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2999FF62B194ADE00F0FEC1 /* FormAutofillPayloadType.swift */; };
 		B2999FFA2B1A3E0700F0FEC1 /* AddressAutofillPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2999FF92B1A3E0700F0FEC1 /* AddressAutofillPayload.swift */; };
+		B2FEA68B2B460D1D0058E616 /* AddressAutofillSettingsEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2FEA68A2B460D1D0058E616 /* AddressAutofillSettingsEmptyView.swift */; };
+		B2FEA68D2B460D390058E616 /* AddressAutofillSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2FEA68C2B460D390058E616 /* AddressAutofillSettingsViewController.swift */; };
+		B2FEA68F2B460D9E0058E616 /* AddressAutofillSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2FEA68E2B460D9E0058E616 /* AddressAutofillSettingsViewModel.swift */; };
 		B640467E29B9B58200C5C7B6 /* TabLocationViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B640467D29B9B58200C5C7B6 /* TabLocationViewTests.swift */; };
 		BCFF93EE2AAA9F6E005B5B71 /* RustFirefoxSuggest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF93ED2AAA9C47005B5B71 /* RustFirefoxSuggest.swift */; };
 		BCFF93F02AABA55A005B5B71 /* BackgroundFirefoxSuggestIngestUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF93EF2AAB97A8005B5B71 /* BackgroundFirefoxSuggestIngestUtility.swift */; };
@@ -6050,6 +6054,7 @@
 		B2474500BBF85DB3C71C329B /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Today.strings; sourceTree = "<group>"; };
 		B25849AE8A390529836D27F0 /* sq */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sq; path = "sq.lproj/Default Browser.strings"; sourceTree = "<group>"; };
 		B25D4E72A0116CFE5BEC29CC /* es-CL */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-CL"; path = "es-CL.lproj/ClearPrivateData.strings"; sourceTree = "<group>"; };
+		B26ADF842B339ED000C6E127 /* AddressAutofillSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressAutofillSetting.swift; sourceTree = "<group>"; };
 		B29049688244A8F79950DF35 /* af */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = af; path = af.lproj/Shared.strings; sourceTree = "<group>"; };
 		B2944B3EAFB1DA22E7F28520 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Shared.strings; sourceTree = "<group>"; };
 		B2999FEC2B044A5900F0FEC1 /* UnencryptedCreditCardFields.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnencryptedCreditCardFields.swift; sourceTree = "<group>"; };
@@ -6063,6 +6068,9 @@
 		B2C74A199A0619104A7635EC /* bs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bs; path = bs.lproj/ClearPrivateData.strings; sourceTree = "<group>"; };
 		B2CD44128F18BC81432BBB4C /* gu-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "gu-IN"; path = "gu-IN.lproj/Search.strings"; sourceTree = "<group>"; };
 		B2E3413DBD459AF31D707785 /* eo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = eo; path = eo.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
+		B2FEA68A2B460D1D0058E616 /* AddressAutofillSettingsEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressAutofillSettingsEmptyView.swift; sourceTree = "<group>"; };
+		B2FEA68C2B460D390058E616 /* AddressAutofillSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressAutofillSettingsViewController.swift; sourceTree = "<group>"; };
+		B2FEA68E2B460D9E0058E616 /* AddressAutofillSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressAutofillSettingsViewModel.swift; sourceTree = "<group>"; };
 		B3154B289D2C0C247745D348 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Search.strings; sourceTree = "<group>"; };
 		B381465688459DB14B2A929C /* gu-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "gu-IN"; path = "gu-IN.lproj/LoginManager.strings"; sourceTree = "<group>"; };
 		B3D34760AD7FE14BBCD912E3 /* es-CL */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-CL"; path = "es-CL.lproj/Menu.strings"; sourceTree = "<group>"; };
@@ -8560,6 +8568,7 @@
 		43D00490296FC44B00CB0F31 /* Autofill */ = {
 			isa = PBXGroup;
 			children = (
+				B2FEA6892B460CEC0058E616 /* Address */,
 				43D00491296FC46E00CB0F31 /* CreditCard */,
 			);
 			path = Autofill;
@@ -8899,6 +8908,7 @@
 				8A19ACB52A3290F9001C2147 /* NotificationsSetting.swift */,
 				8A19ACB72A329128001C2147 /* PrivacyPolicySetting.swift */,
 				8A093D822A4B68940099ABA5 /* PrivacySettingsDelegate.swift */,
+				B26ADF842B339ED000C6E127 /* AddressAutofillSetting.swift */,
 			);
 			path = Privacy;
 			sourceTree = "<group>";
@@ -9639,6 +9649,13 @@
 			path = CreditCardBottomSheet;
 			sourceTree = "<group>";
 		};
+		B26ADF892B362C2400C6E127 /* New Group */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = "New Group";
+			sourceTree = "<group>";
+		};
 		B2999FF82B194B3D00F0FEC1 /* FormAutofillHelper */ = {
 			isa = PBXGroup;
 			children = (
@@ -9650,6 +9667,16 @@
 				B2999FF62B194ADE00F0FEC1 /* FormAutofillPayloadType.swift */,
 			);
 			path = FormAutofillHelper;
+			sourceTree = "<group>";
+		};
+		B2FEA6892B460CEC0058E616 /* Address */ = {
+			isa = PBXGroup;
+			children = (
+				B2FEA68A2B460D1D0058E616 /* AddressAutofillSettingsEmptyView.swift */,
+				B2FEA68C2B460D390058E616 /* AddressAutofillSettingsViewController.swift */,
+				B2FEA68E2B460D9E0058E616 /* AddressAutofillSettingsViewModel.swift */,
+			);
+			path = Address;
 			sourceTree = "<group>";
 		};
 		C22753422A3CA25100B9C0D1 /* WebsiteDataManagement */ = {
@@ -10749,6 +10776,7 @@
 		E1D3FFAF2A66A9BD002D31EF /* Fakespot */ = {
 			isa = PBXGroup;
 			children = (
+				B26ADF892B362C2400C6E127 /* New Group */,
 				8C92DE942A7128FB0090BD28 /* Client */,
 				E16258F02A83D5DE00522742 /* Views */,
 				E13E9AB12AAB0FB4001A0E9D /* FakespotCoordinator.swift */,
@@ -13209,6 +13237,7 @@
 				F85C7F122721048E004BDBA4 /* Layout.swift in Sources */,
 				DF036E43274FD434002E834E /* HistoryHighlightsCell.swift in Sources */,
 				EB9A179C20E69A7F00B12184 /* LegacyDarkTheme.swift in Sources */,
+				B2FEA68D2B460D390058E616 /* AddressAutofillSettingsViewController.swift in Sources */,
 				21618A8A2A4389F700A5189E /* ActiveScreenState.swift in Sources */,
 				DA52E1DA25F5961F0092204C /* LegacyTabTrayViewController.swift in Sources */,
 				8AD40FD327BB068F00672675 /* MainMenuActionHelper.swift in Sources */,
@@ -13657,8 +13686,10 @@
 				2137785F297F3B1B00D01309 /* DownloadsPanelViewModel.swift in Sources */,
 				EBE26B57220C959D00D1D99A /* BrowserViewController+TabToolbarDelegate.swift in Sources */,
 				8A3EF7F02A2FCF3100796E3A /* HiddenSettings.swift in Sources */,
+				B2FEA68F2B460D9E0058E616 /* AddressAutofillSettingsViewModel.swift in Sources */,
 				AB03032B2AB47AF300DCD8EF /* FakespotOptInCardView.swift in Sources */,
 				0BA02DB22942605600C92603 /* FormAutofillHelper.swift in Sources */,
+				B26ADF852B339ED000C6E127 /* AddressAutofillSetting.swift in Sources */,
 				8A19ACB82A329128001C2147 /* PrivacyPolicySetting.swift in Sources */,
 				E68AEDB01B18F81A00133D99 /* SwipeAnimator.swift in Sources */,
 				1DDE3DB32AC34E1E0039363B /* TabCell.swift in Sources */,
@@ -13749,6 +13780,7 @@
 				43D16B8029831DC5009F8279 /* CreditCardInputView.swift in Sources */,
 				21112968289480630082C08B /* HomepageMessageCardViewModel.swift in Sources */,
 				E1CD81BE290C5C7500124B27 /* DevicePickerTableViewHeaderCell.swift in Sources */,
+				B2FEA68B2B460D1D0058E616 /* AddressAutofillSettingsEmptyView.swift in Sources */,
 				E12BD0AC28AC37F00029AAF0 /* UIColor+Extension.swift in Sources */,
 				E4A961181AC041C40069AD6F /* ReadabilityService.swift in Sources */,
 				AB42CC752A1F5240003C9594 /* CreditCardBottomSheetHeaderView.swift in Sources */,

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -479,6 +479,10 @@ public struct AccessibilityIdentifiers {
             static let title = "AutofillCreditCard"
         }
 
+        struct Address {
+            static let title = "AutofillAddress"
+        }
+
         struct ConnectSetting {
             static let title = "SignInToSync"
         }

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -222,6 +222,12 @@ class SettingsCoordinator: BaseCoordinator,
 
     // MARK: PrivacySettingsDelegate
 
+    func pressedAddressAutofill() {
+        let viewModel = AddressAutofillSettingsViewModel()
+        let viewController = AddressAutofillSettingsViewController(addressAutofillViewModel: viewModel)
+        router.push(viewController)
+    }
+
     func pressedCreditCard() {
         findAndHandle(route: .settings(section: .creditCard))
     }

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsEmptyView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsEmptyView.swift
@@ -1,0 +1,61 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+/// TODO FXIOS-8067
+import SwiftUI
+import Common
+import Shared
+
+struct AddressAutofillSettingsEmptyView: View {
+    // Theming
+    @Environment(\.themeType) var themeVal
+    @State private var titleTextColor: Color = .clear
+    @State private var subTextColor: Color = .clear
+    @State private var toggleTextColor: Color = .clear
+    @State private var imageColor: Color = .clear
+
+    @ObservedObject var toggleModel: ToggleModel
+
+    var body: some View {
+        ZStack {
+            UIColor.clear.color
+                .edgesIgnoringSafeArea(.all)
+            GeometryReader { proxy in
+                ScrollView {
+                    VStack {
+                        /// TODO FXIOS-8067
+///                        AddressAutofillToggle(
+///                            textColor: toggleTextColor,
+///                            model: toggleModel)
+///                        .background(Color.white)
+///                       .padding(.top, 25)                        
+                    }
+                    .frame(minHeight: proxy.size.height)
+                }
+                .frame(maxWidth: .infinity)
+            }
+        }
+        .onAppear {
+            applyTheme(theme: themeVal.theme)
+        }
+        .onChange(of: themeVal) { newThemeValue in
+            applyTheme(theme: newThemeValue.theme)
+        }
+    }
+
+    func applyTheme(theme: Theme) {
+        let color = theme.colors
+        titleTextColor = Color(color.textPrimary)
+        subTextColor = Color(color.textSecondary)
+        toggleTextColor = Color(color.textPrimary)
+        imageColor = Color(color.iconSecondary)
+    }
+}
+
+struct AddressAutofillSettingsEmptyView_Previews: PreviewProvider {
+    static var previews: some View {
+        let toggleModel = ToggleModel(isEnabled: true)
+        AddressAutofillSettingsEmptyView(toggleModel: toggleModel)
+    }
+}

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsEmptyView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsEmptyView.swift
@@ -9,7 +9,8 @@ import Shared
 
 struct AddressAutofillSettingsEmptyView: View {
     // Theming
-    @Environment(\.themeType) var themeVal
+    @Environment(\.themeType)
+    var themeVal
     @State private var titleTextColor: Color = .clear
     @State private var subTextColor: Color = .clear
     @State private var toggleTextColor: Color = .clear
@@ -29,7 +30,7 @@ struct AddressAutofillSettingsEmptyView: View {
 ///                            textColor: toggleTextColor,
 ///                            model: toggleModel)
 ///                        .background(Color.white)
-///                       .padding(.top, 25)                        
+///                       .padding(.top, 25)
                     }
                     .frame(minHeight: proxy.size.height)
                 }

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsViewController.swift
@@ -1,0 +1,68 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import Common
+
+// MARK: - AddressAutofillSettingsViewController
+class AddressAutofillSettingsViewController: SensitiveViewController, Themeable {
+    // MARK: Properties
+
+    // ViewModel for managing address autofill settings
+    var viewModel: AddressAutofillSettingsViewModel
+
+    // Observer for theme changes
+    var themeObserver: NSObjectProtocol?
+
+    // Manager responsible for handling themes
+    var themeManager: ThemeManager
+
+    // NotificationCenter for handling notifications
+    var notificationCenter: NotificationProtocol
+
+    // Logger for logging messages and events
+    private let logger: Logger
+
+    // MARK: Initializers
+
+    /// Initialize the AddressAutofillSettingsViewController.
+    /// - Parameters:
+    ///   - addressAutofillViewModel: The ViewModel for address autofill settings.
+    ///   - themeManager: The ThemeManager for managing app themes.
+    ///   - notificationCenter: The NotificationCenter for handling notifications.
+    ///   - logger: The Logger for logging messages and events.
+    init(addressAutofillViewModel: AddressAutofillSettingsViewModel,
+         themeManager: ThemeManager = AppContainer.shared.resolve(),
+         notificationCenter: NotificationCenter = NotificationCenter.default,
+         logger: Logger = DefaultLogger.shared) {
+        self.viewModel = addressAutofillViewModel
+        self.themeManager = themeManager
+        self.notificationCenter = notificationCenter
+        self.logger = logger
+        // ... initialize other dependencies
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    /// Not implemented for this view controller. Raises a fatal error.
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: View Lifecycle
+
+    /// Called after the controller's view is loaded into memory.
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        listenForThemeChange(view)
+        applyTheme()
+    }
+
+    // MARK: Themeable Protocol
+
+    /// Applies the current theme to the view.
+    func applyTheme() {
+        let theme = themeManager.currentTheme
+        view.backgroundColor = theme.colors.layer1
+    }
+}

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsViewModel.swift
@@ -1,0 +1,25 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+/// TODO FXIOS-8067
+class AddressAutofillSettingsViewModel {
+    // This property holds the current state of address autofill settings
+    var isAutofillEnabled: Bool {
+        didSet {
+            // You can perform any additional actions when the value changes
+            // For example, save the new state to UserDefaults or send it to a server
+            UserDefaults.standard.set(isAutofillEnabled, forKey: "IsAutofillEnabled")
+        }
+    }
+
+    // You can add other properties and methods as needed
+
+    init() {
+        // Initialize the state from UserDefaults or any other source
+        self.isAutofillEnabled = UserDefaults.standard.bool(forKey: "IsAutofillEnabled")
+    }
+
+    // Add other methods or properties as needed
+}

--- a/firefox-ios/Client/Frontend/Settings/Main/Privacy/AddressAutofillSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Privacy/AddressAutofillSetting.swift
@@ -1,0 +1,54 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+import Shared
+
+// MARK: - AddressAutofillSetting
+class AddressAutofillSetting: Setting {
+    // MARK: Properties
+
+    // Delegate for handling privacy settings interactions
+    private weak var settingsDelegate: PrivacySettingsDelegate?
+
+    // User profile associated with the address autofill setting
+    private let profile: Profile
+
+    // MARK: Computed Properties
+
+    /// The accessory view for the setting, indicating it has additional details.
+    override var accessoryView: UIImageView? {
+        return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme)
+    }
+
+    /// Accessibility identifier for UI testing purposes.
+    override var accessibilityIdentifier: String? {
+        return AccessibilityIdentifiers.Settings.Address.title
+    }
+
+    // MARK: Initializers
+
+    /// Initialize the AddressAutofillSetting.
+    /// - Parameters:
+    ///   - theme: The theme used for styling the setting.
+    ///   - profile: The user profile associated with the address autofill setting.
+    ///   - settingsDelegate: The delegate for handling privacy settings interactions.
+    init(theme: Theme,
+         profile: Profile,
+         settingsDelegate: PrivacySettingsDelegate?) {
+        self.profile = profile
+        self.settingsDelegate = settingsDelegate
+        super.init(title: NSAttributedString(string: .SettingsAddressAutofill,
+                                             attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary]))
+    }
+
+    // MARK: Action
+
+    /// Triggered when the setting is clicked.
+    /// - Parameter navigationController: The navigation controller, if applicable.
+    override func onClick(_ navigationController: UINavigationController?) {
+        settingsDelegate?.pressedAddressAutofill()
+    }
+}

--- a/firefox-ios/Client/Frontend/Settings/Main/Privacy/PrivacySettingsDelegate.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Privacy/PrivacySettingsDelegate.swift
@@ -6,6 +6,7 @@ import Foundation
 
 /// Child settings pages privacy actions
 protocol PrivacySettingsDelegate: AnyObject {
+    func pressedAddressAutofill()
     func pressedCreditCard()
     func pressedClearPrivateData()
     func pressedContentBlocker()

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -2109,6 +2109,11 @@ extension String {
         tableName: "Settings",
         value: "Payment Methods",
         comment: "Label used as an item in Settings screen. When touched, it will take user to credit card settings page to that will allows to add or modify saved credit cards to allow for autofill in a webpage.")
+    public static let SettingsAddressAutofill = MZLocalizedString(
+        key: "Settings.AddressAutofill.Title.v124",
+        tableName: "Settings",
+        value: "Autofill Addresses",
+        comment: "Label used as an item in Settings screen. When touched, it will take user to address autofill settings page to that will allow user to add or modify saved addresses to allow for autofill in a webpage.")
 }
 
 // MARK: - Error pages

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
@@ -448,6 +448,15 @@ final class SettingsCoordinatorTests: XCTestCase {
         XCTAssertTrue(mockRouter.pushedViewController is SettingsContentViewController)
     }
 
+    func testPrivacySettingsDelegate_pressedAddressAutofill() {
+        let subject = createSubject()
+
+        subject.pressedAddressAutofill()
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+        XCTAssertTrue(mockRouter.pushedViewController is AddressAutofillSettingsViewController)
+    }
+
     // MARK: AccountSettingsDelegate
 
     func testAccountSettingsDelegate_pushedConnectSetting() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSettingsFlowDelegate.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSettingsFlowDelegate.swift
@@ -79,6 +79,8 @@ class MockSettingsFlowDelegate: SettingsFlowDelegate,
 
     func pressedNotifications() {}
 
+    func pressedAddressAutofill() {}
+
     func askedToOpen(url: URL?, withTitle title: NSAttributedString?) {}
 
     // MARK: AccountSettingsDelegate


### PR DESCRIPTION
Implemented pressedAddressAutofill in SettingsCoordinator. Created and implemented AddressAutofillSettingsEmptyView. Developed AddressAutofillSettingsViewController.
Implemented AddressAutofillSettingsViewModel.
Refactored AppSettingsTableViewController.
Added AddressAutofillSetting to PrivacySettingsDelegate. Introduced String for Settings.

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8048)

## :bulb: Description
Update the settings page item to support the new credit card section. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

