### PR TITLE
Refactor FXIOS-8008 [v123] Replaced roundedButton with PrimaryRoundedButton type

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/InactiveTabs/InactiveTabsFooterView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/InactiveTabs/InactiveTabsFooterView.swift
@@ -3,15 +3,13 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
+import ComponentLibrary
 import UIKit
 
 class InactiveTabsFooterView: UICollectionReusableView, ReusableCell, ThemeApplicable {
     struct UX {
         static let buttonInset: CGFloat = 14
         static let buttonImagePadding: CGFloat = 11
-        static let buttonFontSize: CGFloat = 16
-        static let buttonCornerRadius: CGFloat = 13.5
-        static let buttonBorderWidth: CGFloat = 1
         static let iPadOffset: CGFloat = 100
         static let iPhoneOffset: CGFloat = 23
         static let buttonTopOffset: CGFloat = 16
@@ -21,18 +19,13 @@ class InactiveTabsFooterView: UICollectionReusableView, ReusableCell, ThemeAppli
     var buttonClosure: (() -> Void)?
 
     // MARK: - UI Elements
-    private lazy var roundedButton: UIButton = .build { button in
-        button.titleLabel?.font = DefaultDynamicFontHelper.preferredBoldFont(
-            withTextStyle: .body,
-            size: UX.buttonFontSize)
-        button.setImage(UIImage(systemName: StandardImageIdentifiers.Large.delete), for: .normal)
-        button.setTitle(.TabsTray.InactiveTabs.CloseAllInactiveTabsButton, for: .normal)
-        button.titleLabel?.textAlignment = .center
-        button.titleLabel?.lineBreakMode = .byTruncatingTail
-        button.titleLabel?.adjustsFontForContentSizeCategory = true
-        button.layer.cornerRadius = UX.buttonCornerRadius
-        button.layer.borderWidth = UX.buttonBorderWidth
-        button.accessibilityIdentifier = AccessibilityIdentifiers.TabTray.InactiveTabs.deleteButton
+    private lazy var roundedButton: PrimaryRoundedButton = .build { button in
+        let viewModel = PrimaryRoundedButtonViewModel(
+            title: .TabsTray.InactiveTabs.CloseAllInactiveTabsButton,
+            a11yIdentifier: AccessibilityIdentifiers.TabTray.InactiveTabs.deleteButton,
+            imageTitlePadding: UX.buttonImagePadding
+        )
+        button.configure(viewModel: viewModel)
         button.addTarget(self, action: #selector(self.buttonPressed), for: .touchUpInside)
     }
 
@@ -80,10 +73,8 @@ class InactiveTabsFooterView: UICollectionReusableView, ReusableCell, ThemeAppli
 
     func applyTheme(theme: Theme) {
         backgroundColor = theme.colors.layer2
-        roundedButton.setTitleColor(theme.colors.textPrimary, for: .normal)
-        roundedButton.backgroundColor = theme.colors.layer3
-        roundedButton.tintColor = theme.colors.textPrimary
+        roundedButton.applyTheme(theme: theme)
         let image = UIImage(named: StandardImageIdentifiers.Large.delete)?.tinted(withColor: theme.colors.iconPrimary)
-        roundedButton.setImage(image, for: .normal)
+        roundedButton.configuration?.image = image?.withRenderingMode(.alwaysTemplate)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/InactiveTabs/InactiveTabsFooterView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/InactiveTabs/InactiveTabsFooterView.swift
@@ -8,7 +8,6 @@ import UIKit
 
 class InactiveTabsFooterView: UICollectionReusableView, ReusableCell, ThemeApplicable {
     struct UX {
-        static let buttonInset: CGFloat = 14
         static let buttonImagePadding: CGFloat = 11
         static let iPadOffset: CGFloat = 100
         static let iPhoneOffset: CGFloat = 23
@@ -41,18 +40,6 @@ class InactiveTabsFooterView: UICollectionReusableView, ReusableCell, ThemeAppli
 
     func setupView() {
         addSubview(roundedButton)
-
-        roundedButton.contentEdgeInsets = UIEdgeInsets(
-            top: UX.buttonInset,
-            left: UX.buttonInset,
-            bottom: UX.buttonInset,
-            right: UX.buttonInset)
-        roundedButton.titleEdgeInsets = UIEdgeInsets(
-            top: 0,
-            left: UX.buttonImagePadding,
-            bottom: 0,
-            right: UX.buttonImagePadding
-        )
 
         let horizontalOffSet: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? UX.iPadOffset : UX.iPhoneOffset
         accessibilityIdentifier = AccessibilityIdentifiers.TabTray.InactiveTabs.footerView


### PR DESCRIPTION
…dButton

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8008)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17879)

## :bulb: Description
Replaced roundedButton in InactiveTabsFooterView to PrimaryRoundedButton

| Before | After |
| ------- | ----- |
| <img src="https://github.com/mozilla-mobile/firefox-ios/assets/5124098/0cd0715f-4822-4566-a74c-1962959ec003" />|<img src="https://github.com/mozilla-mobile/firefox-ios/assets/5124098/b10e1671-db7a-4897-86d3-0e5c99fe2ef6" />


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

