### PR TITLE
Bugfix EXP-4270 [v125] Fixup message validation to be closer to Android

### DIFF
--- a/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessage.swift
+++ b/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessage.swift
@@ -46,6 +46,10 @@ struct GleanPlumbMessage {
         metadata.isExpired || metadata.impressions >= style.maxDisplayCount
     }
 
+    var isInteractedWith: Bool {
+        metadata.isExpired || metadata.dismissals > 0
+    }
+
     var buttonLabel: String? {
         data.buttonLabel
     }

--- a/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
+++ b/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
@@ -336,16 +336,14 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
     private func sanitizeTriggers(_ unsafeTriggers: [String], table: [String: String]) -> [String]? {
         var triggers = [String]()
         for unsafeTrigger in unsafeTriggers {
-            guard let safeTrigger = table[unsafeTrigger] else {
-                return nil
-            }
+            guard let safeTrigger = table[unsafeTrigger] else { return nil }
             triggers.append(safeTrigger)
         }
         return triggers
     }
 
     private func sanitizeStyle(_ unsafeStyle: String, table: [String: StyleData]) -> StyleData? {
-        table[unsafeStyle]
+        return table[unsafeStyle]
     }
 
     private func baseTelemetryExtras(using message: GleanPlumbMessage) -> [String: String] {

--- a/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
+++ b/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
@@ -64,7 +64,6 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
     typealias MessagingKey = TelemetryWrapper.EventExtraKey
 
     private enum CreateMessageError: Error {
-        case expired
         case malformed
     }
 
@@ -99,8 +98,13 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
 
     public func getNextMessage(
         for surface: MessageSurfaceId,
-        availableMessages: [GleanPlumbMessage]
+        availableMessages messages: [GleanPlumbMessage]
     ) -> GleanPlumbMessage? {
+        let availableMessages = messages.filter {
+            $0.data.surface == surface
+        }.filter {
+            !$0.isExpired && !$0.isInteractedWith
+        }
         // If `NimbusMessagingHelper` creation fails, we cannot continue with this
         // feature! For that reason, return `nil`. We need to recreate the helper
         // for each request to get a message because device context can change.
@@ -123,10 +127,8 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
             messagingHelper: NimbusMessagingHelperProtocol,
             jexlCache: inout [String: Bool]
     ) -> GleanPlumbMessage? {
-        let feature = messagingFeature.value()
         let message = availableMessages.first { message in
-            guard message.surface == surface &&
-                    !excluded.contains(message.id) else {
+            if excluded.contains(message.id) {
                 return false
             }
             do {
@@ -155,7 +157,7 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
         // because they're not displayed.
         messagingStore.onMessageDisplayed(message)
 
-        switch feature.onControl {
+        switch messagingFeature.value().onControl {
         case .showNone:
             return nil
         case .showNextMessage:
@@ -290,24 +292,24 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
         message: MessageData,
         lookupTables: Messaging
     ) -> Result<GleanPlumbMessage, CreateMessageError> {
-        // Guard against a message with a blank `text` property.
-        guard !message.text.isEmpty else { return .failure(.malformed) }
+        var action: String
+        if !message.isControl {
+            // Guard against a message with a blank `text` property.
+            guard !message.text.isEmpty else { return .failure(.malformed) }
 
-        // Ascertain a Message's style, to know priority and max impressions.
-        guard let style = lookupTables.styles[message.style] else { return .failure(.malformed) }
-
-        // The message action should be either from the lookup table OR a URL.
-        let action = lookupTables.actions[message.action] ?? message.action
-        guard action.contains("://") else { return .failure(.malformed) }
-
-        let triggers = message.trigger.compactMap { trigger in
-            lookupTables.triggers[trigger]
+            // The message action should be either from the lookup table OR a URL.
+            guard let safeAction = sanitizeAction(message.action, table: lookupTables.actions) else {
+                return .failure(.malformed)
+            }
+            action = safeAction
+        } else {
+            action = "CONTROL_ACTION"
         }
 
-        // Be sure the count on `triggers` and `message.triggers` are equal.
-        // If these mismatch, that means a message contains a trigger not in the triggers lookup table.
-        // JEXLS can only be evaluated on supported triggers. Otherwise, consider the message malformed.
-        if triggers.count != message.trigger.count {
+        // Ascertain a Message's style, to know priority and max impressions.
+        guard let style = sanitizeStyle(message.style, table: lookupTables.styles) else { return .failure(.malformed) }
+
+        guard let triggers = sanitizeTriggers(message.trigger, table: lookupTables.triggers) else {
             return .failure(.malformed)
         }
 
@@ -320,6 +322,30 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
                               style: style,
                               metadata: messageMetadata)
         )
+    }
+
+    private func sanitizeAction(_ unsafeAction: String, table: [String: String]) -> String? {
+        let action = table[unsafeAction] ?? unsafeAction
+        if action.contains("://") {
+            return action
+        } else {
+            return nil
+        }
+    }
+
+    private func sanitizeTriggers(_ unsafeTriggers: [String], table: [String: String]) -> [String]? {
+        var triggers = [String]()
+        for unsafeTrigger in unsafeTriggers {
+            guard let safeTrigger = table[unsafeTrigger] else {
+                return nil
+            }
+            triggers.append(safeTrigger)
+        }
+        return triggers
+    }
+
+    private func sanitizeStyle(_ unsafeStyle: String, table: [String: StyleData]) -> StyleData? {
+        table[unsafeStyle]
     }
 
     private func baseTelemetryExtras(using message: GleanPlumbMessage) -> [String: String] {


### PR DESCRIPTION
Relates to [ EXP-4720](https://mozilla-hub.atlassian.net/browse/EXP-4720).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This PR:

- tightens up validation of the messaging feature. A lot of validation has moved into the Nimbus SDK and FML layers. This removes much of the in-code defaults.
- removes validation of the action and content in the event of a control message.
- moves the filtering of the messages for dismissed/clicked/expired methods from the getAllMessages to the more frequently called `getNextMessage`.

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

