### PR TITLE
Add FXIOS-8472 [v124] Create SwiftUI components for header and footer to share between login and address autofill

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -858,6 +858,9 @@
 		8AFCE50729DE0CD500B1B253 /* LaunchCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFCE50629DE0CD500B1B253 /* LaunchCoordinatorTests.swift */; };
 		8AFCE50929DE136300B1B253 /* MockLaunchFinishedLoadingDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFCE50829DE136300B1B253 /* MockLaunchFinishedLoadingDelegate.swift */; };
 		8AFE4C2127480D0C00B97C65 /* LegacyTabTrayViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFE4C2027480D0B00B97C65 /* LegacyTabTrayViewControllerTests.swift */; };
+		8C19532E2B85E7AE00761B20 /* SelfSizingHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C19532D2B85E7AE00761B20 /* SelfSizingHostingController.swift */; };
+		8C1953302B85E7EC00761B20 /* AutoFillFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C19532F2B85E7EC00761B20 /* AutoFillFooterView.swift */; };
+		8C1953322B85EAB500761B20 /* AutoFillHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C1953312B85EAB500761B20 /* AutoFillHeaderView.swift */; };
 		8C29627C2B1F473800571655 /* AdEventsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C29627B2B1F473800571655 /* AdEventsResponse.swift */; };
 		8C44A9D22A6A99FE009A1AA7 /* ShoppingProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C44A9D12A6A99FE009A1AA7 /* ShoppingProduct.swift */; };
 		8C46E1B72B2209F000F56521 /* FakespotAdsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C46E1B62B2209F000F56521 /* FakespotAdsEvent.swift */; };
@@ -5913,6 +5916,9 @@
 		8BF7415AADE68847B78B376B /* mr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = mr; path = mr.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
 		8BFA4413BB71963DB0E69F82 /* ses */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ses; path = ses.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
 		8BFD47109E07F897D604AEBE /* uz */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uz; path = uz.lproj/ClearPrivateData.strings; sourceTree = "<group>"; };
+		8C19532D2B85E7AE00761B20 /* SelfSizingHostingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelfSizingHostingController.swift; sourceTree = "<group>"; };
+		8C19532F2B85E7EC00761B20 /* AutoFillFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoFillFooterView.swift; sourceTree = "<group>"; };
+		8C1953312B85EAB500761B20 /* AutoFillHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoFillHeaderView.swift; sourceTree = "<group>"; };
 		8C264BF5A1C7B2B6378D4DFF /* fa */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fa; path = fa.lproj/Today.strings; sourceTree = "<group>"; };
 		8C29627B2B1F473800571655 /* AdEventsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdEventsResponse.swift; sourceTree = "<group>"; };
 		8C44A9D12A6A99FE009A1AA7 /* ShoppingProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoppingProduct.swift; sourceTree = "<group>"; };
@@ -8812,6 +8818,9 @@
 			isa = PBXGroup;
 			children = (
 				B2981F892B71AD7A00132C1B /* AutofillAccessoryViewButtonItem.swift */,
+				8C19532D2B85E7AE00761B20 /* SelfSizingHostingController.swift */,
+				8C19532F2B85E7EC00761B20 /* AutoFillFooterView.swift */,
+				8C1953312B85EAB500761B20 /* AutoFillHeaderView.swift */,
 				B2FEA6892B460CEC0058E616 /* Address */,
 				43D00491296FC46E00CB0F31 /* CreditCard */,
 			);
@@ -13489,6 +13498,8 @@
 				8C46E1B72B2209F000F56521 /* FakespotAdsEvent.swift in Sources */,
 				396E38F11EE0C8EC00CC180F /* FxAPushMessageHandler.swift in Sources */,
 				8A76B01629F6EB3900A82607 /* ScreenshotService.swift in Sources */,
+				8C1953322B85EAB500761B20 /* AutoFillHeaderView.swift in Sources */,
+				8C19532E2B85E7AE00761B20 /* SelfSizingHostingController.swift in Sources */,
 				E4CD9F6D1A77DD2800318571 /* ReaderModeStyleViewController.swift in Sources */,
 				E13E9AB52AAB0FB5001A0E9D /* FakespotViewModel.swift in Sources */,
 				8A5D1CBD2A30DC4E005AD35C /* AccountStatusSetting.swift in Sources */,
@@ -13986,6 +13997,7 @@
 				43F7952525795F69005AEE40 /* SearchTelemetry.swift in Sources */,
 				E65075541E37F6FC006961AC /* LegacyDynamicFontHelper.swift in Sources */,
 				8ADAE4242A33A126007BF926 /* StudiesToggleSetting.swift in Sources */,
