### PR TITLE
Added FXIOS-7532 [v123] Add telemetry to new tab tray

### DIFF
--- a/firefox-ios/Client/Coordinators/TabTray/RemoteTabsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/TabTray/RemoteTabsCoordinator.swift
@@ -46,6 +46,10 @@ class RemoteTabsCoordinator: BaseCoordinator,
     }
 
     func presentFxAccountSettings() {
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .tap,
+                                     object: .syncSignIn)
+        
         parentCoordinator?.didFinish(from: self)
         let urlString = URL.mozInternalScheme + "://deep-link?url=/settings/fxa"
         guard let url = URL(string: urlString) else { return }

--- a/firefox-ios/Client/Coordinators/TabTray/RemoteTabsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/TabTray/RemoteTabsCoordinator.swift
@@ -49,7 +49,6 @@ class RemoteTabsCoordinator: BaseCoordinator,
         TelemetryWrapper.recordEvent(category: .action,
                                      method: .tap,
                                      object: .syncSignIn)
-        
         parentCoordinator?.didFinish(from: self)
         let urlString = URL.mozInternalScheme + "://deep-link?url=/settings/fxa"
         guard let url = URL(string: urlString) else { return }

--- a/firefox-ios/Client/Coordinators/TabTray/TabTrayCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/TabTray/TabTrayCoordinator.swift
@@ -57,6 +57,9 @@ class TabTrayCoordinator: BaseCoordinator,
     }
 
     func start(panelType: TabTrayPanelType, navigationController: UINavigationController) {
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .open,
+                                     object: .tabTray)
         switch panelType {
         case .tabs:
             makeTabsCoordinator(navigationController: navigationController)
@@ -104,12 +107,18 @@ class TabTrayCoordinator: BaseCoordinator,
 
     // MARK: - ParentCoordinatorDelegate
     func didFinish(from childCoordinator: Coordinator) {
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .close,
+                                     object: .tabTray)
         remove(child: childCoordinator)
         parentCoordinator?.didDismissTabTray(from: self)
     }
 
     // MARK: - TabTrayViewControllerDelegate
     func didFinish() {
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .close,
+                                     object: .tabTray)
         parentCoordinator?.didDismissTabTray(from: self)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -31,6 +31,7 @@ class TabManagerMiddleware {
             store.dispatch(TabPanelAction.didLoadTabPanel(tabState))
 
         case TabTrayAction.changePanel(let panelType):
+            self.trackPanelChange(panelType)
             let isPrivate = panelType == TabTrayPanelType.privateTabs
             let tabState = self.getTabsDisplayModel(for: isPrivate)
             if panelType != .syncedTabs {
@@ -112,6 +113,10 @@ class TabManagerMiddleware {
             store.dispatch(TabTrayAction.dismissTabTray)
 
         case RemoteTabsPanelAction.openSelectedURL(let url):
+            TelemetryWrapper.recordEvent(category: .action,
+                                         method: .open,
+                                         object: .syncTab)
+            
             let urlRequest = URLRequest(url: url)
             self.addNewTab(with: urlRequest, isPrivate: false)
             store.dispatch(TabTrayAction.dismissTabTray)
@@ -225,6 +230,10 @@ class TabManagerMiddleware {
     ///   - originIndex: from original position
     ///   - destinationIndex: to destination position
     private func moveTab(from originIndex: Int, to destinationIndex: Int) {
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .drop,
+                                     object: .tab,
+                                     value: .tabTray)
         defaultTabManager.moveTab(isPrivate: false, fromIndex: originIndex, toIndex: destinationIndex)
     }
 
@@ -399,5 +408,28 @@ class TabManagerMiddleware {
 
     private func tabPeekCloseTab(with tabID: String) {
         closeTabFromTabPanel(with: tabID)
+    }
+
+    private func trackPanelChange(_ panel: TabTrayPanelType) {
+        switch panel {
+        case .tabs:
+            TelemetryWrapper.recordEvent(
+                category: .action,
+                method: .tap,
+                object: .privateBrowsingButton,
+                extras: ["is-private": false.description])
+        case .privateTabs:
+            TelemetryWrapper.recordEvent(
+                category: .action,
+                method: .tap,
+                object: .privateBrowsingButton,
+                extras: ["is-private": true.description])
+        case .syncedTabs:
+            TelemetryWrapper.recordEvent(category: .action,
+                                         method: .tap,
+                                         object: .libraryPanel,
+                                         value: .syncPanel,
+                                         extras: nil)
+        }
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -116,7 +116,6 @@ class TabManagerMiddleware {
             TelemetryWrapper.recordEvent(category: .action,
                                          method: .open,
                                          object: .syncTab)
-            
             let urlRequest = URLRequest(url: url)
             self.addNewTab(with: urlRequest, isPrivate: false)
             store.dispatch(TabTrayAction.dismissTabTray)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsPanel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsPanel.swift
@@ -143,7 +143,6 @@ class RemoteTabsPanel: UIViewController,
     }
 
     private func handleOpenSelectedURL(_ url: URL) {
-        TelemetryWrapper.recordEvent(category: .action, method: .open, object: .syncTab)
         store.dispatch(RemoteTabsPanelAction.openSelectedURL(url))
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7532)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16734)

## :bulb: Description
Adds the existing telemetry calls for the old tab tray to the new one

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

