### PR TITLE
Add  FXIOS-8067 [V123] support for Address autofill toggle persistence on empty state + Update empty state with a blue toggle

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -933,6 +933,7 @@
 		B2FEA68B2B460D1D0058E616 /* AddressAutofillSettingsEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2FEA68A2B460D1D0058E616 /* AddressAutofillSettingsEmptyView.swift */; };
 		B2FEA68D2B460D390058E616 /* AddressAutofillSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2FEA68C2B460D390058E616 /* AddressAutofillSettingsViewController.swift */; };
 		B2FEA68F2B460D9E0058E616 /* AddressAutofillSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2FEA68E2B460D9E0058E616 /* AddressAutofillSettingsViewModel.swift */; };
+		B2FEA6912B4661BE0058E616 /* AddressAutofillToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2FEA6902B4661BE0058E616 /* AddressAutofillToggle.swift */; };
 		B640467E29B9B58200C5C7B6 /* TabLocationViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B640467D29B9B58200C5C7B6 /* TabLocationViewTests.swift */; };
 		BCFF93EE2AAA9F6E005B5B71 /* RustFirefoxSuggest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF93ED2AAA9C47005B5B71 /* RustFirefoxSuggest.swift */; };
 		BCFF93F02AABA55A005B5B71 /* BackgroundFirefoxSuggestIngestUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF93EF2AAB97A8005B5B71 /* BackgroundFirefoxSuggestIngestUtility.swift */; };
@@ -6100,6 +6101,7 @@
 		B2FEA68A2B460D1D0058E616 /* AddressAutofillSettingsEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressAutofillSettingsEmptyView.swift; sourceTree = "<group>"; };
 		B2FEA68C2B460D390058E616 /* AddressAutofillSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressAutofillSettingsViewController.swift; sourceTree = "<group>"; };
 		B2FEA68E2B460D9E0058E616 /* AddressAutofillSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressAutofillSettingsViewModel.swift; sourceTree = "<group>"; };
+		B2FEA6902B4661BE0058E616 /* AddressAutofillToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressAutofillToggle.swift; sourceTree = "<group>"; };
 		B3154B289D2C0C247745D348 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Search.strings; sourceTree = "<group>"; };
 		B381465688459DB14B2A929C /* gu-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "gu-IN"; path = "gu-IN.lproj/LoginManager.strings"; sourceTree = "<group>"; };
 		B3D34760AD7FE14BBCD912E3 /* es-CL */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-CL"; path = "es-CL.lproj/Menu.strings"; sourceTree = "<group>"; };
@@ -9704,6 +9706,7 @@
 				B2FEA68A2B460D1D0058E616 /* AddressAutofillSettingsEmptyView.swift */,
 				B2FEA68C2B460D390058E616 /* AddressAutofillSettingsViewController.swift */,
 				B2FEA68E2B460D9E0058E616 /* AddressAutofillSettingsViewModel.swift */,
+				B2FEA6902B4661BE0058E616 /* AddressAutofillToggle.swift */,
 			);
 			path = Address;
 			sourceTree = "<group>";
@@ -13715,6 +13718,7 @@
 				2137785F297F3B1B00D01309 /* DownloadsPanelViewModel.swift in Sources */,
 				EBE26B57220C959D00D1D99A /* BrowserViewController+TabToolbarDelegate.swift in Sources */,
 				8A3EF7F02A2FCF3100796E3A /* HiddenSettings.swift in Sources */,
