### PR TITLE
Bugfix FXIOS-8281 [v122.1] Fix bug with Felt Privacy experiment & theming

### DIFF
--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -340,6 +340,8 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
 
             if featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly) {
                 store.dispatch(PrivateModeUserAction.setPrivateModeTo(tab.isPrivate))
+            } else {
+                store.dispatch(PrivateModeUserAction.setPrivateModeTo(false))
             }
 
             didSelectTab(url)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8281)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18374)

## :bulb: Description
Basically, this should turn the "private mode" stuff off, when the feature flag is disabled. This is an edge caseish bug that happens only in a very specific circumstance with experiments - you must be in private mode, while an experiment is on, and then the experiment must turn off, and you must restart the app so the new configuration gets applied, before you leave private mode.

The, full, correct solution for this bug is actually to inject the feature flag manager into `DefaultThemeManager` so that we can check, in `isPrivateModeOn` whether the feature flag is enabled, but this **really** complicates things, given that the manager is initialized quite a bit before Nimbus and needs to be constantly updated with Nimbus's newest value. So, I've opted for a simpler, though not as clean, solution that also handles some of the other fuzzy logic that would result from this state. Having said that, I'm fine with this implementation because  this is a temporary situation, as the private mode theme will not be under a feature flag for long, so all the checks can be removed and the bug would never happen.

To clarify, once the feature flag is removed, none of those previous checks would be needed anymore.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

