### PR TITLE
Bugfix MTE-2376 [v125] Fix L10nbuild

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -8,9 +8,6 @@ pipelines:
     - build_applications: {}
     - run_tests: {}
 stages:
-  l10n_screenshots:
-    workflows:
-    - L10nBuild: {}
   pre_configuration:
     workflows:
     - determine_apps_affected: {}
@@ -2124,15 +2121,13 @@ app:
 
 trigger_map:
 - push_branch: main
-  workflow: L10nBuild
-  #pipeline: pipeline_build_and_test
+  pipeline: pipeline_build_and_test
 - push_branch: epic-branch/*
   pipeline: pipeline_build_and_test
 - push_branch: release/v125
   pipeline: pipeline_build_and_test
 - pull_request_target_branch: main
-  workflow: L10nBuild
-  #pipeline: pipeline_build_and_test
+  pipeline: pipeline_build_and_test
 - pull_request_target_branch: epic-branch/*
   pipeline: pipeline_build_and_test
 - pull_request_target_branch: release/v*

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -826,7 +826,7 @@ workflows:
             # debug log
             set -x
             asdf global ruby 3.1
-            gem install fastlane -v 2.216.0
+            gem install fastlane -v 2.219.0
             fastlane -version
 
             ./firefox-ios/l10n-screenshots.sh en-US
@@ -885,7 +885,7 @@ workflows:
             # workaround until 2.187 version is installed. Error with 2.186
             # fastlane update_fastlane
             asdf global ruby 3.1
-            gem install fastlane -v 2.216.0
+            gem install fastlane -v 2.219.0
             fastlane -version
             ./firefox-ios/l10n-screenshots.sh --test-without-building $MOZ_LOCALES
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -4,10 +4,14 @@ project_type: ios
 pipelines:
   pipeline_build_and_test:
     stages:
-    - pre_configuration: {}
-    - build_applications: {}
-    - run_tests: {}
+    - l10n_screenshots: {}
+    # - pre_configuration: {}
+    # - build_applications: {}
+    # - run_tests: {}
 stages:
+  l10n_screenshots:
+    workflows:
+    - L10nBuild: {}
   pre_configuration:
     workflows:
     - determine_apps_affected: {}

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -826,7 +826,7 @@ workflows:
             set -e
             # debug log
             set -x
-            gem uninstall fastlane --all --executable
+            gem uninstall fastlane
             gem install fastlane -v 2.216.0 --no-document
             fastlane -version
 
@@ -885,7 +885,7 @@ workflows:
             set -x
             # workaround until 2.187 version is installed. Error with 2.186
             # fastlane update_fastlane
-            gem uninstall fastlane --all --executable
+            gem uninstall fastlane
             gem install fastlane -v 2.216.0 --no-document
             fastlane -version
             ./firefox-ios/l10n-screenshots.sh --test-without-building $MOZ_LOCALES

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -827,10 +827,7 @@ workflows:
             # debug log
             set -x
             asdf global ruby 3.1
-            which fastlane
-            fastlane -version
-            gem install fastlane -v 2.216.0 --verbose
-            which fastlane
+            gem install fastlane -v 2.216.0
             fastlane -version
 
             ./firefox-ios/l10n-screenshots.sh en-US
@@ -889,10 +886,7 @@ workflows:
             # workaround until 2.187 version is installed. Error with 2.186
             # fastlane update_fastlane
             asdf global ruby 3.1
-            which fastlane
-            fastlane -version
-            gem install fastlane -v 2.216.0 --verbose
-            which fastlane
+            gem install fastlane -v 2.216.0
             fastlane -version
 
             ./firefox-ios/l10n-screenshots.sh --test-without-building $MOZ_LOCALES

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -827,9 +827,8 @@ workflows:
             # debug log
             set -x
             which fastlane
-            fastlane -version
-            gem install fastlane -v 2.216.0 --no-document --verbose
-            asdf reshim fastlane 2.216.0
+            asdf install fastlane 2.216.0
+            asdf global fastlane 2.216.0
             which fastlane
             fastlane -version
 
@@ -890,8 +889,8 @@ workflows:
             # fastlane update_fastlane
             which fastlane
             fastlane -version
-            gem install fastlane -v 2.216.0 --no-document --verbose
-            asdf reshim fastlane 2.216.0
+            asdf install fastlane 2.216.0
+            asdf global fastlane 2.216.0
             which fastlane
             fastlane -versionn
             ./firefox-ios/l10n-screenshots.sh --test-without-building $MOZ_LOCALES

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -826,7 +826,10 @@ workflows:
             set -e
             # debug log
             set -x
-            asdf local fastlane 2.216.0
+            which fastlane
+            fastlane -version
+            gem install fastlane -v 2.216.0 --no-document
+            which fastlane
             fastlane -version
 
             ./firefox-ios/l10n-screenshots.sh en-US
@@ -884,8 +887,11 @@ workflows:
             set -x
             # workaround until 2.187 version is installed. Error with 2.186
             # fastlane update_fastlane
-            asdf local fastlane 2.216.0
+            which fastlane
             fastlane -version
+            gem install fastlane -v 2.216.0 --no-document
+            which fastlane
+            fastlane -versionn
             ./firefox-ios/l10n-screenshots.sh --test-without-building $MOZ_LOCALES
 
             mkdir -p artifacts

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -826,7 +826,6 @@ workflows:
             set -e
             # debug log
             set -x
-            gem uninstall fastlane --all --executables
             gem install fastlane -v 2.216.0 --no-document
             fastlane -version
 
@@ -885,7 +884,6 @@ workflows:
             set -x
             # workaround until 2.187 version is installed. Error with 2.186
             # fastlane update_fastlane
-            gem uninstall fastlane --all --executables
             gem install fastlane -v 2.216.0 --no-document
             fastlane -version
             ./firefox-ios/l10n-screenshots.sh --test-without-building $MOZ_LOCALES

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -828,7 +828,7 @@ workflows:
             set -x
             which fastlane
             fastlane -version
-            gem install fastlane -v 2.216.0 --no-document
+            gem install fastlane -v 2.216.0 --no-document --verbose
             which fastlane
             fastlane -version
 
@@ -889,7 +889,7 @@ workflows:
             # fastlane update_fastlane
             which fastlane
             fastlane -version
-            gem install fastlane -v 2.216.0 --no-document
+            gem install fastlane -v 2.216.0 --no-document --verbose
             which fastlane
             fastlane -versionn
             ./firefox-ios/l10n-screenshots.sh --test-without-building $MOZ_LOCALES

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -822,7 +822,8 @@ workflows:
             set -e
             # debug log
             set -x
-            gem install fastlane -v 2.216.0
+            gem uninstall fastlane --all --executables
+            gem install fastlane -v 2.216.0 --no-document
             fastlane -version
 
             ./firefox-ios/l10n-screenshots.sh en-US
@@ -880,7 +881,8 @@ workflows:
             set -x
             # workaround until 2.187 version is installed. Error with 2.186
             # fastlane update_fastlane
-            gem install fastlane -v 2.216.0
+            gem uninstall fastlane --all --executables
+            gem install fastlane -v 2.216.0 --no-document
             fastlane -version
             ./firefox-ios/l10n-screenshots.sh --test-without-building $MOZ_LOCALES
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -827,8 +827,11 @@ workflows:
             # debug log
             set -x
             which fastlane
-            asdf install fastlane 2.216.0
-            asdf global fastlane 2.216.0
+            asdf list all ruby
+            gem install fastlane -v 2.216.0
+            which fastlane
+            fastlane -version
+            export PATH=/Users/vagrant/.asdf/installs/ruby/3.2.3/bin/fastlane:$PATH
             which fastlane
             fastlane -version
 
@@ -888,11 +891,14 @@ workflows:
             # workaround until 2.187 version is installed. Error with 2.186
             # fastlane update_fastlane
             which fastlane
-            fastlane -version
-            asdf install fastlane 2.216.0
-            asdf global fastlane 2.216.0
+            asdf list all ruby
+            gem install fastlane -v 2.216.0
             which fastlane
-            fastlane -versionn
+            fastlane -version
+            export PATH=/Users/vagrant/.asdf/installs/ruby/3.2.3/bin/fastlane:$PATH
+            which fastlane
+            fastlane -version
+            
             ./firefox-ios/l10n-screenshots.sh --test-without-building $MOZ_LOCALES
 
             mkdir -p artifacts

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -829,6 +829,7 @@ workflows:
             which fastlane
             fastlane -version
             gem install fastlane -v 2.216.0 --no-document --verbose
+            asdf reshim fastlane 2.216.0
             which fastlane
             fastlane -version
 
@@ -890,6 +891,7 @@ workflows:
             which fastlane
             fastlane -version
             gem install fastlane -v 2.216.0 --no-document --verbose
+            asdf reshim fastlane 2.216.0
             which fastlane
             fastlane -versionn
             ./firefox-ios/l10n-screenshots.sh --test-without-building $MOZ_LOCALES

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -4,10 +4,9 @@ project_type: ios
 pipelines:
   pipeline_build_and_test:
     stages:
-    - l10n_screenshots: {}
-    # - pre_configuration: {}
-    # - build_applications: {}
-    # - run_tests: {}
+    - pre_configuration: {}
+    - build_applications: {}
+    - run_tests: {}
 stages:
   l10n_screenshots:
     workflows:
@@ -2129,13 +2128,15 @@ app:
 
 trigger_map:
 - push_branch: main
-  pipeline: pipeline_build_and_test
+  workflow: L10nBuild
+  #pipeline: pipeline_build_and_test
 - push_branch: epic-branch/*
   pipeline: pipeline_build_and_test
 - push_branch: release/v125
   pipeline: pipeline_build_and_test
 - pull_request_target_branch: main
-  pipeline: pipeline_build_and_test
+  workflow: L10nBuild
+  #pipeline: pipeline_build_and_test
 - pull_request_target_branch: epic-branch/*
   pipeline: pipeline_build_and_test
 - pull_request_target_branch: release/v*

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -826,12 +826,10 @@ workflows:
             set -e
             # debug log
             set -x
-            which fastlane
-            asdf global ruby 3.2.3
-            gem install fastlane -v 2.216.0 --verbose
+            asdf global ruby 3.1
             which fastlane
             fastlane -version
-            export PATH=/Users/vagrant/.asdf/installs/ruby/3.2.3/bin/:$PATH
+            gem install fastlane -v 2.216.0 --verbose
             which fastlane
             fastlane -version
 
@@ -890,12 +888,10 @@ workflows:
             set -x
             # workaround until 2.187 version is installed. Error with 2.186
             # fastlane update_fastlane
-            which fastlane
-            asdf global ruby 3.2.3
-            gem install fastlane -v 2.216.0 --verbose
+            asdf global ruby 3.1
             which fastlane
             fastlane -version
-            export PATH=/Users/vagrant/.asdf/installs/ruby/3.2.3/bin/:$PATH
+            gem install fastlane -v 2.216.0 --verbose
             which fastlane
             fastlane -version
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -826,7 +826,7 @@ workflows:
             # debug log
             set -x
             asdf global ruby 3.1
-            gem install fastlane -v 2.219.0
+            gem install fastlane -v 2.216.0
             fastlane -version
 
             ./firefox-ios/l10n-screenshots.sh en-US
@@ -885,7 +885,7 @@ workflows:
             # workaround until 2.187 version is installed. Error with 2.186
             # fastlane update_fastlane
             asdf global ruby 3.1
-            gem install fastlane -v 2.219.0
+            gem install fastlane -v 2.216.0
             fastlane -version
             ./firefox-ios/l10n-screenshots.sh --test-without-building $MOZ_LOCALES
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -12,7 +12,6 @@ stages:
   l10n_screenshots:
     workflows:
     - L10nBuild: {}
-    - L10nScreenshotsTests: {}
   pre_configuration:
     workflows:
     - determine_apps_affected: {}

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -821,11 +821,12 @@ workflows:
     - script@1.1:
         inputs:
         - content: |-
-            #!/usr/bin/env bash
+            #!/usr/bin/env bashset -ex
             # fail if any commands fails
             set -e
             # debug log
             set -x
+            gem uninstall fastlane --all --executable
             gem install fastlane -v 2.216.0 --no-document
             fastlane -version
 
@@ -877,13 +878,14 @@ workflows:
     - script@1.1:
         inputs:
         - content: |-
-            #!/usr/bin/env bash
+            #!/usr/bin/env bashset -ex
             # fail if any commands fails
             set -e
             # debug log
             set -x
             # workaround until 2.187 version is installed. Error with 2.186
             # fastlane update_fastlane
+            gem uninstall fastlane --all --executable
             gem install fastlane -v 2.216.0 --no-document
             fastlane -version
             ./firefox-ios/l10n-screenshots.sh --test-without-building $MOZ_LOCALES

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -821,7 +821,7 @@ workflows:
     - script@1.1:
         inputs:
         - content: |-
-            #!/usr/bin/env bashset -ex
+            #!/usr/bin/env bash
             # fail if any commands fails
             set -e
             # debug log
@@ -883,7 +883,7 @@ workflows:
     - script@1.1:
         inputs:
         - content: |-
-            #!/usr/bin/env bashset -ex
+            #!/usr/bin/env bash
             # fail if any commands fails
             set -e
             # debug log
@@ -898,7 +898,7 @@ workflows:
             export PATH=/Users/vagrant/.asdf/installs/ruby/3.2.3/bin/fastlane:$PATH
             which fastlane
             fastlane -version
-            
+
             ./firefox-ios/l10n-screenshots.sh --test-without-building $MOZ_LOCALES
 
             mkdir -p artifacts

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -12,6 +12,7 @@ stages:
   l10n_screenshots:
     workflows:
     - L10nBuild: {}
+    - L10nScreenshotsTests: {}
   pre_configuration:
     workflows:
     - determine_apps_affected: {}
@@ -888,7 +889,6 @@ workflows:
             asdf global ruby 3.1
             gem install fastlane -v 2.216.0
             fastlane -version
-
             ./firefox-ios/l10n-screenshots.sh --test-without-building $MOZ_LOCALES
 
             mkdir -p artifacts

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -826,8 +826,7 @@ workflows:
             set -e
             # debug log
             set -x
-            gem uninstall fastlane
-            gem install fastlane -v 2.216.0 --no-document
+            asdf local fastlane 2.216.0
             fastlane -version
 
             ./firefox-ios/l10n-screenshots.sh en-US
@@ -885,8 +884,7 @@ workflows:
             set -x
             # workaround until 2.187 version is installed. Error with 2.186
             # fastlane update_fastlane
-            gem uninstall fastlane
-            gem install fastlane -v 2.216.0 --no-document
+            asdf local fastlane 2.216.0
             fastlane -version
             ./firefox-ios/l10n-screenshots.sh --test-without-building $MOZ_LOCALES
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -831,7 +831,7 @@ workflows:
             gem install fastlane -v 2.216.0
             which fastlane
             fastlane -version
-            export PATH=/Users/vagrant/.asdf/installs/ruby/3.2.3/bin/fastlane:$PATH
+            export PATH=/Users/vagrant/.asdf/installs/ruby/3.2.3/bin/:$PATH
             which fastlane
             fastlane -version
 
@@ -895,7 +895,7 @@ workflows:
             gem install fastlane -v 2.216.0
             which fastlane
             fastlane -version
-            export PATH=/Users/vagrant/.asdf/installs/ruby/3.2.3/bin/fastlane:$PATH
+            export PATH=/Users/vagrant/.asdf/installs/ruby/3.2.3/bin/:$PATH
             which fastlane
             fastlane -version
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -825,7 +825,6 @@ workflows:
             set -e
             # debug log
             set -x
-            asdf global ruby 3.1
             gem install fastlane -v 2.219.0
             fastlane -version
 
@@ -882,9 +881,6 @@ workflows:
             set -e
             # debug log
             set -x
-            # workaround until 2.187 version is installed. Error with 2.186
-            # fastlane update_fastlane
-            asdf global ruby 3.1
             gem install fastlane -v 2.219.0
             fastlane -version
             ./firefox-ios/l10n-screenshots.sh --test-without-building $MOZ_LOCALES

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -827,8 +827,8 @@ workflows:
             # debug log
             set -x
             which fastlane
-            asdf list all ruby
-            gem install fastlane -v 2.216.0
+            asdf global ruby 3.2.3
+            gem install fastlane -v 2.216.0 --verbose
             which fastlane
             fastlane -version
             export PATH=/Users/vagrant/.asdf/installs/ruby/3.2.3/bin/:$PATH
@@ -891,8 +891,8 @@ workflows:
             # workaround until 2.187 version is installed. Error with 2.186
             # fastlane update_fastlane
             which fastlane
-            asdf list all ruby
-            gem install fastlane -v 2.216.0
+            asdf global ruby 3.2.3
+            gem install fastlane -v 2.216.0 --verbose
             which fastlane
             fastlane -version
             export PATH=/Users/vagrant/.asdf/installs/ruby/3.2.3/bin/:$PATH

--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nBaseSnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nBaseSnapshotTests.swift
@@ -20,7 +20,7 @@ class L10nBaseSnapshotTests: XCTestCase {
                 LaunchArguments.SkipContextualHints,
                 LaunchArguments.DisableAnimations]
 
-    override func setUp() {
+    @MainActor override func setUp() {
         super.setUp()
         continueAfterFailure = false
         app = XCUIApplication()

--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nBaseSnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nBaseSnapshotTests.swift
@@ -20,7 +20,7 @@ class L10nBaseSnapshotTests: XCTestCase {
                 LaunchArguments.SkipContextualHints,
                 LaunchArguments.DisableAnimations]
 
-    @MainActor 
+    @MainActor
     override func setUp() {
         super.setUp()
         continueAfterFailure = false

--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nBaseSnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nBaseSnapshotTests.swift
@@ -20,7 +20,8 @@ class L10nBaseSnapshotTests: XCTestCase {
                 LaunchArguments.SkipContextualHints,
                 LaunchArguments.DisableAnimations]
 
-    @MainActor override func setUp() {
+    @MainActor 
+    override func setUp() {
         super.setUp()
         continueAfterFailure = false
         app = XCUIApplication()

--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nPermissionStringsSnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nPermissionStringsSnapshotTests.swift
@@ -5,6 +5,7 @@
 import XCTest
 
 class L10nPermissionStringsSnapshotTests: L10nBaseSnapshotTests {
+    @MainActor
     func testNSLocationWhenInUseUsageDescription() {
         var didShowDialog = false
         expectation(

--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
@@ -11,7 +11,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
     var rootA11yId: String {
         return "\(AccessibilityIdentifiers.Onboarding.onboarding)\(currentScreen)"
     }
-    
+
     @MainActor
     override func setUp() {
         // Test name looks like: "[Class testFunc]", parse out the function name

--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
@@ -11,7 +11,8 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
     var rootA11yId: String {
         return "\(AccessibilityIdentifiers.Onboarding.onboarding)\(currentScreen)"
     }
-
+    
+    @MainActor
     override func setUp() {
         // Test name looks like: "[Class testFunc]", parse out the function name
         let parts = name.replacingOccurrences(of: "]", with: "").split(separator: " ")
@@ -26,6 +27,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
         super.setUp()
     }
 
+    @MainActor
     func testIntro() {
         mozWaitForElementToExist(app.scrollViews.staticTexts["\(rootA11yId)TitleLabel"], timeout: 15)
         mozWaitForElementToExist(app.scrollViews.staticTexts["\(rootA11yId)DescriptionLabel"], timeout: 15)
@@ -86,6 +88,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
 //        navigator.back()
     }
 
+    @MainActor
     func testWebViewAuthenticationDialog() {
         navigator.openURL("https://jigsaw.w3.org/HTTP/Basic/", waitForLoading: false)
         mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
@@ -93,6 +96,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
         snapshot("WebViewAuthenticationDialog-01", waitForLoadingIndicator: false)
     }
 
+    @MainActor
     func test3ReloadButtonContextMenu() {
         navigator.openURL(loremIpsumURL)
         waitUntilPageLoad()
@@ -106,6 +110,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
         snapshot("ContextMenuReloadButton-02", waitForLoadingIndicator: false)
     }
 
+    @MainActor
     func testTopSitesMenu() {
         sleep(3)
         // mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 15)
@@ -122,6 +127,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
 //        snapshot("TopSitesMenu-01")
     }
 
+    @MainActor
     func testHistoryTableContextMenu() {
         navigator.openURL(loremIpsumURL)
         mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"], timeout: 5)
@@ -136,6 +142,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
         snapshot("HistoryTableContextMenu-01")
     }
 
+    @MainActor
     func testBookmarksTableContextMenu() {
         sleep(3)
         navigator.openURL(loremIpsumURL)
@@ -162,6 +169,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
         snapshot("21ReaderModeSettingsMenu-01")
     }*/
 
