### PR TITLE
Add FXIOS-8295, DISCO-2668 [v124] Hide sponsored and non-sponsored Firefox Suggestions in private tabs

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/SearchViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/SearchViewControllerTests.swift
@@ -17,12 +17,26 @@ actor MockRustFirefoxSuggest: RustFirefoxSuggestActor {
         includeSponsored: Bool,
         includeNonSponsored: Bool
     ) async throws -> [RustFirefoxSuggestion] {
-        return [RustFirefoxSuggestion(title: "Mozilla",
-                                      url: URL(string: "https://mozilla.org")!,
-                                      isSponsored: true,
-                                      iconImage: nil,
-                                      fullKeyword: "mozilla"
-                                     )]
+        var suggestions = [RustFirefoxSuggestion]()
+        if includeSponsored {
+            suggestions.append(RustFirefoxSuggestion(
+                title: "Mozilla",
+                url: URL(string: "https://mozilla.org")!,
+                isSponsored: true,
+                iconImage: nil,
+                fullKeyword: "mozilla"
+            ))
+        }
+        if includeNonSponsored {
+            suggestions.append(RustFirefoxSuggestion(
+                title: "California",
+                url: URL(string: "https://wikipedia.org/California")!,
+                isSponsored: false,
+                iconImage: nil,
+                fullKeyword: "california"
+            ))
+        }
+        return suggestions
     }
     nonisolated func interruptReader() {
     }
@@ -31,6 +45,7 @@ actor MockRustFirefoxSuggest: RustFirefoxSuggestActor {
 @MainActor
 class SearchViewControllerTest: XCTestCase {
     var profile: MockProfile!
+    var engines: SearchEngines!
     var searchViewController: SearchViewController!
     var remoteClient: RemoteClient!
 
@@ -42,7 +57,7 @@ class SearchViewControllerTest: XCTestCase {
         LegacyFeatureFlagsManager.shared.set(feature: .firefoxSuggestFeature, to: true)
 
         let mockSearchEngineProvider = MockSearchEngineProvider()
-        let engines = SearchEngines(
+        engines = SearchEngines(
             prefs: profile.prefs,
             files: profile.files,
             engineProvider: mockSearchEngineProvider
@@ -78,17 +93,17 @@ class SearchViewControllerTest: XCTestCase {
         profile.prefs.setBool(true, forKey: PrefsKeys.FirefoxSuggestShowNonSponsoredSuggestions)
         await searchViewController.loadFirefoxSuggestions()?.value
 
-        XCTAssertEqual(searchViewController.firefoxSuggestions.count, 1)
+        XCTAssertEqual(searchViewController.firefoxSuggestions.count, 2)
     }
 
     func testFirefoxSuggestionReturnsNoSuggestions() async throws {
-        profile.prefs.setBool(false, forKey: PrefsKeys.FirefoxSuggestShowSponsoredSuggestions )
+        profile.prefs.setBool(false, forKey: PrefsKeys.FirefoxSuggestShowSponsoredSuggestions)
         profile.prefs.setBool(false, forKey: PrefsKeys.FirefoxSuggestShowNonSponsoredSuggestions)
         await searchViewController.loadFirefoxSuggestions()?.value
         XCTAssertEqual(searchViewController.firefoxSuggestions.count, 0)
     }
 
-    func testHistoryandBookmarksAreFilteredWhenShowSponsoredSuggestionsIsTrue() {
+    func testHistoryAndBookmarksAreFilteredWhenShowSponsoredSuggestionsIsTrue() {
         profile.prefs.setBool(true, forKey: PrefsKeys.FirefoxSuggestShowSponsoredSuggestions)
         let data = ArrayCursor<Site>(data: [ Site(url: "https://example.com?mfadid=adm", title: "Test1"),
                                              Site(url: "https://example.com", title: "Test2"),
@@ -106,7 +121,7 @@ class SearchViewControllerTest: XCTestCase {
         XCTAssertEqual(searchViewController.data.count, 3)
     }
 
-    func testSyncTabsAreFilteredWhenShowSponsoredSuggestionsIsTrue() {
+    func testSyncedTabsAreFilteredWhenShowSponsoredSuggestionsIsTrue() {
         profile.prefs.setBool(true, forKey: PrefsKeys.FirefoxSuggestShowSponsoredSuggestions)
         let remoteTab1 = RemoteTab(
             clientGUID: "1",
@@ -139,7 +154,7 @@ class SearchViewControllerTest: XCTestCase {
         XCTAssertEqual(searchViewController.filteredRemoteClientTabs.count, 2)
     }
 
-    func testSyncedTabssAreNotFilteredWhenShowSponsoredSuggestionsIsTrue() {
+    func testSyncedTabsAreNotFilteredWhenShowSponsoredSuggestionsIsFalse() {
         profile.prefs.setBool(false, forKey: PrefsKeys.FirefoxSuggestShowSponsoredSuggestions)
 
         let remoteTab1 = RemoteTab(
@@ -171,5 +186,37 @@ class SearchViewControllerTest: XCTestCase {
                                                  ClientTabsSearchWrapper(client: remoteClient, tab: remoteTab3)]
         searchViewController.searchRemoteTabs(for: "Mozilla")
         XCTAssertEqual(searchViewController.filteredRemoteClientTabs.count, 3)
+    }
+
+    func testSponsoredSuggestionsAreNotShownInPrivateBrowsingMode() async throws {
+        let viewModel = SearchViewModel(isPrivate: true, isBottomSearchBar: false)
+        let searchViewController = SearchViewController(
+            profile: profile,
+            viewModel: viewModel,
+            model: engines,
+            tabManager: MockTabManager()
+        )
+
+        profile.prefs.setBool(true, forKey: PrefsKeys.FirefoxSuggestShowSponsoredSuggestions)
+        profile.prefs.setBool(true, forKey: PrefsKeys.FirefoxSuggestShowNonSponsoredSuggestions)
+        await searchViewController.loadFirefoxSuggestions()?.value
+
+        XCTAssert(searchViewController.firefoxSuggestions.isEmpty)
+    }
+
+    func testNonSponsoredSuggestionsAreNotShownInPrivateBrowsingMode() async throws {
+        let viewModel = SearchViewModel(isPrivate: true, isBottomSearchBar: false)
+        let searchViewController = SearchViewController(
+            profile: profile,
+            viewModel: viewModel,
+            model: engines,
+            tabManager: MockTabManager()
+        )
+
+        profile.prefs.setBool(true, forKey: PrefsKeys.FirefoxSuggestShowSponsoredSuggestions)
+        profile.prefs.setBool(true, forKey: PrefsKeys.FirefoxSuggestShowNonSponsoredSuggestions)
+        await searchViewController.loadFirefoxSuggestions()?.value
+
+        XCTAssert(searchViewController.firefoxSuggestions.isEmpty)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8295)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18402)

## :bulb: Description

Firefox Desktop and Android never show sponsored or non-sponsored suggestions from Firefox Suggest in private browsing tabs, even if "show suggestions in private browsing" is switched on. This PR brings Firefox for iOS in line with that product decision.

/cc @adudenamedruby @tiftran

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

