### PR TITLE
Add Bug 1823684 [v124] Server Knobs for iOS

### DIFF
--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -106,6 +106,9 @@ class TelemetryWrapper: TelemetryWrapperProtocol, FeatureFlaggable {
                          configuration: gleanConfig,
                          buildInfo: GleanMetrics.GleanBuild.info)
 
+        // Set the metric configuration from Nimbus.
+        glean.setMetricsEnabledConfig(FxNimbus.shared.features.gleanServerKnobs.value().toJSONString())
+
         // Save the profile so we can record settings from it when the notification below fires.
         self.profile = profile
 

--- a/firefox-ios/nimbus-features/gleanServerKnobs.yaml
+++ b/firefox-ios/nimbus-features/gleanServerKnobs.yaml
@@ -1,0 +1,8 @@
+features:
+  glean-server-knobs:
+    description: "A feature that provides server-side configurations for Glean metrics (aka Server Knobs)."
+    variables:
+      metrics-enabled:
+        description: "A map of metric base-identifiers to booleans representing the state of the 'enabled' flag for that metric."
+        type: Map<String, Boolean>
+        default: {}

--- a/firefox-ios/nimbus.fml.yaml
+++ b/firefox-ios/nimbus.fml.yaml
@@ -22,6 +22,7 @@ include:
   - nimbus-features/feltPrivacyFeature.yaml
   - nimbus-features/firefoxSuggestFeature.yaml
   - nimbus-features/generalFeatures.yaml
+  - nimbus-features/gleanServerKnobs.yaml
   - nimbus-features/homescreenFeature.yaml
   - nimbus-features/messagingFeature.yaml
   - nimbus-features/onboardingFrameworkFeature.yaml


### PR DESCRIPTION
## :scroll: Tickets
[Bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1823684)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Configure Server Knobs for iOS. Makes use of the `glean.setMetricsEnabledConfig` to remotely enable/disable metric collection via Nimbus experiment.

The Nimbus experiment hasn't been created yet so the API is just getting the default value of "{}", which enables/disables no metrics. Everything should just be working like before.

**Testing**
1. Setting debug view tag via the [GLEAN_DEBUG_VIEW_TAG](https://mozilla.github.io/glean/book/reference/debug/debugViewTag.html#glean_debug_view_tag)
2. Run the app and look for the `topsites-impression` pings. You can trigger this ping by foregrounding the app while on the new tab screen, where you can see topsites.
3. Observe in each ping in the debug viewer that you see the `top_sites.contile_advertiser` metric being collected - [example](https://debug-ping-preview.firebaseapp.com/pings/bruno-ios/271b5f09-30bf-4975-9255-a67f5d2dd99d#L61).
4. Change line 110 of `TelemetryWrapper.swift` to `glean.setMetricsEnabledConfig("{\"top_sites.contile_advertiser\": false}")`.
5. Run the app again, trigger the topsites-impression ping.
6. Observe that the metric is no longer being collected on the newer pings - [example](https://debug-ping-preview.firebaseapp.com/pings/bruno-ios/984bcb23-7bec-433f-810c-986d50825484#L56).

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

