### PR TITLE
Add FXIOS-8417 [v124] Firefox default browser onboarding footer string

### DIFF
--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -1218,6 +1218,11 @@ extension String {
                 tableName: "Onboarding",
                 value: "3. Select *%@*",
                 comment: "The third label on the Default Browser Popup, which is a card with instructions telling the user how to set Firefox as their default browser. Placeholder is the app name. The *text inside asterisks* denotes part of the string to bold, please leave the text inside the '*' so that it is bolded correctly.")
+            public static let DescriptionFooter = MZLocalizedString(
+                key: "DefaultBrowserPopup.DescriptionFooter.v124",
+                tableName: "Onboarding",
+                value: "*Is %@ already your default?* Close this message and tap Skip.",
+                comment: "The footer label on the Default Browser Popup, which is below all the instructions asking the users if their Firefox browser is the default browser. If it is then close this message and tap skip. The *text inside asterisks* denotes part of the string to bold, please leave the text inside the '*' so that it is bolded correctly.")
             public static let ButtonTitle = MZLocalizedString(
                 key: "DefaultBrowserPopup.ButtonTitle.v114",
                 tableName: "Onboarding",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket - 8417](https://mozilla-hub.atlassian.net/browse/FXIOS-8417)
[Github issue - 18658](https://github.com/mozilla-mobile/firefox-ios/issues/18658)

## :bulb: Description
Added Firefox default browser onboarding footer string

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods
