### PR TITLE
Add - WebEngine documentation

### DIFF
--- a/BrowserKit/Sources/WebEngine/EngineSessionDelegate.swift
+++ b/BrowserKit/Sources/WebEngine/EngineSessionDelegate.swift
@@ -7,12 +7,6 @@ import UIKit.UIContextMenuConfiguration
 
 /// Delegate used by the class that want to observe an engine session
 public protocol EngineSessionDelegate: AnyObject {
-    /// Event to indicate the scroll position of the content has changed.
-    func onScrollChange(scrollX: Int, scrollY: Int)
-
-    /// Event to indicate that this session has had a long press.
-    func onLongPress(touchPoint: CGPoint)
-
     /// Event to indicate the title on the session has changed.
     func onTitleChange(title: String)
 

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockEngineSessionDelegate.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockEngineSessionDelegate.swift
@@ -7,8 +7,6 @@ import UIKit.UIContextMenuConfiguration
 @testable import WebEngine
 
 class MockEngineSessionDelegate: EngineSessionDelegate {
-    var onScrollChangeCalled = 0
-    var onLongPressCalled = 0
     var onTitleChangeCalled = 0
     var onProgressCalled = 0
     var onNavigationStateChangeCalled = 0
@@ -20,9 +18,6 @@ class MockEngineSessionDelegate: EngineSessionDelegate {
     var searchCalled = 0
     var onProvideContextualMenuCalled = 0
 
-    var savedScrollX: Int?
-    var savedScrollY: Int?
-    var savedTouchPoint: CGPoint?
     var savedTitleChange: String?
     var savedURL: String?
     var savedHasOnlySecureContent: Bool?
@@ -33,17 +28,6 @@ class MockEngineSessionDelegate: EngineSessionDelegate {
     var savedPagemetaData: EnginePageMetadata?
     var savedFindInPageSelection: String?
     var savedSearchSelection: String?
-
-    func onScrollChange(scrollX: Int, scrollY: Int) {
-        onScrollChangeCalled += 1
-        savedScrollX = scrollX
-        savedScrollY = scrollY
-    }
-
-    func onLongPress(touchPoint: CGPoint) {
-        onLongPressCalled += 1
-        savedTouchPoint = touchPoint
-    }
 
     func onTitleChange(title: String) {
         onTitleChangeCalled += 1

--- a/focus-ios/Blockzilla/BrowserViewController.swift
+++ b/focus-ios/Blockzilla/BrowserViewController.swift
@@ -186,6 +186,7 @@ class BrowserViewController: UIViewController {
             make.top.bottom.leading.width.equalToSuperview()
         }
 
+        // FXIOS-8617 - #19118 ⁃ Integrate EngineSession in Focus iOS
         webViewController.delegate = self
 
         setupBackgroundImage()
@@ -264,11 +265,13 @@ class BrowserViewController: UIViewController {
 
         // Listen for request desktop site notifications
         NotificationCenter.default.addObserver(forName: Notification.Name(rawValue: UIConstants.strings.requestDesktopNotification), object: nil, queue: nil) { [weak self] _ in
+            // FXIOS-8638 - #19161 ⁃ Handle webViewController requestUserAgentChange
             self?.webViewController.requestUserAgentChange()
         }
 
         // Listen for request mobile site notifications
         NotificationCenter.default.addObserver(forName: Notification.Name(rawValue: UIConstants.strings.requestMobileNotification), object: nil, queue: nil) { [weak self] _ in
+            // FXIOS-8638 - #19161 ⁃ Handle webViewController requestUserAgentChange
             self?.webViewController.requestUserAgentChange()
         }
 
@@ -495,6 +498,7 @@ class BrowserViewController: UIViewController {
                     shortcutsBackground.isHidden = !shouldShowShortcuts || !urlBar.inBrowsingMode
 
                 case .dismissedURLBar:
+                    // FXIOS-8636 - #19159 - Integrate onProgress and onNavigationStateChange in Focus iOS
                     shortcutsContainer.isHidden = urlBar.inBrowsingMode || webViewController.isLoading
                     shortcutsBackground.isHidden = true
 
@@ -554,6 +558,7 @@ class BrowserViewController: UIViewController {
     }
 
     private func updateLockIcon(trackingProtectionStatus: TrackingProtectionStatus) {
+        // FXIOS-8643 - #19166 ⁃ Integrate content blocking in Focus iOS
         let isSecureConnection = urlBar.inBrowsingMode ? self.webViewController.connectionIsSecure : true
         let shieldIconStatus: ShieldIconStatus
         if isSecureConnection {
@@ -606,11 +611,13 @@ class BrowserViewController: UIViewController {
         }
     }
 
+    // FXIOS-8632 - #19158 - Integrate EngineSession full screen in Focus iOS
     public func exitFullScreenVideo() {
         let js = "closeFullScreen()"
         webViewController.evaluate(js, completion: nil)
     }
 
+    // FXIOS-8617 - #19118 ⁃ Integrate EngineSession in Focus iOS
     private func containWebView() {
         addChild(webViewController)
         webViewContainer.addSubview(webViewController.view)
@@ -649,9 +656,11 @@ class BrowserViewController: UIViewController {
                         self.presentContextMenu(from: anchor)
 
                     case .backButtonTap:
+                        // FXIOS-8626 - #19148 - Integrate basics APIs of WebEngine in Focus iOS
                         self.webViewController.goBack()
 
                     case .forwardButtonTap:
+                        // FXIOS-8626 - #19148 - Integrate basics APIs of WebEngine in Focus iOS
                         self.webViewController.goForward()
 
                     case .deleteButtonTap:
@@ -663,9 +672,11 @@ class BrowserViewController: UIViewController {
                         self.urlBarDidTapShield(self.urlBar)
 
                     case .stopButtonTap:
+                        // FXIOS-8626 - #19148 - Integrate basics APIs of WebEngine in Focus iOS
                         self.webViewController.stop()
 
                     case .reloadButtonTap:
+                        // FXIOS-8626 - #19148 - Integrate basics APIs of WebEngine in Focus iOS
                         self.webViewController.reload()
 
                     case .dragInteractionStarted:
@@ -756,7 +767,10 @@ class BrowserViewController: UIViewController {
             self.findInPageBar?.becomeFirstResponder()
         } else if let findInPageBar = self.findInPageBar {
             findInPageBar.endEditing(true)
+            // FXIOS-8631 - #19154 ⁃ Integrate EngineSession focus in Focus iOS
             webViewController.focus()
+            // FXIOS-8628 - #19150 ⁃ Integrate EngineSession find in page in Focus iOS
+            // This is done through `func findInPageDone()`
             webViewController.evaluate("__firefox__.findDone()", completion: nil)
             findInPageBar.removeFromSuperview()
             fillerView?.removeFromSuperview()
@@ -812,6 +826,7 @@ class BrowserViewController: UIViewController {
     private func clearBrowser() {
         // Helper function for resetBrowser that handles all the logic of actually clearing user data and the browsing session
         overlayView.currentURL = ""
+        // FXIOS-8639 - #19162 - Handle reset webview in Focus iOS
         webViewController.reset()
         webViewContainer.isHidden = true
         browserToolbar.isHidden = true
@@ -935,6 +950,7 @@ class BrowserViewController: UIViewController {
                 browserToolbar.animateHidden(false, duration: UIConstants.layout.toolbarFadeAnimationDuration)
             }
         }
+        // FXIOS-8626 - #19148 - Integrate basics APIs of WebEngine in Focus iOS
         webViewController.load(URLRequest(url: url))
 
         if urlBar.url != url {
@@ -996,6 +1012,7 @@ class BrowserViewController: UIViewController {
 
             self.browserToolbar.animateHidden(!self.urlBar.inBrowsingMode || self.showsToolsetInURLBar, duration: coordinator.transitionDuration, completion: {
                 self.updateViewConstraints()
+                // FXIOS-8627 - #19151 - Integrate EngineSession zoom in Focus iOS
                 self.webViewController.resetZoom()
             })
         })
@@ -1022,14 +1039,17 @@ class BrowserViewController: UIViewController {
     }
 
     @objc private func reload() {
+        // FXIOS-8626 - #19148 - Integrate basics APIs of WebEngine in Focus iOS
         webViewController.reload()
     }
 
     @objc private func goBack() {
+        // FXIOS-8626 - #19148 - Integrate basics APIs of WebEngine in Focus iOS
         webViewController.goBack()
     }
 
     @objc private func goForward() {
+        // FXIOS-8626 - #19148 - Integrate basics APIs of WebEngine in Focus iOS
         webViewController.goForward()
     }
 
@@ -1088,6 +1108,8 @@ class BrowserViewController: UIViewController {
         UserDefaults.standard.set(numberOfTrackers, forKey: BrowserViewController.userDefaultsTrackersBlockedKey)
     }
 
+    // FXIOS-8640 - #19163 - Clean up Focus iOS WebEngine related code
+    // This function won't exist as is as part of the WebEngine. URL bar gets updated through onLocationChange(url:)
     func updateURLBar() {
         if webViewController.url?.absoluteString != "about:blank" {
             urlBar.url = webViewController.url
@@ -1204,6 +1226,7 @@ extension BrowserViewController: UIDropInteractionDelegate {
     }
 }
 
+// FXIOS-8628 - #19150 ⁃ Integrate EngineSession find in page in Focus iOS
 extension BrowserViewController: FindInPageBarDelegate {
     func findInPage(_ findInPage: FindInPageBar, didTextChange text: String) {
         find(text, function: "find")
@@ -1224,6 +1247,8 @@ extension BrowserViewController: FindInPageBarDelegate {
     }
 
     private func find(_ text: String, function: String) {
+        // FXIOS-8628 - #19150 ⁃ Integrate EngineSession find in page in Focus iOS
+        // This is done through `func findInPage(text: String, function: FindInPageFunction)`
         let escaped = text.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\"")
         webViewController.evaluate("__firefox__.\(function)(\"\(escaped)\")", completion: nil)
     }
@@ -1305,6 +1330,7 @@ extension BrowserViewController: URLBarDelegate {
                 return
             }
 
+            // FXIOS-8635 - #19155 Integrate EngineSession scrolling to top in Focus iOS
             // Just scroll the vertical position so the page doesn't appear under
             // the notch on the iPhone X
             var point = webViewController.scrollView.contentOffset
@@ -1319,6 +1345,7 @@ extension BrowserViewController: URLBarDelegate {
         let text = text.trimmingCharacters(in: .whitespaces)
 
         guard !text.isEmpty else {
+            // FXIOS-8637 - #19160 - Integrate onTitleChange, onLocationChange in Focus iOS
             urlBar.url = webViewController.url
             return
         }
@@ -1347,8 +1374,12 @@ extension BrowserViewController: URLBarDelegate {
 
         guard !shortcutContextMenuIsOpenOnIpad() else { return }
         overlayView.dismiss()
+
+        // FXIOS-8636 - #19159 - Integrate onProgress and onNavigationStateChange in Focus iOS
         toggleURLBarBackground(isBright: !webViewController.isLoading)
         shortcutsPresenter.shortcutsState = .dismissedURLBar
+
+        // FXIOS-8631 - #19154 ⁃ Integrate EngineSession focus in Focus iOS
         webViewController.focus()
     }
 
@@ -1381,6 +1412,7 @@ extension BrowserViewController: URLBarDelegate {
 
         guard let modalDelegate = modalDelegate else { return }
 
+        // FXIOS-8634 - #19156 ⁃ Integrate EngineSession favicon in Focus iOS
         let favIconPublisher: AnyPublisher<URL?, Never> =
         webViewController
             .getMetadata()
@@ -1390,6 +1422,7 @@ extension BrowserViewController: URLBarDelegate {
             .receive(on: DispatchQueue.main)
             .eraseToAnyPublisher()
 
+        // FXIOS-8643 - #19166 ⁃ Integrate content blocking in Focus iOS
         let state: TrackingProtectionState = urlBar.inBrowsingMode
         ? .browsing(status: SecureConnectionStatus(
             url: webViewController.url!,
@@ -1442,11 +1475,13 @@ extension BrowserViewController: PhotonActionSheetDelegate {
         darkView.isHidden = true
     }
 
+    // FXIOS-8643 - #19166 ⁃ Integrate content blocking in Focus iOS
     func photonActionSheetDidToggleProtection(enabled: Bool) {
         enabled ? webViewController.enableTrackingProtection() : webViewController.disableTrackingProtection()
 
         TipManager.sitesNotWorkingTip = false
 
+        // FXIOS-8626 - #19148 - Integrate basics APIs of WebEngine in Focus iOS
         webViewController.reload()
     }
 }
@@ -1460,11 +1495,13 @@ extension BrowserViewController: UIAdaptivePresentationControllerDelegate {
 }
 
 extension BrowserViewController: TrackingProtectionDelegate {
+    // FXIOS-8643 - #19166 ⁃ Integrate content blocking in Focus iOS
     func trackingProtectionDidToggleProtection(enabled: Bool) {
         enabled ? webViewController.enableTrackingProtection() : webViewController.disableTrackingProtection()
         
         TipManager.sitesNotWorkingTip = false
 
+        // FXIOS-8626 - #19148 - Integrate basics APIs of WebEngine in Focus iOS
         webViewController.reload()
     }
 }
@@ -1562,6 +1599,7 @@ extension BrowserViewController: OverlayViewDelegate {
     func overlayView(_ overlayView: OverlayView, didSubmitText text: String) {
         let text = text.trimmingCharacters(in: .whitespaces)
         guard !text.isEmpty else {
+            // FXIOS-8637 - #19160 - Integrate onTitleChange, onLocationChange in Focus iOS
             urlBar.url = webViewController.url
             return
         }
@@ -1638,12 +1676,14 @@ extension BrowserViewController: WebControllerDelegate {
         urlBarViewModel.loadingProgres = 1
         toggleURLBarBackground(isBright: !urlBar.isEditing)
         GleanMetrics.Browser.totalUriCount.add()
+        // FXIOS-8641 - #19164 ⁃ Handle webViewController evaluateDocumentContentType
         webViewController.evaluateDocumentContentType { documentType in
             if documentType == "application/pdf" {
                 GleanMetrics.Browser.pdfViewerUsed.add()
             }
         }
         Task {
+            // FXIOS-8634 - #19156 ⁃ Integrate EngineSession favicon in Focus iOS
             let faviconURL = try? await webViewController.getMetadata().icon.flatMap(URL.init(string:))
             guard let faviconURL = faviconURL, let url = urlBar.url else { return }
             shortcutManager.update(faviconURL: faviconURL, for: url)
@@ -1655,6 +1695,7 @@ extension BrowserViewController: WebControllerDelegate {
     }
 
     func webController(_ controller: WebController, didFailNavigationWithError error: Error) {
+        // FXIOS-8637 - #19160 - Integrate onTitleChange, onLocationChange in Focus iOS
         urlBar.url = webViewController.url
         toggleURLBarBackground(isBright: true)
         urlBarViewModel.isLoading = false
@@ -1669,23 +1710,28 @@ extension BrowserViewController: WebControllerDelegate {
         urlBarViewModel.canGoForward = canGoForward
     }
 
+    // FXIOS-8636 - #19159 - Integrate onProgress and onNavigationStateChange in Focus iOS
     func webController(_ controller: WebController, didUpdateEstimatedProgress estimatedProgress: Double) {
         // Don't update progress if the home view is visible. This prevents the centered URL bar
         // from catching the global progress events.
         guard urlBar.inBrowsingMode else { return }
 
+
         urlBarViewModel.loadingProgres = estimatedProgress
     }
 
+    // FXIOS-8642 - #19165 ⁃ Integrate scroll controller delegate with Focus iOS
     func webController(_ controller: WebController, scrollViewWillBeginDragging scrollView: UIScrollView) {
         lastScrollOffset = scrollView.contentOffset
         lastScrollTranslation = scrollView.panGestureRecognizer.translation(in: scrollView)
     }
 
+    // FXIOS-8642 - #19165 ⁃ Integrate scroll controller delegate with Focus iOS
     func webController(_ controller: WebController, scrollViewDidEndDragging scrollView: UIScrollView) {
         snapToolbars(scrollView: scrollView)
     }
 
+    // FXIOS-8642 - #19165 ⁃ Integrate scroll controller delegate with Focus iOS
     func webController(_ controller: WebController, scrollViewDidScroll scrollView: UIScrollView) {
         let translation = scrollView.panGestureRecognizer.translation(in: scrollView)
         let isDragging = scrollView.panGestureRecognizer.state != .possible
@@ -1745,6 +1791,7 @@ extension BrowserViewController: WebControllerDelegate {
         lastScrollOffset = scrollView.contentOffset
     }
 
+    // FXIOS-8642 - #19165 ⁃ Integrate scroll controller delegate with Focus iOS
     func webControllerShouldScrollToTop(_ controller: WebController) -> Bool {
         guard scrollBarOffsetAlpha == 0 else {
             showToolbars()
@@ -1802,6 +1849,7 @@ extension BrowserViewController: WebControllerDelegate {
         updateLockIcon(trackingProtectionStatus: trackingStatus)
     }
 
+    // FXIOS-8642 - #19165 ⁃ Integrate scroll controller delegate with Focus iOS
     private func showToolbars() {
         let scrollView = webViewController.scrollView
 
@@ -1819,6 +1867,7 @@ extension BrowserViewController: WebControllerDelegate {
         })
     }
 
+    // FXIOS-8642 - #19165 ⁃ Integrate scroll controller delegate with Focus iOS
     private func hideToolbars() {
         let scrollView = webViewController.scrollView
         scrollBarState = .animating
@@ -2015,6 +2064,7 @@ extension BrowserViewController: MenuActionable {
 
     func addToShortcuts(url: URL) {
         Task {
+            // FXIOS-8634 - #19156 ⁃ Integrate EngineSession favicon in Focus iOS
             let imageURL = try? await webViewController.getMetadata().icon.flatMap(URL.init(string:))
             let shortcut = Shortcut(url: url, imageURL: imageURL)
             self.shortcutManager.add(shortcutViewModel: .init(shortcut: shortcut))

--- a/focus-ios/Blockzilla/Modules/WebView/WebViewController.swift
+++ b/focus-ios/Blockzilla/Modules/WebView/WebViewController.swift
@@ -547,6 +547,7 @@ extension WebViewController: WKUIDelegate {
 
 extension WebViewController: WKScriptMessageHandler {
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        // FXIOS-8090 - #19152 ⁃ Integrate EngineSession ads handler in Focus iOS
         if message.name == "adsMessageHandler" {
             adsTelemetryHelper.trackAds(message: message)
         }
@@ -574,6 +575,7 @@ extension WebViewController: WKScriptMessageHandler {
         components.scheme = "http"
         guard let url = components.url else { return }
 
+        // FXIOS-8643 - #19166 ⁃ Integrate content blocking in Focus iOS
         let enabled = Utils.getEnabledLists().compactMap { BlocklistName(rawValue: $0) }
         TPStatsBlocklistChecker.shared.isBlocked(url: url, enabledLists: enabled).uponQueue(.main) { [unowned self] listItem in
             if let listItem = listItem {


### PR DESCRIPTION
## :scroll: Tickets
No ticket

## :bulb: Description
- Adding comments in the Focus iOS codebase to match some tasks for the WebEngine integration epic.
- Clean up some EngineSessionDelegate call I initially added as I though we would use it like this, but turns out they won't be like that. So might as well clean up now. Worst case they can be added back when needed.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

