### PR TITLE
Refactor FXIOS-8095, 8127 [v123] [Multi-window] Support auto-closing panels across multiple windows

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		1DA3CE5D24EEE73100422BB2 /* OpenTabsWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA3CE5C24EEE73100422BB2 /* OpenTabsWidget.swift */; };
 		1DA3CE5F24EEE7C600422BB2 /* LegacyTabDataRetriever.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA3CE5E24EEE7C600422BB2 /* LegacyTabDataRetriever.swift */; };
 		1DA3CE6724EEE86C00422BB2 /* AppInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65075641E37F7AB006961AC /* AppInfo.swift */; };
+		1DA6F6512B48B42900BB5AD6 /* WindowEventCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA6F6502B48B42900BB5AD6 /* WindowEventCoordinator.swift */; };
 		1DA710072AE7106B00677F6B /* AppDataUsageReportSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA710062AE7106B00677F6B /* AppDataUsageReportSetting.swift */; };
 		1DC372022B23C80F000F96C8 /* WindowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC372012B23C80F000F96C8 /* WindowManager.swift */; };
 		1DDAD13E24F0651C007623C8 /* TopSitesWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DDAD13C24F064F7007623C8 /* TopSitesWidget.swift */; };
@@ -2186,6 +2187,7 @@
 		1DA3CE5C24EEE73100422BB2 /* OpenTabsWidget.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenTabsWidget.swift; sourceTree = "<group>"; };
 		1DA3CE5E24EEE7C600422BB2 /* LegacyTabDataRetriever.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyTabDataRetriever.swift; sourceTree = "<group>"; };
 		1DA64656B1F6A74800D22055 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/LoginManager.strings; sourceTree = "<group>"; };
+		1DA6F6502B48B42900BB5AD6 /* WindowEventCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowEventCoordinator.swift; sourceTree = "<group>"; };
 		1DA710062AE7106B00677F6B /* AppDataUsageReportSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDataUsageReportSetting.swift; sourceTree = "<group>"; };
 		1DC372012B23C80F000F96C8 /* WindowManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowManager.swift; sourceTree = "<group>"; };
 		1DDAD13C24F064F7007623C8 /* TopSitesWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSitesWidget.swift; sourceTree = "<group>"; };
@@ -11413,6 +11415,7 @@
 				5A3A2A0C287F742C00B79EAC /* BackgroundSyncUtility.swift */,
 				602B3D6629B0E1DB0066DEF8 /* ConversionValueUtil.swift */,
 				1DC372012B23C80F000F96C8 /* WindowManager.swift */,
+				1DA6F6502B48B42900BB5AD6 /* WindowEventCoordinator.swift */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -13688,6 +13691,7 @@
 				8ADAE4242A33A126007BF926 /* StudiesToggleSetting.swift in Sources */,
 				C82CDD47233E8996002E2743 /* Tab+ChangeUserAgent.swift in Sources */,
 				81122E212B221AC0003DD9F8 /* SearchScreenState.swift in Sources */,
+				1DA6F6512B48B42900BB5AD6 /* WindowEventCoordinator.swift in Sources */,
 				C4E3984C1D21F2FD004E89BA /* TabTrayButtonExtensions.swift in Sources */,
 				437A857827E43FE100E42764 /* FxAWebViewTelemetry.swift in Sources */,
 				E13E9AB42AAB0FB5001A0E9D /* FakespotCoordinator.swift in Sources */,

--- a/firefox-ios/Client/Application/SceneDelegate.swift
+++ b/firefox-ios/Client/Application/SceneDelegate.swift
@@ -56,14 +56,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Handle clean-up here for closing windows on iPad
         guard let sceneCoordinator = (scene.delegate as? SceneDelegate)?.sceneCoordinator else { return }
 
-        // Give all coordinators a chance to respond to scene disconnect (window close).
-        sceneCoordinator.recurseChildCoordinators {
-            ($0 as? WindowEventCoordinator)?.coordinatorWindowWillClose()
-        }
-
         // Notify WindowManager that window is closing
