### PR TITLE
Bugfix FXIOS-8274 [v123] Fix toasts not showing on tab tray every time we close a tab

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanel.swift
@@ -173,8 +173,7 @@ class TabDisplayPanel: UIViewController,
         shouldShowEmptyView(tabsState.isPrivateTabsEmpty)
         let uuid = windowUUID
         // Avoid showing toast multiple times
-        if let toastType = tabsState.toastType,
-            shownToast == nil {
+        if let toastType = tabsState.toastType {
             store.dispatch(TabPanelAction.hideUndoToast(windowUUID.context))
             presentToast(toastType: toastType) { undoClose in
                 if let action = toastType.reduxAction(for: uuid), undoClose {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8274)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18364)

## :bulb: Description
Remove check to see if toast is showing to permit showing another one, this allows us to not skip toasts due to timing on tapping close.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

