### PR TITLE
Add FXIOS-8223, DISCO-2665 [v124] Record Category 2.5 impressions for sponsored and non-sponsored suggestions from Firefox Suggest

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -946,6 +946,7 @@
 		B2FEA68F2B460D9E0058E616 /* AddressAutofillSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2FEA68E2B460D9E0058E616 /* AddressAutofillSettingsViewModel.swift */; };
 		B2FEA6912B4661BE0058E616 /* AddressAutofillToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2FEA6902B4661BE0058E616 /* AddressAutofillToggle.swift */; };
 		B640467E29B9B58200C5C7B6 /* TabLocationViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B640467D29B9B58200C5C7B6 /* TabLocationViewTests.swift */; };
+		BC003F5E2B59F44600929ECB /* BrowserViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC003F5D2B59F44500929ECB /* BrowserViewControllerTests.swift */; };
 		BCFF93EE2AAA9F6E005B5B71 /* RustFirefoxSuggest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF93ED2AAA9C47005B5B71 /* RustFirefoxSuggest.swift */; };
 		BCFF93F02AABA55A005B5B71 /* BackgroundFirefoxSuggestIngestUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF93EF2AAB97A8005B5B71 /* BackgroundFirefoxSuggestIngestUtility.swift */; };
 		BCFF93F22AAF9688005B5B71 /* FirefoxSuggestSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF93F12AAF9688005B5B71 /* FirefoxSuggestSettings.swift */; };
@@ -6281,6 +6282,7 @@
 		BBB44277B3EB5E6A0CE1D47C /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
 		BBE94C27A604339C9C38E02F /* km */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = km; path = km.lproj/Menu.strings; sourceTree = "<group>"; };
 		BBF04862A944340C80C053E0 /* si */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = si; path = si.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
+		BC003F5D2B59F44500929ECB /* BrowserViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserViewControllerTests.swift; sourceTree = "<group>"; };
 		BC4B49618B8FC822D4D0FCC2 /* hr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hr; path = hr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		BC81442AA84F635F3067A2C5 /* es-CL */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-CL"; path = "es-CL.lproj/PrivateBrowsing.strings"; sourceTree = "<group>"; };
 		BCD04CE4A62EAA4DF96DE812 /* es-MX */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-MX"; path = "es-MX.lproj/Storage.strings"; sourceTree = "<group>"; };
