### PR TITLE
Refactor FXIOS-8114 [v123] Tab tray screenshot fix

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/LayoutManager/TabsSectionManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/LayoutManager/TabsSectionManager.swift
@@ -25,13 +25,13 @@ class TabsSectionManager {
     func layoutSection(_ layoutEnvironment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(0.5),
-            heightDimension: .estimated(UX.cellEstimatedHeight)
+            heightDimension: .absolute(UX.cellEstimatedHeight)
         )
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
         let groupSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1),
-            heightDimension: .estimated(UX.cellEstimatedHeight)
+            heightDimension: .absolute(UX.cellEstimatedHeight)
         )
 
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -184,8 +184,7 @@ class TabManagerMiddleware {
                                     tabTitle: tab.displayTitle,
                                     url: tab.url,
                                     screenshot: tab.screenshot,
-                                    hasHomeScreenshot: tab.hasHomeScreenshot,
-                                    margin: 0)
+                                    hasHomeScreenshot: tab.hasHomeScreenshot)
             tabs.append(tabModel)
         }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Models/TabModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Models/TabModel.swift
@@ -15,8 +15,6 @@ struct TabModel: Equatable {
     let screenshot: UIImage?
     let hasHomeScreenshot: Bool
 
-    let margin: CGFloat // (Changes depending on fullscreen)
-
     static func emptyTabState(tabUUID: String, title: String) -> TabModel {
         return TabModel(
             tabUUID: tabUUID,
@@ -26,8 +24,7 @@ struct TabModel: Equatable {
             tabTitle: title,
             url: nil,
             screenshot: nil,
-            hasHomeScreenshot: false,
-            margin: 0.0
+            hasHomeScreenshot: false
         )
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabCell.swift
@@ -21,6 +21,10 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         static let faviconSize: CGFloat = 20
         static let closeButtonSize: CGFloat = 32
         static let textBoxHeight: CGFloat = 32
+        static let closeButtonEdgeInset = NSDirectionalEdgeInsets(top: 10,
+                                                                  leading: 10,
+                                                                  bottom: 10,
+                                                                  trailing: 10)
     }
     // MARK: - Properties
 
@@ -63,7 +67,9 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         button.setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross), for: [])
         button.imageView?.contentMode = .scaleAspectFit
         button.contentMode = .center
-        button.imageEdgeInsets = UIEdgeInsets(equalInset: LegacyGridTabViewController.UX.closeButtonEdgeInset)
+        var configuration = UIButton.Configuration.filled()
+        configuration.contentInsets = UX.closeButtonEdgeInset
+        button.configuration = configuration
     }
 
     // MARK: - Initializer
@@ -118,7 +124,7 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
 
         configureScreenshot(tabModel: tabModel)
 
-        if let theme = theme {
+        if let theme {
             applyTheme(theme: theme)
         }
     }
@@ -131,7 +137,7 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         delegate?.tabCellDidClose(for: tabModel.tabUUID)
     }
 
-    // MARK: - Configuration
+    // MARK: - ThemeApplicable
 
     func applyTheme(theme: Theme) {
         backgroundHolder.backgroundColor = theme.colors.layer1
@@ -141,6 +147,8 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         favicon.tintColor = theme.colors.textPrimary
         smallFaviconView.tintColor = theme.colors.textPrimary
     }
+
+    // MARK: - Configuration
 
     private func hasHomeScreenshot(tabModel: TabModel) -> Bool {
         guard let url = tabModel.url,
@@ -207,7 +215,7 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         }
     }
 
