### PR TITLE
Add FXIOS-7899 [v123] Engine session observers

### DIFF
--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineKVOConstants.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineKVOConstants.swift
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// Constants use to monitor WKEngineWebView changes with KVO
+enum WKEngineKVOConstants: String, CaseIterable {
+    case loading
+    case estimatedProgress
+    case URL
+    case title
+    case canGoBack
+    case canGoForward
+    case contentSize
+}

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -154,7 +154,7 @@ class WKEngineSession: NSObject, EngineSession {
     override func observeValue(
         forKeyPath keyPath: String?,
         of object: Any?,
-        change: [NSKeyValueChangeKey : Any]?,
+        change: [NSKeyValueChangeKey: Any]?,
         context: UnsafeMutableRawPointer?
     ) {
         guard let keyPath, let path = WKEngineKVOConstants(rawValue: keyPath) else {

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -162,6 +162,7 @@ class WKEngineSession: NSObject, EngineSession {
             return
         }
 
+        // Will be used as needed when we start using the engine session
         switch path {
         case .canGoBack:
             break

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -6,7 +6,7 @@ import Common
 import Foundation
 import WebKit
 
-class WKEngineSession: EngineSession {
+class WKEngineSession: NSObject, EngineSession {
     weak var delegate: EngineSessionDelegate?
     private var webView: WKEngineWebView
     private var logger: Logger
@@ -26,10 +26,12 @@ class WKEngineSession: EngineSession {
         self.webView = webView
         self.logger = logger
         self.sessionData = sessionData
+        super.init()
 
-        // TODO: FXIOS-7899 #17644 Handle WKEngineSession observers
-//        self.webView.addObserver(self, forKeyPath: KVOConstants.URL.rawValue, options: .new, context: nil)
-//        self.webView.addObserver(self, forKeyPath: KVOConstants.title.rawValue, options: .new, context: nil)
+        self.setupObservers()
+
+        // TODO: FXIOS-8106 Add UI delegate
+//        webView.uiDelegate = self
 
         // TODO: FXIOS-7900 #17645 Handle WKEngineSession scripts
 //        UserScriptManager.shared.injectUserScriptsIntoWebView(webView, nightMode: nightMode, noImageMode: noImageMode)
@@ -118,15 +120,63 @@ class WKEngineSession: EngineSession {
         // TODO: FXIOS-7900 #17645 Handle WKEngineSession scripts
 //        contentScriptManager.uninstall(tab: self)
         webView.removeAllUserScripts()
-
-        // TODO: FXIOS-7899 #17644 Handle WKEngineSession observers
-//        webView.removeObserver(self, forKeyPath: KVOConstants.URL.rawValue)
-//        webView.removeObserver(self, forKeyPath: KVOConstants.title.rawValue)
+        removeObservers()
 
         // TODO: FXIOS-7901 #17646 Handle WKEngineSession tabDelegate
 //        tabDelegate?.tab(self, willDeleteWebView: webView)
 
         webView.navigationDelegate = nil
+        // TODO: FXIOS-8106 Add UI delegate
+//        webView.uiDelegate = nil
+
         webView.removeFromSuperview()
+    }
+
+    // MARK: Observe values
+
+    private func setupObservers() {
+        WKEngineKVOConstants.allCases.forEach {
+            webView.addObserver(
+                self,
+                forKeyPath: $0.rawValue,
+                options: .new,
+                context: nil
+            )
+        }
+    }
+
+    private func removeObservers() {
+        WKEngineKVOConstants.allCases.forEach {
+            webView.removeObserver(self, forKeyPath: $0.rawValue)
+        }
+    }
+
+    override func observeValue(
+        forKeyPath keyPath: String?,
+        of object: Any?,
+        change: [NSKeyValueChangeKey : Any]?,
+        context: UnsafeMutableRawPointer?
+    ) {
+        guard let keyPath, let path = WKEngineKVOConstants(rawValue: keyPath) else {
+            logger.log("Unhandled KVO key: \(keyPath ?? "nil")", level: .debug, category: .webview)
+            return
+        }
+
+        switch path {
+        case .canGoBack:
+            break
+        case .canGoForward:
+            break
+        case .contentSize:
+            break
+        case .estimatedProgress:
+            break
+        case .loading:
+            break
+        case .title:
+            break
+        case .URL:
+            break
+        }
     }
 }

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
@@ -20,6 +20,7 @@ protocol WKEngineWebView {
     var backgroundColor: UIColor? { get set }
     var interactionState: Any? { get set }
     var url: URL? { get }
+    var scrollView: UIScrollView { get }
 
     @available(iOS 16.4, *)
     var isInspectable: Bool { get set }
@@ -57,6 +58,15 @@ protocol WKEngineWebView {
     /// Use JS to redirect the page without adding a history entry
     /// - Parameter url: The URL to replace the location with
     func replaceLocation(with url: URL)
+
+    func addObserver(
+        _ observer: NSObject,
+        forKeyPath keyPath: String,
+        options: NSKeyValueObservingOptions,
+        context: UnsafeMutableRawPointer?
+    )
+
+    func removeObserver(_ observer: NSObject, forKeyPath keyPath: String)
 }
 
 extension WKEngineWebView {

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebView.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebView.swift
@@ -79,14 +79,14 @@ class MockWKEngineWebView: WKEngineWebView {
         removeFromSuperviewCalled += 1
     }
 
-    func addObserver(_ observer: NSObject, 
+    func addObserver(_ observer: NSObject,
                      forKeyPath keyPath: String,
                      options: NSKeyValueObservingOptions,
                      context: UnsafeMutableRawPointer?) {
         addObserverCalled += 1
     }
 
-    func removeObserver(_ observer: NSObject, 
+    func removeObserver(_ observer: NSObject,
                         forKeyPath keyPath: String) {
         removeObserverCalled += 1
     }

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebView.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebView.swift
@@ -8,6 +8,7 @@ import WebKit
 
 class MockWKEngineWebView: WKEngineWebView {
     var interactionState: Any?
+    var scrollView = UIScrollView()
     var url: URL?
     var navigationDelegate: WKNavigationDelegate?
     var allowsBackForwardNavigationGestures = true
@@ -25,6 +26,8 @@ class MockWKEngineWebView: WKEngineWebView {
     var goForwardCalled = 0
     var removeAllUserScriptsCalled = 0
     var removeFromSuperviewCalled = 0
+    var addObserverCalled = 0
+    var removeObserverCalled = 0
 
     var loadFileReadAccessURL: URL?
 
@@ -74,5 +77,17 @@ class MockWKEngineWebView: WKEngineWebView {
 
     func removeFromSuperview() {
         removeFromSuperviewCalled += 1
+    }
+
+    func addObserver(_ observer: NSObject, 
+                     forKeyPath keyPath: String,
+                     options: NSKeyValueObservingOptions,
+                     context: UnsafeMutableRawPointer?) {
+        addObserverCalled += 1
+    }
+
+    func removeObserver(_ observer: NSObject, 
+                        forKeyPath keyPath: String) {
+        removeObserverCalled += 1
     }
 }

--- a/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
@@ -151,6 +151,21 @@ final class WKEngineSessionTests: XCTestCase {
         XCTAssertEqual(webViewProvider.webView.loadCalled, 2, "Load calls it once, then restore calls it again")
     }
 
+    // MARK: Observers
+
+    func testAddObserversWhenCreatedSubjectThenObserversAreAdded() {
+        _ = createSubject()
+        XCTAssertEqual(webViewProvider.webView.addObserverCalled, 7, "There are 7 KVO Constants")
+    }
+
+    func testRemoveObserversWhenCloseIsCalledThenObserversAreRemoved() {
+        let subject = createSubject()
+
+        subject?.close()
+
+        XCTAssertEqual(webViewProvider.webView.removeObserverCalled, 7, "There are 7 KVO Constants")
+    }
+
     // MARK: Helper
 
     func createSubject() -> WKEngineSession? {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7899)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17644)

## :bulb: Description
Add observers on the web view so we can observe different changes like the title, URL, estimated progress and so on. This is the setup only for those observers, actually using them in callbacks will be done later when needed.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

