### PR TITLE
Add FXIOS-8096 [v122] Telemetry for data clearance button

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -768,6 +768,8 @@
 		8ABA9C8D28931223002C0077 /* MockDispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABA9C8C28931223002C0077 /* MockDispatchQueue.swift */; };
 		8ABA9C8E28931288002C0077 /* JumpBackInDataAdaptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABA9C8A28931207002C0077 /* JumpBackInDataAdaptorTests.swift */; };
 		8ABC5AEE284532C900FEA552 /* PocketDiscoverCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABC5AED284532C900FEA552 /* PocketDiscoverCell.swift */; };
+		8ABCFEA32B45C36100C2988A /* PrivateBrowsingTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABCFEA22B45C36100C2988A /* PrivateBrowsingTelemetry.swift */; };
+		8ABCFEA62B45CB4C00C2988A /* PrivateBrowsingTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABCFEA42B45CAC300C2988A /* PrivateBrowsingTelemetryTests.swift */; };
 		8AC1065F28D0CD700013263A /* OpenQLPreviewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC1065E28D0CD700013263A /* OpenQLPreviewHelper.swift */; };
 		8AC5D55F28BFE6C8001F6F7F /* Presenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC5D55E28BFE6C8001F6F7F /* Presenter.swift */; };
 		8ACA8F74291987AE00D3075D /* AccountSyncHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACA8F73291987AE00D3075D /* AccountSyncHandlerTests.swift */; };
@@ -5627,6 +5629,8 @@
 		8ABA9C8A28931207002C0077 /* JumpBackInDataAdaptorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JumpBackInDataAdaptorTests.swift; sourceTree = "<group>"; };
 		8ABA9C8C28931223002C0077 /* MockDispatchQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDispatchQueue.swift; sourceTree = "<group>"; };
 		8ABC5AED284532C900FEA552 /* PocketDiscoverCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketDiscoverCell.swift; sourceTree = "<group>"; };
+		8ABCFEA22B45C36100C2988A /* PrivateBrowsingTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateBrowsingTelemetry.swift; sourceTree = "<group>"; };
+		8ABCFEA42B45CAC300C2988A /* PrivateBrowsingTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateBrowsingTelemetryTests.swift; sourceTree = "<group>"; };
 		8AC1065E28D0CD700013263A /* OpenQLPreviewHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenQLPreviewHelper.swift; sourceTree = "<group>"; };
 		8AC5D55E28BFE6C8001F6F7F /* Presenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Presenter.swift; sourceTree = "<group>"; };
 		8ACA8F73291987AE00D3075D /* AccountSyncHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSyncHandlerTests.swift; sourceTree = "<group>"; };
@@ -11114,6 +11118,7 @@
 				8A04136828258DF600D20B10 /* SponsoredTileTelemetry.swift */,
 				8A0727452B4890B50071BB9F /* WebviewTelemetry.swift */,
 				8AD08D1427E9198E00B8E907 /* TabsTelemetry.swift */,
+				8ABCFEA22B45C36100C2988A /* PrivateBrowsingTelemetry.swift */,
 				EBF47E6F1F7979DF00899189 /* TelemetryWrapper.swift */,
 				8ADC2A132A33762900543DAA /* ReferringPage.swift */,
 				8A95FF632B1E969E00AC303D /* TelemetryContextualIdentifier.swift */,
@@ -11354,6 +11359,7 @@
 				F80D53CD2A09A30F0047ED14 /* RustSyncManagerTests.swift */,
 				8A5D1CA12A30CF2E005AD35C /* Settings */,
 				8A04136A2825ABEA00D20B10 /* SponsoredTileTelemetryTests.swift */,
+				8ABCFEA42B45CAC300C2988A /* PrivateBrowsingTelemetryTests.swift */,
 				213B67A727CE721E000542F5 /* StartAtHomeHelperTests.swift */,
 				2F13E79A1AC0C02700D75081 /* StringExtensionsTests.swift */,
 				F84B21D71A090F8100AAB793 /* Supporting Files */,
