### PR TITLE
Refactor FXIOS-8229 [v124] Compositional layout refresh data on homepage

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1287,7 +1287,7 @@ class BrowserViewController: UIViewController,
     func setupMiddleButtonStatus(isLoading: Bool) {
         // Setting the default state to search to account for no tab or starting page tab
         // `state` will be modified later if needed
-        var state: MiddleButtonState = .search
+        let state: MiddleButtonState = .search
 
         // No tab
         guard let tab = tabManager.selectedTab else {

--- a/firefox-ios/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionViewModel.swift
@@ -26,7 +26,11 @@ extension CustomizeHomepageSectionViewModel: HomepageViewModelProtocol {
         return .emptyHeader
     }
 
-    func section(for traitCollection: UITraitCollection, size: CGSize) -> NSCollectionLayoutSection {
+    func section(for traitCollection: UITraitCollection,
+                 size: CGSize,
+                 isPortrait: Bool = UIWindow.isPortrait,
+                 device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom
+    ) -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
                                               heightDimension: .estimated(100))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)

--- a/firefox-ios/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
@@ -183,7 +183,11 @@ extension HistoryHighlightsViewModel: HomepageViewModelProtocol, FeatureFlaggabl
         return !isPrivate
     }
 
-    func section(for traitCollection: UITraitCollection, size: CGSize) -> NSCollectionLayoutSection {
+    func section(for traitCollection: UITraitCollection,
+                 size: CGSize,
+                 isPortrait: Bool = UIWindow.isPortrait,
+                 device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom
+    ) -> NSCollectionLayoutSection {
         let item = NSCollectionLayoutItem(
             layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
                                                heightDimension: .estimated(UX.estimatedCellHeight))

--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -249,7 +249,7 @@ class HomepageViewController:
 
     func createLayout() -> UICollectionViewLayout {
         // swiftlint:disable line_length
-        let layout = UICollectionViewCompositionalLayout { [weak self] (sectionIndex: Int, layoutEnvironment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? in
+        return UICollectionViewCompositionalLayout { [weak self] (sectionIndex: Int, layoutEnvironment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? in
         // swiftlint:enable line_length
             guard let self = self,
                   let viewModel = self.viewModel.getSectionViewModel(shownSection: sectionIndex),
@@ -265,7 +265,6 @@ class HomepageViewController:
                 size: layoutEnvironment.container.effectiveContentSize
             )
         }
-        return layout
     }
 
     // MARK: Long press

--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -262,7 +262,7 @@ class HomepageViewController:
             )
             return viewModel.section(
                 for: layoutEnvironment.traitCollection,
-                size: self.view.frame.size
+                size: layoutEnvironment.container.effectiveContentSize
             )
         }
         return layout
@@ -308,7 +308,7 @@ class HomepageViewController:
         }
 
         // Force the entire collection view to re-layout
-        viewModel.refreshData(for: traitCollection, size: newSize)
+        viewModel.updateEnabledSections()
         collectionView.reloadData()
         collectionView.collectionViewLayout.invalidateLayout()
 
@@ -814,7 +814,7 @@ extension HomepageViewController: HomepageViewModelDelegate {
         ensureMainThread { [weak self] in
             guard let self = self else { return }
 
-            self.viewModel.refreshData(for: self.traitCollection, size: self.view.frame.size)
+            self.viewModel.updateEnabledSections()
             self.collectionView.reloadData()
             self.collectionView.collectionViewLayout.invalidateLayout()
             self.logger.log("Amount of sections shown is \(self.viewModel.shownSections.count)",

--- a/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
@@ -224,16 +224,6 @@ class HomepageViewModel: FeatureFlaggable {
                    category: .homepage)
     }
 
-    func refreshData(for traitCollection: UITraitCollection, size: CGSize) {
-        updateEnabledSections()
-        childViewModels.forEach {
-            $0.refreshData(for: traitCollection,
-                           size: size,
-                           isPortrait: UIWindow.isPortrait,
-                           device: UIDevice.current.userInterfaceIdiom)
-        }
-    }
-
     // MARK: - Section ViewModel helper
 
     func getSectionViewModel(shownSection: Int) -> HomepageViewModelProtocol? {

--- a/firefox-ios/Client/Frontend/Home/HomepageViewModelProtocol.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewModelProtocol.swift
@@ -10,7 +10,7 @@ import Shared
 protocol HomepageViewModelProtocol {
     var sectionType: HomepageSectionType { get }
 
-    // Layout section so FirefoxHomeViewController view controller can setup the section
+    // Layout section so HomepageViewController view controller can setup the section
     func section(for traitCollection: UITraitCollection, size: CGSize) -> NSCollectionLayoutSection
 
     func numberOfItemsInSection() -> Int
@@ -26,12 +26,6 @@ protocol HomepageViewModelProtocol {
 
     // Returns true when section has data and is enabled
     var shouldShow: Bool { get }
-
-    // Refresh data from adaptor to ensure it refresh the right state before laying itself out
-    func refreshData(for traitCollection: UITraitCollection,
-                     size: CGSize,
-                     isPortrait: Bool,
-                     device: UIUserInterfaceIdiom)
 
     // Update section that are privacy sensitive, only implement when needed
     func updatePrivacyConcernedSection(isPrivate: Bool)
@@ -52,11 +46,6 @@ extension HomepageViewModelProtocol {
     }
 
     func updatePrivacyConcernedSection(isPrivate: Bool) {}
-
-    func refreshData(for traitCollection: UITraitCollection,
-                     size: CGSize,
-                     isPortrait: Bool,
-                     device: UIUserInterfaceIdiom) {}
 
     func screenWasShown() {}
 }

--- a/firefox-ios/Client/Frontend/Home/HomepageViewModelProtocol.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewModelProtocol.swift
@@ -11,7 +11,11 @@ protocol HomepageViewModelProtocol {
     var sectionType: HomepageSectionType { get }
 
     // Layout section so HomepageViewController view controller can setup the section
-    func section(for traitCollection: UITraitCollection, size: CGSize) -> NSCollectionLayoutSection
+    func section(for traitCollection: UITraitCollection,
+                 size: CGSize,
+                 isPortrait: Bool,
+                 device: UIUserInterfaceIdiom
+    ) -> NSCollectionLayoutSection
 
     func numberOfItemsInSection() -> Int
 
@@ -39,6 +43,14 @@ protocol HomepageViewModelProtocol {
 }
 
 extension HomepageViewModelProtocol {
+    func section(for traitCollection: UITraitCollection,
+                 size: CGSize,
+                 isPortrait: Bool = UIWindow.isPortrait,
+                 device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom
+    ) -> NSCollectionLayoutSection {
+        section(for: traitCollection, size: size, isPortrait: isPortrait, device: device)
+    }
+
     var hasData: Bool { return true }
 
     var shouldShow: Bool {

--- a/firefox-ios/Client/Frontend/Home/JumpBackIn/JumpBackInSectionLayout.swift
+++ b/firefox-ios/Client/Frontend/Home/JumpBackIn/JumpBackInSectionLayout.swift
@@ -54,7 +54,7 @@ enum JumpBackInSectionLayout: Equatable {
 
     // The maximum number of items to display in the whole section
     func maxItemsToDisplay(hasAccount: Bool,
-                           device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom
+                           device: UIUserInterfaceIdiom
     ) -> JumpBackInDisplayGroupCount {
         return JumpBackInDisplayGroupCount(
             tabsCount: maxJumpBackInItemsToDisplay(device: device),

--- a/firefox-ios/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -99,8 +99,8 @@ class JumpBackInViewModel: FeatureFlaggable {
     }
 
     private func updateSectionLayout(for traitCollection: UITraitCollection,
-                                     isPortrait: Bool = UIWindow.isPortrait,
-                                     device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
+                                     isPortrait: Bool,
+                                     device: UIUserInterfaceIdiom) {
         let isPhoneInLandscape = device == .phone && !isPortrait
         let isPadInPortrait = device == .pad && isPortrait
         let isPadInLandscapeTwoThirdSplit = isPadInLandscapeSplit(split: 2/3, isPortrait: isPortrait, device: device)
@@ -315,8 +315,12 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
         return jumpBackInList.itemsToDisplay + (hasSyncedTab ? UX.maxDisplayedSyncedTabs : 0)
     }
 
-    func section(for traitCollection: UITraitCollection, size: CGSize) -> NSCollectionLayoutSection {
-        refreshData(for: traitCollection)
+    func section(for traitCollection: UITraitCollection,
+                 size: CGSize,
+                 isPortrait: Bool = UIWindow.isPortrait,
+                 device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom
+    ) -> NSCollectionLayoutSection {
+        refreshData(for: traitCollection, isPortrait: isPortrait, device: device)
 
         // Prepare section layout with refreshed data
         var section: NSCollectionLayoutSection
@@ -346,10 +350,13 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
     }
 
     /// Refresh our data set for jump back in, should only be called when we build the section layout
-    private func refreshData(for traitCollection: UITraitCollection) {
-        updateSectionLayout(for: traitCollection)
+    private func refreshData(for traitCollection: UITraitCollection,
+                             isPortrait: Bool,
+                             device: UIUserInterfaceIdiom) {
+        updateSectionLayout(for: traitCollection, isPortrait: isPortrait, device: device)
         let maxItemsToDisplay = sectionLayout.maxItemsToDisplay(
-            hasAccount: isSyncTabFeatureEnabled
+            hasAccount: isSyncTabFeatureEnabled,
+            device: device
         )
         refreshData(maxItemsToDisplay: maxItemsToDisplay)
     }

--- a/firefox-ios/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -316,6 +316,9 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
     }
 
     func section(for traitCollection: UITraitCollection, size: CGSize) -> NSCollectionLayoutSection {
+        refreshData(for: traitCollection)
+
+        // Prepare section layout with refreshed data
         var section: NSCollectionLayoutSection
         switch sectionLayout {
         case .compactSyncedTab, .compactJumpBackInAndSyncedTab:
@@ -342,25 +345,17 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
         return section
     }
 
-    var hasData: Bool {
-        return hasJumpBackIn || hasSyncedTab
-    }
-
-    func refreshData(for traitCollection: UITraitCollection,
-                     size: CGSize,
-                     isPortrait: Bool = UIWindow.isPortrait,
-                     device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
-        updateSectionLayout(for: traitCollection,
-                            isPortrait: isPortrait,
-                            device: device)
+    /// Refresh our data set for jump back in, should only be called when we build the section layout
+    private func refreshData(for traitCollection: UITraitCollection) {
+        updateSectionLayout(for: traitCollection)
         let maxItemsToDisplay = sectionLayout.maxItemsToDisplay(
-            hasAccount: isSyncTabFeatureEnabled,
-            device: device
+            hasAccount: isSyncTabFeatureEnabled
         )
         refreshData(maxItemsToDisplay: maxItemsToDisplay)
-        logger.log("JumpBackIn section shouldShow \(shouldShow)",
-                   level: .debug,
-                   category: .homepage)
+    }
+
+    var hasData: Bool {
+        return hasJumpBackIn || hasSyncedTab
     }
 
     func updatePrivacyConcernedSection(isPrivate: Bool) {

--- a/firefox-ios/Client/Frontend/Home/LogoHeader/HomeLogoHeaderViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/LogoHeader/HomeLogoHeaderViewModel.swift
@@ -31,7 +31,11 @@ extension HomeLogoHeaderViewModel: HomepageViewModelProtocol, FeatureFlaggable {
         return .emptyHeader
     }
 
-    func section(for traitCollection: UITraitCollection, size: CGSize) -> NSCollectionLayoutSection {
+    func section(for traitCollection: UITraitCollection,
+                 size: CGSize,
+                 isPortrait: Bool = UIWindow.isPortrait,
+                 device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom
+    ) -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
                                               heightDimension: .estimated(100))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)

--- a/firefox-ios/Client/Frontend/Home/MessageCard/HomepageMessageCardViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/MessageCard/HomepageMessageCardViewModel.swift
@@ -62,7 +62,11 @@ extension HomepageMessageCardViewModel: HomepageViewModelProtocol {
         return .messageCard
     }
 
-    func section(for traitCollection: UITraitCollection, size: CGSize) -> NSCollectionLayoutSection {
+    func section(for traitCollection: UITraitCollection,
+                 size: CGSize,
+                 isPortrait: Bool = UIWindow.isPortrait,
+                 device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom
+    ) -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
                                               heightDimension: .estimated(180))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)

--- a/firefox-ios/Client/Frontend/Home/Pocket/PocketViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/Pocket/PocketViewModel.swift
@@ -137,7 +137,11 @@ extension PocketViewModel: HomepageViewModelProtocol {
             textColor: textColor)
     }
 
-    func section(for traitCollection: UITraitCollection, size: CGSize) -> NSCollectionLayoutSection {
+    func section(for traitCollection: UITraitCollection,
+                 size: CGSize,
+                 isPortrait: Bool = UIWindow.isPortrait,
+                 device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom
+    ) -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1),
             heightDimension: .estimated(PocketStandardCell.UX.cellHeight)

--- a/firefox-ios/Client/Frontend/Home/RecentlySaved/RecentlySavedViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/RecentlySaved/RecentlySavedViewModel.swift
@@ -70,7 +70,11 @@ extension RecentlySavedViewModel: HomepageViewModelProtocol, FeatureFlaggable {
             textColor: textColor)
     }
 
-    func section(for traitCollection: UITraitCollection, size: CGSize) -> NSCollectionLayoutSection {
+    func section(for traitCollection: UITraitCollection,
+                 size: CGSize,
+                 isPortrait: Bool = UIWindow.isPortrait,
+                 device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom
+    ) -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .absolute(UX.cellWidth),
             heightDimension: .estimated(UX.cellHeight)

--- a/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -146,7 +146,11 @@ extension TopSitesViewModel: HomepageViewModelProtocol, FeatureFlaggable {
         return numberOfItems
     }
 
-    func section(for traitCollection: UITraitCollection, size: CGSize) -> NSCollectionLayoutSection {
+    func section(for traitCollection: UITraitCollection,
+                 size: CGSize,
+                 isPortrait: Bool = UIWindow.isPortrait,
+                 device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom
+    ) -> NSCollectionLayoutSection {
         let sectionDimension = refreshData(for: traitCollection, size: size)
 
         // Prepare section layout with refreshed data

--- a/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -147,6 +147,9 @@ extension TopSitesViewModel: HomepageViewModelProtocol, FeatureFlaggable {
     }
 
     func section(for traitCollection: UITraitCollection, size: CGSize) -> NSCollectionLayoutSection {
+        let sectionDimension = refreshData(for: traitCollection, size: size)
+
+        // Prepare section layout with refreshed data
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1),
             heightDimension: .estimated(UX.cellEstimatedSize.height)
@@ -158,10 +161,6 @@ extension TopSitesViewModel: HomepageViewModelProtocol, FeatureFlaggable {
             heightDimension: .estimated(UX.cellEstimatedSize.height)
         )
 
-        let interface = TopSitesUIInterface(trait: traitCollection, availableWidth: size.width)
-        let sectionDimension = dimensionManager.getSectionDimension(for: topSites,
-                                                                    numberOfRows: numberOfRows,
-                                                                    interface: interface)
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize,
                                                        subitem: item,
                                                        count: sectionDimension.numberOfTilesPerRow)
@@ -180,14 +179,8 @@ extension TopSitesViewModel: HomepageViewModelProtocol, FeatureFlaggable {
         return section
     }
 
-    var hasData: Bool {
-        return !topSites.isEmpty
-    }
-
-    func refreshData(for traitCollection: UITraitCollection,
-                     size: CGSize,
-                     isPortrait: Bool = UIWindow.isPortrait,
-                     device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
+    /// Refresh our data set for top sites, should only be called when we build the section layout
+    private func refreshData(for traitCollection: UITraitCollection, size: CGSize) -> TopSitesSectionDimension {
         let interface = TopSitesUIInterface(trait: traitCollection,
                                             availableWidth: size.width)
         let sectionDimension = dimensionManager.getSectionDimension(for: topSites,
@@ -199,6 +192,12 @@ extension TopSitesViewModel: HomepageViewModelProtocol, FeatureFlaggable {
             let range = numberOfItems..<unfilteredTopSites.count
             topSites.removeSubrange(range)
         }
+
+        return sectionDimension
+    }
+
+    var hasData: Bool {
+        return !topSites.isEmpty
     }
 
     func screenWasShown() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
@@ -350,7 +350,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         // Mock rotation to landscape
         let landscapeTrait = MockTraitCollection(verticalSizeClass: .compact).getTraitCollection()
-        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .phone)
+        _ = subject.section(for: landscapeTrait, size: iPhone14ScreenSize, isPortrait: false, device: .phone)
         XCTAssertEqual(subject.sectionLayout, .medium)
 
         // Go back to portrait

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
@@ -80,13 +80,15 @@ class JumpBackInViewModelTests: XCTestCase {
 
     func testMaxJumpBackInItemsToDisplay_compactJumpBackIn() async {
         let subject = createSubject()
+        let tab1 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
+        await adaptor.setRecentTabs(recentTabs: [tab1])
 
         // iPhone layout portrait
         let trait = MockTraitCollection(horizontalSizeClass: .compact).getTraitCollection()
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
+        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: false,
                                                                device: .phone)
         XCTAssertEqual(maxItems.tabsCount, 2)
@@ -103,7 +105,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
+        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .phone)
 
@@ -123,7 +125,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
+        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .phone)
 
@@ -143,7 +145,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .phone)
+        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .phone)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .phone)
 
@@ -163,7 +165,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .phone)
+        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .phone)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .phone)
 
@@ -183,7 +185,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .pad)
+        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .pad)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .pad)
 
@@ -203,7 +205,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .pad)
+        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .pad)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .pad)
 
@@ -223,7 +225,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .pad)
+        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .pad)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .pad)
 
