### PR TITLE
Bugfix FXIOS-6074 [v124] Change folder to cache for changed user-agent file

### DIFF
--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -137,6 +137,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                    level: .info,
                    category: .lifecycle)
 
+        // Perform migration if needed
+        Tab.ChangeUserAgent.performMigrationIfNeeded()
+
         return true
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6074)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13754)

## :bulb: Description
- This pull request addresses the issue of storing the user agent set file in the documents directory, moving it to the cache directory for improved file management.

### Changes Made:
- Updated the file URL in `ChangeUserAgent` to use the cache directory for storing the user agent set file.
- Added a call in `AppDelegate` to perform a migration during the app launch, moving the existing file from documents to the cache directory.


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods