### PR TITLE
Refactor FXIOS-8428 [v125] Use single name field for addresses & update SPM with latest rust-component 125.0.20240226160923

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -21265,7 +21265,7 @@
 			repositoryURL = "https://github.com/mozilla/rust-components-swift.git";
 			requirement = {
 				kind = exactVersion;
-				version = 125.0.20240222050253;
+				version = 125.0.20240226160923;
 			};
 		};
 		435C85EE2788F4D00072B526 /* XCRemoteSwiftPackageReference "glean-swift" */ = {

--- a/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla/rust-components-swift.git",
       "state" : {
-        "revision" : "e8697f9fa64537558dcf7cf2b14502eaa5f3770d",
-        "version" : "125.0.20240222050253"
+        "revision" : "bd033893e2602ad0f6d0a3b93c6491a176afe527",
+        "version" : "125.0.20240226160923"
       }
     },
     {

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressCellView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressCellView.swift
@@ -34,7 +34,7 @@ struct AddressCellView: View {
                         .foregroundColor(iconPrimary)
                         .offset(y: -14)
                     VStack(alignment: .leading) {
-                        Text(address.fullName)
+                        Text(address.name)
                             .font(.body)
                             .foregroundColor(textColor)
                         Text(address.streetAddress)

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
@@ -15,10 +15,6 @@ import Storage
 
 // TODO: Refactor the Address extension for global usage (FXIOS-8337)
 extension Address {
-    var fullName: String {
-        return "\(givenName) \(familyName)"
-    }
-
     var addressCityStateZipcode: String {
         return "\(addressLevel2), \(addressLevel1) \(postalCode)"
     }

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -46,9 +46,7 @@ class RustAutofillTests: XCTestCase {
 
     func addAddress(completion: @escaping (Address?, Error?) -> Void) {
         let address = UpdatableAddressFields(
-            givenName: "Jane",
-            additionalName: "",
-            familyName: "Doe",
+            name: "Jane Doe",
             organization: "",
             streetAddress: "123 Second Avenue",
             addressLevel3: "",
@@ -72,8 +70,7 @@ class RustAutofillTests: XCTestCase {
                 return
             }
 
-            XCTAssertEqual(address.givenName, "Jane")
-            XCTAssertEqual(address.familyName, "Doe")
+            XCTAssertEqual(address.name, "Jane Doe")
             XCTAssertEqual(address.streetAddress, "123 Second Avenue")
             XCTAssertEqual(address.addressLevel2, "Chicago, IL")
             XCTAssertEqual(address.country, "United States")
@@ -104,8 +101,7 @@ class RustAutofillTests: XCTestCase {
 
             // Assert on individual addresses in the list
             for address in addresses ?? [] {
-                XCTAssertEqual(address.givenName, "Jane")
-                XCTAssertEqual(address.familyName, "Doe")
+                XCTAssertEqual(address.name, "Jane Doe")
                 XCTAssertEqual(address.streetAddress, "123 Second Avenue")
                 XCTAssertEqual(address.addressLevel2, "Chicago, IL")
                 XCTAssertEqual(address.country, "United States")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8428)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18688)

## :bulb: Description
This PR (is):
- Updates address types to have a single `name` field instead of 3 `*-name` fields
- Blocked by this PR https://github.com/mozilla/application-services/pull/6118 in a-s


ℹ️ **Note:** I built the a-s change locally and all tests related to addresses are passing

<img width="630" alt="Screenshot 2024-02-13 at 15 05 04" src="https://github.com/mozilla-mobile/firefox-ios/assets/26678795/3d334b94-27ff-424a-9414-08888e882d4c">

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] ~When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)~
- [ ] ~If needed I updated documentation / comments for complex code and public methods~

