### PR TITLE
 Add FXIOS-7981 [v124] Security manager in WebEngine

### DIFF
--- a/BrowserKit/Sources/WebEngine/Security/BrowsingContext.swift
+++ b/BrowserKit/Sources/WebEngine/Security/BrowsingContext.swift
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// The BrowsingContext is used by the Security Manager to determine if a URL can be navigated to
+public struct BrowsingContext {
+    var type: BrowsingType
+    var url: String
+}

--- a/BrowserKit/Sources/WebEngine/Security/BrowsingType.swift
+++ b/BrowserKit/Sources/WebEngine/Security/BrowsingType.swift
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// The BrowsingType determines what type of BrowsingContext we are in
+public enum BrowsingType {
+    /// External navigation refers to external deep links, such as `firefox://open-url` scheme
+    case externalNavigation
+
+    /// Internal navigation refers to navigation triggered internally by the user through entering a URL in the URL bar manually for instance.
+    case internalNavigation
+
+    /// Redirection navigation refers to calls through the navigation delegation `WKNavigationDelegate`
+    case redirectionNavigation
+}

--- a/BrowserKit/Sources/WebEngine/Security/BrowsingType.swift
+++ b/BrowserKit/Sources/WebEngine/Security/BrowsingType.swift
@@ -10,12 +10,11 @@ public enum BrowsingType {
     /// External navigation refers to external deep links, such as `firefox://open-url` scheme
     case externalNavigation
 
-    /// Internal navigation refers to navigation triggered internally by the user through entering a URL in the URL bar manually for instance.
+    /// Internal navigation refers to navigation triggered internally by the user through entering a 
+    /// URL in the URL bar manually for instance.
     case internalNavigation
 
     /// Redirection navigation refers to calls through the navigation delegation `WKNavigationDelegate`
     /// This should not never be called by the Client
     case redirectionNavigation(type: WKNavigationType)
 }
-
-

