### PR TITLE
Add FXIOS-7945 [v123] Add webview and tabs timing distribution

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -573,6 +573,8 @@
 		8A04136B2825ABEA00D20B10 /* SponsoredTileTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A04136A2825ABEA00D20B10 /* SponsoredTileTelemetryTests.swift */; };
 		8A05B0052A69A0C40011B622 /* Common in Frameworks */ = {isa = PBXBuildFile; productRef = 8A05B0042A69A0C40011B622 /* Common */; };
 		8A05B0072A69A25C0011B622 /* Common in Frameworks */ = {isa = PBXBuildFile; productRef = 8A05B0062A69A25C0011B622 /* Common */; };
+		8A0727462B4890B50071BB9F /* WebviewTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0727452B4890B50071BB9F /* WebviewTelemetry.swift */; };
+		8A0727492B4898D20071BB9F /* WebviewTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0727472B4898750071BB9F /* WebviewTelemetryTests.swift */; };
 		8A07910F278F62F2005529CB /* AdjustHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A07910E278F62F2005529CB /* AdjustHelper.swift */; };
 		8A08EC6227EBDCA400E119C7 /* iAd.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E4B334871BBF23F3004E2BFF /* iAd.framework */; };
 		8A08EC6427EBDCAD00E119C7 /* AdServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A08EC6327EBDCAC00E119C7 /* AdServices.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
@@ -771,8 +773,8 @@
 		8ACA8F74291987AE00D3075D /* AccountSyncHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACA8F73291987AE00D3075D /* AccountSyncHandlerTests.swift */; };
 		8ACA8F7629198D6400D3075D /* ThrottlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACA8F7529198D6400D3075D /* ThrottlerTests.swift */; };
 		8ACE9BFB2A54A010001E7A73 /* ExpandButtonState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACE9BFA2A54A010001E7A73 /* ExpandButtonState.swift */; };
-		8AD08D1527E9198E00B8E907 /* TabsQuantityTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD08D1427E9198E00B8E907 /* TabsQuantityTelemetry.swift */; };
-		8AD08D1727E91AC800B8E907 /* TabsQuantityTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD08D1627E91AC800B8E907 /* TabsQuantityTelemetryTests.swift */; };
+		8AD08D1527E9198E00B8E907 /* TabsTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD08D1427E9198E00B8E907 /* TabsTelemetry.swift */; };
+		8AD08D1727E91AC800B8E907 /* TabsTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD08D1627E91AC800B8E907 /* TabsTelemetryTests.swift */; };
 		8AD1980F27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD1980E27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift */; };
 		8AD3271527E3B45D00EAF033 /* SponsoredTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD3271427E3B45D00EAF033 /* SponsoredTile.swift */; };
 		8AD40FC527BADC1F00672675 /* TabToolbarHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD40FC427BADC1E00672675 /* TabToolbarHelper.swift */; };
@@ -5419,6 +5421,8 @@
 		8A05813728B56D9B00FD8D46 /* ta */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ta; path = ta.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
 		8A05813928B56DB900FD8D46 /* bo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bo; path = bo.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
 		8A05813B28B56DD700FD8D46 /* uz */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uz; path = uz.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
+		8A0727452B4890B50071BB9F /* WebviewTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebviewTelemetry.swift; sourceTree = "<group>"; };
+		8A0727472B4898750071BB9F /* WebviewTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebviewTelemetryTests.swift; sourceTree = "<group>"; };
 		8A07910E278F62F2005529CB /* AdjustHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdjustHelper.swift; sourceTree = "<group>"; };
 		8A08EC6327EBDCAC00E119C7 /* AdServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdServices.framework; path = System/Library/Frameworks/AdServices.framework; sourceTree = SDKROOT; };
 		8A093D7C2A4B3E4F0099ABA5 /* DebugSettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSettingsDelegate.swift; sourceTree = "<group>"; };
@@ -5627,8 +5631,8 @@
 		8ACA8F73291987AE00D3075D /* AccountSyncHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSyncHandlerTests.swift; sourceTree = "<group>"; };
 		8ACA8F7529198D6400D3075D /* ThrottlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThrottlerTests.swift; sourceTree = "<group>"; };
 		8ACE9BFA2A54A010001E7A73 /* ExpandButtonState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpandButtonState.swift; sourceTree = "<group>"; };
-		8AD08D1427E9198E00B8E907 /* TabsQuantityTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsQuantityTelemetry.swift; sourceTree = "<group>"; };
-		8AD08D1627E91AC800B8E907 /* TabsQuantityTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsQuantityTelemetryTests.swift; sourceTree = "<group>"; };
+		8AD08D1427E9198E00B8E907 /* TabsTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsTelemetry.swift; sourceTree = "<group>"; };
+		8AD08D1627E91AC800B8E907 /* TabsTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsTelemetryTests.swift; sourceTree = "<group>"; };
 		8AD1980E27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotonActionSheetViewModel.swift; sourceTree = "<group>"; };
 		8AD3271427E3B45D00EAF033 /* SponsoredTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SponsoredTile.swift; sourceTree = "<group>"; };
 		8AD40FC427BADC1E00672675 /* TabToolbarHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabToolbarHelper.swift; sourceTree = "<group>"; };
@@ -8702,7 +8706,7 @@
 				AB7D4C3029ACAED100626427 /* Tab+ChangeUserAgentTests.swift */,
 				215B458327DA87FC00E5E800 /* TabMetadataManagerTests.swift */,
 				39236E711FCC600200A38F1B /* TabEventHandlerTests.swift */,
-				8AD08D1627E91AC800B8E907 /* TabsQuantityTelemetryTests.swift */,
+				8AD08D1627E91AC800B8E907 /* TabsTelemetryTests.swift */,
 			);
 			path = Legacy;
 			sourceTree = "<group>";
@@ -11105,7 +11109,8 @@
 				8AABBCFB2A0010900089941E /* GleanWrapper.swift */,
 				43F7952425795F69005AEE40 /* SearchTelemetry.swift */,
 				8A04136828258DF600D20B10 /* SponsoredTileTelemetry.swift */,
-				8AD08D1427E9198E00B8E907 /* TabsQuantityTelemetry.swift */,
+				8A0727452B4890B50071BB9F /* WebviewTelemetry.swift */,
+				8AD08D1427E9198E00B8E907 /* TabsTelemetry.swift */,
 				EBF47E6F1F7979DF00899189 /* TelemetryWrapper.swift */,
 				8ADC2A132A33762900543DAA /* ReferringPage.swift */,
 				8A95FF632B1E969E00AC303D /* TelemetryContextualIdentifier.swift */,
@@ -11372,6 +11377,7 @@
 				1DDE3DB42AC360EC0039363B /* TabCellTests.swift */,
 				8A6E139B2A71BB5700A88FA8 /* LegacyTabCellTests.swift */,
 				8A6E139D2A71C78A00A88FA8 /* GridTabViewControllerTests.swift */,
+				8A0727472B4898750071BB9F /* WebviewTelemetryTests.swift */,
 				1D74FF4D2B27962200FF01D0 /* WindowManagerTests.swift */,
 				253648E02B2111C100D5C2C5 /* SearchViewControllerTests.swift */,
 			);
@@ -13296,6 +13302,7 @@
 				C87D8B802818333F00A6307D /* NimbusManager.swift in Sources */,
 				8A4AC0EB28C929D700439F83 /* URLSessionDataTaskProtocol.swift in Sources */,
 				C45F44691D087DB600CB7EF0 /* TopTabsViewController.swift in Sources */,
+				8A0727462B4890B50071BB9F /* WebviewTelemetry.swift in Sources */,
 				8ADC2A212A3399DC00543DAA /* YourRightsSetting.swift in Sources */,
 				DF529E9F2AA86FF4003C5373 /* FakespotReviewQualityCardView.swift in Sources */,
 				DFACDFAF274D4D6D00A94EEC /* ReusableCell.swift in Sources */,
