### PR TITLE
Add FXIOS-8068 [v123] item for sync settings to allow Address syncing 

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -232,12 +232,26 @@ class SyncContentSettingsViewController: SettingsTableViewController, FeatureFla
             attributedStatusText: nil,
             settingDidChange: engineSettingChanged(.creditcards))
 
+        let addresses = BoolSetting(
+            prefs: profile.prefs,
+            prefKey: "sync.engine.addresses.enabled",
+            defaultValue: true,
+            attributedTitleText: NSAttributedString(string: .FirefoxSyncAddressesEngine),
+            attributedStatusText: nil,
+            settingDidChange: engineSettingChanged(.addresses))
+
         var engineSectionChildren: [Setting] = [bookmarks, history, tabs, passwords]
 
         if featureFlags.isFeatureEnabled(
             .creditCardAutofillStatus,
             checking: .buildOnly) {
             engineSectionChildren.append(creditCards)
+        }
+
+        if featureFlags.isFeatureEnabled(
+            .addressAutofill,
+            checking: .buildOnly) {
+            engineSectionChildren.append(addresses)
         }
 
         let enginesSection = SettingSection(

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -2291,6 +2291,11 @@ extension String {
         tableName: "FirefoxSync",
         value: "Payment Methods",
         comment: "Toggle for credit cards syncing setting")
+    public static let FirefoxSyncAddressesEngine = MZLocalizedString(
+        key: "FirefoxSync.AddressAutofillEngine.v124",
+        tableName: "FirefoxSync",
+        value: "Addresses",
+        comment: "Toggle for address autofill syncing setting")
 }
 
 // MARK: - Firefox Logins

--- a/firefox-ios/Providers/RustSyncManager.swift
+++ b/firefox-ios/Providers/RustSyncManager.swift
@@ -361,6 +361,9 @@ public class RustSyncManager: NSObject, SyncManager {
                                   category: .sync)
                    }
                }
