### PR TITLE
Bugfix FXIOS-8249 [v124] Fixed inconsistent UI in ShareTo extension

### DIFF
--- a/firefox-ios/Client/Frontend/DevicePickerTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/DevicePickerTableViewCell.swift
@@ -9,8 +9,12 @@ import Shared
 class DevicePickerTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
     private struct UX {
         static let deviceRowTextFont = UIFont.systemFont(ofSize: 16)
-        static let deviceRowTextPaddingLeft: CGFloat = 72
-        static let deviceRowTextPaddingRight: CGFloat = 50
+        static let deviceRowTextPaddingLeft: CGFloat = 60
+        static let deviceRowTextPaddingRight: CGFloat = 20
+        static let deviceRowTopMargin: CGFloat = 0
+        static let deviceRowLeadingMargin: CGFloat = 16
+        static let deviceRowBottomMargin: CGFloat = 0
+        static let deviceRowTrailingMargin: CGFloat = 0
     }
 
     private lazy var nameLabel: UILabel = .build { label in
@@ -59,6 +63,12 @@ class DevicePickerTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable 
     func configureCell(_ text: String, _ clientType: ClientType) {
         nameLabel.text = text
         self.clientType = clientType
+        directionalLayoutMargins = NSDirectionalEdgeInsets(
+            top: UX.deviceRowTopMargin,
+            leading: UX.deviceRowLeadingMargin,
+            bottom: UX.deviceRowBottomMargin,
+            trailing: UX.deviceRowTrailingMargin
+        )
     }
 
     required init(coder aDecoder: NSCoder) {
@@ -70,5 +80,7 @@ class DevicePickerTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable 
         nameLabel.textColor = colors.textPrimary
         imageView?.image = imageView?.image?.withRenderingMode(.alwaysTemplate)
         imageView?.tintColor = colors.textPrimary
+        backgroundColor = colors.layer2
+        tintColor = colors.textPrimary
     }
 }

--- a/firefox-ios/Client/Frontend/DevicePickerTableViewHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/DevicePickerTableViewHeaderCell.swift
@@ -45,5 +45,6 @@ class DevicePickerTableViewHeaderCell: UITableViewCell, ReusableCell, ThemeAppli
     func applyTheme(theme: Theme) {
         let colors = theme.colors
         nameLabel.textColor = colors.textSecondary
+        backgroundColor = colors.layer2
     }
 }

--- a/firefox-ios/Client/Frontend/Extensions/DevicePickerViewController.swift
+++ b/firefox-ios/Client/Frontend/Extensions/DevicePickerViewController.swift
@@ -53,7 +53,7 @@ class DevicePickerViewController: UITableViewController {
         static let deviceRowHeight: CGFloat = 50
         static let tabTitleTextFont = UIFont.boldSystemFont(ofSize: 16)
     }
-    
+
     private lazy var tabTitleLabel: UILabel = .build { label in
         label.font = UX.tabTitleTextFont
         label.textColor = self.themeManager.currentTheme.colors.textPrimary

--- a/firefox-ios/Client/Frontend/Extensions/DevicePickerViewController.swift
+++ b/firefox-ios/Client/Frontend/Extensions/DevicePickerViewController.swift
@@ -51,6 +51,12 @@ class DevicePickerViewController: UITableViewController {
     private struct UX {
         static let tableHeaderRowHeight: CGFloat = 50
         static let deviceRowHeight: CGFloat = 50
+        static let tabTitleTextFont = UIFont.boldSystemFont(ofSize: 16)
+    }
+    
+    private lazy var tabTitleLabel: UILabel = .build { label in
+        label.font = UX.tabTitleTextFont
+        label.textColor = self.themeManager.currentTheme.colors.textPrimary
     }
 
     private var devices = [RemoteDevice]()
@@ -79,7 +85,9 @@ class DevicePickerViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = .SendToTitle
+        let tabTitle = tabTitleLabel
+        tabTitle.text = .SendToTitle
+        navigationItem.titleView = tabTitle
         refreshControl = UIRefreshControl()
         refreshControl?.addTarget(self, action: #selector(refresh), for: .valueChanged)
         navigationItem.leftBarButtonItem = UIBarButtonItem(
@@ -98,6 +106,8 @@ class DevicePickerViewController: UITableViewController {
         tableView.tableFooterView = UIView(frame: .zero)
 
         tableView.allowsSelection = true
+        tableView.backgroundColor = themeManager.currentTheme.colors.layer2
+        tableView.separatorStyle = .none
 
         notification = NotificationCenter.default.addObserver(forName: Notification.Name.constellationStateUpdate,
                                                               object: nil,

--- a/firefox-ios/Extensions/ShareTo/ShareViewController.swift
+++ b/firefox-ios/Extensions/ShareTo/ShareViewController.swift
@@ -129,7 +129,9 @@ class ShareViewController: UIViewController {
     private func setupRows() {
         let pageInfoRow = makePageInfoRow(addTo: stackView)
         pageInfoRowTitleLabel = pageInfoRow.titleLabel
+        pageInfoRowTitleLabel?.textColor = themeManager.currentTheme.colors.textPrimary
         pageInfoRowUrlLabel = pageInfoRow.urlLabel
+        pageInfoRowUrlLabel?.textColor = themeManager.currentTheme.colors.textPrimary
         makeSeparator(addTo: stackView)
 
         if shareItem?.isUrlType() ?? true {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8249)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18331)

## :bulb: Description
Updated the UI so that the 2 ShareTo tabs are consistent with each other and to Firefox theme.
1. Styled the webpage name and url text in the menu tab with the theme color
2. Styled the tab title in the SendTo tab with the theme color
3. Styled the device list icon, text, and checkmark with the theme color
4. Styled the device list table and cell background with the theme color
5. Adjusted the left margin of the device list so that it is consistent with the menu list from the menu tab
6. Removed the row separators from the device list table so that it is consistent with the menu list

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

![image](https://github.com/mozilla-mobile/firefox-ios/assets/98071325/4898a0d8-4364-4ebf-a29d-dbec11d59be7)

