### PR TITLE
Bugfix FXIOS-8397 [v124] App is crashing when moving a quick search engine

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -445,26 +445,17 @@ class SearchSettingsTableViewController: ThemedTableViewController, FeatureFlagg
         targetIndexPathForMoveFromRowAt sourceIndexPath: IndexPath,
         toProposedIndexPath proposedDestinationIndexPath: IndexPath
     ) -> IndexPath {
-        // You can't drag or drop on the default engine.
-        if sourceIndexPath.section == Section.defaultEngine.rawValue
-            || proposedDestinationIndexPath.section == Section.defaultEngine.rawValue {
+        // Make drag or drop available only for quickEngines section
+        guard proposedDestinationIndexPath.section == Section.quickEngines.rawValue else {
             return sourceIndexPath
         }
 
-        // Can't drag/drop over "Add Custom Engine button"
-        let sourceIndexCheck = sourceIndexPath.item + 1 == model.orderedEngines.count
-        let destinationIndexCheck = proposedDestinationIndexPath.item + 1 == model.orderedEngines.count
-        if sourceIndexCheck || destinationIndexCheck {
+        // Can't drag/drop over "Add Search Engine button"
+        if [sourceIndexPath.item, proposedDestinationIndexPath.item]
+            .contains(where: { $0 + 1 == model.orderedEngines.count }) {
             return sourceIndexPath
         }
 
-        if sourceIndexPath.section != proposedDestinationIndexPath.section {
-            var row = 0
-            if sourceIndexPath.section < proposedDestinationIndexPath.section {
-                row = tableView.numberOfRows(inSection: sourceIndexPath.section) - 1
-            }
-            return IndexPath(row: row, section: sourceIndexPath.section)
-        }
         return proposedDestinationIndexPath
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8397)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18617)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

- The crash was occuring while dragging and dropping a quick search engine after the "Add Search Engine" button (this being an action that should not be permitted) causing the quick search engines array to go out of bounds..
- This PR adds a guard statement to make sure that we remain in the same section (quickEngines) during drag&drop actions.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

