### PR TITLE
Add FXIOS-8111 [v124] urlBar search abandonment telemetry

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
@@ -425,7 +425,9 @@ extension BrowserViewController: URLBarDelegate {
             case .cancelled: .abandoned
             }
         }
-
+        if reason == .finished {
+            searchController?.searchTelemetry?.recordURLBarSearchAbandonmentTelemetryEvent()
+        }
         destroySearchController()
         updateInContentHomePanel(tabManager.selectedTab?.url as URL?)
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2407,7 +2407,7 @@ extension BrowserViewController: SearchViewControllerDelegate {
             let visibleSuggestionsTelemetryInfo = searchViewController.visibleSuggestionsTelemetryInfo
             visibleSuggestionsTelemetryInfo.forEach { trackVisibleSuggestion(telemetryInfo: $0) }
             TelemetryWrapper.gleanRecordEvent(category: .action, method: .abandonment, object: .locationBar)
-
+            searchViewController.searchTelemetry?.recordURLBarSearchAbandonmentTelemetryEvent()
         default:
             break
         }

--- a/firefox-ios/Client/Telemetry/SearchTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/SearchTelemetry.swift
@@ -193,7 +193,7 @@ class SearchTelemetry {
         impressionTelemetryTimer?.invalidate()
         impressionTelemetryTimer = Timer.scheduledTimer(timeInterval: 1.0,
                                                         target: self,
-                                                        selector: #selector(recordImpressionTelemetryEvent),
+                                                        selector: #selector(recordURLBarSearchImpressionTelemetryEvent),
                                                         userInfo: nil,
                                                         repeats: false)
     }
@@ -203,7 +203,7 @@ class SearchTelemetry {
     }
 
     @objc
