### PR TITLE
Refactor FXIOS-8430 [v124] ContentBlocker.compileListsNotInStore  with DispatchGroup instead of Deferred lib

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -970,6 +970,7 @@
 		BD57D9A729D4C42B00039394 /* ZoomLevelStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD57D9A629D4C42B00039394 /* ZoomLevelStoreTests.swift */; };
 		BD6B361E2B3C2511005E5345 /* CircularProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6B361D2B3C2511005E5345 /* CircularProgressView.swift */; };
 		BD6CC84229CDDA3400546A5D /* ZoomLevelStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6CC84129CDDA3400546A5D /* ZoomLevelStore.swift */; };
+		C2200A6A2B7D148C00DC062A /* ContentBlockerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2200A692B7D148C00DC062A /* ContentBlockerTests.swift */; };
 		C22753402A3C9E1300B9C0D1 /* WebsiteDataManagementViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C227533F2A3C9E1300B9C0D1 /* WebsiteDataManagementViewModel.swift */; };
 		C2296FCC2A601C190046ECA6 /* IntensityVisualEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2296FCB2A601C190046ECA6 /* IntensityVisualEffectView.swift */; };
 		C23889DF2A4EFCE500429673 /* ShareExtensionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23889DE2A4EFCE500429673 /* ShareExtensionCoordinator.swift */; };
@@ -6357,6 +6358,7 @@
 		C1C54E119D804703437D116C /* kab */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kab; path = kab.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
 		C1DF4F71AB33BAB7B199F361 /* si */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = si; path = si.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		C1F24EFFB6E9B114849A4DB3 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
+		C2200A692B7D148C00DC062A /* ContentBlockerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentBlockerTests.swift; sourceTree = "<group>"; };
 		C227533F2A3C9E1300B9C0D1 /* WebsiteDataManagementViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebsiteDataManagementViewModel.swift; sourceTree = "<group>"; };
 		C2296FCB2A601C190046ECA6 /* IntensityVisualEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntensityVisualEffectView.swift; sourceTree = "<group>"; };
 		C23889DE2A4EFCE500429673 /* ShareExtensionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareExtensionCoordinator.swift; sourceTree = "<group>"; };
@@ -11495,6 +11497,7 @@
 				8A28C627291028870078A81A /* CanRemoveQuickActionBookmarkTests.swift */,
 				F84B21D91A090F8100AAB793 /* ClientTests.swift */,
 				8A86DAD7277298DE00D7BFFF /* ClosedTabsStoreTests.swift */,
+				C2200A692B7D148C00DC062A /* ContentBlockerTests.swift */,
 				C889D7CD2858C4B500121E1D /* ContextMenuHelperTests.swift */,
 				8A93F86329D37314004159D9 /* Coordinators */,
 				43B658D729CE249D00C9EF08 /* CreditCard */,
@@ -14233,6 +14236,7 @@
 				F98CB66E2A4123F1005F38E9 /* EnhancedTrackingProtectionMenuVMTests.swift in Sources */,
 				DF8C6DD72A52EED1007FAAF2 /* ClientSyncManagerTests.swift in Sources */,
 				C2D1A1112A67E73D00205DCC /* BookmarksCoordinatorTests.swift in Sources */,
+				C2200A6A2B7D148C00DC062A /* ContentBlockerTests.swift in Sources */,
 				C869916328918C36007ACC5C /* WallpaperNetworkingModuleTests.swift in Sources */,
 				B640467E29B9B58200C5C7B6 /* TabLocationViewTests.swift in Sources */,
 				8ABA9C8D28931223002C0077 /* MockDispatchQueue.swift in Sources */,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ContentBlockerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ContentBlockerTests.swift
@@ -1,0 +1,25 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Client
+
+final class ContentBlockerTests: XCTestCase {
+    func testCompileListsNotInStore_callsCompletionHandlerSuccessfully() {
+        ensureAllRulesAreRemovedFromStore()
+        let excpectation = XCTestExpectation()
+        ContentBlocker.shared.compileListsNotInStore {
+            excpectation.fulfill()
+        }
+        wait(for: [excpectation])
+    }
+
+    private func ensureAllRulesAreRemovedFromStore() {
+        let expectation = XCTestExpectation()
+        ContentBlocker.shared.removeAllRulesInStore {
+            expectation.fulfill()
+        }
+        wait(for: [expectation])
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ContentBlockerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ContentBlockerTests.swift
@@ -8,11 +8,11 @@ import XCTest
 final class ContentBlockerTests: XCTestCase {
     func testCompileListsNotInStore_callsCompletionHandlerSuccessfully() {
         ensureAllRulesAreRemovedFromStore()
-        let excpectation = XCTestExpectation()
+        let expectation = XCTestExpectation()
         ContentBlocker.shared.compileListsNotInStore {
-            excpectation.fulfill()
+            expectation.fulfill()
         }
-        wait(for: [excpectation])
+        wait(for: [expectation])
     }
 
     private func ensureAllRulesAreRemovedFromStore() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ContentBlockerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ContentBlockerTests.swift
@@ -6,18 +6,22 @@ import XCTest
 @testable import Client
 
 final class ContentBlockerTests: XCTestCase {
-    func testCompileListsNotInStore_callsCompletionHandlerSuccessfully() {
+    override func setUp() {
+        super.setUp()
         ensureAllRulesAreRemovedFromStore()
-        let expectation = XCTestExpectation()
-        ContentBlocker.shared.compileListsNotInStore {
-            expectation.fulfill()
-        }
-        wait(for: [expectation])
     }
 
     private func ensureAllRulesAreRemovedFromStore() {
         let expectation = XCTestExpectation()
         ContentBlocker.shared.removeAllRulesInStore {
+            expectation.fulfill()
+        }
+        wait(for: [expectation])
+    }
+
+    func testCompileListsNotInStore_callsCompletionHandlerSuccessfully() {
+        let expectation = XCTestExpectation()
+        ContentBlocker.shared.compileListsNotInStore {
             expectation.fulfill()
         }
         wait(for: [expectation])


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8430)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18694)

## :bulb: Description
Refactor `ContentBlocker.compileListsNotInStore` implementation with `DispatchGroup` instead of `Deferred` lib.
Add UnitTests for the refactored method.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

