### PR TITLE
Remove MTE-2219 [v124] workaround for onboarding tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FakespotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FakespotTests.swift
@@ -128,9 +128,10 @@ class FakespotTests: IphoneOnlyTestCase {
         app.webViews["contentView"].firstMatch.images.firstMatch.tap()
         waitUntilPageLoad()
 
-        // Retry loading the page if shopping button is not visible
+        // Retry loading the page if page is not loading
         while app.webViews.staticTexts["Enter the characters you see below"].exists {
-            reachReviewChecker()
+            app.buttons["Reload page"].tap()
+            waitUntilPageLoad()
         }
         // Tap the shopping cart icon
         app.buttons[AccessibilityIdentifiers.Toolbar.shoppingButton].tap()
@@ -143,6 +144,10 @@ class FakespotTests: IphoneOnlyTestCase {
 
         // Search for and open a shoe listing
         let searchAmazon = website.textFields["Search Amazon"]
+        if !searchAmazon.exists {
+            navigator.openURL("https://www.amazon.com")
+            waitUntilPageLoad()
+        }
         mozWaitForElementToExist(searchAmazon)
         XCTAssert(searchAmazon.isEnabled)
         searchAmazon.tap()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/OnboardingTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/OnboardingTests.swift
@@ -53,12 +53,6 @@ class OnboardingTests: BaseTestCase {
 
         // Finish onboarding
         app.buttons["\(rootA11yId)SecondaryButton"].tap()
-        // Workaround to bypass https://github.com/mozilla-mobile/firefox-ios/issues/18370
-        navigator.nowAt(NewTabScreen)
-        navigator.goto(HomeSettings)
-        navigator.goto(SettingsScreen)
-        navigator.goto(NewTabScreen)
-
         let topSites = app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]
         mozWaitForElementToExist(topSites)
     }
@@ -67,12 +61,6 @@ class OnboardingTests: BaseTestCase {
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2306816
     func testCloseTour() {
         app.buttons["\(AccessibilityIdentifiers.Onboarding.closeButton)"].tap()
-        // Workaround to bypass https://github.com/mozilla-mobile/firefox-ios/issues/18370
-        navigator.nowAt(NewTabScreen)
-        navigator.goto(HomeSettings)
-        navigator.goto(SettingsScreen)
-        navigator.goto(NewTabScreen)
-
         let topSites = app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]
         mozWaitForElementToExist(topSites)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2219)

## :bulb: Description
Issue https://github.com/mozilla-mobile/firefox-ios/issues/18370 has been fixed. Removed workaround

<img width="731" alt="Screenshot 2024-01-30 at 07 23 33" src="https://github.com/mozilla-mobile/firefox-ios/assets/134391433/494e7c5b-4afe-4185-921e-c0f133bed3db">

Also added improvements for fakespot tests.