@@ -13826,6 +13832,7 @@
 				AB42CC752A1F5240003C9594 /* CreditCardBottomSheetHeaderView.swift in Sources */,
 				21371FA428AA7A8D00BC3F37 /* OnboardingViewModelProtocol.swift in Sources */,
 				21DB34342B20FE35008CCB8E /* LegacyRemoteTabsTableViewController.swift in Sources */,
+				8ABCFEA32B45C36100C2988A /* PrivateBrowsingTelemetry.swift in Sources */,
 				8ADC2A1F2A3399BD00543DAA /* LicenseAndAcknowledgementsSetting.swift in Sources */,
 				8CCCB08B2AE26B5C0073ADB9 /* ReportResponse.swift in Sources */,
 				21A43CDD291461C700B1206D /* ReaderModeFontTypeButton.swift in Sources */,
@@ -13978,6 +13985,7 @@
 				219935F12B07DFA200E5966F /* TabDisplayPanelTests.swift in Sources */,
 				E1AEC179286E0CF500062E29 /* FirefoxHomeViewModelTests.swift in Sources */,
 				DF940A0C2A96352B00C1497D /* FakespotSettingsCardViewModelTests.swift in Sources */,
+				8ABCFEA62B45CB4C00C2988A /* PrivateBrowsingTelemetryTests.swift in Sources */,
 				281B2BEA1ADF4D90002917DC /* MockProfile.swift in Sources */,
 				96AF8C1C29FC14F700EC2219 /* CreditCardInputFieldHelperTests.swift in Sources */,
 				21FA8FB02AE856590013B815 /* RemoteTabsCoordinatorTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -46,13 +46,16 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
         let cancelAction = UIAlertAction(
             title: .Alerts.FeltDeletion.CancelButton,
             style: .cancel,
-            handler: nil
+            handler: { [weak self] _ in
+                self?.privateBrowsingTelemetry.sendDataClearanceTappedTelemetry(didConfirm: false)
+            }
         )
 
         let deleteDataAction = UIAlertAction(
             title: .Alerts.FeltDeletion.ConfirmButton,
             style: .destructive,
             handler: { [weak self] _ in
+                self?.privateBrowsingTelemetry.sendDataClearanceTappedTelemetry(didConfirm: true)
                 self?.closePrivateTabsAndOpenNewPrivateHomepage()
                 self?.showDataClearanceConfirmationToast()
             }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -67,7 +67,10 @@ class BrowserViewController: UIViewController,
     var dataClearanceContextHintVC: ContextualHintViewController
     let shoppingContextHintVC: ContextualHintViewController
     private var backgroundTabLoader: DefaultBackgroundTabLoader
+
+    // MARK: Telemetry Variables
     var webviewTelemetry = WebViewLoadMeasurementTelemetry()
+    var privateBrowsingTelemetry = PrivateBrowsingTelemetry()
 
     // popover rotation handling
     var displayedPopoverController: UIViewController?

--- a/firefox-ios/Client/Telemetry/PrivateBrowsingTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/PrivateBrowsingTelemetry.swift
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Glean
+
+struct PrivateBrowsingTelemetry {
+    func sendDataClearanceTappedTelemetry(didConfirm: Bool) {
+        let didConfirmExtra = GleanMetrics.PrivateBrowsing.DataClearanceIconTappedExtra(didConfirm: didConfirm.description)
+        GleanMetrics.PrivateBrowsing.dataClearanceIconTapped.record(didConfirmExtra)
+    }
+}

--- a/firefox-ios/Client/Telemetry/PrivateBrowsingTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/PrivateBrowsingTelemetry.swift
@@ -7,7 +7,7 @@ import Glean
 
 struct PrivateBrowsingTelemetry {
     func sendDataClearanceTappedTelemetry(didConfirm: Bool) {
-        let didConfirmExtra = GleanMetrics.PrivateBrowsing.DataClearanceIconTappedExtra(didConfirm: didConfirm.description)
+        let didConfirmExtra = GleanMetrics.PrivateBrowsing.DataClearanceIconTappedExtra(didConfirm: didConfirm)
         GleanMetrics.PrivateBrowsing.dataClearanceIconTapped.record(didConfirmExtra)
     }
 }

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -2712,6 +2712,25 @@ preferences:
       - fx-ios-data-stewards@mozilla.com
     expires: "2024-06-01"
 
+# Private Browsing
+private_browsing:
+  data_clearance_icon_tapped:
+    type: event
+    description: |
+      Records when the private browsing button is tapped.
+    extra_keys:
+      did_confirm:
+       type: string
+       description: |
+         Whether the user confirmed the reset action via the confirmation dialog.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/#####
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/#####
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "####-##-##"
+
 # Password Manager metrics
 logins:
   autofilled:

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -2724,12 +2724,12 @@ private_browsing:
        description: |
          Whether the user confirmed the reset action via the confirmation dialog.
     bugs:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/#####
+      - https://github.com/mozilla-mobile/firefox-ios/issues/18078
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/#####
+      - https://github.com/mozilla-mobile/firefox-ios/pull/18080
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "####-##-##"
+    expires: "2024-07-06"
 
 # Password Manager metrics
 logins:

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -2720,7 +2720,7 @@ private_browsing:
       Records when the private browsing button is tapped.
     extra_keys:
       did_confirm:
-       type: string
+       type: boolean
        description: |
          Whether the user confirmed the reset action via the confirmation dialog.
     bugs:
@@ -2729,7 +2729,7 @@ private_browsing:
       - https://github.com/mozilla-mobile/firefox-ios/pull/18080
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: "2024-07-06"
+    expires: "2024-06-01"
 
 # Password Manager metrics
 logins:

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/PrivateBrowsingTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/PrivateBrowsingTelemetryTests.swift
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Glean
+import XCTest
+
+@testable import Client
+
+final class PrivateBrowsingTelemetryTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        Glean.shared.resetGlean(clearStores: true)
+        Glean.shared.enableTestingMode()
+    }
+
+    func testDataClearanceConfirmed() throws {
+        let subject = PrivateBrowsingTelemetry()
+
+        subject.sendDataClearanceTappedTelemetry(didConfirm: true)
+
+        testEventMetricRecordingSuccess(metric: GleanMetrics.PrivateBrowsing.dataClearanceIconTapped)
+
+        let resultValue = try XCTUnwrap(GleanMetrics.PrivateBrowsing.dataClearanceIconTapped.testGetValue())
+        XCTAssertEqual(resultValue[0].extra?["did_confirm"], "true")
+    }
+
+    func testDataClearanceCancelled() throws {
+        let subject = PrivateBrowsingTelemetry()
+
+        subject.sendDataClearanceTappedTelemetry(didConfirm: false)
+
+        testEventMetricRecordingSuccess(metric: GleanMetrics.PrivateBrowsing.dataClearanceIconTapped)
+
+        let resultValue = try XCTUnwrap(GleanMetrics.PrivateBrowsing.dataClearanceIconTapped.testGetValue())
+        XCTAssertEqual(resultValue[0].extra?["did_confirm"], "false")
+    }
+}

--- a/firefox-ios/nimbus-features/feltPrivacyFeature.yaml
+++ b/firefox-ios/nimbus-features/feltPrivacyFeature.yaml
@@ -19,6 +19,6 @@ features:
           felt-deletion-enabled: false
       - channel: developer
         value:
-          simplified-ui-enabled: false
-          felt-deletion-enabled: false
+          simplified-ui-enabled: true
+          felt-deletion-enabled: true
 

--- a/firefox-ios/nimbus-features/feltPrivacyFeature.yaml
+++ b/firefox-ios/nimbus-features/feltPrivacyFeature.yaml
@@ -19,6 +19,6 @@ features:
           felt-deletion-enabled: false
       - channel: developer
         value:
-          simplified-ui-enabled: true
-          felt-deletion-enabled: true
+          simplified-ui-enabled: false
+          felt-deletion-enabled: false
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8096)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18078)

## :bulb: Description
Add data clearance button tapped telemetry:

- Send extra key for `did_confirm` as `false` if user cancels the alert shown after tapping on the fire / data clearance icon
- Send extra key for `did_confirm` as `true` if user confirms the alert shown after tapping on the fire / data clearance icon

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

## Screenshot

<img width="376" alt="image" src="https://github.com/mozilla-mobile/firefox-ios/assets/6743397/5f5eee44-7946-4e98-be81-74c88b025777">