### PR TITLE
Refactor FXIOS-8108 [v123] [Swiftlint] line_length, part 3

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,5 +1,5 @@
 only_rules: # Only enforce these rules, ignore all others
-  # - line_length
+  - line_length
   - blanket_disable_command
   - class_delegate_protocol
   - closure_spacing
@@ -92,9 +92,10 @@ only_rules: # Only enforce these rules, ignore all others
   # - prohibited_super_call
   # - protocol_property_accessors_order
 
-# line_length:
-#   ignores_urls: true
-#   ignores_interpolated_strings: true
+line_length:
+  warning: 125
+  ignores_urls: true
+  ignores_interpolated_strings: true
 
 file_header:
   required_string: |

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/PrimaryRoundedButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/PrimaryRoundedButton.swift
@@ -47,7 +47,9 @@ public class PrimaryRoundedButton: ResizableButton, ThemeApplicable {
             updatedConfiguration.background.backgroundColor = backgroundColorNormal
         }
 
+        // swiftlint:disable line_length
         updatedConfiguration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { [weak self] incoming in
+        // swiftlint:enable line_length
             var container = incoming
             container.foregroundColor = self?.foregroundColor
             container.font = DefaultDynamicFontHelper.preferredBoldFont(

--- a/BrowserKit/Sources/WebEngine/Engine.swift
+++ b/BrowserKit/Sources/WebEngine/Engine.swift
@@ -4,7 +4,8 @@
 
 import Foundation
 
-/// The engine used to create an `EngineView` and `EngineSession`. There is only when engine view to be created, but multiple sessions can exists.
+/// The engine used to create an `EngineView` and `EngineSession`.
+/// There is only when engine view to be created, but multiple sessions can exists.
 public protocol Engine {
     /// Creates a new view for rendering web content.
     func createView() -> EngineView

--- a/BrowserKit/Sources/WebEngine/WKWebview/Scripts/WKContentScript.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/Scripts/WKContentScript.swift
@@ -5,7 +5,8 @@
 import Foundation
 import WebKit
 
-/// Protocol each script injected into a WKEngineSession needs to follow. Scripts are injected through the `WKContentScriptManager`
+/// Protocol each script injected into a WKEngineSession needs to follow.
+/// Scripts are injected through the `WKContentScriptManager`
 protocol WKContentScript {
     static func name() -> String
 

--- a/BrowserKit/Sources/WebEngine/WKWebview/Scripts/WKUserScriptManager.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/Scripts/WKUserScriptManager.swift
@@ -31,10 +31,12 @@ class DefaultUserScriptManager: WKUserScriptManager {
         webView.configuration.userContentController.removeAllUserScripts()
 
         // Inject all pre-compiled user scripts.
-        [UserScriptInfo(injectionTime: WKUserScriptInjectionTime.atDocumentStart, isMainFrame: false),
-         UserScriptInfo(injectionTime: WKUserScriptInjectionTime.atDocumentEnd, isMainFrame: false),
-         UserScriptInfo(injectionTime: WKUserScriptInjectionTime.atDocumentStart, isMainFrame: true),
-         UserScriptInfo(injectionTime: WKUserScriptInjectionTime.atDocumentEnd, isMainFrame: true)].forEach { userScriptInfo in
+        [
+            UserScriptInfo(injectionTime: WKUserScriptInjectionTime.atDocumentStart, isMainFrame: false),
+            UserScriptInfo(injectionTime: WKUserScriptInjectionTime.atDocumentEnd, isMainFrame: false),
+            UserScriptInfo(injectionTime: WKUserScriptInjectionTime.atDocumentStart, isMainFrame: true),
+            UserScriptInfo(injectionTime: WKUserScriptInjectionTime.atDocumentEnd, isMainFrame: true)
+        ].forEach { userScriptInfo in
             let fullName = buildScriptName(from: userScriptInfo)
 
             if let userScript = compiledUserScripts[fullName] {
@@ -50,10 +52,12 @@ class DefaultUserScriptManager: WKUserScriptManager {
 
     /// Cache all of the pre-compiled user scripts so they don't need re-fetched from disk for each webview.
     private func injectUserScripts() {
-        [UserScriptInfo(injectionTime: WKUserScriptInjectionTime.atDocumentStart, isMainFrame: false),
-         UserScriptInfo(injectionTime: WKUserScriptInjectionTime.atDocumentEnd, isMainFrame: false),
-         UserScriptInfo(injectionTime: WKUserScriptInjectionTime.atDocumentStart, isMainFrame: true),
-         UserScriptInfo(injectionTime: WKUserScriptInjectionTime.atDocumentEnd, isMainFrame: true)].forEach { userScriptInfo in
+        [
+            UserScriptInfo(injectionTime: WKUserScriptInjectionTime.atDocumentStart, isMainFrame: false),
+            UserScriptInfo(injectionTime: WKUserScriptInjectionTime.atDocumentEnd, isMainFrame: false),
+            UserScriptInfo(injectionTime: WKUserScriptInjectionTime.atDocumentStart, isMainFrame: true),
+            UserScriptInfo(injectionTime: WKUserScriptInjectionTime.atDocumentEnd, isMainFrame: true)
+        ].forEach { userScriptInfo in
             let fullName = buildScriptName(from: userScriptInfo)
 
             injectFrameScript(name: fullName, userScriptInfo: userScriptInfo)

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -568,7 +568,8 @@ class BrowserCoordinator: BaseCoordinator,
         if let qrCodeCoordinator = childCoordinators.first(where: { $0 is QRCodeCoordinator }) as? QRCodeCoordinator {
             coordinator = qrCodeCoordinator
         } else {
-            let router = rootNavigationController != nil ? DefaultRouter(navigationController: rootNavigationController!) : router
+            let defaultRouter = DefaultRouter(navigationController: rootNavigationController!)
+            let router = rootNavigationController != nil ? defaultRouter : router
             coordinator = QRCodeCoordinator(parentCoordinator: self, router: router)
             add(child: coordinator)
         }

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -568,9 +568,18 @@ class BrowserCoordinator: BaseCoordinator,
         if let qrCodeCoordinator = childCoordinators.first(where: { $0 is QRCodeCoordinator }) as? QRCodeCoordinator {
             coordinator = qrCodeCoordinator
         } else {
-            let defaultRouter = DefaultRouter(navigationController: rootNavigationController!)
-            let router = rootNavigationController != nil ? defaultRouter : router
-            coordinator = QRCodeCoordinator(parentCoordinator: self, router: router)
+            if rootNavigationController != nil {
+                coordinator = QRCodeCoordinator(
+                    parentCoordinator: self,
+                    router: DefaultRouter(navigationController: rootNavigationController!)
+                )
+            } else {
+                coordinator = QRCodeCoordinator(
+                    parentCoordinator: self,
+                    router: router
+                )
+            }
+
             add(child: coordinator)
         }
         coordinator.showQRCode(delegate: delegate)

--- a/firefox-ios/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -139,9 +139,17 @@ class LaunchCoordinator: BaseCoordinator,
         if let qrCodeCoordinator = childCoordinators.first(where: { $0 is QRCodeCoordinator }) as? QRCodeCoordinator {
             coordinator = qrCodeCoordinator
         } else {
-            let defaultRouter = DefaultRouter(navigationController: rootNavigationController!)
-            let router = rootNavigationController != nil ? defaultRouter : router
-            coordinator = QRCodeCoordinator(parentCoordinator: self, router: router)
+            if rootNavigationController != nil {
+                coordinator = QRCodeCoordinator(
+                    parentCoordinator: self,
+                    router: DefaultRouter(navigationController: rootNavigationController!)
+                )
+            } else {
+                coordinator = QRCodeCoordinator(
+                    parentCoordinator: self,
+                    router: router
+                )
+            }
             add(child: coordinator)
         }
         coordinator.showQRCode(delegate: delegate)

--- a/firefox-ios/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -115,7 +115,8 @@ class LaunchCoordinator: BaseCoordinator,
         defaultOnboardingViewController.preferredContentSize = CGSize(
             width: ViewControllerConsts.PreferredSize.DBOnboardingViewController.width,
             height: ViewControllerConsts.PreferredSize.DBOnboardingViewController.height)
-        defaultOnboardingViewController.modalPresentationStyle = UIDevice.current.userInterfaceIdiom == .phone ? .fullScreen : .formSheet
+        let isiPhone = UIDevice.current.userInterfaceIdiom == .phone
+        defaultOnboardingViewController.modalPresentationStyle = isiPhone ? .fullScreen : .formSheet
         router.present(defaultOnboardingViewController)
     }
 
@@ -138,7 +139,8 @@ class LaunchCoordinator: BaseCoordinator,
         if let qrCodeCoordinator = childCoordinators.first(where: { $0 is QRCodeCoordinator }) as? QRCodeCoordinator {
             coordinator = qrCodeCoordinator
         } else {
-            let router = rootNavigationController != nil ? DefaultRouter(navigationController: rootNavigationController!) : router
+            let defaultRouter = DefaultRouter(navigationController: rootNavigationController!)
+            let router = rootNavigationController != nil ? defaultRouter : router
             coordinator = QRCodeCoordinator(parentCoordinator: self, router: router)
             add(child: coordinator)
         }

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -209,7 +209,8 @@ class SettingsCoordinator: BaseCoordinator,
         if let qrCodeCoordinator = childCoordinators.first(where: { $0 is QRCodeCoordinator }) as? QRCodeCoordinator {
             coordinator = qrCodeCoordinator
         } else {
-            let router = rootNavigationController != nil ? DefaultRouter(navigationController: rootNavigationController!) : router
+            let defaultRouter = DefaultRouter(navigationController: rootNavigationController!)
+            let router = rootNavigationController != nil ? defaultRouter : router
             coordinator = QRCodeCoordinator(parentCoordinator: self, router: router)
             add(child: coordinator)
         }

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -209,9 +209,17 @@ class SettingsCoordinator: BaseCoordinator,
         if let qrCodeCoordinator = childCoordinators.first(where: { $0 is QRCodeCoordinator }) as? QRCodeCoordinator {
             coordinator = qrCodeCoordinator
         } else {
-            let defaultRouter = DefaultRouter(navigationController: rootNavigationController!)
-            let router = rootNavigationController != nil ? defaultRouter : router
-            coordinator = QRCodeCoordinator(parentCoordinator: self, router: router)
+            if rootNavigationController != nil {
+                coordinator = QRCodeCoordinator(
+                    parentCoordinator: self,
+                    router: DefaultRouter(navigationController: rootNavigationController!)
+                )
+            } else {
+                coordinator = QRCodeCoordinator(
+                    parentCoordinator: self,
+                    router: router
+                )
+            }
             add(child: coordinator)
         }
         coordinator.showQRCode(delegate: delegate)

--- a/firefox-ios/Client/Coordinators/TabTray/RemoteTabsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/TabTray/RemoteTabsCoordinator.swift
@@ -67,9 +67,17 @@ class RemoteTabsCoordinator: BaseCoordinator,
         if let qrCodeCoordinator = childCoordinators.first(where: { $0 is QRCodeCoordinator }) as? QRCodeCoordinator {
             coordinator = qrCodeCoordinator
         } else {
-            let defaultRouter = DefaultRouter(navigationController: rootNavigationController!)
-            let router = rootNavigationController != nil ? defaultRouter : router
-            coordinator = QRCodeCoordinator(parentCoordinator: self, router: router)
+            if rootNavigationController != nil {
+                coordinator = QRCodeCoordinator(
+                    parentCoordinator: self,
+                    router: DefaultRouter(navigationController: rootNavigationController!)
+                )
+            } else {
+                coordinator = QRCodeCoordinator(
+                    parentCoordinator: self,
+                    router: router
+                )
+            }
             add(child: coordinator)
         }
         coordinator.showQRCode(delegate: delegate)

--- a/firefox-ios/Client/Coordinators/TabTray/RemoteTabsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/TabTray/RemoteTabsCoordinator.swift
@@ -67,7 +67,8 @@ class RemoteTabsCoordinator: BaseCoordinator,
         if let qrCodeCoordinator = childCoordinators.first(where: { $0 is QRCodeCoordinator }) as? QRCodeCoordinator {
             coordinator = qrCodeCoordinator
         } else {
-            let router = rootNavigationController != nil ? DefaultRouter(navigationController: rootNavigationController!) : router
+            let defaultRouter = DefaultRouter(navigationController: rootNavigationController!)
+            let router = rootNavigationController != nil ? defaultRouter : router
             coordinator = QRCodeCoordinator(parentCoordinator: self, router: router)
             add(child: coordinator)
         }

--- a/firefox-ios/Client/Extensions/NSAttributedString+Extension.swift
+++ b/firefox-ios/Client/Extensions/NSAttributedString+Extension.swift
@@ -7,7 +7,13 @@ import Foundation
 // MARK: - Common UITableView text styling
 extension NSAttributedString {
     static func tableRowTitle(_ string: String, enabled: Bool) -> NSAttributedString {
-        let color = enabled ? [NSAttributedString.Key.foregroundColor: UIColor.legacyTheme.tableView.rowText] : [NSAttributedString.Key.foregroundColor: UIColor.legacyTheme.tableView.disabledRowText]
+        var color: [NSAttributedString.Key : UIColor]
+        if enabled {
+            color = [NSAttributedString.Key.foregroundColor: UIColor.legacyTheme.tableView.rowText]
+        } else {
+            color = [NSAttributedString.Key.foregroundColor: UIColor.legacyTheme.tableView.disabledRowText]
+        }
+
         return NSAttributedString(string: string, attributes: color)
     }
 }

--- a/firefox-ios/Client/Extensions/NSAttributedString+Extension.swift
+++ b/firefox-ios/Client/Extensions/NSAttributedString+Extension.swift
@@ -7,7 +7,7 @@ import Foundation
 // MARK: - Common UITableView text styling
 extension NSAttributedString {
     static func tableRowTitle(_ string: String, enabled: Bool) -> NSAttributedString {
-        var color: [NSAttributedString.Key : UIColor]
+        var color: [NSAttributedString.Key: UIColor]
         if enabled {
             color = [NSAttributedString.Key.foregroundColor: UIColor.legacyTheme.tableView.rowText]
         } else {

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
@@ -158,7 +158,8 @@ class CreditCardBottomSheetViewController: UIViewController,
         let estimatedFooterHeight = cardTableView.estimatedSectionFooterHeight
         let estimatedCellHeight = cardTableView.estimatedRowHeight
 
-        var estimatedContentHeight = headerHeight + estimatedCellHeight + estimatedFooterHeight + UX.yesButtonHeight + UX.bottomSpacing + UX.buttonsSpacing
+        let UXSpacing = UX.yesButtonHeight + UX.bottomSpacing + UX.buttonsSpacing
+        var estimatedContentHeight = headerHeight + estimatedCellHeight + estimatedFooterHeight + UXSpacing
 
         if UIDevice.current.userInterfaceIdiom == .pad {
             estimatedContentHeight += UX.yesButtonHeight
@@ -169,7 +170,8 @@ class CreditCardBottomSheetViewController: UIViewController,
         )
         contentViewHeightConstraint.priority = UILayoutPriority(999)
 
-        let contentViewWidth = UX.contentViewWidth > view.frame.width ? view.frame.width - UX.containerPadding : UX.contentViewWidth
+        let contentWidthCheck = UX.contentViewWidth > view.frame.width
+        let contentViewWidth = contentWidthCheck ? view.frame.width - UX.containerPadding : UX.contentViewWidth
         contentWidthConstraint = contentView.widthAnchor.constraint(equalToConstant: contentViewWidth)
         contentWidthConstraint.priority = UILayoutPriority(999)
 
@@ -216,7 +218,8 @@ class CreditCardBottomSheetViewController: UIViewController,
         let aspectRatio = estimatedContentHeight / contentView.bounds.size.height
         contentViewHeightConstraint.constant = contentViewHeightConstraint.constant * aspectRatio
 
-        let contentViewWidth = UX.contentViewWidth > view.frame.size.width ? view.frame.size.width - UX.containerPadding : UX.contentViewWidth
+        let contentWidthCheck = UX.contentViewWidth > view.frame.size.width
+        let contentViewWidth = contentWidthCheck ? view.frame.size.width - UX.containerPadding : UX.contentViewWidth
         contentWidthConstraint.constant = contentViewWidth
     }
 
@@ -228,10 +231,11 @@ class CreditCardBottomSheetViewController: UIViewController,
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
-        let contentViewWidth = UX.contentViewWidth > size.width ? size.width - UX.containerPadding : UX.contentViewWidth
+        let contentWidthCheck = UX.contentViewWidth > size.width
+        let contentViewWidth = contentWidthCheck ? size.width - UX.containerPadding : UX.contentViewWidth
         contentWidthConstraint.constant = contentViewWidth
         if let header = cardTableView.headerView(forSection: 0) as? CreditCardBottomSheetHeaderView {
-            header.titleLabelTrailingConstraint.constant = UX.contentViewWidth > size.width ? -UX.closeButtonMarginAndWidth : 0
+            header.titleLabelTrailingConstraint.constant = contentWidthCheck ? -UX.closeButtonMarginAndWidth : 0
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BackForwardListAnimator.swift
+++ b/firefox-ios/Client/Frontend/Browser/BackForwardListAnimator.swift
@@ -14,7 +14,9 @@ class BackForwardListAnimator: NSObject, UIViewControllerAnimatedTransitioning {
             to: transitionContext.viewController(forKey: .to)!
         )
 
-        guard let backForwardViewController = !self.presenting ? screens.from as? BackForwardListViewController : screens.to as? BackForwardListViewController else { return }
+        let screensFrom = screens.from as? BackForwardListViewController
+        let screensTo = screens.to as? BackForwardListViewController
+        guard let backForwardViewController = !self.presenting ? screensFrom : screensTo else { return }
 
         var bottomViewController = !self.presenting ? screens.to as UIViewController : screens.from as UIViewController
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+KeyCommands.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+KeyCommands.swift
@@ -413,7 +413,8 @@ extension BrowserViewController {
         // Open tab in background || Open in new tab
         if keyboardPressesHandler().isOnlyCmdPressed || keyboardPressesHandler().isCmdAndShiftPressed {
             guard let isPrivate = tabManager.selectedTab?.isPrivate else { return shouldCancelHandler }
-            let selectNewTab = !keyboardPressesHandler().isOnlyCmdPressed && keyboardPressesHandler().isCmdAndShiftPressed
+            let selectNewTab = !keyboardPressesHandler().isOnlyCmdPressed
+                               && keyboardPressesHandler().isCmdAndShiftPressed
             homePanelDidRequestToOpenInNewTab(url, isPrivate: isPrivate, selectNewTab: selectNewTab)
             shouldCancelHandler = true
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ReaderMode.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ReaderMode.swift
@@ -195,7 +195,8 @@ extension BrowserViewController: ReaderModeBarViewDelegate {
             readerModeStyleViewController.modalPresentationStyle = .popover
 
             let setupPopover = { [unowned self] in
-                guard let popoverPresentationController = readerModeStyleViewController.popoverPresentationController else { return }
+                guard let popoverPresentationController = readerModeStyleViewController.popoverPresentationController
+                else { return }
 
                 let arrowDirection: UIPopoverArrowDirection = isBottomSearchBar ? .down : .up
                 let ySpacing = isBottomSearchBar ? -1 : UIConstants.ToolbarHeight

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -201,9 +201,15 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
 
     func tabToolbarDidPressTabs(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
         updateZoomPageBarVisibility(visible: false)
-        let segmentToFocus = tabManager.selectedTab?.isPrivate ?? false ? TabTrayPanelType.privateTabs : TabTrayPanelType.tabs
+        let isPrivateTab = tabManager.selectedTab?.isPrivate ?? false
+        let segmentToFocus = isPrivateTab ? TabTrayPanelType.privateTabs : TabTrayPanelType.tabs
         showTabTray(focusedSegment: segmentToFocus)
-        TelemetryWrapper.recordEvent(category: .action, method: .press, object: .tabToolbar, value: .tabView)
+        TelemetryWrapper.recordEvent(
+            category: .action,
+            method: .press,
+            object: .tabToolbar,
+            value: .tabView
+        )
     }
 
     func getTabToolbarLongPressActionsForModeSwitching() -> [PhotonRowActions] {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -292,7 +292,10 @@ extension BrowserViewController: WKUIDelegate {
                                                      value: .contextMenu)
                     }
 
-                    let isBookmarkedSite = profile.places.isBookmarked(url: url.absoluteString).value.successValue ?? false
+                    let isBookmarkedSite = profile.places
+                        .isBookmarked(url: url.absoluteString)
+                        .value
+                        .successValue ?? false
                     actions.append(isBookmarkedSite ? removeAction : addBookmarkAction)
 
                     actions.append(UIAction(

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -781,7 +781,9 @@ class BrowserViewController: UIViewController,
 
         var fakespotNeedsUpdate = false
         if urlBar.currentURL != nil {
-            fakespotNeedsUpdate = contentStackView.isSidebarVisible != FakespotUtils().shouldDisplayInSidebar(viewSize: size)
+            fakespotNeedsUpdate = contentStackView.isSidebarVisible != FakespotUtils().shouldDisplayInSidebar(
+                viewSize: size
+            )
             if let fakespotState = browserViewControllerState?.fakespotState {
                 fakespotNeedsUpdate = fakespotNeedsUpdate && fakespotState.isOpen
             }
@@ -1730,13 +1732,17 @@ class BrowserViewController: UIViewController,
     }
 
     internal func updateFakespot(tab: Tab) {
-        guard let webView = tab.webView, let url = webView.url else {
+        guard let webView = tab.webView,
+              let url = webView.url
+        else {
             // We're on homepage or a blank tab
             store.dispatch(FakespotAction.setAppearanceTo(false))
             return
         }
+
         store.dispatch(FakespotAction.tabDidChange(tabUIDD: tab.tabUUID))
-        let environment = featureFlags.isCoreFeatureEnabled(.useStagingFakespotAPI) ? FakespotEnvironment.staging : .prod
+        let isFeatureEnabled = featureFlags.isCoreFeatureEnabled(.useStagingFakespotAPI)
+        let environment = isFeatureEnabled ? FakespotEnvironment.staging : .prod
         let product = ShoppingProduct(url: url, client: FakespotClient(environment: environment))
 
         guard product.product != nil, !tab.isPrivate else {
@@ -1912,8 +1918,13 @@ class BrowserViewController: UIViewController,
     // Disable search suggests view only if user is in private mode and setting is enabled
     private var shouldDisableSearchSuggestsForPrivateMode: Bool {
         let featureFlagEnabled = featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly)
-        let alwaysShowSearchSuggestionsView = browserViewControllerState?.searchScreenState.showSearchSugestionsView ?? false
-        let isSettingEnabled = profile.prefs.boolForKey(PrefsKeys.SearchSettings.showPrivateModeSearchSuggestions) ?? false
+        let alwaysShowSearchSuggestionsView = browserViewControllerState?
+            .searchScreenState
+            .showSearchSugestionsView ?? false
+        let isSettingEnabled = profile.prefs.boolForKey(
+            PrefsKeys.SearchSettings.showPrivateModeSearchSuggestions
+        ) ?? false
+
         return featureFlagEnabled && !alwaysShowSearchSuggestionsView && !isSettingEnabled
     }
 
@@ -2730,43 +2741,46 @@ extension BrowserViewController {
     }
 
     func trackAccessibility() {
+        typealias Key = TelemetryWrapper.EventExtraKey
         TelemetryWrapper.recordEvent(
             category: .action,
             method: .voiceOver,
             object: .app,
-            extras: [TelemetryWrapper.EventExtraKey.isVoiceOverRunning.rawValue: UIAccessibility.isVoiceOverRunning.description]
+            extras: [Key.isVoiceOverRunning.rawValue: UIAccessibility.isVoiceOverRunning.description]
         )
         TelemetryWrapper.recordEvent(
             category: .action,
             method: .switchControl,
             object: .app,
-            extras: [TelemetryWrapper.EventExtraKey.isSwitchControlRunning.rawValue: UIAccessibility.isSwitchControlRunning.description]
+            extras: [Key.isSwitchControlRunning.rawValue: UIAccessibility.isSwitchControlRunning.description]
         )
         TelemetryWrapper.recordEvent(
             category: .action,
             method: .reduceTransparency,
             object: .app,
-            extras: [TelemetryWrapper.EventExtraKey.isReduceTransparencyEnabled.rawValue: UIAccessibility.isReduceTransparencyEnabled.description]
+            extras: [Key.isReduceTransparencyEnabled.rawValue: UIAccessibility.isReduceTransparencyEnabled.description]
         )
         TelemetryWrapper.recordEvent(
             category: .action,
             method: .reduceMotion,
             object: .app,
-            extras: [TelemetryWrapper.EventExtraKey.isReduceMotionEnabled.rawValue: UIAccessibility.isReduceMotionEnabled.description]
+            extras: [Key.isReduceMotionEnabled.rawValue: UIAccessibility.isReduceMotionEnabled.description]
         )
         TelemetryWrapper.recordEvent(
             category: .action,
             method: .invertColors,
             object: .app,
-            extras: [TelemetryWrapper.EventExtraKey.isInvertColorsEnabled.rawValue: UIAccessibility.isInvertColorsEnabled.description]
+            extras: [Key.isInvertColorsEnabled.rawValue: UIAccessibility.isInvertColorsEnabled.description]
         )
+
+        let a11yEnabled = UIApplication.shared.preferredContentSizeCategory.isAccessibilityCategory.description
+        let a11yCategory = UIApplication.shared.preferredContentSizeCategory.rawValue.description
         TelemetryWrapper.recordEvent(
             category: .action,
             method: .dynamicTextSize,
             object: .app,
-            extras: [
-                TelemetryWrapper.EventExtraKey.isAccessibilitySizeEnabled.rawValue: UIApplication.shared.preferredContentSizeCategory.isAccessibilityCategory.description,
-                TelemetryWrapper.EventExtraKey.preferredContentSizeCategory.rawValue: UIApplication.shared.preferredContentSizeCategory.rawValue.description]
+            extras: [Key.isAccessibilitySizeEnabled.rawValue: a11yEnabled,
+                     Key.preferredContentSizeCategory.rawValue: a11yCategory]
         )
     }
 

--- a/firefox-ios/Client/Frontend/Browser/DownloadQueue.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadQueue.swift
@@ -54,7 +54,9 @@ class Download: NSObject {
             count += 1
 
             let proposedFilenameWithoutExtension = "\(filenameWithoutExtension) (\(count))"
-            proposedPath = downloadsPath.appendingPathComponent(proposedFilenameWithoutExtension).appendingPathExtension(fileExtension)
+            proposedPath = downloadsPath
+                .appendingPathComponent(proposedFilenameWithoutExtension)
+                .appendingPathExtension(fileExtension)
         }
 
         return proposedPath

--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -351,6 +351,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
         let toggleActionTitle: String
         let toggleActionIcon: String
         let siteTypeTelemetryObject: TelemetryWrapper.EventObject
+        // swiftlint:disable line_length
         if defaultUAisDesktop {
             toggleActionTitle = tab.changedUserAgent ? .AppMenu.AppMenuViewDesktopSiteTitleString : .AppMenu.AppMenuViewMobileSiteTitleString
             toggleActionIcon = tab.changedUserAgent ? StandardImageIdentifiers.Large.deviceDesktop : StandardImageIdentifiers.Large.deviceMobile
@@ -360,6 +361,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
             toggleActionIcon = tab.changedUserAgent ? StandardImageIdentifiers.Large.deviceMobile : StandardImageIdentifiers.Large.deviceDesktop
             siteTypeTelemetryObject = .requestMobileSite
         }
+        // swiftlint:enable line_length
 
         return SingleActionViewModel(title: toggleActionTitle,
                                      iconString: toggleActionIcon) { _ in

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEngines.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEngines.swift
@@ -46,7 +46,9 @@ class SearchEngines {
         self.prefs = prefs
         // By default, show search suggestions
         self.shouldShowSearchSuggestions = prefs.boolForKey(showSearchSuggestions) ?? true
-        self.shouldShowPrivateModeSearchSuggestions = prefs.boolForKey(PrefsKeys.SearchSettings.showPrivateModeSearchSuggestions) ?? false
+        self.shouldShowPrivateModeSearchSuggestions = prefs.boolForKey(
+            PrefsKeys.SearchSettings.showPrivateModeSearchSuggestions
+        ) ?? false
         self.fileAccessor = files
         self.engineProvider = engineProvider
         self.orderedEngines = []

--- a/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
@@ -69,7 +69,6 @@ class SearchViewController: SiteTableViewController,
                             LoaderListener,
                             FeatureFlaggable,
                             Notifiable {
-
     typealias ExtraKey = TelemetryWrapper.EventExtraKey
 
     var searchDelegate: SearchViewControllerDelegate?

--- a/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
@@ -69,6 +69,9 @@ class SearchViewController: SiteTableViewController,
                             LoaderListener,
                             FeatureFlaggable,
                             Notifiable {
+
+    typealias ExtraKey = TelemetryWrapper.EventExtraKey
+
     var searchDelegate: SearchViewControllerDelegate?
     private let viewModel: SearchViewModel
     private let model: SearchEngines
@@ -429,8 +432,10 @@ class SearchViewController: SiteTableViewController,
             assertionFailure()
             return
         }
-        let extras = [TelemetryWrapper.EventExtraKey.recordSearchLocation.rawValue: SearchesMeasurement.SearchLocation.quickSearch,
-                      TelemetryWrapper.EventExtraKey.recordSearchEngineID.rawValue: engine.engineID as Any] as [String: Any]
+        let extras = [
+            ExtraKey.recordSearchLocation.rawValue: SearchesMeasurement.SearchLocation.quickSearch,
+            ExtraKey.recordSearchEngineID.rawValue: engine.engineID as Any
+        ] as [String: Any]
         TelemetryWrapper.gleanRecordEvent(category: .action,
                                           method: .tap,
                                           object: .recordSearch,
@@ -588,7 +593,9 @@ class SearchViewController: SiteTableViewController,
                 self.suggestions = suggestions!
                 // Remove user searching term inside suggestions list
                 self.suggestions?.removeAll(where: {
+                    // swiftlint:disable line_length
                     $0.trimmingCharacters(in: .whitespacesAndNewlines) == self.searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+                    // swiftlint:enable line_length
                 })
                 // First suggestion should be what the user is searching
                 self.suggestions?.insert(self.searchQuery, at: 0)
@@ -626,8 +633,10 @@ class SearchViewController: SiteTableViewController,
                   let url = defaultEngine.searchURLForQuery(suggestion)
             else { return }
 
-            let extras = [TelemetryWrapper.EventExtraKey.recordSearchLocation.rawValue: SearchesMeasurement.SearchLocation.suggestion,
-                          TelemetryWrapper.EventExtraKey.recordSearchEngineID.rawValue: defaultEngine.engineID as Any] as [String: Any]
+            let extras = [
+                ExtraKey.recordSearchLocation.rawValue: SearchesMeasurement.SearchLocation.suggestion,
+                ExtraKey.recordSearchEngineID.rawValue: defaultEngine.engineID as Any
+            ] as [String: Any]
             TelemetryWrapper.gleanRecordEvent(category: .action,
                                               method: .tap,
                                               object: .recordSearch,

--- a/firefox-ios/Client/Frontend/Browser/SimpleToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/SimpleToast.swift
@@ -69,7 +69,9 @@ struct SimpleToast: ThemeApplicable {
                 toast.frame = frame
             },
             completion: { finished in
-                let voiceOverDelay = UIAccessibility.isVoiceOverRunning ? DispatchTimeInterval.milliseconds(1000) : DispatchTimeInterval.milliseconds(0)
+                let thousandMilliseconds = DispatchTimeInterval.milliseconds(1000)
+                let zeroMilliseconds = DispatchTimeInterval.milliseconds(0)
+                let voiceOverDelay = UIAccessibility.isVoiceOverRunning ? thousandMilliseconds : zeroMilliseconds
                 let dispatchTime = DispatchTime.now() + Toast.UX.toastDismissAfter + voiceOverDelay
 
                 DispatchQueue.main.asyncAfter(deadline: dispatchTime, execute: {

--- a/firefox-ios/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabDisplayManager.swift
@@ -204,7 +204,10 @@ class LegacyTabDisplayManager: NSObject, FeatureFlaggable {
         self.dataStore.removeAll()
         getTabsAndUpdateInactiveState { [weak self] tabsToDisplay in
             guard let self, !tabsToDisplay.isEmpty else { return }
-            let orderedRegularTabs = tabDisplayType == .TopTabTray ? tabsToDisplay : self.getRegularOrderedTabs() ?? tabsToDisplay
+
+            let defaultTabsValue = self.getRegularOrderedTabs() ?? tabsToDisplay
+            let orderedRegularTabs = tabDisplayType == .TopTabTray ? tabsToDisplay : defaultTabsValue
+
             if self.getRegularOrderedTabs() == nil {
                 self.saveRegularOrderedTabs(from: tabsToDisplay)
             }

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
@@ -238,7 +238,10 @@ private extension TabScrollingController {
 
     func isBouncingAtBottom() -> Bool {
         guard let scrollView = scrollView else { return false }
-        return contentOffset.y > (contentSize.height - scrollView.frame.size.height) && contentSize.height > scrollView.frame.size.height
+        let yOffsetCheck = contentOffset.y > (contentSize.height - scrollView.frame.size.height)
+        let heightCheck = contentSize.height > scrollView.frame.size.height
+
+        return yOffsetCheck && heightCheck
     }
 
     func shouldAllowScroll(with topIsRubberbanding: Bool,

--- a/firefox-ios/Client/Frontend/Browser/TabTrayController+KeyCommands.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabTrayController+KeyCommands.swift
@@ -7,7 +7,8 @@ import UIKit
 
 extension LegacyGridTabViewController {
     override var keyCommands: [UIKeyCommand]? {
-        let toggleText: String = tabDisplayManager.isPrivate ? .KeyboardShortcuts.NormalBrowsingMode: .KeyboardShortcuts.PrivateBrowsingMode
+        typealias Shortcuts = String.KeyboardShortcuts
+        let toggleText: String = tabDisplayManager.isPrivate ? Shortcuts.NormalBrowsingMode: Shortcuts.PrivateBrowsingMode
         let commands = [
             UIKeyCommand(
                 action: #selector(didTogglePrivateModeKeyCommand),

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabLayoutDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabLayoutDelegate.swift
@@ -97,17 +97,18 @@ class LegacyTabLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayout, UIG
         }
 
         let closeAllButtonHeight = LegacyInactiveTabCell.UX.CloseAllTabRowHeight
-        let headerHeightWithRoundedCorner = LegacyInactiveTabCell.UX.HeaderAndRowHeight + LegacyInactiveTabCell.UX.RoundedContainerPaddingClosed
-        var totalHeight = headerHeightWithRoundedCorner
+        let roundedCornerHeaderHeight = LegacyInactiveTabCell.UX.HeaderAndRowHeight +
+        LegacyInactiveTabCell.UX.RoundedContainerPaddingClosed
+        var totalHeight = roundedCornerHeaderHeight
         let width: CGFloat = collectionView.frame.size.width - LegacyInactiveTabCell.UX.InactiveTabTrayWidthPadding
         let inactiveTabs = inactiveTabViewModel.inactiveTabs
 
         // Calculate height based on number of tabs in the inactive tab section section
-        let calculatedInactiveTabsTotalHeight = (LegacyInactiveTabCell.UX.HeaderAndRowHeight * CGFloat(inactiveTabs.count)) +
+        let calculatedInactiveTabsHeight = (LegacyInactiveTabCell.UX.HeaderAndRowHeight * CGFloat(inactiveTabs.count)) +
         LegacyInactiveTabCell.UX.RoundedContainerPaddingClosed +
         LegacyInactiveTabCell.UX.RoundedContainerAdditionalPaddingOpened + closeAllButtonHeight
 
-        totalHeight = tabDisplayManager.isInactiveViewExpanded ? calculatedInactiveTabsTotalHeight : headerHeightWithRoundedCorner
+        totalHeight = tabDisplayManager.isInactiveViewExpanded ? calculatedInactiveTabsHeight : roundedCornerHeaderHeight
 
         if UIDevice.current.userInterfaceIdiom == .pad {
             return CGSize(width: collectionView.frame.size.width/1.5, height: totalHeight)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabLayoutDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabLayoutDelegate.swift
@@ -75,7 +75,9 @@ class LegacyTabLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayout, UIG
         sizeForItemAt indexPath: IndexPath
     ) -> CGSize {
         let margin = LegacyGridTabViewController.UX.margin * CGFloat(numberOfColumns + 1)
-        let calculatedWidth = collectionView.bounds.width - collectionView.safeAreaInsets.left - collectionView.safeAreaInsets.right - margin
+        let calculatedWidth = collectionView.bounds.width -
+        collectionView.safeAreaInsets.left -
+        collectionView.safeAreaInsets.right - margin
         let cellWidth = floor(calculatedWidth / CGFloat(numberOfColumns))
 
         switch TabDisplaySection(rawValue: indexPath.section) {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -89,7 +89,9 @@ class TabDisplayView: UIView,
     }
 
     private func createLayout() -> UICollectionViewCompositionalLayout {
+        // swiftlint:disable line_length
         let layout = UICollectionViewCompositionalLayout { [weak self] (sectionIndex: Int, layoutEnvironment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? in
+        // swiftlint:enable line_length
             guard let self else { return nil }
 
             // If on private mode or regular mode but without inactive

--- a/firefox-ios/Client/Frontend/ContextualHint/ContextualHintEligibilityUtility.swift
+++ b/firefox-ios/Client/Frontend/ContextualHint/ContextualHintEligibilityUtility.swift
@@ -106,7 +106,8 @@ struct ContextualHintEligibilityUtility: ContextualHintEligibilityUtilityProtoco
     private var canPresentShoppingCFR: Bool {
         guard !hasAlreadyBeenPresented(.shoppingExperience) else {
             // Retrieve the counter for shopping onboarding CFRs
-            let cfrCounter = profile.prefs.intForKey(PrefsKeys.ContextualHints.shoppingOnboardingCFRsCounterKey.rawValue) ?? 1
+            let shoppingOnboardingKey = PrefsKeys.ContextualHints.shoppingOnboardingCFRsCounterKey.rawValue
+            let cfrCounter = profile.prefs.intForKey(shoppingOnboardingKey) ?? 1
             // Check if the user has opted in for Shopping Experience
             let hasOptedIn = profile.prefs.boolForKey(PrefsKeys.Shopping2023OptIn) ?? false
             // Retrieve the last timestamp for Fakespot CFRs

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotViewController.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotViewController.swift
@@ -322,7 +322,9 @@ class FakespotViewController: UIViewController,
         let betaViewWidth = betaLabelWidth + UX.betaHorizontalSpace * 2
         let maxTitleWidth = availableTitleStackWidth - betaViewWidth - UX.titleStackSpacing
 
+        // swiftlint:disable line_length
         betaView.layer.borderWidth = contentSizeCategory.isAccessibilityCategory ? UX.betaBorderWidthA11ySize : UX.betaBorderWidth
+        // swiftlint:enable line_length
 
         if contentSizeCategory.isAccessibilityCategory || titleTextWidth > maxTitleWidth {
             titleStackView.axis = .vertical
@@ -417,7 +419,8 @@ class FakespotViewController: UIViewController,
 
         case .qualityDeterminationCard:
             let reviewQualityCardView: FakespotReviewQualityCardView = .build()
-            viewModel.reviewQualityCardViewModel.expandState = (fakespotState?.isReviewQualityExpanded ?? false)  ? .expanded : .collapsed
+            let isReviewQualityExpanded = fakespotState?.isReviewQualityExpanded ?? false
+            viewModel.reviewQualityCardViewModel.expandState = isReviewQualityExpanded ? .expanded : .collapsed
             viewModel.reviewQualityCardViewModel.dismissViewController = {
                 store.dispatch(FakespotAction.setAppearanceTo(false))
             }
@@ -425,11 +428,13 @@ class FakespotViewController: UIViewController,
                 store.dispatch(FakespotAction.reviewQualityDidChange)
             }
             reviewQualityCardView.configure(viewModel.reviewQualityCardViewModel)
+
             return reviewQualityCardView
 
         case .settingsCard:
             let view: FakespotSettingsCardView = .build()
-            viewModel.settingsCardViewModel.expandState = (fakespotState?.isSettingsExpanded ?? false) ? .expanded : .collapsed
+            let isSettingsExpanded = fakespotState?.isSettingsExpanded ?? false
+            viewModel.settingsCardViewModel.expandState = isSettingsExpanded ? .expanded : .collapsed
             viewModel.settingsCardViewModel.dismissViewController = { [weak self] action in
                 guard let self = self, let action else { return }
 
@@ -443,6 +448,7 @@ class FakespotViewController: UIViewController,
                 store.dispatch(FakespotAction.settingsStateDidChange)
             }
             view.configure(viewModel.settingsCardViewModel)
+
             return view
 
         case .noAnalysisCard:

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotViewModel.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotViewModel.swift
@@ -378,7 +378,9 @@ class FakespotViewModel {
             let productAds = await loadProductAds(for: product?.productId)
 
             let needsAnalysis = product?.needsAnalysis ?? false
+            // swiftlint:disable line_length
             let analysis: AnalysisStatus? = needsAnalysis ? try? await shoppingProduct.getProductAnalysisStatus()?.status : nil
+            // swiftlint:enable line_length
             state = .loaded(
                 ProductState(
                     product: product,
@@ -472,7 +474,9 @@ class FakespotViewModel {
 
                         await MainActor.run {
                             self.analysisProgressViewModel.analysisProgress = result.progress
-                            self.analysisProgressViewModel.analysisProgressChanged?(self.analysisProgressViewModel.analysisProgress)
+                            self.analysisProgressViewModel.analysisProgressChanged?(
+                                self.analysisProgressViewModel.analysisProgress
+                            )
                         }
 
                         continuation.yield(result.status)

--- a/firefox-ios/Client/Frontend/Fakespot/Views/FakespotAdView.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/Views/FakespotAdView.swift
@@ -290,7 +290,9 @@ class FakespotAdView: UIView, Notifiable, ThemeApplicable, UITextViewDelegate {
         defaultProductImageWidthConstraint?.constant = minSize(minValue: UX.defaultImageSize.width,
                                                                maxValue: UX.defaultImageMaxSize.width)
 
+        // swiftlint:disable line_length
         let shouldUpdateLayout = previousPreferredContentSizeCategory?.isAccessibilityCategory != UIApplication.shared.preferredContentSizeCategory.isAccessibilityCategory
+        // swiftlint:enable line_length
 
         guard previousPreferredContentSizeCategory == nil || shouldUpdateLayout else { return }
 

--- a/firefox-ios/Client/Frontend/Fakespot/Views/FakespotSettingsCardView.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/Views/FakespotSettingsCardView.swift
@@ -50,7 +50,9 @@ class FakespotSettingsCardViewModel {
         return String.localizedStringWithFormat(
             .Shopping.SettingsCardGroupedRecommendedProductsAndSwitchAccessibilityLabel,
             showProductsLabelTitle,
+            // swiftlint:disable line_length
             areAdsEnabled ? String.Shopping.SettingsCardSwitchValueOnAccessibilityLabel : String.Shopping.SettingsCardSwitchValueOffAccessibilityLabel
+            // swiftlint:enable line_length
         )
     }
 

--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -248,7 +248,9 @@ class HomepageViewController:
     }
 
     func createLayout() -> UICollectionViewLayout {
+        // swiftlint:disable line_length
         let layout = UICollectionViewCompositionalLayout { [weak self] (sectionIndex: Int, layoutEnvironment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? in
+        // swiftlint:enable line_length
             guard let self = self,
                   let viewModel = self.viewModel.getSectionViewModel(shownSection: sectionIndex),
                   viewModel.shouldShow
@@ -464,7 +466,9 @@ extension HomepageViewController: UICollectionViewDelegate, UICollectionViewData
             else { return reusableView }
 
             // Configure header only if section is shown
+            // swiftlint:disable line_length
             let headerViewModel = sectionViewModel.shouldShow ? sectionViewModel.headerViewModel : LabelButtonHeaderViewModel.emptyHeader
+            // swiftlint:enable line_length
             headerView.configure(viewModel: headerViewModel, theme: themeManager.currentTheme)
 
             // Jump back in header specific setup

--- a/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -131,7 +131,7 @@ extension TopSitesViewModel: HomepageViewModelProtocol, FeatureFlaggable {
     }
 
     var headerViewModel: LabelButtonHeaderViewModel {
-        var textColor = wallpaperManager.currentWallpaper.textColor
+        let textColor = wallpaperManager.currentWallpaper.textColor
 
         return LabelButtonHeaderViewModel(
             title: nil,

--- a/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -131,13 +131,11 @@ extension TopSitesViewModel: HomepageViewModelProtocol, FeatureFlaggable {
     }
 
     var headerViewModel: LabelButtonHeaderViewModel {
-        let textColor = wallpaperManager.currentWallpaper.textColor
-
         return LabelButtonHeaderViewModel(
             title: nil,
             titleA11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.topSites,
             isButtonHidden: true,
-            textColor: textColor)
+            textColor: wallpaperManager.currentWallpaper.textColor)
     }
 
     var isEnabled: Bool {

--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperBackgroundView.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperBackgroundView.swift
@@ -63,7 +63,8 @@ class WallpaperBackgroundView: UIView {
     }
 
     private func currentWallpaperImage() -> UIImage? {
-        return UIDevice.current.orientation.isLandscape ? wallpaperManager.currentWallpaper.landscape : wallpaperManager.currentWallpaper.portrait
+        let isLandscape = UIDevice.current.orientation.isLandscape
+        return isLandscape ? wallpaperManager.currentWallpaper.landscape : wallpaperManager.currentWallpaper.portrait
     }
 }
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
@@ -91,7 +91,9 @@ class BookmarksPanel: SiteTableViewController,
          logger: Logger = DefaultLogger.shared) {
         self.viewModel = viewModel
         self.logger = logger
-        self.state = viewModel.bookmarkFolderGUID == BookmarkRoots.MobileFolderGUID ? .bookmarks(state: .mainView) : .bookmarks(state: .inFolder)
+
+        let guidMatches = viewModel.bookmarkFolderGUID == BookmarkRoots.MobileFolderGUID
+        self.state = guidMatches ? .bookmarks(state: .mainView) : .bookmarks(state: .inFolder)
         self.bookmarksHandler = viewModel.profile.places
         super.init(profile: viewModel.profile)
 

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -856,6 +856,8 @@ extension HistoryPanel: UITableViewDataSourcePrefetching {
     func shouldLoadRow(for indexPath: IndexPath) -> Bool {
         guard HistoryPanelSections(rawValue: indexPath.section) != .additionalHistoryActions else { return false }
 
-        return indexPath.row >= viewModel.groupedSites.numberOfItemsForSection(indexPath.section - 1) - historyPanelPrefetchOffset
+        return indexPath.row >= viewModel.groupedSites.numberOfItemsForSection(
+            indexPath.section - 1
+        ) - historyPanelPrefetchOffset
     }
 }

--- a/firefox-ios/Client/Frontend/PasswordManagement/AddCredentialViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/AddCredentialViewController.swift
@@ -249,7 +249,9 @@ extension AddCredentialViewController: LoginDetailTableViewCellDelegate {
 
         // Menu actions for password
         if item == .passwordItem {
-            let showRevealOption = cell.descriptionLabel.isSecureTextEntry ? (action == MenuHelper.SelectorReveal) : (action == MenuHelper.SelectorHide)
+            let revealAction = action == MenuHelper.SelectorReveal
+            let hideAction = action == MenuHelper.SelectorHide
+            let showRevealOption = cell.descriptionLabel.isSecureTextEntry ? revealAction : hideAction
             return action == MenuHelper.SelectorCopy || showRevealOption
         }
 

--- a/firefox-ios/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -56,7 +56,9 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
 
     private var clearButtonEnabled = true {
         didSet {
-            clearButton?.textLabel?.textColor = clearButtonEnabled ? themeManager.currentTheme.colors.textWarning : themeManager.currentTheme.colors.textDisabled
+            let textWarningColor = themeManager.currentTheme.colors.textWarning
+            let textDisabledColor = themeManager.currentTheme.colors.textDisabled
+            clearButton?.textLabel?.textColor = clearButtonEnabled ? textWarningColor : textDisabledColor
         }
     }
 

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -43,7 +43,8 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
         self.tabManager = tabManager
 
         title = .SettingsHomePageSectionName
-        navigationController?.navigationBar.accessibilityIdentifier = AccessibilityIdentifiers.Settings.Homepage.homePageNavigationBar
+        typealias A11yId = AccessibilityIdentifiers.Settings.Homepage
+        navigationController?.navigationBar.accessibilityIdentifier = A11yId.homePageNavigationBar
 
         navigationItem.rightBarButtonItem = UIBarButtonItem(
             title: .AppSettingsDone,
@@ -193,8 +194,9 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
     }
 
     private func setupStartAtHomeSection() -> SettingSection {
-        let prefs = prefs.stringForKey(PrefsKeys.UserFeatureFlagPrefs.StartAtHome) ?? StartAtHomeSetting.afterFourHours.rawValue
-        currentStartAtHomeSetting = StartAtHomeSetting(rawValue: prefs) ?? .afterFourHours
+        let defaultSetting = StartAtHomeSetting.afterFourHours.rawValue
+        let prefsSetting = prefs.stringForKey(PrefsKeys.UserFeatureFlagPrefs.StartAtHome) ?? defaultSetting
+        currentStartAtHomeSetting = StartAtHomeSetting(rawValue: prefsSetting) ?? .afterFourHours
 
         typealias a11y = AccessibilityIdentifiers.Settings.Homepage.StartAtHome
 
@@ -264,7 +266,8 @@ extension HomePageSettingViewController {
 
         override var status: NSAttributedString {
             let areShortcutsOn = profile.prefs.boolForKey(PrefsKeys.UserFeatureFlagPrefs.TopSiteSection) ?? true
-            let status: String = areShortcutsOn ? .Settings.Homepage.Shortcuts.ToggleOn : .Settings.Homepage.Shortcuts.ToggleOff
+            typealias Shortcuts = String.Settings.Homepage.Shortcuts
+            let status: String = areShortcutsOn ? Shortcuts.ToggleOn : Shortcuts.ToggleOff
             return NSAttributedString(string: String(format: status))
         }
 

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesRowCountSettingsController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesRowCountSettingsController.swift
@@ -12,7 +12,8 @@ class TopSitesRowCountSettingsController: SettingsTableViewController {
 
     init(prefs: Prefs) {
         self.prefs = prefs
-        numberOfRows = self.prefs.intForKey(PrefsKeys.NumberOfTopSiteRows) ?? TopSitesRowCountSettingsController.defaultNumberOfRows
+        let defaultValue = TopSitesRowCountSettingsController.defaultNumberOfRows
+        numberOfRows = self.prefs.intForKey(PrefsKeys.NumberOfTopSiteRows) ?? defaultValue
         super.init(style: .grouped)
         self.title = .Settings.Homepage.Shortcuts.RowsPageTitle
     }

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
@@ -11,7 +11,8 @@ class TopSitesSettingsViewController: SettingsTableViewController, FeatureFlagga
         super.init(style: .grouped)
 
         self.title = .Settings.Homepage.Shortcuts.ShortcutsPageTitle
-        self.navigationController?.navigationBar.accessibilityIdentifier = AccessibilityIdentifiers.Settings.Homepage.CustomizeFirefox.Shortcuts.settingsPage
+        self.navigationController?.navigationBar.accessibilityIdentifier = AccessibilityIdentifiers
+            .Settings.Homepage.CustomizeFirefox.Shortcuts.settingsPage
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -62,7 +63,9 @@ extension TopSitesSettingsViewController {
 
         override var accessoryType: UITableViewCell.AccessoryType { return .disclosureIndicator }
         override var status: NSAttributedString {
-            let numberOfRows = profile.prefs.intForKey(PrefsKeys.NumberOfTopSiteRows) ?? TopSitesRowCountSettingsController.defaultNumberOfRows
+            let defaultValue = TopSitesRowCountSettingsController.defaultNumberOfRows
+            let numberOfRows = profile.prefs.intForKey(PrefsKeys.NumberOfTopSiteRows) ?? defaultValue
+
             return NSAttributedString(string: String(format: "%d", numberOfRows))
         }
 
@@ -76,7 +79,9 @@ extension TopSitesSettingsViewController {
             super.init(
                 title: NSAttributedString(
                     string: .Settings.Homepage.Shortcuts.Rows,
-                    attributes: [NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary]
+                    attributes: [
+                        NSAttributedString.Key.foregroundColor: settings.themeManager.currentTheme.colors.textPrimary
+                    ]
                 )
             )
         }

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -198,7 +198,9 @@ class AppSettingsTableViewController: SettingsTableViewController,
 
         let accountSectionTitle = NSAttributedString(string: .FxAFirefoxAccount)
 
-        let accountFooterText = !profile.hasAccount() ? NSAttributedString(string: .Settings.Sync.ButtonDescription) : nil
+        let attributedString = NSAttributedString(string: .Settings.Sync.ButtonDescription)
+        let accountFooterText = !profile.hasAccount() ? attributedString : nil
+
         return [SettingSection(title: accountSectionTitle, footerTitle: accountFooterText, children: [
             // Without a Firefox Account:
             ConnectSetting(settings: self, settingsDelegate: parentCoordinator),

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/SwitchFakespotProduction.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/SwitchFakespotProduction.swift
@@ -21,7 +21,8 @@ class SwitchFakespotProduction: HiddenSetting, FeatureFlaggable {
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
-        let channels = featureFlags.isCoreFeatureEnabled(.useStagingFakespotAPI) ? [AppBuildChannel.release] : [.developer, .beta]
+        let useStagingAPI = featureFlags.isCoreFeatureEnabled(.useStagingFakespotAPI)
+        let channels = useStagingAPI ? [AppBuildChannel.release] : [.developer, .beta]
         featureFlags.set(feature: .useStagingFakespotAPI, toChannels: channels)
 
         settingsDelegate?.askedToReload()

--- a/firefox-ios/Client/Frontend/Settings/Main/Privacy/ContentBlockerSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Privacy/ContentBlockerSetting.swift
@@ -18,7 +18,8 @@ class ContentBlockerSetting: Setting {
     }
 
     override var status: NSAttributedString? {
-        let isOn = profile.prefs.boolForKey(ContentBlockingConfig.Prefs.EnabledKey) ?? ContentBlockingConfig.Defaults.NormalBrowsing
+        let defaultValue = ContentBlockingConfig.Defaults.NormalBrowsing
+        let isOn = profile.prefs.boolForKey(ContentBlockingConfig.Prefs.EnabledKey) ?? defaultValue
 
         if isOn {
             let currentBlockingStrength = profile

--- a/firefox-ios/Client/Frontend/Settings/PasswordDetailViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/PasswordDetailViewController.swift
@@ -423,7 +423,9 @@ extension PasswordDetailViewController: LoginDetailTableViewCellDelegate {
             return action == MenuHelper.SelectorCopy
         case .password:
             // Menu actions for password
-            let showRevealOption = cell.descriptionLabel.isSecureTextEntry ? (action == MenuHelper.SelectorReveal) : (action == MenuHelper.SelectorHide)
+            let revealOption = action == MenuHelper.SelectorReveal
+            let hideOption = action == MenuHelper.SelectorHide
+            let showRevealOption = cell.descriptionLabel.isSecureTextEntry ? revealOption : hideOption
             return action == MenuHelper.SelectorCopy || showRevealOption
         default:
             return false

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -433,7 +433,9 @@ class SearchSettingsTableViewController: ThemedTableViewController, FeatureFlagg
         }
 
         // Can't drag/drop over "Add Custom Engine button"
-        if sourceIndexPath.item + 1 == model.orderedEngines.count || proposedDestinationIndexPath.item + 1 == model.orderedEngines.count {
+        let sourceIndexCheck = sourceIndexPath.item + 1 == model.orderedEngines.count
+        let destinationIndexCheck = proposedDestinationIndexPath.item + 1 == model.orderedEngines.count
+        if sourceIndexCheck || destinationIndexCheck {
             return sourceIndexPath
         }
 

--- a/firefox-ios/Client/Frontend/TabContentsScripts/UserScriptManager.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/UserScriptManager.swift
@@ -36,7 +36,9 @@ class UserScriptManager: FeatureFlaggable {
          (WKUserScriptInjectionTime.atDocumentStart, mainFrameOnly: true),
          (WKUserScriptInjectionTime.atDocumentEnd, mainFrameOnly: true)].forEach { arg in
             let (injectionTime, mainFrameOnly) = arg
-            let name = (mainFrameOnly ? "MainFrame" : "AllFrames") + "AtDocument" + (injectionTime == .atDocumentStart ? "Start" : "End")
+            let mainframeString = mainFrameOnly ? "MainFrame" : "AllFrames"
+            let injectionString = injectionTime == .atDocumentStart ? "Start" : "End"
+            let name = mainframeString + "AtDocument" + injectionString
             if let path = Bundle.main.path(forResource: name, ofType: "js"),
                 let source = try? NSString(contentsOfFile: path, encoding: String.Encoding.utf8.rawValue) as String {
                 let wrappedSource = "(function() { const APP_ID_TOKEN = '\(UserScriptManager.appIdToken)'; \(source) })()"
@@ -96,7 +98,9 @@ class UserScriptManager: FeatureFlaggable {
          (WKUserScriptInjectionTime.atDocumentStart, mainFrameOnly: true),
          (WKUserScriptInjectionTime.atDocumentEnd, mainFrameOnly: true)].forEach { arg in
             let (injectionTime, mainFrameOnly) = arg
-            let name = (mainFrameOnly ? "MainFrame" : "AllFrames") + "AtDocument" + (injectionTime == .atDocumentStart ? "Start" : "End")
+            let mainframeString = mainFrameOnly ? "MainFrame" : "AllFrames"
+            let injectionString = injectionTime == .atDocumentStart ? "Start" : "End"
+            let name = mainframeString + "AtDocument" + injectionString
             if let userScript = compiledUserScripts[name] {
                 webView?.configuration.userContentController.addUserScript(userScript)
             }

--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
@@ -78,7 +78,7 @@ extension PhotonActionSheetProtocol {
     }
 
     func getRefreshLongPressMenu(for tab: Tab) -> [PhotonRowActions] {
-        guard tab.webView?.url != nil 
+        guard tab.webView?.url != nil
                 && (tab.getContentScript(name: ReaderMode.name()) as? ReaderMode)?.state != .active
         else { return [] }
 

--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
@@ -78,17 +78,19 @@ extension PhotonActionSheetProtocol {
     }
 
     func getRefreshLongPressMenu(for tab: Tab) -> [PhotonRowActions] {
-        guard tab.webView?.url != nil && (tab.getContentScript(name: ReaderMode.name()) as? ReaderMode)?.state != .active else {
-            return []
-        }
+        guard tab.webView?.url != nil 
+                && (tab.getContentScript(name: ReaderMode.name()) as? ReaderMode)?.state != .active
+        else { return [] }
 
         let defaultUAisDesktop = UserAgent.isDesktop(ua: UserAgent.getUserAgent())
         let toggleActionTitle: String
+        // swiftlint:disable line_length
         if defaultUAisDesktop {
             toggleActionTitle = tab.changedUserAgent ? .AppMenu.AppMenuViewDesktopSiteTitleString : .AppMenu.AppMenuViewMobileSiteTitleString
         } else {
             toggleActionTitle = tab.changedUserAgent ? .AppMenu.AppMenuViewMobileSiteTitleString : .AppMenu.AppMenuViewDesktopSiteTitleString
         }
+        // swiftlint:enable line_length
         let toggleDesktopSite = SingleActionViewModel(title: toggleActionTitle,
                                                       iconString: StandardImageIdentifiers.Large.deviceDesktop) { _ in
             if let url = tab.url {

--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetViewModel.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetViewModel.swift
@@ -193,10 +193,11 @@ class PhotonActionSheetViewModel {
         let bottomInset = isAtTopMainMenu ? PhotonActionSheet.UX.smallSpacing : PhotonActionSheet.UX.bigSpacing
 
         // Save available space so we can calculate the needed menu height later on
-        let topMenuHeight = convertedPoint.y + view.frame.height)
+        let topMenuHeight = convertedPoint.y + view.frame.height
         let bottomMenuHeight = viewControllerHeight - convertedPoint.y - view.frame.height
         let buttonSpace = isAtTopMainMenu ? topMenuHeight : bottomMenuHeight
-        availableMainMenuHeight = viewControllerHeight - buttonSpace - bottomInset - topInset - viewController.view.safeAreaInsets.top
+        let insetHeight = buttonSpace - bottomInset - topInset
+        availableMainMenuHeight = viewControllerHeight - insetHeight - viewController.view.safeAreaInsets.top
 
         return UIEdgeInsets(top: topInset,
                             left: PhotonActionSheet.UX.spacing,

--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetViewModel.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetViewModel.swift
@@ -182,7 +182,8 @@ class PhotonActionSheetViewModel {
         // Align menu icons with popover icons
         let extraLandscapeSpacing: CGFloat = UIWindow.isLandscape ? 10 : 0
         let statusIconSize = PhotonActionSheetView.UX.StatusIconSize.width
-        let rightInset = view.frame.size.width / 2 - PhotonActionSheet.UX.spacing - statusIconSize / 2 + extraLandscapeSpacing
+        let halfFrameWidth = view.frame.size.width / 2
+        let rightInset = halfFrameWidth - PhotonActionSheet.UX.spacing - statusIconSize / 2 + extraLandscapeSpacing
 
         // Calculate top and bottom insets
         let convertedPoint = view.convert(view.frame.origin, to: viewController.view)
@@ -192,7 +193,9 @@ class PhotonActionSheetViewModel {
         let bottomInset = isAtTopMainMenu ? PhotonActionSheet.UX.smallSpacing : PhotonActionSheet.UX.bigSpacing
 
         // Save available space so we can calculate the needed menu height later on
-        let buttonSpace = isAtTopMainMenu ? (convertedPoint.y + view.frame.height) : (viewControllerHeight - convertedPoint.y - view.frame.height)
+        let topMenuHeight = convertedPoint.y + view.frame.height)
+        let bottomMenuHeight = viewControllerHeight - convertedPoint.y - view.frame.height
+        let buttonSpace = isAtTopMainMenu ? topMenuHeight : bottomMenuHeight
         availableMainMenuHeight = viewControllerHeight - buttonSpace - bottomInset - topInset - viewController.view.safeAreaInsets.top
 
         return UIEdgeInsets(top: topInset,

--- a/firefox-ios/Extensions/ShareTo/EmbeddedNavController.swift
+++ b/firefox-ios/Extensions/ShareTo/EmbeddedNavController.swift
@@ -51,13 +51,15 @@ class EmbeddedNavController {
 
         let updatedHeight: CGFloat
         if UX.enableResizeRowsForSmallScreens {
-            let shrinkage = UX.navBarLandscapeShrinkage + (UX.numberOfActionRows + 1 /*one info row*/) * UX.perRowShrinkageForLandscape
+            // Account for one info row
+            let shrinkage = UX.navBarLandscapeShrinkage + (UX.numberOfActionRows + 1) * UX.perRowShrinkageForLandscape
             updatedHeight = CGFloat(
                 isLandscapeSmallScreen(forTraitCollection) ? UX.topViewHeight - shrinkage : UX.topViewHeight
             )
         } else {
+            let compactSize = UX.topViewHeight - UX.navBarLandscapeShrinkage
             updatedHeight = CGFloat(
-                forTraitCollection.verticalSizeClass == .compact ? UX.topViewHeight - UX.navBarLandscapeShrinkage : UX.topViewHeight
+                forTraitCollection.verticalSizeClass == .compact ? compactSize : UX.topViewHeight
             )
         }
 

--- a/firefox-ios/Extensions/ShareTo/ShareViewController.swift
+++ b/firefox-ios/Extensions/ShareTo/ShareViewController.swift
@@ -241,9 +241,10 @@ class ShareViewController: UIViewController {
         row.translatesAutoresizingMaskIntoConstraints = false
         row.rightLeftEdges(inset: UX.rowInset)
         parent.addArrangedSubview(row)
+        let pageInfoHeightAdjustment = UX.pageInfoRowHeight - UX.perRowShrinkageForLandscape
         pageInfoHeight = row.heightAnchor.constraint(
             equalToConstant: CGFloat(
-                isLandscapeSmallScreen(traitCollection) ? UX.pageInfoRowHeight - UX.perRowShrinkageForLandscape : UX.pageInfoRowHeight
+                isLandscapeSmallScreen(traitCollection) ? pageInfoHeightAdjustment : UX.pageInfoRowHeight
             )
         )
         pageInfoHeight?.isActive = true

--- a/firefox-ios/Extensions/ShareTo/ShareViewController.swift
+++ b/firefox-ios/Extensions/ShareTo/ShareViewController.swift
@@ -216,11 +216,15 @@ class ShareViewController: UIViewController {
             return
         }
 
+        let pageInfoHeightAdjustment = UX.pageInfoRowHeight - UX.perRowShrinkageForLandscape
         pageInfoHeight?.constant = CGFloat(
-            isLandscapeSmallScreen(traitCollection) ? UX.pageInfoRowHeight - UX.perRowShrinkageForLandscape : UX.pageInfoRowHeight
+            isLandscapeSmallScreen(traitCollection) ? pageInfoHeightAdjustment : UX.pageInfoRowHeight
         )
+        let actionRowHeightAdjustment = UX.actionRowHeight - UX.perRowShrinkageForLandscape
         actionRowHeights.forEach {
-            $0.constant = CGFloat(isLandscapeSmallScreen(traitCollection) ? UX.actionRowHeight - UX.perRowShrinkageForLandscape : UX.actionRowHeight)
+            $0.constant = CGFloat(
+                isLandscapeSmallScreen(traitCollection) ? actionRowHeightAdjustment : UX.actionRowHeight
+            )
         }
     }
 
@@ -277,10 +281,9 @@ class ShareViewController: UIViewController {
         row.translatesAutoresizingMaskIntoConstraints = false
         row.rightLeftEdges(inset: UX.rowInset)
         parent.addArrangedSubview(row)
+        let heightAdjustment = UX.actionRowHeight - UX.perRowShrinkageForLandscape
         let heightConstraint = row.heightAnchor.constraint(
-            equalToConstant: CGFloat(
-                isLandscapeSmallScreen(traitCollection) ? UX.actionRowHeight - UX.perRowShrinkageForLandscape : UX.actionRowHeight
-            )
+            equalToConstant: CGFloat(isLandscapeSmallScreen(traitCollection) ? heightAdjustment : UX.actionRowHeight)
         )
         heightConstraint.isActive = true
         actionRowHeights.append(heightConstraint)

--- a/firefox-ios/RustFxA/RustFirefoxAccounts.swift
+++ b/firefox-ios/RustFxA/RustFirefoxAccounts.swift
@@ -125,7 +125,11 @@ open class RustFirefoxAccounts {
         }
 
         let config: FxAConfig
-        let useCustom = prefs?.boolForKey(PrefsKeys.KeyUseCustomFxAContentServer) ?? false || prefs?.boolForKey(PrefsKeys.KeyUseCustomSyncTokenServerOverride) ?? false
+        let useCustom = prefs?.boolForKey(
+            PrefsKeys.KeyUseCustomFxAContentServer
+        ) ?? false || prefs?.boolForKey(
+            PrefsKeys.KeyUseCustomSyncTokenServerOverride
+        ) ?? false
         if useCustom {
             let contentUrl: String
             if prefs?.boolForKey(PrefsKeys.KeyUseCustomFxAContentServer) ?? false,
@@ -135,7 +139,8 @@ open class RustFirefoxAccounts {
                 contentUrl = "https://stable.dev.lcip.org"
             }
 
-            let tokenServer = prefs?.boolForKey(PrefsKeys.KeyUseCustomSyncTokenServerOverride) ?? false ? prefs?.stringForKey(PrefsKeys.KeyCustomSyncTokenServerOverride) : nil
+            let serverOverride = prefs?.boolForKey(PrefsKeys.KeyUseCustomSyncTokenServerOverride) ?? false
+            let tokenServer = serverOverride ? prefs?.stringForKey(PrefsKeys.KeyCustomSyncTokenServerOverride) : nil
             config = FxAConfig(
                 contentUrl: contentUrl,
                 clientId: RustFirefoxAccounts.clientID,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataAdaptorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataAdaptorTests.swift
@@ -431,6 +431,7 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
 
 // MARK: - ContileProviderMock
 class ContileProviderMock: ContileProviderInterface {
+    typealias Mock = ContileProviderMock
     private var result: ContileResult
 
     static var defaultSuccessData: [Contile] {
@@ -476,7 +477,7 @@ extension ContileProviderMock {
         var defaultData = ContileProviderMock.defaultSuccessData
 
         if duplicateFirstTile {
-            let duplicateTile = pinnedDuplicateTile ? ContileProviderMock.pinnedDuplicateTile : ContileProviderMock.duplicateTile
+            let duplicateTile = pinnedDuplicateTile ? Mock.pinnedDuplicateTile : Mock.duplicateTile
             defaultData.insert(duplicateTile, at: 0)
         }
 
@@ -490,8 +491,8 @@ extension ContileProviderMock {
 
     static var pinnedDuplicateTile: Contile {
         return Contile(id: 1,
-                       name: String(format: ContileProviderMock.pinnedTitle, "0"),
-                       url: String(format: ContileProviderMock.pinnedURL, "0"),
+                       name: String(format: Mock.pinnedTitle, "0"),
+                       url: String(format: Mock.pinnedURL, "0"),
                        clickUrl: "https://www.test.com/click",
                        imageUrl: "https://test.com/image0.jpg",
                        imageSize: 200,
@@ -501,8 +502,8 @@ extension ContileProviderMock {
 
     static var duplicateTile: Contile {
         return Contile(id: 1,
-                       name: String(format: ContileProviderMock.title, "0"),
-                       url: String(format: ContileProviderMock.url, "0"),
+                       name: String(format: Mock.title, "0"),
+                       url: String(format: Mock.url, "0"),
                        clickUrl: "https://www.test.com/click",
                        imageUrl: "https://test.com/image0.jpg",
                        imageSize: 200,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/RustSyncManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/RustSyncManagerTests.swift
@@ -55,7 +55,15 @@ class RustSyncManagerTests: XCTestCase {
     }
 
     func testGetEnginesAndKeys() {
-        let engines: [RustSyncManagerAPI.TogglableEngine] = [.bookmarks, .creditcards, .history, .passwords, .tabs, .addresses]
+        let engines: [RustSyncManagerAPI.TogglableEngine] = [
+            .bookmarks,
+            .creditcards,
+            .history,
+            .passwords,
+            .tabs,
+            .addresses
+        ]
+
         rustSyncManager.getEnginesAndKeys(engines: engines) { (engines, keys) in
             XCTAssertEqual(engines.count, 6)
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -8,6 +8,9 @@ import Glean
 import XCTest
 
 class TelemetryWrapperTests: XCTestCase {
+    typealias ExtraKey = TelemetryWrapper.EventExtraKey
+    typealias ValueKey = TelemetryWrapper.EventValue
+
     override func setUp() {
         super.setUp()
         Glean.shared.resetGlean(clearStores: true)
@@ -107,7 +110,10 @@ class TelemetryWrapperTests: XCTestCase {
     }
 
     func test_topSiteContextualMenu_GleanIsCalled() {
-        let extras = [TelemetryWrapper.EventExtraKey.contextualMenuType.rawValue: HomepageContextMenuHelper.ContextualActionType.settings.rawValue]
+        let extras = [
+            ExtraKey.contextualMenuType.rawValue: HomepageContextMenuHelper.ContextualActionType.settings.rawValue
+        ]
+
         TelemetryWrapper.recordEvent(
             category: .action,
             method: .view,
@@ -146,8 +152,11 @@ class TelemetryWrapperTests: XCTestCase {
     // MARK: - Preferences
 
     func test_preferencesWithExtras_GleanIsCalled() {
-        let extras: [String: Any] = [TelemetryWrapper.EventExtraKey.preference.rawValue: "ETP-strength",
-                                      TelemetryWrapper.EventExtraKey.preferenceChanged.rawValue: BlockingStrength.strict.rawValue]
+        let extras: [String: Any] = [
+            ExtraKey.preference.rawValue: "ETP-strength",
+            ExtraKey.preferenceChanged.rawValue: BlockingStrength.strict.rawValue
+        ]
+
         TelemetryWrapper.recordEvent(
             category: .action,
             method: .change,
@@ -216,7 +225,7 @@ class TelemetryWrapperTests: XCTestCase {
     }
 
     func test_firefoxHomePageAddView_GleanIsCalled() {
-        let extras = [TelemetryWrapper.EventExtraKey.fxHomepageOrigin.rawValue: TelemetryWrapper.EventValue.fxHomepageOriginZeroSearch.rawValue]
+        let extras = [ExtraKey.fxHomepageOrigin.rawValue: ValueKey.fxHomepageOriginZeroSearch.rawValue]
         TelemetryWrapper.recordEvent(
             category: .action,
             method: .view,
@@ -794,7 +803,7 @@ class TelemetryWrapperTests: XCTestCase {
 
     // MARK: - Awesomebar result tap
     func test_AwesomebarResults_GleanIsCalledForSearchSuggestion() {
-        let extra = [TelemetryWrapper.EventExtraKey.awesomebarSearchTapType.rawValue: TelemetryWrapper.EventValue.searchSuggestion.rawValue]
+        let extra = [ExtraKey.awesomebarSearchTapType.rawValue: ValueKey.searchSuggestion.rawValue]
         TelemetryWrapper.recordEvent(category: .action,
                                      method: .tap,
                                      object: .awesomebarResults,
@@ -804,7 +813,7 @@ class TelemetryWrapperTests: XCTestCase {
     }
 
     func test_AwesomebarResults_GleanIsCalledRemoteTabs() {
-        let extra = [TelemetryWrapper.EventExtraKey.awesomebarSearchTapType.rawValue: TelemetryWrapper.EventValue.remoteTab.rawValue]
+        let extra = [ExtraKey.awesomebarSearchTapType.rawValue: ValueKey.remoteTab.rawValue]
         TelemetryWrapper.recordEvent(category: .action,
                                      method: .tap,
                                      object: .awesomebarResults,
@@ -814,7 +823,7 @@ class TelemetryWrapperTests: XCTestCase {
     }
 
     func test_AwesomebarResults_GleanIsCalledHighlights() {
-        let extra = [TelemetryWrapper.EventExtraKey.awesomebarSearchTapType.rawValue: TelemetryWrapper.EventValue.searchHighlights.rawValue]
+        let extra = [ExtraKey.awesomebarSearchTapType.rawValue: ValueKey.searchHighlights.rawValue]
         TelemetryWrapper.recordEvent(category: .action,
                                      method: .tap,
                                      object: .awesomebarResults,

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -333,7 +333,13 @@ class BaseTestCase: XCTestCase {
         mozWaitForElementToNotExist(passcodeInput)
     }
 
-    func scrollToElement(_ element: XCUIElement, swipeableElement: XCUIElement? = nil, swipe: String = "up", isHittable: Bool = false, maxNumberOfScreenSwipes: Int = 12) {
+    func scrollToElement(
+        _ element: XCUIElement,
+        swipeableElement: XCUIElement? = nil,
+        swipe: String = "up",
+        isHittable: Bool = false,
+        maxNumberOfScreenSwipes: Int = 12
+    ) {
         let app = XCUIApplication()
         let swipeableElement = swipeableElement ?? app
         var nrOfSwipes = 0

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SyncFAUITests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SyncFAUITests.swift
@@ -131,7 +131,10 @@ class SyncUITests: BaseTestCase {
         navigator.goto(Intro_FxASignin)
         // QR does not work on sim but checking that the button works, no crash
         navigator.performAction(Action.OpenEmailToQR)
-        mozWaitForElementToExist(app.navigationBars[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaNavigationBar], timeout: 5)
+        mozWaitForElementToExist(
+            app.navigationBars[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaNavigationBar],
+            timeout: 5
+        )
         mozWaitForElementToExist(app.buttons["Ready to Scan"])
         mozWaitForElementToExist(app.buttons["Use Email Instead"])
         app.navigationBars[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaNavigationBar].buttons["Close"].tap()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ThirdPartySearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ThirdPartySearchTest.swift
@@ -139,7 +139,13 @@ class ThirdPartySearchTest: BaseTestCase {
         app.navigationBars["Add Search Engine"].buttons["Save"].tap()
 
         mozWaitForElementToExist(app.alerts.element(boundBy: 0))
-        XCTAssertTrue(app.alerts.staticTexts["Failed"].exists, "Alert title is missing or is incorrect")
-        XCTAssertTrue(app.alerts.staticTexts["Please fill all fields correctly."].exists, "Alert message is missing or is incorrect")
+        XCTAssertTrue(
+            app.alerts.staticTexts["Failed"].exists,
+            "Alert title is missing or is incorrect"
+        )
+        XCTAssertTrue(
+            app.alerts.staticTexts["Please fill all fields correctly."].exists,
+            "Alert message is missing or is incorrect"
+        )
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8101)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18028)

## :bulb: Description
This is the third and final part of the `line_length` implementation. The most common offender of the `line_length` rule is the ternary operator.
The fixes here are of several types:
- Breaking some brackets resulting is not the best looking code (I've only used this a few times)
- disabling/enabling `line_length` for one or more lines (especially in the few instances of closures with long statements where not disabling this rule would conflict with other rules)
- creating variables on new lines to shorten statements
- typealiasing for repeated offenders in a similar spot, if possible

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

