### PR TITLE
Add FXIOS-8490 [v124] Add `AutofillTelemetry` to list of files pulled from mozilla-central

### DIFF
--- a/firefox-ios/Client/Assets/CC_Script/CC_Python_Update.py
+++ b/firefox-ios/Client/Assets/CC_Script/CC_Python_Update.py
@@ -20,6 +20,7 @@ FILES_TO_DOWNLOAD = [
     "toolkit/components/formautofill/shared/AddressMetaData.sys.mjs",
     "toolkit/components/formautofill/shared/AddressMetaDataExtension.sys.mjs",
     "toolkit/components/formautofill/shared/AddressMetaDataLoader.sys.mjs",
+    "toolkit/components/formautofill/shared/AutofillTelemetry.sys.mjs",
     "toolkit/components/formautofill/shared/FormAutofillHandler.sys.mjs",
     "toolkit/components/formautofill/shared/FormAutofillHeuristics.sys.mjs",
     "toolkit/components/formautofill/shared/FormAutofillNameUtils.sys.mjs",

--- a/firefox-ios/Client/Frontend/TabContentsScripts/FormAutofillHelper/FormAutofillHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/FormAutofillHelper/FormAutofillHelper.swift
@@ -86,9 +86,9 @@ class FormAutofillHelper: TabContentScript {
         switch HandlerName(rawValue: message.name) {
         case .addressFormTelemetryMessageHandler:
             // TODO(FXIOS-7547): Implement telemetry forwarding logic
-            logger.log("Received telemery data",
+            logger.log("Received address telemery data",
                        level: .debug,
-                       category: .webview)
+                       category: .address)
         case .addressFormMessageHandler:
             // Parse message payload for address form autofill
             guard let data = getValidPayloadData(from: message),

--- a/firefox-ios/Client/Frontend/TabContentsScripts/FormAutofillHelper/FormAutofillHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/FormAutofillHelper/FormAutofillHelper.swift
@@ -23,6 +23,7 @@ class FormAutofillHelper: TabContentScript {
     enum HandlerName: String {
         case addressFormMessageHandler
         case creditCardFormMessageHandler
+        case addressFormTelemetryMessageHandler
     }
 
     // MARK: - Properties
@@ -51,7 +52,9 @@ class FormAutofillHelper: TabContentScript {
     // MARK: - Script Message Handler
 
     func scriptMessageHandlerNames() -> [String]? {
-        return [HandlerName.addressFormMessageHandler.rawValue, HandlerName.creditCardFormMessageHandler.rawValue]
+        return [HandlerName.addressFormMessageHandler.rawValue,
+            HandlerName.addressFormTelemetryMessageHandler.rawValue,
+            HandlerName.creditCardFormMessageHandler.rawValue]
     }
 
     // MARK: - Deinitialization
@@ -81,6 +84,11 @@ class FormAutofillHelper: TabContentScript {
         }
 
         switch HandlerName(rawValue: message.name) {
+        case .addressFormTelemetryMessageHandler:
+            // TODO(FXIOS-7547): Implement telemetry forwarding logic
+            logger.log("Received telemery data",
+                       level: .debug,
+                       category: .webview)
         case .addressFormMessageHandler:
             // Parse message payload for address form autofill
             guard let data = getValidPayloadData(from: message),

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/FormAutofillHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/FormAutofillHelperTests.swift
@@ -225,7 +225,7 @@ class FormAutofillHelperTests: XCTestCase {
 
         // Assert that the handler names are not nil and contain expected values
         XCTAssertNotNil(handlerNames)
-        XCTAssertEqual(handlerNames?.count, 2) // Assuming you have two handler names
+        XCTAssertEqual(handlerNames?.count, 3) // Assuming you have three handler names
 
         XCTAssertTrue(handlerNames!.contains(FormAutofillHelper.HandlerName.addressFormMessageHandler.rawValue))
         XCTAssertTrue(handlerNames!.contains(FormAutofillHelper.HandlerName.creditCardFormMessageHandler.rawValue))


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8490)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18854)

## :bulb: Description
This PR:
- Adds `AutofillTelemetry` file to list of files pulled from m-c
- Adds `addressFormTelemetryMessageHandler` as it's needed by  https://github.com/mozilla-mobile/firefox-ios/pull/18842
- Blocks  https://github.com/mozilla-mobile/firefox-ios/pull/18842

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] ~Wrote unit tests and/or ensured the tests suite is passing~
- [ ] ~When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)~
- [ ] ~If needed, I updated documentation / comments for complex code and public methods~
- [ ] ~If needed, added a backport comment (example `@Mergifyio backport release/v120`)~

