### PR TITLE
Add FXIOS-8513 [v125] Create protocol for RustLogins, first step in removing deferred

### DIFF
--- a/firefox-ios/Storage/Rust/RustLogins.swift
+++ b/firefox-ios/Storage/Rust/RustLogins.swift
@@ -526,7 +526,13 @@ public class LoginRecordError: MaybeErrorType {
     }
 }
 
-public class RustLogins {
+/// This is a protocol followed by RustLogins to provide an alternative to using `Deferred` in that code
+/// Its part of a long term effort to remove `Deferred` usage inside the application and is a work in progress.
+protocol LoginsProtocol {
+    func getLogin(id: String, completionHandler: @escaping (Result<EncryptedLogin?, Error>) -> Void)
+}
+
+public class RustLogins: LoginsProtocol {
     let perFieldDatabasePath: String
 
     let queue: DispatchQueue
@@ -606,6 +612,23 @@ public class RustLogins {
         }
 
         return error
+    }
+
+    public func getLogin(id: String, completionHandler: @escaping (Result<EncryptedLogin?, Error>) -> Void) {
+        queue.async {
+            guard self.isOpen else {
+                let error = LoginsStoreError.UnexpectedLoginsApiError(reason: "Database is closed")
+                completionHandler(.failure(error))
+                return
+            }
+
+            do {
+                let record = try self.storage?.get(id: id)
+                completionHandler(.success(record))
+            } catch let err as NSError {
+                completionHandler(.failure(err))
+            }
+        }
     }
 
     public func getLogin(id: String) -> Deferred<Maybe<EncryptedLogin?>> {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8513)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18912)

## :bulb: Description
I just want to create a first method in this protocol, so the direction we're aiming to take with the Deferred removal epic is a bit clearer (for communication purpose with contributors).

If this is approved, I'll create a task for each of the methods to be added in this protocol, rather than one big task which will be hard to review.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

