### PR TITLE
Add FXIOS-8241 [v124] Fix icon and set .inactive for synced tabs.

### DIFF
--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -306,9 +306,13 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         }
     }
 
-    func saveTabs(toProfile profile: Profile, _ tabs: [Tab]) {
+    func saveTabs(toProfile profile: Profile, _ tabs: [Tab], _ inactiveTabs: [Tab]) {
+        let inactiveTabs = Set(inactiveTabs)
         // It is possible that not all tabs have loaded yet, so we filter out tabs with a nil URL.
-        let storedTabs: [RemoteTab] = tabs.compactMap( Tab.toRemoteTab )
+        let storedTabs: [RemoteTab] = tabs.compactMap {
+            let inactive = inactiveTabs.contains($0)
+            return Tab.toRemoteTab($0, inactive: inactive)
+        }
 
         // Don't insert into the DB immediately. We tend to contend with more important
         // work like querying for top sites.

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -426,11 +426,12 @@ class Tab: NSObject, ThemeApplicable {
         )
     }
 
-    class func toRemoteTab(_ tab: Tab) -> RemoteTab? {
+    class func toRemoteTab(_ tab: Tab, inactive: Bool) -> RemoteTab? {
         if tab.isPrivate {
             return nil
         }
 
+        let icon = (tab.faviconURL ?? tab.pageMetadata?.faviconURL).flatMap { URL(string: $0) }
         if let displayURL = tab.url?.displayURL, RemoteTab.shouldIncludeURL(displayURL) {
             let history = Array(tab.historyList.filter(RemoteTab.shouldIncludeURL).reversed())
             return RemoteTab(
@@ -439,7 +440,8 @@ class Tab: NSObject, ThemeApplicable {
                 title: tab.title ?? tab.displayTitle,
                 history: history,
                 lastUsed: tab.lastExecutedTime ?? 0,
-                icon: nil
+                icon: icon,
+                inactive: inactive
             )
         } else if let sessionData = tab.sessionData, !sessionData.urls.isEmpty {
             let history = Array(sessionData.urls.filter(RemoteTab.shouldIncludeURL).reversed())
@@ -450,7 +452,8 @@ class Tab: NSObject, ThemeApplicable {
                     title: tab.title ?? tab.displayTitle,
                     history: history,
                     lastUsed: sessionData.lastUsedTime,
-                    icon: nil
+                    icon: icon,
+                    inactive: inactive
                 )
             }
         }
@@ -827,7 +830,7 @@ class Tab: NSObject, ThemeApplicable {
         if let title = self.webView?.title, !title.isEmpty,
            path == KVOConstants.title.rawValue {
             metadataManager?.updateObservationTitle(title)
-            _ = Tab.toRemoteTab(self)
+            _ = Tab.toRemoteTab(self, inactive: false)
         }
     }
 

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -285,7 +285,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
 
     /// storeChanges is called when a web view has finished loading a page
     override func storeChanges() {
-        saveTabs(toProfile: profile, normalTabs)
+        saveTabs(toProfile: profile, normalTabs, inactiveTabs)
         preserveTabs()
         saveCurrentTabSessionData()
     }

--- a/firefox-ios/Storage/RemoteTabs.swift
+++ b/firefox-ios/Storage/RemoteTabs.swift
@@ -31,6 +31,7 @@ public struct RemoteTab: Equatable {
     public let history: [Foundation.URL]
     public let lastUsed: Timestamp
     public let icon: Foundation.URL?
+    public let inactive: Bool
 
     public static func shouldIncludeURL(_ url: Foundation.URL) -> Bool {
         if InternalURL(url) != nil {
@@ -50,7 +51,8 @@ public struct RemoteTab: Equatable {
         title: String,
         history: [Foundation.URL],
         lastUsed: Timestamp,
-        icon: Foundation.URL?
+        icon: Foundation.URL?,
+        inactive: Bool
     ) {
         self.clientGUID = clientGUID
         self.URL = URL
@@ -58,6 +60,7 @@ public struct RemoteTab: Equatable {
         self.history = history
         self.lastUsed = lastUsed
         self.icon = icon
+        self.inactive = inactive
     }
 
     public func withClientGUID(_ clientGUID: String?) -> RemoteTab {
@@ -67,7 +70,8 @@ public struct RemoteTab: Equatable {
             title: title,
             history: history,
             lastUsed: lastUsed,
-            icon: icon
+            icon: icon,
+            inactive: inactive
         )
     }
 
@@ -77,7 +81,13 @@ public struct RemoteTab: Equatable {
 
         let icon = self.icon != nil ? self.icon?.absoluteString : nil
 
-        return RemoteTabRecord(title: self.title, urlHistory: history, icon: icon, lastUsed: Int64(self.lastUsed))
+        return RemoteTabRecord(
+            title: self.title,
+            urlHistory: history,
+            icon: icon,
+            lastUsed: Int64(self.lastUsed),
+            inactive: self.inactive
+        )
     }
 }
 
@@ -87,5 +97,6 @@ public func == (lhs: RemoteTab, rhs: RemoteTab) -> Bool {
         lhs.title == rhs.title &&
         lhs.history == rhs.history &&
         lhs.lastUsed == rhs.lastUsed &&
-        lhs.icon == rhs.icon
+        lhs.icon == rhs.icon &&
+        lhs.inactive == rhs.inactive
 }

--- a/firefox-ios/Storage/Rust/RustRemoteTabs.swift
+++ b/firefox-ios/Storage/Rust/RustRemoteTabs.swift
@@ -186,7 +186,8 @@ public extension RemoteTabRecord {
             title: self.title,
             history: history,
             lastUsed: Timestamp(self.lastUsed),
-            icon: icon
+            icon: icon,
+            inactive: self.inactive
         )
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInDataAdaptorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInDataAdaptorTests.swift
@@ -190,7 +190,8 @@ extension JumpBackInDataAdaptorTests {
                                 title: "Mozilla \(index)",
                                 history: [],
                                 lastUsed: UInt64(index),
-                                icon: nil)
+                                icon: nil,
+                                inactive: false)
             remoteTabs.append(tab)
         }
         return remoteTabs

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
@@ -610,7 +610,8 @@ extension JumpBackInViewModelTests {
                          title: "Mozilla 1",
                          history: [],
                          lastUsed: 1,
-                         icon: nil)
+                         icon: nil,
+                         inactive: false)
     }
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/LegacyRemoteTabsPanelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/LegacyRemoteTabsPanelTests.swift
@@ -124,7 +124,8 @@ private extension LegacyRemoteTabsPanelTests {
                           title: "Mozilla",
                           history: [],
                           lastUsed: 1,
-                          icon: nil)]
+                          icon: nil,
+                          inactive: false)]
     }
 
     func panelRefreshWithExpectation(panel: LegacyRemoteTabsPanel, completion: @escaping () -> Void) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/SearchViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/SearchViewControllerTests.swift
