### PR TITLE
Add FXIOS-8316, DISCO-2730 [v124] Show sponsored and non-sponsored suggestions by default if the Firefox Suggest feature is enabled

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
@@ -215,13 +215,13 @@ class SearchViewController: SiteTableViewController,
     /// is switched on.
     private var shouldShowSponsoredSuggestions: Bool {
         !viewModel.isPrivate &&
-            profile.prefs.boolForKey(PrefsKeys.FirefoxSuggestShowSponsoredSuggestions) ?? false
+            profile.prefs.boolForKey(PrefsKeys.FirefoxSuggestShowSponsoredSuggestions) ?? true
     }
 
     /// Whether to show non-sponsored suggestions from Firefox Suggest.
     private var shouldShowNonSponsoredSuggestions: Bool {
         !viewModel.isPrivate &&
-            profile.prefs.boolForKey(PrefsKeys.FirefoxSuggestShowNonSponsoredSuggestions) ?? false
+            profile.prefs.boolForKey(PrefsKeys.FirefoxSuggestShowNonSponsoredSuggestions) ?? true
     }
 
     func loadFirefoxSuggestions() -> Task<(), Never>? {

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -208,7 +208,7 @@ class SearchSettingsTableViewController: ThemedTableViewController, FeatureFlagg
                     prefs: profile.prefs,
                     theme: themeManager.currentTheme,
                     prefKey: PrefsKeys.FirefoxSuggestShowNonSponsoredSuggestions,
-                    defaultValue: profile.prefs.boolForKey(PrefsKeys.FirefoxSuggestShowNonSponsoredSuggestions) ?? false,
+                    defaultValue: profile.prefs.boolForKey(PrefsKeys.FirefoxSuggestShowNonSponsoredSuggestions) ?? true,
                     titleText: String.localizedStringWithFormat(
                         .Settings.Search.Suggest.ShowNonSponsoredSuggestionsTitle,
                         AppName.shortName.rawValue
@@ -232,7 +232,7 @@ class SearchSettingsTableViewController: ThemedTableViewController, FeatureFlagg
                     prefs: profile.prefs,
                     theme: themeManager.currentTheme,
                     prefKey: PrefsKeys.FirefoxSuggestShowSponsoredSuggestions,
-                    defaultValue: profile.prefs.boolForKey(PrefsKeys.FirefoxSuggestShowSponsoredSuggestions) ?? false,
+                    defaultValue: profile.prefs.boolForKey(PrefsKeys.FirefoxSuggestShowSponsoredSuggestions) ?? true,
                     titleText: .Settings.Search.Suggest.ShowSponsoredSuggestionsTitle,
                     statusText: String.localizedStringWithFormat(
                         .Settings.Search.Suggest.ShowSponsoredSuggestionsDescription,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8316)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18431)

## :bulb: Description

When the Enhanced Cross-Platform Suggest experiment is enabled—either via Nimbus, or via the secret setting override switch—we should switch on sponsored and non-sponsored suggestions by default.

All our checks for `PrefKeys.FirefoxSuggestShowSponsoredSuggestions` and `PrefKeys.FirefoxSuggestShowNonSponsoredSuggestions` are gated behind a `featureFlags.isFeatureEnabled` check, so I think we can just change the default value from `false` to `true`. If the experiment is disabled, the prefs will remain, but have no effect.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

