### PR TITLE
Bugfix FXIOS-7850 [v122.1] Show search suggestions and engines in private mode

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
@@ -285,15 +285,18 @@ class SearchViewController: SiteTableViewController,
             // Query and reload the table with new search suggestions.
             querySuggestClient()
 
-            // Show the default search engine first.
-            if !viewModel.isPrivate {
-                let ua = SearchViewController.userAgent ?? "FxSearch"
-                suggestClient = SearchSuggestClient(searchEngine: defaultEngine, userAgent: ua)
-            }
+            setupSuggestClient(with: defaultEngine)
 
             // Reload the footer list of search engines.
             reloadSearchEngines()
         }
+    }
+
+    /// Sets up the suggestClient used to query our searches
+    /// - Parameter defaultEngine: default search engine set in settings (i.e. Google)
+    private func setupSuggestClient(with defaultEngine: OpenSearchEngine) {
+        let ua = SearchViewController.userAgent ?? "FxSearch"
+        suggestClient = SearchSuggestClient(searchEngine: defaultEngine, userAgent: ua)
     }
 
     private var quickSearchEngines: [OpenSearchEngine] {
@@ -303,7 +306,7 @@ class SearchViewController: SiteTableViewController,
 
         // If we're not showing search suggestions, the default search engine won't be visible
         // at the top of the table. Show it with the others in the bottom search bar.
-        if viewModel.isPrivate || !(searchEngines?.shouldShowSearchSuggestions ?? false) {
+        if !(searchEngines?.shouldShowSearchSuggestions ?? false) {
             engines?.insert(defaultEngine, at: 0)
         }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7850)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17529)

Related:
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8129)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18095)

## :bulb: Description
Show search suggestions in search view for private mode. 

We want to keep consistency for the search view for both normal and private mode. The only differences between the two is tab search.

The guidelines will be the following when the search view appears:

**Show Search Suggestions Enabled:**

- Show Search suggestions via default engine
- Remove default engine from list of search engines on the bottom of the view

**Show Search Suggestions Disabled:**

- Do not show Search suggestions via default engine
- Add default engine to the list of search engines on the bottom of the view

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

## Screenshot

https://github.com/mozilla-mobile/firefox-ios/assets/6743397/919a3f0b-ea99-4813-89a3-5e66b4b3a578

