### PR TITLE
Refactor FXIOS-8560 [v124] Missing original "Show Search Suggestions" on Search Settings

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2046,16 +2046,22 @@ class BrowserViewController: UIViewController,
     // MARK: Overlay View
     // Disable search suggests view only if user is in private mode and setting is enabled
     private var shouldDisableSearchSuggestsForPrivateMode: Bool {
-        let featureFlagEnabled = featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly)
-        let nimbusSuggestEnabled = featureFlags.isFeatureEnabled(.firefoxSuggestFeature, checking: .buildAndUser)
+        let feltPrivacyFlagEnabled = featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly)
+        let firefoxSuggestFlagEnabled = featureFlags.isFeatureEnabled(.firefoxSuggestFeature, checking: .buildAndUser)
         let alwaysShowSearchSuggestionsView = browserViewControllerState?
             .searchScreenState
             .showSearchSugestionsView ?? false
-        let engines = profile.searchEngines
-        let isSettingEnabled = nimbusSuggestEnabled ?
-        engines.isPrivateModeSettingEnabled :
-        engines.shouldShowPrivateModeSearchSuggestions
-        return featureFlagEnabled && !alwaysShowSearchSuggestionsView && !isSettingEnabled
+
+        let isSettingEnabled = if firefoxSuggestFlagEnabled {
+            !profile.searchEngines.isPrivateModeSettingEnabled &&
+            tabManager.selectedTab?.isPrivate == true
+        } else {
+            feltPrivacyFlagEnabled &&
+            !alwaysShowSearchSuggestionsView &&
+            !profile.searchEngines.shouldShowPrivateModeSearchSuggestions
+        }
+
+        return isSettingEnabled
     }
 
     // Configure dimming view to show for private mode

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2046,22 +2046,14 @@ class BrowserViewController: UIViewController,
     // MARK: Overlay View
     // Disable search suggests view only if user is in private mode and setting is enabled
     private var shouldDisableSearchSuggestsForPrivateMode: Bool {
-        let feltPrivacyFlagEnabled = featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly)
-        let firefoxSuggestFlagEnabled = featureFlags.isFeatureEnabled(.firefoxSuggestFeature, checking: .buildAndUser)
+        let featureFlagEnabled = featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly)
         let alwaysShowSearchSuggestionsView = browserViewControllerState?
             .searchScreenState
             .showSearchSugestionsView ?? false
 
-        let isSettingEnabled = if firefoxSuggestFlagEnabled {
-            !profile.searchEngines.isPrivateModeSettingEnabled &&
-            tabManager.selectedTab?.isPrivate == true
-        } else {
-            feltPrivacyFlagEnabled &&
-            !alwaysShowSearchSuggestionsView &&
-            !profile.searchEngines.shouldShowPrivateModeSearchSuggestions
-        }
+        let isSettingEnabled = profile.searchEngines.shouldShowPrivateModeSearchSuggestions
 
-        return isSettingEnabled
+        return featureFlagEnabled && !alwaysShowSearchSuggestionsView && !isSettingEnabled
     }
 
     // Configure dimming view to show for private mode

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEngines.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEngines.swift
@@ -192,17 +192,6 @@ class SearchEngines {
         }
     }
 
-    var shouldHidePrivateModeFirefoxSuggestSetting: Bool {
-        return !shouldShowBookmarksSuggestions &&
-        !shouldShowSyncedTabsSuggestions &&
-        !shouldShowBrowsingHistorySuggestions
-    }
-
-    var isPrivateModeSettingEnabled: Bool {
-        return shouldShowPrivateModeFirefoxSuggestions ||
-               shouldShowSearchSuggestions
-    }
-
     func isEngineEnabled(_ engine: OpenSearchEngine) -> Bool {
         return disabledEngines.index(forKey: engine.shortName) == nil
     }

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEngines.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEngines.swift
@@ -192,12 +192,15 @@ class SearchEngines {
         }
     }
 
