### PR TITLE
Refactor FXIOS-7586 [v124]  Fix deeplink logic

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -636,7 +636,7 @@ extension BrowserViewController: WKNavigationDelegate {
                 } else if UIApplication.shared.canOpenURL(url) {
                     UIApplication.shared.open(url, options: [.universalLinksOnly: true]) { isAppInstalled in
                         if isAppInstalled {
-                            #warning("TODO: https://mozilla-hub.atlassian.net/browse/FXIOS-7524")
+                           // TODO: https://mozilla-hub.atlassian.net/browse/FXIOS-7524
                         }
                     }
                 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -627,6 +627,21 @@ extension BrowserViewController: WKNavigationDelegate {
             } else {
                 webView.customUserAgent = UserAgent.getUserAgent(domain: url.baseDomain ?? "")
             }
+
+            if navigationAction.navigationType == .linkActivated {
+                if tab.isPrivate {
+                    decisionHandler(.cancel)
+                    webView.load(navigationAction.request)
+                    return
+                } else if UIApplication.shared.canOpenURL(url) {
+                    UIApplication.shared.open(url, options: [.universalLinksOnly: true]) { isAppInstalled in
+                        if isAppInstalled {
+                            #warning("TODO: https://mozilla-hub.atlassian.net/browse/FXIOS-7524")
+                        }
+                    }
+                }
+            }
+
             decisionHandler(.allow)
             return
         }
@@ -891,7 +906,7 @@ extension BrowserViewController: WKNavigationDelegate {
         }
 
         // When tab url changes after web content starts loading on the page
-        // We notify the content blocker change so that content blocker status 
+        // We notify the content blocker change so that content blocker status
         // can be correctly shown on beside the URL bar
         tab.contentBlocker?.notifyContentBlockingChanged()
         self.scrollController.resetZoomState()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7586)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16885)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Make all links that are tapped to always open in the app, when in private mode.
- For normal mode, if the link tapped is a deeplink, it will open in the respective app and the completion will return true, and from there, the telemetry events can be handled.
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

