### PR TITLE
Add FXIOS-7009 [v124] Toast for closing all tabs in private mode

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
@@ -317,6 +317,13 @@ class LegacyGridTabViewController: UIViewController,
                     self.tabManager.cleanupClosedTabs(recentlyClosedTabs,
                                                       previous: previousTab,
                                                       isPrivate: isPrivateState)
+
+                    presentToastForClosingAllTabs(
+                        recentlyClosedTabs: recentlyClosedTabs,
+                        previousTabUUID: previousTabUUID,
+                        isPrivate: isPrivateState
+                    )
+
                     TelemetryWrapper.recordEvent(
                         category: .action,
                         method: .tap,
@@ -331,6 +338,17 @@ class LegacyGridTabViewController: UIViewController,
                 }
                 closeTabsTrayHelper()
             }
+        }
+    }
+
+    private func presentToastForClosingAllTabs(recentlyClosedTabs: [Tab], previousTabUUID: String, isPrivate: Bool) {
+        self.presentUndoToast(tabsCount: recentlyClosedTabs.count) { [weak self] undoButtonPressed in
+            guard undoButtonPressed else { return }
+            self?.tabManager.undoCloseAllTabsLegacy(
+                recentlyClosedTabs: recentlyClosedTabs,
+                previousTabUUID: previousTabUUID,
+                isPrivate: isPrivate
+            )
         }
     }
 

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -834,8 +834,8 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         let tabToSelect = tabs.first(where: { $0.tabUUID == previousTabUUID })
         let currentlySelectedTab = selectedTab
         if let tabToSelect = tabToSelect, let currentlySelectedTab = currentlySelectedTab {
-            // remove currently selected tab only for normal mode
-            if isPrivate {
+            // remove tab only in normal mode because we don't create a new tab after users closes all tabs in private mode
+            if !isPrivate {
                 removeTabs([currentlySelectedTab])
             }
             // select previous tab

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -748,9 +748,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
                                 completion: { buttonPressed in
             // Handles undo to Close tabs
             if buttonPressed {
-                self.reAddTabs(tabsToAdd: recentlyClosedTabs,
-                               previousTabUUID: previousTabUUID)
-                NotificationCenter.default.post(name: .DidTapUndoCloseAllTabToast, object: nil)
+                self.undoCloseAllTabsLegacy(recentlyClosedTabs: recentlyClosedTabs, previousTabUUID: previousTabUUID)
             } else {
                 // Finish clean up for recently close tabs
                 DispatchQueue.global().async { [unowned self] in
@@ -763,6 +761,16 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
             }
         })
         delegates.forEach { $0.get()?.tabManagerDidRemoveAllTabs(self, toast: toast) }
+    }
+
+    /// Restore recently closed tabs when tab tray refactor is disabled
+    func undoCloseAllTabsLegacy(recentlyClosedTabs: [Tab], previousTabUUID: String, isPrivate: Bool = false) {
+        self.reAddTabs(
+            tabsToAdd: recentlyClosedTabs,
+            previousTabUUID: previousTabUUID,
+            isPrivate: isPrivate
+        )
+        NotificationCenter.default.post(name: .DidTapUndoCloseAllTabToast, object: nil)
     }
 
     func tabDidSetScreenshot(_ tab: Tab, hasHomeScreenshot: Bool) {}
@@ -821,13 +829,15 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         }
     }
 
-    private func reAddTabs(tabsToAdd: [Tab], previousTabUUID: String) {
+    private func reAddTabs(tabsToAdd: [Tab], previousTabUUID: String, isPrivate: Bool = false) {
         tabs.append(contentsOf: tabsToAdd)
         let tabToSelect = tabs.first(where: { $0.tabUUID == previousTabUUID })
         let currentlySelectedTab = selectedTab
         if let tabToSelect = tabToSelect, let currentlySelectedTab = currentlySelectedTab {
-            // remove currently selected tab
-            removeTabs([currentlySelectedTab])
+            // remove currently selected tab only for normal mode
+            if isPrivate {
+                removeTabs([currentlySelectedTab])
+            }
             // select previous tab
             selectTab(tabToSelect, previous: nil)
         }

--- a/firefox-ios/Client/TabManagement/TabManager.swift
+++ b/firefox-ios/Client/TabManagement/TabManager.swift
@@ -58,6 +58,8 @@ protocol TabManager: AnyObject {
     func makeToastFromRecentlyClosedUrls(_ recentlyClosedTabs: [Tab],
                                          isPrivate: Bool,
                                          previousTabUUID: String)
+    func undoCloseAllTabsLegacy(recentlyClosedTabs: [Tab], previousTabUUID: String, isPrivate: Bool)
+
     @discardableResult
     func addTab(_ request: URLRequest!,
                 configuration: WKWebViewConfiguration!,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -131,6 +131,8 @@ class MockTabManager: TabManager {
                                          isPrivate: Bool,
                                          previousTabUUID: String) {}
 
+    func undoCloseAllTabsLegacy(recentlyClosedTabs: [Client.Tab], previousTabUUID: String, isPrivate: Bool) {}
+
     @discardableResult
     func addTab(_ request: URLRequest!,
                 configuration: WKWebViewConfiguration!,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7009)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15561)

## :bulb: Description
Show toast with option to undo when all private tabs are closed. Showing a toast for single tabs in private mode is already implemented. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

## Screenshots

https://github.com/mozilla-mobile/firefox-ios/assets/6743397/af82b5c4-050c-47a4-b054-315e4f3ea46a


