### PR TITLE
Refactor MTE-2296 [v124] Add next version to the PRs Automatically

### DIFF
--- a/.github/workflows/firefox-check-rust-component-dependency.yml
+++ b/.github/workflows/firefox-check-rust-component-dependency.yml
@@ -20,43 +20,64 @@ jobs:
       with:
         persist-credentials: false 
         token: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r ./test-fixtures/requirements.txt
+
     - name: Modifing Swift Package dependencies
       run: |
         python ./test-fixtures/update-rust-component-version.py
+
     - name: Get new A-S tag to be used in the PR info
       run: |
         cd test-fixtures/
         chmod u+x read-rust-component-tag.sh
-        echo "version=$(./read-rust-component-tag.sh)" >> $GITHUB_ENV
+        echo "rust_version=$(./read-rust-component-tag.sh)" >> $GITHUB_ENV
+
     - name: Remove temp file created to store the tag info
       run: |
         cd test-fixtures/
         [ ! -e newest_tag.txt ] || rm newest_tag.txt
+
     - name: Script to check if branch exists to not commit again
       run: |-
         branch=$(curl -X GET -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/mozilla-mobile/firefox-ios/branches?per_page=100 | jq -r '.[].name | select(contains("update-spm-new-rust-component-tag-${{ env.version }}"))')
         echo $branch
         if [ -z "$branch" ]; then echo "BRANCH_CREATED=false" >> $GITHUB_ENV; else echo "BRANCH_CREATED=true"  >> $GITHUB_ENV;fi
+ 
+    - name: Determine PR Version Number
+      id: versioning
+      run: |
+        # This step is used to determine the next version number for the PR title
+        # The output includes debugging for the piped commands that generate
+        # the version number and the last line is the version number itself
+
+        output=$(bash test-fixtures/ci/get-next-pr-version)
+        echo "$output"
+        next_version=$(echo "$output" | tail -n 1) # get the last line of the output
+        echo "Next Firefox iOS version is: v${next_version}"
+        echo "next_app_version=${next_version}" >> $GITHUB_ENV
+
     - name: Update rust-component version
       if: env.BRANCH_CREATED == 'false'
       run: |-
         git diff
          git diff --quiet || (git add firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved firefox-ios/Client.xcodeproj/project.pbxproj)
+
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3
       if: env.BRANCH_CREATED == 'false'
       with:
-        commit-message: Auto update SPM with latest rust-component release ${{ env.version }}
+        commit-message: Auto update SPM with latest rust-component release ${{ env.rust_version }}
         author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
         committer: GitHub <noreply@github.com>
