### PR TITLE
Bugfix FXIOS-8550 Adjust the urlbar.abandonment and urlbar.engagement events

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
@@ -425,9 +425,6 @@ extension BrowserViewController: URLBarDelegate {
             case .cancelled: .abandoned
             }
         }
-        if reason == .finished {
-            searchController?.searchTelemetry?.recordURLBarSearchAbandonmentTelemetryEvent()
-        }
         destroySearchController()
         updateInContentHomePanel(tabManager.selectedTab?.url as URL?)
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
@@ -328,6 +328,7 @@ extension BrowserViewController: URLBarDelegate {
         )
         searchController?.searchQuery = text
         searchController?.searchTelemetry?.searchQuery = text
+        searchController?.searchTelemetry?.clearVisibleResults()
         searchLoader?.query = text
         searchController?.searchTelemetry?.determineInteractionType()
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2548,11 +2548,13 @@ extension BrowserViewController: SearchViewControllerDelegate {
         case .engaged:
             let visibleSuggestionsTelemetryInfo = searchViewController.visibleSuggestionsTelemetryInfo
             visibleSuggestionsTelemetryInfo.forEach { trackVisibleSuggestion(telemetryInfo: $0) }
-
+            TelemetryWrapper.gleanRecordEvent(category: .action, method: .engagement, object: .locationBar)
+            searchViewController.searchTelemetry?.recordURLBarSearchEngagementTelemetryEvent()
         case .abandoned:
             searchViewController.searchTelemetry?.engagementType = .dismiss
             let visibleSuggestionsTelemetryInfo = searchViewController.visibleSuggestionsTelemetryInfo
             visibleSuggestionsTelemetryInfo.forEach { trackVisibleSuggestion(telemetryInfo: $0) }
+            TelemetryWrapper.gleanRecordEvent(category: .action, method: .abandonment, object: .locationBar)
             searchViewController.searchTelemetry?.recordURLBarSearchAbandonmentTelemetryEvent()
         default:
             break

--- a/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
@@ -219,7 +219,6 @@ class SearchViewController: SiteTableViewController,
             resultCount: 3) { results in
             guard let results = results else { return }
             self.searchHighlights = results
-            self.searchTelemetry?.searchHighlights = results
             self.tableView.reloadData()
         }
     }
@@ -271,7 +270,6 @@ class SearchViewController: SiteTableViewController,
             await MainActor.run {
                 guard let self, self.searchQuery == tempSearchQuery else { return }
                 self.firefoxSuggestions = suggestions
-                self.searchTelemetry?.firefoxSuggestions = suggestions
                 self.tableView.reloadData()
             }
         }
@@ -602,7 +600,6 @@ class SearchViewController: SiteTableViewController,
                         self.remoteClientTabs.append(ClientTabsSearchWrapper(client: value.client, tab: tab))
                     }
                 }
-                self.searchTelemetry?.remoteClientTabs = self.remoteClientTabs
             }
         }
     }
@@ -642,7 +639,6 @@ class SearchViewController: SiteTableViewController,
             let text = lines.joined(separator: "\n")
             return find(in: text)
         }
-        searchTelemetry?.filteredOpenedTabs = filteredOpenedTabs
     }
 
     func searchRemoteTabs(for searchString: String) {
@@ -674,8 +670,6 @@ class SearchViewController: SiteTableViewController,
 
             return false
         }
-
-        searchTelemetry?.filteredRemoteClientTabs = filteredRemoteClientTabs
     }
 
     private func querySuggestClient() {
@@ -704,6 +698,7 @@ class SearchViewController: SiteTableViewController,
                 })
                 // First suggestion should be what the user is searching
                 self.suggestions?.insert(self.searchQuery, at: 0)
+                self.searchTelemetry?.clearVisibleResults()
             }
 
             // If there are no suggestions, just use whatever the user typed.
@@ -712,7 +707,6 @@ class SearchViewController: SiteTableViewController,
                 self.suggestions = [self.searchQuery]
             }
 
-            self.searchTelemetry?.suggestions = self.suggestions
             self.searchTabs(for: self.searchQuery)
             self.searchRemoteTabs(for: self.searchQuery)
             // Reload the tableView to show the new list of search suggestions.
@@ -729,7 +723,6 @@ class SearchViewController: SiteTableViewController,
             data
         }
 
-        searchTelemetry?.data = data
         tableView.reloadData()
     }
 

--- a/firefox-ios/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -146,6 +146,10 @@ class SiteTableViewController: UIViewController,
         return cell
     }
 
+    // for being overwritten by subclasses
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+    }
+
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         return tableView.dequeueReusableHeaderFooterView(withIdentifier: SiteTableViewHeader.cellIdentifier)
     }

