### PR TITLE
Refactor FXIOS-7030 [v124] move bookmarks telemetry at app startup

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksPanelViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksPanelViewModel.swift
@@ -104,28 +104,6 @@ class BookmarksPanelViewModel {
                 self.bookmarkFolder = mobileFolder
                 self.bookmarkNodes = mobileFolder.fxChildren ?? []
 
-                if let mobileBookmarks = mobileFolder.fxChildren, !mobileBookmarks.isEmpty {
-                    TelemetryWrapper.recordEvent(category: .information,
-                                                 method: .view,
-                                                 object: .mobileBookmarks,
-                                                 value: .doesHaveMobileBookmarks)
-
-                    let mobileBookmarksExtra = [
-                        TelemetryWrapper.EventExtraKey.mobileBookmarksQuantity.rawValue: Int64(mobileBookmarks.count)
-                    ]
-
-                    TelemetryWrapper.recordEvent(category: .information,
-                                                 method: .view,
-                                                 object: .mobileBookmarks,
-                                                 value: .mobileBookmarksCount,
-                                                 extras: mobileBookmarksExtra)
-                } else {
-                    TelemetryWrapper.recordEvent(category: .information,
-                                                 method: .view,
-                                                 object: .mobileBookmarks,
-                                                 value: .doesNotHaveMobileBookmarks)
-                }
-
                 let desktopFolder = LocalDesktopFolder()
                 self.bookmarkNodes.insert(desktopFolder, at: 0)
 

--- a/firefox-ios/Client/Telemetry/AppStartupTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/AppStartupTelemetry.swift
@@ -17,12 +17,22 @@ final class AppStartupTelemetry {
 
     // MARK: Logic
     public func sendStartupTelemetry() {
+        querryCreditCards()
+        querryLogins()
+        querryBookmarks()
+    }
+
+    // MARK: Credit Cards
+    func querryCreditCards() {
         _ = profile.autofill.reopenIfClosed()
         profile.autofill.listCreditCards(completion: { cards, error in
             guard let cards = cards, error == nil else { return }
             self.sendCreditCardsSavedAllTelemetry(numberOfSavedCreditCards: cards.count)
         })
+    }
 
+    // MARK: Logins
+    func querryLogins() {
         let searchController = UISearchController()
         let loginsViewModel = PasswordManagerViewModel(
             profile: profile,
@@ -35,6 +45,24 @@ final class AppStartupTelemetry {
         loginsViewModel.queryLogins("") { logins in
             self.sendLoginsSavedAllTelemetry(numberOfSavedLogins: logins.count)
         }
+    }
+
+    // MARK: Bookmarks
+    func querryBookmarks() {
+        profile.places
+            .getBookmarksTree(rootGUID: BookmarkRoots.MobileFolderGUID, recursive: false)
+            .uponQueue(.main) { result in
+                guard let mobileFolder = result.successValue as? BookmarkFolderData else {
+                    return
+                }
+
+                if let mobileBookmarks = mobileFolder.fxChildren, !mobileBookmarks.isEmpty {
+                    self.sendDoesHaveMobileBookmarksTelemetry()
+                    self.sendMobileBookmarksCountTelemetry(bookmarksCount: Int64(mobileBookmarks.count))
+                } else {
+                    self.sendDoesntHaveMobileBookmarksTelemetry()
+                }
+            }
     }
 
     // MARK: Telemetry Events
@@ -54,5 +82,31 @@ final class AppStartupTelemetry {
                                      method: .foreground,
                                      object: .creditCardSavedAll,
                                      extras: savedCardsExtra)
+    }
+
+    private func sendDoesHaveMobileBookmarksTelemetry() {
+        TelemetryWrapper.recordEvent(category: .information,
+                                     method: .view,
+                                     object: .mobileBookmarks,
+                                     value: .doesHaveMobileBookmarks)
+    }
+
+    private func sendDoesntHaveMobileBookmarksTelemetry() {
+        TelemetryWrapper.recordEvent(category: .information,
+                                     method: .view,
+                                     object: .mobileBookmarks,
+                                     value: .doesNotHaveMobileBookmarks)
+    }
+
+    private func sendMobileBookmarksCountTelemetry(bookmarksCount: Int64) {
+        let mobileBookmarksExtra = [
+            TelemetryWrapper.EventExtraKey.mobileBookmarksQuantity.rawValue: bookmarksCount
+        ]
+
+        TelemetryWrapper.recordEvent(category: .information,
+                                     method: .view,
+                                     object: .mobileBookmarks,
+                                     value: .mobileBookmarksCount,
+                                     extras: mobileBookmarksExtra)
     }
 }

--- a/firefox-ios/Client/Telemetry/AppStartupTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/AppStartupTelemetry.swift
@@ -17,13 +17,13 @@ final class AppStartupTelemetry {
 
     // MARK: Logic
     public func sendStartupTelemetry() {
-        querryCreditCards()
-        querryLogins()
-        querryBookmarks()
+        queryCreditCards()
+        queryLogins()
+        queryBookmarks()
     }
 
     // MARK: Credit Cards
-    func querryCreditCards() {
+    func queryCreditCards() {
         _ = profile.autofill.reopenIfClosed()
         profile.autofill.listCreditCards(completion: { cards, error in
             guard let cards = cards, error == nil else { return }
@@ -32,7 +32,7 @@ final class AppStartupTelemetry {
     }
 
     // MARK: Logins
-    func querryLogins() {
+    func queryLogins() {
         let searchController = UISearchController()
         let loginsViewModel = PasswordManagerViewModel(
             profile: profile,
@@ -48,7 +48,7 @@ final class AppStartupTelemetry {
     }
 
     // MARK: Bookmarks
-    func querryBookmarks() {
+    func queryBookmarks() {
         profile.places
             .getBookmarksTree(rootGUID: BookmarkRoots.MobileFolderGUID, recursive: false)
             .uponQueue(.main) { result in


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7030)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15620)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Moved the telemetry probes for the mobile bookmarks to app startup instead of the bookmarks page and tidied up the code
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