+    @MainActor
     func testETPperSite() {
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
         navigator.nowAt(NewTabScreen)
@@ -185,6 +193,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
         snapshot("TrackingProtectionDisabledPerSite-03")
     }
 
+    @MainActor
     func testSettingsETP() {
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
         navigator.nowAt(NewTabScreen)
@@ -205,6 +214,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
         snapshot("TrackingProtectionStrictMoreInfo-02")
     }
 
+    @MainActor
     func testMenuOnTopSites() {
         typealias homeTabBannerA11y = AccessibilityIdentifiers.FirefoxHomepage.HomeTabBanner
 
@@ -221,6 +231,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
         // snapshot("HomeDefaultBrowserLearnMore")
     }
 
+    @MainActor
     func testSettings() {
         let table = app.tables.element(boundBy: 0)
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
@@ -238,6 +249,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
         }
     }
 
+    @MainActor
     func testPrivateBrowsingTabsEmptyState() {
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
         navigator.nowAt(NewTabScreen)
@@ -245,6 +257,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
         snapshot("PrivateBrowsingTabsEmptyState-01")
     }
 
+    @MainActor
     func testTakeMarketingScreenshots() {
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
         snapshot("00TopSites")

--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
@@ -7,7 +7,7 @@ import Common
 
 class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
     let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
-
+    @MainActor
     func testPanelsEmptyState() {
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
         navigator.nowAt(NewTabScreen)
@@ -20,6 +20,7 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         }
     }
 
