### PR TITLE
Bugfix FXIOS-8547 [v125] Update Fonts related to Inactive Tabs to use FXFontStyles

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/InactiveTabs/InactiveTabsCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/InactiveTabs/InactiveTabsCell.swift
@@ -20,7 +20,7 @@ class InactiveTabsCell: UICollectionViewListCell, ReusableCell, ThemeApplicable 
     private lazy var bottomSeparatorView: UIView = .build { _ in }
 
     private lazy var titleLabel: UILabel = .build { label in
-        label.font = FXFontStyles.Regular.subheadline.scaledFont()
+        label.font = FXFontStyles.Regular.body.scaledFont()
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = AccessibilityIdentifiers.TabTray.InactiveTabs.cellLabel
         label.textAlignment = .natural

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/InactiveTabs/InactiveTabsCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/InactiveTabs/InactiveTabsCell.swift
@@ -10,7 +10,6 @@ class InactiveTabsCell: UICollectionViewListCell, ReusableCell, ThemeApplicable 
     struct UX {
         static let imageSize: CGFloat = 28
         static let labelTopBottomMargin: CGFloat = 11
-        static let titleFontSize: CGFloat = 14
         static let imageViewLeadingConstant: CGFloat = 16
         static let separatorHeight: CGFloat = 0.5
         static let faviconCornerRadius: CGFloat = 5
@@ -21,9 +20,7 @@ class InactiveTabsCell: UICollectionViewListCell, ReusableCell, ThemeApplicable 
     private lazy var bottomSeparatorView: UIView = .build { _ in }
 
     private lazy var titleLabel: UILabel = .build { label in
-        label.font = DefaultDynamicFontHelper.preferredFont(
-            withTextStyle: .caption1,
-            size: UX.titleFontSize)
+        label.font = FXFontStyles.Regular.subheadline.scaledFont()
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = AccessibilityIdentifiers.TabTray.InactiveTabs.cellLabel
         label.textAlignment = .natural

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/InactiveTabs/InactiveTabsHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/InactiveTabs/InactiveTabsHeaderView.swift
@@ -21,9 +21,7 @@ class InactiveTabsHeaderView: UICollectionReusableView, ReusableCell, ThemeAppli
     }
 
     lazy var titleLabel: UILabel = .build { titleLabel in
-        titleLabel.font = DefaultDynamicFontHelper.preferredBoldFont(
-            withTextStyle: .headline,
-            size: UX.titleFontSize)
+        titleLabel.font = FXFontStyles.Bold.headline.scaledFont()
         titleLabel.text = String.TabsTrayInactiveTabsSectionTitle
         titleLabel.adjustsFontForContentSizeCategory = true
         titleLabel.accessibilityIdentifier = AccessibilityIdentifiers.TabTray.InactiveTabs.headerLabel

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/InactiveTabs/InactiveTabsHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/InactiveTabs/InactiveTabsHeaderView.swift
@@ -7,7 +7,6 @@ import Foundation
 
 class InactiveTabsHeaderView: UICollectionReusableView, ReusableCell, ThemeApplicable {
     private struct UX {
-        static let titleFontSize: CGFloat = 17
         static let titleMinimumScaleFactor: CGFloat = 0.7
         static let verticalPadding: CGFloat = 19
         static let horizontalPadding: CGFloat = 16


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8547)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18986)

## :bulb: Description
Replaced with `FXFontStyles`

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)
![Simulator Screenshot - iPhone 15 - 2024-03-05 at 22 02 05](https://github.com/mozilla-mobile/firefox-ios/assets/57953014/e86727f5-a375-42d8-8ac6-b23a5a2296cd)

