### PR TITLE
Add FXIOS-8178 [v125] WebEngine: long press support

### DIFF
--- a/BrowserKit/Sources/WebEngine/EngineSessionDelegate.swift
+++ b/BrowserKit/Sources/WebEngine/EngineSessionDelegate.swift
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import UIKit
+import UIKit.UIContextMenuConfiguration
 
 /// Delegate used by the class that want to observe an engine session
 public protocol EngineSessionDelegate: AnyObject {

--- a/BrowserKit/Sources/WebEngine/EngineSessionDelegate.swift
+++ b/BrowserKit/Sources/WebEngine/EngineSessionDelegate.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import UIKit
 
 /// Delegate used by the class that want to observe an engine session
 public protocol EngineSessionDelegate: AnyObject {
@@ -41,4 +42,10 @@ public protocol EngineSessionDelegate: AnyObject {
 
     /// Event to indicate a webview text field menu item was selected to start a search action
     func search(with selection: String)
+
+    /// Event to indicate that a contextual menu has been requested for the given URL (typically
+    /// as a result of the user long-pressing on link).
+    /// - Parameter linkURL: the link (if any) associatd with the event.
+    /// - Returns: a menu configuration, or nil (will not show a menu)
+    func onProvideContextualMenu(linkURL: URL?) -> UIContextMenuConfiguration?
 }

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -355,7 +355,6 @@ class WKEngineSession: NSObject,
         completionHandler: @escaping (UIContextMenuConfiguration?) -> Void
     ) {
         completionHandler(delegate?.onProvideContextualMenu(linkURL: elementInfo.linkURL))
-        // TODO: FXIOS-8246 - Handle context menu in WebEngine (epic part 3)
     }
 
     @available(iOS 15, *)

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -354,6 +354,7 @@ class WKEngineSession: NSObject,
         contextMenuConfigurationForElement elementInfo: WKContextMenuElementInfo,
         completionHandler: @escaping (UIContextMenuConfiguration?) -> Void
     ) {
+        completionHandler(delegate?.onProvideContextualMenu(linkURL: elementInfo.linkURL))
         // TODO: FXIOS-8246 - Handle context menu in WebEngine (epic part 3)
     }
 

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockEngineSessionDelegate.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockEngineSessionDelegate.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import UIKit.UIContextMenuConfiguration
 @testable import WebEngine
 
 class MockEngineSessionDelegate: EngineSessionDelegate {
@@ -17,6 +18,7 @@ class MockEngineSessionDelegate: EngineSessionDelegate {
     var didLoadPagemetaDataCalled = 0
     var findInPageCalled = 0
     var searchCalled = 0
+    var onProvideContextualMenuCalled = 0
 
     var savedScrollX: Int?
     var savedScrollY: Int?
@@ -87,5 +89,10 @@ class MockEngineSessionDelegate: EngineSessionDelegate {
     func search(with selection: String) {
         searchCalled += 1
         savedSearchSelection = selection
+    }
+
+    func onProvideContextualMenu(linkURL: URL?) -> UIContextMenuConfiguration? {
+        onProvideContextualMenuCalled += 1
+        return nil
     }
 }

--- a/SampleBrowser/SampleBrowser/UI/Browser/BrowserViewController.swift
+++ b/SampleBrowser/SampleBrowser/UI/Browser/BrowserViewController.swift
@@ -203,8 +203,10 @@ class BrowserViewController: UIViewController,
         guard let url = linkURL else { return nil }
 
         let previewProvider: UIContextMenuContentPreviewProvider = {
-            // TODO: Provide a web view controller to display preview of the link
-            nil
+            let previewEngineProvider = EngineProvider()
+            let previewVC = BrowserViewController(engineProvider: previewEngineProvider)
+            previewVC.engineSession.load(url: url.absoluteString)
+            return previewVC
         }
 
         let actionProvider: UIContextMenuActionProvider = { menuElements in
@@ -220,7 +222,7 @@ class BrowserViewController: UIViewController,
 
             return UIMenu(title: url.absoluteString, children: actions)
         }
-        // This is a basic menu for testing purposes in the Sample Browser.
+        // Basic menu for testing purposes in the Sample Browser.
         return UIContextMenuConfiguration(identifier: nil,
                                           previewProvider: previewProvider,
                                           actionProvider: actionProvider)

--- a/SampleBrowser/SampleBrowser/UI/Browser/BrowserViewController.swift
+++ b/SampleBrowser/SampleBrowser/UI/Browser/BrowserViewController.swift
@@ -199,6 +199,33 @@ class BrowserViewController: UIViewController,
         // We currently do not handle favicons in SampleBrowser, so this is empty.
     }
 
+    func onProvideContextualMenu(linkURL: URL?) -> UIContextMenuConfiguration? {
+        guard let url = linkURL else { return nil }
+
+        let previewProvider: UIContextMenuContentPreviewProvider = {
+            // TODO: Provide a web view controller to display preview of the link
+            nil
+        }
+
+        let actionProvider: UIContextMenuActionProvider = { menuElements in
+            var actions = [UIAction]()
+
+            actions.append(UIAction(
+                title: "Open Link",
+                image: nil,
+                identifier: UIAction.Identifier("linkContextMenu.openLink")
+            ) { [weak self] _ in
+                self?.engineSession.load(url: url.absoluteString)
+            })
+
+            return UIMenu(title: url.absoluteString, children: actions)
+        }
+        // This is a basic menu for testing purposes in the Sample Browser.
+        return UIContextMenuConfiguration(identifier: nil,
+                                          previewProvider: previewProvider,
+                                          actionProvider: actionProvider)
+    }
+
     // MARK: - EngineSessionDelegate Menu items
 
     func findInPage(with selection: String) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8178)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18189)

## :bulb: Description

Adds basic API support to WebEngine for supporting contextual menus within WebEngine.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

