### PR TITLE
Bugfix FXIOS-8099 [v123] URL Bar: do not read pasteboard contents until intent has been established (#18023)

### DIFF
--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
@@ -66,7 +66,7 @@ extension PhotonActionSheetProtocol {
             }
         }
 
-        if UIPasteboard.general.string != nil {
+        if UIPasteboard.general.hasStrings {
             return [pasteGoAction.items, pasteAction.items, copyAddressAction.items]
         } else {
             return [copyAddressAction.items]


### PR DESCRIPTION
URL Bar: do not read pasteboard contents until intent has been established (#18023)

See https://developer.apple.com/documentation/uikit/uipasteboard/#2107139:
> Starting in iOS 14, the system notifies the user when an app gets general
> pasteboard content that originates in a different app without user intent.

Therefore we need to avoid reading pasteboard content (e.g. via UIPasteboard.general.string) until after the user has expressed an intent to paste content - or else the user will see spurious dialogs, and possibly erronously and unnecessarily grant permission for Firefox to see pasteboard content when it isn't necessary (e.g. if they merely intend to copy the current URL).

When deciding whether or not the URL-bar's copy/paste dialog should show the two paste options (which should only be shown if there actually *is* text content in the pasteboard), we therefore need to use the presence APIs e.g. UIPasteboard.general.hasStrings instead of checking whether or not UIPasteboard.general.string is not empty.

(Note: this code predates iOS 14 by some years, which is presumably why
 it does or did not use the presence API.)

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8099)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18023)

## :bulb: Description

URL-bar long-press: avoid asking for pasteboard permission until user has indicated intent to paste.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [Unable to do so due to lack of dev environment] Wrote unit tests and/or ensured the tests suite is passing
- [No impact] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [No impact] If needed I updated documentation / comments for complex code and public methods

