### PR TITLE
Add FXIOS-8090 WebEngine: Ads handling

### DIFF
--- a/BrowserKit/Sources/WebEngine/Engine.swift
+++ b/BrowserKit/Sources/WebEngine/Engine.swift
@@ -11,5 +11,5 @@ public protocol Engine {
     func createView() -> EngineView
 
     /// Creates a new engine session.
-    func createSession() throws -> EngineSession
+    func createSession(dependencies: EngineSessionDependencies?) throws -> EngineSession
 }

--- a/BrowserKit/Sources/WebEngine/EngineSessionDelegate.swift
+++ b/BrowserKit/Sources/WebEngine/EngineSessionDelegate.swift
@@ -52,7 +52,7 @@ public protocol EngineSessionDelegate: AnyObject {
     /// Allows delegates to participate in whether or not a keyboard accessory view is shown
     /// for the current engine session.
     func onWillDisplayAccessoryView() -> EngineInputAccessoryView
-    
+ 
     /// Allows delegates to provide custom definitions for ads tracking, for ads found on webpages.
     /// This is utilized in conjunction with the related ads telemetry events (e.g. `.trackAdsFoundOnPage`
     /// which are also passed along to telemetry proxy (`EngineTelemetryProxy`).

--- a/BrowserKit/Sources/WebEngine/EngineSessionDelegate.swift
+++ b/BrowserKit/Sources/WebEngine/EngineSessionDelegate.swift
@@ -52,4 +52,9 @@ public protocol EngineSessionDelegate: AnyObject {
     /// Allows delegates to participate in whether or not a keyboard accessory view is shown
     /// for the current engine session.
     func onWillDisplayAccessoryView() -> EngineInputAccessoryView
+    
+    /// Allows delegates to provide custom definitions for ads tracking, for ads found on webpages.
+    /// This is utilized in conjunction with the related ads telemetry events (e.g. `.trackAdsFoundOnPage`
+    /// which are also passed along to telemetry proxy (`EngineTelemetryProxy`).
+    func adsSearchProviderModels() -> [EngineSearchProviderModel]
 }

--- a/BrowserKit/Sources/WebEngine/EngineSessionDelegate.swift
+++ b/BrowserKit/Sources/WebEngine/EngineSessionDelegate.swift
@@ -52,7 +52,7 @@ public protocol EngineSessionDelegate: AnyObject {
     /// Allows delegates to participate in whether or not a keyboard accessory view is shown
     /// for the current engine session.
     func onWillDisplayAccessoryView() -> EngineInputAccessoryView
- 
+
     /// Allows delegates to provide custom definitions for ads tracking, for ads found on webpages.
     /// This is utilized in conjunction with the related ads telemetry events (e.g. `.trackAdsFoundOnPage`
     /// which are also passed along to telemetry proxy (`EngineTelemetryProxy`).

--- a/BrowserKit/Sources/WebEngine/EngineSessionDependencies.swift
+++ b/BrowserKit/Sources/WebEngine/EngineSessionDependencies.swift
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// Dependencies injected during engine session creation.
+public struct EngineSessionDependencies {
+    var telemetryProxy: EngineTelemetryProxy?
+
+    public init(telemetryProxy: EngineTelemetryProxy? = nil) {
+        self.telemetryProxy = telemetryProxy
+    }
+}

--- a/BrowserKit/Sources/WebEngine/EngineTelemetryProxy.swift
+++ b/BrowserKit/Sources/WebEngine/EngineTelemetryProxy.swift
@@ -14,7 +14,7 @@ public enum EngineTelemetryEvent {
     case didFailProvisionalNavigation
 
     // An error page was shown on the page. Includes error code.
-    case showErrorPage(Int)
+    case showErrorPage(errorCode: Int)
 
     // A page load started.
     case pageLoadStarted
@@ -26,10 +26,10 @@ public enum EngineTelemetryEvent {
     case pageLoadFinished
 
     /// Sends an event for ads found on the page. Includes the provider name and ad URLs.
-    case trackAdsFoundOnPage(String, [String])
+    case trackAdsFoundOnPage(providerName: String, adUrls: [String])
 
     /// Sends an event for ads clicked on the page. Includes the provider name.
-    case trackAdsClickedOnPage(String)
+    case trackAdsClickedOnPage(providerName: String)
 }
 
 /// Protocol for handling WebEngine telemetry events. These can be custom-handled

--- a/BrowserKit/Sources/WebEngine/EngineTelemetryProxy.swift
+++ b/BrowserKit/Sources/WebEngine/EngineTelemetryProxy.swift
@@ -24,6 +24,12 @@ public enum EngineTelemetryEvent {
 
     // A page load was completed.
     case pageLoadFinished
+
+    /// Sends an event for ads found on the page. Includes the provider name and ad URLs.
+    case trackAdsFoundOnPage(String, [String])
+
+    /// Sends an event for ads clicked on the page. Includes the provider name.
+    case trackAdsClickedOnPage(String)
 }
 
 /// Protocol for handling WebEngine telemetry events. These can be custom-handled

--- a/BrowserKit/Sources/WebEngine/WKWebview/Scripts/AdsTelemetryContentScript.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/Scripts/AdsTelemetryContentScript.swift
@@ -31,9 +31,7 @@ public struct EngineSearchProviderModel {
         self.followOnParams = followOnParams
         self.extraAdServersRegexps = extraAdServersRegexps
     }
-}
 
-extension EngineSearchProviderModel {
     func listAdUrls(urls: [String]) -> [String] {
         let predicates: [Predicate] = extraAdServersRegexps.map { regex in
             return { url in
@@ -53,12 +51,15 @@ extension EngineSearchProviderModel {
     }
 }
 
+/// Delegate protocol for AdsTelemetryContentSccript. Provides callbacks to delegates for ad tracking detection
+/// and allows the delegate to provide the search engine definitions and regexes. (See: `EngineSearchProviderModel`)
 protocol AdsTelemetryScriptDelegate: AnyObject {
     func trackAdsFoundOnPage(providerName: String, urls: [String])
     func trackAdsClickedOnPage(providerName: String)
     func searchProviderModels() -> [EngineSearchProviderModel]
 }
 
+/// Script utility to handle tracking of ads on pages, based on provided search engine regexes. (See `searchProviderModels`)
 class AdsTelemetryContentScript: WKContentScript {
     private var logger: Logger
     private weak var delegate: AdsTelemetryScriptDelegate?

--- a/BrowserKit/Sources/WebEngine/WKWebview/Scripts/AdsTelemetryContentScript.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/Scripts/AdsTelemetryContentScript.swift
@@ -1,0 +1,151 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+import WebKit
+
+public enum EngineBasicSearchProvider: String {
+    case google
+    case duckduckgo
+    case yahoo
+    case bing
+}
+
+public struct EngineSearchProviderModel {
+    typealias Predicate = (String) -> Bool
+    let name: String
+    let regexp: String
+    let queryParam: String
+    let codeParam: String
+    let codePrefixes: [String]
+    let followOnParams: [String]
+    let extraAdServersRegexps: [String]
+
+    public static let searchProviderList = [
+        EngineSearchProviderModel(
+            name: EngineBasicSearchProvider.google.rawValue,
+            regexp: #"^https:\/\/www\.google\.(?:.+)\/search"#,
+            queryParam: "q",
+            codeParam: "client",
+            codePrefixes: ["firefox"],
+            followOnParams: ["oq", "ved", "ei"],
+            extraAdServersRegexps: [
+                #"^https?:\/\/www\.google(?:adservices)?\.com\/(?:pagead\/)?aclk"#,
+                #"^(http|https):\/\/clickserve.dartsearch.net\/link\/"#
+            ]
+        ),
+        EngineSearchProviderModel(
+            name: EngineBasicSearchProvider.duckduckgo.rawValue,
+            regexp: #"^https:\/\/duckduckgo\.com\/"#,
+            queryParam: "q",
+            codeParam: "t",
+            codePrefixes: ["f"],
+            followOnParams: [],
+            extraAdServersRegexps: [
+                #"^https:\/\/duckduckgo.com\/y\.js"#,
+                #"^https:\/\/www\.amazon\.(?:[a-z.]{2,24}).*(?:tag=duckduckgo-)"#
+            ]
+        ),
+        // Note: Yahoo shows ads from bing and google
+        EngineSearchProviderModel(
+            name: EngineBasicSearchProvider.yahoo.rawValue,
+            regexp: #"^https:\/\/(?:.*)search\.yahoo\.com\/search"#,
+            queryParam: "p",
+            codeParam: "",
+            codePrefixes: [],
+            followOnParams: [],
+            extraAdServersRegexps: [#"^(http|https):\/\/clickserve.dartsearch.net\/link\/"#,
+                                    #"^https:\/\/www\.bing\.com\/acli?c?k"#,
+                                    #"^https:\/\/www\.bing\.com\/fd\/ls\/GLinkPingPost\.aspx.*acli?c?k"#]
+        ),
+        EngineSearchProviderModel(
+            name: EngineBasicSearchProvider.bing.rawValue,
+            regexp: #"^https:\/\/www\.bing\.com\/search"#,
+            queryParam: "q",
+            codeParam: "pc",
+            codePrefixes: ["MOZ", "MZ"],
+            followOnParams: ["oq"],
+            extraAdServersRegexps: [
+                #"^https:\/\/www\.bing\.com\/acli?c?k"#,
+                #"^https:\/\/www\.bing\.com\/fd\/ls\/GLinkPingPost\.aspx.*acli?c?k"#
+            ]
+        ),
+    ]
+}
+
+extension EngineSearchProviderModel {
+    func listAdUrls(urls: [String]) -> [String] {
+        let predicates: [Predicate] = extraAdServersRegexps.map { regex in
+            return { url in
+                return url.range(of: regex, options: .regularExpression) != nil
+            }
+        }
+
+        var adUrls = [String]()
+        for url in urls {
+            for predicate in predicates {
+                guard predicate(url) else { continue }
+                adUrls.append(url)
+            }
+        }
+
+        return adUrls
+    }
+}
+
+protocol AdsTelemetryScriptDelegate: AnyObject {
+    func trackAdsFoundOnPage(providerName: String, urls: [String])
+    func trackAdsClickedOnPage(providerName: String)
+}
+
+class AdsTelemetryContentScript: WKContentScript {
+    private var logger: Logger
+    private weak var delegate: AdsTelemetryScriptDelegate?
+
+    init(logger: Logger = DefaultLogger.shared,
+         delegate: AdsTelemetryScriptDelegate?) {
+        self.logger = logger
+        self.delegate = delegate
+    }
+
+    class func name() -> String {
+        return "Ads"
+    }
+
+    func scriptMessageHandlerNames() -> [String] {
+        return ["adsMessageHandler"]
+    }
+
+    func userContentController(didReceiveMessage message: Any) {
+        guard
+            let provider = getProviderForMessage(message: message),
+            let body = message as? [String: Any],
+            let urls = body["urls"] as? [String] else { return }
+        let adUrls = provider.listAdUrls(urls: urls)
+        if !adUrls.isEmpty {
+            trackAdsFoundOnPage(providerName: provider.name, urls: adUrls)
+        }
+    }
+
+    private func getProviderForMessage(message: Any) -> EngineSearchProviderModel? {
+        guard let body = message as? [String: Any], let url = body["url"] as? String else { return nil }
+        for provider in EngineSearchProviderModel.searchProviderList {
+            guard url.range(of: provider.regexp, options: .regularExpression) != nil else { continue }
+            return provider
+        }
+
+        return nil
+    }
+
+    // Tracking
+
+    private func trackAdsFoundOnPage(providerName: String, urls: [String]) {
+        delegate?.trackAdsFoundOnPage(providerName: providerName, urls: urls)
+    }
+
+    private func trackAdsClickedOnPage(providerName: String) {
+        delegate?.trackAdsClickedOnPage(providerName: providerName)
+    }
+}

--- a/BrowserKit/Sources/WebEngine/WKWebview/Scripts/AdsTelemetryContentScript.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/Scripts/AdsTelemetryContentScript.swift
@@ -139,7 +139,7 @@ class AdsTelemetryContentScript: WKContentScript {
         return nil
     }
 
-    // Tracking
+    // MARK: - Tracking
 
     private func trackAdsFoundOnPage(providerName: String, urls: [String]) {
         delegate?.trackAdsFoundOnPage(providerName: providerName, urls: urls)

--- a/BrowserKit/Sources/WebEngine/WKWebview/Scripts/AdsTelemetryContentScript.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/Scripts/AdsTelemetryContentScript.swift
@@ -88,6 +88,8 @@ class AdsTelemetryContentScript: WKContentScript {
         }
     }
 
+    // MARK: - Utility
+
     private func getProviderForMessage(message: Any) -> EngineSearchProviderModel? {
         guard let searchProviderModels = delegate?.searchProviderModels() else { return nil }
         guard let body = message as? [String: Any], let url = body["url"] as? String else { return nil }
@@ -106,6 +108,7 @@ class AdsTelemetryContentScript: WKContentScript {
     }
 
     private func trackAdsClickedOnPage(providerName: String) {
+        // TODO: [FXIOS-8629] This will require some client-side integration and hooks. Will revisit soon.
         delegate?.trackAdsClickedOnPage(providerName: providerName)
     }
 }

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngine.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngine.swift
@@ -19,8 +19,9 @@ public class WKEngine: Engine {
         return WKEngineView(frame: .zero)
     }
 
-    public func createSession() throws -> EngineSession {
-        guard let session = WKEngineSession(userScriptManager: userScriptManager) else {
+    public func createSession(dependencies: EngineSessionDependencies?) throws -> EngineSession {
+        guard let session = WKEngineSession(userScriptManager: userScriptManager,
+                                            telemetryProxy: dependencies?.telemetryProxy) else {
             throw EngineError.sessionNotCreated
         }
 

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -469,10 +469,10 @@ class WKEngineSession: NSObject,
     // MARK: - AdsTelemetryScriptDelegate
 
     func trackAdsClickedOnPage(providerName: String) {
-        telemetryProxy?.handleTelemetry(session: self, event: .trackAdsClickedOnPage(providerName))
+        telemetryProxy?.handleTelemetry(session: self, event: .trackAdsClickedOnPage(providerName: providerName))
     }
 
     func trackAdsFoundOnPage(providerName: String, urls: [String]) {
-        telemetryProxy?.handleTelemetry(session: self, event: .trackAdsFoundOnPage(providerName, urls))
+        telemetryProxy?.handleTelemetry(session: self, event: .trackAdsFoundOnPage(providerName: providerName, adUrls: urls))
     }
 }

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -11,7 +11,8 @@ class WKEngineSession: NSObject,
                        WKUIDelegate,
                        WKNavigationDelegate,
                        WKEngineWebViewDelegate,
-                       MetadataFetcherDelegate {
+                       MetadataFetcherDelegate,
+                       AdsTelemetryScriptDelegate {
     weak var delegate: EngineSessionDelegate?
     weak var findInPageDelegate: FindInPageHelperDelegate? {
         didSet {
@@ -32,6 +33,7 @@ class WKEngineSession: NSObject,
     private var contentBlockingSettings: WKContentBlockingSettings = []
 
     init?(userScriptManager: WKUserScriptManager,
+          telemetryProxy: EngineTelemetryProxy? = nil,
           configurationProvider: WKEngineConfigurationProvider = DefaultWKEngineConfigurationProvider(),
           webViewProvider: WKWebViewProvider = DefaultWKWebViewProvider(),
           logger: Logger = DefaultLogger.shared,
@@ -311,6 +313,9 @@ class WKEngineSession: NSObject,
         contentScriptManager.addContentScript(FindInPageContentScript(),
                                               name: FindInPageContentScript.name(),
                                               forSession: self)
+        contentScriptManager.addContentScript(AdsTelemetryContentScript(delegate: self),
+                                              name: AdsTelemetryContentScript.name(),
+                                              forSession: self)
     }
 
     // MARK: - WKUIDelegate
@@ -459,5 +464,15 @@ class WKEngineSession: NSObject,
 
     func didLoad(pageMetadata: EnginePageMetadata) {
         delegate?.didLoad(pageMetadata: pageMetadata)
+    }
+
+    // MARK: - AdsTelemetryScriptDelegate
+
+    func trackAdsClickedOnPage(providerName: String) {
+        telemetryProxy?.handleTelemetry(session: self, event: .trackAdsClickedOnPage(providerName))
+    }
+
+    func trackAdsFoundOnPage(providerName: String, urls: [String]) {
+        telemetryProxy?.handleTelemetry(session: self, event: .trackAdsFoundOnPage(providerName, urls))
     }
 }

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -475,4 +475,8 @@ class WKEngineSession: NSObject,
     func trackAdsFoundOnPage(providerName: String, urls: [String]) {
         telemetryProxy?.handleTelemetry(session: self, event: .trackAdsFoundOnPage(providerName: providerName, adUrls: urls))
     }
+
+    func searchProviderModels() -> [EngineSearchProviderModel] {
+        return delegate?.adsSearchProviderModels() ?? []
+    }
 }

--- a/BrowserKit/Tests/WebEngineTests/AdsTelemetryContentScriptTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/AdsTelemetryContentScriptTests.swift
@@ -26,4 +26,59 @@ final class AdsTelemetryContentScriptTests: XCTestCase {
         XCTAssertEqual(adsTelemetryDelegate.trackAdsFoundOnPageCalled, 0)
         XCTAssertEqual(adsTelemetryDelegate.trackAdsClickedOnPageCalled, 0)
     }
+
+    func testDidReceiveMessageWithNoAdURLMatchThenNoDelegateCalled() {
+        let subject = AdsTelemetryContentScript(delegate: adsTelemetryDelegate)
+
+        subject.userContentController(didReceiveMessage: [
+            "url": "https://www.someSiteWeDontCareAbout.com/search?q=something",
+            "cookies": [["name": "ABCDEFGH", "value": "cookie_val"]],
+            "urls": ["https://www.somewebsite.com/somepage"]
+        ])
+
+        XCTAssertEqual(adsTelemetryDelegate.trackAdsFoundOnPageCalled, 0)
+        XCTAssertEqual(adsTelemetryDelegate.trackAdsClickedOnPageCalled, 0)
+    }
+
+    func testDidReceiveMessageWithBasicURLMatchButNoAdURLsThenNoDelegateCalled() {
+        let subject = AdsTelemetryContentScript(delegate: adsTelemetryDelegate)
+
+        subject.userContentController(didReceiveMessage: [
+            "url": "https://www.mocksearch.com/search?q=something",
+            "cookies": [["name": "ABCDEFGH", "value": "cookie_val"]],
+            "urls": ["https://www.somewebsite.com/somepage"]
+        ])
+
+        XCTAssertEqual(adsTelemetryDelegate.trackAdsFoundOnPageCalled, 0)
+        XCTAssertEqual(adsTelemetryDelegate.trackAdsClickedOnPageCalled, 0)
+    }
+
+    func testDidReceiveMessageWithBasicURLMatchAndMatchingAdURLsThenTrackOnPageCalled() {
+        let subject = AdsTelemetryContentScript(delegate: adsTelemetryDelegate)
+
+        subject.userContentController(didReceiveMessage: [
+            "url": "https://www.mocksearch.com/search?q=something",
+            "cookies": [["name": "ABCDEFGH", "value": "cookie_val"]],
+            "urls": ["https://www.mocksearch.com/pagead/aclk"]
+        ])
+
+        XCTAssertEqual(adsTelemetryDelegate.trackAdsFoundOnPageCalled, 1)
+        XCTAssertEqual(adsTelemetryDelegate.trackAdsClickedOnPageCalled, 0)
+    }
+
+    func testDidReceiveMessageWithBasicURLMatchAndMatchingAdURLsThenTrackOnPageCalledAndURLsSent() {
+        let subject = AdsTelemetryContentScript(delegate: adsTelemetryDelegate)
+
+        subject.userContentController(didReceiveMessage: [
+            "url": "https://www.mocksearch.com/search?q=something",
+            "cookies": [["name": "ABCDEFGH", "value": "cookie_val"]],
+            "urls": ["https://www.mocksearch.com/pagead/aclk",
+                     "https://www.mocksearch.com/pagead/bclk"]
+        ])
+
+        XCTAssertEqual(adsTelemetryDelegate.trackAdsFoundOnPageCalled, 1)
+        XCTAssertEqual(adsTelemetryDelegate.savedTrackAdsOnPageURLs?.count ?? 0, 2)
+        XCTAssertEqual(adsTelemetryDelegate.savedTrackAdsOnPageProviderName, "mocksearch")
+        XCTAssertEqual(adsTelemetryDelegate.trackAdsClickedOnPageCalled, 0)
+    }
 }

--- a/BrowserKit/Tests/WebEngineTests/AdsTelemetryContentScriptTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/AdsTelemetryContentScriptTests.swift
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import WebEngine
+
+final class AdsTelemetryContentScriptTests: XCTestCase {
+    private var adsTelemetryDelegate: MockAdsTelemetryDelegate!
+
+    override func setUp() {
+        super.setUp()
+        adsTelemetryDelegate = MockAdsTelemetryDelegate()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        adsTelemetryDelegate = nil
+    }
+
+    func testDidReceiveMessageGivenEmptyMessageThenNoDelegateCalled() {
+        let subject = AdsTelemetryContentScript(delegate: adsTelemetryDelegate)
+
+        subject.userContentController(didReceiveMessage: [])
+
+        XCTAssertEqual(adsTelemetryDelegate.trackAdsFoundOnPageCalled, 0)
+        XCTAssertEqual(adsTelemetryDelegate.trackAdsClickedOnPageCalled, 0)
+    }
+}

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockAdsTelemetryDelegate.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockAdsTelemetryDelegate.swift
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+@testable import WebEngine
+
+class MockAdsTelemetryDelegate: AdsTelemetryScriptDelegate {
+    var trackAdsFoundOnPageCalled = 0
+    var trackAdsClickedOnPageCalled = 0
+
+    func trackAdsFoundOnPage(providerName: String, urls: [String]) {
+        trackAdsFoundOnPageCalled += 1
+    }
+    
+    func trackAdsClickedOnPage(providerName: String) {
+        trackAdsClickedOnPageCalled += 1
+    }
+
+    func searchProviderModels() -> [EngineSearchProviderModel] {
+        return MockAdsTelemetrySearchProvider.mockSearchProviderModels()
+    }
+}
+
+struct MockAdsTelemetrySearchProvider {
+    static func mockSearchProviderModels() -> [WebEngine.EngineSearchProviderModel] {
+        return [EngineSearchProviderModel(
+                name: "mocksearch",
+                regexp: #"^https:\/\/www\.mocksearch\.(?:.+)\/search"#,
+                queryParam: "q",
+                codeParam: "client",
+                codePrefixes: ["firefox"],
+                followOnParams: ["oq", "ved", "ei"],
+                extraAdServersRegexps: [
+                    #"^https?:\/\/www\.mocksearch(?:adservices)?\.com\/(?:pagead\/)?aclk"#,
+                ]
+            )]
+    }
+}

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockAdsTelemetryDelegate.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockAdsTelemetryDelegate.swift
@@ -17,7 +17,7 @@ class MockAdsTelemetryDelegate: AdsTelemetryScriptDelegate {
         savedTrackAdsOnPageURLs = urls
         savedTrackAdsOnPageProviderName = providerName
     }
-    
+ 
     func trackAdsClickedOnPage(providerName: String) {
         trackAdsClickedOnPageCalled += 1
     }

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockAdsTelemetryDelegate.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockAdsTelemetryDelegate.swift
@@ -9,8 +9,13 @@ class MockAdsTelemetryDelegate: AdsTelemetryScriptDelegate {
     var trackAdsFoundOnPageCalled = 0
     var trackAdsClickedOnPageCalled = 0
 
+    var savedTrackAdsOnPageProviderName: String?
+    var savedTrackAdsOnPageURLs: [String]?
+
     func trackAdsFoundOnPage(providerName: String, urls: [String]) {
         trackAdsFoundOnPageCalled += 1
+        savedTrackAdsOnPageURLs = urls
+        savedTrackAdsOnPageProviderName = providerName
     }
     
     func trackAdsClickedOnPage(providerName: String) {
@@ -33,6 +38,7 @@ struct MockAdsTelemetrySearchProvider {
                 followOnParams: ["oq", "ved", "ei"],
                 extraAdServersRegexps: [
                     #"^https?:\/\/www\.mocksearch(?:adservices)?\.com\/(?:pagead\/)?aclk"#,
+                    #"^https?:\/\/www\.mocksearch(?:adservices)?\.com\/(?:pagead\/)?bclk"#,
                 ]
             )]
     }

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockAdsTelemetryDelegate.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockAdsTelemetryDelegate.swift
@@ -17,7 +17,7 @@ class MockAdsTelemetryDelegate: AdsTelemetryScriptDelegate {
         savedTrackAdsOnPageURLs = urls
         savedTrackAdsOnPageProviderName = providerName
     }
- 
+
     func trackAdsClickedOnPage(providerName: String) {
         trackAdsClickedOnPageCalled += 1
     }

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockEngineSessionDelegate.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockEngineSessionDelegate.swift
@@ -97,8 +97,12 @@ class MockEngineSessionDelegate: EngineSessionDelegate {
         return nil
     }
 
-    func onWillDisplayAccessoryView() -> WebEngine.EngineInputAccessoryView {
+    func onWillDisplayAccessoryView() -> EngineInputAccessoryView {
         onWillDisplayAcccessoryViewCalled += 1
         return .default
+    }
+
+    func adsSearchProviderModels() -> [EngineSearchProviderModel] {
+        return MockAdsTelemetrySearchProvider.mockSearchProviderModels()
     }
 }

--- a/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
@@ -572,9 +572,10 @@ final class WKEngineSessionTests: XCTestCase {
     func testContentScriptGivenInitContentScriptsThenAreAddedAtInit() {
         let subject = createSubject()
 
-        XCTAssertEqual(contentScriptManager.addContentScriptCalled, 1)
-        XCTAssertEqual(contentScriptManager.savedContentScriptNames.count, 1)
+        XCTAssertEqual(contentScriptManager.addContentScriptCalled, 2)
+        XCTAssertEqual(contentScriptManager.savedContentScriptNames.count, 2)
         XCTAssertEqual(contentScriptManager.savedContentScriptNames[0], FindInPageContentScript.name())
+        XCTAssertEqual(contentScriptManager.savedContentScriptNames[1], AdsTelemetryContentScript.name())
         prepareForTearDown(subject!)
     }
 

--- a/BrowserKit/Tests/WebEngineTests/WKEngineTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineTests.swift
@@ -26,7 +26,7 @@ final class WKEngineTests: XCTestCase {
     func testCreateSessionThenCreatesSession() throws {
         let subject = createSubject()
 
-        let session = try XCTUnwrap(subject.createSession())
+        let session = try XCTUnwrap(subject.createSession(dependencies: nil))
         XCTAssertNotNil(session)
     }
 

--- a/SampleBrowser/SampleBrowser.xcodeproj/project.pbxproj
+++ b/SampleBrowser/SampleBrowser.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		1D1C32772B97EFD4006CF034 /* TelemetryHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1C32762B97EFD4006CF034 /* TelemetryHandler.swift */; };
+		1D96A2D72BA14D9500EF7CC7 /* DefaultAdsTrackerDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D96A2D62BA14D9500EF7CC7 /* DefaultAdsTrackerDefinitions.swift */; };
 		8A0687612B6D9F990031427A /* SettingsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0687602B6D9F990031427A /* SettingsDelegate.swift */; };
 		8A0F446B2B56EDC900438589 /* EngineProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0F446A2B56EDC900438589 /* EngineProvider.swift */; };
 		8A0F446E2B56EF1A00438589 /* WebEngine in Frameworks */ = {isa = PBXBuildFile; productRef = 8A0F446D2B56EF1A00438589 /* WebEngine */; };
@@ -49,6 +50,7 @@
 
 /* Begin PBXFileReference section */
 		1D1C32762B97EFD4006CF034 /* TelemetryHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryHandler.swift; sourceTree = "<group>"; };
+		1D96A2D62BA14D9500EF7CC7 /* DefaultAdsTrackerDefinitions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAdsTrackerDefinitions.swift; sourceTree = "<group>"; };
 		8A0687602B6D9F990031427A /* SettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsDelegate.swift; sourceTree = "<group>"; };
 		8A0F44682B56ECBF00438589 /* BrowserKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = BrowserKit; path = ../BrowserKit; sourceTree = "<group>"; };
 		8A0F446A2B56EDC900438589 /* EngineProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngineProvider.swift; sourceTree = "<group>"; };
@@ -133,6 +135,7 @@
 				8A0F447E2B56FDAD00438589 /* BrowserError.swift */,
 				8A0F447C2B56FD9600438589 /* SearchModel.swift */,
 				8A0F44742B56FD5300438589 /* SearchViewModel.swift */,
+				1D96A2D62BA14D9500EF7CC7 /* DefaultAdsTrackerDefinitions.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -353,6 +356,7 @@
 				8A4601E52B0FE20500FFD17F /* AppDelegate.swift in Sources */,
 				8A0F447D2B56FD9600438589 /* SearchModel.swift in Sources */,
 				8A0F44852B56FFFC00438589 /* SearchTerm.swift in Sources */,
+				1D96A2D72BA14D9500EF7CC7 /* DefaultAdsTrackerDefinitions.swift in Sources */,
 				8A3DB32F2B5AD3D400F89705 /* SettingsCell.swift in Sources */,
 				8A0F44792B56FD6E00438589 /* SuggestionCellViewModel.swift in Sources */,
 				8ADF72CD2B73DE6A00530E7A /* FindInPage.swift in Sources */,

--- a/SampleBrowser/SampleBrowser/Engine/EngineProvider.swift
+++ b/SampleBrowser/SampleBrowser/Engine/EngineProvider.swift
@@ -11,14 +11,13 @@ struct EngineProvider {
     let view: EngineView
 
     init(engine: Engine = WKEngine.factory(),
-         telemetryProxy: EngineTelemetryProxy? = nil) {
+         sessionDependencies: EngineSessionDependencies? = nil) {
         do {
-            session = try engine.createSession()
+            session = try engine.createSession(dependencies: sessionDependencies)
         } catch {
             session = nil
         }
 
-        session?.telemetryProxy = telemetryProxy
         view = engine.createView()
     }
 }

--- a/SampleBrowser/SampleBrowser/Model/DefaultAdsTrackerDefinitions.swift
+++ b/SampleBrowser/SampleBrowser/Model/DefaultAdsTrackerDefinitions.swift
@@ -1,0 +1,59 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import WebEngine
+
+struct DefaultAdsTrackerDefinitions {
+    static let searchProviders: [EngineSearchProviderModel] = [
+           EngineSearchProviderModel(
+               name: "google",
+               regexp: #"^https:\/\/www\.google\.(?:.+)\/search"#,
+               queryParam: "q",
+               codeParam: "client",
+               codePrefixes: ["firefox"],
+               followOnParams: ["oq", "ved", "ei"],
+               extraAdServersRegexps: [
+                   #"^https?:\/\/www\.google(?:adservices)?\.com\/(?:pagead\/)?aclk"#,
+                   #"^(http|https):\/\/clickserve.dartsearch.net\/link\/"#
+               ]
+           ),
+           EngineSearchProviderModel(
+               name: "duckduckgo",
+               regexp: #"^https:\/\/duckduckgo\.com\/"#,
+               queryParam: "q",
+               codeParam: "t",
+               codePrefixes: ["f"],
+               followOnParams: [],
+               extraAdServersRegexps: [
+                   #"^https:\/\/duckduckgo.com\/y\.js"#,
+                   #"^https:\/\/www\.amazon\.(?:[a-z.]{2,24}).*(?:tag=duckduckgo-)"#
+               ]
+           ),
+           // Note: Yahoo shows ads from bing and google
+           EngineSearchProviderModel(
+               name: "yahoo",
+               regexp: #"^https:\/\/(?:.*)search\.yahoo\.com\/search"#,
+               queryParam: "p",
+               codeParam: "",
+               codePrefixes: [],
+               followOnParams: [],
+               extraAdServersRegexps: [#"^(http|https):\/\/clickserve.dartsearch.net\/link\/"#,
+                                       #"^https:\/\/www\.bing\.com\/acli?c?k"#,
+                                       #"^https:\/\/www\.bing\.com\/fd\/ls\/GLinkPingPost\.aspx.*acli?c?k"#]
+           ),
+           EngineSearchProviderModel(
+               name: "bing",
+               regexp: #"^https:\/\/www\.bing\.com\/search"#,
+               queryParam: "q",
+               codeParam: "pc",
+               codePrefixes: ["MOZ", "MZ"],
+               followOnParams: ["oq"],
+               extraAdServersRegexps: [
+                   #"^https:\/\/www\.bing\.com\/acli?c?k"#,
+                   #"^https:\/\/www\.bing\.com\/fd\/ls\/GLinkPingPost\.aspx.*acli?c?k"#
+               ]
+           ),
+       ]
+}

--- a/SampleBrowser/SampleBrowser/SceneDelegate.swift
+++ b/SampleBrowser/SampleBrowser/SceneDelegate.swift
@@ -3,10 +3,14 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import UIKit
+import WebEngine
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
-    var engineProvider = EngineProvider(telemetryProxy: TelemetryHandler())
+    var engineProvider: EngineProvider = {
+        let dependencies = EngineSessionDependencies(telemetryProxy: TelemetryHandler())
+        return EngineProvider(sessionDependencies: dependencies)
+    }()
 
     func scene(_ scene: UIScene,
                willConnectTo session: UISceneSession,

--- a/SampleBrowser/SampleBrowser/TelemetryHandler.swift
+++ b/SampleBrowser/SampleBrowser/TelemetryHandler.swift
@@ -20,6 +20,10 @@ final class TelemetryHandler: EngineTelemetryProxy {
             print("Telemetry event triggered: Page load finished.")
         case .pageLoadCancelled:
             print("Telemetry event triggered: Page load cancelled.")
+        case .trackAdsFoundOnPage(let providerName):
+            print("Telemetry event triggered: Track ads found on page \(providerName).")
+        case .trackAdsClickedOnPage(let providerName):
+            print("Telemetry event triggered: Track ads clicked on page \(providerName).")
         }
     }
 }

--- a/SampleBrowser/SampleBrowser/TelemetryHandler.swift
+++ b/SampleBrowser/SampleBrowser/TelemetryHandler.swift
@@ -20,7 +20,7 @@ final class TelemetryHandler: EngineTelemetryProxy {
             print("Telemetry event triggered: Page load finished.")
         case .pageLoadCancelled:
             print("Telemetry event triggered: Page load cancelled.")
-        case .trackAdsFoundOnPage(let providerName):
+        case .trackAdsFoundOnPage(let providerName, let adUrls):
             print("Telemetry event triggered: Track ads found on page \(providerName).")
         case .trackAdsClickedOnPage(let providerName):
             print("Telemetry event triggered: Track ads clicked on page \(providerName).")

--- a/SampleBrowser/SampleBrowser/UI/Browser/BrowserViewController.swift
+++ b/SampleBrowser/SampleBrowser/UI/Browser/BrowserViewController.swift
@@ -232,6 +232,12 @@ class BrowserViewController: UIViewController,
         return .default
     }
 
+    // MARK: - Ads Handling
+
+    func adsSearchProviderModels() -> [WebEngine.EngineSearchProviderModel] {
+        return DefaultAdsTrackerDefinitions.searchProviders
+    }
+
     // MARK: - EngineSessionDelegate Menu items
 
     func findInPage(with selection: String) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8090)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18002)

## :bulb: Description

Initial work to support ads handling and related telemetry hooks for WebEngine clients. WIP

Forthcoming:
- [x] Updates for `trackAdsClickedOnPage` (_see comments on PR_)
- [x] Unit tests

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

