### PR TITLE
Bump - Set Focus version to 125.0

### DIFF
--- a/focus-ios/Blockzilla/Info.plist
+++ b/focus-ios/Blockzilla/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>9000</string>
+	<string>125.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/focus-ios/ContentBlocker/Info.plist
+++ b/focus-ios/ContentBlocker/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>9000</string>
+	<string>125.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/focus-ios/FocusIntentExtension/Info.plist
+++ b/focus-ios/FocusIntentExtension/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>9000</string>
+	<string>125.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSExtension</key>

--- a/focus-ios/OpenInFocus/Info.plist
+++ b/focus-ios/OpenInFocus/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>9000</string>
+	<string>125.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSExtension</key>

--- a/focus-ios/Widgets/Info.plist
+++ b/focus-ios/Widgets/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleShortVersionString</key>
-	<string>9000</string>
+	<string>125.0</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>


### PR DESCRIPTION
Per Slack, we want the Focus version on main to be the Nightly version the same as Firefox.