### PR TITLE
Refactor FXIOS-8102 [v122] Felt privacy work to use redux to show a feature

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
@@ -431,22 +431,4 @@ extension BrowserViewController: URLBarDelegate {
     func urlBarDidBeginDragInteraction(_ urlBar: URLBarView) {
         dismissVisibleMenus()
     }
-
-    private var shouldDisableSearchSuggestsForPrivateMode: Bool {
-        let featureFlagEnabled = featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly)
-        let isPrivateTab = tabManager.selectedTab?.isPrivate ?? false
-        let isSettingEnabled = profile.prefs.boolForKey(PrefsKeys.SearchSettings.showPrivateModeSearchSuggestions) ?? false
-        return featureFlagEnabled && isPrivateTab && !isSettingEnabled
-    }
-
-    // Determines the view user should see when editing the url bar
-    // Dimming view appears if private mode search suggest is disabled
-    // Otherwise shows search suggests screen
-    private func configureOverlayView() {
-        if shouldDisableSearchSuggestsForPrivateMode {
-            configureDimmingView()
-        } else {
-            showSearchController()
-        }
-    }
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -677,21 +677,6 @@ class BrowserViewController: UIViewController,
         view.addSubview(bottomContainer)
     }
 
-    // Configure dimming view to show for private mode
-    func configureDimmingView() {
-        if let selectedTab = tabManager.selectedTab, selectedTab.isPrivate {
-            view.addSubview(privateModeDimmingView)
-            view.bringSubviewToFront(privateModeDimmingView)
-
-            NSLayoutConstraint.activate([
-                privateModeDimmingView.topAnchor.constraint(equalTo: contentStackView.topAnchor),
-                privateModeDimmingView.leadingAnchor.constraint(equalTo: contentStackView.leadingAnchor),
-                privateModeDimmingView.bottomAnchor.constraint(equalTo: contentStackView.bottomAnchor),
-                privateModeDimmingView.trailingAnchor.constraint(equalTo: contentStackView.trailingAnchor)
-            ])
-        }
-    }
-
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
@@ -1905,6 +1890,41 @@ class BrowserViewController: UIViewController,
                                                                    alertContainer: self.contentContainer)
                 }
             }
+        }
+    }
+
+    // MARK: Overlay View
+    // Disable search suggests view only if user is in private mode and setting is enabled
+    private var shouldDisableSearchSuggestsForPrivateMode: Bool {
+        let featureFlagEnabled = featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly)
+        let alwaysShowSearchSuggestionsView = browserViewControllerState?.searchScreenState.showSearchSugestionsView ?? false
+        let isSettingEnabled = profile.prefs.boolForKey(PrefsKeys.SearchSettings.showPrivateModeSearchSuggestions) ?? false
+        return featureFlagEnabled && !alwaysShowSearchSuggestionsView && !isSettingEnabled
+    }
+
+    // Configure dimming view to show for private mode
+    private func configureDimmingView() {
+        if let selectedTab = tabManager.selectedTab, selectedTab.isPrivate {
+            view.addSubview(privateModeDimmingView)
+            view.bringSubviewToFront(privateModeDimmingView)
+
+            NSLayoutConstraint.activate([
+                privateModeDimmingView.topAnchor.constraint(equalTo: contentStackView.topAnchor),
+                privateModeDimmingView.leadingAnchor.constraint(equalTo: contentStackView.leadingAnchor),
+                privateModeDimmingView.bottomAnchor.constraint(equalTo: contentStackView.bottomAnchor),
+                privateModeDimmingView.trailingAnchor.constraint(equalTo: contentStackView.trailingAnchor)
+            ])
+        }
+    }
+
+    // Determines the view user should see when editing the url bar
+    // Dimming view appears if private mode search suggest is disabled
+    // Otherwise shows search suggests screen
+    func configureOverlayView() {
+        if shouldDisableSearchSuggestsForPrivateMode {
+            configureDimmingView()
+        } else {
+            showSearchController()
         }
     }
 

--- a/firefox-ios/Client/Frontend/Home/LogoHeader/HomeLogoHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/LogoHeader/HomeLogoHeaderCell.swift
@@ -63,8 +63,7 @@ class HomeLogoHeaderCell: UICollectionViewCell, ReusableCell {
         containerView.addSubview(logoTextImage)
         contentView.addSubview(containerView)
 
-        // TODO: Felt Privacy - Private mode in Redux to follow
-        let isiPadAndPrivate = UIDevice.current.userInterfaceIdiom == .pad && false
+        let isiPadAndPrivate = UIDevice.current.userInterfaceIdiom == .pad
         let logoSizeConstant = isiPadAndPrivate ? UX.Logo.iPadImageSize : UX.Logo.iPhoneImageSize
         let topAnchorConstant = isiPadAndPrivate ? UX.Logo.iPadTopConstant : UX.Logo.iPhoneTopConstant
         let textImageWidthConstant = isiPadAndPrivate ? UX.TextImage.iPadWidth : UX.TextImage.iPhoneWidth

--- a/firefox-ios/Client/Frontend/Home/LogoHeader/HomeLogoHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/LogoHeader/HomeLogoHeaderCell.swift
@@ -63,11 +63,11 @@ class HomeLogoHeaderCell: UICollectionViewCell, ReusableCell {
         containerView.addSubview(logoTextImage)
         contentView.addSubview(containerView)
 
-        let isiPadAndPrivate = UIDevice.current.userInterfaceIdiom == .pad
-        let logoSizeConstant = isiPadAndPrivate ? UX.Logo.iPadImageSize : UX.Logo.iPhoneImageSize
-        let topAnchorConstant = isiPadAndPrivate ? UX.Logo.iPadTopConstant : UX.Logo.iPhoneTopConstant
-        let textImageWidthConstant = isiPadAndPrivate ? UX.TextImage.iPadWidth : UX.TextImage.iPhoneWidth
-        let textImageLeadingAnchorConstant = isiPadAndPrivate ? UX.TextImage.iPadLeadingConstant : UX.TextImage.iPhoneLeadingConstant
+        let isiPad = UIDevice.current.userInterfaceIdiom == .pad
+        let logoSizeConstant = isiPad ? UX.Logo.iPadImageSize : UX.Logo.iPhoneImageSize
+        let topAnchorConstant = isiPad ? UX.Logo.iPadTopConstant : UX.Logo.iPhoneTopConstant
+        let textImageWidthConstant = isiPad ? UX.TextImage.iPadWidth : UX.TextImage.iPhoneWidth
+        let textImageLeadingAnchorConstant = isiPad ? UX.TextImage.iPadLeadingConstant : UX.TextImage.iPhoneLeadingConstant
 
         NSLayoutConstraint.activate([
             containerView.topAnchor.constraint(equalTo: contentView.topAnchor,
@@ -90,7 +90,7 @@ class HomeLogoHeaderCell: UICollectionViewCell, ReusableCell {
             logoTextImage.centerYAnchor.constraint(equalTo: logoImage.centerYAnchor)
         ])
 
-        if isiPadAndPrivate {
+        if isiPad {
             NSLayoutConstraint.activate([
                 containerView.centerXAnchor.constraint(
                     equalTo: contentView.centerXAnchor


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8102)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18029)

## :bulb: Description
* Consolidate code for the overlay view and update `let isPrivateTab = tabManager.selectedTab?.isPrivate ?? false` to use redux
* Confirmed with design that we can keep iPad logo consistent for both normal and private mode.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods