### PR TITLE
Remove FXIOS-7428 [v123] mobileAdsUserAgent (#16469)

### DIFF
--- a/firefox-ios/Shared/UserAgent.swift
+++ b/firefox-ios/Shared/UserAgent.swift
@@ -100,21 +100,10 @@ public enum UserAgentPlatform {
 public struct CustomUserAgentConstant {
     private static let defaultMobileUA = UserAgentBuilder.defaultMobileUserAgent().userAgent()
     private static let customDesktopUA = UserAgentBuilder.defaultDesktopUserAgent().clone(extensions: "Version/\(AppInfo.appVersion) \(UserAgent.uaBitSafari)")
-    private static let mobileAdsUA = UserAgentBuilder.defaultMobileUserAgent().clone(extensions: "\(UserAgent.uaBitMobile) \(UserAgent.uaBitSafari)")
 
-    // when clicking the videos on nba.com they make requests to
-    // demdex.net ,doubleclick.net, amazon-adsystem.com, rfihub.com as well
-    // and if the User Agent is different in any of those, the video on nba.com won't work either.
-    // Rokuchannel didn't have these restrictions
     public static let customUAFor = [
         "paypal.com": defaultMobileUA,
         "yahoo.com": defaultMobileUA,
-        "demdex.net": mobileAdsUA,
-        "doubleclick.net": mobileAdsUA,
-        "rfihub.com": mobileAdsUA,
-        "amazon-adsystem.com": mobileAdsUA,
-        "nba.com": mobileAdsUA,
-        "roku.com": mobileAdsUA,
         "disneyplus.com": customDesktopUA]
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7428)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16469)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Removed the mobile ads user agent as it's no longer needed by roku.com and nba.com
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