-    // MARK: UICollectionViewCell
+    // MARK: - UICollectionViewCell
 
     override func prepareForReuse() {
         // Reset any close animations.
@@ -232,53 +240,51 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         let imageBackgroundSize = TopSiteItemCell.UX.imageBackgroundSize
         let topSiteIconSize = TopSiteItemCell.UX.iconSize
 
-        NSLayoutConstraint.activate(
-            [
-                backgroundHolder.topAnchor.constraint(equalTo: contentView.topAnchor),
-                backgroundHolder.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-                backgroundHolder.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-                backgroundHolder.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+        NSLayoutConstraint.activate([
+            backgroundHolder.topAnchor.constraint(equalTo: contentView.topAnchor),
+            backgroundHolder.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            backgroundHolder.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            backgroundHolder.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
 
-                title.topAnchor.constraint(equalTo: backgroundHolder.topAnchor),
-                title.leftAnchor.constraint(equalTo: backgroundHolder.leftAnchor),
-                title.rightAnchor.constraint(equalTo: backgroundHolder.rightAnchor),
-                title.heightAnchor.constraint(equalToConstant: textBoxHeight),
+            title.topAnchor.constraint(equalTo: backgroundHolder.topAnchor),
+            title.leftAnchor.constraint(equalTo: backgroundHolder.leftAnchor),
+            title.rightAnchor.constraint(equalTo: backgroundHolder.rightAnchor),
+            title.heightAnchor.constraint(equalToConstant: textBoxHeight),
 
-                favicon.leadingAnchor.constraint(equalTo: title.leadingAnchor, constant: defaultPadding),
-                favicon.topAnchor.constraint(
-                    equalTo: title.topAnchor,
-                    constant: (LegacyGridTabViewController.UX.textBoxHeight - faviconSize) / 2.0
-                ),
-                favicon.heightAnchor.constraint(equalToConstant: faviconSize),
-                favicon.widthAnchor.constraint(equalToConstant: faviconSize),
+            favicon.leadingAnchor.constraint(equalTo: title.leadingAnchor, constant: defaultPadding),
+            favicon.topAnchor.constraint(
+                equalTo: title.topAnchor,
+                constant: (LegacyGridTabViewController.UX.textBoxHeight - faviconSize) / 2.0
+            ),
+            favicon.heightAnchor.constraint(equalToConstant: faviconSize),
+            favicon.widthAnchor.constraint(equalToConstant: faviconSize),
 
-                closeButton.heightAnchor.constraint(equalToConstant: closeButtonSize),
-                closeButton.widthAnchor.constraint(equalToConstant: closeButtonSize),
-                closeButton.centerYAnchor.constraint(equalTo: title.contentView.centerYAnchor),
-                closeButton.trailingAnchor.constraint(equalTo: title.trailingAnchor),
+            closeButton.heightAnchor.constraint(equalToConstant: closeButtonSize),
+            closeButton.widthAnchor.constraint(equalToConstant: closeButtonSize),
+            closeButton.centerYAnchor.constraint(equalTo: title.contentView.centerYAnchor),
+            closeButton.trailingAnchor.constraint(equalTo: title.trailingAnchor),
 
-                titleText.leadingAnchor.constraint(equalTo: favicon.trailingAnchor,
-                                                   constant: defaultPadding),
-                titleText.trailingAnchor.constraint(equalTo: closeButton.leadingAnchor,
-                                                    constant: defaultPadding),
-                titleText.centerYAnchor.constraint(equalTo: title.contentView.centerYAnchor),
+            titleText.leadingAnchor.constraint(equalTo: favicon.trailingAnchor,
+                                               constant: defaultPadding),
+            titleText.trailingAnchor.constraint(equalTo: closeButton.leadingAnchor,
+                                                constant: defaultPadding),
+            titleText.centerYAnchor.constraint(equalTo: title.contentView.centerYAnchor),
 
-                screenshotView.topAnchor.constraint(equalTo: topAnchor),
-                screenshotView.leftAnchor.constraint(equalTo: backgroundHolder.leftAnchor),
-                screenshotView.rightAnchor.constraint(equalTo: backgroundHolder.rightAnchor),
-                screenshotView.bottomAnchor.constraint(equalTo: backgroundHolder.bottomAnchor),
+            screenshotView.topAnchor.constraint(equalTo: topAnchor),
+            screenshotView.leftAnchor.constraint(equalTo: backgroundHolder.leftAnchor),
+            screenshotView.rightAnchor.constraint(equalTo: backgroundHolder.rightAnchor),
+            screenshotView.bottomAnchor.constraint(equalTo: backgroundHolder.bottomAnchor),
 
-                faviconBG.centerYAnchor.constraint(equalTo: centerYAnchor, constant: faviconYOffset),
-                faviconBG.centerXAnchor.constraint(equalTo: centerXAnchor),
-                faviconBG.heightAnchor.constraint(equalToConstant: imageBackgroundSize.height),
-                faviconBG.widthAnchor.constraint(equalToConstant: imageBackgroundSize.width),
+            faviconBG.centerYAnchor.constraint(equalTo: centerYAnchor, constant: faviconYOffset),
+            faviconBG.centerXAnchor.constraint(equalTo: centerXAnchor),
+            faviconBG.heightAnchor.constraint(equalToConstant: imageBackgroundSize.height),
+            faviconBG.widthAnchor.constraint(equalToConstant: imageBackgroundSize.width),
 
-                smallFaviconView.heightAnchor.constraint(equalToConstant: topSiteIconSize.height),
-                smallFaviconView.widthAnchor.constraint(equalToConstant: topSiteIconSize.width),
-                smallFaviconView.centerYAnchor.constraint(equalTo: faviconBG.centerYAnchor),
-                smallFaviconView.centerXAnchor.constraint(equalTo: faviconBG.centerXAnchor),
-            ]
-        )
+            smallFaviconView.heightAnchor.constraint(equalToConstant: topSiteIconSize.height),
+            smallFaviconView.widthAnchor.constraint(equalToConstant: topSiteIconSize.width),
+            smallFaviconView.centerYAnchor.constraint(equalTo: faviconBG.centerYAnchor),
+            smallFaviconView.centerXAnchor.constraint(equalTo: faviconBG.centerXAnchor),
+        ])
     }
 
     // MARK: - Accessibility
@@ -297,7 +303,7 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         return true
     }
 
-    func getA11yTitleLabel(tabModel: TabModel) -> String? {
+    private func getA11yTitleLabel(tabModel: TabModel) -> String? {
         let baseName = tabModel.tabTitle
 
         if isSelectedTab, !baseName.isEmpty {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabCell.swift
@@ -25,6 +25,10 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
                                                                   leading: 10,
                                                                   bottom: 10,
                                                                   trailing: 10)
+
+        // Using the same sizes for fallback favicon as the top sites on the homepage
+        static let imageBackgroundSize = TopSiteItemCell.UX.imageBackgroundSize
+        static let topSiteIconSize = TopSiteItemCell.UX.iconSize
     }
     // MARK: - Properties
 
@@ -36,8 +40,8 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
 
     private lazy var smallFaviconView: FaviconImageView = .build()
     private lazy var favicon: FaviconImageView = .build()
-    private var title =
-        UIVisualEffectView(effect: UIBlurEffect(style: UIColor.legacyTheme.tabTray.tabTitleBlur))
+    private var headerView =
+    UIVisualEffectView(effect: UIBlurEffect(style: UIColor.legacyTheme.tabTray.tabTitleBlur))
 
     // MARK: - UI
 
@@ -51,6 +55,7 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         view.layer.borderWidth = HomepageViewModel.UX.generalBorderWidth
         view.layer.shadowOffset = HomepageViewModel.UX.shadowOffset
         view.layer.shadowRadius = HomepageViewModel.UX.shadowRadius
+        view.isHidden = true
     }
 
     private lazy var screenshotView: UIImageView = .build { view in
@@ -67,7 +72,7 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         button.setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross), for: [])
         button.imageView?.contentMode = .scaleAspectFit
         button.contentMode = .center
-        var configuration = UIButton.Configuration.filled()
+        var configuration = UIButton.Configuration.plain()
         configuration.contentInsets = UX.closeButtonEdgeInset
         button.configuration = configuration
     }
@@ -82,19 +87,18 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         contentView.addSubview(backgroundHolder)
 
         faviconBG.addSubview(smallFaviconView)
-        backgroundHolder.addSubviews(screenshotView, faviconBG)
+        backgroundHolder.addSubviews(screenshotView, faviconBG, headerView)
 
-        self.accessibilityCustomActions = [
+        accessibilityCustomActions = [
             UIAccessibilityCustomAction(name: .TabTrayCloseAccessibilityCustomAction,
                                         target: self.animator,
                                         selector: #selector(SwipeAnimator.closeWithoutGesture))
         ]
 
-        backgroundHolder.addSubview(title)
-        title.translatesAutoresizingMaskIntoConstraints = false
-        title.contentView.addSubview(self.closeButton)
-        title.contentView.addSubview(self.titleText)
-        title.contentView.addSubview(self.favicon)
+        headerView.translatesAutoresizingMaskIntoConstraints = false
+        headerView.contentView.addSubview(self.closeButton)
+        headerView.contentView.addSubview(self.titleText)
+        headerView.contentView.addSubview(self.favicon)
 
         setupConstraints()
     }
@@ -150,39 +154,27 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
 
     // MARK: - Configuration
 
-    private func hasHomeScreenshot(tabModel: TabModel) -> Bool {
-        guard let url = tabModel.url,
-              url.absoluteString.starts(with: "internal"),
-            tabModel.screenshot != nil, tabModel.hasHomeScreenshot else { return false }
-
-        return true
-    }
-
     private func configureScreenshot(tabModel: TabModel) {
-        faviconBG.isHidden = true
-        // Regular screenshot for home or internal url when tab has home screenshot
-        guard !hasHomeScreenshot(tabModel: tabModel) else {
+        if let url = tabModel.url,
+           isInternal(url: url),
+           tabModel.hasHomeScreenshot {
+            // Regular screenshot for home or internal url when tab has home screenshot
             let defaultImage = UIImage(named: StandardImageIdentifiers.Large.globe)?
                 .withRenderingMode(.alwaysTemplate)
             smallFaviconView.manuallySetImage(defaultImage ?? UIImage())
             screenshotView.image = tabModel.screenshot
-            return
-        }
-
-        // Favicon or letter image when home screenshot is present for a regular (non-internal) url
-        if let url = tabModel.url,
-           !url.absoluteString.starts(with: "internal"),
-           tabModel.hasHomeScreenshot {
+        } else if let url = tabModel.url,
+                  !isInternal(url: url),
+                  tabModel.hasHomeScreenshot {
+            // Favicon or letter image when home screenshot is present for a regular (non-internal) url
             let defaultImage = UIImage(
                 named: StandardImageIdentifiers.Large.globe
             )?.withRenderingMode(.alwaysTemplate)
             smallFaviconView.manuallySetImage(defaultImage ?? UIImage())
             faviconBG.isHidden = false
             screenshotView.image = nil
-        }
-
-        // Use Tab screenshot when available
-        if let tabScreenshot = tabModel.screenshot {
+        } else if let tabScreenshot = tabModel.screenshot {
+            // Use Tab screenshot when available
             screenshotView.image = tabScreenshot
         } else {
             // Favicon or letter image when tab screenshot isn't available
@@ -193,6 +185,10 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
                 smallFaviconView.setFavicon(FaviconImageViewModel(siteURLString: tabURL))
             }
         }
+    }
+
+    private func isInternal(url: URL) -> Bool {
+        return url.absoluteString.starts(with: "internal")
     }
 
     private func updateUIForSelectedState(_ selected: Bool,
@@ -223,6 +219,7 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         screenshotView.image = nil
         backgroundHolder.transform = .identity
         backgroundHolder.alpha = 1
+        faviconBG.isHidden = true
         layer.shadowOffset = .zero
         layer.shadowPath = nil
         layer.shadowOpacity = 0
@@ -232,56 +229,51 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
     // MARK: - Auto Layout
 
     private func setupConstraints() {
-        let defaultPadding = UX.subviewDefaultPadding
-        let faviconYOffset = UX.faviconYOffset
-        let faviconSize = UX.faviconSize
-        let closeButtonSize = UX.closeButtonSize
-        let textBoxHeight = UX.textBoxHeight
-        let imageBackgroundSize = TopSiteItemCell.UX.imageBackgroundSize
-        let topSiteIconSize = TopSiteItemCell.UX.iconSize
-
         NSLayoutConstraint.activate([
             backgroundHolder.topAnchor.constraint(equalTo: contentView.topAnchor),
             backgroundHolder.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             backgroundHolder.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
             backgroundHolder.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
 
-            title.topAnchor.constraint(equalTo: backgroundHolder.topAnchor),
-            title.leftAnchor.constraint(equalTo: backgroundHolder.leftAnchor),
-            title.rightAnchor.constraint(equalTo: backgroundHolder.rightAnchor),
-            title.heightAnchor.constraint(equalToConstant: textBoxHeight),
+            headerView.topAnchor.constraint(equalTo: backgroundHolder.topAnchor),
+            headerView.leftAnchor.constraint(equalTo: backgroundHolder.leftAnchor),
+            headerView.rightAnchor.constraint(equalTo: backgroundHolder.rightAnchor),
+            headerView.heightAnchor.constraint(equalToConstant: UX.textBoxHeight),
 
-            favicon.leadingAnchor.constraint(equalTo: title.leadingAnchor, constant: defaultPadding),
+            // Parts of the header view
+            favicon.leadingAnchor.constraint(equalTo: headerView.leadingAnchor, constant: UX.subviewDefaultPadding),
             favicon.topAnchor.constraint(
-                equalTo: title.topAnchor,
-                constant: (LegacyGridTabViewController.UX.textBoxHeight - faviconSize) / 2.0
+                equalTo: headerView.topAnchor,
+                constant: (UX.textBoxHeight - UX.faviconSize) / 2.0
             ),
-            favicon.heightAnchor.constraint(equalToConstant: faviconSize),
-            favicon.widthAnchor.constraint(equalToConstant: faviconSize),
+            favicon.heightAnchor.constraint(equalToConstant: UX.faviconSize),
+            favicon.widthAnchor.constraint(equalToConstant: UX.faviconSize),
 
-            closeButton.heightAnchor.constraint(equalToConstant: closeButtonSize),
-            closeButton.widthAnchor.constraint(equalToConstant: closeButtonSize),
-            closeButton.centerYAnchor.constraint(equalTo: title.contentView.centerYAnchor),
-            closeButton.trailingAnchor.constraint(equalTo: title.trailingAnchor),
+            closeButton.heightAnchor.constraint(equalToConstant: UX.closeButtonSize),
+            closeButton.widthAnchor.constraint(equalToConstant: UX.closeButtonSize),
+            closeButton.centerYAnchor.constraint(equalTo: headerView.contentView.centerYAnchor),
+            closeButton.trailingAnchor.constraint(equalTo: headerView.trailingAnchor),
 
             titleText.leadingAnchor.constraint(equalTo: favicon.trailingAnchor,
-                                               constant: defaultPadding),
+                                               constant: UX.subviewDefaultPadding),
             titleText.trailingAnchor.constraint(equalTo: closeButton.leadingAnchor,
-                                                constant: defaultPadding),
-            titleText.centerYAnchor.constraint(equalTo: title.contentView.centerYAnchor),
+                                                constant: UX.subviewDefaultPadding),
+            titleText.topAnchor.constraint(equalTo: headerView.contentView.topAnchor),
+            titleText.bottomAnchor.constraint(equalTo: headerView.contentView.bottomAnchor),
 
-            screenshotView.topAnchor.constraint(equalTo: topAnchor),
+            // Screenshot either shown or favicon takes its place as fallback
+            screenshotView.topAnchor.constraint(equalTo: headerView.contentView.bottomAnchor),
             screenshotView.leftAnchor.constraint(equalTo: backgroundHolder.leftAnchor),
             screenshotView.rightAnchor.constraint(equalTo: backgroundHolder.rightAnchor),
             screenshotView.bottomAnchor.constraint(equalTo: backgroundHolder.bottomAnchor),
 
-            faviconBG.centerYAnchor.constraint(equalTo: centerYAnchor, constant: faviconYOffset),
-            faviconBG.centerXAnchor.constraint(equalTo: centerXAnchor),
-            faviconBG.heightAnchor.constraint(equalToConstant: imageBackgroundSize.height),
-            faviconBG.widthAnchor.constraint(equalToConstant: imageBackgroundSize.width),
+            faviconBG.centerYAnchor.constraint(equalTo: backgroundHolder.centerYAnchor, constant: UX.faviconYOffset),
+            faviconBG.centerXAnchor.constraint(equalTo: backgroundHolder.centerXAnchor),
+            faviconBG.heightAnchor.constraint(equalToConstant: UX.imageBackgroundSize.height),
+            faviconBG.widthAnchor.constraint(equalToConstant: UX.imageBackgroundSize.width),
 
-            smallFaviconView.heightAnchor.constraint(equalToConstant: topSiteIconSize.height),
-            smallFaviconView.widthAnchor.constraint(equalToConstant: topSiteIconSize.width),
+            smallFaviconView.heightAnchor.constraint(equalToConstant: UX.topSiteIconSize.height),
+            smallFaviconView.widthAnchor.constraint(equalToConstant: UX.topSiteIconSize.width),
             smallFaviconView.centerYAnchor.constraint(equalTo: faviconBG.centerYAnchor),
             smallFaviconView.centerXAnchor.constraint(equalTo: faviconBG.centerXAnchor),
         ])

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabCellTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabCellTests.swift
@@ -57,8 +57,7 @@ class TabCellTests: XCTestCase {
                         tabTitle: "Firefox Browser",
                         url: URL(string: "https://www.mozilla.org/en-US/firefox/")!,
                         screenshot: nil,
-                        hasHomeScreenshot: false,
-                        margin: 0.0)
+                        hasHomeScreenshot: false)
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8114)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18061)