-        let windowManager: WindowManager = AppContainer.shared.resolve()
-        windowManager.windowDidClose(uuid: sceneCoordinator.windowUUID)
+        (AppContainer.shared.resolve() as WindowManager).windowWillClose(uuid: sceneCoordinator.windowUUID)
     }
 
     // MARK: - Transitioning to Foreground

--- a/firefox-ios/Client/Application/WindowEventCoordinator.swift
+++ b/firefox-ios/Client/Application/WindowEventCoordinator.swift
@@ -1,0 +1,26 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Common
+import Shared
+
+/// Events related to multiple window support on iPad. These events are
+/// always associated with one window in particular, but are typically of
+/// interest to all open windows. As such, any WindowEvent posted is
+/// broadcast to any Coordinators interested in responding, across any/all
+/// open windows on iPadOS.
+enum WindowEvent {
+    /// A window is being closed.
+    case windowWillClose
+    /// A window opened the library view controller.
+    case libraryOpened
+}
+
+/// Abstract protocol that any Coordinator can conform to in order to respond
+/// to key window lifecycle events, such as cleaning up when a window is closed.
+protocol WindowEventCoordinator {
+    /// Notifies the coordinator that its parent window/scene is being removed.
+    func coordinatorHandleWindowEvent(event: WindowEvent, uuid: WindowUUID)
+}

--- a/firefox-ios/Client/Application/WindowEventCoordinator.swift
+++ b/firefox-ios/Client/Application/WindowEventCoordinator.swift
@@ -14,6 +14,7 @@ import Shared
 enum WindowEvent {
     /// A window is being closed.
     case windowWillClose
+
     /// A window opened the library view controller.
     case libraryOpened
 }

--- a/firefox-ios/Client/Application/WindowEventCoordinator.swift
+++ b/firefox-ios/Client/Application/WindowEventCoordinator.swift
@@ -17,6 +17,9 @@ enum WindowEvent {
 
     /// A window opened the library view controller.
     case libraryOpened
+
+    /// A window opened the settings menu.
+    case settingsOpened
 }
 
 /// Abstract protocol that any Coordinator can conform to in order to respond

