### PR TITLE
Refactor FXIOS-8012 [v124] Fix closeButton warnings in LegacyTabCell

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabCell.swift
@@ -67,10 +67,12 @@ class LegacyTabCell: UICollectionViewCell,
         button.imageView?.contentMode = .scaleAspectFit
         button.contentMode = .center
         button.configuration?.imagePadding = LegacyGridTabViewController.UX.closeButtonEdgeInset
-        button.configuration?.contentInsets =  NSDirectionalEdgeInsets(top: LegacyGridTabViewController.UX.closeButtonEdgeInset,
-                                                                       leading: LegacyGridTabViewController.UX.closeButtonEdgeInset,
-                                                                       bottom: LegacyGridTabViewController.UX.closeButtonEdgeInset,
-                                                                       trailing: LegacyGridTabViewController.UX.closeButtonEdgeInset)
+        button.configuration?.contentInsets =  NSDirectionalEdgeInsets(
+            top: LegacyGridTabViewController.UX.closeButtonEdgeInset,
+            leading: LegacyGridTabViewController.UX.closeButtonEdgeInset,
+            bottom: LegacyGridTabViewController.UX.closeButtonEdgeInset,
+            trailing: LegacyGridTabViewController.UX.closeButtonEdgeInset
+        )
     }
 
     private var title = UIVisualEffectView(effect: UIBlurEffect(style: .dark))


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8012)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17883)

## :bulb: Description
Merging fixes from @Prathameshchakote's [PR here](https://github.com/mozilla-mobile/firefox-ios/pull/18011)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

