### PR TITLE
Refactor FXIOS-8623 - Clean up of logger category and some logger calls

### DIFF
--- a/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
+++ b/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
@@ -8,17 +8,17 @@ import Foundation
 /// Categories are sorted in alphabetical order.
 /// Do not add new categories unless discussing with the team beforehand.
 public enum LoggerCategory: String {
-    /// Related to autofill
+    /// Related to address and credit card autofill
     case autofill
 
     /// Related to coordinator navigation
     case coordinator
 
-    /// Related to homepage UI and it's data management.
-    case homepage
-
     /// Related to experiments, nimbus and the messaging framework.
     case experiments
+
+    /// Related to homepage UI and it's data management.
+    case homepage
 
     /// Related to errors around image fetches, and includes all image types (`SiteImageType`, and general images).
     case images
@@ -36,24 +36,14 @@ public enum LoggerCategory: String {
     /// Related to the setup of services on app launch.
     case setup
 
-    /// Sentry calls, temporary category while we make the migration.
-    case sentry
-
     /// Related to storage (keychain, SQL database, store of different types, etc).
     case storage
 
     /// Related to sync accounts, sync management, application services.
     case sync
 
-    /// Anything related to telemetry
-    case telemetry
-
     /// Related to the tabs UI, setup and management
     case tabs
-
-    /// For any logs that doesn't fit in any categories. Before using think if your label should fit in any, or a new
-    /// category. If it doesn't and it's a one-off case then let's used 'unlabeled'
-    case unlabeled
 
     /// Webview scripts, webview delegate, webserver like GCDWebserver, showing webview alerts, webview navigation
     case webview

--- a/firefox-ios/Client/Application/BackgroundNotificationSurfaceUtility.swift
+++ b/firefox-ios/Client/Application/BackgroundNotificationSurfaceUtility.swift
@@ -41,7 +41,7 @@ class BackgroundNotificationSurfaceUtility: BackgroundUtilityProtocol {
         } catch {
             logger.log("Could not schedule app refresh: \(error)",
                        level: .debug,
-                       category: .unlabeled)
+                       category: .lifecycle)
         }
     }
 

--- a/firefox-ios/Client/Application/QuickActions.swift
+++ b/firefox-ios/Client/Application/QuickActions.swift
@@ -108,7 +108,7 @@ struct QuickActionsImplementation: QuickActions {
                 dynamicShortcutItems.append(openLastBookmarkShortcut)
             }
         default:
-            logger.log("Cannot add static shortcut item of type \(type)", level: .warning, category: .unlabeled)
+            break
         }
         application.shortcutItems = dynamicShortcutItems
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1419,7 +1419,7 @@ class BrowserViewController: UIViewController,
         else {
             logger.log("BVC observeValue webpage unhandled KVO",
                        level: .info,
-                       category: .unlabeled,
+                       category: .webview,
                        description: "Unhandled KVO key: \(keyPath ?? "nil")")
             return
         }

--- a/firefox-ios/Client/Frontend/Browser/QRCodeViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/QRCodeViewController.swift
@@ -337,9 +337,6 @@ extension QRCodeViewController: AVCaptureMetadataOutputObjectsDelegate {
                       let qrCodeDelegate = self.qrCodeDelegate,
                       let text = metaData.stringValue
                 else {
-                    self.logger.log("Unable to scan QR code",
-                                    level: .debug,
-                                    category: .unlabeled)
                     return
                 }
 

--- a/firefox-ios/Client/Helpers/UserActivityHandler.swift
+++ b/firefox-ios/Client/Helpers/UserActivityHandler.swift
@@ -150,13 +150,6 @@ extension UserActivityHandler {
         }
         do {
             try await searchableIndex.indexSearchableItems([item])
-            logger.log("Spotlight: Search item successfully indexed!",
-                       level: .debug,
-                       category: .unlabeled)
-        } catch {
-            logger.log("Spotlight: Indexing error: \(error.localizedDescription)",
-                       level: .warning,
-                       category: .unlabeled)
-        }
+        } catch {}
     }
 }

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -261,15 +261,6 @@ class TelemetryWrapper: TelemetryWrapperProtocol, FeatureFlaggable {
         let startAtHomeOption = prefs.stringForKey(PrefsKeys.UserFeatureFlagPrefs.StartAtHome) ?? StartAtHomeSetting.afterFourHours.rawValue
         GleanMetrics.Preferences.openingScreen.set(startAtHomeOption)
     }
-
-    @objc
-    func uploadError(notification: NSNotification) {
-        guard !DeviceInfo.isSimulator(), let error = notification.userInfo?["error"] as? NSError else { return }
-        logger.log("Upload Error",
-                   level: .info,
-                   category: .telemetry,
-                   description: error.debugDescription)
-    }
 }
 
 // Enums for Event telemetry.
@@ -2073,7 +2064,7 @@ extension TelemetryWrapper {
     ) {
         DefaultLogger.shared.log("Uninstrumented metric recorded",
                                  level: .info,
-                                 category: .telemetry,
+                                 category: .lifecycle,
                                  description: "\(category), \(method), \(object), \(String(describing: value)), \(String(describing: extras))")
     }
 }

--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -61,9 +61,6 @@ class ProfileFileAccessor: FileAccessor {
         ) {
             rootPath = url.path
         } else {
-            logger.log("Unable to find the shared container. Defaulting profile location to ~/Documents instead.",
-                       level: .warning,
-                       category: .unlabeled)
             rootPath = (NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0])
         }
 

--- a/firefox-ios/Shared/Functions.swift
+++ b/firefox-ios/Shared/Functions.swift
@@ -115,11 +115,6 @@ public func chunkCollection<E, X, T: Collection>(
     f: ([E]) -> [X]
 ) -> [X] where T.Iterator.Element == E {
     guard by >= 0 else {
-        DefaultLogger.shared.log(
-            "Chunking must be done with a non-negative value.",
-            level: .warning,
-            category: .unlabeled
-        )
         return []
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8623)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Clean up of `LoggerCategory`. I removed some logs as I don't believe those are bringing anything, and cleaned up some categories to streamline what we have there for logs.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

