### PR TITLE
Add FXIOS-8182 - Zombified tab reloading from redux

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1122,12 +1122,20 @@ class BrowserViewController: UIViewController,
         // Make sure reload button is working when showing webview
         urlBar.locationView.reloadButton.reloadButtonState = .reload
 
-        guard let webview = tabManager.selectedTab?.webView else {
+        guard let selectedTab = tabManager.selectedTab,
+              let webView = selectedTab.webView else {
             logger.log("Webview of selected tab was not available", level: .debug, category: .lifecycle)
             return
         }
 
-        browserDelegate?.show(webView: webview)
+        if webView.url == nil {
+            // The web view can go gray if it was zombified due to memory pressure.
+            // When this happens, the URL is nil, so try restoring the page upon selection.
+            logger.log("Webview was zombified, reloading before showing", level: .debug, category: .lifecycle)
+            selectedTab.reload()
+        }
+
+        browserDelegate?.show(webView: webView)
     }
 
     // MARK: - Update content


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8182)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19050)

## :bulb: Description
The idea behind this attempt: When the [`didSelectedTabChange`](https://github.com/mozilla-mobile/firefox-ios/blob/d57bd6e4ff2ff5562e35b5c34a6cbea4f58b7787/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift#L2599) delegate is called, there’s [a check in case the `webview.url`](https://github.com/mozilla-mobile/firefox-ios/blob/d57bd6e4ff2ff5562e35b5c34a6cbea4f58b7787/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift#L2643-L2647) is nil to reload before we show the web view from an [`updateContentInHomePanel`](https://github.com/mozilla-mobile/firefox-ios/blob/d57bd6e4ff2ff5562e35b5c34a6cbea4f58b7787/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift#L552). Since we’re now updating frequently the BVC state from Redux, that check doesn’t happen any more necessarily - I am trusting that the zombified comment still apply to this day, and zombifying is still a `WKWebView` thing that can happen.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

