### PR TITLE
Bugfix FXIOS-8608 Save Password pops up shows after using a password that was saved already

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2275,7 +2275,7 @@ extension BrowserViewController: LegacyTabDelegate {
         tab.addContentScript(readerMode, name: ReaderMode.name())
 
         // only add the logins helper if the tab is not a private browsing tab
-        if !tab.isPrivate, autofillLoginNimbusFeatureFlag() {
+        if !tab.isPrivate {
             let logins = LoginsHelper(
                 tab: tab,
                 profile: profile,
@@ -2284,6 +2284,7 @@ extension BrowserViewController: LegacyTabDelegate {
             tab.addContentScript(logins, name: LoginsHelper.name())
             logins.foundFieldValues = { [weak self] field, currentRequestId in
                 Task {
+                    guard self?.autofillLoginNimbusFeatureFlag() == true else { return }
                     guard let tabURL = tab.url else { return }
                     let logins = (try? await self?.profile.logins.listLogins()) ?? []
                     let loginsForCurrentTab = logins.filter { login in

--- a/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
@@ -203,7 +203,7 @@ class LoginsHelper: TabContentScript {
     }
 
     func setCredentials(_ login: LoginEntry) {
-        if login.password.isEmpty {
+        if login.password.isEmpty || login.username.isEmpty {
             return
         }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8608)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19105)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
It seems the username is lost and the prompt interprets this as a new login and if tapped to save it will store a new login with an empty username.
Until we have an updated script we can show the prompt to save only if we have both the username and pass.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

