### PR TITLE
Bugfix FXIOS-8366 [v123.1] Update background color for panels

### DIFF
--- a/BrowserKit/Sources/Common/Theming/DarkTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/DarkTheme.swift
@@ -18,7 +18,6 @@ private struct DarkColourPalette: ThemeColourPalette {
     var layer3: UIColor = FXColors.DarkGrey80
     var layer4: UIColor = FXColors.DarkGrey20.withAlphaComponent(0.7)
     var layer5: UIColor = FXColors.DarkGrey40
-    var layer6: UIColor = FXColors.DarkGrey60
     var layer5Hover: UIColor = FXColors.DarkGrey20
     var layerScrim: UIColor = FXColors.DarkGrey90.withAlphaComponent(0.95)
     var layerGradient = Gradient(colors: [FXColors.Violet40, FXColors.Violet70])

--- a/BrowserKit/Sources/Common/Theming/LightTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/LightTheme.swift
@@ -18,7 +18,6 @@ private struct LightColourPalette: ThemeColourPalette {
     var layer3: UIColor = FXColors.LightGrey20
     var layer4: UIColor = FXColors.LightGrey30.withAlphaComponent(0.6)
     var layer5: UIColor = FXColors.White
-    var layer6: UIColor = FXColors.White
     var layer5Hover: UIColor = FXColors.LightGrey20
     var layerScrim: UIColor = FXColors.DarkGrey30.withAlphaComponent(0.95)
     var layerGradient = Gradient(colors: [FXColors.Violet40, FXColors.Violet70])

--- a/BrowserKit/Sources/Common/Theming/PrivateModeTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/PrivateModeTheme.swift
@@ -18,7 +18,6 @@ private struct PrivateModeColorPalette: ThemeColourPalette {
     var layer3: UIColor = FXColors.Ink90
     var layer4: UIColor = FXColors.DarkGrey20.withAlphaComponent(0.7)
     var layer5: UIColor = FXColors.Ink20
-    var layer6: UIColor = FXColors.DarkGrey60
     var layer5Hover: UIColor = FXColors.DarkGrey20
     var layerScrim: UIColor = FXColors.DarkGrey90.withAlphaComponent(0.95)
     var layerGradient = Gradient(colors: [FXColors.Violet40, FXColors.Violet70])

--- a/BrowserKit/Sources/Common/Theming/ThemeColourPalette.swift
+++ b/BrowserKit/Sources/Common/Theming/ThemeColourPalette.swift
@@ -14,7 +14,6 @@ public protocol ThemeColourPalette {
     var layer3: UIColor { get }
     var layer4: UIColor { get }
     var layer5: UIColor { get }
-    var layer6: UIColor { get }
     var layer5Hover: UIColor { get }
     var layerScrim: UIColor { get }
     var layerGradient: Gradient { get }

--- a/firefox-ios/Client/Frontend/Library/Downloads/DownloadsPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Downloads/DownloadsPanel.swift
@@ -232,7 +232,7 @@ class DownloadsPanel: UIViewController,
 
     private func createEmptyStateOverlayView() -> UIView {
         let overlayView: UIView = .build { view in
-            view.backgroundColor = self.themeManager.currentTheme.colors.layer6
+            view.backgroundColor = self.themeManager.currentTheme.colors.layer1
             view.translatesAutoresizingMaskIntoConstraints = false
         }
         let logoImageView: UIImageView = .build { imageView in
@@ -400,7 +400,7 @@ class DownloadsPanel: UIViewController,
         emptyStateOverlayView = createEmptyStateOverlayView()
         updateEmptyPanelState()
 
-        tableView.backgroundColor = themeManager.currentTheme.colors.layer6
+        tableView.backgroundColor = themeManager.currentTheme.colors.layer1
         tableView.separatorColor = themeManager.currentTheme.colors.borderPrimary
 
         reloadData()

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -567,7 +567,7 @@ class HistoryPanel: UIViewController,
         // overlayView becomes the footer view, and for unknown reason, setting the bgcolor is ignored.
         // Create an explicit view for setting the color.
         let bgColor: UIView = .build { view in
-            view.backgroundColor = self.themeManager.currentTheme.colors.layer6
+            view.backgroundColor = self.themeManager.currentTheme.colors.layer1
         }
         overlayView.addSubview(bgColor)
 
@@ -595,7 +595,9 @@ class HistoryPanel: UIViewController,
     func applyTheme() {
         updateEmptyPanelState()
 
-        tableView.backgroundColor = themeManager.currentTheme.colors.layer6
+        tableView.backgroundColor = themeManager.currentTheme.colors.layer1
+        emptyStateOverlayView.backgroundColor = themeManager.currentTheme.colors.layer1
+
         searchbar.backgroundColor = themeManager.currentTheme.colors.layer3
         let tintColor = themeManager.currentTheme.colors.textPrimary
         let searchBarImage = UIImage(named: StandardImageIdentifiers.Large.history)?

--- a/firefox-ios/Client/Frontend/Library/ReaderPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/ReaderPanel.swift
@@ -566,8 +566,8 @@ class ReadingListPanel: UITableViewController,
 
     func applyTheme() {
         tableView.separatorColor = themeManager.currentTheme.colors.borderPrimary
-        view.backgroundColor = themeManager.currentTheme.colors.layer6
-        tableView.backgroundColor = themeManager.currentTheme.colors.layer6
+        view.backgroundColor = themeManager.currentTheme.colors.layer1
+        tableView.backgroundColor = themeManager.currentTheme.colors.layer1
         refreshReadingList()
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8366)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Update panel screens background to use `layer1` token instead of `layer6`
Remove `layer6` as it is no longer being used

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

## Screenshots
https://github.com/mozilla-mobile/firefox-ios/assets/6743397/addf8e95-4413-4e21-90f9-67196cad66a6