### PR TITLE
Bugfix FXIOS-8426 [v124] Fix contextual tabs showing incorrectly in Inactive Tabs section

### DIFF
--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -416,6 +416,7 @@ class Tab: NSObject, ThemeApplicable {
         self.logger = logger
         super.init()
         self.isPrivate = isPrivate
+        self.firstCreatedTime = Date().toTimestamp()
         debugTabCount += 1
 
         TelemetryWrapper.recordEvent(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -163,16 +163,21 @@ class TabManagerTests: XCTestCase {
     func testGetInactiveTabs() {
         let subject = createSubject()
         addTabs(to: subject, count: 3)
-        guard let tab = subject.tabs.first else {
-            XCTFail("First tab was expected to be found")
-            return
-        }
-        // Override session data to make tab active
-        tab.sessionData = LegacySessionData(currentPage: 0, urls: [], lastUsedTime: Date.now.toTimestamp())
+        XCTAssert(subject.tabs.count == 3, "Expected 3 newly added tabs.")
+
+        // Set createdAt date for all tabs to be distant past (inactive by default)
+        subject.tabs.forEach { $0.firstCreatedTime = Timestamp(0) }
+
+        // Override session data lastUsedTime of 1st tab to indicate tab active
+        let tab1 = subject.tabs[0]
+        tab1.sessionData = LegacySessionData(currentPage: 0,
+                                             urls: [],
+                                             lastUsedTime: Date.now.toTimestamp())
 
         let inactiveTabs = subject.getInactiveTabs()
         let expectedInactiveTabs = 2
 
+        // Expect 2 of 3 tabs are inactive (except 1st)
         XCTAssertEqual(inactiveTabs.count, expectedInactiveTabs)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8426)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18679)

## :bulb: Description

This initializes new `Tab`s with a sensible `firstCreatedAt` timestamp instead of defaulting to `nil` which ends up being calculated as 1970 in several places in the codebase.

Originally this ticket (8426) had been filed on the new tab tray refactor but there are a couple strange things going on here and it appears that our missing `firstCreatedAt` timestamp is the root culprit, because tabs that are created but not switched to (e.g. via the contextual menu) end up being sorted incorrectly into our Inactive Tabs collection because they evaluate to having a date of 1970 for sorting purposes if their `lastExecutedTime` and `lastUsedTime` are both nil:

`let tabTimeStamp = tab.lastExecutedTime ?? tab.sessionData?.lastUsedTime ?? tab.firstCreatedTime ?? 0`

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

