### PR TITLE
Add FXIOS-8372 [v123.1] Proper logo header for compact sizes

### DIFF
--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -202,7 +202,7 @@ class HomepageViewController:
     private func updateHeaderToShowPrivateModeToggle() {
         let featureFlagOn = featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly)
         let showToggle = featureFlagOn && !shouldUseiPadSetup()
-        viewModel.headerViewModel.hidePrivateModeButton = !showToggle
+        viewModel.headerViewModel.showiPadSetup = !showToggle
     }
 
     // MARK: - Layout

--- a/firefox-ios/Client/Frontend/Home/LogoHeader/HomeLogoHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/LogoHeader/HomeLogoHeaderCell.swift
@@ -12,7 +12,10 @@ class HomeLogoHeaderCell: UICollectionViewCell, ReusableCell {
         struct Logo {
             static let iPhoneImageSize: CGFloat = 40
             static let iPadImageSize: CGFloat = 75
-            static let bottomConstant: CGFloat = -10
+
+            static func logoSizeConstant(for iPadSetup: Bool) -> CGFloat {
+                iPadSetup ? UX.Logo.iPadImageSize : UX.Logo.iPhoneImageSize
+            }
         }
 
         struct TextImage {
@@ -21,6 +24,14 @@ class HomeLogoHeaderCell: UICollectionViewCell, ReusableCell {
             static let iPhoneLeadingConstant: CGFloat = 9
             static let iPadLeadingConstant: CGFloat = 17
             static let trailingConstant: CGFloat = -15
+
+            static func textImageWidthConstant(for iPadSetup: Bool) -> CGFloat {
+                iPadSetup ? UX.TextImage.iPadWidth : UX.TextImage.iPhoneWidth
+            }
+
+            static func textImageSpacing(for iPadSetup: Bool) -> CGFloat {
+                iPadSetup ? UX.TextImage.iPadLeadingConstant : UX.TextImage.iPhoneLeadingConstant
+            }
         }
     }
 
@@ -36,7 +47,7 @@ class HomeLogoHeaderCell: UICollectionViewCell, ReusableCell {
         imageView.contentMode = .scaleAspectFit
     }
 
-    private lazy var containerView: UIView = .build { view in
+    private lazy var containerView: UIStackView = .build { view in
         view.backgroundColor = .clear
         view.accessibilityIdentifier = a11y.logoID
         view.accessibilityLabel = AppName.shortName.rawValue
@@ -47,7 +58,6 @@ class HomeLogoHeaderCell: UICollectionViewCell, ReusableCell {
     // MARK: - Initializers
     override init(frame: CGRect) {
         super.init(frame: frame)
-        setupView()
     }
 
     required init?(coder: NSCoder) {
@@ -55,49 +65,43 @@ class HomeLogoHeaderCell: UICollectionViewCell, ReusableCell {
     }
 
     // MARK: - UI Setup
-    func setupView() {
+    func configure(with showiPadSetup: Bool) {
+        setupView(with: showiPadSetup)
+    }
+
+    private func setupView(with showiPadSetup: Bool) {
         contentView.backgroundColor = .clear
-        containerView.addSubview(logoImage)
-        containerView.addSubview(logoTextImage)
+        containerView.addArrangedSubview(logoImage)
+        containerView.addArrangedSubview(logoTextImage)
         contentView.addSubview(containerView)
 
-        let isiPad = UIDevice.current.userInterfaceIdiom == .pad
-        let logoSizeConstant = isiPad ? UX.Logo.iPadImageSize : UX.Logo.iPhoneImageSize
-        let textImageWidthConstant = isiPad ? UX.TextImage.iPadWidth : UX.TextImage.iPhoneWidth
-        let textImageLeadingAnchorConstant = isiPad ? UX.TextImage.iPadLeadingConstant : UX.TextImage.iPhoneLeadingConstant
+        containerView.spacing = UX.TextImage.textImageSpacing(for: showiPadSetup)
 
         NSLayoutConstraint.activate([
-            containerView.heightAnchor.constraint(equalToConstant: logoSizeConstant),
             containerView.topAnchor.constraint(equalTo: contentView.topAnchor),
             containerView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-
-            logoImage.topAnchor.constraint(equalTo: containerView.topAnchor),
-            logoImage.widthAnchor.constraint(equalToConstant: logoSizeConstant),
-            logoImage.heightAnchor.constraint(equalToConstant: logoSizeConstant),
-            logoImage.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
-
-            logoTextImage.widthAnchor.constraint(equalToConstant: textImageWidthConstant),
-            logoTextImage.heightAnchor.constraint(equalTo: logoImage.heightAnchor),
-            logoTextImage.leadingAnchor.constraint(equalTo: logoImage.trailingAnchor,
-                                                   constant: textImageLeadingAnchorConstant),
-            logoTextImage.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
-            logoTextImage.centerYAnchor.constraint(equalTo: logoImage.centerYAnchor)
         ])
 
-        if isiPad {
-            NSLayoutConstraint.activate([
-                containerView.centerXAnchor.constraint(
-                    equalTo: contentView.centerXAnchor
-                ),
-            ])
-        } else {
-            NSLayoutConstraint.activate([
-                containerView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-                containerView.trailingAnchor.constraint(
-                    lessThanOrEqualTo: contentView.trailingAnchor,
-                    constant: UX.TextImage.trailingConstant),
-            ])
+        setupConstraints(for: showiPadSetup)
+    }
+
+    private var logoConstraints = [NSLayoutConstraint]()
+
+    private func setupConstraints(for iPadSetup: Bool) {
+        NSLayoutConstraint.deactivate(logoConstraints)
+        logoConstraints = [
+            logoImage.widthAnchor.constraint(equalToConstant: UX.Logo.logoSizeConstant(for: iPadSetup)),
+            logoImage.heightAnchor.constraint(equalToConstant: UX.Logo.logoSizeConstant(for: iPadSetup)),
+            logoTextImage.widthAnchor.constraint(equalToConstant: UX.TextImage.textImageWidthConstant(for: iPadSetup)),
+            logoTextImage.heightAnchor.constraint(equalTo: logoImage.heightAnchor),
+        ]
+
+        if iPadSetup {
+            logoConstraints.append(
+                containerView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor)
+            )
         }
+        NSLayoutConstraint.activate(logoConstraints)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Home/LogoHeader/HomeLogoHeaderViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/LogoHeader/HomeLogoHeaderViewModel.swift
@@ -16,7 +16,7 @@ class HomepageHeaderViewModel {
     private let profile: Profile
     private let tabManager: TabManager
     var onTapAction: ((UIButton) -> Void)?
-    var hidePrivateModeButton = true
+    var showiPadSetup = false
     var theme: Theme
 
     init(profile: Profile, theme: Theme, tabManager: TabManager) {
@@ -77,15 +77,15 @@ extension HomepageHeaderViewModel: HomepageViewModelProtocol, FeatureFlaggable {
 extension HomepageHeaderViewModel: HomepageSectionHandler {
     func configure(_ cell: UICollectionViewCell, at indexPath: IndexPath) -> UICollectionViewCell {
         guard let headerCell = cell as? HomepageHeaderCell else { return UICollectionViewCell() }
-        headerCell.applyTheme(theme: theme)
         headerCell.configure(
             with: HomepageHeaderCellViewModel(
                 isPrivate: false,
-                hidePrivateModeButton: hidePrivateModeButton,
+                showiPadSetup: showiPadSetup,
                 action: { [weak self] in
                     self?.tabManager.switchPrivacyMode()
                 })
         )
+        headerCell.applyTheme(theme: theme)
         return headerCell
     }
 }

--- a/firefox-ios/Client/Frontend/Home/LogoHeader/HomepageHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/LogoHeader/HomepageHeaderCell.swift
@@ -27,7 +27,7 @@ struct HomepageHeaderCellViewModel {
 
 // Header for the homepage in both normal and private mode
 // Contains the firefox logo and the private browsing shortcut button
-class HomepageHeaderCell: UICollectionViewCell, ReusableCell {
+class HomepageHeaderCell: UICollectionViewCell, ReusableCell, ThemeApplicable {
     enum UX {
         static let iPhoneTopConstant: CGFloat = 16
         static let iPadTopConstant: CGFloat = 54

--- a/firefox-ios/Client/Frontend/Home/LogoHeader/HomepageHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/LogoHeader/HomepageHeaderCell.swift
@@ -7,15 +7,15 @@ import UIKit
 import Common
 
 struct HomepageHeaderCellViewModel {
-    var hidePrivateModeButton: Bool
+    var showiPadSetup: Bool
     var isPrivate: Bool
 
     private var action: (() -> Void)
     private var homepageTelemetry = HomepageTelemetry()
 
-    init(isPrivate: Bool, hidePrivateModeButton: Bool, action: @escaping () -> Void) {
+    init(isPrivate: Bool, showiPadSetup: Bool, action: @escaping () -> Void) {
         self.isPrivate = isPrivate
-        self.hidePrivateModeButton = hidePrivateModeButton
+        self.showiPadSetup = showiPadSetup
         self.action = action
     }
 
@@ -38,7 +38,6 @@ class HomepageHeaderCell: UICollectionViewCell, ReusableCell {
 
     private lazy var stackContainer: UIStackView = .build { stackView in
         stackView.axis = .horizontal
-        stackView.distribution = .fill
     }
 
     private lazy var logoHeaderCell: HomeLogoHeaderCell = {
@@ -60,7 +59,6 @@ class HomepageHeaderCell: UICollectionViewCell, ReusableCell {
     // MARK: - Initializers
     override init(frame: CGRect) {
         super.init(frame: frame)
-        setupView()
     }
 
     required init?(coder: NSCoder) {
@@ -69,29 +67,38 @@ class HomepageHeaderCell: UICollectionViewCell, ReusableCell {
 
     // MARK: - UI Setup
 
-    func setupView() {
-        let isiPad = UIDevice.current.userInterfaceIdiom == .pad
-        let topAnchorConstant = isiPad ? UX.iPadTopConstant : UX.iPhoneTopConstant
-
+    private func setupView(with showiPadSetup: Bool) {
         stackContainer.addArrangedSubview(logoHeaderCell.contentView)
         stackContainer.addArrangedSubview(privateModeButton)
         contentView.addSubview(stackContainer)
 
-        NSLayoutConstraint.activate([
+        setupConstraints(for: showiPadSetup)
+    }
+
+    private var logoConstraints = [NSLayoutConstraint]()
+
+    private func setupConstraints(for iPadSetup: Bool) {
+        NSLayoutConstraint.deactivate(logoConstraints)
+        let topAnchorConstant = iPadSetup ? UX.iPadTopConstant : UX.iPhoneTopConstant
+        logoConstraints = [
             stackContainer.topAnchor.constraint(equalTo: contentView.topAnchor, constant: topAnchorConstant),
             stackContainer.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             stackContainer.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            stackContainer.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            stackContainer.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).priority(.defaultLow),
 
-            logoHeaderCell.contentView.centerYAnchor.constraint(equalTo: stackContainer.centerYAnchor),
+            privateModeButton.widthAnchor.constraint(equalToConstant: UX.circleSize.width),
             privateModeButton.centerYAnchor.constraint(equalTo: stackContainer.centerYAnchor),
-            privateModeButton.widthAnchor.constraint(equalToConstant: UX.circleSize.width)
-        ])
+            logoHeaderCell.contentView.centerYAnchor.constraint(equalTo: stackContainer.centerYAnchor)
+        ]
+
+        NSLayoutConstraint.activate(logoConstraints)
     }
 
     func configure(with viewModel: HomepageHeaderCellViewModel) {
         self.viewModel = viewModel
-        privateModeButton.isHidden = viewModel.hidePrivateModeButton
+        setupView(with: viewModel.showiPadSetup)
+        logoHeaderCell.configure(with: viewModel.showiPadSetup)
+        privateModeButton.isHidden = viewModel.showiPadSetup
     }
 
     @objc

--- a/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
@@ -60,6 +60,15 @@ final class PrivateHomepageViewController:
 
     private let scrollView: UIScrollView = .build()
 
+    private var headerViewModel: HomepageHeaderCellViewModel {
+        return HomepageHeaderCellViewModel(
+            isPrivate: true,
+            showiPadSetup: shouldUseiPadSetup(),
+            action: { [weak self] in
+                self?.parentCoordinator?.switchMode()
+            })
+    }
+
     private lazy var scrollContainer: UIStackView = .build { stackView in
         stackView.axis = .vertical
         stackView.spacing = UX.scrollContainerStackSpacing
@@ -80,14 +89,6 @@ final class PrivateHomepageViewController:
     private lazy var homepageHeaderCell: HomepageHeaderCell = {
         let header = HomepageHeaderCell()
         header.applyTheme(theme: themeManager.currentTheme)
-
-        let headerViewModel = HomepageHeaderCellViewModel(
-            isPrivate: true,
-            hidePrivateModeButton: shouldUseiPadSetup(),
-            action: { [weak self] in
-                self?.parentCoordinator?.switchMode()
-            })
-
         header.configure(with: headerViewModel)
         return header
     }()
@@ -121,7 +122,10 @@ final class PrivateHomepageViewController:
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         updateConstraintsForMultitasking()
-        homepageHeaderCell.viewModel?.hidePrivateModeButton = shouldUseiPadSetup()
+        if previousTraitCollection?.horizontalSizeClass != traitCollection.horizontalSizeClass
+            || previousTraitCollection?.verticalSizeClass != traitCollection.verticalSizeClass {
+            homepageHeaderCell.configure(with: headerViewModel)
+        }
         applyTheme()
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8372)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Ensure header looks good in different orientations (including split view)
* Moved Firefox Logo + Text to stack container to simplify constraints
* Add showiPadSetup boolean to determine what layout the header should be for the homepage when in multitasking view
* Created private func to set up constraints

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

## Screenshots
| Compact | Regular | 
| --- | --- |
| ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-02-06 at 09 10 29](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/9e7e02a2-96c8-4b4c-9e74-95ee7c21cb35)| ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-02-06 at 09 10 23](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/19dd0850-dfd3-490f-bd01-1ec71838a923)|
