### PR TITLE
Add FXIOS-8350 WebEngine: input accessory view API

### DIFF
--- a/BrowserKit/Sources/WebEngine/EngineConstants.swift
+++ b/BrowserKit/Sources/WebEngine/EngineConstants.swift
@@ -17,3 +17,15 @@ public enum ZoomChangeValue {
 
     static let defaultStepIncrease = 0.1
 }
+
+/// Describes the accessory view that should be shown above the keyboard for a given webview.
+public enum EngineInputAccessoryView {
+    /// Use the default accessory view (depends on currently presented web content).
+    case `default`
+
+    /// Do not show an accessory view. This overrides any engine or webview default.
+    case none
+
+    /// Use a custom view (provided). Not currently needed but may be useful in the future.
+    // case custom(UIView)
+}

--- a/BrowserKit/Sources/WebEngine/EngineConstants.swift
+++ b/BrowserKit/Sources/WebEngine/EngineConstants.swift
@@ -26,6 +26,6 @@ public enum EngineInputAccessoryView {
     /// Do not show an accessory view. This overrides any engine or webview default.
     case none
 
-    /// Use a custom view (provided). Not currently needed but may be useful in the future.
+    // Use a custom view (provided). Not currently needed but may be useful in the future.
     // case custom(UIView)
 }

--- a/BrowserKit/Sources/WebEngine/EngineSessionDelegate.swift
+++ b/BrowserKit/Sources/WebEngine/EngineSessionDelegate.swift
@@ -48,7 +48,7 @@ public protocol EngineSessionDelegate: AnyObject {
     /// - Parameter linkURL: the link (if any) associatd with the event.
     /// - Returns: a menu configuration, or nil (will not show a menu)
     func onProvideContextualMenu(linkURL: URL?) -> UIContextMenuConfiguration?
-    
+
     /// Allows delegates to participate in whether or not a keyboard accessory view is shown
     /// for the current engine session.
     func onWillDisplayAccessoryView() -> EngineInputAccessoryView

--- a/BrowserKit/Sources/WebEngine/EngineSessionDelegate.swift
+++ b/BrowserKit/Sources/WebEngine/EngineSessionDelegate.swift
@@ -48,4 +48,8 @@ public protocol EngineSessionDelegate: AnyObject {
     /// - Parameter linkURL: the link (if any) associatd with the event.
     /// - Returns: a menu configuration, or nil (will not show a menu)
     func onProvideContextualMenu(linkURL: URL?) -> UIContextMenuConfiguration?
+    
+    /// Allows delegates to participate in whether or not a keyboard accessory view is shown
+    /// for the current engine session.
+    func onWillDisplayAccessoryView() -> EngineInputAccessoryView
 }

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -451,6 +451,10 @@ class WKEngineSession: NSObject,
         delegate?.search(with: searchSelection)
     }
 
+    func tabWebViewInputAccessoryView(_ webView: WKEngineWebView) -> EngineInputAccessoryView {
+        return delegate?.onWillDisplayAccessoryView() ?? .default
+    }
+
     // MARK: - MetadataFetcherDelegate
 
     func didLoad(pageMetadata: EnginePageMetadata) {

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
@@ -9,6 +9,7 @@ import WebKit
 protocol WKEngineWebViewDelegate: AnyObject {
     func tabWebView(_ webView: WKEngineWebView, findInPageSelection: String)
     func tabWebView(_ webView: WKEngineWebView, searchSelection: String)
+    func tabWebViewInputAccessoryView(_ webView: WKEngineWebView) -> EngineInputAccessoryView
 }
 
 /// Abstraction on top of the `WKWebView`
@@ -134,6 +135,16 @@ class DefaultWKEngineWebView: WKWebView, WKEngineWebView, MenuHelperWebViewInter
     var engineScrollView: WKScrollView!
     var engineConfiguration: WKEngineConfiguration
     weak var delegate: WKEngineWebViewDelegate?
+
+    override var inputAccessoryView: UIView? {
+        if let delegatePreference = delegate?.tabWebViewInputAccessoryView(self) {
+            switch delegatePreference {
+            case .default: break
+            case .none: return nil
+            }
+        }
+        return super.inputAccessoryView
+    }
 
     required init?(frame: CGRect, configurationProvider: WKEngineConfigurationProvider) {
         let configuration = configurationProvider.createConfiguration()

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockEngineSessionDelegate.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockEngineSessionDelegate.swift
@@ -19,6 +19,7 @@ class MockEngineSessionDelegate: EngineSessionDelegate {
     var findInPageCalled = 0
     var searchCalled = 0
     var onProvideContextualMenuCalled = 0
+    var onWillDisplayAcccessoryViewCalled = 0
 
     var savedScrollX: Int?
     var savedScrollY: Int?
@@ -94,5 +95,10 @@ class MockEngineSessionDelegate: EngineSessionDelegate {
     func onProvideContextualMenu(linkURL: URL?) -> UIContextMenuConfiguration? {
         onProvideContextualMenuCalled += 1
         return nil
+    }
+
+    func onWillDisplayAccessoryView() -> WebEngine.EngineInputAccessoryView {
+        onWillDisplayAcccessoryViewCalled += 1
+        return .default
     }
 }

--- a/SampleBrowser/SampleBrowser/UI/Browser/BrowserViewController.swift
+++ b/SampleBrowser/SampleBrowser/UI/Browser/BrowserViewController.swift
@@ -228,6 +228,10 @@ class BrowserViewController: UIViewController,
                                           actionProvider: actionProvider)
     }
 
+    func onWillDisplayAccessoryView() -> EngineInputAccessoryView {
+        return .default
+    }
+
     // MARK: - EngineSessionDelegate Menu items
 
     func findInPage(with selection: String) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8350)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18484)

## :bulb: Description

Allows clients to override or customize the default input accessory view shown by some engines (e.g. WebKit).

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