## :bulb: Description
The tab screenshot was not scaling as it should due to the cell height being estimated. It screenshot would then try to fit itself has being way taller than it needs to be in reality, which made it appear to be zoomed in. When playing with the contraints it resulted in:
![Simulator Screenshot - iPhone 15 - 2024-01-22 at 15 09 28](https://github.com/mozilla-mobile/firefox-ios/assets/11338480/52873feb-e616-4557-a2d4-ffd9214b0d4b)

So changing the `NSCollectionLayoutSection` height dimension to be of `absolute` instead of `estimated` seems appropriate in the current case. I don't think we want tabs to scale height wise in any case, even with bigger font sizes. 

With that being said, I also changed:
- `TabModel` doesn't have margin property anymore since it wasn't used. Let me know if I should put that back.
- Renamed `title` to `headerView` to make it simpler to understand that `title` was the view that holds all the header items in the tab cell.
- Fixed a `button.imageEdgeInsets` warning on the close button
- Shuffled the logic in `configureScreenshot` since with the `guard` and `if` it was harder for me to understand this part of the code than what it was in the legacy one. Happy to change if this doesn't help.
- Changed that the tab screenshot is constraint to the bottom of the header view. This solves an issue where the tab screenshot upper part was behind the header view.
- Indentation fix

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

