### PR TITLE
Refactor FXIOS-7712 [v123] Remove legacy theme manager usage in telemetryWrapper

### DIFF
--- a/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
@@ -59,19 +59,13 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
         self.userDefaults.register(defaults: [ThemeKeys.systemThemeIsOn: true,
                                               ThemeKeys.NightMode.isOn: NSNumber(value: false)])
 
-<<<<<<< HEAD
-<<<<<<< HEAD
         self.userDefaults.register(defaults: [
             ThemeKeys.systemThemeIsOn: true,
             ThemeKeys.NightMode.isOn: NSNumber(value: false),
             ThemeKeys.PrivateMode.isOn: NSNumber(value: false),
         ])
-=======
-            UserDefaults.standard.register(defaults: [DefaultThemeManager.getSystemThemeKey(): true])
->>>>>>> 91c0aa4c5 (Refactor TelemetryWrapper to Use DefaultThemeManager)
-=======
+
         UserDefaults.standard.register(defaults: [DefaultThemeManager.getSystemThemeKey(): true])
->>>>>>> 64a8b84d8 (Fix indentation in the DefaultThemeManager init method)
 
         setSystemThemeIsOn = userDefaults.bool(forKey: DefaultThemeManager.getSystemThemeKey())
         changeCurrentTheme(loadInitialThemeType())

--- a/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
@@ -35,10 +35,6 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
 
     public var window: UIWindow?
 
-    public static var systemThemeKey: String {
-        return ThemeKeys.systemThemeIsOn
-    }
-
     public var isSystemThemeOn: Bool {
         return userDefaults.bool(forKey: ThemeKeys.systemThemeIsOn)
     }

--- a/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
@@ -51,14 +51,15 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
                 notificationCenter: NotificationProtocol = NotificationCenter.default,
                 mainQueue: DispatchQueueInterface = DispatchQueue.main,
                 sharedContainerIdentifier: String) {
-            self.userDefaults = userDefaults
-            self.notificationCenter = notificationCenter
-            self.mainQueue = mainQueue
-            self.sharedContainerIdentifier = sharedContainerIdentifier
+        self.userDefaults = userDefaults
+        self.notificationCenter = notificationCenter
+        self.mainQueue = mainQueue
+        self.sharedContainerIdentifier = sharedContainerIdentifier
 
-            self.userDefaults.register(defaults: [ThemeKeys.systemThemeIsOn: true,
-                                                  ThemeKeys.NightMode.isOn: NSNumber(value: false)])
+        self.userDefaults.register(defaults: [ThemeKeys.systemThemeIsOn: true,
+                                              ThemeKeys.NightMode.isOn: NSNumber(value: false)])
 
+<<<<<<< HEAD
 <<<<<<< HEAD
         self.userDefaults.register(defaults: [
             ThemeKeys.systemThemeIsOn: true,
@@ -68,16 +69,19 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
 =======
             UserDefaults.standard.register(defaults: [DefaultThemeManager.getSystemThemeKey(): true])
 >>>>>>> 91c0aa4c5 (Refactor TelemetryWrapper to Use DefaultThemeManager)
+=======
+        UserDefaults.standard.register(defaults: [DefaultThemeManager.getSystemThemeKey(): true])
+>>>>>>> 64a8b84d8 (Fix indentation in the DefaultThemeManager init method)
 
-            setSystemThemeIsOn = userDefaults.bool(forKey: DefaultThemeManager.getSystemThemeKey())
-            changeCurrentTheme(loadInitialThemeType())
+        setSystemThemeIsOn = userDefaults.bool(forKey: DefaultThemeManager.getSystemThemeKey())
+        changeCurrentTheme(loadInitialThemeType())
 
-            setupNotifications(forObserver: self,
-                               observing: [UIScreen.brightnessDidChangeNotification,
-                                           UIApplication.didBecomeActiveNotification])
+        setupNotifications(forObserver: self,
+                           observing: [UIScreen.brightnessDidChangeNotification,
+                                       UIApplication.didBecomeActiveNotification])
 
-            migrateDefaultsToUseStandard()
-        }
+        migrateDefaultsToUseStandard()
+    }
 
     // MARK: - ThemeManager
 

--- a/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
@@ -35,33 +35,55 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
 
     public var window: UIWindow?
 
+    public var setSystemThemeIsOn: Bool {
+        didSet {
+            UserDefaults.standard.set(setSystemThemeIsOn, forKey: DefaultThemeManager.getSystemThemeKey())
+        }
+    }
+
+    public static var isSystemThemeOn: Bool {
+        return UserDefaults.standard.bool(forKey: DefaultThemeManager.getSystemThemeKey())
+    }
+
     // MARK: - Init
 
     public init(userDefaults: UserDefaultsInterface = UserDefaults.standard,
                 notificationCenter: NotificationProtocol = NotificationCenter.default,
                 mainQueue: DispatchQueueInterface = DispatchQueue.main,
                 sharedContainerIdentifier: String) {
-        self.userDefaults = userDefaults
-        self.notificationCenter = notificationCenter
-        self.mainQueue = mainQueue
-        self.sharedContainerIdentifier = sharedContainerIdentifier
+            self.userDefaults = userDefaults
+            self.notificationCenter = notificationCenter
+            self.mainQueue = mainQueue
+            self.sharedContainerIdentifier = sharedContainerIdentifier
 
-        migrateDefaultsToUseStandard()
+            self.userDefaults.register(defaults: [ThemeKeys.systemThemeIsOn: true,
+                                                  ThemeKeys.NightMode.isOn: NSNumber(value: false)])
 
+<<<<<<< HEAD
         self.userDefaults.register(defaults: [
             ThemeKeys.systemThemeIsOn: true,
             ThemeKeys.NightMode.isOn: NSNumber(value: false),
             ThemeKeys.PrivateMode.isOn: NSNumber(value: false),
         ])
+=======
+            UserDefaults.standard.register(defaults: [DefaultThemeManager.getSystemThemeKey(): true])
+>>>>>>> 91c0aa4c5 (Refactor TelemetryWrapper to Use DefaultThemeManager)
 
-        changeCurrentTheme(loadInitialThemeType())
+            setSystemThemeIsOn = userDefaults.bool(forKey: DefaultThemeManager.getSystemThemeKey())
+            changeCurrentTheme(loadInitialThemeType())
 
-        setupNotifications(forObserver: self,
-                           observing: [UIScreen.brightnessDidChangeNotification,
-                                       UIApplication.didBecomeActiveNotification])
-    }
+            setupNotifications(forObserver: self,
+                               observing: [UIScreen.brightnessDidChangeNotification,
+                                           UIApplication.didBecomeActiveNotification])
+
+            migrateDefaultsToUseStandard()
+        }
 
     // MARK: - ThemeManager