--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -43,9 +43,9 @@ protocol WindowManager {
 
     /// Signals the WindowManager that a window event has occurred. Window events
     /// are communicated to any interested Coordinators for _all_ windows, but
-    /// any one event is always associated with one window in specific. This window
-    /// can be identified by the `windowUUID` parameter.
+    /// any one event is always associated with one window in specific. 
     /// - Parameter event: the event that occurred and any associated metadata.
+    /// - Parameter windowUUID: the UUID of the window triggering the event.
     func postWindowEvent(event: WindowEvent, windowUUID: WindowUUID)
 }
 

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -621,9 +621,9 @@ class BrowserCoordinator: BaseCoordinator,
     func coordinatorHandleWindowEvent(event: WindowEvent, uuid: WindowUUID) {
         switch event {
         case .windowWillClose:
-            // Was the closed window the window for this browser?
             guard uuid == windowUUID else { return }
-            // If so, perform add'tl cleanup required so BVC and other components are properly released.
+            // Additional cleanup performed when the current iPad window is closed.
+            // This is necessary in order to ensure the BVC and other memory is freed correctly.
             browserViewController.contentContainer.subviews.forEach { $0.removeFromSuperview() }
             browserViewController.removeFromParent()
         case .libraryOpened:

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -637,14 +637,13 @@ class BrowserCoordinator: BaseCoordinator,
             browserViewController.contentContainer.subviews.forEach { $0.removeFromSuperview() }
             browserViewController.removeFromParent()
         case .libraryOpened:
-            // If the library was opened for this browser's window, we can ignore
-            // Otherwise, auto-close the panel in this window [FXIOS-8095]
+            // Auto-close library panel if it was opened in another iPad window. [FXIOS-8095]
             guard uuid != windowUUID else { return }
             performIfCoordinatorPresented(LibraryCoordinator.self) { _ in
                 router.dismiss(animated: true, completion: nil)
             }
         case .settingsOpened:
-            // If the settings were opened for this browser's window, we can ignore
+            // Auto-close settings panel if it was opened in another iPad window. [FXIOS-8095]
             guard uuid != windowUUID else { return }
             performIfCoordinatorPresented(SettingsCoordinator.self) {
                 didFinishSettings(from: $0)

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -332,6 +332,7 @@ class BrowserCoordinator: BaseCoordinator,
     }
 
     private func showLibrary(with homepanelSection: Route.HomepanelSection) {
+        windowManager.postWindowEvent(event: .libraryOpened, windowUUID: windowUUID)
         if let libraryCoordinator = childCoordinators[LibraryCoordinator.self] {
             libraryCoordinator.start(with: homepanelSection)
             (libraryCoordinator.router.navigationController as? UINavigationController).map { router.present($0) }
@@ -626,11 +627,15 @@ class BrowserCoordinator: BaseCoordinator,
             browserViewController.removeFromParent()
         case .libraryOpened:
             // If the library was opened for this browser's window, we can ignore
-            // Otherwise, auto-close the panel in this window (FXIOS-8095)
+            // Otherwise, auto-close the panel in this window [FXIOS-8095]
             guard uuid != windowUUID else { return }
-            
-            //TODO: Close the library panel
-            break
+
+            guard let libraryCoordinator = childCoordinators[LibraryCoordinator.self] else { return }
+            let browserPresentedVC = router.navigationController.presentedViewController
+            let rootVC = (browserPresentedVC as? DismissableNavigationViewController)?.viewControllers.first
+            if rootVC === libraryCoordinator.router.rootViewController {
+                router.dismiss(animated: true, completion: nil)
+            }
         }
     }
 }

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -315,6 +315,7 @@ class BrowserCoordinator: BaseCoordinator,
         guard !childCoordinators.contains(where: { $0 is SettingsCoordinator }) else {
             return // route is handled with existing child coordinator
         }
+        windowManager.postWindowEvent(event: .settingsOpened, windowUUID: windowUUID)
         let navigationController = ThemedNavigationController()
         let isPad = UIDevice.current.userInterfaceIdiom == .pad
         let modalPresentationStyle: UIModalPresentationStyle = isPad ? .fullScreen: .formSheet
@@ -632,9 +633,18 @@ class BrowserCoordinator: BaseCoordinator,
 
             guard let libraryCoordinator = childCoordinators[LibraryCoordinator.self] else { return }
             let browserPresentedVC = router.navigationController.presentedViewController
-            let rootVC = (browserPresentedVC as? DismissableNavigationViewController)?.viewControllers.first
+            let rootVC = (browserPresentedVC as? UINavigationController)?.viewControllers.first
             if rootVC === libraryCoordinator.router.rootViewController {
                 router.dismiss(animated: true, completion: nil)
+            }
+        case .settingsOpened:
+            // If the settings were opened for this browser's window, we can ignore
+            guard uuid != windowUUID else { return }
+            guard let settingsCoordinator = childCoordinators[SettingsCoordinator.self] else { return }
+            let browserPresentedVC = router.navigationController.presentedViewController
+            let rootVC = (browserPresentedVC as? UINavigationController)?.viewControllers.first
+            if rootVC === settingsCoordinator.router.rootViewController {
+                didFinishSettings(from: settingsCoordinator)
             }
         }
     }

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -624,7 +624,12 @@ class BrowserCoordinator: BaseCoordinator,
             // If so, perform add'tl cleanup required so BVC and other components are properly released.
             browserViewController.contentContainer.subviews.forEach { $0.removeFromSuperview() }
             browserViewController.removeFromParent()
-        default:
+        case .libraryOpened:
+            // If the library was opened for this browser's window, we can ignore
+            // Otherwise, auto-close the panel in this window (FXIOS-8095)
+            guard uuid != windowUUID else { return }
+            
+            //TODO: Close the library panel
             break
         }
     }

