### PR TITLE
Add FXIOS-8495 [v125] Create package for ToolbarKit

### DIFF
--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -25,7 +25,10 @@ let package = Package(
             targets: ["ComponentLibrary"]),
         .library(
             name: "WebEngine",
-            targets: ["WebEngine"])
+            targets: ["WebEngine"]),
+        .library(
+            name: "ToolbarKit",
+            targets: ["ToolbarKit"])
     ],
     dependencies: [
         .package(
@@ -91,6 +94,13 @@ let package = Package(
             swiftSettings: [.unsafeFlags(["-enable-testing"])]),
         .testTarget(
             name: "WebEngineTests",
-            dependencies: ["WebEngine"])
+            dependencies: ["WebEngine"]),
+        .target(
+            name: "ToolbarKit",
+            dependencies: ["Common"],
+            swiftSettings: [.unsafeFlags(["-enable-testing"])]),
+        .testTarget(
+            name: "ToolbarKitTests",
+            dependencies: ["ToolbarKit"])
     ]
 )

--- a/BrowserKit/Sources/ToolbarKit/Dummy.swift
+++ b/BrowserKit/Sources/ToolbarKit/Dummy.swift
@@ -1,0 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+class Dummy {
+    var blubb: String = "Blubb"
+}

--- a/BrowserKit/Tests/ToolbarKitTests/DummyTest.swift
+++ b/BrowserKit/Tests/ToolbarKitTests/DummyTest.swift
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import ToolbarKit
+
+final class DummyTest: XCTestCase {
+    func testBlubb() {
+        let subject = Dummy()
+        XCTAssertEqual(subject.blubb, "Blubb")
+    }
+}

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -6463,6 +6463,7 @@
 		C2200A692B7D148C00DC062A /* ContentBlockerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentBlockerTests.swift; sourceTree = "<group>"; };
 		C227533F2A3C9E1300B9C0D1 /* WebsiteDataManagementViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebsiteDataManagementViewModel.swift; sourceTree = "<group>"; };
 		C2296FCB2A601C190046ECA6 /* IntensityVisualEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntensityVisualEffectView.swift; sourceTree = "<group>"; };
+		C233D65C2B8D21CF0056D2F0 /* ToolbarKitTests */ = {isa = PBXFileReference; lastKnownFileType = folder; name = ToolbarKitTests; path = ../BrowserKit/Tests/ToolbarKitTests; sourceTree = "<group>"; };
 		C23889DE2A4EFCE500429673 /* ShareExtensionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareExtensionCoordinator.swift; sourceTree = "<group>"; };
 		C23889E02A4F3E7200429673 /* ParentCoordinatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentCoordinatorDelegate.swift; sourceTree = "<group>"; };
 		C23889E22A50319A00429673 /* ShareExtensionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareExtensionCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -11525,6 +11526,7 @@
 		F84B21B51A090F8100AAB793 = {
 			isa = PBXGroup;
 			children = (
+				C233D65C2B8D21CF0056D2F0 /* ToolbarKitTests */,
 				2FA435FC1ABB83B4008031D1 /* Account */,
 				D4F0C2642B2C90FB008ECEE8 /* BrowserKit */,
 				F84B21C01A090F8100AAB793 /* Client */,

--- a/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/Fennec.xcscheme
+++ b/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/Fennec.xcscheme
@@ -497,6 +497,16 @@
                ReferencedContainer = "container:../BrowserKit">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ToolbarKitTests"
+               BuildableName = "ToolbarKitTests"
+               BlueprintName = "ToolbarKitTests"
+               ReferencedContainer = "container:../BrowserKit">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/firefox-ios/firefox-ios-tests/Tests/UnitTest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/UnitTest.xctestplan
@@ -191,6 +191,13 @@
         "identifier" : "ReduxTests",
         "name" : "ReduxTests"
       }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:..\/BrowserKit",
+        "identifier" : "ToolbarKitTests",
+        "name" : "ToolbarKitTests"
+      }
     }
   ],
   "version" : 1


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8495)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18868)

## :bulb: Description
This creates a package for the toolbar code to live in. For now it only has a dummy class which will be deleted in a future PR.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

