### PR TITLE
Bugfix FXIOS-8184 [v123] Fix FakespotMessageCard rounded button

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/Buttons/PrimaryRoundedButtonViewModel.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/PrimaryRoundedButtonViewModel.swift
@@ -3,16 +3,25 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import Common
+import UIKit
 
 /// The view model used to configure a `PrimaryRoundedButton`
 public struct PrimaryRoundedButtonViewModel {
     public let title: String
     public let a11yIdentifier: String
     public let imageTitlePadding: Double?
+    public let backgroundColor: ((Theme) -> UIColor)?
+    public let titleColor: ((Theme) -> UIColor)?
 
-    public init(title: String, a11yIdentifier: String, imageTitlePadding: Double? = nil) {
+    public init(title: String, a11yIdentifier: String,
+                imageTitlePadding: Double? = nil,
+                backgroundColor: ((Theme) -> UIColor)? = nil,
+                titleColor: ((Theme) -> UIColor)? = nil) {
         self.title = title
         self.a11yIdentifier = a11yIdentifier
         self.imageTitlePadding = imageTitlePadding
+        self.backgroundColor = backgroundColor
+        self.titleColor = titleColor
     }
 }

--- a/firefox-ios/Client/Frontend/Fakespot/Views/FakespotMessageCardView.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/Views/FakespotMessageCardView.swift
@@ -270,8 +270,14 @@ final class FakespotMessageCardView: UIView, ThemeApplicable, Notifiable {
 
         if let primaryActionText = viewModel.primaryActionText {
             let primaryButtonViewModel = PrimaryRoundedButtonViewModel(
-                    title: primaryActionText,
-                    a11yIdentifier: viewModel.a11yPrimaryActionIdentifier ?? "")
+                title: primaryActionText,
+                a11yIdentifier: viewModel.a11yPrimaryActionIdentifier ?? "",
+                backgroundColor: { theme in
+                    return viewModel.type.primaryButtonBackground(theme: theme)
+                },
+                titleColor: { theme in
+                    return viewModel.type.primaryButtonTextColor(theme: theme)
+                })
             primaryButton.configure(viewModel: primaryButtonViewModel)
             if primaryButton.superview == nil {
                 containerStackView.addArrangedSubview(primaryButton)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8184)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18202)

## :bulb: Description
- This PR adds the `backgroundColor` and `titleColor` properties to the `PrimaryRoundedButtonViewModel` struct, allowing customization of the background color and title color for instances of the `PrimaryRoundedButton`. 
- The properties are optional and can be provided when initializing the view model.

| Portrait  | Landscape | 
| ------------- | ------------- |
| ![IMG_4944](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/3ed00bc4-438e-4c49-a9da-691e7fc8b52d) | ![IMG_4945](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/8c3cd0c4-605d-49d4-9273-71c958a913cc) |

| Portrait  | Landscape | 
| ------------- | ------------- |
| ![IMG_4946](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/b3ae4973-49fe-4a3a-8060-d8062b68261b) | ![IMG_4947](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/ba2f3471-f974-4fbe-9739-33091c43ea89) | 


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods