### PR TITLE
Bugfix FXIOS-8581 [v125] Deeplink white screen, page won't load - Part 3

### DIFF
--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -659,7 +659,8 @@ class Tab: NSObject, ThemeApplicable {
             }
         }
 
-        if webView?.reloadFromOrigin() != nil {
+        if let webView, let url = webView.url {
+            webView.reloadFromOrigin()
             logger.log("Reloaded zombified tab from origin",
                        level: .debug,
                        category: .tabs)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket #8581](https://mozilla-hub.atlassian.net/browse/FXIOS-8581)
[Github issue #19050](https://github.com/mozilla-mobile/firefox-ios/issues/19050)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
In WKWebView reload() uses cache or might use cache but reloadFromOrigin will force a new reload without cache however if the url is nil or webview is nil we should not reload so even though originally it was doing similar task here we made it more verbose of a check to ensure the url itself is not nil and not just the webview.

This can potentially lead to loading a nil url and that will result in a page not loading and what we want to do is restore the tab if the url is nil 

https://github.com/mozilla-mobile/firefox-ios/pull/19051/files#diff-48aa834424260d7f639803d42a1a2245d97a2f31512800968c0d7297eaaef0e0L669-L673

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

