### PR TITLE
Refactor FXIOS-8461 [v123] Blank screen

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2225,6 +2225,8 @@ extension BrowserViewController {
 // MARK: - LegacyTabDelegate
 extension BrowserViewController: LegacyTabDelegate {
     func tab(_ tab: Tab, didCreateWebView webView: WKWebView) {
+        webView.frame = contentContainer.frame
+
         // Observers that live as long as the tab. Make sure these are all cleared in willDeleteWebView below!
         beginObserving(webView: webView)
         self.scrollController.beginObserving(scrollView: webView.scrollView)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8461)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18773)

## :bulb: Description
I can't reproduce the issue, but this is an idea. When we introduced the web view management from coordinators in #14005 there were some constraints placed on the received web view from the `didCreateWebview` delegate call. That was initially translated as a `browserDelegate?.show(webView: webView)` with the coordinator flag enabled but this was later removed in #14255 since the web view was being shown when it shouldn't resulting in a [blank screen issue](https://mozilla-hub.atlassian.net/browse/FXIOS-6322) (overriding a shown web view with a newly web view created that shouldn't show just yet apparently). This is a theory, as I said I can't confirm, but this area being fishy I rather not discard any ideas.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

