### PR TITLE
Bugfix FXIOS-6838 [v124] Fix closing tabs after moving

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1493,6 +1493,13 @@ class BrowserViewController: UIViewController,
 
         DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500), execute: {
             self.tabManager.addTab(URLRequest(url: url))
+            if TabTrayFlagManager.isRefactorEnabled {
+                let context = AddNewTabContext(urlRequest: nil, isPrivate: false, windowUUID: self.windowUUID)
+                store.dispatch(TabPanelAction.addNewTab(context))
+            } else {
+                self.tabManager.addTab(URLRequest(url: url))
+            }
+
             self.debugOpen(numberOfNewTabs: numberOfNewTabs - 1, at: url)
         })
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1492,12 +1492,12 @@ class BrowserViewController: UIViewController,
         else { return }
 
         DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500), execute: {
-            self.tabManager.addTab(URLRequest(url: url))
+            let urlRequest = URLRequest(url: url)
             if TabTrayFlagManager.isRefactorEnabled {
-                let context = AddNewTabContext(urlRequest: nil, isPrivate: false, windowUUID: self.windowUUID)
+                let context = AddNewTabContext(urlRequest: urlRequest, isPrivate: false, windowUUID: self.windowUUID)
                 store.dispatch(TabPanelAction.addNewTab(context))
             } else {
-                self.tabManager.addTab(URLRequest(url: url))
+                self.tabManager.addTab(urlRequest)
             }
 
             self.debugOpen(numberOfNewTabs: numberOfNewTabs - 1, at: url)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
@@ -13,6 +13,7 @@ struct TabsPanelState: ScreenState, Equatable {
     var toastType: ToastType?
     var windowUUID: WindowUUID
     var scrollToIndex: Int?
+    var tabMoved: Bool?
 
     var isPrivateTabsEmpty: Bool {
         guard isPrivateMode else { return false }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
@@ -13,7 +13,6 @@ struct TabsPanelState: ScreenState, Equatable {
     var toastType: ToastType?
     var windowUUID: WindowUUID
     var scrollToIndex: Int?
-    var tabMoved: Bool?
 
     var isPrivateTabsEmpty: Bool {
         guard isPrivateMode else { return false }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -77,7 +77,11 @@ class TabDisplayView: UIView,
     func newState(state: TabsPanelState) {
         tabsState = state
         collectionView.reloadData()
+        collectionView.collectionViewLayout.invalidateLayout()
 
+        // Needs to check here if the tab moved
+        collectionView.setNeedsLayout()
+        collectionView.layoutIfNeeded()
         if let index = state.scrollToIndex {
             scrollToTab(index)
         }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -76,15 +76,19 @@ class TabDisplayView: UIView,
 
     func newState(state: TabsPanelState) {
         tabsState = state
-        collectionView.reloadData()
-        collectionView.collectionViewLayout.invalidateLayout()
 
-        // Needs to check here if the tab moved
-        collectionView.setNeedsLayout()
-        collectionView.layoutIfNeeded()
+        updateCollectionViewLayout()
+
         if let index = state.scrollToIndex {
             scrollToTab(index)
         }
+    }
+
+    private func updateCollectionViewLayout() {
+        collectionView.reloadData()
+        collectionView.collectionViewLayout.invalidateLayout()
+        collectionView.setNeedsLayout()
+        collectionView.layoutIfNeeded()
     }
 
     private func scrollToTab(_ index: Int) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6838)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15239)

## :bulb: Description
Before change:
When a tab was moved in the tab tray the layout/collection view wouldn't update and when you closed the moved tab it wouldn't close the correct one.

After:
Now when you move the tab the views update properly and you are closing the intended tab.

In addition:
Added an update to the debug settings that generate 50 tabs in the tab tray so that it uses redux when the TabTrayFlag is enabled.

https://github.com/mozilla-mobile/firefox-ios/assets/5545720/18536548-a068-4bd7-9aa7-fca15f22a8ee

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

