### PR TITLE
Bugix MTE-2184 [v124] Ensure password securefield available

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SyncFAUITests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SyncFAUITests.swift
@@ -76,6 +76,7 @@ class SyncUITests: BaseTestCase {
 
         // Enter invalid (too short, it should be at least 8 chars) and incorrect password
         userState.fxaPassword = "foo"
+        mozWaitForElementToExist(app.secureTextFields.element(boundBy: 0))
         navigator.performAction(Action.FxATypePassword)
         mozWaitForElementToExist(app.webViews.staticTexts["At least 8 characters"])
 
@@ -117,6 +118,7 @@ class SyncUITests: BaseTestCase {
         navigator.performAction(Action.FxATapOnContinueButton)
         // Typing on Password should show Show (password) option
         userState.fxaPassword = "f"
+        mozWaitForElementToExist(app.secureTextFields.element(boundBy: 0))
         navigator.performAction(Action.FxATypePassword)
         let passMessage = "Show password as plain text. Your password will be visible on screen."
         mozWaitForElementToExist(app.webViews.otherElements.buttons[passMessage], timeout: 3)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
`SyncFAUITests` from the full functional tests could fail intermittently because the password field has not been displayed yet. At a few other places in the tests when `Action.FxATypePassword` is called, a call to `mozWaitForElementToExist` ensures that the password field is displayed. Let's add this command to be consistent throughout the test.

Note: To be backported to `releases/v123`.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