--- a/firefox-ios/Client/Coordinators/Scene/SceneCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Scene/SceneCoordinator.swift
@@ -25,10 +25,10 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
         self.sceneContainer = sceneContainer
         self.windowManager = windowManager
         // Note: this is where we singularly decide the UUID for this specific iOS browser window (UIScene).
-        // The logic is handled by `nextAvailableWindowUUID`, but this is the point at which a window's UUID
+        // The logic is handled by `reserveNextAvailableWindowUUID`, but this is the point at which a window's UUID
         // is set; this same UUID will be injected throughout several of the window's related components
         // such as its TabManager instance, which also has the window UUID property as a convenience.
-        self.windowUUID = windowManager.nextAvailableWindowUUID()
+        self.windowUUID = windowManager.reserveNextAvailableWindowUUID()
 
         let navigationController = sceneSetupHelper.createNavigationController()
         let router = DefaultRouter(navigationController: navigationController)
@@ -120,7 +120,7 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
                                                     tabManager: tabManager)
 
         let windowInfo = AppWindowInfo(tabManager: tabManager, sceneCoordinator: self)
-        windowManager.newBrowserWindowConfigured(windowInfo, uuid: tabManager.windowUUID)
+        windowManager.newBrowserWindowConfigured(windowInfo, uuid: windowUUID)
 
         add(child: browserCoordinator)
         browserCoordinator.start(with: launchType)

--- a/firefox-ios/Client/Coordinators/Scene/SceneCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Scene/SceneCoordinator.swift
@@ -118,6 +118,10 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
         let browserCoordinator = BrowserCoordinator(router: router,
                                                     screenshotService: screenshotService,
                                                     tabManager: tabManager)
