### PR TITLE
Bugfix FXIOS-8461 [v123.3] Fix bvc overwriting the selected tab url for the webview

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -444,6 +444,7 @@
 		59A68E0B4ABBF55E14819668 /* BookmarksPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A6839879D615FC1C0D71CE /* BookmarksPanel.swift */; };
 		59A68FD5260B8D520F890F4A /* ReaderPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A685F4EAD19EDEC854BCA4 /* ReaderPanel.swift */; };
 		5A06135A29D6052E008F3D38 /* TabDataStore in Frameworks */ = {isa = PBXBuildFile; productRef = 5A06135929D6052E008F3D38 /* TabDataStore */; };
+		5A1947152B8FA9E0009C7A6C /* BrowserViewType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1947142B8FA9E0009C7A6C /* BrowserViewType.swift */; };
 		5A271ABD2860B0D700471CE4 /* WebServerUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A271ABC2860B0D700471CE4 /* WebServerUtil.swift */; };
 		5A2918CB2B522338002B197E /* GeneralBrowserAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2918CA2B522338002B197E /* GeneralBrowserAction.swift */; };
 		5A2918CD2B522381002B197E /* ToastType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2918CC2B522381002B197E /* ToastType.swift */; };
@@ -5205,6 +5206,7 @@
 		59A68B1F857A8638598A63A0 /* TwoLineImageOverlayCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TwoLineImageOverlayCell.swift; sourceTree = "<group>"; };
 		5A0748769E8BD3C8FC5BFEE5 /* ses */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ses; path = ses.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		5A094AD58393196B3DF76119 /* mr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = mr; path = mr.lproj/Intro.strings; sourceTree = "<group>"; };
+		5A1947142B8FA9E0009C7A6C /* BrowserViewType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserViewType.swift; sourceTree = "<group>"; };
 		5A1B494BAB7DF7D2319677F2 /* hsb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hsb; path = hsb.lproj/Today.strings; sourceTree = "<group>"; };
 		5A1D409EB92D8E6AB8FC8813 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/ClearPrivateData.strings; sourceTree = "<group>"; };
 		5A271ABC2860B0D700471CE4 /* WebServerUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebServerUtil.swift; sourceTree = "<group>"; };
@@ -9132,6 +9134,7 @@
 			children = (
 				81CAE4DA2B1A2C220040C78A /* BrowserViewControllerState.swift */,
 				81122E202B221AC0003DD9F8 /* SearchScreenState.swift */,
+				5A1947142B8FA9E0009C7A6C /* BrowserViewType.swift */,
 			);
 			path = State;
 			sourceTree = "<group>";
@@ -14060,6 +14063,7 @@
 				254B760A2B7B44EE00AB8526 /* NimbusFirefoxSuggestFeatureLayer.swift in Sources */,
 				E68AEDB01B18F81A00133D99 /* SwipeAnimator.swift in Sources */,
 				1DDE3DB32AC34E1E0039363B /* TabCell.swift in Sources */,
