### PR TITLE
Bugfix FXIOS-7199 [v123] Url remains static despite webpage change or window selection

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2351,7 +2351,7 @@ extension BrowserViewController: TabManagerDelegate {
 
         if let tab = selected, let webView = tab.webView {
             updateURLBarDisplayURL(tab)
-            if urlBar.inOverlayMode { urlBar.leaveOverlayMode(didCancel: false) }
+            if urlBar.inOverlayMode, tab.url?.displayURL != nil { urlBar.leaveOverlayMode(didCancel: false) }
 
             if previous == nil || tab.isPrivate != previous?.isPrivate {
                 applyTheme()

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2351,6 +2351,7 @@ extension BrowserViewController: TabManagerDelegate {
 
         if let tab = selected, let webView = tab.webView {
             updateURLBarDisplayURL(tab)
+            if urlBar.inOverlayMode { urlBar.leaveOverlayMode(didCancel: false) }
 
             if previous == nil || tab.isPrivate != previous?.isPrivate {
                 applyTheme()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7199)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15971)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
When browsing a webpage, selecting the URL sets the URL bar to overlay mode. Scrolling within this overlay causes the keyboard to disappear, but the URL bar remains unchanged. Additionally, switching between different tabs does not reset the URL bar's state.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

