### PR TITLE
Refactor FXIOS-8297 [v124] Logins Key Retrieval Logic

### DIFF
--- a/firefox-ios/Providers/RustSyncManager.swift
+++ b/firefox-ios/Providers/RustSyncManager.swift
@@ -334,46 +334,61 @@ public class RustSyncManager: NSObject, SyncManager {
        var rustEngines: [String] = []
        var registeredPlaces = false
 
-       for engine in engines.filter({ syncManagerAPI.rustTogglableEngines.contains($0) }) {
-           switch engine {
-           case .tabs:
-               profile?.tabs.registerWithSyncManager()
-               rustEngines.append(engine.rawValue)
-           case .passwords:
-               profile?.logins.registerWithSyncManager()
-               if let key = try? profile?.logins.getStoredKey() {
-                   localEncryptionKeys[engine.rawValue] = key
-                   rustEngines.append(engine.rawValue)
-               } else {
-                   logger.log("Login encryption key could not be retrieved for syncing",
-                              level: .warning,
-                              category: .sync)
-               }
-           case .creditcards:
-               if self.creditCardAutofillEnabled {
-                   profile?.autofill.registerWithSyncManager()
-                   if let key = try? profile?.autofill.getStoredKey() {
-                       localEncryptionKeys[engine.rawValue] = key
-                       rustEngines.append(engine.rawValue)
-                   } else {
-                       logger.log("Credit card encryption key could not be retrieved for syncing",
-                                  level: .warning,
-                                  category: .sync)
-                   }
-               }
-           case .addresses:
-               profile?.autofill.registerWithSyncManager()
-               rustEngines.append(engine.rawValue)
-           case .bookmarks, .history:
-               if !registeredPlaces {
-                   profile?.places.registerWithSyncManager()
-                   registeredPlaces = true
-               }
-               rustEngines.append(engine.rawValue)
-           }
-       }
+        let registerEngines: (String?) -> Void = { loginKey in
+            for engine in engines.filter({ self.syncManagerAPI.rustTogglableEngines.contains($0) }) {
+                switch engine {
+                case .tabs:
+                    self.profile?.tabs.registerWithSyncManager()
+                    rustEngines.append(engine.rawValue)
+                case .passwords:
+                    self.profile?.logins.registerWithSyncManager()
+                    if let key = loginKey {
+                        localEncryptionKeys[engine.rawValue] = key
+                        rustEngines.append(engine.rawValue)
+                    }
+                case .creditcards:
+                    if self.creditCardAutofillEnabled {
+                        self.profile?.autofill.registerWithSyncManager()
+                        if let key = try? self.profile?.autofill.getStoredKey() {
+                            localEncryptionKeys[engine.rawValue] = key
+                            rustEngines.append(engine.rawValue)
+                        } else {
+                            self.logger.log("Credit card encryption key could not be retrieved for syncing",
+                                            level: .warning,
+                                            category: .sync)
+                        }
+                    }
+                case .addresses:
+                    self.profile?.autofill.registerWithSyncManager()
+                    rustEngines.append(engine.rawValue)
+                case .bookmarks, .history:
+                    if !registeredPlaces {
+                        self.profile?.places.registerWithSyncManager()
+                        registeredPlaces = true
+                    }
+                    rustEngines.append(engine.rawValue)
+                }
+            }
+        }
 
-       completion((rustEngines, localEncryptionKeys))
+        let shouldSyncLogins = engines.contains(RustSyncManagerAPI.TogglableEngine.passwords)
+        if shouldSyncLogins {
+            profile?.logins.getStoredKey { result in
+                switch result {
+                case .success(let key):
+                    registerEngines(key)
+                case .failure(let err):
+                    self.logger.log("Login encryption key could not be retrieved for syncing: \(err)",
+                                    level: .warning,
+                                    category: .sync)
+                    registerEngines(nil)
+                }
+                completion((rustEngines, localEncryptionKeys))
+            }
+        } else {
+            registerEngines(nil)
+            completion((rustEngines, localEncryptionKeys))
+        }
    }
 
     private func doSync(params: SyncParams, completion: @escaping (SyncResult) -> Void) {

--- a/firefox-ios/Storage/Rust/RustLogins.swift
+++ b/firefox-ios/Storage/Rust/RustLogins.swift
@@ -417,7 +417,7 @@ public class RustLoginEncryptionKeys {
             let secret = try createKey()
             let canary = try createCanary(text: canaryPhrase, encryptionKey: secret)
 
-            DispatchQueue.global(qos: .background).async {
+            DispatchQueue.global(qos: .background).sync {
                 self.keychain.set(secret,
                                   forKey: self.loginPerFieldKeychainKey,
                                   withAccessibility: MZKeychainItemAccessibility.afterFirstUnlock)
@@ -867,7 +867,7 @@ public class RustLogins {
     }
 
     private func getKeychainData(rustKeys: RustLoginEncryptionKeys, completion: @escaping (String?, String?) -> Void) {
-        queue.async {
+        DispatchQueue.global(qos: .background).sync {
             let key = rustKeys.keychain.string(forKey: rustKeys.loginPerFieldKeychainKey)
             let encryptedCanaryPhrase = rustKeys.keychain.string(forKey: rustKeys.canaryPhraseKey)
             completion(key, encryptedCanaryPhrase)

--- a/firefox-ios/Storage/Rust/RustLogins.swift
+++ b/firefox-ios/Storage/Rust/RustLogins.swift
@@ -394,8 +394,9 @@ public extension LoginEntry {
 }
 
 public enum LoginEncryptionKeyError: Error {
-    case illegalState
     case noKeyCreated
+    case illegalState
+    case dbRecordCountVerificationError(String)
 }
 
 public class RustLoginEncryptionKeys {
@@ -416,17 +417,14 @@ public class RustLoginEncryptionKeys {
             let secret = try createKey()
             let canary = try createCanary(text: canaryPhrase, encryptionKey: secret)
 
-            keychain.set(
-                secret,
-                forKey: loginPerFieldKeychainKey,
-                withAccessibility: MZKeychainItemAccessibility.afterFirstUnlock
-            )
-            keychain.set(
-                canary,
-                forKey: canaryPhraseKey,
-                withAccessibility: MZKeychainItemAccessibility.afterFirstUnlock
-            )
-
+            DispatchQueue.global(qos: .background).async {
+                self.keychain.set(secret,
+                                  forKey: self.loginPerFieldKeychainKey,
+                                  withAccessibility: MZKeychainItemAccessibility.afterFirstUnlock)
+                self.keychain.set(canary,
+                                  forKey: self.canaryPhraseKey,
+                                  withAccessibility: MZKeychainItemAccessibility.afterFirstUnlock)
+            }
             return secret
         } catch let err as NSError {
             if let loginsStoreError = err as? LoginsStoreError {
@@ -728,12 +726,18 @@ public class RustLogins {
                 return
             }
 
-            do {
-                let key = try self.getStoredKey()
-                let id = try self.storage?.add(login: login, encryptionKey: key).record.id
-                deferred.fill(Maybe(success: id!))
-            } catch let err as NSError {
-                deferred.fill(Maybe(failure: err))
+            self.getStoredKey { result in
+                switch result {
+                case .success(let key):
+                    do {
+                        let id = try self.storage?.add(login: login, encryptionKey: key).record.id
+                        deferred.fill(Maybe(success: id!))
+                    } catch let err as NSError {
+                        deferred.fill(Maybe(failure: err))
+                    }
+                case .failure(let err):
+                    deferred.fill(Maybe(failure: err))
+                }
             }
         }
 
@@ -771,12 +775,18 @@ public class RustLogins {
                 return
             }
 
-            do {
-                let key = try self.getStoredKey()
-                _ = try self.storage?.update(id: id, login: login, encryptionKey: key)
-                deferred.fill(Maybe(success: ()))
-            } catch let err as NSError {
-                deferred.fill(Maybe(failure: err))
+            self.getStoredKey { result in
+                switch result {
+                case .success(let key):
+                    do {
+                        _ = try self.storage?.update(id: id, login: login, encryptionKey: key)
+                        deferred.fill(Maybe(success: ()))
+                    } catch let err as NSError {
+                        deferred.fill(Maybe(failure: err))
+                    }
+                case .failure(let err):
+                    deferred.fill(Maybe(failure: err))
+                }
             }
         }
 
@@ -835,76 +845,114 @@ public class RustLogins {
         }
     }
 
-    public func getStoredKey() throws -> String {
-        let rustKeys = RustLoginEncryptionKeys()
-        let key = rustKeys.keychain.string(forKey: rustKeys.loginPerFieldKeychainKey)
-        let encryptedCanaryPhrase = rustKeys.keychain.string(forKey: rustKeys.canaryPhraseKey)
-
-        switch(key, encryptedCanaryPhrase) {
-        case (.some(key), .some(encryptedCanaryPhrase)):
-            // We expected the key to be present, and it is.
-            do {
-                let canaryIsValid = try checkCanary(
-                    canary: encryptedCanaryPhrase!,
-                    text: rustKeys.canaryPhrase,
-                    encryptionKey: key!)
-                if canaryIsValid {
-                    return key!
-                } else {
-                    logger.log("Logins key was corrupted, new one generated",
-                               level: .warning,
-                               category: .storage)
-                    GleanMetrics.LoginsStoreKeyRegeneration.corrupt.record()
-                    _ = self.wipeLocalEngine()
-
-                    return try rustKeys.createAndStoreKey()
-                }
-            } catch let error as NSError {
-                logger.log("Error retrieving logins encryption key",
-                           level: .warning,
-                           category: .storage,
-                           description: error.localizedDescription)
+    private func resetLoginsAndKey(rustKeys: RustLoginEncryptionKeys,
+                                   completion: @escaping (Result<String, NSError>) -> Void) {
+        self.wipeLocalEngine().upon { result in
+            guard result.isSuccess else {
+                completion(.failure(result.failureValue! as NSError))
+                return
             }
-        case (.some(key), .none):
-            // The key is present, but we didn't expect it to be there.
-            do {
-                logger.log("Logins key lost due to storage malfunction, new one generated",
-                           level: .warning,
-                           category: .storage)
-                GleanMetrics.LoginsStoreKeyRegeneration.other.record()
-                _ = self.wipeLocalEngine()
 
-                return try rustKeys.createAndStoreKey()
-            } catch let error as NSError {
-                throw error
-            }
-        case (.none, .some(encryptedCanaryPhrase)):
-            // We expected the key to be present, but it's gone missing on us.
             do {
-                logger.log("Logins key lost, new one generated",
-                           level: .warning,
-                           category: .storage)
-                GleanMetrics.LoginsStoreKeyRegeneration.lost.record()
-                _ = self.wipeLocalEngine()
-
-                return try rustKeys.createAndStoreKey()
+                let key = try rustKeys.createAndStoreKey()
+                completion(.success(key))
             } catch let error as NSError {
-                throw error
+                self.logger.log("Error creating logins encryption key",
+                                level: .warning,
+                                category: .storage,
+                                description: error.localizedDescription)
+                completion(.failure(error))
             }
-        case (.none, .none):
-            // We didn't expect the key to be present, and it's not (which is the case for first-time calls).
-            do {
-                return try rustKeys.createAndStoreKey()
-            } catch let error as NSError {
-                throw error
-            }
-        default:
-            // If none of the above cases apply, we're in a state that shouldn't be possible
-            // but is disallowed nonetheless
-            throw LoginEncryptionKeyError.illegalState
         }
+    }
 
-        // This must be declared again for Swift's sake even though the above switch statement handles all cases
-        throw LoginEncryptionKeyError.illegalState
+    private func getKeychainData(rustKeys: RustLoginEncryptionKeys, completion: @escaping (String?, String?) -> Void) {
+        queue.async {
+            let key = rustKeys.keychain.string(forKey: rustKeys.loginPerFieldKeychainKey)
+            let encryptedCanaryPhrase = rustKeys.keychain.string(forKey: rustKeys.canaryPhraseKey)
+            completion(key, encryptedCanaryPhrase)
+        }
+    }
+
+    public func getStoredKey(completion: @escaping (Result<String, NSError>) -> Void) {
+        let rustKeys = RustLoginEncryptionKeys()
+        getKeychainData(rustKeys: rustKeys) { (key, encryptedCanaryPhrase) in
+            switch(key, encryptedCanaryPhrase) {
+            case (.some(key), .some(encryptedCanaryPhrase)):
+                // We expected the key to be present, and it is.
+                do {
+                    let canaryIsValid = try checkCanary(canary: encryptedCanaryPhrase!,
+                                                        text: rustKeys.canaryPhrase,
+                                                        encryptionKey: key!)
+                    if canaryIsValid {
+                        completion(.success(key!))
+                    } else {
+                        self.logger.log("Logins key was corrupted, new one generated",
+                                        level: .warning,
+                                        category: .storage)
+                        GleanMetrics.LoginsStoreKeyRegeneration.corrupt.record()
+                        self.resetLoginsAndKey(rustKeys: rustKeys, completion: completion)
+                    }
+                } catch let error as NSError {
+                    self.logger.log("Error validating logins encryption key",
+                                    level: .warning,
+                                    category: .storage,
+                                    description: error.localizedDescription)
+                    completion(.failure(error))
+                }
+            case (.some(key), .none):
+                // The key is present, but we didn't expect it to be there.
+
+                self.logger.log("Logins key lost due to storage malfunction, new one generated",
+                                level: .warning,
+                                category: .storage)
+                GleanMetrics.LoginsStoreKeyRegeneration.other.record()
+                self.resetLoginsAndKey(rustKeys: rustKeys, completion: completion)
+            case (.none, .some(encryptedCanaryPhrase)):
+                // We expected the key to be present, but it's gone missing on us.
+
+                self.logger.log("Logins key lost, new one generated",
+                                level: .warning,
+                                category: .storage)
+                GleanMetrics.LoginsStoreKeyRegeneration.lost.record()
+                self.resetLoginsAndKey(rustKeys: rustKeys, completion: completion)
+            case (.none, .none):
+                // We didn't expect the key to be present, which either means this is a first-time
+                // call or the key data has been cleared from the keychain.
+
+                self.hasSyncedLogins().upon { result in
+                    guard result.failureValue == nil else {
+                        completion(.failure(result.failureValue! as NSError))
+                        return
+                    }
+
+                    guard let hasLogins = result.successValue else {
+                        let msg = "Failed to verify logins count before attempting to reset key"
+                        completion(.failure(LoginEncryptionKeyError.dbRecordCountVerificationError(msg) as NSError))
+                        return
+                    }
+
+                    if hasLogins {
+                        // Since the key data isn't present and we have login records in
+                        // the database, we both clear the databbase and the reset the key.
+                        GleanMetrics.LoginsStoreKeyRegeneration.keychainDataLost.record()
+                        self.resetLoginsAndKey(rustKeys: rustKeys, completion: completion)
+                    } else {
+                        // There are no records in the database so we don't need to wipe any
+                        // existing login records. We just need to create a new key.
+                        do {
+                            let key = try rustKeys.createAndStoreKey()
+                            completion(.success(key))
+                        } catch let error as NSError {
+                            completion(.failure(error))
+                        }
+                    }
+                }
+            default:
+                // If none of the above cases apply, we're in a state that shouldn't be
+                // possible but is disallowed nonetheless
+                completion(.failure(LoginEncryptionKeyError.illegalState as NSError))
+            }
+        }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/PasswordManagerViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/PasswordManagerViewModelTests.swift
@@ -56,7 +56,7 @@ class PasswordManagerViewModelTests: XCTestCase {
         XCTAssertTrue(logins.isSuccess)
         XCTAssertNotNil(logins.successValue)
 
-        waitForExpectations(timeout: 15.0, handler: nil)
+        waitForExpectations(timeout: 10.0, handler: nil)
     }
 
     func testQueryLogins() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/PasswordManagerViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/PasswordManagerViewModelTests.swift
@@ -44,14 +44,19 @@ class PasswordManagerViewModelTests: XCTestCase {
                 "username": "username\(i)",
                 "password": "password\(i)"
             ])
-            let addResult = self.viewModel.profile.logins.addLogin(login: login)
-            XCTAssertTrue(addResult.value.isSuccess)
-            XCTAssertNotNil(addResult.value.successValue)
+            let addExp = expectation(description: "\(#function)\(#line)")
+            self.viewModel.profile.logins.addLogin(login: login).upon { addResult in
+                XCTAssertTrue(addResult.isSuccess)
+                XCTAssertNotNil(addResult.successValue)
+                addExp.fulfill()
+            }
         }
 
         let logins = self.viewModel.profile.logins.listLogins().value
         XCTAssertTrue(logins.isSuccess)
         XCTAssertNotNil(logins.successValue)
+
+        waitForExpectations(timeout: 15.0, handler: nil)
     }
 
     func testQueryLogins() {

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustLoginsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustLoginsTests.swift
@@ -9,7 +9,6 @@ import Shared
 class RustLoginsTests: XCTestCase {
     var files: FileAccessor!
     var logins: RustLogins!
-    var encryptionKey: String!
 
     override func setUp() {
         super.setUp()
@@ -21,12 +20,6 @@ class RustLoginsTests: XCTestCase {
                 isDirectory: true
             ).appendingPathComponent("testLoginsPerField.db").path
             try? files.remove("testLoginsPerField.db")
-
-            if let key = try? createKey() {
-                encryptionKey = key
-            } else {
-                XCTFail("Encryption key wasn't created")
-            }
 
             logins = RustLogins(databasePath: databasePath)
             _ = logins.reopenIfClosed()

--- a/firefox-ios/firefox-ios-tests/Tests/UnitTest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/UnitTest.xctestplan
@@ -98,6 +98,7 @@
         "GleanPlumbMessageManagerTests\/testManagerOnMessagePressed_withMalformedURL()",
         "HistoryHighlightsDataAdaptorTests\/testReloadDataOnNotification()",
         "IntroViewControllerTests\/testBasicSetupReturnsExpectedItems()",
+        "RustSyncManagerTests\/testGetEnginesAndKeys()",
         "RustSyncManagerTests\/testGetEnginesAndKeysWithNoKey()",
         "RustSyncManagerTests\/testUpdateEnginePrefs_bookmarksEnabled()",
         "ShortcutRouteTests\/testOpenLastBookmarkShortcutWithInvalidUrl()",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8297)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18405)

## :bulb: Description
The logic being re-introduced was backed out in PR https://github.com/mozilla-mobile/firefox-ios/pull/17954 after the logins incident and was **not** the logic that caused the incident. The problematic code, the verification logic introduced in https://github.com/mozilla-mobile/firefox-ios/pull/17355, is being re-worked and will be added in a later release.

### Local Test Steps

1. Create an FxA account.

1. Log in to sync on Firefox desktop with the account created in step 1.

1. Add logins and sync.

1. Open Xcode.

1. Checkout the code in code in [PR #18401](https://github.com/mozilla-mobile/firefox-ios/pull/18401/).

1. Remove any pre-existing device data from the simulator and run the code.

1. Sign in to sync with the account created in step 1.

1. Sync logins via the settings menu and ensure that the logins from desktop appear in the Firefox iOS Passwords menu. 

1. Stop the simulator.

1. Make the changes below in the `getKeychainData` function in RustLogins.swift:
	a. To test when the key is present but not the encrypted canary phrase, replace the `completion` call with the following:
	```
		completion(key, nil)
	```
	b. To test when the key is missing but the encrypted canary phrase is present, replace the `completion` call with the following:
	```
		completion(nil, encryptedCanaryPhrase)
	```
	c. To test when both the key and the encrypted canary phrase are missing, replace the `completion` call with the following:
	```
		completion(nil, nil)
	```

1. Run the iOS code locally again, this time without removing the device data.
	**Note:** You should add a breakpoint within the switch statement of the `getStoredKey` function for the case you're testing to ensure it's being hit. You may also want to add a breakpoint in the `resetLoginsAndKey` function to ensure it is successfully executed.

1. Sync logins in Firefox iOS.

1. The expected result is that, despite the database being wiped, all of the logins created in desktop should still be visible in the Firefox iOS Passwords menu.
  a. You can ensure this is the case by checking the sync logs for the results of the passwords engine sync. The applied record count should equal the number of records you created in Firefox desktop and there should be no outgoing records. 

<img width="622" alt="Screenshot 2024-01-26 at 7 38 22 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/5533446/6684f5ee-d2d2-45b2-9c3b-c01e6806e902">

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

