### PR TITLE
Refactor FXIOS-8202 [v123] Replace signInButton in LegacyRemoteTabsErrorCell to be a PrimaryRoundedButton

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/RemoteTabs/LegacyRemoteTabsErrorCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/RemoteTabs/LegacyRemoteTabsErrorCell.swift
@@ -12,12 +12,9 @@ class LegacyRemoteTabsErrorCell: UITableViewCell, ReusableCell, ThemeApplicable 
         static let verticalPadding: CGFloat = 40
         static let horizontalPadding: CGFloat = 24
         static let paddingInBetweenItems: CGFloat = 15
-        static let buttonCornerRadius: CGFloat = 13
         static let titleSizeFont: CGFloat = 22
         static let descriptionSizeFont: CGFloat = 17
-        static let buttonSizeFont: CGFloat = 16
         static let imageSize = CGSize(width: 90, height: 60)
-        static let buttonVerticalInset: CGFloat = 12
     }
 
     weak var delegate: RemotePanelDelegate?
@@ -52,16 +49,12 @@ class LegacyRemoteTabsErrorCell: UITableViewCell, ReusableCell, ThemeApplicable 
         label.textAlignment = .center
     }
 
-    private let signInButton: LegacyResizableButton = .build { button in
-        button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .callout,
-                                                                         size: UX.buttonSizeFont)
-        button.setTitle(.Settings.Sync.ButtonTitle, for: [])
-        button.layer.cornerRadius = UX.buttonCornerRadius
-        button.contentEdgeInsets = UIEdgeInsets(top: UX.buttonVerticalInset,
-                                                left: UX.buttonVerticalInset,
-                                                bottom: UX.buttonVerticalInset,
-                                                right: UX.buttonVerticalInset)
-        button.accessibilityIdentifier = AccessibilityIdentifiers.TabTray.syncDataButton
+    private let signInButton: PrimaryRoundedButton = .build { button in
+        let viewModel = PrimaryRoundedButtonViewModel(
+            title: .Settings.Sync.ButtonTitle,
+            a11yIdentifier: AccessibilityIdentifiers.TabTray.syncDataButton
+        )
+        button.configure(viewModel: viewModel)
     }
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -117,12 +110,12 @@ class LegacyRemoteTabsErrorCell: UITableViewCell, ReusableCell, ThemeApplicable 
     }
 
     func applyTheme(theme: Theme) {
-        emptyStateImageView.tintColor = theme.colors.textPrimary
-        titleLabel.textColor = theme.colors.textPrimary
-        instructionsLabel.textColor = theme.colors.textPrimary
-        signInButton.setTitleColor(theme.colors.textInverted, for: .normal)
-        signInButton.backgroundColor = theme.colors.actionPrimary
-        backgroundColor = theme.colors.layer3
+        let colors = theme.colors
+        emptyStateImageView.tintColor = colors.textPrimary
+        titleLabel.textColor = colors.textPrimary
+        instructionsLabel.textColor = colors.textPrimary
+        signInButton.applyTheme(theme: theme)
+        backgroundColor = colors.layer3
     }
 
     @objc


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8202)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18230)

## :bulb: Description
- This pull request refactors the `LegacyRemoteTabsErrorCell` class by replacing the existing `signInButton` with a `PrimaryRoundedButton`. 
- The button is now configured using the `PrimaryRoundedButtonViewModel` for improved consistency and maintainability.


**Light Theme:**
| Portrait  | Landscape | 
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-01-19 at 05 06 06](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/2a084820-e42c-485c-8df1-3f57c2c326a8) | ![Simulator Screenshot - iPhone 15 Pro - 2024-01-19 at 05 17 29](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/e413d178-ef7b-4221-8930-6414cbca3f7b) |


**Dark Theme:**
| Portrait  | Landscape | 
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-01-19 at 05 06 32](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/5e2d8ebf-05be-4a5e-8325-037dd5bda491) | ![Simulator Screenshot - iPhone 15 Pro - 2024-01-19 at 05 06 34](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/84d98d0a-6f1e-4980-94de-eb044715fb8b) |


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods