### PR TITLE
Refactor FXIOS-7704 [v123] Fix contentEdgeInsets in FakespotMessageCardView

### DIFF
--- a/firefox-ios/Client/Frontend/Fakespot/Views/FakespotMessageCardView.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/Views/FakespotMessageCardView.swift
@@ -131,10 +131,13 @@ final class FakespotMessageCardView: UIView, ThemeApplicable, Notifiable {
     private enum UX {
         static let linkFontSize: CGFloat = 12
         static let buttonFontSize: CGFloat = 16
+<<<<<<< HEAD
         static let progressViewFontSize: CGFloat = 15
         static let buttonVerticalInset: CGFloat = 12
         static let buttonHorizontalInset: CGFloat = 16
         static let buttonCornerRadius: CGFloat = 13
+=======
+>>>>>>> bfef0d9b7 (Fixed white space, implemented ViewModel, preserved fonts, removed redundant color assignments.)
         static let contentHorizontalSpacing: CGFloat = 4
         static let contentVerticalSpacing: CGFloat = 8
         static let iconStackViewSpacing: CGFloat = 4
@@ -197,7 +200,6 @@ final class FakespotMessageCardView: UIView, ThemeApplicable, Notifiable {
         button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(
             withTextStyle: .caption1,
             size: UX.linkFontSize)
-        button.contentHorizontalAlignment = .leading
         button.addTarget(self, action: #selector(self.linkAction), for: .touchUpInside)
     }
 
@@ -205,13 +207,8 @@ final class FakespotMessageCardView: UIView, ThemeApplicable, Notifiable {
         button.titleLabel?.font = DefaultDynamicFontHelper.preferredBoldFont(
             withTextStyle: .callout,
             size: UX.buttonFontSize)
-        button.layer.cornerRadius = UX.buttonCornerRadius
         button.titleLabel?.textAlignment = .center
         button.addTarget(self, action: #selector(self.primaryAction), for: .touchUpInside)
-        button.configuration?.contentInsets = NSDirectionalEdgeInsets(top: UX.buttonVerticalInset,
-                                                                      leading: UX.buttonHorizontalInset,
-                                                                      bottom: UX.buttonVerticalInset,
-                                                                      trailing: UX.buttonHorizontalInset)
     }
 
     private var iconContainerHeightConstraint: NSLayoutConstraint?
@@ -282,8 +279,10 @@ final class FakespotMessageCardView: UIView, ThemeApplicable, Notifiable {
         ])
 
         if let primaryActionText = viewModel.primaryActionText {
-            primaryButton.setTitle(primaryActionText, for: .normal)
-            primaryButton.accessibilityIdentifier = viewModel.a11yPrimaryActionIdentifier
+            let primaryButtonViewModel = PrimaryRoundedButtonViewModel(
+                    title: primaryActionText,
+                    a11yIdentifier: viewModel.a11yPrimaryActionIdentifier ?? "")
+            primaryButton.configure(viewModel: primaryButtonViewModel)
             if primaryButton.superview == nil {
                 containerStackView.addArrangedSubview(primaryButton)
             }
@@ -302,8 +301,12 @@ final class FakespotMessageCardView: UIView, ThemeApplicable, Notifiable {
         }
 
         if let linkText = viewModel.linkText {
-            linkButton.setTitle(linkText, for: .normal)
-            linkButton.accessibilityIdentifier = viewModel.a11yLinkActionIdentifier
+            let linkButtonViewModel = LinkButtonViewModel(
+                title: linkText,
+                a11yIdentifier: viewModel.a11yLinkActionIdentifier ?? "",
+                fontSize: UX.linkFontSize,
+                contentHorizontalAlignment: .leading)
+            linkButton.configure(viewModel: linkButtonViewModel)
             if linkButton.superview == nil {
                 labelContainerStackView.addArrangedSubview(linkButton)
             }
@@ -379,11 +382,7 @@ final class FakespotMessageCardView: UIView, ThemeApplicable, Notifiable {
         titleLabel.textColor = colors.textPrimary
         descriptionLabel.textColor  = colors.textPrimary
         iconContainerView.tintColor = colors.textPrimary
-
-        linkButton.setTitleColor(colors.textPrimary, for: .normal)
-        primaryButton.setTitleColor(type.primaryButtonTextColor(theme: theme), for: .normal)
-        primaryButton.backgroundColor = type.primaryButtonBackground(theme: theme)
-
+        containerStackView.backgroundColor = .clear
         cardView.applyTheme(theme: theme)
         linkButton.applyTheme(theme: theme)
         primaryButton.applyTheme(theme: theme)

--- a/firefox-ios/Client/Frontend/Fakespot/Views/FakespotMessageCardView.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/Views/FakespotMessageCardView.swift
@@ -131,13 +131,10 @@ final class FakespotMessageCardView: UIView, ThemeApplicable, Notifiable {
     private enum UX {
         static let linkFontSize: CGFloat = 12
         static let buttonFontSize: CGFloat = 16
-<<<<<<< HEAD
         static let progressViewFontSize: CGFloat = 15
         static let buttonVerticalInset: CGFloat = 12
         static let buttonHorizontalInset: CGFloat = 16
         static let buttonCornerRadius: CGFloat = 13
-=======
->>>>>>> bfef0d9b7 (Fixed white space, implemented ViewModel, preserved fonts, removed redundant color assignments.)
         static let contentHorizontalSpacing: CGFloat = 4
         static let contentVerticalSpacing: CGFloat = 8
         static let iconStackViewSpacing: CGFloat = 4

--- a/firefox-ios/Client/Frontend/Fakespot/Views/FakespotMessageCardView.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/Views/FakespotMessageCardView.swift
@@ -193,28 +193,25 @@ final class FakespotMessageCardView: UIView, ThemeApplicable, Notifiable {
         label.setContentCompressionResistancePriority(.required, for: .vertical)
     }
 
-    private lazy var linkButton: LegacyResizableButton = .build { button in
+    private lazy var linkButton: LinkButton = .build { button in
         button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(
             withTextStyle: .caption1,
             size: UX.linkFontSize)
-        button.buttonEdgeSpacing = 0
         button.contentHorizontalAlignment = .leading
         button.addTarget(self, action: #selector(self.linkAction), for: .touchUpInside)
-        button.titleLabel?.adjustsFontForContentSizeCategory = true
     }
 
-    private lazy var primaryButton: LegacyResizableButton = .build { button in
+    private lazy var primaryButton: PrimaryRoundedButton = .build { button in
         button.titleLabel?.font = DefaultDynamicFontHelper.preferredBoldFont(
             withTextStyle: .callout,
             size: UX.buttonFontSize)
         button.layer.cornerRadius = UX.buttonCornerRadius
         button.titleLabel?.textAlignment = .center
         button.addTarget(self, action: #selector(self.primaryAction), for: .touchUpInside)
-        button.titleLabel?.adjustsFontForContentSizeCategory = true
-        button.contentEdgeInsets = UIEdgeInsets(top: UX.buttonVerticalInset,
-                                                left: UX.buttonHorizontalInset,
-                                                bottom: UX.buttonVerticalInset,
-                                                right: UX.buttonHorizontalInset)
+        button.configuration?.contentInsets = NSDirectionalEdgeInsets(top: UX.buttonVerticalInset,
+                                                                      leading: UX.buttonHorizontalInset,
+                                                                      bottom: UX.buttonVerticalInset,
+                                                                      trailing: UX.buttonHorizontalInset)
     }
 
     private var iconContainerHeightConstraint: NSLayoutConstraint?
@@ -378,14 +375,18 @@ final class FakespotMessageCardView: UIView, ThemeApplicable, Notifiable {
 
     // MARK: - ThemeApplicable
     func applyTheme(theme: Theme) {
-        titleLabel.textColor = theme.colors.textPrimary
-        descriptionLabel.textColor  = theme.colors.textPrimary
-        iconContainerView.tintColor = theme.colors.textPrimary
+        let colors = theme.colors
+        titleLabel.textColor = colors.textPrimary
+        descriptionLabel.textColor  = colors.textPrimary
+        iconContainerView.tintColor = colors.textPrimary
 
-        linkButton.setTitleColor(theme.colors.textPrimary, for: .normal)
+        linkButton.setTitleColor(colors.textPrimary, for: .normal)
         primaryButton.setTitleColor(type.primaryButtonTextColor(theme: theme), for: .normal)
         primaryButton.backgroundColor = type.primaryButtonBackground(theme: theme)
+
         cardView.applyTheme(theme: theme)
+        linkButton.applyTheme(theme: theme)
+        primaryButton.applyTheme(theme: theme)
     }
 
     private func adjustLayout() {

--- a/firefox-ios/Client/Frontend/Fakespot/Views/FakespotMessageCardView.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/Views/FakespotMessageCardView.swift
@@ -194,16 +194,10 @@ final class FakespotMessageCardView: UIView, ThemeApplicable, Notifiable {
     }
 
     private lazy var linkButton: LinkButton = .build { button in
-        button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(
-            withTextStyle: .caption1,
-            size: UX.linkFontSize)
         button.addTarget(self, action: #selector(self.linkAction), for: .touchUpInside)
     }
 
     private lazy var primaryButton: PrimaryRoundedButton = .build { button in
-        button.titleLabel?.font = DefaultDynamicFontHelper.preferredBoldFont(
-            withTextStyle: .callout,
-            size: UX.buttonFontSize)
         button.addTarget(self, action: #selector(self.primaryAction), for: .touchUpInside)
     }
 

--- a/firefox-ios/Client/Frontend/Fakespot/Views/FakespotMessageCardView.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/Views/FakespotMessageCardView.swift
@@ -207,7 +207,6 @@ final class FakespotMessageCardView: UIView, ThemeApplicable, Notifiable {
         button.titleLabel?.font = DefaultDynamicFontHelper.preferredBoldFont(
             withTextStyle: .callout,
             size: UX.buttonFontSize)
-        button.titleLabel?.textAlignment = .center
         button.addTarget(self, action: #selector(self.primaryAction), for: .touchUpInside)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7704)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17184)

## :bulb: Description
This pull request resolves an issue related to contentEdgeInsets in the FakespotMessageCardView. LinkButton and primaryButton were incorrectly subclassing LegacyResizableButton and have been updated to use the appropriate subclasses from the ComponentLibrary:

- LinkButton now subclasses LinkButton from the ComponentLibrary.
- primaryButton now subclasses PrimaryRoundedButton from the ComponentLibrary.

This change addresses warnings and ensures correct handling of contentEdgeInsets in the FakespotMessageCardView.

| Portrait  | Landscape | 
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-01-09 at 11 35 00](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/28a79955-d9cd-42a3-afbd-42764cc6b307) | ![Simulator Screenshot - iPhone 15 Pro - 2024-01-09 at 11 35 02](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/78f1f67c-7d94-49e5-bca0-d45319188d4e) |


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods