### PR TITLE
Add MTE-2050 [v123] Add Bitrise Step to Fail Standalone Builds

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -375,8 +375,8 @@ workflows:
 
             # Check if $BITRISEIO_PIPELINE_ID is unset or empty
             # If so, this is a standalone build and we need to fail it
-            if [ -z "$BITRISEIO_PIPELINE_IDXXX" ]; then
-                printf "\n${RED}Error: BITRISE_PIPELINE_ID is not set.${NC}\n\
+            if [ -z "$BITRISEIO_PIPELINE_ID" ]; then
+                printf "\n${RED}Error: BITRISEIO_PIPELINE_ID is not set.${NC}\n\
                 This means you have triggered a build stage or workflow individually, instead of the entire pipeline.\n\n\
                 The current build workflow is: ${RED}$BITRISE_TRIGGERED_WORKFLOW_TITLE${NC}, but needs to be run in ${RED}pipeline_multiple_shards${NC}.\n\n\
                 To trigger a pipeline rebuild in its entirety, please do the following:\n\n\

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -380,10 +380,10 @@ workflows:
                 This means you have triggered a build stage individually, instead of the entire pipeline.\n\n\
                 To trigger a pipeline rebuild in its entirety, please do the following:\n\n\
                     ${CYAN}1. Select your last failed build for 'pipeline_multiple_shards'.\n\
-                    2. Click the 'Rebuild' button dropdown icon located in the top right of the page.\n\
-                    3. From the dropdown menu, select 'Rebuild entire Pipeline'.\n\
-                    4. If no dropdown menu is present, you are looking at a standalone build\n\
-                       and need to select the initial Github pipeline triggered by the PR.${NC}\n\n\
+                    ${CYAN}2. Click the 'Rebuild' button dropdown icon located in the top right of the page.\n\
+                    ${CYAN}3. From the dropdown menu, select 'Rebuild entire Pipeline'.\n\
+                    ${CYAN}4. If no dropdown menu is present, you are looking at a standalone build\n\
+                       ${CYAN}and need to select the initial Github pipeline triggered by the PR.${NC}\n\n\
                 If you are still having issues, please contact ${GREEN}#mobile-testeng${NC} on Slack.\n"
                 exit 1  # Exit with a failure status
             else

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -365,20 +365,25 @@ workflows:
         inputs:
         - content: |-
             #!/usr/bin/env bash
-            set -ex
+            set -e
+
+            # ANSI color codes
+            RED='\033[0;31m'    # Red color
+            CYAN='\033[0;36m'   # Cyan color
+            NC='\033[0m'        # No Color (resets color to default)
 
             # Check if $BITRISE_PIPELINE_ID is unset or empty
             # If so, this is a standalone build and we need to fail it
             if [ -z "$BITRISE_PIPELINE_ID" ]; then
-                printf "\n\t\tError: BITRISE_PIPELINE_ID is not set.\n\
+                printf "\n${RED}Error: BITRISE_PIPELINE_ID is not set.${NC}\n\
                 This means you have triggered a build stage individually, instead of the entire pipeline.\n\n\
                 To trigger a rebuild pipeline in its entirety, please do the following:\n\n\
-                    1. Select your last failed build for 'pipeline_multiple_shards'.\n\
+                    ${CYAN}1. Select your last failed build for 'pipeline_multiple_shards'.\n\
                     2. Click the 'Rebuild' button dropdown icon.\n\
                     3. From the dropdown menu, select 'Rebuild entire pipeline'.\n\
                     4. If no dropdown menu is present, you are looking at a standalone build\n\
-                       and need to select the initial Github pipeline triggered by the PR.\n\
-                If you are still having issues, please contact #mobile-testeng on Slack.\n"
+                       and need to select the initial Github pipeline triggered by the PR.${NC}\n\n\
+                If you are still having issues, please contact ${GREEN}#mobile-testeng${NC} on Slack.\n"
                 exit 1  # Exit with a failure status
             else
                 echo "BITRISE_PIPELINE_ID is set to $BITRISE_PIPELINE_ID"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -19,6 +19,7 @@ stages:
 workflows:
   configure_build_fennec:
     before_run:
+    - 0_detect_standalone_build
     - 1_git_clone_and_post_clone
     - 2_certificate_and_profile
     - 3_provisioning_and_npm_installation
@@ -154,6 +155,7 @@ workflows:
         machine_type_id: g2-m1.8core
   build_and_test_1_SmokeTest2:
     before_run:
+    - 0_detect_standalone_build
     - 1_git_clone_and_post_clone
     - Decision_to_run_UI_Tests
     steps:
@@ -196,6 +198,7 @@ workflows:
         machine_type_id: g2-m1.8core
   build_and_test_2_SmokeTest:
     before_run:
