### PR TITLE
Bugfix FXIOS-8312 [v123] PasswordManagerCoordinator not getting dismissed

### DIFF
--- a/firefox-ios/Client/Coordinators/PasswordManagerCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/PasswordManagerCoordinator.swift
@@ -5,9 +5,9 @@
 import Foundation
 import Storage
 
-protocol PasswordManagerCoordinatorDelegate: AnyObject {
+protocol PasswordManagerCoordinatorDelegate: AnyObject, ParentCoordinatorDelegate {
     func settingsOpenURLInNewTab(_ url: URL)
-    func didFinishPasswordManager(from coordinator: PasswordManagerCoordinator)
+    func didFinishPasswordManager(from: PasswordManagerCoordinator)
 }
 
 protocol PasswordManagerFlowDelegate: AnyObject {
@@ -40,14 +40,20 @@ class PasswordManagerCoordinator: BaseCoordinator,
     func showPasswordManager() {
         let viewController = PasswordManagerListViewController(profile: profile)
         viewController.coordinator = self
-        router.push(viewController)
+        router.push(viewController) { [weak self] in
+            guard let self = self else { return }
+            parentCoordinator?.didFinish(from: self)
+        }
         passwordManager = viewController
     }
 
     func showPasswordOnboarding() {
         let viewController = PasswordManagerOnboardingViewController()
         viewController.coordinator = self
-        router.push(viewController)
+        router.push(viewController) { [weak self] in
+            guard let self = self else { return }
+            parentCoordinator?.didFinish(from: self)
+        }
     }
 
     func showDevicePassCode() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/PasswordManagerCoordinatorDelegateMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/PasswordManagerCoordinatorDelegateMock.swift
@@ -8,6 +8,7 @@ import Foundation
 class PasswordManagerCoordinatorDelegateMock: PasswordManagerCoordinatorDelegate {
     var settingsOpenURLInNewTabCalled = 0
     var didFinishPasswordManagerCalled = 0
+    var didFinishCalled = 0
     var url: URL?
 
     func settingsOpenURLInNewTab(_ url: URL) {
@@ -17,5 +18,9 @@ class PasswordManagerCoordinatorDelegateMock: PasswordManagerCoordinatorDelegate
 
     func didFinishPasswordManager(from coordinator: PasswordManagerCoordinator) {
         didFinishPasswordManagerCalled += 1
+    }
+
+    func didFinish(from childCoordinator: Coordinator) {
+        didFinishCalled += 1
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/PasswordManagerCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/PasswordManagerCoordinatorTests.swift
@@ -60,6 +60,15 @@ final class PasswordManagerCoordinatorTests: XCTestCase {
         XCTAssertTrue(mockRouter.pushedViewController is PasswordManagerListViewController)
     }
 
+    func testDismissPasswordManager_callsDismissOnParentCoordinator() {
+        let subject = createSubject()
+
+        subject.showPasswordManager()
+
+        mockRouter.popViewController(animated: false)
+        XCTAssertEqual(mockParentCoordinator.didFinishCalled, 1)
+    }
+
     func testShowPasswordOnboarding() {
         let subject = createSubject()
 
@@ -67,6 +76,15 @@ final class PasswordManagerCoordinatorTests: XCTestCase {
 
         XCTAssertEqual(mockRouter.pushCalled, 1)
         XCTAssertTrue(mockRouter.pushedViewController is PasswordManagerOnboardingViewController)
+    }
+
+    func testDismissPasswordOnboarding_callsDismissOnParentCoordinator() {
+        let subject = createSubject()
+
+        subject.showPasswordOnboarding()
+
+        mockRouter.popViewController(animated: false)
+        XCTAssertEqual(mockParentCoordinator.didFinishCalled, 1)
     }
 
     func testPressedPasswordDetail() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockRouter.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockRouter.swift
@@ -42,6 +42,8 @@ class MockRouter: NSObject, Router {
 
     func popViewController(animated: Bool) {
         popViewControllerCalled += 1
+        savedCompletion?()
+        savedCompletion = nil
     }
 
     func setRootViewController(_ viewController: UIViewController, hideBar: Bool, animated: Bool) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8312)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18425)

## :bulb: Description
Bugfix `PasswordManagerCoordinator` not getting dismissed when `PasswordManagerListViewController` or `PasswordOnboardingViewController` get dismissed, this was causing the dismiss of `AppSettingsTableViewController` upon second tap on password or credit card settings.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