+				B2FEA6912B4661BE0058E616 /* AddressAutofillToggle.swift in Sources */,
 				B2FEA68F2B460D9E0058E616 /* AddressAutofillSettingsViewModel.swift in Sources */,
 				AB03032B2AB47AF300DCD8EF /* FakespotOptInCardView.swift in Sources */,
 				0BA02DB22942605600C92603 /* FormAutofillHelper.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -223,7 +223,7 @@ class SettingsCoordinator: BaseCoordinator,
     // MARK: PrivacySettingsDelegate
 
     func pressedAddressAutofill() {
-        let viewModel = AddressAutofillSettingsViewModel()
+        let viewModel = AddressAutofillSettingsViewModel(profile: profile)
         let viewController = AddressAutofillSettingsViewController(addressAutofillViewModel: viewModel)
         router.push(viewController)
     }

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsEmptyView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsEmptyView.swift
@@ -38,7 +38,7 @@ struct AddressAutofillSettingsEmptyView: View {
                         .padding(.top, 25)
                         .frame(maxWidth: .infinity)
 
-                    Spacer() // Spacer to fill remaining space
+                    Spacer()
                 }
                 .frame(minHeight: proxy.size.height)
             }

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsEmptyView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsEmptyView.swift
@@ -2,15 +2,18 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-/// TODO FXIOS-8067
 import SwiftUI
 import Common
 import Shared
 
+/// View for an empty state in address autofill settings, providing a placeholder or introductory content.
 struct AddressAutofillSettingsEmptyView: View {
+    // MARK: - Properties
+
     // Theming
     @Environment(\.themeType)
     var themeVal
+
     @State private var titleTextColor: Color = .clear
     @State private var subTextColor: Color = .clear
     @State private var toggleTextColor: Color = .clear
@@ -18,33 +21,42 @@ struct AddressAutofillSettingsEmptyView: View {
 
     @ObservedObject var toggleModel: ToggleModel
 
+    // MARK: - Body
+
     var body: some View {
         ZStack {
+            // Background
             UIColor.clear.color
                 .edgesIgnoringSafeArea(.all)
+
+            // Content
             GeometryReader { proxy in
-                ScrollView {
-                    VStack {
-                        /// TODO FXIOS-8067
-///                        AddressAutofillToggle(
-///                            textColor: toggleTextColor,
-///                            model: toggleModel)
-///                        .background(Color.white)
-///                       .padding(.top, 25)
-                    }
-                    .frame(minHeight: proxy.size.height)
+                VStack {
+                    // Address Autofill Toggle
+                    AddressAutofillToggle(model: toggleModel)
+                        .background(Color.white)
+                        .padding(.top, 25)
+                        .frame(maxWidth: .infinity)
+
+                    Spacer() // Spacer to fill remaining space
                 }
-                .frame(maxWidth: .infinity)
+                .frame(minHeight: proxy.size.height)
             }
         }
         .onAppear {
+            // Apply theme when the view appears
             applyTheme(theme: themeVal.theme)
         }
         .onChange(of: themeVal) { newThemeValue in
+            // React to changes in theme
             applyTheme(theme: newThemeValue.theme)
         }
     }
 
+    // MARK: - Theme Application
+
+    /// Apply the given theme to the view's appearance.
+    /// - Parameter theme: The theme to be applied.
     func applyTheme(theme: Theme) {
         let color = theme.colors
         titleTextColor = Color(color.textPrimary)
@@ -54,8 +66,11 @@ struct AddressAutofillSettingsEmptyView: View {
     }
 }
 
+// MARK: - Preview
+
 struct AddressAutofillSettingsEmptyView_Previews: PreviewProvider {
     static var previews: some View {
+        // Preview with a sample ToggleModel
         let toggleModel = ToggleModel(isEnabled: true)
         AddressAutofillSettingsEmptyView(toggleModel: toggleModel)
     }

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsEmptyView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsEmptyView.swift
@@ -6,7 +6,7 @@ import SwiftUI
 import Common
 import Shared
 
-/// View for an empty state in address autofill settings, providing a placeholder or introductory content.
+/// View for an empty state in address autofill settings
 struct AddressAutofillSettingsEmptyView: View {
     // MARK: - Properties
 

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsViewController.swift
@@ -4,25 +4,33 @@
 
 import UIKit
 import Common
+import SwiftUI
 
 // MARK: - AddressAutofillSettingsViewController
+
+/// View controller for managing address autofill settings.
 class AddressAutofillSettingsViewController: SensitiveViewController, Themeable {
     // MARK: Properties
 
-    // ViewModel for managing address autofill settings
+    /// ViewModel for managing address autofill settings.
     var viewModel: AddressAutofillSettingsViewModel
 
-    // Observer for theme changes
+    /// Observer for theme changes.
     var themeObserver: NSObjectProtocol?
 
-    // Manager responsible for handling themes
+    /// Manager responsible for handling themes.
     var themeManager: ThemeManager
 
-    // NotificationCenter for handling notifications
+    /// NotificationCenter for handling notifications.
     var notificationCenter: NotificationProtocol
 
-    // Logger for logging messages and events
+    /// Logger for logging messages and events.
     private let logger: Logger
+
+    // MARK: Views
+
+    /// Hosting controller for the empty state view in address autofill settings.
+    var addressAutofillEmptyView: UIHostingController<AddressAutofillSettingsEmptyView>
 
     // MARK: Initializers
 
@@ -40,7 +48,8 @@ class AddressAutofillSettingsViewController: SensitiveViewController, Themeable 
         self.themeManager = themeManager
         self.notificationCenter = notificationCenter
         self.logger = logger
-        // ... initialize other dependencies
+        let emptyView = AddressAutofillSettingsEmptyView(toggleModel: viewModel.toggleModel)
+        self.addressAutofillEmptyView = UIHostingController(rootView: emptyView)
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -54,8 +63,26 @@ class AddressAutofillSettingsViewController: SensitiveViewController, Themeable 
     /// Called after the controller's view is loaded into memory.
     override func viewDidLoad() {
         super.viewDidLoad()
+        viewSetup()
         listenForThemeChange(view)
         applyTheme()
+    }
+
+    /// Sets up the view hierarchy and initial configurations.
+    func viewSetup() {
+        guard let emptyAddressAutofillView = addressAutofillEmptyView.view else { return }
+        emptyAddressAutofillView.translatesAutoresizingMaskIntoConstraints = false
+
+        addChild(addressAutofillEmptyView)
+        view.addSubview(emptyAddressAutofillView)
+        self.title = .SettingsAddressAutofill
+
+        NSLayoutConstraint.activate([
+            emptyAddressAutofillView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            emptyAddressAutofillView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            emptyAddressAutofillView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            emptyAddressAutofillView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+        ])
     }
 
     // MARK: Themeable Protocol

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsViewModel.swift
@@ -12,10 +12,7 @@ class AddressAutofillSettingsViewModel {
     // MARK: Properties
 
     /// Model for managing the state of the address autofill toggle.
-    var toggleModel: ToggleModel!
-
-    /// Protocol for app authentication, providing secure access.
-    var appAuthenticator: AppAuthenticationProtocol?
+    lazy var toggleModel = ToggleModel(isEnabled: isAutofillEnabled, delegate: self)
 
     /// RustAutofill instance for handling autofill functionality.
     var autofill: RustAutofill?
@@ -46,12 +43,10 @@ class AddressAutofillSettingsViewModel {
     /// - Parameters:
     ///   - profile: The profile associated with the address autofill settings.
     ///   - appAuthenticator: Protocol for app authentication, providing secure access.
-    init(profile: Profile, appAuthenticator: AppAuthenticationProtocol = AppAuthenticator()) {
+    init(profile: Profile) {
         self.profile = profile
         guard let profile = profile as? BrowserProfile else { return }
         self.autofill = profile.autofill
-        self.appAuthenticator = appAuthenticator
-        self.toggleModel = ToggleModel(isEnabled: isAutofillEnabled, delegate: self)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsViewModel.swift
@@ -42,7 +42,6 @@ class AddressAutofillSettingsViewModel {
     /// Initializes the AddressAutofillSettingsViewModel.
     /// - Parameters:
     ///   - profile: The profile associated with the address autofill settings.
-    ///   - appAuthenticator: Protocol for app authentication, providing secure access.
     init(profile: Profile) {
         self.profile = profile
         guard let profile = profile as? BrowserProfile else { return }

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsViewModel.swift
@@ -2,24 +2,65 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import Foundation
-/// TODO FXIOS-8067
+import Shared
+import Storage
+
+// MARK: - AddressAutofillSettingsViewModel
+
+/// View model for managing address autofill settings.
 class AddressAutofillSettingsViewModel {
-    // This property holds the current state of address autofill settings
+    // MARK: Properties
+
+    /// Model for managing the state of the address autofill toggle.
+    var toggleModel: ToggleModel!
+
+    /// Protocol for app authentication, providing secure access.
+    var appAuthenticator: AppAuthenticationProtocol?
+
+    /// RustAutofill instance for handling autofill functionality.
+    var autofill: RustAutofill?
+
+    /// Profile associated with the address autofill settings.
+    var profile: Profile
+
+    /// Boolean indicating whether autofill is currently enabled.
     var isAutofillEnabled: Bool {
-        didSet {
-            // You can perform any additional actions when the value changes
-            // For example, save the new state to UserDefaults or send it to a server
-            UserDefaults.standard.set(isAutofillEnabled, forKey: "IsAutofillEnabled")
+        get {
+            let userDefaults = UserDefaults.standard
+            let key = PrefsKeys.KeyAutofillAddressStatus
+            guard userDefaults.value(forKey: key) != nil else {
+                // Default value is true for address autofill input
+                return true
+            }
+
+            return userDefaults.bool(forKey: key)
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: PrefsKeys.KeyAutofillAddressStatus)
         }
     }
 
-    // You can add other properties and methods as needed
+    // MARK: Initializer
 
-    init() {
-        // Initialize the state from UserDefaults or any other source
-        self.isAutofillEnabled = UserDefaults.standard.bool(forKey: "IsAutofillEnabled")
+    /// Initializes the AddressAutofillSettingsViewModel.
+    /// - Parameters:
+    ///   - profile: The profile associated with the address autofill settings.
+    ///   - appAuthenticator: Protocol for app authentication, providing secure access.
+    init(profile: Profile, appAuthenticator: AppAuthenticationProtocol = AppAuthenticator()) {
+        self.profile = profile
+        guard let profile = profile as? BrowserProfile else { return }
+        self.autofill = profile.autofill
+        self.appAuthenticator = appAuthenticator
+        self.toggleModel = ToggleModel(isEnabled: isAutofillEnabled, delegate: self)
     }
+}
 
-    // Add other methods or properties as needed
+// MARK: - ToggleModelDelegate
+
+extension AddressAutofillSettingsViewModel: ToggleModelDelegate {
+    /// Called when the state of the address autofill toggle changes.
+    /// - Parameter toggleModel: The toggle model whose state changed.
+    func toggleDidChange(_ toggleModel: ToggleModel) {
+        isAutofillEnabled = toggleModel.isEnabled
+    }
 }

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
@@ -45,26 +45,28 @@ struct AddressAutofillToggle: View {
             HStack {
                 // Left-aligned stack for title and description
                 VStack(alignment: .leading) {
+                    // Title for the Toggle
                     Text(String.Addresses.EditCard.ToggleToAllowAutofillTitle)
                         .font(.body)
                         .foregroundColor(textColor)
-                        .padding(.leading, 16)
-                        .padding(.trailing, 16)
 
+                    // Description for the Toggle
                     Text(String.Addresses.EditCard.PlaceholderToggleToAllowAutofillTitle)
                         .font(.footnote)
                         .foregroundColor(descriptionTextColor)
-                        .padding(.leading, 16)
-                        .padding(.trailing, 16)
                 }
+                .padding(.leading, 16)
+
+                Spacer()
 
                 // Toggle switch
                 Toggle(isOn: $model.isEnabled) {
                     EmptyView()
                 }
-                .labelsHidden()
                 .padding(.trailing, 16)
+                .labelsHidden()
                 .toggleStyle(SwitchToggleStyle(tint: toggleTintColor))
+                .frame(alignment: .trailing)
             }
 
             // Divider line to separate content

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
@@ -1,0 +1,106 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import SwiftUI
+import Shared
+
+// MARK: - AddressAutofillToggle
+
+/// A SwiftUI view representing a toggle with theming for address autofill functionality.
+struct AddressAutofillToggle: View {
+    // MARK: - Theming
+
+    /// The current theme type provided by the environment.
+    @Environment(\.themeType)
+    var themeVal
+
+    /// Text color for the view.
+    @State private var textColor: Color = .clear
+
+    /// Description text color for the view.
+    @State private var descriptionTextColor: Color = .clear
+
+    /// Background color for the view.
+    @State private var backgroundColor: Color = .clear
+
+    /// Toggle tint color for the view.
+    @State private var toggleTintColor: Color = .clear
+
+    /// Observed object representing the toggle state.
+    @ObservedObject var model: ToggleModel
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack {
+            // Divider line to separate content (hidden by default)
+            Divider()
+                .frame(height: 0.7)
+                .padding(.leading, 16)
+                .hidden()
+
+            // Horizontal stack containing title, description, and toggle
+            HStack {
+                // Left-aligned stack for title and description
+                VStack(alignment: .leading) {
+                    Text(String.Addresses.EditCard.ToggleToAllowAutofillTitle)
+                        .font(.body)
+                        .foregroundColor(textColor)
+                        .padding(.leading, 16)
+                        .padding(.trailing, 16)
+
+                    Text(String.Addresses.EditCard.PlaceholderToggleToAllowAutofillTitle)
+                        .font(.footnote)
+                        .foregroundColor(descriptionTextColor)
+                        .padding(.leading, 16)
+                        .padding(.trailing, 16)
+                }
+
+                // Toggle switch
+                Toggle(isOn: $model.isEnabled) {
+                    EmptyView()
+                }
+                .labelsHidden()
+                .padding(.trailing, 16)
+                .toggleStyle(SwitchToggleStyle(tint: toggleTintColor))
+            }
+
+            // Divider line to separate content
+            Divider()
+                .frame(height: 0.7)
+                .padding(.leading, 16)
+        }
+        .background(backgroundColor)
+        .onAppear {
+            // Apply theme when the view appears
+            applyTheme(theme: themeVal.theme)
+        }
+        .onChange(of: themeVal) { val in
+            // Reapply theme when the environment theme changes
+            applyTheme(theme: val.theme)
+        }
+    }
+
+    // MARK: - Theme Application
+
+    /// Apply the specified theme to the view's colors.
+    func applyTheme(theme: Theme) {
+        let color = theme.colors
+        textColor = Color(color.textPrimary)
+        descriptionTextColor = Color(color.textSecondary)
+        backgroundColor = Color(color.layer2)
+        toggleTintColor = Color(color.actionPrimary)
+    }
+}
+
+// MARK: - AutofillToggle_Previews
+
+/// A preview provider for the AddressAutofillToggle.
+struct AutofillToggle_Previews: PreviewProvider {
+    static var previews: some View {
+        let model = ToggleModel(isEnabled: true)
+        AddressAutofillToggle(model: model)
+    }
+ }

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -229,6 +229,24 @@ extension String {
     }
 }
 
+// MARK: - Address Autofill
+extension String {
+    public struct Addresses {
+        public struct EditCard {
+            public static let ToggleToAllowAutofillTitle = MZLocalizedString(
+                key: "Addresses.Settings.EditCard.ToggleToAllowAutofillTitle.v124",
+                tableName: "Settings",
+                value: "Save and Fill Addresses",
+                comment: "Title label for user to use the toggle settings to allow saving and autofilling of addresses for webpages.")
+            public static let PlaceholderToggleToAllowAutofillTitle = MZLocalizedString(
+                key: "Addresses.Settings.EditCard.PlaceholderToggleToAllowAutofillTitle.v124",
+                tableName: "Settings",
+                value: "Includes phone numbers and email addresses",
+                comment: "Placeholder label for user to use the toggle settings to allow saving and autofilling of addresses for webpages, including phone numbers and email addresses. The placeholder text reads: Includes phone numbers and email addresses.")
+        }
+    }
+}
+
 // MARK: - Credit card
 extension String {
     public struct CreditCard {

--- a/firefox-ios/Shared/Prefs.swift
+++ b/firefox-ios/Shared/Prefs.swift
@@ -37,6 +37,7 @@ public struct PrefsKeys {
     public static let KeyCurrentInstallVersion = "KeyCurrentInstallVersion"
     public static let KeySecondRun = "SecondRun"
     public static let KeyAutofillCreditCardStatus = "KeyAutofillCreditCardStatus"
+    public static let KeyAutofillAddressStatus = "KeyAutofillAddressStatus"
 
     public struct Session {
         public static let FirstAppUse = "firstAppUse"


### PR DESCRIPTION


## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8067)
[Git Issue](https://github.com/mozilla-mobile/firefox-ios/issues/17978)

## :bulb: Description
I added a toggle button and ensured its persistent state across the app using UserDefaults.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