+    - 0_detect_standalone_build
     - 1_git_clone_and_post_clone
     - Decision_to_run_UI_Tests
     steps:
@@ -241,6 +244,7 @@ workflows:
         machine_type_id: g2-m1.8core
   build_and_test_3_SmokeTest3:
     before_run:
+    - 0_detect_standalone_build
     - 1_git_clone_and_post_clone
     - Decision_to_run_UI_Tests
     steps:
@@ -286,6 +290,7 @@ workflows:
         machine_type_id: g2-m1.8core
   build_and_test_4_SmokeTest4:
     before_run:
+    - 0_detect_standalone_build
     - 1_git_clone_and_post_clone
     - Decision_to_run_UI_Tests
     steps:
@@ -354,6 +359,30 @@ workflows:
             App|${BITRISE_APP_URL}
             #mobile-testeng|https://mozilla.slack.com/archives/C02KDDS9QM9
             Mana|https://mana.mozilla.org/wiki/display/MTE/Mobile+Test+Engineering
+  0_detect_standalone_build:
+    steps:
+    - script@1:
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -ex
+
+            # Check if $BITRISE_PIPELINE_ID is unset or empty
+            # If so, this is a standalone build and we need to fail it
+            if [ -z "$BITRISE_PIPELINE_ID" ]; then
+                echo "Error: BITRISE_PIPELINE_ID is not set."
+                echo "This means you have triggered a build stage individually, instead of the entire pipeline."
+                echo "The build stage you have triggered is ${BITRISE_STAGE}, but you need to rebuild the entire pipeline`."
+                echo "To trigger a rebuild pipeline in its entirety, select your last failed build for `pipeline_multiple_shards`."
+                echo "Then, click the `Rebuild` button."
+                echo "From the dropdown menu, select `Rebuild entire pipeline`."
+                echo "If no dropdown menu is present, you are looking at a standalone build and need to select the initial Github pipeline triggered by the PR."
+                echo "If you are still having issues, please contact #mobile-testeng on Slack."
+                exit 1  # Exit with a failure status
+            else
+                echo "BITRISE_PIPELINE_ID is set to $BITRISE_PIPELINE_ID"
+            fi
+        title: Detect standalone build
   1_git_clone_and_post_clone:
     steps:
     - activate-ssh-key@4:
@@ -1534,6 +1563,7 @@ workflows:
             sed 's/.*=//;s/'\''/"/g' data.txt > test.json
             cat test.json
             python3 perfTestTransform.py
+
 app:
   envs:
   - opts:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -370,6 +370,7 @@ workflows:
             # ANSI color codes
             RED='\033[0;31m'    # Red color
             CYAN='\033[0;36m'   # Cyan color
+            GREEN='\033[0;32m'  # Green color
             NC='\033[0m'        # No Color (resets color to default)
 
             # Check if $BITRISE_PIPELINE_ID is unset or empty
@@ -377,10 +378,10 @@ workflows:
             if [ -z "$BITRISE_PIPELINE_ID" ]; then
                 printf "\n${RED}Error: BITRISE_PIPELINE_ID is not set.${NC}\n\
                 This means you have triggered a build stage individually, instead of the entire pipeline.\n\n\
-                To trigger a rebuild pipeline in its entirety, please do the following:\n\n\
+                To trigger a pipeline rebuild in its entirety, please do the following:\n\n\
                     ${CYAN}1. Select your last failed build for 'pipeline_multiple_shards'.\n\
-                    2. Click the 'Rebuild' button dropdown icon.\n\
-                    3. From the dropdown menu, select 'Rebuild entire pipeline'.\n\
+                    2. Click the 'Rebuild' button dropdown icon located in the top right of the page.\n\
+                    3. From the dropdown menu, select 'Rebuild entire Pipeline'.\n\
                     4. If no dropdown menu is present, you are looking at a standalone build\n\
                        and need to select the initial Github pipeline triggered by the PR.${NC}\n\n\
                 If you are still having issues, please contact ${GREEN}#mobile-testeng${NC} on Slack.\n"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -368,9 +368,9 @@ workflows:
             set -e
 
             # ANSI color codes
-            RED='\033[0;31m'    # Red color
-            CYAN='\033[0;36m'   # Cyan color
-            GREEN='\033[0;32m'  # Green color
+            RED='\033[31;1m'
+            CYAN='\033[36;1m'
+            GREEN='\033[32;1m'
             NC='\033[0m'        # No Color (resets color to default)
 
             # Check if $BITRISE_PIPELINE_ID is unset or empty

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -375,9 +375,10 @@ workflows:
 
             # Check if $BITRISEIO_PIPELINE_ID is unset or empty
             # If so, this is a standalone build and we need to fail it
