### PR TITLE
Bugfix FXIOS-8382 [v125] Can't scroll homepage when offline Homepage switches to The Internet connection appears to be offline error page

### DIFF
--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -353,10 +353,6 @@ class HomepageViewController:
         scrollViewDidScroll(collectionView)
     }
 
-    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
-        dismissKeyboard()
-    }
-
     @objc
     private func dismissKeyboard() {
         if currentTab?.lastKnownUrl?.absoluteString.hasPrefix("internal://") ?? false {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8382)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18579)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
There was code in place to watch for scrolling and it was dismissing the overlay only for urls that are not internal (in this case the loading error page). Since we want scrolling for home, that method is not necessary anymore.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

