### PR TITLE
Bugfix FXIOS-6099 [v125] When adding a new log in the text cursor is positioned on the opposite side while typing on RTL locale

### DIFF
--- a/firefox-ios/Client/Frontend/PasswordManagement/AddCredentialViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/AddCredentialViewController.swift
@@ -22,6 +22,10 @@ class AddCredentialViewController: UIViewController, Themeable {
     var themeObserver: NSObjectProtocol?
     var notificationCenter: NotificationProtocol
 
+    private var isRTLLanguage: Bool {
+        UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft
+    }
+
     lazy var tableView: UITableView = .build { [weak self] tableView in
         guard let self = self else { return }
         tableView.accessibilityIdentifier = "Add Credential"
@@ -154,6 +158,9 @@ extension AddCredentialViewController: UITableViewDataSource {
             loginCell.configure(viewModel: cellModel)
             loginCell.applyTheme(theme: themeManager.currentTheme)
             usernameField = loginCell.descriptionLabel
+            if isRTLLanguage {
+                usernameField.textAlignment = .right
+            }
             return loginCell
 
         case .passwordItem:
@@ -177,6 +184,9 @@ extension AddCredentialViewController: UITableViewDataSource {
             loginCell.configure(viewModel: cellModel)
             loginCell.applyTheme(theme: themeManager.currentTheme)
             websiteField = loginCell.descriptionLabel
+            if isRTLLanguage {
+                websiteField.textAlignment = .right
+            }
             return loginCell
         }
     }


### PR DESCRIPTION


## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6099)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13799)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR is fix to show the text cursor correctly on Arabic language. 
I observed that in **textfeild** username and Website for `AddCredentialVC` it's causing issue. However it's working fine in `PasswordDetailVC`. It's because we are already passing values from added Credential to `PasswordDetailVC` fields. If we do same thing in `AddCredentialVC` like pass some value in **descriptionLabel of configure function**(which we don't want but to debug) cursor will align to right.
For Password it's working because of `isSecureTextEntry`. 

Before:
<img width="315" alt="image" src="https://github.com/mozilla-mobile/firefox-ios/assets/59967463/d25c1877-d360-4e52-838d-220695d970e7">


After:
<img width="291" alt="image" src="https://github.com/mozilla-mobile/firefox-ios/assets/59967463/aa018c55-c076-48cb-8ac5-27a9ba9aff2c">

Once we change back to english, it will work fine:
<img width="294" alt="image" src="https://github.com/mozilla-mobile/firefox-ios/assets/59967463/20883d97-f725-43e5-ab7d-b58aacac7e67">


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

