### PR TITLE
Refactor FXIOS-8331 [v124] Disable loadHistory for History Highlight on URL Search Bar and homepage

### DIFF
--- a/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/Firefox.xcscheme
+++ b/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/Firefox.xcscheme
@@ -75,12 +75,6 @@
             </BuildableReference>
             <SkippedTests>
                <Test
-                  Identifier = "HistoryHighlightsDataAdaptorTests">
-               </Test>
-               <Test
-                  Identifier = "HistoryHighlightsTests">
-               </Test>
-               <Test
                   Identifier = "SearchTests/testURIFixupPunyCode()">
                </Test>
                <Test

--- a/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/Firefox.xcscheme
+++ b/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/Firefox.xcscheme
@@ -75,6 +75,12 @@
             </BuildableReference>
             <SkippedTests>
                <Test
+                  Identifier = "HistoryHighlightsDataAdaptorTests">
+               </Test>
+               <Test
+                  Identifier = "HistoryHighlightsTests">
+               </Test>
+               <Test
                   Identifier = "SearchTests/testURIFixupPunyCode()">
                </Test>
                <Test

--- a/firefox-ios/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsDataAdaptor.swift
+++ b/firefox-ios/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsDataAdaptor.swift
@@ -57,6 +57,12 @@ class HistoryHighlightsDataAdaptorImplementation: HistoryHighlightsDataAdaptor, 
     // MARK: - Private Methods
 
     private func loadHistory() {
+        // FXIOS-8331: Disable History Highlight on URL Search Bar
+        // as it is causing the app to slow down on frequent calls
+        // "recent-explorations" in homescreenFeature.yaml has been set to false for all builds
+        // Note: This is also part of FXIOS-8107 and FXIOS-8059 (Epic)
+        guard featureFlags.isFeatureEnabled(.historyHighlights, checking: .buildOnly) else { return }
+
         historyManager.getHighlightsData(
             with: profile,
             and: tabManager.tabs,
@@ -85,11 +91,7 @@ extension HistoryHighlightsDataAdaptorImplementation: Notifiable {
         switch notification.name {
         case .HistoryUpdated,
                 .RustPlacesOpened:
-            // FXIOS-8107: Disabling loadHistory as it is causing the app to slow down on frequent calls
-            // "recent-explorations" in homescreenFeature.yaml has been set to false for all builds
-            if featureFlags.isFeatureEnabled(.historyHighlights, checking: .buildOnly) {
                 loadHistory()
-            }
         default:
             return
         }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/HistoryHighlights/HistoryHighlightsDataAdaptorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/HistoryHighlights/HistoryHighlightsDataAdaptorTests.swift
@@ -5,7 +5,8 @@
 @testable import Client
 import XCTest
 import MozillaAppServices
-
+// FXIOS-8331: Disable History Highlight tests while FXIOS-8059 (Epic) is in progress
+// FXIOS-8367: Added a ticket to enable these tests when we re-enable history highlights
 class HistoryHighlightsDataAdaptorTests: XCTestCase {
     var subject: HistoryHighlightsDataAdaptor!
     var historyManager: MockHistoryHighlightsManager!

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/HistoryHighlights/HistoryHighlightsManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/HistoryHighlights/HistoryHighlightsManagerTests.swift
@@ -7,7 +7,8 @@ import Shared
 
 @testable import Client
 @testable import Storage
-
+// FXIOS-8331: Disable History Highlight tests while FXIOS-8059 (Epic) is in progress
+// FXIOS-8367: Added a ticket to enable these tests when we re-enable history highlights
 class HistoryHighlightsTests: XCTestCase {
     private var manager: HistoryHighlightsManager!
     private var profile: MockProfile!

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/RustSyncManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/RustSyncManagerTests.swift
@@ -196,6 +196,8 @@ class RustSyncManagerTests: XCTestCase {
         XCTAssertNil(profile.prefs.boolForKey(Keys.addressesStateChangedPrefKey))
     }
 
+    // FXIOS-8331: Disable History Highlight tests while FXIOS-8059 (Epic) is in progress
+    // FXIOS-8367: Added a ticket to enable these tests when we re-enable history highlights
     func testUpdateEnginePrefs_addressesDisabled() throws {
         profile.prefs.setBool(false, forKey: Keys.addressesEnabledPrefKey)
         profile.prefs.setBool(false, forKey: Keys.addressesStateChangedPrefKey)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/RustSyncManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/RustSyncManagerTests.swift
@@ -184,6 +184,8 @@ class RustSyncManagerTests: XCTestCase {
         XCTAssertNil(profile.prefs.boolForKey(Keys.tabsStateChangedPrefKey))
     }
 
+    // FXIOS-8331: Disable History Highlight tests while FXIOS-8059 (Epic) is in progress
+    // FXIOS-8367: Added a ticket to enable these tests when we re-enable history highlights
     func testUpdateEnginePrefs_addressesEnabled() throws {
         profile.prefs.setBool(true, forKey: Keys.addressesEnabledPrefKey)
         profile.prefs.setBool(true, forKey: Keys.addressesStateChangedPrefKey)

--- a/firefox-ios/firefox-ios-tests/Tests/UnitTest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/UnitTest.xctestplan
@@ -102,6 +102,7 @@
         "IntroViewControllerTests\/testBasicSetupReturnsExpectedItems()",
         "RustSyncManagerTests\/testGetEnginesAndKeysWithNoKey()",
         "RustSyncManagerTests\/testUpdateEnginePrefs_addressesDisabled()",
+        "RustSyncManagerTests\/testUpdateEnginePrefs_addressesEnabled()",
         "RustSyncManagerTests\/testUpdateEnginePrefs_bookmarksEnabled()",
         "ShortcutRouteTests\/testOpenLastBookmarkShortcutWithInvalidUrl()",
         "TabManagerTests\/testDeleteSelectedTab()",

--- a/firefox-ios/firefox-ios-tests/Tests/UnitTest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/UnitTest.xctestplan
@@ -96,9 +96,12 @@
       "skippedTests" : [
         "ETPCoverSheetTests",
         "GleanPlumbMessageManagerTests\/testManagerOnMessagePressed_withMalformedURL()",
+        "HistoryHighlightsDataAdaptorTests",
         "HistoryHighlightsDataAdaptorTests\/testReloadDataOnNotification()",
+        "HistoryHighlightsTests",
         "IntroViewControllerTests\/testBasicSetupReturnsExpectedItems()",
         "RustSyncManagerTests\/testGetEnginesAndKeysWithNoKey()",
+        "RustSyncManagerTests\/testUpdateEnginePrefs_addressesDisabled()",
         "RustSyncManagerTests\/testUpdateEnginePrefs_bookmarksEnabled()",
         "ShortcutRouteTests\/testOpenLastBookmarkShortcutWithInvalidUrl()",
         "TabManagerTests\/testDeleteSelectedTab()",


### PR DESCRIPTION

## :scroll: Tickets
[Jira ticket - 8331](https://mozilla-hub.atlassian.net/browse/FXIOS-8331)
[Github issue - #18460](https://github.com/mozilla-mobile/firefox-ios/issues/18460)

## :bulb: Description
Disabled History Highlight on URL Search Bar until we can refactor and address the slowness in the app.
On a sidenote, the startup speed and tapping on search bar feels so much better. Yes there is still the homepage flicker but this change has nothing to do with it. 

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

