### PR TITLE
Refactor FXIOS-8413 [v123.2] Night mode experiment

### DIFF
--- a/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
@@ -94,6 +94,10 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
         updateCurrentTheme(to: fetchSavedThemeType())
     }
 
+    public func reloadTheme() {
+        updateCurrentTheme(to: fetchSavedThemeType())
+    }
+
     public func systemThemeChanged() {
         // Ignore if:
         // the system theme is off

--- a/BrowserKit/Sources/Common/Theming/ThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/ThemeManager.swift
@@ -20,4 +20,5 @@ public protocol ThemeManager {
     func setAutomaticBrightnessValue(_ value: Float)
     func brightnessChanged()
     func getNormalSavedTheme() -> ThemeType
+    func reloadTheme()
 }

--- a/BrowserKit/Sources/Common/Utilities/UserDefaultsInterface.swift
+++ b/BrowserKit/Sources/Common/Utilities/UserDefaultsInterface.swift
@@ -16,6 +16,8 @@ public protocol UserDefaultsInterface {
 
     func register(defaults registrationDictionary: [String: Any])
     func array(forKey defaultName: String) -> [Any]?
+
+    func removeObject(forKey defaultName: String)
 }
 
 extension UserDefaults: UserDefaultsInterface {}

--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -26,6 +26,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case inactiveTabs
     case isToolbarCFREnabled
     case jumpBackIn
+    case nightMode
     case preferSwitchToOpenTabOverDuplicate
     case reduxSearchSettings
     case reportSiteIssue
@@ -72,6 +73,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .fakespotFeature,
                 .fakespotProductAds,
                 .isToolbarCFREnabled,
+                .nightMode,
                 .preferSwitchToOpenTabOverDuplicate,
                 .reduxSearchSettings,
                 .reportSiteIssue,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -482,11 +482,7 @@ class BrowserViewController: UIViewController,
         AppEventQueue.started(.browserUpdatedForAppActivation(uuid))
         defer { AppEventQueue.completed(.browserUpdatedForAppActivation(uuid)) }
 
-        if NightModeHelper.isActivated(),
-           !featureFlags.isFeatureEnabled(.nightMode, checking: .buildOnly) {
-            NightModeHelper.turnOff(tabManager: tabManager)
-            themeManager.reloadTheme()
-        }
+        nightModeUpdates()
 
         // Update lock icon without redrawing the whole locationView
         if let tab = tabManager.selectedTab {
@@ -501,6 +497,16 @@ class BrowserViewController: UIViewController,
         AppEventQueue.wait(for: [.startupFlowComplete, .tabRestoration(tabManager.windowUUID)]) { [weak self] in
             self?.backgroundTabLoader.loadBackgroundTabs()
         }
+    }
+
+    private func nightModeUpdates() {
+        if NightModeHelper.isActivated(),
+           !featureFlags.isFeatureEnabled(.nightMode, checking: .buildOnly) {
+            NightModeHelper.turnOff(tabManager: tabManager)
+            themeManager.reloadTheme()
+        }
+
+        NightModeHelper.cleanNightModeDefaults()
     }
 
     private func dismissModalsIfStartAtHome() {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -482,7 +482,8 @@ class BrowserViewController: UIViewController,
         AppEventQueue.started(.browserUpdatedForAppActivation(uuid))
         defer { AppEventQueue.completed(.browserUpdatedForAppActivation(uuid)) }
 
-        if !featureFlags.isFeatureEnabled(.nightMode, checking: .buildOnly) {
+        if NightModeHelper.isActivated(),
+           !featureFlags.isFeatureEnabled(.nightMode, checking: .buildOnly) {
             NightModeHelper.turnOff(tabManager: tabManager)
             themeManager.reloadTheme()
         }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2275,7 +2275,7 @@ extension BrowserViewController: LegacyTabDelegate {
         let printHelper = PrintHelper(tab: tab)
         tab.addContentScriptToPage(printHelper, name: PrintHelper.name())
 
-        let nightModeHelper = NightModeHelper(tab: tab)
+        let nightModeHelper = NightModeHelper()
         tab.addContentScript(nightModeHelper, name: NightModeHelper.name())
 
         // XXX: Bug 1390200 - Disable NSUserActivity/CoreSpotlight temporarily

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -482,6 +482,11 @@ class BrowserViewController: UIViewController,
         AppEventQueue.started(.browserUpdatedForAppActivation(uuid))
         defer { AppEventQueue.completed(.browserUpdatedForAppActivation(uuid)) }
 
+        if !featureFlags.isFeatureEnabled(.nightMode, checking: .buildOnly) {
+            NightModeHelper.turnOff(tabManager: tabManager)
+            themeManager.reloadTheme()
+        }
+
         // Update lock icon without redrawing the whole locationView
         if let tab = tabManager.selectedTab {
             urlBar.locationView.tabDidChangeContentBlocking(tab)

--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -476,7 +476,6 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
             }
 
             self.themeManager.reloadTheme()
-
         }.items
         items.append(nightMode)
 

--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -463,7 +463,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
         let nightMode = SingleActionViewModel(title: nightModeTitle,
                                               iconString: StandardImageIdentifiers.Large.nightMode,
                                               isEnabled: nightModeEnabled) { _ in
-            NightModeHelper.toggle(tabManager: self.tabManager)
+            NightModeHelper().toggle(tabManager: self.tabManager)
 
             if nightModeEnabled {
                 TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .nightModeEnabled)
@@ -475,15 +475,15 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
             if NightModeHelper().isActivated(),
                self.themeManager.currentTheme.type == .light {
                 self.themeManager.changeCurrentTheme(.dark)
-                NightModeHelper.setEnabledDarkTheme(darkTheme: true)
+                NightModeHelper().setEnabledDarkTheme(darkTheme: true)
             }
 
             // If we've disabled night mode and dark theme was activated by it then disable dark theme
             if !NightModeHelper().isActivated(),
-               NightModeHelper.hasEnabledDarkTheme(),
+               NightModeHelper().hasEnabledDarkTheme(),
                self.themeManager.currentTheme.type == .dark {
                 self.themeManager.changeCurrentTheme(.light)
-                NightModeHelper.setEnabledDarkTheme(darkTheme: false)
+                NightModeHelper().setEnabledDarkTheme(darkTheme: false)
             }
         }.items
         items.append(nightMode)

--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -458,7 +458,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     private func getNightModeAction() -> [PhotonRowActions] {
         var items: [PhotonRowActions] = []
 
-        let nightModeEnabled = NightModeHelper.isActivated()
+        let nightModeEnabled = NightModeHelper().isActivated()
         let nightModeTitle: String = nightModeEnabled ? .AppMenu.AppMenuTurnOffNightMode : .AppMenu.AppMenuTurnOnNightMode
         let nightMode = SingleActionViewModel(title: nightModeTitle,
                                               iconString: StandardImageIdentifiers.Large.nightMode,
@@ -472,14 +472,14 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
             }
 
             // If we've enabled night mode and the theme is normal, enable dark theme
-            if NightModeHelper.isActivated(),
+            if NightModeHelper().isActivated(),
                self.themeManager.currentTheme.type == .light {
                 self.themeManager.changeCurrentTheme(.dark)
                 NightModeHelper.setEnabledDarkTheme(darkTheme: true)
             }
 
             // If we've disabled night mode and dark theme was activated by it then disable dark theme
-            if !NightModeHelper.isActivated(),
+            if !NightModeHelper().isActivated(),
                NightModeHelper.hasEnabledDarkTheme(),
                self.themeManager.currentTheme.type == .dark {
                 self.themeManager.changeCurrentTheme(.light)

--- a/firefox-ios/Client/Frontend/TabContentsScripts/NightModeHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/NightModeHelper.swift
@@ -34,7 +34,7 @@ class NightModeHelper: TabContentScript, FeatureFlaggable {
         // Do nothing.
     }
 
-    static func toggle(
+    func toggle(
         _ userDefaults: UserDefaultsInterface = UserDefaults.standard,
         tabManager: TabManager
     ) {
@@ -42,7 +42,7 @@ class NightModeHelper: TabContentScript, FeatureFlaggable {
         setNightMode(userDefaults, tabManager: tabManager, enabled: !isActive)
     }
 
-    static func setNightMode(
+    func setNightMode(
         _ userDefaults: UserDefaultsInterface = UserDefaults.standard,
         tabManager: TabManager,
         enabled: Bool
@@ -54,14 +54,14 @@ class NightModeHelper: TabContentScript, FeatureFlaggable {
         }
     }
 
-    static func setEnabledDarkTheme(
+    func setEnabledDarkTheme(
         _ userDefaults: UserDefaultsInterface = UserDefaults.standard,
         darkTheme enabled: Bool
     ) {
         userDefaults.set(enabled, forKey: NightModeKeys.DarkThemeEnabled)
     }
 
-    static func hasEnabledDarkTheme(_ userDefaults: UserDefaultsInterface = UserDefaults.standard) -> Bool {
+    func hasEnabledDarkTheme(_ userDefaults: UserDefaultsInterface = UserDefaults.standard) -> Bool {
         return userDefaults.bool(forKey: NightModeKeys.DarkThemeEnabled)
     }
 

--- a/firefox-ios/Client/Frontend/TabContentsScripts/NightModeHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/NightModeHelper.swift
@@ -36,14 +36,6 @@ class NightModeHelper: TabContentScript, FeatureFlaggable {
         setNightMode(userDefaults, tabManager: tabManager, enabled: !isActive)
     }
 
-    static func turnOff(
-        _ userDefaults: UserDefaultsInterface = UserDefaults.standard,
-        tabManager: TabManager
-    ) {
-        guard isActivated() else { return }
-        setNightMode(userDefaults, tabManager: tabManager, enabled: false)
-    }
-
     static func setNightMode(
         _ userDefaults: UserDefaultsInterface = UserDefaults.standard,
         tabManager: TabManager,
@@ -56,18 +48,25 @@ class NightModeHelper: TabContentScript, FeatureFlaggable {
         }
     }
 
-    static func setEnabledDarkTheme(
-        _ userDefaults: UserDefaultsInterface = UserDefaults.standard,
-        darkTheme enabled: Bool
-    ) {
-        userDefaults.set(enabled, forKey: NightModeKeys.DarkThemeEnabled)
-    }
-
-    static func hasEnabledDarkTheme(_ userDefaults: UserDefaultsInterface = UserDefaults.standard) -> Bool {
-        return userDefaults.bool(forKey: NightModeKeys.DarkThemeEnabled)
-    }
-
     static func isActivated(_ userDefaults: UserDefaultsInterface = UserDefaults.standard) -> Bool {
         return userDefaults.bool(forKey: NightModeKeys.Status)
+    }
+
+    // MARK: - Temporary functions
+    // These functions are only here to help with the night mode experiment
+    // and will be removed once a decision from that experiment is reached.
+    // TODO: https://mozilla-hub.atlassian.net/browse/FXIOS-8475
+    static func turnOff(
+        _ userDefaults: UserDefaultsInterface = UserDefaults.standard,
+        tabManager: TabManager
+    ) {
+        guard isActivated() else { return }
+        setNightMode(userDefaults, tabManager: tabManager, enabled: false)
+    }
+
+    static func cleanNightModeDefaults(
+        _ userDefaults: UserDefaultsInterface = UserDefaults.standard
+    ) {
+        userDefaults.removeObject(forKey: NightModeKeys.DarkThemeEnabled)
     }
 }

--- a/firefox-ios/Client/Frontend/TabContentsScripts/NightModeHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/NightModeHelper.swift
@@ -13,12 +13,6 @@ class NightModeHelper: TabContentScript, FeatureFlaggable {
         static let DarkThemeEnabled = "NightModeEnabledDarkTheme"
     }
 
-    private var isUnderExperiment: Bool {
-        return featureFlags.isFeatureEnabled(.nightMode, checking: .buildOnly)
-    }
-
-    init() { }
-
     static func name() -> String {
         return "NightMode"
     }
@@ -34,7 +28,7 @@ class NightModeHelper: TabContentScript, FeatureFlaggable {
         // Do nothing.
     }
 
-    func toggle(
+    static func toggle(
         _ userDefaults: UserDefaultsInterface = UserDefaults.standard,
         tabManager: TabManager
     ) {
@@ -42,14 +36,15 @@ class NightModeHelper: TabContentScript, FeatureFlaggable {
         setNightMode(userDefaults, tabManager: tabManager, enabled: !isActive)
     }
 
-    func turnOff(
+    static func turnOff(
         _ userDefaults: UserDefaultsInterface = UserDefaults.standard,
         tabManager: TabManager
     ) {
+        guard isActivated() else { return }
         setNightMode(userDefaults, tabManager: tabManager, enabled: false)
     }
 
-    func setNightMode(
+    static func setNightMode(
         _ userDefaults: UserDefaultsInterface = UserDefaults.standard,
         tabManager: TabManager,
         enabled: Bool
@@ -61,19 +56,18 @@ class NightModeHelper: TabContentScript, FeatureFlaggable {
         }
     }
 
-    func setEnabledDarkTheme(
+    static func setEnabledDarkTheme(
         _ userDefaults: UserDefaultsInterface = UserDefaults.standard,
         darkTheme enabled: Bool
     ) {
         userDefaults.set(enabled, forKey: NightModeKeys.DarkThemeEnabled)
     }
 
-    func hasEnabledDarkTheme(_ userDefaults: UserDefaultsInterface = UserDefaults.standard) -> Bool {
+    static func hasEnabledDarkTheme(_ userDefaults: UserDefaultsInterface = UserDefaults.standard) -> Bool {
         return userDefaults.bool(forKey: NightModeKeys.DarkThemeEnabled)
     }
 
-    func isActivated(_ userDefaults: UserDefaultsInterface = UserDefaults.standard) -> Bool {
-        if isUnderExperiment { return false }
+    static func isActivated(_ userDefaults: UserDefaultsInterface = UserDefaults.standard) -> Bool {
         return userDefaults.bool(forKey: NightModeKeys.Status)
     }
 }

--- a/firefox-ios/Client/Frontend/TabContentsScripts/NightModeHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/NightModeHelper.swift
@@ -14,15 +14,10 @@ class NightModeHelper: TabContentScript, FeatureFlaggable {
     }
 
     private var isUnderExperiment: Bool {
-        guard featureFlags.isFeatureEnabled(.nightMode, checking: .buildOnly) else { return false }
-        return true
+        return featureFlags.isFeatureEnabled(.nightMode, checking: .buildOnly)
     }
 
-    fileprivate weak var tab: Tab?
-
-    required init(tab: Tab) {
-        self.tab = tab
-    }
+    init() { }
 
     static func name() -> String {
         return "NightMode"
@@ -70,7 +65,8 @@ class NightModeHelper: TabContentScript, FeatureFlaggable {
         return userDefaults.bool(forKey: NightModeKeys.DarkThemeEnabled)
     }
 
-    static func isActivated(_ userDefaults: UserDefaultsInterface = UserDefaults.standard) -> Bool {
+    func isActivated(_ userDefaults: UserDefaultsInterface = UserDefaults.standard) -> Bool {
+        if isUnderExperiment { return false }
         return userDefaults.bool(forKey: NightModeKeys.Status)
     }
 }

--- a/firefox-ios/Client/Frontend/TabContentsScripts/NightModeHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/NightModeHelper.swift
@@ -7,10 +7,15 @@ import WebKit
 import Shared
 import Common
 
-class NightModeHelper: TabContentScript {
+class NightModeHelper: TabContentScript, FeatureFlaggable {
     private enum NightModeKeys {
         static let Status = "profile.NightModeStatus"
         static let DarkThemeEnabled = "NightModeEnabledDarkTheme"
+    }
+
+    private var isUnderExperiment: Bool {
+        guard featureFlags.isFeatureEnabled(.nightMode, checking: .buildOnly) else { return false }
+        return true
     }
 
     fileprivate weak var tab: Tab?
@@ -34,15 +39,19 @@ class NightModeHelper: TabContentScript {
         // Do nothing.
     }
 
-    static func toggle(_ userDefaults: UserDefaultsInterface = UserDefaults.standard,
-                       tabManager: TabManager) {
+    static func toggle(
+        _ userDefaults: UserDefaultsInterface = UserDefaults.standard,
+        tabManager: TabManager
+    ) {
         let isActive = userDefaults.bool(forKey: NightModeKeys.Status)
         setNightMode(userDefaults, tabManager: tabManager, enabled: !isActive)
     }
 
-    static func setNightMode(_ userDefaults: UserDefaultsInterface = UserDefaults.standard,
-                             tabManager: TabManager,
-                             enabled: Bool) {
+    static func setNightMode(
+        _ userDefaults: UserDefaultsInterface = UserDefaults.standard,
+        tabManager: TabManager,
+        enabled: Bool
+    ) {
         userDefaults.set(enabled, forKey: NightModeKeys.Status)
         for tab in tabManager.tabs {
             tab.nightMode = enabled
@@ -50,8 +59,10 @@ class NightModeHelper: TabContentScript {
         }
     }
 
-    static func setEnabledDarkTheme(_ userDefaults: UserDefaultsInterface = UserDefaults.standard,
-                                    darkTheme enabled: Bool) {
+    static func setEnabledDarkTheme(
+        _ userDefaults: UserDefaultsInterface = UserDefaults.standard,
+        darkTheme enabled: Bool
+    ) {
         userDefaults.set(enabled, forKey: NightModeKeys.DarkThemeEnabled)
     }
 

--- a/firefox-ios/Client/Frontend/TabContentsScripts/NightModeHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/NightModeHelper.swift
@@ -42,6 +42,13 @@ class NightModeHelper: TabContentScript, FeatureFlaggable {
         setNightMode(userDefaults, tabManager: tabManager, enabled: !isActive)
     }
 
+    func turnOff(
+        _ userDefaults: UserDefaultsInterface = UserDefaults.standard,
+        tabManager: TabManager
+    ) {
+        setNightMode(userDefaults, tabManager: tabManager, enabled: false)
+    }
+
     func setNightMode(
         _ userDefaults: UserDefaultsInterface = UserDefaults.standard,
         tabManager: TabManager,

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -35,9 +35,6 @@ final class NimbusFeatureFlagLayer {
                 .historyHighlights:
             return checkHomescreenSectionsFeature(for: featureID, from: nimbus)
 
-        case .inactiveTabs:
-            return checkTabTrayFeature(for: featureID, from: nimbus)
-
         case .fakespotFeature:
             return checkFakespotFeature(from: nimbus)
 
@@ -52,6 +49,12 @@ final class NimbusFeatureFlagLayer {
 
         case .fakespotBackInStock:
             return checkProductBackInStockFakespotFeature(from: nimbus)
+
+        case .inactiveTabs:
+            return checkTabTrayFeature(for: featureID, from: nimbus)
+
+        case .nightMode:
+            return checkNightModeFeature(from: nimbus)
 
         case .preferSwitchToOpenTabOverDuplicate:
             return checkPreferSwitchToOpenTabOverDuplicate(from: nimbus)
@@ -240,6 +243,12 @@ final class NimbusFeatureFlagLayer {
 
     private func checkReduxSearchSettingsFeature(from nimbus: FxNimbus) -> Bool {
         let config = nimbus.features.reduxSearchSettingsFeature.value()
+        return config.enabled
+    }
+
+    private func checkNightModeFeature(from nimbus: FxNimbus) -> Bool {
+        let config = nimbus.features.nightModeFeature.value()
+
         return config.enabled
     }
 }

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -498,7 +498,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
             }
         }
 
-        tab.nightMode = NightModeHelper.isActivated()
+        tab.nightMode = NightModeHelper().isActivated()
         tab.noImageMode = NoImageModeHelper.isActivated(profile.prefs)
 
         if flushToDisk {

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -498,7 +498,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
             }
         }
 
-        tab.nightMode = NightModeHelper().isActivated()
+        tab.nightMode = NightModeHelper.isActivated()
         tab.noImageMode = NoImageModeHelper.isActivated(profile.prefs)
 
         if flushToDisk {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockThemeManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockThemeManager.swift
@@ -51,4 +51,6 @@ class MockThemeManager: ThemeManager {
     func brightnessChanged() { }
 
     func getNormalSavedTheme() -> ThemeType { return .light }
+
+    func reloadTheme() {}
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockUserDefaults.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockUserDefaults.swift
@@ -49,4 +49,8 @@ class MockUserDefaults: UserDefaultsInterface {
     func register(defaults registrationDictionary: [String: Any]) {
         self.registrationDictionary = registrationDictionary
     }
+
+    func removeObject(forKey defaultName: String) {
+        savedData[defaultName] = nil
+    }
 }

--- a/firefox-ios/nimbus-features/nightModeFeature.yaml
+++ b/firefox-ios/nimbus-features/nightModeFeature.yaml
@@ -1,0 +1,19 @@
+# The configuration for the nightModeFeature feature
+features:
+  night-mode-feature:
+    description: >
+      Describes the night mode feature's configuration
+    variables:
+      enabled:
+        description: >
+          Whether night mode is available for users or not
+        type: Boolean
+        default: true
+    defaults:
+      - channel: beta
+        value:
+          enabled: true
+      - channel: developer
+        value:
+          enabled: false
+

--- a/firefox-ios/nimbus-features/nightModeFeature.yaml
+++ b/firefox-ios/nimbus-features/nightModeFeature.yaml
@@ -15,5 +15,5 @@ features:
           enabled: true
       - channel: developer
         value:
-          enabled: false
+          enabled: true
 

--- a/firefox-ios/nimbus.fml.yaml
+++ b/firefox-ios/nimbus.fml.yaml
@@ -24,6 +24,7 @@ include:
   - nimbus-features/generalFeatures.yaml
   - nimbus-features/homescreenFeature.yaml
   - nimbus-features/messagingFeature.yaml
+  - nimbus-features/nightModeFeature.yaml
   - nimbus-features/onboardingFrameworkFeature.yaml
   - nimbus-features/reduxSearchSettingsFeature.yaml
   - nimbus-features/searchFeature.yaml


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8413)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18644)

## :bulb: Description
This puts nightmode behind an experiment. It also
- `removeObject` in `UserDefaultsInterface`
- adds some functions to `NightModeHelper` help do the experiment stuff and also clean things up
- cleans up the menu settings & `NightModeHelper` having control over the theme (night mode is built into `DefaultThemeManager`)
- adds a `reloadTheme` to the theme manager for times when we just need to reload the current theme, but not do any saving. This is really only used for Night Mode, so it can probably be removed if that gets removed

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

