### PR TITLE
Bugfix-FXIOS-8420 Fix for Retain Cycle in all Function for Deferred<T> Aggregation

### DIFF
--- a/firefox-ios/ThirdParty/Deferred/Deferred/Deferred.swift
+++ b/firefox-ios/ThirdParty/Deferred/Deferred/Deferred.swift
@@ -133,10 +133,10 @@ public func all<T>(_ deferreds: [Deferred<T>]) -> Deferred<[T]> {
     results.reserveCapacity(deferreds.count)
 
     var block: ((T) -> ())!
-    block = { t in
+    block = { [weak combined] t in
         results.append(t)
         if results.count == deferreds.count {
-            combined.fill(results)
+            combined?.fill(results)
         } else {
             deferreds[results.count].upon(block)
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira Ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8420)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18668)

## :bulb: Description
Refactored the original implementation's recursive closure calls that introduced a potential for retain cycles, leading to memory leaks as attached in GitHub issue. The revised approach utilizes a non-recursive helper function, `processNext`, to process each Deferred<T> object and append its result to an aggregate array. This method ensures that all Deferred<T> objects are processed without retaining strong references that could prevent the Deferred objects and their associated closures from being deallocated. 

Verified that no leaks exist after this refactoring. Check the resulting leak dump [here](https://github.com/amanjeetsingh150/firefox-ios/tree/fix-memory-leaks/maestro/leaks/after-fix) which does not have any report referencing paths of ContentBlocker file.


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

