### PR TITLE
 Add FXIOS-8427 [v124] Add functionality to recognize when an address form is detected and display the address autofill accessory view accordingly.

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -942,6 +942,8 @@
 		B15058812AA0A878008B7382 /* OpeningScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15058802AA0A878008B7382 /* OpeningScreenTests.swift */; };
 		B1664E9E2B163B7A005D4C71 /* CreditCardsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1664E9D2B163B7A005D4C71 /* CreditCardsTests.swift */; };
 		B26ADF852B339ED000C6E127 /* AddressAutofillSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = B26ADF842B339ED000C6E127 /* AddressAutofillSetting.swift */; };
+		B28BF6602B7A9E4F006357CA /* FillAddressAutofillForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28BF65F2B7A9E4F006357CA /* FillAddressAutofillForm.swift */; };
+		B28BF6622B7ACC17006357CA /* UnencryptedAddressFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28BF6612B7ACC17006357CA /* UnencryptedAddressFields.swift */; };
 		B2981F8A2B71AD7A00132C1B /* AutofillAccessoryViewButtonItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2981F892B71AD7A00132C1B /* AutofillAccessoryViewButtonItem.swift */; };
 		B2999FED2B044A5900F0FEC1 /* UnencryptedCreditCardFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2999FEC2B044A5900F0FEC1 /* UnencryptedCreditCardFields.swift */; };
 		B2999FEF2B044B4E00F0FEC1 /* RustAutofillEncryptionKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2999FEE2B044B4E00F0FEC1 /* RustAutofillEncryptionKeys.swift */; };
@@ -6215,6 +6217,8 @@
 		B25849AE8A390529836D27F0 /* sq */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sq; path = "sq.lproj/Default Browser.strings"; sourceTree = "<group>"; };
 		B25D4E72A0116CFE5BEC29CC /* es-CL */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-CL"; path = "es-CL.lproj/ClearPrivateData.strings"; sourceTree = "<group>"; };
 		B26ADF842B339ED000C6E127 /* AddressAutofillSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressAutofillSetting.swift; sourceTree = "<group>"; };
+		B28BF65F2B7A9E4F006357CA /* FillAddressAutofillForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FillAddressAutofillForm.swift; sourceTree = "<group>"; };
+		B28BF6612B7ACC17006357CA /* UnencryptedAddressFields.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnencryptedAddressFields.swift; sourceTree = "<group>"; };
 		B29049688244A8F79950DF35 /* af */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = af; path = af.lproj/Shared.strings; sourceTree = "<group>"; };
 		B2944B3EAFB1DA22E7F28520 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Shared.strings; sourceTree = "<group>"; };
 		B2981F892B71AD7A00132C1B /* AutofillAccessoryViewButtonItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutofillAccessoryViewButtonItem.swift; sourceTree = "<group>"; };
@@ -9865,6 +9869,7 @@
 				0BA02DB12942605600C92603 /* FormAutofillHelper.swift */,
 				B2999FF42B194AB200F0FEC1 /* FormAutofillHelperError.swift */,
 				B2999FF62B194ADE00F0FEC1 /* FormAutofillPayloadType.swift */,
+				B28BF65F2B7A9E4F006357CA /* FillAddressAutofillForm.swift */,
 			);
 			path = FormAutofillHelper;
 			sourceTree = "<group>";
@@ -10480,6 +10485,7 @@
 				15DE98FC27FCED4F00F1ECDB /* RustRemoteTabs.swift */,
 				D05434E2225BBC4100FDE4EF /* RustShared.swift */,
 				B2999FEC2B044A5900F0FEC1 /* UnencryptedCreditCardFields.swift */,
+				B28BF6612B7ACC17006357CA /* UnencryptedAddressFields.swift */,
 			);
 			path = Rust;
 			sourceTree = "<group>";
@@ -13109,6 +13115,7 @@
 				D076971F206AC60900FACFD8 /* ReadingList.swift in Sources */,
 				28E08C9A1AF44F00009BA2FA /* BrowserSchema.swift in Sources */,
 				2FCAE2681ABB531100877008 /* BrowserDB.swift in Sources */,
+				B28BF6622B7ACC17006357CA /* UnencryptedAddressFields.swift in Sources */,
 				2FCAE2651ABB531100877008 /* RemoteTabs.swift in Sources */,
 				2FCAE2771ABB531100877008 /* SwiftData.swift in Sources */,
 				D05434D9225BAA6200FDE4EF /* RustPlaces.swift in Sources */,
@@ -14024,6 +14031,7 @@
 				D3BE7B261B054D4400641031 /* main.swift in Sources */,
 				DFD104682B2341F900938418 /* ProductAdsCache.swift in Sources */,
 				C2D71B992A384F6A003DEC7A /* ThemedLeftAlignedTableViewCell.swift in Sources */,
+				B28BF6602B7A9E4F006357CA /* FillAddressAutofillForm.swift in Sources */,
 				21A7C44E283539170071D996 /* IntroViewModel.swift in Sources */,
 				E1FF93E228A2E55700E6360E /* WallpaperSelectorViewController.swift in Sources */,
 				D3A9949C1A3686BD008AD1AC /* BrowserViewController.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -362,7 +362,7 @@
 		4393932029AC6CE900DC5A85 /* EnvironmentValues+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4393931F29AC6CE900DC5A85 /* EnvironmentValues+Extension.swift */; };
 		439A220F29F69A0C00F120EE /* Notification.strings in Resources */ = {isa = PBXBuildFile; fileRef = 439A220D29F69A0C00F120EE /* Notification.strings */; };
 		439A221229F69A0C00F120EE /* ZoomPageBar.strings in Resources */ = {isa = PBXBuildFile; fileRef = 439A221029F69A0C00F120EE /* ZoomPageBar.strings */; };
