### PR TITLE
Bugfix FXIOS-8503 [v125] Opening zoom bar causes website to go blank

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ZoomPage.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ZoomPage.swift
@@ -33,7 +33,9 @@ extension BrowserViewController {
             .isActive = true
         zoomPageBar.applyTheme(theme: themeManager.currentTheme)
 
-        updateViewConstraints()
+        if UIDevice.current.userInterfaceIdiom != .pad {
+            updateViewConstraints()
+        }
     }
 
     private func removeZoomPageBar(_ zoomPageBar: ZoomPageBar) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8503)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18894)

## :bulb: Description
After investigations "opening zoom bar causes website to go blank" because on iPad is not necessary to do update on constraints as on iPhone.

In order to fix this, I added a condition on updateViewConstraints() call.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