@@ -243,7 +245,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let trait = MockTraitCollection(verticalSizeClass: .compact).getTraitCollection()
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
+        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .phone)
 
@@ -263,7 +265,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .pad)
+        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .pad)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .pad)
 
@@ -284,7 +286,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
+        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .phone)
 
@@ -303,7 +305,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .phone)
+        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .phone)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .phone)
 
@@ -322,7 +324,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .pad)
+        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .pad)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .pad)
 
@@ -341,18 +343,18 @@ class JumpBackInViewModelTests: XCTestCase {
         try? await Task.sleep(nanoseconds: sleepTime)
 
         // Start in portrait
-        let portraitTrait = MockTraitCollection(horizontalSizeClass: .compact).getTraitCollection()
+        let trait = MockTraitCollection(horizontalSizeClass: .compact).getTraitCollection()
 
-        subject.refreshData(for: portraitTrait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
+        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
         XCTAssertEqual(subject.sectionLayout, .compactJumpBackIn)
 
         // Mock rotation to landscape
         let landscapeTrait = MockTraitCollection(verticalSizeClass: .compact).getTraitCollection()
-        subject.refreshData(for: landscapeTrait, size: iPhone14ScreenSize, isPortrait: false, device: .phone)
+        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .phone)
         XCTAssertEqual(subject.sectionLayout, .medium)
 
         // Go back to portrait
-        subject.refreshData(for: portraitTrait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
+        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
         XCTAssertEqual(subject.sectionLayout, .compactJumpBackIn)
     }
 
@@ -382,7 +384,6 @@ class JumpBackInViewModelTests: XCTestCase {
         let subject = createSubject()
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        subject.refreshData(for: MockTraitCollection().getTraitCollection(), size: iPhone14ScreenSize)
 
         XCTAssertEqual(subject.jumpBackInList.tabs.count, 0)
         XCTAssertNil(subject.mostRecentSyncedTab)
@@ -392,9 +393,10 @@ class JumpBackInViewModelTests: XCTestCase {
         let subject = createSubject()
         let tab1 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
         await adaptor.setRecentTabs(recentTabs: [tab1])
+
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        subject.refreshData(for: MockTraitCollection().getTraitCollection(), size: iPhone14ScreenSize)
+        _ = subject.section(for: MockTraitCollection().getTraitCollection(), size: iPhone14ScreenSize)
 
         XCTAssertEqual(subject.jumpBackInList.tabs.count, 1)
         XCTAssertNil(subject.mostRecentSyncedTab)
@@ -406,7 +408,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        subject.refreshData(for: MockTraitCollection().getTraitCollection(), size: iPhone14ScreenSize)
+        _ = subject.section(for: MockTraitCollection().getTraitCollection(), size: iPhone14ScreenSize)
 
         XCTAssertEqual(subject.jumpBackInList.tabs.count, 0)
         XCTAssertNotNil(subject.mostRecentSyncedTab)
@@ -426,7 +428,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
+        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
 
         XCTAssertEqual(subject.sectionLayout, .compactJumpBackIn)
         let jumpBackIn = subject.jumpBackInList
@@ -446,7 +448,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
+        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
 
         XCTAssertEqual(subject.sectionLayout, .compactJumpBackIn)
         let jumpBackIn = subject.jumpBackInList
@@ -467,7 +469,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
+        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
 
         let jumpBackIn = subject.jumpBackInList
         XCTAssertEqual(jumpBackIn.tabs.count, 1, "iPhone portrait has 1 tab in it's jumpbackin layout")
@@ -492,7 +494,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .phone)
+        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .phone)
 
         let jumpBackIn = subject.jumpBackInList
         XCTAssertEqual(jumpBackIn.tabs.count, 3, "iPhone landscape has 3 tabs in it's jumpbackin layout, up until 4")
@@ -518,7 +520,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .phone)
+        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .phone)
 
         let jumpBackIn = subject.jumpBackInList
         XCTAssertEqual(jumpBackIn.tabs.count, 2, "iPhone landscape has 2 tabs in it's jumpbackin layout, up until 2")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8229)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18293)

## :bulb: Description
So the initial logic of having a `refreshData` function in our `HomepageViewModelProtocol` was to ensure the data was in sync and properly layout for the right device and trait collection in the top sites and jump back in sections. Turns out, this extra step can be included as part of the `func createLayout() -> UICollectionViewLayout` using `layoutEnvironment.container.effectiveContentSize` in the homepage view controller, reducing the chances the data gets out of sync while the collection view reloads its layout.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

