### PR TITLE
Add FXIOS-8088 [v125] WebEngine API: disable tracking protection

### DIFF
--- a/BrowserKit/Sources/WebEngine/EngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/EngineSession.swift
@@ -57,6 +57,9 @@ public protocol EngineSession {
     /// Switch to strict tracking protection mode.
     func switchToStrictTrackingProtection()
 
+    /// Disable all tracking protection.
+    func disableTrackingProtection()
+
     /// Toggle image blocking mode.
     func toggleNoImageMode()
 }

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -165,6 +165,13 @@ class WKEngineSession: NSObject,
         metadataFetcher.delegate = nil
     }
 
+    func disableTrackingProtection() {
+        var settings = contentBlockingSettings
+        settings.remove(.strict)
+        settings.remove(.standard)
+        contentBlockingSettings = settings
+    }
+
     func switchToStandardTrackingProtection() {
         var settings = contentBlockingSettings
         settings.remove(.strict)

--- a/SampleBrowser/SampleBrowser/UI/Browser/BrowserViewController.swift
+++ b/SampleBrowser/SampleBrowser/UI/Browser/BrowserViewController.swift
@@ -122,6 +122,10 @@ class BrowserViewController: UIViewController,
         engineSession.switchToStrictTrackingProtection()
     }
 
+    func disableTrackingProtection() {
+        engineSession.disableTrackingProtection()
+    }
+
     func toggleNoImageMode() {
         engineSession.toggleNoImageMode()
     }

--- a/SampleBrowser/SampleBrowser/UI/RootViewController.swift
+++ b/SampleBrowser/SampleBrowser/UI/RootViewController.swift
@@ -211,6 +211,10 @@ class RootViewController: UIViewController,
         browserVC.switchToStandardTrackingProtection()
     }
 
+    func disableTrackingProtection() {
+        browserVC.disableTrackingProtection()
+    }
+
     func toggleNoImageMode() {
         browserVC.toggleNoImageMode()
     }

--- a/SampleBrowser/SampleBrowser/UI/Settings/SettingsDataSource.swift
+++ b/SampleBrowser/SampleBrowser/UI/Settings/SettingsDataSource.swift
@@ -17,6 +17,8 @@ class SettingsDataSource: NSObject, UITableViewDataSource {
                                   title: "Trigger standard content blocking"),
             SettingsCellViewModel(settingType: .strictContentBlocking,
                                   title: "Trigger strict content blocking"),
+            SettingsCellViewModel(settingType: .disableContentBlocking,
+                                  title: "Disable content blocking"),
             SettingsCellViewModel(settingType: .noImageMode,
                                   title: "Trigger No Images"),
         ]

--- a/SampleBrowser/SampleBrowser/UI/Settings/SettingsDelegate.swift
+++ b/SampleBrowser/SampleBrowser/UI/Settings/SettingsDelegate.swift
@@ -9,5 +9,6 @@ protocol SettingsDelegate: AnyObject {
     func showFindInPage()
     func switchToStrictTrackingProtection()
     func switchToStandardTrackingProtection()
+    func disableTrackingProtection()
     func toggleNoImageMode()
 }

--- a/SampleBrowser/SampleBrowser/UI/Settings/SettingsType.swift
+++ b/SampleBrowser/SampleBrowser/UI/Settings/SettingsType.swift
@@ -8,6 +8,7 @@ import Foundation
 public enum SettingsType: String {
     case standardContentBlocking
     case strictContentBlocking
+    case disableContentBlocking
     case noImageMode
     case findInPage
     case scrollingToTop

--- a/SampleBrowser/SampleBrowser/UI/Settings/SettingsViewController.swift
+++ b/SampleBrowser/SampleBrowser/UI/Settings/SettingsViewController.swift
@@ -85,6 +85,8 @@ class SettingsViewController: UIViewController, UITableViewDelegate {
             delegate?.switchToStandardTrackingProtection()
         case .strictContentBlocking:
             delegate?.switchToStrictTrackingProtection()
+        case .disableContentBlocking:
+            delegate?.disableTrackingProtection()
         case .noImageMode:
             delegate?.toggleNoImageMode()
         case .findInPage:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8088)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18000)

## :bulb: Description

Minor addition: adds API hook to disable tracking protection.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

