### PR TITLE
Refactor FXIOS-7587 [v123] Replace Padded switch in BoolSetting

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/NotificationsSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/NotificationsSettingsViewController.swift
@@ -20,8 +20,8 @@ class NotificationsSettingsViewController: SettingsTableViewController, FeatureF
 
             Task {
                 let shouldEnable = await self.notificationsChanged(value)
-                self.syncNotifications.control.setOn(shouldEnable, animated: true)
-                self.syncNotifications.writeBool(self.syncNotifications.control)
+                self.syncNotifications.control.switchView.setOn(shouldEnable, animated: true)
+                self.syncNotifications.writeBool(self.syncNotifications.control.switchView)
 
                 // enable/disable sync notifications
                 NotificationCenter.default.post(name: .RegisterForPushNotifications, object: nil)
@@ -44,8 +44,8 @@ class NotificationsSettingsViewController: SettingsTableViewController, FeatureF
 
             Task {
                 let shouldEnable = await self.notificationsChanged(value)
-                self.tipsAndFeaturesNotifications.control.setOn(shouldEnable, animated: true)
-                self.tipsAndFeaturesNotifications.writeBool(self.tipsAndFeaturesNotifications.control)
+                self.tipsAndFeaturesNotifications.control.switchView.setOn(shouldEnable, animated: true)
+                self.tipsAndFeaturesNotifications.writeBool(self.tipsAndFeaturesNotifications.control.switchView)
             }
         }
     }()

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -203,7 +203,7 @@ class SearchSettingsTableViewController: ThemedTableViewController, FeatureFlagg
                     )
                 )
                 setting.onConfigureCell(cell, theme: themeManager.currentTheme)
-                setting.control.addTarget(
+                setting.control.switchView.addTarget(
                     self,
                     action: #selector(didToggleEnableNonSponsoredSuggestions),
                     for: .valueChanged
@@ -223,7 +223,7 @@ class SearchSettingsTableViewController: ThemedTableViewController, FeatureFlagg
                     )
                 )
                 setting.onConfigureCell(cell, theme: themeManager.currentTheme)
-                setting.control.addTarget(
+                setting.control.switchView.addTarget(
                     self,
                     action: #selector(didToggleEnableSponsoredSuggestions),
                     for: .valueChanged

--- a/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -162,12 +162,15 @@ class SettingSection: Setting {
     }
 }
 
-private class PaddedSwitch: UIView {
+class PaddedSwitch: UIView {
     private struct UX {
         static let padding: CGFloat = 8
     }
 
-    init(switchView: UISwitch) {
+    let switchView: UISwitch
+
+    init() {
+        self.switchView = UISwitch()
         super.init(frame: .zero)
 
         addSubview(switchView)
@@ -177,6 +180,11 @@ private class PaddedSwitch: UIView {
             height: switchView.frame.height
         )
         switchView.frame.origin = CGPoint(x: UX.padding, y: 0)
+    }
+
+    func configureSwitch(onTintColor: UIColor, isEnabled: Bool) {
+        switchView.onTintColor = onTintColor
+        switchView.isEnabled = isEnabled
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -278,29 +286,32 @@ class BoolSetting: Setting, FeatureFlaggable {
         return statusText
     }
 
-    public lazy var control: UISwitch = {
-        let control = UISwitch()
-        control.accessibilityIdentifier = prefKey
-        control.addTarget(self, action: #selector(switchValueChanged), for: .valueChanged)
+    public lazy var control: PaddedSwitch = {
+        let control = PaddedSwitch()
+        control.switchView.accessibilityIdentifier = prefKey
+        control.switchView.addTarget(self, action: #selector(switchValueChanged), for: .valueChanged)
         return control
     }()
 
     override func onConfigureCell(_ cell: UITableViewCell, theme: Theme) {
         super.onConfigureCell(cell, theme: theme)
 
-        control.onTintColor = theme.colors.actionPrimary
-        control.isEnabled = enabled
+        control.configureSwitch(
+            onTintColor: theme.colors.actionPrimary,
+            isEnabled: enabled
+        )
 
-        displayBool(control)
+        displayBool(control.switchView)
         if let title = title {
             if let status = status {
-                control.accessibilityLabel = "\(title.string), \(status.string)"
+                control.switchView.accessibilityLabel = "\(title.string), \(status.string)"
             } else {
-                control.accessibilityLabel = title.string
+                control.switchView.accessibilityLabel = title.string
             }
             cell.accessibilityLabel = nil
         }
-        cell.accessoryView = PaddedSwitch(switchView: control)
+
+        cell.accessoryView = control
         cell.selectionStyle = .none
 
         if !enabled {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7587)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16888)

## :bulb: Description
- This pull request refactors the code by making the `PaddedSwitch` class non-private and updating the `BoolSetting` class to use `PaddedSwitch` as the control property.

## Changes Made
- Removed the private status for the `PaddedSwitch` class, allowing it to be accessed outside the module.
- Updated the `BoolSetting` class to utilize `PaddedSwitch` instead of `UISwitch` for the control property.
- Introduced the `configureSwitch` method in `PaddedSwitch` to set properties such as onTintColor and isEnabled from the `BoolSetting` class.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

