### PR TITLE
Add FXIOS-8179 [v124] OnTitle OnUrl WebEngine implementation

### DIFF
--- a/BrowserKit/Sources/Common/Extensions/URLExtension.swift
+++ b/BrowserKit/Sources/Common/Extensions/URLExtension.swift
@@ -240,6 +240,30 @@ extension URL {
 
         return results
     }
+
+    public var origin: String? {
+        guard isWebPage(includeDataURIs: false),
+              let hostPort = self.hostPort,
+              let scheme = scheme
+        else { return nil }
+
+        return "\(scheme)://\(hostPort)"
+    }
+
+    public var hostPort: String? {
+        if let host = self.host {
+            if let port = (self as NSURL).port?.int32Value {
+                return "\(host):\(port)"
+            }
+            return host
+        }
+        return nil
+    }
+
+    public func isWebPage(includeDataURIs: Bool = true) -> Bool {
+        let schemes = includeDataURIs ? ["http", "https", "data"] : ["http", "https"]
+        return scheme.map { schemes.contains($0) } ?? false
+    }
 }
 
 private struct ETLDEntry: CustomStringConvertible {

--- a/BrowserKit/Sources/WebEngine/EngineConstants.swift
+++ b/BrowserKit/Sources/WebEngine/EngineConstants.swift
@@ -4,9 +4,6 @@
 
 import Foundation
 
-/// Struct use to keep in memory the session data
-struct WKEngineSessionData {
-    var url: URL?
-    var lastRequest: URLRequest?
-    var title: String?
+struct EngineConstants {
+    static let aboutBlank = "about:blank"
 }

--- a/BrowserKit/Sources/WebEngine/EngineSessionDelegate.swift
+++ b/BrowserKit/Sources/WebEngine/EngineSessionDelegate.swift
@@ -12,8 +12,11 @@ public protocol EngineSessionDelegate: AnyObject {
     /// Event to indicate that this session has had a long press.
     func onLongPress(touchPoint: CGPoint)
 
-    /// Event to indicate the title has changed.
+    /// Event to indicate the title on the session has changed.
     func onTitleChange(title: String)
+
+    /// Event to indicate the URL on the session has changed.
+    func onLocationChange(url: String)
 
     /// Event to indicate the loading progress has been updated.
     func onProgress(progress: Double)

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -198,8 +198,8 @@ class WKEngineSession: NSObject, EngineSession, WKUIDelegate {
 
     private func handleURLChange() {
         // Special case for "about:blank" popups, if the webView.url is nil, keep the sessionData url as "about:blank"
-        guard sessionData.url?.absoluteString == EngineConstants.aboutBlank
-                && webView.url == nil else { return }
+        if sessionData.url?.absoluteString == EngineConstants.aboutBlank
+                && webView.url == nil { return }
 
         // To prevent spoofing, only change the URL immediately if the new URL is on
         // the same origin as the current URL. Otherwise, do nothing and wait for

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -10,7 +10,7 @@ class WKEngineSession: NSObject, EngineSession, WKUIDelegate {
     weak var delegate: EngineSessionDelegate?
     private(set) var webView: WKEngineWebView
     private var logger: Logger
-    private var sessionData: WKEngineSessionData
+    var sessionData: WKEngineSessionData
     private var contentScriptManager: WKContentScriptManager
 
     init?(userScriptManager: WKUserScriptManager,

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
@@ -22,6 +22,7 @@ protocol WKEngineWebView: UIView {
     var backgroundColor: UIColor? { get set }
     var interactionState: Any? { get set }
     var url: URL? { get }
+    var title: String? { get }
     var scrollView: UIScrollView { get }
     var engineConfiguration: WKEngineConfiguration { get }
 

--- a/BrowserKit/Tests/CommonTests/Extensions/URLExtensionTests.swift
+++ b/BrowserKit/Tests/CommonTests/Extensions/URLExtensionTests.swift
@@ -188,4 +188,56 @@ final class URLExtensionTests: XCTestCase {
 
         XCTAssertEqual(urlParams["a"], "%20")
     }
+
+    // MARK: isWebPage
+
+    // Laurie todo tests
+
+    func testisWebPage() {
+//        let goodurls = [
+//            "http://localhost:\(AppInfo.webserverPort)/reader-mode/page",
+//            "https://127.0.0.1:\(AppInfo.webserverPort)/sessionrestore.html",
+//            "data://:\(AppInfo.webserverPort)/sessionrestore.html"
+//        ]
+//        let badurls = [
+//            "about://google.com",
+//            "tel:6044044004",
+//            "hax://localhost:\(AppInfo.webserverPort)/about"
+//        ]
+//
+//        goodurls.forEach { XCTAssertTrue(URL(string: $0)!.isWebPage(), $0) }
+//        badurls.forEach { XCTAssertFalse(URL(string: $0)!.isWebPage(), $0) }
+    }
+
+    // MARK: Host port
+
+    func testhostPort() {
+        let urls = [
+            ("https://www.example.com", "www.example.com"),
+            ("https://user:pass@www.example.com", "www.example.com"),
+            ("http://localhost:6000/blah", "localhost:6000")
+        ]
+
+        let badurls = [
+            "blah",
+            "http://"
+        ]
+        urls.forEach { XCTAssertEqual(URL(string: $0.0)!.hostPort, $0.1) }
+        badurls.forEach { XCTAssertNil(URL(string: $0)!.hostPort) }
+    }
+
+    // MARK: Origin
+
+    func testorigin() {
+        let urls = [
+            ("https://www.example.com/index.html", "https://www.example.com"),
+            ("https://user:pass@m.foo.com/bar/baz?noo=abc#123", "https://m.foo.com"),
+        ]
+
+        let badurls = [
+            "data://google.com"
+        ]
+        urls.forEach { XCTAssertEqual(URL(string: $0.0)!.origin, $0.1) }
+        badurls.forEach { XCTAssertNil(URL(string: $0)!.origin) }
+    }
 }

--- a/BrowserKit/Tests/CommonTests/Extensions/URLExtensionTests.swift
+++ b/BrowserKit/Tests/CommonTests/Extensions/URLExtensionTests.swift
@@ -6,6 +6,8 @@ import XCTest
 @testable import Common
 
 final class URLExtensionTests: XCTestCase {
+    private var webServerPort = 1234
+
     func testNormalBaseDomainWithSingleSubdomain() {
         // TLD Entry: co.uk
         let url = URL(string: "http://a.bbc.co.uk")!
@@ -191,53 +193,82 @@ final class URLExtensionTests: XCTestCase {
 
     // MARK: isWebPage
 
-    // Laurie todo tests
+    func testIsWebPageGivenReaderModeURLThenisWebPage() {
+        let url = URL(string: "http://localhost:\(webServerPort)/reader-mode/page")!
+        XCTAssertTrue(url.isWebPage())
+    }
 
-    func testisWebPage() {
-//        let goodurls = [
-//            "http://localhost:\(AppInfo.webserverPort)/reader-mode/page",
-//            "https://127.0.0.1:\(AppInfo.webserverPort)/sessionrestore.html",
-//            "data://:\(AppInfo.webserverPort)/sessionrestore.html"
-//        ]
-//        let badurls = [
-//            "about://google.com",
-//            "tel:6044044004",
-//            "hax://localhost:\(AppInfo.webserverPort)/about"
-//        ]
-//
-//        goodurls.forEach { XCTAssertTrue(URL(string: $0)!.isWebPage(), $0) }
-//        badurls.forEach { XCTAssertFalse(URL(string: $0)!.isWebPage(), $0) }
+    func testIsWebPageGivenSessionRestoreHTMLThenisWebPage() {
+        let url = URL(string: "https://127.0.0.1:\(webServerPort)/sessionrestore.html")!
+        XCTAssertTrue(url.isWebPage())
+    }
+
+    func testIsWebPageGivenDataSessionRestoreThenisWebPage() {
+        let url = URL(string: "data://:\(webServerPort)/sessionrestore.html")!
+        XCTAssertTrue(url.isWebPage())
+    }
+
+    func testIsWebPageGivenAboutURLThenisNotWebPage() {
+        let url = URL(string: "about://google.com")!
+        XCTAssertFalse(url.isWebPage())
+    }
+
+    func testIsWebPageGivenTelURLThenisNotWebPage() {
+        let url = URL(string: "tel:6044044004")!
+        XCTAssertFalse(url.isWebPage())
+    }
+
+    func testIsWebPageGivenLocalHostURLThenisNotWebPage() {
+        let url = URL(string: "hax://localhost:\(webServerPort)/about")!
+        XCTAssertFalse(url.isWebPage())
     }
 
     // MARK: Host port
 
-    func testhostPort() {
-        let urls = [
-            ("https://www.example.com", "www.example.com"),
-            ("https://user:pass@www.example.com", "www.example.com"),
-            ("http://localhost:6000/blah", "localhost:6000")
-        ]
+    func testHostPortGivenExampleHostThenIsEqual() {
+        let givenURL = URL(string: "https://www.example.com")!
+        XCTAssertEqual(givenURL.hostPort, "www.example.com")
+    }
 
-        let badurls = [
-            "blah",
-            "http://"
-        ]
-        urls.forEach { XCTAssertEqual(URL(string: $0.0)!.hostPort, $0.1) }
-        badurls.forEach { XCTAssertNil(URL(string: $0)!.hostPort) }
+    func testHostPortGivenUserPassHostThenIsEqual() {
+        let givenURL = URL(string: "https://user:pass@www.example.com")!
+        XCTAssertEqual(givenURL.hostPort, "www.example.com")
+    }
+
+    func testHostPortGivenLocalHostThenIsEqual() {
+        let givenURL = URL(string: "http://localhost:6000/blah")!
+        XCTAssertEqual(givenURL.hostPort, "localhost:6000")
+    }
+
+    func testHostPortGivenBlahURLThenIsNil() {
+        let givenURL = URL(string: "blah")!
+        XCTAssertNil(givenURL.hostPort)
+    }
+
+    func testHostPortGivenEmptyURLThenIsNil() {
+        let givenURL = URL(string: "http://")!
+        XCTAssertNil(givenURL.hostPort)
     }
 
     // MARK: Origin
 
-    func testorigin() {
-        let urls = [
-            ("https://www.example.com/index.html", "https://www.example.com"),
-            ("https://user:pass@m.foo.com/bar/baz?noo=abc#123", "https://m.foo.com"),
-        ]
+    func testOriginGivenExampleIndexURLThenOriginIsExample() {
+        let givenURL = URL(string: "https://www.example.com/index.html")!
+        XCTAssertEqual(givenURL.origin, "https://www.example.com")
 
         let badurls = [
             "data://google.com"
         ]
-        urls.forEach { XCTAssertEqual(URL(string: $0.0)!.origin, $0.1) }
         badurls.forEach { XCTAssertNil(URL(string: $0)!.origin) }
+    }
+
+    func testOriginGivenUserPassURLThenOriginIsFoo() {
+        let givenURL = URL(string: "https://user:pass@m.foo.com/bar/baz?noo=abc#123")!
+        XCTAssertEqual(givenURL.origin, "https://m.foo.com")
+    }
+
+    func testOriginGivenDataURLThenOriginIsNil() {
+        let givenURL = URL(string: "data://google.com")!
+        XCTAssertNil(givenURL.origin)
     }
 }

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockEngineSessionDelegate.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockEngineSessionDelegate.swift
@@ -12,11 +12,13 @@ class MockEngineSessionDelegate: EngineSessionDelegate {
     var onProgressCalled = 0
     var onNavigationStateChangeCalled = 0
     var onLoadingStateChangeCalled = 0
+    var onLocationChangedCalled = 0
 
     var savedScrollX: Int?
     var savedScrollY: Int?
     var savedTouchPoint: CGPoint?
     var savedTitleChange: String?
+    var savedURL: String?
     var savedProgressValue: Double?
     var savedCanGoBack: Bool?
     var savedCanGoForward: Bool?
@@ -36,6 +38,11 @@ class MockEngineSessionDelegate: EngineSessionDelegate {
     func onTitleChange(title: String) {
         onTitleChangeCalled += 1
         savedTitleChange = title
+    }
+
+    func onLocationChange(url: String) {
+        onLocationChangedCalled += 1
+        savedURL = url
     }
 
     func onProgress(progress: Double) {

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebView.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebView.swift
@@ -13,6 +13,7 @@ class MockWKEngineWebView: UIView, WKEngineWebView {
     var interactionState: Any?
     var scrollView = UIScrollView()
     var url: URL?
+    var title: String?
     var allowsBackForwardNavigationGestures = true
     var allowsLinkPreview = true
     var isInspectable = true

--- a/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
@@ -290,6 +290,7 @@ final class WKEngineSessionTests: XCTestCase {
 
         XCTAssertNil(subject?.sessionData.title)
         XCTAssertEqual(engineSessionDelegate.onTitleChangeCalled, 0)
+        prepareForTearDown(subject!)
     }
 
     func testTitleChangeGivenATitleThenCallsDelegate() {
@@ -305,6 +306,21 @@ final class WKEngineSessionTests: XCTestCase {
 
         XCTAssertEqual(subject?.sessionData.title, expectedTitle)
         XCTAssertEqual(engineSessionDelegate.onTitleChangeCalled, 1)
+        prepareForTearDown(subject!)
+    }
+
+    func testURLChangeGivenNilURLThenDoesntCallDelegate() {
+        let subject = createSubject()
+        webViewProvider.webView.title = nil
+
+        subject?.observeValue(forKeyPath: "URL",
+                              of: nil,
+                              change: nil,
+                              context: nil)
+
+        XCTAssertNil(subject?.sessionData.url)
+        XCTAssertEqual(engineSessionDelegate.onLoadingStateChangeCalled, 0)
+        prepareForTearDown(subject!)
     }
 
     func testURLChangeGivenAboutBlankWithNilURLThenDoesntCallDelegate() {
@@ -317,8 +333,8 @@ final class WKEngineSessionTests: XCTestCase {
                               change: nil,
                               context: nil)
 
-        XCTAssertNil(subject?.sessionData.url)
         XCTAssertEqual(engineSessionDelegate.onLoadingStateChangeCalled, 0)
+        prepareForTearDown(subject!)
     }
 
     func testURLChangeGivenNotTheSameOriginThenDoesntCallDelegate() {
@@ -331,24 +347,42 @@ final class WKEngineSessionTests: XCTestCase {
                               change: nil,
                               context: nil)
 
-        XCTAssertNil(subject?.sessionData.url)
         XCTAssertEqual(engineSessionDelegate.onLoadingStateChangeCalled, 0)
+        prepareForTearDown(subject!)
     }
 
     func testURLChangeGivenAboutBlankWithURLThenCallsDelegate() {
+        let aboutBlankURL = URL(string: "about:blank")!
         let subject = createSubject()
-        subject?.sessionData.url = URL(string: "about:blank")!
-        webViewProvider.webView.title = "Webview title"
-        let expectedURL = URL(string: "www.example.com")!
-        webViewProvider.webView.url = expectedURL
+        subject?.delegate = engineSessionDelegate
+        subject?.sessionData.url = aboutBlankURL
+        webViewProvider.webView.url = aboutBlankURL
 
         subject?.observeValue(forKeyPath: "URL",
                               of: nil,
                               change: nil,
                               context: nil)
 
-        XCTAssertEqual(subject?.sessionData.url, expectedURL)
-        XCTAssertEqual(engineSessionDelegate.onLoadingStateChangeCalled, 1)
+        XCTAssertEqual(subject?.sessionData.url, aboutBlankURL)
+        XCTAssertEqual(engineSessionDelegate.onLocationChangedCalled, 1)
+        prepareForTearDown(subject!)
+    }
+
+    func testURLChangeGivenLoadedURLWithURLThenCallsDelegate() {
+        let loadedURL = URL(string: "www.example.com")!
+        let subject = createSubject()
+        subject?.delegate = engineSessionDelegate
+        subject?.sessionData.url = loadedURL
+        webViewProvider.webView.url = loadedURL
+
+        subject?.observeValue(forKeyPath: "URL",
+                              of: nil,
+                              change: nil,
+                              context: nil)
+
+        XCTAssertEqual(subject?.sessionData.url, loadedURL)
+        XCTAssertEqual(engineSessionDelegate.onLocationChangedCalled, 1)
+        prepareForTearDown(subject!)
     }
 
     // MARK: User script manager

--- a/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
@@ -278,6 +278,79 @@ final class WKEngineSessionTests: XCTestCase {
         prepareForTearDown(subject!)
     }
 
+    func testTitleChangeGivenEmptyTitleThenDoesntCallDelegate() {
+        let subject = createSubject()
+        subject?.delegate = engineSessionDelegate
+        webViewProvider.webView.title = nil
+
+        subject?.observeValue(forKeyPath: "title",
+                              of: nil,
+                              change: nil,
+                              context: nil)
+
+        XCTAssertNil(subject?.sessionData.title)
+        XCTAssertEqual(engineSessionDelegate.onTitleChangeCalled, 0)
+    }
+
+    func testTitleChangeGivenATitleThenCallsDelegate() {
+        let expectedTitle = "Webview title"
+        let subject = createSubject()
+        subject?.delegate = engineSessionDelegate
+        webViewProvider.webView.title = expectedTitle
+
+        subject?.observeValue(forKeyPath: "title",
+                              of: nil,
+                              change: nil,
+                              context: nil)
+
+        XCTAssertEqual(subject?.sessionData.title, expectedTitle)
+        XCTAssertEqual(engineSessionDelegate.onTitleChangeCalled, 1)
+    }
+
+    func testURLChangeGivenAboutBlankWithNilURLThenDoesntCallDelegate() {
+        let subject = createSubject()
+        subject?.sessionData.url = URL(string: "about:blank")!
+        webViewProvider.webView.title = nil
+
+        subject?.observeValue(forKeyPath: "URL",
+                              of: nil,
+                              change: nil,
+                              context: nil)
+
+        XCTAssertNil(subject?.sessionData.url)
+        XCTAssertEqual(engineSessionDelegate.onLoadingStateChangeCalled, 0)
+    }
+
+    func testURLChangeGivenNotTheSameOriginThenDoesntCallDelegate() {
+        let subject = createSubject()
+        subject?.sessionData.url = URL(string: "www.example.com/path1")!
+        webViewProvider.webView.url = URL(string: "www.anotherWebsite.com/path2")!
+
+        subject?.observeValue(forKeyPath: "URL",
+                              of: nil,
+                              change: nil,
+                              context: nil)
+
+        XCTAssertNil(subject?.sessionData.url)
+        XCTAssertEqual(engineSessionDelegate.onLoadingStateChangeCalled, 0)
+    }
+
+    func testURLChangeGivenAboutBlankWithURLThenCallsDelegate() {
+        let subject = createSubject()
+        subject?.sessionData.url = URL(string: "about:blank")!
+        webViewProvider.webView.title = "Webview title"
+        let expectedURL = URL(string: "www.example.com")!
+        webViewProvider.webView.url = expectedURL
+
+        subject?.observeValue(forKeyPath: "URL",
+                              of: nil,
+                              change: nil,
+                              context: nil)
+
+        XCTAssertEqual(subject?.sessionData.url, expectedURL)
+        XCTAssertEqual(engineSessionDelegate.onLoadingStateChangeCalled, 1)
+    }
+
     // MARK: User script manager
 
     func testUserScriptWhenSubjectCreatedThenInjectionIntoWebviewCalled() {

--- a/SampleBrowser/SampleBrowser/UI/Browser/BrowserViewController.swift
+++ b/SampleBrowser/SampleBrowser/UI/Browser/BrowserViewController.swift
@@ -6,6 +6,7 @@ import UIKit
 import WebEngine
 
 protocol NavigationDelegate: AnyObject {
+    func onURLChange(url: String)
     func onLoadingStateChange(loading: Bool)
     func onNavigationStateChange(canGoBack: Bool, canGoForward: Bool)
 }
@@ -118,7 +119,11 @@ class BrowserViewController: UIViewController, EngineSessionDelegate {
     }
 
     func onTitleChange(title: String) {
-        // Handle onTitle and onURL changes with FXIOS-8179
+        // If the Client needs to save a title like saving it inside some tab storage then it would do it here
+    }
+
+    func onLocationChange(url: String) {
+        navigationDelegate?.onURLChange(url: url)
     }
 
     func onLoadingStateChange(loading: Bool) {

--- a/SampleBrowser/SampleBrowser/UI/RootViewController.swift
+++ b/SampleBrowser/SampleBrowser/UI/RootViewController.swift
@@ -143,6 +143,10 @@ class RootViewController: UIViewController,
         toolbar.updateBackForwardButtons(canGoBack: canGoBack, canGoForward: canGoForward)
     }
 
+    func onURLChange(url: String) {
+        searchBar.setSearchBarText(url)
+    }
+
     // MARK: - SearchBarDelegate
 
     func searchSuggestions(searchTerm: String) {

--- a/firefox-ios/Shared/Extensions/URLExtensions.swift
+++ b/firefox-ios/Shared/Extensions/URLExtensions.swift
@@ -119,25 +119,6 @@ extension URL {
         return components.url!
     }
 
-    public var hostPort: String? {
-        if let host = self.host {
-            if let port = (self as NSURL).port?.int32Value {
-                return "\(host):\(port)"
-            }
-            return host
-        }
-        return nil
-    }
-
-    public var origin: String? {
-        guard isWebPage(includeDataURIs: false),
-              let hostPort = self.hostPort,
-              let scheme = scheme
-        else { return nil }
-
-        return "\(scheme)://\(hostPort)"
-    }
-
     /// String suitable for displaying outside of the app, for example in notifications, were Data Detectors will
     /// linkify the text and make it into a openable-in-Safari link.
     public var absoluteDisplayExternalString: String {
@@ -170,11 +151,6 @@ extension URL {
         }
 
         return nil
-    }
-
-    public func isWebPage(includeDataURIs: Bool = true) -> Bool {
-        let schemes = includeDataURIs ? ["http", "https", "data"] : ["http", "https"]
-        return scheme.map { schemes.contains($0) } ?? false
     }
 
     /**

--- a/firefox-ios/firefox-ios-tests/Tests/SharedTests/NSURLExtensionsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/SharedTests/NSURLExtensionsTests.swift
@@ -194,22 +194,6 @@ class NSURLExtensionsTests: XCTestCase {
         badurls.forEach { XCTAssertFalse(URL(string: $0)!.schemeIsValid, $0) }
     }
 
-    func testisWebPage() {
-        let goodurls = [
-            "http://localhost:\(AppInfo.webserverPort)/reader-mode/page",
-            "https://127.0.0.1:\(AppInfo.webserverPort)/sessionrestore.html",
-            "data://:\(AppInfo.webserverPort)/sessionrestore.html"
-        ]
-        let badurls = [
-            "about://google.com",
-            "tel:6044044004",
-            "hax://localhost:\(AppInfo.webserverPort)/about"
-        ]
-
-        goodurls.forEach { XCTAssertTrue(URL(string: $0)!.isWebPage(), $0) }
-        badurls.forEach { XCTAssertFalse(URL(string: $0)!.isWebPage(), $0) }
-    }
-
     func testdisplayURL() {
         let goodurls = [
             ("http://localhost:\(AppInfo.webserverPort)/reader-mode/page?url=https%3A%2F%2Fen%2Em%2Ewikipedia%2Eorg%2Fwiki%2F",
@@ -230,34 +214,6 @@ class NSURLExtensionsTests: XCTestCase {
 
         goodurls.forEach { XCTAssertEqual(URL(string: $0.0)!.displayURL?.absoluteString, $0.1) }
         badurls.forEach { XCTAssertNil(URL(string: $0)!.displayURL) }
-    }
-
-    func testorigin() {
-        let urls = [
-            ("https://www.example.com/index.html", "https://www.example.com"),
-            ("https://user:pass@m.foo.com/bar/baz?noo=abc#123", "https://m.foo.com"),
-        ]
-
-        let badurls = [
-            "data://google.com"
-        ]
-        urls.forEach { XCTAssertEqual(URL(string: $0.0)!.origin, $0.1) }
-        badurls.forEach { XCTAssertNil(URL(string: $0)!.origin) }
-    }
-
-    func testhostPort() {
-        let urls = [
-            ("https://www.example.com", "www.example.com"),
-            ("https://user:pass@www.example.com", "www.example.com"),
-            ("http://localhost:6000/blah", "localhost:6000")
-        ]
-
-        let badurls = [
-            "blah",
-            "http://"
-        ]
-        urls.forEach { XCTAssertEqual(URL(string: $0.0)!.hostPort, $0.1) }
-        badurls.forEach { XCTAssertNil(URL(string: $0)!.hostPort) }
     }
 
     func testwithQueryParams() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8179)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18190)

## :bulb: Description
- Move some URL extension and their related tests to be in Common package. Improved those tests while at it.
- Implement `onLocationChange` and `onTitleChange` in WebEngine. Those two delegate calls are triggered when there's respectively a URL change, or a title change on the web view. The `EngineSessionDelegate` is then triggered, so the Client can properly adjust to any URL or title change in a web view.
- `handleURL` and `handleTitleChange` function implementation in the web engine session are based on what currently exists under [BrowserViewController.observeValue](https://github.com/mozilla-mobile/firefox-ios/blob/efa6554570ed2710eddbe110128a85cd31154d31/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift#L1363-L1390) so the "same" functionality is moved inside the WebEngine. Untangling one bit at a time what should be in the WebEngine, and what should be the Client responsibility.
- The SampleBrowser application now implements the `onLocationChange` delegate call to update the URL bar text. See video:

https://github.com/mozilla-mobile/firefox-ios/assets/11338480/927a13f0-2cd3-4337-a79a-790008393dca

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

