### PR TITLE
Add EXP-4270 [v125] Add inverse triggers to messaging component messages

### DIFF
--- a/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessage.swift
+++ b/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessage.swift
@@ -44,7 +44,12 @@ struct GleanPlumbMessage {
     /// The conditions that need to be satisfied for a message to be considered eligible to present.
     ///
     /// Embedding apps should not read from this directly.
-    let triggers: [String]
+    let triggerIfAll: [String]
+
+    /// The conditions that need to be not satisfied for a message to be considered eligible to present.
+    ///
+    /// Embedding apps should not read from this directly.
+    let exceptIfAny: [String]
 
     /// The access point to StyleData from Nimbus Messaging.
     ///

--- a/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
+++ b/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
@@ -310,7 +310,10 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
         // Ascertain a Message's style, to know priority and max impressions.
         guard let style = sanitizeStyle(message.style, table: lookupTables.styles) else { return .failure(.malformed) }
 
-        guard let triggers = sanitizeTriggers(message.trigger, table: lookupTables.triggers) else {
+        guard let triggerIfAll = sanitizeTriggers(message.triggerIfAll, table: lookupTables.triggers) else {
+            return .failure(.malformed)
+        }
+        guard let exceptIfAny = sanitizeTriggers(message.exceptIfAny, table: lookupTables.triggers) else {
             return .failure(.malformed)
         }
 
@@ -319,7 +322,8 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
             GleanPlumbMessage(id: messageId,
                               data: message,
                               action: action,
-                              triggers: triggers,
+                              triggerIfAll: triggerIfAll,
+                              exceptIfAny: exceptIfAny,
                               style: style,
                               metadata: messageMetadata)
         )

--- a/firefox-ios/Client/Experiments/Messaging/NimbusMessagingEvaluationUtility.swift
+++ b/firefox-ios/Client/Experiments/Messaging/NimbusMessagingEvaluationUtility.swift
@@ -16,7 +16,8 @@ class NimbusMessagingEvaluationUtility {
         _ message: GleanPlumbMessage,
         messageHelper: NimbusMessagingHelperProtocol
     ) throws -> Bool {
-        return try isNimbusElementEligible(checking: message.triggers,
+        return try isNimbusElementEligible(checking: message.triggerIfAll,
+                                           except: message.exceptIfAny,
                                            using: messageHelper)
     }
 
@@ -31,11 +32,16 @@ class NimbusMessagingEvaluationUtility {
     }
 
     private func isNimbusElementEligible(
-        checking triggers: [String],
+        checking triggerIfAll: [String],
+        except exceptIfAny: [String] = [],
         using helper: NimbusMessagingHelperProtocol
     ) throws -> Bool {
-        return try triggers.reduce(true) { accumulator, trigger in
+        let ifAll = try triggerIfAll.reduce(true) { accumulator, trigger in
             return try accumulator && (try helper.evalJexl(expression: trigger))
         }
+        let ifAny = try exceptIfAny.reduce(false) { accumulator, trigger in
+            return try accumulator || (try helper.evalJexl(expression: trigger))
+        }
+        return ifAll && !ifAny
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Launch/LaunchCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Launch/LaunchCoordinatorTests.swift
@@ -195,7 +195,8 @@ final class LaunchCoordinatorTests: XCTestCase {
         return GleanPlumbMessage(id: "12345",
                                  data: MockSurveyMessageDataProtocol(surface: surface),
                                  action: "https://mozilla.com",
-                                 triggers: [],
+                                 triggerIfAll: [],
+                                 exceptIfAny: [],
                                  style: MockStyleDataProtocol(),
                                  metadata: metadata)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/LaunchView/LaunchScreenViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/LaunchView/LaunchScreenViewModelTests.swift
@@ -112,7 +112,8 @@ final class LaunchScreenViewModelTests: XCTestCase {
         return GleanPlumbMessage(id: "test-notification",
                                  data: MockNotificationMessageDataProtocol(surface: surface),
                                  action: action,
-                                 triggers: [],
+                                 triggerIfAll: [],
+                                 exceptIfAny: [],
                                  style: MockStyleDataProtocol(),
                                  metadata: metadata)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/MessageCard/HomepageMessageCardViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/MessageCard/HomepageMessageCardViewModelTests.swift
@@ -146,7 +146,8 @@ extension HomepageMessageCardViewModelTests {
         return GleanPlumbMessage(id: "12345",
                                  data: MockMessageDataProtocol(),
                                  action: "",
-                                 triggers: [],
+                                 triggerIfAll: [],
+                                 exceptIfAny: [],
                                  style: MockStyleDataProtocol(),
                                  metadata: metadata)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/MessageCard/MessageCardDataAdaptorImplementationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/MessageCard/MessageCardDataAdaptorImplementationTests.swift
@@ -68,7 +68,8 @@ extension MessageCardDataAdaptorImplementationTests {
         return GleanPlumbMessage(id: "12345",
                                  data: MockMessageDataProtocol(),
                                  action: "",
-                                 triggers: [],
+                                 triggerIfAll: [],
+                                 exceptIfAny: [],
                                  style: MockStyleDataProtocol(),
                                  metadata: metadata)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Messaging/GleanPlumbMessageStoreTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Messaging/GleanPlumbMessageStoreTests.swift
@@ -55,7 +55,8 @@ class GleanPlumbMessageStoreTests: XCTestCase {
         return GleanPlumbMessage(id: messageId,
                                  data: MockMessageData(),
                                  action: "MAKE_DEFAULT",
-                                 triggers: ["ALWAYS"],
+                                 triggerIfAll: ["ALWAYS"],
+                                 exceptIfAny: [],
                                  style: styleData,
                                  metadata: subject.getMessageMetadata(messageId: messageId))
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/NotificationSurface/NotificationSurfaceManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/NotificationSurface/NotificationSurfaceManagerTests.swift
@@ -122,7 +122,8 @@ class NotificationSurfaceManagerTests: XCTestCase {
         return GleanPlumbMessage(id: "test-notification",
                                  data: MockNotificationMessageDataProtocol(surface: surface),
                                  action: action,
-                                 triggers: [],
+                                 triggerIfAll: [],
+                                 exceptIfAny: [],
                                  style: MockStyleDataProtocol(),
                                  metadata: metadata)
     }
@@ -136,7 +137,8 @@ class NotificationSurfaceManagerTests: XCTestCase {
         return GleanPlumbMessage(id: "test-notification",
                                  data: MockNotificationMessageDataProtocol(surface: surface),
                                  action: "://deep-link?url=homepanel/new-tab",
-                                 triggers: ["INACTIVE_NEW_USER", "ALLOWED_TIPS_NOTIFICATIONS"],
+                                 triggerIfAll: ["INACTIVE_NEW_USER", "ALLOWED_TIPS_NOTIFICATIONS"],
+                                 exceptIfAny: [],
                                  style: MockStyleDataProtocol(),
                                  metadata: metadata)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/SurveySurface/SurveySurfaceManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/SurveySurface/SurveySurfaceManagerTests.swift
@@ -126,7 +126,8 @@ extension SurveySurfaceManagerTests {
         return GleanPlumbMessage(id: "12345",
                                  data: MockSurveyMessageDataProtocol(surface: surface),
                                  action: "https://mozilla.com",
-                                 triggers: [],
+                                 triggerIfAll: [],
+                                 exceptIfAny: [],
                                  style: MockStyleDataProtocol(),
                                  metadata: metadata)
     }

--- a/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
@@ -27,10 +27,11 @@ import:
               default-browser:
                 surface: new-tab-card
                 style: FALLBACK
-                trigger:
-                  - I_AM_NOT_DEFAULT_BROWSER
+                trigger-if-all:
                   - SUPPORTS_DEFAULT_BROWSER
                   - ON_FOURTH_LAUNCH_THIS_YEAR
+                except-if-any:
+                  - I_AM_DEFAULT_BROWSER
                 title: Default Browser/DefaultBrowserCard.Title
                 text: Default Browser/DefaultBrowserCard.Description
                 button-label: Default Browser/DefaultBrowserCard.Button.v2
@@ -45,7 +46,7 @@ import:
               survey-surface-message:
                 surface: survey
                 style: SURVEY
-                trigger:
+                trigger-if-all:
                   - NEVER
                 text: ResearchSurface/Body.Text.v112
                 button-label: ResearchSurface/PrimaryButton.Label.v112

--- a/firefox-ios/nimbus-features/messaging/messaging.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging.fml.yaml
@@ -134,13 +134,24 @@ objects:
           The style as described in a
           `StyleData` from the styles table.
         default: DEFAULT
-      trigger:
+
+      trigger-if-all:
+        type: List<TriggerName>
+        description: >
+          A list of strings corresponding to targeting expressions.
+          All named expressions must evaluate to true if the message is
+          to be eligible to be shown.
+        default:
+          - ALWAYS
+
+      except-if-any:
         type: List<TriggerName>
         description: >
           A list of strings corresponding to
-          targeting expressions. The message will be
-          shown if all expressions `true`.
+          targeting expressions. If any of these expressions evaluate to
+          `true`, the message will not be eligible.
         default: []
+
       surface:
         type: MessageSurfaceId
         description: Each message will tell us the surface it is targeting with this.


### PR DESCRIPTION
Relates to [ EXP-4270](https://mozilla-hub.atlassian.net/browse/EXP-4270).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This is a breaking change. It is one of two breaking changes outline in the [Transition Phase 1](https://docs.google.com/document/d/1m6hBG7rjut1Q84Wy9SxxTz8bEXlFkoV-H4GMzZfZ4pY/edit#heading=h.mhha8y8yhj1n) of the Mobile Messaging Go Forward plan.

This changes the `trigger` key to `trigger-if-all` to document that all triggers in this list must evaluate to true.

It also adds `exclude-if-any`, a list of triggers which, if any are true will exclude the message.

This will remove the need for triggers like `I_AM_NOT_BROWSER_DEFAULT`.

~~It should not land until user-research (@El and @roseanne) have been informed.~~ Informed via email.

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

