### PR TITLE
Add FXIOS-8106 [v124] WKUIDelegate in WebEngine groundwork

### DIFF
--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -6,7 +6,7 @@ import Common
 import Foundation
 import WebKit
 
-class WKEngineSession: NSObject, EngineSession {
+class WKEngineSession: NSObject, EngineSession, WKUIDelegate {
     weak var delegate: EngineSessionDelegate?
     private(set) var webView: WKEngineWebView
     private var logger: Logger
@@ -34,9 +34,7 @@ class WKEngineSession: NSObject, EngineSession {
 
         self.setupObservers()
 
-        // TODO: FXIOS-8106 Add UI delegate
-//        webView.uiDelegate = self
-
+        webView.uiDelegate = self
         userScriptManager.injectUserScriptsIntoWebView(webView)
 
         // TODO: FXIOS-7901 #17646 Handle WKEngineSession tabDelegate
@@ -128,8 +126,7 @@ class WKEngineSession: NSObject, EngineSession {
 //        tabDelegate?.tab(self, willDeleteWebView: webView)
 
         webView.navigationDelegate = nil
-        // TODO: FXIOS-8106 Add UI delegate
-//        webView.uiDelegate = nil
+        webView.uiDelegate = nil
 
         webView.removeFromSuperview()
     }
@@ -184,5 +181,64 @@ class WKEngineSession: NSObject, EngineSession {
         case .URL:
             break
         }
+    }
+
+    // MARK: - WKUIDelegate
+
+    func webView(_ webView: WKWebView,
+                 createWebViewWith configuration: WKWebViewConfiguration,
+                 for navigationAction: WKNavigationAction,
+                 windowFeatures: WKWindowFeatures) -> WKWebView? {
+        // FXIOS-8243 - Handle popup windows with createWebViewWith in WebEngine (epic part 2)
+        return nil
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        runJavaScriptAlertPanelWithMessage message: String,
+        initiatedByFrame frame: WKFrameInfo,
+        completionHandler: @escaping () -> Void
+    ) {
+        // FXIOS-8244 - Handle Javascript panel messages in WebEngine (epic part 3)
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        runJavaScriptConfirmPanelWithMessage message: String,
+        initiatedByFrame frame: WKFrameInfo,
+        completionHandler: @escaping (Bool) -> Void
+    ) {
+        // FXIOS-8244 - Handle Javascript panel messages in WebEngine (epic part 3)
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        runJavaScriptTextInputPanelWithPrompt prompt: String,
+        defaultText: String?,
+        initiatedByFrame frame: WKFrameInfo,
+        completionHandler: @escaping (String?) -> Void
+    ) {
+        // FXIOS-8244 - Handle Javascript panel messages in WebEngine (epic part 3)
+    }
+
+    func webViewDidClose(_ webView: WKWebView) {
+        // FXIOS-8245 - Handle webViewDidClose in WebEngine (epic part 3)
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        contextMenuConfigurationForElement elementInfo: WKContextMenuElementInfo,
+        completionHandler: @escaping (UIContextMenuConfiguration?) -> Void
+    ) {
+        // FXIOS-8246 - Handle context menu in WebEngine (epic part 3)
+    }
+
+    @available(iOS 15, *)
+    func webView(_ webView: WKWebView,
+                 requestMediaCapturePermissionFor origin: WKSecurityOrigin,
+                 initiatedByFrame frame: WKFrameInfo,
+                 type: WKMediaCaptureType,
+                 decisionHandler: @escaping (WKPermissionDecision) -> Void) {
+        // FXIOS-8247 - Handle media capture in WebEngine (epic part 3)
     }
 }

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
@@ -15,6 +15,8 @@ protocol WKEngineWebViewDelegate: AnyObject {
 /// Abstraction on top of the `WKWebView`
 protocol WKEngineWebView: UIView {
     var navigationDelegate: WKNavigationDelegate? { get set }
+    var uiDelegate: WKUIDelegate? { get set }
+
     var allowsBackForwardNavigationGestures: Bool { get set }
     var allowsLinkPreview: Bool { get set }
     var backgroundColor: UIColor? { get set }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8106)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18038)

## :bulb: Description
Add the session to be a `WKUIDelegate`. Not doing much here, just creating a bunch of tasks and planning out how this will be implemented (either in part 2 or part 3 of this whole epic work).

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

