### PR TITLE
Add FXIOS-8465 [v125] Run autofill in allowed contexts only

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -961,6 +961,8 @@
 		B2FEA68F2B460D9E0058E616 /* AddressAutofillSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2FEA68E2B460D9E0058E616 /* AddressAutofillSettingsViewModel.swift */; };
 		B2FEA6912B4661BE0058E616 /* AddressAutofillToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2FEA6902B4661BE0058E616 /* AddressAutofillToggle.swift */; };
 		B640467E29B9B58200C5C7B6 /* TabLocationViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B640467D29B9B58200C5C7B6 /* TabLocationViewTests.swift */; };
+		BA1C68BA2B7E9EA0000D9397 /* WKFrameInfoExtensionsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1C68B92B7E9EA0000D9397 /* WKFrameInfoExtensionsTest.swift */; };
+		BA1C68BC2B7ED153000D9397 /* MockWebKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1C68BB2B7ED153000D9397 /* MockWebKit.swift */; };
 		BC003F5E2B59F44600929ECB /* BrowserViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC003F5D2B59F44500929ECB /* BrowserViewControllerTests.swift */; };
 		BCFF93EE2AAA9F6E005B5B71 /* RustFirefoxSuggest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF93ED2AAA9C47005B5B71 /* RustFirefoxSuggest.swift */; };
 		BCFF93F02AABA55A005B5B71 /* BackgroundFirefoxSuggestIngestUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF93EF2AAB97A8005B5B71 /* BackgroundFirefoxSuggestIngestUtility.swift */; };
@@ -6304,6 +6306,8 @@
 		B9D74DA988462CC14EF29D8B /* fil */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fil; path = fil.lproj/Menu.strings; sourceTree = "<group>"; };
 		B9F246E38F80F257C59CEC4A /* ast */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ast; path = ast.lproj/HistoryPanel.strings; sourceTree = "<group>"; };
 		BA05405089CFDC6097258640 /* en-CA */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-CA"; path = "en-CA.lproj/3DTouchActions.strings"; sourceTree = "<group>"; };
+		BA1C68B92B7E9EA0000D9397 /* WKFrameInfoExtensionsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKFrameInfoExtensionsTest.swift; sourceTree = "<group>"; };
+		BA1C68BB2B7ED153000D9397 /* MockWebKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWebKit.swift; sourceTree = "<group>"; };
 		BA354251BD3FFF63A161E385 /* is */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = is; path = is.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
 		BA904A3B89BC820A7A802D55 /* es-CL */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-CL"; path = "es-CL.lproj/Storage.strings"; sourceTree = "<group>"; };
 		BAA64356B54F1CD258764620 /* su */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = su; path = su.lproj/FindInPage.strings; sourceTree = "<group>"; };
@@ -9401,6 +9405,7 @@
 				A83E5B1C1C1DA8D80026D912 /* UIPasteboardExtensionsTests.swift */,
 				8AE1E1D827B1BD380024C45E /* UIStackViewExtensionsTests.swift */,
 				E169C6E72979CA0E0017B8D7 /* URLMailTests.swift */,
+				BA1C68B92B7E9EA0000D9397 /* WKFrameInfoExtensionsTest.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -10270,6 +10275,7 @@
 				C80C11EF28B3C9150062922A /* MockUserDefaults.swift */,
 				E1463D0529830E4F0074E16E /* MockUserNotificationCenter.swift */,
 				2173326929CCF901007F20C7 /* UIPanGestureRecognizerMock.swift */,
+				BA1C68BB2B7ED153000D9397 /* MockWebKit.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -14248,6 +14254,7 @@
 				8A359EF62A1FE840004A5BB7 /* MockAdjustWrapper.swift in Sources */,
 				8AC225662B6D403200CDA7FD /* HomepageTelemetryTests.swift in Sources */,
 				C8DC90D22A067C6D0008832B /* MarkupAttributionUtilityTests.swift in Sources */,
