### PR TITLE
Bugfix FXIOS-8546 [v125] Update Fonts related to Remote Tabs to use FXFontStyles

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/RemoteTabs/LegacyRemoteTabsErrorCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/RemoteTabs/LegacyRemoteTabsErrorCell.swift
@@ -12,7 +12,6 @@ class LegacyRemoteTabsErrorCell: UITableViewCell, ReusableCell, ThemeApplicable 
         static let verticalPadding: CGFloat = 40
         static let horizontalPadding: CGFloat = 24
         static let paddingInBetweenItems: CGFloat = 15
-        static let descriptionSizeFont: CGFloat = 17
         static let imageSize = CGSize(width: 90, height: 60)
     }
 
@@ -41,8 +40,7 @@ class LegacyRemoteTabsErrorCell: UITableViewCell, ReusableCell, ThemeApplicable 
 
     private let instructionsLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
-                                                            size: UX.descriptionSizeFont)
+        label.font = FXFontStyles.Regular.body.scaledFont()
         label.numberOfLines = 0
         label.textAlignment = .center
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/RemoteTabs/LegacyRemoteTabsErrorCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/RemoteTabs/LegacyRemoteTabsErrorCell.swift
@@ -12,7 +12,6 @@ class LegacyRemoteTabsErrorCell: UITableViewCell, ReusableCell, ThemeApplicable 
         static let verticalPadding: CGFloat = 40
         static let horizontalPadding: CGFloat = 24
         static let paddingInBetweenItems: CGFloat = 15
-        static let titleSizeFont: CGFloat = 22
         static let descriptionSizeFont: CGFloat = 17
         static let imageSize = CGSize(width: 90, height: 60)
     }
@@ -35,8 +34,7 @@ class LegacyRemoteTabsErrorCell: UITableViewCell, ReusableCell, ThemeApplicable 
 
     private let titleLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .title2,
-                                                            size: UX.titleSizeFont)
+        label.font = FXFontStyles.Regular.title2.scaledFont()
         label.numberOfLines = 0
         label.textAlignment = .center
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsEmptyView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsEmptyView.swift
@@ -18,7 +18,6 @@ class RemoteTabsEmptyView: UIView, ThemeApplicable {
         static let verticalPadding: CGFloat = 40
         static let horizontalPadding: CGFloat = 24
         static let paddingInBetweenItems: CGFloat = 15
-        static let descriptionSizeFont: CGFloat = 17
         static let imageSize = CGSize(width: 90, height: 60)
     }
 
@@ -47,8 +46,7 @@ class RemoteTabsEmptyView: UIView, ThemeApplicable {
 
     private let instructionsLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
-                                                            size: UX.descriptionSizeFont)
+        label.font = FXFontStyles.Regular.body.scaledFont()
         label.numberOfLines = 0
         label.textAlignment = .center
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsEmptyView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsEmptyView.swift
@@ -18,7 +18,6 @@ class RemoteTabsEmptyView: UIView, ThemeApplicable {
         static let verticalPadding: CGFloat = 40
         static let horizontalPadding: CGFloat = 24
         static let paddingInBetweenItems: CGFloat = 15
-        static let titleSizeFont: CGFloat = 22
         static let descriptionSizeFont: CGFloat = 17
         static let imageSize = CGSize(width: 90, height: 60)
     }
@@ -41,8 +40,7 @@ class RemoteTabsEmptyView: UIView, ThemeApplicable {
 
     private let titleLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .title2,
-                                                            size: UX.titleSizeFont)
+        label.font = FXFontStyles.Regular.title2.scaledFont()
         label.numberOfLines = 0
         label.textAlignment = .center
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8546)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18985)

## :bulb: Description
Replaced with FXFont

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

![Simulator Screenshot - iPhone 15 - 2024-03-05 at 11 01 18](https://github.com/mozilla-mobile/firefox-ios/assets/57953014/53f16539-88c0-4099-baa0-395efec718d4)
