### PR TITLE
Refactor FXIOS-8545 [v125] Update Fonts related to Pocket to use FXFontStyles

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Pocket/PocketDiscoverCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Pocket/PocketDiscoverCell.swift
@@ -10,15 +10,13 @@ import Shared
 /// A cell to be placed at the last position in the Pocket section
 class PocketDiscoverCell: UICollectionViewCell, ReusableCell {
     struct UX {
-        static let discoverMoreFontSize: CGFloat = 20
         static let horizontalMargin: CGFloat = 16
     }
 
     // MARK: - UI Elements
     let itemTitle: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .title3,
-                                                                size: UX.discoverMoreFontSize)
+        label.font = FXFontStyles.Bold.title3.scaledFont()
         label.numberOfLines = 0
         label.textAlignment = .left
     }

--- a/firefox-ios/Client/Frontend/Home/Pocket/PocketStandardCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Pocket/PocketStandardCell.swift
@@ -16,9 +16,6 @@ class PocketStandardCell: UICollectionViewCell, ReusableCell {
         static let interItemSpacing = NSCollectionLayoutSpacing.fixed(8)
         static let interGroupSpacing: CGFloat = 8
         static let generalCornerRadius: CGFloat = 12
-        static let titleFontSize: CGFloat = 15
-        static let sponsoredFontSize: CGFloat = 12
-        static let siteFontSize: CGFloat = 12
         static let horizontalMargin: CGFloat = 16
         static let heroImageSize =  CGSize(width: 108, height: 80)
         static let sponsoredIconSize = CGSize(width: 12, height: 12)
@@ -30,8 +27,7 @@ class PocketStandardCell: UICollectionViewCell, ReusableCell {
 
     private lazy var titleLabel: UILabel = .build { title in
         title.adjustsFontForContentSizeCategory = true
-        title.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .subheadline,
-                                                            size: UX.titleFontSize)
+        title.font = FXFontStyles.Regular.subheadline.scaledFont()
         title.numberOfLines = 2
     }
 
@@ -51,8 +47,7 @@ class PocketStandardCell: UICollectionViewCell, ReusableCell {
 
     private lazy var sponsoredLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .caption2,
-                                                            size: UX.sponsoredFontSize)
+        label.font = FXFontStyles.Regular.caption2.scaledFont()
         label.text = .FirefoxHomepage.Pocket.Sponsored
     }
 
@@ -62,9 +57,7 @@ class PocketStandardCell: UICollectionViewCell, ReusableCell {
 
     private lazy var descriptionLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = DefaultDynamicFontHelper.preferredBoldFont(
-            withTextStyle: .caption1,
-            size: UX.siteFontSize)
+        label.font = FXFontStyles.Bold.caption1.scaledFont()
     }
 
     // MARK: - Variables
@@ -104,10 +97,8 @@ class PocketStandardCell: UICollectionViewCell, ReusableCell {
         heroImageView.setHeroImage(heroImageViewModel)
         sponsoredStack.isHidden = viewModel.shouldHideSponsor
         descriptionLabel.font = viewModel.shouldHideSponsor
-        ? DefaultDynamicFontHelper.preferredFont(withTextStyle: .caption1,
-                                                 size: UX.siteFontSize)
-        : DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .caption1,
-                                                     size: UX.siteFontSize)
+        ? FXFontStyles.Regular.caption1.scaledFont()
+        : FXFontStyles.Bold.caption1.scaledFont()
 
         sponsoredStack.isHidden  = viewModel.shouldHideSponsor
 

--- a/firefox-ios/Client/Frontend/Home/Pocket/PocketStandardCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Pocket/PocketStandardCell.swift
@@ -47,7 +47,7 @@ class PocketStandardCell: UICollectionViewCell, ReusableCell {
 
     private lazy var sponsoredLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = FXFontStyles.Regular.caption2.scaledFont()
+        label.font = FXFontStyles.Regular.caption1.scaledFont()
         label.text = .FirefoxHomepage.Pocket.Sponsored
     }
 

--- a/firefox-ios/Client/Frontend/Home/PocketFooterView.swift
+++ b/firefox-ios/Client/Frontend/Home/PocketFooterView.swift
@@ -8,7 +8,6 @@ import Shared
 
 class PocketFooterView: UICollectionReusableView, ReusableCell, ThemeApplicable {
     private struct UX {
-        static let fontSize: CGFloat = 12
         static let mainContainerSpacing: CGFloat = 8
     }
 
@@ -27,8 +26,7 @@ class PocketFooterView: UICollectionReusableView, ReusableCell, ThemeApplicable 
                             AppName.shortName.rawValue)
         label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .caption1,
-                                                            size: UX.fontSize)
+        label.font = FXFontStyles.Regular.caption1.scaledFont()
     }
 
     private let learnMoreLabel: UILabel = .build { label in
@@ -36,8 +34,7 @@ class PocketFooterView: UICollectionReusableView, ReusableCell, ThemeApplicable 
         label.isUserInteractionEnabled = true
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.Pocket.footerLearnMoreLabel
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .caption1,
-                                                            size: UX.fontSize)
+        label.font = FXFontStyles.Regular.caption1.scaledFont()
     }
 
     private let labelsContainer: UIStackView = .build { stackView in


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8545)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18984)

## :bulb: Description
Updated usage of DefaultDynamicFontHelper to FXFontStyles for:

1. PocketFooterView 
2. PocketStandardCell
3. PocketDiscoverCell

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

Before: 
![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-03-07 at 16 04 46](https://github.com/mozilla-mobile/firefox-ios/assets/61138287/fd2244c5-f2ef-4f6a-ae20-bdf6d17f34bb)

After:
![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-03-07 at 15 57 19](https://github.com/mozilla-mobile/firefox-ios/assets/61138287/5a6d61d9-0a90-4cfd-b2ff-caeafd58adee)

