### PR TITLE
Bugfix FXIOS-8387 [v124] QR code icon has wrong color in dark mode

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/Buttons/PrimaryRoundedButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/PrimaryRoundedButton.swift
@@ -59,6 +59,10 @@ public class PrimaryRoundedButton: ResizableButton, ThemeApplicable {
             return container
         }
 
+        updatedConfiguration.imageColorTransformer = UIConfigurationColorTransformer { [weak self] color in
+            return self?.foregroundColor ?? .white
+        }
+
         configuration = updatedConfiguration
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8387)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18592)

## :bulb: Description
Applies the foreground color to the button image as well.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

