### PR TITLE
Refactor FXIOS-8188 [v124] [Multi-window] Redux refactors (Tab, BVC, Toasts) for multi-window

### DIFF
--- a/BrowserKit/Sources/Redux/Action.swift
+++ b/BrowserKit/Sources/Redux/Action.swift
@@ -5,10 +5,13 @@
 import Foundation
 
 /// Are a declarative way of describing a state change. Actions don’t contain any code,
-/// they are consumed by the store and forwarded to reducers. Are used to express intended state changes. 
+/// they are consumed by the store and forwarded to reducers. Are used to express intended
+/// state changes. Actions include a context object that includes information about the
+/// action, including a UUID for a particular window. If an Action is truly global in
+/// nature or can't be associated with a UUID it can send either the UUID for the active
+/// window (see `WindowManager.activeWindow`) or if needed `WindowUUID.unavailable`.
 public protocol Action {
-    // TODO: [8188] Update to be non-optional; all Actions must occur within a window.
-    var windowUUID: UUID? { get }
+    var windowUUID: UUID { get }
 }
 
 extension Action {

--- a/BrowserKit/Tests/ReduxTests/Utilities/FakeReduxAction.swift
+++ b/BrowserKit/Tests/ReduxTests/Utilities/FakeReduxAction.swift
@@ -18,10 +18,9 @@ enum FakeReduxAction: Action {
     case counterDecreased(Int)
     case setPrivateModeTo(Bool)
 
-    var windowUUID: UUID? {
-        // TODO: [8188] Update to be non-optional and return windowUUID. Forthcoming.
-        switch self {
-        default: return nil
-        }
+    var windowUUID: UUID {
+        // TODO: [8188] Currently these unit tests do not make use of UUIDs. This will be updated soon.
+        // For now, we can just return UUID().
+        return UUID()
     }
 }

--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -86,7 +86,9 @@ final class WindowManagerImplementation: WindowManager {
 
     func tabManager(for windowUUID: WindowUUID) -> TabManager {
         guard let tabManager = window(for: windowUUID)?.tabManager else {
-            fatalError("No tab manager for window UUID.")
+            assertionFailure("Tab Manager unavailable for requested UUID: \(windowUUID). This is a client error.")
+            logger.log("No tab manager for window UUID.", level: .fatal, category: .window)
+            return window(for: activeWindow)?.tabManager ?? windows.first!.value.tabManager!
         }
 
         return tabManager

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
@@ -9,7 +9,7 @@ enum GeneralBrowserAction: Action {
     case showToast(ToastType)
 
     var windowUUID: UUID {
-        // TODO: [8188] Update to be non-optional and return windowUUID. Forthcoming.
+       // TODO: [8188] Use of .unavailable UUID is temporary as part of early MW refactors. WIP. 
         switch self {
         default: return .unavailable
         }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
@@ -6,12 +6,12 @@ import Foundation
 import Redux
 
 enum GeneralBrowserAction: Action {
-    case showToast(ToastType)
+    case showToast(ToastTypeContext)
 
     var windowUUID: UUID {
-       // TODO: [8188] Use of .unavailable UUID is temporary as part of early MW refactors. WIP. 
         switch self {
-        default: return .unavailable
+        case .showToast(let context as ActionContext):
+            return context.windowUUID
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
@@ -8,10 +8,10 @@ import Redux
 enum GeneralBrowserAction: Action {
     case showToast(ToastType)
 
-    var windowUUID: UUID? {
+    var windowUUID: UUID {
         // TODO: [8188] Update to be non-optional and return windowUUID. Forthcoming.
         switch self {
-        default: return nil
+        default: return .unavailable
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -87,7 +87,8 @@ struct BrowserViewControllerState: ScreenState, Equatable {
                 showDataClearanceFlow: state.showDataClearanceFlow,
                 fakespotState: FakespotState.reducer(state.fakespotState, action),
                 windowUUID: state.windowUUID)
-        case GeneralBrowserAction.showToast(let toastType):
+        case GeneralBrowserAction.showToast(let context):
+            let toastType = context.toastType
             return BrowserViewControllerState(
                 searchScreenState: state.searchScreenState,
                 usePrivateHomepage: state.usePrivateHomepage,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -59,7 +59,7 @@ struct BrowserViewControllerState: ScreenState, Equatable {
 
     static let reducer: Reducer<Self> = { state, action in
         // Only process actions for the current window
-        guard action.windowUUID == nil || action.windowUUID == state.windowUUID else { return state }
+        guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID else { return state }
 
         switch action {
         case PrivateModeMiddlewareAction.privateModeUpdated(let privacyState):

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -553,10 +553,11 @@ class BrowserViewController: UIViewController,
         let viewModel = ButtonToastViewModel(
             labelText: toast.title,
             buttonText: toast.buttonText)
+        let uuid = windowUUID
         let toast = ButtonToast(viewModel: viewModel,
                                 theme: themeManager.currentTheme,
                                 completion: { buttonPressed in
-            if let action = toast.reduxAction, buttonPressed {
+            if let action = toast.reduxAction(for: uuid), buttonPressed {
                 store.dispatch(action)
             }
         })

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/RemoteTabsPanelAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/RemoteTabsPanelAction.swift
@@ -6,19 +6,48 @@ import Common
 import Redux
 import Storage
 
+class RemoteTabsRefreshDidFailContext: ActionContext {
+    let reason: RemoteTabsPanelEmptyStateReason
+    init(reason: RemoteTabsPanelEmptyStateReason, windowUUID: WindowUUID) {
+        self.reason = reason
+        super.init(windowUUID: windowUUID)
+    }
+}
+
+class RemoteTabsRefreshSuccessContext: ActionContext {
+    let clientAndTabs: [ClientAndTabs]
+    init(clientAndTabs: [ClientAndTabs], windowUUID: WindowUUID) {
+        self.clientAndTabs = clientAndTabs
+        super.init(windowUUID: windowUUID)
+    }
+}
+
+class URLActionContext: ActionContext {
+    let url: URL
+    init(url: URL, windowUUID: WindowUUID) {
+        self.url = url
+        super.init(windowUUID: windowUUID)
+    }
+}
+
 /// Defines actions sent to Redux for Sync tab in tab tray
 enum RemoteTabsPanelAction: Action {
-    case panelDidAppear
-    case refreshTabs
-    case refreshDidBegin
-    case refreshDidFail(RemoteTabsPanelEmptyStateReason)
-    case refreshDidSucceed([ClientAndTabs])
-    case openSelectedURL(URL)
+    case panelDidAppear(ActionContext)
+    case refreshTabs(ActionContext)
+    case refreshDidBegin(ActionContext)
+    case refreshDidFail(RemoteTabsRefreshDidFailContext)
+    case refreshDidSucceed(RemoteTabsRefreshSuccessContext)
+    case openSelectedURL(URLActionContext)
 
-    var windowUUID: UUID? {
-        // TODO: [8188] Update to be non-optional and return windowUUID. Forthcoming.
+    var windowUUID: UUID {
         switch self {
-        default: return nil
+        case .panelDidAppear(let context),
+                .refreshTabs(let context),
+                .refreshDidBegin(let context),
+                .refreshDidFail(let context as ActionContext),
+                .refreshDidSucceed(let context as ActionContext),
+                .openSelectedURL(let context as ActionContext):
+            return context.windowUUID
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
@@ -89,7 +89,6 @@ class RefreshInactiveTabsContext: ActionContext {
     }
 }
 
-
 enum TabPanelAction: Action {
     case tabPanelDidLoad(BoolValueContext)
     case tabPanelDidAppear(BoolValueContext)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
@@ -74,9 +74,9 @@ class ToastTypeContext: ActionContext {
 }
 
 class RefreshTabContext: ActionContext {
-    let tabModels: [TabModel]
-    init(tabModels: [TabModel], windowUUID: WindowUUID) {
-        self.tabModels = tabModels
+    let tabDisplayModel: TabDisplayModel
+    init(tabDisplayModel: TabDisplayModel, windowUUID: WindowUUID) {
+        self.tabDisplayModel = tabDisplayModel
         super.init(windowUUID: windowUUID)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
@@ -5,6 +5,14 @@
 import Redux
 import Storage
 
+class TabDisplayModelContext: ActionContext {
+    let tabDisplayModel: TabDisplayModel
+    init(tabDisplayModel: TabDisplayModel, windowUUID: WindowUUID) {
+        self.tabDisplayModel = tabDisplayModel
+        super.init(windowUUID: windowUUID)
+    }
+}
+
 class BooleanValueContext: ActionContext {
     let boolValue: Bool
     init(boolValue: Bool, windowUUID: WindowUUID) {
@@ -13,10 +21,20 @@ class BooleanValueContext: ActionContext {
     }
 }
 
+class AddNewTabContext: ActionContext {
+    let urlRequest: URLRequest?
+    let isPrivate: Bool
+    init(urlRequest: URLRequest?, isPrivate: Bool, windowUUID: WindowUUID) {
+        self.urlRequest = urlRequest
+        self.isPrivate = isPrivate
+        super.init(windowUUID: windowUUID)
+    }
+}
+
 enum TabPanelAction: Action {
     case tabPanelDidLoad(Bool)
     case tabPanelDidAppear(Bool)
-    case addNewTab(URLRequest?, Bool)
+    case addNewTab(AddNewTabContext)
     case closeTab(String)
     case undoClose
     case closeAllTabs
@@ -34,14 +52,14 @@ enum TabPanelAction: Action {
     case showShareSheet(URL)
 
     // Middleware actions
-    case didLoadTabPanel(TabDisplayModel)
-    case refreshTab(TabDisplayModel) // Response to all user actions involving tabs ex: add, close and close all tabs
+    case didLoadTabPanel(TabDisplayModelContext)
+    case refreshTab(TabDisplayModelContext) // Response to all user actions involving tabs ex: add, close and close all tabs
     case refreshInactiveTabs([InactiveTabsModel])
 
-    var windowUUID: UUID? {
+    var windowUUID: UUID {
         // TODO: [8188] Update to be non-optional and return windowUUID. Forthcoming.
         switch self {
-        default: return nil
+        default: return .unavailable
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
@@ -13,7 +13,7 @@ class TabDisplayModelContext: ActionContext {
     }
 }
 
-class BooleanValueContext: ActionContext {
+class BoolValueContext: ActionContext {
     let boolValue: Bool
     init(boolValue: Bool, windowUUID: WindowUUID) {
         self.boolValue = boolValue
@@ -31,35 +31,114 @@ class AddNewTabContext: ActionContext {
     }
 }
 
+class URLRequestContext: ActionContext {
+    let urlRequest: URLRequest
+    init(urlRequest: URLRequest, windowUUID: WindowUUID) {
+        self.urlRequest = urlRequest
+        super.init(windowUUID: windowUUID)
+    }
+}
+
+class URLContext: ActionContext {
+    let url: URL
+    init(url: URL, windowUUID: WindowUUID) {
+        self.url = url
+        super.init(windowUUID: windowUUID)
+    }
+}
+
+class TabUUIDContext: ActionContext {
+    let tabUUID: String
+    init(tabUUID: String, windowUUID: WindowUUID) {
+        self.tabUUID = tabUUID
+        super.init(windowUUID: windowUUID)
+    }
+}
+
+class MoveTabContext: ActionContext {
+    let originIndex: Int
+    let destinationIndex: Int
+    init(originIndex: Int, destinationIndex: Int, windowUUID: WindowUUID) {
+        self.originIndex = originIndex
+        self.destinationIndex = destinationIndex
+        super.init(windowUUID: windowUUID)
+    }
+}
+
+class ToastTypeContext: ActionContext {
+    let toastType: ToastType
+    init(toastType: ToastType, windowUUID: WindowUUID) {
+        self.toastType = toastType
+        super.init(windowUUID: windowUUID)
+    }
+}
+
+class RefreshTabContext: ActionContext {
+    let tabModels: [TabModel]
+    init(tabModels: [TabModel], windowUUID: WindowUUID) {
+        self.tabModels = tabModels
+        super.init(windowUUID: windowUUID)
+    }
+}
+
+class RefreshInactiveTabsContext: ActionContext {
+    let inactiveTabModels: [InactiveTabsModel]
+    init(tabModels: [InactiveTabsModel], windowUUID: WindowUUID) {
+        self.inactiveTabModels = tabModels
+        super.init(windowUUID: windowUUID)
+    }
+}
+
+
 enum TabPanelAction: Action {
-    case tabPanelDidLoad(Bool)
-    case tabPanelDidAppear(Bool)
+    case tabPanelDidLoad(BoolValueContext)
+    case tabPanelDidAppear(BoolValueContext)
     case addNewTab(AddNewTabContext)
-    case closeTab(String)
-    case undoClose
-    case closeAllTabs
-    case undoCloseAllTabs
-    case moveTab(Int, Int)
-    case toggleInactiveTabs
-    case closeInactiveTabs(String)
-    case undoCloseInactiveTab
-    case closeAllInactiveTabs
-    case undoCloseAllInactiveTabs
-    case learnMorePrivateMode(URLRequest)
-    case selectTab(String)
-    case showToast(ToastType)
-    case hideUndoToast
-    case showShareSheet(URL)
+    case closeTab(TabUUIDContext)
+    case undoClose(ActionContext)
+    case closeAllTabs(ActionContext)
+    case undoCloseAllTabs(ActionContext)
+    case moveTab(MoveTabContext)
+    case toggleInactiveTabs(ActionContext)
+    case closeInactiveTabs(TabUUIDContext)
+    case undoCloseInactiveTab(ActionContext)
+    case closeAllInactiveTabs(ActionContext)
+    case undoCloseAllInactiveTabs(ActionContext)
+    case learnMorePrivateMode(URLRequestContext)
+    case selectTab(TabUUIDContext)
+    case showToast(ToastTypeContext)
+    case hideUndoToast(ActionContext)
+    case showShareSheet(URLContext)
 
     // Middleware actions
     case didLoadTabPanel(TabDisplayModelContext)
-    case refreshTab(TabDisplayModelContext) // Response to all user actions involving tabs ex: add, close and close all tabs
-    case refreshInactiveTabs([InactiveTabsModel])
+    case refreshTab(RefreshTabContext) // Response to all user actions involving tabs ex: add, close and close all tabs
+    case refreshInactiveTabs(RefreshInactiveTabsContext)
 
     var windowUUID: UUID {
-       // TODO: [8188] Use of .unavailable UUID is temporary as part of early MW refactors. WIP. 
         switch self {
-        default: return .unavailable
+        case .tabPanelDidLoad(let context as ActionContext),
+                .tabPanelDidAppear(let context as ActionContext),
+                .addNewTab(let context as ActionContext),
+                .closeTab(let context as ActionContext),
+                .undoClose(let context),
+                .closeAllTabs(let context),
+                .undoCloseAllTabs(let context),
+                .moveTab(let context as ActionContext),
+                .toggleInactiveTabs(let context),
+                .closeInactiveTabs(let context as ActionContext),
+                .undoCloseInactiveTab(let context),
+                .closeAllInactiveTabs(let context),
+                .undoCloseAllInactiveTabs(let context),
+                .learnMorePrivateMode(let context as ActionContext),
+                .selectTab(let context as ActionContext),
+                .showToast(let context as ActionContext),
+                .hideUndoToast(let context),
+                .showShareSheet(let context as ActionContext),
+                .didLoadTabPanel(let context as ActionContext),
+                .refreshTab(let context as ActionContext),
+                .refreshInactiveTabs(let context as ActionContext):
+            return context.windowUUID
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
@@ -57,7 +57,7 @@ enum TabPanelAction: Action {
     case refreshInactiveTabs([InactiveTabsModel])
 
     var windowUUID: UUID {
-        // TODO: [8188] Update to be non-optional and return windowUUID. Forthcoming.
+       // TODO: [8188] Use of .unavailable UUID is temporary as part of early MW refactors. WIP. 
         switch self {
         default: return .unavailable
         }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPeekAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPeekAction.swift
@@ -15,10 +15,10 @@ enum TabPeekAction: Action {
     // MARK: - Middleware Actions
     case loadTabPeek(tabPeekModel: TabPeekModel)
 
-    var windowUUID: UUID? {
+    var windowUUID: UUID {
         // TODO: [8188] Update to be non-optional and return windowUUID. Forthcoming.
         switch self {
-        default: return nil
+        default: return .unavailable
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPeekAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPeekAction.swift
@@ -16,7 +16,7 @@ enum TabPeekAction: Action {
     case loadTabPeek(tabPeekModel: TabPeekModel)
 
     var windowUUID: UUID {
-        // TODO: [8188] Update to be non-optional and return windowUUID. Forthcoming.
+       // TODO: [8188] Use of .unavailable UUID is temporary as part of early MW refactors. WIP. 
         switch self {
         default: return .unavailable
         }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPeekAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPeekAction.swift
@@ -4,21 +4,34 @@
 
 import Redux
 
+class TabPeekModelContext: ActionContext {
+    let tabPeekModel: TabPeekModel
+    init(tabPeekModel: TabPeekModel, windowUUID: WindowUUID) {
+        self.tabPeekModel = tabPeekModel
+        super.init(windowUUID: windowUUID)
+    }
+}
+
 enum TabPeekAction: Action {
     // MARK: - View Actions
-    case didLoadTabPeek(tabID: String)
-    case addToBookmarks(tabID: String)
-    case sendToDevice(tabID: String)
-    case copyURL(tabID: String)
-    case closeTab(tabID: String)
+    case didLoadTabPeek(TabUUIDContext)
+    case addToBookmarks(TabUUIDContext)
+    case sendToDevice(TabUUIDContext)
+    case copyURL(TabUUIDContext)
+    case closeTab(TabUUIDContext)
 
     // MARK: - Middleware Actions
-    case loadTabPeek(tabPeekModel: TabPeekModel)
+    case loadTabPeek(TabPeekModelContext)
 
     var windowUUID: UUID {
-       // TODO: [8188] Use of .unavailable UUID is temporary as part of early MW refactors. WIP. 
         switch self {
-        default: return .unavailable
+        case .didLoadTabPeek(let context as ActionContext),
+                .addToBookmarks(let context as ActionContext),
+                .sendToDevice(let context as ActionContext),
+                .copyURL(let context as ActionContext),
+                .closeTab(let context as ActionContext),
+                .loadTabPeek(let context as ActionContext):
+            return context.windowUUID
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabTrayAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabTrayAction.swift
@@ -4,19 +4,47 @@
 
 import Redux
 
+class TabTrayPanelContext: ActionContext {
+    let panelType: TabTrayPanelType
+    init(panelType: TabTrayPanelType, windowUUID: WindowUUID) {
+        self.panelType = panelType
+        super.init(windowUUID: windowUUID)
+    }
+}
+
+class TabTrayModelContext: ActionContext {
+    let tabTrayModel: TabTrayModel
+    init(tabTrayModel: TabTrayModel, windowUUID: WindowUUID) {
+        self.tabTrayModel = tabTrayModel
+        super.init(windowUUID: windowUUID)
+    }
+}
+
+class HasSyncableAccountContext: ActionContext {
+    let hasSyncableAccount: Bool
+    init(hasSyncableAccount: Bool, windowUUID: WindowUUID) {
+        self.hasSyncableAccount = hasSyncableAccount
+        super.init(windowUUID: windowUUID)
+    }
+}
+
 enum TabTrayAction: Action {
-    case tabTrayDidLoad(TabTrayPanelType)
-    case changePanel(TabTrayPanelType)
+    case tabTrayDidLoad(TabTrayPanelContext)
+    case changePanel(TabTrayPanelContext)
 
     // Middleware actions
-    case didLoadTabTray(TabTrayModel)
-    case dismissTabTray
-    case firefoxAccountChanged(Bool)
+    case didLoadTabTray(TabTrayModelContext)
+    case dismissTabTray(ActionContext)
+    case firefoxAccountChanged(HasSyncableAccountContext)
 
-    var windowUUID: UUID? {
-        // TODO: [8188] Update to be non-optional and return windowUUID. Forthcoming.
+    var windowUUID: UUID {
         switch self {
-        default: return nil
+        case .tabTrayDidLoad(let context as ActionContext),
+                .changePanel(let context as ActionContext),
+                .didLoadTabTray(let context as ActionContext),
+                .dismissTabTray(let context),
+                .firefoxAccountChanged(let context as ActionContext):
+            return context.windowUUID
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/RemoteTabsPanelMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/RemoteTabsPanelMiddleware.swift
@@ -29,9 +29,7 @@ class RemoteTabsPanelMiddleware {
         switch action {
         case RemoteTabsPanelAction.panelDidAppear:
             self.getSyncState(window: uuid)
-            let context =
-            HasSyncableAccountContext(hasSyncableAccount: self.hasSyncableAccount,
-                                      windowUUID: action.windowUUID)
+            let context = HasSyncableAccountContext(hasSyncableAccount: self.hasSyncableAccount, windowUUID: uuid)
             store.dispatch(TabTrayAction.firefoxAccountChanged(context))
         case RemoteTabsPanelAction.refreshTabs:
             self.getSyncState(window: uuid)
@@ -59,7 +57,7 @@ class RemoteTabsPanelMiddleware {
             // If above checks have succeeded, we know we can perform the tab refresh. We
             // need to update the State to .refreshing since there are implications for being
             // in the middle of a refresh (pull-to-refresh shouldn't trigger a new update etc.)
-            store.dispatch(RemoteTabsPanelAction.refreshDidBegin(ActionContext(windowUUID: window)))
+            store.dispatch(RemoteTabsPanelAction.refreshDidBegin(window.context))
 
             getCachedRemoteTabs(window: window)
         }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/RemoteTabsPanelMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/RemoteTabsPanelMiddleware.swift
@@ -25,48 +25,56 @@ class RemoteTabsPanelMiddleware {
     }
 
     lazy var remoteTabsPanelProvider: Middleware<AppState> = { [self] state, action in
+        let uuid = action.windowUUID
         switch action {
         case RemoteTabsPanelAction.panelDidAppear:
-            self.getSyncState()
-            store.dispatch(TabTrayAction.firefoxAccountChanged(self.hasSyncableAccount))
+            self.getSyncState(window: uuid)
+            let context =
+            HasSyncableAccountContext(hasSyncableAccount: self.hasSyncableAccount,
+                                      windowUUID: action.windowUUID)
+            store.dispatch(TabTrayAction.firefoxAccountChanged(context))
         case RemoteTabsPanelAction.refreshTabs:
-            self.getSyncState()
+            self.getSyncState(window: uuid)
         default:
             break
         }
     }
 
     // MARK: - Internal Utilities
-    private func getSyncState() {
+    private func getSyncState(window: WindowUUID) {
         ensureMainThread { [self] in
             guard self.hasSyncableAccount else {
-                store.dispatch(RemoteTabsPanelAction.refreshDidFail(.notLoggedIn))
+                let context = RemoteTabsRefreshDidFailContext(reason: .notLoggedIn, windowUUID: window)
+                store.dispatch(RemoteTabsPanelAction.refreshDidFail(context))
                 return
             }
 
             let syncEnabled = (profile.prefs.boolForKey(PrefsKeys.TabSyncEnabled) == true)
             guard syncEnabled else {
-                store.dispatch(RemoteTabsPanelAction.refreshDidFail(.syncDisabledByUser))
+                let context = RemoteTabsRefreshDidFailContext(reason: .syncDisabledByUser, windowUUID: window)
+                store.dispatch(RemoteTabsPanelAction.refreshDidFail(context))
                 return
             }
 
             // If above checks have succeeded, we know we can perform the tab refresh. We
             // need to update the State to .refreshing since there are implications for being
             // in the middle of a refresh (pull-to-refresh shouldn't trigger a new update etc.)
-            store.dispatch(RemoteTabsPanelAction.refreshDidBegin)
+            store.dispatch(RemoteTabsPanelAction.refreshDidBegin(ActionContext(windowUUID: window)))
 
-            getCachedRemoteTabs()
+            getCachedRemoteTabs(window: window)
         }
     }
 
-    private func getCachedRemoteTabs() {
+    private func getCachedRemoteTabs(window: WindowUUID) {
         profile.getCachedClientsAndTabs { result in
             guard let clientAndTabs = result else {
-                store.dispatch(RemoteTabsPanelAction.refreshDidFail(.failedToSync))
+                let context = RemoteTabsRefreshDidFailContext(reason: .failedToSync, windowUUID: window)
+                store.dispatch(RemoteTabsPanelAction.refreshDidFail(context))
                 return
             }
 
-            store.dispatch(RemoteTabsPanelAction.refreshDidSucceed(clientAndTabs))
+            let context = RemoteTabsRefreshSuccessContext(clientAndTabs: clientAndTabs, windowUUID: window)
+            store.dispatch(RemoteTabsPanelAction.refreshDidSucceed(context))
         }
     }
 
@@ -88,8 +96,12 @@ class RemoteTabsPanelMiddleware {
         switch notification.name {
         case .FirefoxAccountChanged,
                 .ProfileDidFinishSyncing:
-            getCachedRemoteTabs()
-            store.dispatch(TabTrayAction.firefoxAccountChanged(hasSyncableAccount))
+            // This state change is global in scope and typically occurs independently of specific windows
+            // For now we send .unavailable as the UUID. (Aspects of this are in flux.) [FXIOS-8188]
+            let uuid = WindowUUID.unavailable
+            let context = HasSyncableAccountContext(hasSyncableAccount: hasSyncableAccount, windowUUID: uuid)
+            getCachedRemoteTabs(window: .unavailable)
+            store.dispatch(TabTrayAction.firefoxAccountChanged(context))
         default: break
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/RemoteTabsPanelMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/RemoteTabsPanelMiddleware.swift
@@ -8,7 +8,6 @@ import Common
 import Shared
 import Redux
 
-// TODO: [8188] Middlewares are currently handling actions globally. Need updates for multi-window. Forthcoming.
 class RemoteTabsPanelMiddleware {
     private let profile: Profile
     var notificationCenter: NotificationProtocol

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/RemoteTabsPanelMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/RemoteTabsPanelMiddleware.swift
@@ -94,8 +94,9 @@ class RemoteTabsPanelMiddleware {
         switch notification.name {
         case .FirefoxAccountChanged,
                 .ProfileDidFinishSyncing:
-            // This state change is global in scope and typically occurs independently of specific windows
-            // For now we send .unavailable as the UUID. (Aspects of this are in flux.) [FXIOS-8188]
+            // This update occurs independently of any specific window, so for now we send `.unavailable`
+            // as the window UUID. Aspects of this are TBD and part of ongoing MW/Redux refactors.
+            // TODO: [8188] Revisit UUID here to determine ideal handling.
             let uuid = WindowUUID.unavailable
             let context = HasSyncableAccountContext(hasSyncableAccount: hasSyncableAccount, windowUUID: uuid)
             getCachedRemoteTabs(window: .unavailable)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -215,7 +215,7 @@ class TabManagerMiddleware {
         tabManager.selectTab(tab)
 
         let model = getTabsDisplayModel(for: isPrivate, shouldScrollToTab: true, uuid: uuid)
-        store.dispatch(TabPanelAction.refreshTab(RefreshTabContext(tabModels: model, windowUUID: uuid)))
+        store.dispatch(TabPanelAction.refreshTab(RefreshTabContext(tabDisplayModel: model, windowUUID: uuid)))
         store.dispatch(TabTrayAction.dismissTabTray(uuid.context))
     }
 
@@ -237,8 +237,8 @@ class TabManagerMiddleware {
                                      value: .tabTray)
         tabManager.moveTab(isPrivate: false, fromIndex: originIndex, toIndex: destinationIndex)
 
-        let tabs = self.refreshTabs(for: tabsState.isPrivateMode, uuid: uuid, shouldScrollToTab: false)
-        let context = RefreshTabContext(tabModels: tabs, windowUUID: uuid)
+        let model = getTabsDisplayModel(for: tabsState.isPrivateMode, shouldScrollToTab: false, uuid: uuid)
+        let context = RefreshTabContext(tabDisplayModel: model, windowUUID: uuid)
         store.dispatch(TabPanelAction.refreshTab(context))
     }
 
@@ -276,7 +276,7 @@ class TabManagerMiddleware {
         let tabManager = tabManager(for: uuid)
         let isPrivate = tabManager.selectedTab?.isPrivate ?? false
         let model = getTabsDisplayModel(for: isPrivate, shouldScrollToTab: shouldScrollToTab, uuid: uuid)
-        let context = RefreshTabContext(tabModels: model, windowUUID: uuid)
+        let context = RefreshTabContext(tabDisplayModel: model, windowUUID: uuid)
         store.dispatch(TabPanelAction.refreshTab(context))
     }
 
@@ -290,7 +290,7 @@ class TabManagerMiddleware {
         tabManager.undoCloseTab(tab: backupTab.tab, position: backupTab.restorePosition)
 
         let model = getTabsDisplayModel(for: tabsState.isPrivateMode, shouldScrollToTab: false, uuid: uuid)
-        let context = RefreshTabContext(tabModels: model, windowUUID: uuid)
+        let context = RefreshTabContext(tabDisplayModel: model, windowUUID: uuid)
         store.dispatch(TabPanelAction.refreshTab(context))
     }
 
@@ -301,10 +301,10 @@ class TabManagerMiddleware {
             let count = tabManager.tabs.count
             await tabManager.removeAllTabs(isPrivateMode: tabsState.isPrivateMode)
 
-            ensureMainThread {
+            ensureMainThread { [self] in
                 let model = getTabsDisplayModel(for: tabsState.isPrivateMode, shouldScrollToTab: false, uuid: uuid)
-                let context = RefreshTabContext(tabModels: model, windowUUID: uuid)
-                store.dispatch(TabPanelAction.refreshTab(model))
+                let context = RefreshTabContext(tabDisplayModel: model, windowUUID: uuid)
+                store.dispatch(TabPanelAction.refreshTab(context))
                 store.dispatch(TabTrayAction.dismissTabTray(uuid.context))
                 store.dispatch(GeneralBrowserAction.showToast(ToastTypeContext(toastType: .allTabs(count: count),
                                                                                windowUUID: uuid)))
@@ -380,7 +380,7 @@ class TabManagerMiddleware {
     private func didTapLearnMoreAboutPrivate(with urlRequest: URLRequest, uuid: WindowUUID) {
         addNewTab(with: urlRequest, isPrivate: true, for: uuid)
         let model = getTabsDisplayModel(for: true, shouldScrollToTab: false, uuid: uuid)
-        let context = RefreshTabContext(tabModels: tabs, windowUUID: uuid)
+        let context = RefreshTabContext(tabDisplayModel: model, windowUUID: uuid)
         store.dispatch(TabPanelAction.refreshTab(context))
         store.dispatch(TabTrayAction.dismissTabTray(uuid.context))
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -8,7 +8,6 @@ import TabDataStore
 import Shared
 import Storage
 
-// TODO: [8188] Middlewares are currently handling actions globally. Need updates for multi-window. Forthcoming.
 class TabManagerMiddleware {
     var selectedPanel: TabTrayPanelType = .tabs
     private let profile: Profile
@@ -229,7 +228,6 @@ class TabManagerMiddleware {
                          from originIndex: Int,
                          to destinationIndex: Int,
                          uuid: WindowUUID) {
-        // TODO: [8188] Tab actions will be updated soon to include UUID in related context object. Forthcoming.
         guard let tabsState = state.screenState(TabsPanelState.self, for: .tabsPanel, window: nil) else { return }
 
         let tabManager = tabManager(for: uuid)
@@ -285,7 +283,6 @@ class TabManagerMiddleware {
     /// Handles undoing the close tab action, gets the backup tab from `TabManager`
     private func undoCloseTab(state: AppState, uuid: WindowUUID) {
         let tabManager = tabManager(for: uuid)
-        // TODO: [8188] Tab actions will be updated soon to include UUID in related context object. Forthcoming.
         guard let tabsState = state.screenState(TabsPanelState.self, for: .tabsPanel, window: nil),
               let backupTab = tabManager.backupCloseTab
         else { return }
@@ -299,7 +296,6 @@ class TabManagerMiddleware {
 
     private func closeAllTabs(state: AppState, uuid: WindowUUID) {
         let tabManager = tabManager(for: uuid)
-        // TODO: [8188] Tab actions will be updated soon to include UUID in related context object. Forthcoming.
         guard let tabsState = state.screenState(TabsPanelState.self, for: .tabsPanel, window: nil) else { return }
         Task {
             let count = tabManager.tabs.count
@@ -330,7 +326,6 @@ class TabManagerMiddleware {
     /// Close all inactive tabs removing them from the tabs array on `TabManager`.
     /// Makes a backup of tabs to be deleted in case undo option is selected
     private func closeAllInactiveTabs(state: AppState, uuid: WindowUUID) {
-        // TODO: [8188] Tab actions will be updated soon to include UUID in related context object. Forthcoming.
         guard let tabsState = state.screenState(TabsPanelState.self, for: .tabsPanel, window: nil) else { return }
         let tabManager = tabManager(for: uuid)
         Task {
@@ -355,7 +350,6 @@ class TabManagerMiddleware {
     }
 
     private func closeInactiveTab(for tabUUID: String, state: AppState, uuid: WindowUUID) {
-        // TODO: [8188] Tab actions will be updated soon to include UUID in related context object. Forthcoming.
         guard let tabsState = state.screenState(TabsPanelState.self, for: .tabsPanel, window: nil) else { return }
         let tabManager = tabManager(for: uuid)
         Task {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -12,9 +12,12 @@ import Storage
 class TabManagerMiddleware {
     var selectedPanel: TabTrayPanelType = .tabs
     private let profile: Profile
+    private let logger: Logger
 
-    init(profile: Profile = AppContainer.shared.resolve()) {
+    init(profile: Profile = AppContainer.shared.resolve(),
+         logger: Logger = DefaultLogger.shared) {
         self.profile = profile
+        self.logger = logger
     }
 
     lazy var tabsPanelProvider: Middleware<AppState> = { state, action in
@@ -371,6 +374,11 @@ class TabManagerMiddleware {
 
     private func tabManager(for uuid: WindowUUID) -> TabManager {
         let windowManager: WindowManager = AppContainer.shared.resolve()
+        guard uuid != .unavailable else {
+            logger.log("Unexpected or unavailable UUID for TabManager. Returning active window tab manager by default.", level: .warning, category: .tabs)
+            return windowManager.tabManager(for: windowManager.activeWindow)
+        }
+
         return windowManager.tabManager(for: uuid)
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -13,95 +13,104 @@ class TabManagerMiddleware {
     var selectedPanel: TabTrayPanelType = .tabs
     private let profile: Profile
 
-    var normalTabsCountText: String {
-        (defaultTabManager.normalTabs.count < 100) ? defaultTabManager.normalTabs.count.description : "\u{221E}"
-    }
-
     init(profile: Profile = AppContainer.shared.resolve()) {
         self.profile = profile
     }
 
     lazy var tabsPanelProvider: Middleware<AppState> = { state, action in
+        let uuid = action.windowUUID
         switch action {
-        case TabTrayAction.tabTrayDidLoad(let panelType):
-            let tabTrayModel = self.getTabTrayModel(for: panelType)
-            store.dispatch(TabTrayAction.didLoadTabTray(tabTrayModel))
+        case TabTrayAction.tabTrayDidLoad(let context):
+            let panelType = context.panelType
+            let tabTrayModel = self.getTabTrayModel(for: panelType, window: uuid)
+            let context = TabTrayModelContext(tabTrayModel: tabTrayModel, windowUUID: uuid)
+            store.dispatch(TabTrayAction.didLoadTabTray(context))
 
         case TabPanelAction.tabPanelDidLoad(let isPrivate):
-            let tabState = self.getTabsDisplayModel(for: isPrivate, shouldScrollToTab: true)
-            store.dispatch(TabPanelAction.didLoadTabPanel(tabState))
+            let tabState = self.getTabsDisplayModel(for: isPrivate, shouldScrollToTab: true, uuid: uuid)
+            let context = TabDisplayModelContext(tabDisplayModel: tabState, windowUUID: uuid)
+            store.dispatch(TabPanelAction.didLoadTabPanel(context))
 
-        case TabTrayAction.changePanel(let panelType):
-            self.changePanel(panelType)
+        case TabTrayAction.changePanel(let context):
+            self.changePanel(context.panelType, uuid: uuid)
 
-        case TabPanelAction.addNewTab(let urlRequest, let isPrivateMode):
-            self.addNewTab(with: urlRequest, isPrivate: isPrivateMode)
+        case TabPanelAction.addNewTab(let context):
+            let urlRequest = context.urlRequest
+            let isPrivateMode = context.isPrivate
+            self.addNewTab(with: urlRequest, isPrivate: isPrivateMode, for: uuid)
 
         case TabPanelAction.moveTab(let originIndex, let destinationIndex):
-            self.moveTab(state: state, from: originIndex, to: destinationIndex)
+            self.moveTab(state: state, from: originIndex, to: destinationIndex, uuid: uuid)
 
         case TabPanelAction.closeTab(let tabUUID):
-            self.closeTabFromTabPanel(with: tabUUID)
+            self.closeTabFromTabPanel(with: tabUUID, uuid: uuid)
 
         case TabPanelAction.undoClose:
-            self.undoCloseTab(state: state)
+            self.undoCloseTab(state: state, uuid: uuid)
 
         case TabPanelAction.closeAllTabs:
-            self.closeAllTabs(state: state)
+            self.closeAllTabs(state: state, uuid: uuid)
 
         case TabPanelAction.undoCloseAllTabs:
-            self.defaultTabManager.undoCloseAllTabs()
+            self.tabManager(for: uuid).undoCloseAllTabs()
 
         case TabPanelAction.selectTab(let tabUUID):
-            self.selectTab(for: tabUUID)
-            store.dispatch(TabTrayAction.dismissTabTray)
+            self.selectTab(for: tabUUID, uuid: uuid)
+            store.dispatch(TabTrayAction.dismissTabTray(ActionContext(windowUUID: uuid)))
 
         case TabPanelAction.closeAllInactiveTabs:
-            self.closeAllInactiveTabs(state: state)
+            self.closeAllInactiveTabs(state: state, uuid: uuid)
 
         case TabPanelAction.undoCloseAllInactiveTabs:
-            self.undoCloseAllInactiveTabs()
+            self.undoCloseAllInactiveTabs(uuid: uuid)
 
         case TabPanelAction.closeInactiveTabs(let tabUUID):
 
-            self.closeInactiveTab(for: tabUUID, state: state)
+            self.closeInactiveTab(for: tabUUID, state: state, uuid: uuid)
 
         case TabPanelAction.undoCloseInactiveTab:
-            self.undoCloseInactiveTab()
+            self.undoCloseInactiveTab(uuid: uuid)
 
         case TabPanelAction.learnMorePrivateMode(let urlRequest):
-            self.didTapLearnMoreAboutPrivate(with: urlRequest)
+            self.didTapLearnMoreAboutPrivate(with: urlRequest, uuid: uuid)
 
-        case RemoteTabsPanelAction.openSelectedURL(let url):
-            self.openSelectedURL(url: url)
+        case RemoteTabsPanelAction.openSelectedURL(let context):
+            let url = context.url
+            let uuid = context.windowUUID
+            self.openSelectedURL(url: url, windowUUID: uuid)
 
         case TabPeekAction.didLoadTabPeek(let tabID):
-            self.didLoadTabPeek(tabID: tabID)
+            self.didLoadTabPeek(tabID: tabID, uuid: uuid)
 
         case TabPeekAction.addToBookmarks(let tabID):
-            self.addToBookmarks(with: tabID)
+            self.addToBookmarks(with: tabID, uuid: uuid)
 
         case TabPeekAction.sendToDevice(let tabID):
-            self.sendToDevice(tabID: tabID)
+            self.sendToDevice(tabID: tabID, uuid: uuid)
 
         case TabPeekAction.copyURL(let tabID):
-            self.copyURL(tabID: tabID)
+            self.copyURL(tabID: tabID, uuid: uuid)
 
         case TabPeekAction.closeTab(let tabID):
-            self.tabPeekCloseTab(with: tabID)
+            self.tabPeekCloseTab(with: tabID, uuid: uuid)
             store.dispatch(TabPanelAction.showToast(.singleTab))
         default:
             break
         }
     }
 
-    private func openSelectedURL(url: URL) {
+    private func normalTabsCountText(for windowUUID: WindowUUID) -> String {
+        let tabManager = tabManager(for: windowUUID)
+        return (tabManager.normalTabs.count < 100) ? tabManager.normalTabs.count.description : "\u{221E}"
+    }
+
+    private func openSelectedURL(url: URL, windowUUID: WindowUUID) {
         TelemetryWrapper.recordEvent(category: .action,
                                      method: .open,
                                      object: .syncTab)
         let urlRequest = URLRequest(url: url)
-        self.addNewTab(with: urlRequest, isPrivate: false)
-        store.dispatch(TabTrayAction.dismissTabTray)
+        self.addNewTab(with: urlRequest, isPrivate: false, for: windowUUID)
+        store.dispatch(TabTrayAction.dismissTabTray(ActionContext(windowUUID: windowUUID)))
     }
 
     /// Gets initial state for TabTrayModel includes panelType, if is on Private mode,
@@ -109,13 +118,13 @@ class TabManagerMiddleware {
     /// 
     /// - Parameter panelType: The selected panelType
     /// - Returns: Initial state of TabTrayModel
-    private func getTabTrayModel(for panelType: TabTrayPanelType) -> TabTrayModel {
+    private func getTabTrayModel(for panelType: TabTrayPanelType, window: WindowUUID) -> TabTrayModel {
         selectedPanel = panelType
 
         let isPrivate = panelType == .privateTabs
         return TabTrayModel(isPrivateMode: isPrivate,
                             selectedPanel: panelType,
-                            normalTabsCount: normalTabsCountText,
+                            normalTabsCount: normalTabsCountText(for: window),
                             hasSyncableAccount: false)
     }
 
@@ -123,12 +132,13 @@ class TabManagerMiddleware {
     /// - Parameter isPrivateMode: if Private mode is enabled or not
     /// - Returns:  initial model for `TabDisplayPanel`
     private func getTabsDisplayModel(for isPrivateMode: Bool,
-                                     shouldScrollToTab: Bool) -> TabDisplayModel {
-        let tabs = refreshTabs(for: isPrivateMode)
-        let inactiveTabs = refreshInactiveTabs(for: isPrivateMode)
+                                     shouldScrollToTab: Bool,
+                                     uuid: WindowUUID) -> TabDisplayModel {
+        let tabs = refreshTabs(for: isPrivateMode, uuid: uuid)
+        let inactiveTabs = refreshInactiveTabs(for: isPrivateMode, uuid: uuid)
         let tabDisplayModel = TabDisplayModel(isPrivateMode: isPrivateMode,
                                               tabs: tabs,
-                                              normalTabsCount: normalTabsCountText,
+                                              normalTabsCount: normalTabsCountText(for: uuid),
                                               inactiveTabs: inactiveTabs,
                                               isInactiveTabsExpanded: false,
                                               shouldScrollToTab: shouldScrollToTab)
@@ -138,10 +148,11 @@ class TabManagerMiddleware {
     /// Gets the list of tabs from `TabManager` and builds the array of TabModel to use in TabDisplayView
     /// - Parameter isPrivateMode: is on Private mode or not
     /// - Returns: Array of TabModel used to configure collection view
-    private func refreshTabs(for isPrivateMode: Bool) -> [TabModel] {
+    private func refreshTabs(for isPrivateMode: Bool, uuid: WindowUUID) -> [TabModel] {
         var tabs = [TabModel]()
-        let selectedTab = defaultTabManager.selectedTab
-        let tabManagerTabs = isPrivateMode ? defaultTabManager.privateTabs : defaultTabManager.normalActiveTabs
+        let tabManager = tabManager(for: uuid)
+        let selectedTab = tabManager.selectedTab
+        let tabManagerTabs = isPrivateMode ? tabManager.privateTabs : tabManager.normalActiveTabs
         tabManagerTabs.forEach { tab in
             let tabModel = TabModel(tabUUID: tab.tabUUID,
                                     isSelected: tab == selectedTab,
@@ -162,11 +173,12 @@ class TabManagerMiddleware {
     ///
     /// - Parameter isPrivateMode: is on Private mode or not
     /// - Returns: Array of InactiveTabsModel used to configure collection view
-    private func refreshInactiveTabs(for isPrivateMode: Bool = false) -> [InactiveTabsModel] {
+    private func refreshInactiveTabs(for isPrivateMode: Bool = false, uuid: WindowUUID) -> [InactiveTabsModel] {
         guard !isPrivateMode else { return [InactiveTabsModel]() }
 
+        let tabManager = tabManager(for: uuid)
         var inactiveTabs = [InactiveTabsModel]()
-        for tab in defaultTabManager.getInactiveTabs() {
+        for tab in tabManager.getInactiveTabs() {
             let inactiveTab = InactiveTabsModel(tabUUID: tab.tabUUID,
                                                 title: tab.displayTitle,
                                                 url: tab.url,
@@ -181,15 +193,16 @@ class TabManagerMiddleware {
     /// - Parameters:
     ///   - urlRequest: URL request to load
     ///   - isPrivate: if the tab should be created in private mode or not
-    private func addNewTab(with urlRequest: URLRequest?, isPrivate: Bool) {
+    private func addNewTab(with urlRequest: URLRequest?, isPrivate: Bool, for uuid: WindowUUID) {
         // TODO: Legacy class has a guard to cancel adding new tab if dragging was enabled,
         // check if change is still needed
-        let tab = defaultTabManager.addTab(urlRequest, isPrivate: isPrivate)
-        defaultTabManager.selectTab(tab)
+        let tabManager = tabManager(for: uuid)
+        let tab = tabManager.addTab(urlRequest, isPrivate: isPrivate)
+        tabManager.selectTab(tab)
 
-        let model = getTabsDisplayModel(for: isPrivate, shouldScrollToTab: true)
+        let model = getTabsDisplayModel(for: isPrivate, shouldScrollToTab: true, uuid: uuid)
         store.dispatch(TabPanelAction.refreshTab(model))
-        store.dispatch(TabTrayAction.dismissTabTray)
+        store.dispatch(TabTrayAction.dismissTabTray(ActionContext(windowUUID: uuid))))
     }
 
     /// Move tab on `TabManager` array to support drag and drop
@@ -197,17 +210,21 @@ class TabManagerMiddleware {
     /// - Parameters:
     ///   - originIndex: from original position
     ///   - destinationIndex: to destination position
-    private func moveTab(state: AppState, from originIndex: Int, to destinationIndex: Int) {
+    private func moveTab(state: AppState,
+                         from originIndex: Int,
+                         to destinationIndex: Int,
+                         uuid: WindowUUID) {
         // TODO: [8188] Tab actions will be updated soon to include UUID in related context object. Forthcoming.
         guard let tabsState = state.screenState(TabsPanelState.self, for: .tabsPanel, window: nil) else { return }
 
+        let tabManager = tabManager(for: uuid)
         TelemetryWrapper.recordEvent(category: .action,
                                      method: .drop,
                                      object: .tab,
                                      value: .tabTray)
-        defaultTabManager.moveTab(isPrivate: false, fromIndex: originIndex, toIndex: destinationIndex)
+        tabManager.moveTab(isPrivate: false, fromIndex: originIndex, toIndex: destinationIndex)
 
-        let model = getTabsDisplayModel(for: tabsState.isPrivateMode, shouldScrollToTab: false)
+        let tabs = self.refreshTabs(for: tabsState.isPrivateMode, uuid: uuid, shouldScrollToTab: false)
         store.dispatch(TabPanelAction.refreshTab(model))
     }
 
@@ -217,20 +234,21 @@ class TabManagerMiddleware {
     /// - Parameters:
     ///   - tabUUID: UUID of the tab to be closed/removed
     /// - Returns: If is the last tab to be closed used to trigger dismissTabTray action
-    private func closeTab(with tabUUID: String) async -> Bool {
-        let isLastTab = defaultTabManager.normalTabs.count == 1
-        await defaultTabManager.removeTab(tabUUID)
+    private func closeTab(with tabUUID: String, uuid: WindowUUID) async -> Bool {
+        let tabManager = tabManager(for: uuid)
+        let isLastTab = tabManager.normalTabs.count == 1
+        await tabManager.removeTab(tabUUID)
         return isLastTab
     }
 
     /// Close tab and trigger refresh
     /// - Parameter tabUUID: UUID of the tab to be closed/removed
-    private func closeTabFromTabPanel(with tabUUID: String) {
+    private func closeTabFromTabPanel(with tabUUID: String, uuid: WindowUUID) {
         Task {
-            let shouldDismiss = await self.closeTab(with: tabUUID)
-            await self.triggerRefresh(shouldScrollToTab: false)
+            let shouldDismiss = await self.closeTab(with: tabUUID, uuid: uuid)
+            await self.triggerRefresh(shouldScrollToTab: false, uuid: uuid)
             if shouldDismiss {
-                store.dispatch(TabTrayAction.dismissTabTray)
+                store.dispatch(TabTrayAction.dismissTabTray(ActionContext(windowUUID: uuid)))
                 store.dispatch(GeneralBrowserAction.showToast(.singleTab))
             } else {
                 store.dispatch(TabPanelAction.showToast(.singleTab))
@@ -240,35 +258,38 @@ class TabManagerMiddleware {
 
     /// Trigger refreshTabs action after a change in `TabManager`
     @MainActor
-    private func triggerRefresh(shouldScrollToTab: Bool) {
-        let isPrivate = defaultTabManager.selectedTab?.isPrivate ?? false
+    private func triggerRefresh(shouldScrollToTab: Bool, uuid: WindowUUID) {
+        let tabManager = tabManager(for: uuid)
+        let isPrivate = tabManager.selectedTab?.isPrivate ?? false
         let model = getTabsDisplayModel(for: isPrivate, shouldScrollToTab: shouldScrollToTab)
         store.dispatch(TabPanelAction.refreshTab(model))
     }
 
     /// Handles undoing the close tab action, gets the backup tab from `TabManager`
-    private func undoCloseTab(state: AppState) {
+    private func undoCloseTab(state: AppState, uuid: WindowUUID) {
+        let tabManager = tabManager(for: uuid)
         // TODO: [8188] Tab actions will be updated soon to include UUID in related context object. Forthcoming.
         guard let tabsState = state.screenState(TabsPanelState.self, for: .tabsPanel, window: nil),
-              let backupTab = defaultTabManager.backupCloseTab
+              let backupTab = tabManager.backupCloseTab
         else { return }
 
-        defaultTabManager.undoCloseTab(tab: backupTab.tab, position: backupTab.restorePosition)
-        let model = getTabsDisplayModel(for: tabsState.isPrivateMode, shouldScrollToTab: false)
-        store.dispatch(TabPanelAction.refreshTab(model))
+        tabManager.undoCloseTab(tab: backupTab.tab, position: backupTab.restorePosition)
+        let model = getTabsDisplayModel(for: tabsState.isPrivateMode, shouldScrollToTab: false, uuid: uuid)
+        store.dispatch(TabPanelAction.refreshTab(tabs))
     }
 
-    private func closeAllTabs(state: AppState) {
+    private func closeAllTabs(state: AppState, uuid: WindowUUID) {
+        let tabManager = tabManager(for: uuid)
         // TODO: [8188] Tab actions will be updated soon to include UUID in related context object. Forthcoming.
         guard let tabsState = state.screenState(TabsPanelState.self, for: .tabsPanel, window: nil) else { return }
         Task {
-            let count = self.defaultTabManager.tabs.count
-            await defaultTabManager.removeAllTabs(isPrivateMode: tabsState.isPrivateMode)
+            let count = tabManager.tabs.count
+            await tabManager.removeAllTabs(isPrivateMode: tabsState.isPrivateMode)
 
-            ensureMainThread { [self] in
-                let model = getTabsDisplayModel(for: tabsState.isPrivateMode, shouldScrollToTab: false)
+            ensureMainThread {
+                let model = getTabsDisplayModel(for: tabsState.isPrivateMode, shouldScrollToTab: false, uuid: uuid)
                 store.dispatch(TabPanelAction.refreshTab(model))
-                store.dispatch(TabTrayAction.dismissTabTray)
+                store.dispatch(TabTrayAction.dismissTabTray(ActionContext(windowUUID: uuid)))
                 store.dispatch(GeneralBrowserAction.showToast(.allTabs(count: count)))
             }
         }
@@ -277,81 +298,87 @@ class TabManagerMiddleware {
     /// Handles undo close all tabs. Adds back all tabs depending on mode
     ///
     /// - Parameter isPrivateMode: if private mode is active or not
-    private func undoCloseAllTabs(isPrivateMode: Bool) {
+    private func undoCloseAllTabs(isPrivateMode: Bool, uuid: WindowUUID) {
         // TODO: FXIOS-7978 Handle Undo close all tabs
-        defaultTabManager.undoCloseAllTabs()
+        let tabManager = tabManager(for: uuid)
+        tabManager.undoCloseAllTabs()
     }
 
     // MARK: - Inactive tabs helper
 
     /// Close all inactive tabs removing them from the tabs array on `TabManager`.
     /// Makes a backup of tabs to be deleted in case undo option is selected
-    private func closeAllInactiveTabs(state: AppState) {
+    private func closeAllInactiveTabs(state: AppState, uuid: WindowUUID) {
         // TODO: [8188] Tab actions will be updated soon to include UUID in related context object. Forthcoming.
         guard let tabsState = state.screenState(TabsPanelState.self, for: .tabsPanel, window: nil) else { return }
+        let tabManager = tabManager(for: uuid)
         Task {
-            await defaultTabManager.removeAllInactiveTabs()
+            await tabManager.removeAllInactiveTabs()
             store.dispatch(TabPanelAction.refreshInactiveTabs([InactiveTabsModel]()))
             store.dispatch(TabPanelAction.showToast(.allInactiveTabs(count: tabsState.inactiveTabs.count)))
         }
     }
 
     /// Handles undo close all inactive tabs. Adding back the backup tabs saved previously
-    private func undoCloseAllInactiveTabs() {
+    private func undoCloseAllInactiveTabs(uuid: WindowUUID) {
+        let tabManager = tabManager(for: uuid)
         ensureMainThread {
-            self.defaultTabManager.undoCloseInactiveTabs()
-            let inactiveTabs = self.refreshInactiveTabs()
+            tabManager.undoCloseInactiveTabs()
+            let inactiveTabs = self.refreshInactiveTabs(uuid: uuid)
             store.dispatch(TabPanelAction.refreshInactiveTabs(inactiveTabs))
         }
     }
 
-    private func closeInactiveTab(for tabUUID: String, state: AppState) {
+    private func closeInactiveTab(for tabUUID: String, state: AppState, uuid: WindowUUID) {
         // TODO: [8188] Tab actions will be updated soon to include UUID in related context object. Forthcoming.
         guard let tabsState = state.screenState(TabsPanelState.self, for: .tabsPanel, window: nil) else { return }
+        let tabManager = tabManager(for: uuid)
         Task {
-            if let tabToClose = defaultTabManager.getTabForUUID(uuid: tabUUID) {
+            if let tabToClose = tabManager.getTabForUUID(uuid: tabUUID) {
                 let index = tabsState.inactiveTabs.firstIndex { $0.tabUUID == tabUUID }
-                defaultTabManager.backupCloseTab = BackupCloseTab(tab: tabToClose, restorePosition: index)
+                tabManager.backupCloseTab = BackupCloseTab(tab: tabToClose, restorePosition: index)
             }
-            await defaultTabManager.removeTab(tabUUID)
+            await tabManager.removeTab(tabUUID)
 
-            let inactiveTabs = self.refreshInactiveTabs()
+            let inactiveTabs = self.refreshInactiveTabs(uuid: uuid)
             store.dispatch(TabPanelAction.refreshInactiveTabs(inactiveTabs))
             store.dispatch(TabPanelAction.showToast(.singleInactiveTabs))
         }
     }
 
-    private func undoCloseInactiveTab() {
-        guard let backupTab = defaultTabManager.backupCloseTab else { return }
+    private func undoCloseInactiveTab(uuid: WindowUUID) {
+        let windowTabManager = self.tabManager(for: uuid)
+        guard let backupTab = windowTabManager.backupCloseTab else { return }
 
-        defaultTabManager.undoCloseTab(tab: backupTab.tab, position: backupTab.restorePosition)
-        let inactiveTabs = self.refreshInactiveTabs()
+        windowTabManager.undoCloseTab(tab: backupTab.tab, position: backupTab.restorePosition)
+        let inactiveTabs = self.refreshInactiveTabs(uuid: uuid)
         store.dispatch(TabPanelAction.refreshInactiveTabs(inactiveTabs))
     }
 
-    private func didTapLearnMoreAboutPrivate(with urlRequest: URLRequest) {
-        addNewTab(with: urlRequest, isPrivate: true)
-        let model = getTabsDisplayModel(for: true, shouldScrollToTab: false)
+    private func didTapLearnMoreAboutPrivate(with urlRequest: URLRequest, uuid: WindowUUID) {
+        addNewTab(with: urlRequest, isPrivate: true, for: uuid)
+        let model = getTabsDisplayModel(for: true, shouldScrollToTab: false, uuid: uuid)
         store.dispatch(TabPanelAction.refreshTab(model))
-        store.dispatch(TabTrayAction.dismissTabTray)
+        store.dispatch(TabTrayAction.dismissTabTray(ActionContext(windowUUID: uuid)))
     }
 
-    private func selectTab(for tabUUID: String) {
-        guard let tab = defaultTabManager.getTabForUUID(uuid: tabUUID) else { return }
+    private func selectTab(for tabUUID: String, uuid: WindowUUID) {
+        let tabManager = tabManager(for: uuid)
+        guard let tab = tabManager.getTabForUUID(uuid: tabUUID) else { return }
 
-        defaultTabManager.selectTab(tab)
+        tabManager.selectTab(tab)
     }
 
-    private var defaultTabManager: TabManager {
-        // TODO: [FXIOS-8071] Temporary. WIP for Redux + iPad Multi-window.
+    private func tabManager(for uuid: WindowUUID) -> TabManager {
         let windowManager: WindowManager = AppContainer.shared.resolve()
-        return windowManager.tabManager(for: windowManager.activeWindow)
+        return windowManager.tabManager(for: uuid)
     }
 
     // MARK: - Tab Peek
 
-    private func didLoadTabPeek(tabID: String) {
-        let tab = defaultTabManager.getTabForUUID(uuid: tabID)
+    private func didLoadTabPeek(tabID: String, uuid: WindowUUID) {
+        let tabManager = tabManager(for: uuid)
+        let tab = tabManager.getTabForUUID(uuid: tabID)
         profile.places.isBookmarked(url: tab?.url?.absoluteString ?? "") >>== { isBookmarked in
             var canBeSaved = true
             if isBookmarked || (tab?.urlIsTooLong ?? false) || (tab?.isFxHomeTab ?? false) {
@@ -368,8 +395,9 @@ class TabManagerMiddleware {
         }
     }
 
-    private func addToBookmarks(with tabID: String) {
-        guard let tab = defaultTabManager.getTabForUUID(uuid: tabID),
+    private func addToBookmarks(with tabID: String, uuid: WindowUUID) {
+        let tabManager = tabManager(for: uuid)
+        guard let tab = tabManager.getTabForUUID(uuid: tabID),
               let url = tab.url?.absoluteString, !url.isEmpty
         else { return }
 
@@ -400,29 +428,32 @@ class TabManagerMiddleware {
                                      value: .tabTray)
     }
 
-    private func sendToDevice(tabID: String) {
-        guard let tabToShare = defaultTabManager.getTabForUUID(uuid: tabID),
+    private func sendToDevice(tabID: String, uuid: WindowUUID) {
+        let tabManager = tabManager(for: uuid)
+        guard let tabToShare = tabManager.getTabForUUID(uuid: tabID),
               let url = tabToShare.url
         else { return }
 
         store.dispatch(TabPanelAction.showShareSheet(url))
     }
 
-    private func copyURL(tabID: String) {
-        UIPasteboard.general.url = defaultTabManager.selectedTab?.canonicalURL
+    private func copyURL(tabID: String, uuid: WindowUUID) {
+        let tabManager = tabManager(for: uuid)
+        UIPasteboard.general.url = tabManager.selectedTab?.canonicalURL
         store.dispatch(TabPanelAction.showToast(.copyURL))
     }
 
-    private func tabPeekCloseTab(with tabID: String) {
-        closeTabFromTabPanel(with: tabID)
+    private func tabPeekCloseTab(with tabID: String, uuid: WindowUUID) {
+        closeTabFromTabPanel(with: tabID, uuid: uuid)
     }
 
-    private func changePanel(_ panel: TabTrayPanelType) {
+    private func changePanel(_ panel: TabTrayPanelType, uuid: WindowUUID) {
         self.trackPanelChange(panel)
         let isPrivate = panel == TabTrayPanelType.privateTabs
-        let tabState = self.getTabsDisplayModel(for: isPrivate, shouldScrollToTab: false)
+        let tabState = self.getTabsDisplayModel(for: isPrivate, shouldScrollToTab: false, uuid: uuid)
         if panel != .syncedTabs {
-            store.dispatch(TabPanelAction.didLoadTabPanel(tabState))
+            let context = TabDisplayModelContext(tabDisplayModel: tabState, windowUUID: uuid)
+            store.dispatch(TabPanelAction.didLoadTabPanel(context))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -64,7 +64,7 @@ class TabManagerMiddleware {
         case TabPanelAction.selectTab(let context):
             let tabUUID = context.tabUUID
             self.selectTab(for: tabUUID, uuid: uuid)
-            store.dispatch(TabTrayAction.dismissTabTray(ActionContext(windowUUID: uuid)))
+            store.dispatch(TabTrayAction.dismissTabTray(uuid.context))
 
         case TabPanelAction.closeAllInactiveTabs:
             self.closeAllInactiveTabs(state: state, uuid: uuid)
@@ -125,7 +125,7 @@ class TabManagerMiddleware {
                                      object: .syncTab)
         let urlRequest = URLRequest(url: url)
         self.addNewTab(with: urlRequest, isPrivate: false, for: windowUUID)
-        store.dispatch(TabTrayAction.dismissTabTray(ActionContext(windowUUID: windowUUID)))
+        store.dispatch(TabTrayAction.dismissTabTray(windowUUID.context))
     }
 
     /// Gets initial state for TabTrayModel includes panelType, if is on Private mode,
@@ -217,7 +217,7 @@ class TabManagerMiddleware {
 
         let model = getTabsDisplayModel(for: isPrivate, shouldScrollToTab: true, uuid: uuid)
         store.dispatch(TabPanelAction.refreshTab(RefreshTabContext(tabModels: model, windowUUID: uuid)))
-        store.dispatch(TabTrayAction.dismissTabTray(ActionContext(windowUUID: uuid)))
+        store.dispatch(TabTrayAction.dismissTabTray(uuid.context))
     }
 
     /// Move tab on `TabManager` array to support drag and drop
@@ -264,7 +264,7 @@ class TabManagerMiddleware {
             let shouldDismiss = await self.closeTab(with: tabUUID, uuid: uuid)
             await self.triggerRefresh(shouldScrollToTab: false, uuid: uuid)
             if shouldDismiss {
-                store.dispatch(TabTrayAction.dismissTabTray(ActionContext(windowUUID: uuid)))
+                store.dispatch(TabTrayAction.dismissTabTray(uuid.context))
                 store.dispatch(GeneralBrowserAction.showToast(.singleTab))
             } else {
                 store.dispatch(TabPanelAction.showToast(ToastTypeContext(toastType: .singleTab, windowUUID: uuid)))
@@ -309,7 +309,7 @@ class TabManagerMiddleware {
                 let model = getTabsDisplayModel(for: tabsState.isPrivateMode, shouldScrollToTab: false, uuid: uuid)
                 let context = RefreshTabContext(tabModels: model, windowUUID: uuid)
                 store.dispatch(TabPanelAction.refreshTab(model))
-                store.dispatch(TabTrayAction.dismissTabTray(ActionContext(windowUUID: uuid)))
+                store.dispatch(TabTrayAction.dismissTabTray(uuid.context))
                 store.dispatch(GeneralBrowserAction.showToast(.allTabs(count: count)))
             }
         }
@@ -387,7 +387,7 @@ class TabManagerMiddleware {
         let model = getTabsDisplayModel(for: true, shouldScrollToTab: false, uuid: uuid)
         let context = RefreshTabContext(tabModels: tabs, windowUUID: uuid)
         store.dispatch(TabPanelAction.refreshTab(context))
-        store.dispatch(TabTrayAction.dismissTabTray(ActionContext(windowUUID: uuid)))
+        store.dispatch(TabTrayAction.dismissTabTray(uuid.context))
     }
 
     private func selectTab(for tabUUID: String, uuid: WindowUUID) {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -375,7 +375,9 @@ class TabManagerMiddleware {
     private func tabManager(for uuid: WindowUUID) -> TabManager {
         let windowManager: WindowManager = AppContainer.shared.resolve()
         guard uuid != .unavailable else {
-            logger.log("Unexpected or unavailable UUID for TabManager. Returning active window tab manager by default.", level: .warning, category: .tabs)
+            logger.log("Unexpected or unavailable UUID for TabManager. Returning active window tab manager by default.",
+                       level: .warning,
+                       category: .tabs)
             return windowManager.tabManager(for: windowManager.activeWindow)
         }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -401,7 +401,7 @@ class TabManagerMiddleware {
                        category: .tabs)
             return windowManager.tabManager(for: windowManager.activeWindow)
         }
-        
+
         logger.log(("DBG: returning TM for \(uuid)"), level: .warning, category: .tabs)
         return windowManager.tabManager(for: uuid)
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -265,7 +265,7 @@ class TabManagerMiddleware {
             await self.triggerRefresh(shouldScrollToTab: false, uuid: uuid)
             if shouldDismiss {
                 store.dispatch(TabTrayAction.dismissTabTray(uuid.context))
-                store.dispatch(GeneralBrowserAction.showToast(.singleTab))
+                store.dispatch(GeneralBrowserAction.showToast(ToastTypeContext(toastType: .singleTab, windowUUID: uuid)))
             } else {
                 store.dispatch(TabPanelAction.showToast(ToastTypeContext(toastType: .singleTab, windowUUID: uuid)))
             }
@@ -310,7 +310,8 @@ class TabManagerMiddleware {
                 let context = RefreshTabContext(tabModels: model, windowUUID: uuid)
                 store.dispatch(TabPanelAction.refreshTab(model))
                 store.dispatch(TabTrayAction.dismissTabTray(uuid.context))
-                store.dispatch(GeneralBrowserAction.showToast(.allTabs(count: count)))
+                store.dispatch(GeneralBrowserAction.showToast(ToastTypeContext(toastType: .allTabs(count: count),
+                                                                               windowUUID: uuid)))
             }
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -427,7 +427,8 @@ class TabManagerMiddleware {
                                          isSyncEnabled: !(result?.isEmpty ?? true),
                                          screenshot: tab?.screenshot ?? UIImage(),
                                          accessiblityLabel: tab?.webView?.accessibilityLabel ?? "")
-                store.dispatch(TabPeekAction.loadTabPeek(tabPeekModel: model))
+                let context = TabPeekModelContext(tabPeekModel: model, windowUUID: uuid)
+                store.dispatch(TabPeekAction.loadTabPeek(context))
             }
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -402,7 +402,6 @@ class TabManagerMiddleware {
             return windowManager.tabManager(for: windowManager.activeWindow)
         }
 
-        logger.log(("DBG: returning TM for \(uuid)"), level: .warning, category: .tabs)
         return windowManager.tabManager(for: uuid)
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
@@ -89,7 +89,7 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
 
     static let reducer: Reducer<Self> = { state, action in
         // Only process actions for the current window
-        guard action.windowUUID == nil || action.windowUUID == state.windowUUID else { return state }
+        guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID else { return state }
 
         switch action {
         case RemoteTabsPanelAction.refreshDidBegin:
@@ -99,8 +99,9 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
                                                 clientAndTabs: state.clientAndTabs,
                                                 showingEmptyState: state.showingEmptyState)
             return newState
-        case RemoteTabsPanelAction.refreshDidFail(let reason):
+        case RemoteTabsPanelAction.refreshDidFail(let context):
             // Refresh failed. Show error empty state.
+            let reason = context.reason
             let allowsRefresh = reason.allowsRefresh
             let newState = RemoteTabsPanelState(windowUUID: state.windowUUID,
                                                 refreshState: .idle,
@@ -108,7 +109,8 @@ struct RemoteTabsPanelState: ScreenState, Equatable {
                                                 clientAndTabs: state.clientAndTabs,
                                                 showingEmptyState: reason)
             return newState
-        case RemoteTabsPanelAction.refreshDidSucceed(let newClientAndTabs):
+        case RemoteTabsPanelAction.refreshDidSucceed(let context):
+            let newClientAndTabs = context.clientAndTabs
             let newState = RemoteTabsPanelState(windowUUID: state.windowUUID,
                                                 refreshState: .idle,
                                                 allowsRefresh: true,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabPeekState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabPeekState.swift
@@ -51,7 +51,8 @@ struct TabPeekState: ScreenState, Equatable {
         guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID else { return state }
 
         switch action {
-        case TabPeekAction.loadTabPeek(let tabPeekModel):
+        case TabPeekAction.loadTabPeek(let context):
+            let tabPeekModel = context.tabPeekModel
             return TabPeekState(windowUUID: state.windowUUID,
                                 showAddToBookmarks: tabPeekModel.canTabBeSaved,
                                 showSendToDevice: tabPeekModel.isSyncEnabled && tabPeekModel.canTabBeSaved,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabPeekState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabPeekState.swift
@@ -48,7 +48,7 @@ struct TabPeekState: ScreenState, Equatable {
 
     static let reducer: Reducer<Self> = { state, action in
         // Only process actions for the current window
-        guard action.windowUUID == nil || action.windowUUID == state.windowUUID else { return state }
+        guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID else { return state }
 
         switch action {
         case TabPeekAction.loadTabPeek(let tabPeekModel):

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
@@ -130,8 +130,9 @@ struct TabTrayState: ScreenState, Equatable {
                                 normalTabsCount: state.normalTabsCount,
                                 hasSyncableAccount: state.hasSyncableAccount,
                                 shareURL: shareURL)
-        case TabPanelAction.refreshTab(let tabModel):
+        case TabPanelAction.refreshTab(let context):
             // Only update the nomal tab count if the tabs being refreshed are not private
+            let tabModel = context.tabDisplayModel
             let isPrivate = tabModel.tabs.first?.isPrivate ?? false
             let tabCount = tabModel.normalTabsCount
             return TabTrayState(windowUUID: state.windowUUID,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
@@ -119,7 +119,8 @@ struct TabTrayState: ScreenState, Equatable {
                                 selectedPanel: state.selectedPanel,
                                 normalTabsCount: state.normalTabsCount,
                                 hasSyncableAccount: isSyncAccountEnabled)
-        case TabPanelAction.showShareSheet(let shareURL):
+        case TabPanelAction.showShareSheet(let context):
+            let shareURL = context.url
             return TabTrayState(windowUUID: state.windowUUID,
                                 isPrivateMode: state.isPrivateMode,
                                 selectedPanel: state.selectedPanel,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
@@ -114,7 +114,10 @@ struct TabTrayState: ScreenState, Equatable {
                                 shouldDismiss: true)
         case TabTrayAction.firefoxAccountChanged(let context):
             let isSyncAccountEnabled = context.hasSyncableAccount
-            return TabTrayState(windowUUID: state.windowUUID,
+            // Account updates may occur in a global manner, independent of specific windows.
+            // TODO: [8188] Need to revisit to confirm ideal handling when UUID is `.unavailable`
+            let uuid = state.windowUUID
+            return TabTrayState(windowUUID: uuid,
                                 isPrivateMode: state.isPrivateMode,
                                 selectedPanel: state.selectedPanel,
                                 normalTabsCount: state.normalTabsCount,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
@@ -80,22 +80,25 @@ struct TabTrayState: ScreenState, Equatable {
 
     static let reducer: Reducer<Self> = { state, action in
         // Only process actions for the current window
-        guard action.windowUUID == nil || action.windowUUID == state.windowUUID else { return state }
+        guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID else { return state }
 
         switch action {
-        case TabTrayAction.didLoadTabTray(let tabTrayModel):
+        case TabTrayAction.didLoadTabTray(let context):
+            let tabTrayModel = context.tabTrayModel
             return TabTrayState(windowUUID: state.windowUUID,
                                 isPrivateMode: tabTrayModel.isPrivateMode,
                                 selectedPanel: tabTrayModel.selectedPanel,
                                 normalTabsCount: tabTrayModel.normalTabsCount,
                                 hasSyncableAccount: tabTrayModel.hasSyncableAccount)
-        case TabTrayAction.changePanel(let panelType):
+        case TabTrayAction.changePanel(let context):
+            let panelType = context.panelType
             return TabTrayState(windowUUID: state.windowUUID,
                                 isPrivateMode: panelType == .privateTabs,
                                 selectedPanel: panelType,
                                 normalTabsCount: state.normalTabsCount,
                                 hasSyncableAccount: state.hasSyncableAccount)
-        case TabPanelAction.didLoadTabPanel(let tabState):
+        case TabPanelAction.didLoadTabPanel(let context):
+            let tabState = context.tabDisplayModel
             let panelType = tabState.isPrivateMode ? TabTrayPanelType.privateTabs : TabTrayPanelType.tabs
             return TabTrayState(windowUUID: state.windowUUID,
                                 isPrivateMode: tabState.isPrivateMode,
@@ -109,12 +112,13 @@ struct TabTrayState: ScreenState, Equatable {
                                 normalTabsCount: state.normalTabsCount,
                                 hasSyncableAccount: state.hasSyncableAccount,
                                 shouldDismiss: true)
-        case TabTrayAction.firefoxAccountChanged(let isSyncAccountEnabled):
-                return TabTrayState(windowUUID: state.windowUUID,
-                                    isPrivateMode: state.isPrivateMode,
-                                    selectedPanel: state.selectedPanel,
-                                    normalTabsCount: state.normalTabsCount,
-                                    hasSyncableAccount: isSyncAccountEnabled)
+        case TabTrayAction.firefoxAccountChanged(let context):
+            let isSyncAccountEnabled = context.hasSyncableAccount
+            return TabTrayState(windowUUID: state.windowUUID,
+                                isPrivateMode: state.isPrivateMode,
+                                selectedPanel: state.selectedPanel,
+                                normalTabsCount: state.normalTabsCount,
+                                hasSyncableAccount: isSyncAccountEnabled)
         case TabPanelAction.showShareSheet(let shareURL):
             return TabTrayState(windowUUID: state.windowUUID,
                                 isPrivateMode: state.isPrivateMode,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
@@ -64,10 +64,11 @@ struct TabsPanelState: ScreenState, Equatable {
 
     static let reducer: Reducer<Self> = { state, action in
         // Only process actions for the current window
-        guard action.windowUUID == nil || action.windowUUID == state.windowUUID else { return state }
+        guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID else { return state }
 
         switch action {
-        case TabPanelAction.didLoadTabPanel(let tabsModel):
+        case TabPanelAction.didLoadTabPanel(let context):
+            let tabsModel = context.tabDisplayModel
             let selectedTabIndex = tabsModel.tabs.firstIndex(where: { $0.isSelected })
             return TabsPanelState(windowUUID: state.windowUUID,
                                   isPrivateMode: tabsModel.isPrivateMode,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
@@ -76,7 +76,8 @@ struct TabsPanelState: ScreenState, Equatable {
                                   inactiveTabs: tabsModel.inactiveTabs,
                                   isInactiveTabsExpanded: tabsModel.isInactiveTabsExpanded,
                                   scrollToIndex: selectedTabIndex)
-        case TabPanelAction.refreshTab(let tabModel):
+        case TabPanelAction.refreshTab(let context):
+            let tabModel = context.tabModel
             var selectedTabIndex: Int?
             if tabModel.shouldScrollToTab {
                 selectedTabIndex = tabModel.tabs.firstIndex(where: { $0.isSelected })
@@ -93,13 +94,15 @@ struct TabsPanelState: ScreenState, Equatable {
                                   tabs: state.tabs,
                                   inactiveTabs: state.inactiveTabs,
                                   isInactiveTabsExpanded: !state.isInactiveTabsExpanded)
-        case TabPanelAction.refreshInactiveTabs(let inactiveTabs):
+        case TabPanelAction.refreshInactiveTabs(let context):
+            let inactiveTabs = context.inactiveTabModels
             return TabsPanelState(windowUUID: state.windowUUID,
                                   isPrivateMode: state.isPrivateMode,
                                   tabs: state.tabs,
                                   inactiveTabs: inactiveTabs,
                                   isInactiveTabsExpanded: state.isInactiveTabsExpanded)
-        case TabPanelAction.showToast(let type):
+        case TabPanelAction.showToast(let context):
+            let type = context.toastType
             return TabsPanelState(windowUUID: state.windowUUID,
                                   isPrivateMode: state.isPrivateMode,
                                   tabs: state.tabs,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
@@ -77,7 +77,7 @@ struct TabsPanelState: ScreenState, Equatable {
                                   isInactiveTabsExpanded: tabsModel.isInactiveTabsExpanded,
                                   scrollToIndex: selectedTabIndex)
         case TabPanelAction.refreshTab(let context):
-            let tabModel = context.tabModel
+            let tabModel = context.tabDisplayModel
             var selectedTabIndex: Int?
             if tabModel.shouldScrollToTab {
                 selectedTabIndex = tabModel.tabs.firstIndex(where: { $0.isSelected })

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsPanel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsPanel.swift
@@ -64,7 +64,7 @@ class RemoteTabsPanel: UIViewController,
     private func refreshTabs() {
         // Ensure we do not already have a refresh in progress
         guard state.refreshState != .refreshing else { return }
-        store.dispatch(RemoteTabsPanelAction.refreshTabs)
+        store.dispatch(RemoteTabsPanelAction.refreshTabs(ActionContext(windowUUID: windowUUID)))
     }
 
     // MARK: - View & Layout
@@ -105,7 +105,7 @@ class RemoteTabsPanel: UIViewController,
         store.dispatch(ActiveScreensStateAction.showScreen(
             ScreenActionContext(screen: .remoteTabsPanel, windowUUID: windowUUID)
         ))
-        store.dispatch(RemoteTabsPanelAction.panelDidAppear)
+        store.dispatch(RemoteTabsPanelAction.panelDidAppear(ActionContext(windowUUID: windowUUID)))
         let uuid = windowUUID
         store.subscribe(self, transform: {
             $0.select({ appState in
@@ -153,6 +153,7 @@ class RemoteTabsPanel: UIViewController,
     }
 
     private func handleOpenSelectedURL(_ url: URL) {
-        store.dispatch(RemoteTabsPanelAction.openSelectedURL(url))
+        let context = URLActionContext(url: url, windowUUID: windowUUID)
+        store.dispatch(RemoteTabsPanelAction.openSelectedURL(context))
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsPanel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsPanel.swift
@@ -64,7 +64,7 @@ class RemoteTabsPanel: UIViewController,
     private func refreshTabs() {
         // Ensure we do not already have a refresh in progress
         guard state.refreshState != .refreshing else { return }
-        store.dispatch(RemoteTabsPanelAction.refreshTabs(ActionContext(windowUUID: windowUUID)))
+        store.dispatch(RemoteTabsPanelAction.refreshTabs(windowUUID.context))
     }
 
     // MARK: - View & Layout
@@ -102,10 +102,9 @@ class RemoteTabsPanel: UIViewController,
     // MARK: - Redux
 
     func subscribeToRedux() {
-        store.dispatch(ActiveScreensStateAction.showScreen(
-            ScreenActionContext(screen: .remoteTabsPanel, windowUUID: windowUUID)
-        ))
-        store.dispatch(RemoteTabsPanelAction.panelDidAppear(ActionContext(windowUUID: windowUUID)))
+        store.dispatch(ActiveScreensStateAction.showScreen(ScreenActionContext(screen: .remoteTabsPanel,
+                                                                               windowUUID: windowUUID)))
+        store.dispatch(RemoteTabsPanelAction.panelDidAppear(windowUUID.context))
         let uuid = windowUUID
         store.subscribe(self, transform: {
             $0.select({ appState in

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -148,7 +148,8 @@ class TabDisplayView: UIView,
 
     func deleteInactiveTab(for index: Int) {
         let inactiveTabs = tabsState.inactiveTabs[index]
-        store.dispatch(TabPanelAction.closeInactiveTabs(inactiveTabs.tabUUID))
+        let context = TabUUIDContext(tabUUID: inactiveTabs.tabUUID, windowUUID: windowUUID)
+        store.dispatch(TabPanelAction.closeInactiveTabs(context))
     }
 
     // MARK: UICollectionViewDataSource
@@ -207,8 +208,9 @@ class TabDisplayView: UIView,
                 if let theme = theme {
                     footerView.applyTheme(theme: theme)
                 }
+                let context = windowUUID.context
                 footerView.buttonClosure = {
-                    store.dispatch(TabPanelAction.closeAllInactiveTabs)
+                    store.dispatch(TabPanelAction.closeAllInactiveTabs(context))
                 }
                 return footerView
             }
@@ -251,10 +253,10 @@ class TabDisplayView: UIView,
         switch getTabDisplay(for: indexPath.section) {
         case .inactiveTabs:
             let tabUUID = tabsState.inactiveTabs[indexPath.row].tabUUID
-            store.dispatch(TabPanelAction.selectTab(tabUUID))
+            store.dispatch(TabPanelAction.selectTab(TabUUIDContext(tabUUID: tabUUID, windowUUID: windowUUID)))
         case .tabs:
             let tabUUID = tabsState.tabs[indexPath.row].tabUUID
-            store.dispatch(TabPanelAction.selectTab(tabUUID))
+            store.dispatch(TabPanelAction.selectTab(TabUUIDContext(tabUUID: tabUUID, windowUUID: windowUUID)))
         }
     }
 
@@ -272,13 +274,13 @@ class TabDisplayView: UIView,
 
     @objc
     func toggleInactiveTab() {
-        store.dispatch(TabPanelAction.toggleInactiveTabs)
+        store.dispatch(TabPanelAction.toggleInactiveTabs(windowUUID.context))
         collectionView.collectionViewLayout.invalidateLayout()
     }
 
     // MARK: - TabCellDelegate
     func tabCellDidClose(for tabUUID: String) {
-        store.dispatch(TabPanelAction.closeTab(tabUUID))
+        store.dispatch(TabPanelAction.closeTab(TabUUIDContext(tabUUID: tabUUID, windowUUID: windowUUID)))
     }
 }
 
@@ -312,7 +314,9 @@ extension TabDisplayView: UICollectionViewDragDelegate, UICollectionViewDropDele
         let section = destinationIndexPath.section
         let start = IndexPath(row: sourceIndex, section: section)
         let end = IndexPath(row: destinationIndexPath.item, section: section)
-        store.dispatch(TabPanelAction.moveTab(start.row, end.row))
+        store.dispatch(TabPanelAction.moveTab(MoveTabContext(originIndex: start.row,
+                                                             destinationIndex: end.row,
+                                                             windowUUID: windowUUID)))
         coordinator.drop(dragItem, toItemAt: destinationIndexPath)
 
         collectionView.moveItem(at: start, to: end)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabPeekViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabPeekViewController.swift
@@ -30,7 +30,8 @@ class TabPeekViewController: UIViewController,
         super.init(nibName: nil, bundle: nil)
 
         subscribeToRedux()
-        store.dispatch(TabPeekAction.didLoadTabPeek(tabID: tab.tabUUID))
+        let context = TabUUIDContext(tabUUID: tab.tabUUID, windowUUID: windowUUID)
+        store.dispatch(TabPeekAction.didLoadTabPeek(context))
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -95,7 +96,9 @@ class TabPeekViewController: UIViewController,
             actions.append(UIAction(title: .TabPeekAddToBookmarks,
                                     image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.bookmark),
                                     identifier: nil) { _ in
-                store.dispatch(TabPeekAction.addToBookmarks(tabID: self.tab.tabUUID))
+                let context = TabUUIDContext(tabUUID: self.tab.tabUUID,
+                                             windowUUID: self.windowUUID)
+                store.dispatch(TabPeekAction.addToBookmarks(context))
                 return
             })
         }
@@ -104,7 +107,9 @@ class TabPeekViewController: UIViewController,
                 title: .AppMenu.TouchActions.SendToDeviceTitle,
                 image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.shareApple),
                 identifier: nil) { _ in
-                    store.dispatch(TabPeekAction.sendToDevice(tabID: self.tab.tabUUID))
+                    let context = TabUUIDContext(tabUUID: self.tab.tabUUID,
+                                                 windowUUID: self.windowUUID)
+                    store.dispatch(TabPeekAction.sendToDevice(context))
                     return
             })
         }
@@ -112,7 +117,9 @@ class TabPeekViewController: UIViewController,
             actions.append(UIAction(title: .TabPeekCopyUrl,
                                     image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.link),
                                     identifier: nil) { _ in
-                store.dispatch(TabPeekAction.copyURL(tabID: self.tab.tabUUID))
+                let context = TabUUIDContext(tabUUID: self.tab.tabUUID,
+                                             windowUUID: self.windowUUID)
+                store.dispatch(TabPeekAction.copyURL(context))
                 return
             })
         }
@@ -120,7 +127,9 @@ class TabPeekViewController: UIViewController,
             actions.append(UIAction(title: .TabPeekCloseTab,
                                     image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross),
                                     identifier: nil) { _ in
-                store.dispatch(TabPeekAction.closeTab(tabID: self.tab.tabUUID))
+                let context = TabUUIDContext(tabUUID: self.tab.tabUUID,
+                                             windowUUID: self.windowUUID)
+                store.dispatch(TabPeekAction.closeTab(context))
                 return
             })
         }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -461,8 +461,8 @@ class TabTrayViewController: UIViewController,
     }
 
     @objc
-    private func newTabButtonTapped(uuid: WindowUUID) {
-        let context = AddNewTabContext(urlRequest: nil, isPrivate: tabTrayState.isPrivateMode, windowUUID: uuid)
+    private func newTabButtonTapped() {
+        let context = AddNewTabContext(urlRequest: nil, isPrivate: tabTrayState.isPrivateMode, windowUUID: windowUUID)
         store.dispatch(TabPanelAction.addNewTab(context))
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -457,7 +457,7 @@ class TabTrayViewController: UIViewController,
 
     @objc
     private func deleteTabsButtonTapped() {
-        store.dispatch(TabPanelAction.closeAllTabs)
+        store.dispatch(TabPanelAction.closeAllTabs(windowUUID.context))
     }
 
     @objc

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -474,7 +474,7 @@ class TabTrayViewController: UIViewController,
     }
 
     @objc
-    private func syncTabsTapped(uuid: WindowUUID) {
+    private func syncTabsTapped() {
         store.dispatch(RemoteTabsPanelAction.refreshTabs(windowUUID.context))
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -475,6 +475,6 @@ class TabTrayViewController: UIViewController,
 
     @objc
     private func syncTabsTapped(uuid: WindowUUID) {
-        store.dispatch(RemoteTabsPanelAction.refreshTabs(ActionContext(windowUUID: windowUUID)))
+        store.dispatch(RemoteTabsPanelAction.refreshTabs(windowUUID.context))
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -255,7 +255,8 @@ class TabTrayViewController: UIViewController,
         store.dispatch(ActiveScreensStateAction.showScreen(
             ScreenActionContext(screen: .tabsTray, windowUUID: windowUUID)
         ))
-        store.dispatch(TabTrayAction.tabTrayDidLoad(tabTrayState.selectedPanel))
+        let context = TabTrayPanelContext(panelType: tabTrayState.selectedPanel, windowUUID: windowUUID)
+        store.dispatch(TabTrayAction.tabTrayDidLoad(context))
         let uuid = windowUUID
         store.subscribe(self, transform: {
             $0.select({ appState in
@@ -450,7 +451,8 @@ class TabTrayViewController: UIViewController,
               tabTrayState.selectedPanel != panelType else { return }
 
         setupOpenPanel(panelType: panelType)
-        store.dispatch(TabTrayAction.changePanel(panelType))
+        let context = TabTrayPanelContext(panelType: panelType, windowUUID: windowUUID)
+        store.dispatch(TabTrayAction.changePanel(context))
     }
 
     @objc
@@ -459,8 +461,9 @@ class TabTrayViewController: UIViewController,
     }
 
     @objc
-    private func newTabButtonTapped() {
-        store.dispatch(TabPanelAction.addNewTab(nil, tabTrayState.isPrivateMode))
+    private func newTabButtonTapped(uuid: WindowUUID) {
+        let context = AddNewTabContext(urlRequest: nil, isPrivate: tabTrayState.isPrivateMode, windowUUID: uuid)
+        store.dispatch(TabPanelAction.addNewTab(context))
     }
 
     @objc
@@ -471,7 +474,7 @@ class TabTrayViewController: UIViewController,
     }
 
     @objc
-    private func syncTabsTapped() {
-        store.dispatch(RemoteTabsPanelAction.refreshTabs)
+    private func syncTabsTapped(uuid: WindowUUID) {
+        store.dispatch(RemoteTabsPanelAction.refreshTabs(ActionContext(windowUUID: windowUUID)))
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/ToastType.swift
+++ b/firefox-ios/Client/Frontend/Browser/ToastType.swift
@@ -32,12 +32,12 @@ enum ToastType: Equatable {
         return .TabsTray.CloseTabsToast.Action
     }
 
-    var reduxAction: TabPanelAction? {
+    func reduxAction(for uuid: WindowUUID) -> TabPanelAction? {
         switch self {
-        case .singleTab: return .undoClose
-        case .singleInactiveTabs: return .undoCloseInactiveTab
-        case .allTabs: return .undoCloseAllTabs
-        case .allInactiveTabs: return .undoCloseAllInactiveTabs
+        case .singleTab: return .undoClose(uuid.context)
+        case .singleInactiveTabs: return .undoCloseInactiveTab(uuid.context)
+        case .allTabs: return .undoCloseAllTabs(uuid.context)
+        case .allInactiveTabs: return .undoCloseAllInactiveTabs(uuid.context)
         case .copyURL, .addBookmark: return nil
         }
     }

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotAction.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotAction.swift
@@ -19,8 +19,8 @@ enum FakespotAction: Action {
     case adsExposureEventSendFor(productId: String)
     case surfaceDisplayedEventSend
 
-    var windowUUID: UUID? {
+    var windowUUID: UUID {
         // TODO: [8188] Update to return the windowUUID
-        return nil
+        return .unavailable
     }
 }

--- a/firefox-ios/Client/Frontend/FeltPrivacy/PrivateModeAction.swift
+++ b/firefox-ios/Client/Frontend/FeltPrivacy/PrivateModeAction.swift
@@ -8,10 +8,10 @@ import Redux
 enum PrivateModeMiddlewareAction: Action {
     case privateModeUpdated(Bool)
 
-    var windowUUID: UUID? {
+    var windowUUID: UUID {
         // TODO: [8188] Update to be non-optional and return windowUUID. Forthcoming.
         switch self {
-        default: return nil
+        default: return .unavailable
         }
     }
 }
@@ -19,10 +19,10 @@ enum PrivateModeMiddlewareAction: Action {
 enum PrivateModeUserAction: Action {
     case setPrivateModeTo(Bool)
 
-    var windowUUID: UUID? {
+    var windowUUID: UUID {
         // TODO: [8188] Update to be non-optional and return windowUUID. Forthcoming.
         switch self {
-        default: return nil
+        default: return .unavailable
         }
     }
 }

--- a/firefox-ios/Client/Frontend/FeltPrivacy/PrivateModeAction.swift
+++ b/firefox-ios/Client/Frontend/FeltPrivacy/PrivateModeAction.swift
@@ -9,7 +9,7 @@ enum PrivateModeMiddlewareAction: Action {
     case privateModeUpdated(Bool)
 
     var windowUUID: UUID {
-        // TODO: [8188] Update to be non-optional and return windowUUID. Forthcoming.
+       // TODO: [8188] Use of .unavailable UUID is temporary as part of early MW refactors. WIP. 
         switch self {
         default: return .unavailable
         }
@@ -20,7 +20,7 @@ enum PrivateModeUserAction: Action {
     case setPrivateModeTo(Bool)
 
     var windowUUID: UUID {
-        // TODO: [8188] Update to be non-optional and return windowUUID. Forthcoming.
+       // TODO: [8188] Use of .unavailable UUID is temporary as part of early MW refactors. WIP. 
         switch self {
         default: return .unavailable
         }

--- a/firefox-ios/Client/Frontend/Settings/SearchSettings/SearchSettingsAction.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettings/SearchSettingsAction.swift
@@ -5,10 +5,10 @@
 import Redux
 
 enum SearchSettingsAction: Action {
-    var windowUUID: UUID? {
+    var windowUUID: UUID {
         // TODO: [8188] Revisit UUIDs here.
         switch self {
-        default: return nil
+        default: return .unavailable
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsAction.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsAction.swift
@@ -23,7 +23,7 @@ enum ThemeSettingsAction: Action {
     case systemBrightnessChanged(Float)
 
     var windowUUID: UUID {
-        // TODO: [8188] Update to be non-optional and return windowUUID. Forthcoming.
+       // TODO: [8188] Use of .unavailable UUID is temporary as part of early MW refactors. WIP. 
         switch self {
         case .themeSettingsDidAppear(let context): return context.windowUUID
         default: return .unavailable

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsAction.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsAction.swift
@@ -22,11 +22,11 @@ enum ThemeSettingsAction: Action {
     case userBrightnessChanged(Float)
     case systemBrightnessChanged(Float)
 
-    var windowUUID: UUID? {
+    var windowUUID: UUID {
         // TODO: [8188] Update to be non-optional and return windowUUID. Forthcoming.
         switch self {
         case .themeSettingsDidAppear(let context): return context.windowUUID
-        default: return nil
+        default: return .unavailable
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
@@ -76,7 +76,7 @@ class ThemeSettingsController: ThemedTableViewController, StoreSubscriber {
     // MARK: - Redux
 
     func subscribeToRedux() {
-        store.dispatch(ThemeSettingsAction.themeSettingsDidAppear(ActionContext(windowUUID: windowUUID)))
+        store.dispatch(ThemeSettingsAction.themeSettingsDidAppear(windowUUID.context))
         let uuid = windowUUID
         store.subscribe(self, transform: {
             $0.select({ appState in

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
@@ -56,7 +56,7 @@ struct ThemeSettingsState: ScreenState, Equatable {
 
     static let reducer: Reducer<Self> = { state, action in
         // Only process actions for the current window
-        guard action.windowUUID == nil || action.windowUUID == state.windowUUID else { return state }
+        guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID else { return state }
 
         switch action {
         case ThemeSettingsAction.receivedThemeManagerValues(let themeState):

--- a/firefox-ios/Client/Redux/GlobalState/ActiveScreenAction.swift
+++ b/firefox-ios/Client/Redux/GlobalState/ActiveScreenAction.swift
@@ -26,10 +26,11 @@ enum ActiveScreensStateAction: Action {
     case showScreen(ScreenActionContext)
     case closeScreen(ScreenActionContext)
 
-    var windowUUID: UUID? {
+    var windowUUID: UUID {
         switch self {
-        case .showScreen(let context): return context.windowUUID
-        case .closeScreen(let context): return context.windowUUID
+        case .showScreen(let context as ActionContext),
+                .closeScreen(let context as ActionContext):
+            return context.windowUUID
         }
     }
 }

--- a/firefox-ios/Client/Redux/GlobalState/AppState.swift
+++ b/firefox-ios/Client/Redux/GlobalState/AppState.swift
@@ -51,6 +51,13 @@ class ActionContext {
     }
 }
 
+extension WindowUUID {
+    /// Convenience. Returns an ActionContext object for the receiver.
+    var context: ActionContext {
+        return ActionContext(windowUUID: self)
+    }
+}
+
 let store = Store(state: AppState(),
                   reducer: AppState.reducer,
                   middlewares: [

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/RemoteTabPanelStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/RemoteTabPanelStateTests.swift
@@ -28,7 +28,8 @@ final class RemoteTabPanelStateTests: XCTestCase {
 
         let reducer = remoteTabsPanelReducer()
 
-        let newState = reducer(initialState, RemoteTabsPanelAction.refreshTabs)
+        let context = WindowUUID.XCTestDefaultUUID.context
+        let newState = reducer(initialState, RemoteTabsPanelAction.refreshTabs(context))
 
         // Refresh should fail since Profile.hasSyncableAccount
         // is false for unit test, expected state is .idle
@@ -43,7 +44,8 @@ final class RemoteTabPanelStateTests: XCTestCase {
 
         XCTAssertEqual(initialState.clientAndTabs.count, 0)
 
-        let newState = reducer(initialState, RemoteTabsPanelAction.refreshDidSucceed(testTabs))
+        let context = RemoteTabsRefreshSuccessContext(clientAndTabs: testTabs, windowUUID: .XCTestDefaultUUID)
+        let newState = reducer(initialState, RemoteTabsPanelAction.refreshDidSucceed(context))
 
         XCTAssertEqual(newState.clientAndTabs.count, 1)
         XCTAssertEqual(newState.clientAndTabs.first!.tabs.count, 2)
@@ -53,7 +55,8 @@ final class RemoteTabPanelStateTests: XCTestCase {
         let initialState = createSubject()
         let reducer = remoteTabsPanelReducer()
 
-        let newState = reducer(initialState, RemoteTabsPanelAction.refreshDidFail(.failedToSync))
+        let context = RemoteTabsRefreshDidFailContext(reason: .failedToSync, windowUUID: .XCTestDefaultUUID)
+        let newState = reducer(initialState, RemoteTabsPanelAction.refreshDidFail(context))
 
         XCTAssertEqual(newState.refreshState, RemoteTabsPanelRefreshState.idle)
         XCTAssertNotNil(newState.showingEmptyState)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabsPanelStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabsPanelStateTests.swift
@@ -32,7 +32,8 @@ final class TabPanelStateTests: XCTestCase {
                                               inactiveTabs: [InactiveTabsModel](),
                                               isInactiveTabsExpanded: false,
                                               shouldScrollToTab: false)
-        let newState = reducer(initialState, TabPanelAction.didLoadTabPanel(tabDisplayModel))
+        let context = TabDisplayModelContext(tabDisplayModel: tabDisplayModel, windowUUID: .XCTestDefaultUUID)
+        let newState = reducer(initialState, TabPanelAction.didLoadTabPanel(context))
         XCTAssertFalse(newState.tabs.isEmpty)
     }
 
@@ -40,7 +41,7 @@ final class TabPanelStateTests: XCTestCase {
         let initialState = createInitialState()
         XCTAssertFalse(initialState.isInactiveTabsExpanded)
         let reducer = tabsPanelReducer()
-        let newState = reducer(initialState, TabPanelAction.toggleInactiveTabs)
+        let newState = reducer(initialState, TabPanelAction.toggleInactiveTabs(WindowUUID.XCTestDefaultUUID.context))
         XCTAssertTrue(newState.isInactiveTabsExpanded)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8188)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18209)

## :bulb: Description

Part of ongoing efforts to update our Redux stack to work with multiple iPad windows. I tried to keep the PR as small as possible but these changes impact an entire chain of logic in our Redux engine that requires a number of updates in order to function properly. Several of the remaining Redux components (**ThemeManager**, **FakeSpot**, **Felt Privacy** etc.) have been left unchanged; those will be updated in a separate PR.

Summary of changes:
- Begins moving our `Action` enums towards using a consistent pattern of including an `ActionContext` (or concrete subclass) which includes the window UUID
- Updates `windowUUID` to be non-optional (some code is using `.unavailable` for now, this is largely temporary)
- Refactors to related middleware, reducers, etc. for these changes

### Still forthcoming

- Updates to unit tests will be pushed up once the PR is reviewed, in order to minimize noise in the diff
- Additional refactors to other Redux/multi-window components will be forthcoming in follow-up PRs

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

