### PR TITLE
Remove FXIOS-6744 [v123] Remove wallpaper flag

### DIFF
--- a/firefox-ios/Client/FeatureFlags/FlaggableFeatureOptions.swift
+++ b/firefox-ios/Client/FeatureFlags/FlaggableFeatureOptions.swift
@@ -14,8 +14,3 @@ enum StartAtHomeSetting: String, FlaggableFeatureOptions {
     case always
     case disabled
 }
-
-enum WallpaperVersion: String, FlaggableFeatureOptions {
-    case legacy
-    case v1
-}

--- a/firefox-ios/Client/FeatureFlags/LegacyFeatureFlagsManager.swift
+++ b/firefox-ios/Client/FeatureFlags/LegacyFeatureFlagsManager.swift
@@ -76,14 +76,12 @@ class LegacyFeatureFlagsManager: HasNimbusFeatureFlags {
 
         switch featureID {
         case .searchBarPosition: return SearchBarPosition(rawValue: userSetting) as? T
-        case .wallpaperVersion: return WallpaperVersion(rawValue: userSetting) as? T
         }
     }
 
     private func convertCustomIDToStandard(_ featureID: NimbusFeatureFlagWithCustomOptionsID) -> NimbusFeatureFlagID {
         switch featureID {
         case .searchBarPosition: return .bottomSearchBar
-        case .wallpaperVersion: return .wallpaperVersion
         }
     }
 
@@ -112,8 +110,6 @@ class LegacyFeatureFlagsManager: HasNimbusFeatureFlags {
             if let option = desiredState as? SearchBarPosition {
                 feature.setUserPreference(to: option.rawValue)
             }
-
-        case .wallpaperVersion: return
         }
     }
 

--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -32,9 +32,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case shareSheetChanges
     case shareToolbarChanges
     case tabTrayRefactor
-    case wallpapers
     case wallpaperOnboardingSheet
-    case wallpaperVersion
     case zoomFeature
 }
 
