### PR TITLE
Remove FX-8185, Bug-1874838 [v123] Remove usage of telemetry-ios

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -39,7 +39,6 @@
 		0BF8F8DA1AEFF1C900E90BC2 /* noTitle.html in Resources */ = {isa = PBXBuildFile; fileRef = 0BF8F8D91AEFF1C900E90BC2 /* noTitle.html */; };
 		158241282820698B00956B39 /* RustRemoteTabsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 158241272820698B00956B39 /* RustRemoteTabsTests.swift */; };
 		15DE98FD27FCED4F00F1ECDB /* RustRemoteTabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15DE98FC27FCED4F00F1ECDB /* RustRemoteTabs.swift */; };
-		1B3D99F1270E89D0006E1264 /* Telemetry in Frameworks */ = {isa = PBXBuildFile; productRef = 1B3D99F0270E89D0006E1264 /* Telemetry */; };
 		1D06AE6624FEE4D5000B092B /* TopSitesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D06AE6524FEE4D5000B092B /* TopSitesProvider.swift */; };
 		1D06AE6A24FEE8D6000B092B /* TabProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D06AE6924FEE8D6000B092B /* TabProvider.swift */; };
 		1D0BA05C24F46A0400D731B5 /* TopSitesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D0BA05B24F46A0400D731B5 /* TopSitesProvider.swift */; };
@@ -7699,7 +7698,6 @@
 				E6231C011B90A44F005ABB0D /* libz.tbd in Frameworks */,
 				E4B3348A1BBF23F9004E2BFF /* AdSupport.framework in Frameworks */,
 				5A871488292EA1440039A5BD /* Fuzi in Frameworks */,
-				1B3D99F1270E89D0006E1264 /* Telemetry in Frameworks */,
 				432BD0242790EBD000A0F3C3 /* Adjust in Frameworks */,
 				0B8E0FF41A932BD500161DC3 /* ImageIO.framework in Frameworks */,
 				435C85F02788F4D00072B526 /* Glean in Frameworks */,
@@ -12060,7 +12058,6 @@
 			);
 			name = Client;
 			packageProductDependencies = (
-				1B3D99F0270E89D0006E1264 /* Telemetry */,
 				433F87CD2788EAB600693368 /* GCDWebServers */,
 				435C85EF2788F4D00072B526 /* Glean */,
 				432BD0232790EBD000A0F3C3 /* Adjust */,
@@ -12381,7 +12378,6 @@
 			);
 			mainGroup = F84B21B51A090F8100AAB793;
 			packageReferences = (
-				1B3D99EF270E89D0006E1264 /* XCRemoteSwiftPackageReference "telemetry-ios" */,
 				433F87CC2788EAB600693368 /* XCRemoteSwiftPackageReference "GCDWebServer" */,
 				433F87D12788EF5B00693368 /* XCRemoteSwiftPackageReference "KIF" */,
 				433F87D62788F34500693368 /* XCRemoteSwiftPackageReference "rust-components-swift" */,
@@ -20859,14 +20855,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		1B3D99EF270E89D0006E1264 /* XCRemoteSwiftPackageReference "telemetry-ios" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/mozilla-mobile/telemetry-ios";
-			requirement = {
-				kind = exactVersion;
-				version = 2.0.0;
-			};
-		};
 		432BD0222790EBD000A0F3C3 /* XCRemoteSwiftPackageReference "ios_sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/adjust/ios_sdk.git";
@@ -20942,11 +20930,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		1B3D99F0270E89D0006E1264 /* Telemetry */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 1B3D99EF270E89D0006E1264 /* XCRemoteSwiftPackageReference "telemetry-ios" */;
-			productName = Telemetry;
-		};
 		216A0D752A40E7AB008077BA /* Redux */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Redux;

--- a/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -116,15 +116,6 @@
         "revision" : "1080914828ef1c9ca9cd2bad50667b3d847dabff",
         "version" : "2.0.0"
       }
-    },
-    {
-      "identity" : "telemetry-ios",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mozilla-mobile/telemetry-ios",
-      "state" : {
-        "revision" : "68f2d813320c9fda2fb4aee4548c64293500200a",
-        "version" : "2.0.0"
-      }
     }
   ],
   "version" : 2

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
@@ -4,7 +4,6 @@
 
 import Shared
 import Storage
-import Telemetry
 import Glean
 import Common
 import ComponentLibrary
