### PR TITLE
Bugfix FXIOS-{18953} [280] Fix broken link to ios webxr-2.0.js polyfill

### DIFF
--- a/Client/Application/Settings.bundle/Root.plist
+++ b/Client/Application/Settings.bundle/Root.plist
@@ -32,7 +32,7 @@
 			<key>Key</key>
 			<string>polyfillURL</string>
 			<key>DefaultValue</key>
-			<string>https://webxr-ios.webxrexperiments.com/dist/webxr-2.0.js</string>
+			<string>https://gist.github.com/lxfschr/20c0393c5dd6af616a08657be5d0863a.js</string>
 			<key>IsSecure</key>
 			<false/>
 			<key>KeyboardType</key>

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -489,7 +489,7 @@ class Tab: NSObject {
                     let path = Bundle.main.path(forResource: "webxrShim", ofType: "js"),
                     var source = try? String(contentsOfFile: path)
                 {
-                    let polyfillURL = UserDefaults.standard.string(forKey: Constant.polyfillURLKey()) ?? "https://webxr-ios.webxrexperiments.com/dist/webxr-2.0.js"
+                    let polyfillURL = UserDefaults.standard.string(forKey: Constant.polyfillURLKey()) ?? "https://gist.github.com/lxfschr/20c0393c5dd6af616a08657be5d0863a.js"
                     source = "{ const REALAPI_URL = '\(polyfillURL)'; " + source
                     let userScript = WKUserScript(source: source, injectionTime: .atDocumentStart, forMainFrameOnly: true)
                     webView.configuration.userContentController.addUserScript(userScript)


### PR DESCRIPTION
## :scroll: Tickets
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18953)

## :bulb: Description
Updates links to missing webxr polyfill for iOS from one that is on a website that no longer exists to a Github Gist

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