--- a/firefox-ios/Client/Telemetry/SearchTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/SearchTelemetry.swift
@@ -143,6 +143,15 @@ class SearchTelemetry {
     var searchHighlights = [HighlightItem]()
 
     var data: Cursor<Site> = Cursor<Site>(status: .success, msg: "No data set")
+
+    var visibleRemoteClientTabs = [ClientTabsSearchWrapper]()
+    var visibleFilteredOpenedTabs = [Tab]()
+    var visibleFilteredRemoteClientTabs = [ClientTabsSearchWrapper]()
+    var visibleSuggestions = [String]()
+    var visibleFirefoxSuggestions = [RustFirefoxSuggestion]()
+    var visibleSearchHighlights = [HighlightItem]()
+    var visibleData = [Site]()
+
     var searchQuery: String = ""
     var savedQuery: String = ""
 
@@ -420,35 +429,35 @@ class SearchTelemetry {
     func listResultTypes() -> String {
         var resultTypes: [String] = []
 
-        if let suggestionsCount = suggestions?.count, suggestionsCount > 0 {
+        if !visibleSuggestions.isEmpty {
             resultTypes += Array(repeating: SearchTelemetryValues.Results.searchSuggest.rawValue,
-                                 count: suggestionsCount)
+                                 count: visibleSuggestions.count)
         }
 
-        if !filteredOpenedTabs.isEmpty {
+        if !visibleFilteredOpenedTabs.isEmpty {
             resultTypes += Array(repeating: SearchTelemetryValues.Results.tab.rawValue,
-                                 count: filteredOpenedTabs.count)
+                                 count: visibleFilteredOpenedTabs.count)
         }
 
-        if !filteredRemoteClientTabs.isEmpty {
+        if !visibleFilteredRemoteClientTabs.isEmpty {
             resultTypes += Array(repeating: SearchTelemetryValues.Results.remoteTab.rawValue,
-                                 count: filteredRemoteClientTabs.count)
+                                 count: visibleFilteredRemoteClientTabs.count)
         }
 
-        for clientTab in data {
-            if let isBookmarked = clientTab?.bookmarked {
+        for clientTab in visibleData {
+            if let isBookmarked = clientTab.bookmarked {
                 resultTypes.append(isBookmarked ?
                                    SearchTelemetryValues.Results.bookmark.rawValue :
                                     SearchTelemetryValues.Results.history.rawValue)
             }
         }
 
-        if !searchHighlights.isEmpty {
+        if !visibleSearchHighlights.isEmpty {
             resultTypes += Array(repeating: SearchTelemetryValues.Results.searchHistory.rawValue,
-                                 count: searchHighlights.count)
+                                 count: visibleSearchHighlights.count)
         }
 
-        for suggestion in firefoxSuggestions {
+        for suggestion in visibleFirefoxSuggestions {
             resultTypes.append(suggestion.isSponsored ?
                                SearchTelemetryValues.Results.suggestSponsor.rawValue :
                                 SearchTelemetryValues.Results.suggestNonSponsor.rawValue)

--- a/firefox-ios/Client/Telemetry/SearchTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/SearchTelemetry.swift
@@ -135,15 +135,6 @@ class SearchTelemetry {
     var engagementType: SearchTelemetryValues.EngagementType = .tap
     var impressionTelemetryTimer: Timer?
 
-    var remoteClientTabs = [ClientTabsSearchWrapper]()
-    var filteredOpenedTabs = [Tab]()
-    var filteredRemoteClientTabs = [ClientTabsSearchWrapper]()
-    var suggestions: [String]? = []
-    var firefoxSuggestions = [RustFirefoxSuggestion]()
-    var searchHighlights = [HighlightItem]()
-
-    var data: Cursor<Site> = Cursor<Site>(status: .success, msg: "No data set")
-
     var visibleRemoteClientTabs = [ClientTabsSearchWrapper]()
     var visibleFilteredOpenedTabs = [Tab]()
     var visibleFilteredRemoteClientTabs = [ClientTabsSearchWrapper]()
@@ -420,9 +411,18 @@ class SearchTelemetry {
     }
 
     func numberOfSearchResults() -> Int {
-        return suggestions?.count ?? 0 + data.count + searchHighlights.count
-        + filteredOpenedTabs.count + firefoxSuggestions.count
-        + filteredRemoteClientTabs.count
+        return visibleSuggestions.count + visibleData.count + visibleSearchHighlights.count
+        + visibleFilteredOpenedTabs.count + visibleFirefoxSuggestions.count
+        + visibleFilteredRemoteClientTabs.count
+    }
+
+    func clearVisibleResults() {
+        visibleSuggestions.removeAll()
+        visibleData.removeAll()
+        visibleSearchHighlights.removeAll()
+        visibleFilteredOpenedTabs.removeAll()
+        visibleFirefoxSuggestions.removeAll()
+        visibleFilteredRemoteClientTabs.removeAll()
     }
 
     // Comma separated list of result types in order.

--- a/firefox-ios/Client/Telemetry/SearchTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/SearchTelemetry.swift
@@ -472,34 +472,34 @@ class SearchTelemetry {
     func listGroupTypes() -> String {
         var groupTypes: [String] = []
 
-        if !(suggestions?.isEmpty ?? true) {
+        if !visibleSuggestions.isEmpty {
             groupTypes += Array(repeating: SearchTelemetryValues.Groups.searchSuggest.rawValue,
-                                count: suggestions!.count)
+                                count: visibleSuggestions.count)
         }
 
-        if !filteredOpenedTabs.isEmpty {
+        if !visibleFilteredOpenedTabs.isEmpty {
             groupTypes += Array(repeating: SearchTelemetryValues.Groups.heuristic.rawValue,
-                                count: filteredOpenedTabs.count)
+                                count: visibleFilteredOpenedTabs.count)
         }
 
-        if !filteredRemoteClientTabs.isEmpty {
+        if !visibleFilteredRemoteClientTabs.isEmpty {
             groupTypes += Array(repeating: SearchTelemetryValues.Groups.remoteTab.rawValue,
-                                count: filteredRemoteClientTabs.count)
+                                count: visibleFilteredRemoteClientTabs.count)
         }
 
-        if !remoteClientTabs.isEmpty {
+        if !visibleRemoteClientTabs.isEmpty {
             groupTypes += Array(repeating: SearchTelemetryValues.Groups.general.rawValue,
-                                count: remoteClientTabs.count)
+                                count: visibleRemoteClientTabs.count)
         }
 
-        if !searchHighlights.isEmpty {
+        if !visibleSearchHighlights.isEmpty {
             groupTypes += Array(repeating: SearchTelemetryValues.Groups.searchHistory.rawValue,
-                                count: searchHighlights.count)
+                                count: visibleSearchHighlights.count)
         }
 
-        if !firefoxSuggestions.isEmpty {
+        if !visibleFirefoxSuggestions.isEmpty {
             groupTypes += Array(repeating: SearchTelemetryValues.Groups.suggest.rawValue,
-                                count: firefoxSuggestions.count)
+                                count: visibleFirefoxSuggestions.count)
         }
 
         return groupTypes.joined(separator: ",")

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -1864,6 +1864,10 @@ extension TelemetryWrapper {
             GleanMetrics.Awesomebar.shareButtonTapped.record()
         case (.action, .drag, .locationBar, _, _):
             GleanMetrics.Awesomebar.dragLocationBar.record()
+        case (.action, .engagement, .locationBar, _, _):
+            GleanMetrics.Awesomebar.engagement.record()
+        case (.action, .abandonment, .locationBar, _, _):
+            GleanMetrics.Awesomebar.abandonment.record()
         // MARK: - GleanPlumb Messaging
         case (.information, .view, .messaging, .messageImpression, let extras):
             guard let messageSurface = extras?[EventExtraKey.messageSurface.rawValue] as? String,

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -4462,6 +4462,34 @@ awesomebar:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2024-06-01"
+  engagement:
+    type: event
+    description: |
+      Recorded when the user completes their search session by
+      tapping a search result, or entering a URL or a search term.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-8326
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/18452
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    data_sensitivity:
+      - interaction
+    expires: "2024-06-01"
+  abandonment:
+    type: event
+    description: |
+      Recorded when the user dismisses the awesomebar without completing their
+      search.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-8326
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/18452
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    data_sensitivity:
+      - interaction
+    expires: "2024-06-01"
 
 # Share sheet specific metrics
 

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -4469,8 +4469,10 @@ awesomebar:
       tapping a search result, or entering a URL or a search term.
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-8326
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-8550
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/18452
+      - https://github.com/mozilla-mobile/firefox-ios/pull/19009
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     data_sensitivity:
@@ -4483,8 +4485,10 @@ awesomebar:
       search.
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-8326
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-8550
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/18452
+      - https://github.com/mozilla-mobile/firefox-ios/pull/19009
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     data_sensitivity:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
I've re-added the older "awesomebar.engagement" and "awesomebar.abandonment" events and made the abandonment event fire less often, plus made the calls to both engagement and abandonment to happen at the same time as the older events to balance them out. Also added a check to see if a result is about to be shown to the user and only adding it to the “results” array if so.
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed, I updated documentation / comments for complex code and public methods
- [] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

