### PR TITLE
Bugfix FXIOS-8418 [V123.1] Implement swipe left on tabtray refactor

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/SwipeAnimator.swift
+++ b/firefox-ios/Client/Frontend/Browser/SwipeAnimator.swift
@@ -23,7 +23,7 @@ private let DefaultParameters =
         recenterAnimationDuration: 0.15)
 
 protocol SwipeAnimatorDelegate: AnyObject {
-    func swipeAnimator(_ animator: SwipeAnimator, viewWillExitContainerBounds: UIView)
+    func swipeAnimator(_ animator: SwipeAnimator)
     func swipeAnimatorIsAnimateAwayEnabled(_ animator: SwipeAnimator) -> Bool
 }
 
@@ -80,7 +80,7 @@ extension SwipeAnimator {
         // Calculate the edge to calculate distance from
         let translation = velocity.x >= 0 ? animatingView.frame.width : -animatingView.frame.width
         let timeStep = TimeInterval(abs(translation) / speed)
-        self.delegate?.swipeAnimator(self, viewWillExitContainerBounds: animatingView)
+        self.delegate?.swipeAnimator(self)
         UIView.animate(
             withDuration: timeStep,
             animations: {

--- a/firefox-ios/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabDisplayManager.swift
@@ -498,6 +498,9 @@ extension LegacyTabDisplayManager: UICollectionViewDataSource {
         if tabDisplayType == .TopTabTray {
             guard let tab = dataStore.at(indexPath.row) else { return cell }
             cell = tabDisplayerDelegate?.cellFactory(for: cell, using: tab) ?? cell
+//            guard let tabCell = cell as? TabCell else { return cell }
+//            tabCell.animator?.delegate = self
+//            tabCell.delegate = self
             return cell
         }
 

--- a/firefox-ios/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabDisplayManager.swift
@@ -498,9 +498,6 @@ extension LegacyTabDisplayManager: UICollectionViewDataSource {
         if tabDisplayType == .TopTabTray {
             guard let tab = dataStore.at(indexPath.row) else { return cell }
             cell = tabDisplayerDelegate?.cellFactory(for: cell, using: tab) ?? cell
-//            guard let tabCell = cell as? TabCell else { return cell }
-//            tabCell.animator?.delegate = self
-//            tabCell.delegate = self
             return cell
         }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
@@ -563,7 +563,7 @@ extension LegacyGridTabViewController: UIScrollViewAccessibilityDelegate {
 
 // MARK: - SwipeAnimatorDelegate
 extension LegacyGridTabViewController: SwipeAnimatorDelegate {
-    func swipeAnimator(_ animator: SwipeAnimator, viewWillExitContainerBounds: UIView) {
+    func swipeAnimator(_ animator: SwipeAnimator) {
         guard let tabCell = animator.animatingView as? LegacyTabCell,
               let indexPath = collectionView.indexPath(for: tabCell) else { return }
         if let tab = tabDisplayManager.dataStore.at(indexPath.item) {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabCell.swift
@@ -109,6 +109,10 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         self.tabModel = tabModel
         self.delegate = delegate
 
+        if let swipeAnimatorDelegate = delegate as? SwipeAnimatorDelegate {
+            self.animator?.delegate = swipeAnimatorDelegate
+        }
+
         titleText.text = tabModel.tabTitle
         accessibilityLabel = getA11yTitleLabel(tabModel: tabModel)
         isAccessibilityElement = true

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -318,8 +318,8 @@ extension TabDisplayView: SwipeAnimatorDelegate {
 
         let tab = tabsState.tabs[indexPath.item]
         store.dispatch(TabPanelAction.closeTab(TabUUIDContext(tabUUID: tab.tabUUID, windowUUID: windowUUID)))
-//        UIAccessibility.post(notification: UIAccessibility.Notification.announcement,
-//                             argument: String.TabTrayClosingTabAccessibilityMessage)
+        UIAccessibility.post(notification: UIAccessibility.Notification.announcement,
+                             argument: String.TabTrayClosingTabAccessibilityMessage)
     }
 
     func swipeAnimatorIsAnimateAwayEnabled(_ animator: SwipeAnimator) -> Bool {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -252,7 +252,6 @@ class TabDisplayView: UIView,
             else { return UICollectionViewCell() }
 
             let tabState = tabsState.tabs[indexPath.row]
-            cell.animator?.delegate = self
             cell.configure(with: tabState, theme: theme, delegate: self)
             return cell
         }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -12,6 +12,7 @@ class TabDisplayView: UIView,
                       UICollectionViewDelegate,
                       UICollectionViewDelegateFlowLayout,
                       TabCellDelegate,
+                      SwipeAnimatorDelegate,
                       InactiveTabsSectionManagerDelegate {
     struct UX {
         static let cornerRadius: CGFloat = 6.0
@@ -32,6 +33,24 @@ class TabDisplayView: UIView,
         guard !tabsState.isPrivateMode else { return true }
 
         return tabsState.inactiveTabs.isEmpty
+    }
+
+    // Dragging on the collection view is either an 'active drag' where the item is moved, or
+    // that the item has been long pressed on (and not moved yet), and this gesture recognizer
+    // has been triggered
+    var isDragging: Bool {
+        return collectionView.hasActiveDrag || isLongPressGestureStarted
+    }
+
+    private var isLongPressGestureStarted: Bool {
+        var started = false
+        collectionView.gestureRecognizers?.forEach { recognizer in
+            if let recognizer = recognizer as? UILongPressGestureRecognizer,
+               recognizer.state == .began || recognizer.state == .changed {
+                started = true
+            }
+        }
+        return started
     }
 
     lazy var collectionView: UICollectionView = {
@@ -290,28 +309,8 @@ class TabDisplayView: UIView,
     func tabCellDidClose(for tabUUID: String) {
         store.dispatch(TabPanelAction.closeTab(TabUUIDContext(tabUUID: tabUUID, windowUUID: windowUUID)))
     }
-}
 
-// MARK: - SwipeAnimatorDelegate
-extension TabDisplayView: SwipeAnimatorDelegate {
-    // Dragging on the collection view is either an 'active drag' where the item is moved, or
-    // that the item has been long pressed on (and not moved yet), and this gesture recognizer
-    // has been triggered
-    var isDragging: Bool {
-        return collectionView.hasActiveDrag || isLongPressGestureStarted
-    }
-
-    private var isLongPressGestureStarted: Bool {
-        var started = false
-        collectionView.gestureRecognizers?.forEach { recognizer in
-            if let recognizer = recognizer as? UILongPressGestureRecognizer,
-               recognizer.state == .began || recognizer.state == .changed {
-                started = true
-            }
-        }
-        return started
-    }
-
+    // MARK: - SwipeAnimatorDelegate
     func swipeAnimator(_ animator: SwipeAnimator) {
         guard let tabCell = animator.animatingView as? TabCell,
               let indexPath = collectionView.indexPath(for: tabCell) else { return }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -252,6 +252,7 @@ class TabDisplayView: UIView,
             else { return UICollectionViewCell() }
 
             let tabState = tabsState.tabs[indexPath.row]
+            cell.animator?.delegate = self
             cell.configure(with: tabState, theme: theme, delegate: self)
             return cell
         }
@@ -292,7 +293,6 @@ class TabDisplayView: UIView,
     }
 }
 
-
 // MARK: - SwipeAnimatorDelegate
 extension TabDisplayView: SwipeAnimatorDelegate {
     // Dragging on the collection view is either an 'active drag' where the item is moved, or
@@ -319,8 +319,8 @@ extension TabDisplayView: SwipeAnimatorDelegate {
 
         let tab = tabsState.tabs[indexPath.item]
         store.dispatch(TabPanelAction.closeTab(TabUUIDContext(tabUUID: tab.tabUUID, windowUUID: windowUUID)))
-        UIAccessibility.post(notification: UIAccessibility.Notification.announcement,
-                             argument: String.TabTrayClosingTabAccessibilityMessage)
+//        UIAccessibility.post(notification: UIAccessibility.Notification.announcement,
+//                             argument: String.TabTrayClosingTabAccessibilityMessage)
     }
 
     func swipeAnimatorIsAnimateAwayEnabled(_ animator: SwipeAnimator) -> Bool {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -312,7 +312,7 @@ extension TabDisplayView: SwipeAnimatorDelegate {
         return started
     }
 
-    func swipeAnimator(_ animator: SwipeAnimator, viewWillExitContainerBounds: UIView) {
+    func swipeAnimator(_ animator: SwipeAnimator) {
         guard let tabCell = animator.animatingView as? TabCell,
               let indexPath = collectionView.indexPath(for: tabCell) else { return }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8418)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18664)

## :bulb: Description
Add `SwipeAnimatorDelegate` to `TabDisplayView` so we can swipe left to delete on a cell in the Tab Tray. 
Observed some strange swiping behavior when deleting tabs as well as moving others, added information in [This Ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8449) for Orla to investigate as part of her work.

https://github.com/mozilla-mobile/firefox-ios/assets/5545720/ca57f1e9-4a94-465a-80d4-8e9b683d4080
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

