### PR TITLE
Bugfix FXIOS-6494 [v125] [iPad] Opening a Private Tab via FF Widgets or FF 3D Menu Creates an Extra Empty Tab if no other private tabs were previously opened

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1635,9 +1635,9 @@ class BrowserViewController: UIViewController,
             logger.log("No request for openURLInNewTab", level: .debug, category: .tabs)
         }
 
-        switchToPrivacyMode(isPrivate: isPrivate)
         let tab = tabManager.addTab(request, isPrivate: isPrivate)
         tabManager.selectTab(tab)
+        switchToPrivacyMode(isPrivate: isPrivate)
         return tab
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6494)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14586)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
In the iPad version, the switchToPrivacyMode(isPrivate:) function triggers a delegate method within the tab tray controller. This method includes additional logic that automatically creates a new tab if the current tab collection is empty. However, this behavior inadvertently results in the creation of an extra tab before the one intended by the user.

To address this issue without removing the tab-creation logic (since it is utilized in various contexts and thus its removal could have unintended consequences), I opted for a minimally invasive solution. This involves preemptively creating the necessary tab before invoking switchToPrivacyMode(isPrivate:). By doing so, the delegate method's condition for creating a new tab (i.e., no existing tabs) is no longer met, thereby preventing the addition of an unintended extra tab.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

