### PR TITLE
Add FXIOS-8314 [v124]: Removes all usages of apns in keychain

### DIFF
--- a/firefox-ios/Account/FxAPushMessageHandler.swift
+++ b/firefox-ios/Account/FxAPushMessageHandler.swift
@@ -10,11 +10,8 @@ import Common
 let PendingAccountDisconnectedKey = "PendingAccountDisconnect"
 
 /// This class provides handles push messages from FxA.
-/// For reference, the [message schema][0] and [Android implementation][1] are both useful resources.
-/// [0]: https://github.com/mozilla/fxa-auth-server/blob/master/docs/pushpayloads.schema.json#L26
-/// [1]: https://dxr.mozilla.org/mozilla-central/source/mobile/android/services/src/main/java/org/mozilla/gecko/fxa/FxAccountPushHandler.java
-/// The main entry points are `handle` methods, to accept the raw APNS `userInfo` and then to process
-/// the resulting JSON.
+/// The main entry point is the `handleDecryptedMessage` method to accept the decrypted push message and parse it into a
+/// `PushMessage`
 class FxAPushMessageHandler {
     let profile: Profile
     private let logger: Logger

--- a/firefox-ios/Client/Application/AppDelegate+PushNotifications.swift
+++ b/firefox-ios/Client/Application/AppDelegate+PushNotifications.swift
@@ -49,7 +49,7 @@ extension AppDelegate {
             }
         }
 
-        // If we see our local device with a pushEndpointExpired flag, clear the APNS token and re-register.
+        // If we see our local device with a pushEndpointExpired flag, try to re-register.
         NotificationCenter.default.addObserver(
             forName: .constellationStateUpdate,
             object: nil,
@@ -57,27 +57,10 @@ extension AppDelegate {
         ) { notification in
             if let newState = notification.userInfo?["newState"] as? ConstellationState {
                 if newState.localDevice?.pushEndpointExpired ?? false {
-                    MZKeychainWrapper.sharedClientAppContainerKeychain.removeObject(
-                        forKey: KeychainKey.apnsToken,
-                        withAccessibility: MZKeychainItemAccessibility.afterFirstUnlock
-                    )
                     NotificationCenter.default.post(name: .RegisterForPushNotifications, object: nil)
                     // Our endpoint expired, we should check for missed messages
                     self.profile.pollCommands(forcePoll: true)
                 }
-            }
-        }
-
-        // Use sync event as a periodic check for the apnsToken.
-        // The notification service extension can clear this token if there is an error,
-        // and the main app can detect this and re-register.
-        NotificationCenter.default.addObserver(forName: .ProfileDidStartSyncing, object: nil, queue: .main) { _ in
-            let kc = MZKeychainWrapper.sharedClientAppContainerKeychain
-            if kc.string(
-                forKey: KeychainKey.apnsToken,
-                withAccessibility: MZKeychainItemAccessibility.afterFirstUnlock
-            ) == nil {
-                NotificationCenter.default.post(name: .RegisterForPushNotifications, object: nil)
             }
         }
     }

--- a/firefox-ios/RustFxA/FxAWebViewModel.swift
+++ b/firefox-ios/RustFxA/FxAWebViewModel.swift
@@ -281,10 +281,6 @@ extension FxAWebViewModel {
             // or if the onboarding flow is missing the notifications card
             guard self.shouldAskForNotificationPermission else { return }
 
-            MZKeychainWrapper.sharedClientAppContainerKeychain.removeObject(
-                forKey: KeychainKey.apnsToken,
-                withAccessibility: MZKeychainItemAccessibility.afterFirstUnlock
-            )
             NotificationManager().requestAuthorization { granted, error in
                 guard error == nil else { return }
                 if granted {

--- a/firefox-ios/RustFxA/PushNotificationSetup.swift
+++ b/firefox-ios/RustFxA/PushNotificationSetup.swift
@@ -9,10 +9,6 @@ import MozillaAppServices
 open class PushNotificationSetup {
     /// Disables FxA push notifications for the user
     public func disableNotifications() {
-        MZKeychainWrapper.sharedClientAppContainerKeychain.removeObject(
-            forKey: KeychainKey.apnsToken,
-            withAccessibility: .afterFirstUnlock
-        )
         if let accountManager = RustFirefoxAccounts.shared.accountManager {
             let subscriptionEndpoint = accountManager.deviceConstellation()?
                 .state()?.localDevice?.pushSubscription?.endpoint

--- a/firefox-ios/RustFxA/RustFirefoxAccounts.swift
+++ b/firefox-ios/RustFxA/RustFirefoxAccounts.swift
@@ -235,10 +235,6 @@ open class RustFirefoxAccounts {
         prefs?.removeObjectForKey(prefKeyCachedUserProfile)
         prefs?.removeObjectForKey(PendingAccountDisconnectedKey)
         cachedUserProfile = nil
-        MZKeychainWrapper.sharedClientAppContainerKeychain.removeObject(
-            forKey: KeychainKey.apnsToken,
-            withAccessibility: .afterFirstUnlock
-        )
     }
 
     public func hasAccount(completion: @escaping (Bool) -> Void) {

--- a/firefox-ios/Shared/AppConstants.swift
+++ b/firefox-ios/Shared/AppConstants.swift
@@ -47,10 +47,6 @@ public enum KVOConstants: String {
     case contentSize
 }
 
-public struct KeychainKey {
-    public static let apnsToken = "apnsToken"
-}
-
 public class AppConstants {
     // Any type of tests (UI and Unit)
     public static let isRunningTest = NSClassFromString("XCTestCase") != nil


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8314)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18427)

## :bulb: Description
We moved to the new push component in v116, and since then there has been no need to store the APNS token in keychain. It's also been a few releases since then and I believe it safe enough to remove the removal of the apns tokens as well, it's also inconsequential if a user upgrading from v115 to v124 keeps an old apns token in their local-only keychain.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

