### PR TITLE
Refactor [v124] Change owner for cc scripts changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,7 @@
 # When someone opens a pull request that only modifies those folders / files,
 # those specific persons will be asked for review and not the global owners.
 /firefox-ios/Client/Experiments/initial_experiments.json @dnarcese @afurlan-firefox
+/firefox-ios/Client/Assets/CC_Script @nbhasin2 @issammani
 
 # When someone opens a pull request that only modifies those folders / files, 
 # only @mozilla-mobile/fxios-automation and not the global


### PR DESCRIPTION
## :scroll: Tickets
No tickets

## :bulb: Description
Should've thought about this earlier. With this change any scripts changes in the `CC_Script` folder (as done in this type [of automated PR](https://github.com/mozilla-mobile/firefox-ios/pull/18486)) will be auto assigned for review to @nbhasin2 and @issammani. Let me know if someone else should be reviewer by default. 

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

