### PR TITLE
Add FXIOS-8092 [v124] Scroll to top in WebEngine

### DIFF
--- a/BrowserKit/Sources/WebEngine/EngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/EngineSession.swift
@@ -24,6 +24,9 @@ public protocol EngineSession {
     /// Navigates forward in the history of this session.
     func goForward()
 
+    /// Scroll the session to the top
+    func scrollToTop()
+
     /// Navigates to the specified index in the history of this session. The current index of
     /// this session's history  will be updated but the items within it will be unchanged.
     /// Invalid index values are ignored.

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -108,6 +108,10 @@ class WKEngineSession: NSObject,
         logger.log("Go forward", level: .debug, category: .webview)
     }
 
+    func scrollToTop() {
+        webView.engineScrollView.setContentOffset(CGPoint.zero, animated: true)
+    }
+
     func goToHistory(index: Int) {
         // TODO: FXIOS-7907 #17651 Handle goToHistoryIndex in WKEngineSession (equivalent to goToBackForwardListItem)
     }

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
@@ -23,7 +23,7 @@ protocol WKEngineWebView: UIView {
     var interactionState: Any? { get set }
     var url: URL? { get }
     var title: String? { get }
-    var scrollView: UIScrollView { get }
+    var engineScrollView: WKScrollView! { get }
     var engineConfiguration: WKEngineConfiguration { get }
 
     var estimatedProgress: Double { get }
@@ -130,6 +130,7 @@ extension WKEngineWebView {
 // TODO: FXIOS-7896 #17641 Handle WKEngineWebView ThemeApplicable
 // TODO: FXIOS-7897 #17642 Handle WKEngineWebView AccessoryViewProvider
 class DefaultWKEngineWebView: WKWebView, WKEngineWebView, MenuHelperWebViewInterface {
+    var engineScrollView: WKScrollView!
     var engineConfiguration: WKEngineConfiguration
     weak var delegate: WKEngineWebViewDelegate?
 
@@ -137,7 +138,10 @@ class DefaultWKEngineWebView: WKWebView, WKEngineWebView, MenuHelperWebViewInter
         let configuration = configurationProvider.createConfiguration()
         self.engineConfiguration = configuration
         guard let configuration = configuration as? DefaultEngineConfiguration else { return nil }
+
         super.init(frame: frame, configuration: configuration.webViewConfiguration)
+
+        self.engineScrollView = scrollView
     }
 
     required init?(coder: NSCoder) {

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKScrollView.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKScrollView.swift
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+
+/// The `WKEngineWebView` scroll view
+protocol WKScrollView {
+    func setContentOffset(
+        _ contentOffset: CGPoint,
+        animated: Bool
+    )
+}
+
+extension UIScrollView: WKScrollView {}

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockEngineScrollView.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockEngineScrollView.swift
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+@testable import WebEngine
+
+class MockEngineScrollView: WKScrollView {
+    var setContentOffsetCalled = 0
+    var savedContentOffset: CGPoint?
+
+    func setContentOffset(_ contentOffset: CGPoint, animated: Bool) {
+        setContentOffsetCalled += 1
+        savedContentOffset = contentOffset
+    }
+}

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebView.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebView.swift
@@ -13,7 +13,7 @@ class MockWKEngineWebView: UIView, WKEngineWebView {
 
     var engineConfiguration: WKEngineConfiguration
     var interactionState: Any?
-    var scrollView = UIScrollView()
+    var engineScrollView: WKScrollView! = MockEngineScrollView()
     var url: URL?
     var title: String?
     var allowsBackForwardNavigationGestures = true

--- a/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
@@ -122,6 +122,19 @@ final class WKEngineSessionTests: XCTestCase {
         prepareForTearDown(subject!)
     }
 
+    // MARK: Scroll to top
+
+    func testScrollToTop() {
+        let subject = createSubject()
+
+        subject?.scrollToTop()
+
+        let scrollView = webViewProvider.webView.engineScrollView as? MockEngineScrollView
+        XCTAssertEqual(scrollView?.setContentOffsetCalled, 1)
+        XCTAssertEqual(scrollView?.savedContentOffset, CGPoint.zero)
+        prepareForTearDown(subject!)
+    }
+
     // MARK: Reload
 
     func testReloadThenCallsReloadFromOrigin() {

--- a/SampleBrowser/SampleBrowser.xcodeproj/project.pbxproj
+++ b/SampleBrowser/SampleBrowser.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8A0687612B6D9F990031427A /* SettingsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0687602B6D9F990031427A /* SettingsDelegate.swift */; };
 		8A0F446B2B56EDC900438589 /* EngineProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0F446A2B56EDC900438589 /* EngineProvider.swift */; };
 		8A0F446E2B56EF1A00438589 /* WebEngine in Frameworks */ = {isa = PBXBuildFile; productRef = 8A0F446D2B56EF1A00438589 /* WebEngine */; };
 		8A0F44712B56FD3600438589 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0F44702B56FD3600438589 /* SearchViewController.swift */; };
@@ -41,6 +42,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		8A0687602B6D9F990031427A /* SettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsDelegate.swift; sourceTree = "<group>"; };
 		8A0F44682B56ECBF00438589 /* BrowserKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = BrowserKit; path = ../BrowserKit; sourceTree = "<group>"; };
 		8A0F446A2B56EDC900438589 /* EngineProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngineProvider.swift; sourceTree = "<group>"; };
 		8A0F44702B56FD3600438589 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
@@ -149,6 +151,7 @@
 				8A3DB3302B5AD3E000F89705 /* SettingsDataSource.swift */,
 				8A3DB3322B5AD3EC00F89705 /* SettingsCellViewModel.swift */,
 				8A3DB3342B5AD47500F89705 /* SettingsType.swift */,
+				8A0687602B6D9F990031427A /* SettingsDelegate.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -329,6 +332,7 @@
 				8A0F446B2B56EDC900438589 /* EngineProvider.swift in Sources */,
 				8A0F447F2B56FDAD00438589 /* BrowserError.swift in Sources */,
 				8A4601E72B0FE20500FFD17F /* SceneDelegate.swift in Sources */,
+				8A0687612B6D9F990031427A /* SettingsDelegate.swift in Sources */,
 				8A0F44812B56FDEA00438589 /* SearchDataProvider.swift in Sources */,
 				8A4602202B0FE52F00FFD17F /* UISearchbar+Extension.swift in Sources */,
 				8A3DB3312B5AD3E000F89705 /* SettingsDataSource.swift in Sources */,

--- a/SampleBrowser/SampleBrowser/UI/Browser/BrowserViewController.swift
+++ b/SampleBrowser/SampleBrowser/UI/Browser/BrowserViewController.swift
@@ -91,6 +91,10 @@ class BrowserViewController: UIViewController, EngineSessionDelegate {
         engineSession.stopLoading()
     }
 
+    func scrollToTop() {
+        engineSession.scrollToTop()
+    }
+
     // MARK: - Search
 
     func loadUrlOrSearch(_ searchTerm: SearchTerm) {

--- a/SampleBrowser/SampleBrowser/UI/RootViewController.swift
+++ b/SampleBrowser/SampleBrowser/UI/RootViewController.swift
@@ -10,7 +10,8 @@ class RootViewController: UIViewController,
                           NavigationDelegate,
                           SearchBarDelegate,
                           SearchSuggestionDelegate,
-                          MenuDelegate {
+                          MenuDelegate,
+                          SettingsDelegate {
     private lazy var toolbar: BrowserToolbar = .build { _ in }
     private lazy var searchBar: BrowserSearchBar =  .build { _ in }
     private lazy var statusBarFiller: UIView =  .build { view in
@@ -174,6 +175,7 @@ class RootViewController: UIViewController,
 
     func didClickMenu() {
         let settingsVC = SettingsViewController()
+        settingsVC.delegate = self
         present(settingsVC, animated: true)
     }
 
@@ -182,5 +184,11 @@ class RootViewController: UIViewController,
     func tapOnSuggestion(term: String) {
         searchBar.setSearchBarText(term)
         browse(to: term)
+    }
+
+    // MARK: - SettingsDelegate
+
+    func scrollToTop() {
+        browserVC.scrollToTop()
     }
 }

--- a/SampleBrowser/SampleBrowser/UI/Settings/SettingsDelegate.swift
+++ b/SampleBrowser/SampleBrowser/UI/Settings/SettingsDelegate.swift
@@ -1,0 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+protocol SettingsDelegate: AnyObject {
+    func scrollToTop()
+}

--- a/SampleBrowser/SampleBrowser/UI/Settings/SettingsViewController.swift
+++ b/SampleBrowser/SampleBrowser/UI/Settings/SettingsViewController.swift
@@ -14,6 +14,7 @@ class SettingsViewController: UIViewController, UITableViewDelegate {
 
     private var tableView: UITableView
     private var dataSource = SettingsDataSource()
+    weak var delegate: SettingsDelegate?
 
     private lazy var titleLabel: UILabel = .build { label in
         label.font = UIFont.systemFont(ofSize: 30, weight: UIFont.Weight.medium)
@@ -85,9 +86,11 @@ class SettingsViewController: UIViewController, UITableViewDelegate {
         case .findInPage:
             break // TODO: FXIOS-8087 - Handle find in page in WebEngine
         case .scrollingToTop:
-            break // TODO: FXIOS-8092 - Handle scrolling to top in WebEngine
+            delegate?.scrollToTop()
         case .zoom:
             break // TODO: FXIOS-8089 - Handle zoom in WebEngine
         }
+
+        dismiss(animated: true)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8092)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18004)

## :bulb: Description
Adding scroll to top in WebEngine
- Added unit tests
- Added the implementation to trigger this in the SampleBrowser code
- Note that there is no changes in this PR for Firefox iOS itself, this is only in the WebEngine and the SampleBrowser

https://github.com/mozilla-mobile/firefox-ios/assets/11338480/20357d4a-f4fe-4f9b-a2b5-0f9913c16b83

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

