### PR TITLE
Refactor FXIOS-18945 [v125] Updated Fonts in EmptyPrivateTabsView to use FXFontStyles

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/EmptyPrivateTabsView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/EmptyPrivateTabsView.swift
@@ -36,16 +36,14 @@ class EmptyPrivateTabsView: UIView {
 
     private let titleLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .title2,
-                                                            size: UX.titleSizeFont)
+        label.font = FXFontStyles.Regular.title2.scaledFont()
         label.text =  .PrivateBrowsingTitle
         label.textAlignment = .center
     }
 
     private let descriptionLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
-                                                            size: UX.descriptionSizeFont)
+        label.font = FXFontStyles.Regular.body.scaledFont()
         label.textAlignment = .center
         label.numberOfLines = 0
         label.text = .TabTrayPrivateBrowsingDescription
@@ -54,8 +52,8 @@ class EmptyPrivateTabsView: UIView {
     let learnMoreButton: UIButton = .build { button in
         button.setTitle( .PrivateBrowsingLearnMore, for: [])
         button.titleLabel?.adjustsFontForContentSizeCategory = true
-        button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .subheadline,
-                                                                         size: UX.buttonSizeFont)
+        button.titleLabel?.font = FXFontStyles.Regular.subheadline.scaledFont()
+
     }
 
     private let iconImageView: UIImageView = .build { imageView in

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/EmptyPrivateTabsView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/EmptyPrivateTabsView.swift
@@ -50,7 +50,6 @@ class EmptyPrivateTabsView: UIView {
         button.setTitle( .PrivateBrowsingLearnMore, for: [])
         button.titleLabel?.adjustsFontForContentSizeCategory = true
         button.titleLabel?.font = FXFontStyles.Regular.subheadline.scaledFont()
-
     }
 
     private let iconImageView: UIImageView = .build { imageView in

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/EmptyPrivateTabsView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/EmptyPrivateTabsView.swift
@@ -14,9 +14,6 @@ protocol EmptyPrivateTabsViewDelegate: AnyObject {
 // View we display when there are no private tabs created
 class EmptyPrivateTabsView: UIView {
     struct UX {
-        static let titleSizeFont: CGFloat = 22
-        static let descriptionSizeFont: CGFloat = 17
-        static let buttonSizeFont: CGFloat = 15
         static let paddingInBetweenItems: CGFloat = 15
         static let verticalPadding: CGFloat = 20
         static let horizontalPadding: CGFloat = 24


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18945)

## :bulb: Description
Updated fonts in EmptyPrivateTabsView to use FXFontStyles instead of calling DefaultDynamicFontHelper directly.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)



## Screenshots

## After
![After](https://github.com/mozilla-mobile/firefox-ios/assets/15849394/1a823747-41c6-48f4-b8dd-144b82d5ca2d)


## Before
![Before](https://github.com/mozilla-mobile/firefox-ios/assets/15849394/6b8299b4-353c-4ad6-9d9c-c2dc0e1311cf)