+				5A1947152B8FA9E0009C7A6C /* BrowserViewType.swift in Sources */,
 				3BF56D271CDBBE1F00AC4D75 /* SimpleToast.swift in Sources */,
 				C8B0F5F6283B7CCE007AE65D /* PocketStory.swift in Sources */,
 				C81AC6B626160091007800C5 /* LegacyTabTrayViewModel.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
@@ -6,9 +6,9 @@ import Foundation
 import Redux
 
 class GeneralBrowserContext: ActionContext {
-    let selectedTabURL: URL
+    let selectedTabURL: URL?
     let isPrivateBrowsing: Bool
-    init(selectedTabURL: URL,
+    init(selectedTabURL: URL?,
          isPrivateBrowsing: Bool,
          windowUUID: WindowUUID) {
         self.selectedTabURL = selectedTabURL

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
@@ -5,15 +5,26 @@
 import Foundation
 import Redux
 
+class GeneralBrowserContext: ActionContext {
+    let selectedTabURL: URL
+    init(selectedTabURL: URL, windowUUID: WindowUUID) {
+        self.selectedTabURL = selectedTabURL
+        super.init(windowUUID: windowUUID)
+    }
+}
+
 enum GeneralBrowserAction: Action {
     case showToast(ToastTypeContext)
     case showOverlay(KeyboardContext)
+    case updateSelectedTab(GeneralBrowserContext)
 
     var windowUUID: UUID {
         switch self {
         case .showToast(let context as ActionContext):
             return context.windowUUID
         case .showOverlay(let context as ActionContext):
+            return context.windowUUID
+        case .updateSelectedTab(let context as ActionContext):
             return context.windowUUID
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
@@ -7,8 +7,12 @@ import Redux
 
 class GeneralBrowserContext: ActionContext {
     let selectedTabURL: URL
-    init(selectedTabURL: URL, windowUUID: WindowUUID) {
+    let isPrivateBrowsing: Bool
+    init(selectedTabURL: URL,
+         isPrivateBrowsing: Bool,
+         windowUUID: WindowUUID) {
         self.selectedTabURL = selectedTabURL
+        self.isPrivateBrowsing = isPrivateBrowsing
         super.init(windowUUID: windowUUID)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -36,7 +36,6 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
 
     func tabToolbarDidPressHome(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
         updateZoomPageBarVisibility(visible: false)
-        userHasPressedHomeButton = true
         let page = NewTabAccessors.getHomePage(self.profile.prefs)
         if page == .homePage, let homePageURL = HomeButtonHomePageAccessors.getHomePage(self.profile.prefs) {
             tabManager.selectedTab?.loadRequest(PrivilegedRequest(url: homePageURL) as URLRequest)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
@@ -409,7 +409,7 @@ extension BrowserViewController: URLBarDelegate {
                 toast.removeFromSuperview()
             }
 
-            showEmbeddedHomepage(inline: false)
+            showEmbeddedHomepage(inline: false, isPrivate: tabManager.selectedTab?.isPrivate ?? false)
         }
 
         urlBar.applyTheme(theme: themeManager.currentTheme)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -73,13 +73,17 @@ struct BrowserViewControllerState: ScreenState, Equatable {
 
         switch action {
         case PrivateModeMiddlewareAction.privateModeUpdated(let privacyState):
+            var browserViewType = state.browserViewType
+            if browserViewType != .webview {
+                browserViewType = privacyState ? .privateHomepage : .normalHomepage
+            }
             return BrowserViewControllerState(
                 searchScreenState: SearchScreenState(inPrivateMode: privacyState),
                 showDataClearanceFlow: privacyState,
                 fakespotState: state.fakespotState,
                 windowUUID: state.windowUUID,
                 reloadWebView: true,
-                browserViewType: privacyState ? .privateHomepage : .normalHomepage)
+                browserViewType: browserViewType)
         case FakespotAction.pressedShoppingButton,
             FakespotAction.show,
             FakespotAction.dismiss,
@@ -133,9 +137,14 @@ struct BrowserViewControllerState: ScreenState, Equatable {
     static func resolveStateForUpdateSelectedTab(_ context: GeneralBrowserContext,
                                                  state: BrowserViewControllerState) -> BrowserViewControllerState {
         let isAboutHomeURL = InternalURL(context.selectedTabURL)?.isAboutHomeURL ?? false
-        let isInternal = context.selectedTabURL.absoluteString.hasPrefix("\(InternalURL.baseUrl)/\(SessionRestoreHandler.path)")
+        var browserViewType = BrowserViewType.normalHomepage
 
-     //   if isAboutHomeURL
+        if isAboutHomeURL {
+            browserViewType = context.isPrivateBrowsing ? .privateHomepage : .normalHomepage
+        } else {
+            browserViewType = .webview
+        }
+
         return BrowserViewControllerState(
             searchScreenState: state.searchScreenState,
             showDataClearanceFlow: state.showDataClearanceFlow,
@@ -143,6 +152,6 @@ struct BrowserViewControllerState: ScreenState, Equatable {
             showOverlay: state.showOverlay,
             windowUUID: state.windowUUID,
             reloadWebView: true,
-            browserViewType: .normalHomepage)
+            browserViewType: browserViewType)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -13,6 +13,7 @@ struct BrowserViewControllerState: ScreenState, Equatable {
     var fakespotState: FakespotState
     var toast: ToastType?
     var showOverlay: Bool
+    var webviewURL: URL?
 
     init(appState: AppState, uuid: WindowUUID) {
         guard let bvcState = store.state.screenState(
@@ -30,7 +31,8 @@ struct BrowserViewControllerState: ScreenState, Equatable {
                   fakespotState: bvcState.fakespotState,
                   toast: bvcState.toast,
                   showOverlay: bvcState.showOverlay,
-                  windowUUID: bvcState.windowUUID)
+                  windowUUID: bvcState.windowUUID,
+                  webviewURL: bvcState.webviewURL)
     }
 
     init(windowUUID: WindowUUID) {
@@ -51,7 +53,8 @@ struct BrowserViewControllerState: ScreenState, Equatable {
         fakespotState: FakespotState,
         toast: ToastType? = nil,
         showOverlay: Bool = false,
-        windowUUID: WindowUUID
+        windowUUID: WindowUUID,
+        webviewURL: URL? = nil
     ) {
         self.searchScreenState = searchScreenState
         self.usePrivateHomepage = usePrivateHomepage
@@ -60,6 +63,7 @@ struct BrowserViewControllerState: ScreenState, Equatable {
         self.toast = toast
         self.windowUUID = windowUUID
         self.showOverlay = showOverlay
+        self.webviewURL = webviewURL
     }
 
     static let reducer: Reducer<Self> = { state, action in
@@ -110,8 +114,24 @@ struct BrowserViewControllerState: ScreenState, Equatable {
                 fakespotState: state.fakespotState,
                 showOverlay: showOverlay,
                 windowUUID: state.windowUUID)
+        case GeneralBrowserAction.updateSelectedTab(let context):
+            return BrowserViewControllerState(
+                searchScreenState: state.searchScreenState,
+                usePrivateHomepage: state.usePrivateHomepage,
+                showDataClearanceFlow: state.showDataClearanceFlow,
+                fakespotState: state.fakespotState,
+                showOverlay: state.showOverlay,
+                windowUUID: state.windowUUID,
+                webviewURL: context.selectedTabURL)
         default:
-            return state
+            return BrowserViewControllerState(
+                searchScreenState: state.searchScreenState,
+                usePrivateHomepage: state.usePrivateHomepage,
+                showDataClearanceFlow: state.showDataClearanceFlow,
+                fakespotState: state.fakespotState,
+                showOverlay: state.showOverlay,
+                windowUUID: state.windowUUID,
+                webviewURL: nil)
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewType.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewType.swift
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+enum BrowserViewType {
+    case normalHomepage
+    case privateHomepage
+    case webview
+}

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -553,7 +553,10 @@ class BrowserViewController: UIViewController,
             }
 
             // Update states for felt privacy
-            updateInContentHomePanel(tabManager.selectedTab?.url)
+            if state.webviewURL != nil {
+                updateInContentHomePanel(state.webviewURL)
+            }
+
             setupMiddleButtonStatus(isLoading: false)
 
             if let toast = state.toast {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -162,10 +162,6 @@ class BrowserViewController: UIViewController,
     var pendingToast: Toast? // A toast that might be waiting for BVC to appear before displaying
     var downloadToast: DownloadToast? // A toast that is showing the combined download progress
 
-    /// Set to true when the user taps the home button. Used to prevent entering overlay mode.
-    /// Immediately set to false afterwards.
-    var userHasPressedHomeButton = false
-
     // Tracking navigation items to record history types.
     // TODO: weak references?
     var ignoredNavigation = Set<WKNavigation>()
@@ -552,9 +548,8 @@ class BrowserViewController: UIViewController,
                 dismissFakespotIfNeeded()
             }
 
-            // Update states for felt privacy
-            if state.webviewURL != nil {
-                updateInContentHomePanel(state.webviewURL)
+            if state.reloadWebView {
+                updateContentInHomePanel(state.browserViewType)
             }
 
             setupMiddleButtonStatus(isLoading: false)
@@ -1102,10 +1097,10 @@ class BrowserViewController: UIViewController,
     /// - Parameter inline: Inline is true when the homepage is created from the tab tray, a long press
     /// on the tab bar to open a new tab or by pressing the home page button on the tab bar. Inline is false when
     /// it's the zero search page, aka when the home page is shown by clicking the url bar from a loaded web page.
-    func showEmbeddedHomepage(inline: Bool) {
+    func showEmbeddedHomepage(inline: Bool, isPrivate: Bool) {
         resetDataClearanceCFRTimer()
 
-        guard let isPrivate = browserViewControllerState?.usePrivateHomepage, !isPrivate else {
+        guard !isPrivate else {
             browserDelegate?.showPrivateHomepage(overlayManager: overlayManager)
             return
         }
@@ -1137,6 +1132,22 @@ class BrowserViewController: UIViewController,
 
     // MARK: - Update content
 
+    func updateContentInHomePanel(_ browserViewType: BrowserViewType) {
+        switch browserViewType {
+        case .normalHomepage:
+            showEmbeddedHomepage(inline: true, isPrivate: false)
+        case .privateHomepage:
+            showEmbeddedHomepage(inline: true, isPrivate: true)
+        case .webview:
+            showEmbeddedWebview()
+            urlBar.locationView.reloadButton.isHidden = false
+        }
+
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            topTabsViewController?.refreshTabs()
+        }
+    }
+
     func updateInContentHomePanel(_ url: URL?, focusUrlBar: Bool = false) {
         let isAboutHomeURL = url.flatMap { InternalURL($0)?.isAboutHomeURL } ?? false
         guard let url = url else {
@@ -1146,11 +1157,7 @@ class BrowserViewController: UIViewController,
         }
 
         if isAboutHomeURL {
-            showEmbeddedHomepage(inline: true)
-
-            if userHasPressedHomeButton {
-                userHasPressedHomeButton = false
-            }
+            showEmbeddedHomepage(inline: true, isPrivate: tabManager.selectedTab?.isPrivate ?? false)
         } else if !url.absoluteString.hasPrefix("\(InternalURL.baseUrl)/\(SessionRestoreHandler.path)") {
             showEmbeddedWebview()
             urlBar.locationView.reloadButton.isHidden = false
@@ -2625,7 +2632,7 @@ extension BrowserViewController: TabManagerDelegate {
             selected?.reloadPage()
             return
         }
-        updateInContentHomePanel(selected?.url as URL?, focusUrlBar: true)
+        //updateInContentHomePanel(selected?.url as URL?, focusUrlBar: true)
     }
 
     func tabManager(_ tabManager: TabManager, didAddTab tab: Tab, placeNextToParentTab: Bool, isRestoring: Bool) {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2632,7 +2632,6 @@ extension BrowserViewController: TabManagerDelegate {
             selected?.reloadPage()
             return
         }
-        //updateInContentHomePanel(selected?.url as URL?, focusUrlBar: true)
     }
 
     func tabManager(_ tabManager: TabManager, didAddTab tab: Tab, placeNextToParentTab: Bool, isRestoring: Bool) {

--- a/firefox-ios/Client/Frontend/Browser/Event Queue/AppEvent.swift
+++ b/firefox-ios/Client/Frontend/Browser/Event Queue/AppEvent.swift
@@ -30,5 +30,5 @@ public enum AppEvent: AppEventType {
 
     // Activites: Tabs
     case tabRestoration(WindowUUID)
-    case selectTab(URL, WindowUUID)
+    case selectTab(URL?, WindowUUID)
 }

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -295,6 +295,8 @@ class Tab: NSObject, ThemeApplicable {
            internalUrl.isAboutHomeURL {
             return true
         }
+        // TODO: Find a new home for this FXIOS-8527
+        // A computed variable should not be making view level changes
         ensureMainThread {
             self.setZoomLevelforDomain()
         }

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -372,6 +372,8 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
         tabsTelemetry.stopTabSwitchMeasurement()
         guard let url else { return }
         AppEventQueue.completed(.selectTab(url, windowUUID))
+        let context = GeneralBrowserContext(selectedTabURL: url, windowUUID: windowUUID)
+        store.dispatch(GeneralBrowserAction.updateSelectedTab(context))
     }
 
     @MainActor

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -370,7 +370,6 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
 
     private func didSelectTab(_ url: URL?) {
         tabsTelemetry.stopTabSwitchMeasurement()
-        guard let url else { return }
         AppEventQueue.completed(.selectTab(url, windowUUID))
         let context = GeneralBrowserContext(selectedTabURL: url,
                                             isPrivateBrowsing: selectedTab?.isPrivate ?? false,

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -372,7 +372,9 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
         tabsTelemetry.stopTabSwitchMeasurement()
         guard let url else { return }
         AppEventQueue.completed(.selectTab(url, windowUUID))
-        let context = GeneralBrowserContext(selectedTabURL: url, windowUUID: windowUUID)
+        let context = GeneralBrowserContext(selectedTabURL: url,
+                                            isPrivateBrowsing: selectedTab?.isPrivate ?? false,
+                                            windowUUID: windowUUID)
         store.dispatch(GeneralBrowserAction.updateSelectedTab(context))
     }
 

--- a/firefox-ios/Shared/InternalURL.swift
+++ b/firefox-ios/Shared/InternalURL.swift
@@ -38,8 +38,8 @@ public struct InternalURL {
         return isWebServerUrl || InternalURL.scheme == url.scheme
     }
 
-    public init?(_ url: URL) {
-        guard InternalURL.isValid(url: url) else { return nil }
+    public init?(_ url: URL?) {
+        guard let url, InternalURL.isValid(url: url) else { return nil }
 
         self.url = url
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8461)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18773)

## :bulb: Description
Set BVC to only udpate the embeded webview if there is a change to the selected URL

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

