### PR TITLE
Bugfix FXIOS-7481 [v125] address bar bottom in landscape view makes the top area of the screen not clickable iOS

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -929,7 +929,7 @@ class BrowserViewController: UIViewController,
             topTouchArea.topAnchor.constraint(equalTo: view.topAnchor),
             topTouchArea.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             topTouchArea.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            topTouchArea.heightAnchor.constraint(equalToConstant: UX.ShowHeaderTapAreaHeight)
+            topTouchArea.heightAnchor.constraint(equalToConstant: isBottomSearchBar ? 0 : UX.ShowHeaderTapAreaHeight)
         ])
 
         readerModeBar?.snp.remakeConstraints { make in


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7481)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16611)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
I've encountered this bug a lot while working on the Snackbar overlay, it happens when watching a Youtube video in landscape with the urlBar on the bottom, tapping top area does nothing because the `topTouchArea ` covers it.
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed, I updated documentation / comments for complex code and public methods
- [] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

