### PR TITLE
Bugfix EXP-4270 [v125] Remove jexlCache from jexl message helper

### DIFF
--- a/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
+++ b/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
@@ -105,14 +105,12 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
         // feature! For that reason, return `nil`. We need to recreate the helper
         // for each request to get a message because device context can change.
         guard let messagingHelper = helperUtility.createNimbusMessagingHelper() else { return nil }
-        var jexlCache = [String: Bool]()
 
         var excluded: Set<String> = []
         return getNextMessage(for: surface,
                               availableMessages: availableMessages,
                               excluded: &excluded,
-                              messagingHelper: messagingHelper,
-                              jexlCache: &jexlCache)
+                              messagingHelper: messagingHelper)
     }
 
     // TODO: inout removal ticket https://mozilla-hub.atlassian.net/browse/FXIOS-6572
@@ -120,8 +118,7 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
             for surface: MessageSurfaceId,
             availableMessages: [GleanPlumbMessage],
             excluded: inout Set<String>,
-            messagingHelper: NimbusMessagingHelperProtocol,
-            jexlCache: inout [String: Bool]
+            messagingHelper: NimbusMessagingHelperProtocol
     ) -> GleanPlumbMessage? {
         let feature = messagingFeature.value()
         let message = availableMessages.first { message in
@@ -131,8 +128,7 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
             }
             do {
                 return try evaluationUtility.isMessageEligible(message,
-                                                               messageHelper: messagingHelper,
-                                                               jexlCache: &jexlCache)
+                                                               messageHelper: messagingHelper)
             } catch {
                 return false
             }
@@ -163,8 +159,7 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
             return getNextMessage(for: surface,
                                   availableMessages: availableMessages,
                                   excluded: &excluded,
-                                  messagingHelper: messagingHelper,
-                                  jexlCache: &jexlCache)
+                                  messagingHelper: messagingHelper)
         }
     }
 

--- a/firefox-ios/Client/Experiments/Messaging/NimbusMessagingEvaluationUtility.swift
+++ b/firefox-ios/Client/Experiments/Messaging/NimbusMessagingEvaluationUtility.swift
@@ -14,44 +14,28 @@ class NimbusMessagingEvaluationUtility {
     /// Checks whether a message is eligible to be show by evaluating message JEXLs.
     func isMessageEligible(
         _ message: GleanPlumbMessage,
-        messageHelper: NimbusMessagingHelperProtocol,
-        jexlCache: inout [String: Bool]
+        messageHelper: NimbusMessagingHelperProtocol
     ) throws -> Bool {
         return try isNimbusElementEligible(checking: message.triggers,
-                                           using: messageHelper,
-                                           and: &jexlCache)
+                                           using: messageHelper)
     }
 
     /// Checks whether an object with a generic ``[String]`` lookup table of valid
     /// JEXLs is eligible to be show by evaluating those JEXLs.
     func doesObjectMeet(
         verificationRequirements lookupTable: [String],
-        using helper: NimbusMessagingHelperProtocol,
-        and jexlCache: inout [String: Bool]
+        using helper: NimbusMessagingHelperProtocol
     ) throws -> Bool {
         return try isNimbusElementEligible(checking: lookupTable,
-                                           using: helper,
-                                           and: &jexlCache)
+                                           using: helper)
     }
 
     private func isNimbusElementEligible(
         checking triggers: [String],
-        using helper: NimbusMessagingHelperProtocol,
-        and jexlCache: inout [String: Bool]
+        using helper: NimbusMessagingHelperProtocol
     ) throws -> Bool {
         return try triggers.reduce(true) { accumulator, trigger in
-            guard accumulator else { return false }
-
-            // Check the jexlCache for the `Bool`, in the case we already
-            // evaluated it. Otherwise, perform an expensive Foreign Function
-            // Interface (FFI) operation once for the trigger.
-            guard let evaluation = jexlCache[trigger] else {
-                let evaluation = try helper.evalJexl(expression: trigger)
-                jexlCache[trigger] = evaluation
-                return evaluation
-            }
-
-            return evaluation
+            return try accumulator && (try helper.evalJexl(expression: trigger))
         }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Messaging/NimbusMessagingMessageTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Messaging/NimbusMessagingMessageTests.swift
@@ -43,8 +43,7 @@ final class NimbusMessagingMessageTests: XCTestCase {
             do {
                 _ = try evaluationUtility.isMessageEligible(
                     message,
-                    messageHelper: helper,
-                    jexlCache: &cache)
+                    messageHelper: helper)
             } catch {
                 XCTFail("Message \(message.id) failed with invalid JEXL triggers")
             }


### PR DESCRIPTION
Relates to [ EXP-4270](https://mozilla-hub.atlassian.net/browse/EXP-4270).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This is part two of adding a JEXL eval cache to the messaging helper in Application Services, obviating the need for one in FxiOS.

This also fixes [FXIOS-6572](https://mozilla-hub.atlassian.net/browse/FXIOS-6572).

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

