### PR TITLE
Bugfix FXIOS-8605 Trigger action and filter at the same time

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Event Queue/EventQueue.swift
+++ b/firefox-ios/Client/Frontend/Browser/Event Queue/EventQueue.swift
@@ -238,10 +238,13 @@ public final class EventQueue<QueueEventType: Hashable> {
         isProcessingActions = true
         defer { isProcessingActions = false }
 
-        for enqueued in actions where allDependenciesSatisified(enqueued) {
-            enqueued.action()
+        actions = actions.filter { enqueued in
+            let dependenciesSatisfied = allDependenciesSatisified(enqueued)
+            if dependenciesSatisfied {
+                enqueued.action()
+            }
+            return !dependenciesSatisfied
         }
-        actions = actions.filter { !allDependenciesSatisified($0) }
     }
 
     private func allDependenciesSatisified(_ action: EnqueuedAction) -> Bool {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8605)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19100)

## :bulb: Description
This issue occurred because the allDependenciesSatisified call returns true initially but false when it checks the second time in order to remove it from the actions array. I don't know what happens to the event in order for it to move back to .inProgress from .completed but this check ensures that an action that has been triggered will always be removed avoiding it being triggered multiple times.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

