### PR TITLE
Add FXIOS-8094 [v123.1] [Felt Privacy] Private browsing shortcut on homepage

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -642,6 +642,7 @@
 		8A3EF8152A2FD08800796E3A /* OpenFiftyTabsDebugOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3EF8142A2FD08800796E3A /* OpenFiftyTabsDebugOption.swift */; };
 		8A3EF8172A2FD2B900796E3A /* AdvancedAccountSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3EF8162A2FD2B900796E3A /* AdvancedAccountSettings.swift */; };
 		8A4190D22A6B0848001E8401 /* StatusBarOverlayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4190D02A6B0843001E8401 /* StatusBarOverlayTests.swift */; };
+		8A44F20E2B585E1F0016BC81 /* HomepageTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A44F20D2B585E1F0016BC81 /* HomepageTelemetry.swift */; };
 		8A471183287F6D9C00F5A6EA /* BookmarksPanelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A471182287F6D9C00F5A6EA /* BookmarksPanelViewModel.swift */; };
 		8A471185287F6E4800F5A6EA /* SeparatorTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A471184287F6E4800F5A6EA /* SeparatorTableViewCell.swift */; };
 		8A4AC0EB28C929D700439F83 /* URLSessionDataTaskProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4AC0E928C929D700439F83 /* URLSessionDataTaskProtocol.swift */; };
@@ -709,6 +710,7 @@
 		8A88815A2B20FFE0009635AE /* GCDWebServers in Frameworks */ = {isa = PBXBuildFile; productRef = 8A8881592B20FFE0009635AE /* GCDWebServers */; };
 		8A88815C2B2103AD009635AE /* WebEngine in Frameworks */ = {isa = PBXBuildFile; productRef = 8A88815B2B2103AD009635AE /* WebEngine */; };
 		8A88815E2B21071E009635AE /* GCDWebServers in Frameworks */ = {isa = PBXBuildFile; productRef = 8A88815D2B21071E009635AE /* GCDWebServers */; };
+		8A8917692B57283B008B01EA /* HomepageHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8917682B57283B008B01EA /* HomepageHeaderCell.swift */; };
 		8A8BAE122B2107E400D774EB /* GCDWebServers in Frameworks */ = {isa = PBXBuildFile; productRef = 8A8BAE112B2107E400D774EB /* GCDWebServers */; };
 		8A8BAE142B21110000D774EB /* GCDWebServers in Frameworks */ = {isa = PBXBuildFile; productRef = 8A8BAE132B21110000D774EB /* GCDWebServers */; };
 		8A8BAE162B2119E600D774EB /* InternalURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8BAE152B2119E600D774EB /* InternalURL.swift */; };
@@ -5596,6 +5598,7 @@
 		8A3EF8142A2FD08800796E3A /* OpenFiftyTabsDebugOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenFiftyTabsDebugOption.swift; sourceTree = "<group>"; };
 		8A3EF8162A2FD2B900796E3A /* AdvancedAccountSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedAccountSettings.swift; sourceTree = "<group>"; };
 		8A4190D02A6B0843001E8401 /* StatusBarOverlayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarOverlayTests.swift; sourceTree = "<group>"; };
+		8A44F20D2B585E1F0016BC81 /* HomepageTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageTelemetry.swift; sourceTree = "<group>"; };
 		8A471182287F6D9C00F5A6EA /* BookmarksPanelViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksPanelViewModel.swift; sourceTree = "<group>"; };
 		8A471184287F6E4800F5A6EA /* SeparatorTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeparatorTableViewCell.swift; sourceTree = "<group>"; };
 		8A4AC0E928C929D700439F83 /* URLSessionDataTaskProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionDataTaskProtocol.swift; sourceTree = "<group>"; };
@@ -5671,6 +5674,7 @@
 		8A8629E1288096C40096DDB1 /* BookmarksFolderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksFolderCell.swift; sourceTree = "<group>"; };
 		8A8629E52880B69C0096DDB1 /* BookmarksPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksPanelTests.swift; sourceTree = "<group>"; };
 		8A86DAD7277298DE00D7BFFF /* ClosedTabsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedTabsStoreTests.swift; sourceTree = "<group>"; };
+		8A8917682B57283B008B01EA /* HomepageHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageHeaderCell.swift; sourceTree = "<group>"; };
 		8A8BAE152B2119E600D774EB /* InternalURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalURL.swift; sourceTree = "<group>"; };
 		8A8DDEBE276259A900E7B97A /* RatingPromptManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingPromptManager.swift; sourceTree = "<group>"; };
 		8A93080827BFE88F0052167D /* PhotonActionSheetContainerCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotonActionSheetContainerCell.swift; sourceTree = "<group>"; };
@@ -9421,6 +9425,7 @@
 			isa = PBXGroup;
 			children = (
 				1D69FF8C27B17285001F660E /* HomeLogoHeaderCell.swift */,
+				8A8917682B57283B008B01EA /* HomepageHeaderCell.swift */,
 				8AB8573627D951640075C173 /* HomeLogoHeaderViewModel.swift */,
 			);
 			path = LogoHeader;
@@ -11246,6 +11251,7 @@
 				43F7952425795F69005AEE40 /* SearchTelemetry.swift */,
 				8A04136828258DF600D20B10 /* SponsoredTileTelemetry.swift */,
 				8AD08D1427E9198E00B8E907 /* TabsTelemetry.swift */,