@@ -13418,7 +13425,7 @@
 				0BB5B30B1AC0AD1F0052877D /* LoginsHelper.swift in Sources */,
 				8A3EF8092A2FD02B00796E3A /* ExperimentsSettings.swift in Sources */,
 				C87DF9DB267247190097E707 /* UIConstants+BottomInset.swift in Sources */,
-				8AD08D1527E9198E00B8E907 /* TabsQuantityTelemetry.swift in Sources */,
+				8AD08D1527E9198E00B8E907 /* TabsTelemetry.swift in Sources */,
 				74B420C92A1D0D7A00370E53 /* OnboardingInstructionsPopupInfoModel.swift in Sources */,
 				E13E9AB32AAB0FB5001A0E9D /* FakespotViewController.swift in Sources */,
 				E15DE7C4293A7B0F00B32667 /* PhotonActionSheetTitleHeaderView.swift in Sources */,
@@ -14067,7 +14074,7 @@
 				8A32DD5028B419B300D57C60 /* HomepageMessageCardViewModelTests.swift in Sources */,
 				8A36AC2C2886F27F00CDC0AD /* MockTabManager.swift in Sources */,
 				5A3A7DD62889CF3D0065F81A /* RecentlySavedDataAdaptorTests.swift in Sources */,
-				8AD08D1727E91AC800B8E907 /* TabsQuantityTelemetryTests.swift in Sources */,
+				8AD08D1727E91AC800B8E907 /* TabsTelemetryTests.swift in Sources */,
 				C8C3FE9D29F907B30038E3BA /* MockSearchHandlerRouteCoordinator.swift in Sources */,
 				C8C3FEA129F973C40038E3BA /* MockBrowserViewController.swift in Sources */,
 				8A93F86B29D39BDA004159D9 /* BaseCoordinatorTests.swift in Sources */,
@@ -14207,6 +14214,7 @@
 				E19443F62AF9413300964EA5 /* FakespotUtilsTests.swift in Sources */,
 				8A93F86829D373B0004159D9 /* MockNavigationController.swift in Sources */,
 				8AE1E1D927B1BD380024C45E /* UIStackViewExtensionsTests.swift in Sources */,
+				8A0727492B4898D20071BB9F /* WebviewTelemetryTests.swift in Sources */,
 				3B6F40181DC7849C00656CC6 /* TopSitesViewModelTests.swift in Sources */,
 				C869915528917803007ACC5C /* WallpaperMetadataTestProvider.swift in Sources */,
 			);

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -769,6 +769,8 @@ extension BrowserViewController: WKNavigationDelegate {
                                             method: .error,
                                             object: .webview,
                                             value: .webviewFail)
+
+        webviewTelemetry.cancel()
     }
 
     /// Invoked when an error occurs while starting to load data for the main frame.
@@ -785,6 +787,8 @@ extension BrowserViewController: WKNavigationDelegate {
                                             method: .error,
                                             object: .webview,
                                             value: .webviewFailProvisional)
+
+        webviewTelemetry.cancel()
 
         // Ignore the "Frame load interrupted" error that is triggered when we cancel a request
         // to open an external application and hand it over to UIApplication.openURL(). The result
