### PR TITLE
Refactor EXP-4270 [v125] Move GleanplumbMessageManager singleton to Experiments

### DIFF
--- a/firefox-ios/Client/Coordinators/LaunchView/LaunchScreenViewModel.swift
+++ b/firefox-ios/Client/Coordinators/LaunchView/LaunchScreenViewModel.swift
@@ -18,7 +18,7 @@ class LaunchScreenViewModel {
     weak var delegate: LaunchFinishedLoadingDelegate?
 
     init(profile: Profile = AppContainer.shared.resolve(),
-         messageManager: GleanPlumbMessageManagerProtocol = GleanPlumbMessageManager.shared,
+         messageManager: GleanPlumbMessageManagerProtocol = Experiments.messaging,
          onboardingModel: OnboardingViewModel = NimbusOnboardingFeatureLayer().getOnboardingModel(for: .upgrade)) {
         self.introScreenManager = IntroScreenManager(prefs: profile.prefs)
         let telemetryUtility = OnboardingTelemetryUtility(with: onboardingModel)

--- a/firefox-ios/Client/Experiments/Experiments.swift
+++ b/firefox-ios/Client/Experiments/Experiments.swift
@@ -215,6 +215,12 @@ enum Experiments {
     }
 }
 
+extension Experiments {
+    public static var messaging: GleanPlumbMessageManagerProtocol = {
+        GleanPlumbMessageManager()
+    }()
+}
+
 private extension AppBuildChannel {
     var nimbusString: String {
         switch self {

--- a/firefox-ios/Client/Frontend/Home/MessageCard/HomepageMessageCardViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/MessageCard/HomepageMessageCardViewModel.swift
@@ -24,7 +24,7 @@ class HomepageMessageCardViewModel: MessageSurfaceProtocol {
 
     init(dataAdaptor: MessageCardDataAdaptor,
          theme: Theme,
-         messagingManager: GleanPlumbMessageManagerProtocol = GleanPlumbMessageManager.shared
+         messagingManager: GleanPlumbMessageManagerProtocol = Experiments.messaging
     ) {
         self.dataAdaptor = dataAdaptor
         self.theme = theme

--- a/firefox-ios/Client/Frontend/Home/MessageCard/MessageCardDataAdaptor.swift
+++ b/firefox-ios/Client/Frontend/Home/MessageCard/MessageCardDataAdaptor.swift
@@ -22,7 +22,7 @@ class MessageCardDataAdaptorImplementation: MessageCardDataAdaptor {
         }
     }
 
-    init(messagingManager: GleanPlumbMessageManagerProtocol = GleanPlumbMessageManager.shared) {
+    init(messagingManager: GleanPlumbMessageManagerProtocol = Experiments.messaging) {
         self.messagingManager = messagingManager
     }
 

--- a/firefox-ios/Client/Frontend/NotificationSurface/NotificationSurfaceManager.swift
+++ b/firefox-ios/Client/Frontend/NotificationSurface/NotificationSurfaceManager.swift
@@ -40,7 +40,7 @@ class NotificationSurfaceManager: NotificationSurfaceDelegate {
     }
 
     // MARK: - Initialization
-    init(messagingManager: GleanPlumbMessageManagerProtocol = GleanPlumbMessageManager.shared,
+    init(messagingManager: GleanPlumbMessageManagerProtocol = Experiments.messaging,
          notificationManager: NotificationManagerProtocol = NotificationManager()) {
         self.messagingManager = messagingManager
         self.notificationManager = notificationManager

--- a/firefox-ios/Client/Frontend/SurveySurface/SurveySurfaceManager.swift
+++ b/firefox-ios/Client/Frontend/SurveySurface/SurveySurfaceManager.swift
@@ -32,7 +32,7 @@ class SurveySurfaceManager: SurveySurfaceDelegate {
     // MARK: - Initialization
     init(themeManager: ThemeManager = AppContainer.shared.resolve(),
          notificationCenter: NotificationProtocol = NotificationCenter.default,
-         and messagingManager: GleanPlumbMessageManagerProtocol = GleanPlumbMessageManager.shared
+         and messagingManager: GleanPlumbMessageManagerProtocol = Experiments.messaging
     ) {
         self.themeManager = themeManager
         self.notificationCenter = notificationCenter

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockLaunchScreenManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockLaunchScreenManager.swift
@@ -14,7 +14,7 @@ class MockLaunchScreenViewModel: LaunchScreenViewModel {
 
     override init(
         profile: Profile,
-        messageManager: GleanPlumbMessageManagerProtocol = GleanPlumbMessageManager.shared,
+        messageManager: GleanPlumbMessageManagerProtocol = Experiments.messaging,
         onboardingModel: OnboardingViewModel = NimbusOnboardingFeatureLayer().getOnboardingModel(for: .upgrade)
     ) {
         self.introScreenManager = IntroScreenManager(prefs: profile.prefs)


### PR DESCRIPTION
Relates to [ EXP-4270](https://mozilla-hub.atlassian.net/browse/EXP-4270).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This PR moves the GleanPlumbMessageManager construction away from its singleton `shared` and into the `Experiments` class. This is because:

- we should be separating the construction from the declaration, so we might use messaging in a different module/app
- Experiments will become the API point for creating a JEXL helper, and the nimbus SDK.
- it matches the Android implementation, which makes documenting the messaging component easier.

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

