### PR TITLE
Bugfix MTE-2355 [v125] testTopSitesOpenInNewPrivateTabDefaultTopSite fails on iPad

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -199,8 +199,9 @@ class ActivityStreamTest: BaseTestCase {
         navigator.nowAt(NewTabScreen)
         // Open one of the sites from Topsites and wait until page is loaded
         // Long tap on apple top site, second cell
-        waitForExistence(app.collectionViews.cells.element(boundBy: 4), timeout: 3)
-        app.collectionViews.cells.element(boundBy: 4).press(forDuration: 1)
+        waitForExistence(app.collectionViews["FxCollectionView"].cells.staticTexts[defaultTopSite["bookmarkLabel"]!], 
+                         timeout: 3)
+        app.collectionViews["FxCollectionView"].cells.staticTexts[defaultTopSite["bookmarkLabel"]!].press(forDuration: 1)
         selectOptionFromContextMenu(option: "Open in a Private Tab")
 
         // Check that two tabs are open and one of them is the default top site one

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -199,8 +199,8 @@ class ActivityStreamTest: BaseTestCase {
         navigator.nowAt(NewTabScreen)
         // Open one of the sites from Topsites and wait until page is loaded
         // Long tap on apple top site, second cell
-        waitForExistence(app.collectionViews["FxCollectionView"].cells.staticTexts[defaultTopSite["bookmarkLabel"]!], 
-                         timeout: 3)
+        waitForExistence(app.collectionViews["FxCollectionView"].cells
+            .staticTexts[defaultTopSite["bookmarkLabel"]!], timeout: 3)
         app.collectionViews["FxCollectionView"].cells.staticTexts[defaultTopSite["bookmarkLabel"]!].press(forDuration: 1)
         selectOptionFromContextMenu(option: "Open in a Private Tab")
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2355)

## :bulb: Description
`testTopSitesOpenInNewPrivateTabDefaultTopSite()` has been failing on iPad only since Feb 15. The same test passes on iPhone in the meanwhile.

Let me strengthen the test by using a more specific selector: The labels and static texts are specified instead of using the indexes of the elements

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

