### PR TITLE
Bugfix FXIOS-6040 [v123] Review Download.swift file delegate to be weak

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1445,6 +1445,7 @@
 		E1D6F2D828E325D100B2C8CC /* InstructionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1B04A9C28E20A8300670E54 /* InstructionsView.swift */; };
 		E1D6F2D928E32A5300B2C8CC /* ImageIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9F0B5527C595F300FE09AE /* ImageIdentifiers.swift */; };
 		E1D8BC7A21FF7A0000B100BD /* TPStatsBlocklistsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D8BC7921FF7A0000B100BD /* TPStatsBlocklistsTests.swift */; };
+		E1E425322B5A2E9700899550 /* DownloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E425312B5A2E9700899550 /* DownloadTests.swift */; };
 		E1E5BE252A28F7BE00248F77 /* PasswordDetailViewControllerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E5BE242A28F7BE00248F77 /* PasswordDetailViewControllerModel.swift */; };
 		E1E6F8CE29D4B7E700068D8D /* GleanPlumbContextProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E6F8CD29D4B7E700068D8D /* GleanPlumbContextProviderTests.swift */; };
 		E1FC23F12A8629380089E14D /* FakespotReliabilityCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FC23F02A8629380089E14D /* FakespotReliabilityCardView.swift */; };
@@ -7244,6 +7245,7 @@
 		E1CEC2012A28C3F100B177D5 /* LoginDetailCenteredTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginDetailCenteredTableViewCell.swift; sourceTree = "<group>"; };
 		E1D0406692C3B058BF50AA81 /* sat-Olck */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "sat-Olck"; path = "sat-Olck.lproj/PrivateBrowsing.strings"; sourceTree = "<group>"; };
 		E1D8BC7921FF7A0000B100BD /* TPStatsBlocklistsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPStatsBlocklistsTests.swift; sourceTree = "<group>"; };
+		E1E425312B5A2E9700899550 /* DownloadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadTests.swift; sourceTree = "<group>"; };
 		E1E5BE242A28F7BE00248F77 /* PasswordDetailViewControllerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordDetailViewControllerModel.swift; sourceTree = "<group>"; };
 		E1E6F8CD29D4B7E700068D8D /* GleanPlumbContextProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanPlumbContextProviderTests.swift; sourceTree = "<group>"; };
 		E1FC23F02A8629380089E14D /* FakespotReliabilityCardView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FakespotReliabilityCardView.swift; sourceTree = "<group>"; };
@@ -11470,6 +11472,9 @@
 				1D74FF4D2B27962200FF01D0 /* WindowManagerTests.swift */,
 				D3BA41671BD82F2200DA5457 /* XCTestCaseExtensions.swift */,
 				8A96C4BA28F9E7B300B75884 /* XCTestCaseRootViewController.swift */,
+				253648E02B2111C100D5C2C5 /* SearchViewControllerTests.swift */,
+				814A62452B587A3E00608195 /* DefaultThemeManagerTests.swift */,
+				E1E425312B5A2E9700899550 /* DownloadTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -14272,6 +14277,7 @@
 				4A59B58AD11B5EE1F80BBDEB /* TestHistory.swift in Sources */,
 				A83E5B1D1C1DA8D80026D912 /* UIPasteboardExtensionsTests.swift in Sources */,
 				8A635ECD289437A8006378BA /* SyncedTabCellTests.swift in Sources */,
+				E1E425322B5A2E9700899550 /* DownloadTests.swift in Sources */,
 				5AB4237C28A1947A003BC40C /* MockNotificationCenter.swift in Sources */,
 				8A37C79F28DA4BA600B1FAD4 /* ContextualHintViewProviderTests.swift in Sources */,
 				5A81C5DD2A4C981A00BE88C2 /* PasswordManagerCoordinatorTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/DownloadQueue.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadQueue.swift
@@ -12,7 +12,7 @@ protocol DownloadDelegate: AnyObject {
 }
 
 class Download: NSObject {
-    var delegate: DownloadDelegate?
+    weak var delegate: DownloadDelegate?
 
     fileprivate(set) var filename: String
     fileprivate(set) var mimeType: String

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadTests.swift
@@ -65,8 +65,14 @@ class DownloadTests: XCTestCase {
     }
 }
 
+// MARK: - DownloadDelegate Methods
 class MockDownloadDelegate: DownloadDelegate {
+    // Called when the download is complete
     func download(_ download: Download, didCompleteWithError error: Error?) { }
+
+    // Called when a certain amount of bytes have been downloaded
     func download(_ download: Download, didDownloadBytes bytesDownloaded: Int64) { }
+
+    // Called when the download finishes and provides the location of the downloaded file
     func download(_ download: Download, didFinishDownloadingTo location: URL) { }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadTests.swift
@@ -1,0 +1,72 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Client
+
+class DownloadTests: XCTestCase {
+    var download: Download!
+
+    override func setUp() {
+        super.setUp()
+        download = Download()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        download = nil
+    }
+
+    func testDelegateMemoryLeak() {
+        let mockDownloadDelegate = MockDownloadDelegate()
+        download.delegate = mockDownloadDelegate
+        trackForMemoryLeaks(download, file: #file, line: #line)
+        download = nil
+    }
+
+    func testCancelDoesNotLeak() {
+        let mockDownloadDelegate = MockDownloadDelegate()
+        download.delegate = mockDownloadDelegate
+
+        // Simulate canceling the download
+        download.cancel()
+
+        // Check for memory leaks
+        trackForMemoryLeaks(download, file: #file, line: #line)
+
+        download = nil
+    }
+
+    func testPauseDoesNotLeak() {
+        let mockDownloadDelegate = MockDownloadDelegate()
+        download.delegate = mockDownloadDelegate
+
+        // Simulate pausing the download
+        download.pause()
+
+        // Check for memory leaks
+        trackForMemoryLeaks(download, file: #file, line: #line)
+
+        download = nil
+    }
+
+    func testResumeDoesNotLeak() {
+        let mockDownloadDelegate = MockDownloadDelegate()
+        download.delegate = mockDownloadDelegate
+
+        // Simulate resuming the download
+        download.resume()
+
+        // Check for memory leaks
+        trackForMemoryLeaks(download, file: #file, line: #line)
+
+        download = nil
+    }
+}
+
+class MockDownloadDelegate: DownloadDelegate {
+    func download(_ download: Download, didCompleteWithError error: Error?) { }
+    func download(_ download: Download, didDownloadBytes bytesDownloaded: Int64) { }
+    func download(_ download: Download, didFinishDownloadingTo location: URL) { }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6040)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13690)

## :bulb: Description
- This commit addresses potential reference cycles by making the `delegate` property in the `Download` class weak.
- Additionally, tests have been added to validate that canceling, pausing, and resuming the download do not result in memory leaks.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

