### PR TITLE
Remove [v124] Clean up unused sponsored pocket flag

### DIFF
--- a/firefox-ios/nimbus-features/homescreenFeature.yaml
+++ b/firefox-ios/nimbus-features/homescreenFeature.yaml
@@ -12,12 +12,6 @@ features:
             "jump-back-in": true,
             "recent-explorations": false,
           }
-      pocket-sponsored-stories:
-        description: >
-          This property defines whether pocket sponsored
-          stories appear on the homepage.
-        type: Boolean
-        default: false
       prefer-switch-to-open-tab:
         description: >
            Enables the feature to automatically switch to an existing tab
@@ -31,7 +25,6 @@ features:
             "jump-back-in": true,
             "recent-explorations": false,
           },
-          "pocket-sponsored-stories": true,
           "prefer-switch-to-open-tab": true
         }
       - channel: beta
@@ -40,7 +33,6 @@ features:
             "jump-back-in": true,
             "recent-explorations": false,
           },
-          "pocket-sponsored-stories": false,
           "prefer-switch-to-open-tab": false
         }
 


### PR DESCRIPTION
## :scroll: Tickets
No ticket

## :bulb: Description
Sponsored pocket was removed a while ago with https://github.com/mozilla-mobile/firefox-ios/pull/15180. Seems this is a leftover.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

