### PR TITLE
Fix MTE-2176 [v123] testLongPressReload smoke test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -946,15 +946,9 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         screenState.press(link, to: WebLinkContextMenu)
         screenState.press(image, to: WebImageContextMenu)
 
-        if !isTablet {
-            let reloadButton = app.buttons[AccessibilityIdentifiers.Toolbar.reloadButton]
+        let reloadButton = app.buttons[AccessibilityIdentifiers.Toolbar.reloadButton]
         screenState.press(reloadButton, to: ReloadLongPressMenu)
         screenState.tap(reloadButton, forAction: Action.ReloadURL, transitionTo: WebPageLoading) { _ in }
-        } else {
-            let reloadButton = app.buttons["Reload"]
-        screenState.press(reloadButton, to: ReloadLongPressMenu)
-        screenState.tap(reloadButton, forAction: Action.ReloadURL, transitionTo: WebPageLoading) { _ in }
-        }
         // For iPad there is no long press on tabs button
         if !isTablet {
             let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2176)

## :bulb: Description
Accessibility identifier for reload button has changes for iPad, now its the same as for iPhone. Removed the condition for tablet.

