### PR TITLE
Refactor FXIOS-8081 [v123] [Multi-window] Remove assert for single window closing

### DIFF
--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -109,14 +109,6 @@ final class WindowManagerImplementation: WindowManager {
     // MARK: - Internal Utilities
 
     private func updateWindow(_ info: AppWindowInfo?, for uuid: WindowUUID) {
-        guard info != nil || windows.count > 1 else {
-            let message = "Cannot remove the only active window in the app. This is a client error."
-            logger.log(message, level: .fatal, category: .window)
-            // TODO: [FXIOS-8081] Needs additional investigation for how to handle this with multi-window feature.
-            assertionFailure(message)
-            return
-        }
-
         windows[uuid] = info
         didUpdateWindow(uuid)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8081)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17993)

## :bulb: Description

This removes an incorrect assertion; now that we have the windowDidClose messaging connected to `WindowManager`, there are several scenarios (during normal app lifecycle / usage) where the single main window will be closed. This is valid and is not indicative of a client error.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