+				8A44F20D2B585E1F0016BC81 /* HomepageTelemetry.swift */,
 				8A95FF632B1E969E00AC303D /* TelemetryContextualIdentifier.swift */,
 				EBF47E6F1F7979DF00899189 /* TelemetryWrapper.swift */,
 				8A0727452B4890B50071BB9F /* WebviewTelemetry.swift */,
@@ -13422,6 +13428,7 @@
 				5AA0CC662A4B8F6100014E2A /* PasswordManagerCoordinator.swift in Sources */,
 				8A7368AD27924AAF005D7704 /* CanRemoveQuickActionBookmark.swift in Sources */,
 				C2296FCC2A601C190046ECA6 /* IntensityVisualEffectView.swift in Sources */,
+				8A8917692B57283B008B01EA /* HomepageHeaderCell.swift in Sources */,
 				8ADC2A102A33758E00543DAA /* FxALaunchParams.swift in Sources */,
 				D3C3696E1CC6B78800348A61 /* LocalRequestHelper.swift in Sources */,
 				E17496382991A2720096900A /* AdaptiveStack.swift in Sources */,
@@ -13609,6 +13616,7 @@
 				E18EA56F28AD3279003F97FC /* UIDevice+Extension.swift in Sources */,
 				CDB3BE8724746787009320EE /* FirefoxAccountSignInViewController.swift in Sources */,
 				8A471183287F6D9C00F5A6EA /* BookmarksPanelViewModel.swift in Sources */,
+				8A44F20E2B585E1F0016BC81 /* HomepageTelemetry.swift in Sources */,
 				E1FF93E428A2E74600E6360E /* WallpaperSelectorViewModel.swift in Sources */,
 				D0C95E0E200FD3B200E4E51C /* PrintHelper.swift in Sources */,
 				C8CD80DA2A1E8C1D0097C3AE /* OnboardingTelemetryProtocol.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -776,6 +776,7 @@
 		8ABCFEA32B45C36100C2988A /* PrivateBrowsingTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABCFEA22B45C36100C2988A /* PrivateBrowsingTelemetry.swift */; };
 		8ABCFEA62B45CB4C00C2988A /* PrivateBrowsingTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABCFEA42B45CAC300C2988A /* PrivateBrowsingTelemetryTests.swift */; };
 		8AC1065F28D0CD700013263A /* OpenQLPreviewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC1065E28D0CD700013263A /* OpenQLPreviewHelper.swift */; };
+		8AC225662B6D403200CDA7FD /* HomepageTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC225642B6D3FA400CDA7FD /* HomepageTelemetryTests.swift */; };
 		8AC5D55F28BFE6C8001F6F7F /* Presenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC5D55E28BFE6C8001F6F7F /* Presenter.swift */; };
 		8ACA8F74291987AE00D3075D /* AccountSyncHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACA8F73291987AE00D3075D /* AccountSyncHandlerTests.swift */; };
 		8ACA8F7629198D6400D3075D /* ThrottlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACA8F7529198D6400D3075D /* ThrottlerTests.swift */; };
@@ -5740,6 +5741,7 @@
 		8ABCFEA22B45C36100C2988A /* PrivateBrowsingTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateBrowsingTelemetry.swift; sourceTree = "<group>"; };
 		8ABCFEA42B45CAC300C2988A /* PrivateBrowsingTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateBrowsingTelemetryTests.swift; sourceTree = "<group>"; };
 		8AC1065E28D0CD700013263A /* OpenQLPreviewHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenQLPreviewHelper.swift; sourceTree = "<group>"; };
+		8AC225642B6D3FA400CDA7FD /* HomepageTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageTelemetryTests.swift; sourceTree = "<group>"; };
 		8AC5D55E28BFE6C8001F6F7F /* Presenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Presenter.swift; sourceTree = "<group>"; };
 		8ACA8F73291987AE00D3075D /* AccountSyncHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSyncHandlerTests.swift; sourceTree = "<group>"; };
 		8ACA8F7529198D6400D3075D /* ThrottlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThrottlerTests.swift; sourceTree = "<group>"; };
@@ -9431,6 +9433,14 @@
 			path = LogoHeader;
 			sourceTree = "<group>";
 		};
+		8AC225632B6D3F9600CDA7FD /* Telemetry */ = {
+			isa = PBXGroup;
+			children = (
+				8AC225642B6D3FA400CDA7FD /* HomepageTelemetryTests.swift */,
+			);
+			path = Telemetry;
+			sourceTree = "<group>";
+		};
 		8ACA8F722919870B00D3075D /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
