### PR TITLE
Fixes MTE-2185 [v124] for several iPad tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomeButtonTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomeButtonTests.swift
@@ -22,12 +22,7 @@ class HomeButtonTests: BaseTestCase {
         app.buttons[AccessibilityIdentifiers.Toolbar.homeButton].tap()
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
-
-        if iPad() {
-            XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.homeButton].label, "Home")
-        } else {
-            XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.searchButton].label, "Search")
-        }
+        XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.searchButton].label, "Search")
         if iPad() {
             navigator.nowAt(NewTabScreen)
         }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -254,18 +254,12 @@ class HomePageSettingsUITests: BaseTestCase {
         navigator.performAction(Action.ToggleRecentlySaved)
         // On iPad we have the homepage button always present,
         // on iPhone we have the search button instead when we're on a new tab page
-        if !iPad() {
-            navigator.performAction(Action.ClickSearchButton)
-        } else {
-            navigator.performAction(Action.GoToHomePage)
-        }
+        navigator.performAction(Action.ClickSearchButton)
         XCTAssertFalse(
             app.scrollViews.cells[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.recentlySaved].exists
         )
-        if !iPad() {
-            mozWaitForElementToExist(app.buttons["urlBar-cancel"], timeout: 3)
-            navigator.performAction(Action.CloseURLBarOpen)
-        }
+        mozWaitForElementToExist(app.buttons["urlBar-cancel"], timeout: 3)
+        navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         navigator.performAction(Action.ToggleRecentlySaved)
         navigator.nowAt(HomeSettings)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchSettingsUITest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchSettingsUITest.swift
@@ -41,7 +41,17 @@ class SearchSettingsUITests: BaseTestCase {
         mozWaitForElementToExist(app.buttons["Edit"])
         XCTAssertTrue(app.buttons["Edit"].isEnabled)
         app.buttons["Edit"].tap()
-        mozWaitForElementToExist(app.tables.buttons["Remove \(customSearchEngine["name"]!)"])
+        // Workaround for https://github.com/mozilla-mobile/firefox-ios/issues/18278
+        // Remove if/else after fix
+        if !iPad() {
+            mozWaitForElementToExist(app.tables.buttons["Remove \(customSearchEngine["name"]!)"])
+        } else {
+            navigator.goto(SettingsScreen)
+            navigator.goto(SearchSettings)
+            mozWaitForElementToExist(app.buttons["Edit"])
+            app.buttons["Edit"].tap()
+            mozWaitForElementToExist(app.tables.buttons["Remove \(customSearchEngine["name"]!)"])
+        }
     }
 
     private func addCustomSearchEngine() {
@@ -123,7 +133,18 @@ class SearchSettingsUITests: BaseTestCase {
         app.buttons["Edit"].tap()
         // Remove the custom search engine and check that edit is disabled
         let tablesQuery = app.tables
-        tablesQuery.buttons["Remove \(customSearchEngine["name"]!)"].tap()
+        // Workaround for https://github.com/mozilla-mobile/firefox-ios/issues/18278
+        // Remove if/else after fix
+        if !iPad() {
+            tablesQuery.buttons["Remove \(customSearchEngine["name"]!)"].tap()
+        } else {
+            navigator.goto(SettingsScreen)
+            navigator.goto(SearchSettings)
+            mozWaitForElementToExist(app.buttons["Edit"])
+            app.buttons["Edit"].tap()
+            mozWaitForElementToExist(tablesQuery.buttons["Remove \(customSearchEngine["name"]!)"])
+            tablesQuery.buttons["Remove \(customSearchEngine["name"]!)"].tap()
+        }
         tablesQuery.buttons[AccessibilityIdentifiers.Settings.Search.deleteButton].tap()
         XCTAssertFalse(app.buttons["Edit"].isEnabled)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarTest.swift
@@ -47,12 +47,7 @@ class ToolbarTests: BaseTestCase {
         XCTAssertEqual(valueMozilla, urlValueLong)
         XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
         XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
-        if iPad() {
-            XCTAssertTrue(app.buttons["Reload"].isEnabled)
-        } else {
-            XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.reloadButton].isEnabled)
-        }
-
+        XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.reloadButton].isEnabled)
         navigator.openURL(website2)
         waitUntilPageLoad()
         mozWaitForValueContains(app.textFields["url"], value: "localhost:\(serverPort)")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2185)

## :bulb: Description
Fixes for several tests on iPad. Some elements have changed and are now the same with the ones from iPhone.Removed the iPad() condition.
Also added an workaround for https://github.com/mozilla-mobile/firefox-ios/issues/18278.

