### PR TITLE
Refactor FXIOS-8610 Add event queue unit test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/EventQueueTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/EventQueueTests.swift
@@ -310,4 +310,34 @@ final class EventQueueTests: XCTestCase {
         // overhead of the event queue.
         wait(for: [expectation], timeout: 0.5)
     }
+
+    // This tests a specific bug where enqueued actions potentially change the state of
+    // a dependent event during processing (by moving it from .complete to .inProgress etc.)
+    // This is generally not a supported scenario, however if it happens we should respect
+    // the original state of the events as they were when the enqueued action was peformed.
+    func testChangingAnEventAsPartOfAnActionDoesNotBreakThings() {
+        let expectation = XCTestExpectation(description: "Nested action expectation.")
+        var actionsPerformed = 0
+        queue.wait(for: [.startingEvent, .activityEvent], then: {
+            actionsPerformed += 1
+            // As part of the enqueued action block, change the state of our dependent event out of .completed:
+            self.queue.started(.activityEvent)
+            DispatchQueue.main.async {
+                self.queue.completed(.activityEvent)
+                if actionsPerformed > 1 {
+                    // Action block was not cleaned up and was run repeatedly due
+                    // to dependent event being moved out of .completed state by
+                    // the action itself. This is a bug.
+                    XCTFail("Action block was not cleaned up correctly.")
+                } else {
+                    expectation.fulfill()
+                }
+            }
+        })
+        queue.signal(event: .startingEvent)
+        queue.started(.activityEvent)
+        queue.completed(.activityEvent)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/EventQueueTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/EventQueueTests.swift
@@ -315,8 +315,8 @@ final class EventQueueTests: XCTestCase {
     // a dependent event during processing (by moving it from .complete to .inProgress etc.)
     // This is generally not a supported scenario, however if it happens we should respect
     // the original state of the events as they were when the enqueued action was peformed.
-    func testChangingAnEventAsPartOfAnActionDoesNotBreakThings() {
-        let expectation = XCTestExpectation(description: "Nested action expectation.")
+    func testChangingAnEventAsPartOfAnActionStillRemovesTheActionAfterPerformingIt() {
+        let expectation = XCTestExpectation(description: "Action block cleaned up.")
         var actionsPerformed = 0
         queue.wait(for: [.startingEvent, .activityEvent], then: {
             actionsPerformed += 1


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8610)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19110)

## :bulb: Description

This adds a specific unit test to ensure that the bug fixed by https://github.com/mozilla-mobile/firefox-ios/pull/19109 doesn't break again in the future.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

