### PR TITLE
Add FXIOS-8410 [v124] Standardize Fonts

### DIFF
--- a/BrowserKit/Sources/Common/Utilities/FXFontStyles.swift
+++ b/BrowserKit/Sources/Common/Utilities/FXFontStyles.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import UIKit
 
 // This class contains the Firefox iOS type styles as part of our design system
 public struct FXFontStyles {
@@ -33,26 +32,5 @@ public struct FXFontStyles {
         public static let footnote = TextStyling(for: .footnote, size: 13, weight: .semibold)
         public static let caption1 = TextStyling(for: .caption1, size: 12, weight: .medium)
         public static let caption2 = TextStyling(for: .caption2, size: 11, weight: .semibold)
-    }
-}
-
-// This class should only be instantiated in FXFontStyles
-public struct TextStyling {
-    private let textStyle: UIFont.TextStyle
-    private let size: CGFloat
-    private let weight: UIFont.Weight
-
-    init(for textStyle: UIFont.TextStyle, size: CGFloat, weight: UIFont.Weight) {
-        self.textStyle = textStyle
-        self.size = size
-        self.weight = weight
-    }
-
-    public func scaledFont() -> UIFont {
-        return DefaultDynamicFontHelper.preferredFont(withTextStyle: textStyle, size: size, weight: weight)
-    }
-
-    public func systemFont() -> UIFont {
-        return UIFont.systemFont(ofSize: size, weight: weight)
     }
 }

--- a/BrowserKit/Sources/Common/Utilities/FontStyle.swift
+++ b/BrowserKit/Sources/Common/Utilities/FontStyle.swift
@@ -6,7 +6,7 @@ import Foundation
 import UIKit
 
 // This class contains the Firefox iOS type styles as part of our design system
