### PR TITLE
Refactor FXIOS-8055 [v123] Update the base privacy policy link in the Review Checker opt-in screen

### DIFF
--- a/firefox-ios/Client/Frontend/Fakespot/FakespotOptInCardViewModel.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotOptInCardViewModel.swift
@@ -29,8 +29,7 @@ struct FakespotOptInCardViewModel {
                                                                FakespotName.shortName.rawValue,
                                                                MozillaName.shortName.rawValue)
     let bodyA11yId: String = AccessibilityIdentifiers.Shopping.OptInCard.optInCopy
-    let disclaimer = String.localizedStringWithFormat(.Shopping.OptInCardDisclaimerText,
-                                                      FakespotName.shortName.rawValue)
+    let disclaimer: String = .Shopping.OptInCardDisclaimerText
     let disclaimerLabelA11yId: String = AccessibilityIdentifiers.Shopping.OptInCard.disclaimerText
 
     // MARK: Buttons

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotOptInCardViewModel.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotOptInCardViewModel.swift
@@ -35,9 +35,11 @@ struct FakespotOptInCardViewModel {
     // MARK: Buttons
     let learnMoreButtonText: String = .Shopping.OptInCardLearnMoreButtonTitle
     let learnMoreButtonA11yId: String = AccessibilityIdentifiers.Shopping.OptInCard.learnMoreButton
-    let termsOfUseButtonText: String = .Shopping.OptInCardTermsOfUse
+    let termsOfUseButtonText: String = String.localizedStringWithFormat(.Shopping.OptInCardTermsOfUse,
+                                                                        FakespotName.shortName.rawValue)
     let termsOfUseButtonA11yId: String = AccessibilityIdentifiers.Shopping.OptInCard.termsOfUseButton
-    let privacyPolicyButtonText: String = .Shopping.OptInCardPrivacyPolicy
+    let privacyPolicyButtonText: String = String.localizedStringWithFormat(.Shopping.OptInCardPrivacyPolicy,
+                                                                           AppName.shortName.rawValue)
     let privacyPolicyButtonA11yId: String = AccessibilityIdentifiers.Shopping.OptInCard.privacyPolicyButton
     let mainButtonText: String = .Shopping.OptInCardMainButtonTitle
     let mainButtonA11yId: String = AccessibilityIdentifiers.Shopping.OptInCard.mainButton

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotOptInCardViewModel.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotOptInCardViewModel.swift
@@ -35,11 +35,11 @@ struct FakespotOptInCardViewModel {
     // MARK: Buttons
     let learnMoreButtonText: String = .Shopping.OptInCardLearnMoreButtonTitle
     let learnMoreButtonA11yId: String = AccessibilityIdentifiers.Shopping.OptInCard.learnMoreButton
-    let termsOfUseButtonText: String = String.localizedStringWithFormat(.Shopping.OptInCardTermsOfUse,
-                                                                        FakespotName.shortName.rawValue)
+    let termsOfUseButtonText = String.localizedStringWithFormat(.Shopping.OptInCardTermsOfUse,
+                                                                FakespotName.shortName.rawValue)
     let termsOfUseButtonA11yId: String = AccessibilityIdentifiers.Shopping.OptInCard.termsOfUseButton
-    let privacyPolicyButtonText: String = String.localizedStringWithFormat(.Shopping.OptInCardPrivacyPolicy,
-                                                                           AppName.shortName.rawValue)
+    let privacyPolicyButtonText = String.localizedStringWithFormat(.Shopping.OptInCardPrivacyPolicy,
+                                                                   AppName.shortName.rawValue)
     let privacyPolicyButtonA11yId: String = AccessibilityIdentifiers.Shopping.OptInCard.privacyPolicyButton
     let mainButtonText: String = .Shopping.OptInCardMainButtonTitle
     let mainButtonA11yId: String = AccessibilityIdentifiers.Shopping.OptInCard.mainButton

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotUtils.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotUtils.swift
@@ -22,12 +22,12 @@ public struct FakespotUtils: FeatureFlaggable {
 
     public static var privacyPolicyUrl: URL? {
         // Returns the predefined URL associated to privacy policy button action.
-        return URL(string: "https://www.fakespot.com/privacy-policy")
+        return URL(string: "https://www.mozilla.org/en-US/privacy/firefox?utm_source=review-checker&utm_campaign=privacy-policy&utm_medium=in-product&utm_term=opt-in-screen")
     }
 
     public static var termsOfUseUrl: URL? {
         // Returns the predefined URL associated to terms of use button action.
-        return URL(string: "https://www.fakespot.com/terms")
+        return URL(string: "https://www.fakespot.com/privacy-policy?utm_source=review-checker&utm_campaign=privacy-policy&utm_medium=in-product&utm_term=opt-in-screen")
     }
 
     public static var fakespotUrl: URL? {

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -4031,20 +4031,20 @@ extension String {
             value: "Learn more",
             comment: "Label for the Learn more button in the Shopping Experience Opt In onboarding Card (Fakespot)")
         public static let OptInCardDisclaimerText = MZLocalizedString(
-            key: "Shopping.OptInCard.Disclaimer.Text.v120",
+            key: "Shopping.OptInCard.Disclaimer.Text.v123",
             tableName: "Shopping",
-            value: "By selecting “Yes, Try It” you agree to the following from %@:",
-            comment: "Text for the disclaimer that appears underneath the rating image of the Shopping Experience Opt In onboarding Card (Fakespot). The parameter will be replaced by the Fakespot app name. After the colon, what appears are two links, each on their own line. The first link is to a Privacy policy. The second link is to Terms of use.")
+            value: "By selecting “Yes, Try It” you agree to these items:",
+            comment: "Text for the disclaimer that appears underneath the rating image of the Shopping Experience Opt In onboarding Card (Fakespot). After the colon, there will be two links, each on their own line. The first link is to a Privacy policy. The second link is to Terms of use.")
         public static let OptInCardPrivacyPolicy = MZLocalizedString(
-            key: "Shopping.OptInCard.PrivacyPolicy.Button.Title.v120",
+            key: "Shopping.OptInCard.PrivacyPolicy.Button.Title.v123",
             tableName: "Shopping",
-            value: "Privacy policy",
-            comment: "Show Firefox Browser Privacy Policy page from the Privacy section in the Shopping Experience Opt In onboarding Card (Fakespot). See https://www.mozilla.org/privacy/firefox/")
+            value: "Firefox's privacy notice",
+            comment: "Show Firefox Browser Privacy Policy page from the Privacy section in the Shopping Experience Opt In onboarding Card (Fakespot).")
         public static let OptInCardTermsOfUse = MZLocalizedString(
-            key: "Shopping.OptInCard.TermsOfUse.Button.Title.v120",
+            key: "Shopping.OptInCard.TermsOfUse.Button.Title.v123",
             tableName: "Shopping",
-            value: "Terms of use",
-            comment: "Show Firefox Browser Terms of Use page from the Privacy section in the Shopping Experience Opt In onboarding Card (Fakespot). See https://www.mozilla.org/privacy/firefox/")
+            value: "Fakespot's terms of use",
+            comment: "Show Fakespot Terms of Use page in the Shopping Experience Opt In onboarding Card (Fakespot).")
         public static let OptInCardMainButtonTitle = MZLocalizedString(
             key: "Shopping.OptInCard.MainButton.Title.v120",
             tableName: "Shopping",
@@ -5989,6 +5989,24 @@ extension String {
                 tableName: "Shopping",
                 value: "Checking review quality",
                 comment: "Title for info card when the product is in analysis mode",
+                lastUsedInVersion: 122)
+            public static let OptInCardDisclaimerText = MZLocalizedString(
+                key: "Shopping.OptInCard.Disclaimer.Text.v120",
+                tableName: "Shopping",
+                value: "By selecting “Yes, Try It” you agree to the following from %@:",
+                comment: "Text for the disclaimer that appears underneath the rating image of the Shopping Experience Opt In onboarding Card (Fakespot). The parameter will be replaced by the Fakespot app name. After the colon, what appears are two links, each on their own line. The first link is to a Privacy policy. The second link is to Terms of use.",
+                lastUsedInVersion: 122)
+            public static let OptInCardPrivacyPolicy = MZLocalizedString(
+                key: "Shopping.OptInCard.PrivacyPolicy.Button.Title.v120",
+                tableName: "Shopping",
+                value: "Privacy policy",
+                comment: "Show Firefox Browser Privacy Policy page from the Privacy section in the Shopping Experience Opt In onboarding Card (Fakespot). See https://www.mozilla.org/privacy/firefox/",
+                lastUsedInVersion: 122)
+            public static let OptInCardTermsOfUse = MZLocalizedString(
+                key: "Shopping.OptInCard.TermsOfUse.Button.Title.v120",
+                tableName: "Shopping",
+                value: "Terms of use",
+                comment: "Show Firefox Browser Terms of Use page from the Privacy section in the Shopping Experience Opt In onboarding Card (Fakespot). See https://www.mozilla.org/privacy/firefox/",
                 lastUsedInVersion: 122)
         }
 

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -4038,13 +4038,13 @@ extension String {
         public static let OptInCardPrivacyPolicy = MZLocalizedString(
             key: "Shopping.OptInCard.PrivacyPolicy.Button.Title.v123",
             tableName: "Shopping",
-            value: "Firefox's privacy notice",
-            comment: "Show Firefox Browser Privacy Policy page from the Privacy section in the Shopping Experience Opt In onboarding Card (Fakespot).")
+            value: "%@'s privacy notice",
+            comment: "Show Firefox Browser Privacy Policy page from the Privacy section in the Shopping Experience Opt In onboarding Card (Fakespot). The parameter will be replace by the Firefox app name.")
         public static let OptInCardTermsOfUse = MZLocalizedString(
             key: "Shopping.OptInCard.TermsOfUse.Button.Title.v123",
             tableName: "Shopping",
-            value: "Fakespot's terms of use",
-            comment: "Show Fakespot Terms of Use page in the Shopping Experience Opt In onboarding Card (Fakespot).")
+            value: "%@'s terms of use",
+            comment: "Show Fakespot Terms of Use page in the Shopping Experience Opt In onboarding Card (Fakespot). The parameter will be replace by the Fakespot name.")
         public static let OptInCardMainButtonTitle = MZLocalizedString(
             key: "Shopping.OptInCard.MainButton.Title.v120",
             tableName: "Shopping",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8055)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17959)

## :bulb: Description
Updates the strings for the Fakespot opt-in as well as the links.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

