### PR TITLE
Bugfix FXIOS-8352 [v124] Lock icon doesnt update color when theme changes

### DIFF
--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -45,17 +45,18 @@ class TabLocationView: UIView, FeatureFlaggable {
     var contentView: UIStackView!
 
     var notificationCenter: NotificationProtocol = NotificationCenter.default
+    private var themeManager: ThemeManager = AppContainer.shared.resolve()
 
     /// Tracking protection button, gets updated from tabDidChangeContentBlocking
     var blockerStatus: BlockerStatus = .noBlockedURLs {
         didSet {
-            if oldValue != blockerStatus { setTrackingProtection() }
+            if oldValue != blockerStatus { setTrackingProtection(theme: themeManager.currentTheme) }
         }
     }
 
     var hasSecureContent = false {
         didSet {
-            if oldValue != hasSecureContent { setTrackingProtection() }
+            if oldValue != hasSecureContent { setTrackingProtection(theme: themeManager.currentTheme) }
         }
     }
 
@@ -411,7 +412,7 @@ class TabLocationView: UIView, FeatureFlaggable {
         }
     }
 
-    private func setTrackingProtection(themeManager: ThemeManager = AppContainer.shared.resolve()) {
+    private func setTrackingProtection(theme: Theme) {
         var lockImage: UIImage?
         if !hasSecureContent {
             lockImage = UIImage(imageLiteralResourceName: StandardImageIdentifiers.Large.lockSlash)
@@ -428,7 +429,7 @@ class TabLocationView: UIView, FeatureFlaggable {
         case .safelisted:
             if let smallDotImage = UIImage(
                 systemName: ImageIdentifiers.circleFill
-            )?.withTintColor(themeManager.currentTheme.colors.iconAccentBlue) {
+            )?.withTintColor(theme.colors.iconAccentBlue) {
                 trackingProtectionButton.setImage(lockImage?.overlayWith(image: smallDotImage), for: .normal)
                 trackingProtectionButton.accessibilityLabel = hasSecureContent ?
                     .TabLocationETPOffSecureAccessibilityLabel : .TabLocationETPOffNotSecureAccessibilityLabel
@@ -547,6 +548,7 @@ extension TabLocationView: ThemeApplicable {
         shoppingButton.setImage(UIImage(named: StandardImageIdentifiers.Large.shopping)?
             .withTintColor(theme.colors.actionPrimary),
                                 for: .selected)
+        setTrackingProtection(theme: theme)
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8352)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18489)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Call the update icon with theme when theme changes.

https://github.com/mozilla-mobile/firefox-ios/assets/26011662/d76f7b89-582a-474d-87ab-f0b1933b5ece

Note: The lock icon shows the `safelisted` blocker status and it was mocked in code.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