-		439B78182A09721600CAAE37 /* CreditCardHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 439B78172A09721600CAAE37 /* CreditCardHelperTests.swift */; };
+		439B78182A09721600CAAE37 /* FormAutofillHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 439B78172A09721600CAAE37 /* FormAutofillHelperTests.swift */; };
 		439C489C29760575007C3DCD /* CreditCardValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 439C489B29760575007C3DCD /* CreditCardValidator.swift */; };
 		43A5643823CD1E1C00B6857D /* UpdateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43A5643523CD1E1B00B6857D /* UpdateViewController.swift */; };
 		43A7153D2A2DF94F00DD5747 /* Footer.strings in Resources */ = {isa = PBXBuildFile; fileRef = 43A7153B2A2DF94F00DD5747 /* Footer.strings */; };
@@ -4065,7 +4065,7 @@
 		439A626229C8776D005428EB /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/ErrorState.strings; sourceTree = "<group>"; };
 		439A626329C8776D005428EB /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/Settings.strings; sourceTree = "<group>"; };
 		439A626429C8776D005428EB /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/SnackBar.strings; sourceTree = "<group>"; };
-		439B78172A09721600CAAE37 /* CreditCardHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditCardHelperTests.swift; sourceTree = "<group>"; };
+		439B78172A09721600CAAE37 /* FormAutofillHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormAutofillHelperTests.swift; sourceTree = "<group>"; };
 		439BC6462AC1A4E000AF4D58 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/Share.strings; sourceTree = "<group>"; };
 		439BC6472AC1A4E000AF4D58 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/TabLocation.strings; sourceTree = "<group>"; };
 		439BE0CE2B554A1D00E73966 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/TabToolbar.strings; sourceTree = "<group>"; };
@@ -8720,7 +8720,6 @@
 			isa = PBXGroup;
 			children = (
 				ABEF80D82A2F283D003F52C4 /* CreditCardBottomSheetViewModelTests.swift */,
-				439B78172A09721600CAAE37 /* CreditCardHelperTests.swift */,
 				96AF8C1B29FC14F700EC2219 /* CreditCardInputFieldHelperTests.swift */,
 				967EDABE29D769A10089208D /* CreditCardInputFieldTests.swift */,
 				43B658D829CE251C00C9EF08 /* CreditCardInputViewModelTests.swift */,
@@ -9858,6 +9857,14 @@
 				ABEF80D42A254185003F52C4 /* CreditCardBottomSheetFooterView.swift */,
 			);
 			path = CreditCardBottomSheet;
+			sourceTree = "<group>";
+		};
+		B23620492B7EAF2C000B1DE7 /* Autofill */ = {
+			isa = PBXGroup;
+			children = (
+				439B78172A09721600CAAE37 /* FormAutofillHelperTests.swift */,
+			);
+			path = Autofill;
 			sourceTree = "<group>";
 		};
 		B2999FF82B194B3D00F0FEC1 /* FormAutofillHelper */ = {
@@ -11497,6 +11504,7 @@
 				C889D7CD2858C4B500121E1D /* ContextMenuHelperTests.swift */,
 				8A93F86329D37314004159D9 /* Coordinators */,
 				43B658D729CE249D00C9EF08 /* CreditCard */,
+				B23620492B7EAF2C000B1DE7 /* Autofill */,
 				3B39EDB91E16E18900EF029F /* CustomSearchEnginesTest.swift */,
 				431C0D1C25C9D76B00395CE4 /* DefaultBrowserOnboardingTests */,
 				D82ED2631FEB3C420059570B /* DefaultSearchPrefsTests.swift */,
@@ -14272,7 +14280,7 @@
 				212985E72A72B39D00546684 /* ThemeSettingsControllerTests.swift in Sources */,
 				8A9E46BD2A6599E5003327D4 /* MockStatusBarScrollDelegate.swift in Sources */,
 				E1463D0629830E4F0074E16E /* MockUserNotificationCenter.swift in Sources */,
-				439B78182A09721600CAAE37 /* CreditCardHelperTests.swift in Sources */,
+				439B78182A09721600CAAE37 /* FormAutofillHelperTests.swift in Sources */,
 				8ADED7F0276A7788009C19E6 /* CumulativeDaysOfUseCounterTests.swift in Sources */,
 				8A7653C528A2E69100924ABF /* MockPocketAPI.swift in Sources */,
 				8A83B74A2A265044002FF9AC /* SettingsCoordinatorTests.swift in Sources */,

--- a/firefox-ios/Client/AccessoryViewProvider.swift
+++ b/firefox-ios/Client/AccessoryViewProvider.swift
@@ -188,18 +188,18 @@ class AccessoryViewProvider: UIView, Themeable {
         setupSpacer(trailingFixedSpacer, width: UX.fixedTrailingSpacerWidth)
 
         toolbar.items = [
+            currentAccessoryView,
+            flexibleSpacer,
             previousButton,
             nextButton,
             fixedSpacer,
-            currentAccessoryView,
-            flexibleSpacer,
             doneButton
         ].compactMap { $0 }
 
         toolbar.accessibilityElements = [
+            currentAccessoryView,
             previousButton,
             nextButton,
-            currentAccessoryView,
             doneButton
         ].compactMap { $0 }
 

--- a/firefox-ios/Client/AccessoryViewProvider.swift
+++ b/firefox-ios/Client/AccessoryViewProvider.swift
@@ -197,7 +197,7 @@ class AccessoryViewProvider: UIView, Themeable {
         ].compactMap { $0 }
 
         toolbar.accessibilityElements = [
-            currentAccessoryView,
+            currentAccessoryView?.customView,
             previousButton,
             nextButton,
             doneButton

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1923,7 +1923,9 @@ class BrowserViewController: UIViewController,
                 }
 
                 // Handle action when saved cards button is tapped
-                strongSelf.handleSavedCardsButtonTap(tabWebView: tabWebView, webView: webView, frame: frame)
+                handleSavedCardsButtonTap(tabWebView: tabWebView,
+                                          webView: webView,
+                                          frame: frame)
             }
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1883,14 +1883,14 @@ class BrowserViewController: UIViewController,
             switch fieldValues.fieldValue {
             case .address:
                 guard let addressPayload = fieldValues.fieldData as? UnencryptedAddressFields,
-                      strongSelf.addressAutofillSettingsUserDefaultsIsEnabled(),
-                      strongSelf.addressAutofillNimbusFeatureFlag(),
+                      addressAutofillSettingsUserDefaultsIsEnabled(),
+                      addressAutofillNimbusFeatureFlag(),
                       let type = type else { return }
 
                 // Handle address form filling or capturing
                 switch type {
                 case .fillAddressForm:
-                    strongSelf.displayAddressAutofillAccessoryView(tabWebView: tabWebView)
+                    displayAddressAutofillAccessoryView(tabWebView: tabWebView)
                 case .captureAddressForm:
                     // FXMO-376: No action needed for capturing address form as this is for Phase 2
                     break
@@ -1901,7 +1901,7 @@ class BrowserViewController: UIViewController,
             case .creditCard:
                 guard let creditCardPayload = fieldValues.fieldData as? UnencryptedCreditCardFields,
                       let type = type,
-                      strongSelf.autofillCreditCardSettingsUserDefaultIsEnabled() else { return }
+                      autofillCreditCardSettingsUserDefaultIsEnabled() else { return }
 
                 // Record telemetry for credit card form detection
                 if type == .formInput {
@@ -1910,14 +1910,14 @@ class BrowserViewController: UIViewController,
                                                  object: .creditCardFormDetected)
                 }
 
-                guard strongSelf.autofillCreditCardNimbusFeatureFlag() else { return }
+                guard autofillCreditCardNimbusFeatureFlag() else { return }
 
                 // Handle different types of credit card interactions
                 switch type {
                 case .formInput:
-                    strongSelf.displayAutofillCreditCardAccessoryView(tabWebView: tabWebView)
+                    displayAutofillCreditCardAccessoryView(tabWebView: tabWebView)
                 case .formSubmit:
-                    strongSelf.showCreditCardAutofillSheet(fieldValues: creditCardPayload)
+                    showCreditCardAutofillSheet(fieldValues: creditCardPayload)
                 default:
                     break
                 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1941,7 +1941,7 @@ class BrowserViewController: UIViewController,
         })
     }
 