@@ -11447,6 +11457,7 @@
 		F84B21D61A090F8100AAB793 /* ClientTests */ = {
 			isa = PBXGroup;
 			children = (
+				8AC225632B6D3F9600CDA7FD /* Telemetry */,
 				8A171A6029F82AD90085770E /* Application */,
 				CA7BD564248185B500A0A61B /* BreachAlertsTests.swift */,
 				BC003F5D2B59F44500929ECB /* BrowserViewControllerTests.swift */,
@@ -14176,6 +14187,7 @@
 				C2A72A6B2A77AC10002ACCE2 /* ReadingListCoordinatorTests.swift in Sources */,
 				E19B38B128A3E69300D8C541 /* WallpaperCollectionAvailabilityTests.swift in Sources */,
 				8A359EF62A1FE840004A5BB7 /* MockAdjustWrapper.swift in Sources */,
+				8AC225662B6D403200CDA7FD /* HomepageTelemetryTests.swift in Sources */,
 				C8DC90D22A067C6D0008832B /* MarkupAttributionUtilityTests.swift in Sources */,
 				21737FB72878A4BD000A9A92 /* HistoryPanelViewModelTests.swift in Sources */,
 				43B658D929CE251C00C9EF08 /* CreditCardInputViewModelTests.swift in Sources */,

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -65,6 +65,7 @@ public struct AccessibilityIdentifiers {
 
         struct OtherButtons {
             static let logoID = "FxHomeLogoID"
+            static let privateModeToggleButton = "FirefoxHomepage.OtherButtons.PrivateModeToggle"
             static let customizeHome = "FxHomeCustomizeHomeSettingButton"
         }
 

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -136,6 +136,10 @@ class BrowserCoordinator: BaseCoordinator,
         )
     }
 
+    func switchMode() {
+        browserViewController.tabManager.switchPrivacyMode()
+    }
+
     func show(webView: WKWebView) {
         // Keep the webviewController in memory, update to newest webview when needed
         if let webviewController = webviewController {

--- a/firefox-ios/Client/Frontend/Home/HomepageSectionType.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageSectionType.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 enum HomepageSectionType: Int, CaseIterable {
-    case logoHeader
+    case homepageHeader
     case messageCard
     case topSites
     case jumpBackIn
@@ -26,7 +26,7 @@ enum HomepageSectionType: Int, CaseIterable {
 
     var cellIdentifier: String {
         switch self {
-        case .logoHeader: return HomeLogoHeaderCell.cellIdentifier
+        case .homepageHeader: return HomepageHeaderCell.cellIdentifier
         case .messageCard: return HomepageMessageCardCell.cellIdentifier
         // Top sites has more than 1 cell type, dequeuing is done through FxHomeSectionHandler protocol
         case .topSites: return ""
@@ -41,7 +41,7 @@ enum HomepageSectionType: Int, CaseIterable {
     }
 
     static var cellTypes: [ReusableCell.Type] {
-        return [HomeLogoHeaderCell.self,
+        return [HomepageHeaderCell.self,
                 HomepageMessageCardCell.self,
                 TopSiteItemCell.self,
                 EmptyTopSiteCell.self,

--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -43,6 +43,7 @@ class HomepageViewController:
     private var syncTabContextualHintViewController: ContextualHintViewController
     private var collectionView: UICollectionView! = nil
     private var logger: Logger
+
     var contentType: ContentType = .homepage
 
     var themeManager: ThemeManager
@@ -95,7 +96,7 @@ class HomepageViewController:
         self.notificationCenter = notificationCenter
         self.logger = logger
         super.init(nibName: nil, bundle: nil)
-
+        updateHeaderToShowPrivateModeToggle()
         viewModel.isZeroSearch = isZeroSearch
 
         contextMenuHelper.delegate = self
@@ -188,11 +189,20 @@ class HomepageViewController:
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         applyTheme()
+        updateHeaderToShowPrivateModeToggle()
 
         if previousTraitCollection?.horizontalSizeClass != traitCollection.horizontalSizeClass
             || previousTraitCollection?.verticalSizeClass != traitCollection.verticalSizeClass {
             reloadOnRotation(newSize: view.frame.size)
         }
+    }
+
+    // Displays or hides the private mode toggle button in the header
+    // Depends on feature flag and if user is on iPhone
+    private func updateHeaderToShowPrivateModeToggle() {
+        let featureFlagOn = featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly)
+        let showToggle = featureFlagOn && !shouldUseiPadSetup()
+        viewModel.headerViewModel.hidePrivateModeButton = !showToggle
     }
 
     // MARK: - Layout

--- a/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
@@ -17,7 +17,7 @@ protocol HomepageDataModelDelegate: AnyObject {
 class HomepageViewModel: FeatureFlaggable {
     struct UX {
         static let spacingBetweenSections: CGFloat = 62
-        static let standardInset: CGFloat = 18
+        static let standardInset: CGFloat = 16
         static let iPadInset: CGFloat = 50
         static let iPadTopSiteInset: CGFloat = 25
 
@@ -89,7 +89,7 @@ class HomepageViewModel: FeatureFlaggable {
 
     // Child View models
     private var childViewModels: [HomepageViewModelProtocol]
-    var headerViewModel: HomeLogoHeaderViewModel
+    var headerViewModel: HomepageHeaderViewModel
     var messageCardViewModel: HomepageMessageCardViewModel
     var topSiteViewModel: TopSitesViewModel
     var recentlySavedViewModel: RecentlySavedViewModel
@@ -116,7 +116,7 @@ class HomepageViewModel: FeatureFlaggable {
         self.theme = theme
         self.logger = logger
 
-        self.headerViewModel = HomeLogoHeaderViewModel(profile: profile, theme: theme)
+        self.headerViewModel = HomepageHeaderViewModel(profile: profile, theme: theme, tabManager: tabManager)
         let messageCardAdaptor = MessageCardDataAdaptorImplementation()
         self.messageCardViewModel = HomepageMessageCardViewModel(dataAdaptor: messageCardAdaptor, theme: theme)
         messageCardAdaptor.delegate = messageCardViewModel

--- a/firefox-ios/Client/Frontend/Home/LogoHeader/HomeLogoHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/LogoHeader/HomeLogoHeaderCell.swift
@@ -12,8 +12,6 @@ class HomeLogoHeaderCell: UICollectionViewCell, ReusableCell {
         struct Logo {
             static let iPhoneImageSize: CGFloat = 40
             static let iPadImageSize: CGFloat = 75
-            static let iPhoneTopConstant: CGFloat = 32
-            static let iPadTopConstant: CGFloat = 70
             static let bottomConstant: CGFloat = -10
         }
 
@@ -65,22 +63,18 @@ class HomeLogoHeaderCell: UICollectionViewCell, ReusableCell {
 
         let isiPad = UIDevice.current.userInterfaceIdiom == .pad
         let logoSizeConstant = isiPad ? UX.Logo.iPadImageSize : UX.Logo.iPhoneImageSize
-        let topAnchorConstant = isiPad ? UX.Logo.iPadTopConstant : UX.Logo.iPhoneTopConstant
         let textImageWidthConstant = isiPad ? UX.TextImage.iPadWidth : UX.TextImage.iPhoneWidth
         let textImageLeadingAnchorConstant = isiPad ? UX.TextImage.iPadLeadingConstant : UX.TextImage.iPhoneLeadingConstant
 
         NSLayoutConstraint.activate([
-            containerView.topAnchor.constraint(equalTo: contentView.topAnchor,
-                                               constant: topAnchorConstant),
-            containerView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor,
-                                                  constant: UX.Logo.bottomConstant),
+            containerView.heightAnchor.constraint(equalToConstant: logoSizeConstant),
+            containerView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            containerView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
 
             logoImage.topAnchor.constraint(equalTo: containerView.topAnchor),
             logoImage.widthAnchor.constraint(equalToConstant: logoSizeConstant),
             logoImage.heightAnchor.constraint(equalToConstant: logoSizeConstant),
             logoImage.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
-            logoImage.bottomAnchor.constraint(equalTo: contentView.bottomAnchor,
-                                              constant: UX.Logo.bottomConstant),
 
             logoTextImage.widthAnchor.constraint(equalToConstant: textImageWidthConstant),
             logoTextImage.heightAnchor.constraint(equalTo: logoImage.heightAnchor),

--- a/firefox-ios/Client/Frontend/Home/LogoHeader/HomeLogoHeaderViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/LogoHeader/HomeLogoHeaderViewModel.swift
@@ -6,25 +6,30 @@ import Common
 import Foundation
 import Shared
 
-class HomeLogoHeaderViewModel {
+// Header view model for the Firefox Normal Homepage
+class HomepageHeaderViewModel {
     struct UX {
         static let bottomSpacing: CGFloat = 30
+        static let topSpacing: CGFloat = 16
     }
 
     private let profile: Profile
+    private let tabManager: TabManager
     var onTapAction: ((UIButton) -> Void)?
+    var hidePrivateModeButton = true
     var theme: Theme
 
-    init(profile: Profile, theme: Theme) {
+    init(profile: Profile, theme: Theme, tabManager: TabManager) {
         self.profile = profile
         self.theme = theme
+        self.tabManager = tabManager
     }
 }
 
 // MARK: HomeViewModelProtocol
-extension HomeLogoHeaderViewModel: HomepageViewModelProtocol, FeatureFlaggable {
+extension HomepageHeaderViewModel: HomepageViewModelProtocol, FeatureFlaggable {
     var sectionType: HomepageSectionType {
-        return .logoHeader
+        return .homepageHeader
     }
 
     var headerViewModel: LabelButtonHeaderViewModel {
@@ -48,7 +53,7 @@ extension HomeLogoHeaderViewModel: HomepageViewModelProtocol, FeatureFlaggable {
 
         let leadingInset = HomepageViewModel.UX.leadingInset(traitCollection: traitCollection)
         section.contentInsets = NSDirectionalEdgeInsets(
-            top: 0,
+            top: UX.topSpacing,
             leading: leadingInset,
             bottom: UX.bottomSpacing,
             trailing: leadingInset)
@@ -69,10 +74,18 @@ extension HomeLogoHeaderViewModel: HomepageViewModelProtocol, FeatureFlaggable {
     }
 }
 
-extension HomeLogoHeaderViewModel: HomepageSectionHandler {
+extension HomepageHeaderViewModel: HomepageSectionHandler {
     func configure(_ cell: UICollectionViewCell, at indexPath: IndexPath) -> UICollectionViewCell {
-        guard let logoHeaderCell = cell as? HomeLogoHeaderCell else { return UICollectionViewCell() }
-        logoHeaderCell.applyTheme(theme: theme)
-        return logoHeaderCell
+        guard let headerCell = cell as? HomepageHeaderCell else { return UICollectionViewCell() }
+        headerCell.applyTheme(theme: theme)
+        headerCell.configure(
+            with: HomepageHeaderCellViewModel(
+                isPrivate: false,
+                hidePrivateModeButton: hidePrivateModeButton,
+                action: { [weak self] in
+                    self?.tabManager.switchPrivacyMode()
+                })
+        )
+        return headerCell
     }
 }

--- a/firefox-ios/Client/Frontend/Home/LogoHeader/HomepageHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/LogoHeader/HomepageHeaderCell.swift
@@ -47,7 +47,7 @@ class HomepageHeaderCell: UICollectionViewCell, ReusableCell {
     }()
 
     private lazy var privateModeButton: UIButton = .build { [weak self] button in
-        let maskImage = UIImage(named: ImageIdentifiers.privateMaskSmall)?.withRenderingMode(.alwaysTemplate)
+        let maskImage = UIImage(named: StandardImageIdentifiers.Large.privateMode)?.withRenderingMode(.alwaysTemplate)
         button.setImage(maskImage, for: .normal)
         button.frame = UX.circleSize
         button.layer.cornerRadius = button.frame.size.width / 2

--- a/firefox-ios/Client/Frontend/Home/LogoHeader/HomepageHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/LogoHeader/HomepageHeaderCell.swift
@@ -58,7 +58,6 @@ class HomepageHeaderCell: UICollectionViewCell, ReusableCell {
     private lazy var privateModeButton: UIButton = .build { button in
         let maskImage = UIImage(named: ImageIdentifiers.privateMaskSmall)?.withRenderingMode(.alwaysTemplate)
         button.setImage(maskImage, for: .normal)
-        button.addTarget(self, action: #selector(self.switchMode), for: .touchUpInside)
         button.imageView?.contentMode = .scaleAspectFit
         button.accessibilityLabel = .TabTrayToggleAccessibilityLabel
         button.accessibilityHint = .TabTrayToggleAccessibilityHint

--- a/firefox-ios/Client/Frontend/Home/LogoHeader/HomepageHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/LogoHeader/HomepageHeaderCell.swift
@@ -1,0 +1,122 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import UIKit
+import Common
+
+struct HomepageHeaderCellViewModel {
+    var hidePrivateModeButton: Bool
+    var isPrivate: Bool
+
+    private var action: (() -> Void)
+    private var homepageTelemetry = HomepageTelemetry()
+
+    init(isPrivate: Bool, hidePrivateModeButton: Bool, action: @escaping () -> Void) {
+        self.isPrivate = isPrivate
+        self.hidePrivateModeButton = hidePrivateModeButton
+        self.action = action
+    }
+
+    func switchMode() {
+        action()
+        homepageTelemetry.sendHomepageTappedTelemetry(enteringPrivateMode: !isPrivate)
+    }
+}
+
+// Header for the homepage in both normal and private mode
+// Contains the firefox logo and the private browsing shortcut button
+class HomepageHeaderCell: UICollectionViewCell, ReusableCell {
+    enum UX {
+        static let iPhoneTopConstant: CGFloat = 16
+        static let iPadTopConstant: CGFloat = 54
+        static let circleSize = CGRect(width: 40, height: 40)
+    }
+
+    var viewModel: HomepageHeaderCellViewModel?
+    var actionButtonAction: (() -> Void)?
+
+    private lazy var stackContainer: UIStackView = .build { stackView in
+        stackView.axis = .horizontal
+        stackView.distribution = .fill
+    }
+
+    private lazy var logoHeaderCell: HomeLogoHeaderCell = {
+        let logoHeader = HomeLogoHeaderCell()
+        return logoHeader
+    }()
+
+    private lazy var circularView: UIView = .build { view in
+        view.frame = UX.circleSize
+        view.backgroundColor = UIColor.white
+        view.layer.cornerRadius = view.frame.size.width / 2
+        view.isUserInteractionEnabled = true
+        view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(self.switchMode)))
+    }
+
+    private lazy var privateModeButton: UIButton = .build { button in
+        let maskImage = UIImage(named: ImageIdentifiers.privateMaskSmall)?.withRenderingMode(.alwaysTemplate)
+        button.setImage(maskImage, for: .normal)
+        button.addTarget(self, action: #selector(self.switchMode), for: .touchUpInside)
+        button.imageView?.contentMode = .scaleAspectFit
+        button.accessibilityLabel = .TabTrayToggleAccessibilityLabel
+        button.accessibilityHint = .TabTrayToggleAccessibilityHint
+    }
+
+    // MARK: - Initializers
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - UI Setup
+
+    func setupView() {
+        let isiPad = UIDevice.current.userInterfaceIdiom == .pad
+        let topAnchorConstant = isiPad ? UX.iPadTopConstant : UX.iPhoneTopConstant
+        privateModeButton.insertSubview(circularView, belowSubview: privateModeButton.imageView ?? privateModeButton)
+        stackContainer.addArrangedSubview(logoHeaderCell.contentView)
+        stackContainer.addArrangedSubview(privateModeButton)
+        contentView.addSubview(stackContainer)
+
+        NSLayoutConstraint.activate([
+            stackContainer.topAnchor.constraint(equalTo: contentView.topAnchor, constant: topAnchorConstant),
+            stackContainer.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            stackContainer.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            stackContainer.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+
+            logoHeaderCell.contentView.centerYAnchor.constraint(equalTo: stackContainer.centerYAnchor),
+            privateModeButton.centerYAnchor.constraint(equalTo: stackContainer.centerYAnchor),
+            privateModeButton.widthAnchor.constraint(equalToConstant: UX.circleSize.width),
+
+            circularView.topAnchor.constraint(equalTo: privateModeButton.topAnchor),
+            circularView.trailingAnchor.constraint(equalTo: privateModeButton.trailingAnchor),
+            circularView.leadingAnchor.constraint(equalTo: privateModeButton.leadingAnchor),
+            circularView.bottomAnchor.constraint(equalTo: privateModeButton.bottomAnchor),
+        ])
+    }
+
+    func configure(with viewModel: HomepageHeaderCellViewModel) {
+        self.viewModel = viewModel
+    }
+
+    @objc
+    private func switchMode() {
+        viewModel?.switchMode()
+    }
+
+    // MARK: - ThemeApplicable
+    func applyTheme(theme: Theme) {
+        logoHeaderCell.applyTheme(theme: theme)
+        guard let viewModel else { return }
+        privateModeButton.isHidden = viewModel.hidePrivateModeButton
+        let privateModeButtonTintColor = viewModel.isPrivate ? theme.colors.layer2 : theme.colors.iconPrimary
+        privateModeButton.imageView?.tintColor = privateModeButtonTintColor
+        circularView.backgroundColor = viewModel.isPrivate ? .white : .clear
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/LogoHeader/HomepageHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/LogoHeader/HomepageHeaderCell.swift
@@ -35,7 +35,6 @@ class HomepageHeaderCell: UICollectionViewCell, ReusableCell {
     }
 
     var viewModel: HomepageHeaderCellViewModel?
-    var actionButtonAction: (() -> Void)?
 
     private lazy var stackContainer: UIStackView = .build { stackView in
         stackView.axis = .horizontal
@@ -47,20 +46,15 @@ class HomepageHeaderCell: UICollectionViewCell, ReusableCell {
         return logoHeader
     }()
 
-    private lazy var circularView: UIView = .build { view in
-        view.frame = UX.circleSize
-        view.backgroundColor = UIColor.white
-        view.layer.cornerRadius = view.frame.size.width / 2
-        view.isUserInteractionEnabled = true
-        view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(self.switchMode)))
-    }
-
-    private lazy var privateModeButton: UIButton = .build { button in
+    private lazy var privateModeButton: UIButton = .build { [weak self] button in
         let maskImage = UIImage(named: ImageIdentifiers.privateMaskSmall)?.withRenderingMode(.alwaysTemplate)
         button.setImage(maskImage, for: .normal)
-        button.imageView?.contentMode = .scaleAspectFit
+        button.frame = UX.circleSize
+        button.layer.cornerRadius = button.frame.size.width / 2
+        button.addTarget(self, action: #selector(self?.switchMode), for: .touchUpInside)
         button.accessibilityLabel = .TabTrayToggleAccessibilityLabel
         button.accessibilityHint = .TabTrayToggleAccessibilityHint
+        button.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.OtherButtons.privateModeToggleButton
     }
 
     // MARK: - Initializers
@@ -78,7 +72,7 @@ class HomepageHeaderCell: UICollectionViewCell, ReusableCell {
     func setupView() {
         let isiPad = UIDevice.current.userInterfaceIdiom == .pad
         let topAnchorConstant = isiPad ? UX.iPadTopConstant : UX.iPhoneTopConstant
-        privateModeButton.insertSubview(circularView, belowSubview: privateModeButton.imageView ?? privateModeButton)
+
         stackContainer.addArrangedSubview(logoHeaderCell.contentView)
         stackContainer.addArrangedSubview(privateModeButton)
         contentView.addSubview(stackContainer)
@@ -91,12 +85,7 @@ class HomepageHeaderCell: UICollectionViewCell, ReusableCell {
 
             logoHeaderCell.contentView.centerYAnchor.constraint(equalTo: stackContainer.centerYAnchor),
             privateModeButton.centerYAnchor.constraint(equalTo: stackContainer.centerYAnchor),
-            privateModeButton.widthAnchor.constraint(equalToConstant: UX.circleSize.width),
-
-            circularView.topAnchor.constraint(equalTo: privateModeButton.topAnchor),
-            circularView.trailingAnchor.constraint(equalTo: privateModeButton.trailingAnchor),
-            circularView.leadingAnchor.constraint(equalTo: privateModeButton.leadingAnchor),
-            circularView.bottomAnchor.constraint(equalTo: privateModeButton.bottomAnchor),
+            privateModeButton.widthAnchor.constraint(equalToConstant: UX.circleSize.width)
         ])
     }
 
@@ -116,6 +105,6 @@ class HomepageHeaderCell: UICollectionViewCell, ReusableCell {
         privateModeButton.isHidden = viewModel.hidePrivateModeButton
         let privateModeButtonTintColor = viewModel.isPrivate ? theme.colors.layer2 : theme.colors.iconPrimary
         privateModeButton.imageView?.tintColor = privateModeButtonTintColor
-        circularView.backgroundColor = viewModel.isPrivate ? .white : .clear
+        privateModeButton.backgroundColor = viewModel.isPrivate ? .white : .clear
     }
 }

--- a/firefox-ios/Client/Frontend/Home/LogoHeader/HomepageHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/LogoHeader/HomepageHeaderCell.swift
@@ -91,6 +91,7 @@ class HomepageHeaderCell: UICollectionViewCell, ReusableCell {
 
     func configure(with viewModel: HomepageHeaderCellViewModel) {
         self.viewModel = viewModel
+        privateModeButton.isHidden = viewModel.hidePrivateModeButton
     }
 
     @objc
@@ -102,7 +103,6 @@ class HomepageHeaderCell: UICollectionViewCell, ReusableCell {
     func applyTheme(theme: Theme) {
         logoHeaderCell.applyTheme(theme: theme)
         guard let viewModel else { return }
-        privateModeButton.isHidden = viewModel.hidePrivateModeButton
         let privateModeButtonTintColor = viewModel.isPrivate ? theme.colors.layer2 : theme.colors.iconPrimary
         privateModeButton.imageView?.tintColor = privateModeButtonTintColor
         privateModeButton.backgroundColor = viewModel.isPrivate ? .white : .clear

--- a/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
@@ -19,7 +19,7 @@ final class PrivateHomepageViewController:
     ContentContainable,
     Themeable,
     FeatureFlaggable {
-    
+
     enum UX {
         static let scrollContainerStackSpacing: CGFloat = 24
         static let defaultScrollContainerPadding: CGFloat = 16

--- a/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
@@ -19,7 +19,6 @@ final class PrivateHomepageViewController:
     ContentContainable,
     Themeable,
     FeatureFlaggable {
-
     enum UX {
         static let scrollContainerStackSpacing: CGFloat = 24
         static let defaultScrollContainerPadding: CGFloat = 16

--- a/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
@@ -10,10 +10,16 @@ import Shared
 // Delegate for coordinator to be able to handle navigation
 protocol PrivateHomepageDelegate: AnyObject {
     func homePanelDidRequestToOpenInNewTab(with url: URL, isPrivate: Bool, selectNewTab: Bool)
+    func switchMode()
 }
 
 // Displays the view for the private homepage when users create a new tab in private browsing
-final class PrivateHomepageViewController: UIViewController, ContentContainable, Themeable {
+final class PrivateHomepageViewController:
+    UIViewController,
+    ContentContainable,
+    Themeable,
+    FeatureFlaggable {
+    
     enum UX {
         static let scrollContainerStackSpacing: CGFloat = 24
         static let defaultScrollContainerPadding: CGFloat = 16
@@ -72,10 +78,19 @@ final class PrivateHomepageViewController: UIViewController, ContentContainable,
         return messageCard
     }()
 
-    private lazy var logoHeaderCell: HomeLogoHeaderCell = {
-        let logoHeader = HomeLogoHeaderCell()
-        logoHeader.applyTheme(theme: themeManager.currentTheme)
-        return logoHeader
+    private lazy var homepageHeaderCell: HomepageHeaderCell = {
+        let header = HomepageHeaderCell()
+        header.applyTheme(theme: themeManager.currentTheme)
+
+        let headerViewModel = HomepageHeaderCellViewModel(
+            isPrivate: true,
+            hidePrivateModeButton: shouldUseiPadSetup(),
+            action: { [weak self] in
+                self?.parentCoordinator?.switchMode()
+            })
+
+        header.configure(with: headerViewModel)
+        return header
     }()
 
     init(themeManager: ThemeManager = AppContainer.shared.resolve(),
@@ -107,12 +122,14 @@ final class PrivateHomepageViewController: UIViewController, ContentContainable,
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         updateConstraintsForMultitasking()
+        homepageHeaderCell.viewModel?.hidePrivateModeButton = shouldUseiPadSetup()
+        applyTheme()
     }
 
     private func setupLayout() {
-        scrollContainer.addArrangedSubview(logoHeaderCell.contentView)
+        scrollContainer.addArrangedSubview(homepageHeaderCell.contentView)
         scrollContainer.addArrangedSubview(privateMessageCardCell)
-        scrollContainer.accessibilityElements = [logoHeaderCell.contentView, privateMessageCardCell]
+        scrollContainer.accessibilityElements = [homepageHeaderCell.contentView, privateMessageCardCell]
 
         view.layer.addSublayer(gradient)
         view.addSubview(scrollView)
@@ -176,7 +193,7 @@ final class PrivateHomepageViewController: UIViewController, ContentContainable,
     func applyTheme() {
         let theme = themeManager.currentTheme
         gradient.colors = theme.colors.layerHomepage.cgColors
-        logoHeaderCell.applyTheme(theme: theme)
+        homepageHeaderCell.applyTheme(theme: theme)
     }
 
     private func learnMore() {

--- a/firefox-ios/Client/TabManagement/TabManager.swift
+++ b/firefox-ios/Client/TabManagement/TabManager.swift
@@ -52,6 +52,7 @@ protocol TabManager: AnyObject {
     func getTabForUUID(uuid: String) -> Tab?
     func getTabForURL(_ url: URL) -> Tab?
     func expireSnackbars()
+    @discardableResult
     func switchPrivacyMode() -> SwitchPrivacyModeResult
     func addPopupForParentTab(profile: Profile, parentTab: Tab, configuration: WKWebViewConfiguration) -> Tab
     func makeToastFromRecentlyClosedUrls(_ recentlyClosedTabs: [Tab],

--- a/firefox-ios/Client/Telemetry/HomepageTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/HomepageTelemetry.swift
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Glean
+
+struct HomepageTelemetry {
+    func sendHomepageTappedTelemetry(enteringPrivateMode: Bool) {
+        let isPrivateModeExtra = GleanMetrics.Homepage.PrivateModeToggleExtra(isPrivateMode: enteringPrivateMode)
+        GleanMetrics.Homepage.privateModeToggle.record(isPrivateModeExtra)
+    }
+}

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -2074,9 +2074,9 @@ homepage:
        description: |
         Set to true when you enter private browsing mode, false when you are going back to normal mode.
     bugs:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/#####
+      - https://github.com/mozilla-mobile/firefox-ios/issues/18522
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/#####
+      - https://github.com/mozilla-mobile/firefox-ios/pull/18518
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2024-06-01"

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -1552,7 +1552,7 @@ top_sites:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2024-06-01"
-# HomePage
+# HomePage - Normal
 firefox_home_page:
   open_from_menu_home_button:
     type: counter
@@ -2058,6 +2058,25 @@ firefox_home_page:
       - https://github.com/mozilla-mobile/firefox-ios/pull/11171
       - https://github.com/mozilla-mobile/firefox-ios/pull/12334
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2024-06-01"
+
+# HomePage - General
+homepage:
+  private_mode_toggle:
+    type: event
+    description: |
+      Records when the private browsing mode icon is toggled on homepage.
+    extra_keys:
+      is_private_mode:
+       type: boolean
+       description: |
+        Set to true when you enter private browsing mode, false when you are going back to normal mode.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/#####
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/#####
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2024-06-01"

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/FirefoxHomeViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/FirefoxHomeViewModelTests.swift
@@ -35,7 +35,7 @@ class FirefoxHomeViewModelTests: XCTestCase {
                                           tabManager: MockTabManager(),
                                           theme: LightTheme())
         XCTAssertEqual(viewModel.shownSections.count, 2)
-        XCTAssertEqual(viewModel.shownSections[0], HomepageSectionType.logoHeader)
+        XCTAssertEqual(viewModel.shownSections[0], HomepageSectionType.homepageHeader)
         XCTAssertEqual(viewModel.shownSections[1], HomepageSectionType.customizeHome)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/LogoHeader/HomeLogoHeaderViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/LogoHeader/HomeLogoHeaderViewModelTests.swift
@@ -9,10 +9,12 @@ import Shared
 
 class HomeLogoHeaderViewModelTests: XCTestCase, FeatureFlaggable {
     private var profile: MockProfile!
+    private var tabManager: MockTabManager!
 
     override func setUp() {
         super.setUp()
         profile = MockProfile()
+        tabManager = MockTabManager()
         featureFlags.initializeDeveloperFeatures(with: profile)
     }
 
@@ -23,7 +25,7 @@ class HomeLogoHeaderViewModelTests: XCTestCase, FeatureFlaggable {
 
     func testDefaultHomepageViewModelProtocolValues() {
         let subject = createSubject()
-        XCTAssertEqual(subject.sectionType, .logoHeader)
+        XCTAssertEqual(subject.sectionType, .homepageHeader)
         XCTAssertEqual(subject.headerViewModel, LabelButtonHeaderViewModel.emptyHeader)
         XCTAssertEqual(subject.numberOfItemsInSection(), 1)
         XCTAssertTrue(subject.isEnabled)
@@ -31,8 +33,8 @@ class HomeLogoHeaderViewModelTests: XCTestCase, FeatureFlaggable {
 }
 
 extension HomeLogoHeaderViewModelTests {
-    func createSubject(file: StaticString = #file, line: UInt = #line) -> HomeLogoHeaderViewModel {
-        let subject = HomeLogoHeaderViewModel(profile: profile, theme: LightTheme())
+    func createSubject(file: StaticString = #file, line: UInt = #line) -> HomepageHeaderViewModel {
+        let subject = HomepageHeaderViewModel(profile: profile, theme: LightTheme(), tabManager: tabManager)
         trackForMemoryLeaks(subject, file: file, line: line)
         return subject
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/HomepageTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/HomepageTelemetryTests.swift
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Glean
+import XCTest
+
+@testable import Client
+
+final class HomepageTelemetryTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        Glean.shared.resetGlean(clearStores: true)
+        Glean.shared.enableTestingMode()
+    }
+
+    func testPrivateModeShortcutToggleTappedInNormalMode() throws {
+        let subject = HomepageTelemetry()
+
+        subject.sendHomepageTappedTelemetry(enteringPrivateMode: true)
+
+        testEventMetricRecordingSuccess(metric: GleanMetrics.Homepage.privateModeToggle)
+
+        let resultValue = try XCTUnwrap(GleanMetrics.Homepage.privateModeToggle.testGetValue())
+        XCTAssertEqual(resultValue[0].extra?["is_private_mode"], "true")
+    }
+
+    func testPrivateModeShortcutToggleTappedInPrivateMode() throws {
+        let subject = HomepageTelemetry()
+
+        subject.sendHomepageTappedTelemetry(enteringPrivateMode: false)
+
+        testEventMetricRecordingSuccess(metric: GleanMetrics.Homepage.privateModeToggle)
+
+        let resultValue = try XCTUnwrap(GleanMetrics.Homepage.privateModeToggle.testGetValue())
+        XCTAssertEqual(resultValue[0].extra?["is_private_mode"], "false")
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8094)
[Github telemetry ticket](https://github.com/mozilla-mobile/firefox-ios/issues/18522)

## :bulb: Description
Add private browsing shortcut on homepage to toggle between normal and private mode
* Created `HomepageHeaderCell` that contains the header logo and the new private mode shortcut toggle button
* Utilize existing switch mode functionality to toggle between private and normal mode
* Update padding as discussed with design
* Added `HomepageTelemetry` for new `private_mode_toggle` event

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

## Screenshots

https://github.com/mozilla-mobile/firefox-ios/assets/6743397/d0485944-320a-4f91-92ae-d782564fb6fb