### PR TITLE
Bugfix FXIOS-8225 [v124] Unit Test Failure: testUpdateEnginePrefs_addressesDisabled

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/RustSyncManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/RustSyncManagerTests.swift
@@ -193,7 +193,7 @@ class RustSyncManagerTests: XCTestCase {
         XCTAssertNil(profile.prefs.boolForKey(Keys.addressesStateChangedPrefKey))
     }
 
-///  TO DO FXIOS-8225 
+//  TO DO FXIOS-8225 
 //    func testUpdateEnginePrefs_addressesDisabled() throws {
 //        profile.prefs.setBool(false, forKey: Keys.addressesEnabledPrefKey)
 //        profile.prefs.setBool(false, forKey: Keys.addressesStateChangedPrefKey)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/RustSyncManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/RustSyncManagerTests.swift
@@ -193,15 +193,16 @@ class RustSyncManagerTests: XCTestCase {
         XCTAssertNil(profile.prefs.boolForKey(Keys.addressesStateChangedPrefKey))
     }
 
-    func testUpdateEnginePrefs_addressesDisabled() throws {
-        profile.prefs.setBool(false, forKey: Keys.addressesEnabledPrefKey)
-        profile.prefs.setBool(false, forKey: Keys.addressesStateChangedPrefKey)
-
-        let declined = ["bookmarks", "addresses", "passwords"]
-        rustSyncManager.updateEnginePrefs(declined: declined)
-
-        let key = try XCTUnwrap(profile.prefs.boolForKey(Keys.addressesEnabledPrefKey))
-        XCTAssertFalse(key)
-        XCTAssertNil(profile.prefs.boolForKey(Keys.addressesStateChangedPrefKey))
-    }
+///  TO DO FXIOS-8225 
+//    func testUpdateEnginePrefs_addressesDisabled() throws {
+//        profile.prefs.setBool(false, forKey: Keys.addressesEnabledPrefKey)
+//        profile.prefs.setBool(false, forKey: Keys.addressesStateChangedPrefKey)
+//
+//        let declined = ["bookmarks", "addresses", "passwords"]
+//        rustSyncManager.updateEnginePrefs(declined: declined)
+//
+//        let key = try XCTUnwrap(profile.prefs.boolForKey(Keys.addressesEnabledPrefKey))
+//        XCTAssertFalse(key)
+//        XCTAssertNil(profile.prefs.boolForKey(Keys.addressesStateChangedPrefKey))
+//    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/RustSyncManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/RustSyncManagerTests.swift
@@ -51,6 +51,8 @@ class RustSyncManagerTests: XCTestCase {
         profile.prefs.removeObjectForKey(Keys.passwordsEnabledPrefKey)
         profile.prefs.removeObjectForKey(Keys.tabsStateChangedPrefKey)
         profile.prefs.removeObjectForKey(Keys.tabsEnabledPrefKey)
+        profile.prefs.removeObjectForKey(Keys.addressesStateChangedPrefKey)
+        profile.prefs.removeObjectForKey(Keys.addressesEnabledPrefKey)
         profile = nil
     }
 
@@ -193,16 +195,15 @@ class RustSyncManagerTests: XCTestCase {
         XCTAssertNil(profile.prefs.boolForKey(Keys.addressesStateChangedPrefKey))
     }
 
-//  TO DO FXIOS-8225 
-//    func testUpdateEnginePrefs_addressesDisabled() throws {
-//        profile.prefs.setBool(false, forKey: Keys.addressesEnabledPrefKey)
-//        profile.prefs.setBool(false, forKey: Keys.addressesStateChangedPrefKey)
-//
-//        let declined = ["bookmarks", "addresses", "passwords"]
-//        rustSyncManager.updateEnginePrefs(declined: declined)
-//
-//        let key = try XCTUnwrap(profile.prefs.boolForKey(Keys.addressesEnabledPrefKey))
-//        XCTAssertFalse(key)
-//        XCTAssertNil(profile.prefs.boolForKey(Keys.addressesStateChangedPrefKey))
-//    }
+    func testUpdateEnginePrefs_addressesDisabled() throws {
+        profile.prefs.setBool(false, forKey: Keys.addressesEnabledPrefKey)
+        profile.prefs.setBool(false, forKey: Keys.addressesStateChangedPrefKey)
+
+        let declined = ["bookmarks", "addresses", "passwords"]
+        rustSyncManager.updateEnginePrefs(declined: declined)
+
+        let key = try XCTUnwrap(profile.prefs.boolForKey(Keys.addressesEnabledPrefKey))
+        XCTAssertFalse(key)
+        XCTAssertNil(profile.prefs.boolForKey(Keys.addressesStateChangedPrefKey))
+    }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8225)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18279)

## :bulb: Description
Unit Test Failure: testUpdateEnginePrefs_addressesDisabled fix

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

