### PR TITLE
Refactor FXIOS-8012 [V123] Fix closeButton warnings in TabCell and in LegacyTabCell.

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabCell.swift
@@ -66,7 +66,12 @@ class LegacyTabCell: UICollectionViewCell,
         button.setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross), for: [])
         button.imageView?.contentMode = .scaleAspectFit
         button.contentMode = .center
-        button.imageEdgeInsets = UIEdgeInsets(equalInset: LegacyGridTabViewController.UX.closeButtonEdgeInset)
+        button.configuration?.imagePadding = LegacyGridTabViewController.UX.closeButtonEdgeInset
+        button.configuration?.contentInsets =  NSDirectionalEdgeInsets(top: LegacyGridTabViewController.UX.closeButtonEdgeInset,
+                                                                       leading: LegacyGridTabViewController.UX.closeButtonEdgeInset,
+                                                                       bottom: LegacyGridTabViewController.UX.closeButtonEdgeInset,
+                                                                       trailing: LegacyGridTabViewController.UX.closeButtonEdgeInset)
+    }
     }
 
     // TODO: Handle visual effects theming FXIOS-5064

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabCell.swift
@@ -72,7 +72,6 @@ class LegacyTabCell: UICollectionViewCell,
                                                                        bottom: LegacyGridTabViewController.UX.closeButtonEdgeInset,
                                                                        trailing: LegacyGridTabViewController.UX.closeButtonEdgeInset)
     }
-    }
 
     // TODO: Handle visual effects theming FXIOS-5064
     private var title = UIVisualEffectView(effect: UIBlurEffect(style: UIColor.legacyTheme.tabTray.tabTitleBlur))

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabCell.swift
@@ -63,7 +63,11 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         button.setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross), for: [])
         button.imageView?.contentMode = .scaleAspectFit
         button.contentMode = .center
-        button.imageEdgeInsets = UIEdgeInsets(equalInset: LegacyGridTabViewController.UX.closeButtonEdgeInset)
+        button.configuration?.imagePadding = LegacyGridTabViewController.UX.closeButtonEdgeInset
+        button.configuration?.contentInsets =  NSDirectionalEdgeInsets(top: LegacyGridTabViewController.UX.closeButtonEdgeInset,
+                                                                       leading: LegacyGridTabViewController.UX.closeButtonEdgeInset,
+                                                                       bottom: LegacyGridTabViewController.UX.closeButtonEdgeInset,
+                                                                       trailing: LegacyGridTabViewController.UX.closeButtonEdgeInset)
     }
 
     // MARK: - Initializer


### PR DESCRIPTION

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8012)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17883)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
issue-17883 Removed imageEdgeInsets deprecated Code and added imagepadding and contentInsets of same size as previous.  LegacyTabCell has same warning hence make the same code update in LegacyTabCell as well. 

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods


**Before Changes:**

<img width="1153" alt="Screenshot 2024-01-05 at 10 21 37" src="https://github.com/mozilla-mobile/firefox-ios/assets/30796045/d7644ef5-b94a-45af-bea9-14f1791afb64">
<img width="1169" alt="Screenshot 2024-01-05 at 10 22 19" src="https://github.com/mozilla-mobile/firefox-ios/assets/30796045/61ff074a-eef6-4ef7-813a-b4b8660dbdb7">


**After Changes:**

<img width="1369" alt="Screenshot 2024-01-05 at 10 49 53" src="https://github.com/mozilla-mobile/firefox-ios/assets/30796045/4ca7f25e-26e7-483e-9b1e-2a7c160e07d6">
<img width="1373" alt="Screenshot 2024-01-05 at 10 50 04" src="https://github.com/mozilla-mobile/firefox-ios/assets/30796045/458d803d-c8a6-46c6-8ae2-b0586bab980c">



