### PR TITLE
#17882 Replaced LegacyResizableButton with LinkButton in WallpaperSet…

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsHeaderView.swift
@@ -20,6 +20,9 @@ struct WallpaperSettingsHeaderViewModel {
     var buttonAction: (() -> Void)?
 }
 
+import UIKit
+import ComponentLibrary // Import your ComponentLibrary module
+
 class WallpaperSettingsHeaderView: UICollectionReusableView, ReusableCell {
     private struct UX {
         static let stackViewSpacing: CGFloat = 4.0
@@ -46,10 +49,11 @@ class WallpaperSettingsHeaderView: UICollectionReusableView, ReusableCell {
         label.numberOfLines = 0
     }
 
-    private lazy var learnMoreButton: LegacyResizableButton = .build { button in
+    private lazy var learnMoreButton: LinkButton = .build { button in
+        // Configure your LinkButton properties
         button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 12.0)
         button.contentHorizontalAlignment = .leading
-        button.buttonEdgeSpacing = 0
+       
     }
 
     // MARK: - Initializers
@@ -93,7 +97,7 @@ class WallpaperSettingsHeaderView: UICollectionReusableView, ReusableCell {
             setButtonStyle(theme: viewModel.theme)
             learnMoreButton.addTarget(
                 self,
-                action: #selector((buttonTapped(_:))),
+                action: #selector(buttonTapped(_:)),
                 for: .touchUpInside)
             learnMoreButton.accessibilityIdentifier = buttonA11y
 
@@ -141,7 +145,7 @@ extension WallpaperSettingsHeaderView: ThemeApplicable {
         let color = theme.colors.textPrimary
         learnMoreButton.setTitleColor(color, for: .normal)
 
-        // in iOS 13 the title color set is not used for the attributed text color so we have to set it via attributes
+        // in iOS 13, the title color set is not used for the attributed text color, so we have to set it via attributes
         guard let buttonTitle = viewModel?.buttonTitle else { return }
         let labelAttributes: [NSAttributedString.Key: Any] = [
             .font: DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 12.0),
@@ -149,8 +153,7 @@ extension WallpaperSettingsHeaderView: ThemeApplicable {
             .underlineStyle: NSUnderlineStyle.single.rawValue
         ]
 
-        let attributeString = NSMutableAttributedString(string: buttonTitle,
-                                                        attributes: labelAttributes)
+        let attributeString = NSMutableAttributedString(string: buttonTitle, attributes: labelAttributes)
         learnMoreButton.setAttributedTitle(attributeString, for: .normal)
     }
 }


### PR DESCRIPTION
# Replaced LegacyResizableButton with LinkButton in WallpaperSettingsHeaderView

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

#17882 Description
In this PR, we replaced the usage of the legacy `LegacyResizableButton` with the more modern `LinkButton` from the ComponentLibrary within the `WallpaperSettingsHeaderView`. This change enhances the codebase by adopting the latest button component, promoting a more consistent and up-to-date UI across the application. The transition ensures compatibility with contemporary design practices and facilitates easier maintenance.

## :pencil: Checklist

- [✔️] Filled in the above information (tickets numbers and description of your work)
- [✔️] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [] Wrote unit tests and/or ensured the tests suite is passing
- [] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [] If needed I updated documentation / comments for complex code and public methods



SCREENSHOT ATTACHED

BEFORE:
![image](https://github.com/mozilla-mobile/firefox-ios/assets/91533278/acd823c5-1225-43d9-9953-05703f10b9b4)


AFTER:

![image](https://github.com/mozilla-mobile/firefox-ios/assets/91533278/c6e91799-b2e6-4699-a203-f44380da143c)
