### PR TITLE
Add FXIOS-8135 [v123] Secret setting for React FxA

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/AdvancedAccountSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/AdvancedAccountSettingViewController.swift
@@ -84,6 +84,16 @@ class AdvancedAccountSettingViewController: SettingsTableViewController {
             self.tableView.reloadData()
         }
 
+        let useReactFxA = BoolSetting(
+            prefs: prefs,
+            prefKey: PrefsKeys.KeyUseReactFxA,
+            defaultValue: false,
+            attributedTitleText: NSAttributedString(string: .SettingsAdvancedAccountUseReactContentServer)
+        ) { isOn in
+            self.settings = self.generateSettings()
+            self.tableView.reloadData()
+        }
+
         let customFxA = CustomURLSetting(prefs: prefs,
                                          prefKey: PrefsKeys.KeyCustomFxAContentServer,
                                          placeholder: .SettingsAdvancedAccountCustomFxAContentServerURI,
@@ -108,7 +118,7 @@ class AdvancedAccountSettingViewController: SettingsTableViewController {
             customSyncTokenServerURISetting
         ]
 
-        var settings: [SettingSection] = [SettingSection(title: nil, children: [useStage])]
+        var settings: [SettingSection] = [SettingSection(title: nil, children: [useStage, useReactFxA])]
 
         if !(prefs.boolForKey(PrefsKeys.UseStageServer) ?? false) {
             settings.append(SettingSection(title: nil, children: autoconfigSettings))

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -2486,6 +2486,7 @@ extension String {
     public static let SettingsAdvancedAccountTitle = "Advanced Sync Settings"
     public static let SettingsAdvancedAccountCustomFxAContentServerURI = "Custom Account Content Server URI"
     public static let SettingsAdvancedAccountUseCustomFxAContentServerURITitle = "Use Custom FxA Content Server"
+    public static let SettingsAdvancedAccountUseReactContentServer = "Use React Content Server"
     public static let SettingsAdvancedAccountCustomSyncTokenServerURI = "Custom Sync Token Server URI"
     public static let SettingsAdvancedAccountUseCustomSyncTokenServerTitle = "Use Custom Sync Token Server"
 }

--- a/firefox-ios/RustFxA/FxAWebViewModel.swift
+++ b/firefox-ios/RustFxA/FxAWebViewModel.swift
@@ -95,7 +95,13 @@ class FxAWebViewModel: FeatureFlaggable {
                     accountManager.beginAuthentication(entrypoint: "email_\(entrypoint)") { [weak self] result in
                         guard let self = self else { return }
 
-                        if case .success(let url) = result {
+                        if case .success(var url) = result {
+                            if self.profile.prefs.boolForKey(PrefsKeys.KeyUseReactFxA) ?? false {
+                                url = url.withQueryParams([
+                                    URLQueryItem(name: "forceExperiment", value: "generalizedReactApp"),
+                                    URLQueryItem(name: "forceExperimentGroup", value: "react")
+                                ])
+                            }
                             self.baseURL = url
                             completion(self.makeRequest(url), .emailLogin)
                         }

--- a/firefox-ios/Shared/Prefs.swift
+++ b/firefox-ios/Shared/Prefs.swift
@@ -109,6 +109,7 @@ public struct PrefsKeys {
     public static let KeyUseCustomSyncTokenServerOverride = "useCustomSyncTokenServerOverride"
     public static let KeyCustomSyncTokenServerOverride = "customSyncTokenServerOverride"
     public static let KeyUseCustomFxAContentServer = "useCustomFxAContentServer"
+    public static let KeyUseReactFxA = "useReactFxA"
     public static let KeyCustomFxAContentServer = "customFxAContentServer"
     public static let UseStageServer = "useStageSyncService"
     public static let KeyFxALastCommandIndex = "FxALastCommandIndex"


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8135)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18103)




## :bulb: Description
Adds a new secret setting, under the Account secret settings to use the new react FxA page. To access the secret setting, a user/tester would tap the Firefox version number 5 times in the setting menu, then scroll up to the Advanced Sync Settings (see below)
<img width="369" alt="image" src="https://github.com/mozilla-mobile/firefox-ios/assets/5303520/f6e118a8-acd4-4723-b4ae-fbba3d1ef92d">

Then, the "Use React Content Server"
<img width="383" alt="image" src="https://github.com/mozilla-mobile/firefox-ios/assets/5303520/034d519b-ca8f-4267-bab1-5756ea8bdd11">

cc @LZoog


Note that the string used in the UI is meant only for QA and thus doesn't need to be localized.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
-  [x] If needed I updated documentation / comments for complex code and public methods

