### PR TITLE
Bugfix EXP-4270 [v125] Re-enable ignored tests for TelemeteryWrapper

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -14,11 +14,13 @@ class TelemetryWrapperTests: XCTestCase {
     override func setUp() {
         super.setUp()
         Glean.shared.resetGlean(clearStores: true)
+        Experiments.events.clearEvents()
     }
 
     override func tearDown() {
         super.tearDown()
         Glean.shared.resetGlean(clearStores: true)
+        Experiments.events.clearEvents()
     }
 
     // MARK: - Bookmarks
@@ -1322,33 +1324,43 @@ class TelemetryWrapperTests: XCTestCase {
     // MARK: - Nimbus Calls
 
     func test_appForeground_NimbusIsCalled() throws {
-        throw XCTSkip("Need to be investigated with #12567 so we can enable again")
-//        TelemetryWrapper.recordEvent(
-//            category: .action,
-//            method: .foreground,
-//            object: .app,
-//            value: nil
-//        )
-//        XCTAssertTrue(
-//            try Experiments.shared.createMessageHelper().evalJexl(
-//                expression: "'app_cycle.foreground'|eventSum('Days', 1, 0) > 0"
-//            )
-//        )
+        XCTAssertFalse(
+            try Experiments.createJexlHelper()!.evalJexl(
+                expression: "'app_cycle.foreground'|eventSum('Days', 1, 0) > 0"
+            )
+        )
+        TelemetryWrapper.recordEvent(
+            category: .action,
+            method: .foreground,
+            object: .app,
+            value: nil
+        )
+        Experiments.shared.waitForDbQueue()
+        XCTAssertTrue(
+            try Experiments.createJexlHelper()!.evalJexl(
+                expression: "'app_cycle.foreground'|eventSum('Days', 1, 0) > 0"
+            )
+        )
     }
 
     func test_syncLogin_NimbusIsCalled() throws {
-        throw XCTSkip("Need to be investigated with #12567 so we can enable again")
-//        TelemetryWrapper.recordEvent(
-//            category: .firefoxAccount,
-//            method: .view,
-//            object: .fxaLoginCompleteWebpage,
-//            value: nil
-//        )
-//        XCTAssertTrue(
-//            try Experiments.shared.createMessageHelper().evalJexl(
-//                expression: "'sync.login_completed_view'|eventSum('Days', 1, 0) > 0"
-//            )
-//        )
+        XCTAssertFalse(
+            try Experiments.createJexlHelper()!.evalJexl(
+                expression: "'sync.login_completed_view'|eventSum('Days', 1, 0) > 0"
+            )
+        )
+        TelemetryWrapper.recordEvent(
+            category: .firefoxAccount,
+            method: .view,
+            object: .fxaLoginCompleteWebpage,
+            value: nil
+        )
+        Experiments.shared.waitForDbQueue()
+        XCTAssertTrue(
+            try Experiments.createJexlHelper()!.evalJexl(
+                expression: "'sync.login_completed_view'|eventSum('Days', 1, 0) > 0"
+            )
+        )
     }
 
     // MARK: - App Errors


### PR DESCRIPTION
Relates to [ EXP-4270](https://mozilla-hub.atlassian.net/browse/EXP-4270).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This PR re-enables TelemetryWrapper tests, because the underlying Nimbus API to wait for the DB queue is now available.

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