--- a/BrowserKit/Sources/WebEngine/Security/BrowsingType.swift
+++ b/BrowserKit/Sources/WebEngine/Security/BrowsingType.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import WebKit
 
 /// The BrowsingType determines what type of BrowsingContext we are in
 public enum BrowsingType {
@@ -13,5 +14,8 @@ public enum BrowsingType {
     case internalNavigation
 
     /// Redirection navigation refers to calls through the navigation delegation `WKNavigationDelegate`
-    case redirectionNavigation
+    /// This should not never be called by the Client
+    case redirectionNavigation(type: WKNavigationType)
 }
+
+

--- a/BrowserKit/Sources/WebEngine/Security/NavigationDecisionType.swift
+++ b/BrowserKit/Sources/WebEngine/Security/NavigationDecisionType.swift
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// The navigation decision given by the Security Manager for a given BrowsingContext
+public enum NavigationDecisionType {
+    /// The Browsing Context is permitted
+    case allowed
+
+    /// The Browser Context was not permitted
+    case refused
+
+    /// The Browsing Context needs the user input before we can navigate to it
+    case needsUserInput
+}

--- a/BrowserKit/Sources/WebEngine/Security/NavigationDecisionType.swift
+++ b/BrowserKit/Sources/WebEngine/Security/NavigationDecisionType.swift
@@ -6,10 +6,10 @@ import Foundation
 
 /// The navigation decision given by the Security Manager for a given BrowsingContext
 public enum NavigationDecisionType {
-    /// The Browsing Context is permitted
+    /// The Browsing Context is permitted and will be navigated to
     case allowed
 
-    /// The Browser Context was not permitted
+    /// The Browser Context was not permitted, the search will be made as a search term instead
     case refused
 
     /// The Browsing Context needs the user input before we can navigate to it

--- a/BrowserKit/Sources/WebEngine/Security/NavigationDecisionType.swift
+++ b/BrowserKit/Sources/WebEngine/Security/NavigationDecisionType.swift
@@ -12,6 +12,6 @@ public enum NavigationDecisionType {
     /// The Browser Context was not permitted, the search will be made as a search term instead
     case refused
 
-    /// The Browsing Context needs the user input before we can navigate to it
-    case needsUserInput
+    /// The Browser Context permits this URL, but the navigation is handled by the Client probably by opening a third-party app
+    case clientHandled
 }

--- a/BrowserKit/Sources/WebEngine/Security/NavigationDecisionType.swift
+++ b/BrowserKit/Sources/WebEngine/Security/NavigationDecisionType.swift
@@ -12,6 +12,7 @@ public enum NavigationDecisionType {
     /// The Browser Context was not permitted, the search will be made as a search term instead
     case refused
 
-    /// The Browser Context permits this URL, but the navigation is handled by the Client probably by opening a third-party app
+    /// The Browser Context permits this URL, but the navigation is handled by the 
+    /// Client probably by opening a third-party app
     case clientHandled
 }

--- a/BrowserKit/Sources/WebEngine/Security/SchemesDefinition.swift
+++ b/BrowserKit/Sources/WebEngine/Security/SchemesDefinition.swift
@@ -10,6 +10,7 @@ struct SchemesDefinition {
         case facetimeAudio = "facetime-audio"
         case appStore = "itms-apps"
         case appStores = "itms-appss"
+        case internalURL = "internal"
     }
 
     static let appStoreSchemes = [

--- a/BrowserKit/Sources/WebEngine/Security/SchemesDefinition.swift
+++ b/BrowserKit/Sources/WebEngine/Security/SchemesDefinition.swift
@@ -22,7 +22,7 @@ struct SchemesDefinition {
     static let allowedToBeOpenedAsPopups = [
         standardSchemes.http,
         standardSchemes.https,
-        standardSchemes.javascript, 
+        standardSchemes.javascript,
         standardSchemes.data,
         standardSchemes.about
     ]

--- a/BrowserKit/Sources/WebEngine/Security/SchemesDefinition.swift
+++ b/BrowserKit/Sources/WebEngine/Security/SchemesDefinition.swift
@@ -1,0 +1,134 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+struct SchemesDefinition {
+    enum standardSchemes: String {
+        case http, https, javascript, data, about, sms, tel, facetime, mailto, blob, file
+        case facetimeAudio = "facetime-audio"
+        case appStore = "itms-apps"
+        case appStores = "itms-appss"
+    }
+
+    static let appStoreSchemes = [
+        standardSchemes.appStore,
+        standardSchemes.appStores,
+    ]
+
+    /// List of schemes that are allowed to be opened in new tabs.
+    static let allowedToBeOpenedAsPopups = [
+        standardSchemes.http,
+        standardSchemes.https,
+        standardSchemes.javascript, 
+        standardSchemes.data,
+        standardSchemes.about
+    ]
+
+    static let webpageSchemes = [
+        standardSchemes.http, standardSchemes.https
+    ]
+
+    static let callingSchemes = [
+        standardSchemes.sms, standardSchemes.tel, standardSchemes.facetime, standardSchemes.facetimeAudio
+    ]
+
+    /// The list of permanent URI schemes has been taken from http://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml
+    /// This list only contains accepted permanent schemes: historical and provisional schemes are not accepted.
+    static let permanentURISchemes = [
+        "aaa",
+        "aaas",
+        "about",
+        "acap",
+        "acct",
+        "cap",
+        "cid",
+        "coap",
+        "coaps",
+        "crid",
+        "data",
+        "dav",
+        "dict",
+        "dns",
+        "dtn",
+        "example",
+        "file",
+        "ftp",
+        "geo",
+        "go",
+        "gopher",
+        "h323",
+        "http",
+        "https",
+        "iax",
+        "icap",
+        "im",
+        "imap",
+        "info",
+        "ipn",
+        "ipp",
+        "ipps",
+        "iris",
+        "iris.beep",
+        "iris.lwz",
+        "iris.xpc",
+        "iris.xpcs",
+        "jabber",
+        "ldap",
+        "leaptofrogans",
+        "mailto",
+        "mid",
+        "msrp",
+        "msrps",
+        "mtqp",
+        "mupdate",
+        "news",
+        "nfs",
+        "ni",
+        "nih",
+        "nntp",
+        "opaquelocktoken",
+        "pkcs11",
+        "pop",
+        "pres",
+        "reload",
+        "rtsp",
+        "rtsps",
+        "rtspu",
+        "service",
+        "session",
+        "shttp",
+        "sieve",
+        "sip",
+        "sips",
+        "sms",
+        "snmp",
+        "soap.beep",
+        "soap.beeps",
+        "stun",
+        "stuns",
+        "tag",
+        "tel",
+        "telnet",
+        "tftp",
+        "thismessage",
+        "tip",
+        "tn3270",
+        "turn",
+        "turns",
+        "tv",
+        "urn",
+        "vemmi",
+        "vnc",
+        "ws",
+        "wss",
+        "xcon",
+        "xcon-userid",
+        "xmlrpc.beep",
+        "xmlrpc.beeps",
+        "xmpp",
+        "z39.50r",
+        "z39.50s"
+    ]
+}

--- a/BrowserKit/Sources/WebEngine/Security/SecurityManager.swift
+++ b/BrowserKit/Sources/WebEngine/Security/SecurityManager.swift
@@ -73,7 +73,9 @@ public class DefaultSecurityManager: SecurityManager {
 //    }
 //
 //    private func schemeIsRedirectionThirdPartyNavigationValid(for url: URL) -> Bool {
-//        let acceptedSchemes = [SchemesDefinition.standardSchemes.mailto] + SchemesDefinition.appStoreSchemes + SchemesDefinition.callingSchemes
+//        let acceptedSchemes = [SchemesDefinition.standardSchemes.mailto]
+//        + SchemesDefinition.appStoreSchemes
+//        + SchemesDefinition.callingSchemes
 //        return acceptedSchemes.contains { $0.rawValue == url.scheme }
 //    }
 }

--- a/BrowserKit/Sources/WebEngine/Security/SecurityManager.swift
+++ b/BrowserKit/Sources/WebEngine/Security/SecurityManager.swift
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// The SecurityManager takes in a BrowsingContext to determine if it's safe or not to navigate to a certain URL
+public protocol SecurityManager {
+    func canNavigateWith(browsingContext: BrowsingContext) -> NavigationDecisionType
+}
+
+public class DefaultSecurityManager: SecurityManager {
+    public func canNavigateWith(browsingContext: BrowsingContext) -> NavigationDecisionType {
+        return .allowed // Laurie
+    }
+}

--- a/BrowserKit/Sources/WebEngine/Security/SecurityManager.swift
+++ b/BrowserKit/Sources/WebEngine/Security/SecurityManager.swift
@@ -26,15 +26,53 @@ public class DefaultSecurityManager: SecurityManager {
         }
     }
 
+    // MARK: - External
+
     private func handleExternalNavigation(url: URL) -> NavigationDecisionType {
-        return .allowed
+        return schemeIsExternalNavigationValid(for: url) ? .allowed : .refused
     }
 
-    private func handleInternalNavigation(url: URL) -> NavigationDecisionType {
-        return .allowed
+    private func schemeIsExternalNavigationValid(for url: URL) -> Bool {
+        let acceptedSchemes = [SchemesDefinition.standardSchemes.data] + SchemesDefinition.webpageSchemes
+        return acceptedSchemes.contains { $0.rawValue == url.scheme }
     }
+
+    // MARK: - Internal
+
+    private func handleInternalNavigation(url: URL) -> NavigationDecisionType {
+        return schemeIsInternalNavigationValid(for: url) ? .allowed : .refused
+    }
+
+    /// Returns whether the URL's scheme is one of those listed on the official list of URI schemes
+    private func schemeIsInternalNavigationValid(for url: URL) -> Bool {
+        guard let scheme = url.scheme else { return false }
+
+        let isValidScheme = SchemesDefinition.permanentURISchemes.contains(scheme.lowercased())
+        let urlIsNotComposedOnlyOfAScheme = url.absoluteURL.absoluteString.lowercased() != scheme + ":"
+        return isValidScheme && urlIsNotComposedOnlyOfAScheme
+    }
+
+    // MARK: - Redirection
 
     private func handleRedirectionNavigation(url: URL) -> NavigationDecisionType {
         return .allowed
+        // TODO: FXIOS-XXXX - Handle redirection navigation
+//        if schemeIsRedirectionNavigationValid(for: url) {
+//            return .allowed
+//        } else if schemeIsRedirectionThirdPartyNavigationValid(for: url) {
+//            return .clientHandled
+//        } else {
+//            return .refused
+//        }
     }
+
+//    private func schemeIsRedirectionNavigationValid(for url: URL) -> Bool {
+//        let acceptedSchemes = [SchemesDefinition.standardSchemes.data] + SchemesDefinition.callingSchemes
+//        return acceptedSchemes.contains { $0.rawValue == url.scheme }
+//    }
+//
+//    private func schemeIsRedirectionThirdPartyNavigationValid(for url: URL) -> Bool {
+//        let acceptedSchemes = [SchemesDefinition.standardSchemes.mailto] + SchemesDefinition.appStoreSchemes + SchemesDefinition.callingSchemes
+//        return acceptedSchemes.contains { $0.rawValue == url.scheme }
+//    }
 }

--- a/BrowserKit/Sources/WebEngine/Security/SecurityManager.swift
+++ b/BrowserKit/Sources/WebEngine/Security/SecurityManager.swift
@@ -11,6 +11,30 @@ public protocol SecurityManager {
 
 public class DefaultSecurityManager: SecurityManager {
     public func canNavigateWith(browsingContext: BrowsingContext) -> NavigationDecisionType {
-        return .allowed // Laurie
+        guard let url = URL(string: browsingContext.url) else {
+            // The URL is not a URL, refuse the navigation
+            return .refused
+        }
+
+        switch browsingContext.type {
+        case .externalNavigation:
+            return handleExternalNavigation(url: url)
+        case .internalNavigation:
+            return handleInternalNavigation(url: url)
+        case .redirectionNavigation:
+            return handleRedirectionNavigation(url: url)
+        }
+    }
+
+    private func handleExternalNavigation(url: URL) -> NavigationDecisionType {
+        return .allowed
+    }
+
+    private func handleInternalNavigation(url: URL) -> NavigationDecisionType {
+        return .allowed
+    }
+
+    private func handleRedirectionNavigation(url: URL) -> NavigationDecisionType {
+        return .allowed
     }
 }

--- a/BrowserKit/Sources/WebEngine/Security/SecurityManager.swift
+++ b/BrowserKit/Sources/WebEngine/Security/SecurityManager.swift
@@ -47,7 +47,8 @@ public class DefaultSecurityManager: SecurityManager {
     private func schemeIsInternalNavigationValid(for url: URL) -> Bool {
         guard let scheme = url.scheme else { return false }
 
-        let isValidScheme = SchemesDefinition.permanentURISchemes.contains(scheme.lowercased())
+        let schemesList = SchemesDefinition.permanentURISchemes + [SchemesDefinition.standardSchemes.internalURL.rawValue]
+        let isValidScheme = schemesList.contains(scheme.lowercased())
         let urlIsNotComposedOnlyOfAScheme = url.absoluteURL.absoluteString.lowercased() != scheme + ":"
         return isValidScheme && urlIsNotComposedOnlyOfAScheme
     }

--- a/BrowserKit/Sources/WebEngine/Security/SecurityManager.swift
+++ b/BrowserKit/Sources/WebEngine/Security/SecurityManager.swift
@@ -57,7 +57,7 @@ public class DefaultSecurityManager: SecurityManager {
 
     private func handleRedirectionNavigation(url: URL) -> NavigationDecisionType {
         return .allowed
-        // TODO: FXIOS-XXXX - Handle redirection navigation
+        // TODO: FXIOS-8375 - Handle redirection navigation
 //        if schemeIsRedirectionNavigationValid(for: url) {
 //            return .allowed
 //        } else if schemeIsRedirectionThirdPartyNavigationValid(for: url) {

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -16,13 +16,15 @@ class WKEngineSession: NSObject,
     private var logger: Logger
     var sessionData: WKEngineSessionData
     private var contentScriptManager: WKContentScriptManager
+    private var securityManager: SecurityManager
 
     init?(userScriptManager: WKUserScriptManager,
           configurationProvider: WKEngineConfigurationProvider = DefaultWKEngineConfigurationProvider(),
           webViewProvider: WKWebViewProvider = DefaultWKWebViewProvider(),
           logger: Logger = DefaultLogger.shared,
           sessionData: WKEngineSessionData = WKEngineSessionData(),
-          contentScriptManager: WKContentScriptManager = DefaultContentScriptManager()) {
+          contentScriptManager: WKContentScriptManager = DefaultContentScriptManager(),
+          securityManager: SecurityManager = DefaultSecurityManager()) {
         guard let webView = webViewProvider.createWebview(configurationProvider: configurationProvider) else {
             logger.log("WKEngineWebView creation failed on configuration",
                        level: .fatal,
@@ -34,6 +36,7 @@ class WKEngineSession: NSObject,
         self.logger = logger
         self.sessionData = sessionData
         self.contentScriptManager = contentScriptManager
+        self.securityManager = securityManager
         super.init()
 
         self.setupObservers()
@@ -46,7 +49,8 @@ class WKEngineSession: NSObject,
 
     // TODO: FXIOS-7903 #17648 no return from this load(url:), we need a way to recordNavigationInTab
     func load(url: String) {
-        // Laurie
+        let browsingContext = BrowsingContext(type: .internalNavigation, url: url)
+        guard securityManager.canNavigateWith(browsingContext: browsingContext) == .allowed else { return }
 
         // Convert about:reader?url=http://example.com URLs to local ReaderMode URLs
         if let url = URL(string: url),

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -46,7 +46,7 @@ class WKEngineSession: NSObject,
 
     // TODO: FXIOS-7903 #17648 no return from this load(url:), we need a way to recordNavigationInTab
     func load(url: String) {
-        // TODO: FXIOS-7981 Check scheme before loading
+        // Laurie
 
         // Convert about:reader?url=http://example.com URLs to local ReaderMode URLs
         if let url = URL(string: url),

--- a/BrowserKit/Tests/WebEngineTests/SecurityManagerTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/SecurityManagerTests.swift
@@ -1,0 +1,120 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import WebEngine
+
+final class SecurityManagerTests: XCTestCase {
+    // MARK: - Internal Navigation
+
+    func testCanNavigateGivenInternalNotAUrlThenRefused() {
+        let context = BrowsingContext(type: .internalNavigation,
+                                      url: "blabla")
+        let subject = createSubject()
+
+        let result = subject.canNavigateWith(browsingContext: context)
+
+        XCTAssertEqual(result, .refused)
+    }
+
+    func testCanNavigateGivenInternalNoSchemeThenRefused() {
+        let context = BrowsingContext(type: .internalNavigation,
+                                      url: "banana.com")
+        let subject = createSubject()
+
+        let result = subject.canNavigateWith(browsingContext: context)
+
+        XCTAssertEqual(result, .refused)
+    }
+
+    func testCanNavigateGivenInternalAboutHTTPSThenAllowed() {
+        let context = BrowsingContext(type: .internalNavigation,
+                                      url: "https://mozilla.com")
+        let subject = createSubject()
+
+        let result = subject.canNavigateWith(browsingContext: context)
+
+        XCTAssertEqual(result, .allowed)
+    }
+
+    func testCanNavigateGivenInternalAboutUrlThenAllowed() {
+        let context = BrowsingContext(type: .internalNavigation,
+                                      url: "about://home.com")
+        let subject = createSubject()
+
+        let result = subject.canNavigateWith(browsingContext: context)
+
+        XCTAssertEqual(result, .allowed)
+    }
+
+    func testCanNavigateGivenInternalAboutSchemeOnlyUrlThenRefused() {
+        let context = BrowsingContext(type: .internalNavigation,
+                                      url: "about:")
+        let subject = createSubject()
+
+        let result = subject.canNavigateWith(browsingContext: context)
+
+        XCTAssertEqual(result, .refused)
+    }
+
+    // MARK: - External Navigation
+
+    func testCanNavigateGivenExternalNotAUrlThenRefused() {
+        let context = BrowsingContext(type: .externalNavigation,
+                                      url: "blabla")
+        let subject = createSubject()
+
+        let result = subject.canNavigateWith(browsingContext: context)
+
+        XCTAssertEqual(result, .refused)
+    }
+
+    func testCanNavigateGivenExternalHTTPSURLThenAllowed() {
+        let context = BrowsingContext(type: .externalNavigation,
+                                      url: "https://mozilla.com")
+        let subject = createSubject()
+
+        let result = subject.canNavigateWith(browsingContext: context)
+
+        XCTAssertEqual(result, .allowed)
+    }
+
+    func testCanNavigateGivenExternalHTTPURLThenAllowed() {
+        let context = BrowsingContext(type: .externalNavigation,
+                                      url: "http://mozilla.com")
+        let subject = createSubject()
+
+        let result = subject.canNavigateWith(browsingContext: context)
+
+        XCTAssertEqual(result, .allowed)
+    }
+
+    func testCanNavigateGivenExternalDataURLThenAllowed() {
+        let context = BrowsingContext(type: .externalNavigation,
+                                      url: "data://someDataBlob.com")
+        let subject = createSubject()
+
+        let result = subject.canNavigateWith(browsingContext: context)
+
+        XCTAssertEqual(result, .allowed)
+    }
+
+    func testCanNavigateGivenExternalJavascriptURLThenRefused() {
+        let context = BrowsingContext(type: .externalNavigation,
+                                      url: "javascript://badurl.com")
+        let subject = createSubject()
+
+        let result = subject.canNavigateWith(browsingContext: context)
+
+        XCTAssertEqual(result, .refused)
+    }
+
+    // MARK: Helper
+
+    func createSubject() -> DefaultSecurityManager {
+        let subject = DefaultSecurityManager()
+        trackForMemoryLeaks(subject)
+        return subject
+    }
+}

--- a/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
@@ -48,8 +48,7 @@ final class WKEngineSessionTests: XCTestCase {
 
         subject?.load(url: url)
 
-        // Laurie
-        XCTAssertEqual(webViewProvider.webView.loadCalled, 1)
+        XCTAssertEqual(webViewProvider.webView.loadCalled, 0)
         prepareForTearDown(subject!)
     }
 

--- a/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
@@ -48,7 +48,7 @@ final class WKEngineSessionTests: XCTestCase {
 
         subject?.load(url: url)
 
-        // TODO: FXIOS-7981 Check scheme before loading
+        // Laurie
         XCTAssertEqual(webViewProvider.webView.loadCalled, 1)
         prepareForTearDown(subject!)
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -8,9 +8,6 @@ import WebKit
 import Shared
 import UIKit
 
-/// List of schemes that are allowed to be opened in new tabs.
-private let schemesAllowedToBeOpenedAsPopups = ["http", "https", "javascript", "data", "about"]
-
 // MARK: - WKUIDelegate
 extension BrowserViewController: WKUIDelegate {
     func webView(
@@ -955,17 +952,6 @@ private extension BrowserViewController {
         return false
     }
 
-    // Recognize an Apple Maps URL. This will trigger the native app. But only if a search query is present. Otherwise
-    // it could just be a visit to a regular page on maps.apple.com.
-    func isAppleMapsURL(_ url: URL) -> Bool {
-        if url.scheme == "http" || url.scheme == "https" {
-            if url.host == "maps.apple.com" && url.query != nil {
-                return true
-            }
-        }
-        return false
-    }
-
     // Recognize a iTunes Store URL. These all trigger the native apps. Note that appstore.com and phobos.apple.com
     // used to be in this list. I have removed them because they now redirect to itunes.apple.com. If we special case
     // them then iOS will actually first open Safari, which then redirects to the app store. This works but it will
@@ -1009,6 +995,9 @@ private extension BrowserViewController {
         if request.url?.absoluteString.isEmpty ?? false {
             return true
         }
+
+        /// List of schemes that are allowed to be opened in new tabs.
+        let schemesAllowedToBeOpenedAsPopups = ["http", "https", "javascript", "data", "about"]
 
         if let scheme = request.url?.scheme?.lowercased(), schemesAllowedToBeOpenedAsPopups.contains(scheme) {
             return true

--- a/firefox-ios/Client/Frontend/Share/CopyLinkActivity.swift
+++ b/firefox-ios/Client/Frontend/Share/CopyLinkActivity.swift
@@ -7,7 +7,7 @@ import Foundation
 class CopyLinkActivity: CustomAppActivity {
     // Copy link is only available for URL that are not files
     override func canPerform(withActivityItems activityItems: [Any]) -> Bool {
-        return !url.isFile
+        return !url.isFileURL
     }
 
     override func prepare(withActivityItems activityItems: [Any]) {}

--- a/firefox-ios/Client/Frontend/Share/SendToDeviceActivity.swift
+++ b/firefox-ios/Client/Frontend/Share/SendToDeviceActivity.swift
@@ -8,7 +8,7 @@ import Shared
 class SendToDeviceActivity: CustomAppActivity {
     // Send to device is only available for URL that are files
     override func canPerform(withActivityItems activityItems: [Any]) -> Bool {
-        return !url.isFile
+        return !url.isFileURL
     }
 
     override func prepare(withActivityItems activityItems: [Any]) {}

--- a/firefox-ios/Client/Frontend/Share/ShareExtensionHelper.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareExtensionHelper.swift
@@ -18,7 +18,7 @@ class ShareExtensionHelper: NSObject, FeatureFlaggable {
     private let pocketActionExtension = "com.ideashower.ReadItLaterPro.Action-Extension"
 
     var areShareSheetChangesEnabled: Bool {
-        return featureFlags.isFeatureEnabled(.shareSheetChanges, checking: .buildOnly) && !url.isFile
+        return featureFlags.isFeatureEnabled(.shareSheetChanges, checking: .buildOnly) && !url.isFileURL
     }
 
     /// Exclude 'Add to Reading List' which currently uses Safari. If share sheet changes are enabled exclude
@@ -89,7 +89,7 @@ class ShareExtensionHelper: NSObject, FeatureFlaggable {
     /// - Returns: An array of elements to be shared
     private func getActivityItems(url: URL) -> [Any] {
         // If url is file return only url to be shared
-        guard !url.isFile else { return [url] }
+        guard !url.isFileURL else { return [url] }
 
         var activityItems = [Any]()
         let printInfo = UIPrintInfo(dictionary: nil)
@@ -153,7 +153,7 @@ extension ShareExtensionHelper: UIActivityItemSource {
         if isPasswordManager(activityType: activityType) {
             return browserFillIdentifier
         } else if isOpenByCopy(activityType: activityType) {
-            return url.isFile ? UTType.fileURL.identifier : UTType.url.identifier
+            return url.isFileURL ? UTType.fileURL.identifier : UTType.url.identifier
         }
 
         return activityType == nil ? browserFillIdentifier : UTType.url.identifier

--- a/firefox-ios/Shared/Extensions/URLExtensions.swift
+++ b/firefox-ios/Shared/Extensions/URLExtensions.swift
@@ -195,14 +195,6 @@ extension URL {
     }
 }
 
-// Extensions to deal with ReaderMode URLs
-
-extension URL {
-    public var isFile: Bool {
-        return self.scheme == "file"
-    }
-}
-
 // MARK: - Exported URL Schemes
 
 extension URL {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7981)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17783)

## :bulb: Description
### Web Engine code change
Add a security manager in the web engine, as brought in [this doc](https://docs.google.com/document/d/1dEkOV_T0Gnk2qSxXiLZlWlCmUxnbpRidbGWjkIC9frw/edit?usp=sharing). Managing simple cases for now, and will complicate later on with the redirection in another task [FXIOS-8375](https://mozilla-hub.atlassian.net/browse/FXIOS-8375) 😅 

### Client code changes
Realized as well we have a `public var isFile: Bool {` which is not useful as there exists an method for this already provided by Apple. Also noticed `func isAppleMapsURL(_ url: URL)` was used no where so removed it.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

