### PR TITLE
Refactor FXIOS-8401 [v124] - Update message handler to support showing the accessory view login fields are found

### DIFF
--- a/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
@@ -8,11 +8,42 @@ import Shared
 import Storage
 import WebKit
 
+enum FocusFieldType: String, Codable {
+    case username
+    case password
+}
+
+struct FieldFocusMessage: Codable {
+    let fieldType: FocusFieldType
+    let type: String
+}
+
+struct LoginInjectionData {
+    let requestId: String
+    let name: String = "RemoteLogins:loginsFound"
+    var logins: [[String: Any]]
+
+    func toJSONString() -> String? {
+        let dict: [String: Any] = [
+            "requestId": requestId,
+            "name": name,
+            "logins": logins
+        ]
+        guard let jsonData = try? JSONSerialization.data(withJSONObject: dict, options: []),
+              let jsonString = String(data: jsonData, encoding: .utf8) else {
+            return nil
+        }
+        return jsonString
+    }
+}
+
 class LoginsHelper: TabContentScript {
     private weak var tab: Tab?
     private let profile: Profile
     private let theme: Theme
     private var snackBar: SnackBar?
+    private var currentRequestId: String = ""
+    private var logger: Logger = DefaultLogger.shared
 
     // Exposed for mocking purposes
     var logins: RustLogins {
@@ -23,7 +54,9 @@ class LoginsHelper: TabContentScript {
         String(describing: self)
     }
 
-    required init(tab: Tab, profile: Profile, theme: Theme) {
+    required init(tab: Tab,
+                  profile: Profile,
+                  theme: Theme) {
         self.tab = tab
         self.profile = profile
         self.theme = theme
@@ -94,6 +127,13 @@ class LoginsHelper: TabContentScript {
               let type = res["type"] as? String
         else { return }
 
+        if let parsedMessage = parseFieldFocusMessage(from: res) {
+            logger.log("Parsed message \(String(describing: parsedMessage))",
+                       level: .debug,
+                       category: .webview)
+            sendMessageType(parsedMessage)
+        }
+
         // We don't use the WKWebView's URL since the page can spoof the URL by using document.location
         // right before requesting login data. See bug 1194567 for more context.
         if let url = message.frameInfo.request.url {
@@ -108,6 +148,32 @@ class LoginsHelper: TabContentScript {
                     }
                 }
             }
+        }
+    }
+
+    func sendMessageType(_ message: FieldFocusMessage) {
+        switch message.fieldType {
+        case .username:
+            logger.log("Parsed message username",
+                       level: .debug,
+                       category: .webview)
+        case .password:
+            logger.log("Parsed message password",
+                       level: .debug,
+                       category: .webview)
+        }
+    }
+
+    private func parseFieldFocusMessage(from dictionary: [String: Any]) -> FieldFocusMessage? {
+        do {
+            let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
+            let message = try JSONDecoder().decode(FieldFocusMessage.self, from: data)
+            return message
+        } catch {
+            logger.log("Unable to decode message body in logins helper",
+                       level: .warning,
+                       category: .webview)
+            return nil
         }
     }
 
@@ -262,6 +328,8 @@ class LoginsHelper: TabContentScript {
             let origin = getOrigin(url.absoluteString)
         else { return }
 
+        currentRequestId = requestId
+
         let protectionSpace = URLProtectionSpace.fromOrigin(origin)
 
         profile.logins.getLoginsForProtectionSpace(protectionSpace).uponQueue(.main) { res in
@@ -273,16 +341,25 @@ class LoginsHelper: TabContentScript {
                 return login?.httpRealm == nil ? login?.toJSONDict() : nil
             }
 
-            let dict: [String: Any] = [
-                "requestId": requestId,
-                "name": "RemoteLogins:loginsFound",
-                "logins": logins
-            ]
-            guard let injected = dict.asString else { return }
-            let injectJavaScript = "window.__firefox__.logins.inject(\(injected))"
-            self.tab?.webView?.evaluateJavascriptInDefaultContentWorld(injectJavaScript)
-            self.sendLoginsAutofilledTelemetry()
+            let loginData = LoginInjectionData(requestId: self.currentRequestId,
+                                               logins: logins)
+
+            guard let tab = self.tab else {
+                return
+            }
+
+            LoginsHelper.fillLoginDetails(with: tab, loginData: loginData)
         }
+    }
+
+    public static func fillLoginDetails(with tab: Tab,
+                                        loginData: LoginInjectionData) {
+        guard let injected = loginData.toJSONString() else { return }
+        let injectJavaScript = "window.__firefox__.logins.inject(\(injected))"
+        tab.webView?.evaluateJavascriptInDefaultContentWorld(injectJavaScript)
+        TelemetryWrapper.recordEvent(category: .action,
+                                     method: .tap,
+                                     object: .loginsAutofilled)
     }
 
     // MARK: Theming System
@@ -305,11 +382,5 @@ class LoginsHelper: TabContentScript {
         TelemetryWrapper.recordEvent(category: .action,
                                      method: .add,
                                      object: .loginsSaved)
-    }
-
-    private func sendLoginsAutofilledTelemetry() {
-        TelemetryWrapper.recordEvent(category: .action,
-                                     method: .tap,
-                                     object: .loginsAutofilled)
     }
 }

--- a/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
@@ -127,7 +127,7 @@ class LoginsHelper: TabContentScript {
               let type = res["type"] as? String
         else { return }
 
-        //NOTE: FXIOS-3856 will further enhance the logs into actual callback
+        // NOTE: FXIOS-3856 will further enhance the logs into actual callback
         if let parsedMessage = parseFieldFocusMessage(from: res) {
             logger.log("Parsed message \(String(describing: parsedMessage))",
                        level: .debug,

--- a/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
@@ -127,6 +127,7 @@ class LoginsHelper: TabContentScript {
               let type = res["type"] as? String
         else { return }
 
+        //NOTE: FXIOS-3856 will further enhance the logs into actual callback
         if let parsedMessage = parseFieldFocusMessage(from: res) {
             logger.log("Parsed message \(String(describing: parsedMessage))",
                        level: .debug,
@@ -151,7 +152,9 @@ class LoginsHelper: TabContentScript {
         }
     }
 
-    func sendMessageType(_ message: FieldFocusMessage) {
+    private func sendMessageType(_ message: FieldFocusMessage) {
+        // NOTE: This is a partial stub / placeholder
+        // FXIOS-3856 will further enhance the logs into actual callback
         switch message.fieldType {
         case .username:
             logger.log("Parsed message username",
@@ -344,6 +347,7 @@ class LoginsHelper: TabContentScript {
             let loginData = LoginInjectionData(requestId: self.currentRequestId,
                                                logins: logins)
 
+            // NOTE: FXIOS-3856 This will get disabled in future with addtion of bottom sheet
             guard let tab = self.tab else {
                 return
             }

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/LoginsHelper.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/LoginsHelper.js
@@ -578,6 +578,70 @@ window.__firefox__.includeOnce("LoginsHelper", function() {
     },
   }
 
+  // define the field types for focus events
+  const FocusFieldType = {
+    username: "username",
+    password: "password"
+  };
+
+  // Extended the LoginManagerContent object with a new method for focus events
+  LoginManagerContent._addFocusListenerBasedOnHeuristics = function (form) {
+    // common form structure
+    var commonStructures = `input[type="text"], input[type="email"], input:not([type])`
+    var possibleUsernameFields = Array.from(form.querySelectorAll(commonStructures));
+    var passwordFields = form.querySelectorAll('input[type="password"]');
+
+    // add listener to password fields
+    passwordFields.forEach((field) => this._addFocusListener(field, FocusFieldType.password));
+
+    // determine possible username field
+    possibleUsernameFields = possibleUsernameFields.filter(field =>
+      field.placeholder.toLowerCase().includes("user") ||
+      field.placeholder.toLowerCase().includes("email") ||
+      field.id.toLowerCase().includes("user") ||
+      field.id.toLowerCase().includes("email") ||
+      field.name.toLowerCase().includes("user") ||
+      field.name.toLowerCase().includes("email"));
+
+    // prioritize fields closer to the first password field, if available
+    if (passwordFields.length > 0) {
+      const firstPasswordIndex = Array.from(form.elements).indexOf(passwordFields[0]);
+      possibleUsernameFields = possibleUsernameFields.filter(field =>
+        Array.from(form.elements).indexOf(field) < firstPasswordIndex);
+    }
+
+    // attach listeners to possible username fields, if not already focused on password fields
+    possibleUsernameFields.forEach((field) => this._addFocusListener(field, FocusFieldType.username));
+
+    // no clear username field is identified & password fields are present,
+    // attach to the first text input before the password field as a fallback
+    if (possibleUsernameFields.length === 0 && passwordFields.length > 0) {
+      let precedingTextFields = Array.from(passwordFields[0].parentNode.querySelectorAll('input[type="text"], input[type="email"], input:not([type])'));
+      if (precedingTextFields.length > 0) {
+        // Last text input before the first password field
+        let assumedUsernameField = precedingTextFields[precedingTextFields.length - 1];
+        this._addFocusListener(assumedUsernameField, FocusFieldType.username);
+      }
+    }
+  };
+
+  LoginManagerContent._addFocusListener = function (field, fieldType) {
+    field.addEventListener("focus", function () {
+      // send message with field focus information
+      var messageData = {
+        type: "fieldFocus",
+        fieldType: fieldType
+      };
+      webkit.messageHandlers.loginsManagerMessageHandler.postMessage(messageData);
+    });
+  };
+
+  var originalFindLogins = findLogins;
+  findLogins = function (form) {
+    originalFindLogins(form);
+    LoginManagerContent._addFocusListenerBasedOnHeuristics(form); // Use the new method here
+  };
+    
   var LoginUtils = {
     /*
      * _getPasswordOrigin

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/LoginsHelper.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/LoginsHelper.js
@@ -591,7 +591,7 @@ window.__firefox__.includeOnce("LoginsHelper", function() {
     }
 
     const [username, password] = LoginManagerContent._getFormFields(form, false);
-    if (username && password) {
+    if (password) {
       webkit.messageHandlers.loginsManagerMessageHandler.postMessage({
         type: "fieldType",
         fieldType: event.target === username ? FocusFieldType.username : FocusFieldType.password,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket - 8401](https://mozilla-hub.atlassian.net/browse/FXIOS-8401)
[Github issue - 18628](https://github.com/mozilla-mobile/firefox-ios/issues/18628)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

Note: This does not stop the auto password filling but this change will allow us to know when user taps on the username / password fields so that we can show the user accessory view

https://github.com/mozilla-mobile/firefox-ios/assets/8919439/2990adaa-51ee-4a48-a336-41db1c3ee871

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods


