### PR TITLE
Bugfix FXIOS-8304 [v124] Fakespot - Incorrect "Fakespot's terms of use" link

### DIFF
--- a/firefox-ios/Client/Frontend/Fakespot/FakespotUtils.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotUtils.swift
@@ -27,8 +27,7 @@ public struct FakespotUtils: FeatureFlaggable {
 
     public static var termsOfUseUrl: URL? {
         // Returns the predefined URL associated to terms of use button action.
-        return URL(string:
-            "https://www.fakespot.com/terms?utm_source=review-checker&utm_campaign=terms&utm_medium=in-product&utm_term=opt-in-screen")
+        return URL(string: "https://www.fakespot.com/terms?utm_source=review-checker&utm_campaign=terms&utm_medium=in-product&utm_term=opt-in-screen")
     }
 
     public static var fakespotUrl: URL? {

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotUtils.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotUtils.swift
@@ -27,7 +27,7 @@ public struct FakespotUtils: FeatureFlaggable {
 
     public static var termsOfUseUrl: URL? {
         // Returns the predefined URL associated to terms of use button action.
-        return URL(string: "https://www.fakespot.com/terms")
+        return URL(string: "https://www.fakespot.com/terms?utm_source=review-checker&utm_campaign=privacy-policy&utm_medium=in-product&utm_term=opt-in-screen")
     }
 
     public static var fakespotUrl: URL? {

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotUtils.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotUtils.swift
@@ -27,7 +27,7 @@ public struct FakespotUtils: FeatureFlaggable {
 
     public static var termsOfUseUrl: URL? {
         // Returns the predefined URL associated to terms of use button action.
-        return URL(string: "https://www.fakespot.com/privacy-policy?utm_source=review-checker&utm_campaign=privacy-policy&utm_medium=in-product&utm_term=opt-in-screen")
+        return URL(string: "https://www.fakespot.com/terms")
     }
 
     public static var fakespotUrl: URL? {

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotUtils.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotUtils.swift
@@ -27,9 +27,8 @@ public struct FakespotUtils: FeatureFlaggable {
 
     public static var termsOfUseUrl: URL? {
         // Returns the predefined URL associated to terms of use button action.
-        return URL(
-            string: "https://www.fakespot.com/terms?utm_source=review-checker&utm_campaign=terms&utm_medium=in-product&utm_term=opt-in-screen"
-        )
+        return URL(string:
+            "https://www.fakespot.com/terms?utm_source=review-checker&utm_campaign=terms&utm_medium=in-product&utm_term=opt-in-screen")
     }
 
     public static var fakespotUrl: URL? {

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotUtils.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotUtils.swift
@@ -27,7 +27,9 @@ public struct FakespotUtils: FeatureFlaggable {
 
     public static var termsOfUseUrl: URL? {
         // Returns the predefined URL associated to terms of use button action.
-        return URL(string: "https://www.fakespot.com/terms?utm_source=review-checker&utm_campaign=privacy-policy&utm_medium=in-product&utm_term=opt-in-screen")
+        return URL(
+            string: "https://www.fakespot.com/terms?utm_source=review-checker&utm_campaign=terms&utm_medium=in-product&utm_term=opt-in-screen"
+        )
     }
 
     public static var fakespotUrl: URL? {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8304)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18417)

## :bulb: Description
- Corrects an issue where tapping the "Fakespot's terms of use" link on the contextual opt-in screen redirects users to the outdated privacy policy page instead of the intended terms page. 
- This PR ensures users are directed to the correct page (https://www.fakespot.com/terms) when tapping the link after navigating to a product detail page on Amazon, Walmart, or Best Buy.


https://github.com/mozilla-mobile/firefox-ios/assets/74779930/5c60c7d6-6c42-4275-ac0a-9ec0a48b91ed

https://github.com/mozilla-mobile/firefox-ios/assets/74779930/f9fdde91-5b3c-4aed-a07f-aac13bdea2b3

https://github.com/mozilla-mobile/firefox-ios/assets/74779930/328c2691-cb9b-43cb-9fd7-82a52d5b0905


## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods