### PR TITLE
Refactor FXIOS-8011 [v123] Replace learnMoreButton in WallpaperSettingsHeaderView to be a LinkButton

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsHeaderView.swift
@@ -46,10 +46,8 @@ class WallpaperSettingsHeaderView: UICollectionReusableView, ReusableCell {
         label.numberOfLines = 0
     }
 
-    private lazy var learnMoreButton: LegacyResizableButton = .build { button in
-        button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 12.0)
-        button.contentHorizontalAlignment = .leading
-        button.buttonEdgeSpacing = 0
+    private lazy var learnMoreButton: LinkButton = .build { button in
+        button.addTarget(self, action: #selector(self.buttonTapped), for: .touchUpInside)
     }
 
     // MARK: - Initializers
@@ -87,15 +85,18 @@ class WallpaperSettingsHeaderView: UICollectionReusableView, ReusableCell {
             contentStackView.addArrangedSubview(descriptionLabel)
         }
 
-        if viewModel.buttonTitle != nil,
+        if let buttonTitle = viewModel.buttonTitle,
            let buttonA11y = viewModel.buttonA11yIdentifier,
            viewModel.buttonAction != nil {
+            let learnMoreButtonViewModel = LinkButtonViewModel(
+                title: buttonTitle,
+                a11yIdentifier: buttonA11y,
+                fontSize: 12.0,
+                contentInsets: .zero
+            )
+            learnMoreButton.configure(viewModel: learnMoreButtonViewModel)
+
             setButtonStyle(theme: viewModel.theme)
-            learnMoreButton.addTarget(
-                self,
-                action: #selector((buttonTapped(_:))),
-                for: .touchUpInside)
-            learnMoreButton.accessibilityIdentifier = buttonA11y
 
             contentStackView.addArrangedSubview(learnMoreButton)
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-17882)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17882)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
### Screenshots before PR
<img width="545" alt="Screenshot 2024-01-13 at 12 15 12 AM" src="https://github.com/mozilla-mobile/firefox-ios/assets/15265718/7569499f-c0ed-4695-9316-e3e5fe7d8ba3">
<img width="545" alt="Screenshot 2024-01-13 at 4 44 29 AM" src="https://github.com/mozilla-mobile/firefox-ios/assets/15265718/f5e6e249-10a5-4fea-b4e4-505a68715598">

### Screenshots after PR
<img width="545" alt="Screenshot 2024-01-13 at 4 42 56 AM" src="https://github.com/mozilla-mobile/firefox-ios/assets/15265718/3c66928f-084d-46e7-a5d8-53b9f6bbfcb5">
<img width="545" alt="Screenshot 2024-01-13 at 12 14 31 AM" src="https://github.com/mozilla-mobile/firefox-ios/assets/15265718/3acb7fc5-8107-45a5-a6aa-1e6d7739fefc">



## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

