### PR TITLE
Added FXIOS-8172 [v123] Launch photon action sheet from hamburger menu

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
@@ -49,6 +49,7 @@ class PhotonActionSheetTests: BaseTestCase {
         // User not logged in
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
         waitUntilPageLoad()
+        // Temporarily disabled until url bar redesign work FXIOS-8172
         /*
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.shareButton], timeout: 10)
         app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].tap()
@@ -65,12 +66,17 @@ class PhotonActionSheetTests: BaseTestCase {
         waitUntilPageLoad()
         mozWaitForElementToNotExist(app.staticTexts["Fennec pasted from CoreSimulatorBridge"])
 
-        /*
-        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.shareButton], timeout: 10)
-        app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].tap()
+        // Temporarily workaround for the url bar redesign work FXIOS-8172:
+        // Launch "Share" from the hamburger menu instead of the share icon from the
+        // awesome bar.
+        // mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.shareButton], timeout: 10)
+        // app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].tap()
+        navigator.goto(BrowserTabMenu)
+        app.otherElements[ImageIdentifiers.share].tap()
 
         // This is not ideal but only way to get the element on iPhone 8
         // for iPhone 11, that would be boundBy: 2
+
         mozWaitForElementToExist(app.otherElements["ActivityListView"].otherElements["Example Domain"])
         mozWaitForElementToExist(app.otherElements["ActivityListView"].otherElements["example.com"])
         mozWaitForElementToExist(app.collectionViews.cells["Copy"], timeout: TIMEOUT)
@@ -79,26 +85,23 @@ class PhotonActionSheetTests: BaseTestCase {
         mozWaitForElementToExist(fennecElement, timeout: 5)
         fennecElement.tap()
         mozWaitForElementToExist(app.navigationBars["ShareTo.ShareView"])
-        */
     }
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2306841
     // Smoketest
     func testSharePageWithShareSheetOptions() {
-        // Temporarily disabled until url bar redesign work FXIOS-8172
-//        openNewShareSheet()
-//        mozWaitForElementToExist(app.staticTexts["Open in Firefox"], timeout: 10)
-//        XCTAssertTrue(app.staticTexts["Open in Firefox"].exists)
-//        XCTAssertTrue(app.staticTexts["Load in Background"].exists)
-//        XCTAssertTrue(app.staticTexts["Bookmark This Page"].exists)
-//        XCTAssertTrue(app.staticTexts["Add to Reading List"].exists)
-//        XCTAssertTrue(app.staticTexts["Send to Device"].exists)
+        openNewShareSheet()
+        mozWaitForElementToExist(app.staticTexts["Open in Firefox"], timeout: 10)
+        XCTAssertTrue(app.staticTexts["Open in Firefox"].exists)
+        XCTAssertTrue(app.staticTexts["Load in Background"].exists)
+        XCTAssertTrue(app.staticTexts["Bookmark This Page"].exists)
+        XCTAssertTrue(app.staticTexts["Add to Reading List"].exists)
+        XCTAssertTrue(app.staticTexts["Send to Device"].exists)
     }
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2323203
     func testShareSheetSendToDevice() {
         openNewShareSheet()
-        /*
         mozWaitForElementToExist(app.staticTexts["Send to Device"])
         app.staticTexts["Send to Device"].tap()
         mozWaitForElementToExist(
@@ -108,17 +111,14 @@ class PhotonActionSheetTests: BaseTestCase {
 
         XCTAssertTrue(app.staticTexts["You are not signed in to your account."].exists)
         app.navigationBars.buttons[AccessibilityIdentifiers.ShareTo.HelpView.doneButton].tap()
-        */
     }
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2323204
     func testShareSheetOpenAndCancel() {
         openNewShareSheet()
-        /*
         app.buttons["Cancel"].tap()
         // User is back to the BrowserTab where the sharesheet was launched
         mozWaitForElementToExist(app.textFields["url"])
         mozWaitForValueContains(app.textFields["url"], value: "example.com/")
-        */
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
@@ -76,7 +76,6 @@ class PhotonActionSheetTests: BaseTestCase {
 
         // This is not ideal but only way to get the element on iPhone 8
         // for iPhone 11, that would be boundBy: 2
-
         mozWaitForElementToExist(app.otherElements["ActivityListView"].otherElements["Example Domain"])
         mozWaitForElementToExist(app.otherElements["ActivityListView"].otherElements["example.com"])
         mozWaitForElementToExist(app.collectionViews.cells["Copy"], timeout: TIMEOUT)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
@@ -49,6 +49,7 @@ class PhotonActionSheetTests: BaseTestCase {
         // User not logged in
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
         waitUntilPageLoad()
+        /*
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.shareButton], timeout: 10)
         app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].tap()
         mozWaitForElementToExist(app.cells["Send Link to Device"], timeout: 10)
@@ -56,6 +57,7 @@ class PhotonActionSheetTests: BaseTestCase {
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.ShareTo.HelpView.doneButton])
         XCTAssertTrue(app.staticTexts["You are not signed in to your account."].exists)
         XCTAssertTrue(app.staticTexts["Please open Firefox, go to Settings and sign in to continue."].exists)
+        */
     }
 
     private func openNewShareSheet() {
@@ -63,6 +65,7 @@ class PhotonActionSheetTests: BaseTestCase {
         waitUntilPageLoad()
         mozWaitForElementToNotExist(app.staticTexts["Fennec pasted from CoreSimulatorBridge"])
 
+        /*
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.shareButton], timeout: 10)
         app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].tap()
 
@@ -76,6 +79,7 @@ class PhotonActionSheetTests: BaseTestCase {
         mozWaitForElementToExist(fennecElement, timeout: 5)
         fennecElement.tap()
         mozWaitForElementToExist(app.navigationBars["ShareTo.ShareView"])
+        */
     }
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2306841
@@ -94,6 +98,7 @@ class PhotonActionSheetTests: BaseTestCase {
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2323203
     func testShareSheetSendToDevice() {
         openNewShareSheet()
+        /*
         mozWaitForElementToExist(app.staticTexts["Send to Device"])
         app.staticTexts["Send to Device"].tap()
         mozWaitForElementToExist(
@@ -103,14 +108,17 @@ class PhotonActionSheetTests: BaseTestCase {
 
         XCTAssertTrue(app.staticTexts["You are not signed in to your account."].exists)
         app.navigationBars.buttons[AccessibilityIdentifiers.ShareTo.HelpView.doneButton].tap()
+        */
     }
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2323204
     func testShareSheetOpenAndCancel() {
         openNewShareSheet()
+        /*
         app.buttons["Cancel"].tap()
         // User is back to the BrowserTab where the sharesheet was launched
         mozWaitForElementToExist(app.textFields["url"])
         mozWaitForValueContains(app.textFields["url"], value: "example.com/")
+        */
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8172)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18180)

## :bulb: Description

Following up the test failures since this PR: https://github.com/mozilla-mobile/firefox-ios/pull/18182.

Implement workaround for the `PhotonActionSheetTests` while we don't have the share icon available from the awesome bar. We can launch the same screen from the hamburger menu instead.

Some full functional tests are affected as well. Let me disable the part on insisting the share icon is present.

We need *some* protection while the redesign work is underway. ☔ 

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

