### PR TITLE
Bugfix FXIOS-8392 [v123.1] Convert cancel button to use default styling

### DIFF
--- a/firefox-ios/Client/Extensions/UIAlertController+Extension.swift
+++ b/firefox-ios/Client/Extensions/UIAlertController+Extension.swift
@@ -100,7 +100,7 @@ extension UIAlertController {
 
         let noOption = UIAlertAction(
             title: .ClearWebsiteDataAlertCancel,
-            style: .cancel,
+            style: .default,
             handler: nil
         )
 
@@ -124,7 +124,7 @@ extension UIAlertController {
 
         let noOption = UIAlertAction(
             title: .ClearWebsiteDataAlertCancel,
-            style: .cancel,
+            style: .default,
             handler: nil
         )
 
@@ -166,7 +166,7 @@ extension UIAlertController {
             )
         }
 
-        let cancelAction = UIAlertAction(title: .DeleteLoginAlertCancel, style: .cancel, handler: nil)
+        let cancelAction = UIAlertAction(title: .DeleteLoginAlertCancel, style: .default, handler: nil)
         let deleteAction = UIAlertAction(title: .DeleteLoginAlertDelete, style: .destructive, handler: deleteCallback)
 
         deleteAlert.addAction(cancelAction)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -56,7 +56,7 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
 
         let cancelAction = UIAlertAction(
             title: .Alerts.FeltDeletion.CancelButton,
-            style: .cancel,
+            style: .default,
             handler: { [weak self] _ in
                 self?.privateBrowsingTelemetry.sendDataClearanceTappedTelemetry(didConfirm: false)
             }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
@@ -246,7 +246,7 @@ class BookmarksPanel: SiteTableViewController,
                                                 message: .BookmarksDeleteFolderWarningDescription,
                                                 preferredStyle: .alert)
         alertController.addAction(UIAlertAction(title: .BookmarksDeleteFolderCancelButtonLabel,
-                                                style: .cancel))
+                                                style: .default))
         alertController.addAction(UIAlertAction(title: .BookmarksDeleteFolderDeleteButtonLabel,
                                                 style: .destructive) { [weak self] action in
             self?.deleteBookmarkNode(indexPath, bookmarkNode: bookmarkNode)

--- a/firefox-ios/Client/Frontend/Library/ClearHistorySheetProvider.swift
+++ b/firefox-ios/Client/Frontend/Library/ClearHistorySheetProvider.swift
@@ -106,7 +106,7 @@ class ClearHistorySheetProvider {
     }
 
     func addCancelAction(to alert: UIAlertController) {
-        let cancelAction = UIAlertAction(title: .CancelString, style: .cancel)
+        let cancelAction = UIAlertAction(title: .CancelString, style: .default)
         alert.addAction(cancelAction)
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -216,7 +216,7 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
 
         let noOption = UIAlertAction(
             title: .ClearPrivateDataAlertCancel,
-            style: .cancel,
+            style: .default,
             handler: nil
         )
 
@@ -240,7 +240,7 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
 
         let noOption = UIAlertAction(
             title: .ClearSyncedHistoryAlertCancel,
-            style: .cancel,
+            style: .default,
             handler: nil
         )
 

--- a/firefox-ios/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -67,7 +67,7 @@ class DisconnectSetting: Setting {
             preferredStyle: UIAlertController.Style.alert)
 
         alertController.addAction(
-            UIAlertAction(title: .SettingsDisconnectCancelAction, style: .cancel) { (action) in
+            UIAlertAction(title: .SettingsDisconnectCancelAction, style: .default) { (action) in
                 // Do nothing.
             }
         )

--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
@@ -49,7 +49,7 @@ class PhotonActionSheet: UIViewController, Themeable {
     private lazy var closeButton: UIButton = .build { button in
         button.setTitle(.CloseButtonTitle, for: .normal)
         button.layer.cornerRadius = UX.cornerRadius
-        button.titleLabel?.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .body, size: 19)
+        button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 17, weight: .semibold)
         button.addTarget(self, action: #selector(self.dismiss), for: .touchUpInside)
         button.accessibilityIdentifier = AccessibilityIdentifiers.Photon.closeButton
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8392)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18607)

## :bulb: Description
Change "Cancel" button in our alert views to use `default` style instead of `cancel` style to match the font weight of the destructive style.
Updated "Close" button to match style in Figma (attached to ticket)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

## Screenshots
| Example #5 | Example #9 |
| --- | --- |
| ![simulator_screenshot_5BC34C86-55CA-49E9-A6AF-431D29349633](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/aac49f76-163e-499c-a17e-9eae75220cd4) | ![simulator_screenshot_E615231D-F887-4718-9C1E-3C9F7364692D](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/541c48e1-4c24-4e96-a35c-e7e1897c8f9d) |

| Example #10 | Example #11 |
| --- | --- |
| ![simulator_screenshot_C6DDF61D-8522-4E1D-8C6C-4F7C84638D64](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/3c5ddfdf-4f37-4e41-9fc1-7f43775f6fb2) | ![simulator_screenshot_3FA99A3B-D74A-4E8C-BFFB-C34E0672D2D2](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/0086d04a-df2b-4a2c-bd04-bdfc31a4c1c3) |

| Example #13 | Close Button |
| --- | --- |
| ![simulator_screenshot_6C55DB53-0333-4C3C-9D4D-9A7531744436](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/20100dff-cee4-43de-8722-a27c807970ea) | ![image](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/27a4eac6-0108-4c43-97ce-b841eac86a9b) |
