### PR TITLE
Refactor FXIOS-8570 [v124] - "Suggestions from sponsors" toggle and functionality not visible

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
@@ -167,7 +167,7 @@ class SearchViewController: SiteTableViewController,
                || !filteredOpenedTabs.isEmpty
                || (!filteredRemoteClientTabs.isEmpty && shouldShowSyncedTabsSuggestions)
                || !searchHighlights.isEmpty
-               || (!firefoxSuggestions.isEmpty && (shouldShowNonSponsoredSuggestions 
+               || (!firefoxSuggestions.isEmpty && (shouldShowNonSponsoredSuggestions
                                                    || shouldShowSponsoredSuggestions))
     }
 

--- a/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
@@ -167,7 +167,8 @@ class SearchViewController: SiteTableViewController,
                || !filteredOpenedTabs.isEmpty
                || (!filteredRemoteClientTabs.isEmpty && shouldShowSyncedTabsSuggestions)
                || !searchHighlights.isEmpty
-               || (!firefoxSuggestions.isEmpty && shouldShowNonSponsoredSuggestions)
+               || (!firefoxSuggestions.isEmpty && (shouldShowNonSponsoredSuggestions 
+                                                   || shouldShowSponsoredSuggestions))
     }
 
     init(profile: Profile,
@@ -241,7 +242,7 @@ class SearchViewController: SiteTableViewController,
 
     /// Whether to show sponsored suggestions from Firefox Suggest.
     private var shouldShowSponsoredSuggestions: Bool {
-        shouldShowNonSponsoredSuggestions &&
+        return !viewModel.isPrivate &&
         model.shouldShowSponsoredSuggestions
     }
 

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -286,7 +286,6 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
                     cell: cell,
                     selector: #selector(didToggleEnableSponsoredSuggestions)
                 )
-                cell.isHidden = !model.shouldShowFirefoxSuggestions
 
             case FirefoxSuggestItem.privateSuggestions.rawValue:
                 buildSettingWith(
@@ -422,10 +421,6 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
 
     override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         switch indexPath {
-        case IndexPath(
-                row: FirefoxSuggestItem.sponsored.rawValue,
-                section: Section.firefoxSuggestSettings.rawValue):
-            if  !model.shouldShowFirefoxSuggestions { return 0 }
         case IndexPath(
                 row: FirefoxSuggestItem.privateSuggestions.rawValue,
                 section: Section.firefoxSuggestSettings.rawValue):
@@ -660,14 +655,6 @@ extension SearchSettingsTableViewController {
     @objc
     func didToggleEnableNonSponsoredSuggestions(_ toggle: ThemedSwitch) {
         model.shouldShowFirefoxSuggestions = toggle.isOn
-        model.shouldShowSponsoredSuggestions = toggle.isOn
-
-        updateCells(
-            at: [IndexPath(
-                row: FirefoxSuggestItem.sponsored.rawValue,
-                section: Section.firefoxSuggestSettings.rawValue
-            )]
-        )
     }
 
     @objc


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8570)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19000)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- This pull request modifies the functionality logic of sponsored suggestions. Previously, the sponsored suggestions would only be available if the non-sponsored ones were. Now, with this change, they work individually.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

