### PR TITLE
Bugfix FXIOS-7997 [v122] [Felt Deletion] Update CFR to only display for webpage

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -8,7 +8,18 @@ import UIKit
 
 extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
     // MARK: Data Clearance CFR / Contextual Hint
+
+    // Reset the CFR timer for the data clearance button to avoid presenting the CFR
+    // In cases, such as if user navigates to homepage or if fire icon is not available
+    func resetDataClearanceCFRTimer() {
+        dataClearanceContextHintVC.stopTimer()
+    }
+
     func configureDataClearanceContextualHint() {
+        guard contentContainer.hasWebView, tabManager.selectedTab?.url?.displayURL?.isWebPage() == true else {
+            resetDataClearanceCFRTimer()
+            return
+        }
         dataClearanceContextHintVC.configure(
             anchor: navigationToolbar.multiStateButton,
             withArrowDirection: topTabsVisible ? .up : .down,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1045,6 +1045,8 @@ class BrowserViewController: UIViewController,
     /// on the tab bar to open a new tab or by pressing the home page button on the tab bar. Inline is false when
     /// it's the zero search page, aka when the home page is shown by clicking the url bar from a loaded web page.
     func showEmbeddedHomepage(inline: Bool) {
+        resetDataClearanceCFRTimer()
+
         guard let isPrivate = browserViewControllerState?.usePrivateHomepage, !isPrivate else {
             browserDelegate?.showPrivateHomepage(overlayManager: overlayManager)
             return
@@ -1321,6 +1323,7 @@ class BrowserViewController: UIViewController,
             configureDataClearanceContextualHint()
             return
         }
+        resetDataClearanceCFRTimer()
         navigationToolbar.updateMiddleButtonState(state)
     }
 

--- a/firefox-ios/Client/Frontend/Components/ContentContainer.swift
+++ b/firefox-ios/Client/Frontend/Components/ContentContainer.swift
@@ -31,6 +31,10 @@ class ContentContainer: UIView {
         return type == .privateHomepage
     }
 
+    var hasWebView: Bool {
+        return type == .webview
+    }
+
     /// Determine if the content can be added, making sure we only add once
     /// - Parameters:
     ///   - viewController: The view controller to add to the container

--- a/firefox-ios/Client/Frontend/Components/ContentContainer.swift
+++ b/firefox-ios/Client/Frontend/Components/ContentContainer.swift
@@ -16,7 +16,7 @@ protocol ContentContainable: UIViewController {
 
 /// A container for view controllers, currently used to embed content in BrowserViewController
 class ContentContainer: UIView {
-    var type: ContentType?
+    private var type: ContentType?
     private var contentController: ContentContainable?
 
     var contentView: UIView? {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7997)

## :bulb: Description
Update CFR to not be displayed on the new private home page. It should appear when the user access to the first website (that is not the home page). The idea is that we only show the on boarding message when there is relevant content.

Three cases to reset:
- Current tab is not a webpage
- Current tab is a homepage
- Middle button is no longer a fire icon

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

## Screenshots
https://github.com/mozilla-mobile/firefox-ios/assets/6743397/a3f9c3d3-6665-41e2-99c0-b00e916a6b31

https://github.com/mozilla-mobile/firefox-ios/assets/6743397/e8081d31-8f00-4abd-beb8-926639ff3232


