### PR TITLE
Bugfix FXIOS-7103 [v125] The "Autofill Credit Cards" option opens the "Passwords" screen if the device doesn't have a Face ID or Passcode

### DIFF
--- a/firefox-ios/Client/Coordinators/CredentialAutofillCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/CredentialAutofillCoordinator.swift
@@ -115,6 +115,7 @@ class CredentialAutofillCoordinator: BaseCoordinator {
     func showPassCodeController() {
         let passwordController = DevicePasscodeRequiredViewController()
         passwordController.profile = profile
+        passwordController.parentType = .paymentMethods
         router.present(passwordController)
     }
 

--- a/firefox-ios/Client/Coordinators/PasswordManagerCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/PasswordManagerCoordinator.swift
@@ -59,6 +59,7 @@ class PasswordManagerCoordinator: BaseCoordinator,
     func showDevicePassCode() {
         let passcodeViewController = DevicePasscodeRequiredViewController()
         passcodeViewController.profile = profile
+        passcodeViewController.parentType = .passwords
         router.push(passcodeViewController)
     }
 

--- a/firefox-ios/Client/Frontend/PasswordManagement/DevicePasscodeRequiredViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/DevicePasscodeRequiredViewController.swift
@@ -6,6 +6,11 @@ import Common
 import UIKit
 import Shared
 
+enum ParentControllerType {
+    case passwords
+    case paymentMethods
+}
+
 class DevicePasscodeRequiredViewController: SettingsViewController {
     private var warningLabel: UILabel = {
         let label = UILabel()
@@ -26,10 +31,12 @@ class DevicePasscodeRequiredViewController: SettingsViewController {
         return button
     }()
 
+    var parentType: ParentControllerType = .passwords
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.title = .Settings.Passwords.Title
 
+        configureView()
         self.view.addSubviews(warningLabel, learnMoreButton)
 
         NSLayoutConstraint.activate(
@@ -52,6 +59,17 @@ class DevicePasscodeRequiredViewController: SettingsViewController {
                 )
             ]
         )
+    }
+
+    private func configureView() {
+        switch parentType {
+        case .passwords:
+            self.title = .Settings.Passwords.Title
+            warningLabel.text = .LoginsDevicePasscodeRequiredMessage
+        case .paymentMethods:
+            self.title = .SettingsAutofillCreditCard
+            warningLabel.text = .PaymentMethodsDevicePasscodeRequiredMessage
+        }
     }
 
     @objc

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -2521,6 +2521,11 @@ extension String {
         tableName: "Credentials",
         value: "To save and automatically fill passwords, enable Face ID, Touch ID, or a device passcode.",
         comment: "Message shown when you enter Logins & Passwords without having a device passcode set.")
+    public static let PaymentMethodsDevicePasscodeRequiredMessage = MZLocalizedString(
+        key: "Logins.PaymentMethods.DevicePasscodeRequired.Message.v124",
+        tableName: "Credentials",
+        value: "To save and autofill credit cards cards, enable Face ID, Touch ID, or a device passcode.",
+        comment: "Message shown when you enter Payment Methods without having a device passcode set.")
     public static let LoginsDevicePasscodeRequiredLearnMoreButtonTitle = MZLocalizedString(
         key: "Logins.DevicePasscodeRequired.LearnMoreButtonTitle",
         tableName: nil,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7103)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15782)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Added a configure method that customizes the Device Passcode screen depending on the parent controller type (either Passwords or Credit Cards for now)
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

