### PR TITLE
Bugfix FXIOS-8604 [v125] Bookmark toasts triggered via homepage context menu

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -319,6 +319,15 @@ extension BrowserViewController: ToolBarActionMenuDelegate {
 
     func showToast(message: String, toastAction: MenuButtonToastAction) {
         switch toastAction {
+        case .bookmarkPage:
+            let viewModel = ButtonToastViewModel(labelText: message,
+                                                 buttonText: .BookmarksEdit,
+                                                 textAlignment: .left)
+            let toast = ButtonToast(viewModel: viewModel,
+                                    theme: themeManager.currentTheme) { isButtonTapped in
+                isButtonTapped ? self.openBookmarkEditPanel() : nil
+            }
+            self.show(toast: toast)
         case .removeBookmark:
             let viewModel = ButtonToastViewModel(labelText: message,
                                                  buttonText: .UndoString,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1276,23 +1276,21 @@ class BrowserViewController: UIViewController,
                                                                              withUserData: userData,
                                                                              toApplication: .shared)
 
-        showBookmarksToast()
+        showBookmarkToast(for: .add)
     }
-
-    private func showBookmarksToast() {
-        let viewModel = ButtonToastViewModel(labelText: .AppMenu.AddBookmarkConfirmMessage,
-                                             buttonText: .BookmarksEdit,
-                                             textAlignment: .left)
-        let toast = ButtonToast(viewModel: viewModel,
-                                theme: themeManager.currentTheme) { isButtonTapped in
-            isButtonTapped ? self.openBookmarkEditPanel() : nil
-        }
-        self.show(toast: toast)
-    }
-
+    
     func removeBookmark(url: String) {
         profile.places.deleteBookmarksWithURL(url: url).uponQueue(.main) { result in
             guard result.isSuccess else { return }
+            self.showBookmarkToast(for: .remove)
+        }
+    }
+    
+    private func showBookmarkToast(for action: BookmarkAction) {
+        switch action {
+        case .add:
+            self.showToast(message: .AppMenu.AddBookmarkConfirmMessage, toastAction: .bookmarkPage)
+        case .remove:
             self.showToast(message: .AppMenu.RemoveBookmarkConfirmMessage, toastAction: .removeBookmark)
         }
     }
@@ -1301,7 +1299,7 @@ class BrowserViewController: UIViewController,
     /// Library Panel - Bookmarks section. In order to get the correct information, it needs
     /// to fetch the last added bookmark in the mobile folder, which is the default
     /// location for all bookmarks added on mobile.
-    private func openBookmarkEditPanel() {
+    internal func openBookmarkEditPanel() {
         TelemetryWrapper.recordEvent(
             category: .action,
             method: .change,
@@ -2485,6 +2483,10 @@ extension BrowserViewController: HomePanelDelegate {
 
     func homePanelDidRequestToOpenSettings(at settingsPage: Route.SettingsSection) {
         navigationHandler?.show(settings: settingsPage)
+    }
+        
+    func homePanelDidRequestBookmarkToast(for action: BookmarkAction) {
+        showBookmarkToast(for: action)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1278,14 +1278,14 @@ class BrowserViewController: UIViewController,
 
         showBookmarkToast(for: .add)
     }
-    
+
     func removeBookmark(url: String) {
         profile.places.deleteBookmarksWithURL(url: url).uponQueue(.main) { result in
             guard result.isSuccess else { return }
             self.showBookmarkToast(for: .remove)
         }
     }
-    
+
     private func showBookmarkToast(for action: BookmarkAction) {
         switch action {
         case .add:
@@ -2484,7 +2484,7 @@ extension BrowserViewController: HomePanelDelegate {
     func homePanelDidRequestToOpenSettings(at settingsPage: Route.SettingsSection) {
         navigationHandler?.show(settings: settingsPage)
     }
-        
+
     func homePanelDidRequestBookmarkToast(for action: BookmarkAction) {
         showBookmarkToast(for: action)
     }

--- a/firefox-ios/Client/Frontend/Home/HomePanelDelegate.swift
+++ b/firefox-ios/Client/Frontend/Home/HomePanelDelegate.swift
@@ -11,6 +11,7 @@ protocol HomePanelDelegate: AnyObject {
     func homePanelDidRequestToOpenLibrary(panel: LibraryPanelType)
     func homePanelDidRequestToOpenTabTray(withFocusedTab tabToFocus: Tab?, focusedSegment: TabTrayPanelType?)
     func homePanelDidRequestToOpenSettings(at settingsPage: Route.SettingsSection)
+    func homePanelDidRequestBookmarkToast(for action: BookmarkAction)
 }
 
 extension HomePanelDelegate {

--- a/firefox-ios/Client/Frontend/Home/HomepageContextMenuHelper.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageContextMenuHelper.swift
@@ -199,7 +199,7 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
             self.viewModel.profile.places.deleteBookmarksWithURL(url: site.url) >>== {
                 site.setBookmarked(false)
             }
-            
+
             self.delegate?.homePanelDidRequestBookmarkToast(for: .remove)
 
             TelemetryWrapper.recordEvent(category: .action, method: .delete, object: .bookmark, value: .activityStream)
@@ -226,9 +226,9 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
                                                                                  withUserData: userData,
                                                                                  toApplication: .shared)
             site.setBookmarked(true)
-            
+
             self.delegate?.homePanelDidRequestBookmarkToast(for: .add)
-            
+
             TelemetryWrapper.recordEvent(category: .action, method: .add, object: .bookmark, value: .activityStream)
         })
     }

--- a/firefox-ios/Client/Frontend/Home/HomepageContextMenuHelper.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageContextMenuHelper.swift
@@ -11,6 +11,7 @@ import Storage
 protocol HomepageContextMenuHelperDelegate: UIViewController {
     func homePanelDidRequestToOpenInNewTab(_ url: URL, isPrivate: Bool, selectNewTab: Bool)
     func homePanelDidRequestToOpenSettings(at settingsPage: Route.SettingsSection)
+    func homePanelDidRequestBookmarkToast(for action: BookmarkAction)
 }
 // swiftlint:enable class_delegate_protocol
 
@@ -18,6 +19,11 @@ extension HomepageContextMenuHelperDelegate {
     func homePanelDidRequestToOpenInNewTab(_ url: URL, isPrivate: Bool, selectNewTab: Bool = false) {
         homePanelDidRequestToOpenInNewTab(url, isPrivate: isPrivate, selectNewTab: selectNewTab)
     }
+}
+
+enum BookmarkAction {
+    case add
+    case remove
 }
 
 class HomepageContextMenuHelper: HomepageContextMenuProtocol {
@@ -193,6 +199,8 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
             self.viewModel.profile.places.deleteBookmarksWithURL(url: site.url) >>== {
                 site.setBookmarked(false)
             }
+            
+            self.delegate?.homePanelDidRequestBookmarkToast(for: .remove)
 
             TelemetryWrapper.recordEvent(category: .action, method: .delete, object: .bookmark, value: .activityStream)
         })
@@ -218,6 +226,9 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
                                                                                  withUserData: userData,
                                                                                  toApplication: .shared)
             site.setBookmarked(true)
+            
+            self.delegate?.homePanelDidRequestBookmarkToast(for: .add)
+            
             TelemetryWrapper.recordEvent(category: .action, method: .add, object: .bookmark, value: .activityStream)
         })
     }

--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -772,6 +772,10 @@ extension HomepageViewController: HomepageContextMenuHelperDelegate {
     func homePanelDidRequestToOpenSettings(at settingsPage: Route.SettingsSection) {
         homePanelDelegate?.homePanelDidRequestToOpenSettings(at: settingsPage)
     }
+    
+    func homePanelDidRequestBookmarkToast(for action: BookmarkAction) {
+        homePanelDelegate?.homePanelDidRequestBookmarkToast(for: action)
+    }
 }
 
 // MARK: - Status Bar Background

--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -772,7 +772,7 @@ extension HomepageViewController: HomepageContextMenuHelperDelegate {
     func homePanelDidRequestToOpenSettings(at settingsPage: Route.SettingsSection) {
         homePanelDelegate?.homePanelDidRequestToOpenSettings(at: settingsPage)
     }
-    
+
     func homePanelDidRequestBookmarkToast(for action: BookmarkAction) {
         homePanelDelegate?.homePanelDidRequestBookmarkToast(for: action)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8604)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19095)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Shows the "Bookmark added" and "Bookmark removed" toast messages when performing these actions via the `HomepageContextMenu`
- Cleans up `ShowBookmarkToast()` so that it is used for showing either the "Bookmark added" or "Bookmark removed" toast

<details>
<summary>Video</summary>

https://github.com/mozilla-mobile/firefox-ios/assets/15353801/875e0f1f-125f-4ade-9312-30fbc53a529e

</details>

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