+    var shouldHidePrivateModeFirefoxSuggestSetting: Bool {
+        return !shouldShowBookmarksSuggestions &&
+        !shouldShowSyncedTabsSuggestions &&
+        !shouldShowBrowsingHistorySuggestions
+    }
+
     var isPrivateModeSettingEnabled: Bool {
-        return shouldShowPrivateModeSearchSuggestions ||
-               shouldShowPrivateModeFirefoxSuggestions ||
-               shouldShowBookmarksSuggestions ||
-               shouldShowSyncedTabsSuggestions ||
-               shouldShowBrowsingHistorySuggestions
+        return shouldShowPrivateModeFirefoxSuggestions ||
+               shouldShowSearchSuggestions
     }
 
     func isEngineEnabled(_ engine: OpenSearchEngine) -> Bool {

--- a/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
@@ -164,7 +164,7 @@ class SearchViewController: SiteTableViewController,
                || hasHistorySuggestions
                || hasHistoryAndBookmarksSuggestions
                || !filteredOpenedTabs.isEmpty
-               || (!filteredRemoteClientTabs.isEmpty && model.shouldShowSyncedTabsSuggestions)
+               || (!filteredRemoteClientTabs.isEmpty && shouldShowSyncedTabsSuggestions)
                || !searchHighlights.isEmpty
                || (!firefoxSuggestions.isEmpty && shouldShowNonSponsoredSuggestions)
     }

--- a/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
@@ -143,15 +143,30 @@ class SearchViewController: SiteTableViewController,
             .filter { $0.bookmarked == false }
     }
 
+    private var hasBookmarksSuggestions: Bool {
+        return !bookmarkSites.isEmpty &&
+        shouldShowBookmarksSuggestions
+    }
+
+    private var hasHistorySuggestions: Bool {
+        return !historySites.isEmpty &&
+        shouldShowBrowsingHistorySuggestions
+    }
+
+    private var hasHistoryAndBookmarksSuggestions: Bool {
+        return data.count != 0 &&
+        shouldShowBookmarksSuggestions &&
+        shouldShowBrowsingHistorySuggestions
+    }
+
     var hasFirefoxSuggestions: Bool {
-        let dataCount = data.count
-        return dataCount != 0 &&
-                (shouldShowBookmarksSuggestions
-                || shouldShowBrowsingHistorySuggestions)
-                || !filteredOpenedTabs.isEmpty
-                || (!filteredRemoteClientTabs.isEmpty && shouldShowSyncedTabsSuggestions)
-                || !searchHighlights.isEmpty
-                || (!firefoxSuggestions.isEmpty && shouldShowNonSponsoredSuggestions)
+        return hasBookmarksSuggestions
+               || hasHistorySuggestions
+               || hasHistoryAndBookmarksSuggestions
+               || !filteredOpenedTabs.isEmpty
+               || (!filteredRemoteClientTabs.isEmpty && model.shouldShowSyncedTabsSuggestions)
+               || !searchHighlights.isEmpty
+               || (!firefoxSuggestions.isEmpty && shouldShowNonSponsoredSuggestions)
     }
 
     init(profile: Profile,

--- a/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
@@ -154,7 +154,8 @@ class SearchViewController: SiteTableViewController,
     }
 
     private var hasHistoryAndBookmarksSuggestions: Bool {
-        return data.count != 0 &&
+        let dataCount = data.count
+        return dataCount != 0 &&
         shouldShowBookmarksSuggestions &&
         shouldShowBrowsingHistorySuggestions
     }

--- a/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
@@ -253,7 +253,7 @@ class SearchViewController: SiteTableViewController,
     }
 
     /// Whether to show suggestions from the search engine.
