### PR TITLE
Bugfix MTE-2230 [v124] Add default case for other project directories in determine_apps_affected workflow

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -378,10 +378,10 @@ workflows:
                 echo $BASE_BRANCH
             fi
 
-            # Determine apps affected by the changes
+            # Determine apps affected by the changes introduced in the commit/PR
             APPS_AFFECTED=$(git diff --name-only $BASE_BRANCH..."$BITRISE_GIT_COMMIT" | xargs -n1 dirname | sort | uniq)
 
-            echo "This are the files changed"
+            echo "These are the files changed:"
             echo $APPS_AFFECTED
 
             # Initialize all application flags as "false" by default
@@ -401,6 +401,7 @@ workflows:
             fi
 
             # Check for specific applications and set flags accordingly
+            # Add more specific conditions for directories as needed; otherwise see default case
             for app in $APPS_AFFECTED; do
                 case "$app" in
                     "firefox-ios")
@@ -414,6 +415,12 @@ workflows:
                         ;;
                     ".")
                         # Root directory changes - build all applications
+                        BUILD_FIREFOX_IOS="true"
+                        BUILD_FOCUS_IOS="true"
+                        BUILD_SAMPLE_BROWSER_IOS="true"
+                        ;;
+                    *)
+                        # Default case - build all applications (e.g, BrowserKit)
                         BUILD_FIREFOX_IOS="true"
                         BUILD_FOCUS_IOS="true"
                         BUILD_SAMPLE_BROWSER_IOS="true"


### PR DESCRIPTION
Followup to https://github.com/mozilla-mobile/firefox-ios/commit/9d5ddee48d104bdf6d5161848289bbc588200e64

- Added a default case for other project directories found by the `git diff`. 

**For now build everything** 

https://mozilla-hub.atlassian.net/browse/MTE-2230