### PR TITLE
Add FXIOS-7908 [v123] Implement state restoration in web engine

### DIFF
--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -10,10 +10,12 @@ class WKEngineSession: EngineSession {
     weak var delegate: EngineSessionDelegate?
     private var webView: WKEngineWebView
     private var logger: Logger
+    private var sessionData: WKEngineSessionData
 
     init?(configurationProvider: WKEngineConfigurationProvider = DefaultWKEngineConfigurationProvider(),
           webViewProvider: WKWebViewProvider = DefaultWKWebViewProvider(),
-          logger: Logger = DefaultLogger.shared) {
+          logger: Logger = DefaultLogger.shared,
+          sessionData: WKEngineSessionData = WKEngineSessionData()) {
         guard let webView = webViewProvider.createWebview(configurationProvider: configurationProvider) else {
             logger.log("WKEngineWebView creation failed on configuration",
                        level: .fatal,
@@ -23,6 +25,7 @@ class WKEngineSession: EngineSession {
 
         self.webView = webView
         self.logger = logger
+        self.sessionData = sessionData
 
         // TODO: FXIOS-7899 #17644 Handle WKEngineSession observers
 //        self.webView.addObserver(self, forKeyPath: KVOConstants.URL.rawValue, options: .new, context: nil)
@@ -44,6 +47,9 @@ class WKEngineSession: EngineSession {
            let syncedReaderModeURL = url.decodeReaderModeURL,
            let localReaderModeURL = syncedReaderModeURL.encodeReaderModeURL(WKEngineWebServer.shared.baseReaderModeURL()) {
             let readerModeRequest = URLRequest(url: localReaderModeURL)
+            sessionData.lastRequest = readerModeRequest
+            sessionData.url = url
+
             webView.load(readerModeRequest)
             logger.log("Loaded reader mode request", level: .debug, category: .webview)
             return
@@ -51,6 +57,9 @@ class WKEngineSession: EngineSession {
 
         guard let url = URL(string: url) else { return }
         let request = URLRequest(url: url)
+
+        sessionData.lastRequest = request
+        sessionData.url = url
 
         if let url = request.url, url.isFileURL {
             webView.loadFileURL(url, allowingReadAccessTo: url.deletingLastPathComponent())
@@ -68,7 +77,7 @@ class WKEngineSession: EngineSession {
 
     func reload() {
         // If the current page is an error page load the original URL
-        if let url = webView.url,
+        if let url = sessionData.url,
            let internalUrl = WKInternalURL(url),
            let page = internalUrl.originalURLFromErrorPage {
             webView.replaceLocation(with: page)
@@ -97,7 +106,11 @@ class WKEngineSession: EngineSession {
     }
 
     func restoreState(state: Data) {
-        // TODO: FXIOS-7908 #17652 Handle restoreState in WKEngineSession
+        if let lastRequest = sessionData.lastRequest {
+            webView.load(lastRequest)
+        }
+
+        webView.interactionState = state
     }
 
     func close() {

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSessionData.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSessionData.swift
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// Struct use to keep in memory the session data
+struct WKEngineSessionData {
+    var url: URL?
+    var lastRequest: URLRequest?
+}

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
@@ -18,6 +18,7 @@ protocol WKEngineWebView {
     var allowsBackForwardNavigationGestures: Bool { get set }
     var allowsLinkPreview: Bool { get set }
     var backgroundColor: UIColor? { get set }
+    var interactionState: Any? { get set }
     var url: URL? { get }
 
     @available(iOS 16.4, *)

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebView.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebView.swift
@@ -7,6 +7,7 @@ import WebKit
 @testable import WebEngine
 
 class MockWKEngineWebView: WKEngineWebView {
+    var interactionState: Any?
     var url: URL?
     var navigationDelegate: WKNavigationDelegate?
     var allowsBackForwardNavigationGestures = true

--- a/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
@@ -128,6 +128,29 @@ final class WKEngineSessionTests: XCTestCase {
         XCTAssertEqual(webViewProvider.webView.url?.absoluteString, errorPageURL)
     }
 
+    // MARK: Restore
+
+    func testRestoreWhenNoLastRequestThenLoadNotCalled() {
+        let subject = createSubject()
+        let restoredState = Data()
+
+        subject?.restoreState(state: restoredState)
+
+        XCTAssertEqual(webViewProvider.webView.interactionState as! Data, restoredState)
+        XCTAssertEqual(webViewProvider.webView.loadCalled, 0)
+    }
+
+    func testRestoreWhenHasLastRequestThenLoadISCalled() {
+        let subject = createSubject()
+        let restoredState = Data()
+        subject?.load(url: "https://example.com")
+
+        subject?.restoreState(state: restoredState)
+
+        XCTAssertEqual(webViewProvider.webView.interactionState as! Data, restoredState)
+        XCTAssertEqual(webViewProvider.webView.loadCalled, 2, "Load calls it once, then restore calls it again")
+    }
+
     // MARK: Helper
 
     func createSubject() -> WKEngineSession? {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7908)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17652)

## :bulb: Description
Add the state restoration using [`interactionState`](https://developer.apple.com/documentation/webkit/wkwebview/3752236-interactionstate), keeping a similar behavior to what we have in the Client `Tab.swift` - If there was a previous request, we reload that inside the web view. To do so, I added a `WKEngineSessionData` struct which will keep in memory some web view information without having to rely on the web view itself. I think this will help in the long run to have a reliable way to retrieve the `title` and `URL` from different place in the Client app.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

