### PR TITLE
Refactor FXIOS-8528 [v125] Update Fonts in PrivateMessageCardCell to use FXFontStyles

### DIFF
--- a/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateMessageCardCell.swift
+++ b/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateMessageCardCell.swift
@@ -20,7 +20,6 @@ class PrivateMessageCardCell: UIView, ThemeApplicable {
     enum UX {
         static let contentStackViewSpacing: CGFloat = 8
         static let contentStackPadding: CGFloat = 16
-        static let labelFontSize: CGFloat = 15
         static let actionButtonInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
     }
 

--- a/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateMessageCardCell.swift
+++ b/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateMessageCardCell.swift
@@ -34,10 +34,7 @@ class PrivateMessageCardCell: UIView, ThemeApplicable {
     }
 
     private lazy var headerLabel: UILabel = .build { label in
-        label.font = DefaultDynamicFontHelper.preferredFont(
-            withTextStyle: .headline,
-            size: UX.labelFontSize
-        )
+        label.font = FXFontStyles.Regular.headline.scaledFont()
         label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = a11y.title
@@ -45,20 +42,14 @@ class PrivateMessageCardCell: UIView, ThemeApplicable {
     }
 
     private lazy var bodyLabel: UILabel = .build { label in
-        label.font = DefaultDynamicFontHelper.preferredFont(
-            withTextStyle: .body,
-            size: UX.labelFontSize
-        )
+        label.font = FXFontStyles.Regular.body.scaledFont()
         label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = a11y.body
     }
 
     private lazy var linkLabel: UILabel = .build { label in
-        label.font = DefaultDynamicFontHelper.preferredFont(
-            withTextStyle: .body,
-            size: UX.labelFontSize
-        )
+        label.font = FXFontStyles.Regular.body.scaledFont()
         label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = a11y.link


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8528)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18942)

## :bulb: Description
Added FxFontStyles

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-03-03 at 11 20 58](https://github.com/mozilla-mobile/firefox-ios/assets/57953014/01552b37-1222-4e00-9d40-fff21b0aca9b)
![Simulator Screenshot - iPhone 15 - 2024-03-03 at 11 18 58](https://github.com/mozilla-mobile/firefox-ios/assets/57953014/854a4fb3-1318-4878-a507-c0cafa22fe43)