### PR TITLE
Undo MTE-2424 [v125] workaround for remove custom search engine

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -623,13 +623,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
             // Screengraph will go back to main Settings screen. Manually tap on settings
             app.tables[AccessibilityIdentifiers.Settings.tableViewController].staticTexts["Google"].tap()
             app.navigationBars[AccessibilityIdentifiers.Settings.Search.searchNavigationBar].buttons["Edit"].tap()
-            // Workaround for https://github.com/mozilla-mobile/firefox-ios/issues/18278
-            // Remove if/else after fix
-            if !isTablet {
-                app.tables.buttons[AccessibilityIdentifiers.Settings.Search.deleteMozillaEngine].tap()
-            } else {
-                app.tables.buttons["Remove Learn more about Firefox Suggest"].tap()
-            }
+            app.tables.buttons[AccessibilityIdentifiers.Settings.Search.deleteMozillaEngine].tap()
             app.tables.buttons[AccessibilityIdentifiers.Settings.Search.deleteButton].tap()
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchSettingsUITest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchSettingsUITest.swift
@@ -37,17 +37,7 @@ class SearchSettingsUITests: BaseTestCase {
         XCTAssertTrue(app.buttons["Edit"].isEnabled)
         app.buttons["Edit"].tap()
         XCTAssertTrue(app.buttons["Done"].isEnabled)
-        app.buttons["Done"].tap()
-        mozWaitForElementToExist(app.buttons["Edit"])
-        XCTAssertTrue(app.buttons["Edit"].isEnabled)
-        app.buttons["Edit"].tap()
-        // Workaround for https://github.com/mozilla-mobile/firefox-ios/issues/18278
-        // Remove if/else after fix
-        if !iPad() {
-            mozWaitForElementToExist(app.tables.buttons["Remove \(customSearchEngine["name"]!)"])
-        } else {
-            app.tables.buttons["Remove Learn more about Firefox Suggest"].tap()
-        }
+        mozWaitForElementToExist(app.tables.buttons["Remove \(customSearchEngine["name"]!)"])
     }
 
     private func addCustomSearchEngine() {
@@ -120,22 +110,10 @@ class SearchSettingsUITests: BaseTestCase {
         // Add a custom search engine
         addCustomSearchEngine()
         XCTAssertTrue(app.buttons["Edit"].isEnabled)
-
-        app.buttons["Edit"].tap()
-        XCTAssertTrue(app.buttons["Done"].isEnabled)
-        app.buttons["Done"].tap()
-        mozWaitForElementToExist(app.buttons["Edit"])
-        XCTAssertTrue(app.buttons["Edit"].isEnabled)
         app.buttons["Edit"].tap()
         // Remove the custom search engine and check that edit is disabled
         let tablesQuery = app.tables
-        // Workaround for https://github.com/mozilla-mobile/firefox-ios/issues/18278
-        // Remove if/else after fix
-        if !iPad() {
-            tablesQuery.buttons["Remove \(customSearchEngine["name"]!)"].tap()
-        } else {
-            tablesQuery.buttons["Remove Learn more about Firefox Suggest"].tap()
-        }
+        tablesQuery.buttons["Remove \(customSearchEngine["name"]!)"].tap()
         tablesQuery.buttons[AccessibilityIdentifiers.Settings.Search.deleteButton].tap()
         XCTAssertFalse(app.buttons["Edit"].isEnabled)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2424)

## :bulb: Description
The latest bug fixes might have impacted “Remove youtube” identifier. The workarounds added need to be removed and restore the tests to the initial state.