-    private var shoudShowSearchEngineSuggestions: Bool {
+    private var shouldShowSearchEngineSuggestions: Bool {
         return searchEngines?.shouldShowSearchSuggestions ?? false
     }
 
@@ -734,7 +734,7 @@ class SearchViewController: SiteTableViewController,
         let tempSearchQuery = searchQuery
         suggestClient?.query(searchQuery,
                              callback: { suggestions, error in
-            if error == nil, self.shoudShowSearchEngineSuggestions {
+            if error == nil, self.shouldShowSearchEngineSuggestions {
                 self.suggestions = suggestions!
                 // Remove user searching term inside suggestions list
                 self.suggestions?.removeAll(where: {
@@ -747,7 +747,7 @@ class SearchViewController: SiteTableViewController,
             }
 
             // If there are no suggestions, just use whatever the user typed.
-            if self.shoudShowSearchEngineSuggestions &&
+            if self.shouldShowSearchEngineSuggestions &&
                suggestions?.isEmpty ?? true {
                 self.suggestions = [self.searchQuery]
             }
@@ -1130,7 +1130,7 @@ class SearchViewController: SiteTableViewController,
         case SearchListSection.remoteTabs.rawValue:
             return hasFirefoxSuggestions
         case SearchListSection.searchSuggestions.rawValue:
-            return shoudShowSearchEngineSuggestions
+            return shouldShowSearchEngineSuggestions
         default:
             return false
         }

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -198,19 +198,21 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
                 )
 
             case SearchSuggestItem.privateSuggestions.rawValue:
-                buildSettingWith(
-                    prefKey: PrefsKeys.SearchSettings.showPrivateModeSearchSuggestions,
-                    defaultValue: model.shouldShowPrivateModeSearchSuggestions,
-                    titleText: String.localizedStringWithFormat(
-                        .Settings.Search.PrivateSessionSetting
-                    ),
-                    statusText: String.localizedStringWithFormat(
-                        .Settings.Search.PrivateSessionDescription
-                    ),
-                    cell: cell,
-                    selector: #selector(didToggleShowSearchSuggestionsInPrivateMode)
-                )
-
+                if featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly),
+                   !featureFlags.isFeatureEnabled(.firefoxSuggestFeature, checking: .buildAndUser) {
+                    buildSettingWith(
+                        prefKey: PrefsKeys.SearchSettings.showPrivateModeSearchSuggestions,
+                        defaultValue: model.shouldShowPrivateModeSearchSuggestions,
+                        titleText: String.localizedStringWithFormat(
+                            .Settings.Search.PrivateSessionSetting
+                        ),
+                        statusText: String.localizedStringWithFormat(
+                            .Settings.Search.PrivateSessionDescription
+                        ),
+                        cell: cell,
+                        selector: #selector(didToggleShowSearchSuggestionsInPrivateMode)
+                    )
+                }
             default: break
             }
 
@@ -324,8 +326,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
     override func numberOfSections(in tableView: UITableView) -> Int {
         sectionsToDisplay = [.defaultEngine, .alternateEngines, .searchEnginesSuggestions]
 
-        if featureFlags.isFeatureEnabled(.firefoxSuggestFeature, checking: .buildAndUser),
-           !featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly) {
+        if featureFlags.isFeatureEnabled(.firefoxSuggestFeature, checking: .buildAndUser) {
             sectionsToDisplay.append(.firefoxSuggestSettings)
         }
         return sectionsToDisplay.count
@@ -341,10 +342,9 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
             // But the option to add a Search Engine is.
             return model.orderedEngines.count
         case .searchEnginesSuggestions:
-            return featureFlags.isFeatureEnabled(
-                .feltPrivacyFeltDeletion,
-                checking: .buildAndUser
-            ) ? SearchSuggestItem.allCases.count : 1
+            return featureFlags.isFeatureEnabled(.feltPrivacyFeltDeletion, checking: .buildAndUser) &&
+            !featureFlags.isFeatureEnabled(.firefoxSuggestFeature, checking: .buildAndUser)
+            ? SearchSuggestItem.allCases.count : 1
         case .firefoxSuggestSettings:
             return FirefoxSuggestItem.allCases.count
         }

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -41,6 +41,12 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
     private let profile: Profile
     private let model: SearchEngines
 
+    var shouldHidePrivateModeFirefoxSuggestSetting: Bool {
+        return !model.shouldShowBookmarksSuggestions &&
+        !model.shouldShowSyncedTabsSuggestions &&
+        !model.shouldShowBrowsingHistorySuggestions
+    }
+
     private enum SearchSuggestItem: Int, CaseIterable {
         case defaultSuggestions
         case privateSuggestions
@@ -296,7 +302,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
                     cell: cell,
                     selector: #selector(didToggleShowFirefoxSuggestionsInPrivateMode)
                 )
-                cell.isHidden = model.shouldHidePrivateModeFirefoxSuggestSetting
+                cell.isHidden = shouldHidePrivateModeFirefoxSuggestSetting
 
             case FirefoxSuggestItem.suggestionLearnMore.rawValue:
                 cell.accessibilityLabel = String.localizedStringWithFormat(
@@ -342,7 +348,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
             // But the option to add a Search Engine is.
             return model.orderedEngines.count
         case .searchEnginesSuggestions:
-            return featureFlags.isFeatureEnabled(.feltPrivacyFeltDeletion, checking: .buildAndUser) &&
+            return featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly) &&
             !featureFlags.isFeatureEnabled(.firefoxSuggestFeature, checking: .buildAndUser)
             ? SearchSuggestItem.allCases.count : 1
         case .firefoxSuggestSettings:
@@ -423,7 +429,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
         case IndexPath(
                 row: FirefoxSuggestItem.privateSuggestions.rawValue,
                 section: Section.firefoxSuggestSettings.rawValue):
-            if model.shouldHidePrivateModeFirefoxSuggestSetting { return 0 }
+            if shouldHidePrivateModeFirefoxSuggestSetting { return 0 }
         default: return UITableView.automaticDimension
         }
         return UITableView.automaticDimension
@@ -559,34 +565,34 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
         _ toggle: ThemedSwitch,
         suggestionType: FirefoxSuggestItem
     ) {
-        var shouldShowSuggestions = false
+        var shouldShowPrivateSuggestionsSetting = false
         switch suggestionType {
         case .browsingHistory:
             model.shouldShowBrowsingHistorySuggestions = toggle.isOn
-            shouldShowSuggestions = model.shouldShowBrowsingHistorySuggestions &&
+            shouldShowPrivateSuggestionsSetting = model.shouldShowBrowsingHistorySuggestions &&
             !model.shouldShowBookmarksSuggestions &&
             !model.shouldShowSyncedTabsSuggestions
         case .bookmarks:
             model.shouldShowBookmarksSuggestions = toggle.isOn
-            shouldShowSuggestions = model.shouldShowBookmarksSuggestions &&
+            shouldShowPrivateSuggestionsSetting = model.shouldShowBookmarksSuggestions &&
             !model.shouldShowBrowsingHistorySuggestions &&
             !model.shouldShowSyncedTabsSuggestions
         case .syncedTabs:
             model.shouldShowSyncedTabsSuggestions = toggle.isOn
-            shouldShowSuggestions = model.shouldShowSyncedTabsSuggestions &&
+            shouldShowPrivateSuggestionsSetting = model.shouldShowSyncedTabsSuggestions &&
             !model.shouldShowBrowsingHistorySuggestions &&
             !model.shouldShowBookmarksSuggestions
         default: break
         }
 
-        if shouldShowSuggestions {
+        if shouldShowPrivateSuggestionsSetting {
             updateCells(
                 at: [IndexPath(
                     row: FirefoxSuggestItem.privateSuggestions.rawValue,
                     section: Section.firefoxSuggestSettings.rawValue
                 )]
             )
-        } else if model.shouldHidePrivateModeFirefoxSuggestSetting {
+        } else if shouldHidePrivateModeFirefoxSuggestSetting {
             model.shouldShowPrivateModeFirefoxSuggestions = false
             updateCells(
                 at: [IndexPath(

--- a/firefox-ios/nimbus-features/feltPrivacyFeature.yaml
+++ b/firefox-ios/nimbus-features/feltPrivacyFeature.yaml
@@ -19,6 +19,6 @@ features:
           felt-deletion-enabled: false
       - channel: developer
         value:
-          simplified-ui-enabled: false
-          felt-deletion-enabled: false
+          simplified-ui-enabled: true
+          felt-deletion-enabled: true
 

--- a/firefox-ios/nimbus-features/feltPrivacyFeature.yaml
+++ b/firefox-ios/nimbus-features/feltPrivacyFeature.yaml
@@ -19,6 +19,6 @@ features:
           felt-deletion-enabled: false
       - channel: developer
         value:
-          simplified-ui-enabled: true
-          felt-deletion-enabled: true
+          simplified-ui-enabled: false
+          felt-deletion-enabled: false
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8560)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19030)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Restore `Show Search Suggestions` option for `Default Search Engines` section when the experiment is off.
- Change logic in order that when one of the options `Search Bookmarks`, `Search Browsing History`, `Search Sync Tabs` is on, the `Show in Private Sessions` option is available and vice versa when all these options are off, hide `Show in Private Sessions` from `Address Bar - Firiefox Suggest` section.
- Remove `Show in Private Sessions` option from `Suggestions from Search Engines` section for the `Firefox Suggest` feature.
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

