### PR TITLE
Refactor FXIOS-8461 [v123] Deeplinks improvements and logs

### DIFF
--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -104,7 +104,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             .profileInitialized,
             .preLaunchDependenciesComplete,
             .postLaunchDependenciesComplete,
-            .accountManagerInitialized
+            .accountManagerInitialized,
+            .browserIsReady
         ])
 
         // Then setup dependency container as it's needed for everything else

--- a/firefox-ios/Client/Application/LaunchSessionProvider.swift
+++ b/firefox-ios/Client/Application/LaunchSessionProvider.swift
@@ -9,16 +9,23 @@ protocol LaunchSessionProviderProtocol {
     var openedFromExternalSource: Bool { get set }
 }
 
-class LaunchSessionProvider: LaunchSessionProviderProtocol {
-    init() {
+class LaunchSessionProvider: LaunchSessionProviderProtocol, Notifiable {
+    private var logger: Logger
+    var notificationCenter: NotificationProtocol
+    var openedFromExternalSource = false {
+        didSet {
+            guard openedFromExternalSource else { return }
+            logger.log("openedFromExternalSource was set to true", level: .debug, category: .tabs)
+        }
+    }
+
+    init(notificationCenter: NotificationProtocol = NotificationCenter.default,
+         logger: Logger = DefaultLogger.shared) {
+        self.notificationCenter = notificationCenter
+        self.logger = logger
         addObservers()
     }
 
-    var notificationCenter: NotificationProtocol = NotificationCenter.default
-    var openedFromExternalSource = false
-}
-
-extension LaunchSessionProvider: Notifiable {
     func addObservers() {
         setupNotifications(forObserver: self, observing: [UIApplication.willResignActiveNotification,
                                                           UIScene.willDeactivateNotification])

--- a/firefox-ios/Client/Application/SceneDelegate.swift
+++ b/firefox-ios/Client/Application/SceneDelegate.swift
@@ -48,10 +48,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let sceneCoordinator = SceneCoordinator(scene: scene)
         self.sceneCoordinator = sceneCoordinator
         sceneCoordinator.start()
-
-        AppEventQueue.wait(for: [.startupFlowComplete, .tabRestoration(sceneCoordinator.windowUUID)]) { [weak self] in
-            self?.handle(connectionOptions: connectionOptions)
-        }
+        handle(connectionOptions: connectionOptions)
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {
@@ -171,7 +168,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             return
         }
 
+        logger.log("Scene coordinator will handle a route", level: .info, category: .coordinator)
         sessionManager.launchSessionProvider.openedFromExternalSource = true
-        sceneCoordinator.findAndHandle(route: route)
+
+        AppEventQueue.wait(for: [.startupFlowComplete, .tabRestoration(sceneCoordinator.windowUUID)]) {
+            sceneCoordinator.findAndHandle(route: route)
+        }
     }
 }

--- a/firefox-ios/Client/Application/SceneDelegate.swift
+++ b/firefox-ios/Client/Application/SceneDelegate.swift
@@ -96,9 +96,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     ) {
         guard let url = URLContexts.first?.url,
               let route = routeBuilder.makeRoute(url: url) else { return }
-        sceneCoordinator?.findAndHandle(route: route)
-
         sessionManager.launchSessionProvider.openedFromExternalSource = true
+        sceneCoordinator?.findAndHandle(route: route)
     }
 
     // MARK: - Continuing User Activities
@@ -106,6 +105,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     /// Use this method to handle Handoff-related data or other activities.
     func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
         guard let route = routeBuilder.makeRoute(userActivity: userActivity) else { return }
+        sessionManager.launchSessionProvider.openedFromExternalSource = true
         sceneCoordinator?.findAndHandle(route: route)
     }
 
@@ -124,6 +124,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let route = routeBuilder.makeRoute(shortcutItem: shortcutItem,
                                                  tabSetting: NewTabAccessors.getNewTabPage(profile.prefs))
         else { return }
+        sessionManager.launchSessionProvider.openedFromExternalSource = true
         sceneCoordinator?.findAndHandle(route: route)
     }
 