-public struct FXFontStylez {
+public struct FXFontStyles {
     public struct Regular {
         public static let largeTitle = TextStyling(for: .largeTitle, size: 34, weight: .regular)
         public static let title1 = TextStyling(for: .title1, size: 28, weight: .regular)

--- a/BrowserKit/Sources/Common/Utilities/FontStyle.swift
+++ b/BrowserKit/Sources/Common/Utilities/FontStyle.swift
@@ -36,7 +36,7 @@ public struct FXFontStyles {
     }
 }
 
-// This class should only be instantiated in FXFontStyles, the functions are only called in
+// This class should only be instantiated in FXFontStyles
 public struct TextStyling {
     private let textStyle: UIFont.TextStyle
     private let size: CGFloat

--- a/BrowserKit/Sources/Common/Utilities/FontStyle.swift
+++ b/BrowserKit/Sources/Common/Utilities/FontStyle.swift
@@ -56,4 +56,3 @@ public struct TextStyling {
         return UIFont.systemFont(ofSize: size, weight: weight)
     }
 }
-

--- a/BrowserKit/Sources/Common/Utilities/FontStyle.swift
+++ b/BrowserKit/Sources/Common/Utilities/FontStyle.swift
@@ -1,0 +1,58 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import UIKit
+
+// This class contains the Firefox iOS type styles as part of our design system
+public struct FXFontStylez {
+    public struct Regular {
+        public static let largeTitle = TextStyling(for: .largeTitle, size: 34, weight: .regular)
+        public static let title1 = TextStyling(for: .title1, size: 28, weight: .regular)
+        public static let title2 = TextStyling(for: .title2, size: 22, weight: .regular)
+        public static let title3 = TextStyling(for: .title3, size: 20, weight: .regular)
+        public static let headline = TextStyling(for: .headline, size: 17, weight: .semibold)
+        public static let body = TextStyling(for: .body, size: 17, weight: .regular)
+        public static let callout = TextStyling(for: .callout, size: 16, weight: .regular)
+        public static let subheadline = TextStyling(for: .subheadline, size: 15, weight: .regular)
+        public static let footnote = TextStyling(for: .footnote, size: 13, weight: .regular)
+        public static let caption1 = TextStyling(for: .caption1, size: 12, weight: .regular)
+        public static let caption2 = TextStyling(for: .caption2, size: 11, weight: .regular)
+    }
+
+    public struct Bold {
+        public static let largeTitle = TextStyling(for: .largeTitle, size: 34, weight: .bold)
+        public static let title1 = TextStyling(for: .title1, size: 28, weight: .bold)
+        public static let title2 = TextStyling(for: .title2, size: 22, weight: .bold)
+        public static let title3 = TextStyling(for: .title3, size: 20, weight: .semibold)
+        public static let headline = TextStyling(for: .headline, size: 17, weight: .semibold)
+        public static let body = TextStyling(for: .body, size: 17, weight: .semibold)
+        public static let callout = TextStyling(for: .callout, size: 16, weight: .semibold)
+        public static let subheadline = TextStyling(for: .subheadline, size: 15, weight: .semibold)
+        public static let footnote = TextStyling(for: .footnote, size: 13, weight: .semibold)
+        public static let caption1 = TextStyling(for: .caption1, size: 12, weight: .medium)
+        public static let caption2 = TextStyling(for: .caption2, size: 11, weight: .semibold)
+    }
+}
+
+public struct TextStyling {
+    private let textStyle: UIFont.TextStyle
+    private let size: CGFloat
+    private let weight: UIFont.Weight
+
+    init(for textStyle: UIFont.TextStyle, size: CGFloat, weight: UIFont.Weight) {
+        self.textStyle = textStyle
+        self.size = size
+        self.weight = weight
+    }
+
+    public func scaledFont() -> UIFont {
+        DefaultDynamicFontHelper.preferredFont(withTextStyle: textStyle, size: size, weight: weight)
+    }
+
+    public func systemFont() -> UIFont {
+        UIFont.systemFont(ofSize: size, weight: weight)
+    }
+}
+

--- a/BrowserKit/Sources/Common/Utilities/FontStyle.swift
+++ b/BrowserKit/Sources/Common/Utilities/FontStyle.swift
@@ -36,6 +36,7 @@ public struct FXFontStyles {
     }
 }
 
+// This class should only be instantiated in FXFontStyles, the functions are only called in
 public struct TextStyling {
     private let textStyle: UIFont.TextStyle
     private let size: CGFloat
@@ -48,11 +49,11 @@ public struct TextStyling {
     }
 
     public func scaledFont() -> UIFont {
-        DefaultDynamicFontHelper.preferredFont(withTextStyle: textStyle, size: size, weight: weight)
+        return DefaultDynamicFontHelper.preferredFont(withTextStyle: textStyle, size: size, weight: weight)
     }
 
     public func systemFont() -> UIFont {
-        UIFont.systemFont(ofSize: size, weight: weight)
+        return UIFont.systemFont(ofSize: size, weight: weight)
     }
 }
 

--- a/BrowserKit/Sources/Common/Utilities/TextStyling.swift
+++ b/BrowserKit/Sources/Common/Utilities/TextStyling.swift
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import UIKit
+
+// This class should only be instantiated in FXFontStyles
+public struct TextStyling {
+    private let textStyle: UIFont.TextStyle
+    private let size: CGFloat
+    private let weight: UIFont.Weight
+
+    init(for textStyle: UIFont.TextStyle, size: CGFloat, weight: UIFont.Weight) {
+        self.textStyle = textStyle
+        self.size = size
+        self.weight = weight
+    }
+
+    public func scaledFont() -> UIFont {
+        return DefaultDynamicFontHelper.preferredFont(withTextStyle: textStyle, size: size, weight: weight)
+    }
+
+    public func systemFont() -> UIFont {
+        return UIFont.systemFont(ofSize: size, weight: weight)
+    }
+}

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/PrimaryRoundedButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/PrimaryRoundedButton.swift
@@ -10,7 +10,6 @@ public class PrimaryRoundedButton: ResizableButton, ThemeApplicable {
         static let buttonCornerRadius: CGFloat = 12
         static let buttonVerticalInset: CGFloat = 12
         static let buttonHorizontalInset: CGFloat = 16
-        static let buttonFontSize: CGFloat = 16
 
         static let contentInsets = NSDirectionalEdgeInsets(
             top: buttonVerticalInset,
@@ -52,10 +51,7 @@ public class PrimaryRoundedButton: ResizableButton, ThemeApplicable {
         // swiftlint:enable line_length
             var container = incoming
             container.foregroundColor = self?.foregroundColor
-            container.font = DefaultDynamicFontHelper.preferredBoldFont(
-                withTextStyle: .callout,
-                size: UX.buttonFontSize
-            )
+            container.font = FXFontStylez.Bold.callout.scaledFont()
             return container
         }
 

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/PrimaryRoundedButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/PrimaryRoundedButton.swift
@@ -51,7 +51,7 @@ public class PrimaryRoundedButton: ResizableButton, ThemeApplicable {
         // swiftlint:enable line_length
             var container = incoming
             container.foregroundColor = self?.foregroundColor
-            container.font = FXFontStylez.Bold.callout.scaledFont()
+            container.font = FXFontStyles.Bold.callout.scaledFont()
             return container
         }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8410)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This proposal is to standardize our fonts in our codebase so that it matches our type systems defined in Figma. After noticing inconsistencies in how we set fonts, I hope we can use `FXFontStyles` going forward. 

One example on its usage is provided in this PR, we can create contributor tickets for modifying the other fonts.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

