### PR TITLE
Refactor [v123] Change owner of nimbus file + lower warnings threshold

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,10 @@
 # Order is important; the last matching pattern takes the most
 # precedence. 
 
+# When someone opens a pull request that only modifies those folders / files,
+# those specific persons will be asked for review and not the global owners.
+/firefox-ios/Client/Experiments/initial_experiments.json @dnarcese @afurlan-firefox
+
 # When someone opens a pull request that only modifies those folders / files, 
 # only @mozilla-mobile/fxios-automation and not the global
 # owners will be requested for a review.

--- a/test-fixtures/generate-metrics.sh
+++ b/test-fixtures/generate-metrics.sh
@@ -4,8 +4,8 @@ set -e
 
 BUILD_LOG_FILE="$1"
 TYPE_LOG_FILE="$2"
-THRESHOLD_UNIT_TEST=47
-THRESHOLD_XCUITEST=47
+THRESHOLD_UNIT_TEST=35
+THRESHOLD_XCUITEST=35
 
 WARNING_COUNT=$(grep -E -v "SourcePackages/checkouts" "$BUILD_LOG_FILE" | grep -E "(^|:)[0-9]+:[0-9]+:|warning:|ld: warning:|<unknown>:0: warning:|fatal|===" | uniq | wc -l)
 


### PR DESCRIPTION
## :scroll: Tickets
No tickets

## :bulb: Description
- Changing owners of the file `initial_experiments.json` so @dnarcese and @afurlan-firefox gets tagged for review on it
- Lowering the warnings threshold in our CI pipeline

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