@@ -114,7 +114,8 @@ class SearchViewControllerTest: XCTestCase {
             title: "Mozilla 1",
             history: [],
             lastUsed: UInt64(1),
-            icon: nil
+            icon: nil,
+            inactive: false
         )
         let remoteTab2 = RemoteTab(
             clientGUID: "2",
@@ -122,7 +123,8 @@ class SearchViewControllerTest: XCTestCase {
             title: "Mozilla 2",
             history: [],
             lastUsed: UInt64(2),
-            icon: nil
+            icon: nil,
+            inactive: false
         )
         let remoteTab3 = RemoteTab(
             clientGUID: "3",
@@ -130,7 +132,8 @@ class SearchViewControllerTest: XCTestCase {
             title: "Mozilla 3",
             history: [],
             lastUsed: UInt64(3),
-            icon: nil
+            icon: nil,
+            inactive: false
         )
         searchViewController.remoteClientTabs = [ClientTabsSearchWrapper(client: remoteClient, tab: remoteTab1),
                                                  ClientTabsSearchWrapper(client: remoteClient, tab: remoteTab2),
@@ -148,7 +151,8 @@ class SearchViewControllerTest: XCTestCase {
             title: "Mozilla 1",
             history: [],
             lastUsed: UInt64(1),
-            icon: nil
+            icon: nil,
+            inactive: false
         )
         let remoteTab2 = RemoteTab(
             clientGUID: "2",
@@ -156,7 +160,8 @@ class SearchViewControllerTest: XCTestCase {
             title: "Mozilla 2",
             history: [],
             lastUsed: UInt64(2),
-            icon: nil
+            icon: nil,
+            inactive: false
         )
         let remoteTab3 = RemoteTab(
             clientGUID: "3",
@@ -164,7 +169,8 @@ class SearchViewControllerTest: XCTestCase {
             title: "Mozilla 3",
             history: [],
             lastUsed: UInt64(3),
-            icon: nil
+            icon: nil,
+            inactive: false
         )
         searchViewController.remoteClientTabs = [ClientTabsSearchWrapper(client: remoteClient, tab: remoteTab1),
                                                  ClientTabsSearchWrapper(client: remoteClient, tab: remoteTab2),

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/RemoteTabPanelStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/RemoteTabPanelStateTests.swift
@@ -75,13 +75,15 @@ final class RemoteTabPanelStateTests: XCTestCase {
                              title: "Mozilla Homepage",
                              history: [],
                              lastUsed: 0,
-                             icon: nil)
+                             icon: nil,
+                             inactive: false)
         let tab2 = RemoteTab(clientGUID: "123",
                              URL: URL(string: "https://google.com")!,
                              title: "Google Homepage",
                              history: [],
                              lastUsed: 0,
-                             icon: nil)
+                             icon: nil,
+                             inactive: false)
         let fakeTabs: [RemoteTab] = [tab1, tab2]
         let client = RemoteClient(guid: "123",
                                   name: "Client",

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/RemoteTabPanelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/RemoteTabPanelTests.swift
@@ -49,13 +49,15 @@ final class RemoteTabPanelTests: XCTestCase {
                              title: "Mozilla Homepage",
                              history: [],
                              lastUsed: 0,
-                             icon: nil)
+                             icon: nil,
+                             inactive: false)
         let tab2 = RemoteTab(clientGUID: "123",
                              URL: URL(string: "https://google.com")!,
                              title: "Google Homepage",
                              history: [],
                              lastUsed: 0,
-                             icon: nil)
+                             icon: nil,
+                             inactive: false)
         let fakeTabs: [RemoteTab] = [tab1, tab2]
         let client = RemoteClient(guid: "123",
                                   name: "Client",

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustRemoteTabsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustRemoteTabsTests.swift
@@ -16,7 +16,8 @@ class MockRustRemoteTabs: RustRemoteTabs {
                             title: title,
                             history: [URL(string: url)!],
                             lastUsed: Date.now(),
-                            icon: nil)
+                            icon: nil,
+                            inactive: false)
         let clientRemoteTab = ClientRemoteTabs(clientId: clientGUID,
                                                clientName: "testClient",
                                                deviceType: .mobile,
@@ -31,7 +32,8 @@ class MockRustRemoteTabs: RustRemoteTabs {
                              title: title2,
                              history: [URL(string: url2)!],
                              lastUsed: Date.now(),
-                             icon: nil)
+                             icon: nil,
+                             inactive: false)
 
         let clientRemoteTab2 = ClientRemoteTabs(clientId: clientGUID2,
                                                 clientName: "testClient2",
@@ -82,7 +84,8 @@ class RustRemoteTabsTests: XCTestCase {
             title: title,
             history: [URL(string: url)!],
             lastUsed: Date.now(),
-            icon: nil
+            icon: nil,
+            inactive: false
         )
 
         let count = tabs.setLocalTabs(localTabs: [tab])


### PR DESCRIPTION
Recent app-services added a new `inactive` boolean to tab payloads, with the default value being false. This should be true if the tab is shown in the browser as being one of the "inactive" tabs.

The intent is that desktop will start looking at this flag and treat inactive tabs differently, offering an experience closer to what the user sees re tabs on their mobile device.

Also started filling in the favicon for tabs when available. This doesn't seem to handle all tabs - eg, wikipedia still has nil as the favicon - but some tabs having an icon seems an incremental improvement to zero tabs having an icon.

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8241)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18316)

## :bulb: Description
As aboce.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