+    @MainActor
     // From here on it is fine to load pages
     func testLongPressOnTextOptions() {
         navigator.openURL(loremIpsumURL)
@@ -36,6 +37,7 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         }
     }
 
+    @MainActor
     func testURLBar() {
         navigator.goto(URLBarOpen)
         snapshot("URLBar-01")
@@ -45,6 +47,7 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         snapshot("URLBar-02")
     }
 
+    @MainActor
     func testURLBarContextMenu() {
         if #unavailable(iOS 16.0) {
         // Long press with nothing on the clipboard
@@ -60,6 +63,7 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         }
     }
 
+    @MainActor
     func testMenuOnWebPage() {
         navigator.openURL(loremIpsumURL)
         mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
@@ -74,6 +78,7 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         navigator.back()
     }
 
+    @MainActor
     func testPageMenuOnWebPage() {
         navigator.openURL(loremIpsumURL)
         mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
@@ -82,6 +87,7 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         snapshot("MenuOnWebPage-03")
     }
 
+    @MainActor
     func testFxASignInPage() {
         navigator.openURL(loremIpsumURL)
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
@@ -112,6 +118,7 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         key.tap()
     }
 
+    @MainActor
     func testLoginDetails() {
         let key = 15
         navigator.nowAt(NewTabScreen)
@@ -158,6 +165,7 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         snapshot("RemoveLoginDetailedView")
     }
 
+    @MainActor
     func testFakespotAvailable() throws {
         navigator.openURL("https://www.amazon.com")
         waitUntilPageLoad()

--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
@@ -20,8 +20,8 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         }
     }
 
-    @MainActor
     // From here on it is fine to load pages
+    @MainActor
     func testLongPressOnTextOptions() {
         navigator.openURL(loremIpsumURL)
         waitUntilPageLoad()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2376)

## :bulb: Description
The L10nBuild wasn't working due to a newer `fastlane` executable is used. `fastlane` v2.216 can't be used with the version of Ruby on the Bitrise stack

https://app.bitrise.io/build/f708e2da-0084-47b5-8e0c-3052dee38f67

Upgrading `fastlane` to v2.219 should work.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

