### PR TITLE
Refactor FXIOS-8180 [v123] Fix SampleBrowser basic navigation

### DIFF
--- a/BrowserKit/Sources/WebEngine/EngineSessionDelegate.swift
+++ b/BrowserKit/Sources/WebEngine/EngineSessionDelegate.swift
@@ -23,7 +23,4 @@ public protocol EngineSessionDelegate: AnyObject {
 
     /// Event to indicate the loading state has changed
     func onLoadingStateChange(loading: Bool)
-
-    /// Event to indicate that a url was loaded to this session.
-    func onLoadUrl()
 }

--- a/BrowserKit/Sources/WebEngine/EngineSessionDelegate.swift
+++ b/BrowserKit/Sources/WebEngine/EngineSessionDelegate.swift
@@ -16,10 +16,13 @@ public protocol EngineSessionDelegate: AnyObject {
     func onTitleChange(title: String)
 
     /// Event to indicate the loading progress has been updated.
-    func onProgress(progress: Int)
+    func onProgress(progress: Double)
 
     /// Event to indicate there has been a navigation change.
-    func onNavigationStateChange(canGoBack: Bool?, canGoForward: Bool?)
+    func onNavigationStateChange(canGoBack: Bool, canGoForward: Bool)
+
+    /// Event to indicate the loading state has changed
+    func onLoadingStateChange(loading: Bool)
 
     /// Event to indicate that a url was loaded to this session.
     func onLoadUrl()

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -167,10 +167,10 @@ class WKEngineSession: NSObject, EngineSession {
         // Will be used as needed when we start using the engine session
         switch path {
         case .canGoBack:
-            delegate?.onNavigationStateChange(canGoBack: webView.canGoBack, 
+            delegate?.onNavigationStateChange(canGoBack: webView.canGoBack,
                                               canGoForward: webView.canGoForward)
         case .canGoForward:
-            delegate?.onNavigationStateChange(canGoBack: webView.canGoBack, 
+            delegate?.onNavigationStateChange(canGoBack: webView.canGoBack,
                                               canGoForward: webView.canGoForward)
         case .contentSize:
             break

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -167,15 +167,18 @@ class WKEngineSession: NSObject, EngineSession {
         // Will be used as needed when we start using the engine session
         switch path {
         case .canGoBack:
-            break
+            delegate?.onNavigationStateChange(canGoBack: webView.canGoBack, 
+                                              canGoForward: webView.canGoForward)
         case .canGoForward:
-            break
+            delegate?.onNavigationStateChange(canGoBack: webView.canGoBack, 
+                                              canGoForward: webView.canGoForward)
         case .contentSize:
             break
         case .estimatedProgress:
-            break
+            delegate?.onProgress(progress: webView.estimatedProgress)
         case .loading:
-            break
+            guard let loading = change?[.newKey] as? Bool else { break }
+            delegate?.onLoadingStateChange(loading: loading)
         case .title:
             break
         case .URL:

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
@@ -23,6 +23,10 @@ protocol WKEngineWebView: UIView {
     var scrollView: UIScrollView { get }
     var engineConfiguration: WKEngineConfiguration { get }
 
+    var estimatedProgress: Double { get }
+    var canGoBack: Bool { get }
+    var canGoForward: Bool { get }
+
     @available(iOS 16.4, *)
     var isInspectable: Bool { get set }
 

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockEngineSessionDelegate.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockEngineSessionDelegate.swift
@@ -27,28 +27,28 @@ class MockEngineSessionDelegate: EngineSessionDelegate {
         savedScrollX = scrollX
         savedScrollY = scrollY
     }
-    
+
     func onLongPress(touchPoint: CGPoint) {
         onLongPressCalled += 1
         savedTouchPoint = touchPoint
     }
-    
+
     func onTitleChange(title: String) {
         onTitleChangeCalled += 1
         savedTitleChange = title
     }
-    
+
     func onProgress(progress: Double) {
         onProgressCalled += 1
         savedProgressValue = progress
     }
-    
+
     func onNavigationStateChange(canGoBack: Bool, canGoForward: Bool) {
         onNavigationStateChangeCalled += 1
         savedCanGoBack = canGoBack
         savedCanGoForward = canGoForward
     }
-    
+
     func onLoadingStateChange(loading: Bool) {
         onLoadingStateChangeCalled += 1
         savedLoading = loading

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockEngineSessionDelegate.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockEngineSessionDelegate.swift
@@ -1,0 +1,56 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+@testable import WebEngine
+
+class MockEngineSessionDelegate: EngineSessionDelegate {
+    var onScrollChangeCalled = 0
+    var onLongPressCalled = 0
+    var onTitleChangeCalled = 0
+    var onProgressCalled = 0
+    var onNavigationStateChangeCalled = 0
+    var onLoadingStateChangeCalled = 0
+
+    var savedScrollX: Int?
+    var savedScrollY: Int?
+    var savedTouchPoint: CGPoint?
+    var savedTitleChange: String?
+    var savedProgressValue: Double?
+    var savedCanGoBack: Bool?
+    var savedCanGoForward: Bool?
+    var savedLoading: Bool?
+
+    func onScrollChange(scrollX: Int, scrollY: Int) {
+        onScrollChangeCalled += 1
+        savedScrollX = scrollX
+        savedScrollY = scrollY
+    }
+    
+    func onLongPress(touchPoint: CGPoint) {
+        onLongPressCalled += 1
+        savedTouchPoint = touchPoint
+    }
+    
+    func onTitleChange(title: String) {
+        onTitleChangeCalled += 1
+        savedTitleChange = title
+    }
+    
+    func onProgress(progress: Double) {
+        onProgressCalled += 1
+        savedProgressValue = progress
+    }
+    
+    func onNavigationStateChange(canGoBack: Bool, canGoForward: Bool) {
+        onNavigationStateChangeCalled += 1
+        savedCanGoBack = canGoBack
+        savedCanGoForward = canGoForward
+    }
+    
+    func onLoadingStateChange(loading: Bool) {
+        onLoadingStateChangeCalled += 1
+        savedLoading = loading
+    }
+}

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebView.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebView.swift
@@ -16,6 +16,10 @@ class MockWKEngineWebView: UIView, WKEngineWebView {
     var allowsLinkPreview = true
     var isInspectable = true
 
+    var estimatedProgress: Double = 0
+    var canGoBack = false
+    var canGoForward = false
+
     // MARK: Test properties
     var loadCalled = 0
     var loadFileURLCalled = 0

--- a/SampleBrowser/SampleBrowser/UI/Browser/BrowserViewController.swift
+++ b/SampleBrowser/SampleBrowser/UI/Browser/BrowserViewController.swift
@@ -68,6 +68,10 @@ class BrowserViewController: UIViewController, EngineSessionDelegate {
         progressView.backgroundColor = .white
     }
 
+    private func updateProgressView(loading: Bool) {
+        progressView.isHidden = !loading
+    }
+
     // MARK: - Browser actions
 
     func goBack() {
@@ -119,10 +123,7 @@ class BrowserViewController: UIViewController, EngineSessionDelegate {
 
     func onLoadingStateChange(loading: Bool) {
         navigationDelegate?.onLoadingStateChange(loading: loading)
-    }
-
-    func onLoadUrl() {
-        // Handle onTitle and onURL changes with FXIOS-8179
+        updateProgressView(loading: loading)
     }
 
     func onProgress(progress: Double) {

--- a/SampleBrowser/SampleBrowser/UI/Browser/BrowserViewController.swift
+++ b/SampleBrowser/SampleBrowser/UI/Browser/BrowserViewController.swift
@@ -6,7 +6,8 @@ import UIKit
 import WebEngine
 
 protocol NavigationDelegate: AnyObject {
-    func onNavigationStateChange(canGoBack: Bool?, canGoForward: Bool?)
+    func onLoadingStateChange(loading: Bool)
+    func onNavigationStateChange(canGoBack: Bool, canGoForward: Bool)
 }
 
 // Holds different type of browser views, communicating through protocols with them
@@ -116,15 +117,19 @@ class BrowserViewController: UIViewController, EngineSessionDelegate {
         // Handle onTitle and onURL changes with FXIOS-8179
     }
 
+    func onLoadingStateChange(loading: Bool) {
+        navigationDelegate?.onLoadingStateChange(loading: loading)
+    }
+
     func onLoadUrl() {
         // Handle onTitle and onURL changes with FXIOS-8179
     }
 
-    func onProgress(progress: Int) {
+    func onProgress(progress: Double) {
         progressView.setProgress(Float(progress), animated: true)
     }
 
-    func onNavigationStateChange(canGoBack: Bool?, canGoForward: Bool?) {
+    func onNavigationStateChange(canGoBack: Bool, canGoForward: Bool) {
         navigationDelegate?.onNavigationStateChange(canGoBack: canGoBack,
                                                     canGoForward: canGoForward)
     }

--- a/SampleBrowser/SampleBrowser/UI/Components/BrowserToolbar.swift
+++ b/SampleBrowser/SampleBrowser/UI/Components/BrowserToolbar.swift
@@ -50,6 +50,9 @@ class BrowserToolbar: UIToolbar {
         setItems(items, animated: false)
 
         barTintColor = .white
+
+        // initial state for buttons
+        updateBackForwardButtons(canGoBack: false, canGoForward: false)
     }
 
     required init?(coder: NSCoder) {
@@ -58,16 +61,16 @@ class BrowserToolbar: UIToolbar {
 
     // MARK: - Button states
 
-    func updateReloadStopButton(isLoading: Bool) {
-        guard isLoading != isReloading else { return }
-        reloadStopButton.image = isLoading ? UIImage(named: "Stop") : UIImage(named: "Reload")
-        reloadStopButton.action = isLoading ? #selector(stopButtonClicked) : #selector(reloadButtonClicked)
-        self.isReloading = isLoading
+    func updateReloadStopButton(loading: Bool) {
+        guard loading != isReloading else { return }
+        reloadStopButton.image = loading ? UIImage(named: "Stop") : UIImage(named: "Reload")
+        reloadStopButton.action = loading ? #selector(stopButtonClicked) : #selector(reloadButtonClicked)
+        self.isReloading = loading
     }
 
-    func updateBackForwardButtons(canGoBack: Bool?, canGoForward: Bool?) {
-        backButton.isEnabled = canGoBack ?? false
-        forwardButton.isEnabled = canGoForward ?? false
+    func updateBackForwardButtons(canGoBack: Bool, canGoForward: Bool) {
+        backButton.isEnabled = canGoBack
+        forwardButton.isEnabled = canGoForward
     }
 
     // MARK: - Actions

--- a/SampleBrowser/SampleBrowser/UI/RootViewController.swift
+++ b/SampleBrowser/SampleBrowser/UI/RootViewController.swift
@@ -135,13 +135,12 @@ class RootViewController: UIViewController,
 
     // MARK: - NavigationDelegate
 
-    func onNavigationStateChange(canGoBack: Bool?, canGoForward: Bool?) {
-        toolbar.updateBackForwardButtons(canGoBack: canGoBack, canGoForward: canGoForward)
+    func onLoadingStateChange(loading: Bool) {
+        toolbar.updateReloadStopButton(loading: loading)
     }
 
-    func browserIsLoading(isLoading: Bool) {
-        // TODO: FXIOS-8180 Fix navigation in SampleBrowser
-        toolbar.updateReloadStopButton(isLoading: isLoading)
+    func onNavigationStateChange(canGoBack: Bool, canGoForward: Bool) {
+        toolbar.updateBackForwardButtons(canGoBack: canGoBack, canGoForward: canGoForward)
     }
 
     // MARK: - SearchBarDelegate


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8180)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18191)

## :bulb: Description
- Ensure that back, forward, reload, progress view, stop works as expected by using KVO and calling the right `EngineSessionDelegate` so client can use those.
- Removed `onLoadURL` for now, this functionality won't be needed for now it seems (as we'll be using `onLoadingStateChange` instead)

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

