### PR TITLE
Bugfix FXIOS-8509 [v125] Clipboard prompt missing

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2854,8 +2854,6 @@ extension BrowserViewController: SessionRestoreHelperDelegate {
         if let tab = tabManager.selectedTab, tab.webView === tab.webView {
             updateUIForReaderHomeStateForTab(tab)
         }
-
-        clipboardBarDisplayHandler?.didRestoreSession()
     }
 }
 

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -45,11 +45,6 @@ protocol LegacyTabDelegate: AnyObject {
     func tab(_ tab: Tab, willDeleteWebView webView: WKWebView)
 }
 
-@objc
-protocol URLChangeDelegate {
-    func tab(_ tab: Tab, urlDidChangeTo url: URL)
-}
-
 struct TabState {
     var isPrivate = false
     var url: URL?
@@ -252,7 +247,6 @@ class Tab: NSObject, ThemeApplicable {
     var userActivity: NSUserActivity?
     var webView: TabWebView?
     weak var tabDelegate: LegacyTabDelegate?
-    weak var urlDidChangeDelegate: URLChangeDelegate?
     var bars = [SnackBar]()
     var lastExecutedTime: Timestamp?
     var firstCreatedTime: Timestamp?
@@ -832,10 +826,6 @@ class Tab: NSObject, ThemeApplicable {
             return assertionFailure("Unhandled KVO key: \(keyPath ?? "nil")")
         }
 
-        if let url = self.webView?.url, path == KVOConstants.URL.rawValue {
-            self.urlDidChangeDelegate?.tab(self, urlDidChangeTo: url)
-        }
-
         if let title = self.webView?.title, !title.isEmpty,
            path == KVOConstants.title.rawValue {
             metadataManager?.updateObservationTitle(title)
@@ -845,16 +835,6 @@ class Tab: NSObject, ThemeApplicable {
 
     func isDescendentOf(_ ancestor: Tab) -> Bool {
         return sequence(first: parent) { $0?.parent }.contains { $0 == ancestor }
-    }
-
-    func observeURLChanges(delegate: URLChangeDelegate) {
-        self.urlDidChangeDelegate = delegate
-    }
-
-    func removeURLChangeObserver(delegate: URLChangeDelegate) {
-        if let existing = self.urlDidChangeDelegate, existing === delegate {
-            self.urlDidChangeDelegate = nil
-        }
     }
 
     func getProviderForUrl() -> SearchEngine {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTests.swift
@@ -8,18 +8,15 @@ import WebKit
 
 class TabTests: XCTestCase {
     private var tabDelegate: MockLegacyTabDelegate!
-    private var urlDidChangeDelegate: MockUrlDidChangeDelegate!
 
     override func setUp() {
         super.setUp()
         tabDelegate = MockLegacyTabDelegate()
-        urlDidChangeDelegate = MockUrlDidChangeDelegate()
     }
 
     override func tearDown() {
         super.tearDown()
         tabDelegate = nil
-        urlDidChangeDelegate = nil
     }
 
     func testShareURL_RemovingReaderModeComponents() {
@@ -44,7 +41,6 @@ class TabTests: XCTestCase {
     func testTabDoesntLeak() {
         let tab = Tab(profile: MockProfile(), configuration: WKWebViewConfiguration())
         tab.tabDelegate = tabDelegate
-        tab.urlDidChangeDelegate = urlDidChangeDelegate
         trackForMemoryLeaks(tab)
     }
 }
@@ -62,9 +58,4 @@ class MockLegacyTabDelegate: LegacyTabDelegate {
     func tab(_ tab: Tab, didCreateWebView webView: WKWebView) {}
 
     func tab(_ tab: Tab, willDeleteWebView webView: WKWebView) {}
-}
-
-// MARK: - MockUrlDidChangeDelegate
-class MockUrlDidChangeDelegate: URLChangeDelegate {
-    func tab(_ tab: Tab, urlDidChangeTo url: URL) {}
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8509)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18906)

## :bulb: Description
Fix bug where toast was not appearing despite user having the "Offer to Open Copied Links" setting enabled. We removed the old code for how we wanted to wait until the tabs were properly restored and instead opted to use the `AppEventQueue` and to wait until the app is in a state where users can navigate to the copy link after displaying the toast.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots
| iPhone | iPad | 
| --- | --- |
| ![image](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/b4492cd5-525b-4e16-a939-a11ae47c7c6d) | ![IMG_6EFCE857EBEE-1](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/33c5dfe8-8dd4-452d-945f-684d86e06783) |