-    /// Displays the address autofill accessory view on the given tab web view.
+    /// Displays the address autofill accessory view on the given tab web view
     private func displayAddressAutofillAccessoryView(tabWebView: TabWebView) {
         profile.autofill.listCreditCards(completion: { addresses, error in
             guard let addresses = addresses, !addresses.isEmpty, error == nil else { return }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1862,7 +1862,7 @@ class BrowserViewController: UIViewController,
         return featureFlags.isFeatureEnabled(.addressAutofill, checking: .buildOnly)
     }
 
-    /// Returns whether address autofill settings are enabled based on user defaults.
+    /// Returns whether address autofill settings are enabled based on user defaults
     func addressAutofillSettingsUserDefaultsIsEnabled() -> Bool {
         let userDefaults = UserDefaults.standard
         let keyAddressAutofill = PrefsKeys.KeyAutofillAddressStatus

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1845,12 +1845,12 @@ class BrowserViewController: UIViewController,
     }
 
     /// Returns whether the credit card autofill feature flag is enabled from Nimbus
-    func autofillCreditCardNimbusFeatureFlag() -> Bool {
+    private func autofillCreditCardNimbusFeatureFlag() -> Bool {
         return featureFlags.isFeatureEnabled(.creditCardAutofillStatus, checking: .buildOnly)
     }
 
     /// Returns whether credit card autofill settings are enabled based on user defaults key KeyAutofillCreditCardStatus
-    func autofillCreditCardSettingsUserDefaultIsEnabled() -> Bool {
+    private func autofillCreditCardSettingsUserDefaultIsEnabled() -> Bool {
         let userDefaults = UserDefaults.standard
         let keyCreditCardAutofill = PrefsKeys.KeyAutofillCreditCardStatus
 
@@ -1858,12 +1858,12 @@ class BrowserViewController: UIViewController,
     }
 
     /// Returns whether the address autofill feature flag is enabled from Nimbus
-    func addressAutofillNimbusFeatureFlag() -> Bool {
+    private func addressAutofillNimbusFeatureFlag() -> Bool {
         return featureFlags.isFeatureEnabled(.addressAutofill, checking: .buildOnly)
     }
 
     /// Returns whether address autofill settings are enabled based on user defaults
-    func addressAutofillSettingsUserDefaultsIsEnabled() -> Bool {
+    private func addressAutofillSettingsUserDefaultsIsEnabled() -> Bool {
         let userDefaults = UserDefaults.standard
         let keyAddressAutofill = PrefsKeys.KeyAutofillAddressStatus
 
@@ -1871,7 +1871,7 @@ class BrowserViewController: UIViewController,
     }
 
     /// Sets up credit card autofill handling
-    private func creditCardAutofillSetup(_ tab: Tab, didCreateWebView webView: WKWebView) {
+    private func autofillSetup(_ tab: Tab, didCreateWebView webView: WKWebView) {
         let formAutofillHelper = FormAutofillHelper(tab: tab)
         tab.addContentScript(formAutofillHelper, name: FormAutofillHelper.name())
 
@@ -1882,9 +1882,9 @@ class BrowserViewController: UIViewController,
             // Handle different field types
             switch fieldValues.fieldValue {
             case .address:
-                guard let addressPayload = fieldValues.fieldData as? UnencryptedAddressFields,
-                      addressAutofillSettingsUserDefaultsIsEnabled(),
+                guard addressAutofillSettingsUserDefaultsIsEnabled(),
                       addressAutofillNimbusFeatureFlag(),
+                      // FXMO-376: Phase 2 let addressPayload = fieldValues.fieldData as? UnencryptedAddressFields,
                       let type = type else { return }
 
                 // Handle address form filling or capturing
@@ -2258,7 +2258,7 @@ extension BrowserViewController: LegacyTabDelegate {
         }
 
         // Credit card autofill setup and callback
-        creditCardAutofillSetup(tab, didCreateWebView: webView)
+        autofillSetup(tab, didCreateWebView: webView)
 
         let contextMenuHelper = ContextMenuHelper(tab: tab)
         tab.addContentScript(contextMenuHelper, name: ContextMenuHelper.name())

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1904,7 +1904,9 @@ class BrowserViewController: UIViewController,
 
                 // Record telemetry for credit card form detection
                 if type == .formInput {
-                    TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .creditCardFormDetected)
+                    TelemetryWrapper.recordEvent(category: .action,
+                                                 method: .tap,
+                                                 object: .creditCardFormDetected)
                 }
 
                 guard strongSelf.autofillCreditCardNimbusFeatureFlag() else { return }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1870,7 +1870,7 @@ class BrowserViewController: UIViewController,
         return (userDefaults.object(forKey: keyAddressAutofill) as? Bool ?? true)
     }
 
-    /// Sets up credit card autofill handling.
+    /// Sets up credit card autofill handling
     private func creditCardAutofillSetup(_ tab: Tab, didCreateWebView webView: WKWebView) {
         let formAutofillHelper = FormAutofillHelper(tab: tab)
         tab.addContentScript(formAutofillHelper, name: FormAutofillHelper.name())

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1877,7 +1877,7 @@ class BrowserViewController: UIViewController,
 
         // Closure to handle found field values for credit card and address fields
         formAutofillHelper.foundFieldValues = { [weak self] fieldValues, type, frame in
-            guard let strongSelf = self, let tabWebView = tab.webView else { return }
+            guard let self, let tabWebView = tab.webView else { return }
 
             // Handle different field types
             switch fieldValues.fieldValue {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1930,7 +1930,7 @@ class BrowserViewController: UIViewController,
         }
     }
 
-    /// Displays the credit card autofill accessory view on the given tab web view.
+    /// Displays the credit card autofill accessory view on the given tab web view
     private func displayAutofillCreditCardAccessoryView(tabWebView: TabWebView) {
         profile.autofill.listCreditCards(completion: { cards, error in
             guard let cards = cards, !cards.isEmpty, error == nil else { return }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1892,7 +1892,8 @@ class BrowserViewController: UIViewController,
                 case .fillAddressForm:
                     strongSelf.displayAddressAutofillAccessoryView(tabWebView: tabWebView)
                 case .captureAddressForm:
-                    break // No action needed for capturing address form
+                    // FXMO-376: No action needed for capturing address form as this is for Phase 2
+                    break
                 default:
                     break
                 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1844,12 +1844,10 @@ class BrowserViewController: UIViewController,
         }
     }
 
-    /// Returns whether the credit card autofill feature flag is enabled from Nimbus
     private func autofillCreditCardNimbusFeatureFlag() -> Bool {
         return featureFlags.isFeatureEnabled(.creditCardAutofillStatus, checking: .buildOnly)
     }
 
-    /// Returns whether credit card autofill settings are enabled based on user defaults key KeyAutofillCreditCardStatus
     private func autofillCreditCardSettingsUserDefaultIsEnabled() -> Bool {
         let userDefaults = UserDefaults.standard
         let keyCreditCardAutofill = PrefsKeys.KeyAutofillCreditCardStatus
@@ -1857,12 +1855,10 @@ class BrowserViewController: UIViewController,
         return (userDefaults.object(forKey: keyCreditCardAutofill) as? Bool ?? true)
     }
 
-    /// Returns whether the address autofill feature flag is enabled from Nimbus
     private func addressAutofillNimbusFeatureFlag() -> Bool {
         return featureFlags.isFeatureEnabled(.addressAutofill, checking: .buildOnly)
     }
 
-    /// Returns whether address autofill settings are enabled based on user defaults
     private func addressAutofillSettingsUserDefaultsIsEnabled() -> Bool {
         let userDefaults = UserDefaults.standard
         let keyAddressAutofill = PrefsKeys.KeyAutofillAddressStatus
@@ -1870,7 +1866,6 @@ class BrowserViewController: UIViewController,
         return (userDefaults.object(forKey: keyAddressAutofill) as? Bool ?? true)
     }
 
-    /// Sets up credit card autofill handling
     private func autofillSetup(_ tab: Tab, didCreateWebView webView: WKWebView) {
         let formAutofillHelper = FormAutofillHelper(tab: tab)
         tab.addContentScript(formAutofillHelper, name: FormAutofillHelper.name())
@@ -1930,7 +1925,6 @@ class BrowserViewController: UIViewController,
         }
     }
 
-    /// Displays the credit card autofill accessory view on the given tab web view
     private func displayAutofillCreditCardAccessoryView(tabWebView: TabWebView) {
         profile.autofill.listCreditCards(completion: { cards, error in
             guard let cards = cards, !cards.isEmpty, error == nil else { return }
@@ -1941,7 +1935,6 @@ class BrowserViewController: UIViewController,
         })
     }
 
-    /// Displays the address autofill accessory view on the given tab web view
     private func displayAddressAutofillAccessoryView(tabWebView: TabWebView) {
         profile.autofill.listCreditCards(completion: { addresses, error in
             guard let addresses = addresses, !addresses.isEmpty, error == nil else { return }

--- a/firefox-ios/Client/Frontend/TabContentsScripts/FormAutofillHelper/AddressAutofillPayload.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/FormAutofillHelper/AddressAutofillPayload.swift
@@ -4,8 +4,24 @@
 
 import Foundation
 
-// TO DO: FXIOS-7872 Implement Address Autofill Payloads
-// struct AddressAutofillPayload: Codable {
-//     enum CodingKeys: String, CodingKey, CaseIterable {
-//     }
-// }
+struct AddressAutofillPayload: Codable {
+    let addressLevel1: String
+    let organization: String
+    let country: String
+    let addressLevel2: String
+    let email: String
+    let streetAddress: String
+    let name: String
+    let postalCode: String
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case addressLevel1 = "address-level1"
+        case organization = "organization"
+        case country = "country"
+        case addressLevel2 = "address-level2"
+        case email = "email"
+        case streetAddress = "street-address"
+        case name = "name"
+        case postalCode = "postal-code"
+    }
+}

--- a/firefox-ios/Client/Frontend/TabContentsScripts/FormAutofillHelper/FillAddressAutofillForm.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/FormAutofillHelper/FillAddressAutofillForm.swift
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+struct FillAddressAutofillForm: Codable {
+    let addressPayload: AddressAutofillPayload
+    let type: String
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case addressPayload = "payload"
+        case type = "type"
+    }
+}

--- a/firefox-ios/Client/Frontend/TabContentsScripts/FormAutofillHelper/FormAutofillHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/FormAutofillHelper/FormAutofillHelper.swift
@@ -14,7 +14,7 @@ enum AutofillFieldValueType: String {
 }
 
 struct AutofillFieldValuePayload {
-    let fieldValue: AutofillFieldValue
+    let fieldValue: AutofillFieldValueType
     let fieldData: Any?
 }
 

--- a/firefox-ios/Client/Frontend/TabContentsScripts/FormAutofillHelper/FormAutofillHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/FormAutofillHelper/FormAutofillHelper.swift
@@ -73,9 +73,6 @@ class FormAutofillHelper: TabContentScript {
         // to an embedded iframe on a webpage for injecting card info
         frame = message.frameInfo
 
-        // Check if tabWebView is available
-        guard let tabWebView = tab?.webView else { return }
-
         switch HandlerName(rawValue: message.name) {
         case .addressFormMessageHandler:
             // Parse message payload for address form autofill

--- a/firefox-ios/Client/Frontend/TabContentsScripts/FormAutofillHelper/FormAutofillHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/FormAutofillHelper/FormAutofillHelper.swift
@@ -149,16 +149,16 @@ class FormAutofillHelper: TabContentScript {
     }
 
     func getFieldTypeValues(payload: AddressAutofillPayload) -> AutofillFieldValuePayload {
-        var addressPlainText = UnencryptedAddressFields()
-
-        addressPlainText.addressLevel1 = payload.addressLevel1
-        addressPlainText.organization = payload.organization
-        addressPlainText.country = payload.country
-        addressPlainText.addressLevel2 = payload.addressLevel2
-        addressPlainText.email = payload.email
-        addressPlainText.streetAddress = payload.streetAddress
-        addressPlainText.name = payload.name
-        addressPlainText.postalCode = payload.postalCode
+        var addressPlainText = UnencryptedAddressFields(
+            addressLevel1: payload.addressLevel1,
+            organization: payload.organization,
+            country: payload.country,
+            addressLevel2: payload.addressLevel2,
+            email: payload.email,
+            streetAddress: payload.streetAddress,
+            name: payload.name,
+            postalCode: payload.postalCode
+        )
 
         return AutofillFieldValuePayload(fieldValue: .address, fieldData: addressPlainText)
     }

--- a/firefox-ios/Client/Frontend/TabContentsScripts/FormAutofillHelper/FormAutofillHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/FormAutofillHelper/FormAutofillHelper.swift
@@ -50,9 +50,9 @@ class FormAutofillHelper: TabContentScript {
 
     // MARK: - Script Message Handler
 
-      func scriptMessageHandlerNames() -> [String]? {
-          return [HandlerName.addressFormMessageHandler.rawValue, HandlerName.creditCardFormMessageHandler.rawValue]
-      }
+    func scriptMessageHandlerNames() -> [String]? {
+        return [HandlerName.addressFormMessageHandler.rawValue, HandlerName.creditCardFormMessageHandler.rawValue]
+    }
 
     // MARK: - Deinitialization
 
@@ -210,11 +210,11 @@ class FormAutofillHelper: TabContentScript {
         let sanitizedName = card.ccName.htmlEntityEncodedString
         let sanitizedNumber = card.ccNumber.htmlEntityEncodedString
         let injectionJSON: [String: Any] = [
-                "cc-name": sanitizedName,
-                "cc-number": sanitizedNumber,
-                "cc-exp-month": card.ccExpMonth,
-                "cc-exp-year": card.ccExpYear,
-                "cc-exp": "\(card.ccExpMonth)/\(card.ccExpYear)",
+            "cc-name": sanitizedName,
+            "cc-number": sanitizedNumber,
+            "cc-exp-month": card.ccExpMonth,
+            "cc-exp-year": card.ccExpYear,
+            "cc-exp": "\(card.ccExpMonth)/\(card.ccExpYear)",
         ]
         return injectionJSON
     }

--- a/firefox-ios/Client/Frontend/TabContentsScripts/FormAutofillHelper/FormAutofillHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/FormAutofillHelper/FormAutofillHelper.swift
@@ -8,7 +8,23 @@ import WebKit
 import Common
 import Storage
 
+enum AutofillFieldValue: String {
+    case address
+    case creditCard
+}
+
+struct AutofillFieldValuePayload {
+    let fieldValue: AutofillFieldValue
+    let fieldData: Any?
+}
+
 class FormAutofillHelper: TabContentScript {
+    // MARK: - Handler Names Enum
+    enum HandlerName: String {
+        case addressFormMessageHandler
+        case creditCardFormMessageHandler
+    }
+
     // MARK: - Properties
 
     private weak var tab: Tab?
@@ -16,7 +32,7 @@ class FormAutofillHelper: TabContentScript {
     private var frame: WKFrameInfo?
 
     // Closure to send the field values
-    var foundFieldValues: ((UnencryptedCreditCardFields,
+    var foundFieldValues: ((AutofillFieldValuePayload,
                             FormAutofillPayloadType?,
                             WKFrameInfo?) -> Void)?
 
@@ -34,9 +50,9 @@ class FormAutofillHelper: TabContentScript {
 
     // MARK: - Script Message Handler
 
-    func scriptMessageHandlerNames() -> [String]? {
-        return ["addressFormMessageHandler", "creditCardFormMessageHandler"]
-    }
+      func scriptMessageHandlerNames() -> [String]? {
+          return [HandlerName.addressFormMessageHandler.rawValue, HandlerName.creditCardFormMessageHandler.rawValue]
+      }
 
     // MARK: - Deinitialization
 
@@ -46,24 +62,57 @@ class FormAutofillHelper: TabContentScript {
 
     // MARK: - Retrieval
 
+    /// Called when the user content controller receives a script message.
+    ///
+    /// - Parameters:
+    ///   - userContentController: The user content controller.
+    ///   - message: The script message received.
     func userContentController(_ userContentController: WKUserContentController,
                                didReceiveScriptMessage message: WKScriptMessage) {
         // Note: We require frame so that we can submit information
         // to an embedded iframe on a webpage for injecting card info
         frame = message.frameInfo
 
-        guard let data = getValidPayloadData(from: message),
-              let fieldValues = parseFieldType(messageBody: data),
-              let payloadType = FormAutofillPayloadType(rawValue: fieldValues.type)
-        else {
-            logger.log("Unable to find the payloadType for the credit card JS input",
-                       level: .warning,
-                       category: .webview)
-            return
-        }
+        // Check if tabWebView is available
+        guard let tabWebView = tab?.webView else { return }
 
-        let payloadData = fieldValues.creditCardPayload
-        foundFieldValues?(getFieldTypeValues(payload: payloadData), payloadType, frame)
+        switch HandlerName(rawValue: message.name) {
+        case .addressFormMessageHandler:
+            // Parse message payload for address form autofill
+            guard let data = getValidPayloadData(from: message),
+                  let fieldValues = parseFieldType(messageBody: data, formType: FillAddressAutofillForm.self),
+                  let payloadType = FormAutofillPayloadType(rawValue: fieldValues.type)
+            else {
+                // Log a warning if payload parsing fails
+                logger.log("Unable to find the payloadType for the address form JS input",
+                           level: .warning,
+                           category: .webview)
+                return
+            }
+
+            let payloadData = fieldValues.addressPayload
+            foundFieldValues?(getFieldTypeValues(payload: payloadData), payloadType, frame)
+
+        case .creditCardFormMessageHandler:
+            // Parse message payload for credit card form autofill
+            guard let data = getValidPayloadData(from: message),
+                  let fieldValues = parseFieldType(messageBody: data, formType: FillCreditCardForm.self),
+                  let payloadType = FormAutofillPayloadType(rawValue: fieldValues.type)
+            else {
+                // Log a warning if payload parsing fails
+                logger.log("Unable to find the payloadType for the credit card form JS input",
+                           level: .warning,
+                           category: .webview)
+                return
+            }
+
+            let payloadData = fieldValues.creditCardPayload
+            foundFieldValues?(getFieldTypeValues(payload: payloadData), payloadType, frame)
+
+        case .none:
+            // Do nothing if the handler name is not recognized
+            break
+        }
     }
 
     // MARK: - Payload Data Handling
@@ -72,23 +121,21 @@ class FormAutofillHelper: TabContentScript {
         return message.body as? [String: Any]
     }
 
-    func parseFieldType(messageBody: [String: Any]) -> FillCreditCardForm? {
+    func parseFieldType<T: Decodable>(messageBody: [String: Any], formType: T.Type) -> T? {
         let decoder = JSONDecoder()
 
         do {
             let jsonData = try JSONSerialization.data(withJSONObject: messageBody, options: .prettyPrinted)
-            let fillCreditCardForm = try decoder.decode(FillCreditCardForm.self, from: jsonData)
-            return fillCreditCardForm
+            let formData = try decoder.decode(formType, from: jsonData)
+            return formData
         } catch let error {
-            logger.log("Unable to parse field type for the credit card, \(error)",
-                       level: .warning,
-                       category: .webview)
+            logger.log("Unable to parse field type, \(error)", level: .warning, category: .webview)
         }
 
         return nil
     }
 
-    func getFieldTypeValues(payload: CreditCardPayload) -> UnencryptedCreditCardFields {
+    func getFieldTypeValues(payload: CreditCardPayload) -> AutofillFieldValuePayload {
         var ccPlainText = UnencryptedCreditCardFields()
         let creditCardValidator = CreditCardValidator()
 
@@ -98,9 +145,23 @@ class FormAutofillHelper: TabContentScript {
         ccPlainText.ccNumber = "\(payload.ccNumber.filter { $0.isNumber })"
         ccPlainText.ccNumberLast4 = ccPlainText.ccNumber.count > 4 ? String(ccPlainText.ccNumber.suffix(4)) : ""
         ccPlainText.ccType = creditCardValidator.cardTypeFor(ccPlainText.ccNumber)?.rawValue ?? ""
-        return ccPlainText
+        return AutofillFieldValuePayload(fieldValue: .creditCard, fieldData: ccPlainText)
     }
 
+    func getFieldTypeValues(payload: AddressAutofillPayload) -> AutofillFieldValuePayload {
+        var addressPlainText = UnencryptedAddressFields()
+
+        addressPlainText.addressLevel1 = payload.addressLevel1
+        addressPlainText.organization = payload.organization
+        addressPlainText.country = payload.country
+        addressPlainText.addressLevel2 = payload.addressLevel2
+        addressPlainText.email = payload.email
+        addressPlainText.streetAddress = payload.streetAddress
+        addressPlainText.name = payload.name
+        addressPlainText.postalCode = payload.postalCode
+
+        return AutofillFieldValuePayload(fieldValue: .address, fieldData: addressPlainText)
+    }
     // MARK: - Injection
 
     static func injectCardInfo(logger: Logger,

--- a/firefox-ios/Client/Frontend/TabContentsScripts/FormAutofillHelper/FormAutofillHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/FormAutofillHelper/FormAutofillHelper.swift
@@ -8,7 +8,7 @@ import WebKit
 import Common
 import Storage
 
-enum AutofillFieldValue: String {
+enum AutofillFieldValueType: String {
     case address
     case creditCard
 }

--- a/firefox-ios/Storage/Rust/UnencryptedAddressFields.swift
+++ b/firefox-ios/Storage/Rust/UnencryptedAddressFields.swift
@@ -1,0 +1,36 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+public struct UnencryptedAddressFields {
+    public var addressLevel1: String = ""
+    public var organization: String = ""
+    public var country: String = ""
+    public var addressLevel2: String = ""
+    public var email: String = ""
+    public var streetAddress: String = ""
+    public var name: String = ""
+    public var postalCode: String = ""
+
+    public init() { }
+
+    public init(addressLevel1: String,
+                organization: String,
+                country: String,
+                addressLevel2: String,
+                email: String,
+                streetAddress: String,
+                name: String,
+                postalCode: String) {
+        self.addressLevel1 = addressLevel1
+        self.organization = organization
+        self.country = country
+        self.addressLevel2 = addressLevel2
+        self.email = email
+        self.streetAddress = streetAddress
+        self.name = name
+        self.postalCode = postalCode
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/FormAutofillHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/FormAutofillHelperTests.swift
@@ -149,7 +149,8 @@ class FormAutofillHelperTests: XCTestCase {
 
     func test_parseFieldType_valid() {
         let messageBodyDict = formAutofillHelper.getValidPayloadData(from: validMockWKMessage)
-        let messageFields = formAutofillHelper.parseFieldType(messageBody: messageBodyDict!)
+        let messageFields: FillCreditCardForm? = formAutofillHelper.parseFieldType(messageBody: messageBodyDict!,
+                                                                                   formType: FillCreditCardForm.self)
         XCTAssertNotNil(messageFields)
         XCTAssertEqual(messageFields!.type, FormAutofillPayloadType.formInput.rawValue)
         XCTAssertEqual(messageFields!.creditCardPayload.ccExpMonth, "03")
@@ -160,7 +161,8 @@ class FormAutofillHelperTests: XCTestCase {
 
     func test_parseFieldCaptureJsonType_valid() {
         let messageBodyDict = formAutofillHelper.getValidPayloadData(from: validPayloadCaptureMockWKMessage)
-        let messageFields = formAutofillHelper.parseFieldType(messageBody: messageBodyDict!)
+        let messageFields: FillCreditCardForm? = formAutofillHelper.parseFieldType(messageBody: messageBodyDict!,
+                                                                                   formType: FillCreditCardForm.self)
         XCTAssertNotNil(messageFields)
         XCTAssertEqual(messageFields!.type, FormAutofillPayloadType.formSubmit.rawValue)
         XCTAssertEqual(messageFields!.creditCardPayload.ccExpMonth, "03")
@@ -173,14 +175,18 @@ class FormAutofillHelperTests: XCTestCase {
 
     func test_getFieldTypeValues() {
         let messageBodyDict = formAutofillHelper.getValidPayloadData(from: validMockWKMessage)
-        let messageFields = formAutofillHelper.parseFieldType(messageBody: messageBodyDict!)
+        let messageFields: FillCreditCardForm? = formAutofillHelper.parseFieldType(messageBody: messageBodyDict!,
+                                                                                   formType: FillCreditCardForm.self)
+
         XCTAssertNotNil(messageFields)
-        let fieldValues = formAutofillHelper.getFieldTypeValues(payload: messageFields!.creditCardPayload)
-        XCTAssertEqual(fieldValues.ccExpMonth, 3)
-        XCTAssertEqual(fieldValues.ccExpYear, 2999)
-        XCTAssertEqual(fieldValues.ccName, "Josh Moustache")
-        XCTAssertEqual(fieldValues.ccNumberLast4, "6788")
-        XCTAssertEqual(fieldValues.ccType, "VISA")
+        if let fieldValues = formAutofillHelper.getFieldTypeValues(
+            payload: messageFields!.creditCardPayload).fieldData as? UnencryptedCreditCardFields {
+            XCTAssertEqual(fieldValues.ccExpMonth, 3)
+            XCTAssertEqual(fieldValues.ccExpYear, 2999)
+            XCTAssertEqual(fieldValues.ccName, "Josh Moustache")
+            XCTAssertEqual(fieldValues.ccNumberLast4, "6788")
+            XCTAssertEqual(fieldValues.ccType, "VISA")
+        }
     }
 
     // MARK: Leaks

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/FormAutofillHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/FormAutofillHelperTests.swift
@@ -57,7 +57,7 @@ class FormAutofillHelperTests: XCTestCase {
             fatalError("Unable to convert JSON to dictionary")
         }
         validMockWKMessage = MockWKScriptMessage(
-            name: "validMockWKMessage",
+            name: "creditCardFormMessageHandler",
             body: dictionary)
         guard let jsonDataCapture = validMockPayloadCaptureJson.data(using: .utf8),
               let dictionaryCapture = try? JSONSerialization.jsonObject(
@@ -209,6 +209,85 @@ class FormAutofillHelperTests: XCTestCase {
         }
 
         tab.close()
+    }
+
+    func testScriptMessageHandlerNames() {
+        let formAutofillHelper = FormAutofillHelper(tab: tab)
+        let handlerNames = formAutofillHelper.scriptMessageHandlerNames()
+
+        // Assert that the handler names are not nil and contain expected values
+        XCTAssertNotNil(handlerNames)
+        XCTAssertEqual(handlerNames?.count, 2) // Assuming you have two handler names
+
+        XCTAssertTrue(handlerNames!.contains(FormAutofillHelper.HandlerName.addressFormMessageHandler.rawValue))
+        XCTAssertTrue(handlerNames!.contains(FormAutofillHelper.HandlerName.creditCardFormMessageHandler.rawValue))
+    }
+
+    func testUserContentControllerDidReceiveScriptMessage_withAddressHandler() {
+        let formAutofillHelper = FormAutofillHelper(tab: tab)
+
+        // Create a mock WKScriptMessage with handler name "addressFormMessageHandler"
+        let mockBody: [String: Any] = ["type": "fill-address-form",
+                                       "payload": ["address-level1": "123 Main St",
+                                                   "address-level2": "Apt 101",
+                                                   "email": "mozilla@mozzilla.com",
+                                                   "street-address": "123 mozilla",
+                                                   "name": "John",
+                                                   "organization": "Mozilla",
+                                                   "postal-code": "12345",
+                                                   "country": "USA"]]
+        let mockAddressScriptMessage = MockWKScriptMessage(
+            name: FormAutofillHelper.HandlerName.addressFormMessageHandler.rawValue,
+            body: mockBody)
+
+        // Create an expectation for the closure to be called
+        let expectation = XCTestExpectation(description: "foundFieldValues closure should be called")
+
+        // Set up the closure to fulfill the expectation
+        formAutofillHelper.foundFieldValues = { payload, _, _ in
+            XCTAssertEqual(payload.fieldValue, .address)
+            expectation.fulfill()
+        }
+
+        // Test user content controller's didReceiveScriptMessage method with the mock message
+        formAutofillHelper.userContentController(
+            WKUserContentController(),
+            didReceiveScriptMessage: mockAddressScriptMessage)
+
+        // Wait for the expectation to be fulfilled
+        wait(for: [expectation], timeout: 2.0)
+    }
+
+    func testUserContentControllerDidReceiveScriptMessage_withCreditCardHandler() {
+        let formAutofillHelper = FormAutofillHelper(tab: tab)
+
+        // Create a mock WKScriptMessage with handler name "creditCardFormMessageHandler"
+        let mockBody: [String: Any] = ["type": "fill-credit-card-form",
+                                       "payload": ["cc-number": "1234567812345678",
+                                                   "cc-name": "John Doe",
+                                                   "cc-exp-month": "12",
+                                                   "cc-exp": "12",
+                                                   "cc-exp-year": "2023"]]
+        let mockCreditCardScriptMessage = MockWKScriptMessage(
+            name: FormAutofillHelper.HandlerName.creditCardFormMessageHandler.rawValue,
+            body: mockBody)
+
+        // Create an expectation for the closure to be called
+        let expectation = XCTestExpectation(description: "foundFieldValues closure should be called")
+
+        // Set up the closure to fulfill the expectation
+        formAutofillHelper.foundFieldValues = { payload, _, _ in
+            XCTAssertEqual(payload.fieldValue, .creditCard)
+            expectation.fulfill()
+        }
+
+        // Test user content controller's didReceiveScriptMessage method with the mock message
+        formAutofillHelper.userContentController(
+            WKUserContentController(),
+            didReceiveScriptMessage: mockCreditCardScriptMessage)
+
+        // Wait for the expectation to be fulfilled
+        wait(for: [expectation], timeout: 1.0)
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8427)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18681)

## :bulb: Description
Implement a feature that enables the system to detect when an address form is identified. Upon detection, it triggers an action to display the address autofill accessory view. This ensures that users are provided with autofill suggestions tailored to address fields when filling out forms.
To test this work you need to change the following  and then navigate to firefox-ios folder on your terminal and run npm run dev  
<img width="1153" alt="Screenshot 2024-02-12 at 5 16 31 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/11262696/af9eb0c3-c5d4-49d4-9df4-6cc60629660b">


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

