### PR TITLE
Bugfix FXIOS-8558 [v125] Deeplink white screen, page won't load - Part 2

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2261,6 +2261,7 @@ extension BrowserViewController {
 // MARK: - LegacyTabDelegate
 extension BrowserViewController: LegacyTabDelegate {
     func tab(_ tab: Tab, didCreateWebView webView: WKWebView) {
+        webView.frame = contentContainer.frame
         // Observers that live as long as the tab. Make sure these are all cleared in willDeleteWebView below!
         beginObserving(webView: webView)
         self.scrollController.beginObserving(scrollView: webView.scrollView)

--- a/firefox-ios/Client/Frontend/Browser/WebView/WebviewViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebView/WebviewViewController.swift
@@ -28,10 +28,10 @@ class WebviewViewController: UIViewController, ContentContainable, Screenshotabl
         view.addSubview(webView)
         webView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            view.topAnchor.constraint(equalTo: webView.topAnchor),
-            view.leadingAnchor.constraint(equalTo: webView.leadingAnchor),
-            view.bottomAnchor.constraint(equalTo: webView.bottomAnchor),
-            view.trailingAnchor.constraint(equalTo: webView.trailingAnchor)
+            webView.topAnchor.constraint(equalTo: view.topAnchor),
+            webView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            webView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            webView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8558)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19024)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

This is more of a refactor to ensure the constraints for WebViewViewController and webview are aligned.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

