### PR TITLE
Bugfix FXIOS-8549 [v125] Specify the number of FX suggestions to retrieve

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
@@ -171,6 +171,8 @@ class SearchViewController: SiteTableViewController,
                                                    || shouldShowSponsoredSuggestions))
     }
 
+    private let maxNumOfFirefoxSuggestions: Int32 = 1
+
     init(profile: Profile,
          viewModel: SearchViewModel,
          model: SearchEngines,
@@ -306,7 +308,8 @@ class SearchViewController: SiteTableViewController,
         return Task { [weak self] in
             guard let suggestions = try? await self?.profile.firefoxSuggest?.query(
                 tempSearchQuery,
-                providers: providers
+                providers: providers,
+                limit: self?.maxNumOfFirefoxSuggestions
             ) else { return }
             await MainActor.run {
                 guard let self, self.searchQuery == tempSearchQuery else { return }

--- a/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
@@ -306,10 +306,11 @@ class SearchViewController: SiteTableViewController,
                 }
             }
         return Task { [weak self] in
-            guard let suggestions = try? await self?.profile.firefoxSuggest?.query(
-                tempSearchQuery,
-                providers: providers,
-                limit: self?.maxNumOfFirefoxSuggestions
+            guard let limit = self?.maxNumOfFirefoxSuggestions,
+                  let suggestions = try? await self?.profile.firefoxSuggest?.query(
+                    tempSearchQuery,
+                    providers: providers,
+                    limit: limit
             ) else { return }
             await MainActor.run {
                 guard let self, self.searchQuery == tempSearchQuery else { return }

--- a/firefox-ios/Storage/Rust/RustFirefoxSuggest.swift
+++ b/firefox-ios/Storage/Rust/RustFirefoxSuggest.swift
@@ -13,7 +13,7 @@ public protocol RustFirefoxSuggestActor: Actor {
     func query(
         _ keyword: String,
         providers: [SuggestionProvider],
-        limit: Int32?
+        limit: Int32
     ) async throws -> [RustFirefoxSuggestion]
 
     /// Interrupts any ongoing queries for suggestions.
@@ -48,12 +48,12 @@ public actor RustFirefoxSuggest: RustFirefoxSuggestActor {
     public func query(
         _ keyword: String,
         providers: [SuggestionProvider],
-        limit: Int32?
+        limit: Int32
     ) async throws -> [RustFirefoxSuggestion] {
         return try store.query(query: SuggestionQuery(
             keyword: keyword,
             providers: providers,
-            limit: limit ?? 1
+            limit: limit
         )).compactMap(RustFirefoxSuggestion.init)
     }
 

--- a/firefox-ios/Storage/Rust/RustFirefoxSuggest.swift
+++ b/firefox-ios/Storage/Rust/RustFirefoxSuggest.swift
@@ -12,7 +12,8 @@ public protocol RustFirefoxSuggestActor: Actor {
     /// Searches the store for matching suggestions.
     func query(
         _ keyword: String,
-        providers: [SuggestionProvider]
+        providers: [SuggestionProvider],
+        limit: Int32?
     ) async throws -> [RustFirefoxSuggestion]
 
     /// Interrupts any ongoing queries for suggestions.
@@ -46,11 +47,13 @@ public actor RustFirefoxSuggest: RustFirefoxSuggestActor {
 
     public func query(
         _ keyword: String,
-        providers: [SuggestionProvider]
+        providers: [SuggestionProvider],
+        limit: Int32?
     ) async throws -> [RustFirefoxSuggestion] {
         return try store.query(query: SuggestionQuery(
             keyword: keyword,
-            providers: providers
+            providers: providers,
+            limit: limit ?? 1
         )).compactMap(RustFirefoxSuggestion.init)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/SearchViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/SearchViewControllerTests.swift
@@ -14,7 +14,8 @@ actor MockRustFirefoxSuggest: RustFirefoxSuggestActor {
     }
     func query(
         _ keyword: String,
-        providers: [SuggestionProvider]
+        providers: [SuggestionProvider],
+        limit: Int32?
     ) async throws -> [RustFirefoxSuggestion] {
         var suggestions = [RustFirefoxSuggestion]()
         if providers.contains(.ampMobile) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/SearchViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/SearchViewControllerTests.swift
@@ -15,7 +15,7 @@ actor MockRustFirefoxSuggest: RustFirefoxSuggestActor {
     func query(
         _ keyword: String,
         providers: [SuggestionProvider],
-        limit: Int32?
+        limit: Int32
     ) async throws -> [RustFirefoxSuggestion] {
         var suggestions = [RustFirefoxSuggestion]()
         if providers.contains(.ampMobile) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8549)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19005)

## :bulb: Description
Added usage of the "limit" param when querying for FX suggestions. To be consistent with Desktop, I have the limit set as 1.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

