### PR TITLE
Refactor FXIOS-8502 [v125] Handle url adapted following blank tab issue fix in Client

### DIFF
--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -238,8 +238,8 @@ class WKEngineSession: NSObject,
         // didCommitNavigation to confirm the page load.
         guard sessionData.url?.origin == webView.url?.origin else { return }
 
-        sessionData.url = webView.url
         if let url = webView.url {
+            sessionData.url = url
             delegate?.onLocationChange(url: url.absoluteString)
 
             metadataFetcher.fetch(fromSession: self, url: url)

--- a/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
@@ -404,7 +404,7 @@ final class WKEngineSessionTests: XCTestCase {
 
     func testURLChangeGivenNilURLThenDoesntCallDelegate() {
         let subject = createSubject()
-        webViewProvider.webView.title = nil
+        webViewProvider.webView.url = nil
 
         subject?.observeValue(forKeyPath: "URL",
                               of: nil,
@@ -419,7 +419,7 @@ final class WKEngineSessionTests: XCTestCase {
     func testURLChangeGivenAboutBlankWithNilURLThenDoesntCallDelegate() {
         let subject = createSubject()
         subject?.sessionData.url = URL(string: "about:blank")!
-        webViewProvider.webView.title = nil
+        webViewProvider.webView.url = nil
 
         subject?.observeValue(forKeyPath: "URL",
                               of: nil,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8502)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18891)

## :bulb: Description
This change is to adapt the `WKEngineSession` following [that fix](https://github.com/mozilla-mobile/firefox-ios/pull/18884) that was made for a recent bug in the Client app. Tests were adjusted as I realized I had a copy paste issue 😬 (I was setting the `title` to nil, when we are in fact testing the URL change here... so the URL should be set to `nil` to ensure we have proper GIVEN for those tests.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

