### PR TITLE
Revert FXIOS-8415 [v123] Revert homepage changes

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1330,7 +1330,7 @@ class BrowserViewController: UIViewController,
     func setupMiddleButtonStatus(isLoading: Bool) {
         // Setting the default state to search to account for no tab or starting page tab
         // `state` will be modified later if needed
-        let state: MiddleButtonState = .search
+        var state: MiddleButtonState = .search
 
         // No tab
         guard let tab = tabManager.selectedTab else {

--- a/firefox-ios/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionViewModel.swift
@@ -26,11 +26,7 @@ extension CustomizeHomepageSectionViewModel: HomepageViewModelProtocol {
         return .emptyHeader
     }
 
-    func section(for traitCollection: UITraitCollection,
-                 size: CGSize,
-                 isPortrait: Bool = UIWindow.isPortrait,
-                 device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom
-    ) -> NSCollectionLayoutSection {
+    func section(for traitCollection: UITraitCollection, size: CGSize) -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
                                               heightDimension: .estimated(100))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)

--- a/firefox-ios/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsViewModel.swift
@@ -183,11 +183,7 @@ extension HistoryHighlightsViewModel: HomepageViewModelProtocol, FeatureFlaggabl
         return !isPrivate
     }
 
-    func section(for traitCollection: UITraitCollection,
-                 size: CGSize,
-                 isPortrait: Bool = UIWindow.isPortrait,
-                 device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom
-    ) -> NSCollectionLayoutSection {
+    func section(for traitCollection: UITraitCollection, size: CGSize) -> NSCollectionLayoutSection {
         let item = NSCollectionLayoutItem(
             layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
                                                heightDimension: .estimated(UX.estimatedCellHeight))

--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -260,7 +260,7 @@ class HomepageViewController:
 
     func createLayout() -> UICollectionViewLayout {
         // swiftlint:disable line_length
-        return UICollectionViewCompositionalLayout { [weak self] (sectionIndex: Int, layoutEnvironment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? in
+        let layout = UICollectionViewCompositionalLayout { [weak self] (sectionIndex: Int, layoutEnvironment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? in
         // swiftlint:enable line_length
             guard let self = self,
                   let viewModel = self.viewModel.getSectionViewModel(shownSection: sectionIndex),
@@ -273,9 +273,10 @@ class HomepageViewController:
             )
             return viewModel.section(
                 for: layoutEnvironment.traitCollection,
-                size: layoutEnvironment.container.effectiveContentSize
+                size: self.view.frame.size
             )
         }
+        return layout
     }
 
     // MARK: Long press
@@ -318,7 +319,7 @@ class HomepageViewController:
         }
 
         // Force the entire collection view to re-layout
-        viewModel.updateEnabledSections()
+        viewModel.refreshData(for: traitCollection, size: newSize)
         collectionView.reloadData()
         collectionView.collectionViewLayout.invalidateLayout()
 
@@ -824,7 +825,7 @@ extension HomepageViewController: HomepageViewModelDelegate {
         ensureMainThread { [weak self] in
             guard let self = self else { return }
 
-            self.viewModel.updateEnabledSections()
+            self.viewModel.refreshData(for: self.traitCollection, size: self.view.frame.size)
             self.collectionView.reloadData()
             self.collectionView.collectionViewLayout.invalidateLayout()
             self.logger.log("Amount of sections shown is \(self.viewModel.shownSections.count)",

--- a/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
@@ -224,6 +224,16 @@ class HomepageViewModel: FeatureFlaggable {
                    category: .homepage)
     }
 
+    func refreshData(for traitCollection: UITraitCollection, size: CGSize) {
+        updateEnabledSections()
+        childViewModels.forEach {
+            $0.refreshData(for: traitCollection,
+                           size: size,
+                           isPortrait: UIWindow.isPortrait,
+                           device: UIDevice.current.userInterfaceIdiom)
+        }
+    }
+
     // MARK: - Section ViewModel helper
 
     func getSectionViewModel(shownSection: Int) -> HomepageViewModelProtocol? {

--- a/firefox-ios/Client/Frontend/Home/HomepageViewModelProtocol.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewModelProtocol.swift
@@ -10,12 +10,8 @@ import Shared
 protocol HomepageViewModelProtocol {
     var sectionType: HomepageSectionType { get }
 
-    // Layout section so HomepageViewController view controller can setup the section
-    func section(for traitCollection: UITraitCollection,
-                 size: CGSize,
-                 isPortrait: Bool,
-                 device: UIUserInterfaceIdiom
-    ) -> NSCollectionLayoutSection
+    // Layout section so FirefoxHomeViewController view controller can setup the section
+    func section(for traitCollection: UITraitCollection, size: CGSize) -> NSCollectionLayoutSection
 
     func numberOfItemsInSection() -> Int
 
@@ -31,6 +27,12 @@ protocol HomepageViewModelProtocol {
     // Returns true when section has data and is enabled
     var shouldShow: Bool { get }
 
+    // Refresh data from adaptor to ensure it refresh the right state before laying itself out
+    func refreshData(for traitCollection: UITraitCollection,
+                     size: CGSize,
+                     isPortrait: Bool,
+                     device: UIUserInterfaceIdiom)
+
     // Update section that are privacy sensitive, only implement when needed
     func updatePrivacyConcernedSection(isPrivate: Bool)
 
@@ -43,14 +45,6 @@ protocol HomepageViewModelProtocol {
 }
 
 extension HomepageViewModelProtocol {
-    func section(for traitCollection: UITraitCollection,
-                 size: CGSize,
-                 isPortrait: Bool = UIWindow.isPortrait,
-                 device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom
-    ) -> NSCollectionLayoutSection {
-        section(for: traitCollection, size: size, isPortrait: isPortrait, device: device)
-    }
-
     var hasData: Bool { return true }
 
     var shouldShow: Bool {
@@ -58,6 +52,11 @@ extension HomepageViewModelProtocol {
     }
 
     func updatePrivacyConcernedSection(isPrivate: Bool) {}
+
+    func refreshData(for traitCollection: UITraitCollection,
+                     size: CGSize,
+                     isPortrait: Bool,
+                     device: UIUserInterfaceIdiom) {}
 
     func screenWasShown() {}
 }

--- a/firefox-ios/Client/Frontend/Home/JumpBackIn/JumpBackInSectionLayout.swift
+++ b/firefox-ios/Client/Frontend/Home/JumpBackIn/JumpBackInSectionLayout.swift
@@ -54,7 +54,7 @@ enum JumpBackInSectionLayout: Equatable {
 
     // The maximum number of items to display in the whole section
     func maxItemsToDisplay(hasAccount: Bool,
-                           device: UIUserInterfaceIdiom
+                           device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom
     ) -> JumpBackInDisplayGroupCount {
         return JumpBackInDisplayGroupCount(
             tabsCount: maxJumpBackInItemsToDisplay(device: device),

--- a/firefox-ios/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -99,8 +99,8 @@ class JumpBackInViewModel: FeatureFlaggable {
     }
 
     private func updateSectionLayout(for traitCollection: UITraitCollection,
-                                     isPortrait: Bool,
-                                     device: UIUserInterfaceIdiom) {
+                                     isPortrait: Bool = UIWindow.isPortrait,
+                                     device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
         let isPhoneInLandscape = device == .phone && !isPortrait
         let isPadInPortrait = device == .pad && isPortrait
         let isPadInLandscapeTwoThirdSplit = isPadInLandscapeSplit(split: 2/3, isPortrait: isPortrait, device: device)
@@ -315,14 +315,7 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
         return jumpBackInList.itemsToDisplay + (hasSyncedTab ? UX.maxDisplayedSyncedTabs : 0)
     }
 
-    func section(for traitCollection: UITraitCollection,
-                 size: CGSize,
-                 isPortrait: Bool = UIWindow.isPortrait,
-                 device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom
-    ) -> NSCollectionLayoutSection {
-        refreshData(for: traitCollection, isPortrait: isPortrait, device: device)
-
-        // Prepare section layout with refreshed data
+    func section(for traitCollection: UITraitCollection, size: CGSize) -> NSCollectionLayoutSection {
         var section: NSCollectionLayoutSection
         switch sectionLayout {
         case .compactSyncedTab, .compactJumpBackInAndSyncedTab:
@@ -349,20 +342,25 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
         return section
     }
 
-    /// Refresh our data set for jump back in, should only be called when we build the section layout
-    private func refreshData(for traitCollection: UITraitCollection,
-                             isPortrait: Bool,
-                             device: UIUserInterfaceIdiom) {
-        updateSectionLayout(for: traitCollection, isPortrait: isPortrait, device: device)
+    var hasData: Bool {
+        return hasJumpBackIn || hasSyncedTab
+    }
+
+    func refreshData(for traitCollection: UITraitCollection,
+                     size: CGSize,
+                     isPortrait: Bool = UIWindow.isPortrait,
+                     device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
+        updateSectionLayout(for: traitCollection,
+                            isPortrait: isPortrait,
+                            device: device)
         let maxItemsToDisplay = sectionLayout.maxItemsToDisplay(
             hasAccount: isSyncTabFeatureEnabled,
             device: device
         )
         refreshData(maxItemsToDisplay: maxItemsToDisplay)
-    }
-
-    var hasData: Bool {
-        return hasJumpBackIn || hasSyncedTab
+        logger.log("JumpBackIn section shouldShow \(shouldShow)",
+                   level: .debug,
+                   category: .homepage)
     }
 
     func updatePrivacyConcernedSection(isPrivate: Bool) {

--- a/firefox-ios/Client/Frontend/Home/LogoHeader/HomeLogoHeaderViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/LogoHeader/HomeLogoHeaderViewModel.swift
@@ -37,11 +37,7 @@ extension HomepageHeaderViewModel: HomepageViewModelProtocol, FeatureFlaggable {
         return .emptyHeader
     }
 
-    func section(for traitCollection: UITraitCollection,
-                 size: CGSize,
-                 isPortrait: Bool = UIWindow.isPortrait,
-                 device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom
-    ) -> NSCollectionLayoutSection {
+    func section(for traitCollection: UITraitCollection, size: CGSize) -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
                                               heightDimension: .estimated(100))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)

--- a/firefox-ios/Client/Frontend/Home/MessageCard/HomepageMessageCardViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/MessageCard/HomepageMessageCardViewModel.swift
@@ -62,11 +62,7 @@ extension HomepageMessageCardViewModel: HomepageViewModelProtocol {
         return .messageCard
     }
 
-    func section(for traitCollection: UITraitCollection,
-                 size: CGSize,
-                 isPortrait: Bool = UIWindow.isPortrait,
-                 device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom
-    ) -> NSCollectionLayoutSection {
+    func section(for traitCollection: UITraitCollection, size: CGSize) -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
                                               heightDimension: .estimated(180))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)

--- a/firefox-ios/Client/Frontend/Home/Pocket/PocketViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/Pocket/PocketViewModel.swift
@@ -137,11 +137,7 @@ extension PocketViewModel: HomepageViewModelProtocol {
             textColor: textColor)
     }
 
-    func section(for traitCollection: UITraitCollection,
-                 size: CGSize,
-                 isPortrait: Bool = UIWindow.isPortrait,
-                 device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom
-    ) -> NSCollectionLayoutSection {
+    func section(for traitCollection: UITraitCollection, size: CGSize) -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1),
             heightDimension: .estimated(PocketStandardCell.UX.cellHeight)

--- a/firefox-ios/Client/Frontend/Home/RecentlySaved/RecentlySavedViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/RecentlySaved/RecentlySavedViewModel.swift
@@ -70,11 +70,7 @@ extension RecentlySavedViewModel: HomepageViewModelProtocol, FeatureFlaggable {
             textColor: textColor)
     }
 
-    func section(for traitCollection: UITraitCollection,
-                 size: CGSize,
-                 isPortrait: Bool = UIWindow.isPortrait,
-                 device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom
-    ) -> NSCollectionLayoutSection {
+    func section(for traitCollection: UITraitCollection, size: CGSize) -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .absolute(UX.cellWidth),
             heightDimension: .estimated(UX.cellHeight)

--- a/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -148,14 +148,7 @@ extension TopSitesViewModel: HomepageViewModelProtocol, FeatureFlaggable {
         return numberOfItems == 0 ? topSites.count : numberOfItems
     }
 
-    func section(for traitCollection: UITraitCollection,
-                 size: CGSize,
-                 isPortrait: Bool = UIWindow.isPortrait,
-                 device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom
-    ) -> NSCollectionLayoutSection {
-        let sectionDimension = refreshData(for: traitCollection, size: size)
-
-        // Prepare section layout with refreshed data
+    func section(for traitCollection: UITraitCollection, size: CGSize) -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1),
             heightDimension: .estimated(UX.cellEstimatedSize.height)
@@ -167,6 +160,10 @@ extension TopSitesViewModel: HomepageViewModelProtocol, FeatureFlaggable {
             heightDimension: .estimated(UX.cellEstimatedSize.height)
         )
 
+        let interface = TopSitesUIInterface(trait: traitCollection, availableWidth: size.width)
+        let sectionDimension = dimensionManager.getSectionDimension(for: topSites,
+                                                                    numberOfRows: numberOfRows,
+                                                                    interface: interface)
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize,
                                                        subitem: item,
                                                        count: sectionDimension.numberOfTilesPerRow)
@@ -185,8 +182,14 @@ extension TopSitesViewModel: HomepageViewModelProtocol, FeatureFlaggable {
         return section
     }
 
-    /// Refresh our data set for top sites, should only be called when we build the section layout
-    private func refreshData(for traitCollection: UITraitCollection, size: CGSize) -> TopSitesSectionDimension {
+    var hasData: Bool {
+        return !topSites.isEmpty
+    }
+
+    func refreshData(for traitCollection: UITraitCollection,
+                     size: CGSize,
+                     isPortrait: Bool = UIWindow.isPortrait,
+                     device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
         let interface = TopSitesUIInterface(trait: traitCollection,
                                             availableWidth: size.width)
         let sectionDimension = dimensionManager.getSectionDimension(for: topSites,
@@ -198,12 +201,6 @@ extension TopSitesViewModel: HomepageViewModelProtocol, FeatureFlaggable {
             let range = numberOfItems..<unfilteredTopSites.count
             topSites.removeSubrange(range)
         }
-
-        return sectionDimension
-    }
-
-    var hasData: Bool {
-        return !topSites.isEmpty
     }
 
     func screenWasShown() {

--- a/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -143,9 +143,7 @@ extension TopSitesViewModel: HomepageViewModelProtocol, FeatureFlaggable {
     }
 
     func numberOfItemsInSection() -> Int {
-        // If the number of items is empty, double check to ensure there is indeed no data to show
-        // This is to go around an issue on fresh install where the numberOfItems variable isn't updated yet
-        return numberOfItems == 0 ? topSites.count : numberOfItems
+        return numberOfItems
     }
 
     func section(for traitCollection: UITraitCollection, size: CGSize) -> NSCollectionLayoutSection {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
@@ -80,15 +80,13 @@ class JumpBackInViewModelTests: XCTestCase {
 
     func testMaxJumpBackInItemsToDisplay_compactJumpBackIn() async {
         let subject = createSubject()
-        let tab1 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
-        await adaptor.setRecentTabs(recentTabs: [tab1])
 
         // iPhone layout portrait
         let trait = MockTraitCollection(horizontalSizeClass: .compact).getTraitCollection()
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
+        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: false,
                                                                device: .phone)
         XCTAssertEqual(maxItems.tabsCount, 2)
@@ -105,7 +103,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
+        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .phone)
 
@@ -125,7 +123,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
+        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .phone)
 
@@ -145,7 +143,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .phone)
+        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .phone)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .phone)
 
@@ -165,7 +163,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .phone)
+        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .phone)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .phone)
 
@@ -185,7 +183,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .pad)
+        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .pad)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .pad)
 
@@ -205,7 +203,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .pad)
+        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .pad)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .pad)
 
@@ -225,7 +223,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .pad)
+        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .pad)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .pad)
 
