### PR TITLE
Refactor FXIOS-8299 [v124] Use the `safe` subscript in `SearchViewController.visibleSuggestionsTelemetryInfo`

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
@@ -360,8 +360,8 @@ class SearchViewController: SiteTableViewController,
         return visibleIndexPaths.enumerated().compactMap { (position, indexPath) in
             switch SearchListSection(rawValue: indexPath.section)! {
             case .firefoxSuggestions:
-                let firefoxSuggestion = firefoxSuggestions[indexPath.row]
-                guard let telemetryInfo = firefoxSuggestion.telemetryInfo else {
+                let firefoxSuggestion = firefoxSuggestions[safe: indexPath.row]
+                guard let telemetryInfo = firefoxSuggestion?.telemetryInfo else {
                     return nil
                 }
                 return .firefoxSuggestion(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8299)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18408)

## :bulb: Description

While working on #18273, I noticed that the table view's visible index paths could sometimes get out of sync with the data in the `firefoxSuggestions` array, and crash the browser with an out-of-bounds access.

I wasn't able to reproduce that crash consistently—especially after switching to reading `visibleIndexPaths` in `viewWillDisappear`/`searchViewControllerWillHide` only—but I did notice it a few times that it made me go 🤨

I'm wondering if we can end up in a race where:

1. `loadFirefoxSuggestions()` sets `self.firefoxSuggestions`, and calls `tableView.reloadData()`.
2. The search view is hidden before the table can finish reloading, triggering `viewWillDisappear()` and then `searchViewControllerWillHide()`.
3. `searchViewControllerWillHide()` accesses `visibleSuggestionsTelemetryInfo`, but the table view's `visibleIndexPaths` is now out of sync with the data—because the data has been updated, but the table view hasn't been redrawn.

I'm not sure if this can occur in practice? So if this isn't a real issue, let's close out this PR! But if it could occur, we can avoid an out-of-bounds access, at the cost of recording stale telemetry if a user happens to trigger this edge case.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

