### PR TITLE
Localize FXIOS-8525 [v125] Add Description Strings for `Show in Private Sessions`

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -206,6 +206,9 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
                     titleText: String.localizedStringWithFormat(
                         .Settings.Search.PrivateSessionSetting
                     ),
+                    statusText: String.localizedStringWithFormat(
+                        .Settings.Search.PrivateSessionDescription
+                    ),
                     cell: cell,
                     selector: #selector(didToggleShowSearchSuggestionsInPrivateMode)
                 )
@@ -286,6 +289,10 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
                     defaultValue: model.shouldShowPrivateModeFirefoxSuggestions,
                     titleText: String.localizedStringWithFormat(
                         .Settings.Search.PrivateSessionSetting
+                    ),
+                    statusText: String.localizedStringWithFormat(
+                        .Settings.Search.Suggest.PrivateSessionDescription,
+                        AppName.shortName.rawValue
                     ),
                     cell: cell,
                     selector: #selector(didToggleShowFirefoxSuggestionsInPrivateMode)

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -1849,7 +1849,11 @@ extension String {
                 tableName: "Settings",
                 value: "Show in Private Sessions",
                 comment: "Label for toggle. Explains that in private browsing mode, the search suggestions which appears at the top of the search bar, can be toggled on or off. Located in `Suggestions from Search Engines` and `Address Bar - Firefox Suggest` sections in the Search page in the Settings menu.")
-
+            public static let PrivateSessionDescription = MZLocalizedString(
+                key: "Settings.Search.PrivateSession.Description.v125",
+                tableName: "Settings",
+                value: "Show suggestions from search engines in private sessions",
+                comment: "Description for `Show in Private Sessions` toggle, located in `Suggestions from Search Engines` section in the Search page in the Settings menu.")
             public struct AccessibilityLabels {
                 public static let DefaultSearchEngine = MZLocalizedString(
                     key: "Settings.Search.Accessibility.DefaultSearchEngine.v121",
@@ -1882,7 +1886,7 @@ extension String {
                 public static let ShowSponsoredSuggestionsTitle = MZLocalizedString(
                     key: "Settings.Search.Suggest.ShowSponsoredSuggestions.Title.v124",
                     tableName: "Settings",
-                    value: "Suggestions from sponsors",
+                    value: "Suggestions from Sponsors",
                     comment: "In the Search page of the Settings menu, the title for the setting to enable Suggestions from sponsors.")
                 public static let ShowSponsoredSuggestionsDescription = MZLocalizedString(
                     key: "Settings.Search.Suggest.ShowSponsoredSuggestions.Description.v124",
@@ -1904,6 +1908,11 @@ extension String {
                     tableName: "Settings",
                     value: "Search Synced Tabs",
                     comment: "In the Search page of the Settings menu, the title for the setting to enable synced tabs.")
+                public static let PrivateSessionDescription = MZLocalizedString(
+                    key: "Settings.Search.Suggest.PrivateSession.Description.v125",
+                    tableName: "Settings",
+                    value: "Show suggestions from %@ Suggest in private sessions",
+                    comment: "Description for `Show in Private Sessions` toggle, located in `Address Bar - Firefox Suggest` section in the Search page in the Settings menu. Placeholder is for the app name - Firefox.")
                 public static let LearnAboutSuggestions = MZLocalizedString(
                     key: "Settings.Search.Suggest.LearnAboutSuggestions.v124",
                     tableName: "Settings",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8525)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18937)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR adds the following strings:

`Show in Private Sessions` from section `Suggestions from Search Engines` - “Show suggestions from search engines in private sessions”

`Show in Private Sessions` from section `Address Bar - Firefox Suggest` - “Show suggestions from Firefox Suggest in private sessions”
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

