### PR TITLE
Refactor EXP-4270 [v125] Reduce visibility of isExpired in GleanPlumbMessage

### DIFF
--- a/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessage.swift
+++ b/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessage.swift
@@ -42,7 +42,7 @@ struct GleanPlumbMessage {
     /// The minimal data about a message that we should persist.
     internal var metadata: GleanPlumbMessageMetaData
 
-    var isExpired: Bool {
+    internal var isExpired: Bool {
         metadata.isExpired || metadata.impressions >= style.maxDisplayCount
     }
 

--- a/firefox-ios/Client/Frontend/Home/MessageCard/MessageCardDataAdaptor.swift
+++ b/firefox-ios/Client/Frontend/Home/MessageCard/MessageCardDataAdaptor.swift
@@ -34,10 +34,8 @@ class MessageCardDataAdaptorImplementation: MessageCardDataAdaptor {
     /// An expired message will not trigger a reload of the section
     /// - Parameter surface: Message surface id
     func updateMessage(for surface: MessageSurfaceId = .newTabCard) {
-        guard let validMessage = messagingManager.getNextMessage(for: surface) else { return }
-
-        if !validMessage.isExpired {
-            message = validMessage
+        if let message = messagingManager.getNextMessage(for: surface) {
+            self.message = message
             delegate?.didLoadNewData()
         }
     }

--- a/firefox-ios/Client/Frontend/NotificationSurface/NotificationSurfaceManager.swift
+++ b/firefox-ios/Client/Frontend/NotificationSurface/NotificationSurfaceManager.swift
@@ -105,10 +105,6 @@ class NotificationSurfaceManager: NotificationSurfaceDelegate {
 
     /// Call messagingManager to retrieve the message for notification surface.
     private func updateMessage() {
-        // Set the message to nil just to make sure we're not accidentally
-        // showing an old message.
-        message = nil
-        guard let newMessage = messagingManager.getNextMessage(for: notificationSurfaceID) else { return }
-        if !newMessage.isExpired { message = newMessage }
+        message = messagingManager.getNextMessage(for: notificationSurfaceID)
     }
 }

--- a/firefox-ios/Client/Frontend/SurveySurface/SurveySurfaceManager.swift
+++ b/firefox-ios/Client/Frontend/SurveySurface/SurveySurfaceManager.swift
@@ -46,7 +46,6 @@ class SurveySurfaceManager: SurveySurfaceDelegate {
     /// - Returns: An optional `SurveySurfaceViewController`
     func getSurveySurface() -> SurveySurfaceViewController? {
         guard let message = message,
-              !message.isExpired,
               let image = UIImage(named: ImageIdentifiers.logo)
         else { return nil }
 
@@ -66,11 +65,7 @@ class SurveySurfaceManager: SurveySurfaceDelegate {
 
     /// Call messagingManager to retrieve the message for research surface.
     private func updateMessage() {
-        // Set the message to nil just to make sure we're not accidentally
-        // showing an old message.
-        message = nil
-        guard let newMessage = messagingManager.getNextMessage(for: surveySurfaceID) else { return }
-        if !newMessage.isExpired { message = newMessage }
+        message = messagingManager.getNextMessage(for: surveySurfaceID)
     }
 
     // MARK: - MessageSurfaceProtocol

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/LaunchView/LaunchScreenViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/LaunchView/LaunchScreenViewModelTests.swift
@@ -73,7 +73,7 @@ final class LaunchScreenViewModelTests: XCTestCase {
     func testLaunchType_survey() async {
         profile.prefs.setString("112.0", forKey: PrefsKeys.AppVersion.Latest)
         profile.prefs.setInt(1, forKey: PrefsKeys.IntroSeen)
-        let message = createMessage(isExpired: false)
+        let message = createMessage()
         messageManager.message = message
 
         let subject = createSubject()
@@ -86,21 +86,6 @@ final class LaunchScreenViewModelTests: XCTestCase {
         }
         XCTAssertEqual(delegate.launchBrowserCalled, 0)
         XCTAssertEqual(delegate.launchWithTypeCalled, 1)
-    }
-
-    func testLaunchType_nilBrowserIsStarted() async {
-        profile.prefs.setString("112.0", forKey: PrefsKeys.AppVersion.Latest)
-        profile.prefs.setInt(1, forKey: PrefsKeys.IntroSeen)
-        let message = createMessage(isExpired: true)
-        messageManager.message = message
-
-        let subject = createSubject()
-        subject.delegate = delegate
-        await subject.startLoading(appVersion: "112.0")
-
-        XCTAssertEqual(delegate.launchBrowserCalled, 1)
-        XCTAssertEqual(delegate.launchWithTypeCalled, 0)
-        XCTAssertNil(delegate.savedLaunchType)
     }
 
     // MARK: - Helpers
@@ -117,13 +102,12 @@ final class LaunchScreenViewModelTests: XCTestCase {
 
     private func createMessage(
         for surface: MessageSurfaceId = .survey,
-        isExpired: Bool,
         action: String = "OPEN_NEW_TAB"
     ) -> GleanPlumbMessage {
         let metadata = GleanPlumbMessageMetaData(id: "",
                                                  impressions: 0,
                                                  dismissals: 0,
-                                                 isExpired: isExpired)
+                                                 isExpired: false)
 
         return GleanPlumbMessage(id: "test-notification",
                                  data: MockNotificationMessageDataProtocol(surface: surface),

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/MessageCard/MessageCardDataAdaptorImplementationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/MessageCard/MessageCardDataAdaptorImplementationTests.swift
@@ -33,14 +33,6 @@ class MessageCardDataAdaptorImplementationTests: XCTestCase {
         XCTAssertNil(subject.getMessageCardData())
     }
 
-    func testSettingDelegateUpdateData_expiredMessage() {
-        messageManager.message = createMessage(isExpired: true)
-        let subject = createSubject()
-        subject.delegate = self
-        XCTAssertEqual(didLoadNewDataCalled, 0)
-        XCTAssertNil(subject.getMessageCardData())
-    }
-
     func testSettingDelegateUpdateData_validMessage() {
         let message = createMessage(isExpired: false)
         messageManager.message = message

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/NotificationSurface/NotificationSurfaceManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/NotificationSurface/NotificationSurfaceManagerTests.swift
@@ -30,17 +30,9 @@ class NotificationSurfaceManagerTests: XCTestCase {
         XCTAssertFalse(subject.shouldShowSurface)
     }
 
-    func testShouldShowSurface_expiredMessage() {
-        let subject = createSubject()
-        let message = createMessage(isExpired: true)
-        messageManager.message = message
-
-        XCTAssertFalse(subject.shouldShowSurface)
-    }
-
     func testShouldShowSurface_validMessage() {
         let subject = createSubject()
-        let message = createMessage(isExpired: false)
+        let message = createMessage()
         messageManager.message = message
 
         XCTAssertTrue(subject.shouldShowSurface)
@@ -57,22 +49,9 @@ class NotificationSurfaceManagerTests: XCTestCase {
         XCTAssertEqual(notificationManager.scheduledNotifications, 0)
     }
 
-    func testShowSurface_expiredMessage() {
-        let subject = createSubject()
-        let message = createMessage(isExpired: true)
-        messageManager.message = message
-
-        XCTAssertFalse(subject.shouldShowSurface)
-
-        subject.showNotificationSurface()
-
-        XCTAssertFalse(notificationManager.scheduleWithIntervalWasCalled)
-        XCTAssertEqual(notificationManager.scheduledNotifications, 0)
-    }
-
     func testShowSurface_validMessage() {
         let subject = createSubject()
-        let message = createMessage(isExpired: false)
+        let message = createMessage()
         messageManager.message = message
 
         XCTAssertTrue(subject.shouldShowSurface)
@@ -99,7 +78,7 @@ class NotificationSurfaceManagerTests: XCTestCase {
 
     func testDidTapNotification_openNewTabAction() {
         let subject = createSubject()
-        let message = createMessage(isExpired: false)
+        let message = createMessage()
         messageManager.message = message
 
         XCTAssertTrue(subject.shouldShowSurface)
@@ -111,7 +90,7 @@ class NotificationSurfaceManagerTests: XCTestCase {
 
     func testDidTapNotification_defaultAction() {
         let subject = createSubject()
-        let message = createMessage(isExpired: false, action: "test-action")
+        let message = createMessage(action: "test-action")
         messageManager.message = message
 
         XCTAssertTrue(subject.shouldShowSurface)
@@ -133,13 +112,12 @@ class NotificationSurfaceManagerTests: XCTestCase {
 
     private func createMessage(
         for surface: MessageSurfaceId = .notification,
-        isExpired: Bool,
         action: String = "://deep-link?url=homepanel/new-tab"
     ) -> GleanPlumbMessage {
         let metadata = GleanPlumbMessageMetaData(id: "",
                                                  impressions: 0,
                                                  dismissals: 0,
-                                                 isExpired: isExpired)
+                                                 isExpired: false)
 
         return GleanPlumbMessage(id: "test-notification",
                                  data: MockNotificationMessageDataProtocol(surface: surface),

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/SurveySurface/SurveySurfaceManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/SurveySurface/SurveySurfaceManagerTests.swift
@@ -29,14 +29,6 @@ class SurveySurfaceManagerTests: XCTestCase {
         XCTAssertFalse(subject.shouldShowSurveySurface)
     }
 
-    func testExpiredMessage_surveySurfaceShouldNotShow() {
-        let subject = createSubject()
-        let expiredMessage = createMessage(isExpired: true)
-        messageManager.message = expiredMessage
-
-        XCTAssertFalse(subject.shouldShowSurveySurface)
-    }
-
     func testGoodButNotSurveyMessage_surveySurfaceShouldNotShow() {
         let subject = createSubject()
         let goodMessage = createMessage(for: .newTabCard, isExpired: false)


### PR DESCRIPTION
Relates to [ EXP-4270](https://mozilla-hub.atlassian.net/browse/EXP-4270).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This is largely mechanical, but rewrites or removes some logic in the presentation layer.

Its principle goal is to reduce the visibility of the `isExired` calculated field, and remove its use from anywhere outside of the messaging manager.

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

