### PR TITLE
Bugfix FXIOS-8227 [v124] Fakespot bottom sheet's highlights section should remember their expanded state for the current page

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -65,6 +65,7 @@ struct BrowserViewControllerState: ScreenState, Equatable {
             FakespotAction.setAppearanceTo,
             FakespotAction.settingsStateDidChange,
             FakespotAction.reviewQualityDidChange,
+            FakespotAction.highlightsDidChange,
             FakespotAction.tabDidChange,
             FakespotAction.tabDidReload,
             FakespotAction.surfaceDisplayedEventSend,

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotAction.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotAction.swift
@@ -6,8 +6,9 @@ import Common
 import Redux
 
 enum FakespotAction: Action {
-    case settingsStateDidChange
-    case reviewQualityDidChange
+    case settingsStateDidChange(isExpanded: Bool)
+    case reviewQualityDidChange(isExpanded: Bool)
+    case highlightsDidChange(isExpanded: Bool)
     case tabDidChange(tabUIDD: String)
     case tabDidReload(tabUIDD: String, productId: String)
     case pressedShoppingButton

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -25,10 +25,12 @@ struct FakespotState: ScreenState, Equatable {
     struct ExpandState: Equatable {
         var isSettingsExpanded = false
         var isReviewQualityExpanded = false
+        var isHighlightsSectionExpanded = false
     }
 
     var isReviewQualityExpanded: Bool { expandState[currentTabUUID]?.isReviewQualityExpanded ?? false }
     var isSettingsExpanded: Bool { expandState[currentTabUUID]?.isSettingsExpanded ?? false }
+    var isHighlightsSectionExpanded: Bool { expandState[currentTabUUID]?.isHighlightsSectionExpanded ?? false }
 
     init(_ appState: BrowserViewControllerState) {
         self.init(
@@ -66,14 +68,19 @@ struct FakespotState: ScreenState, Equatable {
 
     static let reducer: Reducer<Self> = { state, action in
         switch action {
-        case FakespotAction.settingsStateDidChange:
+        case FakespotAction.settingsStateDidChange(let isExpanded):
             var state = state
-            state.expandState[state.currentTabUUID, default: ExpandState()].isSettingsExpanded.toggle()
+            state.expandState[state.currentTabUUID, default: ExpandState()].isSettingsExpanded = isExpanded
             return state
 
-        case FakespotAction.reviewQualityDidChange:
+        case FakespotAction.reviewQualityDidChange(let isExpanded):
             var state = state
-            state.expandState[state.currentTabUUID, default: ExpandState()].isReviewQualityExpanded.toggle()
+            state.expandState[state.currentTabUUID, default: ExpandState()].isReviewQualityExpanded = isExpanded
+            return state
+
+        case FakespotAction.highlightsDidChange(let isExpanded):
+            var state = state
+            state.expandState[state.currentTabUUID, default: ExpandState()].isHighlightsSectionExpanded = isExpanded
             return state
 
         case FakespotAction.tabDidChange(let tabUUID):

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotViewController.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotViewController.swift
@@ -437,7 +437,11 @@ class FakespotViewController: UIViewController,
             return view
 
         case .highlightsCard:
-            guard let cardViewModel = viewModel.highlightsCardViewModel else { return nil }
+            guard var cardViewModel = viewModel.highlightsCardViewModel else { return nil }
+            cardViewModel.expandState = fakespotState.isHighlightsSectionExpanded ? .expanded : .collapsed
+            cardViewModel.onExpandStateChanged = { state in
+                store.dispatch(FakespotAction.highlightsDidChange(isExpanded: state == .expanded))
+            }
             let view: FakespotHighlightsCardView = .build()
             view.configure(cardViewModel)
             return view
@@ -449,7 +453,7 @@ class FakespotViewController: UIViewController,
                 store.dispatch(FakespotAction.setAppearanceTo(false))
             }
             viewModel.reviewQualityCardViewModel.onExpandStateChanged = { state in
-                store.dispatch(FakespotAction.reviewQualityDidChange)
+                store.dispatch(FakespotAction.reviewQualityDidChange(isExpanded: state == .expanded))
             }
             reviewQualityCardView.configure(viewModel.reviewQualityCardViewModel)
 
@@ -469,7 +473,7 @@ class FakespotViewController: UIViewController,
                 self?.viewModel.toggleAdsEnabled()
             }
             viewModel.settingsCardViewModel.onExpandStateChanged = { state in
-                store.dispatch(FakespotAction.settingsStateDidChange)
+                store.dispatch(FakespotAction.settingsStateDidChange(isExpanded: state == .expanded))
             }
             view.configure(viewModel.settingsCardViewModel)
 

--- a/firefox-ios/Client/Frontend/Fakespot/Views/FakespotHighlightsCardView.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/Views/FakespotHighlightsCardView.swift
@@ -15,6 +15,9 @@ struct FakespotHighlightsCardViewModel {
     let lessButtonTitle: String = .Shopping.HighlightsCardLessButtonTitle
     let lessButtonA11yId: String = AccessibilityIdentifiers.Shopping.HighlightsCard.lessButton
 
+    var expandState: CollapsibleCardView.ExpandButtonState = .collapsed
+    var onExpandStateChanged: ((CollapsibleCardView.ExpandButtonState) -> Void)?
+
     let highlights: [FakespotHighlightGroup]
 
     var longestTextFromReviews: String? {
@@ -144,6 +147,10 @@ class FakespotHighlightsCardView: UIView, ThemeApplicable {
             }
             contentStackBottomConstraint?.constant = -UX.highlightStackBottomSpace
         }
+
+        isShowingPreview = viewModel.expandState == .collapsed
+        updateHighlights()
+        updateExpandState()
     }
 
     func applyTheme(theme: Theme) {
@@ -229,10 +236,14 @@ class FakespotHighlightsCardView: UIView, ThemeApplicable {
 
     @objc
     private func showMoreAction() {
-        guard let viewModel else { return }
-
         isShowingPreview = !isShowingPreview
         updateHighlights()
+        updateExpandState()
+        viewModel?.onExpandStateChanged?(isShowingPreview ? .collapsed : .expanded)
+    }
+
+    func updateExpandState() {
+        guard let viewModel else { return }
 
         let moreButtonViewModel = SecondaryRoundedButtonViewModel(
             title: isShowingPreview ? viewModel.moreButtonTitle : viewModel.lessButtonTitle,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8227)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18281)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Now, the highlights section will remember whether it's expanded or collapsed as users explore a page.

https://github.com/mozilla-mobile/firefox-ios/assets/26011662/4aa1b199-e853-4f89-bf45-d75ffa013648

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