+           case .addresses:
+               profile?.autofill.registerWithSyncManager()
+               rustEngines.append(engine.rawValue)
            case .bookmarks, .history:
                if !registeredPlaces {
                    profile?.places.registerWithSyncManager()

--- a/firefox-ios/RustFxA/FxAWebViewModel.swift
+++ b/firefox-ios/RustFxA/FxAWebViewModel.swift
@@ -206,7 +206,11 @@ extension FxAWebViewModel {
     /// signing up for an account). This latter case is also used for the sign-in state.
     private func onSessionStatus(id: Int, webView: WKWebView) {
         let autofillCreditCardStatus = featureFlags.isFeatureEnabled(.creditCardAutofillStatus, checking: .buildOnly)
+        let addressAutofillStatus = featureFlags.isFeatureEnabled(.addressAutofill, checking: .buildOnly)
+
         let creditCardCapability =  autofillCreditCardStatus ? ", \"creditcards\"" : ""
+        let addressAutofillCapability =  addressAutofillStatus ? ", \"addresses\"" : ""
+
         guard let fxa = profile.rustFxA.accountManager else { return }
         let cmd = "fxaccounts:fxa_status"
         let typeId = "account_updates"
@@ -231,7 +235,7 @@ extension FxAWebViewModel {
         case .emailLoginFlow, .qrCode:
             data = """
                     { capabilities:
-                        { choose_what_to_sync: true, engines: ["bookmarks", "history", "tabs", "passwords"\(creditCardCapability)] },
+                        { choose_what_to_sync: true, engines: ["bookmarks", "history", "tabs", "passwords"\(creditCardCapability)\(addressAutofillCapability)] },
                     }
                 """
         }

--- a/firefox-ios/Sync/RustSyncManagerAPI.swift
+++ b/firefox-ios/Sync/RustSyncManagerAPI.swift
@@ -18,9 +18,10 @@ open class RustSyncManagerAPI {
         case bookmarks
         case history
         case creditcards
+        case addresses
     }
 
-    public var rustTogglableEngines: [TogglableEngine] = [.tabs, .passwords, .bookmarks, .history, .creditcards]
+    public var rustTogglableEngines: [TogglableEngine] = [.tabs, .passwords, .bookmarks, .history, .creditcards, .addresses]
     public init(logger: Logger = DefaultLogger.shared) {
         self.api = SyncManagerComponent()
         self.logger = logger

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/SyncContentSettingsViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/SyncContentSettingsViewControllerTests.swift
@@ -46,6 +46,6 @@ class SyncContentSettingsViewControllerTests: XCTestCase {
         // tabs
         // passwords
         // credit cards
-        XCTAssertEqual(engineSectionChildren?.count, 5)
+        XCTAssertEqual(engineSectionChildren?.count, 6)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/SyncContentSettingsViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/SyncContentSettingsViewControllerTests.swift
@@ -46,7 +46,6 @@ class SyncContentSettingsViewControllerTests: XCTestCase {
         // tabs
         // passwords
         // credit cards
-        // addresses
-        XCTAssertEqual(engineSectionChildren?.count, 6)
+        XCTAssertEqual(engineSectionChildren?.count, 5)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/SyncContentSettingsViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/SyncContentSettingsViewControllerTests.swift
@@ -46,6 +46,7 @@ class SyncContentSettingsViewControllerTests: XCTestCase {
         // tabs
         // passwords
         // credit cards
-        XCTAssertEqual(engineSectionChildren?.count, 5)
+        // addresses
+        XCTAssertEqual(engineSectionChildren?.count, 6)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/RustSyncManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/RustSyncManagerTests.swift
@@ -13,6 +13,8 @@ class RustSyncManagerTests: XCTestCase {
         static let bookmarksEnabledPrefKey = "sync.engine.bookmarks.enabled"
         static let creditcardsStateChangedPrefKey = "sync.engine.creditcards.enabledStateChanged"
         static let creditcardsEnabledPrefKey = "sync.engine.creditcards.enabled"
+        static let addressesStateChangedPrefKey = "sync.engine.addresses.enabledStateChanged"
+        static let addressesEnabledPrefKey = "sync.engine.addresses.enabled"
         static let historyStateChangedPrefKey = "sync.engine.history.enabledStateChanged"
         static let historyEnabledPrefKey = "sync.engine.history.enabled"
         static let passwordsStateChangedPrefKey = "sync.engine.passwords.enabledStateChanged"
@@ -53,14 +55,15 @@ class RustSyncManagerTests: XCTestCase {
     }
 
     func testGetEnginesAndKeys() {
-        let engines: [RustSyncManagerAPI.TogglableEngine] = [.bookmarks, .creditcards, .history, .passwords, .tabs]
+        let engines: [RustSyncManagerAPI.TogglableEngine] = [.bookmarks, .creditcards, .history, .passwords, .tabs, .addresses]
         rustSyncManager.getEnginesAndKeys(engines: engines) { (engines, keys) in
-            XCTAssertEqual(engines.count, 5)
+            XCTAssertEqual(engines.count, 6)
 
             XCTAssertTrue(engines.contains("bookmarks"))
             XCTAssertTrue(engines.contains("history"))
             XCTAssertTrue(engines.contains("passwords"))
             XCTAssertTrue(engines.contains("tabs"))
+            XCTAssertTrue(engines.contains("addresses"))
             XCTAssertFalse(keys.isEmpty)
 
             XCTAssertEqual(keys.count, 2)
@@ -168,5 +171,29 @@ class RustSyncManagerTests: XCTestCase {
         let key = try XCTUnwrap(profile.prefs.boolForKey(Keys.tabsEnabledPrefKey))
         XCTAssertTrue(key)
         XCTAssertNil(profile.prefs.boolForKey(Keys.tabsStateChangedPrefKey))
+    }
+
+    func testUpdateEnginePrefs_addressesEnabled() throws {
+        profile.prefs.setBool(true, forKey: Keys.addressesEnabledPrefKey)
+        profile.prefs.setBool(true, forKey: Keys.addressesStateChangedPrefKey)
+
+        let declined = ["bookmarks", "creditcards", "passwords"]
+        rustSyncManager.updateEnginePrefs(declined: declined)
+
+        let key = try XCTUnwrap(profile.prefs.boolForKey(Keys.addressesEnabledPrefKey))
+        XCTAssertTrue(key)
+        XCTAssertNil(profile.prefs.boolForKey(Keys.addressesStateChangedPrefKey))
+    }
+
+    func testUpdateEnginePrefs_addressesDisabled() throws {
+        profile.prefs.setBool(false, forKey: Keys.addressesEnabledPrefKey)
+        profile.prefs.setBool(false, forKey: Keys.addressesStateChangedPrefKey)
+
+        let declined = ["bookmarks", "addresses", "passwords"]
+        rustSyncManager.updateEnginePrefs(declined: declined)
+
+        let key = try XCTUnwrap(profile.prefs.boolForKey(Keys.addressesEnabledPrefKey))
+        XCTAssertFalse(key)
+        XCTAssertNil(profile.prefs.boolForKey(Keys.addressesStateChangedPrefKey))
     }
 }

--- a/firefox-ios/nimbus-features/addressAutofillFeature.yaml
+++ b/firefox-ios/nimbus-features/addressAutofillFeature.yaml
@@ -13,4 +13,4 @@ features:
           status: false
       - channel: developer
         value:
-          status: false
+          status: true


### PR DESCRIPTION


## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8068)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Enhanced SyncContentSettingViewController to support addresses under the feature flag. Expanded the string file with additional entries. Updated tests in SyncContentSettingsViewControllerTests and RustSyncManagerTests. Integrated address handling in TogglabEngine and implemented corresponding actions in RustSyncManager. This update enables address autofill in sync settings, facilitating the synchronization of addresses."

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

