### PR TITLE
Bugfix FXIOS-8548 [v125] Update Fonts related to Onboarding to use FXFontStyles

### DIFF
--- a/firefox-ios/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
+++ b/firefox-ios/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
@@ -49,12 +49,6 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
     // Public constants
     let viewModel = DefaultBrowserOnboardingViewModel()
 
-    // Private vars
-    private var titleFontSize: CGFloat {
-        return screenSize.height > 1000 ? UX.titleSizeLarge :
-               screenSize.height > 640 ? UX.titleSize : UX.titleSizeSmall
-    }
-
     // Orientation independent screen size
     private let screenSize = DeviceInfo.screenSizeOrientationIndependent()
 

--- a/firefox-ios/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
+++ b/firefox-ios/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
@@ -29,10 +29,6 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
     private struct UX {
         static let textOffset: CGFloat = 20
         static let textOffsetSmall: CGFloat = 13
-        static let titleSize: CGFloat = 28
-        static let titleSizeSmall: CGFloat = 24
-        static let titleSizeLarge: CGFloat = 34
-        static let ctaButtonCornerRadius: CGFloat = 10
         static let ctaButtonWidth: CGFloat = 350
         static let ctaButtonWidthSmall: CGFloat = 300
         static let ctaButtonBottomSpace: CGFloat = 60

--- a/firefox-ios/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
+++ b/firefox-ios/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
@@ -71,33 +71,32 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
     }
 
     private lazy var titleLabel: UILabel = .build { [weak self] label in
-        label.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .title1,
-                                                                size: self?.titleFontSize ?? UX.titleSize)
+        label.font = FXFontStyles.Bold.title1.scaledFont()
         label.textAlignment = .center
         label.numberOfLines = 0
         label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.HomeTabBanner.titleLabel
     }
 
     private lazy var descriptionText: UILabel = .build { label in
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 17)
+        label.font = FXFontStyles.Regular.body.scaledFont()
         label.numberOfLines = 0
         label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.HomeTabBanner.descriptionLabel
     }
 
     private lazy var descriptionLabel1: UILabel = .build { label in
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 17)
+        label.font = FXFontStyles.Regular.body.scaledFont()
         label.numberOfLines = 0
         label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.HomeTabBanner.descriptionLabel1
     }
 
     private lazy var descriptionLabel2: UILabel = .build { label in
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 17)
+        label.font = FXFontStyles.Regular.body.scaledFont()
         label.numberOfLines = 0
         label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.HomeTabBanner.descriptionLabel2
     }
 
     private lazy var descriptionLabel3: UILabel = .build { label in
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 17)
+        label.font = FXFontStyles.Regular.body.scaledFont()
         label.numberOfLines = 0
         label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.HomeTabBanner.descriptionLabel3
     }

--- a/firefox-ios/Client/Frontend/Onboarding/ViewControllers/OnboardingInstructionPopupViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/ViewControllers/OnboardingInstructionPopupViewController.swift
@@ -12,10 +12,6 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
         static let contentStackViewSpacing: CGFloat = 40
         static let textStackViewSpacing: CGFloat = 24
 
-        static let titleFontSize: CGFloat = 20
-        static let numeratedTextFontSize: CGFloat = 15
-        static let buttonFontSize: CGFloat = 16
-
         static let buttonVerticalInset: CGFloat = 12
         static let buttonHorizontalInset: CGFloat = 16
         static let buttonCornerRadius: CGFloat = 13
@@ -49,7 +45,7 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
     private lazy var titleLabel: UILabel = .build { label in
         label.textAlignment = .center
         label.numberOfLines = 0
-        label.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .title3, size: UX.titleFontSize)
+        label.font = FXFontStyles.Bold.title3.scaledFont()
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = "\(self.viewModel.a11yIdRoot).DefaultBrowserSettings.TitleLabel"
     }
@@ -212,16 +208,12 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
     private func createLabels(from descriptionTexts: [String]) {
         numeratedLabels.removeAll()
         let attributedStrings = viewModel.getAttributedStrings(
-            with: DefaultDynamicFontHelper.preferredFont(
-                withTextStyle: .subheadline,
-                size: UX.numeratedTextFontSize))
+            with: FXFontStyles.Regular.subheadline.scaledFont())
         attributedStrings.forEach { attributedText in
             let index = attributedStrings.firstIndex(of: attributedText)! as Int
             let label: UILabel = .build { label in
                 label.textAlignment = .left
-                label.font = DefaultDynamicFontHelper.preferredFont(
-                    withTextStyle: .subheadline,
-                    size: UX.numeratedTextFontSize)
+                label.font = FXFontStyles.Regular.subheadline.scaledFont()
                 label.adjustsFontForContentSizeCategory = true
                 label.accessibilityIdentifier = "\(self.viewModel.a11yIdRoot).DefaultBrowserSettings.NumeratedLabel\(index)"
                 label.attributedText = attributedText


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8548)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18987)

## :bulb: Description
Replaced with FXFontStyles

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

### DefaultBrowserOnboardingViewController
![Simulator Screenshot - iPhone 15 - 2024-03-05 at 16 31 46](https://github.com/mozilla-mobile/firefox-ios/assets/57953014/669d2c31-edd1-428e-bd37-22ef8e97bc00)

### OnboardingInstructionPopupViewController
![Simulator Screenshot - iPhone 15 - 2024-03-05 at 16 50 26](https://github.com/mozilla-mobile/firefox-ios/assets/57953014/cdf91d06-77bd-4969-88c1-dce83f512dd1)