-        title: Refactor [vXXX] Auto update SPM with latest rust-component ${{ env.version }}
-        branch: update-spm-new-rust-component-tag-${{ env.version }}
+        title: Refactor [v${{ env.next_app_version }}] Auto update SPM with latest rust-component ${{ env.rust_version }}
+        branch: update-spm-new-rust-component-tag-${{ env.rust_version }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/firefox-check-rust-component-dependency.yml
+++ b/.github/workflows/firefox-check-rust-component-dependency.yml
@@ -48,7 +48,7 @@ jobs:
 
     - name: Script to check if branch exists to not commit again
       run: |-
-        branch=$(curl -X GET -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/mozilla-mobile/firefox-ios/branches?per_page=100 | jq -r '.[].name | select(contains("update-spm-new-rust-component-tag-${{ env.version }}"))')
+        branch=$(curl -X GET -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/mozilla-mobile/firefox-ios/branches?per_page=100 | jq -r '.[].name | select(contains("update-spm-new-rust-component-tag-${{ env.rust_version }}"))')
         echo $branch
         if [ -z "$branch" ]; then echo "BRANCH_CREATED=false" >> $GITHUB_ENV; else echo "BRANCH_CREATED=true"  >> $GITHUB_ENV;fi
  
@@ -69,7 +69,8 @@ jobs:
       if: env.BRANCH_CREATED == 'false'
       run: |-
         git diff
-         git diff --quiet || (git add firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved firefox-ios/Client.xcodeproj/project.pbxproj)
+        git diff --quiet || (git add firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved firefox-ios/Client.xcodeproj/project.pbxproj)
+        git commit --allow-empty -m "empty commit for testing"
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/firefox-ios-import-strings.yml
+++ b/.github/workflows/firefox-ios-import-strings.yml
@@ -22,12 +22,15 @@ jobs:
         persist-credentials: false
         token: ${{ secrets.GITHUB_TOKEN }}
         ref: ${{ github.event.inputs.branchName }}
+
     - name: Select Xcode ${{ matrix.xcode }}
       run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Get PR info
       run: |
         current_date=$(date +"%Y-%m-%d")
@@ -45,12 +48,28 @@ jobs:
           echo "pr_title=Localize [$version] String import $current_date" >> $GITHUB_ENV
           echo "pr_body=This automated PR imports string changes into branch '$current_branch'" >> $GITHUB_ENV
         fi
+
+    - name: Determine PR Version Number
+      id: versioning
+      run: |
+        # This step is used to determine the next version number for the PR title
+        # The output includes debugging for the piped commands that generate
+        # the version number and the last line is the version number itself
+
+        output=$(bash test-fixtures/ci/get-next-pr-version)
+        echo "$output"
+        next_version=$(echo "$output" | tail -n 1) # get the last line of the output
+        echo "Next version is: v${next_version}"
+        echo "next_version=${next_version}" >> $GITHUB_ENV
+
     - name: Run script to import strings
       run: sh ./bootstrap.sh --importLocales
+
     - name: Update new strings
       run: |-
         git diff || (git add firefox-ios/Shared/*/*.lproj/* firefox-ios/Shared/*.lproj/* firefox-ios/WidgetKit/*.lproj/* firefox-ios/Client/*/*.lproj/* firefox-ios/Client/*.lproj/*)
         git restore firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v5
       with:
@@ -58,6 +77,6 @@ jobs:
         committer: GitHub <noreply@github.com>
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: ${{ env.pr_title }}
-        title: ${{ env.pr_title }}
+        title: "Localize [v${{ env.next_version }}] String import ${{ env.current_date }}"
         branch: ${{ env.branch_name }}
         body: ${{ env.pr_body }}

--- a/.github/workflows/firefox-ios-import-strings.yml
+++ b/.github/workflows/firefox-ios-import-strings.yml
@@ -31,24 +31,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Get PR info
-      run: |
-        current_date=$(date +"%Y-%m-%d")
-        # Use 'main' when triggered via cron
-        current_branch=${{ github.event.inputs.branchName || 'main' }}
-        echo "current_date=$current_date" >> $GITHUB_ENV
-        if [[ $current_branch == 'main' ]]; then
-          echo "branch_name=string-import-$current_date" >> $GITHUB_ENV
-          echo "pr_title=Localize [ver] String import $current_date" >> $GITHUB_ENV
-          echo "pr_body=This automated PR imports string changes" >> $GITHUB_ENV
-        else
-          # version: v105.0 -> v105
-          version=${current_branch%??}
-          echo "branch_name=string-import-$current_branch-$current_date" >> $GITHUB_ENV
-          echo "pr_title=Localize [$version] String import $current_date" >> $GITHUB_ENV
-          echo "pr_body=This automated PR imports string changes into branch '$current_branch'" >> $GITHUB_ENV
-        fi
-
     - name: Determine PR Version Number
       id: versioning
       run: |
@@ -61,6 +43,24 @@ jobs:
         next_version=$(echo "$output" | tail -n 1) # get the last line of the output
         echo "Next version is: v${next_version}"
         echo "next_version=${next_version}" >> $GITHUB_ENV
+  
+    - name: Get PR info
+      run: |
+        current_date=$(date +"%Y-%m-%d")
+        # Use 'main' when triggered via cron
+        current_branch=${{ github.event.inputs.branchName || 'main' }}
+        echo "current_date=$current_date" >> $GITHUB_ENV
+        if [[ $current_branch == 'main' ]]; then
+          echo "branch_name=string-import-$current_date" >> $GITHUB_ENV
+          echo "pr_title=Localize [v${{ env.next_version }}] String import $current_date" >> $GITHUB_ENV
+          echo "pr_body=This automated PR imports string changes" >> $GITHUB_ENV
+        else
+          # version: v105.0 -> v105
+          version=${current_branch%??}
+          echo "branch_name=string-import-$current_branch-$current_date" >> $GITHUB_ENV
+          echo "pr_title=Localize [$version] String import $current_date" >> $GITHUB_ENV
+          echo "pr_body=This automated PR imports string changes into branch '$current_branch'" >> $GITHUB_ENV
+        fi
 
     - name: Run script to import strings
       run: sh ./bootstrap.sh --importLocales

--- a/.github/workflows/firefox-ios-update-effective-tld-names-file.yml
+++ b/.github/workflows/firefox-ios-update-effective-tld-names-file.yml
@@ -43,14 +43,28 @@ jobs:
           echo "create_pr=true" >> $GITHUB_ENV
           cp tmp.dat firefox-ios/Shared/effective_tld_names.dat
           echo "branch_name=refactor-update-effective-tld-names" >> $GITHUB_ENV
-          echo "pr_title=Refactor [vXXX] Update effective_tld_names file $current_date" >> $GITHUB_ENV
           echo "pr_body=This automated PR updates the effective_tld_names file" >> $GITHUB_ENV
           rm tmp.dat
         fi
+
+    - name: Determine PR Version Number
+      id: versioning
+      run: |
+        # This step is used to determine the next version number for the PR title
+        # The output includes debugging for the piped commands that generate
+        # the version number and the last line is the version number itself
+        
+        output=$(bash test-fixtures/ci/get-next-pr-version)
+        echo "$output"
+        next_version=$(echo "$output" | tail -n 1) # get the last line of the output
+        echo "Next version is: v${next_version}"
+        echo "next_version=${next_version}" >> $GITHUB_ENV
+    
     - name: Add Modified File to PR
       if: ${{ env.create_pr }}
       run: |-
         git diff || (git add firefox-ios/Shared/effective_tld_names.dat)
+
     - name: Create Pull Request
       if: ${{ env.create_pr }}
       uses: peter-evans/create-pull-request@v3
@@ -60,5 +74,5 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: ${{ env.pr_title }}
         title: ${{ env.pr_title }}
-        branch: ${{ env.branch_name }}
+        branch: "Refactor [v${{ env.next_version }}] Update effective_tld_names file ${{ env.current_date }}"
         body: ${{ env.pr_body }}

--- a/.github/workflows/firefox-ios-update-effective-tld-names-file.yml
+++ b/.github/workflows/firefox-ios-update-effective-tld-names-file.yml
@@ -73,6 +73,6 @@ jobs:
         committer: GitHub <noreply@github.com>
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: ${{ env.pr_title }}
-        title: ${{ env.pr_title }}
-        branch: "Refactor [v${{ env.next_version }}] Update effective_tld_names file ${{ env.current_date }}"
+        title: "Refactor [v${{ env.next_version }}] Update effective_tld_names file ${{ env.current_date }}"
+        branch: ${{ env.branch_name }}
         body: ${{ env.pr_body }}

--- a/test-fixtures/ci/get-next-pr-version
+++ b/test-fixtures/ci/get-next-pr-version
@@ -93,8 +93,9 @@ commands=("git ls-remote" "grep 'refs/heads/release/v'" "awk -F'/'" "sort -Vr" "
 for i in "${!return_codes[@]}"; do
   echo "Command ${commands[$i]} exited with code ${return_codes[$i]}"
   if [ "${return_codes[$i]}" -ne 0 ]; then
+    # Github Actions that use the branch name as a build parameter for the version number
+    # shouldn't fail if this script fails. Don't exit with a non-zero status here. 
     echo "Failure in pipeline at command index: $i with exit code ${return_codes[$i]}"
-    exit 1
   fi
 done
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2296)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description

I've updated the following Github Actions to use the `get-pr-next-version` script to automatically update the pr title portion `[vXXX]` to now contain the `next version`, `[v124]`

- firefox-ios-update-effective-tld-names
- firefox-ios-import-strings
- firefox-check-rust-component-dependency

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

