### PR TITLE
Bugfix FXIOS-8494 [v123.3] Fetch sync data directly instead of cache

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/RemoteTabsPanelMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/RemoteTabsPanelMiddleware.swift
@@ -58,12 +58,12 @@ class RemoteTabsPanelMiddleware {
             // in the middle of a refresh (pull-to-refresh shouldn't trigger a new update etc.)
             store.dispatch(RemoteTabsPanelAction.refreshDidBegin(window.context))
 
-            getCachedRemoteTabs(window: window)
+            getRemoteTabs(window: window)
         }
     }
 
-    private func getCachedRemoteTabs(window: WindowUUID) {
-        profile.getCachedClientsAndTabs { result in
+    private func getRemoteTabs(window: WindowUUID) {
+        profile.getClientsAndTabs { result in
             guard let clientAndTabs = result else {
                 let context = RemoteTabsRefreshDidFailContext(reason: .failedToSync, windowUUID: window)
                 store.dispatch(RemoteTabsPanelAction.refreshDidFail(context))
@@ -98,7 +98,6 @@ class RemoteTabsPanelMiddleware {
             // TODO: [8188] Revisit UUID here to determine ideal handling.
             let uuid = WindowUUID.unavailable
             let context = HasSyncableAccountContext(hasSyncableAccount: hasSyncableAccount, windowUUID: uuid)
-            getCachedRemoteTabs(window: .unavailable)
             store.dispatch(TabTrayAction.firefoxAccountChanged(context))
         default: break
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8494)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18865)

## :bulb: Description
Call the function to trigger a full sync instead of getting the cached data.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

