### PR TITLE
Refactor FXIOS-7700 [v123] Fix Warnings about LegacyResizableButton

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -602,7 +602,8 @@ public struct AccessibilityIdentifiers {
 
     struct RememberCreditCard {
         static let rememberCreditCardHeader = "RememberCreditCard.Header"
-        static let yesButton = "RememberCreditCard.yesButton"
+        static let saveButton = "RememberCreditCard.saveButton"
+        static let manageCardsButton = "RememberCreditCard.manageCardsButton"
         static let notNowButton = "RememberCreditCard.notNowButton"
     }
 }

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -602,7 +602,7 @@ public struct AccessibilityIdentifiers {
 
     struct RememberCreditCard {
         static let rememberCreditCardHeader = "RememberCreditCard.Header"
-        static let saveButton = "RememberCreditCard.saveButton"
+        static let yesButton = "RememberCreditCard.yesButton"
         static let manageCardsButton = "RememberCreditCard.manageCardsButton"
         static let notNowButton = "RememberCreditCard.notNowButton"
     }

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetFooterView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetFooterView.swift
@@ -17,7 +17,7 @@ class CreditCardBottomSheetFooterView: UITableViewHeaderFooterView, ReusableCell
         static let titleVerticalLongPadding: CGFloat = 20
     }
 
-    public lazy var manageCardsButton: PrimaryRoundedButton = .build { button in
+    public lazy var manageCardsButton: LinkButton = .build { button in
         button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(
             withTextStyle: .callout,
             size: UX.manageCardsButtonFontSize)

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetFooterView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetFooterView.swift
@@ -15,29 +15,12 @@ class CreditCardBottomSheetFooterView: UITableViewHeaderFooterView, ReusableCell
         static let manageCardsButtonBottomSpace: CGFloat = 24
     }
 
-    public lazy var manageCardsButton: LinkButton  = .build { button in
-//        button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(
-//            withTextStyle: .callout,
-//            size: UX.manageCardsButtonFontSize)
-//        button.setTitle(.CreditCard.UpdateCreditCard.ManageCardsButtonTitle, for: .normal)
-//        button.titleLabel?.textAlignment = .left
-//        button.contentHorizontalAlignment = .left
-//        button.titleLabel?.adjustsFontForContentSizeCategory = true
-//        button.accessibilityIdentifier = AccessibilityIdentifiers.RememberCreditCard.manageCardsButton
-    }
+    public lazy var manageCardsButton = LinkButton()
 
     override init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)
-        contentView.addSubview(manageCardsButton)
+        setupManageCardsButton()
         setupView()
-
-        let buttonViewModel = LinkButtonViewModel(
-            title: .CreditCard.UpdateCreditCard.ManageCardsButtonTitle,
-            a11yIdentifier: AccessibilityIdentifiers.RememberCreditCard.manageCardsButton,
-            fontSize: UX.manageCardsButtonFontSize,
-            contentHorizontalAlignment: .left
-        )
-        manageCardsButton.configure(viewModel: buttonViewModel)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -47,6 +30,18 @@ class CreditCardBottomSheetFooterView: UITableViewHeaderFooterView, ReusableCell
     func applyTheme(theme: Theme) {
         contentView.backgroundColor = theme.colors.layer1
         manageCardsButton.applyTheme(theme: theme)
+    }
+
+    func setupManageCardsButton() {
+        contentView.addSubview(manageCardsButton)
+        let buttonViewModel = LinkButtonViewModel(
+            title: .CreditCard.UpdateCreditCard.ManageCardsButtonTitle,
+            a11yIdentifier: AccessibilityIdentifiers.RememberCreditCard.manageCardsButton,
+            fontSize: UX.manageCardsButtonFontSize,
+            contentHorizontalAlignment: .left
+        )
+
+        manageCardsButton.configure(viewModel: buttonViewModel)
     }
 
     private func setupView() {

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetFooterView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetFooterView.swift
@@ -15,7 +15,7 @@ class CreditCardBottomSheetFooterView: UITableViewHeaderFooterView, ReusableCell
         static let manageCardsButtonBottomSpace: CGFloat = 24
     }
 
-    public lazy var manageCardsButton = LinkButton()
+    public lazy var manageCardsButton: LinkButton  = .build { button in }
 
     override init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetFooterView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetFooterView.swift
