### PR TITLE
Refactor EXP-4270 [v125] Update visibility of fields in GleanPlumbMessage

### DIFF
--- a/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessage.swift
+++ b/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessage.swift
@@ -22,48 +22,83 @@ protocol StyleDataProtocol {
 
 extension StyleData: StyleDataProtocol {}
 
-/// Message is a representation of `MessageData` from `GleanPlumb` that we can better utilize.
+/// Message is a facade object onto configuration provided by the Nimbus Messaging component
+/// and the Nimbus SDK.
 struct GleanPlumbMessage {
     /// The message Key, a unique identifier.
-    let id: String
+    ///
+    /// This is corresponds to a MessageKey string from Nimbus.
+    ///
+    public let id: String
 
-    /// An access point to MessageData from Nimbus Messaging.
-    internal let data: MessageDataProtocol
+    /// The underlying MessageData from Nimbus.
+    ///
+    /// Embedding apps should not read from this directly.
+    let data: MessageDataProtocol
 
-    /// The action to be done when a user positively engages with the message (CTA).
+    /// The action URL as resolved by the Nimbus Messaging component.
+    ///
+    /// Embedding apps should not read from this directly.
     let action: String
 
     /// The conditions that need to be satisfied for a message to be considered eligible to present.
+    ///
+    /// Embedding apps should not read from this directly.
     let triggers: [String]
 
     /// The access point to StyleData from Nimbus Messaging.
+    ///
+    /// Embedding apps should not read from this directly.
     let style: StyleDataProtocol
 
     /// The minimal data about a message that we should persist.
-    internal var metadata: GleanPlumbMessageMetaData
+    ///
+    /// Embedding apps should not read from this directly.
+    var metadata: GleanPlumbMessageMetaData
 
-    internal var isExpired: Bool {
+    /// Has the message been shown a maximal number of times?
+    ///
+    /// Embedding apps should not read from this directly.
+    var isExpired: Bool {
         metadata.isExpired || metadata.impressions >= style.maxDisplayCount
     }
 
+    /// Has the message been tapped on or dismissed.
+    ///
+    /// Embedding apps should not read from this directly.
     var isInteractedWith: Bool {
         metadata.isExpired || metadata.dismissals > 0
     }
 
-    var buttonLabel: String? {
+    /// The surface id for this message.
+    ///
+    /// Embedding apps should not read from this directly.
+    var surface: MessageSurfaceId {
+        data.surface
+    }
+}
+
+/// Public properties for this message.
+///
+/// These are the only properties needed by the message surfaces.
+extension GleanPlumbMessage {
+    /// Button label. If the button is tapped then call `messaging.onMessageClicked(message)`
+    ///
+    /// If the button label is `nil`, don't draw a button, and make the whole message surface tappable.
+    public var buttonLabel: String? {
         data.buttonLabel
     }
 
-    var text: String {
+    /// The message to be displayed
+    public var text: String {
         data.text
     }
 
-    var title: String? {
+    /// The title to be displayed above the message.
+    ///
+    /// If this is `nil` then do not display a title.
+    public var title: String? {
         data.title
-    }
-
-    var surface: MessageSurfaceId {
-        data.surface
     }
 }
 

--- a/firefox-ios/Client/Frontend/Home/MessageCard/HomepageMessageCard.swift
+++ b/firefox-ios/Client/Frontend/Home/MessageCard/HomepageMessageCard.swift
@@ -188,7 +188,7 @@ class HomepageMessageCardCell: UICollectionViewCell, ReusableCell {
 
     /// Apply message data, including handling of cases where certain parts of the message are missing.
     private func applyGleanMessage(_ message: GleanPlumbMessage) {
-        if let buttonLabel = message.data.buttonLabel {
+        if let buttonLabel = message.buttonLabel {
             let buttonViewModel = PrimaryRoundedButtonViewModel(
                 title: buttonLabel,
                 a11yIdentifier: a11y.ctaButton
@@ -202,13 +202,13 @@ class HomepageMessageCardCell: UICollectionViewCell, ReusableCell {
             cardView.isUserInteractionEnabled = true
         }
 
-        if let title = message.data.title {
+        if let title = message.title {
             bannerTitle.text = title
         } else {
             textStackView.removeArrangedView(titleContainerView)
         }
 
-        descriptionText.text = message.data.text
+        descriptionText.text = message.text
     }
 
     // MARK: Actions

--- a/firefox-ios/Client/Frontend/NotificationSurface/NotificationSurfaceManager.swift
+++ b/firefox-ios/Client/Frontend/NotificationSurface/NotificationSurfaceManager.swift
@@ -88,8 +88,8 @@ class NotificationSurfaceManager: NotificationSurfaceDelegate {
     private func scheduleNotification(message: GleanPlumbMessage, notificationId: String) {
         let userInfo = [Constant.messageIdKey: message.id]
         let fallbackTitle = String(format: .Notification.FallbackTitle, AppInfo.displayName)
-        let body = String(format: message.data.text, AppInfo.displayName)
-        notificationManager.schedule(title: message.data.title ?? fallbackTitle,
+        let body = String(format: message.text, AppInfo.displayName)
+        notificationManager.schedule(title: message.title ?? fallbackTitle,
                                      body: body,
                                      id: notificationId,
                                      userInfo: userInfo,


### PR DESCRIPTION
Relates to [ EXP-4270](https://mozilla-hub.atlassian.net/browse/EXP-4270).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This PR reduces the visibility of properties in GleanPlumbMessage, in order to increase encapsulation.

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

