### PR TITLE
Refactor FXIOS-8320 [v124] Multiple snack bars stack up

### DIFF
--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -764,7 +764,7 @@ class Tab: NSObject, ThemeApplicable {
     }
 
     func addSnackbar(_ bar: SnackBar) {
-        if bars.count > 2 { return } // maximum 3 snackbars allowed on a tab
+        guard bars.isEmpty else { return } // maximum 1 snackbar allowed on a tab
         bars.append(bar)
         tabDelegate?.tab(self, didAddSnackbar: bar)
     }
@@ -774,11 +774,6 @@ class Tab: NSObject, ThemeApplicable {
             bars.remove(at: index)
             tabDelegate?.tab(self, didRemoveSnackbar: bar)
         }
-    }
-
-    func removeAllSnackbars() {
-        // Enumerate backwards here because we'll remove items from the list as we go.
-        bars.reversed().forEach { removeSnackbar($0) }
     }
 
     func expireSnackbars() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8320)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18438)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
 - Allow only one snackbar per tab
 - Remove removeAllSnackbars() func. It is only declared, not called anywhere.
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

