### PR TITLE
Bugfix FXIOS-4958 [v125] Selected text menu’s “Search Firefox” don’t search for text selected in a PDF

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ZoomPage.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ZoomPage.swift
@@ -33,7 +33,9 @@ extension BrowserViewController {
             .isActive = true
         zoomPageBar.applyTheme(theme: themeManager.currentTheme)
 
-        updateViewConstraints()
+        if UIDevice.current.userInterfaceIdiom != .pad {
+            updateViewConstraints()
+        }
     }
 
     private func removeZoomPageBar(_ zoomPageBar: ZoomPageBar) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-4958)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/11956)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

