### PR TITLE
Bugfix FXIOS-8363 [v124] Opening new tab opens keyboard overlay

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
@@ -7,10 +7,13 @@ import Redux
 
 enum GeneralBrowserAction: Action {
     case showToast(ToastTypeContext)
+    case showKeyboard(KeyboardContext)
 
     var windowUUID: UUID {
         switch self {
         case .showToast(let context as ActionContext):
+            return context.windowUUID
+        case .showKeyboard(let context as ActionContext):
             return context.windowUUID
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
@@ -7,13 +7,13 @@ import Redux
 
 enum GeneralBrowserAction: Action {
     case showToast(ToastTypeContext)
-    case showKeyboard(KeyboardContext)
+    case showOverlay(KeyboardContext)
 
     var windowUUID: UUID {
         switch self {
         case .showToast(let context as ActionContext):
             return context.windowUUID
-        case .showKeyboard(let context as ActionContext):
+        case .showOverlay(let context as ActionContext):
             return context.windowUUID
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -50,7 +50,7 @@ struct BrowserViewControllerState: ScreenState, Equatable {
         showDataClearanceFlow: Bool,
         fakespotState: FakespotState,
         toast: ToastType? = nil,
-        keyboardState: Bool,
+        keyboardState: Bool = false,
         windowUUID: WindowUUID
     ) {
         self.searchScreenState = searchScreenState
@@ -73,7 +73,6 @@ struct BrowserViewControllerState: ScreenState, Equatable {
                 usePrivateHomepage: privacyState,
                 showDataClearanceFlow: privacyState,
                 fakespotState: state.fakespotState,
-                keyboardState: state.keyboardState,
                 windowUUID: state.windowUUID)
         case FakespotAction.pressedShoppingButton,
             FakespotAction.show,
@@ -92,7 +91,6 @@ struct BrowserViewControllerState: ScreenState, Equatable {
                 usePrivateHomepage: state.usePrivateHomepage,
                 showDataClearanceFlow: state.showDataClearanceFlow,
                 fakespotState: FakespotState.reducer(state.fakespotState, action),
-                keyboardState: state.keyboardState,
                 windowUUID: state.windowUUID)
         case GeneralBrowserAction.showToast(let context):
             let toastType = context.toastType
@@ -102,7 +100,6 @@ struct BrowserViewControllerState: ScreenState, Equatable {
                 showDataClearanceFlow: state.showDataClearanceFlow,
                 fakespotState: state.fakespotState,
                 toast: toastType,
-                keyboardState: state.keyboardState,
                 windowUUID: state.windowUUID)
         case GeneralBrowserAction.showKeyboard(let context):
             let keyboardState = context.keyboardShowing

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -12,7 +12,7 @@ struct BrowserViewControllerState: ScreenState, Equatable {
     var showDataClearanceFlow: Bool
     var fakespotState: FakespotState
     var toast: ToastType?
-    var keyboardState: Bool
+    var showOverlay: Bool
 
     init(appState: AppState, uuid: WindowUUID) {
         guard let bvcState = store.state.screenState(
@@ -29,7 +29,7 @@ struct BrowserViewControllerState: ScreenState, Equatable {
                   showDataClearanceFlow: bvcState.showDataClearanceFlow,
                   fakespotState: bvcState.fakespotState,
                   toast: bvcState.toast,
-                  keyboardState: bvcState.keyboardState,
+                  showOverlay: bvcState.showOverlay,
                   windowUUID: bvcState.windowUUID)
     }
 
@@ -40,7 +40,7 @@ struct BrowserViewControllerState: ScreenState, Equatable {
             showDataClearanceFlow: false,
             fakespotState: FakespotState(windowUUID: windowUUID),
             toast: nil,
-            keyboardState: false,
+            showOverlay: false,
             windowUUID: windowUUID)
     }
 
@@ -50,7 +50,7 @@ struct BrowserViewControllerState: ScreenState, Equatable {
         showDataClearanceFlow: Bool,
         fakespotState: FakespotState,
         toast: ToastType? = nil,
-        keyboardState: Bool = false,
+        showOverlay: Bool = false,
         windowUUID: WindowUUID
     ) {
         self.searchScreenState = searchScreenState
@@ -59,7 +59,7 @@ struct BrowserViewControllerState: ScreenState, Equatable {
         self.fakespotState = fakespotState
         self.toast = toast
         self.windowUUID = windowUUID
-        self.keyboardState = keyboardState
+        self.showOverlay = showOverlay
     }
 
     static let reducer: Reducer<Self> = { state, action in
@@ -101,14 +101,14 @@ struct BrowserViewControllerState: ScreenState, Equatable {
                 fakespotState: state.fakespotState,
                 toast: toastType,
                 windowUUID: state.windowUUID)
-        case GeneralBrowserAction.showKeyboard(let context):
-            let keyboardState = context.keyboardShowing
+        case GeneralBrowserAction.showOverlay(let context):
+            let showOverlay = context.showOverlay
             return BrowserViewControllerState(
                 searchScreenState: state.searchScreenState,
                 usePrivateHomepage: state.usePrivateHomepage,
                 showDataClearanceFlow: state.showDataClearanceFlow,
                 fakespotState: state.fakespotState,
-                keyboardState: keyboardState,
+                showOverlay: showOverlay,
                 windowUUID: state.windowUUID)
         default:
             return state

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -12,6 +12,7 @@ struct BrowserViewControllerState: ScreenState, Equatable {
     var showDataClearanceFlow: Bool
     var fakespotState: FakespotState
     var toast: ToastType?
+    var keyboardState: Bool
 
     init(appState: AppState, uuid: WindowUUID) {
         guard let bvcState = store.state.screenState(
@@ -28,6 +29,7 @@ struct BrowserViewControllerState: ScreenState, Equatable {
                   showDataClearanceFlow: bvcState.showDataClearanceFlow,
                   fakespotState: bvcState.fakespotState,
                   toast: bvcState.toast,
+                  keyboardState: bvcState.keyboardState,
                   windowUUID: bvcState.windowUUID)
     }
 
@@ -38,6 +40,7 @@ struct BrowserViewControllerState: ScreenState, Equatable {
             showDataClearanceFlow: false,
             fakespotState: FakespotState(windowUUID: windowUUID),
             toast: nil,
+            keyboardState: false,
             windowUUID: windowUUID)
     }
 
@@ -47,6 +50,7 @@ struct BrowserViewControllerState: ScreenState, Equatable {
         showDataClearanceFlow: Bool,
         fakespotState: FakespotState,
         toast: ToastType? = nil,
+        keyboardState: Bool,
         windowUUID: WindowUUID
     ) {
         self.searchScreenState = searchScreenState
@@ -55,6 +59,7 @@ struct BrowserViewControllerState: ScreenState, Equatable {
         self.fakespotState = fakespotState
         self.toast = toast
         self.windowUUID = windowUUID
+        self.keyboardState = keyboardState
     }
 
     static let reducer: Reducer<Self> = { state, action in
@@ -68,6 +73,7 @@ struct BrowserViewControllerState: ScreenState, Equatable {
                 usePrivateHomepage: privacyState,
                 showDataClearanceFlow: privacyState,
                 fakespotState: state.fakespotState,
+                keyboardState: state.keyboardState,
                 windowUUID: state.windowUUID)
         case FakespotAction.pressedShoppingButton,
             FakespotAction.show,
@@ -86,6 +92,7 @@ struct BrowserViewControllerState: ScreenState, Equatable {
                 usePrivateHomepage: state.usePrivateHomepage,
                 showDataClearanceFlow: state.showDataClearanceFlow,
                 fakespotState: FakespotState.reducer(state.fakespotState, action),
+                keyboardState: state.keyboardState,
                 windowUUID: state.windowUUID)
         case GeneralBrowserAction.showToast(let context):
             let toastType = context.toastType
@@ -95,6 +102,15 @@ struct BrowserViewControllerState: ScreenState, Equatable {
                 showDataClearanceFlow: state.showDataClearanceFlow,
                 fakespotState: state.fakespotState,
                 toast: toastType,
+                keyboardState: state.keyboardState,
+                windowUUID: state.windowUUID)
+        case GeneralBrowserAction.showKeyboard(let context):
+            return BrowserViewControllerState(
+                searchScreenState: state.searchScreenState,
+                usePrivateHomepage: state.usePrivateHomepage,
+                showDataClearanceFlow: state.showDataClearanceFlow,
+                fakespotState: state.fakespotState,
+                keyboardState: state.keyboardState,
                 windowUUID: state.windowUUID)
         default:
             return state

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -105,12 +105,13 @@ struct BrowserViewControllerState: ScreenState, Equatable {
                 keyboardState: state.keyboardState,
                 windowUUID: state.windowUUID)
         case GeneralBrowserAction.showKeyboard(let context):
+            let keyboardState = context.keyboardShowing
             return BrowserViewControllerState(
                 searchScreenState: state.searchScreenState,
                 usePrivateHomepage: state.usePrivateHomepage,
                 showDataClearanceFlow: state.showDataClearanceFlow,
                 fakespotState: state.fakespotState,
-                keyboardState: state.keyboardState,
+                keyboardState: keyboardState,
                 windowUUID: state.windowUUID)
         default:
             return state

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -547,7 +547,7 @@ class BrowserViewController: UIViewController,
                 self.showToastType(toast: toast)
             }
 
-            if state.keyboardState == true {
+            if state.showOverlay == true {
                 overlayManager.openNewTab(url: nil, newTabSettings: newTabSettings)
             }
         }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -548,8 +548,7 @@ class BrowserViewController: UIViewController,
             }
 
             if state.keyboardState == true {
-                _ = urlBar.becomeFirstResponder()
-                
+                overlayManager.openNewTab(url: nil, newTabSettings: newTabSettings)
             }
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -546,6 +546,11 @@ class BrowserViewController: UIViewController,
             if let toast = state.toast {
                 self.showToastType(toast: toast)
             }
+
+            if state.keyboardState == true {
+                _ = urlBar.becomeFirstResponder()
+                
+            }
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
@@ -73,6 +73,14 @@ class ToastTypeContext: ActionContext {
     }
 }
 
+class KeyboardContext: ActionContext {
+    let keyboardShowing: Bool
+    init(keyboardShowing: Bool, windowUUID: WindowUUID) {
+        self.keyboardShowing = keyboardShowing
+        super.init(windowUUID: windowUUID)
+    }
+}
+
 class RefreshTabContext: ActionContext {
     let tabDisplayModel: TabDisplayModel
     init(tabDisplayModel: TabDisplayModel, windowUUID: WindowUUID) {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
@@ -74,9 +74,9 @@ class ToastTypeContext: ActionContext {
 }
 
 class KeyboardContext: ActionContext {
-    let keyboardShowing: Bool
-    init(keyboardShowing: Bool, windowUUID: WindowUUID) {
-        self.keyboardShowing = keyboardShowing
+    let showOverlay: Bool
+    init(showOverlay: Bool, windowUUID: WindowUUID) {
+        self.showOverlay = showOverlay
         super.init(windowUUID: windowUUID)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -217,6 +217,7 @@ class TabManagerMiddleware {
         let model = getTabsDisplayModel(for: isPrivate, shouldScrollToTab: true, uuid: uuid)
         store.dispatch(TabPanelAction.refreshTab(RefreshTabContext(tabDisplayModel: model, windowUUID: uuid)))
         store.dispatch(TabTrayAction.dismissTabTray(uuid.context))
+        store.dispatch(GeneralBrowserAction.showKeyboard(KeyboardContext(keyboardShowing: true, windowUUID: uuid)))
     }
 
     /// Move tab on `TabManager` array to support drag and drop

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -217,7 +217,7 @@ class TabManagerMiddleware {
         let model = getTabsDisplayModel(for: isPrivate, shouldScrollToTab: true, uuid: uuid)
         store.dispatch(TabPanelAction.refreshTab(RefreshTabContext(tabDisplayModel: model, windowUUID: uuid)))
         store.dispatch(TabTrayAction.dismissTabTray(uuid.context))
-        store.dispatch(GeneralBrowserAction.showKeyboard(KeyboardContext(keyboardShowing: true, windowUUID: uuid)))
+        store.dispatch(GeneralBrowserAction.showOverlay(KeyboardContext(showOverlay: true, windowUUID: uuid)))
     }
 
     /// Move tab on `TabManager` array to support drag and drop


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8363)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18517)

## :bulb: Description
Added showOverlay Bool property to the BrowserViewControllerState so that we can call `overlayManager.openNewTab()` when it's set to true (default is false)

https://github.com/mozilla-mobile/firefox-ios/assets/5545720/556572e7-ae69-4bfd-925b-9645bb2005fc


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

