### PR TITLE
Add FXIOS-8213 [v124] Add settings in SampleBrowser

### DIFF
--- a/SampleBrowser/SampleBrowser.xcodeproj/project.pbxproj
+++ b/SampleBrowser/SampleBrowser.xcodeproj/project.pbxproj
@@ -21,6 +21,11 @@
 		8A0F44832B56FE1300438589 /* UIAlertController+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0F44822B56FE1300438589 /* UIAlertController+Error.swift */; };
 		8A0F44852B56FFFC00438589 /* SearchTerm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0F44842B56FFFC00438589 /* SearchTerm.swift */; };
 		8A0F44872B57000C00438589 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0F44862B57000C00438589 /* String+Extension.swift */; };
+		8A3DB32D2B5AD3C700F89705 /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3DB32C2B5AD3C700F89705 /* SettingsViewController.swift */; };
+		8A3DB32F2B5AD3D400F89705 /* SettingsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3DB32E2B5AD3D400F89705 /* SettingsCell.swift */; };
+		8A3DB3312B5AD3E000F89705 /* SettingsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3DB3302B5AD3E000F89705 /* SettingsDataSource.swift */; };
+		8A3DB3332B5AD3EC00F89705 /* SettingsCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3DB3322B5AD3EC00F89705 /* SettingsCellViewModel.swift */; };
+		8A3DB3352B5AD47500F89705 /* SettingsType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3DB3342B5AD47500F89705 /* SettingsType.swift */; };
 		8A4601E52B0FE20500FFD17F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4601E42B0FE20500FFD17F /* AppDelegate.swift */; };
 		8A4601E72B0FE20500FFD17F /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4601E62B0FE20500FFD17F /* SceneDelegate.swift */; };
 		8A4601E92B0FE20500FFD17F /* RootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4601E82B0FE20500FFD17F /* RootViewController.swift */; };