+				8C1953302B85E7EC00761B20 /* AutoFillFooterView.swift in Sources */,
 				C82CDD47233E8996002E2743 /* Tab+ChangeUserAgent.swift in Sources */,
 				81122E212B221AC0003DD9F8 /* SearchScreenState.swift in Sources */,
 				1DA6F6512B48B42900BB5AD6 /* WindowEventCoordinator.swift in Sources */,

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -617,5 +617,9 @@ public struct AccessibilityIdentifiers {
         static let manageCardsButton = "RememberCreditCard.manageCardsButton"
         static let notNowButton = "RememberCreditCard.notNowButton"
     }
+
+    enum Autofill {
+        static let footerPrimaryAction = "Autofill.footerPrimaryAction"
+    }
 }
 // swiftlint:enable line_length

--- a/firefox-ios/Client/Frontend/Autofill/AutoFillFooterView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/AutoFillFooterView.swift
@@ -1,0 +1,52 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import SwiftUI
+
+struct AutoFillFooterView: View {
+    // Constants for UI layout and styling adapted for LoginAutoFill feature
+    private enum UX {
+        static let actionButtonFontSize: CGFloat = 16
+        static let actionButtonLeadingSpace: CGFloat = 0
+        static let actionButtonTopSpace: CGFloat = 24
+        static let actionButtonBottomSpace: CGFloat = 24
+    }
+
+    private let actionButtonTitle: String
+    private let primaryAction: () -> Void
+
+    init(
+        title: String,
+        primaryAction: @escaping () -> Void
+    ) {
+        self.actionButtonTitle = title
+        self.primaryAction = primaryAction
+    }
+
+    @Environment(\.themeType)
+    var theme
+
+    var body: some View {
+        VStack {
+            Button(action: primaryAction) {
+                Text(actionButtonTitle)
+                    .font(.system(size: UX.actionButtonFontSize))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding([.leading, .trailing], UX.actionButtonLeadingSpace)
+            .accessibility(identifier: AccessibilityIdentifiers.Autofill.footerPrimaryAction)
+        }
+    }
+}
+
+struct AutoFillFooterView_Previews: PreviewProvider {
+    static var previews: some View {
+        AutoFillFooterView(
+            title: "Manage Login Info",
+            primaryAction: { }
+        )
+        .previewLayout(.sizeThatFits)
+        .padding()
+    }
+}

--- a/firefox-ios/Client/Frontend/Autofill/AutoFillFooterView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/AutoFillFooterView.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import SwiftUI
+import Common
 
 struct AutoFillFooterView: View {
     // Constants for UI layout and styling adapted for LoginAutoFill feature
@@ -12,6 +13,8 @@ struct AutoFillFooterView: View {
         static let actionButtonTopSpace: CGFloat = 24
         static let actionButtonBottomSpace: CGFloat = 24
     }
+
+    @State private var actionPrimary: Color = .clear
 
     private let actionButtonTitle: String
     private let primaryAction: () -> Void
@@ -33,10 +36,26 @@ struct AutoFillFooterView: View {
                 Text(actionButtonTitle)
                     .font(.system(size: UX.actionButtonFontSize))
                     .frame(maxWidth: .infinity, alignment: .leading)
+                    .foregroundColor(actionPrimary)
             }
             .padding([.leading, .trailing], UX.actionButtonLeadingSpace)
             .accessibility(identifier: AccessibilityIdentifiers.Autofill.footerPrimaryAction)
         }
+        .onAppear {
+            applyTheme(theme: theme.theme)
+        }
+        .onChange(of: theme) { newThemeValue in
+            applyTheme(theme: newThemeValue.theme)
+        }
+    }
+
+    // MARK: - Theme Application
+
+    /// Applies the theme to the view.
+    /// - Parameter theme: The theme to be applied.
+    func applyTheme(theme: Theme) {
+        let color = theme.colors
+        actionPrimary = Color(color.actionPrimary)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Autofill/AutoFillHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/AutoFillHeaderView.swift
@@ -1,0 +1,65 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import SwiftUI
+import Common
+
+struct AutoFillHeaderView: View {
+    // Constants for UI layout and styling
+    private struct UX {
+        static let headerElementsSpacing: CGFloat = 7.0
+        static let mainContainerElementsSpacing: CGFloat = 10
+        static let bottomSpacing: CGFloat = 24.0
+        static let logoSize: CGFloat = 36.0
+        static let closeButtonMarginAndWidth: CGFloat = 46.0
+        static let buttonSize: CGFloat = 30
+    }
+
+    @Environment(\.themeType)
+    var theme
+
+    var title: String
+    var subtitle: String?
+
+    init(title: String, subtitle: String? = nil) {
+        self.title = title
+        self.subtitle = subtitle
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: UX.mainContainerElementsSpacing) {
+            HStack {
+                Image(uiImage: UIImage(imageLiteralResourceName: ImageIdentifiers.homeHeaderLogoBall))
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: UX.logoSize, height: UX.logoSize)
+                    .foregroundColor(.accentColor) // Use your theme's accent color
+                VStack(alignment: .leading) {
+                    Text(title)
+                        .font(.body)
+                        .fontWeight(.bold)
+                    subtitle.map {
+                        Text($0)
+                            .font(.footnote)
+                            .foregroundColor(Color(theme.theme.colors.textSecondary))
+                    }
+                }
+                Spacer()
+            }
+        }
+        .padding([.leading, .trailing], UX.headerElementsSpacing)
+        .padding(.bottom, UX.bottomSpacing)
+    }
+}
+
+struct AutoFillHeaderView_Previews: PreviewProvider {
+    static var previews: some View {
+        AutoFillHeaderView(
+                title: "Use this login?",
+                subtitle: "You’ll sign into cnn.com"
+        )
+        .previewLayout(.sizeThatFits)
+        .padding()
+    }
+}

