### PR TITLE
Bugfix FXIOS-8139, DISCO-2714 [v123] description for firefox suggest settings

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -84,6 +84,8 @@ class SearchSettingsTableViewController: ThemedTableViewController, FeatureFlagg
 
         tableView.register(ThemedTableSectionHeaderFooterView.self,
                            forHeaderFooterViewReuseIdentifier: ThemedTableSectionHeaderFooterView.cellIdentifier)
+        tableView.register(ThemedSubtitleTableViewCell.self,
+                           forCellReuseIdentifier: ThemedSubtitleTableViewCell.cellIdentifier)
 
         // Insert Done button if being presented outside of the Settings Nav stack
         if !(self.navigationController is ThemedNavigationController) {
@@ -117,8 +119,7 @@ class SearchSettingsTableViewController: ThemedTableViewController, FeatureFlagg
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = dequeueCellFor(indexPath: indexPath)
-        cell.applyTheme(theme: themeManager.currentTheme)
+        let cell = tableView.dequeueReusableCell(withIdentifier: ThemedSubtitleTableViewCell.cellIdentifier, for: indexPath)
         var engine: OpenSearchEngine!
         let section = Section(rawValue: sectionsToDisplay[indexPath.section].rawValue) ?? .defaultEngine
         switch section {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8139)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18114)

## :bulb: Description
This probably got lost while doing my rebases
<img width="335" alt="Screenshot 2024-01-11 at 3 37 07 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/25379936/3c7e4b0a-7ab8-4061-97b3-733e3994c4ce">
 
but we want

<img width="336" alt="Screenshot 2024-01-11 at 5 02 54 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/25379936/ead27f5e-2ad0-4882-ae31-d8987f5a5b98">



## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