@@ -49,6 +54,11 @@
 		8A0F44822B56FE1300438589 /* UIAlertController+Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+Error.swift"; sourceTree = "<group>"; };
 		8A0F44842B56FFFC00438589 /* SearchTerm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTerm.swift; sourceTree = "<group>"; };
 		8A0F44862B57000C00438589 /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
+		8A3DB32C2B5AD3C700F89705 /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
+		8A3DB32E2B5AD3D400F89705 /* SettingsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsCell.swift; sourceTree = "<group>"; };
+		8A3DB3302B5AD3E000F89705 /* SettingsDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsDataSource.swift; sourceTree = "<group>"; };
+		8A3DB3322B5AD3EC00F89705 /* SettingsCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsCellViewModel.swift; sourceTree = "<group>"; };
+		8A3DB3342B5AD47500F89705 /* SettingsType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsType.swift; sourceTree = "<group>"; };
 		8A4601E12B0FE20500FFD17F /* SampleBrowser.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SampleBrowser.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A4601E42B0FE20500FFD17F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		8A4601E62B0FE20500FFD17F /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -129,6 +139,18 @@
 			path = Suggestion;
 			sourceTree = "<group>";
 		};
+		8A3DB32B2B5AD3B200F89705 /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				8A3DB32C2B5AD3C700F89705 /* SettingsViewController.swift */,
+				8A3DB32E2B5AD3D400F89705 /* SettingsCell.swift */,
+				8A3DB3302B5AD3E000F89705 /* SettingsDataSource.swift */,
+				8A3DB3322B5AD3EC00F89705 /* SettingsCellViewModel.swift */,
+				8A3DB3342B5AD47500F89705 /* SettingsType.swift */,
+			);
+			path = Settings;
+			sourceTree = "<group>";
+		};
 		8A4601D82B0FE20500FFD17F = {
 			isa = PBXGroup;
 			children = (
@@ -167,6 +189,7 @@
 		8A4602142B0FE40E00FFD17F /* UI */ = {
 			isa = PBXGroup;
 			children = (
+				8A3DB32B2B5AD3B200F89705 /* Settings */,
 				8A0F448A2B57053500438589 /* Suggestion */,
 				8A4602232B0FE57C00FFD17F /* Browser */,
 				8A4602152B0FE42300FFD17F /* Components */,
@@ -281,9 +304,11 @@
 				8A0F447B2B56FD8300438589 /* SearchDataProviderProtocol.swift in Sources */,
 				8A4602222B0FE55300FFD17F /* UIViewController+Extension.swift in Sources */,
 				8A0F44712B56FD3600438589 /* SearchViewController.swift in Sources */,
+				8A3DB3352B5AD47500F89705 /* SettingsType.swift in Sources */,
 				8A0F44832B56FE1300438589 /* UIAlertController+Error.swift in Sources */,
 				8A4602172B0FE43A00FFD17F /* BrowserSearchBar.swift in Sources */,
 				8A46021E2B0FE50D00FFD17F /* UIView+Extension.swift in Sources */,
+				8A3DB3332B5AD3EC00F89705 /* SettingsCellViewModel.swift in Sources */,
 				8A46021B2B0FE47C00FFD17F /* BrowserViewController.swift in Sources */,
 				8A0F44752B56FD5300438589 /* SearchViewModel.swift in Sources */,
 				8A0F44772B56FD6300438589 /* SuggestionDataSource.swift in Sources */,
@@ -292,7 +317,9 @@
 				8A0F447D2B56FD9600438589 /* SearchModel.swift in Sources */,
 				8A0F44872B57000C00438589 /* String+Extension.swift in Sources */,
 				8A0F44852B56FFFC00438589 /* SearchTerm.swift in Sources */,
+				8A3DB32F2B5AD3D400F89705 /* SettingsCell.swift in Sources */,
 				8A0F44792B56FD6E00438589 /* SuggestionCellViewModel.swift in Sources */,
+				8A3DB32D2B5AD3C700F89705 /* SettingsViewController.swift in Sources */,
 				8A4602192B0FE45200FFD17F /* BrowserToolbar.swift in Sources */,
 				8A0F44732B56FD4500438589 /* SuggestionViewController.swift in Sources */,
 				8A0F446B2B56EDC900438589 /* EngineProvider.swift in Sources */,
@@ -300,6 +327,7 @@
 				8A4601E72B0FE20500FFD17F /* SceneDelegate.swift in Sources */,
 				8A0F44812B56FDEA00438589 /* SearchDataProvider.swift in Sources */,
 				8A4602202B0FE52F00FFD17F /* UISearchbar+Extension.swift in Sources */,
+				8A3DB3312B5AD3E000F89705 /* SettingsDataSource.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SampleBrowser/SampleBrowser/UI/RootViewController.swift
+++ b/SampleBrowser/SampleBrowser/UI/RootViewController.swift
@@ -169,7 +169,8 @@ class RootViewController: UIViewController,
     // MARK: - MenuDelegate
 
     func didClickMenu() {
-        // Not implementing Settings for now, will see later on if this is needed or not
+        let settingsVC = SettingsViewController()
+        present(settingsVC, animated: true)
     }
 
     // MARK: - SearchViewDelegate

--- a/SampleBrowser/SampleBrowser/UI/Settings/SettingsCell.swift
+++ b/SampleBrowser/SampleBrowser/UI/Settings/SettingsCell.swift
@@ -15,6 +15,10 @@ class SettingsCell: UITableViewCell {
         initialViewSetup()
     }
 
+    override func setHighlighted(_ highlighted: Bool, animated: Bool) {
+        contentView.backgroundColor = highlighted ? .lightGray.withAlphaComponent(0.2) : .white
+    }
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -26,7 +30,7 @@ class SettingsCell: UITableViewCell {
             titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 8),
             titleLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -8),
             titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 8),
-            titleLabel.trailingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: -8)
+            titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -8)
         ])
     }
 

--- a/SampleBrowser/SampleBrowser/UI/Settings/SettingsCell.swift
+++ b/SampleBrowser/SampleBrowser/UI/Settings/SettingsCell.swift
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+
+class SettingsCell: UITableViewCell {
+    static let identifier = "SettingsIdentifier"
+    private var viewModel: SettingsCellViewModel?
+    private lazy var titleLabel: UILabel = .build()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        selectionStyle = .none
+        initialViewSetup()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func initialViewSetup() {
+        contentView.addSubview(titleLabel)
+
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 8),
+            titleLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -8),
+            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 8),
+            titleLabel.trailingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: -8)
+        ])
+    }
+
+    func configureCell(viewModel: SettingsCellViewModel) {
+        self.viewModel = viewModel
+        titleLabel.text = viewModel.title
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        titleLabel.text = nil
+    }
+}

--- a/SampleBrowser/SampleBrowser/UI/Settings/SettingsCellViewModel.swift
+++ b/SampleBrowser/SampleBrowser/UI/Settings/SettingsCellViewModel.swift
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+struct SettingsCellViewModel {
+    var settingType: SettingsType
+    var title: String
+}

--- a/SampleBrowser/SampleBrowser/UI/Settings/SettingsDataSource.swift
+++ b/SampleBrowser/SampleBrowser/UI/Settings/SettingsDataSource.swift
@@ -6,12 +6,16 @@ import UIKit
 
 class SettingsDataSource: NSObject, UITableViewDataSource {
     var models: [SettingsCellViewModel] {
-        var settingsModel = [
+        return [
+            SettingsCellViewModel(settingType: .contentBlocking,
+                                  title: "Trigger content blocking"),
             SettingsCellViewModel(settingType: .findInPage,
-                                  title: "Trigger find in page")
+                                  title: "Trigger find in page"),
+            SettingsCellViewModel(settingType: .scrollingToTop,
+                                  title: "Trigger scroll to top"),
+            SettingsCellViewModel(settingType: .zoom,
+                                  title: "Trigger zoom")
         ]
-
-        return settingsModel
     }
 
     // MARK: - UITableViewDataSource

--- a/SampleBrowser/SampleBrowser/UI/Settings/SettingsDataSource.swift
+++ b/SampleBrowser/SampleBrowser/UI/Settings/SettingsDataSource.swift
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+
+class SettingsDataSource: NSObject, UITableViewDataSource {
+    var models: [SettingsCellViewModel] {
+        var settingsModel = [
+            SettingsCellViewModel(settingType: .findInPage,
+                                  title: "Trigger find in page")
+        ]
+
+        return settingsModel
+    }
+
+    // MARK: - UITableViewDataSource
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return models.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: SettingsCell.identifier,
+                                                       for: indexPath) as? SettingsCell
+        else {
+            return UITableViewCell()
+        }
+
+        cell.configureCell(viewModel: models[indexPath.row])
+        return cell
+    }
+}

--- a/SampleBrowser/SampleBrowser/UI/Settings/SettingsType.swift
+++ b/SampleBrowser/SampleBrowser/UI/Settings/SettingsType.swift
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+// Used to trigger some functionalities from the WebEngine with a simple UI
+public enum SettingsType: String {
+    case findInPage
+}

--- a/SampleBrowser/SampleBrowser/UI/Settings/SettingsType.swift
+++ b/SampleBrowser/SampleBrowser/UI/Settings/SettingsType.swift
@@ -6,8 +6,8 @@ import Foundation
 
 // Used to trigger some functionalities from the WebEngine with a simple UI
 public enum SettingsType: String {
-    case findInPage
     case contentBlocking
-    case zoom
+    case findInPage
     case scrollingToTop
+    case zoom
 }

--- a/SampleBrowser/SampleBrowser/UI/Settings/SettingsType.swift
+++ b/SampleBrowser/SampleBrowser/UI/Settings/SettingsType.swift
@@ -7,4 +7,7 @@ import Foundation
 // Used to trigger some functionalities from the WebEngine with a simple UI
 public enum SettingsType: String {
     case findInPage
+    case contentBlocking
+    case zoom
+    case scrollingToTop
 }

--- a/SampleBrowser/SampleBrowser/UI/Settings/SettingsViewController.swift
+++ b/SampleBrowser/SampleBrowser/UI/Settings/SettingsViewController.swift
@@ -71,14 +71,14 @@ class SettingsViewController: UIViewController, UITableViewDelegate {
         let settingType = model.settingType
 
         switch settingType {
-        case .findInPage:
-            break // TODO: FXIOS-8087 - Handle find in page in WebEngine
         case .contentBlocking:
             break // TODO: FXIOS-8088 - Handle content blocking in WebEngine
-        case .zoom:
-            break // TODO: FXIOS-8089 - Handle zoom in WebEngine
+        case .findInPage:
+            break // TODO: FXIOS-8087 - Handle find in page in WebEngine
         case .scrollingToTop:
             break // TODO: FXIOS-8092 - Handle scrolling to top in WebEngine
+        case .zoom:
+            break // TODO: FXIOS-8089 - Handle zoom in WebEngine
         }
     }
 }

--- a/SampleBrowser/SampleBrowser/UI/Settings/SettingsViewController.swift
+++ b/SampleBrowser/SampleBrowser/UI/Settings/SettingsViewController.swift
@@ -73,6 +73,12 @@ class SettingsViewController: UIViewController, UITableViewDelegate {
         switch settingType {
         case .findInPage:
             break // TODO: FXIOS-8087 - Handle find in page in WebEngine
+        case .contentBlocking:
+            break // TODO: FXIOS-8088 - Handle content blocking in WebEngine
+        case .zoom:
+            break // TODO: FXIOS-8089 - Handle zoom in WebEngine
+        case .scrollingToTop:
+            break // TODO: FXIOS-8092 - Handle scrolling to top in WebEngine
         }
     }
 }

--- a/SampleBrowser/SampleBrowser/UI/Settings/SettingsViewController.swift
+++ b/SampleBrowser/SampleBrowser/UI/Settings/SettingsViewController.swift
@@ -1,0 +1,78 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import WebKit
+
+/// The settings page
+class SettingsViewController: UIViewController, UITableViewDelegate {
+    private var tableView: UITableView
+    private var dataSource = SettingsDataSource()
+
+    private lazy var titleLabel: UILabel = .build { label in
+        label.font = UIFont.systemFont(ofSize: 30, weight: UIFont.Weight.medium)
+        label.text = "Settings"
+        label.textAlignment = .center
+    }
+
+    init() {
+        self.tableView = UITableView(frame: .zero, style: .grouped)
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Life cycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureTableView()
+        configureTitle()
+        tableView.reloadData()
+        view.backgroundColor = tableView.backgroundColor
+    }
+
+    private func configureTableView() {
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.isScrollEnabled = false
+        view.addSubview(tableView)
+
+        NSLayoutConstraint.activate([
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+
+        tableView.tableHeaderView = UIView(frame: CGRect(origin: .zero,
+                                                         size: CGSize(width: 0, height: CGFloat.leastNormalMagnitude)))
+        tableView.dataSource = dataSource
+        tableView.delegate = self
+        tableView.register(SettingsCell.self, forCellReuseIdentifier: SettingsCell.identifier)
+    }
+
+    private func configureTitle() {
+        view.addSubview(titleLabel)
+
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 16),
+            titleLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 8),
+            titleLabel.bottomAnchor.constraint(equalTo: tableView.topAnchor, constant: -16),
+            titleLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+    }
+
+    // MARK: - UITableViewDelegate
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let model: SettingsCellViewModel = dataSource.models[indexPath.row]
+        let settingType = model.settingType
+
+        switch settingType {
+        case .findInPage:
+            break // TODO: FXIOS-8087 - Handle find in page in WebEngine
+        }
+    }
+}

--- a/SampleBrowser/SampleBrowser/UI/Settings/SettingsViewController.swift
+++ b/SampleBrowser/SampleBrowser/UI/Settings/SettingsViewController.swift
@@ -7,6 +7,11 @@ import WebKit
 
 /// The settings page
 class SettingsViewController: UIViewController, UITableViewDelegate {
+    private struct UX {
+        static let titleLabelVerticalSpacing: CGFloat = 16
+        static let titleLabelHorizontalSpacing: CGFloat = 8
+    }
+
     private var tableView: UITableView
     private var dataSource = SettingsDataSource()
 
@@ -46,6 +51,7 @@ class SettingsViewController: UIViewController, UITableViewDelegate {
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
 
+        // this ensures the table view header is removed and not shown
         tableView.tableHeaderView = UIView(frame: CGRect(origin: .zero,
                                                          size: CGSize(width: 0, height: CGFloat.leastNormalMagnitude)))
         tableView.dataSource = dataSource
@@ -57,9 +63,12 @@ class SettingsViewController: UIViewController, UITableViewDelegate {
         view.addSubview(titleLabel)
 
         NSLayoutConstraint.activate([
-            titleLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 16),
-            titleLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 8),
-            titleLabel.bottomAnchor.constraint(equalTo: tableView.topAnchor, constant: -16),
+            titleLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor,
+                                            constant: UX.titleLabelVerticalSpacing),
+            titleLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor,
+                                                constant: UX.titleLabelHorizontalSpacing),
+            titleLabel.bottomAnchor.constraint(equalTo: tableView.topAnchor,
+                                               constant: -UX.titleLabelVerticalSpacing),
             titleLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
     }

--- a/SampleBrowser/SampleBrowser/UI/Suggestion/SuggestionViewController.swift
+++ b/SampleBrowser/SampleBrowser/UI/Suggestion/SuggestionViewController.swift
@@ -71,6 +71,7 @@ class SuggestionViewController: UIViewController, UITableViewDelegate {
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
 
+        // this ensures the table view header is removed and not shown
         tableView.tableHeaderView = UIView(frame: CGRect(origin: .zero,
                                                          size: CGSize(width: 0, height: CGFloat.leastNormalMagnitude)))
         tableView.delegate = self


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8213)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18245)

## :bulb: Description
Adding a settings VC showing when we click the hamburger menu icon. This "settings" page will be used to trigger some functionalities inside the `WebEngine`. This is so we don't have to build a fancy UI in the `SampleBrowser` to have some input interactions with it. The settings are not doing anything right now, as those will be implemented in subsequent tasks.

https://github.com/mozilla-mobile/firefox-ios/assets/11338480/28f4229f-af76-466f-8e58-696ebdd15287

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

