### PR TITLE
Refactor FXIOS-8315 [v125] Credit card key management logic

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewModel.swift
@@ -151,7 +151,7 @@ class CreditCardBottomSheetViewModel {
     // MARK: Update Credit Card
     func updateCreditCard(for creditCardGUID: String?,
                           with decryptedCard: UnencryptedCreditCardFields?,
-                          completion: @escaping (Bool, Error?) -> Void) {
+                          completion: @escaping (Bool?, Error?) -> Void) {
         guard let creditCardGUID = creditCardGUID else {
             completion(false, AutofillApiError.UnexpectedAutofillApiError(reason: "nil credit card GUID"))
             return

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputViewModel.swift
@@ -237,7 +237,7 @@ class CreditCardInputViewModel: ObservableObject {
                                completion: completion)
     }
 
-    func updateCreditCard(completion: @escaping (Bool, Error?) -> Void) {
+    func updateCreditCard(completion: @escaping (Bool?, Error?) -> Void) {
         guard let creditCard = creditCard,
               let plainCreditCard = getDisplayedCCValues() else {
             completion(true, InputVMError.unableToUpdateCC)

--- a/firefox-ios/Storage/Rust/RustAutofill.swift
+++ b/firefox-ios/Storage/Rust/RustAutofill.swift
@@ -50,7 +50,6 @@ public class RustAutofill {
     /// - Returns: An optional NSError if an error occurs during the database opening process.
     internal func open() -> NSError? {
         do {
-            try getStoredKey()
             storage = try AutofillStore(dbpath: databasePath)
             isOpen = true
             return nil
@@ -108,11 +107,14 @@ public class RustAutofill {
                 completion(nil, error)
                 return
             }
-            do {
-                let id = try self.storage?.addCreditCard(cc: creditCard.toUpdatableCreditCardFields())
-                completion(id!, nil)
-            } catch let err as NSError {
-                completion(nil, err)
+
+            self.encryptCreditCard(creditCard: creditCard) { encCreditCard in
+                do {
+                    let id = try self.storage?.addCreditCard(cc: encCreditCard)
+                    completion(id!, nil)
+                } catch let err as NSError {
+                    completion(nil, err)
+                }
             }
         }
     }
@@ -213,14 +215,14 @@ public class RustAutofill {
                 completion(false, error)
                 return
             }
-            do {
-                try self.storage?.updateCreditCard(
-                    guid: id,
-                    cc: creditCard.toUpdatableCreditCardFields()
-                )
-                completion(true, nil)
-            } catch let err as NSError {
-                completion(false, err)
+
+            self.encryptCreditCard(creditCard: creditCard) { encCreditCard in
+                do {
+                    try self.storage?.updateCreditCard(guid: id, cc: encCreditCard)
+                    completion(true, nil)
+                } catch let err as NSError {
+                    completion(false, err)
+                }
             }
         }
     }
@@ -269,19 +271,19 @@ public class RustAutofill {
 
     /// Performs an operation to scrub encrypted credit card numbers from the database.
     ///
-    /// - Parameter completion: A closure called upon completion with a boolean indicating success and an error if any.
+    /// - Parameter completion: A closure called upon completion with a result indicating success or failure.
     /// - Note: Scrubs encrypted credit card numbers and reports the result using a completion handler.
-    public func scrubCreditCardNums(completion: @escaping (Bool, Error?) -> Void) {
+    public func scrubCreditCardNums(completion: @escaping (Result<Void, Error>) -> Void) {
         performDatabaseOperation { error in
             guard error == nil else {
-                completion(false, error)
+                completion(.failure(error!))
                 return
             }
             do {
                 try self.storage?.scrubEncryptedData()
-                completion(true, nil)
+                completion(.success(()))
             } catch let err as NSError {
-                completion(false, err)
+                completion(.failure(err))
             }
         }
     }
@@ -376,67 +378,76 @@ public class RustAutofill {
         }
     }
 
-    // MARK: - Key Management
-
     /// Retrieves the stored encryption key.
-    /// - Throws: An error if there is an issue retrieving the key.
-    /// - Returns: The retrieved encryption key.
-    /// - Note: Uses Swift's `throws` for error handling, providing a clear indication of potential failures.
-    @discardableResult
-    public func getStoredKey() throws -> String {
+    ///
+    /// - Parameters:
+    ///   - completion: A closure called upon completion with the encryption key or an error upon failure.
+    public func getStoredKey(completion: @escaping (Result<String, NSError>) -> Void) {
         let rustKeys = RustAutofillEncryptionKeys()
-        let key = rustKeys.keychain.string(forKey: rustKeys.ccKeychainKey)
-        let encryptedCanaryPhrase = rustKeys.keychain.string(
-            forKey: rustKeys.ccCanaryPhraseKey
-        )
 
-        switch (key, encryptedCanaryPhrase) {
-        case (.some(let key), .some(let encryptedCanaryPhrase)):
-            // We expected the key to be present, and it is.
-            do {
-                let canaryIsValid = try rustKeys.checkCanary(
-                    canary: encryptedCanaryPhrase,
-                    text: rustKeys.canaryPhrase,
-                    key: key
-                )
-                if canaryIsValid {
-                    return key
-                } else {
-                    handleKeyCorruption()
-                    return try rustKeys.createAndStoreKey()
+        getKeychainData(rustKeys: rustKeys) { (key, encryptedCanaryPhrase) in
+            switch (key, encryptedCanaryPhrase) {
+            case (.some(key), .some(encryptedCanaryPhrase)):
+                // We expected the key to be present, and it is.
+                do {
+                    let canaryIsValid = try rustKeys.checkCanary(
+                        canary: encryptedCanaryPhrase!,
+                        text: rustKeys.canaryPhrase,
+                        key: key!
+                    )
+                    if canaryIsValid {
+                        completion(.success(key!))
+                    } else {
+                        self.logger.log("Autofill key was corrupted, new one generated",
+                                        level: .warning,
+                                        category: .storage)
+                        self.resetCreditCardsAndKey(rustKeys: rustKeys, completion: completion)
+                    }
+                } catch let error as NSError {
+                    self.logger.log("Error retrieving autofill encryption key",
+                                    level: .warning,
+                                    category: .storage,
+                                    description: error.localizedDescription)
+                    completion(.failure(error))
                 }
-            } catch let error as NSError {
-                logger.log("Error retrieving autofill encryption key",
-                           level: .warning,
-                           category: .storage,
-                           description: error.localizedDescription)
+            case (.some(key), .none), (.none, .some(encryptedCanaryPhrase)):
+                // The key is present, but we didn't expect it to be there.
+                // or
+                // We expected the key to be present, but it's gone missing on us
+                self.logger.log("Autofill key lost, new one generated",
+                                level: .warning,
+                                category: .storage)
+                self.resetCreditCardsAndKey(rustKeys: rustKeys, completion: completion)
+            case (.none, .none):
+                // We didn't expect the key to be present, which either means this is a first-time
+                // call or the key data has been cleared from the keychain.
+                self.hasCreditCards { result in
+                    switch result {
+                    case .success(let hasCreditCards):
+                        if hasCreditCards {
+                            // Since the key data isn't present and we have credit card records in
+                            // the database, we both scrub the records and reset the key.
+                            self.resetCreditCardsAndKey(rustKeys: rustKeys, completion: completion)
+                        } else {
+                            // There are no records in the database so we don't need to scrub any
+                            // existing credit card records. We just need to create a new key.
+                            do {
+                                let key = try rustKeys.createAndStoreKey()
+                                completion(.success(key))
+                            } catch let error as NSError {
+                                completion(.failure(error))
+                            }
+                        }
+                    case .failure(let err):
+                        completion(.failure(err as NSError))
+                    }
+                }
+            default:
+                // If none of the above cases apply, we're in a state that shouldn't be possible
+                // but is disallowed nonetheless
+                completion(.failure(AutofillEncryptionKeyError.illegalState as NSError))
             }
-        case (.some(key), .none), (.none, .some(encryptedCanaryPhrase)):
-            // The key is present, but we didn't expect it to be there.
-            // or
-            // We expected the key to be present, but it's gone missing on us
-            do {
-                handleKeyLoss()
-                return try rustKeys.createAndStoreKey()
-            } catch let error as NSError {
-                throw error
-            }
-        case (.none, .none):
-            // We didn't expect the key to be present, and it's not (which is the case for
-            // first-time calls).
-            do {
-                return try rustKeys.createAndStoreKey()
-            } catch let error as NSError {
-                throw error
-            }
-        default:
-            // If none of the above cases apply, we're in a state that shouldn't be possible
-            // but is disallowed nonetheless
-            throw AutofillEncryptionKeyError.illegalState
         }
-        // This must be declared again for Swift's sake even though the above switch statement
-        // handles all cases
-        throw AutofillEncryptionKeyError.illegalState
     }
 
     // MARK: - Private Helper Methods
@@ -475,17 +486,73 @@ public class RustAutofill {
         }
     }
 
-    private func handleKeyCorruption() {
-        logger.log("Autofill key was corrupted, new one generated",
-                   level: .warning,
-                   category: .storage)
-        scrubCreditCardNums(completion: { _, _ in })
+    private func getKeychainData(rustKeys: RustAutofillEncryptionKeys,
+                                 completion: @escaping (String?, String?) -> Void) {
+        DispatchQueue.global(qos: .background).sync {
+            let key = rustKeys.keychain.string(forKey: rustKeys.ccKeychainKey)
+            let encryptedCanaryPhrase = rustKeys.keychain.string(forKey: rustKeys.ccCanaryPhraseKey)
+            completion(key, encryptedCanaryPhrase)
+        }
     }
 
-    private func handleKeyLoss() {
-        logger.log("Autofill key lost, new one generated",
-                   level: .warning,
-                   category: .storage)
-        scrubCreditCardNums(completion: { _, _ in })
+    private func resetCreditCardsAndKey(rustKeys: RustAutofillEncryptionKeys,
+                                        completion: @escaping (Result<String, NSError>) -> Void) {
+        self.scrubCreditCardNums { result in
+            switch result {
+            case .success(()):
+                do {
+                    let key = try rustKeys.createAndStoreKey()
+                    completion(.success(key))
+                } catch let error as NSError {
+                    self.logger.log("Error creating credit card encryption key",
+                                    level: .warning,
+                                    category: .storage,
+                                    description: error.localizedDescription)
+                    completion(.failure(error))
+                }
+            case .failure(let err):
+                completion(.failure(err as NSError))
+            }
+        }
+    }
+
+    private func hasCreditCards(completion: @escaping (Result<Bool, Error>) -> Void) {
+        return listCreditCards { (creditCards, err) in
+            guard err == nil else {
+                completion(.failure(err!))
+                return
+            }
+
+            completion(.success(creditCards?.count ?? 0 > 0))
+        }
+    }
+
+    private func encryptCreditCard(creditCard: UnencryptedCreditCardFields,
+                                   completion: @escaping (UpdatableCreditCardFields) -> Void) {
+        getStoredKey { result in
+            var ccNumberEnc = ""
+
+            switch result {
+            case .success(let key):
+                do {
+                    ccNumberEnc = try encryptString(key: key, cleartext: creditCard.ccNumber)
+                } catch let error as NSError {
+                    self.logger.log("Error encrypting credit card number",
+                                    level: .warning,
+                                    category: .storage,
+                                    description: error.localizedDescription)
+                }
+            case .failure:
+                break
+            }
+
+            let encCreditCard = UpdatableCreditCardFields(ccName: creditCard.ccName,
+                                                          ccNumberEnc: ccNumberEnc,
+                                                          ccNumberLast4: creditCard.ccNumberLast4,
+                                                          ccExpMonth: creditCard.ccExpMonth,
+                                                          ccExpYear: creditCard.ccExpYear,
+                                                          ccType: creditCard.ccType)
+            completion(encCreditCard)
+        }
     }
 }

--- a/firefox-ios/Storage/Rust/RustLogins.swift
+++ b/firefox-ios/Storage/Rust/RustLogins.swift
@@ -927,7 +927,7 @@ public class RustLogins: LoginsProtocol {
 
                     if hasLogins {
                         // Since the key data isn't present and we have login records in
-                        // the database, we both clear the databbase and the reset the key.
+                        // the database, we both clear the database and reset the key.
                         GleanMetrics.LoginsStoreKeyRegeneration.keychainDataLost.record()
                         self.resetLoginsAndKey(rustKeys: rustKeys, completion: completion)
                     } else {

--- a/firefox-ios/Storage/Rust/UnencryptedCreditCardFields.swift
+++ b/firefox-ios/Storage/Rust/UnencryptedCreditCardFields.swift
@@ -29,17 +29,6 @@ public struct UnencryptedCreditCardFields {
         self.ccType = ccType
     }
 
-    func toUpdatableCreditCardFields() -> UpdatableCreditCardFields {
-        let rustKeys = RustAutofillEncryptionKeys()
-        let ccNumberEnc = rustKeys.encryptCreditCardNum(creditCardNum: self.ccNumber)
-        return UpdatableCreditCardFields(ccName: self.ccName,
-                                         ccNumberEnc: ccNumberEnc ?? "",
-                                         ccNumberLast4: self.ccNumberLast4,
-                                         ccExpMonth: self.ccExpMonth,
-                                         ccExpYear: self.ccExpYear,
-                                         ccType: self.ccType)
-    }
-
     public func convertToTempCreditCard() -> CreditCard {
         let convertedCreditCard = CreditCard(guid: "",
                                              ccName: self.ccName,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardBottomSheetViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardBottomSheetViewModelTests.swift
@@ -133,7 +133,10 @@ class CreditCardBottomSheetViewModelTests: XCTestCase {
 
             self.viewModel.updateCreditCard(for: creditCard.guid,
                                             with: self.samplePlainTextCard) { didUpdate, error in
-                XCTAssertTrue(didUpdate)
+                XCTAssertNotNil(didUpdate)
+                if let updated = didUpdate {
+                    XCTAssert(updated)
+                }
                 XCTAssertNil(error)
                 expectationUpdate.fulfill()
             }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardInputViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardInputViewModelTests.swift
@@ -261,7 +261,10 @@ class CreditCardInputViewModelTests: XCTestCase {
                 // Update card with new values
                 self.viewModel.updateCreditCard { success, error in
                     XCTAssertNil(error)
-                    XCTAssertTrue(success)
+                    XCTAssertNotNil(success)
+                    if let updated = success {
+                        XCTAssert(updated)
+                    }
                     // Check updated values
                     self.viewModel.autofill.getCreditCard(id: ccCard.guid) { ccUpdatedCard, error in
                         XCTAssertNil(error)

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -202,7 +202,10 @@ class RustAutofillTests: XCTestCase {
                                                                     ccType: creditCard!.ccType)
                 self.autofill.updateCreditCard(id: creditCard!.guid,
                                                creditCard: updatedCreditCard) { success, err in
-                    XCTAssert(success)
+                    XCTAssertNotNil(success)
+                    if let updated = success {
+                        XCTAssert(updated)
+                    }
                     XCTAssertNil(err)
                     expectationUpdateCard.fulfill()
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8315)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18428)

## :bulb: Description
This logic is similar to the work that was done in logins in PR #18401 and includes the following changes for the autofill encryption key logic:
- Ensures that saved credit cards are successfully scrubbed before the encryption key is recreated
- Moves keychain calls to background threads
- Prevents `registerWithSyncManager` from being called multiple times on the autofill store for one sync
- Removes the superfluous `getStoreKey` call in `RustAutofill.open`

### Local Test Steps

1. Create an FxA account.

1. Log in to sync on Firefox desktop with the account created in step 1.

1. Add credit cards and sync.

1. Open Xcode.

1. Checkout the code in this PR.

1. Remove any pre-existing device data from the simulator and run the code.

1. Sign in to sync with the account created in step 1.

1. Sync credit cards via the Settings menu and ensure that the credit cards from desktop appear in the Firefox iOS Payment Methods menu. 

1. Stop the simulator.

1. Make the changes below in the `getKeychainData` function in RustAutofill.swift:
	a. To test when the key is present but not the encrypted canary phrase, replace the `completion` call with the following:
	```
		completion(key, nil)
	```
	b. To test when the key is missing but the encrypted canary phrase is present, replace the `completion` call with the following:
	```
		completion(nil, encryptedCanaryPhrase)
	```
	c. To test when both the key and the encrypted canary phrase are missing, replace the `completion` call with the following:
	```
		completion(nil, nil)
	```

1. Run the iOS code locally again, this time without removing the device data.
	**Note:** You should add a breakpoint within the switch statement of the `getStoredKey` function for the case you're testing to ensure it's being hit. You may also want to add a breakpoint in the `resetCreditCardsAndKey` function to ensure it is successfully executed.

1. Sync logins in Firefox iOS.

1. The expected result is that, despite the database being wiped, all of the logins created in desktop should still be visible in the Firefox iOS Passwords menu.
  a. You can ensure this is the case by checking the sync logs for the results of the passwords engine sync. The applied record count should equal the number of records you created in Firefox desktop and there should be no outgoing records. 

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

