### PR TITLE
Bugfix FXIOS-8103 [v122] Fix bug in AppEventQueue causing some actions to be skipped

### DIFF
--- a/firefox-ios/Client/Application/SceneDelegate.swift
+++ b/firefox-ios/Client/Application/SceneDelegate.swift
@@ -24,7 +24,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     // MARK: - Connecting / Disconnecting Scenes
 
-    /// Invoked when the app creates OR restores an instance of the UI.
+    /// Invoked when the app creates OR restores an instance of the UI. This is also where deeplinks are handled
+    /// when the app is launched from a cold start. The deeplink URLs are passed in via the `connectionOptions`.
     ///
     /// Use this method to respond to the addition of a new scene, and begin loading data that needs to display.
     /// Take advantage of what's given in `options`.
@@ -87,7 +88,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     /// Asks the delegate to open one or more URLs.
     ///
-    /// This method is equivalent to AppDelegate's openURL method. We implement deep links this way.
+    /// This method is equivalent to AppDelegate's openURL method. Deeplinks opened while
+    /// the app is running are passed in through this delegate method.
     func scene(
         _ scene: UIScene,
         openURLContexts URLContexts: Set<UIOpenURLContext>


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8103)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18033)

## :bulb: Description

Speculative fix for [FXIOS-8103](https://mozilla-hub.atlassian.net/browse/FXIOS-8103). I tested for 6 hours today but I still haven't been able to replicate it locally. However during the process I found an issue within App Event Queue that is probably the culprit (and needs to be fixed regardless). It can potentially impact the startup logic and was causing a similar but slightly-different bug with background tab loading.

The problem is that the queue's processing is not reentrant; usually this doesn't matter but if you attempt to enqueue an action as part of another action (so that the enqueued action is added while the previous actions are being processed) **AND** the newly-enqueued action already has all of its dependencies satisfied, the queue would incorrectly clear it out after the first round of processing completed. The fix is to wait to enqueue the newly added actions until we are ready to process them on the next iteration of `processActions()`.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

