### PR TITLE
Bugfix FXIOS-8334 [v122.1] Users can be moved from private browsing tabs to regular tabs with prefer switch to open tab enabled

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2009,7 +2009,7 @@ class BrowserViewController: UIViewController,
         guard let tab = tabManager.selectedTab else { return }
 
         if isPreferSwitchToOpenTabOverDuplicateFeatureEnabled,
-           let tab = tabManager.getTabFor(url, reversed: true, isPrivate: tab.isPrivate) {
+           let tab = tabManager.tabs.reversed().first(where: { $0.url == url && $0.isPrivate == tab.isPrivate }) {
             tabManager.selectTab(tab)
         } else {
             // Handle keyboard shortcuts from homepage with url selection
@@ -2280,7 +2280,7 @@ extension BrowserViewController: HomePanelDelegate {
         guard let tab = tabManager.selectedTab else { return }
 
         if isPreferSwitchToOpenTabOverDuplicateFeatureEnabled,
-           let tab = tabManager.getTabFor(url, reversed: true, isPrivate: tab.isPrivate) {
+           let tab = tabManager.tabs.reversed().first(where: { $0.url == url && $0.isPrivate == tab.isPrivate }) {
             tabManager.selectTab(tab)
         } else {
             if isGoogleTopSite {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2006,11 +2006,12 @@ class BrowserViewController: UIViewController,
     // MARK: - LibraryPanelDelegate
 
     func libraryPanel(didSelectURL url: URL, visitType: VisitType) {
-        if isPreferSwitchToOpenTabOverDuplicateFeatureEnabled, let tab = tabManager.getTabFor(url, reversed: true) {
+        guard let tab = tabManager.selectedTab else { return }
+
+        if isPreferSwitchToOpenTabOverDuplicateFeatureEnabled,
+           let tab = tabManager.getTabFor(url, reversed: true, isPrivate: tab.isPrivate) {
             tabManager.selectTab(tab)
         } else {
-            guard let tab = tabManager.selectedTab else { return }
-
             // Handle keyboard shortcuts from homepage with url selection
             // (ex: Cmd + Tap on Link; which is a cell in this case)
             if navigateLinkShortcutIfNeeded(url: url) {
@@ -2276,10 +2277,12 @@ extension BrowserViewController: HomePanelDelegate {
     }
 
     func homePanel(didSelectURL url: URL, visitType: VisitType, isGoogleTopSite: Bool) {
-        if isPreferSwitchToOpenTabOverDuplicateFeatureEnabled, let tab = tabManager.getTabFor(url, reversed: true) {
+        guard let tab = tabManager.selectedTab else { return }
+
+        if isPreferSwitchToOpenTabOverDuplicateFeatureEnabled,
+           let tab = tabManager.getTabFor(url, reversed: true, isPrivate: tab.isPrivate) {
             tabManager.selectTab(tab)
         } else {
-            guard let tab = tabManager.selectedTab else { return }
             if isGoogleTopSite {
                 tab.urlType = .googleTopSite
                 searchTelemetry?.shouldSetGoogleTopSiteSearch = true

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -232,13 +232,8 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     }
 
     // MARK: Get tabs
-    func getTabFor(_ url: URL, reversed: Bool = false, isPrivate: Bool? = nil) -> Tab? {
-        let tabs = reversed ? self.tabs.reversed() : self.tabs
+    func getTabFor(_ url: URL) -> Tab? {
         for tab in tabs {
-            // Check the privacy of the tab if required
-            if let isPrivate = isPrivate, tab.isPrivate != isPrivate {
-                continue
-            }
             if let webViewUrl = tab.webView?.url,
                url.isEqual(webViewUrl) {
                 return tab

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -232,9 +232,13 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     }
 
     // MARK: Get tabs
-    func getTabFor(_ url: URL, reversed: Bool = false) -> Tab? {
+    func getTabFor(_ url: URL, reversed: Bool = false, isPrivate: Bool? = nil) -> Tab? {
         let tabs = reversed ? self.tabs.reversed() : self.tabs
         for tab in tabs {
+            // Check the privacy of the tab if required
+            if let isPrivate = isPrivate, tab.isPrivate != isPrivate {
+                continue
+            }
             if let webViewUrl = tab.webView?.url,
                url.isEqual(webViewUrl) {
                 return tab

--- a/firefox-ios/Client/TabManagement/TabManager.swift
+++ b/firefox-ios/Client/TabManagement/TabManager.swift
@@ -41,7 +41,7 @@ protocol TabManager: AnyObject {
     func removeTabs(_ tabs: [Tab])
     func undoCloseTab(tab: Tab, position: Int?)
     func getMostRecentHomepageTab() -> Tab?
-    func getTabFor(_ url: URL, reversed: Bool, isPrivate: Bool?) -> Tab?
+    func getTabFor(_ url: URL) -> Tab?
     func clearAllTabsHistory()
     func willSwitchTabMode(leavingPBM: Bool)
     func cleanupClosedTabs(_ closedTabs: [Tab], previous: Tab?, isPrivate: Bool)
@@ -94,10 +94,6 @@ protocol TabManager: AnyObject {
 }
 
 extension TabManager {
-    func getTabFor(_ url: URL, reversed: Bool = false, isPrivate: Bool? = nil) -> Tab? {
-        getTabFor(url, reversed: reversed, isPrivate: isPrivate)
-    }
-
     func removeDelegate(_ delegate: TabManagerDelegate) {
         removeDelegate(delegate, completion: nil)
     }

--- a/firefox-ios/Client/TabManagement/TabManager.swift
+++ b/firefox-ios/Client/TabManagement/TabManager.swift
@@ -41,7 +41,7 @@ protocol TabManager: AnyObject {
     func removeTabs(_ tabs: [Tab])
     func undoCloseTab(tab: Tab, position: Int?)
     func getMostRecentHomepageTab() -> Tab?
-    func getTabFor(_ url: URL, reversed: Bool) -> Tab?
+    func getTabFor(_ url: URL, reversed: Bool, isPrivate: Bool?) -> Tab?
     func clearAllTabsHistory()
     func willSwitchTabMode(leavingPBM: Bool)
     func cleanupClosedTabs(_ closedTabs: [Tab], previous: Tab?, isPrivate: Bool)
@@ -94,8 +94,8 @@ protocol TabManager: AnyObject {
 }
 
 extension TabManager {
-    func getTabFor(_ url: URL, reversed: Bool = false) -> Tab? {
-        getTabFor(url, reversed: reversed)
+    func getTabFor(_ url: URL, reversed: Bool = false, isPrivate: Bool? = nil) -> Tab? {
+        getTabFor(url, reversed: reversed, isPrivate: isPrivate)
     }
 
     func removeDelegate(_ delegate: TabManagerDelegate) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8334)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18469)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
We need to filter by privacy in order to keep user preference. If there's no private tab with the url, the user will navigate in the same tab. 
I also defaulted to the previous implementation for `getTabFor(_ url:` method since this case is too specific.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

