### PR TITLE
Add FXIOS-8268 [v124] Engine session is now a WKNavigationDelegate

### DIFF
--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -6,7 +6,11 @@ import Common
 import Foundation
 import WebKit
 
-class WKEngineSession: NSObject, EngineSession, WKUIDelegate {
+class WKEngineSession: NSObject, 
+                        EngineSession,
+                        WKUIDelegate, 
+                        WKNavigationDelegate,
+                        WKEngineWebViewDelegate {
     weak var delegate: EngineSessionDelegate?
     private(set) var webView: WKEngineWebView
     private var logger: Logger
@@ -35,6 +39,8 @@ class WKEngineSession: NSObject, EngineSession, WKUIDelegate {
         self.setupObservers()
 
         webView.uiDelegate = self
+        webView.navigationDelegate = self
+        webView.delegate = self
         userScriptManager.injectUserScriptsIntoWebView(webView)
 
         // TODO: FXIOS-7901 #17646 Handle WKEngineSession tabDelegate
@@ -127,6 +133,7 @@ class WKEngineSession: NSObject, EngineSession, WKUIDelegate {
 
         webView.navigationDelegate = nil
         webView.uiDelegate = nil
+        webView.delegate = nil
 
         webView.removeFromSuperview()
     }
@@ -189,7 +196,7 @@ class WKEngineSession: NSObject, EngineSession, WKUIDelegate {
                  createWebViewWith configuration: WKWebViewConfiguration,
                  for navigationAction: WKNavigationAction,
                  windowFeatures: WKWindowFeatures) -> WKWebView? {
-        // FXIOS-8243 - Handle popup windows with createWebViewWith in WebEngine (epic part 2)
+        // TODO: FXIOS-8243 - Handle popup windows with createWebViewWith in WebEngine (epic part 2)
         return nil
     }
 
@@ -199,7 +206,7 @@ class WKEngineSession: NSObject, EngineSession, WKUIDelegate {
         initiatedByFrame frame: WKFrameInfo,
         completionHandler: @escaping () -> Void
     ) {
-        // FXIOS-8244 - Handle Javascript panel messages in WebEngine (epic part 3)
+        // TODO: FXIOS-8244 - Handle Javascript panel messages in WebEngine (epic part 3)
     }
 
     func webView(
@@ -208,7 +215,7 @@ class WKEngineSession: NSObject, EngineSession, WKUIDelegate {
         initiatedByFrame frame: WKFrameInfo,
         completionHandler: @escaping (Bool) -> Void
     ) {
-        // FXIOS-8244 - Handle Javascript panel messages in WebEngine (epic part 3)
+        // TODO: FXIOS-8244 - Handle Javascript panel messages in WebEngine (epic part 3)
     }
 
     func webView(
@@ -218,11 +225,11 @@ class WKEngineSession: NSObject, EngineSession, WKUIDelegate {
         initiatedByFrame frame: WKFrameInfo,
         completionHandler: @escaping (String?) -> Void
     ) {
-        // FXIOS-8244 - Handle Javascript panel messages in WebEngine (epic part 3)
+        // TODO: FXIOS-8244 - Handle Javascript panel messages in WebEngine (epic part 3)
     }
 
     func webViewDidClose(_ webView: WKWebView) {
-        // FXIOS-8245 - Handle webViewDidClose in WebEngine (epic part 3)
+        // TODO: FXIOS-8245 - Handle webViewDidClose in WebEngine (epic part 3)
     }
 
     func webView(
@@ -230,7 +237,7 @@ class WKEngineSession: NSObject, EngineSession, WKUIDelegate {
         contextMenuConfigurationForElement elementInfo: WKContextMenuElementInfo,
         completionHandler: @escaping (UIContextMenuConfiguration?) -> Void
     ) {
-        // FXIOS-8246 - Handle context menu in WebEngine (epic part 3)
+        // TODO: FXIOS-8246 - Handle context menu in WebEngine (epic part 3)
     }
 
     @available(iOS 15, *)
@@ -239,6 +246,69 @@ class WKEngineSession: NSObject, EngineSession, WKUIDelegate {
                  initiatedByFrame frame: WKFrameInfo,
                  type: WKMediaCaptureType,
                  decisionHandler: @escaping (WKPermissionDecision) -> Void) {
-        // FXIOS-8247 - Handle media capture in WebEngine (epic part 3)
+        // TODO: FXIOS-8247 - Handle media capture in WebEngine (epic part 3)
+    }
+
+    // MARK: - WKNavigationDelegate
+
+    func webView(_ webView: WKWebView,
+                 didCommit navigation: WKNavigation!) {
+        // TODO: FXIOS-8277 - Determine navigation calls with EngineSessionDelegate
+    }
+
+    func webView(_ webView: WKWebView, 
+                 didFinish navigation: WKNavigation!) {
+        // TODO: FXIOS-8277 - Determine navigation calls with EngineSessionDelegate
+    }
+
+    func webView(_ webView: WKWebView, 
+                 didFail navigation: WKNavigation!,
+                 withError error: Error) {
+        // TODO: FXIOS-8277 - Determine navigation calls with EngineSessionDelegate
+    }
+
+    func webView(_ webView: WKWebView, 
+                 didFailProvisionalNavigation navigation: WKNavigation!,
+                 withError error: Error) {
+        // TODO: FXIOS-8277 - Determine navigation calls with EngineSessionDelegate
+    }
+
+    func webView(_ webView: WKWebView,
+                 didStartProvisionalNavigation navigation: WKNavigation!) {
+        // TODO: FXIOS-8277 - Determine navigation calls with EngineSessionDelegate
+    }
+
+    func webView(_ webView: WKWebView,
+                 decidePolicyFor navigationResponse: WKNavigationResponse,
+                 decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void) {
+        // TODO: FXIOS-8277 - Determine navigation calls with EngineSessionDelegate
+    }
+
+    func webView(_ webView: WKWebView, 
+                 decidePolicyFor navigationAction: WKNavigationAction,
+                 preferences: WKWebpagePreferences,
+                 decisionHandler: @escaping (WKNavigationActionPolicy, WKWebpagePreferences) -> Void) {
+        // TODO: FXIOS-8277 - Determine navigation calls with EngineSessionDelegate
+    }
+
+    func webView(_ webView: WKWebView,
+                 didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation!) {
+        // TODO: FXIOS-8275 - Handle didReceiveServerRedirectForProvisionalNavigation (epic part 3)
+    }
+
+    func webView(_ webView: WKWebView,
+                 didReceive challenge: URLAuthenticationChallenge,
+                 completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+        // TODO: FXIOS-8276 - Handle didReceive challenge: URLAuthenticationChallenge (epic part 3)
+    }
+
+    // MARK: - WKEngineWebViewDelegate
+
+    func tabWebView(_ webView: WKEngineWebView, findInPageSelection: String) {
+        // TODO: FXIOS-7901 - Handle WKEngineSession tabDelegate
+    }
+
+    func tabWebView(_ webView: WKEngineWebView, searchSelection: String) {
+        // TODO: FXIOS-7901 - Handle WKEngineSession tabDelegate
     }
 }

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
@@ -16,6 +16,7 @@ protocol WKEngineWebViewDelegate: AnyObject {
 protocol WKEngineWebView: UIView {
     var navigationDelegate: WKNavigationDelegate? { get set }
     var uiDelegate: WKUIDelegate? { get set }
+    var delegate: WKEngineWebViewDelegate?  { get set }
 
     var allowsBackForwardNavigationGestures: Bool { get set }
     var allowsLinkPreview: Bool { get set }
@@ -131,11 +132,6 @@ extension WKEngineWebView {
 class DefaultWKEngineWebView: WKWebView, WKEngineWebView {
     var engineConfiguration: WKEngineConfiguration
     weak var delegate: WKEngineWebViewDelegate?
-    func configure(delegate: WKEngineWebViewDelegate,
-                   navigationDelegate: WKNavigationDelegate?) {
-        self.delegate = delegate
-        self.navigationDelegate = navigationDelegate
-    }
 
     required init?(frame: CGRect, configurationProvider: WKEngineConfigurationProvider) {
         let configuration = configurationProvider.createConfiguration()

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebView.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebView.swift
@@ -7,8 +7,10 @@ import WebKit
 @testable import WebEngine
 
 class MockWKEngineWebView: UIView, WKEngineWebView {
+    var delegate: WKEngineWebViewDelegate?
     var uiDelegate: WKUIDelegate?
     var navigationDelegate: WKNavigationDelegate?
+
     var engineConfiguration: WKEngineConfiguration
     var interactionState: Any?
     var scrollView = UIScrollView()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8268)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18356)

## :bulb: Description
Engine session is now a `WKNavigationDelegate`. Again this PR isn't doing much, it's just adding the session to be a delegate. Still need to determine how all those methods will integrate here, I'll write some documentation about this and plan the tasks to come!

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