@@ -42,7 +40,6 @@ enum NimbusFeatureFlagID: String, CaseIterable {
 /// just an ON or OFF setting. These option must also be added to `NimbusFeatureFlagID`
 enum NimbusFeatureFlagWithCustomOptionsID {
     case searchBarPosition
-    case wallpaperVersion
 }
 
 struct NimbusFlaggableFeature: HasNimbusSearchBar {
@@ -66,8 +63,6 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
             return FlagKeys.InactiveTabs
         case .jumpBackIn:
             return FlagKeys.JumpBackInSection
-        case .wallpapers:
-            return FlagKeys.CustomWallpaper
 
         // Cases where users do not have the option to manipulate a setting.
         case .contextualHintForToolbar,
@@ -87,7 +82,6 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .shareToolbarChanges,
                 .tabTrayRefactor,
                 .wallpaperOnboardingSheet,
-                .wallpaperVersion,
                 .zoomFeature:
             return nil
         }
@@ -132,9 +126,6 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
         switch featureID {
         case .bottomSearchBar:
             return nimbusSearchBar.getDefaultPosition().rawValue
-
-        case .wallpaperVersion:
-            return nimbusLayer.checkNimbusForWallpapersVersion()
 
         default: return nil
         }

--- a/firefox-ios/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
@@ -165,10 +165,7 @@ extension HistoryHighlightsViewModel: HomepageViewModelProtocol, FeatureFlaggabl
     }
 
     var headerViewModel: LabelButtonHeaderViewModel {
-        var textColor: UIColor?
-        if wallpaperManager.featureAvailable {
-            textColor = wallpaperManager.currentWallpaper.textColor
-        }
+        let textColor = wallpaperManager.currentWallpaper.textColor
 
         return LabelButtonHeaderViewModel(
             title: HomepageSectionType.historyHighlights.title,

--- a/firefox-ios/Client/Frontend/Home/HomepageSectionType.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageSectionType.swift
@@ -19,7 +19,6 @@ enum HomepageSectionType: Int, CaseIterable {
         case .pocket: return .FirefoxHomepage.Pocket.SectionTitle
         case .jumpBackIn: return .FirefoxHomeJumpBackInSectionTitle
         case .recentlySaved: return .RecentlySavedSectionTitle
-        case .topSites: return .ASShortcutsTitle
         case .historyHighlights: return .FirefoxHomepage.HistoryHighlights.Title
         default: return nil
         }

--- a/firefox-ios/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -293,10 +293,7 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
     }
 
     var headerViewModel: LabelButtonHeaderViewModel {
-        var textColor: UIColor?
-        if wallpaperManager.featureAvailable {
-            textColor = wallpaperManager.currentWallpaper.textColor
-        }
+        let textColor = wallpaperManager.currentWallpaper.textColor
 
         return LabelButtonHeaderViewModel(
             title: HomepageSectionType.jumpBackIn.title,

--- a/firefox-ios/Client/Frontend/Home/LogoHeader/HomeLogoHeaderViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/LogoHeader/HomeLogoHeaderViewModel.swift
@@ -57,7 +57,7 @@ extension HomeLogoHeaderViewModel: HomepageViewModelProtocol, FeatureFlaggable {
     }
 
     var isEnabled: Bool {
-        return profile.prefs.boolForKey(PrefsKeys.UserFeatureFlagPrefs.CustomWallpaper) ?? true
+        return true
     }
 
     func setTheme(theme: Theme) {

--- a/firefox-ios/Client/Frontend/Home/LogoHeader/HomeLogoHeaderViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/LogoHeader/HomeLogoHeaderViewModel.swift
@@ -57,7 +57,7 @@ extension HomeLogoHeaderViewModel: HomepageViewModelProtocol, FeatureFlaggable {
     }
 
     var isEnabled: Bool {
-        return featureFlags.isFeatureEnabled(.wallpapers, checking: .buildOnly)
+        return profile.prefs.boolForKey(PrefsKeys.UserFeatureFlagPrefs.CustomWallpaper) ?? true
     }
 
     func setTheme(theme: Theme) {

--- a/firefox-ios/Client/Frontend/Home/Pocket/PocketViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/Pocket/PocketViewModel.swift
@@ -128,10 +128,7 @@ extension PocketViewModel: HomepageViewModelProtocol {
     }
 
     var headerViewModel: LabelButtonHeaderViewModel {
-        var textColor: UIColor?
-        if wallpaperManager.featureAvailable {
-            textColor = wallpaperManager.currentWallpaper.textColor
-        }
+        let textColor = wallpaperManager.currentWallpaper.textColor
 
         return LabelButtonHeaderViewModel(
             title: HomepageSectionType.pocket.title,

--- a/firefox-ios/Client/Frontend/Home/PocketFooterView.swift
+++ b/firefox-ios/Client/Frontend/Home/PocketFooterView.swift
@@ -91,8 +91,7 @@ class PocketFooterView: UICollectionReusableView, ReusableCell, ThemeApplicable 
 
     func applyTheme(theme: Theme) {
         let colors = theme.colors
-        titleLabel.textColor = wallpaperManager.featureAvailable ?
-        wallpaperManager.currentWallpaper.textColor : colors.textPrimary
+        titleLabel.textColor = wallpaperManager.currentWallpaper.textColor
         learnMoreLabel.textColor = colors.textAccent
     }
 }

--- a/firefox-ios/Client/Frontend/Home/RecentlySaved/RecentlySavedViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/RecentlySaved/RecentlySavedViewModel.swift
@@ -58,10 +58,7 @@ extension RecentlySavedViewModel: HomepageViewModelProtocol, FeatureFlaggable {
     }
 
     var headerViewModel: LabelButtonHeaderViewModel {
-        var textColor: UIColor?
-        if wallpaperManager.featureAvailable {
-            textColor = wallpaperManager.currentWallpaper.textColor
-        }
+        let textColor = wallpaperManager.currentWallpaper.textColor
 
         return LabelButtonHeaderViewModel(
             title: HomepageSectionType.recentlySaved.title,

--- a/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -132,7 +132,7 @@ extension TopSitesViewModel: HomepageViewModelProtocol, FeatureFlaggable {
 
     var headerViewModel: LabelButtonHeaderViewModel {
         // Only show a header if the firefox browser logo isn't showing
-        let shouldShow = !featureFlags.isFeatureEnabled(.wallpapers, checking: .buildOnly)
+        let shouldShow = !(profile.prefs.boolForKey(PrefsKeys.UserFeatureFlagPrefs.CustomWallpaper) ?? false)
         var textColor: UIColor?
         if wallpaperManager.featureAvailable {
             textColor = wallpaperManager.currentWallpaper.textColor

--- a/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -131,15 +131,10 @@ extension TopSitesViewModel: HomepageViewModelProtocol, FeatureFlaggable {
     }
 
     var headerViewModel: LabelButtonHeaderViewModel {
-        // Only show a header if the firefox browser logo isn't showing
-        let shouldShow = !(profile.prefs.boolForKey(PrefsKeys.UserFeatureFlagPrefs.CustomWallpaper) ?? false)
-        var textColor: UIColor?
-        if wallpaperManager.featureAvailable {
-            textColor = wallpaperManager.currentWallpaper.textColor
-        }
+        var textColor = wallpaperManager.currentWallpaper.textColor
 
         return LabelButtonHeaderViewModel(
-            title: shouldShow ? HomepageSectionType.topSites.title: nil,
+            title: nil,
             titleA11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.topSites,
             isButtonHidden: true,
             textColor: textColor)
@@ -234,10 +229,7 @@ extension TopSitesViewModel: HomepageSectionHandler {
                    at indexPath: IndexPath) -> UICollectionViewCell {
         if let cell = collectionView.dequeueReusableCell(cellType: TopSiteItemCell.self, for: indexPath),
            let contentItem = topSites[safe: indexPath.row] {
-            var textColor: UIColor?
-            if wallpaperManager.featureAvailable {
-                textColor = wallpaperManager.currentWallpaper.textColor
-            }
+            let textColor = wallpaperManager.currentWallpaper.textColor
 
             cell.configure(contentItem,
                            position: indexPath.row,

--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Interface/WallpaperManager.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Interface/WallpaperManager.swift
@@ -81,8 +81,7 @@ class WallpaperManager: WallpaperManagerInterface, FeatureFlaggable {
 
     /// Determines whether the wallpaper settings can be shown
     var canSettingsBeShown: Bool {
-        guard hasEnoughThumbnailsToShow
-        else { return false }
+        guard hasEnoughThumbnailsToShow else { return false }
 
         return true
     }

--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Interface/WallpaperManager.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Interface/WallpaperManager.swift
@@ -35,16 +35,19 @@ class WallpaperManager: WallpaperManagerInterface, FeatureFlaggable {
     private var networkingModule: WallpaperNetworking
     private var userDefaults: UserDefaultsInterface
     private var logger: Logger
+    private var prefs: Prefs
 
     // MARK: - Initializers
     init(
         with networkingModule: WallpaperNetworking = WallpaperNetworkingModule(),
         userDefaults: UserDefaultsInterface = UserDefaults.standard,
-        logger: Logger = DefaultLogger.shared
+        logger: Logger = DefaultLogger.shared,
+        profile: Profile = AppContainer.shared.resolve()
     ) {
         self.networkingModule = networkingModule
         self.userDefaults = userDefaults
         self.logger = logger
+        self.prefs = profile.prefs
     }
 
     // MARK: Public Interface
@@ -98,14 +101,9 @@ class WallpaperManager: WallpaperManagerInterface, FeatureFlaggable {
         return true
     }
 
-    /// Returns true if the feature is enabled for the build and the version matches the
-    /// current shipped version.
+    /// Returns true if the feature is enabled by the user
     public var featureAvailable: Bool {
-        guard let wallpaperVersion: WallpaperVersion = featureFlags.getCustomState(for: .wallpaperVersion),
-              wallpaperVersion == .v1
-        else { return false }
-
-        return true
+        return prefs.boolForKey(PrefsKeys.UserFeatureFlagPrefs.CustomWallpaper) ?? false
     }
 
     /// Sets and saves a selected wallpaper as currently selected wallpaper.

--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Interface/WallpaperManager.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Interface/WallpaperManager.swift
@@ -35,19 +35,16 @@ class WallpaperManager: WallpaperManagerInterface, FeatureFlaggable {
     private var networkingModule: WallpaperNetworking
     private var userDefaults: UserDefaultsInterface
     private var logger: Logger
-    private var prefs: Prefs
 
     // MARK: - Initializers
     init(
         with networkingModule: WallpaperNetworking = WallpaperNetworkingModule(),
         userDefaults: UserDefaultsInterface = UserDefaults.standard,
-        logger: Logger = DefaultLogger.shared,
-        profile: Profile = AppContainer.shared.resolve()
+        logger: Logger = DefaultLogger.shared
     ) {
         self.networkingModule = networkingModule
         self.userDefaults = userDefaults
         self.logger = logger
-        self.prefs = profile.prefs
     }
 
     // MARK: Public Interface
@@ -73,7 +70,6 @@ class WallpaperManager: WallpaperManagerInterface, FeatureFlaggable {
         let cfrsHaveBeenShown = toolbarCFRShown && jumpBackInCFRShown
 
         guard cfrsHaveBeenShown,
-              featureAvailable,
               hasEnoughThumbnailsToShow,
               !userDefaults.bool(forKey: PrefsKeys.Wallpapers.OnboardingSeenKey),
               featureFlags.isFeatureEnabled(.wallpaperOnboardingSheet,
@@ -85,8 +81,7 @@ class WallpaperManager: WallpaperManagerInterface, FeatureFlaggable {
 
     /// Determines whether the wallpaper settings can be shown
     var canSettingsBeShown: Bool {
-        guard featureAvailable,
-              hasEnoughThumbnailsToShow
+        guard hasEnoughThumbnailsToShow
         else { return false }
 
         return true
@@ -96,14 +91,9 @@ class WallpaperManager: WallpaperManagerInterface, FeatureFlaggable {
     private var hasEnoughThumbnailsToShow: Bool {
         let thumbnailUtility = WallpaperThumbnailUtility(with: networkingModule)
 
-        guard featureAvailable, thumbnailUtility.areThumbnailsAvailable else { return false }
+        guard thumbnailUtility.areThumbnailsAvailable else { return false }
 
         return true
-    }
-
-    /// Returns true if the feature is enabled by the user
-    public var featureAvailable: Bool {
-        return prefs.boolForKey(PrefsKeys.UserFeatureFlagPrefs.CustomWallpaper) ?? false
     }
 
     /// Sets and saves a selected wallpaper as currently selected wallpaper.

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -20,8 +20,7 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
     }
 
     var isWallpaperSectionEnabled: Bool {
-        return wallpaperManager.canSettingsBeShown &&
-            profile.prefs.boolForKey(PrefsKeys.UserFeatureFlagPrefs.CustomWallpaper) ?? false
+        return wallpaperManager.canSettingsBeShown
     }
 
     var isPocketSectionEnabled: Bool {

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -21,7 +21,7 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
 
     var isWallpaperSectionEnabled: Bool {
         return wallpaperManager.canSettingsBeShown &&
-            featureFlags.isFeatureEnabled(.wallpapers, checking: .buildOnly)
+            profile.prefs.boolForKey(PrefsKeys.UserFeatureFlagPrefs.CustomWallpaper) ?? false
     }
 
     var isPocketSectionEnabled: Bool {

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -1918,11 +1918,6 @@ extension String {
 
 // MARK: - Activity Stream
 extension String {
-    public static let ASShortcutsTitle =  MZLocalizedString(
-        key: "ActivityStream.Shortcuts.SectionTitle",
-        tableName: nil,
-        value: "Shortcuts",
-        comment: "Section title label for Shortcuts")
     public static let RecentlySavedSectionTitle = MZLocalizedString(
         key: "ActivityStream.Library.Title",
         tableName: nil,
@@ -5942,6 +5937,15 @@ extension String {
                 value: "Card Information updated",
                 comment: "Label text that gets presented as a confirmation at the bottom of screen when credit card information gets updated successfully",
                 lastUsedInVersion: 121)
+        }
+
+        struct v123 {
+            public static let ASShortcutsTitle =  MZLocalizedString(
+                key: "ActivityStream.Shortcuts.SectionTitle",
+                tableName: nil,
+                value: "Shortcuts",
+                comment: "Section title label for Shortcuts",
+                lastUsedInVersion: 123)
         }
     }
 }

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -66,10 +66,6 @@ final class NimbusFeatureFlagLayer {
         case .tabTrayRefactor:
             return checkTabTrayRefactorFeature(from: nimbus)
 
-        case .wallpapers,
-                .wallpaperVersion:
-            return checkNimbusForWallpapersFeature(using: nimbus)
-
         case .wallpaperOnboardingSheet:
             return checkNimbusForWallpaperOnboarding(using: nimbus)
 

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -137,20 +137,8 @@ final class NimbusFeatureFlagLayer {
         return status
     }
 
-    private func checkNimbusForWallpapersFeature(using nimbus: FxNimbus) -> Bool {
-        let config = nimbus.features.wallpaperFeature.value()
-
-        return config.configuration.status
-    }
-
     private func checkNimbusForWallpaperOnboarding(using nimbus: FxNimbus) -> Bool {
         return nimbus.features.wallpaperFeature.value().onboardingSheet
-    }
-
-    public func checkNimbusForWallpapersVersion(using nimbus: FxNimbus = FxNimbus.shared) -> String {
-        let config = nimbus.features.wallpaperFeature.value()
-
-        return config.configuration.version.rawValue
     }
 
     private func checkQRCodeCoordinatorRefactorFeature(from nimbus: FxNimbus) -> Bool {

--- a/firefox-ios/Shared/Prefs.swift
+++ b/firefox-ios/Shared/Prefs.swift
@@ -82,7 +82,6 @@ public struct PrefsKeys {
 
     public struct UserFeatureFlagPrefs {
         public static let ASPocketStories = "ASPocketStoriesUserPrefsKey"
-        public static let CustomWallpaper = "CustomWallpaperUserPrefsKey"
         public static let RecentlySavedSection = "RecentlySavedSectionUserPrefsKey"
         public static let SponsoredShortcuts = "SponsoredShortcutsUserPrefsKey"
         public static let StartAtHome = "StartAtHomeUserPrefsKey"

--- a/firefox-ios/Shared/Prefs.swift
+++ b/firefox-ios/Shared/Prefs.swift
@@ -68,7 +68,6 @@ public struct PrefsKeys {
 
     // For ease of use, please list keys alphabetically.
     public struct FeatureFlags {
-        public static let CustomWallpaper = "CustomWallpaperUserPrefsKey"
         public static let FirefoxSuggest = "FirefoxSuggest"
         public static let HistoryHighlightsSection = "HistoryHighlightsSectionUserPrefsKey"
         public static let HistoryGroups = "HistoryGroupsUserPrefsKey"
@@ -83,6 +82,7 @@ public struct PrefsKeys {
 
     public struct UserFeatureFlagPrefs {
         public static let ASPocketStories = "ASPocketStoriesUserPrefsKey"
+        public static let CustomWallpaper = "CustomWallpaperUserPrefsKey"
         public static let RecentlySavedSection = "RecentlySavedSectionUserPrefsKey"
         public static let SponsoredShortcuts = "SponsoredShortcutsUserPrefsKey"
         public static let StartAtHome = "StartAtHomeUserPrefsKey"

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/FeatureFlagManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/FeatureFlagManagerTests.swift
@@ -44,12 +44,10 @@ class FeatureFlagManagerTests: XCTestCase, FeatureFlaggable {
         XCTAssertTrue(featureFlags.isFeatureEnabled(.jumpBackIn, checking: .userOnly))
         XCTAssertTrue(featureFlags.isFeatureEnabled(.reportSiteIssue, checking: .buildOnly))
         XCTAssertTrue(featureFlags.isFeatureEnabled(.reportSiteIssue, checking: .userOnly))
-        XCTAssertTrue(featureFlags.isFeatureEnabled(.wallpapers, checking: .buildOnly))
     }
 
     func testDefaultNimbusCustomFlags() {
         XCTAssertEqual(featureFlags.getCustomState(for: .searchBarPosition), SearchBarPosition.top)
-        XCTAssertEqual(featureFlags.getCustomState(for: .wallpaperVersion), WallpaperVersion.v1)
     }
 
     // Changing the prefs manually, to make sure settings are respected through

--- a/firefox-ios/nimbus-features/wallpaperFeature.yaml
+++ b/firefox-ios/nimbus-features/wallpaperFeature.yaml
@@ -2,14 +2,6 @@ features:
   wallpaper-feature:
     description: This property defines the configuration for the wallpaper feature
     variables:
-      configuration:
-        description: This property defines the configuration for the wallpaper feature
-        type: WallpaperConfiguration
-        default:
-          {
-            "status": true,
-            "version": v1,
-          }
       onboarding-sheet:
         description: This property defines whether the wallpaper onboarding is shown or not
         type: Boolean
@@ -17,39 +9,9 @@ features:
     defaults:
       - channel: beta
         value: {
-          "configuration": {
-            "status": true,
-            "version": v1,
-          },
           "onboarding-sheet": true
         }
       - channel: developer
         value: {
-          "configuration": {
-            "status": true,
-            "version": v1,
-          },
           "onboarding-sheet": true
         }
-
-objects:
-  WallpaperConfiguration:
-    description: "The configuration for the a feature that can be enabled or disabled"
-    fields:
-      status:
-        type: Boolean
-        description: Whether or not the feature is enabled
-        default: false
-      version:
-        type: WallpaperVariantVersion
-        description: Which version of the wallpaper sytem to use
-        default: legacy
-
-enums:
-  WallpaperVariantVersion:
-    description: An enum to identify which version of the wallpaper system to use
-    variants:
-      legacy:
-        description: The legacy wallpaper version
-      v1:
-        description: The 2022 MR version


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6744)
No Github issue

## :bulb: Description
Remove the `.wallpapers` and `.wallpaperVersion` feature flags. This means wallpaper won't be experimentable anymore with this PR. With this clean up, we're also effectively removing the homepage without the Firefox logo (where we had the "top sites" string at the top instead).

Since there are no settings to disable wallpaper, I removed the `CustomWallpaper` prefs key since it's in fact never set from the settings (i.e. once we have enough thumbnails, we show the wallpapers. The user can select the default wallpaper but cannot turn off wallpapers feature in itself). This simplifies the code in the homepage area related to the headers text color.

I tested with and without wallpapers and all seemed to behave properly (homepage header text colors, light mode, dark mode, etc). 

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

