### PR TITLE
Bugfix FXIOS-8119 [v123] Fix a11y label key for switch value off from Settings Card

### DIFF
--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -3892,7 +3892,7 @@ extension String {
             value: "On",
             comment: "Toggled On accessibility value, from Settings Card within the shopping product review bottom sheet.")
         public static let SettingsCardSwitchValueOffAccessibilityLabel = MZLocalizedString(
-            key: "Shopping.SettingsCard.SwitchValueOn.AccessibilityLabel.v123",
+            key: "Shopping.SettingsCard.SwitchValueOff.AccessibilityLabel.v123",
             tableName: "Shopping",
             value: "Off",
             comment: "Toggled Off accessibility switch value from Settings Card within the shopping product review bottom sheet.")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8119)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18074)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

