### PR TITLE
Add FXIOS-8511 - Test setup for Swiftlint on Focus iOS

### DIFF
--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -1,0 +1,126 @@
+only_rules: # Only enforce these rules, ignore all others
+  - line_length
+  # - blanket_disable_command
+  # - class_delegate_protocol
+  # - closure_spacing
+  # - closure_parameter_position
+  # - colon
+  # - comma
+  # - comment_spacing
+  # - compiler_protocol_init
+  # - computed_accessors_order
+  # - control_statement
+  # - duplicate_conditions
+  # - dynamic_inline
+  # - empty_enum_arguments
+  # - empty_parameters
+  # - empty_parentheses_with_trailing_closure
+  # - for_where
+  # - force_try
+  # - implicit_getter
+  # - inclusive_language
+  # - invalid_swiftlint_command
+  # - large_tuple
+  # - leading_whitespace
+  # - legacy_cggeometry_functions
+  # - legacy_constant
+  # - legacy_constructor
+  # - legacy_hashing
+  # - legacy_nsgeometry_functions
+  # - mark
+  # - no_space_in_method_call
+  # - ns_number_init_as_function_reference
+  # - operator_whitespace
+  # - orphaned_doc_comment
+  # - private_over_fileprivate
+  # - protocol_property_accessors_order
+  # - redundant_discardable_let
+  # - redundant_objc_attribute
+  # - redundant_optional_initialization
+  # - redundant_string_enum_value
+  # - redundant_void_return
+  # - return_arrow_whitespace
+  # - statement_position
+  # - switch_case_alignment
+  # - syntactic_sugar
+  # - trailing_newline
+  # - trailing_semicolon
+  # - trailing_whitespace
+  # - unavailable_condition
+  # - unneeded_override
+  # - unneeded_synthesized_initializer
+  # - unused_optional_binding
+  # - unused_setter_value
+  # - vertical_parameter_alignment
+  # - vertical_whitespace
+  # - void_function_in_ternary
+  # - void_return
+  # - file_header
+  # - redundant_type_annotation
+  # - attributes
+  # - closing_brace
+  # - closure_end_indentation
+  # - contains_over_filter_count
+  # - contains_over_filter_is_empty
+  # - contains_over_first_not_nil
+  # - contains_over_range_nil_comparison
+  # - empty_collection_literal
+  # - empty_count
+  # - empty_string
+  # - empty_xctest_method
+  # - explicit_init
+  # - first_where
+  # - discouraged_assert
+  # - duplicate_imports
+  # - duplicate_enum_cases
+  # - last_where
+  # - modifier_order
+  # - multiline_arguments
+  # - opening_brace
+  # - overridden_super_call
+  # - vertical_parameter_alignment_on_call
+  # - vertical_whitespace_closing_braces
+  # - vertical_whitespace_opening_braces
+  # - yoda_condition
+
+# These rules were originally opted into. Disabling for now to get
+# Swiftlint up and running.
+
+  # - deployment_target
+  # - discouraged_optional_collection
+  # - prohibited_interface_builder
+  # - prohibited_super_call
+  # - protocol_property_accessors_order
+
+line_length:
+  warning: 125
+  ignores_urls: true
+  ignores_interpolated_strings: true
+
+file_header:
+  required_string: |
+                    // This Source Code Form is subject to the terms of the Mozilla Public
+                    // License, v. 2.0. If a copy of the MPL was not distributed with this
+                    // file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+analyzer_rules: # Rules run by `swiftlint analyze`
+  - unused_import
+
+excluded: # paths to ignore during linting. Takes precedence over `included`.
+  - build/
+  - .build/
+  - test-fixtures/tmp
+  - l10n-screenshots-dd/
+  - DerivedData/
+  # Package.swift files need a custom header for swift-tools-version
+  # so must be excluded due to file_header rule
+  - BrowserKit/Package.swift
+  - BrowserKit/.build/
+  - Package.swift
+
+included:
+  - /Users/vagrant/git
+  - .
+
+# reporter: "json" # reporter type (xcode, json, csv, checkstyle)
+reporter: "xcode" # reporter type (xcode, json, csv, checkstyle)

--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -1,5 +1,5 @@
 only_rules: # Only enforce these rules, ignore all others
-  - line_length
+  # - line_length
   # - blanket_disable_command
   # - class_delegate_protocol
   # - closure_spacing

--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -92,16 +92,16 @@ only_rules: # Only enforce these rules, ignore all others
   # - prohibited_super_call
   # - protocol_property_accessors_order
 
-line_length:
-  warning: 125
-  ignores_urls: true
-  ignores_interpolated_strings: true
+# line_length:
+#   warning: 125
+#   ignores_urls: true
+#   ignores_interpolated_strings: true
 
-file_header:
-  required_string: |
-                    // This Source Code Form is subject to the terms of the Mozilla Public
-                    // License, v. 2.0. If a copy of the MPL was not distributed with this
-                    // file, You can obtain one at http://mozilla.org/MPL/2.0/
+# file_header:
+#   required_string: |
+#                     // This Source Code Form is subject to the terms of the Mozilla Public
+#                     // License, v. 2.0. If a copy of the MPL was not distributed with this
+#                     // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 analyzer_rules: # Rules run by `swiftlint analyze`
   - unused_import

--- a/focus-ios/Blockzilla.xcodeproj/project.pbxproj
+++ b/focus-ios/Blockzilla.xcodeproj/project.pbxproj
@@ -2431,8 +2431,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "
-";
+			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]; then\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif which swiftlint > /dev/null; then\n    swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 		D5D067F9252F939600C35227 /* Glean */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8511)

## :bulb: Description
Enabling running swiftlint on a separate file from Xcode for Focus iOS, but still preserving the root .swiftlint.yml for BitRise.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

