### PR TITLE
Remove FXIOS-8459 [v125] Awesomebar.engagement and Awesomebar.abandonment Telemetry Events

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2473,13 +2473,11 @@ extension BrowserViewController: SearchViewControllerDelegate {
         case .engaged:
             let visibleSuggestionsTelemetryInfo = searchViewController.visibleSuggestionsTelemetryInfo
             visibleSuggestionsTelemetryInfo.forEach { trackVisibleSuggestion(telemetryInfo: $0) }
-            TelemetryWrapper.gleanRecordEvent(category: .action, method: .engagement, object: .locationBar)
 
         case .abandoned:
             searchViewController.searchTelemetry?.engagementType = .dismiss
             let visibleSuggestionsTelemetryInfo = searchViewController.visibleSuggestionsTelemetryInfo
             visibleSuggestionsTelemetryInfo.forEach { trackVisibleSuggestion(telemetryInfo: $0) }
-            TelemetryWrapper.gleanRecordEvent(category: .action, method: .abandonment, object: .locationBar)
             searchViewController.searchTelemetry?.recordURLBarSearchAbandonmentTelemetryEvent()
         default:
             break

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -1864,10 +1864,6 @@ extension TelemetryWrapper {
             GleanMetrics.Awesomebar.shareButtonTapped.record()
         case (.action, .drag, .locationBar, _, _):
             GleanMetrics.Awesomebar.dragLocationBar.record()
-        case (.action, .engagement, .locationBar, _, _):
-            GleanMetrics.Awesomebar.engagement.record()
-        case (.action, .abandonment, .locationBar, _, _):
-            GleanMetrics.Awesomebar.abandonment.record()
         // MARK: - GleanPlumb Messaging
         case (.information, .view, .messaging, .messageImpression, let extras):
             guard let messageSurface = extras?[EventExtraKey.messageSurface.rawValue] as? String,

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -4462,34 +4462,6 @@ awesomebar:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2024-06-01"
-  engagement:
-    type: event
-    description: |
-      Recorded when the user completes their search session by
-      tapping a search result, or entering a URL or a search term.
-    bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXIOS-8326
-    data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/18452
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    data_sensitivity:
-      - interaction
-    expires: "2024-06-01"
-  abandonment:
-    type: event
-    description: |
-      Recorded when the user dismisses the awesomebar without completing their
-      search.
-    bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXIOS-8326
-    data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/18452
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    data_sensitivity:
-      - interaction
-    expires: "2024-06-01"
 
 # Share sheet specific metrics
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8459)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18758)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Those events have been replaced by the urlbar.engagement and urlbar.abandonment events which include more info
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed I updated documentation / comments for complex code and public methods

