### PR TITLE
Refactor FXIOS- 8354 [v124] Felt Privacy - Theme picker checkbox is missing while user is in Private mode

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeMiddleware.swift
@@ -57,9 +57,19 @@ class ThemeManagerMiddleware: ThemeManagerProvider {
         ThemeSettingsState(windowUUID: windowUUID ?? WindowUUID.unavailable,
                            useSystemAppearance: themeManager.systemThemeIsOn,
                            isAutomaticBrightnessEnable: themeManager.automaticBrightnessIsOn,
-                           manualThemeSelected: themeManager.currentTheme.type,
+                           manualThemeSelected: getManuallySetTheme(),
                            userBrightnessThreshold: themeManager.automaticBrightnessValue,
                            systemBrightness: getScreenBrightness())
+    }
+
+    func getManuallySetTheme() -> ThemeType {
+        // We store the theme apart from .privateMode in below UserDefaults key.
+        // It is set/updated in DefaultThemeManager
+        if let savedThemeDescription = UserDefaults.standard.string(forKey: "prefKeyThemeName"),
+           let savedTheme = ThemeType(rawValue: savedThemeDescription) {
+            return savedTheme
+        }
+        return themeManager.currentTheme.type
     }
 
     func toggleUseSystemAppearance(_ enabled: Bool) {

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
@@ -338,7 +338,7 @@ class ThemeSettingsController: ThemedTableViewController, StoreSubscriber {
                 cell.textLabel?.text = .DisplayThemeOptionDark
             }
 
-            let themeType = themeManager.currentTheme.type
+            let themeType = manualThemeType
             if (indexPath.row == 0 && themeType == .light) ||
                 (indexPath.row == 1 && themeType == .dark) {
                 cell.accessoryType = .checkmark


### PR DESCRIPTION
## :scroll: Tickets
[Jira Task](https://mozilla-hub.atlassian.net/browse/FXIOS-8354)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18492)


https://github.com/mozilla-mobile/firefox-ios/assets/29454998/0813571a-27f0-4694-8cc0-6a2da26c8148



## :bulb: Description
We are setting the theme apart from .privateMode in the UserDefaults key(**prefKeyThemeName**).
Using the same to set the manual theme in ThemeSettingController.


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

