### PR TITLE
Refactor FXIOS-8374 [v124] Deeplink logging

### DIFF
--- a/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
+++ b/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
@@ -17,6 +17,9 @@ public enum LoggerCategory: String {
     /// Related to anything about credit cards.
     case creditcard
 
+    /// Related to anything involving handling of external links.
+    case deeplinks
+
     /// Related to homepage UI and it's data management.
     case homepage
 

--- a/firefox-ios/Client/Application/SceneDelegate.swift
+++ b/firefox-ios/Client/Application/SceneDelegate.swift
@@ -239,7 +239,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 logger.log("Deeplink tab check: success.", level: .debug, category: .deeplinks)
             } else {
                 // Indicates a Sent Tab or deeplink that failed to open. Log to Sentry. [FXIOS-8374]
-                logger.log("Deeplink tab check: failed. Tab not opened for incoming deeplink", level: .fatal, category: .deeplinks)
+                logger.log("Deeplink tab check: failed.", level: .fatal, category: .deeplinks)
             }
         }
     }

--- a/firefox-ios/Client/Application/SceneDelegate.swift
+++ b/firefox-ios/Client/Application/SceneDelegate.swift
@@ -239,9 +239,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 logger.log("Deeplink tab check: success.", level: .debug, category: .deeplinks)
             } else {
                 // Indicates a Sent Tab or deeplink that failed to open. Log to Sentry. [FXIOS-8374]
-                logger.log("Deeplink tab check: failed. Tab not opened for incoming deeplink",
-                           level: .fatal,
-                           category: .deeplinks)
+                logger.log("Deeplink tab check: failed. Tab not opened for incoming deeplink", level: .fatal, category: .deeplinks)
             }
         }
     }

--- a/firefox-ios/Client/Application/SceneDelegate.swift
+++ b/firefox-ios/Client/Application/SceneDelegate.swift
@@ -67,25 +67,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     private func logWillConnectToSession(options: UIScene.ConnectionOptions) {
         #if MOZ_CHANNEL_FENNEC
-        logger.log("Scene Delegate: willConnectTo session. Options: \(options)",
-                   level: .debug,
-                   category: .deeplinks)
+        logger.log("Scene Delegate: willConnectTo session. Options: \(options)", level: .debug, category: .deeplinks)
         #else
-        logger.log("Scene Delegate: willConnectTo session",
-                   level: .debug,
-                   category: .deeplinks)
+        logger.log("Scene Delegate: willConnectTo session", level: .debug, category: .deeplinks)
         #endif
     }
 
     private func logWillConnectDeeplink(_ deeplinkURL: URL) {
         #if MOZ_CHANNEL_FENNEC
-        logger.log("Incoming deeplink (willConnectTo). URL: \(deeplinkURL)",
-                   level: .debug,
-                   category: .deeplinks)
+        logger.log("Incoming deeplink (willConnectTo). URL: \(deeplinkURL)", level: .debug, category: .deeplinks)
         #else
-        logger.log("Incoming deeplink (willConnectTo)",
-                   level: .debug,
-                   category: .deeplinks)
+        logger.log("Incoming deeplink (willConnectTo)", level: .debug, category: .deeplinks)
         #endif
     }
 

--- a/firefox-ios/Client/Application/SceneDelegate.swift
+++ b/firefox-ios/Client/Application/SceneDelegate.swift
@@ -58,9 +58,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
 
         AppEventQueue.wait(for: [.startupFlowComplete, .tabRestoration(sceneCoordinator.windowUUID)]) { [weak self] in
-            self?.logger.log("Event queue: handle deeplink via connectionOptions",
-                             level: .debug,
-                             category: .deeplinks)
+            self?.logger.log("Event queue: handle deeplink via connectionOptions", level: .debug, category: .deeplinks)
             self?.handle(connectionOptions: connectionOptions)
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/Event Queue/EventQueue.swift
+++ b/firefox-ios/Client/Frontend/Browser/Event Queue/EventQueue.swift
@@ -83,7 +83,7 @@ public final class EventQueue<QueueEventType: Hashable> {
 
             // If a specific ID has been provided for this action, ensure
             guard !actions.contains(where: { $0.token == token }) else {
-                logger.log("Ignoring duplicate action (ID: \(token))", level: .info, category: .library)
+                logger.log("Ignoring duplicate action (ID: \(token))", level: .debug, category: .library)
                 return
             }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8374)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18553)

## :bulb: Description

Early work to add diagnostic logging for troubleshooting Sent Tabs and deeplinks. Also adds a new Sentry fatal error when we detect that an incoming deeplink failed to open in the app.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