@@ -132,17 +133,20 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     private func handle(connectionOptions: UIScene.ConnectionOptions) {
         if let context = connectionOptions.urlContexts.first,
            let route = routeBuilder.makeRoute(url: context.url) {
+            sessionManager.launchSessionProvider.openedFromExternalSource = true
             sceneCoordinator?.findAndHandle(route: route)
         }
 
         if let activity = connectionOptions.userActivities.first,
            let route = routeBuilder.makeRoute(userActivity: activity) {
+            sessionManager.launchSessionProvider.openedFromExternalSource = true
             sceneCoordinator?.findAndHandle(route: route)
         }
 
         if let shortcut = connectionOptions.shortcutItem,
            let route = routeBuilder.makeRoute(shortcutItem: shortcut,
                                               tabSetting: NewTabAccessors.getNewTabPage(profile.prefs)) {
+            sessionManager.launchSessionProvider.openedFromExternalSource = true
             sceneCoordinator?.findAndHandle(route: route)
         }
 
@@ -162,6 +166,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             guard let urlString = tab["url"] as? String,
                   let url = URL(string: urlString),
                   let route = routeBuilder.makeRoute(url: url) else { continue }
+            sessionManager.launchSessionProvider.openedFromExternalSource = true
             sceneCoordinator?.findAndHandle(route: route)
         }
     }

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -148,13 +148,15 @@ class BrowserCoordinator: BaseCoordinator,
         if let webviewController = webviewController {
             webviewController.update(webView: webView, isPrivate: tabManager.selectedTab?.isPrivate ?? false)
             browserViewController.frontEmbeddedContent(webviewController)
+            logger.log("Webview content was updated", level: .info, category: .coordinator)
         } else {
             let webviewViewController = WebviewViewController(
                 webView: webView,
                 isPrivate: tabManager.selectedTab?.isPrivate ?? false
             )
             webviewController = webviewViewController
-            _ = browserViewController.embedContent(webviewViewController)
+            let isEmbedded = browserViewController.embedContent(webviewViewController)
+            logger.log("Webview controller was created and embedded \(isEmbedded)", level: .info, category: .coordinator)
         }
 
         screenshotService.screenshotableView = webviewController

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -200,13 +200,11 @@ class BrowserCoordinator: BaseCoordinator,
     // MARK: - Route handling
 
     override func canHandle(route: Route) -> Bool {
-        // Due to the new AppEventQueue, this should not be needed anymore. Adding a fatal log to confirm
-        // this use case can be cleaned up
         guard browserIsReady, !tabManager.isRestoringTabs else {
             let readyMessage = "browser is ready? \(browserIsReady)"
             let restoringMessage = "is restoring tabs? \(tabManager.isRestoringTabs)"
             logger.log("Could not handle route, \(readyMessage), \(restoringMessage)",
-                       level: .fatal,
+                       level: .info,
                        category: .coordinator)
             return false
         }

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -90,6 +90,9 @@ class BrowserCoordinator: BaseCoordinator,
 
         // Once launch is done, we check for any saved Route
         if let savedRoute {
+            logger.log("Find and handle route called after didFinishLaunch after onboarding",
+                       level: .info,
+                       category: .coordinator)
             findAndHandle(route: savedRoute)
         }
     }
@@ -162,6 +165,9 @@ class BrowserCoordinator: BaseCoordinator,
         logger.log("Browser has loaded", level: .info, category: .coordinator)
 
         if let savedRoute {
+            logger.log("Find and handle route called after browserHasLoaded",
+                       level: .info,
+                       category: .coordinator)
             findAndHandle(route: savedRoute)
         }
     }