@@ -245,7 +243,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let trait = MockTraitCollection(verticalSizeClass: .compact).getTraitCollection()
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
+        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .phone)
 
@@ -265,7 +263,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .pad)
+        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .pad)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .pad)
 
@@ -286,7 +284,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
+        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .phone)
 
@@ -305,7 +303,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .phone)
+        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .phone)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .phone)
 
@@ -324,7 +322,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .pad)
+        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .pad)
         let maxItems = subject.sectionLayout.maxItemsToDisplay(hasAccount: true,
                                                                device: .pad)
 
@@ -343,18 +341,18 @@ class JumpBackInViewModelTests: XCTestCase {
         try? await Task.sleep(nanoseconds: sleepTime)
 
         // Start in portrait
-        let trait = MockTraitCollection(horizontalSizeClass: .compact).getTraitCollection()
+        let portraitTrait = MockTraitCollection(horizontalSizeClass: .compact).getTraitCollection()
 
-        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
+        subject.refreshData(for: portraitTrait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
         XCTAssertEqual(subject.sectionLayout, .compactJumpBackIn)
 
         // Mock rotation to landscape
         let landscapeTrait = MockTraitCollection(verticalSizeClass: .compact).getTraitCollection()
-        _ = subject.section(for: landscapeTrait, size: iPhone14ScreenSize, isPortrait: false, device: .phone)
+        subject.refreshData(for: landscapeTrait, size: iPhone14ScreenSize, isPortrait: false, device: .phone)
         XCTAssertEqual(subject.sectionLayout, .medium)
 
         // Go back to portrait
-        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
+        subject.refreshData(for: portraitTrait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
         XCTAssertEqual(subject.sectionLayout, .compactJumpBackIn)
     }
 
@@ -384,6 +382,7 @@ class JumpBackInViewModelTests: XCTestCase {
         let subject = createSubject()
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
+        subject.refreshData(for: MockTraitCollection().getTraitCollection(), size: iPhone14ScreenSize)
 
         XCTAssertEqual(subject.jumpBackInList.tabs.count, 0)
         XCTAssertNil(subject.mostRecentSyncedTab)
@@ -393,10 +392,9 @@ class JumpBackInViewModelTests: XCTestCase {
         let subject = createSubject()
         let tab1 = createTab(profile: mockProfile, urlString: "www.firefox1.com")
         await adaptor.setRecentTabs(recentTabs: [tab1])
-
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        _ = subject.section(for: MockTraitCollection().getTraitCollection(), size: iPhone14ScreenSize)
+        subject.refreshData(for: MockTraitCollection().getTraitCollection(), size: iPhone14ScreenSize)
 
         XCTAssertEqual(subject.jumpBackInList.tabs.count, 1)
         XCTAssertNil(subject.mostRecentSyncedTab)
@@ -408,7 +406,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        _ = subject.section(for: MockTraitCollection().getTraitCollection(), size: iPhone14ScreenSize)
+        subject.refreshData(for: MockTraitCollection().getTraitCollection(), size: iPhone14ScreenSize)
 
         XCTAssertEqual(subject.jumpBackInList.tabs.count, 0)
         XCTAssertNotNil(subject.mostRecentSyncedTab)
@@ -428,7 +426,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
+        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
 
         XCTAssertEqual(subject.sectionLayout, .compactJumpBackIn)
         let jumpBackIn = subject.jumpBackInList
@@ -448,7 +446,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
+        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
 
         XCTAssertEqual(subject.sectionLayout, .compactJumpBackIn)
         let jumpBackIn = subject.jumpBackInList
@@ -469,7 +467,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
+        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: true, device: .phone)
 
         let jumpBackIn = subject.jumpBackInList
         XCTAssertEqual(jumpBackIn.tabs.count, 1, "iPhone portrait has 1 tab in it's jumpbackin layout")
@@ -494,7 +492,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .phone)
+        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .phone)
 
         let jumpBackIn = subject.jumpBackInList
         XCTAssertEqual(jumpBackIn.tabs.count, 3, "iPhone landscape has 3 tabs in it's jumpbackin layout, up until 4")
@@ -520,7 +518,7 @@ class JumpBackInViewModelTests: XCTestCase {
 
         subject.didLoadNewData()
         try? await Task.sleep(nanoseconds: sleepTime)
-        _ = subject.section(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .phone)
+        subject.refreshData(for: trait, size: iPhone14ScreenSize, isPortrait: false, device: .phone)
 
         let jumpBackIn = subject.jumpBackInList
         XCTAssertEqual(jumpBackIn.tabs.count, 2, "iPhone landscape has 2 tabs in it's jumpbackin layout, up until 2")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8415)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18650)

## :bulb: Description
Revert the homepage changes that were made on v123 related to compositional layout. This was understood as a risky change and an attempt to improve the homepage layout problems. Turns out this is in fact causing other issues, so for now let's revert for the release and reassess at a later point.

This reverts PRs https://github.com/mozilla-mobile/firefox-ios/pull/18309 and https://github.com/mozilla-mobile/firefox-ios/pull/18385.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