-            if [ -z "$BITRISEIO_PIPELINE_ID" ]; then
+            if [ -z "$BITRISEIO_PIPELINE_IDXXX" ]; then
                 printf "\n${RED}Error: BITRISE_PIPELINE_ID is not set.${NC}\n\
-                This means you have triggered a build stage individually, instead of the entire pipeline.\n\n\
+                This means you have triggered a build stage or workflow individually, instead of the entire pipeline.\n\n\
+                The current build workflow is: ${RED}$BITRISE_TRIGGERED_WORKFLOW_TITLE${NC}, but needs to be run in ${RED}pipeline_multiple_shards${NC}.\n\n\
                 To trigger a pipeline rebuild in its entirety, please do the following:\n\n\
                     ${CYAN}1. Select your last failed build for 'pipeline_multiple_shards'.\n\
                     ${CYAN}2. Click the 'Rebuild' button dropdown icon located in the top right of the page.\n\
@@ -387,7 +388,7 @@ workflows:
                 If you are still having issues, please contact ${GREEN}#mobile-testeng${NC} on Slack.\n"
                 exit 1  # Exit with a failure status
             else
-                echo "BITRISE_PIPELINE_ID is set to $BITRISE_PIPELINE_ID"
+                echo "BITRISEIO_PIPELINE_ID is set to $BITRISEIO_PIPELINE_ID"
             fi
         title: Detect standalone build
   1_git_clone_and_post_clone:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -373,9 +373,9 @@ workflows:
             GREEN='\033[32;1m'
             NC='\033[0m'        # No Color (resets color to default)
 
-            # Check if $BITRISE_PIPELINE_ID is unset or empty
+            # Check if $BITRISEIO_PIPELINE_ID is unset or empty
             # If so, this is a standalone build and we need to fail it
-            if [ -z "$BITRISE_PIPELINE_ID" ]; then
+            if [ -z "$BITRISEIO_PIPELINE_ID" ]; then
                 printf "\n${RED}Error: BITRISE_PIPELINE_ID is not set.${NC}\n\
                 This means you have triggered a build stage individually, instead of the entire pipeline.\n\n\
                 To trigger a pipeline rebuild in its entirety, please do the following:\n\n\

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -370,14 +370,15 @@ workflows:
             # Check if $BITRISE_PIPELINE_ID is unset or empty
             # If so, this is a standalone build and we need to fail it
             if [ -z "$BITRISE_PIPELINE_ID" ]; then
-                echo "Error: BITRISE_PIPELINE_ID is not set."
-                echo "This means you have triggered a build stage individually, instead of the entire pipeline."
-                echo "The build stage you have triggered is ${BITRISE_STAGE}, but you need to rebuild the entire pipeline`."
-                echo "To trigger a rebuild pipeline in its entirety, select your last failed build for `pipeline_multiple_shards`."
-                echo "Then, click the `Rebuild` button."
-                echo "From the dropdown menu, select `Rebuild entire pipeline`."
-                echo "If no dropdown menu is present, you are looking at a standalone build and need to select the initial Github pipeline triggered by the PR."
-                echo "If you are still having issues, please contact #mobile-testeng on Slack."
+                printf "\n\t\tError: BITRISE_PIPELINE_ID is not set.\n\
+                This means you have triggered a build stage individually, instead of the entire pipeline.\n\n\
+                To trigger a rebuild pipeline in its entirety, please do the following:\n\n\
+                    1. Select your last failed build for 'pipeline_multiple_shards'.\n\
+                    2. Click the 'Rebuild' button dropdown icon.\n\
+                    3. From the dropdown menu, select 'Rebuild entire pipeline'.\n\
+                    4. If no dropdown menu is present, you are looking at a standalone build\n\
+                       and need to select the initial Github pipeline triggered by the PR.\n\
+                If you are still having issues, please contact #mobile-testeng on Slack.\n"
                 exit 1  # Exit with a failure status
             else
                 echo "BITRISE_PIPELINE_ID is set to $BITRISE_PIPELINE_ID"


### PR DESCRIPTION
When Bitrise builds fail from being triggered by a Github PR, it is common to attempt to rebuild them as a standalone stage or workflow, causing a build failure due to the Bitrise step network call returning a `500` error, making it seem like there is a network or backend error by Bitrise, even though it is due to missing required env vars only available during a `Pipeline` build.

I'm adding a step to first verify the build isn't a standalone build by checking for the primary env var that is generated by all pipeline builds, `BITRISEIO_PIPELINE_ID`. If it doesn't exist, then a standalone build has been triggered and the build will auto-fail with more clear messaging around this error.

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

