### PR TITLE
Add FXIOS-6505 [v123] Show back forward list from browser coordinator

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -598,6 +598,16 @@ class BrowserCoordinator: BaseCoordinator,
 
         router.present(navigationController)
     }
+    
+    func showBackForwardList() {
+        guard let backForwardList = tabManager.selectedTab?.webView?.backForwardList else { return }
+        let backForwardListVC = BackForwardListViewController(profile: profile, backForwardList: backForwardList)
+        backForwardListVC.backForwardTransitionDelegate = BackForwardListAnimator()
+        backForwardListVC.browserFrameInfoProvider = browserViewController
+        backForwardListVC.tabManager = tabManager
+        backForwardListVC.modalPresentationStyle = .overCurrentContext
+        router.present(backForwardListVC)
+    }
 
     // MARK: - ParentCoordinatorDelegate
     func didFinish(from childCoordinator: Coordinator) {

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -598,7 +598,7 @@ class BrowserCoordinator: BaseCoordinator,
 
         router.present(navigationController)
     }
-    
+
     func showBackForwardList() {
         guard let backForwardList = tabManager.selectedTab?.webView?.backForwardList else { return }
         let backForwardListVC = BackForwardListViewController(profile: profile, backForwardList: backForwardList)

--- a/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
@@ -75,6 +75,9 @@ protocol BrowserNavigationHandler: AnyObject, QRCodeNavigationHandler {
 
     /// Shows the Tab Tray View Controller.
     func showTabTray(selectedPanel: TabTrayPanelType)
+    
+    /// Shows the Back Forward List View Controller.
+    func showBackForwardList()
 }
 
 extension BrowserNavigationHandler {

--- a/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
@@ -75,7 +75,7 @@ protocol BrowserNavigationHandler: AnyObject, QRCodeNavigationHandler {
 
     /// Shows the Tab Tray View Controller.
     func showTabTray(selectedPanel: TabTrayPanelType)
-    
+
     /// Shows the Back Forward List View Controller.
     func showBackForwardList()
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -125,7 +125,7 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
     func tabToolbarDidLongPressForward(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
         handleTabToolBarDidLongPressForwardOrBack()
     }
-    
+
     private func handleTabToolBarDidLongPressForwardOrBack() {
         let generator = UIImpactFeedbackGenerator(style: .heavy)
         generator.impactOccurred()

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -114,9 +114,7 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
     }
 
     func tabToolbarDidLongPressBack(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
-        let generator = UIImpactFeedbackGenerator(style: .heavy)
-        generator.impactOccurred()
-        showBackForwardList()
+        handleTabToolBarDidLongPressForwardOrBack()
     }
 
     func tabToolbarDidPressForward(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
@@ -125,9 +123,17 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
     }
 
     func tabToolbarDidLongPressForward(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
+        handleTabToolBarDidLongPressForwardOrBack()
+    }
+    
+    private func handleTabToolBarDidLongPressForwardOrBack() {
         let generator = UIImpactFeedbackGenerator(style: .heavy)
         generator.impactOccurred()
-        showBackForwardList()
+        if CoordinatorFlagManager.isBackForwardListShownFromCoordaintorEnabled {
+            navigationHandler?.showBackForwardList()
+        } else {
+            showBackForwardList()
+        }
     }
 
     func tabToolbarDidPressBookmarks(_ tabToolbar: TabToolbarProtocol, button: UIButton) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -261,7 +261,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         XCTAssertEqual(mockRouter.presentCalled, 1)
         XCTAssertTrue(mockRouter.presentedViewController is QRCodeNavigationController)
     }
-    
+
     func testShowBackForwardList_presentsBackForwardListViewController() {
         let mockTab = Tab(profile: profile, configuration: .init())
         mockTab.url = URL(string: "https://www.google.com")

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -261,6 +261,19 @@ final class BrowserCoordinatorTests: XCTestCase {
         XCTAssertEqual(mockRouter.presentCalled, 1)
         XCTAssertTrue(mockRouter.presentedViewController is QRCodeNavigationController)
     }
+    
+    func testShowBackForwardList_presentsBackForwardListViewController() {
+        let mockTab = Tab(profile: profile, configuration: .init())
+        mockTab.url = URL(string: "https://www.google.com")
+        mockTab.createWebview()
+        tabManager.selectedTab = mockTab
+
+        let subject = createSubject()
+        subject.showBackForwardList()
+
+        XCTAssertEqual(mockRouter.presentCalled, 1)
+        XCTAssertTrue(mockRouter.presentedViewController is BackForwardListViewController)
+    }
 
     func testShowTabTray() throws {
         let subject = createSubject()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
@@ -72,7 +72,7 @@ class MockBrowserCoordinator: BrowserNavigationHandler, ParentCoordinatorDelegat
     func showQRCode() {
         showQrCodeCalled += 1
     }
-    
+
     func showBackForwardList() {
         showBackForwardListCalled += 1
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
@@ -21,6 +21,7 @@ class MockBrowserCoordinator: BrowserNavigationHandler, ParentCoordinatorDelegat
     var didFinishCalled = 0
     var showFakespotFlowAsModalCalled = 0
     var showFakespotFlowAsSidebarCalled = 0
+    var showBackForwardListCalled = 0
     var dismissFakespotModalCalled = 0
     var dismissFakespotSidebarCalled = 0
     var updateFakespotSidebarCalled = 0
@@ -70,6 +71,10 @@ class MockBrowserCoordinator: BrowserNavigationHandler, ParentCoordinatorDelegat
 
     func showQRCode() {
         showQrCodeCalled += 1
+    }
+    
+    func showBackForwardList() {
+        showBackForwardListCalled += 1
     }
 
     func didFinish(from childCoordinator: Coordinator) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6505)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14599)

## :bulb: Description
I linked this pr to a closed issue, it's shouldn't be close, because the issue was split in two pr. 
Added show of `BackForwardListViewController` from `BrowserCoordinator`. 
All the modified unrelated files are there because i ran the swiftlint cli, if i should restore as previous state let me know, thank you.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

