### PR TITLE
Add FXIOS-8356 [v124] Add accessibility to the Address Autofill Settings page

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
@@ -68,6 +68,11 @@ struct AddressAutofillToggle: View {
                 .toggleStyle(SwitchToggleStyle(tint: toggleTintColor))
                 .frame(alignment: .trailing)
             }
+            .accessibilityElement()
+            .accessibilityLabel("\(String.Addresses.Settings.SwitchTitle), \(String.Addresses.Settings.SwitchDescription)")
+            .accessibilityAction {
+                model.isEnabled = !model.isEnabled
+            }
 
             // Divider line to separate content
             Divider()
@@ -105,4 +110,4 @@ struct AutofillToggle_Previews: PreviewProvider {
         let model = ToggleModel(isEnabled: true)
         AddressAutofillToggle(model: model)
     }
- }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8356)

## :bulb: Description
Having examined the settings' address autofill page, I have identified that the "AddressAutofillToggle" component requires the addition of accessibility properties and an accessibility action. This enhancement is necessary to ensure the page is accessible for users with disabilities. Additionally, we need to make sure to encapsulate the entire toggle view as an accessibility element and ensure that a double-tap action toggles it on and off.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

