### PR TITLE
Bugfix FXIOS-8105 [v121] Fix Send to Device failing intermittently

### DIFF
--- a/firefox-ios/Extensions/ShareTo/ShareViewController.swift
+++ b/firefox-ios/Extensions/ShareTo/ShareViewController.swift
@@ -485,10 +485,10 @@ extension ShareViewController {
         guard let shareItem = shareItem, case .shareItem(let item) = shareItem else { return }
 
         gesture.isEnabled = false
-        sendToDevice = SendToDevice()
-        guard let sendToDevice = sendToDevice else { return }
+        self.sendToDevice = SendToDevice()
+        guard let sendToDevice = self.sendToDevice else { return }
         sendToDevice.sharedItem = item
-        sendToDevice.delegate = delegate
+        sendToDevice.delegate = self.delegate
         let vc = sendToDevice.initialViewController()
         navigationController?.pushViewController(vc, animated: true)
     }

--- a/firefox-ios/Extensions/ShareTo/ShareViewController.swift
+++ b/firefox-ios/Extensions/ShareTo/ShareViewController.swift
@@ -95,24 +95,21 @@ class ShareViewController: UIViewController {
         setupNavBar()
         setupStackView()
 
-        guard RustFirefoxAccounts.shared.hasAccount() else {
-            // Show brief spinner in UI while necessary startup is finishing
+        if RustFirefoxAccounts.shared.accountManager == nil {
+            // Show brief spinner in UI while startup is finishing
             showProgressIndicator()
 
             let profile = BrowserProfile(localName: "profile")
             Viaduct.shared.useReqwestBackend()
             RustFirefoxAccounts.startup(prefs: profile.prefs) { [weak self] _ in
-                // Hide spinner and finish UI setup
-                // (Note: this completion block is currently guaranteed
-                // to arrive on the main thread. No dispatch needed.)
+                // Hide spinner and finish UI setup (Note: this completion
+                // block is currently guaranteed to arrive on main thread.)
                 self?.hideProgressIndicator()
                 self?.finalizeUISetup()
             }
-
-            return
+        } else {
+            finalizeUISetup()
         }
-
-        finalizeUISetup()
     }
 
     private func finalizeUISetup() {

--- a/firefox-ios/Extensions/ShareTo/ShareViewController.swift
+++ b/firefox-ios/Extensions/ShareTo/ShareViewController.swift
@@ -68,6 +68,7 @@ class ShareViewController: UIViewController {
     var shareItem: ExtensionUtils.ExtractedShareItem?
     private var viewsShownDuringDoneAnimation = [UIView]()
     private var stackView: UIStackView!
+    private var spinner: UIActivityIndicatorView?
     private var actionDoneRow: (row: UIStackView, label: UILabel)!
     private var sendToDevice: SendToDevice?
     private var pageInfoHeight: NSLayoutConstraint?
@@ -93,6 +94,28 @@ class ShareViewController: UIViewController {
 
         setupNavBar()
         setupStackView()
+
+        guard RustFirefoxAccounts.shared.hasAccount() else {
+            // Show brief spinner in UI while necessary startup is finishing
+            showProgressIndicator()
+
+            let profile = BrowserProfile(localName: "profile")
+            Viaduct.shared.useReqwestBackend()
+            RustFirefoxAccounts.startup(prefs: profile.prefs) { [weak self] _ in
+                // Hide spinner and finish UI setup
+                // (Note: this completion block is currently guaranteed
+                // to arrive on the main thread. No dispatch needed.)
+                self?.hideProgressIndicator()
+                self?.finalizeUISetup()
+            }
+
+            return
+        }
+
+        finalizeUISetup()
+    }
+
+    private func finalizeUISetup() {
         setupRows()
 
         guard let shareItem = shareItem else { return }
@@ -104,10 +127,6 @@ class ShareViewController: UIViewController {
         case .rawText(let text):
             self.pageInfoRowTitleLabel?.text = text.quoted
         }
-
-        let profile = BrowserProfile(localName: "profile")
-        Viaduct.shared.useReqwestBackend()
-        RustFirefoxAccounts.startup(prefs: profile.prefs) { _ in }
     }
 
     private func setupRows() {
@@ -383,6 +402,27 @@ class ShareViewController: UIViewController {
             stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
          ])
     }
+
+    private func showProgressIndicator() {
+        let indicator = UIActivityIndicatorView(style: .large)
+        let defaultSize = CGSize(width: 40.0, height: 40.0)
+        view.addSubview(indicator)
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            indicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            indicator.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            indicator.widthAnchor.constraint(equalToConstant: defaultSize.width),
+            indicator.heightAnchor.constraint(equalToConstant: defaultSize.height),
+         ])
+        indicator.startAnimating()
+        spinner = indicator
+    }
+
+    private func hideProgressIndicator() {
+        spinner?.stopAnimating()
+        spinner?.removeFromSuperview()
+        spinner = nil
+    }
 }
 
 extension ShareViewController {
@@ -449,15 +489,13 @@ extension ShareViewController {
 
         gesture.isEnabled = false
         view.isUserInteractionEnabled = false
-        if RustFirefoxAccounts.shared.accountManager != nil {
-            self.view.isUserInteractionEnabled = true
-            self.sendToDevice = SendToDevice()
-            guard let sendToDevice = self.sendToDevice else { return }
-            sendToDevice.sharedItem = item
-            sendToDevice.delegate = self.delegate
-            let vc = sendToDevice.initialViewController()
-            self.navigationController?.pushViewController(vc, animated: true)
-        }
+        self.view.isUserInteractionEnabled = true
+        self.sendToDevice = SendToDevice()
+        guard let sendToDevice = self.sendToDevice else { return }
+        sendToDevice.sharedItem = item
+        sendToDevice.delegate = self.delegate
+        let vc = sendToDevice.initialViewController()
+        self.navigationController?.pushViewController(vc, animated: true)
     }
 
     func openFirefox(withUrl url: String, isSearch: Bool) {

--- a/firefox-ios/Extensions/ShareTo/ShareViewController.swift
+++ b/firefox-ios/Extensions/ShareTo/ShareViewController.swift
@@ -485,14 +485,12 @@ extension ShareViewController {
         guard let shareItem = shareItem, case .shareItem(let item) = shareItem else { return }
 
         gesture.isEnabled = false
-        view.isUserInteractionEnabled = false
-        self.view.isUserInteractionEnabled = true
-        self.sendToDevice = SendToDevice()
-        guard let sendToDevice = self.sendToDevice else { return }
+        sendToDevice = SendToDevice()
+        guard let sendToDevice = sendToDevice else { return }
         sendToDevice.sharedItem = item
-        sendToDevice.delegate = self.delegate
+        sendToDevice.delegate = delegate
         let vc = sendToDevice.initialViewController()
-        self.navigationController?.pushViewController(vc, animated: true)
+        navigationController?.pushViewController(vc, animated: true)
     }
 
     func openFirefox(withUrl url: String, isSearch: Bool) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8105)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18037)

## :bulb: Description

Fix for an intermittent bug that can cause Send to Device to fail. The issue appears to be a potential race between the UI setup code and the RustFXAccounts `startup()`. There are a few different solutions we can explore for addressing this; the approach here was the most straightforward solution I could find with the current info I have. This area could likely use additional discussion, particularly with UX/UI teams, to revisit how we're handling situations like this where we need to accommodate for possible delays in code that is required before the user can take certain share actions.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

