### PR TITLE
Bugfix FXIOS-8561 [v125] Fix BG task crash when backgrounding app

### DIFF
--- a/firefox-ios/Client/Application/BackgroundFirefoxSuggestIngestUtility.swift
+++ b/firefox-ios/Client/Application/BackgroundFirefoxSuggestIngestUtility.swift
@@ -15,6 +15,7 @@ class BackgroundFirefoxSuggestIngestUtility: BackgroundUtilityProtocol, FeatureF
 
     let firefoxSuggest: RustFirefoxSuggestActor
     let logger: Logger
+    private var didRegisterTaskHandler = false
 
     init(firefoxSuggest: RustFirefoxSuggestActor, logger: Logger = DefaultLogger.shared) {
         self.firefoxSuggest = firefoxSuggest
@@ -40,6 +41,7 @@ class BackgroundFirefoxSuggestIngestUtility: BackgroundUtilityProtocol, FeatureF
 
     /// Submits a request to schedule the background ingestion task.
     private func submitBackgroundTaskRequest() throws {
+        guard didRegisterTaskHandler else { return }
         let request = BGProcessingTaskRequest(identifier: Self.taskIdentifier)
         request.requiresNetworkConnectivity = true
         request.requiresExternalPower = true
@@ -88,5 +90,6 @@ class BackgroundFirefoxSuggestIngestUtility: BackgroundUtilityProtocol, FeatureF
                 task.setTaskCompleted(success: success)
             }
         }
+        didRegisterTaskHandler = true
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8561)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19031)

## :bulb: Description

Ensures that we do not attempt to schedule a background task unless we have registered a task handler in `setUp()`.

This fixes a crash that can occur if the `firefoxSuggestFeature` is switched on (from being off) after launch flow. In that scenario the `setUp()` in `BackgroundFirefoxSuggestIngestUtility` is potentially never run. This never registers a BG task handler, which means that when the app is backgrounded we call into `submitBackgroundTaskRequest` which causes a crash.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

