### PR TITLE
Refactor FXIOS-8555 [v125] Adjust codeowners file following monorepo changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 
 # When someone opens a pull request that only modifies those folders / files,
 # those specific persons will be asked for review and not the global owners.
-/firefox-ios/Client/Experiments/initial_experiments.json @dnarcese @afurlan-firefox
+/firefox-ios/Client/Experiments/initial_experiments.json @afurlan-firefox
 /firefox-ios/Client/Assets/CC_Script @nbhasin2 @issammani
 
 # When someone opens a pull request that only modifies those folders / files, 
@@ -14,6 +14,8 @@
 # owners will be requested for a review.
 /firefox-ios/firefox-ios-tests/Tests/UITests @mozilla-mobile/fxios-automation-1
 /firefox-ios/firefox-ios-tests/Tests/XCUITests @mozilla-mobile/fxios-automation-1
+/focus-ios/focus-ios-tests @mozilla-mobile/fxios-automation-1
+/focus-ios/focus-ios-tests/ClientTests @mozilla-mobile/fxios-eng
 bitrise.yml @mozilla-mobile/fxios-automation-1
 .taskcluster.yml @mozilla-mobile/fxios-automation-1
 /taskcluster @mozilla-mobile/fxios-automation-1


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8555)
No Github issue

## :bulb: Description
Adjust codeowners file following monorepo changes. I discussed with Daniela to remove her from the `initial_experiments.json`, and making sure that Focus iOS automation code is reviewed by the automation team (but ClientTests are unit tests and should be reviewed by the dev team). Let me know if I missed anything!

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

