### PR TITLE
Bugfix FXIOS-8287 [v124] Settings page cannot be opened again

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -327,9 +327,10 @@ class BrowserCoordinator: BaseCoordinator,
         add(child: settingsCoordinator)
         settingsCoordinator.start(with: section)
 
-        router.present(navigationController) { [weak self] in
+        navigationController.onViewDismissed = { [weak self] in
             self?.didFinishSettings(from: settingsCoordinator)
         }
+        router.present(navigationController)
     }
 
     private func showLibrary(with homepanelSection: Route.HomepanelSection) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -614,8 +614,6 @@ final class BrowserCoordinatorTests: XCTestCase {
         mockRouter.savedCompletion?()
 
         XCTAssertTrue(result)
-        XCTAssertEqual(mockRouter.dismissCalled, 1)
-        XCTAssertTrue(subject.childCoordinators.isEmpty)
     }
 
     func testSettingsCoordinatorDelegate_openURLinNewTab() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8287)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18380)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

