### PR TITLE
Refactor EXP-4270 [v125] Rename to messagemanager.getNextMessage(for:from:)

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Messaging/GleanPlumbMessageManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Messaging/GleanPlumbMessageManagerTests.swift
@@ -73,7 +73,7 @@ class GleanPlumbMessageManagerTests: XCTestCase {
             createMessage(messageId: "notification", surface: .notification),
             createMessage(messageId: expectedId, surface: .newTabCard)
         ]
-        guard let observed = subject.getNextMessage(for: .newTabCard, availableMessages: messages) else {
+        guard let observed = subject.getNextMessage(for: .newTabCard, from: messages) else {
             XCTFail("Expected to retrieve message")
             return
         }
@@ -87,7 +87,7 @@ class GleanPlumbMessageManagerTests: XCTestCase {
             createMessage(messageId: "infoCard-notyet", surface: .newTabCard, trigger: ["false"]),
             createMessage(messageId: expectedId, surface: .newTabCard)
         ]
-        guard let observed = subject.getNextMessage(for: .newTabCard, availableMessages: messages) else {
+        guard let observed = subject.getNextMessage(for: .newTabCard, from: messages) else {
             XCTFail("Expected to retrieve message")
             return
         }
@@ -101,7 +101,7 @@ class GleanPlumbMessageManagerTests: XCTestCase {
             createMessage(messageId: "infoCard-notyet", surface: .newTabCard, trigger: ["true", "false"]),
             createMessage(messageId: expectedId, surface: .newTabCard, trigger: ["true", "true"])
         ]
-        guard let observed = subject.getNextMessage(for: .newTabCard, availableMessages: messages) else {
+        guard let observed = subject.getNextMessage(for: .newTabCard, from: messages) else {
             XCTFail("Expected to retrieve message")
             return
         }
@@ -117,7 +117,7 @@ class GleanPlumbMessageManagerTests: XCTestCase {
         let messages = [
             createMessage(messageId: expectedId, surface: .newTabCard, experiment: experiment)
         ]
-        guard let observed = subject.getNextMessage(for: .newTabCard, availableMessages: messages) else {
+        guard let observed = subject.getNextMessage(for: .newTabCard, from: messages) else {
             XCTFail("Expected to retrieve message")
             return
         }
@@ -138,7 +138,7 @@ class GleanPlumbMessageManagerTests: XCTestCase {
             createMessage(messageId: "control", surface: .newTabCard, experiment: experiment, isControl: true),
             createMessage(messageId: expectedId, surface: .newTabCard)
         ]
-        guard let observed = subject.getNextMessage(for: .newTabCard, availableMessages: messages) else {
+        guard let observed = subject.getNextMessage(for: .newTabCard, from: messages) else {
             XCTFail("Expected to retrieve message")
             return
         }
@@ -160,7 +160,7 @@ class GleanPlumbMessageManagerTests: XCTestCase {
             createMessage(messageId: "control", surface: .newTabCard, isControl: true),
             createMessage(messageId: expectedId, surface: .newTabCard)
         ]
-        guard let observed = subject.getNextMessage(for: .newTabCard, availableMessages: messages) else {
+        guard let observed = subject.getNextMessage(for: .newTabCard, from: messages) else {
             XCTFail("Expected to retrieve message")
             return
         }
@@ -186,7 +186,7 @@ class GleanPlumbMessageManagerTests: XCTestCase {
             createMessage(messageId: "control-2", surface: .newTabCard, experiment: experiment, isControl: true),
             createMessage(messageId: expectedId, surface: .newTabCard)
         ]
-        guard let observed = subject.getNextMessage(for: .newTabCard, availableMessages: messages) else {
+        guard let observed = subject.getNextMessage(for: .newTabCard, from: messages) else {
             XCTFail("Expected to retrieve message")
             return
         }


### PR DESCRIPTION
Relates to [ EXP-4270](https://mozilla-hub.atlassian.net/browse/EXP-4270).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_1_) change.

This is a largely mechanical rename conducted by the IDE.

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

