### PR TITLE
Add FXIOS-8175 [v122.1] Refresh button to URL bar and keep toolbar button consistent on iPad

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ReaderMode.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ReaderMode.swift
@@ -9,7 +9,7 @@ extension BrowserViewController: ReaderModeDelegate {
     func readerMode(_ readerMode: ReaderMode, didChangeReaderModeState state: ReaderModeState, forTab tab: Tab) {
         // Update reader mode state if is the selected tab. Otherwise it will update once is active
         if tabManager.selectedTab === tab {
-            urlBar.updateReaderModeState(state, hideReloadButton: shouldUseiPadSetup())
+            urlBar.updateReaderModeState(state)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -95,33 +95,6 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
     func tabToolbarDidPressLibrary(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
     }
 
-    func tabToolbarDidPressReload(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
-        tabManager.selectedTab?.reload()
-    }
-
-    func tabToolbarDidLongPressReload(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
-        guard let tab = tabManager.selectedTab else { return }
-
-        let urlActions = self.getRefreshLongPressMenu(for: tab)
-        guard !urlActions.isEmpty else { return }
-
-        let generator = UIImpactFeedbackGenerator(style: .heavy)
-        generator.impactOccurred()
-
-        let shouldSuppress = UIDevice.current.userInterfaceIdiom == .pad
-        let style: UIModalPresentationStyle = shouldSuppress ? .popover : .overCurrentContext
-        let viewModel = PhotonActionSheetViewModel(
-            actions: [urlActions],
-            closeButtonTitle: .CloseButtonTitle,
-            modalStyle: style
-        )
-        presentSheetWith(viewModel: viewModel, on: self, from: button)
-    }
-
-    func tabToolbarDidPressStop(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
-        tabManager.selectedTab?.stop()
-    }
-
     func tabToolbarDidPressBack(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
         updateZoomPageBarVisibility(visible: false)
         tabManager.selectedTab?.goBack()

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -468,7 +468,7 @@ extension BrowserViewController: WKNavigationDelegate {
         // (orange color) as soon as the page has loaded.
         if let url = webView.url {
             if !url.isReaderModeURL {
-                urlBar.updateReaderModeState(ReaderModeState.unavailable, hideReloadButton: shouldUseiPadSetup())
+                urlBar.updateReaderModeState(ReaderModeState.unavailable)
                 hideReaderModeBar(animated: false)
             }
         }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1306,13 +1306,7 @@ class BrowserViewController: UIViewController,
             return
         }
 
-        if traitCollection.horizontalSizeClass == .compact {
-            state = .home
-        } else {
-            state = isLoading ? .stop : .reload
-        }
-
-        handleMiddleButtonState(state)
+        handleMiddleButtonState(.home)
         if !toolbar.isHidden {
             urlBar.locationView.reloadButton.reloadButtonState = isLoading ? .stop : .reload
         }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -328,9 +328,8 @@ class BrowserViewController: UIViewController,
         let showToolbar = shouldShowToolbarForTraitCollection(newCollection)
         let showTopTabs = shouldShowTopTabsForTraitCollection(newCollection)
 
-        let hideReloadButton = shouldUseiPadSetup(traitCollection: newCollection)
         urlBar.topTabsIsShowing = showTopTabs
-        urlBar.setShowToolbar(!showToolbar, hideReloadButton: hideReloadButton)
+        urlBar.setShowToolbar(!showToolbar)
         toolbar.addNewTabButton.isHidden = showToolbar
 
         if showToolbar {
@@ -1094,7 +1093,7 @@ class BrowserViewController: UIViewController,
             }
         } else if !url.absoluteString.hasPrefix("\(InternalURL.baseUrl)/\(SessionRestoreHandler.path)") {
             showEmbeddedWebview()
-            urlBar.shouldHideReloadButton(shouldUseiPadSetup())
+            urlBar.locationView.reloadButton.isHidden = false
         }
 
         if UIDevice.current.userInterfaceIdiom == .pad {
@@ -1307,9 +1306,7 @@ class BrowserViewController: UIViewController,
         }
 
         handleMiddleButtonState(.home)
-        if !toolbar.isHidden {
-            urlBar.locationView.reloadButton.reloadButtonState = isLoading ? .stop : .reload
-        }
+        urlBar.locationView.reloadButton.reloadButtonState = isLoading ? .stop : .reload
         currentMiddleButtonState = state
     }
 
@@ -2425,14 +2422,14 @@ extension BrowserViewController: TabManagerDelegate {
         }
 
         if let readerMode = selected?.getContentScript(name: ReaderMode.name()) as? ReaderMode {
-            urlBar.updateReaderModeState(readerMode.state, hideReloadButton: shouldUseiPadSetup())
+            urlBar.updateReaderModeState(readerMode.state)
             if readerMode.state == .active {
                 showReaderModeBar(animated: false)
             } else {
                 hideReaderModeBar(animated: false)
             }
         } else {
-            urlBar.updateReaderModeState(ReaderModeState.unavailable, hideReloadButton: shouldUseiPadSetup())
+            urlBar.updateReaderModeState(ReaderModeState.unavailable)
         }
 
         if topTabsVisible {

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/TabToolbar.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/TabToolbar.swift
@@ -14,7 +14,6 @@ class TabToolbar: UIView, SearchBarLocationProvider {
     let tabsButton = TabsButton()
     let addNewTabButton = ToolbarButton()
     let appMenuButton = ToolbarButton()
-    let homeButton = ToolbarButton()
     let bookmarksButton = ToolbarButton()
     let forwardButton = ToolbarButton()
     let backButton = ToolbarButton()

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/TabToolbarHelper.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/TabToolbarHelper.swift
@@ -34,9 +34,6 @@ protocol TabToolbarDelegate: AnyObject {
     func tabToolbarDidPressForward(_ tabToolbar: TabToolbarProtocol, button: UIButton)
     func tabToolbarDidLongPressBack(_ tabToolbar: TabToolbarProtocol, button: UIButton)
     func tabToolbarDidLongPressForward(_ tabToolbar: TabToolbarProtocol, button: UIButton)
-    func tabToolbarDidPressReload(_ tabToolbar: TabToolbarProtocol, button: UIButton)
-    func tabToolbarDidLongPressReload(_ tabToolbar: TabToolbarProtocol, button: UIButton)
-    func tabToolbarDidPressStop(_ tabToolbar: TabToolbarProtocol, button: UIButton)
     func tabToolbarDidPressHome(_ tabToolbar: TabToolbarProtocol, button: UIButton)
     func tabToolbarDidPressFire(_ tabToolbar: TabToolbarProtocol, button: UIButton)
     func tabToolbarDidPressMenu(_ tabToolbar: TabToolbarProtocol, button: UIButton)
@@ -48,8 +45,6 @@ protocol TabToolbarDelegate: AnyObject {
 }
 
 enum MiddleButtonState {
-    case reload
-    case stop
     case search
     case home
     case fire
@@ -58,8 +53,6 @@ enum MiddleButtonState {
 @objcMembers
 open class TabToolbarHelper: NSObject {
     let toolbar: TabToolbarProtocol
-    let ImageReload = UIImage.templateImageNamed("nav-refresh")
-    let ImageStop = UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross)
     let ImageSearch = UIImage.templateImageNamed("search")
     let ImageNewTab = UIImage.templateImageNamed(StandardImageIdentifiers.Large.plus)
     let ImageHome = UIImage.templateImageNamed(StandardImageIdentifiers.Large.home)
@@ -83,20 +76,6 @@ open class TabToolbarHelper: NSObject {
             toolbar.multiStateButton.largeContentTitle = .TabToolbarSearchAccessibilityLabel
             toolbar.multiStateButton.largeContentImage = ImageSearch
             toolbar.multiStateButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.searchButton
-        case (.reload, .pad):
-            middleButtonState = .reload
-            toolbar.multiStateButton.setImage(ImageReload, for: .normal)
-            toolbar.multiStateButton.accessibilityLabel = .TabToolbarReloadAccessibilityLabel
-            toolbar.multiStateButton.largeContentTitle = .TabToolbarReloadAccessibilityLabel
-            toolbar.multiStateButton.largeContentImage = ImageReload
-            toolbar.multiStateButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.reloadButton
-        case (.stop, .pad):
-            middleButtonState = .stop
-            toolbar.multiStateButton.setImage(ImageStop, for: .normal)
-            toolbar.multiStateButton.accessibilityLabel = .TabToolbarStopAccessibilityLabel
-            toolbar.multiStateButton.largeContentTitle = .TabToolbarStopAccessibilityLabel
-            toolbar.multiStateButton.largeContentImage = ImageStop
-            toolbar.multiStateButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.stopButton
         default:
             toolbar.multiStateButton.setImage(ImageHome, for: .normal)
             toolbar.multiStateButton.accessibilityLabel = .TabToolbarHomeAccessibilityLabel
@@ -151,22 +130,10 @@ open class TabToolbarHelper: NSObject {
         toolbar.forwardButton.addGestureRecognizer(longPressGestureForwardButton)
         toolbar.forwardButton.addTarget(self, action: #selector(didClickForward), for: .touchUpInside)
 
-        if UIDevice.current.userInterfaceIdiom == .phone {
-            toolbar.multiStateButton.setImage(ImageHome, for: .normal)
-        } else {
-            toolbar.multiStateButton.setImage(ImageReload, for: .normal)
-        }
+        toolbar.multiStateButton.setImage(ImageHome, for: .normal)
         toolbar.multiStateButton.accessibilityLabel = .TabToolbarReloadAccessibilityLabel
         toolbar.multiStateButton.showsLargeContentViewer = true
-
-        let longPressMultiStateButton = UILongPressGestureRecognizer(
-            target: self,
-            action: #selector(didLongPressMultiStateButton)
-        )
-        longPressMultiStateButton.delegate = self
-        toolbar.multiStateButton.addGestureRecognizer(longPressMultiStateButton)
         toolbar.multiStateButton.addTarget(self, action: #selector(didPressMultiStateButton), for: .touchUpInside)
-        longPressGestureRecognizers.append(longPressMultiStateButton)
 
         toolbar.tabsButton.addTarget(self, action: #selector(didClickTabs), for: .touchUpInside)
         let longPressGestureTabsButton = UILongPressGestureRecognizer(target: self, action: #selector(didLongPressTabs))
@@ -278,23 +245,8 @@ open class TabToolbarHelper: NSObject {
         case .search:
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .startSearchButton)
             toolbar.tabToolbarDelegate?.tabToolbarDidPressSearch(toolbar, button: toolbar.multiStateButton)
-        case .stop:
-            toolbar.tabToolbarDelegate?.tabToolbarDidPressStop(toolbar, button: toolbar.multiStateButton)
-        case .reload:
-            toolbar.tabToolbarDelegate?.tabToolbarDidPressReload(toolbar, button: toolbar.multiStateButton)
         case .fire:
             toolbar.tabToolbarDelegate?.tabToolbarDidPressFire(toolbar, button: toolbar.multiStateButton)
-        }
-    }
-
-    func didLongPressMultiStateButton(_ recognizer: UILongPressGestureRecognizer) {
-        switch middleButtonState {
-        case .search, .home:
-            return
-        default:
-            if recognizer.state == .began {
-                toolbar.tabToolbarDelegate?.tabToolbarDidLongPressReload(toolbar, button: toolbar.multiStateButton)
-            }
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/TabToolbarHelper.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/TabToolbarHelper.swift
@@ -13,7 +13,6 @@ protocol TabToolbarProtocol: AnyObject {
     var tabsButton: TabsButton { get }
     var appMenuButton: ToolbarButton { get }
     var bookmarksButton: ToolbarButton { get }
-    var homeButton: ToolbarButton { get }
     var forwardButton: ToolbarButton { get }
     var backButton: ToolbarButton { get }
     var multiStateButton: ToolbarButton { get }
@@ -194,15 +193,6 @@ open class TabToolbarHelper: NSObject {
         toolbar.appMenuButton.addTarget(self, action: #selector(didClickMenu), for: .touchUpInside)
         toolbar.appMenuButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.settingsMenuButton
 
-        toolbar.homeButton.contentMode = .center
-        toolbar.homeButton.showsLargeContentViewer = true
-        toolbar.homeButton.largeContentImage = ImageHome
-        toolbar.homeButton.largeContentTitle = .TabToolbarHomeAccessibilityLabel
-        toolbar.homeButton.setImage(ImageHome, for: .normal)
-        toolbar.homeButton.accessibilityLabel = .AppMenu.Toolbar.HomeMenuButtonAccessibilityLabel
-        toolbar.homeButton.addTarget(self, action: #selector(didClickHome), for: .touchUpInside)
-        toolbar.homeButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.homeButton
-
         toolbar.bookmarksButton.contentMode = .center
         toolbar.bookmarksButton.showsLargeContentViewer = true
         toolbar.bookmarksButton.largeContentImage = ImageBookmark
@@ -270,10 +260,6 @@ open class TabToolbarHelper: NSObject {
 
     func didClickMenu() {
         toolbar.tabToolbarDelegate?.tabToolbarDidPressMenu(toolbar, button: toolbar.appMenuButton)
-    }
-
-    func didClickHome() {
-        toolbar.tabToolbarDelegate?.tabToolbarDidPressHome(toolbar, button: toolbar.appMenuButton)
     }
 
     func didClickLibrary() {

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -188,7 +188,6 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
 
     var appMenuButton = ToolbarButton()
     var bookmarksButton = ToolbarButton()
-    var homeButton = ToolbarButton()
     var addNewTabButton = ToolbarButton()
     var forwardButton = ToolbarButton()
     var multiStateButton = ToolbarButton()
@@ -201,7 +200,6 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
 
     lazy var actionButtons: [ThemeApplicable & UIButton] = [
         self.tabsButton,
-        self.homeButton,
         self.bookmarksButton,
         self.appMenuButton,
         self.addNewTabButton,
@@ -258,7 +256,6 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
             progressBar,
             cancelButton,
             showQRScannerButton,
-            homeButton,
             bookmarksButton,
             appMenuButton,
             addNewTabButton,
@@ -322,12 +319,6 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
 
         multiStateButton.snp.makeConstraints { make in
             make.leading.equalTo(self.forwardButton.snp.trailing)
-            make.centerY.equalTo(self)
-            make.size.equalTo(URLBarViewUX.ButtonHeight)
-        }
-
-        homeButton.snp.makeConstraints { make in
-            make.trailing.equalTo(self.bookmarksButton.snp.leading)
             make.centerY.equalTo(self)
             make.size.equalTo(URLBarViewUX.ButtonHeight)
         }
@@ -428,7 +419,7 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
                     // If we are showing a toolbar, show the text field next to the forward button
                     make.leading.equalTo(self.multiStateButton.snp.trailing).offset(URLBarViewUX.Padding)
                     if self.topTabsIsShowing {
-                        make.trailing.equalTo(self.homeButton.snp.leading).offset(-URLBarViewUX.Padding)
+                        make.trailing.equalTo(self.bookmarksButton.snp.leading).offset(-URLBarViewUX.Padding)
                     } else {
                         make.trailing.equalTo(self.addNewTabButton.snp.leading).offset(-URLBarViewUX.Padding)
                     }
@@ -596,7 +587,6 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
         progressBar.isHidden = false
         addNewTabButton.isHidden = !toolbarIsShowing || topTabsIsShowing
         appMenuButton.isHidden = !toolbarIsShowing
-        homeButton.isHidden = !toolbarIsShowing || !topTabsIsShowing
         bookmarksButton.isHidden = !toolbarIsShowing || !topTabsIsShowing
         forwardButton.isHidden = !toolbarIsShowing
         backButton.isHidden = !toolbarIsShowing
@@ -611,7 +601,6 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
         progressBar.alpha = inOverlayMode || didCancel ? 0 : 1
         tabsButton.alpha = inOverlayMode ? 0 : 1
         appMenuButton.alpha = inOverlayMode ? 0 : 1
-        homeButton.alpha = inOverlayMode ? 0 : 1
         bookmarksButton.alpha = inOverlayMode ? 0 : 1
         addNewTabButton.alpha = inOverlayMode ? 0 : 1
         forwardButton.alpha = inOverlayMode ? 0 : 1
@@ -643,7 +632,6 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
         progressBar.isHidden = inOverlayMode
         addNewTabButton.isHidden = !toolbarIsShowing || topTabsIsShowing || inOverlayMode
         appMenuButton.isHidden = !toolbarIsShowing || inOverlayMode
-        homeButton.isHidden = !toolbarIsShowing || inOverlayMode || !topTabsIsShowing
         bookmarksButton.isHidden = !toolbarIsShowing || inOverlayMode || !topTabsIsShowing
         forwardButton.isHidden = !toolbarIsShowing || inOverlayMode
         backButton.isHidden = !toolbarIsShowing || inOverlayMode
@@ -753,7 +741,6 @@ extension URLBarView: TabToolbarProtocol {
                         multiStateButton,
                         locationView,
                         tabsButton,
-                        homeButton,
                         bookmarksButton,
                         appMenuButton,
                         addNewTabButton,

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -481,8 +481,8 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
 
     /// Ideally we'd split this implementation in two, one URLBarView with a toolbar and one without
     /// However, switching views dynamically at runtime is a difficult. For now, we just use one view
-    /// that can show in either mode. For the reload button, we hide it on iPad (apart from multitasking mode)
-    func setShowToolbar(_ shouldShow: Bool, hideReloadButton: Bool) {
+    /// that can show in either mode.
+    func setShowToolbar(_ shouldShow: Bool) {
         toolbarIsShowing = shouldShow
         setNeedsUpdateConstraints()
         // when we transition from portrait to landscape, calling this here causes
@@ -490,7 +490,6 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
         if !toolbarIsShowing {
             updateConstraintsIfNeeded()
         }
-        shouldHideReloadButton(hideReloadButton)
         updateViewsForOverlayModeAndToolbarChanges()
     }
 
@@ -510,15 +509,8 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
         progressBar.setProgress(0, animated: false)
     }
 
-    /// We hide reload button on iPad, but not in multitasking mode
-    func updateReaderModeState(_ state: ReaderModeState, hideReloadButton: Bool) {
+    func updateReaderModeState(_ state: ReaderModeState) {
         locationView.readerModeState = state
-        shouldHideReloadButton(hideReloadButton)
-    }
-
-    /// We hide reload button on iPad, but not in multitasking mode
-    func shouldHideReloadButton(_ isHidden: Bool) {
-        locationView.reloadButton.isHidden = isHidden
     }
 
     func setAutocompleteSuggestion(_ suggestion: String?) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabToolbarHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabToolbarHelperTests.swift
@@ -105,9 +105,6 @@ class MockTabToolbar: TabToolbarProtocol {
     var _addNewTabButton = MockToolbarButton()
     var addNewTabButton: ToolbarButton { return _addNewTabButton }
 
-    var _homeButton = MockToolbarButton()
-    var homeButton: ToolbarButton { return _homeButton }
-
     var _appMenuButton = MockToolbarButton()
     var appMenuButton: ToolbarButton { return _appMenuButton }
 


### PR DESCRIPTION
## :scroll: Tickets
Add Refresh Button to URL Button on iPad
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8175)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18185)

Remove Long Press from multi state button
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8151)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18150)

## :bulb: Description
Made the following updates for both normal / private mode on iPad:
* Remove **home button on right side of URL bar** (for iPad)
* Update the **multi state button (left side of URL bar)** to match on the logic on iPhone. (aka remove stop and reload buttons)
    * We either show search or home button
     * Only exception is when felt deletion feature is enabled, we show the fire icon for private mode
* Add **reload / refresh button** inside of the URL bar (exists for iPhone, need to update for iPad)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

# Screenshots
iPad w/o Felt Privacy

https://github.com/mozilla-mobile/firefox-ios/assets/6743397/80ea2247-f80a-4afe-9780-68c306b0fce4 

iPad with Felt Privacy

https://github.com/mozilla-mobile/firefox-ios/assets/6743397/d616d670-c451-46f9-bb77-7d5fe0306e79
