### PR TITLE
Bugfix FXIOS-8104 [v124] Add takeScreenshot for tab tray refactor when the tabTray shows

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
@@ -35,6 +35,10 @@ extension BrowserViewController: URLBarDelegate {
         updateFindInPageVisibility(visible: false)
 
         guard !isTabTrayRefactorEnabled else {
+            if let tab = tabManager.selectedTab {
+                screenshotHelper.takeScreenshot(tab)
+            }
+
             navigationHandler?.showTabTray(selectedPanel: focusedSegment ?? .tabs)
             return
         }

--- a/firefox-ios/Client/Frontend/Browser/ScreenshotHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/ScreenshotHelper.swift
@@ -70,28 +70,4 @@ class ScreenshotHelper {
             }
         }
     }
-
-    /// Takes a screenshot after a small delay.
-    /// Trying to take a screenshot immediately after didFinishNavigation results in a screenshot
-    /// of the previous page, presumably due to an iOS bug. Adding a brief delay fixes this.
-    func takeDelayedScreenshot(_ tab: Tab) {
-        let time = DispatchTime.now() + Double(Int64(100 * NSEC_PER_MSEC)) / Double(NSEC_PER_SEC)
-        DispatchQueue.main.asyncAfter(deadline: time) {
-            // If the view controller isn't visible, the screenshot will be blank.
-            // Wait until the view controller is visible again to take the screenshot.
-            guard self.viewIsVisible else {
-                tab.pendingScreenshot = true
-                return
-            }
-
-            self.takeScreenshot(tab)
-        }
-    }
-
-    func takePendingScreenshots(_ tabs: [Tab]) {
-        for tab in tabs where tab.pendingScreenshot {
-            tab.pendingScreenshot = false
-            takeDelayedScreenshot(tab)
-        }
-    }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8104)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18034)

## :bulb: Description
After investigating the issue I found that there was an additional call to `takeScreenshot` called in `showLegacyTabTrayViewController` that had no equivalent when the refactor was enabled, adding it made it so the most recent tab showed up more reliably.

As for issues after letting the app sit for awhile, I couldn't repro the older tabs issue with not loading the screenshot reliably without letting the app sit open for a long time, so it wasn't feasible to debug.

I could repro some loading issues when doing some navigation flows like Go to private mode from home page -> go back to a non private tab -> open new tab -> navigate away very quickly, but I think this might be because of the 500ms debounce time when taking screenshots after navigating which you can see in BVC `func navigateInTab`.

So, in short, issues probably still exist with this, but it should be better with this change in the tab tray refactor.

Changes:
- Deleted unused timed takeScreenshot methods in the ScreenshotHelper
- Add an additional takeScreenshot call for tab when we show the tab tray when the refactor flag is enabled, this was causing the most recently opened tab to rarely show up.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

