### PR TITLE
Add FXIOS-8484 [V124] Add a Custom Autofill Accessory View Supporting Credit Cards and Addresses

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -938,6 +938,7 @@
 		B15058812AA0A878008B7382 /* OpeningScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15058802AA0A878008B7382 /* OpeningScreenTests.swift */; };
 		B1664E9E2B163B7A005D4C71 /* CreditCardsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1664E9D2B163B7A005D4C71 /* CreditCardsTests.swift */; };
 		B26ADF852B339ED000C6E127 /* AddressAutofillSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = B26ADF842B339ED000C6E127 /* AddressAutofillSetting.swift */; };
+		B2981F8A2B71AD7A00132C1B /* AutofillAccessoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2981F892B71AD7A00132C1B /* AutofillAccessoryView.swift */; };
 		B2999FED2B044A5900F0FEC1 /* UnencryptedCreditCardFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2999FEC2B044A5900F0FEC1 /* UnencryptedCreditCardFields.swift */; };
 		B2999FEF2B044B4E00F0FEC1 /* RustAutofillEncryptionKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2999FEE2B044B4E00F0FEC1 /* RustAutofillEncryptionKeys.swift */; };
 		B2999FF12B194A5800F0FEC1 /* CreditCardPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2999FF02B194A5800F0FEC1 /* CreditCardPayload.swift */; };
@@ -6207,6 +6208,7 @@
 		B26ADF842B339ED000C6E127 /* AddressAutofillSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressAutofillSetting.swift; sourceTree = "<group>"; };
 		B29049688244A8F79950DF35 /* af */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = af; path = af.lproj/Shared.strings; sourceTree = "<group>"; };
 		B2944B3EAFB1DA22E7F28520 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Shared.strings; sourceTree = "<group>"; };
