### PR TITLE
Refactor FXIOS-8145 [v123] Remove LegacyThemeManager from BrowserViewController

### DIFF
--- a/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
@@ -35,10 +35,6 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
 
     public var window: UIWindow?
 
-    public var isSystemThemeOn: Bool {
-        return userDefaults.bool(forKey: ThemeKeys.systemThemeIsOn)
-    }
-
     // MARK: - Init
 
     public init(userDefaults: UserDefaultsInterface = UserDefaults.standard,

--- a/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
@@ -39,11 +39,6 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
         return userDefaults.bool(forKey: ThemeKeys.systemThemeIsOn)
     }
 
-    // UIViewControllers / UINavigationControllers need to have `preferredStatusBarStyle` and call this.
-    public var statusBarStyle: UIStatusBarStyle {
-        return .default
-    }
-
     // MARK: - Init
 
     public init(userDefaults: UserDefaultsInterface = UserDefaults.standard,

--- a/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
@@ -35,6 +35,15 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
 
     public var window: UIWindow?
 
+    public var isSystemThemeOn: Bool {
+        return userDefaults.bool(forKey: ThemeKeys.systemThemeIsOn)
+    }
+
+    // UIViewControllers / UINavigationControllers need to have `preferredStatusBarStyle` and call this.
+    public var statusBarStyle: UIStatusBarStyle {
+        return .default
+    }
+
     // MARK: - Init
 
     public init(userDefaults: UserDefaultsInterface = UserDefaults.standard,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -180,6 +180,8 @@ class BrowserViewController: UIViewController,
         return NewTabAccessors.getNewTabPage(profile.prefs)
     }
 
+    private var defaultThemeManager = DefaultThemeManager(sharedContainerIdentifier: AppInfo.sharedContainerIdentifier)
+
     @available(iOS 13.4, *)
     func keyboardPressesHandler() -> KeyboardPressesHandler {
         guard let keyboardPressesHandlerValue = keyboardPressesHandlerValue as? KeyboardPressesHandler else {
@@ -252,6 +254,10 @@ class BrowserViewController: UIViewController,
             guard !AppEventQueue.activityIsCompleted(.browserUpdatedForAppActivation(tabWindowUUID)) else { return }
             self?.browserDidBecomeActive()
         }
+    }
+
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        defaultThemeManager.statusBarStyle
     }
 
     @objc
@@ -835,10 +841,10 @@ class BrowserViewController: UIViewController,
     private func updateLegacyTheme() {
         if let state = browserViewControllerState,
            !NightModeHelper.isActivated()
-            && LegacyThemeManager.instance.systemThemeIsOn
+            && defaultThemeManager.isSystemThemeOn
             && !state.usePrivateHomepage {
             let userInterfaceStyle = traitCollection.userInterfaceStyle
-            LegacyThemeManager.instance.current = userInterfaceStyle == .dark ? LegacyDarkTheme() : LegacyNormalTheme()
+            defaultThemeManager.currentTheme = userInterfaceStyle == .dark ? DarkTheme() : LightTheme()
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -180,8 +180,6 @@ class BrowserViewController: UIViewController,
         return NewTabAccessors.getNewTabPage(profile.prefs)
     }
 
-    private var defaultThemeManager = DefaultThemeManager(sharedContainerIdentifier: AppInfo.sharedContainerIdentifier)
-
     @available(iOS 13.4, *)
     func keyboardPressesHandler() -> KeyboardPressesHandler {
         guard let keyboardPressesHandlerValue = keyboardPressesHandlerValue as? KeyboardPressesHandler else {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -256,10 +256,6 @@ class BrowserViewController: UIViewController,
         }
     }
 
-    override var preferredStatusBarStyle: UIStatusBarStyle {
-        defaultThemeManager.statusBarStyle
-    }
-
     @objc
     private func didAddPendingBlobDownloadToQueue() {
         pendingDownloadWebView = nil
@@ -561,8 +557,6 @@ class BrowserViewController: UIViewController,
         let dropInteraction = UIDropInteraction(delegate: self)
         view.addInteraction(dropInteraction)
 
-        updateLegacyTheme()
-
         searchTelemetry = SearchTelemetry()
 
         // Awesomebar Location Telemetry
@@ -833,19 +827,8 @@ class BrowserViewController: UIViewController,
         super.traitCollectionDidChange(previousTraitCollection)
         if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
             themeManager.systemThemeChanged()
-            updateLegacyTheme()
         }
         setupMiddleButtonStatus(isLoading: false)
-    }
-
-    private func updateLegacyTheme() {
-        if let state = browserViewControllerState,
-           !NightModeHelper.isActivated()
-            && defaultThemeManager.isSystemThemeOn
-            && !state.usePrivateHomepage {
-            let userInterfaceStyle = traitCollection.userInterfaceStyle
-            defaultThemeManager.currentTheme = userInterfaceStyle == .dark ? DarkTheme() : LightTheme()
-        }
     }
 
     // MARK: - Constraints


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8145)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18132)

## :bulb: Description
- This pull request addresses the removal of the LegacyThemeManager dependency in the BrowserViewController by introducing the DefaultThemeManager. 
- The DefaultThemeManager now handles status bar style and system theme settings, resulting in a more streamlined and modern implementation.


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods