### PR TITLE
Refactor [v124] Adjust codeowners for generate-metrics.sh to be fxios-eng

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,3 +19,4 @@ bitrise.yml @mozilla-mobile/fxios-automation-1
 /taskcluster @mozilla-mobile/fxios-automation-1
 .github/workflows @mozilla-mobile/fxios-automation-1
 /test-fixtures @mozilla-mobile/fxios-automation-1
+/test-fixtures/generate-metrics.sh @mozilla-mobile/fxios-eng


### PR DESCRIPTION
## :scroll: Tickets
No tickets

## :bulb: Description
Adjust codeowners to be `fxios-eng` on the `generate-metrics.sh` file to allow the eng team to be owners of the warnings threshold.

Note; the last matching pattern takes the most precedence. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

