### PR TITLE
Bugfix FXIOS-8416 [v124] Fix potential KVO crash if BVC is dellocated before unregistering

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2258,13 +2258,20 @@ extension BrowserViewController: LegacyTabDelegate {
     }
 
     private func beginObserving(webView: WKWebView) {
-        guard !observedWebViews.contains(webView) else { return }
+        guard !observedWebViews.contains(webView) else {
+            logger.log("Duplicate observance of webView", level: .warning, category: .webview)
+            return
+        }
         observedWebViews.insert(webView)
         KVOs.forEach { webView.addObserver(self, forKeyPath: $0.rawValue, options: .new, context: nil) }
     }
 
     private func stopObserving(webView: WKWebView?) {
         guard let webView else { return }
+        guard observedWebViews.contains(webView) else {
+            logger.log("Duplicate KVO de-registration of webView", level: .warning, category: .webview)
+            return
+        }
         observedWebViews.remove(webView)
         KVOs.forEach { webView.removeObserver(self, forKeyPath: $0.rawValue) }
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -86,6 +86,7 @@ class BrowserViewController: UIViewController,
     let shoppingContextHintVC: ContextualHintViewController
     private var backgroundTabLoader: DefaultBackgroundTabLoader
     var windowUUID: WindowUUID { return tabManager.windowUUID }
+    private var observedWebViews = WeakList<WKWebView>()
 
     // MARK: Telemetry Variables
     var webviewTelemetry = WebViewLoadMeasurementTelemetry()
@@ -251,6 +252,7 @@ class BrowserViewController: UIViewController,
 
     deinit {
         unsubscribeFromRedux()
+        observedWebViews.forEach({ stopObserving(webView: $0) })
     }
 
     override var prefersStatusBarHidden: Bool {
@@ -2169,20 +2171,8 @@ extension BrowserViewController {
 extension BrowserViewController: LegacyTabDelegate {
     func tab(_ tab: Tab, didCreateWebView webView: WKWebView) {
         // Observers that live as long as the tab. Make sure these are all cleared in willDeleteWebView below!
-        KVOs.forEach {
-            webView.addObserver(
-                self,
-                forKeyPath: $0.rawValue,
-                options: .new,
-                context: nil
-            )
-        }
-        webView.scrollView.addObserver(
-            self.scrollController,
-            forKeyPath: KVOConstants.contentSize.rawValue,
-            options: .new,
-            context: nil
-        )
+        beginObserving(webView: webView)
+        self.scrollController.beginObserving(scrollView: webView.scrollView)
         webView.uiDelegate = self
 
         let formPostHelper = FormPostHelper(tab: tab)
@@ -2250,8 +2240,8 @@ extension BrowserViewController: LegacyTabDelegate {
     func tab(_ tab: Tab, willDeleteWebView webView: WKWebView) {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
-            KVOs.forEach { webView.removeObserver(self, forKeyPath: $0.rawValue) }
-            webView.scrollView.removeObserver(self.scrollController, forKeyPath: KVOConstants.contentSize.rawValue)
+            stopObserving(webView: webView)
+            self.scrollController.stopObserving(scrollView: webView.scrollView)
             webView.uiDelegate = nil
             webView.scrollView.delegate = nil
             webView.removeFromSuperview()
@@ -2265,6 +2255,18 @@ extension BrowserViewController: LegacyTabDelegate {
 
     func tab(_ tab: Tab, didSelectSearchWithFirefoxForSelection selection: String) {
         openSearchNewTab(isPrivate: tab.isPrivate, selection)
+    }
+
+    private func beginObserving(webView: WKWebView) {
+        guard !observedWebViews.contains(webView) else { return }
+        observedWebViews.insert(webView)
+        KVOs.forEach { webView.addObserver(self, forKeyPath: $0.rawValue, options: .new, context: nil) }
+    }
+
+    private func stopObserving(webView: WKWebView?) {
+        guard let webView else { return }
+        observedWebViews.remove(webView)
+        KVOs.forEach { webView.removeObserver(self, forKeyPath: $0.rawValue) }
     }
 
     // MARK: Snack bar

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2266,8 +2266,7 @@ extension BrowserViewController: LegacyTabDelegate {
         KVOs.forEach { webView.addObserver(self, forKeyPath: $0.rawValue, options: .new, context: nil) }
     }
 
-    private func stopObserving(webView: WKWebView?) {
-        guard let webView else { return }
+    private func stopObserving(webView: WKWebView) {
         guard observedWebViews.contains(webView) else {
             logger.log("Duplicate KVO de-registration of webView", level: .warning, category: .webview)
             return

--- a/firefox-ios/Shared/WeakList.swift
+++ b/firefox-ios/Shared/WeakList.swift
@@ -50,6 +50,7 @@ open class WeakList<T: AnyObject>: Sequence {
         items.removeAll()
     }
 
+    @discardableResult
     open func remove(_ item: T) -> Int? {
         guard let index = self.index(of: item) else { return nil }
         items.remove(at: index)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8416)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18655)

## :bulb: Description

This is a fix to avoid potential crashes in WebKit if the BVC or its `scrollController` are deallocated without de-registering them as observers of the `WKWebView` or its scroll view.

(Related discussion thread: https://mozilla.slack.com/archives/C05C9RET70F/p1707832410945339 )

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed I updated documentation / comments for complex code and public methods

