### PR TITLE
Add EXP-4268 [v125] Add action-params and change type of action

### DIFF
--- a/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessage.swift
+++ b/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessage.swift
@@ -11,6 +11,7 @@ protocol MessageDataProtocol {
     var text: String { get }
     var buttonLabel: String? { get }
     var experiment: String? { get }
+    var actionParams: [String: String] { get }
 }
 
 extension MessageData: MessageDataProtocol {}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/MessageCard/HomepageMessageCardViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/MessageCard/HomepageMessageCardViewModelTests.swift
@@ -170,6 +170,7 @@ class MockMessageDataProtocol: MessageDataProtocol {
     var text: String = "This is a test"
     var buttonLabel: String?
     var experiment: String?
+    var actionParams: [String: String] = [:]
 }
 
 // MARK: - MockStyleDataProtocol

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Messaging/GleanPlumbMessageStoreTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Messaging/GleanPlumbMessageStoreTests.swift
@@ -75,19 +75,22 @@ class MockMessageData: MessageDataProtocol {
     var text: String
     var buttonLabel: String?
     var experiment: String?
+    var actionParams: [String: String]
 
     init(
         surface: MessageSurfaceId = .newTabCard,
         isControl: Bool = false,
         title: String? = "Title",
         text: String = "text",
-        buttonLabel: String? = "Tap"
+        buttonLabel: String? = "Tap",
+        actionParams: [String: String] = [:]
     ) {
         self.surface = surface
         self.isControl = isControl
         self.title = title
         self.text = text
         self.buttonLabel = buttonLabel
+        self.actionParams = actionParams
     }
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/NotificationSurface/NotificationSurfaceManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/NotificationSurface/NotificationSurfaceManagerTests.swift
@@ -152,6 +152,7 @@ class MockNotificationMessageDataProtocol: MessageDataProtocol {
     var text: String = "text label test"
     var buttonLabel: String? = "button label test"
     var experiment: String?
+    var actionParams: [String: String] = [:]
 
     init(surface: MessageSurfaceId = .notification) {
         self.surface = surface

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/Mocks/MockGleanPlumbEvaluationUtility.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/Mocks/MockGleanPlumbEvaluationUtility.swift
@@ -25,11 +25,19 @@ class MockNimbusTargetingHelper: NimbusTargetingHelperProtocol {
 
 class MockNimbusStringHelper: NimbusStringHelperProtocol {
     func stringFormat(template: String, uuid: String?) -> String {
-        return template
+        if let uuid = uuid {
+            return template.replacingOccurrences(of: "{uuid}", with: uuid)
+        } else {
+            return template
+        }
     }
 
     func getUuid(template: String) -> String? {
-        return nil
+        if template.contains("{uuid}") {
+            return "MY-UUID"
+        } else {
+            return nil
+        }
     }
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/SurveySurface/SurveySurfaceManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/SurveySurface/SurveySurfaceManagerTests.swift
@@ -149,6 +149,7 @@ class MockSurveyMessageDataProtocol: MessageDataProtocol {
     var text: String = "text label test"
     var buttonLabel: String? = "button label test"
     var experiment: String?
+    var actionParams: [String: String] = [:]
 
     init(surface: MessageSurfaceId = .survey) {
         self.surface = surface

--- a/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
@@ -50,4 +50,6 @@ import:
                   - NEVER
                 text: ResearchSurface/Body.Text.v112
                 button-label: ResearchSurface/PrimaryButton.Label.v112
-                action: https://www.macrumors.com
+                action: OPEN_URL
+                action-params:
+                  url: https://www.macrumors.com

--- a/firefox-ios/nimbus-features/messaging/messaging-firefox-ios.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging-firefox-ios.fml.yaml
@@ -46,6 +46,7 @@ import:
               OPEN_SETTINGS_PRIVACY:              ://deep-link?url=settings/clear-private-data
               OPEN_SETTINGS_FXA:                  ://deep-link?url=settings/fxa
               OPEN_SETTINGS_THEME:                ://deep-link?url=settings/theme
+              OPEN_URL:                           ://open-url
               VIEW_BOOKMARKS:                     ://deep-link?url=homepanel/bookmarks
               VIEW_TOP_SITES:                     ://deep-link?url=homepanel/top-sites
               VIEW_READING_LIST:                  ://deep-link?url=homepanel/reading-list

--- a/firefox-ios/nimbus-features/messaging/messaging.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging.fml.yaml
@@ -103,12 +103,15 @@ objects:
       action:
         # We would like this to be of ActionName type, but it accepts https:// URLs
         # so changing this would be a breaking change.
-        type: String
+        type: ActionName
         description: >
-          A URL of a page or a deeplink.
-          This may have substitution variables in.
+          The name of a deeplink URL to be opened if the button is clicked.
         # This should never be defaulted.
-        default: ""
+        default: OPEN_URL
+      action-params:
+        type: Map<String, String>
+        description: Query parameters appended to the deeplink action URL
+        default: {}
       title:
         type: Option<Text>
         description: "The title text displayed to the user"


### PR DESCRIPTION
Relates to [ EXP-4268](https://mozilla-hub.atlassian.net/browse/EXP-4268).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This is a breaking change, for experimenter users of the messaging feature.

It tightens up the type of `action` to use the string-alias `ActionName`, i.e. only keys of the `actions` table.

This is a large improvment in usability for message senders using the experimenter UI.

This removes the ability to open URLs directly in the action.

For this, the new `action-params` map is used to parameterize the action's deeplink URL.

The same string interpolation used on `action` is used on the `action` deeplink URL, and the values of the params.

For example, whereas before you may have said:

```json
"action": "https://example.com/survey?client={uuid}"
```

now you might write:

```json
"action": "OPEN_URL"
"action-params": {
    "private": "true",
    "url": "https://example.com/survey?client={uuid}"
}
```

Note that `action-params` are specific to each action, and so cannot be validated by the messsaging system.

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

