### PR TITLE
Refactor FXIOS-8398 [v125] Disable user interaction in the tab while we show the snack bar view

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -36,6 +36,7 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
 
     func tabToolbarDidPressHome(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
         updateZoomPageBarVisibility(visible: false)
+        tabManager.selectedTab?.removeAllSnackbars()
         userHasPressedHomeButton = true
         let page = NewTabAccessors.getHomePage(self.profile.prefs)
         if page == .homePage, let homePageURL = HomeButtonHomePageAccessors.getHomePage(self.profile.prefs) {
@@ -213,6 +214,7 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
 
     func tabToolbarDidPressTabs(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
         updateZoomPageBarVisibility(visible: false)
+        tabManager.selectedTab?.removeAllSnackbars()
         let isPrivateTab = tabManager.selectedTab?.isPrivate ?? false
         let segmentToFocus = isPrivateTab ? TabTrayPanelType.privateTabs : TabTrayPanelType.tabs
         showTabTray(focusedSegment: segmentToFocus)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
@@ -30,6 +30,10 @@ class DismissableNavigationViewController: UINavigationController, OnViewDismiss
 }
 
 extension BrowserViewController: URLBarDelegate {
+    func urlBarWillBeginEditing(_ urlBar: URLBarView) {
+        tabManager.selectedTab?.removeAllSnackbars()
+    }
+
     func showTabTray(withFocusOnUnselectedTab tabToFocus: Tab? = nil,
                      focusedSegment: TabTrayPanelType? = nil) {
         updateFindInPageVisibility(visible: false)
@@ -45,6 +49,7 @@ extension BrowserViewController: URLBarDelegate {
 
     private func showLegacyTabTrayViewController(withFocusOnUnselectedTab tabToFocus: Tab? = nil,
                                                  focusedSegment: TabTrayPanelType? = nil) {
+        tabManager.selectedTab?.removeAllSnackbars()
         tabTrayViewController = LegacyTabTrayViewController(
             tabTrayDelegate: self,
             profile: profile,
@@ -98,6 +103,7 @@ extension BrowserViewController: URLBarDelegate {
     }
 
     func urlBarDidPressReload(_ urlBar: URLBarView) {
+        tabManager.selectedTab?.removeAllSnackbars()
         tabManager.selectedTab?.reload()
     }
 
@@ -170,6 +176,7 @@ extension BrowserViewController: URLBarDelegate {
     }
 
     func urlBarDidPressQRButton(_ urlBar: URLBarView) {
+        tabManager.selectedTab?.removeAllSnackbars()
         navigationHandler?.showQRCode(delegate: self)
     }
 
@@ -183,6 +190,7 @@ extension BrowserViewController: URLBarDelegate {
     }
 
     func urlBarDidPressTabs(_ urlBar: URLBarView) {
+        tabManager.selectedTab?.removeAllSnackbars()
         showTabTray()
     }
 
@@ -193,6 +201,7 @@ extension BrowserViewController: URLBarDelegate {
 
         switch readerMode.state {
         case .available:
+            tabManager.selectedTab?.removeAllSnackbars()
             enableReaderMode()
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .readerModeOpenButton)
         case .active:

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2616,6 +2616,8 @@ extension BrowserViewController: TabManagerDelegate {
                 tab.reload()
             }
 
+            tab.removeAllSnackbars()
+
             // Update Fakespot sidebar if necessary
             updateFakespot(tab: tab)
         }

--- a/firefox-ios/Client/Frontend/Components/BaseContentStackView.swift
+++ b/firefox-ios/Client/Frontend/Components/BaseContentStackView.swift
@@ -38,7 +38,7 @@ class BaseAlphaStackView: UIStackView, AlphaDimmable, ThemeApplicable {
     }
 
     func toggleOverlayMode(shouldEnterOverlayMode: Bool) {
-        alignment = shouldEnterOverlayMode? .center : .fill
+        alignment = shouldEnterOverlayMode ? .center : .fill
         isOverlayMode = shouldEnterOverlayMode
     }
 

--- a/firefox-ios/Client/Frontend/Components/BaseContentStackView.swift
+++ b/firefox-ios/Client/Frontend/Components/BaseContentStackView.swift
@@ -12,6 +12,8 @@ protocol AlphaDimmable {
 
 class BaseAlphaStackView: UIStackView, AlphaDimmable, ThemeApplicable {
     var isClearBackground = false
+    var isOverlayMode = false
+
     override init(frame: CGRect) {
         super.init(frame: frame)
 
@@ -33,6 +35,11 @@ class BaseAlphaStackView: UIStackView, AlphaDimmable, ThemeApplicable {
         axis = .vertical
         distribution = .fill
         alignment = .fill
+    }
+
+    func toggleOverlayMode(shouldEnterOverlayMode: Bool) {
+        alignment = shouldEnterOverlayMode? .center : .fill
+        isOverlayMode = shouldEnterOverlayMode
     }
 
     // MARK: - Spacer view
@@ -79,7 +86,10 @@ class BaseAlphaStackView: UIStackView, AlphaDimmable, ThemeApplicable {
     }
 
     func applyTheme(theme: Theme) {
-        let color = isClearBackground ? .clear : theme.colors.layer1
+        var color = isClearBackground ? .clear : theme.colors.layer1
+        if isOverlayMode {
+            color = theme.colors.layer4
+        }
         backgroundColor = color
         keyboardSpacer?.backgroundColor = color
     }

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -49,6 +49,7 @@ protocol URLBarDelegate: AnyObject {
     func urlBarDidTapShield(_ urlBar: URLBarView)
     func urlBarLocationAccessibilityActions(_ urlBar: URLBarView) -> [UIAccessibilityCustomAction]?
     func urlBarDidPressScrollToTop(_ urlBar: URLBarView)
+    func urlBarWillBeginEditing(_ urlBar: URLBarView)
     func urlBar(_ urlBar: URLBarView, didRestoreText text: String)
     func urlBar(_ urlBar: URLBarView, didEnterText text: String)
     func urlBar(_ urlBar: URLBarView, didSubmitText text: String)
@@ -835,6 +836,10 @@ extension URLBarView: TabLocationViewDelegate {
 }
 
 extension URLBarView: AutocompleteTextFieldDelegate {
+    func autocompleteTextFieldWillBeginEditing(_ autocompleteTextField: AutocompleteTextField) {
+        delegate?.urlBarWillBeginEditing(self)
+    }
+
     func autocompleteTextFieldShouldReturn(_ autocompleteTextField: AutocompleteTextField) -> Bool {
         guard let text = locationTextField?.text else { return true }
         if !text.trimmingCharacters(in: .whitespaces).isEmpty {

--- a/firefox-ios/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/firefox-ios/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -11,6 +11,7 @@ import Common
 /// Delegate for the text field events. Since AutocompleteTextField owns the UITextFieldDelegate,
 /// callers must use this instead.
 protocol AutocompleteTextFieldDelegate: AnyObject {
+    func autocompleteTextFieldWillBeginEditing(_ autocompleteTextField: AutocompleteTextField)
     func autocompleteTextField(_ autocompleteTextField: AutocompleteTextField, didEnterText text: String)
     func autocompleteTextFieldShouldReturn(_ autocompleteTextField: AutocompleteTextField) -> Bool
     func autocompleteTextFieldShouldClear(_ autocompleteTextField: AutocompleteTextField) -> Bool
@@ -315,6 +316,11 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
         frame.size.height = self.frame.size.height
         label.frame = frame
         return label
+    }
+
+    func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
+        autocompleteDelegate?.autocompleteTextFieldWillBeginEditing(self)
+        return true
     }
 
     func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -606,10 +606,12 @@ class Tab: NSObject, ThemeApplicable {
     }
 
     func goBack() {
+        removeAllSnackbars()
         _ = webView?.goBack()
     }
 
     func goForward() {
+        removeAllSnackbars()
         _ = webView?.goForward()
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8398)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18618)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This is the version that still uses snapkit for removing the overlay, I tried a few variants using NSLayoutConstraints and I'm close to making that approach work as well, but that version's got an app breaking bug on screen rotation, while this one works fine. To make the overlay more user friendly I also removed it when going into reader mode, refreshing the page, tapping the urlBar, putting the app to background, opening the tab tray, going back/forward, as these actions can have a negative impact on UX if the screen is blocked by the overlay.
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed, I updated documentation / comments for complex code and public methods
- [] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