@@ -13,25 +13,31 @@ class CreditCardBottomSheetFooterView: UITableViewHeaderFooterView, ReusableCell
         static let manageCardsButtonLeadingSpace: CGFloat = 0
         static let manageCardsButtonTopSpace: CGFloat = 24
         static let manageCardsButtonBottomSpace: CGFloat = 24
-        static let titleVerticalPadding: CGFloat = 6
-        static let titleVerticalLongPadding: CGFloat = 20
     }
 
-    public lazy var manageCardsButton: LinkButton = .build { button in
-        button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(
-            withTextStyle: .callout,
-            size: UX.manageCardsButtonFontSize)
-        button.setTitle(.CreditCard.UpdateCreditCard.ManageCardsButtonTitle, for: .normal)
-        button.titleLabel?.textAlignment = .left
-        button.contentHorizontalAlignment = .left
-        button.titleLabel?.adjustsFontForContentSizeCategory = true
-        button.accessibilityIdentifier = AccessibilityIdentifiers.RememberCreditCard.manageCardsButton
+    public lazy var manageCardsButton: LinkButton  = .build { button in
+//        button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(
+//            withTextStyle: .callout,
+//            size: UX.manageCardsButtonFontSize)
+//        button.setTitle(.CreditCard.UpdateCreditCard.ManageCardsButtonTitle, for: .normal)
+//        button.titleLabel?.textAlignment = .left
+//        button.contentHorizontalAlignment = .left
+//        button.titleLabel?.adjustsFontForContentSizeCategory = true
+//        button.accessibilityIdentifier = AccessibilityIdentifiers.RememberCreditCard.manageCardsButton
     }
 
     override init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)
         contentView.addSubview(manageCardsButton)
         setupView()
+
+        let buttonViewModel = LinkButtonViewModel(
+            title: .CreditCard.UpdateCreditCard.ManageCardsButtonTitle,
+            a11yIdentifier: AccessibilityIdentifiers.RememberCreditCard.manageCardsButton,
+            fontSize: UX.manageCardsButtonFontSize,
+            contentHorizontalAlignment: .left
+        )
+        manageCardsButton.configure(viewModel: buttonViewModel)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -40,7 +46,7 @@ class CreditCardBottomSheetFooterView: UITableViewHeaderFooterView, ReusableCell
 
     func applyTheme(theme: Theme) {
         contentView.backgroundColor = theme.colors.layer1
-        manageCardsButton.setTitleColor(theme.colors.textAccent, for: .normal)
+        manageCardsButton.applyTheme(theme: theme)
     }
 
     private func setupView() {

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetFooterView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetFooterView.swift
@@ -17,7 +17,7 @@ class CreditCardBottomSheetFooterView: UITableViewHeaderFooterView, ReusableCell
         static let titleVerticalLongPadding: CGFloat = 20
     }
 