+				BA1C68BC2B7ED153000D9397 /* MockWebKit.swift in Sources */,
 				21737FB72878A4BD000A9A92 /* HistoryPanelViewModelTests.swift in Sources */,
 				43B658D929CE251C00C9EF08 /* CreditCardInputViewModelTests.swift in Sources */,
 				C8501F5128510DA1003B09AB /* WallpaperMigrationUtilityTests.swift in Sources */,
@@ -14395,6 +14402,7 @@
 				8AABBD032A001CBC0089941E /* MockApplicationHelper.swift in Sources */,
 				8A1E3BE328CBACDD003388C4 /* SponsoredContentFilterUtilityTests.swift in Sources */,
 				2173326829CCDA8E007F20C7 /* TabScrollControllerTests.swift in Sources */,
+				BA1C68BA2B7E9EA0000D9397 /* WKFrameInfoExtensionsTest.swift in Sources */,
 				9614BF4228A53FDF00D3F7EA /* ContextualHintEligibilityUtilityTests.swift in Sources */,
 				21B548972B1E6AC300DC1DF8 /* MockInactiveTabsManager.swift in Sources */,
 				21B337BB29B67E4100E4F806 /* BrowserViewControllerWebViewDelegateTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/TabContentsScripts/FormAutofillHelper/FormAutofillHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/FormAutofillHelper/FormAutofillHelper.swift
@@ -73,6 +73,13 @@ class FormAutofillHelper: TabContentScript {
         // to an embedded iframe on a webpage for injecting card info
         frame = message.frameInfo
 
+        guard let frame = frame, frame.isFrameLoadedInSecureContext else {
+            logger.log("Ignoring request as it came from an insecure context",
+                       level: .info,
+                       category: .webview)
+            return
+        }
+
         switch HandlerName(rawValue: message.name) {
         case .addressFormMessageHandler:
             // Parse message payload for address form autofill
@@ -86,7 +93,6 @@ class FormAutofillHelper: TabContentScript {
                            category: .webview)
                 return
             }
-
             let payloadData = fieldValues.addressPayload
             foundFieldValues?(getFieldTypeValues(payload: payloadData), payloadType, frame)
 

--- a/firefox-ios/Shared/Extensions/WKWebViewExtensions.swift
+++ b/firefox-ios/Shared/Extensions/WKWebViewExtensions.swift
@@ -76,7 +76,6 @@ extension WKUserScript {
     }
 }
 
-
 extension WKFrameInfo {
     // We check both the top and current frame protocol. This is to also check for mixed content.
     // For most cases checking the top frame protocol.`hasOnlySecureContent` is deliberatly not used here

--- a/firefox-ios/Shared/Extensions/WKWebViewExtensions.swift
+++ b/firefox-ios/Shared/Extensions/WKWebViewExtensions.swift
@@ -82,6 +82,7 @@ extension WKFrameInfo {
     // For most cases checking the top frame protocol.`hasOnlySecureContent` is deliberatly not used here
     // since it will return false if any external resource on the page is loaded via
     // an insecure connection (i.e styles, images, ...), which might be too strict for most applications.
+    // Note: We should drop this extension in favour of SecurityManager in the future.
     public var isFrameLoadedInSecureContext: Bool {
         return self.webView?.url?.scheme == "https" && self.securityOrigin.protocol == "https"
     }

--- a/firefox-ios/Shared/Extensions/WKWebViewExtensions.swift
+++ b/firefox-ios/Shared/Extensions/WKWebViewExtensions.swift
@@ -75,3 +75,14 @@ extension WKUserScript {
         )
     }
 }
+
+
+extension WKFrameInfo {
+    // We check both the top and current frame protocol. This is to also check for mixed content.
+    // For most cases checking the top frame protocol.`hasOnlySecureContent` is deliberatly not used here
+    // since it will return false if any external resource on the page is loaded via
+    // an insecure connection (i.e styles, images, ...), which might be too strict for most applications.
+    public var isFrameLoadedInSecureContext: Bool {
+        return self.webView?.url?.scheme == "https" && self.securityOrigin.protocol == "https"
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Extensions/WKFrameInfoExtensionsTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Extensions/WKFrameInfoExtensionsTest.swift
@@ -6,7 +6,6 @@ import XCTest
 import WebKit
 
 final class WKFrameInfoExtensionsTests: XCTestCase {
-    
     let secureURL = URL(string: "https://foo.com")!
     let insecureURL = URL(string: "http://bar.com")!
 
@@ -15,25 +14,22 @@ final class WKFrameInfoExtensionsTests: XCTestCase {
         let frame = WKFrameInfoMock(webView: webView, frameURL: insecureURL)
         XCTAssertFalse(frame.isFrameLoadedInSecureContext)
     }
-    
+
     func test_insecureTopFrame_secureFrame() {
         let webView = WKWebViewMock(insecureURL)
         let frame = WKFrameInfoMock(webView: webView, frameURL: secureURL)
         XCTAssertFalse(frame.isFrameLoadedInSecureContext)
     }
-    
+
     func test_secureTopFrame_insecureFrame() {
         let webView = WKWebViewMock(secureURL)
         let frame = WKFrameInfoMock(webView: webView, frameURL: insecureURL)
         XCTAssertFalse(frame.isFrameLoadedInSecureContext)
     }
-    
+
     func test_secureTopFrame_secureFrame() {
         let webView = WKWebViewMock(secureURL)
         let frame = WKFrameInfoMock(webView: webView, frameURL: secureURL)
         XCTAssertTrue(frame.isFrameLoadedInSecureContext)
     }
-    
-
-
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Extensions/WKFrameInfoExtensionsTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Extensions/WKFrameInfoExtensionsTest.swift
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import WebKit
+
+final class WKFrameInfoExtensionsTests: XCTestCase {
+    
+    let secureURL = URL(string: "https://foo.com")!
+    let insecureURL = URL(string: "http://bar.com")!
+
+    func test_insecureTopFrame_insecureFrame() {
+        let webView = WKWebViewMock(insecureURL)
+        let frame = WKFrameInfoMock(webView: webView, frameURL: insecureURL)
+        XCTAssertFalse(frame.isFrameLoadedInSecureContext)
+    }
+    
+    func test_insecureTopFrame_secureFrame() {
+        let webView = WKWebViewMock(insecureURL)
+        let frame = WKFrameInfoMock(webView: webView, frameURL: secureURL)
+        XCTAssertFalse(frame.isFrameLoadedInSecureContext)
+    }
+    
+    func test_secureTopFrame_insecureFrame() {
+        let webView = WKWebViewMock(secureURL)
+        let frame = WKFrameInfoMock(webView: webView, frameURL: insecureURL)
+        XCTAssertFalse(frame.isFrameLoadedInSecureContext)
+    }
+    
+    func test_secureTopFrame_secureFrame() {
+        let webView = WKWebViewMock(secureURL)
+        let frame = WKFrameInfoMock(webView: webView, frameURL: secureURL)
+        XCTAssertTrue(frame.isFrameLoadedInSecureContext)
+    }
+    
+
+
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/WebView/WebViewNavigationHandlerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/WebView/WebViewNavigationHandlerTests.swift
@@ -224,25 +224,3 @@ class WebViewNavigationHandlerTests: XCTestCase {
                                            navigationAction: policy)
     }
 }
-
-// MARK: WKNavigationActionMock
-class WKNavigationActionMock: WKNavigationAction {
-    var overridenTargetFrame: WKFrameInfoMock?
-
-    override var targetFrame: WKFrameInfo? {
-        return overridenTargetFrame
-    }
-}
-
-// MARK: WKFrameInfoMock
-class WKFrameInfoMock: WKFrameInfo {
-    let overridenTargetFrame: Bool
-
-    init(isMainFrame: Bool) {
-        overridenTargetFrame = isMainFrame
-    }
-
-    override var isMainFrame: Bool {
-        return overridenTargetFrame
-    }
-}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWebKit.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWebKit.swift
@@ -82,3 +82,28 @@ class WKWebViewMock: WKWebView {
         return overridenURL
     }
 }
+
+// MARK: - WKScriptMessageMock
+class WKScriptMessageMock: WKScriptMessage {
+    let overridenBody: Any
+    let overridenName: String
+    let overridenFrameInfo: WKFrameInfo
+
+    init(name: String, body: Any, frameInfo: WKFrameInfo) {
+        overridenBody = body
+        overridenName = name
+        overridenFrameInfo = frameInfo
+    }
+
+    override var body: Any {
+        return overridenBody
+    }
+
+    override var name: String {
+        return overridenName
+    }
+
+    override var frameInfo: WKFrameInfo {
+        return overridenFrameInfo
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWebKit.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWebKit.swift
@@ -1,0 +1,84 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import WebKit
+
+// MARK: WKNavigationActionMock
+class WKNavigationActionMock: WKNavigationAction {
+    var overridenTargetFrame: WKFrameInfoMock?
+
+    override var targetFrame: WKFrameInfo? {
+        return overridenTargetFrame
+    }
+}
+
+// MARK: WKFrameInfoMock
+class WKFrameInfoMock: WKFrameInfo {
+    let overridenSecurityOrigin: WKSecurityOrigin
+    let overridenWebView: WKWebView?
+    let overridenTargetFrame: Bool
+
+    init(webView: WKWebViewMock? = nil, frameURL: URL? = nil, isMainFrame: Bool? = false) {
+        overridenSecurityOrigin = WKSecurityOriginMock.new(frameURL)
+        overridenWebView = webView
+        overridenTargetFrame = isMainFrame ?? false
+    }
+
+    override var isMainFrame: Bool {
+        return overridenTargetFrame
+    }
+
+    override var securityOrigin: WKSecurityOrigin {
+        return overridenSecurityOrigin
+    }
+
+    override var webView: WKWebView? {
+        return overridenWebView
+    }
+}
+
+// MARK: WKSecurityOriginMock
+class WKSecurityOriginMock: WKSecurityOrigin {
+    var overridenProtocol: String!
+    var overridenHost: String!
+    var overridenPort: Int!
+
+    class func new(_ url: URL?) -> WKSecurityOriginMock {
+        // Dynamically allocate a WKSecurityOriginMock instance because 
+        // the initializer for WKSecurityOrigin is unavailable
+        //  https://github.com/WebKit/WebKit/blob/52222cf447b7215dd9bcddee659884f704001827/Source/WebKit/UIProcess/API/Cocoa/WKSecurityOrigin.h#L40
+        guard let instance = self.perform(NSSelectorFromString("alloc"))?.takeUnretainedValue()
+                as? WKSecurityOriginMock
+        else {
+            fatalError("Could not allocate WKSecurityOriginMock instance")
+        }
+        instance.overridenProtocol = url?.scheme ?? ""
+        instance.overridenHost = url?.host ?? ""
+        instance.overridenPort = url?.port ?? 0
+        return instance
+    }
+
+    override var `protocol`: String { overridenProtocol }
+    override var host: String { overridenHost }
+    override var port: Int { overridenPort }
+}
+
+// MARK: WKWebViewMock
+class WKWebViewMock: WKWebView {
+    var overridenURL: URL
+
+    init(_ url: URL) {
+        self.overridenURL = url
+        super.init(frame: .zero, configuration: WKWebViewConfiguration())
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("Not implemented")
+    }
+
+    override var url: URL {
+        return overridenURL
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8465)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18776)

## :bulb: Description
This PR:
- Adds a `isFrameLoadedInSecureContext` field that checks the frame context.
- Adds tests for `isFrameLoadedInSecureContext`
- Adds early return check in formautofill to check context of iframes.  

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] ~When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)~
- [ ] ~If needed I updated documentation / comments for complex code and public methods~

