### PR TITLE
Refactor FXIOS-8169 [v122.1] Theming manager not saving theme

### DIFF
--- a/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
@@ -29,22 +29,36 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
 
     public var currentTheme: Theme = LightTheme()
     public var notificationCenter: NotificationProtocol
+    public var window: UIWindow?
+
     private var userDefaults: UserDefaultsInterface
     private var mainQueue: DispatchQueueInterface
     private var sharedContainerIdentifier: String
 
-    public var window: UIWindow?
+    private var nightModeIsOn: Bool {
+        guard let isOn = userDefaults.object(forKey: ThemeKeys.NightMode.isOn) as? NSNumber,
+              isOn.boolValue == true
+        else { return false }
+
+        return true
+    }
+
+    private var privateModeIsOn: Bool {
+        return userDefaults.bool(forKey: ThemeKeys.PrivateMode.isOn)
+    }
 
     public var isSystemThemeOn: Bool {
         return userDefaults.bool(forKey: ThemeKeys.systemThemeIsOn)
     }
 
-    // MARK: - Init
+    // MARK: - Initializers
 
-    public init(userDefaults: UserDefaultsInterface = UserDefaults.standard,
-                notificationCenter: NotificationProtocol = NotificationCenter.default,
-                mainQueue: DispatchQueueInterface = DispatchQueue.main,
-                sharedContainerIdentifier: String) {
+    public init(
+        userDefaults: UserDefaultsInterface = UserDefaults.standard,
+        notificationCenter: NotificationProtocol = NotificationCenter.default,
+        mainQueue: DispatchQueueInterface = DispatchQueue.main,
+        sharedContainerIdentifier: String
+    ) {
         self.userDefaults = userDefaults
         self.notificationCenter = notificationCenter
         self.mainQueue = mainQueue
@@ -55,10 +69,10 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
         self.userDefaults.register(defaults: [
             ThemeKeys.systemThemeIsOn: true,
             ThemeKeys.NightMode.isOn: NSNumber(value: false),
-            ThemeKeys.PrivateMode.isOn: NSNumber(value: false),
+            ThemeKeys.PrivateMode.isOn: false,
         ])
 
-        changeCurrentTheme(loadInitialThemeType())
+        changeCurrentTheme(fetchSavedThemeType())
 
         setupNotifications(forObserver: self,
                            observing: [UIScreen.brightnessDidChangeNotification,
@@ -69,15 +83,9 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
 
     public func changeCurrentTheme(_ newTheme: ThemeType) {
         guard currentTheme.type != newTheme else { return }
-        currentTheme = newThemeForType(newTheme)
 
-        // overwrite the user interface style on the window attached to our scene
-        // once we have multiple scenes we need to update all of them
-        window?.overrideUserInterfaceStyle = currentTheme.type.getInterfaceStyle()
-
-        mainQueue.ensureMainThread { [weak self] in
-            self?.notificationCenter.post(name: .ThemeDidChange)
-        }
+        updateSavedTheme(to: newTheme)
+        updateCurrentTheme(to: fetchSavedThemeType())
     }
 
     public func systemThemeChanged() {
@@ -85,11 +93,9 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
         // the system theme is off
         // OR night mode is on
         // OR private mode is on
-        guard userDefaults.bool(forKey: ThemeKeys.systemThemeIsOn),
-              let nightModeIsOn = userDefaults.object(forKey: ThemeKeys.NightMode.isOn) as? NSNumber,
-              nightModeIsOn.boolValue == false,
-              let privateModeIsOn = userDefaults.object(forKey: ThemeKeys.PrivateMode.isOn) as? NSNumber,
-              privateModeIsOn.boolValue == false
+        guard isSystemThemeOn,
+              !nightModeIsOn,
+              !privateModeIsOn
         else { return }
 
         changeCurrentTheme(getSystemThemeType())
@@ -108,7 +114,7 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
     public func setPrivateTheme(isOn: Bool) {
         userDefaults.set(isOn, forKey: ThemeKeys.PrivateMode.isOn)
 
-        changeCurrentTheme(loadInitialThemeType())
+        changeCurrentTheme(fetchSavedThemeType())
     }
 
     public func setAutomaticBrightness(isOn: Bool) {
@@ -126,16 +132,28 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
 
     // MARK: - Private methods
 
-    private func loadInitialThemeType() -> ThemeType {
-        if let privateModeIsOn = userDefaults.object(forKey: ThemeKeys.PrivateMode.isOn) as? NSNumber,
-           privateModeIsOn.boolValue == true {
-            return .privateMode
-        }
+    private func updateSavedTheme(to newTheme: ThemeType) {
+        // As the private theme is a special instance of a theme,
+        // we don't want to save it.
+        guard newTheme != .privateMode else { return }
+        userDefaults.set(newTheme, forKey: ThemeKeys.themeName)
+    }
 
-        if let nightModeIsOn = userDefaults.object(forKey: ThemeKeys.NightMode.isOn) as? NSNumber,
-           nightModeIsOn.boolValue == true {
-            return .dark
+    private func updateCurrentTheme(to newTheme: ThemeType) {
+        currentTheme = newThemeForType(newTheme)
+
+        // Overwrite the user interface style on the window attached to our scene
+        // once we have multiple scenes we need to update all of them
+        window?.overrideUserInterfaceStyle = currentTheme.type.getInterfaceStyle()
+
+        mainQueue.ensureMainThread { [weak self] in
+            self?.notificationCenter.post(name: .ThemeDidChange)
         }
+    }
+
+    private func fetchSavedThemeType() -> ThemeType {
+        if privateModeIsOn { return .privateMode }
+        if nightModeIsOn { return .dark }
 
         var themeType = getSystemThemeType()
         if let savedThemeDescription = userDefaults.string(forKey: ThemeKeys.themeName),

--- a/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
@@ -136,7 +136,7 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
         // As the private theme is a special instance of a theme,
         // we don't want to save it.
         guard newTheme != .privateMode else { return }
-        userDefaults.set(newTheme, forKey: ThemeKeys.themeName)
+        userDefaults.set(newTheme.rawValue, forKey: ThemeKeys.themeName)
     }
 
     private func updateCurrentTheme(to newTheme: ThemeType) {

--- a/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
@@ -7,7 +7,7 @@ import UIKit
 /// The `ThemeManager` will be responsible for providing the theme throughout the app
 public final class DefaultThemeManager: ThemeManager, Notifiable {
     // These have been carried over from the legacy system to maintain backwards compatibility
-    private enum ThemeKeys {
+    enum ThemeKeys {
         static let themeName = "prefKeyThemeName"
         static let systemThemeIsOn = "prefKeySystemThemeSwitchOnOff"
 
@@ -114,7 +114,7 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
     public func setPrivateTheme(isOn: Bool) {
         userDefaults.set(isOn, forKey: ThemeKeys.PrivateMode.isOn)
 
-        changeCurrentTheme(fetchSavedThemeType())
+        updateCurrentTheme(to: fetchSavedThemeType())
     }
 
     public func setAutomaticBrightness(isOn: Bool) {
@@ -133,8 +133,9 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
     // MARK: - Private methods
 
     private func updateSavedTheme(to newTheme: ThemeType) {
-        // As the private theme is a special instance of a theme,
-        // we don't want to save it.
+        // We never want to save the private theme because it's meant to override
+        // whatever current theme is set. This means that we need to know the theme
+        // before we went into private mode, in order to be able to return to it.
         guard newTheme != .privateMode else { return }
         userDefaults.set(newTheme.rawValue, forKey: ThemeKeys.themeName)
     }

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -565,6 +565,7 @@
 		810FF3562B1783B0009F062C /* FeltPrivacyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810FF3552B1783B0009F062C /* FeltPrivacyManager.swift */; };
 		810FF3582B1784E7009F062C /* PrivateModeAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810FF3572B1784E7009F062C /* PrivateModeAction.swift */; };
 		81122E212B221AC0003DD9F8 /* SearchScreenState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81122E202B221AC0003DD9F8 /* SearchScreenState.swift */; };
+		814A62462B587A3E00608195 /* DefaultThemeManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 814A62452B587A3E00608195 /* DefaultThemeManagerTests.swift */; };
 		81CAE4DB2B1A2C220040C78A /* BrowserViewControllerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81CAE4DA2B1A2C220040C78A /* BrowserViewControllerState.swift */; };
 		884CA7492344A301002E4711 /* TextContentDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 884CA7482344A301002E4711 /* TextContentDetector.swift */; };
 		8A0017C128A3FF6100FEFC8B /* MessageCardDataAdaptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0017C028A3FF6100FEFC8B /* MessageCardDataAdaptor.swift */; };
@@ -5416,6 +5417,7 @@
 		810FF3552B1783B0009F062C /* FeltPrivacyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeltPrivacyManager.swift; sourceTree = "<group>"; };
 		810FF3572B1784E7009F062C /* PrivateModeAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateModeAction.swift; sourceTree = "<group>"; };
 		81122E202B221AC0003DD9F8 /* SearchScreenState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScreenState.swift; sourceTree = "<group>"; };
+		814A62452B587A3E00608195 /* DefaultThemeManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultThemeManagerTests.swift; sourceTree = "<group>"; };
 		81504EA4876ED3D974FDA0F6 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
 		81584D62B22049E40FC78F93 /* sl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sl; path = sl.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
 		816D458CBEAE2A6721134028 /* dsb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = dsb; path = dsb.lproj/ClearPrivateData.strings; sourceTree = "<group>"; };
@@ -11467,6 +11469,7 @@
 				8A0727472B4898750071BB9F /* WebviewTelemetryTests.swift */,
 				1D74FF4D2B27962200FF01D0 /* WindowManagerTests.swift */,
 				253648E02B2111C100D5C2C5 /* SearchViewControllerTests.swift */,
+				814A62452B587A3E00608195 /* DefaultThemeManagerTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -14174,6 +14177,7 @@
 				C8C3FEA129F973C40038E3BA /* MockBrowserViewController.swift in Sources */,
 				8A93F86B29D39BDA004159D9 /* BaseCoordinatorTests.swift in Sources */,
 				8AF3B15A2AF99B86009BB262 /* HistoryPanelTests.swift in Sources */,
+				814A62462B587A3E00608195 /* DefaultThemeManagerTests.swift in Sources */,
 				967EDABD29D705300089208D /* CreditCardValidatorTests.swift in Sources */,
 				D815A3A824A53F3200AAB221 /* TabToolbarHelperTests.swift in Sources */,
 				967EDABF29D769A10089208D /* CreditCardInputFieldTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Theme/LegacyThemeManager/LegacyThemeManager.swift
+++ b/firefox-ios/Client/Frontend/Theme/LegacyThemeManager/LegacyThemeManager.swift
@@ -14,18 +14,8 @@ enum LegacyThemeManagerPrefs: String {
 class LegacyThemeManager {
     static let instance = LegacyThemeManager()
 
-    var current: LegacyTheme = themeFrom(
-        name: UserDefaults.standard.string(forKey: LegacyThemeManagerPrefs.themeName.rawValue)
-    ) {
-        didSet {
-            ensureMainThread {
-                UserDefaults.standard.set(
-                    self.current.name,
-                    forKey: LegacyThemeManagerPrefs.themeName.rawValue
-                )
-            }
-        }
-    }
+    var current: LegacyTheme = themeFrom(name: UserDefaults.standard.string(
+        forKey: LegacyThemeManagerPrefs.themeName.rawValue))
 
     var currentName: BuiltinThemeName {
         return BuiltinThemeName(rawValue: LegacyThemeManager.instance.current.name) ?? .normal
@@ -57,7 +47,10 @@ class LegacyThemeManager {
 
     var systemThemeIsOn: Bool {
         didSet {
-            UserDefaults.standard.set(systemThemeIsOn, forKey: LegacyThemeManagerPrefs.systemThemeIsOn.rawValue)
+            UserDefaults.standard.set(
+                systemThemeIsOn,
+                forKey: LegacyThemeManagerPrefs.systemThemeIsOn.rawValue
+            )
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DefaultThemeManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DefaultThemeManagerTests.swift
@@ -30,7 +30,7 @@ final class DefaultThemeManagerTests: XCTestCase {
 
         XCTAssert(
             userDefaults.registrationDictionary.isEmpty,
-            "registrationDictionary should be empty when intitializing object"
+            "registrationDictionary should be empty when initializing object"
         )
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DefaultThemeManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DefaultThemeManagerTests.swift
@@ -55,6 +55,177 @@ final class DefaultThemeManagerTests: XCTestCase {
         XCTAssertEqual(privateModeResult, expectedPrivateModeResult)
     }
 
+    func testDTM_onInitialization_hasLightTheme() {
+        let sut = createSubject(with: userDefaults)
+
+        let expectedResult = ThemeType.light
+
+        XCTAssertEqual(sut.currentTheme.type, expectedResult)
+    }
+
+    // MARK: - Changing current theme tests
+
+    func testDTM_changeToDarkTheme_changesToDarkTheme() {
+        let sut = createSubject(with: userDefaults)
+        let expectedResult = ThemeType.dark
+
+        sut.changeCurrentTheme(.dark)
+
+        XCTAssertEqual(sut.currentTheme.type, expectedResult)
+        XCTAssertEqual(
+            userDefaults.string(forKey: DefaultThemeManager.ThemeKeys.themeName),
+            expectedResult.rawValue
+        )
+    }
+
+    func testDTM_changeToLightTheme_changesToLightTheme() {
+        let sut = createSubject(with: userDefaults)
+        let expectedResult = ThemeType.light
+
+        sut.changeCurrentTheme(.dark)
+        sut.changeCurrentTheme(.light)
+
+        XCTAssertEqual(sut.currentTheme.type, expectedResult)
+        XCTAssertEqual(
+            userDefaults.string(forKey: DefaultThemeManager.ThemeKeys.themeName),
+            expectedResult.rawValue
+        )
+    }
+
+    // MARK: - System theme tests
+
+    func testDTM_systemThemeTurnedOff_returnsDefaultTheme() {
+        let sut = createSubject(with: userDefaults)
+        let expectedResult = ThemeType.light
+
+        sut.setSystemTheme(isOn: false)
+
+        XCTAssertEqual(sut.currentTheme.type, expectedResult)
+    }
+
+    func testDTM_systemThemeTurnedOffThenOn_returnsDefaultTheme() {
+        let sut = createSubject(with: userDefaults)
+        let expectedResult = ThemeType.light
+
+        sut.setSystemTheme(isOn: false)
+        sut.setSystemTheme(isOn: true)
+
+        XCTAssertEqual(sut.currentTheme.type, expectedResult)
+    }
+
+    // MARK: - Private theme tests
+
+    func testDTM_privateModeEnabled_returnsPrivateTheme() {
+        let sut = createSubject(with: userDefaults)
+        let expectedResult = ThemeType.privateMode
+
+        sut.setPrivateTheme(isOn: true)
+
+        XCTAssertEqual(sut.currentTheme.type, expectedResult)
+    }
+
+    func testDTM_privateModeEnabledAndThenDisabled_returnsOriginalTheme() {
+        let sut = createSubject(with: userDefaults)
+        let expectedResult = ThemeType.light
+
+        sut.setPrivateTheme(isOn: true)
+        sut.setPrivateTheme(isOn: false)
+
+        XCTAssertEqual(sut.currentTheme.type, expectedResult)
+    }
+
+    func testDTM_privateModeEnabled_originalThemeRemainsSaved() {
+        let sut = createSubject(with: userDefaults)
+        let expectedResult = ThemeType.dark.rawValue
+
+        sut.changeCurrentTheme(.dark)
+        sut.setPrivateTheme(isOn: true)
+
+        XCTAssertEqual(
+            userDefaults.string(forKey: DefaultThemeManager.ThemeKeys.themeName),
+            expectedResult
+        )
+    }
+
+    // MARK: - Brightness Tests
+
+    func testDTM_autoBrightnessIsOn_returnsExpectedThemeAndBrightness() {
+        let sut = createSubject(with: userDefaults)
+        let expectedBrightnessState = true
+        let expectedBrightnessValue = Float(0.0)
+        let expectedTheme = ThemeType.light
+
+        sut.setSystemTheme(isOn: false)
+        sut.setAutomaticBrightness(isOn: true)
+
+        XCTAssertEqual(
+            userDefaults.bool(forKey: DefaultThemeManager.ThemeKeys.AutomaticBrightness.isOn),
+            expectedBrightnessState
+        )
+        XCTAssertEqual(
+            userDefaults.float(forKey: DefaultThemeManager.ThemeKeys.AutomaticBrightness.thresholdValue),
+            expectedBrightnessValue
+        )
+        XCTAssertEqual(sut.currentTheme.type, expectedTheme)
+    }
+
+    func testDTM_settingAutoBrightnessThresholdValue_changesToNewValue() {
+        let sut = createSubject(with: userDefaults)
+        let firstExpectedResult = Float(42.0)
+        let secondExpectedResult = Float(68.0)
+
+        sut.setAutomaticBrightnessValue(firstExpectedResult)
+        XCTAssertEqual(
+            userDefaults.float(forKey: DefaultThemeManager.ThemeKeys.AutomaticBrightness.thresholdValue),
+            firstExpectedResult
+        )
+
+        sut.setAutomaticBrightnessValue(secondExpectedResult)
+        XCTAssertEqual(
+            userDefaults.float(forKey: DefaultThemeManager.ThemeKeys.AutomaticBrightness.thresholdValue),
+            secondExpectedResult
+        )
+    }
+
+    func testDTM_autoBrightnessOnThresholdLowerThanScreenBrigthness_returnsLightTheme() {
+        let sut = createSubject(with: userDefaults)
+        let expectedTheme = ThemeType.light
+
+        testBrightnessWith(threshold: 0.25, in: sut)
+
+        XCTAssertEqual(sut.currentTheme.type, expectedTheme)
+    }
+
+    func testDTM_autoBrightnessOnThresholdEqualToScreenBrigthness_returnsLightTheme() {
+        let sut = createSubject(with: userDefaults)
+        let expectedTheme = ThemeType.light
+
+        testBrightnessWith(threshold: 0.50, in: sut)
+
+        XCTAssertEqual(sut.currentTheme.type, expectedTheme)
+    }
+
+    func testDTM_autoBrightnessOnThresholdGreaterThanScreenBrigthness_returnsDarkTheme() {
+        let sut = createSubject(with: userDefaults)
+        let expectedTheme = ThemeType.dark
+
+        testBrightnessWith(threshold: 0.75, in: sut)
+
+        XCTAssertEqual(sut.currentTheme.type, expectedTheme)
+    }
+
+    func testDTM_autoBrightnessOn_changeValues_thenOff_returnsToExpectedSystemTheme() {
+        let sut = createSubject(with: userDefaults)
+        let expectedThemeInBrightnessMode = ThemeType.dark
+        let expectedThemeInSystemMode = ThemeType.light
+
+        testBrightnessWith(threshold: 0.75, in: sut)
+        XCTAssertEqual(sut.currentTheme.type, expectedThemeInBrightnessMode)
+
+        sut.setSystemTheme(isOn: true)
+        XCTAssertEqual(sut.currentTheme.type, expectedThemeInSystemMode)
+    }
+
     // MARK: - Helper methods
 
     private func createSubject(with userDefaults: UserDefaultsInterface,
@@ -66,5 +237,15 @@ final class DefaultThemeManagerTests: XCTestCase {
         trackForMemoryLeaks(subject, file: file, line: line)
 
         return subject
+    }
+
+    private func testBrightnessWith(
+        threshold: Double,
+        in sut: DefaultThemeManager
+    ) {
+        sut.setSystemTheme(isOn: false)
+        sut.setAutomaticBrightness(isOn: true)
+        UIScreen.main.brightness = 0.5
+        sut.setAutomaticBrightnessValue(Float(threshold))
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DefaultThemeManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DefaultThemeManagerTests.swift
@@ -1,0 +1,70 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Common
+
+final class DefaultThemeManagerTests: XCTestCase {
+    // MARK: - Variables
+
+    private var userDefaults: MockUserDefaults!
+
+    // MARK: - Test lifecycle
+    override func setUp() {
+        super.setUp()
+        userDefaults = MockUserDefaults()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        userDefaults = nil
+    }
+
+    // MARK: - Initialization tests
+    func test_mockDefaultsInitializesEmpty() {
+        XCTAssert(
+            userDefaults.savedData.isEmpty,
+            "savedData should be empty when intitializing object"
+        )
+
+        XCTAssert(
+            userDefaults.registrationDictionary.isEmpty,
+            "registrationDictionary should be empty when intitializing object"
+        )
+    }
+
+    func test_sutInitializesWithExpectedRegisteredValues() {
+        let sut = createSubject(with: userDefaults)
+        let expectedSystemResult = true
+        let expectedNightModeResult = NSNumber(value: false)
+        let expectedPrivateModeResult = false
+
+        XCTAssertEqual(userDefaults.registrationDictionary.count, 3)
+
+        guard let systemResult = userDefaults.registrationDictionary["prefKeySystemThemeSwitchOnOff"] as? Bool,
+              let nightModeResult = userDefaults.registrationDictionary["profile.NightModeStatus"] as? NSNumber,
+              let privateModeResult = userDefaults.registrationDictionary["profile.PrivateModeStatus"] as? Bool
+        else {
+            XCTFail("Failed to fetch one or more expected keys")
+            return
+        }
+
+        XCTAssertEqual(systemResult, expectedSystemResult)
+        XCTAssertEqual(nightModeResult, expectedNightModeResult)
+        XCTAssertEqual(privateModeResult, expectedPrivateModeResult)
+    }
+
+    // MARK: - Helper methods
+
+    private func createSubject(with userDefaults: UserDefaultsInterface,
+                               file: StaticString = #file,
+                               line: UInt = #line) -> DefaultThemeManager {
+        let subject = DefaultThemeManager(
+            userDefaults: userDefaults,
+            sharedContainerIdentifier: "")
+        trackForMemoryLeaks(subject, file: file, line: line)
+
+        return subject
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DefaultThemeManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DefaultThemeManagerTests.swift
@@ -25,7 +25,7 @@ final class DefaultThemeManagerTests: XCTestCase {
     func test_mockDefaultsInitializesEmpty() {
         XCTAssert(
             userDefaults.savedData.isEmpty,
-            "savedData should be empty when intitializing object"
+            "savedData should be empty when initializing object"
         )
 
         XCTAssert(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockUserDefaults.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockUserDefaults.swift
@@ -9,10 +9,12 @@ import Common
 class MockUserDefaults: UserDefaultsInterface {
     // MARK: - Properties
     public var savedData: [String: Any?]
+    public var registrationDictionary: [String: Any]
 
     // MARK: - Initializers
     init() {
         self.savedData = [:]
+        self.registrationDictionary = [:]
     }
 
     // MARK: - Public interface
@@ -44,5 +46,7 @@ class MockUserDefaults: UserDefaultsInterface {
         return savedData[defaultName] as? [Any]
     }
 
-    func register(defaults registrationDictionary: [String: Any]) {}
+    func register(defaults registrationDictionary: [String: Any]) {
+        self.registrationDictionary = registrationDictionary
+    }
 }

--- a/firefox-ios/nimbus-features/feltPrivacyFeature.yaml
+++ b/firefox-ios/nimbus-features/feltPrivacyFeature.yaml
@@ -20,5 +20,5 @@ features:
       - channel: developer
         value:
           simplified-ui-enabled: true
-          felt-deletion-enabled: false
+          felt-deletion-enabled: true
 

--- a/firefox-ios/nimbus-features/feltPrivacyFeature.yaml
+++ b/firefox-ios/nimbus-features/feltPrivacyFeature.yaml
@@ -19,6 +19,6 @@ features:
           felt-deletion-enabled: false
       - channel: developer
         value:
-          simplified-ui-enabled: false
+          simplified-ui-enabled: true
           felt-deletion-enabled: false
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8169)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18174)

## :bulb: Description
The theming manager wasn't saving the theme when it was changed. This fixes that in a way that preserves consistency with what has happening before, and also respecting the special private mode theme.

I still need to write a few more tests which i'll push tomorrow morning to this same PR, as the manager isn't really tested at all. But throwing this up to get eyes on to merge because it's a blocking bug for 122.

In the video below, you can see themes changing from a variety of sources for testing purposes.

https://github.com/mozilla-mobile/firefox-ios/assets/11182210/2c2107af-ba17-49d4-86cd-e792727c9a46

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

