### PR TITLE
Bugfix FXIOS-8552 [v125] Fix "Customize Homepage" button margins

### DIFF
--- a/firefox-ios/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionCell.swift
+++ b/firefox-ios/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionCell.swift
@@ -11,7 +11,6 @@ class CustomizeHomepageSectionCell: UICollectionViewCell, ReusableCell {
     typealias a11y = AccessibilityIdentifiers.FirefoxHomepage.OtherButtons
 
     private struct UX {
-        static let buttonTrailingSpace: CGFloat = 12
         static let buttonVerticalInset: CGFloat = 11
         static let buttonCornerRadius: CGFloat = 4
     }
@@ -42,10 +41,7 @@ class CustomizeHomepageSectionCell: UICollectionViewCell, ReusableCell {
                 goToSettingsButton.topAnchor.constraint(equalTo: contentView.topAnchor),
                 goToSettingsButton.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
                 goToSettingsButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-                goToSettingsButton.trailingAnchor.constraint(
-                    equalTo: contentView.trailingAnchor,
-                    constant: -UX.buttonTrailingSpace
-                )
+                goToSettingsButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
             ]
         )
 

--- a/firefox-ios/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionViewModel.swift
@@ -35,13 +35,13 @@ extension CustomizeHomepageSectionViewModel: HomepageViewModelProtocol {
                                                heightDimension: .estimated(100))
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: item, count: 1)
 
-        let leadingInset = HomepageViewModel.UX.leadingInset(traitCollection: traitCollection)
+        let horizontalInsets = HomepageViewModel.UX.leadingInset(traitCollection: traitCollection)
         let section = NSCollectionLayoutSection(group: group)
         section.contentInsets = NSDirectionalEdgeInsets(
             top: HomepageViewModel.UX.spacingBetweenSections,
-            leading: leadingInset,
+            leading: horizontalInsets,
             bottom: HomepageViewModel.UX.spacingBetweenSections,
-            trailing: 0)
+            trailing: horizontalInsets)
         return section
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8552)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18995)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19017)

## :bulb: Description
- Set leading and trailing margins equal for the "Customize Homepage" button on the HomePage screen

### Screenshots
<details>
<summary>iPhone portrait</summary>

| Before | After |
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-03-04 at 22 25 55](https://github.com/mozilla-mobile/firefox-ios/assets/15353801/90793d54-6d0e-49f3-bf64-26b382b641f5) | ![Simulator Screenshot - iPhone 15 Pro - 2024-03-04 at 22 30 15](https://github.com/mozilla-mobile/firefox-ios/assets/15353801/c10901a5-aa18-400c-8d8e-65a55d1e3058) |
</details>

<details>
<summary>iPhone landscape</summary>

| Before | After |
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-03-04 at 22 27 10](https://github.com/mozilla-mobile/firefox-ios/assets/15353801/a531b4e1-689b-4f30-a090-a81f8a9258c0) | ![Simulator Screenshot - iPhone 15 Pro - 2024-03-04 at 22 30 20](https://github.com/mozilla-mobile/firefox-ios/assets/15353801/79a27db4-86bc-44fa-870a-c956ad535249) |
</details>

<details>
<summary>iPad portrait</summary>

| Before | After |
| ------------- | ------------- |
| ![Simulator Screenshot - iPad Air (5th generation) - 2024-03-04 at 22 28 12](https://github.com/mozilla-mobile/firefox-ios/assets/15353801/01cbeb81-3398-42b2-9a15-760ad6fadfc7) | ![Simulator Screenshot - iPad Air (5th generation) - 2024-03-04 at 22 29 16](https://github.com/mozilla-mobile/firefox-ios/assets/15353801/9c89b2c8-8e17-4f35-a803-62e9207b0588) |
</details>

<details>
<summary>iPad landscape</summary>

| Before | After |
| ------------- | ------------- |
| ![Simulator Screenshot - iPad Air (5th generation) - 2024-03-04 at 22 28 18](https://github.com/mozilla-mobile/firefox-ios/assets/15353801/27535a4d-0799-412c-851e-950ff6e02051) | ![Simulator Screenshot - iPad Air (5th generation) - 2024-03-04 at 22 29 21](https://github.com/mozilla-mobile/firefox-ios/assets/15353801/584fd1a8-9bc3-49fe-b8c2-d16eb8262198) |
</details>

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

