### PR TITLE
Bugfix FXIOS-7751 [v124] Site Identity Lock Issue with Lock while switching open tabs

### DIFF
--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
@@ -28,7 +28,6 @@ protocol WKEngineWebView: UIView {
     var estimatedProgress: Double { get }
     var canGoBack: Bool { get }
     var canGoForward: Bool { get }
-    var hasOnlySecureContent: Bool { get }
 
     @available(iOS 16.4, *)
     var isInspectable: Bool { get set }

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
@@ -28,6 +28,7 @@ protocol WKEngineWebView: UIView {
     var estimatedProgress: Double { get }
     var canGoBack: Bool { get }
     var canGoForward: Bool { get }
+    var hasOnlySecureContent: Bool { get }
 
     @available(iOS 16.4, *)
     var isInspectable: Bool { get set }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -37,6 +37,7 @@ class BrowserViewController: UIViewController,
         .canGoForward,
         .URL,
         .title,
+        .hasOnlySecureContent
     ]
 
     weak var browserDelegate: BrowserDelegate?
@@ -1398,6 +1399,9 @@ class BrowserViewController: UIViewController,
                   let canGoForward = change?[.newKey] as? Bool
             else { break }
             navigationToolbar.updateForwardStatus(canGoForward)
+        case .hasOnlySecureContent:
+            urlBar.locationView.hasSecureContent = webView.hasOnlySecureContent
+            urlBar.locationView.showTrackingProtectionButton(for: webView.url)
         default:
             assertionFailure("Unhandled KVO key: \(keyPath ?? "nil")")
         }
@@ -1430,7 +1434,6 @@ class BrowserViewController: UIViewController,
                 isPrivate: tab.isPrivate)
         }
         urlBar.currentURL = tab.url?.displayURL
-        urlBar.locationView.tabDidChangeContentBlocking(tab)
         urlBar.locationView.updateShoppingButtonVisibility(for: tab)
         let isPage = tab.url?.displayURL?.isWebPage() ?? false
         navigationToolbar.updatePageStatus(isPage)
