### PR TITLE
Refactor FXIOS-8581 - Should not be privileged request

### DIFF
--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -535,7 +535,7 @@ class Tab: NSObject, ThemeApplicable {
 
     func restore(_ webView: WKWebView, interactionState: Data? = nil) {
         if let url = url {
-            webView.load(PrivilegedRequest(url: url) as URLRequest)
+            webView.load(URLRequest(url: url))
         }
 
         if let interactionState = interactionState {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8581)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19050)

## :bulb: Description
This shouldn't be a privileged request when we restore. We've kept this as historically, we've had been restoring a web view URL through a custom scheme handler (with session restore handler, which was removed from the Tab.restore in [this PR](https://github.com/mozilla-mobile/firefox-ios/pull/17655)) and this was needed to be a privileged request at the time. Since we don't have this mechanism in place anymore (since we're now using the [interactionState](https://developer.apple.com/documentation/webkit/wkwebview/3752236-interactionstate)) let's clean this up.

I wonder if this could have effect when loading a request when we're configuring a new tab, as we:
1. Configure a new tab, create the new web view which then restore the web view session
2. When we select that tab (which we do by default when we open a deep link for a user) we load a new request
Could loading two different requests have some side effect? Far-fetched theory, but everything's on the table. 

In all cases, this won't hurt as this really shouldn't be privileged IMO, see comment as well [here](https://github.com/mozilla-mobile/firefox-ios/blob/38f9a48a1f4d864bcc44f2d92df1a38d35fef4d1/firefox-ios/Client/Frontend/Browser/PrivilegedRequest.swift#L17-L19).

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

