### PR TITLE
Bugfix FXIOS-8221 [v123] scroll to tab position

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
@@ -35,7 +35,7 @@ enum TabPanelAction: Action {
 
     // Middleware actions
     case didLoadTabPanel(TabDisplayModel)
-    case refreshTab([TabModel], Bool) // Response to all user actions involving tabs ex: add, close and close all tabs
+    case refreshTab(TabDisplayModel) // Response to all user actions involving tabs ex: add, close and close all tabs
     case refreshInactiveTabs([InactiveTabsModel])
 
     var windowUUID: UUID? {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
@@ -35,7 +35,7 @@ enum TabPanelAction: Action {
 
     // Middleware actions
     case didLoadTabPanel(TabDisplayModel)
-    case refreshTab([TabModel]) // Response to all user actions involving tabs ex: add, close and close all tabs
+    case refreshTab([TabModel], Bool) // Response to all user actions involving tabs ex: add, close and close all tabs
     case refreshInactiveTabs([InactiveTabsModel])
 
     var windowUUID: UUID? {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -28,7 +28,7 @@ class TabManagerMiddleware {
             store.dispatch(TabTrayAction.didLoadTabTray(tabTrayModel))
 
         case TabPanelAction.tabPanelDidLoad(let isPrivate):
-            let tabState = self.getTabsDisplayModel(for: isPrivate)
+            let tabState = self.getTabsDisplayModel(for: isPrivate, shouldScrollToTab: true)
             store.dispatch(TabPanelAction.didLoadTabPanel(tabState))
 
         case TabTrayAction.changePanel(let panelType):
@@ -122,14 +122,16 @@ class TabManagerMiddleware {
     /// Gets initial model for TabDisplay from `TabManager`, including list of tabs and inactive tabs.
     /// - Parameter isPrivateMode: if Private mode is enabled or not
     /// - Returns:  initial model for `TabDisplayPanel`
-    private func getTabsDisplayModel(for isPrivateMode: Bool) -> TabDisplayModel {
+    private func getTabsDisplayModel(for isPrivateMode: Bool,
+                                     shouldScrollToTab: Bool) -> TabDisplayModel {
         let tabs = refreshTabs(for: isPrivateMode)
         let inactiveTabs = refreshInactiveTabs(for: isPrivateMode)
         let tabDisplayModel = TabDisplayModel(isPrivateMode: isPrivateMode,
                                               tabs: tabs,
                                               normalTabsCount: normalTabsCountText,
                                               inactiveTabs: inactiveTabs,
-                                              isInactiveTabsExpanded: false)
+                                              isInactiveTabsExpanded: false,
+                                              shouldScrollToTab: shouldScrollToTab)
         return tabDisplayModel
     }
 
@@ -185,8 +187,8 @@ class TabManagerMiddleware {
         let tab = defaultTabManager.addTab(urlRequest, isPrivate: isPrivate)
         defaultTabManager.selectTab(tab)
 
-        let tabs = self.refreshTabs(for: isPrivate)
-        store.dispatch(TabPanelAction.refreshTab(tabs, true))
+        let model = getTabsDisplayModel(for: isPrivate, shouldScrollToTab: true)
+        store.dispatch(TabPanelAction.refreshTab(model))
         store.dispatch(TabTrayAction.dismissTabTray)
     }
 
@@ -205,8 +207,8 @@ class TabManagerMiddleware {
                                      value: .tabTray)
         defaultTabManager.moveTab(isPrivate: false, fromIndex: originIndex, toIndex: destinationIndex)
 
-        let tabs = self.refreshTabs(for: tabsState.isPrivateMode)
-        store.dispatch(TabPanelAction.refreshTab(tabs, false))
+        let model = getTabsDisplayModel(for: tabsState.isPrivateMode, shouldScrollToTab: false)
+        store.dispatch(TabPanelAction.refreshTab(model))
     }
 
     /// Async close single tab. If is the last tab the Tab Tray is dismissed and undo
@@ -226,7 +228,7 @@ class TabManagerMiddleware {
     private func closeTabFromTabPanel(with tabUUID: String) {
         Task {
             let shouldDismiss = await self.closeTab(with: tabUUID)
-            await self.triggerRefresh(with: shouldDismiss, shouldScrollToTab: false)
+            await self.triggerRefresh(shouldScrollToTab: false)
             if shouldDismiss {
                 store.dispatch(TabTrayAction.dismissTabTray)
                 store.dispatch(GeneralBrowserAction.showToast(.singleTab))
@@ -237,13 +239,11 @@ class TabManagerMiddleware {
     }
 
     /// Trigger refreshTabs action after a change in `TabManager`
-    /// - Parameter shouldDismiss: If Tab Tray should dismiss while refresh is done
     @MainActor
-    private func triggerRefresh(with shouldDismiss: Bool, shouldScrollToTab: Bool) {
+    private func triggerRefresh(shouldScrollToTab: Bool) {
         let isPrivate = defaultTabManager.selectedTab?.isPrivate ?? false
-        let tabs = self.refreshTabs(for: isPrivate)
-
-        store.dispatch(TabPanelAction.refreshTab(tabs, shouldScrollToTab))
+        let model = getTabsDisplayModel(for: isPrivate, shouldScrollToTab: shouldScrollToTab)
+        store.dispatch(TabPanelAction.refreshTab(model))
     }
 
     /// Handles undoing the close tab action, gets the backup tab from `TabManager`
@@ -254,8 +254,8 @@ class TabManagerMiddleware {
         else { return }
 
         defaultTabManager.undoCloseTab(tab: backupTab.tab, position: backupTab.restorePosition)
-        let tabs = self.refreshTabs(for: tabsState.isPrivateMode)
-        store.dispatch(TabPanelAction.refreshTab(tabs, false))
+        let model = getTabsDisplayModel(for: tabsState.isPrivateMode, shouldScrollToTab: false)
+        store.dispatch(TabPanelAction.refreshTab(model))
     }
 
     private func closeAllTabs(state: AppState) {
@@ -266,8 +266,8 @@ class TabManagerMiddleware {
             await defaultTabManager.removeAllTabs(isPrivateMode: tabsState.isPrivateMode)
 
             ensureMainThread { [self] in
-                let tabs = self.refreshTabs(for: tabsState.isPrivateMode)
-                store.dispatch(TabPanelAction.refreshTab(tabs, false))
+                let model = getTabsDisplayModel(for: tabsState.isPrivateMode, shouldScrollToTab: false)
+                store.dispatch(TabPanelAction.refreshTab(model))
                 store.dispatch(TabTrayAction.dismissTabTray)
                 store.dispatch(GeneralBrowserAction.showToast(.allTabs(count: count)))
             }
@@ -331,8 +331,8 @@ class TabManagerMiddleware {
 
     private func didTapLearnMoreAboutPrivate(with urlRequest: URLRequest) {
         addNewTab(with: urlRequest, isPrivate: true)
-        let tabs = self.refreshTabs(for: true)
-        store.dispatch(TabPanelAction.refreshTab(tabs, false))
+        let model = getTabsDisplayModel(for: true, shouldScrollToTab: false)
+        store.dispatch(TabPanelAction.refreshTab(model))
         store.dispatch(TabTrayAction.dismissTabTray)
     }
 
@@ -420,7 +420,7 @@ class TabManagerMiddleware {
     private func changePanel(_ panel: TabTrayPanelType) {
         self.trackPanelChange(panel)
         let isPrivate = panel == TabTrayPanelType.privateTabs
-        let tabState = self.getTabsDisplayModel(for: isPrivate)
+        let tabState = self.getTabsDisplayModel(for: isPrivate, shouldScrollToTab: false)
         if panel != .syncedTabs {
             store.dispatch(TabPanelAction.didLoadTabPanel(tabState))
         }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Models/TabDisplayModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Models/TabDisplayModel.swift
@@ -11,4 +11,5 @@ struct TabDisplayModel: Equatable {
     var inactiveTabs: [InactiveTabsModel]
     var isInactiveTabsExpanded: Bool
     var undoCloseType: ToastType?
+    var shouldScrollToTab: Bool
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
@@ -125,7 +125,7 @@ struct TabTrayState: ScreenState, Equatable {
         case TabPanelAction.refreshTab(let tabModel):
             // Only update the nomal tab count if the tabs being refreshed are not private
             let isPrivate = tabModel.tabs.first?.isPrivate ?? false
-            let tabCount = ""//tabModel.normalTabsCountText
+            let tabCount = tabModel.normalTabsCountText
             return TabTrayState(windowUUID: state.windowUUID,
                                 isPrivateMode: state.isPrivateMode,
                                 selectedPanel: state.selectedPanel,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
@@ -122,6 +122,14 @@ struct TabTrayState: ScreenState, Equatable {
                                 normalTabsCount: state.normalTabsCount,
                                 hasSyncableAccount: state.hasSyncableAccount,
                                 shareURL: shareURL)
+        case TabPanelAction.refreshTab(let tabModel, _):
+            // Only update the nomal tab count if the tabs being refreshed are not private
+            let isPrivate = tabModel.first?.isPrivate ?? false
+            let tabCount = isPrivate ? state.normalTabsCount : String(tabModel.count)
+            return TabTrayState(isPrivateMode: state.isPrivateMode,
+                                selectedPanel: state.selectedPanel,
+                                normalTabsCount: tabCount,
+                                hasSyncableAccount: state.hasSyncableAccount)
         default:
             return state
         }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
@@ -122,11 +122,12 @@ struct TabTrayState: ScreenState, Equatable {
                                 normalTabsCount: state.normalTabsCount,
                                 hasSyncableAccount: state.hasSyncableAccount,
                                 shareURL: shareURL)
-        case TabPanelAction.refreshTab(let tabModel, _):
+        case TabPanelAction.refreshTab(let tabModel):
             // Only update the nomal tab count if the tabs being refreshed are not private
-            let isPrivate = tabModel.first?.isPrivate ?? false
-            let tabCount = isPrivate ? state.normalTabsCount : String(tabModel.count)
-            return TabTrayState(isPrivateMode: state.isPrivateMode,
+            let isPrivate = tabModel.tabs.first?.isPrivate ?? false
+            let tabCount = ""//tabModel.normalTabsCountText
+            return TabTrayState(windowUUID: state.windowUUID,
+                                isPrivateMode: state.isPrivateMode,
                                 selectedPanel: state.selectedPanel,
                                 normalTabsCount: tabCount,
                                 hasSyncableAccount: state.hasSyncableAccount)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
@@ -125,7 +125,7 @@ struct TabTrayState: ScreenState, Equatable {
         case TabPanelAction.refreshTab(let tabModel):
             // Only update the nomal tab count if the tabs being refreshed are not private
             let isPrivate = tabModel.tabs.first?.isPrivate ?? false
-            let tabCount = tabModel.normalTabsCountText
+            let tabCount = tabModel.normalTabsCount
             return TabTrayState(windowUUID: state.windowUUID,
                                 isPrivateMode: state.isPrivateMode,
                                 selectedPanel: state.selectedPanel,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
@@ -110,9 +110,12 @@ struct TabsPanelState: ScreenState, Equatable {
                                   isPrivateMode: state.isPrivateMode,
                                   tabs: state.tabs,
                                   inactiveTabs: state.inactiveTabs,
-                                  isInactiveTabsExpanded: state.isInactiveTabsExpanded,
-                                  toastType: nil)
-        default: return state
+                                  isInactiveTabsExpanded: state.isInactiveTabsExpanded)
+        default: return TabsPanelState(isPrivateMode: state.isPrivateMode,
+                                       tabs: state.tabs,
+                                       inactiveTabs: state.inactiveTabs,
+                                       isInactiveTabsExpanded: state.isInactiveTabsExpanded)
+
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
@@ -75,14 +75,14 @@ struct TabsPanelState: ScreenState, Equatable {
                                   inactiveTabs: tabsModel.inactiveTabs,
                                   isInactiveTabsExpanded: tabsModel.isInactiveTabsExpanded,
                                   scrollToIndex: selectedTabIndex)
-        case TabPanelAction.refreshTab(let tabs, let scrollToTab):
+        case TabPanelAction.refreshTab(let tabModel):
             var selectedTabIndex: Int?
-            if scrollToTab {
-                selectedTabIndex = tabs.firstIndex(where: { $0.isSelected })
+            if tabModel.shouldScrollToTab {
+                selectedTabIndex = tabModel.tabs.firstIndex(where: { $0.isSelected })
             }
             return TabsPanelState(windowUUID: state.windowUUID,
                                   isPrivateMode: state.isPrivateMode,
-                                  tabs: tabs,
+                                  tabs: tabModel.tabs,
                                   inactiveTabs: state.inactiveTabs,
                                   isInactiveTabsExpanded: state.isInactiveTabsExpanded,
                                   scrollToIndex: selectedTabIndex)
@@ -111,7 +111,8 @@ struct TabsPanelState: ScreenState, Equatable {
                                   tabs: state.tabs,
                                   inactiveTabs: state.inactiveTabs,
                                   isInactiveTabsExpanded: state.isInactiveTabsExpanded)
-        default: return TabsPanelState(isPrivateMode: state.isPrivateMode,
+        default: return TabsPanelState(windowUUID: state.windowUUID,
+                                       isPrivateMode: state.isPrivateMode,
                                        tabs: state.tabs,
                                        inactiveTabs: state.inactiveTabs,
                                        isInactiveTabsExpanded: state.isInactiveTabsExpanded)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
@@ -115,7 +115,6 @@ struct TabsPanelState: ScreenState, Equatable {
                                        tabs: state.tabs,
                                        inactiveTabs: state.inactiveTabs,
                                        isInactiveTabsExpanded: state.isInactiveTabsExpanded)
-
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
@@ -12,6 +12,7 @@ struct TabsPanelState: ScreenState, Equatable {
     var isInactiveTabsExpanded: Bool
     var toastType: ToastType?
     var windowUUID: WindowUUID
+    var scrollToIndex: Int?
 
     var isPrivateTabsEmpty: Bool {
         guard isPrivateMode else { return false }
@@ -31,7 +32,8 @@ struct TabsPanelState: ScreenState, Equatable {
                   tabs: panelState.tabs,
                   inactiveTabs: panelState.inactiveTabs,
                   isInactiveTabsExpanded: panelState.isInactiveTabsExpanded,
-                  toastType: panelState.toastType)
+                  toastType: panelState.toastType,
+                  scrollToIndex: panelState.scrollToIndex)
     }
 
     init(windowUUID: WindowUUID, isPrivateMode: Bool = false) {
@@ -49,13 +51,15 @@ struct TabsPanelState: ScreenState, Equatable {
          tabs: [TabModel],
          inactiveTabs: [InactiveTabsModel],
          isInactiveTabsExpanded: Bool,
-         toastType: ToastType? = nil) {
+         toastType: ToastType? = nil,
+         scrollToIndex: Int? = nil) {
         self.isPrivateMode = isPrivateMode
         self.tabs = tabs
         self.inactiveTabs = inactiveTabs
         self.isInactiveTabsExpanded = isInactiveTabsExpanded
         self.toastType = toastType
         self.windowUUID = windowUUID
+        self.scrollToIndex = scrollToIndex
     }
 
     static let reducer: Reducer<Self> = { state, action in
@@ -64,17 +68,24 @@ struct TabsPanelState: ScreenState, Equatable {
 
         switch action {
         case TabPanelAction.didLoadTabPanel(let tabsModel):
+            let selectedTabIndex = tabsModel.tabs.firstIndex(where: { $0.isSelected })
             return TabsPanelState(windowUUID: state.windowUUID,
                                   isPrivateMode: tabsModel.isPrivateMode,
                                   tabs: tabsModel.tabs,
                                   inactiveTabs: tabsModel.inactiveTabs,
-                                  isInactiveTabsExpanded: tabsModel.isInactiveTabsExpanded)
-        case TabPanelAction.refreshTab(let tabs):
+                                  isInactiveTabsExpanded: tabsModel.isInactiveTabsExpanded,
+                                  scrollToIndex: selectedTabIndex)
+        case TabPanelAction.refreshTab(let tabs, let scrollToTab):
+            var selectedTabIndex: Int?
+            if scrollToTab {
+                selectedTabIndex = tabs.firstIndex(where: { $0.isSelected })
+            }
             return TabsPanelState(windowUUID: state.windowUUID,
                                   isPrivateMode: state.isPrivateMode,
                                   tabs: tabs,
                                   inactiveTabs: state.inactiveTabs,
-                                  isInactiveTabsExpanded: state.isInactiveTabsExpanded)
+                                  isInactiveTabsExpanded: state.isInactiveTabsExpanded,
+                                  scrollToIndex: selectedTabIndex)
         case TabPanelAction.toggleInactiveTabs:
             return TabsPanelState(windowUUID: state.windowUUID,
                                   isPrivateMode: state.isPrivateMode,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -77,6 +77,19 @@ class TabDisplayView: UIView,
     func newState(state: TabsPanelState) {
         tabsState = state
         collectionView.reloadData()
+
+        if let index = state.scrollToIndex {
+            scrollToTab(index)
+        }
+    }
+
+    private func scrollToTab(_ index: Int) {
+        let section = shouldHideInactiveTabs ? 0 : 1
+        let indexPath = IndexPath(row: index,
+                                  section: section)
+            collectionView.scrollToItem(at: indexPath,
+                                        at: .centeredVertically,
+                                        animated: false)
     }
 
     private func setupLayout() {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -89,7 +89,7 @@ class TabTrayViewController: UIViewController,
         label.font = TabsButton.UX.titleFont
         label.layer.cornerRadius = TabsButton.UX.cornerRadius
         label.textAlignment = .center
-        label.text = self.tabTrayState.normalTabsCount
+        label.text = "0"
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
@@ -273,6 +273,7 @@ class TabTrayViewController: UIViewController,
 
     func newState(state: TabTrayState) {
         tabTrayState = state
+        countLabel.text = self.tabTrayState.normalTabsCount
 
         if tabTrayState.shouldDismiss {
             delegate?.didFinish()

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -280,9 +280,6 @@ class TabTrayViewController: UIViewController,
         }
         if let url = tabTrayState.shareURL {
             navigationHandler?.shareTab(url: url, sourceView: self.view)
-
-            // Reload to clear the share sheet item
-            store.dispatch(TabTrayAction.tabTrayDidLoad(tabTrayState.selectedPanel))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -273,7 +273,7 @@ class TabTrayViewController: UIViewController,
 
     func newState(state: TabTrayState) {
         tabTrayState = state
-        countLabel.text = self.tabTrayState.normalTabsCount
+        updateTabCountImage(count: state.normalTabsCount)
 
         if tabTrayState.shouldDismiss {
             delegate?.didFinish()
@@ -281,6 +281,12 @@ class TabTrayViewController: UIViewController,
         if let url = tabTrayState.shareURL {
             navigationHandler?.shareTab(url: url, sourceView: self.view)
         }
+    }
+
+    func updateTabCountImage(count: String) {
+        countLabel.text = count
+        segmentedControl.setImage(TabTrayPanelType.tabs.image!.overlayWith(image: countLabel),
+                                  forSegmentAt: 0)
     }
 
     // MARK: Themeable

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabsPanelStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabsPanelStateTests.swift
@@ -30,7 +30,8 @@ final class TabPanelStateTests: XCTestCase {
                                               tabs: tabs,
                                               normalTabsCount: "\(tabs.count)",
                                               inactiveTabs: [InactiveTabsModel](),
-                                              isInactiveTabsExpanded: false)
+                                              isInactiveTabsExpanded: false,
+                                              shouldScrollToTab: false)
         let newState = reducer(initialState, TabPanelAction.didLoadTabPanel(tabDisplayModel))
         XCTAssertFalse(newState.tabs.isEmpty)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8221)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18264)

## :bulb: Description
Updates the tab tray to scroll to the active tab
Fixes the bug where the count on the segment control is not updated

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