-    func recordImpressionTelemetryEvent() {
+    func recordURLBarSearchImpressionTelemetryEvent() {
         guard let tab = tabManager.selectedTab else { return }
         let reasonKey = TelemetryWrapper.EventExtraKey.UrlbarTelemetry.reason.rawValue
         let reason = SearchTelemetryValues.Reason.pause.rawValue
@@ -245,6 +245,50 @@ class SearchTelemetry {
         TelemetryWrapper.recordEvent(category: .information,
                                      method: .view,
                                      object: .urlbarImpression,
+                                     extras: extraDetails)
+    }
+
+    func recordURLBarSearchAbandonmentTelemetryEvent() {
+        guard let tab = tabManager.selectedTab else { return }
+
+        let sapKey = TelemetryWrapper.EventExtraKey.UrlbarTelemetry.sap.rawValue
+        let sap = checkSAP(for: tab).rawValue
+
+        let interactionKey = TelemetryWrapper.EventExtraKey.UrlbarTelemetry.interaction.rawValue
+        let interaction = interactionType.rawValue
+
+        let searchModeKey = TelemetryWrapper.EventExtraKey.UrlbarTelemetry.searchMode.rawValue
+        let searchMode = SearchTelemetryValues.SearchMode.tabs.rawValue
+
+        let nCharsKey = TelemetryWrapper.EventExtraKey.UrlbarTelemetry.nChars.rawValue
+        let nChars = Int32(searchQuery.count)
+
+        let nWordsKey = TelemetryWrapper.EventExtraKey.UrlbarTelemetry.nWords.rawValue
+        let nWords = numberOfWords(in: searchQuery)
+
+        let nResultsKey = TelemetryWrapper.EventExtraKey.UrlbarTelemetry.nResults.rawValue
+        let nResults = Int32(numberOfSearchResults())
+
+        let groupsKey = TelemetryWrapper.EventExtraKey.UrlbarTelemetry.groups.rawValue
+        let groups = listGroupTypes()
+
+        let resultsKey = TelemetryWrapper.EventExtraKey.UrlbarTelemetry.results.rawValue
+        let results = listResultTypes()
+
+        let extraDetails = [
+            sapKey: sap,
+            interactionKey: interaction,
+            searchModeKey: searchMode,
+            nCharsKey: nChars,
+            nWordsKey: nWords,
+            nResultsKey: nResults,
+            groupsKey: groups,
+            resultsKey: results
+        ] as [String: Any]
+
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .close,
+                                     object: .urlbarAbandonment,
                                      extras: extraDetails)
     }
 

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -529,6 +529,7 @@ extension TelemetryWrapper {
         case fxSuggest = "fx-suggest"
         case webview = "webview"
         case urlbarImpression = "urlbar-impression"
+        case urlbarAbandonment = "urlbar-abandonment"
     }
 
     public enum EventValue: String {
@@ -1113,6 +1114,33 @@ extension TelemetryWrapper {
                                                                        sap: sap,
                                                                        searchMode: searchMode)
                 GleanMetrics.Urlbar.impression.record(extraDetails)
+            } else {
+                recordUninstrumentedMetrics(
+                    category: category,
+                    method: method,
+                    object: object,
+                    value: value,
+                    extras: extras)
+            }
+
+        case(.action, .close, .urlbarAbandonment, _, let extras):
+            if let groups = extras?[EventExtraKey.UrlbarTelemetry.groups.rawValue] as? String,
+               let interaction = extras?[EventExtraKey.UrlbarTelemetry.interaction.rawValue] as? String,
+               let nChars = extras?[EventExtraKey.UrlbarTelemetry.nChars.rawValue] as? Int32,
+               let nResults = extras?[EventExtraKey.UrlbarTelemetry.nResults.rawValue] as? Int32,
+               let nWords = extras?[EventExtraKey.UrlbarTelemetry.nWords.rawValue] as? Int32,
+               let results = extras?[EventExtraKey.UrlbarTelemetry.results.rawValue] as? String,
+               let sap = extras?[EventExtraKey.UrlbarTelemetry.sap.rawValue] as? String,
+               let searchMode = extras?[EventExtraKey.UrlbarTelemetry.searchMode.rawValue] as? String {
+                let extraDetails = GleanMetrics.Urlbar.AbandonmentExtra(groups: groups,
+                                                                        interaction: interaction,
+                                                                        nChars: nChars,
+                                                                        nResults: nResults,
+                                                                        nWords: nWords,
+                                                                        results: results,
+                                                                        sap: sap,
+                                                                        searchMode: searchMode)
+                GleanMetrics.Urlbar.abandonment.record(extraDetails)
             } else {
                 recordUninstrumentedMetrics(
                     category: category,

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -4211,6 +4211,60 @@ urlbar:
       - fx-ios-data-stewards@mozilla.com
     expires: "2024-06-01"
 
+  abandonment:
+    type: event
+    description: |
+      Recorded when urlbar results are shown to the user
+    extra_keys:
+      sap:
+        type: string
+        description: |
+          Where the user action started, like urlbar or urlbar_newtab
+      interaction:
+        type: string
+        description: |
+          How the user started the search, by typing or pasting text
+      search_mode:
+        type: string
+        description: |
+          If the urlbar is in search mode, thus restricting results to a 
+          specific search engine or local source, this is set to the search
+          mode source. For iOS the search starts from tabs
+      n_chars:
+        type: quantity
+        description: |
+         Number of typed characters
+      n_words:
+        type: quantity
+        description: |
+         Number of typed words (doesn’t support CJK languages)
+      n_results:
+        type: quantity
+        description: |
+         Number of results, if this is high the results
+         list below may be incomplete due to size limits
+      groups:
+        type: string
+        description: |
+          Comma separated list of result groups in order, groups may be        
+          repeated, since the list will match 1:1 the results list, so we
+          Can link each result to a group, like  heuristic, adaptive_history,
+           search_history, search_suggest, top_pick, top_site, remote_tab, addon,
+            general, suggest
+      results:
+        type: string
+        description: |
+          Comma separated list of result types in order. Possible values are:
+           unknown, bookmark, history, search_engine, search_suggest, search_history,
+           tab, remote_tab, suggest_sponsor, suggest_non_sponsor
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-8111
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/18507
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2024-06-01"
+
 # Awesomebar related telemetry
 
 awesomebar:

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -4260,7 +4260,7 @@ urlbar:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-8111
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/18507
+      - https://github.com/mozilla-mobile/firefox-ios/pull/18654
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2024-06-01"

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -881,6 +881,51 @@ class TelemetryWrapperTests: XCTestCase {
         testEventMetricRecordingSuccess(metric: GleanMetrics.Urlbar.impression)
     }
 
+    func test_AwesomebarAbandonment_GleanIsCalled() {
+        let groupsKey = TelemetryWrapper.EventExtraKey.UrlbarTelemetry.groups.rawValue
+        let groups = SearchTelemetryValues.Groups.adaptiveHistory.rawValue
+
+        let interactionKey = TelemetryWrapper.EventExtraKey.UrlbarTelemetry.interaction.rawValue
+        let interaction = SearchTelemetryValues.Interaction.persistedSearchTerms.rawValue
+
+        let nCharsKey = TelemetryWrapper.EventExtraKey.UrlbarTelemetry.nChars.rawValue
+        let nChars: Int32 = 5
+
+        let nResultsKey = TelemetryWrapper.EventExtraKey.UrlbarTelemetry.nResults.rawValue
+        let nResults: Int32 = 12
+
+        let nWordsKey = TelemetryWrapper.EventExtraKey.UrlbarTelemetry.nWords.rawValue
+        let nWords: Int32 = 1
+
+        let resultsKey = TelemetryWrapper.EventExtraKey.UrlbarTelemetry.results.rawValue
+        let results = SearchTelemetryValues.Results.searchEngine.rawValue + ","
+        + SearchTelemetryValues.Results.tabToSearch.rawValue
+
+        let sapKey = TelemetryWrapper.EventExtraKey.UrlbarTelemetry.sap.rawValue
+        let sap = SearchTelemetryValues.Sap.urlbar.rawValue
+
+        let searchModeKey = TelemetryWrapper.EventExtraKey.UrlbarTelemetry.searchMode.rawValue
+        let searchMode = SearchTelemetryValues.SearchMode.bookmarks.rawValue
+
+        let extraDetails = [
+            groupsKey: groups,
+            interactionKey: interaction,
+            nCharsKey: nChars,
+            nResultsKey: nResults,
+            nWordsKey: nWords,
+            resultsKey: results,
+            sapKey: sap,
+            searchModeKey: searchMode
+        ] as [String: Any]
+
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .close,
+                                     object: .urlbarAbandonment,
+                                     extras: extraDetails)
+
+        testEventMetricRecordingSuccess(metric: GleanMetrics.Urlbar.abandonment)
+    }
+
     // MARK: - Page Action Menu
 
     func test_createNewTab_GleanIsCalled() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8111)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18054)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Added the urlBar search abandonment telemetry event
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