--- a/firefox-ios/Client/Frontend/Autofill/AutoFillHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/AutoFillHeaderView.swift
@@ -16,6 +16,9 @@ struct AutoFillHeaderView: View {
         static let buttonSize: CGFloat = 30
     }
 
+    @State private var textPrimary: Color = .clear
+    @State private var textSecondary: Color = .clear
+
     @Environment(\.themeType)
     var theme
 
@@ -34,15 +37,15 @@ struct AutoFillHeaderView: View {
                     .resizable()
                     .aspectRatio(contentMode: .fit)
                     .frame(width: UX.logoSize, height: UX.logoSize)
-                    .foregroundColor(.accentColor) // Use your theme's accent color
                 VStack(alignment: .leading) {
                     Text(title)
                         .font(.body)
                         .fontWeight(.bold)
+                        .foregroundColor(textPrimary)
                     subtitle.map {
                         Text($0)
                             .font(.footnote)
-                            .foregroundColor(Color(theme.theme.colors.textSecondary))
+                            .foregroundColor(textSecondary)
                     }
                 }
                 Spacer()
@@ -50,6 +53,23 @@ struct AutoFillHeaderView: View {
         }
         .padding([.leading, .trailing], UX.headerElementsSpacing)
         .padding(.bottom, UX.bottomSpacing)
+
+        .onAppear {
+            applyTheme(theme: theme.theme)
+        }
+        .onChange(of: theme) { newThemeValue in
+            applyTheme(theme: newThemeValue.theme)
+        }
+    }
+
+    // MARK: - Theme Application
+
+    /// Applies the theme to the view.
+    /// - Parameter theme: The theme to be applied.
+    func applyTheme(theme: Theme) {
+        let color = theme.colors
+        textPrimary = Color(color.textPrimary)
+        textSecondary = Color(color.textSecondary)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Autofill/SelfSizingHostingController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/SelfSizingHostingController.swift
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import SwiftUI
+import ComponentLibrary
+
+/// A `UIHostingController` subclass that automatically adjusts its size to fit its SwiftUI `View` content.
+/// It also conforms to `BottomSheetChild` for use in bottom sheet contexts, allowing for dismissal handling.
+class SelfSizingHostingController<Content>: UIHostingController<Content>, BottomSheetChild where Content: View {
+    /// Ensures the view controller dynamically adjusts its size to its content after layout changes.
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        self.view.invalidateIntrinsicContentSize() // Adjusts size based on content.
+    }
+
+    /// Placeholder for bottom sheet dismissal handling. Override to add custom behavior.
+    public func willDismiss() {}
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8472)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18794)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

Addresses
![Screenshot 2024-02-21 at 11 51 19](https://github.com/mozilla-mobile/firefox-ios/assets/26011662/0064a28d-8f74-4732-b883-d444f3e2b56b)
Passwords
![Screenshot 2024-02-21 at 11 50 54](https://github.com/mozilla-mobile/firefox-ios/assets/26011662/59648061-abbb-41da-82cc-50c32910fa2c)
Passwords footer
![Screenshot 2024-02-21 at 10 54 48](https://github.com/mozilla-mobile/firefox-ios/assets/26011662/2728d242-d658-49dc-b1d2-ec81b28017aa)


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

