### PR TITLE
Bugfix FXIOS-8482 [v125] Private homepage icon issue with RTL

### DIFF
--- a/firefox-ios/Client/Frontend/Home/LogoHeader/HomeLogoHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/LogoHeader/HomeLogoHeaderCell.swift
@@ -100,6 +100,10 @@ class HomeLogoHeaderCell: UICollectionViewCell, ReusableCell {
             logoConstraints.append(
                 containerView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor)
             )
+        } else {
+            logoConstraints.append(
+                containerView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor)
+            )
         }
         NSLayoutConstraint.activate(logoConstraints)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8482)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18838)

## :bulb: Description
Added constraints to fix the issue of alignment of private button and the firefox logo in the homescreen when a RTL language is chosen.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Before
![Screenshot 2024-02-24 at 11 16 48 PM](https://github.com/mozilla-mobile/firefox-ios/assets/57953014/3fde3e75-bc83-4343-a8ac-b830a680d1ed)
![Screenshot 2024-02-24 at 11 18 25 PM](https://github.com/mozilla-mobile/firefox-ios/assets/57953014/5d7d9af8-ecce-437f-bc6b-ba4ce89da47a)

## After
![Screenshot 2024-02-24 at 11 17 30 PM](https://github.com/mozilla-mobile/firefox-ios/assets/57953014/a6b542c9-67c7-4bb3-91cd-e81030e80735)
![Screenshot 2024-02-24 at 11 17 39 PM](https://github.com/mozilla-mobile/firefox-ios/assets/57953014/ff321217-e51b-411d-9aa1-72776542c6db)



