### PR TITLE
Bugfix FXIOS-8414 [v125] The `shopping.surface_displayed` event is not generated in glean

### DIFF
--- a/firefox-ios/Client/Frontend/Fakespot/FakespotViewController.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotViewController.swift
@@ -146,7 +146,7 @@ class FakespotViewController: UIViewController,
         let uuid = windowUUID
         store.subscribe(self, transform: {
             $0.select({ appState in
-                return BrowserViewControllerState(windowUUID: uuid)
+                return BrowserViewControllerState(appState: appState, uuid: uuid)
             })
         })
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8414)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18649)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Return the latest App State
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