+		B2981F892B71AD7A00132C1B /* AutofillAccessoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutofillAccessoryView.swift; sourceTree = "<group>"; };
 		B2999FEC2B044A5900F0FEC1 /* UnencryptedCreditCardFields.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnencryptedCreditCardFields.swift; sourceTree = "<group>"; };
 		B2999FEE2B044B4E00F0FEC1 /* RustAutofillEncryptionKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustAutofillEncryptionKeys.swift; sourceTree = "<group>"; };
 		B2999FF02B194A5800F0FEC1 /* CreditCardPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditCardPayload.swift; sourceTree = "<group>"; };
@@ -8716,6 +8718,7 @@
 		43D00490296FC44B00CB0F31 /* Autofill */ = {
 			isa = PBXGroup;
 			children = (
+				B2981F892B71AD7A00132C1B /* AutofillAccessoryView.swift */,
 				B2FEA6892B460CEC0058E616 /* Address */,
 				43D00491296FC46E00CB0F31 /* CreditCard */,
 			);
@@ -13593,6 +13596,7 @@
 				EBB8950C21939E4100EB91A0 /* FirefoxTabContentBlocker.swift in Sources */,
 				21618A632A422A3900A5189E /* ThemeMiddleware.swift in Sources */,
 				219A0FDB2ACCCFFC009A6D1A /* InactiveTabsSectionManager.swift in Sources */,
+				B2981F8A2B71AD7A00132C1B /* AutofillAccessoryView.swift in Sources */,
 				211F00AC27F4D918001D9189 /* HistoryPanel+Search.swift in Sources */,
 				96EB6C3827D821B800A9D159 /* HistoryPanelViewModel.swift in Sources */,
 				AB52ED3B2A0E8873001067F5 /* UserConversionMetrics.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Autofill/AutofillAccessoryView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/AutofillAccessoryView.swift
@@ -1,0 +1,111 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import Common
+import Shared
+
+/// Custom UIBarButtonItem with an autofill accessory view.
+///
+/// This class provides a reusable and configurable autofill accessory view for use in navigation bars.
+///
+/// # Attributes
+/// - `accessoryImageViewSize`: Size of the accessory image view.
+/// - `accessoryButtonStackViewSpacing`: Spacing between the accessory image view and text label in the stack view.
+/// - `cornerRadius`: Corner radius for the accessory view.
+///
+/// # Properties
+/// - `accessoryImageViewTintColor`: Tint color for the accessory image view.
+/// - `backgroundColor`: Background color for the accessory view.
+///
+/// # Methods
+/// - `init(image:labelText:tappedAction:)`: Initializes the accessory view with an image, label, and optional tap action.
+/// - `tappedAccessoryButton()`: Handles the tap action on the accessory view.
+class AutofillAccessoryView: UIBarButtonItem {
+    // MARK: - Constants
+    private struct UX {
+        static let accessoryImageViewSize: CGFloat = 24
+        static let accessoryButtonStackViewSpacing: CGFloat = 2
+        static let cornerRadius: CGFloat = 4
+    }
+
+    // MARK: - Properties
+    private let accessoryImageView: UIImageView
+    private let useAccessoryTextLabel: UILabel
+    private let tappedAccessoryButtonAction: (() -> Void)?
+
+    /// Tint color for the accessory image view.
+    var accessoryImageViewTintColor: UIColor? {
+        get {
+            return accessoryImageView.tintColor
+        }
+        set {
+            accessoryImageView.tintColor = newValue
+        }
+    }
+
+    /// Background color for the accessory view.
+    var backgroundColor: UIColor? {
+        didSet {
+            updateBackgroundColor()
+        }
+    }
+
+    // MARK: - Initialization
+    /// Initializes the accessory view with an image, label, and optional tap action.
+    /// - Parameters:
+    ///   - image: The image for the accessory image view.
+    ///   - labelText: The text for the accessory view label.
+    ///   - tappedAction: The closure to be executed when the accessory view is tapped.
+    init(image: UIImage?, labelText: String, tappedAction: (() -> Void)? = nil) {
+        self.accessoryImageView = .build { imageView in
+            imageView.image = image?.withRenderingMode(.alwaysTemplate)
+            imageView.contentMode = .scaleAspectFit
+            imageView.accessibilityElementsHidden = true
+
+            NSLayoutConstraint.activate([
+                imageView.widthAnchor.constraint(equalToConstant: UX.accessoryImageViewSize),
+                imageView.heightAnchor.constraint(equalToConstant: UX.accessoryImageViewSize)
+            ])
+        }
+
+        self.useAccessoryTextLabel = .build { label in
+            label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .title3, size: 16, weight: .medium)
+            label.text = labelText
+            label.numberOfLines = 0
+            label.accessibilityTraits = .button
+        }
+
+        self.tappedAccessoryButtonAction = tappedAction
+        super.init()
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Setup
+    private func setup() {
+        let stackViewTapped = UITapGestureRecognizer(target: self, action: #selector(tappedAccessoryButton))
+        let accessoryView = UIStackView(arrangedSubviews: [accessoryImageView, useAccessoryTextLabel])
+        accessoryView.spacing = UX.accessoryButtonStackViewSpacing
+        accessoryView.distribution = .equalCentering
+        accessoryView.layer.cornerRadius = UX.cornerRadius
+        accessoryView.addGestureRecognizer(stackViewTapped)
+        self.customView = accessoryView
+    }
+
+    private func updateBackgroundColor() {
+        if let backgroundColor = backgroundColor {
+            customView?.backgroundColor = backgroundColor
+        }
+    }
+
+    // MARK: - Actions
+    @objc
+    private func tappedAccessoryButton() {
+        tappedAccessoryButtonAction?()
+    }
+}

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -245,6 +245,11 @@ extension String {
                 tableName: "Settings",
                 value: "SAVED ADDRESSES",
                 comment: "On the autofill settings screen, a label for the section that displays the list of saved addresses. This label adds additional context for users regarding the toggle switch that allows saving and autofilling of addresses for webpages.")
+            public static let UseSavedAddressFromKeyboard = MZLocalizedString(
+                key: "Addresses.Settings.UseSavedAddressFromKeyboard.v124",
+                tableName: "Settings",
+                value: "Use saved address",
+                comment: "Displayed inside the keyboard hint when a user is entering their address and has at least one saved address. Indicates that there are stored addresses available for use in filling out a form.")
         }
     }
 }


### PR DESCRIPTION


## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8383)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18583)

## :bulb: Description
Created a versatile and reusable custom accessory view adhering to Figma designs. The accessory view should allow customization with images, text, and actions, offering flexibility for various use cases.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