@@ -858,6 +862,7 @@ extension BrowserViewController: WKNavigationDelegate {
         else { return }
 
         searchTelemetry?.trackTabAndTopSiteSAP(tab, webView: webView)
+        webviewTelemetry.start()
         tab.url = webView.url
 
         // Only update search term data with valid search term data
@@ -896,6 +901,8 @@ extension BrowserViewController: WKNavigationDelegate {
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        webviewTelemetry.stop()
+
         if let tab = tabManager[webView],
            let metadataManager = tab.metadataManager {
             navigateInTab(tab: tab, to: navigation, webViewStatus: .finishedNavigation)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -67,6 +67,7 @@ class BrowserViewController: UIViewController,
     var dataClearanceContextHintVC: ContextualHintViewController
     let shoppingContextHintVC: ContextualHintViewController
     private var backgroundTabLoader: DefaultBackgroundTabLoader
+    var webviewTelemetry = WebViewLoadMeasurementTelemetry()
 
     // popover rotation handling
     var displayedPopoverController: UIViewController?
@@ -398,7 +399,7 @@ class BrowserViewController: UIViewController,
         // individual TabManager instances for each BVC, so we perform these here instead.
         tabManager.preserveTabs()
         // TODO: [FXIOS-7856] Some additional updates for telemetry forthcoming, once iPad multi-window is enabled.
-        TabsQuantityTelemetry.trackTabsQuantity(tabManager: tabManager)
+        TabsTelemetry.trackTabsQuantity(tabManager: tabManager)
     }
 
     @objc

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -15,6 +15,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
     private let tabSessionStore: TabSessionStore
     private let imageStore: DiskImageStore?
     private let tabMigration: TabMigrationUtility
+    private var tabsTelemetry = TabsTelemetry()
     var notificationCenter: NotificationProtocol
     var inactiveTabsManager: InactiveTabsManagerProtocol
 
@@ -357,11 +358,13 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
     }
 
     private func willSelectTab(_ url: URL?) {
+        tabsTelemetry.startTabSwitchMeasurement()
         guard let url else { return }
         AppEventQueue.started(.selectTab(url, windowUUID))
     }
 
     private func didSelectTab(_ url: URL?) {
+        tabsTelemetry.stopTabSwitchMeasurement()
         guard let url else { return }
         AppEventQueue.completed(.selectTab(url, windowUUID))
     }

--- a/firefox-ios/Client/Telemetry/TabsTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/TabsTelemetry.swift
@@ -3,8 +3,22 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import Glean
 
-struct TabsQuantityTelemetry {
+final class TabsTelemetry {
+    /// Measure with a time distribution https://mozilla.github.io/glean/book/reference/metrics/timing_distribution.html
+    /// how long it takes to switch to a new tab
+    private var tabSwitchTimerId: GleanTimerId?
+
+    func startTabSwitchMeasurement() {
+        tabSwitchTimerId = GleanMetrics.Tabs.tabSwitch.start()
+    }
+
+    func stopTabSwitchMeasurement() {
+        guard let timerId = tabSwitchTimerId else { return }
+        GleanMetrics.Tabs.tabSwitch.stopAndAccumulate(timerId)
+    }
+
     static func trackTabsQuantity(tabManager: TabManager) {
         let privateExtra = [
             TelemetryWrapper.EventExtraKey.tabsQuantity.rawValue: Int64(tabManager.privateTabs.count)

--- a/firefox-ios/Client/Telemetry/WebviewTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/WebviewTelemetry.swift
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Glean
+
+/// Measure with a time distribution https://mozilla.github.io/glean/book/reference/metrics/timing_distribution.html
+/// how long it takes to load a webpage
+final class WebViewLoadMeasurementTelemetry {
+    private var loadTimerId: GleanTimerId?
+
+    func start() {
+        loadTimerId = GleanMetrics.Webview.pageLoad.start()
+    }
+
+    func stop() {
+        guard let timerId = loadTimerId else { return }
+        GleanMetrics.Webview.pageLoad.stopAndAccumulate(timerId)
+    }
+
+    func cancel() {
+        if let loadTimerId {
+            GleanMetrics.Webview.pageLoad.cancel(loadTimerId)
+        }
+    }
+}

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -3615,6 +3615,18 @@ tabs:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2024-06-01"
+  tab_switch:
+    type: timing_distribution
+    time_unit: millisecond
+    description: >
+      Counts how long it takes to switch to another tab
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/17717
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
 
 # Theme metrics
 theme:
@@ -4982,6 +4994,18 @@ webview:
       - https://github.com/mozilla-mobile/firefox-ios/issues/17716
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/17910
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+  page_load:
+    type: timing_distribution
+    time_unit: millisecond
+    description: >
+      Counts how long each page takes to load
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/17717
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -3623,7 +3623,7 @@ tabs:
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/17717
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/18012
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
@@ -5005,7 +5005,7 @@ webview:
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/17717
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/18012
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Legacy/TabsTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Legacy/TabsTelemetryTests.swift
@@ -8,7 +8,7 @@ import Glean
 import XCTest
 import Common
 
-class TabsQuantityTelemetryTests: XCTestCase {
+class TabsTelemetryTests: XCTestCase {
     var profile: Profile!
     var inactiveTabsManager: MockInactiveTabsManager!
 
@@ -37,7 +37,7 @@ class TabsQuantityTelemetryTests: XCTestCase {
         inactiveTabsManager.activeTabs = [tab]
         _ = inactiveTabsManager.getInactiveTabs(tabs: [tab])
 
-        TabsQuantityTelemetry.trackTabsQuantity(tabManager: tabManager)
+        TabsTelemetry.trackTabsQuantity(tabManager: tabManager)
 
         testQuantityMetricSuccess(metric: GleanMetrics.Tabs.privateTabsQuantity,
                                   expectedValue: 0,
@@ -52,7 +52,7 @@ class TabsQuantityTelemetryTests: XCTestCase {
         let tabManager = TabManagerImplementation(profile: profile)
         tabManager.addTab(isPrivate: true)
 
-        TabsQuantityTelemetry.trackTabsQuantity(tabManager: tabManager)
+        TabsTelemetry.trackTabsQuantity(tabManager: tabManager)
 
         testQuantityMetricSuccess(metric: GleanMetrics.Tabs.privateTabsQuantity,
                                   expectedValue: 1,
@@ -70,7 +70,7 @@ class TabsQuantityTelemetryTests: XCTestCase {
         inactiveTabsManager.activeTabs = [tab]
         _ = inactiveTabsManager.getInactiveTabs(tabs: [tab])
 
-        TabsQuantityTelemetry.trackTabsQuantity(tabManager: tabManager)
+        TabsTelemetry.trackTabsQuantity(tabManager: tabManager)
 
         testQuantityMetricSuccess(metric: GleanMetrics.Tabs.privateTabsQuantity,
                                   expectedValue: 0,
@@ -79,5 +79,16 @@ class TabsQuantityTelemetryTests: XCTestCase {
         testQuantityMetricSuccess(metric: GleanMetrics.Tabs.inactiveTabsCount,
                                   expectedValue: 0,
                                   failureMessage: "Should have no inactive tabs, since a new tab was just created.")
+    }
+
+    func testTabSwitchMeasurement() throws {
+        let subject = TabsTelemetry()
+
+        subject.startTabSwitchMeasurement()
+        subject.stopTabSwitchMeasurement()
+
+        let resultValue = try XCTUnwrap(GleanMetrics.Tabs.tabSwitch.testGetValue())
+        XCTAssertEqual(1, resultValue.count, "Should have been measured once")
+        XCTAssertEqual(0, GleanMetrics.Tabs.tabSwitch.testGetNumRecordedErrors(.invalidValue))
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebviewTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebviewTelemetryTests.swift
@@ -1,0 +1,36 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+
+import Glean
+import XCTest
+
+class WebviewTelemetryTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        Glean.shared.resetGlean(clearStores: true)
+    }
+
+    func testLoadMeasurement() throws {
+        let subject = WebViewLoadMeasurementTelemetry()
+
+        subject.start()
+        subject.stop()
+
+        let resultValue = try XCTUnwrap(GleanMetrics.Webview.pageLoad.testGetValue())
+        XCTAssertEqual(1, resultValue.count, "Should have been measured once")
+        XCTAssertEqual(0, GleanMetrics.Webview.pageLoad.testGetNumRecordedErrors(.invalidValue))
+    }
+
+    func testCancelLoadMeasurement() {
+        let subject = WebViewLoadMeasurementTelemetry()
+
+        subject.start()
+        subject.cancel()
+
+        XCTAssertNil(GleanMetrics.Webview.pageLoad.testGetValue(), "Should not have been measured")
+        XCTAssertEqual(0, GleanMetrics.Webview.pageLoad.testGetNumRecordedErrors(.invalidValue))
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7945)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17717)

## :bulb: Description
Add webview and tabs telemetry with timing distribution to get baseline measurement of:
- How long it takes to load a webpage
- How long it takes to switch between tabs

Tagging @travis79 for review as it's the first time I use this telemetry event, just want to make sure it's fine like this, thank you!🙏  

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