+
+    public static func getSystemThemeKey() -> String {
+        return ThemeKeys.systemThemeIsOn
+    }
 
     public func changeCurrentTheme(_ newTheme: ThemeType) {
         guard currentTheme.type != newTheme else { return }

--- a/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
@@ -35,14 +35,12 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
 
     public var window: UIWindow?
 
-    public var setSystemThemeIsOn: Bool {
-        didSet {
-            UserDefaults.standard.set(setSystemThemeIsOn, forKey: DefaultThemeManager.getSystemThemeKey())
-        }
+    public static var systemThemeKey: String {
+        return ThemeKeys.systemThemeIsOn
     }
 
-    public static var isSystemThemeOn: Bool {
-        return UserDefaults.standard.bool(forKey: DefaultThemeManager.getSystemThemeKey())
+    public var isSystemThemeOn: Bool {
+        return userDefaults.bool(forKey: ThemeKeys.systemThemeIsOn)
     }
 
     // MARK: - Init
@@ -56,8 +54,7 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
         self.mainQueue = mainQueue
         self.sharedContainerIdentifier = sharedContainerIdentifier
 
-        self.userDefaults.register(defaults: [ThemeKeys.systemThemeIsOn: true,
-                                              ThemeKeys.NightMode.isOn: NSNumber(value: false)])
+        migrateDefaultsToUseStandard()
 
         self.userDefaults.register(defaults: [
             ThemeKeys.systemThemeIsOn: true,
@@ -65,23 +62,14 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
             ThemeKeys.PrivateMode.isOn: NSNumber(value: false),
         ])
 
-        UserDefaults.standard.register(defaults: [DefaultThemeManager.getSystemThemeKey(): true])
-
-        setSystemThemeIsOn = userDefaults.bool(forKey: DefaultThemeManager.getSystemThemeKey())
         changeCurrentTheme(loadInitialThemeType())
 
         setupNotifications(forObserver: self,
                            observing: [UIScreen.brightnessDidChangeNotification,
                                        UIApplication.didBecomeActiveNotification])
-
-        migrateDefaultsToUseStandard()
     }
 
     // MARK: - ThemeManager
-
-    public static func getSystemThemeKey() -> String {
-        return ThemeKeys.systemThemeIsOn
-    }
 
     public func changeCurrentTheme(_ newTheme: ThemeType) {
         guard currentTheme.type != newTheme else { return }

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -102,7 +102,7 @@ class TelemetryWrapper: TelemetryWrapperProtocol, FeatureFlaggable {
         telemetryConfig.measureUserDefaultsSetting(forKey: "profile.prefkey.trackingprotection.normalbrowsing", withDefaultValue: true)
         telemetryConfig.measureUserDefaultsSetting(forKey: "profile.prefkey.trackingprotection.privatebrowsing", withDefaultValue: true)
         telemetryConfig.measureUserDefaultsSetting(forKey: "profile.prefkey.trackingprotection.strength", withDefaultValue: "basic")
-        telemetryConfig.measureUserDefaultsSetting(forKey: DefaultThemeManager.getSystemThemeKey(), withDefaultValue: true)
+        telemetryConfig.measureUserDefaultsSetting(forKey: DefaultThemeManager.systemThemeKey, withDefaultValue: true)
 
         let prefs = profile.prefs
         legacyTelemetry.beforeSerializePing(pingType: CorePingBuilder.PingType) { (inputDict) -> [String: Any?] in
@@ -289,7 +289,8 @@ class TelemetryWrapper: TelemetryWrapperProtocol, FeatureFlaggable {
             GleanMetrics.TrackingProtection.strength.set("basic")
         }
         // System theme enabled
-        GleanMetrics.Theme.useSystemTheme.set(DefaultThemeManager.isSystemThemeOn)
+        let themeManager = DefaultThemeManager(sharedContainerIdentifier: AppInfo.sharedContainerIdentifier)
+        GleanMetrics.Theme.useSystemTheme.set(themeManager.isSystemThemeOn)
         // Installed Mozilla applications
         GleanMetrics.InstalledMozillaProducts.focus.set(UIApplication.shared.canOpenURL(URL(string: "firefox-focus://")!))
         GleanMetrics.InstalledMozillaProducts.klar.set(UIApplication.shared.canOpenURL(URL(string: "firefox-klar://")!))

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -102,7 +102,7 @@ class TelemetryWrapper: TelemetryWrapperProtocol, FeatureFlaggable {
         telemetryConfig.measureUserDefaultsSetting(forKey: "profile.prefkey.trackingprotection.normalbrowsing", withDefaultValue: true)
         telemetryConfig.measureUserDefaultsSetting(forKey: "profile.prefkey.trackingprotection.privatebrowsing", withDefaultValue: true)
         telemetryConfig.measureUserDefaultsSetting(forKey: "profile.prefkey.trackingprotection.strength", withDefaultValue: "basic")
-        telemetryConfig.measureUserDefaultsSetting(forKey: DefaultThemeManager.systemThemeKey, withDefaultValue: true)
+        telemetryConfig.measureUserDefaultsSetting(forKey: LegacyThemeManagerPrefs.systemThemeIsOn.rawValue, withDefaultValue: true)
 
         let prefs = profile.prefs
         legacyTelemetry.beforeSerializePing(pingType: CorePingBuilder.PingType) { (inputDict) -> [String: Any?] in

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -102,7 +102,7 @@ class TelemetryWrapper: TelemetryWrapperProtocol, FeatureFlaggable {
         telemetryConfig.measureUserDefaultsSetting(forKey: "profile.prefkey.trackingprotection.normalbrowsing", withDefaultValue: true)
         telemetryConfig.measureUserDefaultsSetting(forKey: "profile.prefkey.trackingprotection.privatebrowsing", withDefaultValue: true)
         telemetryConfig.measureUserDefaultsSetting(forKey: "profile.prefkey.trackingprotection.strength", withDefaultValue: "basic")
-        telemetryConfig.measureUserDefaultsSetting(forKey: LegacyThemeManagerPrefs.systemThemeIsOn.rawValue, withDefaultValue: true)
+        telemetryConfig.measureUserDefaultsSetting(forKey: DefaultThemeManager.getSystemThemeKey(), withDefaultValue: true)
 
         let prefs = profile.prefs
         legacyTelemetry.beforeSerializePing(pingType: CorePingBuilder.PingType) { (inputDict) -> [String: Any?] in
@@ -289,7 +289,7 @@ class TelemetryWrapper: TelemetryWrapperProtocol, FeatureFlaggable {
             GleanMetrics.TrackingProtection.strength.set("basic")
         }
         // System theme enabled
-        GleanMetrics.Theme.useSystemTheme.set(LegacyThemeManager.instance.systemThemeIsOn)
+        GleanMetrics.Theme.useSystemTheme.set(DefaultThemeManager.isSystemThemeOn)
         // Installed Mozilla applications
         GleanMetrics.InstalledMozillaProducts.focus.set(UIApplication.shared.canOpenURL(URL(string: "firefox-focus://")!))
         GleanMetrics.InstalledMozillaProducts.klar.set(UIApplication.shared.canOpenURL(URL(string: "firefox-klar://")!))


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7712)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17202)

## :bulb: Description
- This PR addresses the usage of the legacy theme manager in the TelemetryWrapper by transitioning to the modern `DefaultThemeManager`. 
- The updates include modifying the method for measuring UserDefaults settings and replacing deprecated references to the system theme property with the corresponding accessor from `DefaultThemeManager`.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

