### PR TITLE
Bugfix FXIOS-8140 [v123] Fakespot - iPad - the ad link is not displayed correctly for a specific scenario

### DIFF
--- a/firefox-ios/Client/Frontend/Fakespot/Views/FakespotAdLinkButton.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/Views/FakespotAdLinkButton.swift
@@ -36,13 +36,13 @@ class FakespotAdLinkButton: LinkButton {
     }
 
     override public func layoutSubviews() {
+        if let titleLabel {
+            // hack to be able to restrict the number of lines displayed
+            titleLabel.numberOfLines = UX.numberOfLines
+            sizeToFit()
+        }
+
         super.layoutSubviews()
-
-        guard let titleLabel else { return }
-
-        // hack to be able to restrict the number of lines displayed
-        titleLabel.numberOfLines = UX.numberOfLines
-        sizeToFit()
     }
 
     override public var intrinsicContentSize: CGSize {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8140)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18118)

## :bulb: Description
Fixes the ad link being displayed with only 1 line instead of 3.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

