### PR TITLE
Refactor FXIOS-8064, 8076 [v123] [Multi-window] Fix memory leaks when closing iPad window

### DIFF
--- a/firefox-ios/Client/Application/SceneDelegate.swift
+++ b/firefox-ios/Client/Application/SceneDelegate.swift
@@ -52,6 +52,16 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
     }
 
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Handle clean-up here for closing windows on iPad
+        guard let sceneCoordinator = (scene.delegate as? SceneDelegate)?.sceneCoordinator else { return }
+        
+        // Give all coordinators a chance to respond to scene disconnect (window close).
+        sceneCoordinator.recurseChildCoordinators {
+            ($0 as? WindowEventCoordinator)?.coordinatorWindowWillClose()
+        }
+    }
+
     // MARK: - Transitioning to Foreground
 
     /// Invoked when the interface is finished loading for your screen, but before that interface appears on screen.

--- a/firefox-ios/Client/Application/SceneDelegate.swift
+++ b/firefox-ios/Client/Application/SceneDelegate.swift
@@ -60,6 +60,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         sceneCoordinator.recurseChildCoordinators {
             ($0 as? WindowEventCoordinator)?.coordinatorWindowWillClose()
         }
+
+        // Notify WindowManager that window is closing
+        let windowManager: WindowManager = AppContainer.shared.resolve()
+        windowManager.windowDidClose(uuid: sceneCoordinator.windowUUID)
     }
 
     // MARK: - Transitioning to Foreground

