### PR TITLE
Refactor MTE-2425 [v125] Ignore focus-ios path in swiftlint temporarly

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -132,6 +132,8 @@ excluded: # paths to ignore during linting. Takes precedence over `included`.
   - firefox-ios/Client/ContentBlocker/ContentBlockerGenerator/Package.swift
   - Package.swift
   - firefox-ios/Build/Intermediates.noindex/Client.build/Fennec-iphoneos/WidgetKitExtension.build/DerivedSources/IntentDefinitionGenerated/WidgetIntents/*
+  # Temporarly ignore focus-ios folder
+  - focus-ios/
 
 included:
   - /Users/vagrant/git


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE2425)

The rules applied on firefox has not been added to focus repo. Since they are going to share the same swiftlint file, we need to ignore focus for now, otherwise there are ~1200 issues we would need to address at once. It is better to fix those step by step and rule by rule

See build log: https://app.bitrise.io/build/b4a66f3d-292f-4b53-ad15-1083977ef27f

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

