### PR TITLE
Bugfix [v123.1] Logo header with experiment off

### DIFF
--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -202,7 +202,8 @@ class HomepageViewController:
     private func updateHeaderToShowPrivateModeToggle() {
         let featureFlagOn = featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly)
         let showToggle = featureFlagOn && !shouldUseiPadSetup()
-        viewModel.headerViewModel.showiPadSetup = !showToggle
+        viewModel.headerViewModel.showPrivateModeToggle = showToggle
+        viewModel.headerViewModel.showiPadSetup = shouldUseiPadSetup()
     }
 
     // MARK: - Layout

--- a/firefox-ios/Client/Frontend/Home/LogoHeader/HomeLogoHeaderViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/LogoHeader/HomeLogoHeaderViewModel.swift
@@ -17,6 +17,7 @@ class HomepageHeaderViewModel {
     private let tabManager: TabManager
     var onTapAction: ((UIButton) -> Void)?
     var showiPadSetup = false
+    var showPrivateModeToggle = false
     var theme: Theme
 
     init(profile: Profile, theme: Theme, tabManager: TabManager) {
@@ -81,6 +82,7 @@ extension HomepageHeaderViewModel: HomepageSectionHandler {
             with: HomepageHeaderCellViewModel(
                 isPrivate: false,
                 showiPadSetup: showiPadSetup,
+                showPrivateModeToggle: showPrivateModeToggle,
                 action: { [weak self] in
                     self?.tabManager.switchPrivacyMode()
                 })

--- a/firefox-ios/Client/Frontend/Home/LogoHeader/HomepageHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/LogoHeader/HomepageHeaderCell.swift
@@ -8,14 +8,16 @@ import Common
 
 struct HomepageHeaderCellViewModel {
     var showiPadSetup: Bool
+    var showPrivateModeToggle: Bool
     var isPrivate: Bool
 
     private var action: (() -> Void)
     private var homepageTelemetry = HomepageTelemetry()
 
-    init(isPrivate: Bool, showiPadSetup: Bool, action: @escaping () -> Void) {
+    init(isPrivate: Bool, showiPadSetup: Bool, showPrivateModeToggle: Bool, action: @escaping () -> Void) {
         self.isPrivate = isPrivate
         self.showiPadSetup = showiPadSetup
+        self.showPrivateModeToggle = showPrivateModeToggle
         self.action = action
     }
 
@@ -98,7 +100,7 @@ class HomepageHeaderCell: UICollectionViewCell, ReusableCell, ThemeApplicable {
         self.viewModel = viewModel
         setupView(with: viewModel.showiPadSetup)
         logoHeaderCell.configure(with: viewModel.showiPadSetup)
-        privateModeButton.isHidden = viewModel.showiPadSetup
+        privateModeButton.isHidden = !viewModel.showPrivateModeToggle
     }
 
     @objc

--- a/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
@@ -64,6 +64,7 @@ final class PrivateHomepageViewController:
         return HomepageHeaderCellViewModel(
             isPrivate: true,
             showiPadSetup: shouldUseiPadSetup(),
+            showPrivateModeToggle: !shouldUseiPadSetup(),
             action: { [weak self] in
                 self?.parentCoordinator?.switchMode()
             })


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8372)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18541)

## :bulb: Description
Bug in which logo header with felt privacy experiment off was not small size. 
Created a separate boolean to handle showing the toggle as we should decouple whether to show large or small logo header size and toggle button separately.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods


## Testing Steps:  
See below for the expectations in the UI when the experiment for felt privacy is turned on and off
iPhone:

Experiment Off: The logo should be small size and match similar to what we have in production
Experiment On: The logo should be small size and match similar to what we have in production AND we should see the private toggle mask

iPad:

Experiment Off: The logo should be large size and match similar to what we have in production
Experiment On: The logo should be large size and match similar to what we have in production AND we should not see the private toggle mask

iPad (Multi-tasking / Split View):

Experiment Off: The logo should be large size if we see the top tabs, otherwise we see the small size logo
Experiment On: The logo should be large size if we see the top tabs, otherwise we see the small size logo AND we should see the private toggle mask only when the logo is small size