--- a/firefox-ios/Client/Application/SceneDelegate.swift
+++ b/firefox-ios/Client/Application/SceneDelegate.swift
@@ -55,7 +55,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneDidDisconnect(_ scene: UIScene) {
         // Handle clean-up here for closing windows on iPad
         guard let sceneCoordinator = (scene.delegate as? SceneDelegate)?.sceneCoordinator else { return }
-        
+
         // Give all coordinators a chance to respond to scene disconnect (window close).
         sceneCoordinator.recurseChildCoordinators {
             ($0 as? WindowEventCoordinator)?.coordinatorWindowWillClose()

--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -40,9 +40,9 @@ protocol WindowManager {
 }
 
 /// Abstract protocol that any Coordinator can conform to in order to respond
-/// to key events for window lifecycle events, such as performing clean-up
-/// actions when a window is closed.
+/// to key window lifecycle events, such as cleaning up when a window is closed.
 protocol WindowEventCoordinator {
+    /// Notifies the coordinator that its parent window/scene is being removed.
     func coordinatorWindowWillClose()
 }
 

--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -39,6 +39,13 @@ protocol WindowManager {
     func nextAvailableWindowUUID() -> WindowUUID
 }
 
+/// Abstract protocol that any Coordinator can conform to in order to respond
+/// to key events for window lifecycle events, such as performing clean-up
+/// actions when a window is closed.
+protocol WindowEventCoordinator {
+    func coordinatorWindowWillClose()
+}
+
 /// Captures state and coordinator references specific to one particular app window.
 struct AppWindowInfo {
     var tabManager: TabManager?

--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -112,6 +112,7 @@ final class WindowManagerImplementation: WindowManager {
         guard info != nil || windows.count > 1 else {
             let message = "Cannot remove the only active window in the app. This is a client error."
             logger.log(message, level: .fatal, category: .window)
+            // TODO: [FXIOS-8081] Needs additional investigation for how to handle this with multi-window feature.
             assertionFailure(message)
             return
         }

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -21,7 +21,8 @@ class BrowserCoordinator: BaseCoordinator,
                           ParentCoordinatorDelegate,
                           TabManagerDelegate,
                           TabTrayCoordinatorDelegate,
-                          PrivateHomepageDelegate {
+                          PrivateHomepageDelegate,
+                          WindowEventCoordinator {
     var browserViewController: BrowserViewController
     var webviewController: WebviewViewController?
     var homepageViewController: HomepageViewController?
@@ -568,5 +569,13 @@ class BrowserCoordinator: BaseCoordinator,
     func didDismissTabTray(from coordinator: TabTrayCoordinator) {
         router.dismiss(animated: true, completion: nil)
         remove(child: coordinator)
+    }
+
+    // MARK: - WindowEventCoordinator
+
+    func coordinatorWindowWillClose() {
+        // This cleanup is necessary to ensure BVC and other components are properly released.
+        browserViewController.contentContainer.subviews.forEach { $0.removeFromSuperview() }
+        browserViewController.removeFromParent()
     }
 }

--- a/firefox-ios/Client/Coordinators/Coordinator.swift
+++ b/firefox-ios/Client/Coordinators/Coordinator.swift
@@ -50,3 +50,12 @@ extension Array where Element == Coordinator {
         self.first(where: { $0 is T }) as? T
     }
 }
+
+extension Coordinator {
+    /// Recursively performs an operation (defined by the supplied `action`)
+    /// on the receiver and its entire sub-tree of child coordinators.
+    func recurseChildCoordinators(_ action: (Coordinator) -> Void) {
+        action(self)
+        childCoordinators.forEach { $0.recurseChildCoordinators(action) }
+    }
+}

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -571,14 +571,16 @@ class BrowserViewController: UIViewController,
         // UIAccessibilityCustomAction subclass holding an AccessibleAction instance does not work,
         // thus unable to generate AccessibleActions and UIAccessibilityCustomActions "on-demand" and need
         // to make them "persistent" e.g. by being stored in BVC
-        pasteGoAction = AccessibleAction(name: .PasteAndGoTitle, handler: { () -> Bool in
+        pasteGoAction = AccessibleAction(name: .PasteAndGoTitle, handler: { [weak self] () -> Bool in
+            guard let self else { return false }
             if let pasteboardContents = UIPasteboard.general.string {
                 self.urlBar(self.urlBar, didSubmitText: pasteboardContents)
                 return true
             }
             return false
         })
-        pasteAction = AccessibleAction(name: .PasteTitle, handler: { () -> Bool in
+        pasteAction = AccessibleAction(name: .PasteTitle, handler: {  [weak self] () -> Bool in
+            guard let self else { return false }
             if let pasteboardContents = UIPasteboard.general.string {
                 // Enter overlay mode and make the search controller appear.
                 self.overlayManager.openSearch(with: pasteboardContents)
@@ -587,7 +589,8 @@ class BrowserViewController: UIViewController,
             }
             return false
         })
-        copyAddressAction = AccessibleAction(name: .CopyAddressTitle, handler: { () -> Bool in
+        copyAddressAction = AccessibleAction(name: .CopyAddressTitle, handler: { [weak self] () -> Bool in
+            guard let self else { return false }
             if let url = self.tabManager.selectedTab?.canonicalURL?.displayURL ?? self.urlBar.currentURL {
                 UIPasteboard.general.url = url
             }
@@ -2083,7 +2086,8 @@ extension BrowserViewController: LegacyTabDelegate {
     }
 
     func tab(_ tab: Tab, willDeleteWebView webView: WKWebView) {
-        DispatchQueue.main.async { [unowned self] in
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
             KVOs.forEach { webView.removeObserver(self, forKeyPath: $0.rawValue) }
             webView.scrollView.removeObserver(self.scrollController, forKeyPath: KVOConstants.contentSize.rawValue)
             webView.uiDelegate = nil

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -316,7 +316,7 @@ class TabManagerMiddleware {
     }
 
     private var defaultTabManager: TabManager {
-        // TODO: [FXIOS-7863] Temporary. WIP for Redux + iPad Multi-window.
+        // TODO: [FXIOS-8071] Temporary. WIP for Redux + iPad Multi-window.
         return windowManager.tabManager(for: windowManager.activeWindow)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8064)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17971)

and
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8076)

## :bulb: Description

Fixes several issues when closing a window on iPad (when using the forthcoming multi-window support).

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