+
+        let windowInfo = AppWindowInfo(tabManager: tabManager, sceneCoordinator: self)
+        windowManager.newBrowserWindowConfigured(windowInfo, uuid: tabManager.windowUUID)
+
         add(child: browserCoordinator)
         browserCoordinator.start(with: launchType)
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -10,16 +10,13 @@ import Storage
 
 class TabManagerMiddleware {
     var selectedPanel: TabTrayPanelType = .tabs
-    private let windowManager: WindowManager
     private let profile: Profile
 
     var normalTabsCountText: String {
         (defaultTabManager.normalTabs.count < 100) ? defaultTabManager.normalTabs.count.description : "\u{221E}"
     }
 
-    init(windowManager: WindowManager = AppContainer.shared.resolve(),
-         profile: Profile = AppContainer.shared.resolve()) {
-        self.windowManager = windowManager
+    init(profile: Profile = AppContainer.shared.resolve()) {
         self.profile = profile
     }
 
@@ -330,6 +327,7 @@ class TabManagerMiddleware {
 
     private var defaultTabManager: TabManager {
         // TODO: [FXIOS-8071] Temporary. WIP for Redux + iPad Multi-window.
+        let windowManager: WindowManager = AppContainer.shared.resolve()
         return windowManager.tabManager(for: windowManager.activeWindow)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -20,13 +20,14 @@ final class BrowserCoordinatorTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        DependencyHelperMock().bootstrapDependencies()
+        let mockTabManager = MockTabManager()
+        self.tabManager = mockTabManager
+        DependencyHelperMock().bootstrapDependencies(injectedTabManager: mockTabManager)
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: AppContainer.shared.resolve())
         self.mockRouter = MockRouter(navigationController: MockNavigationController())
         self.profile = MockProfile()
         self.overlayModeManager = MockOverlayModeManager()
         self.screenshotService = ScreenshotService()
-        self.tabManager = MockTabManager()
         self.applicationHelper = MockApplicationHelper()
         self.glean = MockGleanWrapper()
         self.scrollDelegate = MockStatusBarScrollDelegate()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/TabTray/TabTrayCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/TabTray/TabTrayCoordinatorTests.swift
@@ -9,13 +9,16 @@ final class TabTrayCoordinatorTests: XCTestCase {
     private var mockRouter: MockRouter!
     private var profile: MockProfile!
     private var parentCoordinator: MockTabTrayCoordinatorDelegate!
+    private var tabManager: TabManager!
 
     override func setUp() {
         super.setUp()
-        DependencyHelperMock().bootstrapDependencies()
+        let mockTabManager = MockTabManager()
+        DependencyHelperMock().bootstrapDependencies(injectedTabManager: mockTabManager)
         mockRouter = MockRouter(navigationController: MockNavigationController())
         profile = MockProfile()
         parentCoordinator = MockTabTrayCoordinatorDelegate()
+        tabManager = mockTabManager
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: MockProfile())
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabTrayViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabTrayViewControllerTests.swift
@@ -10,12 +10,15 @@ import XCTest
 final class TabTrayViewControllerTests: XCTestCase {
     var delegate: MockTabTrayViewControllerDelegate!
     var navigationController: DismissableNavigationViewController!
+    private var tabManager: MockTabManager!
 
     override func setUp() {
         super.setUp()
-        DependencyHelperMock().bootstrapDependencies()
+        let mockTabManager = MockTabManager()
+        DependencyHelperMock().bootstrapDependencies(injectedTabManager: mockTabManager)
         delegate = MockTabTrayViewControllerDelegate()
         navigationController = DismissableNavigationViewController()
+        tabManager = mockTabManager
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: MockProfile())
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WindowManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WindowManagerTests.swift
@@ -93,7 +93,7 @@ class WindowManagerTests: XCTestCase {
         XCTAssertEqual(firstWindowUUID, subject.activeWindow)
 
         // Close the first window
-        subject.windowDidClose(uuid: firstWindowUUID)
+        subject.windowWillClose(uuid: firstWindowUUID)
 
         // Check that the second window is now the only window
         XCTAssertEqual(1, subject.windows.count)
@@ -183,7 +183,7 @@ class WindowManagerTests: XCTestCase {
         XCTAssert(allTabManagers.contains(where: { $0 === tabManager2 }))
 
         // Close first window and check that only the 2nd tab manager instance is returned
-        subject.windowDidClose(uuid: uuid1)
+        subject.windowWillClose(uuid: uuid1)
         allTabManagers = subject.allWindowTabManagers()
         XCTAssertEqual(allTabManagers.count, 1)
         XCTAssert(tabManager2 === allTabManagers.first!)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WindowManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WindowManagerTests.swift
@@ -111,8 +111,8 @@ class WindowManagerTests: XCTestCase {
         // Check that asking for two UUIDs results in two unique/random UUIDs
         // Note: there is a possibility of collision between any two randomly-
         // generated UUIDs but it is astronomically small (1 out of 2^122).
-        let uuid1 = subject.nextAvailableWindowUUID()
-        let uuid2 = subject.nextAvailableWindowUUID()
+        let uuid1 = subject.reserveNextAvailableWindowUUID()
+        let uuid2 = subject.reserveNextAvailableWindowUUID()
         XCTAssertNotEqual(uuid1, uuid2)
     }
 
@@ -126,11 +126,11 @@ class WindowManagerTests: XCTestCase {
         mockTabDataStore.injectMockTabWindowUUID(savedUUID)
 
         // Check that asking for first UUID returns the expected UUID
-        XCTAssertEqual(savedUUID, subject.nextAvailableWindowUUID())
+        XCTAssertEqual(savedUUID, subject.reserveNextAvailableWindowUUID())
         // Open a window using this UUID
         subject.newBrowserWindowConfigured(AppWindowInfo(), uuid: savedUUID)
         // Check that asking for another UUID returns a new, random UUID
-        XCTAssertNotEqual(savedUUID, subject.nextAvailableWindowUUID())
+        XCTAssertNotEqual(savedUUID, subject.reserveNextAvailableWindowUUID())
     }
 
     func testNextAvailableUUIDWhenMultipleWindowsSaved() {
@@ -146,9 +146,9 @@ class WindowManagerTests: XCTestCase {
         mockTabDataStore.injectMockTabWindowUUID(uuid2)
 
         // Ask for UUIDs for two windows, which we open and configure
-        let result1 = subject.nextAvailableWindowUUID()
+        let result1 = subject.reserveNextAvailableWindowUUID()
         subject.newBrowserWindowConfigured(AppWindowInfo(), uuid: result1)
-        let result2 = subject.nextAvailableWindowUUID()
+        let result2 = subject.reserveNextAvailableWindowUUID()
         subject.newBrowserWindowConfigured(AppWindowInfo(), uuid: result2)
 
         // Check that our UUIDs are the ones we expected
@@ -158,7 +158,7 @@ class WindowManagerTests: XCTestCase {
         XCTAssertEqual(expectedUUIDs.count, 2)
 
         // Check that asking for a 3rd UUID returns a new, random UUID
-        let result3 = subject.nextAvailableWindowUUID()
+        let result3 = subject.reserveNextAvailableWindowUUID()
         XCTAssertFalse(expectedUUIDs.contains(result3))
         XCTAssertNotEqual(result1, result3)
         XCTAssertNotEqual(result2, result3)
@@ -171,9 +171,9 @@ class WindowManagerTests: XCTestCase {
         let tabManager2 = MockTabManager()
 
         // Create two separate windows with associated Tab Managers
-        let uuid1 = subject.nextAvailableWindowUUID()
+        let uuid1 = subject.reserveNextAvailableWindowUUID()
         subject.newBrowserWindowConfigured(AppWindowInfo(tabManager: tabManager1), uuid: uuid1)
-        let uuid2 = subject.nextAvailableWindowUUID()
+        let uuid2 = subject.reserveNextAvailableWindowUUID()
         subject.newBrowserWindowConfigured(AppWindowInfo(tabManager: tabManager2), uuid: uuid2)
 
         // Check that allWindowTabManagers returns both expected instances

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WindowManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WindowManagerTests.swift
@@ -189,6 +189,25 @@ class WindowManagerTests: XCTestCase {
         XCTAssert(tabManager2 === allTabManagers.first!)
     }
 
+    func testReservedUUIDsAreUnavailableInSuccessiveCalls() {
+        let subject = createSubject()
+        let tabDataStore: TabDataStore = AppContainer.shared.resolve()
+        let mockTabDataStore = tabDataStore as! MockTabDataStore
+        mockTabDataStore.resetMockTabWindowUUIDs()
+
+        let savedUUID = UUID()
+        mockTabDataStore.injectMockTabWindowUUID(savedUUID)
+
+        // Request a UUID. We expect it to be the first persisted WindowData
+        // UUID, which will also be reserved for use.
+        let requestedUUID1 = subject.reserveNextAvailableWindowUUID()
+        XCTAssertEqual(requestedUUID1, savedUUID)
+
+        // Request a 2nd UUID. We expect it to be a different UUID.
+        let requestedUUID2 = subject.reserveNextAvailableWindowUUID()
+        XCTAssertNotEqual(requestedUUID2, savedUUID)
+    }
+
     // MARK: - Test Subject
 
     private func createSubject() -> WindowManager {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8095)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18013)

Also:
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8127)

## :bulb: Description

In this PR:
- Early work to support auto-closing panels when using multiple windows on iPad (see notes below)
- Adds some new plumbing to facilitate window events to communicate changes that typically require a response across multiple windows
- Fixes an issue with UUIDs when restoring the app when multiple windows were already previously open

There are some additional changes still forthcoming related to the auto-closing panels. For context, this is being added as part of the iPad multi-window MVP in order to resolve a variety of tricky situations that we would otherwise need to deal with when certain panels (like Recent History) are opened across multiple windows at the same time. The forthcoming move to adopt Redux will likely resolve much of this, so this area is a WIP.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

