### PR TITLE
Bugfix FXIOS-8432 [v124] Check URL before opening from drag and drop

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+UIDropInteractionDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+UIDropInteractionDelegate.swift
@@ -27,7 +27,7 @@ extension BrowserViewController: UIDropInteractionDelegate {
         TelemetryWrapper.recordEvent(category: .action, method: .drop, object: .url, value: .browser)
 
         _ = session.loadObjects(ofClass: URL.self) { urls in
-            guard let url = urls.first else { return }
+            guard let draggedUrl = urls.first, let url = URIFixup.getURL(draggedUrl.absoluteString) else { return }
 
             self.finishEditingAndSubmit(url, visitType: VisitType.typed, forTab: tab)
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8432)
No Github issue

## :bulb: Description
Check URL before opening from drag and drop

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