@@ -1660,10 +1663,6 @@ class BrowserViewController: UIViewController,
         guard let webView = tab.webView else { return }
 
         if let url = webView.url {
-            if tab === tabManager.selectedTab {
-                urlBar.locationView.tabDidChangeContentBlocking(tab)
-            }
-
             if (!InternalURL.isValid(url: url) || url.isReaderModeURL) && !url.isFileURL {
                 postLocationChangeNotificationForTab(tab, navigation: navigation)
                 tab.readabilityResult = nil

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -546,11 +546,12 @@ extension TabLocationView: TabEventHandler {
             self.blockerStatus = blocker.status
         }
     }
-    
+
     func tabDidGainFocus(_ tab: Tab) {
         guard let blocker = tab.contentBlocker else { return }
 
         ensureMainThread { [self] in
+            self.showTrackingProtectionButton(for: tab.webView?.url)
             self.hasSecureContent = (tab.webView?.hasOnlySecureContent ?? false)
             self.blockerStatus = blocker.status
         }

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -53,7 +53,7 @@ class TabLocationView: UIView, FeatureFlaggable {
 
     var hasSecureContent = false {
         didSet {
-            if oldValue != blockerStatus { setTrackingProtection() }
+            if oldValue != hasSecureContent { setTrackingProtection() }
         }
     }
 

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -396,20 +396,20 @@ class TabLocationView: UIView, FeatureFlaggable {
     }
 
     func showTrackingProtectionButton(for url: URL?) {
-            ensureMainThread {
-                let isValidHttpUrlProtocol = self.isValidHttpUrlProtocol(url)
-                if isValidHttpUrlProtocol, self.trackingProtectionButton.isHidden {
-                    self.trackingProtectionButton.transform = UX.trackingProtectionxOffset
-                    self.trackingProtectionButton.alpha = 0
-                    self.trackingProtectionButton.isHidden = false
-                    UIView.animate(withDuration: UX.trackingProtectionAnimationDuration) {
-                        self.trackingProtectionButton.alpha = 1
-                        self.trackingProtectionButton.transform = .identity
-                    }
+        ensureMainThread {
+            let isValidHttpUrlProtocol = self.isValidHttpUrlProtocol(url)
+            if isValidHttpUrlProtocol, self.trackingProtectionButton.isHidden {
+                self.trackingProtectionButton.transform = UX.trackingProtectionxOffset
+                self.trackingProtectionButton.alpha = 0
+                self.trackingProtectionButton.isHidden = false
+                UIView.animate(withDuration: UX.trackingProtectionAnimationDuration) {
+                    self.trackingProtectionButton.alpha = 1
+                    self.trackingProtectionButton.transform = .identity
                 }
-                self.trackingProtectionButton.isHidden = !isValidHttpUrlProtocol
             }
+            self.trackingProtectionButton.isHidden = !isValidHttpUrlProtocol
         }
+    }
 
     private func setTrackingProtection(themeManager: ThemeManager = AppContainer.shared.resolve()) {
         var lockImage: UIImage?

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -394,10 +394,20 @@ class TabLocationView: UIView, FeatureFlaggable {
     }
 
     func showTrackingProtectionButton(for url: URL?) {
-        ensureMainThread {
-            self.trackingProtectionButton.isHidden = !self.isValidHttpUrlProtocol(url)
+            ensureMainThread {
+                let isValidHttpUrlProtocol = self.isValidHttpUrlProtocol(url)
+                if isValidHttpUrlProtocol, self.trackingProtectionButton.isHidden {
+                    self.trackingProtectionButton.transform = CGAffineTransform(translationX: 25, y: 0)
+                    self.trackingProtectionButton.alpha = 0
+                    self.trackingProtectionButton.isHidden = false
+                    UIView.animate(withDuration: 0.3) {
+                        self.trackingProtectionButton.alpha = 1
+                        self.trackingProtectionButton.transform = .identity
+                    }
+                }
+                self.trackingProtectionButton.isHidden = !isValidHttpUrlProtocol
+            }
         }
-    }
 
     private func setTrackingProtection(themeManager: ThemeManager = AppContainer.shared.resolve()) {
         var lockImage: UIImage?

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -34,6 +34,8 @@ class TabLocationView: UIView, FeatureFlaggable {
         static let statusIconSize: CGFloat = 18
         static let buttonSize: CGFloat = 40
         static let urlBarPadding = 4
+        static let trackingProtectionAnimationDuration = 0.3
+        static let trackingProtectionxOffset = CGAffineTransform(translationX: 25, y: 0)
     }
 
     // MARK: Variables
@@ -397,10 +399,10 @@ class TabLocationView: UIView, FeatureFlaggable {
             ensureMainThread {
                 let isValidHttpUrlProtocol = self.isValidHttpUrlProtocol(url)
                 if isValidHttpUrlProtocol, self.trackingProtectionButton.isHidden {
-                    self.trackingProtectionButton.transform = CGAffineTransform(translationX: 25, y: 0)
+                    self.trackingProtectionButton.transform = UX.trackingProtectionxOffset
                     self.trackingProtectionButton.alpha = 0
                     self.trackingProtectionButton.isHidden = false
-                    UIView.animate(withDuration: 0.3) {
+                    UIView.animate(withDuration: UX.trackingProtectionAnimationDuration) {
                         self.trackingProtectionButton.alpha = 1
                         self.trackingProtectionButton.transform = .identity
                     }

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -517,6 +517,12 @@ class Tab: NSObject, ThemeApplicable {
                 options: .new,
                 context: nil
             )
+            self.webView?.addObserver(
+                self,
+                forKeyPath: KVOConstants.hasOnlySecureContent.rawValue,
+                options: .new,
+                context: nil
+            )
             UserScriptManager.shared.injectUserScriptsIntoWebView(
                 webView,
                 nightMode: nightMode,

--- a/firefox-ios/Shared/AppConstants.swift
+++ b/firefox-ios/Shared/AppConstants.swift
@@ -45,6 +45,7 @@ public enum KVOConstants: String {
     case canGoBack
     case canGoForward
     case contentSize
+    case hasOnlySecureContent
 }
 
 public struct KeychainKey {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7751)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17299)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
A recent observation revealed an issue related to the security status indicator, particularly in scenarios involving tab switching. The core of the problem lies in two aspects:

Initial Setting of 'hasSecureContent': The application initializes with 'hasSecureContent' set to false. This results in the security button displaying an unsecure connection at the outset.
Behaviour during Tab Switching: The function updateBlockerStatus(forTab:) is activated when switching tabs. However we will see the not secure state for a brief moment until tab.webView?.hasOnlySecureContent is interogated. This leads to a misleading indication of the security status.
By adding a KVO listener, the application can now detect changes in the webpage's security status in real-time. This enhancement ensures that the security button's status is updated accurately

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

