### PR TITLE
Refactor FXIOS-8461 [v123.2] Blank tab issue

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1427,11 +1427,14 @@ class BrowserViewController: UIViewController,
                 break
             }
 
+            // Ensure we do have a URL from that observer
+            guard let url = webView.url else { return }
+
             // To prevent spoofing, only change the URL immediately if the new URL is on
             // the same origin as the current URL. Otherwise, do nothing and wait for
             // didCommitNavigation to confirm the page load.
-            if tab.url?.origin == webView.url?.origin {
-                tab.url = webView.url
+            if tab.url?.origin == url.origin {
+                tab.url = url
 
                 if tab === tabManager.selectedTab {
                     updateUIForReaderHomeStateForTab(tab)

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -260,13 +260,6 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
                 logger.log("Tab has empty tab.URL \(logMessage)",
                            level: .debug,
                            category: .tabs)
-
-                // lastKnownUrl is the fallback in case tab.url is empty. If this one is empty too then this is a problem
-                if tab.lastKnownUrl == nil {
-                    logger.log("Tab has empty tab.lastKnownURL \(logMessage)",
-                               level: .fatal,
-                               category: .tabs)
-                }
             }
 
             return TabData(id: tabId,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8461)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18773)

## :bulb: Description
- Fix to improve on the blank tab issue. We recently added redux updates as part of BVC, which is triggering more UI updates. The current `newState` function in BVC updates the UI based on the tab manager selected tab URL. This URL happens to be niled whenever we have a URL update from the observers, if the webview url is nil. This use case can happen for example if a webview attempts to load a URL (the observer is notified that the URL started changed, but the webview URL is nil at that point), then the webview load fails for some reasons and didCommit is never called. The `tab.url` stays nil, but we update the UI with that URL... so we effectively loose the user URL as we have overriden it, and the tab has become a blank tab with no information.
- Removing a `.fatal` log that will be noisy in prod (since the lastKnownURL is trying to fetch from the legacy `sessionData` object on `Tab.swift`. This means if the `tab.url` is nil, then the `tab.lastKnownURL` will also be nil, so having that log doesn't have any more value than the one above it.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

