### PR TITLE
Refactor EXP-4270 [v125] Move onMessageDisplayed bookkeeping

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Messaging/GleanPlumbMessageManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Messaging/GleanPlumbMessageManagerTests.swift
@@ -121,6 +121,7 @@ class GleanPlumbMessageManagerTests: XCTestCase {
             XCTFail("Expected to retrieve message")
             return
         }
+        subject.onMessageDisplayed(observed)
         XCTAssertEqual(observed.id, expectedId)
 
         XCTAssertEqual(hardcodedNimbusFeatures.getExposureCount(featureId: "messaging"), 1)


### PR DESCRIPTION
Relates to [ EXP-4270](https://mozilla-hub.atlassian.net/browse/EXP-4270).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This PR moves the message displayed bookkeeping (storage of impressions metadata), the recording of exposure events and the recording of the `message_shown` events all into the same place where they can be called by `onMessageDisplayed`.

It moves the recording of exposure events from the `getNextMessage` call into `onMessageDisplayed`.

This should all but remove the discrepancies seen between exposure events and the message_shown events.

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

