### PR TITLE
Add [v124] Exclude generated files from Swiftlint

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -130,7 +130,8 @@ excluded: # paths to ignore during linting. Takes precedence over `included`.
   - BrowserKit/Package.swift
   - BrowserKit/.build/
   - firefox-ios/Client/ContentBlocker/ContentBlockerGenerator/Package.swift
-  - Package.swift 
+  - Package.swift
+  - firefox-ios/Build/Intermediates.noindex/Client.build/Fennec-iphoneos/WidgetKitExtension.build/DerivedSources/IntentDefinitionGenerated/WidgetIntents/*
 
 included:
   - /Users/vagrant/git


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
<img width="1008" alt="Screenshot 2024-02-16 at 12 26 11" src="https://github.com/mozilla-mobile/firefox-ios/assets/51127880/b5b079b6-0f41-4954-b50e-efce63d6320a">

- Because of the `Line Length` Swiftlint rule, the project can't be build.
- This PR adds generated files `QuickActionType.swift` & `QuickActionIntent.swift` to excluded swiftlint files.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

