### PR TITLE
Bug MTE-2052 [v123] Fix Performance Test Path for Mono-Repo Change

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1235,8 +1235,6 @@ workflows:
             # debug log
             set -x
             # get dependency
-            echo "current directory ${PWD}"
-            find . -mindepth 2 -maxdepth 2 -type d
             cd ./firefox-ios/test-fixtures && git clone https://github.com/isabelrios/xcresult_extract.git
             
             echo $BITRISE_XCRESULT_PATH

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1598,15 +1598,13 @@ meta:
 
 trigger_map:
 - push_branch: main
-  #pipeline: pipeline_multiple_shards
-  workflow: Bitrise_Performance_Test
+  pipeline: pipeline_multiple_shards
 - push_branch: epic-branch/*
   pipeline: pipeline_multiple_shards
 - push_branch: release/v123
   pipeline: pipeline_multiple_shards
 - pull_request_target_branch: main
-  #pipeline: pipeline_multiple_shards
-  workflow: Bitrise_Performance_Test
+  pipeline: pipeline_multiple_shards
 - pull_request_target_branch: epic-branch/*
   pipeline: pipeline_multiple_shards
 - pull_request_target_branch: release/v*

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1612,4 +1612,5 @@ trigger_map:
 - pull_request_target_branch: release/v*
   pipeline: pipeline_multiple_shards
 - pull_request_target_branch: main
+  pull_request_source_branch: "*jjSDET*"
   workflow: Bitrise_Performance_Test

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1218,9 +1218,19 @@ workflows:
     steps:
     - cache-pull@2.1:
         is_always_run: true
+    - script@1.1:
+        is_always_run: true
+        title: test script to get env var
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -ex
+            echo $BITRISE_PROJECT_PATH
+            env-man add --key BITRISE_PERFORMANCE_PATH --value "firefox-ios/Clients.xcodeproj"
+            echo "updated BITRISE_PERFORMANCE_PATH: *** ${BITRISE_PERFORMANCE_PATH} ***"
     - xcode-test@4.5:
         inputs:
-        - project_path: firefox-ios/Client.xcodeproj
+        - project_path: $BITRISE_PERFORMANCE_PATH
         - scheme: Fennec
         - destination: platform=iOS Simulator,name=iPhone 15,OS=17.2
         - test_plan: PerformanceTestPlan   

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1218,19 +1218,9 @@ workflows:
     steps:
     - cache-pull@2.1:
         is_always_run: true
-    - script@1.1:
-        is_always_run: true
-        title: test script to get env var
-        inputs:
-        - content: |-
-            #!/usr/bin/env bash
-            set -ex
-            echo $BITRISE_PROJECT_PATH
-            env-man add --key BITRISE_PERFORMANCE_PATH --value "firefox-ios/Clients.xcodeproj"
-            echo "updated BITRISE_PERFORMANCE_PATH: *** ${BITRISE_PERFORMANCE_PATH} ***"
     - xcode-test@4.5:
         inputs:
-        - project_path: $BITRISE_PERFORMANCE_PATH
+        - project_path: firefox-ios/Client.xcodeproj
         - scheme: Fennec
         - destination: platform=iOS Simulator,name=iPhone 15,OS=17.2
         - test_plan: PerformanceTestPlan   
@@ -1621,6 +1611,3 @@ trigger_map:
   pipeline: pipeline_multiple_shards
 - pull_request_target_branch: release/v*
   pipeline: pipeline_multiple_shards
-- pull_request_target_branch: main
-  pull_request_source_branch: "*jjSDET*"
-  workflow: Bitrise_Performance_Test

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1220,6 +1220,7 @@ workflows:
         is_always_run: true
     - xcode-test@4.5:
         inputs:
+        - project_path: firefox-ios/Client.xcodeproj
         - scheme: Fennec
         - destination: platform=iOS Simulator,name=iPhone 15,OS=17.2
         - test_plan: PerformanceTestPlan   
@@ -1234,7 +1235,9 @@ workflows:
             # debug log
             set -x
             # get dependency
-            cd .firefox-ios/test-fixtures && git clone https://github.com/isabelrios/xcresult_extract.git
+            echo "current directory ${PWD}"
+            find . -mindepth 2 -maxdepth 2 -type d
+            cd ./firefox-ios/test-fixtures && git clone https://github.com/isabelrios/xcresult_extract.git
             
             echo $BITRISE_XCRESULT_PATH
             ls
@@ -1608,3 +1611,5 @@ trigger_map:
   pipeline: pipeline_multiple_shards
 - pull_request_target_branch: release/v*
   pipeline: pipeline_multiple_shards
+- pull_request_target_branch: main
+  workflow: Bitrise_Performance_Test

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1235,7 +1235,7 @@ workflows:
             # debug log
             set -x
             # get dependency
-            cd ./firefox-ios/test-fixtures && git clone https://github.com/isabelrios/xcresult_extract.git
+            cd ./test-fixtures && git clone https://github.com/isabelrios/xcresult_extract.git
             
             echo $BITRISE_XCRESULT_PATH
             ls

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1598,13 +1598,15 @@ meta:
 
 trigger_map:
 - push_branch: main
-  pipeline: pipeline_multiple_shards
+  #pipeline: pipeline_multiple_shards
+  workflow: Bitrise_Performance_Test
 - push_branch: epic-branch/*
   pipeline: pipeline_multiple_shards
 - push_branch: release/v123
   pipeline: pipeline_multiple_shards
 - pull_request_target_branch: main
-  pipeline: pipeline_multiple_shards
+  #pipeline: pipeline_multiple_shards
+  workflow: Bitrise_Performance_Test
 - pull_request_target_branch: epic-branch/*
   pipeline: pipeline_multiple_shards
 - pull_request_target_branch: release/v*


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2052)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
The `Bitrise_Performance_Test` workflow is still using the old path for `Client.xcodeproj` and wasn't updated for the mono-repo change.

We need to update the path to `firefox-ios/Client.xcodeproj` to fix it.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

