### PR TITLE
Refactor FXIOS-7711 [v123] Remove LegacyThemeManager.instance.statusBarStyle

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -254,10 +254,6 @@ class BrowserViewController: UIViewController,
         }
     }
 
-    override var preferredStatusBarStyle: UIStatusBarStyle {
-        LegacyThemeManager.instance.statusBarStyle
-    }
-
     @objc
     private func didAddPendingBlobDownloadToQueue() {
         pendingDownloadWebView = nil

--- a/firefox-ios/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -128,10 +128,6 @@ class LibraryViewController: UIViewController, Themeable {
         ])
     }
 
-    override var preferredStatusBarStyle: UIStatusBarStyle {
-        LegacyThemeManager.instance.statusBarStyle
-    }
-
     func updateViewWithState() {
         setupButtons()
     }

--- a/firefox-ios/Client/Frontend/Settings/SettingsNavigationController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsNavigationController.swift
@@ -31,7 +31,7 @@ class ThemedNavigationController: DismissableNavigationViewController, Themeable
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        return topViewController?.preferredStatusBarStyle ?? LegacyThemeManager.instance.statusBarStyle
+        return topViewController?.preferredStatusBarStyle ?? .default
     }
 
     override func viewDidLoad() {

--- a/firefox-ios/Client/Frontend/Theme/LegacyThemeManager/LegacyThemeManager.swift
+++ b/firefox-ios/Client/Frontend/Theme/LegacyThemeManager/LegacyThemeManager.swift
@@ -75,11 +75,6 @@ class LegacyThemeManager {
                                                object: nil)
     }
 
-    // UIViewControllers / UINavigationControllers need to have `preferredStatusBarStyle` and call this.
-    var statusBarStyle: UIStatusBarStyle {
-        return .default
-    }
-
     var userInterfaceStyle: UIUserInterfaceStyle {
         switch currentName {
         case .dark:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7711)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17201)

## :bulb: Description
Refactor out usage of LegacyThemeManager.instance.statusBarStyle and replace with .default. I could not repro the bug before refactoring this part of the code, but I am getting Jeremy to follow up with the person who submitted the ticket so I will check if there's reproducible test steps on Monday before I merge this.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

