### PR TITLE
Fixed issue 17863

### DIFF
--- a/firefox-ios/Client/Frontend/Widgets/TabsButton.swift
+++ b/firefox-ios/Client/Frontend/Widgets/TabsButton.swift
@@ -124,9 +124,14 @@ class TabsButton: UIButton, ThemeApplicable {
         button.countLabel.font = countLabel.font
         button.countLabel.layer.cornerRadius = countLabel.layer.cornerRadius
         button.labelBackground.layer.cornerRadius = labelBackground.layer.cornerRadius
+        
+        // Issue #17863 - theme property is never set and is always nil.  Since button.applyTheme(theme:) never runs, button is styled with a default blue border.
         if let theme {
             button.applyTheme(theme: theme)
         }
+        
+        // Issue #17863 - button.borderView.tintColor is set directly to self.unselectedTintColor to fix issue.
+        button.borderView.tintColor = self.unselectedTintColor
 
         return button
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8004)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17863)

## :bulb: Description
The animated button was not styled with unselectedTintColor from the theme.  The animated button is created in func createTabsButton and configured by copying the parent button's settings.  There is a a conditional to check if property theme is not nil.  If theme is present, method applyTheme(theme:) is run on the animated button.  However, the theme property is never set and therefore the animated button never gets the theme style.  The animated button defaults to the blue border style.  To fix the issue, the animated button's border style is set directly from the parent's unselectedTintColor property.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