@@ -383,10 +382,8 @@ extension BrowserViewController: URLBarDelegate {
 
         let conversionMetrics = UserConversionMetrics()
         conversionMetrics.didPerformSearch()
-        // We couldn't find a matching search keyword, so do a search query.
-        Telemetry.default.recordSearch(location: .actionBar, searchEngine: engine.engineID ?? "other")
         GleanMetrics.Search
-            .counts["\(engine.engineID ?? "custom").\(SearchesMeasurement.SearchLocation.actionBar.rawValue)"]
+            .counts["\(engine.engineID ?? "custom").\(SearchLocation.actionBar.rawValue)"]
             .add()
         searchTelemetry?.shouldSetUrlTypeSearch = true
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -11,7 +11,6 @@ import Storage
 import SnapKit
 import Account
 import MobileCoreServices
-import Telemetry
 import Common
 import ComponentLibrary
 import Redux

--- a/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
@@ -5,7 +5,6 @@
 import UIKit
 import Shared
 import Storage
-import Telemetry
 import Common
 import SiteImageView
 
@@ -432,7 +431,7 @@ class SearchViewController: SiteTableViewController,
             return
         }
         let extras = [
-            ExtraKey.recordSearchLocation.rawValue: SearchesMeasurement.SearchLocation.quickSearch,
+            ExtraKey.recordSearchLocation.rawValue: SearchLocation.quickSearch,
             ExtraKey.recordSearchEngineID.rawValue: engine.engineID as Any
         ] as [String: Any]
         TelemetryWrapper.gleanRecordEvent(category: .action,
@@ -633,7 +632,7 @@ class SearchViewController: SiteTableViewController,
             else { return }
 
             let extras = [
-                ExtraKey.recordSearchLocation.rawValue: SearchesMeasurement.SearchLocation.suggestion,
+                ExtraKey.recordSearchLocation.rawValue: SearchLocation.suggestion,
                 ExtraKey.recordSearchEngineID.rawValue: defaultEngine.engineID as Any
             ] as [String: Any]
             TelemetryWrapper.gleanRecordEvent(category: .action,

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -7,7 +7,6 @@
 import Common
 import Glean
 import Shared
-import Telemetry
 import Account
 import Sync
 import Storage
@@ -34,6 +33,13 @@ extension TelemetryWrapperProtocol {
     }
 }
 
+enum SearchLocation: String {
+    case actionBar = "actionbar"
+    case listItem = "listitem"
+    case suggestion = "suggestion"
+    case quickSearch = "quicksearch"
+}
+
 class TelemetryWrapper: TelemetryWrapperProtocol, FeatureFlaggable {
     typealias ExtraKey = TelemetryWrapper.EventExtraKey
 
@@ -42,7 +48,6 @@ class TelemetryWrapper: TelemetryWrapperProtocol, FeatureFlaggable {
     // TODO [7856]: Temporary. Additional telemetry updates forthcoming once iPad multi-window enabled.
     var defaultTabManager: TabManager?
 
-    let legacyTelemetry = Telemetry.default
     let glean = Glean.shared
     // Boolean flag to temporarily remember if we crashed during the
     // last run of the app. We cannot simply use `Sentry.crashedLastLaunch`
@@ -83,86 +88,7 @@ class TelemetryWrapper: TelemetryWrapperProtocol, FeatureFlaggable {
         migratePathComponentInDocumentsDirectory("MozTelemetry-Default-mobile-event", to: .cachesDirectory)
         migratePathComponentInDocumentsDirectory("eventArray-MozTelemetry-Default-mobile-event.json", to: .cachesDirectory)
 
-        NotificationCenter.default.addObserver(self, selector: #selector(uploadError), name: Telemetry.notificationReportError, object: nil)
-
-        let telemetryConfig = legacyTelemetry.configuration
-        telemetryConfig.appName = "Fennec"
-        telemetryConfig.userDefaultsSuiteName = AppInfo.sharedContainerIdentifier
-        telemetryConfig.dataDirectory = .cachesDirectory
-        telemetryConfig.updateChannel = AppConstants.buildChannel.rawValue
         let sendUsageData = profile.prefs.boolForKey(AppConstants.prefSendUsageData) ?? true
-        telemetryConfig.isCollectionEnabled = sendUsageData
-        telemetryConfig.isUploadEnabled = sendUsageData
-
-        telemetryConfig.measureUserDefaultsSetting(forKey: "profile.saveLogins", withDefaultValue: true)
-        telemetryConfig.measureUserDefaultsSetting(forKey: "profile.showClipboardBar", withDefaultValue: false)
-        telemetryConfig.measureUserDefaultsSetting(forKey: "profile.settings.closePrivateTabs", withDefaultValue: false)
-        telemetryConfig.measureUserDefaultsSetting(forKey: "profile.ASPocketStoriesVisible", withDefaultValue: true)
-        telemetryConfig.measureUserDefaultsSetting(forKey: "profile.ASBookmarkHighlightsVisible", withDefaultValue: true)
-        telemetryConfig.measureUserDefaultsSetting(forKey: "profile.prefkey.trackingprotection.normalbrowsing", withDefaultValue: true)
-        telemetryConfig.measureUserDefaultsSetting(forKey: "profile.prefkey.trackingprotection.privatebrowsing", withDefaultValue: true)
-        telemetryConfig.measureUserDefaultsSetting(forKey: "profile.prefkey.trackingprotection.strength", withDefaultValue: "basic")
-        telemetryConfig.measureUserDefaultsSetting(forKey: LegacyThemeManagerPrefs.systemThemeIsOn.rawValue, withDefaultValue: true)
-
-        let prefs = profile.prefs
-        legacyTelemetry.beforeSerializePing(pingType: CorePingBuilder.PingType) { (inputDict) -> [String: Any?] in
-            var outputDict = inputDict // make a mutable copy
-
-            var settings: [String: Any?] = inputDict["settings"] as? [String: Any?] ?? [:]
-
-            if let newTabChoice = prefs.stringForKey(NewTabAccessors.HomePrefKey) {
-                outputDict["defaultNewTabExperience"] = newTabChoice as AnyObject?
-            }
-
-            // Report this flag as a `1` or `0` integer to allow it
-            // to be counted easily when reporting. Then, clear the
-            // flag to avoid it getting reported multiple times.
-            settings["crashedLastLaunch"] = self.crashedLastLaunch ? 1 : 0
-            self.crashedLastLaunch = false
-
-            outputDict["settings"] = settings
-
-            // TODO [7856]: Additional telemetry updates forthcoming once iPad multi-window enabled.
-            outputDict["openTabCount"] = self.defaultTabManager?.count ?? 0
-
-            outputDict["systemTheme"] = UITraitCollection.current.userInterfaceStyle == .dark ? "dark" : "light"
-
-            return outputDict
-        }
-
-        legacyTelemetry.beforeSerializePing(pingType: MobileEventPingBuilder.PingType) { (inputDict) -> [String: Any?] in
-            var outputDict = inputDict
-
-            var settings: [String: String?] = inputDict["settings"] as? [String: String?] ?? [:]
-
-            let defaultEngine = profile.searchEngines.defaultEngine
-            settings["defaultSearchEngine"] = defaultEngine?.engineID ?? "custom"
-
-            if let windowBounds = UIWindow.keyWindow?.bounds {
-                settings["windowWidth"] = String(describing: windowBounds.width)
-                settings["windowHeight"] = String(describing: windowBounds.height)
-            }
-
-            outputDict["settings"] = settings
-
-            // App Extension telemetry requires reading events stored in prefs, then clearing them from prefs.
-            if let extensionEvents = profile.prefs.arrayForKey(PrefsKeys.AppExtensionTelemetryEventArray) as? [[String: String]],
-                var pingEvents = outputDict["events"] as? [[Any?]] {
-                profile.prefs.removeObjectForKey(PrefsKeys.AppExtensionTelemetryEventArray)
-
-                extensionEvents.forEach { extensionEvent in
-                    let category = TelemetryWrapper.EventCategory.appExtensionAction.rawValue
-                    let newEvent = TelemetryEvent(category: category, method: extensionEvent["method"] ?? "", object: extensionEvent["object"] ?? "")
-                    pingEvents.append(newEvent.toArray())
-                }
-                outputDict["events"] = pingEvents
-            }
-
-            return outputDict
-        }
-
-        legacyTelemetry.add(pingBuilderType: CorePingBuilder.self)
-        legacyTelemetry.add(pingBuilderType: MobileEventPingBuilder.self)
 
         // Initialize Glean
         initGlean(profile, sendUsageData: sendUsageData)
@@ -808,8 +734,6 @@ extension TelemetryWrapper {
     }
 
     public static func recordEvent(category: EventCategory, method: EventMethod, object: EventObject, value: EventValue? = nil, extras: [String: Any]? = nil) {
-        Telemetry.default.recordEvent(category: category.rawValue, method: method.rawValue, object: object.rawValue, value: value?.rawValue ?? "", extras: extras)
-
         gleanRecordEvent(category: category, method: method, object: object, value: value, extras: extras)
     }
 
@@ -1108,9 +1032,8 @@ extension TelemetryWrapper {
             GleanMetrics.Search.startSearchPressed.add()
         case(.action, .tap, .recordSearch, _, let extras):
             if let searchLocation = extras?[EventExtraKey.recordSearchLocation.rawValue]
-                as? SearchesMeasurement.SearchLocation,
+                as? SearchLocation,
                let searchEngineID = extras?[EventExtraKey.recordSearchEngineID.rawValue] as? String? {
-                Telemetry.default.recordSearch(location: searchLocation, searchEngine: searchEngineID ?? "other")
                 GleanMetrics.Search.counts["\(searchEngineID ?? "custom").\(searchLocation.rawValue)"].add()
             } else {
                 recordUninstrumentedMetrics(


### PR DESCRIPTION
## :scroll: Tickets
[Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1874838)
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8185)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18203)

## :bulb: Description
telemetry-ios has been deprecated since 2021.
All data collection is handled by Glean now.

This is a very crude first attempt at removing everything related to legacy telemetry, simply by removing the telemetry-ios dependency and removing code until it compiled again.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

