### PR TITLE
Bugfix FXIOS-8433 [v125] Fix Favicon mismatch bug

### DIFF
--- a/BrowserKit/Sources/SiteImageView/SiteImageView.swift
+++ b/BrowserKit/Sources/SiteImageView/SiteImageView.swift
@@ -30,10 +30,10 @@ extension SiteImageView {
     func updateImage(site: SiteImageModel) {
         Task {
             let imageModel = await imageFetcher.getImage(site: site)
-            guard uniqueID == imageModel.id else { return }
 
             DispatchQueue.main.async { [weak self] in
-                self?.setImage(imageModel: imageModel)
+                guard let self, uniqueID == imageModel.id else { return }
+                setImage(imageModel: imageModel)
             }
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabCell.swift
@@ -114,8 +114,10 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         isAccessibilityElement = true
         accessibilityHint = .TabTraySwipeToCloseAccessibilityHint
 
-        favicon.image = UIImage(named: StandardImageIdentifiers.Large.globe)?
-            .withRenderingMode(.alwaysTemplate)
+        let identifier = StandardImageIdentifiers.Large.globe
+        if let globeFavicon = UIImage(named: identifier)?.withRenderingMode(.alwaysTemplate) {
+            favicon.manuallySetImage(globeFavicon)
+        }
 
         if !tabModel.isFxHomeTab, let tabURL = tabModel.url?.absoluteString {
             favicon.setFavicon(FaviconImageViewModel(siteURLString: tabURL))


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8433)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18705)

## :bulb: Description

Fixes a bug that could cause favicons to become mismatched, especially during cell reuse. The dispatched code updating the favicon was checking the IDs before dispatching but not at the time that the image view was set, and the code that was explicitly setting the "globe" favicon for homepages was not setting it with `manuallySetImage` which could result in a potentially invalid UUID for the favicon.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