-    public lazy var manageCardsButton: LegacyResizableButton = .build { button in
+    public lazy var manageCardsButton: PrimaryRoundedButton = .build { button in
         button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(
             withTextStyle: .callout,
             size: UX.manageCardsButtonFontSize)
@@ -25,7 +25,7 @@ class CreditCardBottomSheetFooterView: UITableViewHeaderFooterView, ReusableCell
         button.titleLabel?.textAlignment = .left
         button.contentHorizontalAlignment = .left
         button.titleLabel?.adjustsFontForContentSizeCategory = true
-        button.accessibilityIdentifier = AccessibilityIdentifiers.RememberCreditCard.yesButton
+        button.accessibilityIdentifier = AccessibilityIdentifiers.RememberCreditCard.manageCardsButton
     }
 
     override init(reuseIdentifier: String?) {

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
@@ -143,7 +143,7 @@ class CreditCardBottomSheetViewController: UIViewController,
             buttonsContainerStackView.addArrangedSubview(yesButton)
             let buttonViewModel = PrimaryRoundedButtonViewModel(
                 title: .CreditCard.RememberCreditCard.MainButtonTitle,
-                a11yIdentifier: AccessibilityIdentifiers.RememberCreditCard.saveButton
+                a11yIdentifier: AccessibilityIdentifiers.RememberCreditCard.yesButton
             )
             yesButton.configure(viewModel: buttonViewModel)
             yesButton.applyTheme(theme: themeManager.currentTheme)

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
@@ -85,15 +85,8 @@ class CreditCardBottomSheetViewController: UIViewController,
         stack.spacing = UX.buttonsSpacing
     }
 
-    private lazy var yesButton: LegacyResizableButton = .build { button in
-        button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(
-            withTextStyle: .headline,
-            size: UX.yesButtonFontSize)
+    private lazy var yesButton: PrimaryRoundedButton = .build { button in
         button.addTarget(self, action: #selector(self.didTapYes), for: .touchUpInside)
-        button.setTitle(.CreditCard.RememberCreditCard.MainButtonTitle, for: .normal)
-        button.layer.cornerRadius = UX.yesButtonCornerRadius
-        button.titleLabel?.adjustsFontForContentSizeCategory = true
-        button.accessibilityIdentifier = AccessibilityIdentifiers.RememberCreditCard.yesButton
     }
 
     private var contentViewHeightConstraint: NSLayoutConstraint!
@@ -148,7 +141,14 @@ class CreditCardBottomSheetViewController: UIViewController,
     func addSubviews() {
         if viewModel.state != .selectSavedCard {
             buttonsContainerStackView.addArrangedSubview(yesButton)
+            let buttonViewModel = PrimaryRoundedButtonViewModel(
+                title: .CreditCard.RememberCreditCard.MainButtonTitle,
+                a11yIdentifier: AccessibilityIdentifiers.RememberCreditCard.saveButton
+            )
+            yesButton.configure(viewModel: buttonViewModel)
+            yesButton.applyTheme(theme: themeManager.currentTheme)
         }
+
         contentView.addSubviews(cardTableView, buttonsContainerStackView)
         view.addSubview(contentView)
     }
@@ -354,15 +354,12 @@ class CreditCardBottomSheetViewController: UIViewController,
 
     // MARK: Themable
     func applyTheme() {
-        let currentTheme = themeManager.currentTheme
-        view.backgroundColor = currentTheme.colors.layer1
-        yesButton.backgroundColor = currentTheme.colors.actionPrimary
-        yesButton.setTitleColor(currentTheme.colors.textInverted, for: .normal)
+        let currentTheme = themeManager.currentTheme.colors
+        view.backgroundColor = currentTheme.layer1
         cardTableView.reloadData()
     }
 
     // MARK: Telemetry
-
     fileprivate func sendCreditCardAutofillPromptDismissedTelemetry() {
         TelemetryWrapper.recordEvent(category: .action,
                                      method: .close,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Changes the `yesButton` to `PrimaryRoundedButton` and `manageCardsButton` to `LinkButton` in the `CreditCardBottomSheet`. Added the corresponding viewModels and and configurations to the new views.
For `manageCardsButton` I noticed that the button selectors are set on line 322 of `CreditCardBottomSheetViewController` and have some logic/interaction through that selector setting with the Coordinator, so I opted not to touch that since it seemed a bit out of scope for this ticket, but I'm happy to make a follow up ticket to refactor that part further if someone with more experience in that part of the codebase can take a look and see if it's worth it.
I also added a separate accessibility identifier for `manageCards` since it was reusing `yesButtons` identifier before.
I confirmed that the change was reflected in Dark and Light themes.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

## Screenshots

### Before
![Simulator Screenshot - iPhone 15 Plus - 2024-01-08 at 21 27 47](https://github.com/mozilla-mobile/firefox-ios/assets/5545720/dd340bbc-6322-41b8-bfd3-7c80b1981b21)
![Simulator Screenshot - iPhone 15 Plus - 2024-01-08 at 21 27 12](https://github.com/mozilla-mobile/firefox-ios/assets/5545720/6bcd3db1-910e-4a4f-b104-54ce957bb8b9)

### After
![Simulator Screenshot - iPhone 15 Plus - 2024-01-08 at 21 50 44](https://github.com/mozilla-mobile/firefox-ios/assets/5545720/1436367b-1c58-436b-8534-986231e33283)
![Simulator Screenshot - iPhone 15 Plus - 2024-01-08 at 21 22 06](https://github.com/mozilla-mobile/firefox-ios/assets/5545720/4cef4b66-2c3e-4afc-a686-d19b9017105a)
