### PR TITLE
Move MTE-2451 [v125] testOptInNotificationLayout to functional plan

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
@@ -65,7 +65,6 @@
         "DragAndDropTests\/testRearrangeTabsTabTray()",
         "ExperimentIntegrationTests",
         "FakespotTests\/testAcceptTheRejectedOptInNotification()",
-        "FakespotTests\/testOptInNotificationLayout()",
         "FakespotTests\/testPriceTagIconAvailableOnlyOnDetailPage()",
         "FakespotTests\/testPriceTagNotDisplayedInPrivateMode()",
         "FakespotTests\/testReviewQualityCheckBottomSheetUI()",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest1.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest1.xctestplan
@@ -82,6 +82,7 @@
         "ExperimentIntegrationTests",
         "FakespotTests\/testAcceptTheRejectedOptInNotification()",
         "FakespotTests\/testFakespotAvailable()",
+        "FakespotTests\/testOptInNotificationLayout()",
         "FakespotTests\/testPriceTagIconAvailableOnlyOnDetailPage()",
         "FakespotTests\/testPriceTagNotDisplayedInPrivateMode()",
         "FakespotTests\/testPriceTagNotDisplayedOnSitesNotIntegratedFakespot()",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2451)

## :bulb: Description
Moving testOptInNotificationLayout to functional plan. It has the potential to be unstable and is a risk for smoke plans.