@@ -194,11 +200,13 @@ class BrowserCoordinator: BaseCoordinator,
     // MARK: - Route handling
 
     override func canHandle(route: Route) -> Bool {
+        // Due to the new AppEventQueue, this should not be needed anymore. Adding a fatal log to confirm
+        // this use case can be cleaned up
         guard browserIsReady, !tabManager.isRestoringTabs else {
             let readyMessage = "browser is ready? \(browserIsReady)"
             let restoringMessage = "is restoring tabs? \(tabManager.isRestoringTabs)"
             logger.log("Could not handle route, \(readyMessage), \(restoringMessage)",
-                       level: .info,
+                       level: .fatal,
                        category: .coordinator)
             return false
         }
@@ -213,6 +221,9 @@ class BrowserCoordinator: BaseCoordinator,
 
     override func handle(route: Route) {
         guard browserIsReady, !tabManager.isRestoringTabs else {
+            logger.log("Not handling route. Ready? \(browserIsReady), restoring? \(tabManager.isRestoringTabs)",
+                       level: .info,
+                       category: .coordinator)
             return
         }
 
@@ -636,6 +647,9 @@ class BrowserCoordinator: BaseCoordinator,
     func tabManagerDidRestoreTabs(_ tabManager: TabManager) {
         // Once tab restore is made, if there's any saved route we make sure to call it
         if let savedRoute {
+            logger.log("Find and handle route called after tabManagerDidRestoreTabs",
+                       level: .info,
+                       category: .coordinator)
             findAndHandle(route: savedRoute)
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -77,7 +77,6 @@ class BrowserViewController: UIViewController,
     var urlFromAnotherApp: UrlToOpenModel?
     var isCrashAlertShowing = false
     var currentMiddleButtonState: MiddleButtonState?
-    var openedUrlFromExternalSource = false
     var passBookHelper: OpenPassBookHelper?
     var overlayManager: OverlayModeManager
     var appAuthenticator: AppAuthenticationProtocol
@@ -1579,6 +1578,7 @@ class BrowserViewController: UIViewController,
     func switchToTabForURLOrOpen(_ url: URL, uuid: String? = nil, isPrivate: Bool = false) {
         guard !isCrashAlertShowing else {
             urlFromAnotherApp = UrlToOpenModel(url: url, isPrivate: isPrivate)
+            logger.log("Saving urlFromAnotherApp since crash alert is showing", level: .debug, category: .tabs)
             return
         }
         popToBVC()
@@ -1586,7 +1586,6 @@ class BrowserViewController: UIViewController,
             tabManager.addTab(URLRequest(url: url), isPrivate: isPrivate)
             return
         }
-        openedUrlFromExternalSource = true
 
         if let uuid = uuid, let tab = tabManager.getTabForUUID(uuid: uuid) {
             tabManager.selectTab(tab)
@@ -1607,6 +1606,7 @@ class BrowserViewController: UIViewController,
             request = URLRequest(url: url)
         } else {
             request = nil
+            logger.log("No request for openURLInNewTab", level: .debug, category: .tabs)
         }
 
         switchToPrivacyMode(isPrivate: isPrivate)
@@ -1644,7 +1644,6 @@ class BrowserViewController: UIViewController,
             tabManager.addTab(nil, isPrivate: isPrivate)
             return
         }
-        openedUrlFromExternalSource = true
 
         let freshTab = openURLInNewTab(nil, isPrivate: isPrivate)
         freshTab.metadataManager?.updateTimerAndObserving(state: .newTab, isPrivate: freshTab.isPrivate)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -764,6 +764,7 @@ class BrowserViewController: UIViewController,
         prepareURLOnboardingContextualHint()
 
         browserDelegate?.browserHasLoaded()
+        AppEventQueue.signal(event: .browserIsReady)
     }
 
     private func prepareURLOnboardingContextualHint() {

--- a/firefox-ios/Client/Frontend/Browser/Event Queue/AppEvent.swift
+++ b/firefox-ios/Client/Frontend/Browser/Event Queue/AppEvent.swift
@@ -18,6 +18,7 @@ public enum AppEvent: AppEventType {
     case preLaunchDependenciesComplete
     case postLaunchDependenciesComplete
     case accountManagerInitialized
+    case browserIsReady
 
     // Activities: Profile Syncing
     case profileSyncing

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -889,7 +889,10 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     func startAtHomeCheck() -> Bool {
         let startAtHomeManager = StartAtHomeHelper(prefs: profile.prefs, isRestoringTabs: !tabRestoreHasFinished)
 
-        guard !startAtHomeManager.shouldSkipStartHome else { return false }
+        guard !startAtHomeManager.shouldSkipStartHome else {
+            logger.log("Skipping start at home", level: .debug, category: .tabs)
+            return false
+        }
 
         if startAtHomeManager.shouldStartAtHome() {
             let wasLastSessionPrivate = selectedTab?.isPrivate ?? false

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -260,10 +260,13 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
                 logger.log("Tab has empty tab.URL \(logMessage)",
                            level: .debug,
                            category: .tabs)
-            } else if tab.lastKnownUrl == nil {
-                logger.log("Tab has empty tab.lastKnownURL \(logMessage)",
-                           level: .fatal,
-                           category: .tabs)
+
+                // lastKnownUrl is the fallback in case tab.url is empty. If this one is empty too then this is a problem
+                if tab.lastKnownUrl == nil {
+                    logger.log("Tab has empty tab.lastKnownURL \(logMessage)",
+                               level: .fatal,
+                               category: .tabs)
+                }
             }
 
             return TabData(id: tabId,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8461)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18773)

## :bulb: Description
Didn't find the root cause yet, but this aims at:
- Adding logs so we can clean up some code that shouldn't be needed anymore in `BrowserCoordinator`
- Add `openedFromExternalSource = true` in most places where we open from external deep links. This `openedFromExternalSource` is used to ensure we don't start at home when a deep link was request by the user. The user should always have what they request to be opened, opened.
- Improve log when `tab.URL` is empty, want to check if fallback works or not as with the current log setup we cannot determine this.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