@@ -11437,6 +11439,7 @@
 			children = (
 				8A171A6029F82AD90085770E /* Application */,
 				CA7BD564248185B500A0A61B /* BreachAlertsTests.swift */,
+				BC003F5D2B59F44500929ECB /* BrowserViewControllerTests.swift */,
 				8A28C627291028870078A81A /* CanRemoveQuickActionBookmarkTests.swift */,
 				F84B21D91A090F8100AAB793 /* ClientTests.swift */,
 				8A86DAD7277298DE00D7BFFF /* ClosedTabsStoreTests.swift */,
@@ -14365,6 +14368,7 @@
 				8A0727492B4898D20071BB9F /* WebviewTelemetryTests.swift in Sources */,
 				3B6F40181DC7849C00656CC6 /* TopSitesViewModelTests.swift in Sources */,
 				C869915528917803007ACC5C /* WallpaperMetadataTestProvider.swift in Sources */,
+				BC003F5E2B59F44600929ECB /* BrowserViewControllerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
@@ -412,6 +412,11 @@ extension BrowserViewController: URLBarDelegate {
     }
 
     func urlBar(_ urlBar: URLBarView, didLeaveOverlayModeForReason reason: URLBarLeaveOverlayModeReason) {
+        searchEngagementState = switch reason {
+        case .finished: .engaged
+        case .cancelled: .abandoned
+        }
+
         destroySearchController()
         updateInContentHomePanel(tabManager.selectedTab?.url as URL?)
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
@@ -411,7 +411,7 @@ extension BrowserViewController: URLBarDelegate {
         urlBar.applyTheme(theme: themeManager.currentTheme)
     }
 
-    func urlBarDidLeaveOverlayMode(_ urlBar: URLBarView) {
+    func urlBar(_ urlBar: URLBarView, didLeaveOverlayModeForReason reason: URLBarLeaveOverlayModeReason) {
         destroySearchController()
         updateInContentHomePanel(tabManager.selectedTab?.url as URL?)
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1267,7 +1267,7 @@ class BrowserViewController: UIViewController,
 
     override func accessibilityPerformEscape() -> Bool {
         if overlayManager.inOverlayMode {
-            overlayManager.finishEditing(shouldCancelLoading: true)
+            overlayManager.cancelEditing(shouldCancelLoading: true)
             return true
         } else if let selectedTab = tabManager.selectedTab, selectedTab.canGoBack {
             selectedTab.goBack()
@@ -2354,7 +2354,9 @@ extension BrowserViewController: TabManagerDelegate {
 
         if let tab = selected, let webView = tab.webView {
             updateURLBarDisplayURL(tab)
-            if urlBar.inOverlayMode, tab.url?.displayURL != nil { urlBar.leaveOverlayMode(didCancel: false) }
+            if urlBar.inOverlayMode, tab.url?.displayURL != nil {
+                urlBar.leaveOverlayMode(reason: .finished, shouldCancelLoading: false)
+            }
 
             if previous == nil || tab.isPrivate != previous?.isPrivate {
                 applyTheme()
@@ -2601,7 +2603,7 @@ extension BrowserViewController: KeyboardHelperDelegate {
         // If keyboard is dismiss leave edition mode Homepage case is handled in HomepageVC
         let newTabChoice = NewTabAccessors.getNewTabPage(profile.prefs)
         if newTabChoice != .topSites, newTabChoice != .blankPage {
-            overlayManager.finishEditing(shouldCancelLoading: false)
+            overlayManager.cancelEditing(shouldCancelLoading: false)
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2381,6 +2381,7 @@ extension BrowserViewController: SearchViewControllerDelegate {
                 extras: [
                     TelemetryWrapper.EventValue.fxSuggestionTelemetryInfo.rawValue: telemetryInfo,
                     TelemetryWrapper.EventValue.fxSuggestionPosition.rawValue: position,
+                    TelemetryWrapper.EventValue.fxSuggestionDidTap.rawValue: didTap,
                 ]
             )
             if didTap {

--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -348,7 +348,7 @@ class HomepageViewController:
     @objc
     private func dismissKeyboard() {
         if currentTab?.lastKnownUrl?.absoluteString.hasPrefix("internal://") ?? false {
-            overlayManager.finishEditing(shouldCancelLoading: false)
+            overlayManager.cancelEditing(shouldCancelLoading: false)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
@@ -24,10 +24,18 @@ protocol OverlayModeManager: OverlayStateProtocol {
     ///   - newTabSettings: User option for new tab, if it's a custom url (homepage) the keyboard is not raised
     func openNewTab(url: URL?, newTabSettings: NewTabPage)
 
-    /// Leave overlay mode when user finishes editing, either by pressing the go button, enter etc
+    /// Leave overlay mode when the user finishes editing. This is called when
+    /// the user commits their edits, either by tapping "go" / Enter on the
+    /// keyboard, or by tapping on a suggestion in the search view.
     /// - Parameter shouldCancelLoading: Bool value determine if the loading animation of the current
     ///                                  search should be canceled
     func finishEditing(shouldCancelLoading: Bool)
+
+    /// Leave overlay mode when the user cancels editing. This is called when
+    /// the user dismisses the search view without committing their edits.
+    /// - Parameter shouldCancelLoading: Bool value determine if the loading animation of the current
+    ///                                  search should be canceled
+    func cancelEditing(shouldCancelLoading: Bool)
 
     /// Leave overlay mode when tab change happens, like switching tabs or open a site from any homepage section
     /// - Parameter shouldCancelLoading: Bool value determine if the loading animation of the current
@@ -59,13 +67,17 @@ class DefaultOverlayModeManager: OverlayModeManager {
     }
 
     func finishEditing(shouldCancelLoading: Bool) {
-        leaveOverlayMode(didCancel: shouldCancelLoading)
+        leaveOverlayMode(reason: .finished, shouldCancelLoading: shouldCancelLoading)
+    }
+
+    func cancelEditing(shouldCancelLoading: Bool) {
+        leaveOverlayMode(reason: .cancelled, shouldCancelLoading: shouldCancelLoading)
     }
 
     func switchTab(shouldCancelLoading: Bool) {
         guard inOverlayMode else { return }
 
-        leaveOverlayMode(didCancel: shouldCancelLoading)
+        leaveOverlayMode(reason: .finished, shouldCancelLoading: shouldCancelLoading)
     }
 
     private func shouldEnterOverlay(for url: URL?, newTabSettings: NewTabPage) -> Bool {
@@ -82,7 +94,7 @@ class DefaultOverlayModeManager: OverlayModeManager {
         urlBarView?.enterOverlayMode(locationText, pasted: pasted, search: search)
     }
 
-    private func leaveOverlayMode(didCancel cancel: Bool) {
-        urlBarView?.leaveOverlayMode(didCancel: cancel)
+    private func leaveOverlayMode(reason: URLBarLeaveOverlayModeReason, shouldCancelLoading cancel: Bool) {
+        urlBarView?.leaveOverlayMode(reason: reason, shouldCancelLoading: cancel)
     }
 }

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -613,7 +613,7 @@ extension TelemetryWrapper {
         case crashedLastLaunch = "crashed_last_launch"
         case cpuException = "cpu_exception"
         case hangException = "hang-exception"
-        case fxSuggestionClickInfo = "fx-suggestion-click-info"
+        case fxSuggestionTelemetryInfo = "fx-suggestion-telemetry-info"
         case fxSuggestionPosition = "fx-suggestion-position"
         case webviewFail = "webview-fail"
         case webviewFailProvisional = "webview-fail-provisional"
@@ -1851,34 +1851,52 @@ extension TelemetryWrapper {
             }
 
         // MARK: - FX Suggest
-        case(.action, .tap, .fxSuggest, _, let extras ):
+        case(.action, .tap, .fxSuggest, _, let extras):
             guard let contextIdString = TelemetryContextualIdentifier.contextId,
                   let contextId = UUID(uuidString: contextIdString),
-                  let interactionInfo = extras?[EventValue.fxSuggestionClickInfo.rawValue] as? RustFirefoxSuggestionInteractionInfo else {
+                  let telemetryInfo = extras?[EventValue.fxSuggestionTelemetryInfo.rawValue] as? RustFirefoxSuggestionTelemetryInfo,
+                  let position = extras?[EventValue.fxSuggestionPosition.rawValue] as? Int else {
                 return recordUninstrumentedMetrics(category: category, method: method, object: object, value: value, extras: extras)
             }
-            switch interactionInfo {
-            case let .amp(blockId, advertiser, iabCategory, reportingURL):
-                GleanMetrics.FxSuggest.contextId.set(contextId)
-                GleanMetrics.FxSuggest.pingType.set("fxsuggest-click")
+            GleanMetrics.FxSuggest.contextId.set(contextId)
+            GleanMetrics.FxSuggest.pingType.set("fxsuggest-click")
+            GleanMetrics.FxSuggest.position.set(Int64(position))
+            switch telemetryInfo {
+            case let .amp(blockId, advertiser, iabCategory, _, clickReportingURL):
                 GleanMetrics.FxSuggest.blockId.set(blockId)
                 GleanMetrics.FxSuggest.advertiser.set(advertiser)
                 GleanMetrics.FxSuggest.iabCategory.set(iabCategory)
-                if let reportingURL {
-                    GleanMetrics.FxSuggest.reportingUrl.set(url: reportingURL)
-                }
-                if let position = extras?[EventValue.fxSuggestionPosition.rawValue] as? Int {
-                    GleanMetrics.FxSuggest.position.set(Int64(position))
+                if let clickReportingURL {
+                    GleanMetrics.FxSuggest.reportingUrl.set(url: clickReportingURL)
                 }
             case .wikipedia:
-                GleanMetrics.FxSuggest.pingType.set("fxsuggest-click")
-                GleanMetrics.FxSuggest.contextId.set(contextId)
                 GleanMetrics.FxSuggest.advertiser.set("wikipedia")
-                if let position = extras?[EventValue.fxSuggestionPosition.rawValue] as? Int {
-                    GleanMetrics.FxSuggest.position.set(Int64(position))
-                }
             }
             GleanMetrics.Pings.shared.fxSuggest.submit()
+        case(.action, .view, .fxSuggest, _, let extras):
+            guard let contextIdString = TelemetryContextualIdentifier.contextId,
+                  let contextId = UUID(uuidString: contextIdString),
+                  let telemetryInfo = extras?[EventValue.fxSuggestionTelemetryInfo.rawValue] as? RustFirefoxSuggestionTelemetryInfo,
+                  let position = extras?[EventValue.fxSuggestionPosition.rawValue] as? Int else {
+                return recordUninstrumentedMetrics(category: category, method: method, object: object, value: value, extras: extras)
+            }
+            GleanMetrics.FxSuggest.contextId.set(contextId)
+            GleanMetrics.FxSuggest.pingType.set("fxsuggest-impression")
+            GleanMetrics.FxSuggest.position.set(Int64(position))
+            switch telemetryInfo {
+            case let .amp(blockId, advertiser, iabCategory, impressionReportingURL, _):
+                GleanMetrics.FxSuggest.blockId.set(blockId)
+                GleanMetrics.FxSuggest.advertiser.set(advertiser)
+                GleanMetrics.FxSuggest.iabCategory.set(iabCategory)
+                if let impressionReportingURL {
+                    GleanMetrics.FxSuggest.reportingUrl.set(url: impressionReportingURL)
+                }
+            case .wikipedia:
+                GleanMetrics.FxSuggest.advertiser.set("wikipedia")
+            }
+            GleanMetrics.Pings.shared.fxSuggest.submit()
+
+        // MARK: - Uninstrumented
         default:
             recordUninstrumentedMetrics(category: category, method: method, object: object, value: value, extras: extras)
         }

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -615,6 +615,7 @@ extension TelemetryWrapper {
         case hangException = "hang-exception"
         case fxSuggestionTelemetryInfo = "fx-suggestion-telemetry-info"
         case fxSuggestionPosition = "fx-suggestion-position"
+        case fxSuggestionDidTap = "fx-suggestion-did-tap"
         case webviewFail = "webview-fail"
         case webviewFailProvisional = "webview-fail-provisional"
         case webviewShowErrorPage = "webview-show-error-page"
@@ -1860,6 +1861,7 @@ extension TelemetryWrapper {
             }
             GleanMetrics.FxSuggest.contextId.set(contextId)
             GleanMetrics.FxSuggest.pingType.set("fxsuggest-click")
+            GleanMetrics.FxSuggest.isClicked.set(true)
             GleanMetrics.FxSuggest.position.set(Int64(position))
             switch telemetryInfo {
             case let .amp(blockId, advertiser, iabCategory, _, clickReportingURL):
@@ -1877,11 +1879,13 @@ extension TelemetryWrapper {
             guard let contextIdString = TelemetryContextualIdentifier.contextId,
                   let contextId = UUID(uuidString: contextIdString),
                   let telemetryInfo = extras?[EventValue.fxSuggestionTelemetryInfo.rawValue] as? RustFirefoxSuggestionTelemetryInfo,
-                  let position = extras?[EventValue.fxSuggestionPosition.rawValue] as? Int else {
+                  let position = extras?[EventValue.fxSuggestionPosition.rawValue] as? Int,
+                  let didTap = extras?[EventValue.fxSuggestionDidTap.rawValue] as? Bool else {
                 return recordUninstrumentedMetrics(category: category, method: method, object: object, value: value, extras: extras)
             }
             GleanMetrics.FxSuggest.contextId.set(contextId)
             GleanMetrics.FxSuggest.pingType.set("fxsuggest-impression")
+            GleanMetrics.FxSuggest.isClicked.set(didTap)
             GleanMetrics.FxSuggest.position.set(Int64(position))
             switch telemetryInfo {
             case let .amp(blockId, advertiser, iabCategory, impressionReportingURL, _):

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -5102,6 +5102,26 @@ fx_suggest:
     expires: never
     send_in_pings:
       - fx-suggest
+  is_clicked:
+    type: boolean
+    description: >
+      If `ping_type` is "fxsuggest-impression", indicates whether this
+      impression is for a clicked suggestion.
+      If `ping_type` is "fxsuggest-click", always `true`.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-8223
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/18273
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+      - lina@mozilla.com
+      - ttran@mozilla.com
+      - najiang@mozilla.com
+    expires: never
+    send_in_pings:
+      - fx-suggest
   reporting_url:
     type: url
     description: |

--- a/firefox-ios/Storage/Rust/RustFirefoxSuggestion.swift
+++ b/firefox-ios/Storage/Rust/RustFirefoxSuggestion.swift
@@ -8,8 +8,14 @@ import UIKit
 
 /// Additional information about a Firefox Suggestion to record
 /// in telemetry when the user interacts with the suggestion
-public enum RustFirefoxSuggestionInteractionInfo {
-    case amp(blockId: Int64, advertiser: String, iabCategory: String, reportingURL: URL?)
+public enum RustFirefoxSuggestionTelemetryInfo {
+    case amp(
+        blockId: Int64,
+        advertiser: String,
+        iabCategory: String,
+        impressionReportingURL: URL?,
+        clickReportingURL: URL?
+    )
     case wikipedia
 }
 /// A Firefox Suggest search suggestion. This struct is a Swiftier
@@ -20,7 +26,7 @@ public struct RustFirefoxSuggestion {
     public let isSponsored: Bool
     public let iconImage: UIImage?
     public let fullKeyword: String
-    public let clickInfo: RustFirefoxSuggestionInteractionInfo?
+    public let telemetryInfo: RustFirefoxSuggestionTelemetryInfo?
 
     public init(title: String, url: URL, isSponsored: Bool, iconImage: UIImage?, fullKeyword: String) {
         self.title = title
@@ -28,7 +34,7 @@ public struct RustFirefoxSuggestion {
         self.isSponsored = isSponsored
         self.iconImage = iconImage
         self.fullKeyword = fullKeyword
-        self.clickInfo = nil
+        self.telemetryInfo = nil
     }
 
     internal init?(_ suggestion: Suggestion) {
@@ -48,7 +54,7 @@ public struct RustFirefoxSuggestion {
             blockId,
             advertiser,
             iabCategory,
-            _,
+            impressionUrlString,
             clickUrlString,
             _
         ) = suggestion {
@@ -60,11 +66,12 @@ public struct RustFirefoxSuggestion {
             self.isSponsored = true
             self.iconImage = iconBytes.flatMap { UIImage(data: Data($0)) }
             self.fullKeyword = fullKeyword
-            self.clickInfo = .amp(
+            self.telemetryInfo = .amp(
                 blockId: blockId,
-                advertiser: advertiser,
+                advertiser: advertiser.lowercased(),
                 iabCategory: iabCategory,
-                reportingURL: URL(string: clickUrlString)
+                impressionReportingURL: URL(string: impressionUrlString),
+                clickReportingURL: URL(string: clickUrlString)
             )
         } else if case let .wikipedia(title, urlString, iconBytes, fullKeyword) = suggestion {
             // This use of `URL(string:)` is OK.
@@ -74,7 +81,7 @@ public struct RustFirefoxSuggestion {
             self.isSponsored = false
             self.iconImage = iconBytes.flatMap { UIImage(data: Data($0)) }
             self.fullKeyword = fullKeyword
-            self.clickInfo = .wikipedia
+            self.telemetryInfo = .wikipedia
         } else {
             return nil
         }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Storage
+import XCTest
+import Shared
+import Glean
+
+@testable import Client
+
+class BrowserViewControllerTests: XCTestCase {
+    var profile: MockProfile!
+    var tabManager: MockTabManager!
+    var browserViewController: BrowserViewController!
+
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+        TelemetryContextualIdentifier.setupContextId()
+        Glean.shared.resetGlean(clearStores: true)
+        Glean.shared.enableTestingMode()
+
+        profile = MockProfile()
+        tabManager = MockTabManager()
+        browserViewController = BrowserViewController(profile: profile, tabManager: tabManager)
+    }
+
+    override func tearDown() {
+        TelemetryContextualIdentifier.clearUserDefaults()
+        DependencyHelperMock().reset()
+        super.tearDown()
+    }
+
+    func testRecordEngagedSearchTelemetryForVisibleSuggestion() {
+        let expectation = expectation(description: "The Firefox Suggest ping was sent")
+
+        GleanMetrics.Pings.shared.fxSuggest.testBeforeNextSubmit { _ in
+            XCTAssertEqual(GleanMetrics.FxSuggest.pingType.testGetValue(), "fxsuggest-impression")
+            XCTAssertEqual(
+                GleanMetrics.FxSuggest.contextId.testGetValue()?.uuidString,
+                TelemetryContextualIdentifier.contextId
+            )
+            XCTAssertEqual(GleanMetrics.FxSuggest.position.testGetValue(), 3)
+            XCTAssertEqual(GleanMetrics.FxSuggest.blockId.testGetValue(), 1)
+            XCTAssertEqual(GleanMetrics.FxSuggest.advertiser.testGetValue(), "test advertiser")
+            XCTAssertEqual(GleanMetrics.FxSuggest.iabCategory.testGetValue(), "999 - Test Category")
+            XCTAssertEqual(GleanMetrics.FxSuggest.reportingUrl.testGetValue(), "https://example.com/ios_test_impression_reporting_url")
+            expectation.fulfill()
+        }
+
+        browserViewController.trackEngagedSearchTelemetry(visibleSuggestionInfo: .firefoxSuggestion(
+            RustFirefoxSuggestionTelemetryInfo.amp(
+                blockId: 1,
+                advertiser: "test advertiser",
+                iabCategory: "999 - Test Category",
+                impressionReportingURL: URL(string: "https://example.com/ios_test_impression_reporting_url"),
+                clickReportingURL: URL(string: "https://example.com/ios_test_click_reporting_url")
+            ),
+            position: 3,
+            didTap: false
+        ))
+
+        wait(for: [expectation], timeout: 5.0)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
@@ -42,6 +42,7 @@ class BrowserViewControllerTests: XCTestCase {
                 GleanMetrics.FxSuggest.contextId.testGetValue()?.uuidString,
                 TelemetryContextualIdentifier.contextId
             )
+            XCTAssertEqual(GleanMetrics.FxSuggest.isClicked.testGetValue(), false)
             XCTAssertEqual(GleanMetrics.FxSuggest.position.testGetValue(), 3)
             XCTAssertEqual(GleanMetrics.FxSuggest.blockId.testGetValue(), 1)
             XCTAssertEqual(GleanMetrics.FxSuggest.advertiser.testGetValue(), "test advertiser")

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockURLBarView.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockURLBarView.swift
@@ -9,7 +9,7 @@ class MockURLBarView: URLBarViewProtocol {
     var leaveOverlayModeCallCount = 0
     var enterOverlayModeCallCount = 0
 
-    func leaveOverlayMode(didCancel cancel: Bool) {
+    func leaveOverlayMode(reason: URLBarLeaveOverlayModeReason, shouldCancelLoading cancel: Bool) {
         leaveOverlayModeCallCount += 1
         inOverlayMode = false
     }


### PR DESCRIPTION
## :scroll: Tickets

[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8223)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18272)

## :bulb: Description

This PR adds telemetry for sponsored and non-sponsored suggestion impressions to Firefox for iOS. Once this PR lands, Firefox Android and iOS will be recording the same Category 2.5 telemetry for these new types of suggestions, which we're pretty excited about on the DISCO team!

First, I wanted to provide a bit of background for this change.

Today, Firefox Desktop and Android collect two categories of data for sponsored and non-sponsored suggestion impressions and clicks. The Category 2.5 data is sent in the Glean `fx-suggest` ping (`quick-suggest` ping on Desktop), and is used for revenue analysis and partner reporting. For privacy, this ping does not include the `client_id`. The Category 2 data is sent in the Glean `events` ping, and does include the `client_id`. This data is used exclusively for our own analyses, and never reported to partners.

This PR only implements the Category 2.5 data, but lays the groundwork for recording Category 2 events in a future PR.

@tiftran added the `fx-suggest` ping, and Category 2.5 clicks, to iOS in mozilla-mobile/firefox-ios#17556. This PR builds on her work to add Category 2.5 impressions.

But what's an impression, anyway? Here are the definitions we use on Desktop and Android:

* An "impression" for a sponsored or a non-sponsored suggestion is recorded if that suggestion was visible at the end of an engaged search session.
* A "search session" begins when the URL bar is focused, and ends when the URL bar is blurred. On iOS, this definition seems to map perfectly to entering and leaving overlay mode. A search session can be either engaged or abandoned.
* An "engaged search session" is when the user finishes their search, by typing a URL or a search term and pressing "Go" / Enter, or by tapping on any visible suggestion.
* An "abandoned search session" is when the user aborts their search by dismissing the URL bar.

With that in mind, here's a quick overview of each commit. I tried to split them up to make it a little easier to review:

1. The first commit adds a new method, `OverlayModeManager.cancelEditing(shouldCancelLoading:)`, to tell the overlay manager that the user cancelled editing. It also adds `URLBarLeaveOverlayModeReason`, and forwards it to the URL bar's delegate. We'll use this in the second commit to track engaged and abandoned search sessions.
2. The second commit records impressions for sponsored and non-sponsored suggestions. It instruments `SearchViewController` to notify its delegate just before the search view is dismissed, and to provide telemetry information for visible suggestions. `BrowserViewController` uses this new `searchViewControllerWillHide(_:)` delegate method, together with the URL bar's reason for leaving overlay mode, to record impressions for engaged search sessions. This commit also moves the logic for reporting clicks out of `SearchViewController` and into `BrowserViewController`, which we'll use in the next commit.
3. The third commit adds a new metric, `fx_suggest.is_clicked`, to the `fx-suggest` ping. This metric is used for partner reporting, and records whether the user clicked on an impressed sponsored or non-sponsored suggestion. This commit brings Firefox for iOS's `fx-suggest` ping in line with [Android's `fx-suggest` ping](https://dictionary.telemetry.mozilla.org/apps/fenix/pings/fx-suggest).

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

