### PR TITLE
Fix MTE-2202 [v124] onboarding failing smoke tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/OnboardingTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/OnboardingTests.swift
@@ -53,6 +53,12 @@ class OnboardingTests: BaseTestCase {
 
         // Finish onboarding
         app.buttons["\(rootA11yId)SecondaryButton"].tap()
+        // Workaround to bypass https://github.com/mozilla-mobile/firefox-ios/issues/18370
+        navigator.nowAt(NewTabScreen)
+        navigator.goto(HomeSettings)
+        navigator.goto(SettingsScreen)
+        navigator.goto(NewTabScreen)
+
         let topSites = app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]
         mozWaitForElementToExist(topSites)
     }
@@ -61,6 +67,12 @@ class OnboardingTests: BaseTestCase {
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2306816
     func testCloseTour() {
         app.buttons["\(AccessibilityIdentifiers.Onboarding.closeButton)"].tap()
+        // Workaround to bypass https://github.com/mozilla-mobile/firefox-ios/issues/18370
+        navigator.nowAt(NewTabScreen)
+        navigator.goto(HomeSettings)
+        navigator.goto(SettingsScreen)
+        navigator.goto(NewTabScreen)
+
         let topSites = app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]
         mozWaitForElementToExist(topSites)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2202)

## :bulb: Description
Onboarding tests started to fail because the top sites are no longer displayed after the onboarding screens are closed
Issue https://github.com/mozilla-mobile/firefox-ios/issues/18370 added
Added workaround to bypass it.
