### PR TITLE
Refactor FXIOS-8146 [v123] Use correct quotes for highlights in DE/FR

### DIFF
--- a/firefox-ios/Client/Frontend/Fakespot/Views/FakespotHighlightGroupView.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/Views/FakespotHighlightGroupView.swift
@@ -108,7 +108,11 @@ class FakespotHighlightGroupView: UIView, ThemeApplicable, Notifiable {
     }
 
     private func updateHighlightLabel(_ highlights: [String]) {
-        let highlightText = "\"\(highlights.joined(separator: "\"\n\""))\""
+        let locale = Locale.current
+        let quotationBegin = locale.quotationBeginDelimiter ?? "\""
+        let quotationEnd = locale.quotationEndDelimiter ?? "\""
+
+        let highlightText = "\(quotationBegin)\(highlights.joined(separator: "\"\n\""))\(quotationEnd)"
 
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.paragraphSpacing = 8


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8146)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18142)

## :bulb: Description
Use localized quotations for highlights.

<details><summary>Screenshots</summary>
<p>
American quotes

![Simulator Screenshot - iPhone 15 Pro Max - 2024-01-16 at 10 34 18](https://github.com/mozilla-mobile/firefox-ios/assets/4530/1920da83-cb0e-48e2-880f-dc13fc6a9a8f)
</p>
<p>
German quotes

![Simulator Screenshot - iPhone 15 Pro Max - 2024-01-16 at 10 44 43](https://github.com/mozilla-mobile/firefox-ios/assets/4530/b939467d-9d7b-4ae3-b371-6ec5dda79163)
</p>
<p>
French quotes

![Simulator Screenshot - iPhone 15 Pro Max - 2024-01-16 at 10 45 32](https://github.com/mozilla-mobile/firefox-ios/assets/4530/487cb3af-abb6-4c94-b5a4-26e30e00a226)
</p>
</details> 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

