### PR TITLE
Add [v125] Pass in a data path to the suggest component

### DIFF
--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -633,13 +633,16 @@ open class BrowserProfile: Profile {
 
     lazy var firefoxSuggest: RustFirefoxSuggestActor? = {
         do {
-            let databaseFileURL = try FileManager.default.url(
+            let cacheFileURL = try FileManager.default.url(
                 for: .cachesDirectory,
                 in: .userDomainMask,
                 appropriateFor: nil,
                 create: true
             ).appendingPathComponent("suggest.db", isDirectory: false)
-            return try RustFirefoxSuggest(databasePath: databaseFileURL.path)
+            return try RustFirefoxSuggest(
+                dataPath: URL(fileURLWithPath: directory, isDirectory: true).appendingPathComponent("suggest-data.db").path,
+                cachePath: cacheFileURL.path
+            )
         } catch {
             logger.log("Failed to open Firefox Suggest database: \(error.localizedDescription)",
                        level: .warning,

--- a/firefox-ios/Storage/Rust/RustFirefoxSuggest.swift
+++ b/firefox-ios/Storage/Rust/RustFirefoxSuggest.swift
@@ -24,8 +24,16 @@ public protocol RustFirefoxSuggestActor: Actor {
 public actor RustFirefoxSuggest: RustFirefoxSuggestActor {
     private let store: SuggestStore
 
-    public init(databasePath: String, remoteSettingsConfig: RemoteSettingsConfig? = nil) throws {
-        store = try SuggestStore(path: databasePath, settingsConfig: remoteSettingsConfig)
+    public init(dataPath: String, cachePath: String, remoteSettingsConfig: RemoteSettingsConfig? = nil) throws {
+        var builder = SuggestStoreBuilder()
+            .dataPath(path: dataPath)
+            .cachePath(path: cachePath)
+
+        if let remoteSettingsConfig {
+            builder = builder.remoteSettingsConfig(config: remoteSettingsConfig)
+        }
+
+        store = try builder.build()
     }
 
     public func ingest() async throws {


### PR DESCRIPTION
## :scroll: Tickets
[Bugzilla issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1879647)

## :bulb: Description
This sends a data path to the suggest component, which we will need once we start storing persistent data.

This is a pretty simple change, but I wrote it completely blind and also I don't have enough iOS knowledge to know if I'm choosing the correct path here.  I need someone to a) run the tests and see if they pass and b) check that I'm putting the persistent data in the right directly.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods