### PR TITLE
Bugfix MTE-2111 [v124] Update the number of stories displayed by iPhone

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PocketTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PocketTests.swift
@@ -14,12 +14,18 @@ class PocketTests: BaseTestCase {
             "Thought-Provoking Stories"
         )
 
-        // There should be at least 8 stories on iPhone and three on iPad
+        // There should be at least 8 stories on iPhone and 7 on iPad.
+        // You can see more stories on iPhone by swiping left, but not all
+        // stories are displayed at once.
         let numPocketStories = app.collectionViews.containing(
             .cell,
             identifier: AccessibilityIdentifiers.FirefoxHomepage.Pocket.itemCell
         ).children(matching: .cell).count-1
-        XCTAssertTrue(numPocketStories > 7)
+        if iPad() {
+            XCTAssertTrue(numPocketStories > 7)
+        } else {
+            XCTAssertTrue(numPocketStories > 6)
+        }
 
         // Disable Pocket
         navigator.performAction(Action.TogglePocketInNewTab)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2111)

## :bulb: Description
On iPhone 15 simulator, at most 7 stories from Pocket can be displayed at once. Although we can view more stories by swiping left, but the `debugDescription` at a given point only contains 7 stories on the iPhone simulator.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

