### PR TITLE
Refactor FXIOS-8015 [v123] Replace primaryButton in OnboardingInstructionPopupViewController to be a PrimaryRoundedButton

### DIFF
--- a/firefox-ios/Client/Frontend/Onboarding/ViewControllers/OnboardingInstructionPopupViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/ViewControllers/OnboardingInstructionPopupViewController.swift
@@ -65,6 +65,7 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
     }
 
     private lazy var primaryButton: PrimaryRoundedButton = .build { button in
+        button.addTarget(self, action: #selector(self.primaryAction), for: .touchUpInside)
     }
 
     var viewModel: OnboardingDefaultBrowserModelProtocol

--- a/firefox-ios/Client/Frontend/SurveySurface/SurveySurfaceViewController.swift
+++ b/firefox-ios/Client/Frontend/SurveySurface/SurveySurfaceViewController.swift
@@ -74,7 +74,7 @@ class SurveySurfaceViewController: UIViewController, Themeable {
         label.alpha = 0.0
     }
 
-    private lazy var takeSurveyButton: ResizableButton = .build { button in
+    private lazy var takeSurveyButton: LegacyResizableButton = .build { button in
         button.titleLabel?.font = DefaultDynamicFontHelper.preferredBoldFont(
             withTextStyle: .callout,
             size: UX.buttonFontSize)
@@ -90,7 +90,7 @@ class SurveySurfaceViewController: UIViewController, Themeable {
         button.alpha = 0.0
     }
 
-    private lazy var dismissSurveyButton: ResizableButton = .build { button in
+    private lazy var dismissSurveyButton: LegacyResizableButton = .build { button in
         button.titleLabel?.font = DefaultDynamicFontHelper.preferredBoldFont(
             withTextStyle: .callout,
             size: UX.buttonFontSize)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8015)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17886)

## :bulb: Description
Refactor the styling of the primary button in the `OnboardingInstructionPopupViewController`. This change involves updating the styling properties to align with best practices and improve the overall visual appearance of the primary button. The refactor includes changes to the font, corner radius, text alignment, content insets, and accessibility settings.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

