### PR TITLE
Fix MTE-2457 - history tests on iPad

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -854,11 +854,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         }
 
         screenState.onEnter { userState in
-            if isTablet {
-                userState.numTabs = Int(app.collectionViews["Top Tabs View"].cells.count)
-            } else {
-                userState.numTabs = Int(app.otherElements["Tabs Tray"].cells.count)
-            }
+            userState.numTabs = Int(app.otherElements["Tabs Tray"].cells.count)
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-2457

## :bulb: Description
Removed iPad condition for tabs tray cell element
